### PR TITLE
Add Android SAF/content URI scanning support behind a routing seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ interfaces: the UI talks only to `SelectedFolderController` and
 The scan itself is still exposed as `LibraryController.scanFolder(path)` and runs
 through `LocalMusicSource`, so the flow stays fully testable without a real disk
 or OS dialog (the picker, the file-system seam, and the selected-folder store are
-each overridden with a fake/in-memory binding in tests). See **Android folder
-selection & known limitations** below for what still needs care on modern
-Android.
+each overridden with a fake/in-memory binding in tests). The scan seam now also
+routes Android `content://` Storage Access Framework selections to a SAF-aware
+scanner rather than assuming a filesystem path. See **Android folder selection &
+known limitations** below for what still needs care on modern Android.
 
 A temporary `InMemoryMusicLibraryRepository` (`lib/data/repositories/`) also
 implements the `MusicLibraryRepository` contract, so the app and its tests have
@@ -70,8 +71,10 @@ repository abstraction.
 Not built yet (planned, in roughly this order):
 
 - Local music library scanning — *v1 done (scan → persist → list); native
-  folder picker + persisted selection now done; tag parsing and Android
-  runtime storage permissions still pending*
+  folder picker + persisted selection now done; Android `content://` tree URIs
+  are now routed and resolved for external storage; tag parsing,
+  content-resolver SAF scanning, and a narrow Android media permission still
+  pending*
 - Audio playback
 - Playlists
 - User-controlled offline downloads
@@ -213,27 +216,63 @@ playable is found it shows that folder and offers **Rescan folder** / **Change
 folder**. On Linux/desktop the same flow uses the GTK/Win32 directory dialog and
 returns a real filesystem path, which `LocalMusicSource` scans directly.
 
-Library scanning is exercisable on an Android device, with a few deliberate gaps
-the next PRs will close:
+**How content:// folders are scanned.** On modern Android the folder chooser
+hands back a `content://…/tree/…` URI under the Storage Access Framework rather
+than a filesystem path. Scanning now routes each selection through a single seam
+(`PlatformAudioFileScanner`):
 
-- **Android returns a SAF tree URI, not always a filesystem path.** On modern
-  Android the system folder chooser hands back a `content://…/tree/…` URI under
-  Storage Access Framework. The current `dart:io`-based scanner
-  (`IoAudioFileScanner`) reads real filesystem paths, so it can scan folders the
-  app can already reach by path but cannot yet walk a raw SAF tree URI.
-  Document-tree traversal (or resolving the URI to a path) is a planned
-  follow-up; the picker + persistence seam is in place for it.
-- **No runtime storage permissions yet.** No `READ_MEDIA_AUDIO` /
-  `MANAGE_EXTERNAL_STORAGE` request flow is wired up, so on modern Android you
-  may need to point the scan at a directory the app can already read. We are
-  intentionally not requesting broad storage permissions in this PR.
+- **Filesystem paths** (desktop/Linux, and any path Android hands back) go to
+  `IoAudioFileScanner` — the existing `dart:io` walk, unchanged.
+- **`content://` tree URIs** go to `ContentUriAudioFileScanner`, which uses
+  `SafTreeUriResolver` to map an external-storage tree URI to a real path
+  (`primary:Music` → `/storage/emulated/0/Music`, named SD-card volumes →
+  `/storage/<volume>/…`, and `raw:` ids that already carry an absolute path),
+  then walks that path. Folders selected this way are stored as ordinary file
+  paths, so playback resolution is unchanged.
+
+How a selection is addressed (path vs `content://`) is decided once by
+`FolderLocation`; nothing downstream re-parses the string, and the UI never
+sees any of it.
+
+Deliberate gaps the next PRs will close:
+
+- **Scoped storage / content-resolver scanning.** `SafTreeUriResolver` covers
+  the common `com.android.externalstorage.documents` provider. Other SAF
+  providers (downloads, media, cloud/document providers) don't expose a stable
+  path, so a selection from one of those surfaces a clear `FolderScanException`
+  in the Library error state instead of a silent empty list. The full
+  follow-up is reading a SAF tree through Android's content resolver (via a
+  native plugin), which also covers devices where scoped storage hides a
+  resolved path behind the framework. The routing and error seams are in place
+  for it.
+- **No runtime storage permissions yet.** No `READ_MEDIA_AUDIO` request flow is
+  wired up, and **`MANAGE_EXTERNAL_STORAGE` is intentionally *not* requested** —
+  it is an "all files access" permission Google restricts on the Play Store and
+  it is the opposite of the scoped-storage approach this project prefers. On
+  Android 11+ a resolved path can still be unreadable without a media
+  permission; granting `READ_MEDIA_AUDIO` (a narrow, audio-only permission) is
+  the natural next step. Until then, point the scan at a folder the app can
+  already read, or use the content-resolver follow-up above.
 - **No tag/metadata parsing.** Tracks show their title (derived from the file
   name) and fall back to the file path when artist/album tags are absent.
 - **No queue, playlists, downloads, or remote sources** (Jellyfin/WebDAV) yet.
 
+### Testing scanning on Android
+
+1. Build and install a debug APK (see *Building a debug APK* above) on a device
+   or emulator.
+2. Put a few audio files under a folder on shared storage, e.g.
+   `/storage/emulated/0/Music`.
+3. In **Library**, tap the folder icon and pick that folder. The chooser
+   returns a `content://…/tree/primary:Music` URI; Sonara resolves it to the
+   path and scans it.
+4. Picking a folder from a provider that has no filesystem mapping (for example
+   a cloud "Documents" provider) is expected to show the Library error state
+   with a clear message — that's the documented limitation, not a crash.
+
 The next PR is expected to be queue polish or a playlist-editor foundation;
-SAF document-tree scanning and Android runtime storage permissions remain the
-natural follow-ups to this folder-selection work.
+content-resolver SAF scanning and a narrow `READ_MEDIA_AUDIO` permission flow
+remain the natural follow-ups to this work.
 
 ## Continuous integration
 

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -1,24 +1,38 @@
 import 'dart:io';
 
+import 'folder_location.dart';
+import 'folder_scan_exception.dart';
+import 'saf_tree_uri_resolver.dart';
+
 /// Discovers files under a folder on the device.
 ///
-/// This is the single seam through which the local source touches the file
-/// system. Isolating it keeps the source's discovery/mapping logic pure enough
-/// to unit-test against a fake. Deciding which files are audio is the caller's
+/// This is the single seam through which the local source touches storage.
+/// Isolating it keeps the source's discovery/mapping logic pure enough to
+/// unit-test against a fake. Deciding which files are audio is the caller's
 /// job, not the scanner's.
+///
+/// A [folder] is whatever the picker returned: a desktop filesystem path or an
+/// Android SAF `content://` tree URI. [PlatformAudioFileScanner] routes each to
+/// the implementation that can handle it, so [LocalMusicSource] stays unaware
+/// of the platform split. Implementations throw [FolderScanException] when a
+/// folder cannot be scanned.
 abstract interface class AudioFileScanner {
-  /// Returns the absolute paths of every regular file under [folderPath],
-  /// searched recursively. Returns an empty list when the folder is missing.
-  Future<List<String>> listFiles(String folderPath);
+  /// Returns the absolute paths of every regular file under [folder], searched
+  /// recursively. Returns an empty list when the folder is missing.
+  Future<List<String>> listFiles(String folder);
 }
 
-/// An [AudioFileScanner] backed by `dart:io`.
+/// An [AudioFileScanner] backed by `dart:io` for real filesystem paths.
+///
+/// This is the desktop/Linux scanner and the final hop for any Android folder
+/// that resolves to a path. It does not understand `content://` URIs — routing
+/// is [PlatformAudioFileScanner]'s job.
 class IoAudioFileScanner implements AudioFileScanner {
   const IoAudioFileScanner();
 
   @override
-  Future<List<String>> listFiles(String folderPath) async {
-    final Directory directory = Directory(folderPath);
+  Future<List<String>> listFiles(String folder) async {
+    final Directory directory = Directory(folder);
     if (!await directory.exists()) {
       return const <String>[];
     }
@@ -34,5 +48,69 @@ class IoAudioFileScanner implements AudioFileScanner {
       }
     }
     return paths;
+  }
+}
+
+/// Scans an Android SAF `content://` tree URI by resolving it to a filesystem
+/// path and delegating to a filesystem scanner.
+///
+/// This is the Android-capable scanner. It does not touch `dart:io` itself: it
+/// resolves the URI with a [SafTreeUriResolver] and hands the resulting path to
+/// an injected [AudioFileScanner] (the real one is [IoAudioFileScanner]). When
+/// the URI maps to no reachable path, it throws [FolderScanException] so the
+/// user sees a clear message instead of an empty library. Walking SAF trees
+/// that scoped storage only exposes through the content resolver is the
+/// documented native follow-up.
+class ContentUriAudioFileScanner implements AudioFileScanner {
+  const ContentUriAudioFileScanner({
+    AudioFileScanner filesystemScanner = const IoAudioFileScanner(),
+    SafTreeUriResolver resolver = const SafTreeUriResolver(),
+  })  : _filesystemScanner = filesystemScanner,
+        _resolver = resolver;
+
+  final AudioFileScanner _filesystemScanner;
+  final SafTreeUriResolver _resolver;
+
+  @override
+  Future<List<String>> listFiles(String folder) {
+    final String? path = _resolver.resolveToPath(folder);
+    if (path == null) {
+      throw FolderScanException(
+        "This folder can't be scanned yet. It was shared through Android's "
+        'Storage Access Framework, which Sonara cannot walk directly on this '
+        'device. Try selecting a folder on your phone or SD card storage.',
+        folder: folder,
+      );
+    }
+    return _filesystemScanner.listFiles(path);
+  }
+}
+
+/// The default [AudioFileScanner]: routes each folder to the scanner that can
+/// handle it based on whether it is a filesystem path or a `content://` URI.
+///
+/// Desktop/Linux selections are filesystem paths and go straight to
+/// [IoAudioFileScanner], preserving existing behavior exactly. Android SAF
+/// selections are `content://` URIs and go to [ContentUriAudioFileScanner].
+/// This is the only place that knows about the platform split.
+class PlatformAudioFileScanner implements AudioFileScanner {
+  const PlatformAudioFileScanner({
+    AudioFileScanner filesystemScanner = const IoAudioFileScanner(),
+    AudioFileScanner contentUriScanner = const ContentUriAudioFileScanner(),
+  })  : _filesystemScanner = filesystemScanner,
+        _contentUriScanner = contentUriScanner;
+
+  final AudioFileScanner _filesystemScanner;
+  final AudioFileScanner _contentUriScanner;
+
+  @override
+  Future<List<String>> listFiles(String folder) {
+    final FolderLocation location = FolderLocation.parse(folder);
+    switch (location.kind) {
+      case FolderLocationKind.filesystemPath:
+        return _filesystemScanner.listFiles(folder);
+      case FolderLocationKind.contentUri:
+        return _contentUriScanner.listFiles(folder);
+    }
   }
 }

--- a/lib/core/sources/local/folder_location.dart
+++ b/lib/core/sources/local/folder_location.dart
@@ -1,0 +1,40 @@
+/// How a selected music folder is addressed on the current platform.
+///
+/// The folder picker hands back a single opaque string (see
+/// [FolderPickerService]). On desktop that is a real filesystem path; on
+/// Android the Storage Access Framework returns a `content://…/tree/…` URI.
+/// Scanning has to treat those two cases differently, so this classifies a raw
+/// selection without anyone downstream having to re-parse the string.
+enum FolderLocationKind {
+  /// A real filesystem path the `dart:io` scanner can walk directly.
+  filesystemPath,
+
+  /// An Android SAF `content://` tree/document URI.
+  contentUri,
+}
+
+/// A parsed view of a selected folder string and how to reach it.
+class FolderLocation {
+  const FolderLocation({required this.kind, required this.raw});
+
+  /// Classifies [raw]. Anything using the `content` URI scheme is treated as a
+  /// SAF selection; everything else is treated as a filesystem path. The check
+  /// is scheme-based and case-insensitive, so `CONTENT://…` is still a content
+  /// URI while `/home/me/Music` and `C:\Music` are paths.
+  factory FolderLocation.parse(String raw) {
+    final Uri? uri = Uri.tryParse(raw);
+    final bool isContent = uri != null && uri.scheme.toLowerCase() == 'content';
+    return FolderLocation(
+      kind: isContent
+          ? FolderLocationKind.contentUri
+          : FolderLocationKind.filesystemPath,
+      raw: raw,
+    );
+  }
+
+  final FolderLocationKind kind;
+  final String raw;
+
+  bool get isContentUri => kind == FolderLocationKind.contentUri;
+  bool get isFilesystemPath => kind == FolderLocationKind.filesystemPath;
+}

--- a/lib/core/sources/local/folder_scan_exception.dart
+++ b/lib/core/sources/local/folder_scan_exception.dart
@@ -1,0 +1,19 @@
+/// Raised when a selected folder cannot be scanned for audio.
+///
+/// This is the single, typed error the scanning layer throws so the controller
+/// can surface a clear message to the user instead of leaking a raw plugin or
+/// `dart:io` failure. The most common case today is an Android SAF
+/// `content://` tree URI that cannot be reached as a filesystem path on this
+/// device (see [SafTreeUriResolver]).
+class FolderScanException implements Exception {
+  const FolderScanException(this.message, {this.folder});
+
+  /// A user-facing explanation of why the scan could not run.
+  final String message;
+
+  /// The folder path or URI that could not be scanned, when known.
+  final String? folder;
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/sources/local/saf_tree_uri_resolver.dart
+++ b/lib/core/sources/local/saf_tree_uri_resolver.dart
@@ -1,0 +1,82 @@
+/// Best-effort mapping from an Android SAF tree/document URI to a real
+/// filesystem path.
+///
+/// When the system folder picker returns a `content://…/tree/…` URI, scanning
+/// still needs *something* the `dart:io` scanner can walk. For the common
+/// external-storage provider the document id encodes a volume and a relative
+/// path (e.g. `primary:Music`), which maps deterministically onto the device's
+/// storage layout — so we can resolve it to a path without any native plugin or
+/// extra permission.
+///
+/// This is intentionally pure string logic with no `dart:io` import: it is the
+/// whole reason content-URI scanning is unit-testable. It is *best effort* —
+/// SAF providers that don't expose a filesystem layout (cloud/document
+/// providers, the downloads/media providers) return `null`, and the caller
+/// turns that into a clear [FolderScanException]. Resolving those, and reading
+/// trees that scoped storage hides behind the content resolver, is the native
+/// SAF follow-up documented in the README.
+class SafTreeUriResolver {
+  const SafTreeUriResolver();
+
+  /// The authority whose document ids map onto the on-device storage layout.
+  static const String _externalStorageAuthority =
+      'com.android.externalstorage.documents';
+
+  /// The mount point of the device's primary (built-in) shared storage.
+  static const String _primaryStorageRoot = '/storage/emulated/0';
+
+  /// Resolves [folderUri] to an absolute filesystem path, or returns `null`
+  /// when no reliable path mapping exists for it.
+  String? resolveToPath(String folderUri) {
+    final Uri? uri = Uri.tryParse(folderUri);
+    if (uri == null || uri.scheme.toLowerCase() != 'content') {
+      return null;
+    }
+    if (uri.host != _externalStorageAuthority) {
+      // Other SAF providers (downloads, media, cloud) don't expose a stable
+      // filesystem path we can walk.
+      return null;
+    }
+
+    final String? documentId = _documentId(uri.pathSegments);
+    if (documentId == null) {
+      return null;
+    }
+
+    final int separator = documentId.indexOf(':');
+    if (separator < 0) {
+      return null;
+    }
+    final String volume = documentId.substring(0, separator);
+    final String relativePath = documentId.substring(separator + 1);
+
+    // `raw:` ids already carry an absolute path.
+    if (volume == 'raw') {
+      return relativePath.isEmpty ? null : relativePath;
+    }
+
+    final String root =
+        volume == 'primary' ? _primaryStorageRoot : '/storage/$volume';
+    if (relativePath.isEmpty) {
+      return root;
+    }
+    return '$root/$relativePath';
+  }
+
+  /// Picks the most specific document id from a SAF URI's path segments.
+  ///
+  /// A tree URI is `…/tree/<treeDocId>`; selecting a sub-folder yields
+  /// `…/tree/<treeDocId>/document/<docId>`, where the `document` id is the
+  /// folder actually chosen — so prefer it when present.
+  String? _documentId(List<String> segments) {
+    final int documentIndex = segments.indexOf('document');
+    if (documentIndex >= 0 && documentIndex + 1 < segments.length) {
+      return segments[documentIndex + 1];
+    }
+    final int treeIndex = segments.indexOf('tree');
+    if (treeIndex >= 0 && treeIndex + 1 < segments.length) {
+      return segments[treeIndex + 1];
+    }
+    return null;
+  }
+}

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -4,15 +4,17 @@ import '../../core/services/file_picker_folder_picker_service.dart';
 import '../../core/services/folder_picker_service.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
 
-/// The file-system seam the library scan uses to discover audio files.
+/// The storage seam the library scan uses to discover audio files.
 ///
-/// Defaults to the real `dart:io` scanner. Tests override it with a fake so a
-/// scan can run end-to-end without touching a real disk. This is the only new
-/// provider the scan flow needs — the repository and library state already have
-/// their own providers (`musicLibraryRepositoryProvider`,
-/// `libraryControllerProvider`).
+/// Defaults to [PlatformAudioFileScanner], which routes a selected folder to
+/// the right backend: a `dart:io` walk for desktop/Linux filesystem paths, and
+/// the SAF-aware [ContentUriAudioFileScanner] for Android `content://` tree
+/// URIs. Tests override it with a fake so a scan can run end-to-end without
+/// touching a real disk. This is the only new provider the scan flow needs —
+/// the repository and library state already have their own providers
+/// (`musicLibraryRepositoryProvider`, `libraryControllerProvider`).
 final audioFileScannerProvider = Provider<AudioFileScanner>((ref) {
-  return const IoAudioFileScanner();
+  return const PlatformAudioFileScanner();
 });
 
 /// The folder-chooser seam the Library uses to let the user pick a music

--- a/test/core/sources/local/content_uri_audio_file_scanner_test.dart
+++ b/test/core/sources/local/content_uri_audio_file_scanner_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:sonara/core/sources/local/folder_scan_exception.dart';
+
+/// Records the folder it was asked to scan and returns a fixed list, so we can
+/// assert the content scanner resolved the URI to a path before delegating.
+class _RecordingScanner implements AudioFileScanner {
+  _RecordingScanner(this._files);
+
+  final List<String> _files;
+  String? requestedFolder;
+
+  @override
+  Future<List<String>> listFiles(String folder) async {
+    requestedFolder = folder;
+    return _files;
+  }
+}
+
+void main() {
+  group('ContentUriAudioFileScanner', () {
+    test('resolves a SAF tree URI to a path and delegates the walk', () async {
+      final filesystem = _RecordingScanner(<String>[
+        '/storage/emulated/0/Music/One.mp3',
+      ]);
+      final scanner = ContentUriAudioFileScanner(filesystemScanner: filesystem);
+
+      final files = await scanner.listFiles(
+        'content://com.android.externalstorage.documents/tree/primary%3AMusic',
+      );
+
+      expect(filesystem.requestedFolder, '/storage/emulated/0/Music');
+      expect(files, <String>['/storage/emulated/0/Music/One.mp3']);
+    });
+
+    test('throws a useful error for an unresolvable provider', () async {
+      final filesystem = _RecordingScanner(const <String>[]);
+      final scanner = ContentUriAudioFileScanner(filesystemScanner: filesystem);
+
+      expect(
+        () => scanner.listFiles(
+          'content://com.android.providers.downloads.documents/tree/raw%3A',
+        ),
+        throwsA(isA<FolderScanException>()),
+      );
+      // The walk is never attempted when the URI can't be resolved.
+      expect(filesystem.requestedFolder, isNull);
+    });
+  });
+}

--- a/test/core/sources/local/folder_location_test.dart
+++ b/test/core/sources/local/folder_location_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/folder_location.dart';
+
+void main() {
+  group('FolderLocation', () {
+    test('classifies a POSIX filesystem path', () {
+      final location = FolderLocation.parse('/home/me/Music');
+      expect(location.kind, FolderLocationKind.filesystemPath);
+      expect(location.isFilesystemPath, isTrue);
+      expect(location.isContentUri, isFalse);
+      expect(location.raw, '/home/me/Music');
+    });
+
+    test('classifies a Windows filesystem path', () {
+      final location = FolderLocation.parse(r'C:\Users\me\Music');
+      expect(location.kind, FolderLocationKind.filesystemPath);
+    });
+
+    test('classifies an Android SAF content tree URI', () {
+      final location = FolderLocation.parse(
+        'content://com.android.externalstorage.documents/tree/primary%3AMusic',
+      );
+      expect(location.kind, FolderLocationKind.contentUri);
+      expect(location.isContentUri, isTrue);
+      expect(location.isFilesystemPath, isFalse);
+    });
+
+    test('treats the content scheme case-insensitively', () {
+      final location = FolderLocation.parse('CONTENT://authority/tree/x');
+      expect(location.kind, FolderLocationKind.contentUri);
+    });
+
+    test('treats a file:// URI as a filesystem path, not a content URI', () {
+      final location = FolderLocation.parse('file:///home/me/Music');
+      expect(location.kind, FolderLocationKind.filesystemPath);
+    });
+  });
+}

--- a/test/core/sources/local/platform_audio_file_scanner_test.dart
+++ b/test/core/sources/local/platform_audio_file_scanner_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+
+/// Records that it was called and with which folder, so we can assert the
+/// router picked this backend.
+class _RecordingScanner implements AudioFileScanner {
+  _RecordingScanner(this.label, [this._files = const <String>[]]);
+
+  final String label;
+  final List<String> _files;
+  String? requestedFolder;
+
+  @override
+  Future<List<String>> listFiles(String folder) async {
+    requestedFolder = folder;
+    return _files;
+  }
+}
+
+void main() {
+  group('PlatformAudioFileScanner', () {
+    test('routes a filesystem path to the filesystem scanner', () async {
+      final filesystem = _RecordingScanner('fs', <String>['/music/One.mp3']);
+      final contentUri = _RecordingScanner('content');
+      final scanner = PlatformAudioFileScanner(
+        filesystemScanner: filesystem,
+        contentUriScanner: contentUri,
+      );
+
+      final files = await scanner.listFiles('/home/me/Music');
+
+      expect(filesystem.requestedFolder, '/home/me/Music');
+      expect(contentUri.requestedFolder, isNull);
+      expect(files, <String>['/music/One.mp3']);
+    });
+
+    test('routes a content URI to the Android-capable scanner', () async {
+      final filesystem = _RecordingScanner('fs');
+      final contentUri = _RecordingScanner('content', <String>['/x/Two.flac']);
+      final scanner = PlatformAudioFileScanner(
+        filesystemScanner: filesystem,
+        contentUriScanner: contentUri,
+      );
+
+      const uri = 'content://com.android.externalstorage.documents/tree/'
+          'primary%3AMusic';
+      final files = await scanner.listFiles(uri);
+
+      expect(contentUri.requestedFolder, uri);
+      expect(filesystem.requestedFolder, isNull);
+      expect(files, <String>['/x/Two.flac']);
+    });
+  });
+}

--- a/test/core/sources/local/saf_tree_uri_resolver_test.dart
+++ b/test/core/sources/local/saf_tree_uri_resolver_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/sources/local/saf_tree_uri_resolver.dart';
+
+void main() {
+  const resolver = SafTreeUriResolver();
+
+  group('SafTreeUriResolver', () {
+    test('resolves a primary-volume tree URI to a path', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.externalstorage.documents/tree/primary%3AMusic',
+      );
+      expect(path, '/storage/emulated/0/Music');
+    });
+
+    test('resolves a nested primary-volume folder', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.externalstorage.documents/tree/'
+        'primary%3AMusic%2FAlbums',
+      );
+      expect(path, '/storage/emulated/0/Music/Albums');
+    });
+
+    test('resolves the primary volume root', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.externalstorage.documents/tree/primary%3A',
+      );
+      expect(path, '/storage/emulated/0');
+    });
+
+    test('resolves a named (SD card) volume', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.externalstorage.documents/tree/'
+        '1234-5678%3AMusic',
+      );
+      expect(path, '/storage/1234-5678/Music');
+    });
+
+    test('uses the document id when the URI selects a sub-folder', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.externalstorage.documents/tree/'
+        'primary%3AMusic/document/primary%3AMusic%2FLive',
+      );
+      expect(path, '/storage/emulated/0/Music/Live');
+    });
+
+    test('passes through a raw absolute path', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.externalstorage.documents/tree/'
+        'raw%3A%2Fstorage%2Femulated%2F0%2FMusic',
+      );
+      expect(path, '/storage/emulated/0/Music');
+    });
+
+    test('returns null for a non-external-storage provider', () {
+      final path = resolver.resolveToPath(
+        'content://com.android.providers.downloads.documents/tree/raw%3A',
+      );
+      expect(path, isNull);
+    });
+
+    test('returns null for a non-content URI', () {
+      expect(resolver.resolveToPath('/home/me/Music'), isNull);
+    });
+  });
+}

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonara/core/models/track.dart';
 import 'package:sonara/core/repositories/music_library_repository.dart';
+import 'package:sonara/core/sources/local/audio_file_scanner.dart';
 import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
 import 'package:sonara/data/repositories/music_library_repository_provider.dart';
 import 'package:sonara/features/library/library_controller.dart';
@@ -25,7 +26,7 @@ ProviderContainer _containerWith(FakeMusicLibraryRepository repository) {
 
 ProviderContainer _scanContainer({
   required MusicLibraryRepository repository,
-  required FakeAudioFileScanner scanner,
+  required AudioFileScanner scanner,
 }) {
   final container = ProviderContainer(
     overrides: [
@@ -122,6 +123,50 @@ void main() {
       final state = container.read(libraryControllerProvider);
       expect(state.status, LibraryStatus.error);
       expect(state.errorMessage, contains('no such folder'));
+    });
+
+    test('scanFolder routes a content URI through the Android scanner',
+        () async {
+      final repository = InMemoryMusicLibraryRepository();
+      // A filesystem fake stands in for the on-device walk; the real routing +
+      // SAF tree-URI resolution runs in front of it.
+      final filesystem = FakeAudioFileScanner(
+        files: <String>['/storage/emulated/0/Music/One.mp3'],
+      );
+      final container = _scanContainer(
+        repository: repository,
+        scanner: PlatformAudioFileScanner(filesystemScanner: filesystem),
+      );
+
+      const folderUri = 'content://com.android.externalstorage.documents/tree/'
+          'primary%3AMusic';
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder(folderUri);
+
+      // The content URI was resolved to a path before the walk.
+      expect(filesystem.requestedFolder, '/storage/emulated/0/Music');
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.loaded);
+      expect(state.tracks.map((t) => t.title), <String>['One']);
+    });
+
+    test('scanFolder surfaces a clean error for an unscannable content URI',
+        () async {
+      final container = _scanContainer(
+        repository: InMemoryMusicLibraryRepository(),
+        scanner: const PlatformAudioFileScanner(),
+      );
+
+      const folderUri = 'content://com.android.providers.downloads.documents/'
+          'tree/raw%3A';
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder(folderUri);
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.error);
+      expect(state.errorMessage, contains('Storage Access Framework'));
     });
   });
 }

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -133,9 +133,14 @@ void main() {
       final filesystem = FakeAudioFileScanner(
         files: <String>['/storage/emulated/0/Music/One.mp3'],
       );
+      // Wire the fake into the content scanner's walk: a content URI routes to
+      // ContentUriAudioFileScanner, which resolves the URI to a path and then
+      // delegates that path to its filesystem scanner.
+      final contentScanner =
+          ContentUriAudioFileScanner(filesystemScanner: filesystem);
       final container = _scanContainer(
         repository: repository,
-        scanner: PlatformAudioFileScanner(filesystemScanner: filesystem),
+        scanner: PlatformAudioFileScanner(contentUriScanner: contentScanner),
       );
 
       const folderUri = 'content://com.android.externalstorage.documents/tree/'


### PR DESCRIPTION
## Summary

Adds Android-friendly scanning for folders returned by the system picker,
especially SAF `content://` tree URIs, without touching playback, queue, or
adding any new dependency or broad storage permission.

Scanning now goes through a single routing seam. A selection is classified once
(`FolderLocation`) as either a filesystem path or a `content://` URI, then
dispatched: filesystem paths keep using the existing `dart:io` walk, and
content URIs go to a SAF-aware scanner that resolves external-storage tree URIs
to a real path before walking them. Folders selected via SAF are stored as
ordinary file paths, so playback resolution is unchanged. Unscannable
selections surface a clear, typed error in the Library error state.

## Files changed

New (`lib/core/sources/local/`):
- `folder_location.dart` — classifies a raw selection as a filesystem path vs a
  `content://` URI (scheme-based, case-insensitive).
- `saf_tree_uri_resolver.dart` — pure-Dart, `dart:io`-free mapping of an
  Android external-storage tree/document URI to a filesystem path
  (`primary:`, named SD-card volumes, `raw:` absolute paths). Returns `null`
  for providers with no path mapping.
- `folder_scan_exception.dart` — the single typed error the scan layer throws.

Modified:
- `audio_file_scanner.dart` — adds `ContentUriAudioFileScanner` (resolves a URI
  then delegates the walk; throws `FolderScanException` when it can't) and
  `PlatformAudioFileScanner` (the router); `IoAudioFileScanner` is unchanged
  behavior.
- `library_providers.dart` — `audioFileScannerProvider` now defaults to
  `PlatformAudioFileScanner`.
- `README.md` — Android scanning status, permissions notes, limitations, and a
  "Testing scanning on Android" section.

## Android SAF / content URI behavior

- The folder picker can return `content://com.android.externalstorage.documents/tree/primary%3AMusic`.
  `SafTreeUriResolver` maps that to `/storage/emulated/0/Music` (named volumes →
  `/storage/<volume>/…`, `raw:` ids pass through their absolute path), and the
  resolved path is walked by the filesystem scanner.
- Providers without a stable filesystem layout (downloads, media, cloud/document
  providers) resolve to `null`, which becomes a `FolderScanException` shown in
  the Library error state — not a silent empty list.

## Linux/desktop behavior

Unchanged. Desktop selections are filesystem paths, classified as such and sent
straight to `IoAudioFileScanner` exactly as before.

## Permissions / storage notes

- No new dependencies.
- No new permissions requested. **`MANAGE_EXTERNAL_STORAGE` is deliberately not
  used** — it's an "all files access" permission Google restricts on the Play
  Store and runs counter to the scoped-storage approach. The narrow,
  audio-only `READ_MEDIA_AUDIO` is documented as the natural next step but is
  intentionally out of scope here.
- On Android 11+ a resolved path may still be unreadable without a media
  permission; the documented follow-up is content-resolver-based SAF reads.

## Tests added

- `folder_location_test.dart` — path vs content URI classification.
- `saf_tree_uri_resolver_test.dart` — primary/named/`raw:`/document-id
  resolution and `null` for unmappable providers.
- `content_uri_audio_file_scanner_test.dart` — content URI resolved and routed
  to the filesystem walk; unresolvable URI throws `FolderScanException` without
  attempting a walk.
- `platform_audio_file_scanner_test.dart` — routing: filesystem path → fs
  scanner, content URI → Android-capable scanner.
- `library_controller_test.dart` — scan of a content URI is routed and persists
  tracks; an unscannable content URI surfaces a clean error state.

## Known limitations

- No content-resolver-based SAF tree traversal yet (needed for scoped-storage
  cases the path resolver can't reach, and for non-external-storage providers).
- No runtime media permission flow yet.
- No tag/metadata parsing, queue, playlists, downloads, or remote sources.

## Next recommended PR

Queue polish or playlist-editor foundation. Content-resolver SAF scanning and a
narrow `READ_MEDIA_AUDIO` permission flow remain the natural follow-ups.

## Verification

CI runs `flutter pub get`, `dart format --set-exit-if-changed .`,
`flutter analyze`, and `flutter test`. (Flutter tooling isn't available in this
environment, so these were not run locally; the new logic is pure-Dart and
fully unit-tested.)

https://claude.ai/code/session_014B5fQG3kJhfk6yPxNCNcKN

---
_Generated by [Claude Code](https://claude.ai/code/session_014B5fQG3kJhfk6yPxNCNcKN)_