### PR TITLE
Add manual workflow to generate Drift files in CI

### DIFF
--- a/.github/workflows/generate-drift.yml
+++ b/.github/workflows/generate-drift.yml
@@ -1,0 +1,54 @@
+name: Generate Drift files
+
+# Manually run Dart code generation (Drift / build_runner) on a chosen branch
+# and commit the generated files back to that same branch. Intended for PR
+# branches where local generation is unreliable. This NEVER runs automatically:
+# it only triggers on workflow_dispatch, and it pushes to whatever branch you
+# select when launching it (so it only touches main if you deliberately run it
+# on main). It does not build, sign, or publish anything.
+on:
+  workflow_dispatch:
+
+# Needed so the job can push the generated commit back to the selected branch.
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    name: Generate Drift files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Match the Flutter version pinned by CI (.github/workflows/ci.yml) so the
+      # generated output matches what CI then validates.
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.27.4
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Format
+        run: dart format .
+
+      - name: Commit generated files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Stage first so newly generated files (e.g. *.g.dart) are detected;
+          # a bare `git diff` ignores untracked files.
+          git add .
+          if git diff --cached --quiet; then
+            echo "No generated changes to commit."
+            exit 0
+          fi
+          git commit -m "Generate Drift files"
+          git push

--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ SDK locally avoids spurious `dart format` diffs from formatter changes in newer
 Dart releases. This is code-quality CI only — there are no native build,
 signing, or store-publishing steps yet.
 
+### Generating Drift files in CI
+
+Drift/SQLite persistence relies on `build_runner` code generation, which can be
+unreliable to run locally. The **Generate Drift files** workflow
+(`.github/workflows/generate-drift.yml`) runs that generation in CI and commits
+the result back to the chosen branch. It is **manual only** (`workflow_dispatch`)
+— it never runs on a normal push or PR, and it neither builds nor publishes
+anything. It uses the same Flutter version as the main CI workflow, runs
+`flutter pub get`, `dart run build_runner build --delete-conflicting-outputs`,
+and `dart format .`, then commits **only if** something actually changed.
+
+To regenerate Drift files on a PR:
+
+1. Open the Drift PR.
+2. Go to the **Actions** tab.
+3. Select the **Generate Drift files** workflow.
+4. Click **Run workflow** and choose the PR branch.
+5. Wait for the bot to push the generated commit (`Generate Drift files`).
+6. Let normal CI run against the updated branch.
+
+The workflow pushes to whichever branch you launch it on, so run it on the PR
+branch rather than `main`.
+
 ## Roadmap (MVP)
 
 1. Local music library scanning


### PR DESCRIPTION
## Summary

Local `build_runner` generation has been unreliable, which is currently blocking Drift/SQLite persistence. This adds a small, manually-triggered workflow that runs the code generation in CI and commits the result back to the chosen branch — so maintainers can regenerate Drift files on a PR branch without depending on their local toolchain.

This PR is **only the generator workflow** — it does not implement Drift itself.

## What's included

- **`.github/workflows/generate-drift.yml`** — a `workflow_dispatch`-only workflow that:
  - checks out the selected branch (`actions/checkout@v4`) with `contents: write` permission so it can push back,
  - installs Flutter via `subosito/flutter-action@v2` pinned to **3.27.4 / stable** (same as `ci.yml`),
  - runs `flutter pub get`, `dart run build_runner build --delete-conflicting-outputs`, and `dart format .`,
  - commits and pushes `Generate Drift files` **only if** something changed, otherwise prints a message and exits 0.
- **README** — a "Generating Drift files in CI" note with the maintainer steps.

## Safety properties

- Manual only — never runs on push or PR automatically.
- No build / sign / publish / release steps.
- No force push; pushes to whichever branch it was launched on (so it only touches `main` if deliberately run on `main`). Run it on the PR branch.
- Does not touch app features.

## Note on change detection

The task suggested `git diff --quiet`. Newly generated files (e.g. `*.g.dart`) are **untracked**, and a bare `git diff` ignores untracked files — so I stage first (`git add .`) and check `git diff --cached --quiet`. Without this, the workflow would silently skip the brand-new generated files it exists to commit.

## Test plan

- [ ] Merge, then on a Drift PR branch (with `drift_dev` + `build_runner` in `pubspec.yaml`), run **Actions → Generate Drift files → Run workflow** on that branch.
- [ ] Confirm a `Generate Drift files` commit is pushed by `github-actions[bot]`.
- [ ] Re-run on an already-generated branch and confirm it exits with "No generated changes to commit." and no empty commit.

https://claude.ai/code/session_01ByS6oztR3azPC4Csp9kmYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByS6oztR3azPC4Csp9kmYa)_