### PR TITLE
Library v1: scan a folder, persist tracks, list them

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,26 @@ project structure, dark-first theming, navigation, the app shell, placeholder
 screens, the core domain models, and the service/repository *interfaces* that
 future features will implement.
 
-The **local library scanning foundation** has now started: `LocalMusicSource`
-(`lib/core/sources/local/`) discovers audio files under a configured folder and
-maps them into `Track`s. It does no tag parsing and isn't wired into the UI yet
-— it's the first concrete `MusicSource` and the seam future metadata parsing
-will extend.
+**Library v1 is now wired end to end.** The Library screen can scan a local
+folder, persist the discovered tracks through `MusicLibraryRepository`, and list
+them back. The flow is: `LocalMusicSource` discovers audio files under a folder
+→ `LibraryController` persists them via `MusicLibraryRepository.upsertCatalog`
+→ `LibraryScreen` renders the stored tracks (each as title + uri/path). The
+screen renders four states — loading, empty, populated, and error — and the
+UI only ever talks to `LibraryController`/`LibraryState` and the repository
+abstraction, never to Drift or a source directly.
+
+`LocalMusicSource` (`lib/core/sources/local/`) discovers audio files under a
+configured folder and maps them into `Track`s. It does no tag parsing yet —
+it's the first concrete `MusicSource` and the seam future metadata parsing will
+extend.
+
+Scanning is triggered from a deliberately minimal **dev entry point**: a folder
+icon in the Library app bar opens a small text prompt for a folder path. There
+is no real folder picker or Android runtime-permission flow yet — those come
+later. The scan path is exposed as `LibraryController.scanFolder(path)`, which
+keeps the flow fully testable without a real disk (the file-system seam,
+`audioFileScannerProvider`, is overridden with a fake in tests).
 
 A temporary `InMemoryMusicLibraryRepository` (`lib/data/repositories/`) also
 implements the `MusicLibraryRepository` contract, so the app and its tests have
@@ -33,13 +48,16 @@ catalog the UI will read from, backed by `SonaraDatabase`
 `getAllTracks`, `getTrackById`, and `upsertCatalog` are real, while
 `getAllAlbums`/`getAllArtists` return empty lists for now. Domain models
 (`core/models/`) stay separate from Drift rows; conversion lives in small,
-explicit mappers (`lib/data/mappers/`). It is **not yet wired into the UI**.
-The generated `*.g.dart` files are produced by the **Generate Drift files**
-workflow (see below), not committed by hand.
+explicit mappers (`lib/data/mappers/`). The generated `*.g.dart` files are
+produced by the **Generate Drift files** workflow (see below), not committed by
+hand. The Library v1 flow currently persists through the in-memory repository
+by default (`musicLibraryRepositoryProvider`); the Drift repository implements
+the same contract and can be swapped in without touching any UI code.
 
 Not built yet (planned, in roughly this order):
 
-- Local music library scanning — *foundation started; tag parsing & UI pending*
+- Local music library scanning — *v1 done (scan → persist → list); tag parsing,
+  a real folder picker, and Android permissions still pending*
 - Audio playback
 - Playlists
 - User-controlled offline downloads

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/sources/local/local_music_source.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
+import 'library_providers.dart';
 import 'library_state.dart';
 
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
@@ -14,8 +16,33 @@ class LibraryController extends Notifier<LibraryState> {
     return const LibraryState.loading();
   }
 
-  /// Re-reads the catalog. Safe to call again (e.g. after a future scan).
+  /// Re-reads the catalog. Safe to call again (e.g. after a scan).
   Future<void> refresh() => _load();
+
+  /// Scans [folderPath] with a [LocalMusicSource], persists the discovered
+  /// tracks through the [MusicLibraryRepository], then reloads so the screen
+  /// shows what was just stored. Any failure surfaces as an error state.
+  Future<void> scanFolder(String folderPath) async {
+    state = const LibraryState.loading();
+    try {
+      final source = LocalMusicSource(
+        folderPath: folderPath,
+        scanner: ref.read(audioFileScannerProvider),
+      );
+      final tracks = await source.fetchTracks();
+      final albums = await source.fetchAlbums();
+      final artists = await source.fetchArtists();
+      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+        sourceId: source.id,
+        tracks: tracks,
+        albums: albums,
+        artists: artists,
+      );
+      await _load();
+    } catch (error) {
+      state = LibraryState.error(error.toString());
+    }
+  }
 
   Future<void> _load() async {
     state = const LibraryState.loading();

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -32,7 +32,8 @@ class LibraryController extends Notifier<LibraryState> {
       final tracks = await source.fetchTracks();
       final albums = await source.fetchAlbums();
       final artists = await source.fetchArtists();
-      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+      final repository = ref.read(musicLibraryRepositoryProvider);
+      await repository.upsertCatalog(
         sourceId: source.id,
         tracks: tracks,
         albums: albums,

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/sources/local/audio_file_scanner.dart';
+
+/// The file-system seam the library scan uses to discover audio files.
+///
+/// Defaults to the real `dart:io` scanner. Tests override it with a fake so a
+/// scan can run end-to-end without touching a real disk. This is the only new
+/// provider the scan flow needs — the repository and library state already have
+/// their own providers (`musicLibraryRepositoryProvider`,
+/// `libraryControllerProvider`).
+final audioFileScannerProvider = Provider<AudioFileScanner>((ref) {
+  return const IoAudioFileScanner();
+});

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -16,9 +16,31 @@ class LibraryScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(libraryControllerProvider);
     return Scaffold(
-      appBar: AppBar(title: const Text('Library')),
+      appBar: AppBar(
+        title: const Text('Library'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.create_new_folder_outlined),
+            tooltip: 'Scan a folder',
+            onPressed: () => _promptScan(context, ref),
+          ),
+        ],
+      ),
       body: _body(ref, state),
     );
+  }
+
+  /// Dev entry point for the scan flow: ask for a folder path and hand it to
+  /// the controller. Deliberately a plain text prompt — a real folder picker
+  /// and runtime permissions land in a later PR.
+  Future<void> _promptScan(BuildContext context, WidgetRef ref) async {
+    final path = await showDialog<String>(
+      context: context,
+      builder: (_) => const _ScanFolderDialog(),
+    );
+    if (path != null && path.isNotEmpty) {
+      await ref.read(libraryControllerProvider.notifier).scanFolder(path);
+    }
   }
 
   Widget _body(WidgetRef ref, LibraryState state) {
@@ -35,7 +57,7 @@ class LibraryScreen extends ConsumerWidget {
           return const EmptyState(
             icon: Icons.library_music_outlined,
             title: 'Your library is empty',
-            message: 'Scan a folder to add your music. Coming soon.',
+            message: 'Tap the folder icon to scan a folder for music.',
           );
         }
         return _TrackList(tracks: state.tracks);
@@ -87,6 +109,50 @@ class _TrackTile extends StatelessWidget {
         track.albumName!,
     ];
     return parts.isEmpty ? track.uri : parts.join(' • ');
+  }
+}
+
+/// Simple prompt for a folder path to scan. Pops the trimmed path, or null
+/// when cancelled. Kept tiny on purpose; a proper picker comes later.
+class _ScanFolderDialog extends StatefulWidget {
+  const _ScanFolderDialog();
+
+  @override
+  State<_ScanFolderDialog> createState() => _ScanFolderDialogState();
+}
+
+class _ScanFolderDialogState extends State<_ScanFolderDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() => Navigator.of(context).pop(_controller.text.trim());
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Scan a folder'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        decoration: const InputDecoration(
+          labelText: 'Folder path',
+          hintText: '/storage/emulated/0/Music',
+        ),
+        onSubmitted: (_) => _submit(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('Scan')),
+      ],
+    );
   }
 }
 

--- a/test/features/library/fake_audio_file_scanner.dart
+++ b/test/features/library/fake_audio_file_scanner.dart
@@ -1,0 +1,18 @@
+import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+
+/// Returns a fixed list of file paths, or throws [error] when one is set, so a
+/// scan can be driven without a real file system.
+class FakeAudioFileScanner implements AudioFileScanner {
+  FakeAudioFileScanner({this.files = const <String>[], this.error});
+
+  final List<String> files;
+  final Object? error;
+  String? requestedFolder;
+
+  @override
+  Future<List<String>> listFiles(String folderPath) async {
+    requestedFolder = folderPath;
+    if (error != null) throw error!;
+    return files;
+  }
+}

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -1,10 +1,14 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonara/core/models/track.dart';
+import 'package:sonara/core/repositories/music_library_repository.dart';
+import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
 import 'package:sonara/data/repositories/music_library_repository_provider.dart';
 import 'package:sonara/features/library/library_controller.dart';
+import 'package:sonara/features/library/library_providers.dart';
 import 'package:sonara/features/library/library_state.dart';
 
+import 'fake_audio_file_scanner.dart';
 import 'fake_music_library_repository.dart';
 
 Track _track(String id) => Track(id: id, title: 'Track $id', uri: 'file://$id');
@@ -13,6 +17,20 @@ ProviderContainer _containerWith(FakeMusicLibraryRepository repository) {
   final container = ProviderContainer(
     overrides: [
       musicLibraryRepositoryProvider.overrideWithValue(repository),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+ProviderContainer _scanContainer({
+  required MusicLibraryRepository repository,
+  required FakeAudioFileScanner scanner,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      musicLibraryRepositoryProvider.overrideWithValue(repository),
+      audioFileScannerProvider.overrideWithValue(scanner),
     ],
   );
   addTearDown(container.dispose);
@@ -63,6 +81,47 @@ void main() {
       final state = container.read(libraryControllerProvider);
       expect(state.status, LibraryStatus.error);
       expect(state.errorMessage, contains('boom'));
+    });
+
+    test('scanFolder persists discovered tracks and reloads', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      final scanner = FakeAudioFileScanner(
+        files: <String>[
+          '/music/One.mp3',
+          '/music/Two.flac',
+          '/music/cover.jpg',
+        ],
+      );
+      final container = _scanContainer(
+        repository: repository,
+        scanner: scanner,
+      );
+
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder('/music');
+
+      final state = container.read(libraryControllerProvider);
+      expect(scanner.requestedFolder, '/music');
+      expect(state.status, LibraryStatus.loaded);
+      // The non-audio file is dropped; the two tracks are persisted.
+      expect(state.tracks.map((t) => t.title), <String>['One', 'Two']);
+      expect(await repository.getAllTracks(), hasLength(2));
+    });
+
+    test('scanFolder surfaces an error when scanning fails', () async {
+      final container = _scanContainer(
+        repository: InMemoryMusicLibraryRepository(),
+        scanner: FakeAudioFileScanner(error: Exception('no such folder')),
+      );
+
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder('/missing');
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.error);
+      expect(state.errorMessage, contains('no such folder'));
     });
   });
 }

--- a/test/features/library/library_screen_test.dart
+++ b/test/features/library/library_screen_test.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
 import 'package:sonara/data/repositories/music_library_repository_provider.dart';
+import 'package:sonara/features/library/library_providers.dart';
 import 'package:sonara/features/library/library_screen.dart';
 
+import 'fake_audio_file_scanner.dart';
 import 'fake_music_library_repository.dart';
 
 Future<void> _pumpScreen(
@@ -75,6 +78,38 @@ void main() {
 
       expect(find.text("Couldn't load your library"), findsOneWidget);
       expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('scanning a folder populates the list from the prompt', (
+      tester,
+    ) async {
+      final scanner = FakeAudioFileScanner(
+        files: <String>['/music/Hello.mp3', '/music/notes.txt'],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            musicLibraryRepositoryProvider.overrideWithValue(
+              InMemoryMusicLibraryRepository(),
+            ),
+            audioFileScannerProvider.overrideWithValue(scanner),
+          ],
+          child: const MaterialApp(home: LibraryScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Your library is empty'), findsOneWidget);
+
+      // Open the scan prompt, type a path, and confirm.
+      await tester.tap(find.byTooltip('Scan a folder'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '/music');
+      await tester.tap(find.widgetWithText(FilledButton, 'Scan'));
+      await tester.pumpAndSettle();
+
+      expect(scanner.requestedFolder, '/music');
+      expect(find.text('Hello'), findsOneWidget);
+      expect(find.text('Your library is empty'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

First end-to-end Library flow: **scan local files → persist through `MusicLibraryRepository` → display in `LibraryScreen`**. The display/loading/empty/error states already existed; this PR adds the missing scan + persist half and wires it into the UI.

## End-to-end behavior

1. Tap the folder icon in the Library app bar → a small text prompt asks for a folder path (deliberately minimal dev entry point; no real picker or runtime permissions yet).
2. `LibraryController.scanFolder(path)` builds a `LocalMusicSource` for that folder, walks it, and keeps only recognized audio files.
3. The discovered tracks are persisted via `MusicLibraryRepository.upsertCatalog(sourceId: 'local', ...)`.
4. The controller reloads from the repository, so the list shows exactly what was stored.
5. Each track renders as **title** + **uri/path** (artist/album subtitle when present); tapping is still a no-op.

The screen renders four states: loading, empty, populated, error.

## Files changed

- `lib/features/library/library_providers.dart` *(new)* — `audioFileScannerProvider`, the file-system seam (defaults to the real `dart:io` scanner; overridden by a fake in tests). The only new provider needed.
- `lib/features/library/library_controller.dart` — adds `scanFolder(path)`; scans, persists, reloads, and surfaces failures as an error state.
- `lib/features/library/library_screen.dart` — app-bar scan action + a tiny `_ScanFolderDialog` prompt; refreshed empty-state copy.
- `test/features/library/fake_audio_file_scanner.dart` *(new)* — fake scanner (fixed file list, or throws).
- `test/features/library/library_controller_test.dart` — scan-persists and scan-error tests.
- `test/features/library/library_screen_test.dart` — end-to-end UI test: prompt → scan → list populated.
- `README.md` — documents Library v1 behavior.

## Architecture summary

- UI depends only on `LibraryController`/`LibraryState` and the `MusicLibraryRepository` abstraction — never on Drift or a `MusicSource` directly.
- Scanning, persistence, and UI state stay separated; scanning reuses the existing `LocalMusicSource`/`AudioFileScanner` seam, so the whole flow is testable without a real disk.
- Persistence currently defaults to the in-memory repository via `musicLibraryRepositoryProvider`; the Drift repo implements the same contract and can be swapped in later with no UI change.
- No database schema changes.

## Out of scope (unchanged)

No playback, no `just_audio`, no queue, no playlists, no downloads, no Jellyfin/WebDAV, no Android permissions, no real folder picker, no tag/metadata parsing beyond the existing filename-based mapping.

## Test plan

- [ ] `flutter pub get`
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] `flutter test`

## Next recommended PR

Basic playback with `just_audio` behind `PlaybackController`.

https://claude.ai/code/session_01NJqZpNnB9fZCTpNYFfWiGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJqZpNnB9fZCTpNYFfWiGD)_