### PR TITLE
Add Drift/SQLite persistence for tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,22 @@ maps them into `Track`s. It does no tag parsing and isn't wired into the UI yet
 — it's the first concrete `MusicSource` and the seam future metadata parsing
 will extend.
 
-A temporary `InMemoryMusicLibraryRepository` (`lib/data/repositories/`) now
+A temporary `InMemoryMusicLibraryRepository` (`lib/data/repositories/`) also
 implements the `MusicLibraryRepository` contract, so the app and its tests have
-a concrete catalog to read from before storage lands. It keeps tracks, albums,
-and artists in memory, grouped by source — it is **not persistent** and exists
-only for development and testing. Drift/SQLite-backed persistence is planned
-next, once Dart code generation (`build_runner`) can be verified in CI.
+a concrete catalog to read from. It keeps tracks, albums, and artists in memory,
+grouped by source — it is **not persistent** and exists only for development and
+testing.
+
+**Drift/SQLite persistence** has now landed for tracks.
+`DriftMusicLibraryRepository` (`lib/data/repositories/`) is the persistent
+catalog the UI will read from, backed by `SonaraDatabase`
+(`lib/data/database/`). At schema **v1** only the `tracks` table is persisted:
+`getAllTracks`, `getTrackById`, and `upsertCatalog` are real, while
+`getAllAlbums`/`getAllArtists` return empty lists for now. Domain models
+(`core/models/`) stay separate from Drift rows; conversion lives in small,
+explicit mappers (`lib/data/mappers/`). It is **not yet wired into the UI**.
+The generated `*.g.dart` files are produced by the **Generate Drift files**
+workflow (see below), not committed by hand.
 
 Not built yet (planned, in roughly this order):
 
@@ -57,12 +67,14 @@ codebase.
 | Framework        | Flutter                                           |
 | State management | Riverpod                                          |
 | Navigation       | go_router (`StatefulShellRoute` for bottom nav)   |
-| Local metadata   | SQLite (planned via `drift`)                      |
+| Local metadata   | SQLite via `drift`                                |
 | Playback         | `just_audio` + `audio_service` (behind interface) |
 
 Dependencies are added when a feature needs them rather than up front, so
 `pubspec.yaml` stays honest about what the code actually uses. Today that's
-`flutter_riverpod`, `go_router`, and `path` (for the local file scanner).
+`flutter_riverpod`, `go_router`, `path` (for the local file scanner), and
+`drift` + `sqlite3_flutter_libs` + `path_provider` for SQLite persistence
+(`drift_dev` + `build_runner` are dev-only, for code generation).
 
 ## Architecture
 
@@ -89,8 +101,11 @@ lib/
                             MusicSource, ConnectivityService
     sources/                concrete MusicSource implementations:
                             local/ (LocalMusicSource + file scanning)
-  data/                     concrete repository implementations
-    repositories/           in_memory_music_library_repository.dart (dev/tests)
+  data/                     concrete repository implementations + storage
+    database/               SonaraDatabase (Drift) + tables/ (tracks_table.dart)
+    mappers/                domain <-> Drift row conversion (track_mapper.dart)
+    repositories/           drift_music_library_repository.dart (persistent),
+                            in_memory_music_library_repository.dart (dev/tests)
   features/                 one folder per screen/feature
     library/  player/  playlists/  downloads/  settings/  shell/
   shared/

--- a/lib/data/database/sonara_database.dart
+++ b/lib/data/database/sonara_database.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'tables/tracks_table.dart';
+
+part 'sonara_database.g.dart';
+
+/// The app's local SQLite database — the offline-first catalog the UI reads
+/// from. Kept deliberately outside the UI and feature layers; repositories in
+/// `data/repositories/` are the only callers.
+///
+/// Schema is at v1 with no migrations yet. When the schema changes, bump
+/// [schemaVersion] and add a `MigrationStrategy`; we are not pre-building that
+/// machinery while there is nothing to migrate from.
+@DriftDatabase(tables: [Tracks])
+class SonaraDatabase extends _$SonaraDatabase {
+  SonaraDatabase() : super(_openConnection());
+
+  /// Builds a database over a caller-supplied executor. Used by tests to run
+  /// against an in-memory SQLite instance (`NativeDatabase.memory()`).
+  SonaraDatabase.forTesting(super.executor);
+
+  @override
+  int get schemaVersion => 1;
+}
+
+QueryExecutor _openConnection() {
+  return LazyDatabase(() async {
+    final Directory dir = await getApplicationDocumentsDirectory();
+    final File file = File(p.join(dir.path, 'sonara.sqlite'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/lib/data/database/tables/tracks_table.dart
+++ b/lib/data/database/tables/tracks_table.dart
@@ -1,0 +1,27 @@
+import 'package:drift/drift.dart';
+
+/// The persisted shape of a [Track] in the local SQLite catalog.
+///
+/// The generated row class is named `TrackRow` (not `Track`) so it never
+/// collides with the domain model in `core/models/track.dart`. Conversion
+/// between the two lives in the explicit mappers under `data/mappers/`.
+///
+/// `sourceId` records which [MusicSource] a row came from so a re-scan of one
+/// source can replace just its rows (see `upsertCatalog`) without touching the
+/// others. `durationMs` and `artworkUri` are stored as primitives (SQLite has
+/// no Duration/Uri types); the mappers rebuild the rich types on read.
+@DataClassName('TrackRow')
+class Tracks extends Table {
+  TextColumn get id => text()();
+  TextColumn get sourceId => text()();
+  TextColumn get title => text()();
+  TextColumn get uri => text()();
+  TextColumn get artistName => text().nullable()();
+  TextColumn get albumName => text().nullable()();
+  IntColumn get durationMs => integer().withDefault(const Constant(0))();
+  IntColumn get trackNumber => integer().nullable()();
+  TextColumn get artworkUri => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}

--- a/lib/data/mappers/track_mapper.dart
+++ b/lib/data/mappers/track_mapper.dart
@@ -1,0 +1,39 @@
+import 'package:drift/drift.dart';
+
+import '../../core/models/track.dart';
+import '../database/sonara_database.dart';
+
+/// Explicit, one-way conversions between the [Track] domain model and its
+/// persisted form. Kept tiny and dumb on purpose: no IO, no defaults beyond
+/// what the schema guarantees, so the domain and database shapes can drift
+/// apart (pun intended) without leaking either into the other.
+
+/// Rebuilds a domain [Track] from a stored row.
+Track trackFromRow(TrackRow row) {
+  return Track(
+    id: row.id,
+    title: row.title,
+    uri: row.uri,
+    artistName: row.artistName,
+    albumName: row.albumName,
+    duration: Duration(milliseconds: row.durationMs),
+    trackNumber: row.trackNumber,
+    artworkUri: row.artworkUri == null ? null : Uri.tryParse(row.artworkUri!),
+  );
+}
+
+/// Builds an insertable companion for [track], tagged with the [sourceId] it
+/// belongs to. `durationMs`/`artworkUri` are flattened to primitives here.
+TracksCompanion trackToCompanion(Track track, String sourceId) {
+  return TracksCompanion(
+    id: Value(track.id),
+    sourceId: Value(sourceId),
+    title: Value(track.title),
+    uri: Value(track.uri),
+    artistName: Value(track.artistName),
+    albumName: Value(track.albumName),
+    durationMs: Value(track.duration.inMilliseconds),
+    trackNumber: Value(track.trackNumber),
+    artworkUri: Value(track.artworkUri?.toString()),
+  );
+}

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -26,9 +26,9 @@ class DriftMusicLibraryRepository implements MusicLibraryRepository {
 
   @override
   Future<Track?> getTrackById(String id) async {
-    final TrackRow? row =
-        await (_db.select(_db.tracks)..where((t) => t.id.equals(id)))
-            .getSingleOrNull();
+    final TrackRow? row = await (_db.select(_db.tracks)
+          ..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
     return row == null ? null : trackFromRow(row);
   }
 

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -1,0 +1,63 @@
+import 'package:drift/drift.dart';
+
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/music_library_repository.dart';
+import '../database/sonara_database.dart';
+import '../mappers/track_mapper.dart';
+
+/// SQLite-backed [MusicLibraryRepository] using Drift. This is the persistent
+/// catalog the UI reads from; it replaces the in-memory stand-in once storage
+/// is wired up.
+///
+/// Albums and artists are not persisted yet — [getAllAlbums] and
+/// [getAllArtists] return empty lists. Only tracks are stored at v1.
+class DriftMusicLibraryRepository implements MusicLibraryRepository {
+  DriftMusicLibraryRepository(this._db);
+
+  final SonaraDatabase _db;
+
+  @override
+  Future<List<Track>> getAllTracks() async {
+    final List<TrackRow> rows = await _db.select(_db.tracks).get();
+    return rows.map(trackFromRow).toList();
+  }
+
+  @override
+  Future<Track?> getTrackById(String id) async {
+    final TrackRow? row =
+        await (_db.select(_db.tracks)..where((t) => t.id.equals(id)))
+            .getSingleOrNull();
+    return row == null ? null : trackFromRow(row);
+  }
+
+  @override
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
+
+  @override
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
+
+  /// Replaces every track previously stored for [sourceId] with [tracks], in a
+  /// single transaction so a reader never observes a half-applied catalog.
+  /// Albums and artists are accepted for interface parity but not persisted at
+  /// v1.
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    await _db.transaction(() async {
+      await (_db.delete(_db.tracks)..where((t) => t.sourceId.equals(sourceId)))
+          .go();
+      await _db.batch((Batch batch) {
+        batch.insertAll(
+          _db.tracks,
+          tracks.map((Track t) => trackToCompanion(t, sourceId)).toList(),
+        );
+      });
+    });
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,11 +17,22 @@ dependencies:
   go_router: ^14.6.2
   # Cross-platform path parsing for the local file scanner (Dart-team package).
   path: ^1.9.0
+  # SQLite-backed local catalog persistence (the offline-first cache the UI
+  # reads from). drift is the typed query layer; sqlite3_flutter_libs bundles
+  # the native SQLite engine on device; path_provider locates the on-device
+  # database file.
+  drift: ^2.18.0
+  sqlite3_flutter_libs: ^0.5.20
+  path_provider: ^2.1.4
 
 dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
+  # Drift code generation. Run via the manual "Generate Drift files" workflow;
+  # produces the *.g.dart files that back SonaraDatabase.
+  drift_dev: ^2.18.0
+  build_runner: ^2.4.13
 
 flutter:
   uses-material-design: true

--- a/test/data/repositories/drift_music_library_repository_test.dart
+++ b/test/data/repositories/drift_music_library_repository_test.dart
@@ -1,0 +1,124 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/album.dart';
+import 'package:sonara/core/models/artist.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/database/sonara_database.dart';
+import 'package:sonara/data/repositories/drift_music_library_repository.dart';
+
+Track _track(String id, {int durationMs = 0, String? artworkUri}) => Track(
+      id: id,
+      title: 'Track $id',
+      uri: 'file:///$id.flac',
+      artistName: 'Artist $id',
+      albumName: 'Album $id',
+      duration: Duration(milliseconds: durationMs),
+      trackNumber: 1,
+      artworkUri: artworkUri == null ? null : Uri.parse(artworkUri),
+    );
+
+void main() {
+  group('DriftMusicLibraryRepository', () {
+    late SonaraDatabase db;
+    late DriftMusicLibraryRepository repository;
+
+    setUp(() {
+      db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      repository = DriftMusicLibraryRepository(db);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('starts empty', () async {
+      expect(await repository.getAllTracks(), isEmpty);
+      expect(await repository.getAllAlbums(), isEmpty);
+      expect(await repository.getAllArtists(), isEmpty);
+    });
+
+    test('upsertCatalog persists tracks that getAllTracks returns', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a'), _track('b')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(all.map((Track t) => t.id), containsAll(<String>['a', 'b']));
+    });
+
+    test('round-trips duration and artwork through the mappers', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[
+          _track('a', durationMs: 187000, artworkUri: 'file:///art/a.jpg'),
+        ],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final Track? track = await repository.getTrackById('a');
+      expect(track, isNotNull);
+      expect(track!.duration, const Duration(milliseconds: 187000));
+      expect(track.artworkUri, Uri.parse('file:///art/a.jpg'));
+      expect(track.artistName, 'Artist a');
+      expect(track.albumName, 'Album a');
+      expect(track.trackNumber, 1);
+    });
+
+    test('getTrackById returns null when absent', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      expect(await repository.getTrackById('missing'), isNull);
+    });
+
+    test('second upsert for a source replaces its tracks', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('old')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('new')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all.map((Track t) => t.id), <String>['new']);
+      expect(await repository.getTrackById('old'), isNull);
+    });
+
+    test('upserting another source leaves existing tracks intact', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('local-1')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_track('jellyfin-1')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(
+        all.map((Track t) => t.id),
+        containsAll(<String>['local-1', 'jellyfin-1']),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds real SQLite persistence for **tracks** using Drift, behind the existing `MusicLibraryRepository` contract. No playback, no Library UI wiring, no folder picker/downloads/remote sources — storage only.

- **Dependencies**: `drift`, `sqlite3_flutter_libs`, `path_provider` (runtime) and `drift_dev` + `build_runner` (dev, code-gen).
- **`SonaraDatabase`** (`lib/data/database/sonara_database.dart`) — Drift database, schema **v1**, no migrations yet. On-device file via `path_provider`; a `forTesting` ctor accepts an in-memory executor.
- **`tracks` table** (`lib/data/database/tables/tracks_table.dart`) — row class named `TrackRow` (via `@DataClassName`) to avoid colliding with the domain `Track`. Stores `sourceId` so a re-scan replaces only that source's rows; `durationMs`/`artworkUri` stored as primitives.
- **Mappers** (`lib/data/mappers/track_mapper.dart`) — small, explicit `trackFromRow` / `trackToCompanion`; domain models stay separate from rows.
- **`DriftMusicLibraryRepository`** (`lib/data/repositories/`) — persistent `getAllTracks`, `getTrackById`, and per-source `upsertCatalog` (delete-then-insert in a transaction). `getAllAlbums`/`getAllArtists` return empty lists for now.
- **Tests** against an in-memory SQLite DB covering empty state, persistence, duration/artwork round-trip, per-source replace, and cross-source isolation.
- **README** updated with a short Drift/SQLite storage note.

## Generated files

The `*.g.dart` files are **not** committed by hand. After this PR is open, run **Actions → Generate Drift files** on this branch to generate and commit them; normal CI (analyze/test) is expected to be red until that runs.

## Test plan

- [ ] Run **Generate Drift files** workflow on `claude/determined-johnson-XevZK`
- [ ] CI green: `flutter analyze` + `flutter test`
- [ ] New repository tests pass against in-memory SQLite

https://claude.ai/code/session_016iWpRaLmapQN7tuxxXbZNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016iWpRaLmapQN7tuxxXbZNQ)_