### PR TITLE
Add minimal Flutter CI workflow and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+# Run the Flutter quality checks on every PR and on pushes to main.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  flutter:
+    name: Flutter checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pinned to a 3.27.x (Dart 3.6.x) stable release for reproducible runs.
+      # Keep this in sync with the SDK constraint in pubspec.yaml; bumping it
+      # may require reformatting with the newer `dart format`.
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.27.4
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test

--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ flutter run
 > Note: `flutter create` may regenerate template files such as `main.dart`.
 > If prompted, keep the existing versions in this repo.
 
+## Continuous integration
+
+Every pull request and every push to `main` runs a small Flutter workflow
+(`.github/workflows/ci.yml`). It needs to be green before a change merges.
+
+CI runs the checks below, and you can run the exact same ones locally before
+opening a PR:
+
+```bash
+flutter pub get                      # resolve dependencies
+dart format --set-exit-if-changed .  # code must already match `dart format`
+flutter analyze                      # static analysis + lints
+flutter test                         # widget/unit tests
+```
+
+CI pins **Flutter 3.27.x (stable)** for reproducible results; using a matching
+SDK locally avoids spurious `dart format` diffs from formatter changes in newer
+Dart releases. This is code-quality CI only — there are no native build,
+signing, or store-publishing steps yet.
+
 ## Roadmap (MVP)
 
 1. Local music library scanning

--- a/test/app_smoke_test.dart
+++ b/test/app_smoke_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/app/sonara_app.dart';
+
+void main() {
+  testWidgets('App boots to the Library screen', (tester) async {
+    await tester.pumpWidget(const ProviderScope(child: SonaraApp()));
+    await tester.pumpAndSettle();
+
+    // The persistent shell and its bottom navigation render.
+    expect(find.byType(NavigationBar), findsOneWidget);
+
+    // The initial route is the Library tab, showing its empty state.
+    expect(find.text('Your library is empty'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Adds a clean, minimal CI foundation for Sonara — nothing more. No new app
features, no refactors, no release/build/signing pipeline.

- **`.github/workflows/ci.yml`** — a single `Flutter checks` job that runs on
  `pull_request` and on `push` to `main`.
- **`test/app_smoke_test.dart`** — a widget smoke test so `flutter test` has
  something valid to run.
- **`README.md`** — a short "Continuous integration" section documenting the
  checks and how to run them locally.

## What CI does

The workflow checks out the repo, sets up Flutter via the standard
`subosito/flutter-action@v2`, then runs:

| Step | Command | Purpose |
| ---- | ------- | ------- |
| Install dependencies | `flutter pub get` | Resolve packages |
| Verify formatting | `dart format --set-exit-if-changed .` | Fail if code isn't formatted |
| Analyze | `flutter analyze` | Static analysis + lints |
| Run tests | `flutter test` | Widget/unit tests |

## Notes

- **Flutter is pinned to `3.27.4` (stable, Dart 3.6.x)** for reproducible runs
  and to match the existing code's formatter style. The repo's source is
  formatted in the pre-Dart-3.7 style, so a newer SDK's `dart format` would
  reformat unrelated files and fail the formatting gate. Bumping the SDK later
  should be a deliberate, separate change that includes a reformat.
- `flutter test` runs headless and does **not** require the git-ignored native
  platform folders, so CI stays simple (no `flutter create` step).

## Test plan

- [ ] CI runs on this PR and all four steps pass
- [ ] `dart format --set-exit-if-changed .` reports no changes
- [ ] `flutter analyze` reports no issues
- [ ] `flutter test` passes the smoke test

> Heads-up: no Dart/Flutter toolchain was available in the authoring
> environment, so these checks were not run locally — this PR's own CI run is
> the first execution.

https://claude.ai/code/session_01Dj9ePpwAPmbqcenWZQsxVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj9ePpwAPmbqcenWZQsxVX)_