### PR TITLE
Wire Library screen to MusicLibraryRepository

### DIFF
--- a/lib/data/repositories/music_library_repository_provider.dart
+++ b/lib/data/repositories/music_library_repository_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/music_library_repository.dart';
+import 'in_memory_music_library_repository.dart';
+
+/// The single [MusicLibraryRepository] the app reads its catalog from.
+///
+/// Defaults to the in-memory implementation while the app is being built out;
+/// once a scan flow exists, this can be overridden (e.g. in `main`) to the
+/// Drift-backed repository without touching any UI code that depends on it.
+final musicLibraryRepositoryProvider = Provider<MusicLibraryRepository>((ref) {
+  return InMemoryMusicLibraryRepository();
+});

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/music_library_repository_provider.dart';
+import 'library_state.dart';
+
+/// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
+/// and exposes them as a [LibraryState]. Keeps the UI free of any direct
+/// knowledge of the repository or its backing store.
+class LibraryController extends Notifier<LibraryState> {
+  @override
+  LibraryState build() {
+    // Kick off the initial load; the screen shows a spinner until it lands.
+    _load();
+    return const LibraryState.loading();
+  }
+
+  /// Re-reads the catalog. Safe to call again (e.g. after a future scan).
+  Future<void> refresh() => _load();
+
+  Future<void> _load() async {
+    state = const LibraryState.loading();
+    try {
+      final tracks = await ref
+          .read(musicLibraryRepositoryProvider)
+          .getAllTracks();
+      state = LibraryState.loaded(tracks);
+    } catch (error) {
+      state = LibraryState.error(error.toString());
+    }
+  }
+}
+
+final libraryControllerProvider =
+    NotifierProvider<LibraryController, LibraryState>(LibraryController.new);

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -20,9 +20,8 @@ class LibraryController extends Notifier<LibraryState> {
   Future<void> _load() async {
     state = const LibraryState.loading();
     try {
-      final tracks = await ref
-          .read(musicLibraryRepositoryProvider)
-          .getAllTracks();
+      final tracks =
+          await ref.read(musicLibraryRepositoryProvider).getAllTracks();
       state = LibraryState.loaded(tracks);
     } catch (error) {
       state = LibraryState.error(error.toString());

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -1,20 +1,134 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../app/dimens.dart';
+import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
+import 'library_controller.dart';
+import 'library_state.dart';
 
-/// Browse tracks, albums, and artists from the local catalog.
-/// Placeholder until the library scanning + catalog feature lands.
-class LibraryScreen extends StatelessWidget {
+/// Browse tracks from the local catalog. Reads entirely from
+/// [libraryControllerProvider]; it has no knowledge of where tracks are stored.
+class LibraryScreen extends ConsumerWidget {
   const LibraryScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(libraryControllerProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('Library')),
-      body: const EmptyState(
-        icon: Icons.library_music_outlined,
-        title: 'Your library is empty',
-        message: 'Scan a folder to add your music. Coming soon.',
+      body: _body(ref, state),
+    );
+  }
+
+  Widget _body(WidgetRef ref, LibraryState state) {
+    switch (state.status) {
+      case LibraryStatus.loading:
+        return const Center(child: CircularProgressIndicator());
+      case LibraryStatus.error:
+        return _LibraryError(
+          message: state.errorMessage,
+          onRetry: () => ref.read(libraryControllerProvider.notifier).refresh(),
+        );
+      case LibraryStatus.loaded:
+        if (state.isEmpty) {
+          return const EmptyState(
+            icon: Icons.library_music_outlined,
+            title: 'Your library is empty',
+            message: 'Scan a folder to add your music. Coming soon.',
+          );
+        }
+        return _TrackList(tracks: state.tracks);
+    }
+  }
+}
+
+class _TrackList extends StatelessWidget {
+  const _TrackList({required this.tracks});
+
+  final List<Track> tracks;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: tracks.length,
+      itemBuilder: (context, index) => _TrackTile(track: tracks[index]),
+    );
+  }
+}
+
+class _TrackTile extends StatelessWidget {
+  const _TrackTile({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.music_note_outlined),
+      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        _subtitle(track),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      // Playback lands in a later PR; tapping is a no-op for now.
+      onTap: () {},
+    );
+  }
+
+  /// Prefer human-readable artist/album metadata; fall back to the raw
+  /// uri/path when a track has no tags yet.
+  static String _subtitle(Track track) {
+    final parts = <String>[
+      if (track.artistName != null && track.artistName!.isNotEmpty)
+        track.artistName!,
+      if (track.albumName != null && track.albumName!.isNotEmpty)
+        track.albumName!,
+    ];
+    return parts.isEmpty ? track.uri : parts.join(' • ');
+  }
+}
+
+class _LibraryError extends StatelessWidget {
+  const _LibraryError({required this.message, required this.onRetry});
+
+  final String? message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              "Couldn't load your library",
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            if (message != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                message!,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            const SizedBox(height: AppSpacing.md),
+            FilledButton.tonal(
+              onPressed: onRetry,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/library/library_state.dart
+++ b/lib/features/library/library_state.dart
@@ -1,0 +1,32 @@
+import '../../core/models/track.dart';
+
+/// Where the Library screen is in its load lifecycle.
+enum LibraryStatus { loading, loaded, error }
+
+/// Immutable snapshot the [LibraryScreen] renders from.
+///
+/// The screen never reaches into the repository directly — it reads this
+/// state and the controller is the only thing that mutates it.
+class LibraryState {
+  const LibraryState({
+    required this.status,
+    this.tracks = const <Track>[],
+    this.errorMessage,
+  });
+
+  const LibraryState.loading() : this(status: LibraryStatus.loading);
+
+  const LibraryState.loaded(List<Track> tracks)
+      : this(status: LibraryStatus.loaded, tracks: tracks);
+
+  const LibraryState.error(String message)
+      : this(status: LibraryStatus.error, errorMessage: message);
+
+  final LibraryStatus status;
+  final List<Track> tracks;
+  final String? errorMessage;
+
+  /// True only once a load has succeeded but returned no tracks, so the screen
+  /// can distinguish "nothing here" from "still loading".
+  bool get isEmpty => status == LibraryStatus.loaded && tracks.isEmpty;
+}

--- a/test/features/library/fake_music_library_repository.dart
+++ b/test/features/library/fake_music_library_repository.dart
@@ -1,0 +1,43 @@
+import 'package:sonara/core/models/album.dart';
+import 'package:sonara/core/models/artist.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/core/repositories/music_library_repository.dart';
+
+/// A minimal [MusicLibraryRepository] for driving controller/widget tests.
+///
+/// [getAllTracks] returns [tracks], or throws [error] when one is set, so a
+/// test can exercise the loaded, empty, and error paths.
+class FakeMusicLibraryRepository implements MusicLibraryRepository {
+  FakeMusicLibraryRepository({this.tracks = const <Track>[], this.error});
+
+  final List<Track> tracks;
+  final Object? error;
+
+  @override
+  Future<List<Track>> getAllTracks() async {
+    if (error != null) throw error!;
+    return tracks;
+  }
+
+  @override
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
+
+  @override
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
+
+  @override
+  Future<Track?> getTrackById(String id) async {
+    for (final track in tracks) {
+      if (track.id == id) return track;
+    }
+    return null;
+  }
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {}
+}

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/repositories/music_library_repository_provider.dart';
+import 'package:sonara/features/library/library_controller.dart';
+import 'package:sonara/features/library/library_state.dart';
+
+import 'fake_music_library_repository.dart';
+
+Track _track(String id) => Track(id: id, title: 'Track $id', uri: 'file://$id');
+
+ProviderContainer _containerWith(FakeMusicLibraryRepository repository) {
+  final container = ProviderContainer(
+    overrides: [
+      musicLibraryRepositoryProvider.overrideWithValue(repository),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('LibraryController', () {
+    test('starts in the loading state', () {
+      final container = _containerWith(FakeMusicLibraryRepository());
+
+      expect(
+        container.read(libraryControllerProvider).status,
+        LibraryStatus.loading,
+      );
+    });
+
+    test('loads tracks from the repository', () async {
+      final container = _containerWith(
+        FakeMusicLibraryRepository(tracks: <Track>[_track('a'), _track('b')]),
+      );
+
+      await container.read(libraryControllerProvider.notifier).refresh();
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.loaded);
+      expect(state.tracks, hasLength(2));
+      expect(state.isEmpty, isFalse);
+    });
+
+    test('reports empty when the repository has no tracks', () async {
+      final container = _containerWith(FakeMusicLibraryRepository());
+
+      await container.read(libraryControllerProvider.notifier).refresh();
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.loaded);
+      expect(state.isEmpty, isTrue);
+    });
+
+    test('surfaces an error when the repository throws', () async {
+      final container = _containerWith(
+        FakeMusicLibraryRepository(error: Exception('boom')),
+      );
+
+      await container.read(libraryControllerProvider.notifier).refresh();
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.error);
+      expect(state.errorMessage, contains('boom'));
+    });
+  });
+}

--- a/test/features/library/library_screen_test.dart
+++ b/test/features/library/library_screen_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/repositories/music_library_repository_provider.dart';
+import 'package:sonara/features/library/library_screen.dart';
+
+import 'fake_music_library_repository.dart';
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  FakeMusicLibraryRepository repository,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        musicLibraryRepositoryProvider.overrideWithValue(repository),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+}
+
+void main() {
+  group('LibraryScreen', () {
+    testWidgets('shows a spinner while loading', (tester) async {
+      await _pumpScreen(tester, FakeMusicLibraryRepository());
+
+      // Before the async load settles, the loading indicator is visible.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('shows the empty state when there are no tracks', (
+      tester,
+    ) async {
+      await _pumpScreen(tester, FakeMusicLibraryRepository());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Your library is empty'), findsOneWidget);
+    });
+
+    testWidgets('lists tracks with title and subtitle', (tester) async {
+      await _pumpScreen(
+        tester,
+        FakeMusicLibraryRepository(
+          tracks: <Track>[
+            const Track(
+              id: '1',
+              title: 'Song One',
+              uri: 'file:///song1.mp3',
+              artistName: 'Artist A',
+              albumName: 'Album X',
+            ),
+            const Track(id: '2', title: 'Song Two', uri: 'file:///song2.mp3'),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.text('Artist A • Album X'), findsOneWidget);
+      // No metadata: falls back to the uri/path.
+      expect(find.text('Song Two'), findsOneWidget);
+      expect(find.text('file:///song2.mp3'), findsOneWidget);
+    });
+
+    testWidgets('shows an error state with a retry action', (tester) async {
+      await _pumpScreen(
+        tester,
+        FakeMusicLibraryRepository(error: Exception('disk on fire')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("Couldn't load your library"), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Wires the Library screen to `MusicLibraryRepository` through a Riverpod controller, so the UI renders tracks from the repository abstraction instead of a static placeholder. No playback, folder picker, downloads, remote sources, or schema changes — those stay out of scope.

## Files changed

- `lib/features/library/library_state.dart` — new immutable `LibraryState` (`LibraryStatus` loading/loaded/error, `tracks`, `errorMessage`, `isEmpty`).
- `lib/features/library/library_controller.dart` — new `LibraryController` (`Notifier<LibraryState>`) + `libraryControllerProvider`.
- `lib/data/repositories/music_library_repository_provider.dart` — new `musicLibraryRepositoryProvider`, defaulting to the in-memory repository.
- `lib/features/library/library_screen.dart` — now a `ConsumerWidget` that renders from the controller.
- `test/features/library/fake_music_library_repository.dart` — shared fake repo for tests.
- `test/features/library/library_controller_test.dart` — controller state-transition tests.
- `test/features/library/library_screen_test.dart` — widget tests for each UI state.

## State / controller summary

- `LibraryController.build()` returns `loading` and kicks off an async load.
- `_load()` reads `getAllTracks()` from `musicLibraryRepositoryProvider`, then sets `loaded` (with tracks) or `error` (with message). `refresh()` re-runs it.
- The screen only ever reads `LibraryState` — it has no knowledge of the repository or its backing store. The repository provider defaults to `InMemoryMusicLibraryRepository`, so it can later be overridden to the Drift-backed implementation in `main` without touching UI code.

## UI behavior

- **Loading:** centered `CircularProgressIndicator`.
- **Empty** (loaded, no tracks): existing `EmptyState` ("Your library is empty").
- **Populated:** `ListView` of tracks; each shows the title plus an artist • album subtitle, falling back to the raw uri/path when no metadata is present.
- **Error:** icon, message, and a Retry button that calls `refresh()`.
- Track tap is a no-op for now.

## Limitations

- In-memory repository by default, so the library is empty on a fresh boot (smoke test still passes via the empty state).
- No playback, scanning trigger, folder picker, downloads, or remote sources.
- Tracks are listed flat (no album/artist grouping or sorting).

## Verification

Relies on CI: `flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test`. Flutter isn't available in the dev container, so checks were not run locally.

## Next recommended PR

Add a simple library scan action / settings flow so local files can be scanned into the repository (populating the now-wired UI).

---
_Generated by [Claude Code](https://claude.ai/code/session_018hqbDpPFYTCecpb9Zj5ghA)_