### PR TITLE
Add basic local playback with just_audio behind PlaybackController

### DIFF
--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:just_audio/just_audio.dart';
+
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import 'playback_controller.dart';
+
+/// [PlaybackController] backed by `just_audio`.
+///
+/// This is the only file in the app that knows `just_audio` exists. It adapts
+/// the player's separate event streams (state, position, duration) into the
+/// single immutable [PlaybackState] the UI renders from. Swapping the engine or
+/// wrapping it for background playback later means replacing this class, not
+/// the feature code.
+class JustAudioPlaybackController implements PlaybackController {
+  JustAudioPlaybackController({AudioPlayer? player})
+      : _player = player ?? AudioPlayer() {
+    _wire();
+  }
+
+  final AudioPlayer _player;
+  final StreamController<PlaybackState> _states =
+      StreamController<PlaybackState>.broadcast();
+  final List<StreamSubscription<void>> _subscriptions =
+      <StreamSubscription<void>>[];
+
+  PlaybackState _state = PlaybackState.idle;
+
+  @override
+  PlaybackState get state => _state;
+
+  @override
+  Stream<PlaybackState> get stateStream => _states.stream;
+
+  void _wire() {
+    _subscriptions.add(_player.playerStateStream.listen((playerState) {
+      _emit(_state.copyWith(status: _statusFor(playerState)));
+    }));
+    _subscriptions.add(_player.positionStream.listen((position) {
+      _emit(_state.copyWith(position: position));
+    }));
+    _subscriptions.add(_player.durationStream.listen((duration) {
+      if (duration != null) _emit(_state.copyWith(duration: duration));
+    }));
+  }
+
+  static PlaybackStatus _statusFor(PlayerState playerState) {
+    switch (playerState.processingState) {
+      case ProcessingState.idle:
+        return PlaybackStatus.idle;
+      case ProcessingState.loading:
+      case ProcessingState.buffering:
+        return PlaybackStatus.loading;
+      case ProcessingState.ready:
+        return playerState.playing
+            ? PlaybackStatus.playing
+            : PlaybackStatus.paused;
+      case ProcessingState.completed:
+        return PlaybackStatus.completed;
+    }
+  }
+
+  void _emit(PlaybackState next) {
+    if (next == _state) return;
+    _state = next;
+    if (!_states.isClosed) _states.add(next);
+  }
+
+  @override
+  Future<void> playTrack(Track track) async {
+    // Reset position/duration up front so the UI doesn't show the previous
+    // track's progress while the new one loads.
+    _emit(PlaybackState(status: PlaybackStatus.loading, currentTrack: track));
+    try {
+      // Track.uri is a local file path (see LocalTrackMapper); remote sources
+      // arrive in a later PR.
+      await _player.setFilePath(track.uri);
+      // play()'s future completes when playback ends, so we don't await it.
+      unawaited(_player.play());
+    } catch (_) {
+      _emit(_state.copyWith(status: PlaybackStatus.error));
+    }
+  }
+
+  @override
+  Future<void> play() async {
+    // play()'s future completes when playback ends, so we don't await it.
+    unawaited(_player.play());
+  }
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> stop() async {
+    await _player.stop();
+    _emit(PlaybackState(currentTrack: _state.currentTrack));
+  }
+
+  @override
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  @override
+  Future<void> dispose() async {
+    for (final subscription in _subscriptions) {
+      await subscription.cancel();
+    }
+    await _states.close();
+    await _player.dispose();
+  }
+}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
+import '../../app/routes.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
+import '../player/player_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
 
@@ -79,13 +82,13 @@ class _TrackList extends StatelessWidget {
   }
 }
 
-class _TrackTile extends StatelessWidget {
+class _TrackTile extends ConsumerWidget {
   const _TrackTile({required this.track});
 
   final Track track;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return ListTile(
       leading: const Icon(Icons.music_note_outlined),
       title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
@@ -94,8 +97,11 @@ class _TrackTile extends StatelessWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      // Playback lands in a later PR; tapping is a no-op for now.
-      onTap: () {},
+      // Start playback, then surface the now-playing screen.
+      onTap: () {
+        ref.read(playbackControllerProvider).playTrack(track);
+        context.push(AppRoutes.player);
+      },
     );
   }
 

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/playback_state.dart';
+import '../../core/services/just_audio_playback_controller.dart';
+import '../../core/services/playback_controller.dart';
+
+/// The single [PlaybackController] the app drives playback through.
+///
+/// Defaults to the `just_audio`-backed implementation. Tests override it with a
+/// fake so playback can be exercised without the audio plugin. Disposed with
+/// the provider scope so native resources are released on shutdown.
+final playbackControllerProvider = Provider<PlaybackController>((ref) {
+  final controller = JustAudioPlaybackController();
+  ref.onDispose(controller.dispose);
+  return controller;
+});
+
+/// Streams [PlaybackState] for the UI. Until the first event arrives, callers
+/// fall back to the controller's synchronous [PlaybackController.state].
+final playbackStateProvider = StreamProvider<PlaybackState>((ref) {
+  final controller = ref.watch(playbackControllerProvider);
+  return controller.stateStream;
+});

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -1,21 +1,129 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../app/dimens.dart';
+import '../../core/models/playback_state.dart';
 import '../../shared/widgets/empty_state.dart';
+import 'player_providers.dart';
 
-/// Full-screen now-playing view. Placeholder until playback is wired to the
-/// PlaybackController. Pushed above the shell via AppRoutes.player.
-class PlayerScreen extends StatelessWidget {
+/// Full-screen now-playing view. Renders from [playbackStateProvider] and
+/// drives playback through the [PlaybackController]; it never touches the audio
+/// engine directly. Pushed above the shell via AppRoutes.player.
+class PlayerScreen extends ConsumerWidget {
   const PlayerScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(playbackControllerProvider);
+    final state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Now Playing')),
-      body: const EmptyState(
-        icon: Icons.music_note_outlined,
-        title: 'Nothing playing',
-        message: 'Pick a track to start listening.',
+      body: state.hasTrack ? _NowPlaying(state: state) : const _Nothing(),
+    );
+  }
+}
+
+class _Nothing extends StatelessWidget {
+  const _Nothing();
+
+  @override
+  Widget build(BuildContext context) {
+    return const EmptyState(
+      icon: Icons.music_note_outlined,
+      title: 'Nothing playing',
+      message: 'Pick a track to start listening.',
+    );
+  }
+}
+
+class _NowPlaying extends ConsumerWidget {
+  const _NowPlaying({required this.state});
+
+  final PlaybackState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final track = state.currentTrack!;
+    final controller = ref.read(playbackControllerProvider);
+
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.xl),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.music_note,
+            size: 96,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(height: AppSpacing.xl),
+          Text(
+            track.title,
+            style: theme.textTheme.headlineSmall,
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (track.artistName != null && track.artistName!.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              track.artistName!,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+          const SizedBox(height: AppSpacing.lg),
+          Text(
+            _statusLabel(state.status),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              IconButton.filled(
+                iconSize: 48,
+                onPressed: state.isPlaying ? controller.pause : controller.play,
+                icon: Icon(state.isPlaying ? Icons.pause : Icons.play_arrow),
+                tooltip: state.isPlaying ? 'Pause' : 'Play',
+              ),
+              const SizedBox(width: AppSpacing.lg),
+              IconButton.filledTonal(
+                iconSize: 48,
+                onPressed: controller.stop,
+                icon: const Icon(Icons.stop),
+                tooltip: 'Stop',
+              ),
+            ],
+          ),
+        ],
       ),
     );
+  }
+
+  static String _statusLabel(PlaybackStatus status) {
+    switch (status) {
+      case PlaybackStatus.idle:
+        return 'Stopped';
+      case PlaybackStatus.loading:
+        return 'Loading…';
+      case PlaybackStatus.playing:
+        return 'Playing';
+      case PlaybackStatus.paused:
+        return 'Paused';
+      case PlaybackStatus.completed:
+        return 'Finished';
+      case PlaybackStatus.error:
+        return "Couldn't play this track";
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,10 @@ dependencies:
   drift: ^2.18.0
   sqlite3_flutter_libs: ^0.5.20
   path_provider: ^2.1.4
+  # Local audio playback engine. Used only by JustAudioPlaybackController in the
+  # services layer; the UI depends on the PlaybackController interface, never on
+  # just_audio directly. Background playback (audio_service) lands in a later PR.
+  just_audio: ^0.9.42
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/test/features/library/library_playback_test.dart
+++ b/test/features/library/library_playback_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sonara/app/routes.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/repositories/music_library_repository_provider.dart';
+import 'package:sonara/features/library/library_screen.dart';
+import 'package:sonara/features/player/player_providers.dart';
+import 'package:sonara/features/player/player_screen.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+void main() {
+  testWidgets('tapping a track plays it and opens the player', (tester) async {
+    final controller = FakePlaybackController();
+    final repository = FakeMusicLibraryRepository(
+      tracks: const <Track>[
+        Track(id: '1', title: 'Song One', uri: '/music/song1.mp3'),
+      ],
+    );
+    final router = GoRouter(
+      initialLocation: AppRoutes.library,
+      routes: [
+        GoRoute(
+          path: AppRoutes.library,
+          builder: (_, __) => const LibraryScreen(),
+        ),
+        GoRoute(
+          path: AppRoutes.player,
+          builder: (_, __) => const PlayerScreen(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          musicLibraryRepositoryProvider.overrideWithValue(repository),
+          playbackControllerProvider.overrideWithValue(controller),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Song One'));
+    await tester.pumpAndSettle();
+
+    expect(controller.playedTracks.single.id, '1');
+    // The now-playing screen is shown for the tapped track.
+    expect(find.text('Now Playing'), findsOneWidget);
+    expect(find.text('Playing'), findsOneWidget);
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:sonara/core/models/playback_state.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/core/services/playback_controller.dart';
+
+/// In-memory [PlaybackController] for widget/provider tests.
+///
+/// Records the calls it receives and lets a test push arbitrary
+/// [PlaybackState]s, so playback flows can be exercised without `just_audio` or
+/// any platform plugin.
+class FakePlaybackController implements PlaybackController {
+  FakePlaybackController({PlaybackState initial = PlaybackState.idle})
+      : _state = initial;
+
+  final StreamController<PlaybackState> _states =
+      StreamController<PlaybackState>.broadcast();
+  PlaybackState _state;
+
+  final List<Track> playedTracks = <Track>[];
+  int playCount = 0;
+  int pauseCount = 0;
+  int stopCount = 0;
+  final List<Duration> seeks = <Duration>[];
+
+  /// Pushes [next] to listeners and updates the synchronous [state].
+  void emit(PlaybackState next) {
+    _state = next;
+    _states.add(next);
+  }
+
+  @override
+  PlaybackState get state => _state;
+
+  @override
+  Stream<PlaybackState> get stateStream => _states.stream;
+
+  @override
+  Future<void> playTrack(Track track) async {
+    playedTracks.add(track);
+    emit(PlaybackState(status: PlaybackStatus.playing, currentTrack: track));
+  }
+
+  @override
+  Future<void> play() async {
+    playCount++;
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCount++;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCount++;
+  }
+
+  @override
+  Future<void> seek(Duration position) async {
+    seeks.add(position);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+}

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/playback_state.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/core/services/playback_controller.dart';
+import 'package:sonara/features/player/player_providers.dart';
+import 'package:sonara/features/player/player_screen.dart';
+
+import 'fake_playback_controller.dart';
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  PlaybackController controller,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: const MaterialApp(home: PlayerScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('PlayerScreen', () {
+    testWidgets('shows the empty state when nothing is loaded', (tester) async {
+      await _pumpScreen(tester, FakePlaybackController());
+
+      expect(find.text('Nothing playing'), findsOneWidget);
+    });
+
+    testWidgets('shows the current track title, artist, and Playing status', (
+      tester,
+    ) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(
+            id: '1',
+            title: 'Song One',
+            uri: '/music/song1.mp3',
+            artistName: 'Artist A',
+          ),
+        ),
+      );
+      await _pumpScreen(tester, controller);
+
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.text('Artist A'), findsOneWidget);
+      expect(find.text('Playing'), findsOneWidget);
+      // While playing, the toggle offers Pause.
+      expect(find.byTooltip('Pause'), findsOneWidget);
+    });
+
+    testWidgets('the play/pause button delegates to the controller', (
+      tester,
+    ) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.paused,
+          currentTrack: Track(id: '1', title: 'Song One', uri: '/s.mp3'),
+        ),
+      );
+      await _pumpScreen(tester, controller);
+
+      // Paused: tapping the toggle resumes playback.
+      await tester.tap(find.byTooltip('Play'));
+      expect(controller.playCount, 1);
+
+      // Stop is always available.
+      await tester.tap(find.byTooltip('Stop'));
+      expect(controller.stopCount, 1);
+    });
+
+    testWidgets('reacts to state pushed on the stream', (tester) async {
+      final controller = FakePlaybackController();
+      await _pumpScreen(tester, controller);
+      expect(find.text('Nothing playing'), findsOneWidget);
+
+      controller.emit(
+        const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(id: '1', title: 'Live Track', uri: '/l.mp3'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Live Track'), findsOneWidget);
+      expect(find.text('Playing'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds basic local audio playback for a single track, wired end to end behind the existing `PlaybackController` interface. Tapping a track in the Library plays it through a `just_audio`-backed controller and opens the now-playing screen. The UI never touches `just_audio` directly — it depends only on `PlaybackController` and the immutable `PlaybackState`.

No queue, playlists, downloads, remote sources, background audio, or MPRIS — those stay out of this PR by design.

## Files changed

- **`pubspec.yaml`** — add `just_audio: ^0.9.42`.
- **`lib/core/services/just_audio_playback_controller.dart`** (new) — the only file that knows `just_audio` exists. Adapts the player's separate state/position/duration streams into a single `PlaybackState` stream.
- **`lib/features/player/player_providers.dart`** (new) — `playbackControllerProvider` (disposes the controller with the scope) and `playbackStateProvider` (`StreamProvider<PlaybackState>`).
- **`lib/features/player/player_screen.dart`** — now renders from `playbackStateProvider`: track title, artist, status label, and play/pause + stop buttons. Falls back to the empty state when nothing is loaded.
- **`lib/features/library/library_screen.dart`** — `_TrackTile` now plays the tapped track and pushes the player route. Tap behavior kept to two lines.
- **Tests** (new):
  - `test/features/player/fake_playback_controller.dart` — in-memory `PlaybackController` fake.
  - `test/features/player/player_screen_test.dart` — empty state, now-playing rendering, button delegation, reacting to streamed state.
  - `test/features/library/library_playback_test.dart` — tap-to-play wiring through a `GoRouter`.

## Playback behavior

- Tap a track → controller calls `setFilePath(track.uri)` then `play()`, and the player route opens.
- `PlaybackState.status` maps from `just_audio`'s `ProcessingState`/`playing`: idle → loading → playing/paused → completed; failures surface as `error`.
- Play/pause toggles based on `isPlaying`; stop resets to a stopped state while keeping the current track shown.
- Position and duration are tracked on the state but no seek UI is exposed yet (kept minimal, see limitations).

## Limitations

- **Single track only** — no queue, no auto-advance after completion.
- **No seek UI** — position/duration are wired into `PlaybackState` but no slider is shown yet, to avoid shipping an unreliable seek bar.
- **No background playback / lock-screen controls** — `audio_service` is intentionally deferred.
- **Local files only** — `Track.uri` is treated as a local file path (per `LocalTrackMapper`); remote/Jellyfin/WebDAV sources are out of scope.
- The now-playing screen is reached only by tapping a track; there's no persistent mini-player yet.

## Android test notes

- Verification (`flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test`) is expected to run in CI — the dev container here has no Flutter toolchain, so it could not be run locally. CI targets Flutter 3.27.4 / stable.
- Unit/widget tests use a `FakePlaybackController`, so they don't load the `just_audio` plugin or hit any platform channel.
- On-device smoke test (manual, not in this PR): scan a folder with the Library's folder prompt, tap a track, and confirm audio plays and the play/pause/stop controls behave. `just_audio` needs no extra Android permissions for local file playback beyond the storage access the scan flow already requires.

## Next recommended PR

Android folder picker + runtime storage permissions, **or** queue management (play-next / auto-advance and a basic now-playing queue).


---
_Generated by [Claude Code](https://claude.ai/code/session_01U7KHNxmVRAv2cmSZVBwAMx)_