### PR TITLE
Add local music scanning foundation behind MusicSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ project structure, dark-first theming, navigation, the app shell, placeholder
 screens, the core domain models, and the service/repository *interfaces* that
 future features will implement.
 
+The **local library scanning foundation** has now started: `LocalMusicSource`
+(`lib/core/sources/local/`) discovers audio files under a configured folder and
+maps them into `Track`s. It does no tag parsing and isn't wired into the UI yet
+— it's the first concrete `MusicSource` and the seam future metadata parsing
+will extend.
+
 Not built yet (planned, in roughly this order):
 
-- Local music library scanning
+- Local music library scanning — *foundation started; tag parsing & UI pending*
 - Audio playback
 - Playlists
 - User-controlled offline downloads
@@ -48,8 +54,8 @@ codebase.
 | Playback         | `just_audio` + `audio_service` (behind interface) |
 
 Dependencies are added when a feature needs them rather than up front, so
-`pubspec.yaml` stays honest about what the code actually uses. Today that's just
-`flutter_riverpod` and `go_router`.
+`pubspec.yaml` stays honest about what the code actually uses. Today that's
+`flutter_riverpod`, `go_router`, and `path` (for the local file scanner).
 
 ## Architecture
 
@@ -74,6 +80,8 @@ lib/
                             PlaylistRepository, DownloadRepository
     services/               device-facing contracts: PlaybackController,
                             MusicSource, ConnectivityService
+    sources/                concrete MusicSource implementations:
+                            local/ (LocalMusicSource + file scanning)
   features/                 one folder per screen/feature
     library/  player/  playlists/  downloads/  settings/  shell/
   shared/

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+/// Discovers files under a folder on the device.
+///
+/// This is the single seam through which the local source touches the file
+/// system. Isolating it keeps the source's discovery/mapping logic pure enough
+/// to unit-test against a fake. Deciding which files are audio is the caller's
+/// job, not the scanner's.
+abstract interface class AudioFileScanner {
+  /// Returns the absolute paths of every regular file under [folderPath],
+  /// searched recursively. Returns an empty list when the folder is missing.
+  Future<List<String>> listFiles(String folderPath);
+}
+
+/// An [AudioFileScanner] backed by `dart:io`.
+class IoAudioFileScanner implements AudioFileScanner {
+  const IoAudioFileScanner();
+
+  @override
+  Future<List<String>> listFiles(String folderPath) async {
+    final Directory directory = Directory(folderPath);
+    if (!await directory.exists()) {
+      return const <String>[];
+    }
+
+    final List<String> paths = <String>[];
+    final Stream<FileSystemEntity> entities = directory.list(
+      recursive: true,
+      followLinks: false,
+    );
+    await for (final FileSystemEntity entity in entities) {
+      if (entity is File) {
+        paths.add(entity.absolute.path);
+      }
+    }
+    return paths;
+  }
+}

--- a/lib/core/sources/local/audio_file_types.dart
+++ b/lib/core/sources/local/audio_file_types.dart
@@ -1,0 +1,32 @@
+import 'package:path/path.dart' as p;
+
+/// The audio file extensions Sonara's local scanner recognizes.
+///
+/// Kept small and centralized on purpose: supporting a new container format
+/// later is a one-line change here that the rest of the scanner picks up for
+/// free.
+abstract final class AudioFileTypes {
+  /// Recognized extensions, lower-case and *without* the leading dot.
+  static const Set<String> supportedExtensions = <String>{
+    'mp3',
+    'flac',
+    'm4a',
+    'aac',
+    'ogg',
+    'opus',
+    'wav',
+  };
+
+  /// Whether [path] points at a file with a recognized audio extension.
+  ///
+  /// Matching is case-insensitive and ignores the directory part, so
+  /// `/Music/Album/Track.FLAC` is recognized. Files with no extension —
+  /// including dotfiles such as `.DS_Store` — are not treated as audio.
+  static bool isSupported(String path) {
+    final String ext = p.extension(path).toLowerCase();
+    if (ext.isEmpty) {
+      return false;
+    }
+    return supportedExtensions.contains(ext.substring(1));
+  }
+}

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -1,0 +1,65 @@
+import '../../models/album.dart';
+import '../../models/artist.dart';
+import '../../models/track.dart';
+import '../../services/music_source.dart';
+import 'audio_file_scanner.dart';
+import 'audio_file_types.dart';
+import 'local_track_mapper.dart';
+
+/// A [MusicSource] that scans audio files already present on the device.
+///
+/// This is the first concrete source and the reference implementation of the
+/// contract. It does no tag parsing yet: a scan walks [folderPath], keeps only
+/// recognized audio files (see [AudioFileTypes]), and maps each one to a
+/// [Track] via [LocalTrackMapper]. Album/artist grouping is therefore empty
+/// until tag reading lands.
+///
+/// File-system access is delegated to an [AudioFileScanner] so the scanning
+/// logic stays testable without a real disk.
+class LocalMusicSource implements MusicSource {
+  const LocalMusicSource({
+    required this.folderPath,
+    AudioFileScanner scanner = const IoAudioFileScanner(),
+  }) : _scanner = scanner;
+
+  /// Absolute path of the folder to scan, or `null` when the user has not
+  /// chosen one yet — in which case scans simply return nothing.
+  final String? folderPath;
+
+  final AudioFileScanner _scanner;
+
+  @override
+  String get id => 'local';
+
+  @override
+  String get displayName => 'On this device';
+
+  @override
+  Future<List<Track>> fetchTracks() async {
+    final String? folder = folderPath;
+    if (folder == null || folder.isEmpty) {
+      return const <Track>[];
+    }
+
+    final List<String> files = await _scanner.listFiles(folder);
+    final List<Track> tracks = <Track>[];
+    for (final String path in files) {
+      if (AudioFileTypes.isSupported(path)) {
+        tracks.add(LocalTrackMapper.fromPath(path));
+      }
+    }
+    return tracks;
+  }
+
+  /// Empty until tag parsing exists: albums can't be grouped from file paths
+  /// alone.
+  @override
+  Future<List<Album>> fetchAlbums() async => const <Album>[];
+
+  /// Empty until tag parsing exists — see [fetchAlbums].
+  @override
+  Future<List<Artist>> fetchArtists() async => const <Artist>[];
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async => Uri.file(track.uri);
+}

--- a/lib/core/sources/local/local_track_mapper.dart
+++ b/lib/core/sources/local/local_track_mapper.dart
@@ -1,0 +1,23 @@
+import 'package:path/path.dart' as p;
+
+import '../../models/track.dart';
+
+/// Builds a [Track] from a local file path.
+///
+/// This is intentionally the *only* place that turns a file into a [Track], so
+/// richer metadata (ID3/Vorbis tags, embedded artwork, real duration) can be
+/// added here later without changing the scanner or the source.
+abstract final class LocalTrackMapper {
+  /// Maps [path] to a [Track] using only what the path itself reveals.
+  ///
+  /// The title is the file name without its extension. Artist, album and
+  /// duration are left unset until tag parsing lands. The path doubles as both
+  /// the stable [Track.id] and the [Track.uri].
+  static Track fromPath(String path) {
+    return Track(
+      id: path,
+      title: p.basenameWithoutExtension(path),
+      uri: path,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.6.1
   go_router: ^14.6.2
+  # Cross-platform path parsing for the local file scanner (Dart-team package).
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/test/core/sources/local/audio_file_scanner_test.dart
+++ b/test/core/sources/local/audio_file_scanner_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+
+void main() {
+  group('IoAudioFileScanner', () {
+    late Directory root;
+
+    setUp(() async {
+      root = await Directory.systemTemp.createTemp('sonara_scan_test');
+    });
+
+    tearDown(() async {
+      if (await root.exists()) {
+        await root.delete(recursive: true);
+      }
+    });
+
+    test('lists every file recursively, including non-audio files', () async {
+      final nested = Directory('${root.path}/Album')..createSync();
+      File('${root.path}/a.mp3').writeAsStringSync('x');
+      File('${nested.path}/b.flac').writeAsStringSync('x');
+      File('${nested.path}/notes.txt').writeAsStringSync('x');
+
+      const scanner = IoAudioFileScanner();
+      final files = await scanner.listFiles(root.path);
+
+      expect(files, hasLength(3));
+      expect(files.every((path) => File(path).existsSync()), isTrue);
+      expect(files.any((path) => path.endsWith('a.mp3')), isTrue);
+      expect(files.any((path) => path.endsWith('b.flac')), isTrue);
+      expect(files.any((path) => path.endsWith('notes.txt')), isTrue);
+    });
+
+    test('returns an empty list for a folder that does not exist', () async {
+      const scanner = IoAudioFileScanner();
+      final files = await scanner.listFiles('${root.path}/missing');
+      expect(files, isEmpty);
+    });
+  });
+}

--- a/test/core/sources/local/audio_file_types_test.dart
+++ b/test/core/sources/local/audio_file_types_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/audio_file_types.dart';
+
+void main() {
+  group('AudioFileTypes.isSupported', () {
+    test('recognizes every supported extension', () {
+      const List<String> names = <String>[
+        'song.mp3',
+        'song.flac',
+        'song.m4a',
+        'song.aac',
+        'song.ogg',
+        'song.opus',
+        'song.wav',
+      ];
+      for (final String name in names) {
+        expect(AudioFileTypes.isSupported(name), isTrue, reason: name);
+      }
+    });
+
+    test('is case-insensitive', () {
+      expect(AudioFileTypes.isSupported('SONG.MP3'), isTrue);
+      expect(AudioFileTypes.isSupported('Song.Flac'), isTrue);
+      expect(AudioFileTypes.isSupported('track.OpUs'), isTrue);
+    });
+
+    test('matches files inside nested directories', () {
+      expect(
+        AudioFileTypes.isSupported('/music/Artist/Album/01 - Track.flac'),
+        isTrue,
+      );
+    });
+
+    test('rejects unsupported extensions', () {
+      const List<String> names = <String>[
+        'cover.jpg',
+        'notes.txt',
+        'video.mp4',
+        'archive.zip',
+        'playlist.m3u',
+      ];
+      for (final String name in names) {
+        expect(AudioFileTypes.isSupported(name), isFalse, reason: name);
+      }
+    });
+
+    test('rejects files with no extension and dotfiles', () {
+      expect(AudioFileTypes.isSupported('README'), isFalse);
+      expect(AudioFileTypes.isSupported('/music/album/folder'), isFalse);
+      expect(AudioFileTypes.isSupported('.DS_Store'), isFalse);
+      expect(AudioFileTypes.isSupported('song.'), isFalse);
+    });
+
+    test('exposes exactly the seven documented formats', () {
+      expect(AudioFileTypes.supportedExtensions, hasLength(7));
+      expect(
+        AudioFileTypes.supportedExtensions,
+        containsAll(<String>[
+          'mp3',
+          'flac',
+          'm4a',
+          'aac',
+          'ogg',
+          'opus',
+          'wav',
+        ]),
+      );
+    });
+  });
+}

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:sonara/core/sources/local/local_music_source.dart';
+
+/// Returns a fixed list of paths and records the folder it was asked to scan,
+/// so the source can be tested without touching a real file system.
+class _FakeScanner implements AudioFileScanner {
+  _FakeScanner(this._files);
+
+  final List<String> _files;
+  String? requestedFolder;
+
+  @override
+  Future<List<String>> listFiles(String folderPath) async {
+    requestedFolder = folderPath;
+    return _files;
+  }
+}
+
+void main() {
+  group('LocalMusicSource', () {
+    test('identifies itself as the local source', () {
+      const source = LocalMusicSource(folderPath: '/music');
+      expect(source.id, 'local');
+      expect(source.displayName, isNotEmpty);
+    });
+
+    test('returns no tracks when no folder is set', () async {
+      final scanner = _FakeScanner(<String>['/music/song.mp3']);
+      final source = LocalMusicSource(folderPath: null, scanner: scanner);
+
+      expect(await source.fetchTracks(), isEmpty);
+      expect(scanner.requestedFolder, isNull);
+    });
+
+    test('returns no tracks for an empty folder path', () async {
+      final scanner = _FakeScanner(<String>['/music/song.mp3']);
+      final source = LocalMusicSource(folderPath: '', scanner: scanner);
+
+      expect(await source.fetchTracks(), isEmpty);
+      expect(scanner.requestedFolder, isNull);
+    });
+
+    test('keeps audio files and ignores the rest', () async {
+      final scanner = _FakeScanner(<String>[
+        '/music/Track One.mp3',
+        '/music/cover.jpg',
+        '/music/Track Two.flac',
+        '/music/notes.txt',
+        '/music/Track Three.WAV',
+        '/music/.DS_Store',
+      ]);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+
+      final tracks = await source.fetchTracks();
+
+      expect(tracks.map((track) => track.title).toList(), <String>[
+        'Track One',
+        'Track Two',
+        'Track Three',
+      ]);
+      expect(scanner.requestedFolder, '/music');
+    });
+
+    test('maps each kept file to a track uri', () async {
+      final scanner = _FakeScanner(<String>['/music/song.opus']);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+
+      final tracks = await source.fetchTracks();
+
+      expect(tracks, hasLength(1));
+      expect(tracks.single.uri, '/music/song.opus');
+      expect(tracks.single.title, 'song');
+    });
+
+    test('exposes no albums or artists yet', () async {
+      final scanner = _FakeScanner(<String>['/music/song.mp3']);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+
+      expect(await source.fetchAlbums(), isEmpty);
+      expect(await source.fetchArtists(), isEmpty);
+    });
+
+    test('resolves a track to a file uri', () async {
+      final scanner = _FakeScanner(<String>['/music/song.mp3']);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+      final tracks = await source.fetchTracks();
+
+      final uri = await source.resolvePlayableUri(tracks.single);
+
+      expect(uri, Uri.file('/music/song.mp3'));
+    });
+  });
+}

--- a/test/core/sources/local/local_track_mapper_test.dart
+++ b/test/core/sources/local/local_track_mapper_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/local_track_mapper.dart';
+
+void main() {
+  group('LocalTrackMapper.fromPath', () {
+    test('uses the file name without extension as the title', () {
+      final track = LocalTrackMapper.fromPath('/music/Holocene.mp3');
+      expect(track.title, 'Holocene');
+    });
+
+    test('keeps the full path as both id and uri', () {
+      const path = '/music/Bon Iver/Holocene.flac';
+      final track = LocalTrackMapper.fromPath(path);
+      expect(track.id, path);
+      expect(track.uri, path);
+    });
+
+    test('preserves spaces and punctuation in the title', () {
+      final track = LocalTrackMapper.fromPath('/music/01 - Intro (Live).m4a');
+      expect(track.title, '01 - Intro (Live)');
+    });
+
+    test('only strips the final extension when the name has dots', () {
+      final track = LocalTrackMapper.fromPath('/music/a.b.c.opus');
+      expect(track.title, 'a.b.c');
+    });
+
+    test('leaves metadata minimal until tag parsing exists', () {
+      final track = LocalTrackMapper.fromPath('/music/song.wav');
+      expect(track.artistName, isNull);
+      expect(track.albumName, isNull);
+      expect(track.duration, Duration.zero);
+      expect(track.trackNumber, isNull);
+      expect(track.artworkUri, isNull);
+    });
+
+    test('produces tracks that are equal by path identity', () {
+      final a = LocalTrackMapper.fromPath('/music/song.mp3');
+      final b = LocalTrackMapper.fromPath('/music/song.mp3');
+      expect(a, b);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First reviewable slice of **local library scanning**. Introduces `LocalMusicSource` — the first concrete implementation of the existing `MusicSource` interface — which discovers audio files under a configured folder and maps them into minimal `Track` objects.

Scanning logic is deliberately split into small, single-purpose pieces so file-system access stays behind one seam and metadata parsing is easy to extend later.

### What's included (`lib/core/sources/local/`)

- **`AudioFileTypes`** — centralized, case-insensitive detection of supported extensions: `.mp3 .flac .m4a .aac .ogg .opus .wav`. Adding a format later is a one-line change.
- **`AudioFileScanner`** (interface) + **`IoAudioFileScanner`** (`dart:io`) — the *single* file-system seam. Isolating it keeps the source unit-testable without a real disk.
- **`LocalTrackMapper`** — the one place a file path becomes a `Track` (title from filename; `artist`/`album`/`duration` left unset). This is the hook future tag parsing will extend.
- **`LocalMusicSource`** — ties discovery + filtering + mapping together. Takes a configurable `folderPath`; `fetchAlbums()`/`fetchArtists()` return empty until tags are read.

### Tests (`test/core/sources/local/`)

- Supported / unsupported / case-insensitive extension detection (incl. dotfiles & no-extension files).
- Source ignores unsupported files and maps the rest to `Track`s in order.
- Path → `Track` mapping (title, id, uri, minimal metadata).
- `IoAudioFileScanner` recursive walk against a real temp directory.

### Notes / scope

- Adds the `path` dependency (Dart-team package) for cross-platform path parsing.
- README updated to note the foundation has started.
- **Out of scope by design:** playback, Jellyfin/WebDAV, downloads, full metadata/tag parsing, UI wiring, and platform permissions.

## Limitations

- No tag parsing yet — titles come from filenames; artist/album/duration are unset, so album/artist views stay empty.
- Not wired into the UI or any provider; `folderPath` is a constructor argument (no folder picker / persisted setting yet).
- `IoAudioFileScanner` assumes a readable tree; permission handling is a later PR.

## Next recommended PR

Wire `LocalMusicSource` into the app: a Riverpod provider + a folder-picker setting that feeds `folderPath`, and have it sync into `MusicLibraryRepository` so the Library screen renders scanned tracks. Tag parsing (duration/artist/album/artwork) can follow as its own slice extending `LocalTrackMapper`.

## Test plan

> No Flutter SDK is available in the authoring environment, so these were not run locally — CI runs the same checks.

- [ ] `flutter pub get`
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] `flutter test`

https://claude.ai/code/session_01ATEtwX3u5nGTePZ4g9UsVx

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATEtwX3u5nGTePZ4g9UsVx)_