### PR TITLE
Add in-memory MusicLibraryRepository for development and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ maps them into `Track`s. It does no tag parsing and isn't wired into the UI yet
 — it's the first concrete `MusicSource` and the seam future metadata parsing
 will extend.
 
+A temporary `InMemoryMusicLibraryRepository` (`lib/data/repositories/`) now
+implements the `MusicLibraryRepository` contract, so the app and its tests have
+a concrete catalog to read from before storage lands. It keeps tracks, albums,
+and artists in memory, grouped by source — it is **not persistent** and exists
+only for development and testing. Drift/SQLite-backed persistence is planned
+next, once Dart code generation (`build_runner`) can be verified in CI.
+
 Not built yet (planned, in roughly this order):
 
 - Local music library scanning — *foundation started; tag parsing & UI pending*
@@ -82,6 +89,8 @@ lib/
                             MusicSource, ConnectivityService
     sources/                concrete MusicSource implementations:
                             local/ (LocalMusicSource + file scanning)
+  data/                     concrete repository implementations
+    repositories/           in_memory_music_library_repository.dart (dev/tests)
   features/                 one folder per screen/feature
     library/  player/  playlists/  downloads/  settings/  shell/
   shared/

--- a/lib/data/repositories/in_memory_music_library_repository.dart
+++ b/lib/data/repositories/in_memory_music_library_repository.dart
@@ -1,0 +1,77 @@
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/music_library_repository.dart';
+
+/// An in-memory [MusicLibraryRepository] for development and tests.
+///
+/// A temporary stand-in for the planned Drift/SQLite implementation. The
+/// whole catalog lives in plain maps on the heap, so nothing is persisted —
+/// data is lost when the instance is dropped. That is fine for unit tests
+/// and for running the app before storage code generation is in place.
+///
+/// Items are grouped by `sourceId`. Each [upsertCatalog] call fully replaces
+/// the catalog for that one source, leaving every other source untouched.
+/// The `getAll*` methods flatten across sources, preserving the order that
+/// sources were first seen and the item order within each source.
+class InMemoryMusicLibraryRepository implements MusicLibraryRepository {
+  // Per-source catalogs. Keyed by sourceId so a re-scan of one source can
+  // replace just its slice without disturbing the others. `upsertCatalog` is
+  // the only writer, which keeps the three maps in sync.
+  final Map<String, List<Track>> _tracksBySource = <String, List<Track>>{};
+  final Map<String, List<Album>> _albumsBySource = <String, List<Album>>{};
+  final Map<String, List<Artist>> _artistsBySource = <String, List<Artist>>{};
+
+  @override
+  Future<List<Track>> getAllTracks() async {
+    final List<Track> all = <Track>[];
+    for (final List<Track> tracks in _tracksBySource.values) {
+      all.addAll(tracks);
+    }
+    return all;
+  }
+
+  @override
+  Future<List<Album>> getAllAlbums() async {
+    final List<Album> all = <Album>[];
+    for (final List<Album> albums in _albumsBySource.values) {
+      all.addAll(albums);
+    }
+    return all;
+  }
+
+  @override
+  Future<List<Artist>> getAllArtists() async {
+    final List<Artist> all = <Artist>[];
+    for (final List<Artist> artists in _artistsBySource.values) {
+      all.addAll(artists);
+    }
+    return all;
+  }
+
+  @override
+  Future<Track?> getTrackById(String id) async {
+    for (final List<Track> tracks in _tracksBySource.values) {
+      for (final Track track in tracks) {
+        if (track.id == id) {
+          return track;
+        }
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    // Store defensive copies so later mutation of the caller's lists can't
+    // silently change what we've cached.
+    _tracksBySource[sourceId] = List<Track>.of(tracks);
+    _albumsBySource[sourceId] = List<Album>.of(albums);
+    _artistsBySource[sourceId] = List<Artist>.of(artists);
+  }
+}

--- a/test/data/repositories/in_memory_music_library_repository_test.dart
+++ b/test/data/repositories/in_memory_music_library_repository_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/album.dart';
+import 'package:sonara/core/models/artist.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
+
+Track _track(String id) => Track(id: id, title: 'Track $id', uri: id);
+
+Album _album(String id) => Album(id: id, title: 'Album $id');
+
+Artist _artist(String id) => Artist(id: id, name: 'Artist $id');
+
+void main() {
+  group('InMemoryMusicLibraryRepository', () {
+    late InMemoryMusicLibraryRepository repository;
+
+    setUp(() {
+      repository = InMemoryMusicLibraryRepository();
+    });
+
+    test('starts empty', () async {
+      expect(await repository.getAllTracks(), isEmpty);
+      expect(await repository.getAllAlbums(), isEmpty);
+      expect(await repository.getAllArtists(), isEmpty);
+    });
+
+    test('upsertCatalog stores tracks', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a'), _track('b')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      expect(await repository.getAllTracks(), hasLength(2));
+    });
+
+    test('getAllTracks returns the stored tracks', () async {
+      final List<Track> stored = <Track>[_track('a'), _track('b')];
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: stored,
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      expect(await repository.getAllTracks(), stored);
+    });
+
+    test('getAllAlbums and getAllArtists return stored items', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: const <Track>[],
+        albums: <Album>[_album('a')],
+        artists: <Artist>[_artist('a')],
+      );
+
+      expect(await repository.getAllAlbums(), <Album>[_album('a')]);
+      expect(await repository.getAllArtists(), <Artist>[_artist('a')]);
+    });
+
+    test('getTrackById returns a match, or null if absent', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a'), _track('b')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      expect(await repository.getTrackById('b'), _track('b'));
+      expect(await repository.getTrackById('missing'), isNull);
+    });
+
+    test('second upsert for a source replaces its tracks', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('old')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('new')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      expect(await repository.getAllTracks(), <Track>[_track('new')]);
+      expect(await repository.getTrackById('old'), isNull);
+    });
+
+    test('upserting another source keeps existing tracks', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('local-1')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_track('jellyfin-1')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(all, contains(_track('local-1')));
+      expect(all, contains(_track('jellyfin-1')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a concrete `MusicLibraryRepository` implementation so the rest of the app (controllers, UI) and its tests have a real catalog to read from **before** the Drift/SQLite layer lands. This is a small, additive, no-risk change — no existing code is modified.

## Files changed

- `lib/data/repositories/in_memory_music_library_repository.dart` — new `InMemoryMusicLibraryRepository`.
- `test/data/repositories/in_memory_music_library_repository_test.dart` — unit tests.
- `README.md` — notes the in-memory repo and that Drift/SQLite is planned next.

## Behavior summary

`InMemoryMusicLibraryRepository implements MusicLibraryRepository` and keeps the catalog in plain in-memory maps **grouped by `sourceId`**:

- `getAllTracks()` / `getAllAlbums()` / `getAllArtists()` — flatten across all sources, preserving the order sources were first seen and item order within each source.
- `getTrackById(id)` — returns the first matching track, or `null` if absent.
- `upsertCatalog(sourceId:, tracks:, albums:, artists:)` — **fully replaces** the catalog slice for that one `sourceId` and leaves every other source untouched. Stores defensive copies so later mutation of the caller's lists can't change cached state.

It is **not persistent** — everything is lost when the instance is dropped. That's intentional; it exists purely for development and testing.

## Why Drift is deferred

Drift/SQLite requires generated code via `build_runner`, and Flutter/Dart codegen can't be run/verified in the current environment. Rather than commit unverified generated code, this PR ships a simple in-memory implementation behind the unchanged `MusicLibraryRepository` interface. When code generation can be verified, a Drift-backed implementation can drop in behind the same contract with no caller changes.

## Tests added

- starts empty (tracks, albums, artists)
- `upsertCatalog` stores tracks
- `getAllTracks` returns the stored tracks
- `getAllAlbums` / `getAllArtists` return stored items
- `getTrackById` returns a match, and `null` when absent
- a second upsert for the same source **replaces** that source's tracks
- upserting another source **keeps** the existing source's tracks

## Verification note

Flutter/Dart is **not available** in this environment, so formatting, analysis, and tests were **not** run locally. Code was hand-written to match `dart format` output and the project's lint rules (`directives_ordering`, `prefer_final_locals`, `always_declare_return_types`, etc.). GitHub Actions CI (`dart format --set-exit-if-changed`, `flutter analyze`, `flutter test`) is the source of truth here.

## Next recommended PR

Wire the Library screen to the in-memory repository/controller first (validating the read path end-to-end), then swap in the Drift-backed implementation later behind the same `MusicLibraryRepository` interface.


---
_Generated by [Claude Code](https://claude.ai/code/session_015qx2gd5DA8u9ABoyzx2Lyz)_