### PR TITLE
Scaffold Echora foundation: architecture, theming, and navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Dart / Flutter
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+build/
+
+# Native platform scaffolding is generated locally via `flutter create .`
+# (kept out of the repo until we decide which platforms to commit).
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# Echora
+
+A modern, **local-first**, privacy-focused music player. Echora is a clean
+alternative to bloated streaming apps — your library lives on your device, and
+downloads are always under your explicit control.
+
+> Status: early foundation. The project scaffold, architecture, theming, and
+> navigation are in place; feature implementations are landing incrementally.
+
+## Philosophy
+
+- **Local-first & offline-first** — the UI always reads from a local cache.
+- **Privacy-focused** — no telemetry, no forced sync.
+- **User-controlled downloads** — never automatic; "Wi-Fi only" is respected.
+- **No vendor lock-in** — sources (local, Jellyfin, WebDAV, NAS) sit behind a
+  single interface.
+- **Contributor-friendly** — small focused files, explicit naming, clean layers.
+
+## Tech stack
+
+| Concern           | Choice                                            |
+| ----------------- | ------------------------------------------------- |
+| Framework         | Flutter                                           |
+| State management  | Riverpod                                          |
+| Navigation        | go_router (`StatefulShellRoute` for bottom nav)   |
+| Local metadata    | SQLite (planned via `drift`)                      |
+| Playback          | `just_audio` + `audio_service` (behind interface) |
+
+Dependencies are added when a feature needs them rather than up front, so the
+`pubspec.yaml` stays honest about what the code actually uses.
+
+## Architecture
+
+Layered and feature-first. Three horizontal layers, sliced vertically by
+feature. The golden rule: **features depend on interfaces, never on concrete
+services or storage.** That seam is what makes the Jellyfin/WebDAV roadmap
+possible without rewriting the UI.
+
+```
+lib/
+  core/        cross-cutting: theme, routing, constants
+  models/      immutable domain entities (Song, Album, Artist, Playlist)
+  storage/     persistence contract (MusicRepository) + impls
+  services/    device-facing contracts (MusicSource, AudioController,
+               ConnectivityService) + impls
+  features/    UI + state per feature (library, player, playlists,
+               downloads, settings, shell)
+  widgets/     shared reusable widgets
+```
+
+### Key extension points
+
+- **`MusicSource`** (`lib/services/music_source.dart`) — a media backend.
+  `LocalMusicSource` ships first; `JellyfinMusicSource` / `WebDavMusicSource`
+  implement the same contract later.
+- **`MusicRepository`** (`lib/storage/music_repository.dart`) — the local
+  SQLite cache the UI reads from. Sources *sync into* it; the UI never talks to
+  a source directly. This is what keeps the app fast and fully offline.
+- **`AudioController`** (`lib/services/audio_controller.dart`) — playback,
+  fully decoupled from `just_audio`. Swappable/wrappable for background audio,
+  MPRIS, and Android Auto without touching feature code.
+
+## Getting started
+
+This repository currently contains the Dart/Flutter source and config. Native
+platform folders are generated locally (they're git-ignored for now):
+
+```bash
+# 1. Generate platform scaffolding (preserves lib/, pubspec.yaml, etc.)
+flutter create --platforms=android,linux .
+
+# 2. Fetch dependencies
+flutter pub get
+
+# 3. Run
+flutter run
+```
+
+> Note: `flutter create` may regenerate template files such as `main.dart`.
+> If prompted, keep the existing versions in this repo.
+
+## Roadmap (MVP)
+
+1. Local music library scanning
+2. Artist / album / song views
+3. Playlist creation & editing
+4. Audio playback
+5. Queue management
+6. Search
+7. Album artwork
+8. Explicit offline downloads
+9. "Wi-Fi only downloads" option
+10. Settings
+
+Later: Jellyfin, WebDAV, NAS, lyrics, ReplayGain, MPRIS, Android Auto, smart
+playlists, and more.
+
+## License
+
+[MPL-2.0](./LICENSE)

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,16 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    - prefer_const_constructors
+    - prefer_const_declarations
+    - prefer_final_locals
+    - directives_ordering
+    - always_declare_return_types
+    - avoid_print
+    - unawaited_futures

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'core/constants/app_info.dart';
+import 'core/routing/app_router.dart';
+import 'core/theme/app_theme.dart';
+
+/// Root widget. Dark mode is the primary experience; light theme follows the
+/// system setting when the user opts out of dark.
+class EchoraApp extends ConsumerWidget {
+  const EchoraApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    return MaterialApp.router(
+      title: AppInfo.name,
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
+      themeMode: ThemeMode.dark,
+      routerConfig: router,
+    );
+  }
+}

--- a/lib/core/constants/app_info.dart
+++ b/lib/core/constants/app_info.dart
@@ -1,0 +1,5 @@
+/// Static, build-time app metadata.
+abstract final class AppInfo {
+  static const String name = 'Echora';
+  static const String tagline = 'Your music, local and yours.';
+}

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../features/downloads/presentation/downloads_screen.dart';
+import '../../features/library/presentation/library_screen.dart';
+import '../../features/player/presentation/player_screen.dart';
+import '../../features/playlists/presentation/playlists_screen.dart';
+import '../../features/settings/presentation/settings_screen.dart';
+import '../../features/shell/presentation/home_shell.dart';
+import 'routes.dart';
+
+/// Single source of truth for navigation. Exposed through Riverpod so future
+/// guards (e.g. "onboarding complete?", multi-user) can depend on app state.
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: [
+      // Persistent bottom-nav shell with an independent navigation stack per
+      // tab, so switching tabs preserves scroll position and history.
+      StatefulShellRoute.indexedStack(
+        builder: (context, state, navigationShell) =>
+            HomeShell(navigationShell: navigationShell),
+        branches: [
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: AppRoutes.library,
+                builder: (context, state) => const LibraryScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: AppRoutes.playlists,
+                builder: (context, state) => const PlaylistsScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: AppRoutes.downloads,
+                builder: (context, state) => const DownloadsScreen(),
+              ),
+            ],
+          ),
+          StatefulShellBranch(
+            routes: [
+              GoRoute(
+                path: AppRoutes.settings,
+                builder: (context, state) => const SettingsScreen(),
+              ),
+            ],
+          ),
+        ],
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (context, state) => const PlayerScreen(),
+      ),
+    ],
+  );
+});

--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -1,0 +1,11 @@
+/// Canonical route paths. Reference these constants instead of raw strings so
+/// navigation targets are discoverable and refactor-safe.
+abstract final class AppRoutes {
+  static const String library = '/library';
+  static const String playlists = '/playlists';
+  static const String downloads = '/downloads';
+  static const String settings = '/settings';
+
+  /// Full-screen now-playing view, pushed above the shell.
+  static const String player = '/player';
+}

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+/// Centralized color palette. Dark mode is the primary experience; the light
+/// palette mirrors it so both themes feel like the same product.
+abstract final class AppColors {
+  // Brand accent — a calm violet that reads well on dark surfaces.
+  static const Color accent = Color(0xFF8B7CF6);
+  static const Color accentMuted = Color(0xFF5B53A8);
+
+  // Dark surfaces (primary).
+  static const Color darkBackground = Color(0xFF0E0F13);
+  static const Color darkSurface = Color(0xFF16181F);
+  static const Color darkSurfaceHigh = Color(0xFF1E212B);
+  static const Color darkOnSurface = Color(0xFFE7E7EC);
+  static const Color darkOnSurfaceMuted = Color(0xFF9A9BA6);
+
+  // Light surfaces.
+  static const Color lightBackground = Color(0xFFF6F6FA);
+  static const Color lightSurface = Color(0xFFFFFFFF);
+  static const Color lightOnSurface = Color(0xFF1A1B20);
+  static const Color lightOnSurfaceMuted = Color(0xFF6B6C76);
+
+  static const Color error = Color(0xFFE5484D);
+}

--- a/lib/core/theme/app_dimens.dart
+++ b/lib/core/theme/app_dimens.dart
@@ -1,0 +1,17 @@
+/// Spacing scale. Use these instead of magic numbers so layout stays
+/// consistent and easy to retune globally.
+abstract final class AppSpacing {
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+}
+
+/// Corner radii. Soft rounded corners are part of the visual identity.
+abstract final class AppRadii {
+  static const double sm = 10;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double pill = 999;
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import 'app_colors.dart';
+import 'app_dimens.dart';
+
+/// Builds the light and dark [ThemeData] for Echora. Both share the same
+/// shape language and accent so the product feels cohesive across modes.
+abstract final class AppTheme {
+  static ThemeData get dark => _build(
+        brightness: Brightness.dark,
+        background: AppColors.darkBackground,
+        surface: AppColors.darkSurface,
+        surfaceHigh: AppColors.darkSurfaceHigh,
+        onSurface: AppColors.darkOnSurface,
+        onSurfaceMuted: AppColors.darkOnSurfaceMuted,
+      );
+
+  static ThemeData get light => _build(
+        brightness: Brightness.light,
+        background: AppColors.lightBackground,
+        surface: AppColors.lightSurface,
+        surfaceHigh: AppColors.lightSurface,
+        onSurface: AppColors.lightOnSurface,
+        onSurfaceMuted: AppColors.lightOnSurfaceMuted,
+      );
+
+  static ThemeData _build({
+    required Brightness brightness,
+    required Color background,
+    required Color surface,
+    required Color surfaceHigh,
+    required Color onSurface,
+    required Color onSurfaceMuted,
+  }) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: AppColors.accent,
+      brightness: brightness,
+    ).copyWith(
+      primary: AppColors.accent,
+      surface: surface,
+      onSurface: onSurface,
+      error: AppColors.error,
+    );
+
+    final cardShape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(AppRadii.md),
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: brightness,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: background,
+      splashFactory: InkSparkle.splashFactory,
+      cardTheme: CardThemeData(
+        color: surfaceHigh,
+        elevation: 0,
+        shape: cardShape,
+        margin: EdgeInsets.zero,
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: background,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        centerTitle: false,
+        titleTextStyle: TextStyle(
+          color: onSurface,
+          fontSize: 22,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: surface,
+        surfaceTintColor: Colors.transparent,
+        indicatorColor: AppColors.accentMuted.withValues(alpha: 0.35),
+        labelTextStyle: WidgetStateProperty.all(
+          TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: onSurface),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadii.pill),
+          ),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.lg,
+            vertical: AppSpacing.md,
+          ),
+        ),
+      ),
+      listTileTheme: ListTileThemeData(
+        iconColor: onSurfaceMuted,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.sm),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/downloads/presentation/downloads_screen.dart
+++ b/lib/features/downloads/presentation/downloads_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/empty_state.dart';
+
+/// Manage explicit, user-controlled downloads. Placeholder until the downloads
+/// feature lands. Downloads are always user-initiated — never automatic.
+class DownloadsScreen extends StatelessWidget {
+  const DownloadsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Downloads')),
+      body: const EmptyState(
+        icon: Icons.download_outlined,
+        title: 'Nothing downloaded',
+        message: 'Downloads you start will appear here.',
+      ),
+    );
+  }
+}

--- a/lib/features/library/presentation/library_screen.dart
+++ b/lib/features/library/presentation/library_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/empty_state.dart';
+
+/// Browse songs, albums, and artists from the local catalog.
+/// Placeholder until the library scanning + catalog feature lands.
+class LibraryScreen extends StatelessWidget {
+  const LibraryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Library')),
+      body: const EmptyState(
+        icon: Icons.library_music_outlined,
+        title: 'Your library is empty',
+        message: 'Scan a folder to add your music. Coming soon.',
+      ),
+    );
+  }
+}

--- a/lib/features/player/presentation/player_screen.dart
+++ b/lib/features/player/presentation/player_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/empty_state.dart';
+
+/// Full-screen now-playing view. Placeholder until playback is wired to the
+/// AudioController. Pushed above the shell via AppRoutes.player.
+class PlayerScreen extends StatelessWidget {
+  const PlayerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Now Playing')),
+      body: const EmptyState(
+        icon: Icons.music_note_outlined,
+        title: 'Nothing playing',
+        message: 'Pick a song to start listening.',
+      ),
+    );
+  }
+}

--- a/lib/features/playlists/presentation/playlists_screen.dart
+++ b/lib/features/playlists/presentation/playlists_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/empty_state.dart';
+
+/// Create and edit playlists. Placeholder until the playlists feature lands.
+class PlaylistsScreen extends StatelessWidget {
+  const PlaylistsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Playlists')),
+      body: const EmptyState(
+        icon: Icons.queue_music_outlined,
+        title: 'No playlists yet',
+        message: 'Your playlists will appear here.',
+      ),
+    );
+  }
+}

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../../../widgets/empty_state.dart';
+
+/// Simple, clean settings. Placeholder until the settings feature lands.
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: const EmptyState(
+        icon: Icons.settings_outlined,
+        title: 'Settings',
+        message: 'Theme, downloads, and library options will live here.',
+      ),
+    );
+  }
+}

--- a/lib/features/shell/presentation/home_shell.dart
+++ b/lib/features/shell/presentation/home_shell.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// The persistent app frame: hosts the active tab and the bottom navigation
+/// bar. Tab state is owned by go_router's [StatefulNavigationShell], so each
+/// tab keeps its own stack and scroll position across switches.
+class HomeShell extends StatelessWidget {
+  const HomeShell({required this.navigationShell, super.key});
+
+  final StatefulNavigationShell navigationShell;
+
+  static const _destinations = <NavigationDestination>[
+    NavigationDestination(
+      icon: Icon(Icons.library_music_outlined),
+      selectedIcon: Icon(Icons.library_music),
+      label: 'Library',
+    ),
+    NavigationDestination(
+      icon: Icon(Icons.queue_music_outlined),
+      selectedIcon: Icon(Icons.queue_music),
+      label: 'Playlists',
+    ),
+    NavigationDestination(
+      icon: Icon(Icons.download_outlined),
+      selectedIcon: Icon(Icons.download),
+      label: 'Downloads',
+    ),
+    NavigationDestination(
+      icon: Icon(Icons.settings_outlined),
+      selectedIcon: Icon(Icons.settings),
+      label: 'Settings',
+    ),
+  ];
+
+  void _onDestinationSelected(int index) {
+    // `initialLocation: true` re-pops a tab to its root when re-tapped.
+    navigationShell.goBranch(
+      index,
+      initialLocation: index == navigationShell.currentIndex,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: navigationShell,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: navigationShell.currentIndex,
+        onDestinationSelected: _onDestinationSelected,
+        destinations: _destinations,
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app.dart';
+
+void main() {
+  // ProviderScope hosts all Riverpod state for the app.
+  runApp(const ProviderScope(child: EchoraApp()));
+}

--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -1,0 +1,26 @@
+/// An album grouping. References its artist by name to stay decoupled from any
+/// particular source's ID scheme.
+class Album {
+  const Album({
+    required this.id,
+    required this.title,
+    this.artistName,
+    this.year,
+    this.artworkUri,
+    this.trackCount = 0,
+  });
+
+  final String id;
+  final String title;
+  final String? artistName;
+  final int? year;
+  final Uri? artworkUri;
+  final int trackCount;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is Album && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/models/artist.dart
+++ b/lib/models/artist.dart
@@ -1,0 +1,21 @@
+/// An artist grouping.
+class Artist {
+  const Artist({
+    required this.id,
+    required this.name,
+    this.albumCount = 0,
+    this.artworkUri,
+  });
+
+  final String id;
+  final String name;
+  final int albumCount;
+  final Uri? artworkUri;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is Artist && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/models/playlist.dart
+++ b/lib/models/playlist.dart
@@ -1,0 +1,38 @@
+/// A user-created, ordered collection of songs. Stores song IDs rather than
+/// full Song objects so ordering and membership persist cheaply.
+class Playlist {
+  const Playlist({
+    required this.id,
+    required this.name,
+    this.songIds = const [],
+    this.createdAt,
+  });
+
+  final String id;
+  final String name;
+  final List<String> songIds;
+  final DateTime? createdAt;
+
+  int get length => songIds.length;
+
+  Playlist copyWith({
+    String? id,
+    String? name,
+    List<String>? songIds,
+    DateTime? createdAt,
+  }) {
+    return Playlist(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      songIds: songIds ?? this.songIds,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is Playlist && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/models/song.dart
+++ b/lib/models/song.dart
@@ -1,0 +1,55 @@
+/// A single playable track, independent of where it came from.
+///
+/// [uri] may point to a local file path or a remote resource. Keeping it
+/// source-agnostic lets the same model flow through local, Jellyfin, and
+/// WebDAV sources without change.
+class Song {
+  const Song({
+    required this.id,
+    required this.title,
+    required this.uri,
+    this.artistName,
+    this.albumName,
+    this.duration = Duration.zero,
+    this.trackNumber,
+    this.artworkUri,
+  });
+
+  final String id;
+  final String title;
+  final String uri;
+  final String? artistName;
+  final String? albumName;
+  final Duration duration;
+  final int? trackNumber;
+  final Uri? artworkUri;
+
+  Song copyWith({
+    String? id,
+    String? title,
+    String? uri,
+    String? artistName,
+    String? albumName,
+    Duration? duration,
+    int? trackNumber,
+    Uri? artworkUri,
+  }) {
+    return Song(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      uri: uri ?? this.uri,
+      artistName: artistName ?? this.artistName,
+      albumName: albumName ?? this.albumName,
+      duration: duration ?? this.duration,
+      trackNumber: trackNumber ?? this.trackNumber,
+      artworkUri: artworkUri ?? this.artworkUri,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is Song && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/services/audio_controller.dart
+++ b/lib/services/audio_controller.dart
@@ -1,0 +1,32 @@
+import '../models/song.dart';
+
+/// High-level playback state, deliberately decoupled from any audio package.
+enum PlaybackStatus { idle, loading, playing, paused, completed, error }
+
+/// The only playback contract the UI knows about.
+///
+/// The UI and player feature depend on this interface, never on `just_audio`
+/// or `audio_service` directly. The concrete `JustAudioController` lives in the
+/// services layer and can be swapped or wrapped (e.g. to add `audio_service`
+/// background handling, MPRIS, or Android Auto) without touching feature code.
+abstract interface class AudioController {
+  /// Emits whenever playback state changes.
+  Stream<PlaybackStatus> get statusStream;
+
+  /// Emits the current playback position, suitable for driving a seek bar.
+  Stream<Duration> get positionStream;
+
+  /// The track currently loaded, or null if nothing is loaded.
+  Song? get currentSong;
+
+  /// Loads [song] (resolving its playable URI) and begins playback.
+  Future<void> playSong(Song song);
+
+  Future<void> play();
+  Future<void> pause();
+  Future<void> stop();
+  Future<void> seek(Duration position);
+
+  /// Releases native resources. Call on app shutdown.
+  Future<void> dispose();
+}

--- a/lib/services/connectivity_service.dart
+++ b/lib/services/connectivity_service.dart
@@ -1,0 +1,11 @@
+/// Network reachability, abstracted so the downloads feature can enforce the
+/// user's "Wi-Fi only downloads" preference without binding to a plugin.
+enum NetworkStatus { offline, wifi, mobile }
+
+abstract interface class ConnectivityService {
+  /// Emits whenever connectivity changes.
+  Stream<NetworkStatus> get statusStream;
+
+  /// One-shot read of the current status.
+  Future<NetworkStatus> currentStatus();
+}

--- a/lib/services/music_source.dart
+++ b/lib/services/music_source.dart
@@ -1,0 +1,33 @@
+import '../models/album.dart';
+import '../models/artist.dart';
+import '../models/song.dart';
+
+/// A backend that *provides* media to Echora.
+///
+/// This is the core extension point for the project's roadmap. The MVP ships a
+/// `LocalMusicSource` (scans on-device files); future `JellyfinMusicSource`,
+/// `WebDavMusicSource`, and NAS sources implement this same contract. Nothing
+/// in the UI or storage layers should depend on a concrete source — only on
+/// this interface — which is what keeps the app vendor-lock-in free.
+///
+/// A source's job is discovery and resolution. Persisting the results into the
+/// local SQLite cache is the MusicRepository's responsibility, not the
+/// source's, so that offline-first behavior stays centralized.
+abstract interface class MusicSource {
+  /// Stable identifier for this source, e.g. `'local'` or `'jellyfin:<id>'`.
+  String get id;
+
+  /// Human-readable name for settings/UI, e.g. "On this device".
+  String get displayName;
+
+  Future<List<Song>> fetchSongs();
+  Future<List<Album>> fetchAlbums();
+  Future<List<Artist>> fetchArtists();
+
+  /// Resolves a [Song] to a URI the audio backend can actually open.
+  ///
+  /// For local files this is typically a no-op returning the file path; for
+  /// remote sources it may mint a streaming/auth'd URL or return the path to a
+  /// previously downloaded copy when offline.
+  Future<Uri?> resolvePlayableUri(Song song);
+}

--- a/lib/storage/music_repository.dart
+++ b/lib/storage/music_repository.dart
@@ -1,0 +1,34 @@
+import '../models/album.dart';
+import '../models/artist.dart';
+import '../models/playlist.dart';
+import '../models/song.dart';
+
+/// The local, offline-first cache the UI reads from.
+///
+/// Critical separation of concerns: the UI always reads from the repository
+/// (backed by SQLite), never directly from a MusicSource. Sources *sync into*
+/// the repository on demand. This is what makes Echora work fully offline and
+/// keeps remote latency out of the render path.
+///
+/// The concrete implementation (`DriftMusicRepository`) is added when the
+/// library feature lands; until then this contract lets the rest of the app be
+/// built and tested against fakes.
+abstract interface class MusicRepository {
+  Future<List<Song>> getAllSongs();
+  Future<List<Album>> getAllAlbums();
+  Future<List<Artist>> getAllArtists();
+  Future<Song?> getSongById(String id);
+
+  Future<List<Playlist>> getAllPlaylists();
+  Future<Playlist> createPlaylist(String name);
+  Future<void> updatePlaylist(Playlist playlist);
+  Future<void> deletePlaylist(String id);
+
+  /// Replaces the cached catalog for a given source after a scan/sync.
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Song> songs,
+    required List<Album> albums,
+    required List<Artist> artists,
+  });
+}

--- a/lib/widgets/empty_state.dart
+++ b/lib/widgets/empty_state.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../core/theme/app_dimens.dart';
+
+/// A calm, centered placeholder used by screens that have no content yet.
+/// Shared so every feature presents an empty state consistently.
+class EmptyState extends StatelessWidget {
+  const EmptyState({
+    required this.icon,
+    required this.title,
+    this.message,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 48, color: theme.colorScheme.primary),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              title,
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            if (message != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                message!,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,25 @@
+name: echora
+description: A modern, local-first, privacy-focused music player.
+publish_to: "none"
+version: 0.1.0+1
+
+environment:
+  sdk: ">=3.6.0 <4.0.0"
+
+# Dependencies are added as features need them, not speculatively.
+# The planned full stack (just_audio, audio_service, drift, connectivity_plus,
+# permission_handler, ...) is documented in README.md and wired in behind the
+# interfaces under lib/services and lib/storage when each feature lands.
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.6.1
+  go_router: ^14.6.2
+
+dev_dependencies:
+  flutter_lints: ^5.0.0
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary

First foundational increment for **Echora**, a local-first, privacy-focused music player. This is a runnable scaffold — architecture, theming, and navigation — with no feature logic yet (by design).

Two foundational choices were made up front (confirmed with the maintainer):
- **State management:** Riverpod
- **Navigation:** go_router (`StatefulShellRoute` for persistent bottom-nav)

## What's included

- **Layered, feature-first structure** matching the agreed `lib/` layout (`core`, `models`, `storage`, `services`, `features`, `widgets`).
- **Abstraction seams** — the architecturally important part:
  - `MusicSource` — media backend contract; `LocalMusicSource` first, Jellyfin/WebDAV/NAS later.
  - `MusicRepository` — local SQLite cache the UI reads from (offline-first; sources sync *into* it).
  - `AudioController` — playback decoupled from `just_audio`/`audio_service`.
  - `ConnectivityService` — backs the "Wi-Fi only downloads" preference.
- **Dark-mode-first theme** with soft rounded corners and a calm accent (Material 3).
- **Source-agnostic domain models**: `Song`, `Album`, `Artist`, `Playlist`.
- **App shell** with bottom navigation + placeholder screens for each feature.

Dependencies are intentionally minimal (`flutter_riverpod`, `go_router`) — feature deps get added as features land, so `pubspec.yaml` stays honest.

## Notes

- Flutter SDK isn't available in the build environment, so this code was written but **not compiled here**. Please run locally to verify:
  ```bash
  flutter create --platforms=android,linux .   # generate native folders (git-ignored)
  flutter pub get
  flutter run
  ```
- SDK constraint is `>=3.6.0` (uses `Color.withValues`).

## Test plan

- [ ] `flutter pub get` resolves
- [ ] `flutter analyze` is clean
- [ ] `flutter run` launches to the Library tab; bottom nav switches between Library / Playlists / Downloads / Settings
- [ ] Dark theme renders as the default

https://claude.ai/code/session_01573mzD6Cox9BtiDaqc8Yjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01573mzD6Cox9BtiDaqc8Yjj)_