### PR TITLE
Add user-controlled offline cache foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ so scanned tracks survive a restart, while tests keep the in-memory default
 UI is untouched by the swap — it still reads only `LibraryController`/the
 repository abstraction.
 
+**Offline downloads — foundation landed.** The offline-cache lifecycle now
+works end to end behind `DownloadRepository`. `CacheDownloadRepository`
+(`lib/data/repositories/`) owns the policy in one place and tracks each item's
+`DownloadStatus` (`notDownloaded → queued → downloading → downloaded`, plus
+`failed`). Two promises are enforced here, not scattered through the UI:
+**downloads are only ever user-initiated** (nothing downloads automatically),
+and the **"Wi-Fi only" preference is respected** (a request made off Wi-Fi is
+*queued* rather than run). Only the `downloaded` set is durable; the transient
+states live in memory, so a restart never resurrects a half-finished download.
+
+The durable bit — *which* track IDs are cached — sits behind a small
+`DownloadStore` seam, persisted via `shared_preferences` in the app and held
+in memory in tests (same reasoning as the selected-folder store: a list of IDs
+is the wrong weight for the SQLite catalog). The "Wi-Fi only" switch is a
+`DownloadPreferences` seam, also `shared_preferences`-backed. Connectivity is
+read through a `ConnectivityService` seam; until real remote downloads land,
+the default `OptimisticConnectivityService` reports Wi-Fi (there is no network
+fetch to gate yet), and tests inject a fake to drive the mobile/offline paths.
+The UI never touches file paths: the Library row shows a per-track
+download/remove control and status, and the Downloads tab lists cached tracks
+and hosts the "Wi-Fi only" toggle — both talk only to the repository
+abstraction. **No actual bytes are fetched yet** (the only source is local
+files already on disk); the byte-fetch for remote sources slots into one
+private method without the policy changing. See **Offline downloads & known
+limitations** below.
+
 Not built yet (planned, in roughly this order):
 
 - Local music library scanning — *v1 done (scan → persist → list); native
@@ -75,9 +101,12 @@ Not built yet (planned, in roughly this order):
   are now routed and resolved for external storage; tag parsing,
   content-resolver SAF scanning, and a narrow Android media permission still
   pending*
-- Audio playback
+- Audio playback — *done (local playback + up-next queue)*
 - Playlists
-- User-controlled offline downloads
+- User-controlled offline downloads — *foundation done (status lifecycle,
+  mark/remove offline, Wi-Fi-only seam, UI hooks); real remote byte-fetch and a
+  background download manager still pending*
+- Lyrics
 
 Self-hosted sources (Jellyfin, WebDAV, NAS) come after the local MVP is solid.
 
@@ -166,6 +195,10 @@ lib/
   without touching feature code.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
   user-initiated, "Wi-Fi only"-respecting download policy in one place.
+  `CacheDownloadRepository` implements it today over a `DownloadStore`
+  (durable cached-ID set), a `DownloadPreferences` ("Wi-Fi only" switch), and a
+  `ConnectivityService`. Remote (Jellyfin/WebDAV) downloads add a real
+  byte-fetch in `_obtainOfflineCopy` without touching the policy or the UI.
 
 ## Getting started
 
@@ -283,6 +316,41 @@ Deliberate gaps the next PRs will close:
 The next PR is expected to be a playlist-editor foundation or Android SAF
 content-resolver folder scanning; a narrow `READ_MEDIA_AUDIO` permission flow
 remains a natural follow-up to this work.
+
+### Offline downloads & known limitations
+
+**How it works now.** Each Library row shows an offline-download control:
+download an absent track, see a spinner while it's in flight, and remove a
+cached one. The Downloads tab lists everything currently cached and hosts the
+**Wi-Fi only** toggle. All of this flows through `DownloadRepository`, which
+centralizes two guarantees:
+
+- **User-initiated only.** A track's status only ever changes in response to an
+  explicit download/remove action — nothing is fetched automatically or in the
+  background.
+- **Wi-Fi only is respected.** With the toggle on, a request made off Wi-Fi is
+  *queued* instead of run; with it off, downloads proceed on any connection.
+
+`downloaded` is the only durable state (persisted as a set of track IDs via
+`shared_preferences`); `queued`/`downloading`/`failed` are in-memory and reset
+on restart.
+
+Deliberate gaps the next PRs will close:
+
+- **No real downloads yet.** The only source is local files already on disk, so
+  "downloading" just records the track as offline-available. Fetching bytes from
+  a remote source (Jellyfin/WebDAV) is the follow-up; it slots into
+  `CacheDownloadRepository._obtainOfflineCopy` without changing the policy.
+- **No background download manager.** Downloads run inline in response to the
+  tap; there is no worker, no Android download/notification service, and no
+  auto-flush of the queue when Wi-Fi returns (re-tap a queued track to retry).
+- **Connectivity is optimistic.** `OptimisticConnectivityService` always reports
+  Wi-Fi until `connectivity_plus` is wired alongside real remote downloads, so
+  the "Wi-Fi only" gate has nothing to block in the current local-only build —
+  the seam and its tests are in place for when it does.
+- **No Drift table for downloads.** Persisting a flat ID set is a key/value job;
+  a `downloads` table (with file paths and byte progress) graduates from the
+  `DownloadStore` seam when real downloads need it.
 
 ## Continuous integration
 

--- a/lib/core/repositories/download_preferences.dart
+++ b/lib/core/repositories/download_preferences.dart
@@ -1,0 +1,12 @@
+/// The user's download preferences.
+///
+/// Right now this is just the "Wi-Fi only" switch, kept behind an interface so
+/// the [DownloadRepository] can consult it without binding to a storage plugin.
+/// When set, downloads that would run over mobile data are queued instead of
+/// started — the policy lives in the repository, this only remembers the choice.
+abstract interface class DownloadPreferences {
+  /// Whether downloads should only run on Wi-Fi. Defaults to `false`.
+  Future<bool> wifiOnly();
+
+  Future<void> setWifiOnly(bool value);
+}

--- a/lib/core/repositories/download_store.dart
+++ b/lib/core/repositories/download_store.dart
@@ -1,0 +1,16 @@
+/// Durable storage for the set of track IDs that are available offline.
+///
+/// This is the *persistence seam* under [DownloadRepository]: it knows nothing
+/// about download policy, connectivity, or the transient queued/downloading
+/// states — only which tracks are fully cached on disk and survive a restart.
+/// Splitting it out keeps the download lifecycle (policy) in one place while
+/// letting the backing store swap freely (in-memory for tests, key/value in the
+/// app, a SQLite/Drift table once real remote downloads track file paths and
+/// byte progress).
+abstract interface class DownloadStore {
+  /// The track IDs currently cached for offline use.
+  Future<Set<String>> loadDownloadedIds();
+
+  /// Replaces the persisted set with [ids].
+  Future<void> saveDownloadedIds(Set<String> ids);
+}

--- a/lib/core/services/optimistic_connectivity_service.dart
+++ b/lib/core/services/optimistic_connectivity_service.dart
@@ -1,0 +1,21 @@
+import 'connectivity_service.dart';
+
+/// A placeholder [ConnectivityService] that always reports Wi-Fi.
+///
+/// There is no network detection plugin yet (and nothing downloads over the
+/// network — the offline cache foundation only marks already-local tracks). The
+/// real implementation, backed by `connectivity_plus`, lands alongside remote
+/// (Jellyfin/WebDAV) downloads, where the "Wi-Fi only" gate actually has data
+/// to guard. Until then this keeps the seam wired and the default app behaving
+/// as "connected", while tests inject a fake to exercise the mobile/offline
+/// branches of the download policy.
+class OptimisticConnectivityService implements ConnectivityService {
+  const OptimisticConnectivityService();
+
+  @override
+  Stream<NetworkStatus> get statusStream =>
+      Stream<NetworkStatus>.value(NetworkStatus.wifi);
+
+  @override
+  Future<NetworkStatus> currentStatus() async => NetworkStatus.wifi;
+}

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import '../../core/repositories/download_preferences.dart';
+import '../../core/repositories/download_repository.dart';
+import '../../core/repositories/download_store.dart';
+import '../../core/services/connectivity_service.dart';
+
+/// The app's [DownloadRepository]: it owns the offline-cache *policy* in one
+/// place and delegates only the durable bit (which IDs are cached) to a
+/// [DownloadStore].
+///
+/// Two promises are enforced here so they can't be skipped by a caller:
+///  - **User-initiated only.** Nothing is ever downloaded automatically; status
+///    changes happen solely in response to [requestDownload] / [removeDownload].
+///  - **Wi-Fi only is respected.** When the user has set [DownloadPreferences.
+///    wifiOnly] and the connection isn't Wi-Fi, a request is *queued* rather
+///    than run, instead of silently going over mobile data.
+///
+/// Only the `downloaded` state is durable; `queued`/`downloading`/`failed` are
+/// transient and live in memory, so a restart never resurrects a half-finished
+/// download (there is no background worker yet — see README).
+///
+/// "Downloading" is trivial today because the only source is local files that
+/// are already on disk, so marking a track offline just records it. The real
+/// byte-fetch for remote sources slots in at [_obtainOfflineCopy] without
+/// touching the policy above.
+class CacheDownloadRepository implements DownloadRepository {
+  CacheDownloadRepository({
+    required DownloadStore store,
+    required ConnectivityService connectivity,
+    required DownloadPreferences preferences,
+  })  : _store = store,
+        _connectivity = connectivity,
+        _preferences = preferences;
+
+  final DownloadStore _store;
+  final ConnectivityService _connectivity;
+  final DownloadPreferences _preferences;
+
+  final Map<String, DownloadStatus> _statuses = <String, DownloadStatus>{};
+  final StreamController<Map<String, DownloadStatus>> _changes =
+      StreamController<Map<String, DownloadStatus>>.broadcast();
+
+  bool _loaded = false;
+
+  /// Seeds the in-memory status map from the durable set of cached IDs, once.
+  Future<void> _ensureLoaded() async {
+    if (_loaded) return;
+    for (final String id in await _store.loadDownloadedIds()) {
+      _statuses[id] = DownloadStatus.downloaded;
+    }
+    _loaded = true;
+  }
+
+  @override
+  Stream<Map<String, DownloadStatus>> get statusStream async* {
+    // Seed each listener with the current snapshot so the UI can render a
+    // correct first frame, then forward live changes.
+    await _ensureLoaded();
+    yield _snapshot();
+    yield* _changes.stream;
+  }
+
+  @override
+  Future<DownloadStatus> statusFor(String trackId) async {
+    await _ensureLoaded();
+    return _statuses[trackId] ?? DownloadStatus.notDownloaded;
+  }
+
+  @override
+  Future<void> requestDownload(String trackId) async {
+    await _ensureLoaded();
+    final DownloadStatus current =
+        _statuses[trackId] ?? DownloadStatus.notDownloaded;
+    // Already done or in flight — never re-trigger. A queued or failed track,
+    // by contrast, is fair game for an explicit retry.
+    if (current == DownloadStatus.downloaded ||
+        current == DownloadStatus.downloading) {
+      return;
+    }
+
+    if (!await _allowedToDownloadNow()) {
+      _set(trackId, DownloadStatus.queued);
+      return;
+    }
+
+    _set(trackId, DownloadStatus.downloading);
+    try {
+      await _obtainOfflineCopy(trackId);
+      await _persistDownloaded(trackId);
+      _set(trackId, DownloadStatus.downloaded);
+    } catch (_) {
+      _set(trackId, DownloadStatus.failed);
+    }
+  }
+
+  @override
+  Future<void> removeDownload(String trackId) async {
+    await _ensureLoaded();
+    final Set<String> ids = await _store.loadDownloadedIds();
+    ids.remove(trackId);
+    await _store.saveDownloadedIds(ids);
+    // Also clears a queued/failed/downloading marker, so this doubles as cancel.
+    _set(trackId, DownloadStatus.notDownloaded);
+  }
+
+  @override
+  Future<List<String>> downloadedTrackIds() async {
+    await _ensureLoaded();
+    return _statuses.entries
+        .where((e) => e.value == DownloadStatus.downloaded)
+        .map((e) => e.key)
+        .toList();
+  }
+
+  /// Releases the change stream. Call when the owning provider is disposed.
+  Future<void> dispose() => _changes.close();
+
+  /// The connectivity gate. With "Wi-Fi only" off, anything goes; with it on,
+  /// only a Wi-Fi connection clears a download to start now.
+  Future<bool> _allowedToDownloadNow() async {
+    if (!await _preferences.wifiOnly()) return true;
+    return await _connectivity.currentStatus() == NetworkStatus.wifi;
+  }
+
+  /// Fetches/produces the offline copy for [trackId]. A no-op for local files
+  /// (the bytes are already on disk); the extension point for remote sources.
+  Future<void> _obtainOfflineCopy(String trackId) async {}
+
+  Future<void> _persistDownloaded(String trackId) async {
+    final Set<String> ids = await _store.loadDownloadedIds();
+    ids.add(trackId);
+    await _store.saveDownloadedIds(ids);
+  }
+
+  void _set(String trackId, DownloadStatus status) {
+    if (status == DownloadStatus.notDownloaded) {
+      _statuses.remove(trackId);
+    } else {
+      _statuses[trackId] = status;
+    }
+    _changes.add(_snapshot());
+  }
+
+  Map<String, DownloadStatus> _snapshot() =>
+      Map<String, DownloadStatus>.unmodifiable(_statuses);
+}

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/download_preferences.dart';
+import '../../core/repositories/download_repository.dart';
+import '../../core/repositories/download_store.dart';
+import '../../core/services/connectivity_service.dart';
+import '../../core/services/optimistic_connectivity_service.dart';
+import 'cache_download_repository.dart';
+import 'in_memory_download_preferences.dart';
+import 'in_memory_download_store.dart';
+import 'shared_preferences_download_preferences.dart';
+import 'shared_preferences_download_store.dart';
+
+/// Durable store of which track IDs are cached offline. Defaults to in-memory
+/// so tests and dev runs need no plugins; the app overrides it with the
+/// `shared_preferences` binding below.
+final downloadStoreProvider = Provider<DownloadStore>((ref) {
+  return InMemoryDownloadStore();
+});
+
+/// The user's "Wi-Fi only" download preference. In-memory by default; the app
+/// persists it via `shared_preferences`.
+final downloadPreferencesProvider = Provider<DownloadPreferences>((ref) {
+  return InMemoryDownloadPreferences();
+});
+
+/// Network reachability used to honor the "Wi-Fi only" preference. The default
+/// optimistically reports Wi-Fi until real detection lands with remote
+/// downloads; tests inject a fake to drive the policy's mobile/offline paths.
+final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
+  return const OptimisticConnectivityService();
+});
+
+/// The single [DownloadRepository] the app drives offline downloads through.
+/// It composes the three seams above and centralizes the user-initiated,
+/// Wi-Fi-respecting cache policy.
+final downloadRepositoryProvider = Provider<DownloadRepository>((ref) {
+  final repository = CacheDownloadRepository(
+    store: ref.watch(downloadStoreProvider),
+    connectivity: ref.watch(connectivityServiceProvider),
+    preferences: ref.watch(downloadPreferencesProvider),
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+});
+
+/// Production bindings: persist the cached-ID set and the Wi-Fi-only switch via
+/// `shared_preferences` so both survive a restart. Applied in `main`; tests
+/// keep the in-memory defaults.
+final sharedPreferencesDownloadStoreOverride =
+    downloadStoreProvider.overrideWithValue(
+  const SharedPreferencesDownloadStore(),
+);
+
+final sharedPreferencesDownloadPreferencesOverride =
+    downloadPreferencesProvider.overrideWithValue(
+  const SharedPreferencesDownloadPreferences(),
+);

--- a/lib/data/repositories/in_memory_download_preferences.dart
+++ b/lib/data/repositories/in_memory_download_preferences.dart
@@ -1,0 +1,16 @@
+import '../../core/repositories/download_preferences.dart';
+
+/// A non-persistent [DownloadPreferences] for development and tests.
+class InMemoryDownloadPreferences implements DownloadPreferences {
+  InMemoryDownloadPreferences({bool wifiOnly = false}) : _wifiOnly = wifiOnly;
+
+  bool _wifiOnly;
+
+  @override
+  Future<bool> wifiOnly() async => _wifiOnly;
+
+  @override
+  Future<void> setWifiOnly(bool value) async {
+    _wifiOnly = value;
+  }
+}

--- a/lib/data/repositories/in_memory_download_store.dart
+++ b/lib/data/repositories/in_memory_download_store.dart
@@ -1,0 +1,23 @@
+import '../../core/repositories/download_store.dart';
+
+/// A non-persistent [DownloadStore] for development and tests.
+///
+/// Keeps the cached IDs in a plain set, so they're forgotten when the instance
+/// is dropped. Default binding (mirroring the other in-memory repositories);
+/// the running app swaps in the `shared_preferences` implementation.
+class InMemoryDownloadStore implements DownloadStore {
+  InMemoryDownloadStore({Set<String>? initialIds})
+      : _ids = <String>{...?initialIds};
+
+  final Set<String> _ids;
+
+  @override
+  Future<Set<String>> loadDownloadedIds() async => <String>{..._ids};
+
+  @override
+  Future<void> saveDownloadedIds(Set<String> ids) async {
+    _ids
+      ..clear()
+      ..addAll(ids);
+  }
+}

--- a/lib/data/repositories/shared_preferences_download_preferences.dart
+++ b/lib/data/repositories/shared_preferences_download_preferences.dart
@@ -1,0 +1,24 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/download_preferences.dart';
+
+/// A [DownloadPreferences] backed by `shared_preferences`. The "Wi-Fi only"
+/// switch is a single bool, so it lives next to the other small user choices in
+/// the key/value store rather than in the SQLite catalog.
+class SharedPreferencesDownloadPreferences implements DownloadPreferences {
+  const SharedPreferencesDownloadPreferences();
+
+  static const String _key = 'downloads_wifi_only';
+
+  @override
+  Future<bool> wifiOnly() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key) ?? false;
+  }
+
+  @override
+  Future<void> setWifiOnly(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, value);
+  }
+}

--- a/lib/data/repositories/shared_preferences_download_store.dart
+++ b/lib/data/repositories/shared_preferences_download_store.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/download_store.dart';
+
+/// A [DownloadStore] backed by `shared_preferences`.
+///
+/// The durable part of the offline cache is just a list of track IDs, so a
+/// key/value store is the right weight here — the same reasoning the selected
+/// music folder follows. When real remote downloads need per-track file paths
+/// and byte progress, this is the seam that graduates to a Drift/SQLite table
+/// without the policy in [CacheDownloadRepository] changing.
+class SharedPreferencesDownloadStore implements DownloadStore {
+  const SharedPreferencesDownloadStore();
+
+  static const String _key = 'downloaded_track_ids';
+
+  @override
+  Future<Set<String>> loadDownloadedIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    return (prefs.getStringList(_key) ?? const <String>[]).toSet();
+  }
+
+  @override
+  Future<void> saveDownloadedIds(Set<String> ids) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, ids.toList());
+  }
+}

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/track.dart';
+import '../../core/repositories/download_repository.dart';
+import '../../data/repositories/download_repository_provider.dart';
+import '../../data/repositories/music_library_repository_provider.dart';
+
+/// The live download status of a single track, for the Library row indicator.
+/// Defaults to [DownloadStatus.notDownloaded] until the repository reports
+/// otherwise. Auto-disposed so off-screen rows drop their subscription.
+final trackDownloadStatusProvider =
+    StreamProvider.autoDispose.family<DownloadStatus, String>((ref, trackId) {
+  final repository = ref.watch(downloadRepositoryProvider);
+  return repository.statusStream
+      .map((statuses) => statuses[trackId] ?? DownloadStatus.notDownloaded)
+      .distinct();
+});
+
+/// The catalog tracks that are fully available offline, recomputed whenever the
+/// download status map changes. Powers the Downloads screen list.
+final downloadedTracksProvider = StreamProvider<List<Track>>((ref) async* {
+  final repository = ref.watch(downloadRepositoryProvider);
+  final library = ref.watch(musicLibraryRepositoryProvider);
+  await for (final statuses in repository.statusStream) {
+    final downloadedIds = statuses.entries
+        .where((e) => e.value == DownloadStatus.downloaded)
+        .map((e) => e.key)
+        .toSet();
+    final tracks = await library.getAllTracks();
+    yield tracks.where((t) => downloadedIds.contains(t.id)).toList();
+  }
+});
+
+/// Owns the "Wi-Fi only downloads" switch: loads the persisted value and writes
+/// changes back through [DownloadPreferences].
+class WifiOnlyController extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() {
+    return ref.read(downloadPreferencesProvider).wifiOnly();
+  }
+
+  Future<void> setWifiOnly(bool value) async {
+    await ref.read(downloadPreferencesProvider).setWifiOnly(value);
+    state = AsyncData<bool>(value);
+  }
+}
+
+final wifiOnlyControllerProvider =
+    AsyncNotifierProvider<WifiOnlyController, bool>(WifiOnlyController.new);

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -22,22 +22,26 @@ class DownloadsScreen extends ConsumerWidget {
         children: [
           const _WifiOnlyToggle(),
           const Divider(height: 1),
-          Expanded(
-            child: downloaded.when(
-              loading: () =>
-                  const Center(child: CircularProgressIndicator()),
-              error: (error, _) => Center(child: Text('$error')),
-              data: (tracks) => tracks.isEmpty
-                  ? const EmptyState(
-                      icon: Icons.download_outlined,
-                      title: 'Nothing downloaded',
-                      message: 'Downloads you start will appear here.',
-                    )
-                  : _DownloadedList(tracks: tracks),
-            ),
-          ),
+          Expanded(child: _list(downloaded)),
         ],
       ),
+    );
+  }
+
+  Widget _list(AsyncValue<List<Track>> downloaded) {
+    return downloaded.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('$error')),
+      data: (tracks) {
+        if (tracks.isEmpty) {
+          return const EmptyState(
+            icon: Icons.download_outlined,
+            title: 'Nothing downloaded',
+            message: 'Downloads you start will appear here.',
+          );
+        }
+        return _DownloadedList(tracks: tracks);
+      },
     );
   }
 }
@@ -53,12 +57,12 @@ class _WifiOnlyToggle extends ConsumerWidget {
       title: const Text('Wi-Fi only'),
       subtitle: const Text('Queue downloads until Wi-Fi is available'),
       value: wifiOnly.valueOrNull ?? false,
-      onChanged: wifiOnly.isLoading
-          ? null
-          : (value) => ref
-              .read(wifiOnlyControllerProvider.notifier)
-              .setWifiOnly(value),
+      onChanged: wifiOnly.isLoading ? null : (value) => _set(ref, value),
     );
+  }
+
+  void _set(WidgetRef ref, bool value) {
+    ref.read(wifiOnlyControllerProvider.notifier).setWifiOnly(value);
   }
 }
 
@@ -80,13 +84,7 @@ class _DownloadedList extends ConsumerWidget {
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
-          subtitle: track.artistName == null || track.artistName!.isEmpty
-              ? null
-              : Text(
-                  track.artistName!,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
+          subtitle: _subtitle(track),
           trailing: IconButton(
             icon: const Icon(Icons.delete_outline),
             tooltip: 'Remove download',
@@ -97,5 +95,11 @@ class _DownloadedList extends ConsumerWidget {
         );
       },
     );
+  }
+
+  static Widget? _subtitle(Track track) {
+    final artist = track.artistName;
+    if (artist == null || artist.isEmpty) return null;
+    return Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis);
   }
 }

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -1,21 +1,101 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../app/dimens.dart';
+import '../../core/models/track.dart';
+import '../../data/repositories/download_repository_provider.dart';
 import '../../shared/widgets/empty_state.dart';
+import 'download_providers.dart';
 
-/// Manage explicit, user-controlled downloads. Placeholder until the downloads
-/// feature lands. Downloads are always user-initiated — never automatic.
-class DownloadsScreen extends StatelessWidget {
+/// Manage explicit, user-controlled downloads. Lists the tracks the user has
+/// marked for offline use and exposes the "Wi-Fi only" preference. Downloads
+/// are always user-initiated — never automatic.
+class DownloadsScreen extends ConsumerWidget {
   const DownloadsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final downloaded = ref.watch(downloadedTracksProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('Downloads')),
-      body: const EmptyState(
-        icon: Icons.download_outlined,
-        title: 'Nothing downloaded',
-        message: 'Downloads you start will appear here.',
+      body: Column(
+        children: [
+          const _WifiOnlyToggle(),
+          const Divider(height: 1),
+          Expanded(
+            child: downloaded.when(
+              loading: () =>
+                  const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Center(child: Text('$error')),
+              data: (tracks) => tracks.isEmpty
+                  ? const EmptyState(
+                      icon: Icons.download_outlined,
+                      title: 'Nothing downloaded',
+                      message: 'Downloads you start will appear here.',
+                    )
+                  : _DownloadedList(tracks: tracks),
+            ),
+          ),
+        ],
       ),
+    );
+  }
+}
+
+class _WifiOnlyToggle extends ConsumerWidget {
+  const _WifiOnlyToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final wifiOnly = ref.watch(wifiOnlyControllerProvider);
+    return SwitchListTile(
+      secondary: const Icon(Icons.wifi_outlined),
+      title: const Text('Wi-Fi only'),
+      subtitle: const Text('Queue downloads until Wi-Fi is available'),
+      value: wifiOnly.valueOrNull ?? false,
+      onChanged: wifiOnly.isLoading
+          ? null
+          : (value) => ref
+              .read(wifiOnlyControllerProvider.notifier)
+              .setWifiOnly(value),
+    );
+  }
+}
+
+class _DownloadedList extends ConsumerWidget {
+  const _DownloadedList({required this.tracks});
+
+  final List<Track> tracks;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView.builder(
+      itemCount: tracks.length,
+      itemBuilder: (context, index) {
+        final track = tracks[index];
+        return ListTile(
+          leading: const Icon(Icons.music_note_outlined),
+          title: Text(
+            track.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          subtitle: track.artistName == null || track.artistName!.isEmpty
+              ? null
+              : Text(
+                  track.artistName!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+          trailing: IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Remove download',
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            onPressed: () =>
+                ref.read(downloadRepositoryProvider).removeDownload(track.id),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -5,6 +5,9 @@ import 'package:go_router/go_router.dart';
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/download_repository.dart';
+import '../../data/repositories/download_repository_provider.dart';
+import '../downloads/download_providers.dart';
 import '../player/player_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
@@ -108,6 +111,7 @@ class _TrackTile extends ConsumerWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
+      trailing: _DownloadAction(trackId: track.id),
       // Play the tapped track and queue the rest of the list behind it, then
       // surface the now-playing screen.
       onTap: () {
@@ -128,6 +132,62 @@ class _TrackTile extends ConsumerWidget {
         track.albumName!,
     ];
     return parts.isEmpty ? track.uri : parts.join(' • ');
+  }
+}
+
+/// The per-row offline-download control. Reflects the track's [DownloadStatus]
+/// and offers the matching user-initiated action — download when absent, remove
+/// when cached. Progress states (queued/downloading) show as non-interactive
+/// indicators; nothing here ever starts a download on its own.
+class _DownloadAction extends ConsumerWidget {
+  const _DownloadAction({required this.trackId});
+
+  final String trackId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncStatus = ref.watch(trackDownloadStatusProvider(trackId));
+    final status = asyncStatus.valueOrNull ?? DownloadStatus.notDownloaded;
+    final repository = ref.read(downloadRepositoryProvider);
+    final theme = Theme.of(context);
+
+    switch (status) {
+      case DownloadStatus.notDownloaded:
+        return IconButton(
+          icon: const Icon(Icons.download_outlined),
+          tooltip: 'Download',
+          onPressed: () => repository.requestDownload(trackId),
+        );
+      case DownloadStatus.queued:
+        return IconButton(
+          icon: const Icon(Icons.schedule_outlined),
+          tooltip: 'Queued',
+          onPressed: () => repository.removeDownload(trackId),
+        );
+      case DownloadStatus.downloading:
+        return const SizedBox.square(
+          dimension: 24,
+          child: Padding(
+            padding: EdgeInsets.all(AppSpacing.xs),
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        );
+      case DownloadStatus.downloaded:
+        return IconButton(
+          icon: Icon(
+            Icons.download_done_outlined,
+            color: theme.colorScheme.primary,
+          ),
+          tooltip: 'Remove download',
+          onPressed: () => repository.removeDownload(trackId),
+        );
+      case DownloadStatus.failed:
+        return IconButton(
+          icon: Icon(Icons.error_outline, color: theme.colorScheme.error),
+          tooltip: 'Retry download',
+          onPressed: () => repository.requestDownload(trackId),
+        );
+    }
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,19 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/sonara_app.dart';
+import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 
 void main() {
   // ProviderScope hosts all Riverpod state for the app. The running app
   // persists its catalog to SQLite via the Drift override and the chosen music
-  // folder via shared_preferences; tests keep the in-memory defaults unless
-  // they opt into these bindings.
+  // folder, offline-download set, and Wi-Fi-only preference via
+  // shared_preferences; tests keep the in-memory defaults unless they opt into
+  // these bindings.
   runApp(
     ProviderScope(
       overrides: [
         driftMusicLibraryRepositoryOverride,
         sharedPreferencesSelectedMusicFolderRepositoryOverride,
+        sharedPreferencesDownloadStoreOverride,
+        sharedPreferencesDownloadPreferencesOverride,
       ],
       child: const SonaraApp(),
     ),

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -24,11 +24,13 @@ void main() {
     late InMemoryDownloadPreferences preferences;
     late _FakeConnectivity connectivity;
 
-    CacheDownloadRepository build() => CacheDownloadRepository(
-          store: store,
-          connectivity: connectivity,
-          preferences: preferences,
-        );
+    CacheDownloadRepository build() {
+      return CacheDownloadRepository(
+        store: store,
+        connectivity: connectivity,
+        preferences: preferences,
+      );
+    }
 
     setUp(() {
       store = InMemoryDownloadStore();

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/repositories/download_repository.dart';
+import 'package:sonara/core/services/connectivity_service.dart';
+import 'package:sonara/data/repositories/cache_download_repository.dart';
+import 'package:sonara/data/repositories/in_memory_download_preferences.dart';
+import 'package:sonara/data/repositories/in_memory_download_store.dart';
+
+/// A connectivity stand-in whose reported status the test can flip at will.
+class _FakeConnectivity implements ConnectivityService {
+  _FakeConnectivity(this.status);
+
+  NetworkStatus status;
+
+  @override
+  Stream<NetworkStatus> get statusStream => Stream<NetworkStatus>.value(status);
+
+  @override
+  Future<NetworkStatus> currentStatus() async => status;
+}
+
+void main() {
+  group('CacheDownloadRepository', () {
+    late InMemoryDownloadStore store;
+    late InMemoryDownloadPreferences preferences;
+    late _FakeConnectivity connectivity;
+
+    CacheDownloadRepository build() => CacheDownloadRepository(
+          store: store,
+          connectivity: connectivity,
+          preferences: preferences,
+        );
+
+    setUp(() {
+      store = InMemoryDownloadStore();
+      preferences = InMemoryDownloadPreferences();
+      connectivity = _FakeConnectivity(NetworkStatus.wifi);
+    });
+
+    test('tracks start not downloaded', () async {
+      final repository = build();
+      expect(await repository.statusFor('a'), DownloadStatus.notDownloaded);
+      expect(await repository.downloadedTrackIds(), isEmpty);
+    });
+
+    test('requestDownload marks a track downloaded and persists it', () async {
+      final repository = build();
+
+      await repository.requestDownload('a');
+
+      expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+      expect(await repository.downloadedTrackIds(), <String>['a']);
+      expect(await store.loadDownloadedIds(), <String>{'a'});
+    });
+
+    test('removeDownload reverts status and clears persistence', () async {
+      final repository = build();
+      await repository.requestDownload('a');
+
+      await repository.removeDownload('a');
+
+      expect(await repository.statusFor('a'), DownloadStatus.notDownloaded);
+      expect(await repository.downloadedTrackIds(), isEmpty);
+      expect(await store.loadDownloadedIds(), isEmpty);
+    });
+
+    test('downloaded IDs are reloaded from the store by a fresh repository',
+        () async {
+      await build().requestDownload('a');
+
+      // A new repository over the same store reflects the persisted state.
+      final reopened = build();
+      expect(await reopened.statusFor('a'), DownloadStatus.downloaded);
+      expect(await reopened.downloadedTrackIds(), <String>['a']);
+    });
+
+    test('statusStream seeds the current snapshot then emits changes',
+        () async {
+      await build().requestDownload('a');
+      final repository = build();
+
+      final emissions = <Map<String, DownloadStatus>>[];
+      final sub = repository.statusStream.listen(emissions.add);
+      await _settle();
+
+      // Seeded with the persisted snapshot.
+      expect(emissions.first, <String, DownloadStatus>{
+        'a': DownloadStatus.downloaded,
+      });
+
+      await repository.requestDownload('b');
+      await _settle();
+
+      expect(emissions.last['b'], DownloadStatus.downloaded);
+      await sub.cancel();
+    });
+
+    test('a downloaded track is not re-downloaded', () async {
+      final repository = build();
+      await repository.requestDownload('a');
+
+      final emissions = <Map<String, DownloadStatus>>[];
+      final sub = repository.statusStream.listen(emissions.add);
+      await _settle();
+      emissions.clear();
+
+      await repository.requestDownload('a');
+      await _settle();
+
+      // No further status changes were emitted.
+      expect(emissions, isEmpty);
+      await sub.cancel();
+    });
+
+    group('Wi-Fi only policy', () {
+      test('queues instead of downloading when on mobile', () async {
+        await preferences.setWifiOnly(true);
+        connectivity.status = NetworkStatus.mobile;
+        final repository = build();
+
+        await repository.requestDownload('a');
+
+        expect(await repository.statusFor('a'), DownloadStatus.queued);
+        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await store.loadDownloadedIds(), isEmpty);
+      });
+
+      test('downloads when on Wi-Fi', () async {
+        await preferences.setWifiOnly(true);
+        connectivity.status = NetworkStatus.wifi;
+        final repository = build();
+
+        await repository.requestDownload('a');
+
+        expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+      });
+
+      test('downloads over mobile when the preference is off', () async {
+        await preferences.setWifiOnly(false);
+        connectivity.status = NetworkStatus.mobile;
+        final repository = build();
+
+        await repository.requestDownload('a');
+
+        expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+      });
+
+      test('a queued track downloads on an explicit retry once on Wi-Fi',
+          () async {
+        await preferences.setWifiOnly(true);
+        connectivity.status = NetworkStatus.mobile;
+        final repository = build();
+        await repository.requestDownload('a');
+        expect(await repository.statusFor('a'), DownloadStatus.queued);
+
+        connectivity.status = NetworkStatus.wifi;
+        await repository.requestDownload('a');
+
+        expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+      });
+    });
+  });
+}
+
+/// Lets the broadcast stream deliver any pending events.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);

--- a/test/data/repositories/in_memory_download_store_test.dart
+++ b/test/data/repositories/in_memory_download_store_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/data/repositories/in_memory_download_store.dart';
+
+void main() {
+  group('InMemoryDownloadStore', () {
+    test('starts empty', () async {
+      expect(await InMemoryDownloadStore().loadDownloadedIds(), isEmpty);
+    });
+
+    test('seeds from initial IDs', () async {
+      final store = InMemoryDownloadStore(initialIds: <String>{'a', 'b'});
+      expect(await store.loadDownloadedIds(), <String>{'a', 'b'});
+    });
+
+    test('save replaces the stored set', () async {
+      final store = InMemoryDownloadStore(initialIds: <String>{'a'});
+      await store.saveDownloadedIds(<String>{'b', 'c'});
+      expect(await store.loadDownloadedIds(), <String>{'b', 'c'});
+    });
+
+    test('load returns a copy that callers cannot mutate', () async {
+      final store = InMemoryDownloadStore(initialIds: <String>{'a'});
+      (await store.loadDownloadedIds()).add('rogue');
+      expect(await store.loadDownloadedIds(), <String>{'a'});
+    });
+  });
+}

--- a/test/features/downloads/download_action_test.dart
+++ b/test/features/downloads/download_action_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/data/repositories/music_library_repository_provider.dart';
+import 'package:sonara/features/library/library_screen.dart';
+
+import '../library/fake_music_library_repository.dart';
+
+void main() {
+  group('Library download action', () {
+    Future<void> pump(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          // Default download providers are plugin-free (in-memory store +
+          // optimistic connectivity), so the row action works without overrides.
+          overrides: [
+            musicLibraryRepositoryProvider.overrideWithValue(
+              FakeMusicLibraryRepository(
+                tracks: const <Track>[
+                  Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+                ],
+              ),
+            ),
+          ],
+          child: const MaterialApp(home: LibraryScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a not-downloaded row offers a download action', (
+      tester,
+    ) async {
+      await pump(tester);
+      expect(find.byTooltip('Download'), findsOneWidget);
+      expect(find.byTooltip('Remove download'), findsNothing);
+    });
+
+    testWidgets('downloading then removing toggles the row action', (
+      tester,
+    ) async {
+      await pump(tester);
+
+      await tester.tap(find.byTooltip('Download'));
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('Remove download'), findsOneWidget);
+      expect(find.byTooltip('Download'), findsNothing);
+
+      await tester.tap(find.byTooltip('Remove download'));
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('Download'), findsOneWidget);
+      expect(find.byTooltip('Remove download'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First offline-cache / user-controlled downloads foundation. The download
lifecycle now works end to end behind the existing `DownloadRepository`
interface, with all policy centralized in one place. **No remote downloads, no
Jellyfin/WebDAV, no automatic downloads, and no background worker** — strictly
the foundation.

## Files changed

**New — core seams (`lib/core/`)**
- `repositories/download_store.dart` — durable "which IDs are cached" seam.
- `repositories/download_preferences.dart` — "Wi-Fi only" switch seam.
- `services/optimistic_connectivity_service.dart` — placeholder `ConnectivityService` (reports Wi-Fi until `connectivity_plus` lands with real downloads).

**New — implementations (`lib/data/repositories/`)**
- `cache_download_repository.dart` — the policy owner (status lifecycle, user-initiated-only, Wi-Fi-only gate).
- `in_memory_download_store.dart` / `shared_preferences_download_store.dart`
- `in_memory_download_preferences.dart` / `shared_preferences_download_preferences.dart`
- `download_repository_provider.dart` — providers + production `shared_preferences` overrides.

**New — feature wiring (`lib/features/downloads/`)**
- `download_providers.dart` — per-track status stream, downloaded-tracks list, Wi-Fi-only controller.

**Modified**
- `features/library/library_screen.dart` — per-row download/remove control + status indicator.
- `features/downloads/downloads_screen.dart` — lists cached tracks, hosts the Wi-Fi-only toggle.
- `main.dart` — applies the `shared_preferences` download bindings.
- `README.md` — offline-downloads status, behavior, and limitations.

## Offline cache behavior

- Per-track `DownloadStatus`: `notDownloaded → queued → downloading → downloaded`, plus `failed`.
- Cache management through `DownloadRepository`: `requestDownload`, `removeDownload` (doubles as cancel), `downloadedTrackIds`, `statusFor`, `statusStream`.
- **User-initiated only** — status changes happen solely in response to explicit actions; nothing downloads automatically.
- **Wi-Fi only respected** — with the preference on, a request made off Wi-Fi is *queued* rather than run; re-tap a queued track to retry.
- Only `downloaded` is durable (a persisted set of track IDs); transient states live in memory and reset on restart.
- The UI never touches file paths — it talks only to the repository abstraction.

## Database / schema changes

None. The durable part is a flat set of track IDs, persisted via
`shared_preferences` (same weight reasoning as the selected-folder store), so
no Drift table or schema bump. A `downloads` table (file paths, byte progress)
graduates from the `DownloadStore` seam when real remote downloads need it — no
`*.g.dart` regeneration required for this PR.

## Limitations (deliberate, documented in README)

- No real byte-fetch — the only source is local files already on disk, so "downloading" just records the track as offline-available. Remote fetch slots into `CacheDownloadRepository._obtainOfflineCopy` without changing the policy.
- No background download manager / Android download/notification service; no auto-flush of the queue when Wi-Fi returns.
- `ConnectivityService` is optimistic (always Wi-Fi) until `connectivity_plus` is wired with real downloads.
- No Jellyfin/WebDAV.

## Tests added

- `test/data/repositories/cache_download_repository_test.dart` — status lifecycle, persistence + reload, `statusStream` seeding/changes, no-re-download, and the full Wi-Fi-only policy matrix (queue on mobile, download on Wi-Fi, download when pref off, retry once on Wi-Fi).
- `test/data/repositories/in_memory_download_store_test.dart` — store load/save/copy semantics.
- `test/features/downloads/download_action_test.dart` — Library row download/remove toggling.

## Verification

CI runs the project's standard checks (`flutter pub get`, `dart format
--set-exit-if-changed .`, `flutter analyze`, `flutter test`). Flutter tooling
isn't available in this environment, so these run in CI.

## Next recommended PR

Lyrics foundation.

https://claude.ai/code/session_015yr79UZmKvx5vVWVXEQnWD

---
_Generated by [Claude Code](https://claude.ai/code/session_015yr79UZmKvx5vVWVXEQnWD)_