### PR TITLE
Android-ready Library v1: scan → persist → list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,22 @@ control.
 
 ## Status
 
-**Early-stage. This is the foundation/scaffold only.** What exists today is the
-project structure, dark-first theming, navigation, the app shell, placeholder
-screens, the core domain models, and the service/repository *interfaces* that
-future features will implement.
+**Early-stage, but Library v1 is wired end to end.** Alongside the project
+structure, dark-first theming, navigation, app shell, core domain models, and
+the service/repository *interfaces*, the Library feature now works as a real
+vertical slice.
 
-**Library v1 is now wired end to end.** The Library screen can scan a local
-folder, persist the discovered tracks through `MusicLibraryRepository`, and list
-them back. The flow is: `LocalMusicSource` discovers audio files under a folder
-→ `LibraryController` persists them via `MusicLibraryRepository.upsertCatalog`
-→ `LibraryScreen` renders the stored tracks (each as title + uri/path). The
-screen renders four states — loading, empty, populated, and error — and the
-UI only ever talks to `LibraryController`/`LibraryState` and the repository
-abstraction, never to Drift or a source directly.
+**Library v1.** The Library screen can scan a local folder, persist the
+discovered tracks through `MusicLibraryRepository`, and list them back. The
+flow is: `LocalMusicSource` discovers audio files under a folder →
+`LibraryController` persists them via `MusicLibraryRepository.upsertCatalog`
+→ `LibraryScreen` renders the stored tracks (each as title + artist/album, or
+the uri/path when no tags exist). The screen renders four states — **loading,
+empty, populated, and error** (with retry) — and the UI only ever talks to
+`LibraryController`/`LibraryState` and the repository abstraction, never to
+Drift or a `MusicSource` directly. Scanning, persistence, and UI state stay in
+separate, individually testable layers. See **Android readiness & known
+limitations** below for what is intentionally deferred.
 
 `LocalMusicSource` (`lib/core/sources/local/`) discovers audio files under a
 configured folder and maps them into `Track`s. It does no tag parsing yet —
@@ -147,7 +150,8 @@ lib/
 ## Getting started
 
 This repository currently contains the Dart/Flutter source and config. Native
-platform folders are generated locally (they're git-ignored for now):
+platform folders (`android/`, `linux/`, …) are **not committed** — they're
+generated locally so the repo stays focused on the cross-platform Dart code.
 
 ```bash
 # 1. Generate platform scaffolding (preserves lib/, pubspec.yaml, etc.)
@@ -156,12 +160,57 @@ flutter create --platforms=android,linux .
 # 2. Fetch dependencies
 flutter pub get
 
-# 3. Run
+# 3. Run on a connected device or emulator
 flutter run
 ```
 
 > Note: `flutter create` may regenerate template files such as `main.dart`.
 > If prompted, keep the existing versions in this repo.
+
+### Building a debug APK (Android)
+
+To install and test Sonara on an Android phone:
+
+```bash
+# Generate the Android scaffold (skip if android/ already exists locally)
+flutter create --platforms=android .
+
+flutter pub get
+
+# Build an unsigned debug APK
+flutter build apk --debug
+# → build/app/outputs/flutter-apk/app-debug.apk
+
+# Or build and install straight onto a connected device
+flutter run --debug          # hot-reloadable dev session
+flutter install              # installs the last debug build
+```
+
+The debug APK is unsigned and meant for local testing only. **Release signing,
+store-ready bundles, and APK publishing are intentionally out of scope** for
+this stage — there are no native build, signing, or publishing steps in CI.
+
+### Android readiness & known limitations
+
+Library v1 is built to be exercisable on an Android device, with a few
+deliberate gaps that the next PRs will close:
+
+- **No folder picker yet.** Scanning is driven by a minimal dev prompt that
+  takes a folder *path* (e.g. `/storage/emulated/0/Music`). A real
+  system folder picker (Storage Access Framework) is not wired up.
+- **No runtime storage permissions yet.** The scan reads whatever paths the OS
+  already grants; `READ_MEDIA_AUDIO` / `MANAGE_EXTERNAL_STORAGE` request flows
+  are not implemented, so on modern Android you may need to point the scan at a
+  directory the app can already read.
+- **No playback.** Tapping a track is a no-op; `just_audio`/`audio_service`
+  are not added yet.
+- **No tag/metadata parsing.** Tracks show their title (derived from the file
+  name) and fall back to the file path when artist/album tags are absent.
+- **No queue, playlists, downloads, or remote sources** (Jellyfin/WebDAV) yet.
+
+The next PR is expected to add the Android folder picker + storage-permission
+flow, or basic playback with `just_audio` — whichever is more stable once this
+lands.
 
 ## Continuous integration
 


### PR DESCRIPTION
## Summary

Implements **Library v1** as a real vertical slice and documents Android build
readiness so Sonara can be installed and tested on a phone — without taking on
playback complexity. The UI talks only to `LibraryController`/`LibraryState`
and the `MusicLibraryRepository` abstraction; scanning, persistence, and UI
state stay in separate, individually testable layers.

## End-to-end behavior

1. On open, `LibraryScreen` watches `libraryControllerProvider`; the controller
   loads persisted tracks from `MusicLibraryRepository` (spinner until it lands).
2. The folder icon opens a minimal dev prompt for a folder **path**.
3. `LibraryController.scanFolder(path)` runs `LocalMusicSource` over that path
   (via the `audioFileScannerProvider` file-system seam), persists the
   discovered tracks through `MusicLibraryRepository.upsertCatalog`, then
   reloads so the screen shows what was just stored.
4. The screen renders four states: **loading, empty, populated, error** (with
   retry). Non-audio files are dropped during the scan; tracks show
   title + artist/album, falling back to the uri/path when no tags exist.

The UI never touches Drift or a `MusicSource` directly. The default repository
binding is in-memory; `DriftMusicLibraryRepository` implements the same
contract and can be swapped in without UI changes.

## Files changed

- `lib/features/library/library_controller.dart` — Riverpod `Notifier`; load +
  `scanFolder` + `refresh`.
- `lib/features/library/library_state.dart` — immutable state (loading/loaded/
  error, `isEmpty`).
- `lib/features/library/library_providers.dart` — `audioFileScannerProvider`
  (file-system seam).
- `lib/features/library/library_screen.dart` — four-state UI, scan prompt,
  small widgets.
- `lib/data/repositories/music_library_repository_provider.dart` — repository
  provider.
- `lib/core/sources/local/*`, `lib/data/**` — local scan source + in-memory and
  Drift repositories (already on branch).
- `test/features/library/*` — controller, screen, and fakes.
- `README.md` — Library v1 behavior, how to run, how to build a debug APK,
  Android readiness & known limitations.

## Tests

- Controller: starts loading; loads persisted tracks; reports empty; surfaces
  repository errors; `scanFolder` persists discovered tracks (drops non-audio)
  and reloads; scan failure becomes error state.
- Screen: spinner while loading; empty state; populated list (title + subtitle,
  uri fallback); error state with retry; scan-from-prompt populates the list.

## Android readiness status

- App is structured to build/run on Android. Native folders are generated
  locally (`flutter create --platforms=android .`) per repo convention, then
  `flutter build apk --debug` produces an unsigned debug APK. Documented in the
  README.

## Known limitations (intentionally deferred)

- No system folder picker — scan takes a folder path for now.
- No runtime storage-permission flow (`READ_MEDIA_AUDIO` etc.).
- No playback, queue, playlists, downloads, or remote sources.
- No tag/metadata parsing.
- No release signing, store bundles, or APK publishing.

## Verification status

No Flutter/Dart toolchain in the execution environment, so verification relies
on CI (`flutter pub get`, `dart format --set-exit-if-changed .`,
`flutter analyze`, `flutter test`). The README-only commit in this PR does not
affect Dart formatting or tests.

## Next recommended PR

Android folder picker + storage-permission flow, **or** basic playback with
`just_audio` — whichever is more stable once this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AG12rw4r2o7By2AyiAQVSr)_