### PR TITLE
Persist the catalog: wire DriftMusicLibraryRepository into the running app

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ catalog the UI will read from, backed by `SonaraDatabase`
 (`core/models/`) stay separate from Drift rows; conversion lives in small,
 explicit mappers (`lib/data/mappers/`). The generated `*.g.dart` files are
 produced by the **Generate Drift files** workflow (see below), not committed by
-hand. The Library v1 flow currently persists through the in-memory repository
-by default (`musicLibraryRepositoryProvider`); the Drift repository implements
-the same contract and can be swapped in without touching any UI code.
+hand. The running app now persists through the Drift repository: `main`
+applies `driftMusicLibraryRepositoryOverride` over `musicLibraryRepositoryProvider`
+so scanned tracks survive a restart, while tests keep the in-memory default
+(no `path_provider`/SQLite needed) unless they opt into the Drift binding. The
+UI is untouched by the swap — it still reads only `LibraryController`/the
+repository abstraction.
 
 Not built yet (planned, in roughly this order):
 

--- a/lib/data/database/sonara_database_provider.dart
+++ b/lib/data/database/sonara_database_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'sonara_database.dart';
+
+/// The app-wide [SonaraDatabase]. The underlying SQLite connection is opened
+/// lazily on first query and closed when the provider is disposed, so nothing
+/// touches the disk until the catalog is actually read or written.
+final sonaraDatabaseProvider = Provider<SonaraDatabase>((ref) {
+  final db = SonaraDatabase();
+  ref.onDispose(db.close);
+  return db;
+});

--- a/lib/data/repositories/music_library_repository_provider.dart
+++ b/lib/data/repositories/music_library_repository_provider.dart
@@ -1,13 +1,24 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/repositories/music_library_repository.dart';
+import '../database/sonara_database_provider.dart';
+import 'drift_music_library_repository.dart';
 import 'in_memory_music_library_repository.dart';
 
 /// The single [MusicLibraryRepository] the app reads its catalog from.
 ///
-/// Defaults to the in-memory implementation while the app is being built out;
-/// once a scan flow exists, this can be overridden (e.g. in `main`) to the
-/// Drift-backed repository without touching any UI code that depends on it.
+/// Defaults to the in-memory implementation, which keeps widget and unit tests
+/// fast and free of platform plugins (no `path_provider`, no real SQLite). The
+/// running app overrides this with [driftMusicLibraryRepositoryOverride] so the
+/// catalog persists across restarts.
 final musicLibraryRepositoryProvider = Provider<MusicLibraryRepository>((ref) {
   return InMemoryMusicLibraryRepository();
 });
+
+/// Production binding: a Drift/SQLite-backed repository so scanned tracks
+/// survive app restarts. Applied in `main`; tests can apply it over an
+/// in-memory database by also overriding [sonaraDatabaseProvider].
+final driftMusicLibraryRepositoryOverride =
+    musicLibraryRepositoryProvider.overrideWith(
+  (ref) => DriftMusicLibraryRepository(ref.watch(sonaraDatabaseProvider)),
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/sonara_app.dart';
+import 'data/repositories/music_library_repository_provider.dart';
 
 void main() {
-  // ProviderScope hosts all Riverpod state for the app.
-  runApp(const ProviderScope(child: SonaraApp()));
+  // ProviderScope hosts all Riverpod state for the app. The running app
+  // persists its catalog to SQLite via the Drift override; tests keep the
+  // in-memory default unless they opt into the Drift binding.
+  runApp(
+    ProviderScope(
+      overrides: [driftMusicLibraryRepositoryOverride],
+      child: const SonaraApp(),
+    ),
+  );
 }

--- a/test/data/repositories/drift_repository_wiring_test.dart
+++ b/test/data/repositories/drift_repository_wiring_test.dart
@@ -1,0 +1,63 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/album.dart';
+import 'package:sonara/core/models/artist.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/database/sonara_database.dart';
+import 'package:sonara/data/database/sonara_database_provider.dart';
+import 'package:sonara/data/repositories/drift_music_library_repository.dart';
+import 'package:sonara/data/repositories/music_library_repository_provider.dart';
+import 'package:sonara/features/library/library_controller.dart';
+import 'package:sonara/features/library/library_state.dart';
+
+void main() {
+  group('driftMusicLibraryRepositoryOverride', () {
+    test('binds the repository provider to the Drift implementation', () {
+      final db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final container = ProviderContainer(
+        overrides: [
+          sonaraDatabaseProvider.overrideWithValue(db),
+          driftMusicLibraryRepositoryOverride,
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(musicLibraryRepositoryProvider),
+        isA<DriftMusicLibraryRepository>(),
+      );
+    });
+
+    test('catalog persists through the controller via the Drift binding',
+        () async {
+      final db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final container = ProviderContainer(
+        overrides: [
+          sonaraDatabaseProvider.overrideWithValue(db),
+          driftMusicLibraryRepositoryOverride,
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Seed the catalog the way a scan would, through the repository the
+      // running app actually uses.
+      await container.read(musicLibraryRepositoryProvider).upsertCatalog(
+        sourceId: 'local',
+        tracks: const <Track>[
+          Track(id: '1', title: 'Persisted', uri: 'file:///1.mp3'),
+        ],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      await container.read(libraryControllerProvider.notifier).refresh();
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.loaded);
+      expect(state.tracks.single.title, 'Persisted');
+    });
+  });
+}


### PR DESCRIPTION
## Context

The Library screen, `LibraryController`/`LibraryState`, providers, the in-memory repository, and the Drift/SQLite repository all already exist and are merged into `main` — the originally-scoped "wire Library to repository" work (and the follow-up scan action) is done. The remaining gap was that **the Drift repository was built and tested but never used by the app**: `musicLibraryRepositoryProvider` returned `InMemoryMusicLibraryRepository`, so scanned tracks disappeared on restart. The code comments explicitly flagged this binding as the intended next step. This PR closes that gap.

## Files changed

- **`lib/data/database/sonara_database_provider.dart`** (new) — `sonaraDatabaseProvider` exposing the app-wide `SonaraDatabase`, closed on dispose. The connection opens lazily on first query.
- **`lib/data/repositories/music_library_repository_provider.dart`** — keeps the in-memory default and adds `driftMusicLibraryRepositoryOverride`, the production binding to `DriftMusicLibraryRepository` backed by `sonaraDatabaseProvider`.
- **`lib/main.dart`** — applies `driftMusicLibraryRepositoryOverride` in the root `ProviderScope`.
- **`test/data/repositories/drift_repository_wiring_test.dart`** (new) — proves the wiring.
- **`README.md`** — updated the persistence note to reflect that the running app now persists via Drift.

## State / controller summary

No changes to `LibraryState` or `LibraryController`. The point of the abstraction is demonstrated here: only the *binding* of `musicLibraryRepositoryProvider` changes; the controller and screen are untouched.

## UI behavior

No visible change. Loading / empty / populated / error states behave exactly as before — but a scanned catalog now survives an app restart because reads/writes go through SQLite instead of an in-memory map.

## Why an override in `main` (not a new default)

`app_smoke_test.dart` boots the full app with no overrides. Making Drift the provider *default* would make every widget test reach for `path_provider`/native SQLite, which the test harness doesn't have. Keeping the in-memory default and applying the Drift override only in `main` keeps `flutter test` green while production persists.

## Tests added

`drift_repository_wiring_test.dart` (over an in-memory SQLite db, mirroring the production override):
- `musicLibraryRepositoryProvider` resolves to a `DriftMusicLibraryRepository` under the override.
- A catalog upserted through the production binding is loaded back by `LibraryController` (status `loaded`, track present) — i.e. the persistence path the app uses actually round-trips.

## Limitations

- Albums/artists still aren't persisted (Drift v1 stores tracks only) — unchanged from before.
- No schema changes, no migrations (schema stays at v1).
- Manual on-device restart persistence wasn't exercised here (no device/emulator in CI); the in-memory-SQLite test covers the wiring contract.

## Verification

CI runs `flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test`. No Flutter SDK is available in the authoring environment, so CI is the gate.

## Next recommended PR

Persist albums and artists in Drift (add `albums`/`artists` tables + mappers) so `getAllAlbums`/`getAllArtists` return real data, enabling album/artist browsing in the Library.

---
_Generated by [Claude Code](https://claude.ai/code/session_016MUpJQifuUvkBapjye4fCf)_