### PR TITLE
Add native folder selection foundation for local scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,19 @@ configured folder and maps them into `Track`s. It does no tag parsing yet —
 it's the first concrete `MusicSource` and the seam future metadata parsing will
 extend.
 
-Scanning is triggered from a deliberately minimal **dev entry point**: a folder
-icon in the Library app bar opens a small text prompt for a folder path. There
-is no real folder picker or Android runtime-permission flow yet — those come
-later. The scan path is exposed as `LibraryController.scanFolder(path)`, which
-keeps the flow fully testable without a real disk (the file-system seam,
-`audioFileScannerProvider`, is overridden with a fake in tests).
+**Folder selection now uses the native picker.** The folder icon in the Library
+app bar opens the OS folder chooser (Android Storage Access Framework / desktop
+GTK) via a `FolderPickerService` seam, persists the chosen folder through a
+`SelectedMusicFolderRepository`, and then scans it. The choice survives restarts
+(`shared_preferences` in the app; in-memory in tests). All of this stays behind
+interfaces: the UI talks only to `SelectedFolderController` and
+`LibraryController`, never to `file_picker` or `shared_preferences` directly.
+The scan itself is still exposed as `LibraryController.scanFolder(path)` and runs
+through `LocalMusicSource`, so the flow stays fully testable without a real disk
+or OS dialog (the picker, the file-system seam, and the selected-folder store are
+each overridden with a fake/in-memory binding in tests). See **Android folder
+selection & known limitations** below for what still needs care on modern
+Android.
 
 A temporary `InMemoryMusicLibraryRepository` (`lib/data/repositories/`) also
 implements the `MusicLibraryRepository` contract, so the app and its tests have
@@ -62,8 +69,9 @@ repository abstraction.
 
 Not built yet (planned, in roughly this order):
 
-- Local music library scanning — *v1 done (scan → persist → list); tag parsing,
-  a real folder picker, and Android permissions still pending*
+- Local music library scanning — *v1 done (scan → persist → list); native
+  folder picker + persisted selection now done; tag parsing and Android
+  runtime storage permissions still pending*
 - Audio playback
 - Playlists
 - User-controlled offline downloads
@@ -96,9 +104,11 @@ codebase.
 
 Dependencies are added when a feature needs them rather than up front, so
 `pubspec.yaml` stays honest about what the code actually uses. Today that's
-`flutter_riverpod`, `go_router`, `path` (for the local file scanner), and
-`drift` + `sqlite3_flutter_libs` + `path_provider` for SQLite persistence
-(`drift_dev` + `build_runner` are dev-only, for code generation).
+`flutter_riverpod`, `go_router`, `path` (for the local file scanner),
+`drift` + `sqlite3_flutter_libs` + `path_provider` for SQLite persistence,
+`just_audio` for playback, `file_picker` for the native folder chooser, and
+`shared_preferences` for remembering the selected folder (`drift_dev` +
+`build_runner` are dev-only, for code generation).
 
 ## Architecture
 
@@ -193,27 +203,37 @@ The debug APK is unsigned and meant for local testing only. **Release signing,
 store-ready bundles, and APK publishing are intentionally out of scope** for
 this stage — there are no native build, signing, or publishing steps in CI.
 
-### Android readiness & known limitations
+### Android folder selection & known limitations
 
-Library v1 is built to be exercisable on an Android device, with a few
-deliberate gaps that the next PRs will close:
+**How scanning works now.** Tap the folder icon in the Library app bar → the
+native folder chooser opens → the chosen folder is persisted and immediately
+scanned. The selection survives restarts, and the empty state adapts: when no
+folder is chosen it invites you to pick one; when a folder is chosen but nothing
+playable is found it shows that folder and offers **Rescan folder** / **Change
+folder**. On Linux/desktop the same flow uses the GTK/Win32 directory dialog and
+returns a real filesystem path, which `LocalMusicSource` scans directly.
 
-- **No folder picker yet.** Scanning is driven by a minimal dev prompt that
-  takes a folder *path* (e.g. `/storage/emulated/0/Music`). A real
-  system folder picker (Storage Access Framework) is not wired up.
-- **No runtime storage permissions yet.** The scan reads whatever paths the OS
-  already grants; `READ_MEDIA_AUDIO` / `MANAGE_EXTERNAL_STORAGE` request flows
-  are not implemented, so on modern Android you may need to point the scan at a
-  directory the app can already read.
-- **No playback.** Tapping a track is a no-op; `just_audio`/`audio_service`
-  are not added yet.
+Library scanning is exercisable on an Android device, with a few deliberate gaps
+the next PRs will close:
+
+- **Android returns a SAF tree URI, not always a filesystem path.** On modern
+  Android the system folder chooser hands back a `content://…/tree/…` URI under
+  Storage Access Framework. The current `dart:io`-based scanner
+  (`IoAudioFileScanner`) reads real filesystem paths, so it can scan folders the
+  app can already reach by path but cannot yet walk a raw SAF tree URI.
+  Document-tree traversal (or resolving the URI to a path) is a planned
+  follow-up; the picker + persistence seam is in place for it.
+- **No runtime storage permissions yet.** No `READ_MEDIA_AUDIO` /
+  `MANAGE_EXTERNAL_STORAGE` request flow is wired up, so on modern Android you
+  may need to point the scan at a directory the app can already read. We are
+  intentionally not requesting broad storage permissions in this PR.
 - **No tag/metadata parsing.** Tracks show their title (derived from the file
   name) and fall back to the file path when artist/album tags are absent.
 - **No queue, playlists, downloads, or remote sources** (Jellyfin/WebDAV) yet.
 
-The next PR is expected to add the Android folder picker + storage-permission
-flow, or basic playback with `just_audio` — whichever is more stable once this
-lands.
+The next PR is expected to be queue polish or a playlist-editor foundation;
+SAF document-tree scanning and Android runtime storage permissions remain the
+natural follow-ups to this folder-selection work.
 
 ## Continuous integration
 

--- a/lib/core/repositories/selected_music_folder_repository.dart
+++ b/lib/core/repositories/selected_music_folder_repository.dart
@@ -1,0 +1,18 @@
+/// Remembers which folder the user chose to scan for music.
+///
+/// Kept deliberately separate from the picker (which only chooses a folder)
+/// and from the scan logic (which only reads files): this contract owns just
+/// the persistence of the single selected folder path/URI, so the choice
+/// survives app restarts without any layer reaching into another's concerns.
+abstract interface class SelectedMusicFolderRepository {
+  /// The persisted folder path/URI, or `null` if the user has never chosen one
+  /// (or has since cleared it).
+  Future<String?> getSelectedFolder();
+
+  /// Persists [pathOrUri] as the selected music folder, replacing any previous
+  /// choice.
+  Future<void> setSelectedFolder(String pathOrUri);
+
+  /// Forgets the current selection.
+  Future<void> clearSelectedFolder();
+}

--- a/lib/core/services/file_picker_folder_picker_service.dart
+++ b/lib/core/services/file_picker_folder_picker_service.dart
@@ -1,0 +1,20 @@
+import 'package:file_picker/file_picker.dart';
+
+import 'folder_picker_service.dart';
+
+/// A [FolderPickerService] backed by the `file_picker` plugin.
+///
+/// `getDirectoryPath` shows the OS folder chooser on Android (Storage Access
+/// Framework) and on desktop (GTK/Win32). On Android the returned value can be
+/// a `content://` tree URI rather than a filesystem path — see the README's
+/// "Android folder selection" notes for the implications for scanning.
+class FilePickerFolderPickerService implements FolderPickerService {
+  const FilePickerFolderPickerService();
+
+  @override
+  Future<String?> pickFolder() {
+    return FilePicker.platform.getDirectoryPath(
+      dialogTitle: 'Select your music folder',
+    );
+  }
+}

--- a/lib/core/services/folder_picker_service.dart
+++ b/lib/core/services/folder_picker_service.dart
@@ -1,0 +1,16 @@
+/// Opens the platform's native folder chooser so the user can pick a music
+/// folder to scan.
+///
+/// This is the single seam between the app and whatever folder-picking plugin
+/// runs underneath. Feature code depends only on this interface, so the UI
+/// never imports `file_picker` (or any other plugin) directly and tests can
+/// drive the flow with a fake.
+abstract interface class FolderPickerService {
+  /// Shows the folder chooser and returns the chosen folder's path or URI.
+  ///
+  /// Returns `null` when the user cancels, or when no picker is available on
+  /// the current platform. The returned string is passed through verbatim to
+  /// the scan flow; it may be a filesystem path (desktop) or a Storage Access
+  /// Framework tree URI (Android).
+  Future<String?> pickFolder();
+}

--- a/lib/data/repositories/in_memory_selected_music_folder_repository.dart
+++ b/lib/data/repositories/in_memory_selected_music_folder_repository.dart
@@ -1,0 +1,28 @@
+import '../../core/repositories/selected_music_folder_repository.dart';
+
+/// A non-persistent [SelectedMusicFolderRepository] for development and tests.
+///
+/// Holds the selection in a single field, so it is forgotten when the instance
+/// is dropped. This is the default binding (mirroring how the catalog defaults
+/// to the in-memory repository); the running app swaps in the
+/// `shared_preferences` implementation so the choice survives restarts.
+class InMemorySelectedMusicFolderRepository
+    implements SelectedMusicFolderRepository {
+  InMemorySelectedMusicFolderRepository({String? initialFolder})
+      : _folder = initialFolder;
+
+  String? _folder;
+
+  @override
+  Future<String?> getSelectedFolder() async => _folder;
+
+  @override
+  Future<void> setSelectedFolder(String pathOrUri) async {
+    _folder = pathOrUri;
+  }
+
+  @override
+  Future<void> clearSelectedFolder() async {
+    _folder = null;
+  }
+}

--- a/lib/data/repositories/selected_music_folder_repository_provider.dart
+++ b/lib/data/repositories/selected_music_folder_repository_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/selected_music_folder_repository.dart';
+import 'in_memory_selected_music_folder_repository.dart';
+import 'shared_preferences_selected_music_folder_repository.dart';
+
+/// The single [SelectedMusicFolderRepository] the app reads the chosen music
+/// folder from.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins (no `shared_preferences`). The running app overrides
+/// this with [sharedPreferencesSelectedMusicFolderRepositoryOverride] so the
+/// selection persists across restarts.
+final selectedMusicFolderRepositoryProvider =
+    Provider<SelectedMusicFolderRepository>((ref) {
+  return InMemorySelectedMusicFolderRepository();
+});
+
+/// Production binding: persists the selected folder via `shared_preferences`.
+/// Applied in `main`.
+final sharedPreferencesSelectedMusicFolderRepositoryOverride =
+    selectedMusicFolderRepositoryProvider.overrideWithValue(
+  const SharedPreferencesSelectedMusicFolderRepository(),
+);

--- a/lib/data/repositories/shared_preferences_selected_music_folder_repository.dart
+++ b/lib/data/repositories/shared_preferences_selected_music_folder_repository.dart
@@ -1,0 +1,35 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/selected_music_folder_repository.dart';
+
+/// A [SelectedMusicFolderRepository] backed by `shared_preferences`.
+///
+/// The selected folder is a single small string, so a key/value store is the
+/// right weight here — no need to involve the SQLite catalog. The plugin is
+/// touched lazily on first call, so constructing this object is cheap and never
+/// blocks app start.
+class SharedPreferencesSelectedMusicFolderRepository
+    implements SelectedMusicFolderRepository {
+  const SharedPreferencesSelectedMusicFolderRepository();
+
+  static const String _key = 'selected_music_folder';
+
+  @override
+  Future<String?> getSelectedFolder() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_key);
+    return (value == null || value.isEmpty) ? null : value;
+  }
+
+  @override
+  Future<void> setSelectedFolder(String pathOrUri) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, pathOrUri);
+  }
+
+  @override
+  Future<void> clearSelectedFolder() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/services/file_picker_folder_picker_service.dart';
+import '../../core/services/folder_picker_service.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
 
 /// The file-system seam the library scan uses to discover audio files.
@@ -11,4 +13,11 @@ import '../../core/sources/local/audio_file_scanner.dart';
 /// `libraryControllerProvider`).
 final audioFileScannerProvider = Provider<AudioFileScanner>((ref) {
   return const IoAudioFileScanner();
+});
+
+/// The folder-chooser seam the Library uses to let the user pick a music
+/// folder. Defaults to the `file_picker`-backed implementation; tests override
+/// it with a fake so the pick-and-scan flow runs without a real OS dialog.
+final folderPickerServiceProvider = Provider<FolderPickerService>((ref) {
+  return const FilePickerFolderPickerService();
 });

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -5,48 +5,54 @@ import 'package:go_router/go_router.dart';
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
 import '../../core/models/track.dart';
-import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
+import 'selected_folder_controller.dart';
 
 /// Browse tracks from the local catalog. Reads entirely from
-/// [libraryControllerProvider]; it has no knowledge of where tracks are stored.
+/// [libraryControllerProvider] and [selectedFolderControllerProvider]; it has
+/// no knowledge of where tracks are stored or which plugin picks the folder.
 class LibraryScreen extends ConsumerWidget {
   const LibraryScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(libraryControllerProvider);
+    final selectedFolder = ref.watch(selectedFolderControllerProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('Library'),
         actions: [
           IconButton(
             icon: const Icon(Icons.create_new_folder_outlined),
-            tooltip: 'Scan a folder',
-            onPressed: () => _promptScan(context, ref),
+            tooltip: 'Select music folder',
+            onPressed: () => _pickAndScan(ref),
           ),
         ],
       ),
-      body: _body(ref, state),
+      body: _body(ref, state, selectedFolder.valueOrNull),
     );
   }
 
-  /// Dev entry point for the scan flow: ask for a folder path and hand it to
-  /// the controller. Deliberately a plain text prompt — a real folder picker
-  /// and runtime permissions land in a later PR.
-  Future<void> _promptScan(BuildContext context, WidgetRef ref) async {
-    final path = await showDialog<String>(
-      context: context,
-      builder: (_) => const _ScanFolderDialog(),
-    );
-    if (path != null && path.isNotEmpty) {
+  /// Open the system folder picker, persist the choice, then scan it. A
+  /// cancelled pick leaves everything untouched. The UI only talks to the two
+  /// controllers — never to a picker plugin or the file system directly.
+  Future<void> _pickAndScan(WidgetRef ref) async {
+    final path = await ref
+        .read(selectedFolderControllerProvider.notifier)
+        .pickAndPersist();
+    if (path != null) {
       await ref.read(libraryControllerProvider.notifier).scanFolder(path);
     }
   }
 
-  Widget _body(WidgetRef ref, LibraryState state) {
+  /// Re-scan the folder the user already selected, without opening the picker.
+  Future<void> _rescan(WidgetRef ref, String folder) {
+    return ref.read(libraryControllerProvider.notifier).scanFolder(folder);
+  }
+
+  Widget _body(WidgetRef ref, LibraryState state, String? selectedFolder) {
     switch (state.status) {
       case LibraryStatus.loading:
         return const Center(child: CircularProgressIndicator());
@@ -57,10 +63,12 @@ class LibraryScreen extends ConsumerWidget {
         );
       case LibraryStatus.loaded:
         if (state.isEmpty) {
-          return const EmptyState(
-            icon: Icons.library_music_outlined,
-            title: 'Your library is empty',
-            message: 'Tap the folder icon to scan a folder for music.',
+          return _LibraryEmpty(
+            selectedFolder: selectedFolder,
+            onPick: () => _pickAndScan(ref),
+            onRescan: selectedFolder == null
+                ? null
+                : () => _rescan(ref, selectedFolder),
           );
         }
         return _TrackList(tracks: state.tracks);
@@ -118,46 +126,74 @@ class _TrackTile extends ConsumerWidget {
   }
 }
 
-/// Simple prompt for a folder path to scan. Pops the trimmed path, or null
-/// when cancelled. Kept tiny on purpose; a proper picker comes later.
-class _ScanFolderDialog extends StatefulWidget {
-  const _ScanFolderDialog();
+/// The empty state, split by whether a folder has been selected yet so the
+/// user always sees the right next step:
+///  - no folder chosen → invite them to pick one;
+///  - folder chosen but nothing found → show the folder and offer a re-scan or
+///    a change of folder.
+class _LibraryEmpty extends StatelessWidget {
+  const _LibraryEmpty({
+    required this.selectedFolder,
+    required this.onPick,
+    this.onRescan,
+  });
 
-  @override
-  State<_ScanFolderDialog> createState() => _ScanFolderDialogState();
-}
-
-class _ScanFolderDialogState extends State<_ScanFolderDialog> {
-  final _controller = TextEditingController();
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _submit() => Navigator.of(context).pop(_controller.text.trim());
+  final String? selectedFolder;
+  final VoidCallback onPick;
+  final VoidCallback? onRescan;
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      title: const Text('Scan a folder'),
-      content: TextField(
-        controller: _controller,
-        autofocus: true,
-        decoration: const InputDecoration(
-          labelText: 'Folder path',
-          hintText: '/storage/emulated/0/Music',
+    final theme = Theme.of(context);
+    final hasFolder = selectedFolder != null;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              hasFolder
+                  ? Icons.library_music_outlined
+                  : Icons.folder_off_outlined,
+              size: 48,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              hasFolder ? 'No music found' : 'No music folder selected',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              hasFolder
+                  ? 'Nothing playable turned up in:\n$selectedFolder'
+                  : 'Choose a folder on your device to scan for music.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.md),
+            if (hasFolder) ...[
+              FilledButton.tonal(
+                onPressed: onRescan,
+                child: const Text('Rescan folder'),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              TextButton(
+                onPressed: onPick,
+                child: const Text('Change folder'),
+              ),
+            ] else
+              FilledButton(
+                onPressed: onPick,
+                child: const Text('Select a folder'),
+              ),
+          ],
         ),
-        onSubmitted: (_) => _submit(),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(onPressed: _submit, child: const Text('Scan')),
-      ],
     );
   }
 }

--- a/lib/features/library/selected_folder_controller.dart
+++ b/lib/features/library/selected_folder_controller.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/selected_music_folder_repository_provider.dart';
+import 'library_providers.dart';
+
+/// Owns the user's chosen music folder: loads the persisted selection, lets the
+/// user pick a new one, and persists the result.
+///
+/// Deliberately separate from the library controller/scanning — this only
+/// answers "which folder did the user choose?". The screen combines it with the
+/// scan flow. State is the selected folder path/URI, or `null` when none is set.
+class SelectedFolderController extends AsyncNotifier<String?> {
+  @override
+  Future<String?> build() {
+    return ref.read(selectedMusicFolderRepositoryProvider).getSelectedFolder();
+  }
+
+  /// Opens the folder picker and, if the user chooses one, persists it and
+  /// updates state. Returns the chosen folder, or `null` when cancelled (state
+  /// is left unchanged in that case).
+  Future<String?> pickAndPersist() async {
+    final picked = await ref.read(folderPickerServiceProvider).pickFolder();
+    if (picked == null || picked.isEmpty) {
+      return null;
+    }
+    await ref
+        .read(selectedMusicFolderRepositoryProvider)
+        .setSelectedFolder(picked);
+    state = AsyncData<String?>(picked);
+    return picked;
+  }
+
+  /// Forgets the current selection.
+  Future<void> clear() async {
+    await ref.read(selectedMusicFolderRepositoryProvider).clearSelectedFolder();
+    state = const AsyncData<String?>(null);
+  }
+}
+
+final selectedFolderControllerProvider =
+    AsyncNotifierProvider<SelectedFolderController, String?>(
+  SelectedFolderController.new,
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/sonara_app.dart';
 import 'data/repositories/music_library_repository_provider.dart';
+import 'data/repositories/selected_music_folder_repository_provider.dart';
 
 void main() {
   // ProviderScope hosts all Riverpod state for the app. The running app
-  // persists its catalog to SQLite via the Drift override; tests keep the
-  // in-memory default unless they opt into the Drift binding.
+  // persists its catalog to SQLite via the Drift override and the chosen music
+  // folder via shared_preferences; tests keep the in-memory defaults unless
+  // they opt into these bindings.
   runApp(
     ProviderScope(
-      overrides: [driftMusicLibraryRepositoryOverride],
+      overrides: [
+        driftMusicLibraryRepositoryOverride,
+        sharedPreferencesSelectedMusicFolderRepositoryOverride,
+      ],
       child: const SonaraApp(),
     ),
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,14 @@ dependencies:
   # services layer; the UI depends on the PlaybackController interface, never on
   # just_audio directly. Background playback (audio_service) lands in a later PR.
   just_audio: ^0.9.42
+  # Native folder chooser for selecting a music folder to scan. Used only by
+  # FilePickerFolderPickerService; the UI depends on the FolderPickerService
+  # interface, never on file_picker directly.
+  file_picker: ^8.1.4
+  # Persists the single selected music folder path/URI across restarts. Used
+  # only by SharedPreferencesSelectedMusicFolderRepository, behind the
+  # SelectedMusicFolderRepository interface.
+  shared_preferences: ^2.3.3
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/test/app_smoke_test.dart
+++ b/test/app_smoke_test.dart
@@ -11,7 +11,8 @@ void main() {
     // The persistent shell and its bottom navigation render.
     expect(find.byType(NavigationBar), findsOneWidget);
 
-    // The initial route is the Library tab, showing its empty state.
-    expect(find.text('Your library is empty'), findsOneWidget);
+    // The initial route is the Library tab. With no folder selected yet, the
+    // empty state invites the user to choose one.
+    expect(find.text('No music folder selected'), findsOneWidget);
   });
 }

--- a/test/data/repositories/in_memory_selected_music_folder_repository_test.dart
+++ b/test/data/repositories/in_memory_selected_music_folder_repository_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/data/repositories/in_memory_selected_music_folder_repository.dart';
+
+void main() {
+  group('InMemorySelectedMusicFolderRepository', () {
+    test('returns null when nothing has been selected', () async {
+      final repository = InMemorySelectedMusicFolderRepository();
+
+      expect(await repository.getSelectedFolder(), isNull);
+    });
+
+    test('exposes an initial folder when seeded', () async {
+      final repository =
+          InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+
+      expect(await repository.getSelectedFolder(), '/music');
+    });
+
+    test('setSelectedFolder replaces the stored value', () async {
+      final repository = InMemorySelectedMusicFolderRepository();
+
+      await repository.setSelectedFolder('/a');
+      await repository.setSelectedFolder('/b');
+
+      expect(await repository.getSelectedFolder(), '/b');
+    });
+
+    test('clearSelectedFolder forgets the selection', () async {
+      final repository =
+          InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+
+      await repository.clearSelectedFolder();
+
+      expect(await repository.getSelectedFolder(), isNull);
+    });
+  });
+}

--- a/test/features/library/fake_folder_picker_service.dart
+++ b/test/features/library/fake_folder_picker_service.dart
@@ -1,0 +1,18 @@
+import 'package:sonara/core/services/folder_picker_service.dart';
+
+/// Returns a fixed folder (or `null` to simulate cancellation) so the
+/// pick-and-scan flow can be driven without a real OS folder dialog.
+class FakeFolderPickerService implements FolderPickerService {
+  FakeFolderPickerService({this.folder});
+
+  /// The folder the picker "returns". `null` simulates the user cancelling.
+  final String? folder;
+
+  int pickCount = 0;
+
+  @override
+  Future<String?> pickFolder() async {
+    pickCount++;
+    return folder;
+  }
+}

--- a/test/features/library/library_screen_test.dart
+++ b/test/features/library/library_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:sonara/features/library/library_providers.dart';
 import 'package:sonara/features/library/library_screen.dart';
 
 import 'fake_audio_file_scanner.dart';
+import 'fake_folder_picker_service.dart';
 import 'fake_music_library_repository.dart';
 
 Future<void> _pumpScreen(
@@ -35,13 +36,17 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('shows the empty state when there are no tracks', (
+    testWidgets('prompts to select a folder when none is chosen', (
       tester,
     ) async {
       await _pumpScreen(tester, FakeMusicLibraryRepository());
       await tester.pumpAndSettle();
 
-      expect(find.text('Your library is empty'), findsOneWidget);
+      expect(find.text('No music folder selected'), findsOneWidget);
+      expect(
+        find.widgetWithText(FilledButton, 'Select a folder'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('lists tracks with title and subtitle', (tester) async {
@@ -80,7 +85,7 @@ void main() {
       expect(find.text('Retry'), findsOneWidget);
     });
 
-    testWidgets('scanning a folder populates the list from the prompt', (
+    testWidgets('picking a folder scans it and populates the list', (
       tester,
     ) async {
       final scanner = FakeAudioFileScanner(
@@ -93,23 +98,48 @@ void main() {
               InMemoryMusicLibraryRepository(),
             ),
             audioFileScannerProvider.overrideWithValue(scanner),
+            folderPickerServiceProvider.overrideWithValue(
+              FakeFolderPickerService(folder: '/music'),
+            ),
           ],
           child: const MaterialApp(home: LibraryScreen()),
         ),
       );
       await tester.pumpAndSettle();
-      expect(find.text('Your library is empty'), findsOneWidget);
+      expect(find.text('No music folder selected'), findsOneWidget);
 
-      // Open the scan prompt, type a path, and confirm.
-      await tester.tap(find.byTooltip('Scan a folder'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextField), '/music');
-      await tester.tap(find.widgetWithText(FilledButton, 'Scan'));
+      // Tap the folder action: the fake picker returns '/music', which is then
+      // scanned.
+      await tester.tap(find.byTooltip('Select music folder'));
       await tester.pumpAndSettle();
 
       expect(scanner.requestedFolder, '/music');
       expect(find.text('Hello'), findsOneWidget);
-      expect(find.text('Your library is empty'), findsNothing);
+      expect(find.text('No music folder selected'), findsNothing);
+    });
+
+    testWidgets('cancelling the picker leaves the empty state untouched', (
+      tester,
+    ) async {
+      final picker = FakeFolderPickerService(folder: null);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            musicLibraryRepositoryProvider.overrideWithValue(
+              InMemoryMusicLibraryRepository(),
+            ),
+            folderPickerServiceProvider.overrideWithValue(picker),
+          ],
+          child: const MaterialApp(home: LibraryScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Select music folder'));
+      await tester.pumpAndSettle();
+
+      expect(picker.pickCount, 1);
+      expect(find.text('No music folder selected'), findsOneWidget);
     });
   });
 }

--- a/test/features/library/selected_folder_controller_test.dart
+++ b/test/features/library/selected_folder_controller_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:sonara/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:sonara/features/library/library_providers.dart';
+import 'package:sonara/features/library/selected_folder_controller.dart';
+
+import 'fake_folder_picker_service.dart';
+
+ProviderContainer _container({
+  required FakeFolderPickerService picker,
+  required InMemorySelectedMusicFolderRepository repository,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      folderPickerServiceProvider.overrideWithValue(picker),
+      selectedMusicFolderRepositoryProvider.overrideWithValue(repository),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('SelectedFolderController', () {
+    test('loads the persisted folder on build', () async {
+      final container = _container(
+        picker: FakeFolderPickerService(),
+        repository:
+            InMemorySelectedMusicFolderRepository(initialFolder: '/music'),
+      );
+
+      final value =
+          await container.read(selectedFolderControllerProvider.future);
+
+      expect(value, '/music');
+    });
+
+    test('starts with no folder when none is persisted', () async {
+      final container = _container(
+        picker: FakeFolderPickerService(),
+        repository: InMemorySelectedMusicFolderRepository(),
+      );
+
+      final value =
+          await container.read(selectedFolderControllerProvider.future);
+
+      expect(value, isNull);
+    });
+
+    test('pickAndPersist stores the chosen folder and updates state', () async {
+      final repository = InMemorySelectedMusicFolderRepository();
+      final container = _container(
+        picker: FakeFolderPickerService(folder: '/new/music'),
+        repository: repository,
+      );
+      await container.read(selectedFolderControllerProvider.future);
+
+      final picked = await container
+          .read(selectedFolderControllerProvider.notifier)
+          .pickAndPersist();
+
+      expect(picked, '/new/music');
+      expect(
+        container.read(selectedFolderControllerProvider).value,
+        '/new/music',
+      );
+      expect(await repository.getSelectedFolder(), '/new/music');
+    });
+
+    test('pickAndPersist leaves state unchanged when cancelled', () async {
+      final repository =
+          InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+      final container = _container(
+        picker: FakeFolderPickerService(folder: null),
+        repository: repository,
+      );
+      await container.read(selectedFolderControllerProvider.future);
+
+      final picked = await container
+          .read(selectedFolderControllerProvider.notifier)
+          .pickAndPersist();
+
+      expect(picked, isNull);
+      expect(container.read(selectedFolderControllerProvider).value, '/music');
+      expect(await repository.getSelectedFolder(), '/music');
+    });
+
+    test('clear forgets the selection', () async {
+      final repository =
+          InMemorySelectedMusicFolderRepository(initialFolder: '/music');
+      final container = _container(
+        picker: FakeFolderPickerService(),
+        repository: repository,
+      );
+      await container.read(selectedFolderControllerProvider.future);
+
+      await container.read(selectedFolderControllerProvider.notifier).clear();
+
+      expect(container.read(selectedFolderControllerProvider).value, isNull);
+      expect(await repository.getSelectedFolder(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the first Android-friendly folder selection / storage-access foundation for scanning local music. The Library can now pick a music folder via the OS chooser, persist the choice across restarts, and scan it through `LocalMusicSource` — all behind interfaces, so no platform plugin leaks into the UI.

The dev-only text-path prompt is replaced by a real picker seam. Folder *selection* and *persistence* are kept separate from *scanning*, matching the existing repository/provider patterns (default in-memory binding for tests, production override applied in `main`).

## Files changed

New abstractions & implementations:
- `lib/core/services/folder_picker_service.dart` — `FolderPickerService` interface.
- `lib/core/services/file_picker_folder_picker_service.dart` — `file_picker`-backed impl (Android SAF / desktop GTK).
- `lib/core/repositories/selected_music_folder_repository.dart` — `SelectedMusicFolderRepository` interface.
- `lib/data/repositories/in_memory_selected_music_folder_repository.dart` — default (dev/tests).
- `lib/data/repositories/shared_preferences_selected_music_folder_repository.dart` — persistent impl.
- `lib/data/repositories/selected_music_folder_repository_provider.dart` — provider + production override.
- `lib/features/library/selected_folder_controller.dart` — `SelectedFolderController` (load / pick+persist / clear).

Wiring & UI:
- `lib/features/library/library_providers.dart` — adds `folderPickerServiceProvider`.
- `lib/features/library/library_screen.dart` — replaces the text prompt with the picker flow; richer empty states.
- `lib/main.dart` — applies the `shared_preferences` override alongside the Drift override.
- `pubspec.yaml` — adds `file_picker` and `shared_preferences`.
- `README.md` — folder-selection status, how scanning works now, known limitations.

## Android folder selection behavior

Tap the folder icon → native folder chooser opens → chosen folder is persisted and scanned. Selection survives restarts (`shared_preferences`). Empty state adapts: no folder chosen → "Select a folder"; folder chosen but empty → shows the folder with **Rescan folder** / **Change folder**.

## Linux/desktop behavior

Same flow uses the GTK/Win32 directory dialog and returns a real filesystem path, which `IoAudioFileScanner`/`LocalMusicSource` scans directly — unchanged scanning logic.

## Known limitations

- On modern Android the chooser returns a SAF `content://…/tree/…` URI; the current `dart:io` scanner reads real filesystem paths, so raw SAF tree traversal (or URI→path resolution) is a deliberate follow-up. The picker + persistence seam is in place for it.
- No runtime storage permission flow (`READ_MEDIA_AUDIO` / `MANAGE_EXTERNAL_STORAGE`) — intentionally not requesting broad permissions in this PR.
- No tag/metadata parsing; no queue/playlists/downloads/remote sources.

## Tests added

- `selected_folder_controller_test.dart` — load persisted folder, pick+persist, cancel (state unchanged), clear, using a fake picker + in-memory store.
- `in_memory_selected_music_folder_repository_test.dart` — get/set/clear behavior.
- `fake_folder_picker_service.dart` — test fake.
- Updated `library_screen_test.dart` — picking a folder scans it; cancelling leaves the empty state untouched; "no folder selected" empty state.
- Updated `app_smoke_test.dart` — initial empty state text.

## Verification

No Flutter toolchain in this environment; relying on CI (`flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test`). New plugins are only invoked behind interfaces overridden with fakes/in-memory bindings in tests.

## Next recommended PR

Queue polish or playlist-editor foundation. (SAF document-tree scanning + Android runtime storage permissions remain the natural follow-ups to this folder-selection work.)

https://claude.ai/code/session_016NvGUe4BZCbeet6ZSHf6v4

---
_Generated by [Claude Code](https://claude.ai/code/session_016NvGUe4BZCbeet6ZSHf6v4)_