### PR TITLE
Add background audio / Android Auto media session foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Not built yet (planned, in roughly this order):
   are now routed and resolved for external storage; tag parsing,
   content-resolver SAF scanning, and a narrow Android media permission still
   pending*
-- Audio playback — *done (local playback + up-next queue)*
+- Audio playback — *done (local playback + up-next queue); background playback
+  + media session foundation via `audio_service` now wired (Android Auto
+  readiness, not yet a full car UI)*
 - Playlists
 - User-controlled offline downloads — *foundation done (status lifecycle,
   mark/remove offline, Wi-Fi-only seam, UI hooks); real remote byte-fetch and a
@@ -138,9 +140,10 @@ Dependencies are added when a feature needs them rather than up front, so
 `pubspec.yaml` stays honest about what the code actually uses. Today that's
 `flutter_riverpod`, `go_router`, `path` (for the local file scanner),
 `drift` + `sqlite3_flutter_libs` + `path_provider` for SQLite persistence,
-`just_audio` for playback, `file_picker` for the native folder chooser, and
-`shared_preferences` for remembering the selected folder (`drift_dev` +
-`build_runner` are dev-only, for code generation).
+`just_audio` for playback, `audio_service` for the background media session
+(notification / lock screen / Android Auto), `file_picker` for the native
+folder chooser, and `shared_preferences` for remembering the selected folder
+(`drift_dev` + `build_runner` are dev-only, for code generation).
 
 ## Architecture
 
@@ -191,8 +194,9 @@ lib/
   [`PlaybackQueue`](lib/core/models/playback_queue.dart) model (current track +
   upcoming tracks) and exposes `playTracks`, `playNext`, `skipToNext`, and
   `clearQueue`; the UI reads the queue from `PlaybackState` and never edits it
-  directly. Swappable/wrappable for background audio, MPRIS, and Android Auto
-  without touching feature code.
+  directly. `SonaraAudioHandler` wraps it for background audio / the platform
+  media session (notification, lock screen, Android Auto) without touching
+  feature code; MPRIS can attach the same way later.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
   user-initiated, "Wi-Fi only"-respecting download policy in one place.
   `CacheDownloadRepository` implements it today over a `DownloadStore`
@@ -242,6 +246,80 @@ flutter install              # installs the last debug build
 The debug APK is unsigned and meant for local testing only. **Release signing,
 store-ready bundles, and APK publishing are intentionally out of scope** for
 this stage — there are no native build, signing, or publishing steps in CI.
+
+### Background playback & Android Auto
+
+Sonara registers a platform **media session** through `audio_service` so
+playback survives backgrounding and shows up where the OS expects it:
+
+- **Notification & lock screen.** A media notification mirrors the current
+  track (title / artist / album) and exposes **play/pause**, **stop**, and
+  **skip-next** (the skip control only appears when the up-next queue has a
+  track). Position updates flow through so scrubbing/seek work from the system
+  UI.
+- **Android Auto readiness.** The same session is what Android Auto and other
+  media browsers attach to, so the now-playing card and transport controls are
+  reachable from the car head unit. This PR lays the **foundation** — it does
+  *not* yet ship a browsable media library (folders/albums/playlists in the car
+  UI). That polish is a later PR.
+
+**Architecture.** `audio_service` is a pure infrastructure layer.
+`SonaraAudioHandler` (`lib/core/services/sonara_audio_handler.dart`) is the
+only file that imports it: it forwards session commands
+(play/pause/stop/skip/seek) to the `PlaybackController` and mirrors the
+controller's `PlaybackState` back out as the session's playback state + media
+item. The controller (still `just_audio`-backed) stays the single source of
+truth, and **the UI continues to depend only on `PlaybackController`** — never
+on `audio_service`. Attaching the session in `main.dart` is best-effort: if it
+fails to initialise (e.g. an unsupported platform) basic playback still works.
+
+**Required native setup** (the `android/` folder is generated locally, see
+above). For the media session to run as a foreground service and be visible to
+Android Auto, add to `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<manifest ...>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission
+      android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
+  <application ...>
+    <!-- audio_service playback service -->
+    <service
+        android:name="com.ryanheise.audioservice.AudioService"
+        android:foregroundServiceType="mediaPlayback"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.media.browse.MediaBrowserService" />
+      </intent-filter>
+    </service>
+
+    <!-- Media button + Android Auto receiver -->
+    <receiver
+        android:name="com.ryanheise.audioservice.MediaButtonReceiver"
+        android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MEDIA_BUTTON" />
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>
+```
+
+The main activity should extend `AudioServiceActivity` (per the `audio_service`
+README) so the session binds correctly. The notification channel id/name are
+configured in `connectMediaSession` (`com.sonara.audio` / "Sonara playback").
+
+**Limitations (this PR).**
+
+- No browsable car/media-browser tree yet (no folder/album/playlist nodes in
+  Android Auto) — only the now-playing session.
+- No previous-track / skip-to-previous control (the queue model is forward-only
+  for now).
+- No advanced queue editing from the session.
+- No MPRIS (Linux desktop media keys) yet.
+- Lock-screen artwork depends on `Track.artworkUri`, which local scanning does
+  not populate yet.
 
 ### Android folder selection & known limitations
 

--- a/lib/core/services/sonara_audio_handler.dart
+++ b/lib/core/services/sonara_audio_handler.dart
@@ -54,9 +54,8 @@ class SonaraAudioHandler extends audio.BaseAudioHandler {
   audio.MediaItem _mediaItemFor(Track track, PlaybackState state) {
     // Prefer the live duration the engine reported; fall back to the track's
     // catalog duration, and omit it entirely when unknown.
-    final duration = state.duration > Duration.zero
-        ? state.duration
-        : track.duration;
+    final live = state.duration;
+    final duration = live > Duration.zero ? live : track.duration;
     return audio.MediaItem(
       id: track.id,
       title: track.title,
@@ -79,10 +78,7 @@ class SonaraAudioHandler extends audio.BaseAudioHandler {
 
   List<audio.MediaControl> _controlsFor(PlaybackState state) {
     return <audio.MediaControl>[
-      if (state.isPlaying)
-        audio.MediaControl.pause
-      else
-        audio.MediaControl.play,
+      state.isPlaying ? audio.MediaControl.pause : audio.MediaControl.play,
       audio.MediaControl.stop,
       if (state.hasNext) audio.MediaControl.skipToNext,
     ];

--- a/lib/core/services/sonara_audio_handler.dart
+++ b/lib/core/services/sonara_audio_handler.dart
@@ -54,8 +54,9 @@ class SonaraAudioHandler extends audio.BaseAudioHandler {
   audio.MediaItem _mediaItemFor(Track track, PlaybackState state) {
     // Prefer the live duration the engine reported; fall back to the track's
     // catalog duration, and omit it entirely when unknown.
-    final duration =
-        state.duration > Duration.zero ? state.duration : track.duration;
+    final duration = state.duration > Duration.zero
+        ? state.duration
+        : track.duration;
     return audio.MediaItem(
       id: track.id,
       title: track.title,

--- a/lib/core/services/sonara_audio_handler.dart
+++ b/lib/core/services/sonara_audio_handler.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:audio_service/audio_service.dart' as audio;
+
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import 'playback_controller.dart';
+
+/// Bridges the app's [PlaybackController] to the platform media session via
+/// `audio_service`. This is the only file in the app that knows
+/// `audio_service` exists.
+///
+/// It is a thin infrastructure adapter, deliberately *not* a second playback
+/// engine: it forwards media-session commands (play/pause/stop/skip) to the
+/// controller and mirrors the controller's [PlaybackState] back out as
+/// audio_service playback state + media item, so the notification, lock screen,
+/// and Android Auto reflect what is playing. The controller stays the single
+/// source of truth and owns `just_audio`; the UI never touches this class.
+class SonaraAudioHandler extends audio.BaseAudioHandler {
+  SonaraAudioHandler(this._controller) {
+    _subscription = _controller.stateStream.listen(_broadcast);
+    // Seed the session from the latest known state so a freshly attached
+    // notification/Android Auto isn't blank before the first stream event.
+    _broadcast(_controller.state);
+  }
+
+  final PlaybackController _controller;
+  late final StreamSubscription<PlaybackState> _subscription;
+
+  @override
+  Future<void> play() => _controller.play();
+
+  @override
+  Future<void> pause() => _controller.pause();
+
+  @override
+  Future<void> stop() async {
+    await _controller.stop();
+    await super.stop();
+  }
+
+  @override
+  Future<void> skipToNext() => _controller.skipToNext();
+
+  @override
+  Future<void> seek(Duration position) => _controller.seek(position);
+
+  void _broadcast(PlaybackState state) {
+    final track = state.currentTrack;
+    mediaItem.add(track == null ? null : _mediaItemFor(track, state));
+    playbackState.add(_playbackStateFor(state));
+  }
+
+  audio.MediaItem _mediaItemFor(Track track, PlaybackState state) {
+    // Prefer the live duration the engine reported; fall back to the track's
+    // catalog duration, and omit it entirely when unknown.
+    final duration =
+        state.duration > Duration.zero ? state.duration : track.duration;
+    return audio.MediaItem(
+      id: track.id,
+      title: track.title,
+      artist: track.artistName,
+      album: track.albumName,
+      duration: duration > Duration.zero ? duration : null,
+      artUri: track.artworkUri,
+    );
+  }
+
+  audio.PlaybackState _playbackStateFor(PlaybackState state) {
+    return audio.PlaybackState(
+      controls: _controlsFor(state),
+      systemActions: const <audio.MediaAction>{audio.MediaAction.seek},
+      processingState: _processingStateFor(state.status),
+      playing: state.isPlaying,
+      updatePosition: state.position,
+    );
+  }
+
+  List<audio.MediaControl> _controlsFor(PlaybackState state) {
+    return <audio.MediaControl>[
+      if (state.isPlaying)
+        audio.MediaControl.pause
+      else
+        audio.MediaControl.play,
+      audio.MediaControl.stop,
+      if (state.hasNext) audio.MediaControl.skipToNext,
+    ];
+  }
+
+  audio.AudioProcessingState _processingStateFor(PlaybackStatus status) {
+    switch (status) {
+      case PlaybackStatus.idle:
+        return audio.AudioProcessingState.idle;
+      case PlaybackStatus.loading:
+        return audio.AudioProcessingState.loading;
+      case PlaybackStatus.playing:
+      case PlaybackStatus.paused:
+        return audio.AudioProcessingState.ready;
+      case PlaybackStatus.completed:
+        return audio.AudioProcessingState.completed;
+      case PlaybackStatus.error:
+        return audio.AudioProcessingState.error;
+    }
+  }
+
+  /// Stops mirroring controller state. Call before disposing the controller.
+  Future<void> dispose() => _subscription.cancel();
+}
+
+/// Registers [controller] with the platform media session so playback appears
+/// in the notification / lock screen and is reachable from Android Auto.
+///
+/// Best-effort by design: returns `null` when `audio_service` can't initialise
+/// (a platform without the native setup, or a test environment). Playback still
+/// works through the controller in that case, so a missing media session never
+/// breaks basic playback.
+Future<SonaraAudioHandler?> connectMediaSession(
+  PlaybackController controller,
+) async {
+  try {
+    return await audio.AudioService.init(
+      builder: () => SonaraAudioHandler(controller),
+      config: const audio.AudioServiceConfig(
+        androidNotificationChannelId: 'com.sonara.audio',
+        androidNotificationChannelName: 'Sonara playback',
+        androidNotificationOngoing: true,
+      ),
+    );
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/sonara_app.dart';
+import 'core/services/just_audio_playback_controller.dart';
+import 'core/services/sonara_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
+import 'features/player/player_providers.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Build the playback controller up front so the *same* instance backs both
+  // the UI (via playbackControllerProvider) and the platform media session
+  // (via audio_service). Attaching the session is best-effort: on a platform
+  // without the native setup it returns null and basic playback still works.
+  final controller = JustAudioPlaybackController();
+  final handler = await connectMediaSession(controller);
+
   // ProviderScope hosts all Riverpod state for the app. The running app
   // persists its catalog to SQLite via the Drift override and the chosen music
   // folder, offline-download set, and Wi-Fi-only preference via
@@ -15,6 +27,13 @@ void main() {
   runApp(
     ProviderScope(
       overrides: [
+        playbackControllerProvider.overrideWith((ref) {
+          ref.onDispose(() async {
+            await handler?.dispose();
+            await controller.dispose();
+          });
+          return controller;
+        }),
         driftMusicLibraryRepositoryOverride,
         sharedPreferencesSelectedMusicFolderRepositoryOverride,
         sharedPreferencesDownloadStoreOverride,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,8 +26,13 @@ dependencies:
   path_provider: ^2.1.4
   # Local audio playback engine. Used only by JustAudioPlaybackController in the
   # services layer; the UI depends on the PlaybackController interface, never on
-  # just_audio directly. Background playback (audio_service) lands in a later PR.
+  # just_audio directly.
   just_audio: ^0.9.42
+  # Background playback + platform media session (notification, lock screen,
+  # Android Auto). Used only by SonaraAudioHandler in the services layer, which
+  # forwards session commands to PlaybackController and mirrors its state out.
+  # The UI never depends on audio_service directly.
+  audio_service: ^0.18.15
   # Native folder chooser for selecting a music folder to scan. Used only by
   # FilePickerFolderPickerService; the UI depends on the FolderPickerService
   # interface, never on file_picker directly.

--- a/test/core/services/sonara_audio_handler_test.dart
+++ b/test/core/services/sonara_audio_handler_test.dart
@@ -59,8 +59,7 @@ void main() {
       expect(item.album, 'Album a');
     });
 
-    test('reports playing state with pause/stop/skip controls when a queue '
-        'exists', () async {
+    test('queue: state is ready with pause, stop and skip controls', () async {
       await controller.playTracks([_track('a'), _track('b')]);
       await _settle();
 

--- a/test/core/services/sonara_audio_handler_test.dart
+++ b/test/core/services/sonara_audio_handler_test.dart
@@ -6,13 +6,15 @@ import 'package:sonara/core/services/sonara_audio_handler.dart';
 
 import '../../features/player/fake_playback_controller.dart';
 
-Track _track(String id) => Track(
-      id: id,
-      title: 'Song $id',
-      uri: '/$id.mp3',
-      artistName: 'Artist $id',
-      albumName: 'Album $id',
-    );
+Track _track(String id) {
+  return Track(
+    id: id,
+    title: 'Song $id',
+    uri: '/$id.mp3',
+    artistName: 'Artist $id',
+    albumName: 'Album $id',
+  );
+}
 
 /// Lets the broadcast from the controller's stream reach the handler's
 /// listener before assertions read the mirrored session state.

--- a/test/core/services/sonara_audio_handler_test.dart
+++ b/test/core/services/sonara_audio_handler_test.dart
@@ -1,0 +1,99 @@
+import 'package:audio_service/audio_service.dart' as audio;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonara/core/models/playback_state.dart';
+import 'package:sonara/core/models/track.dart';
+import 'package:sonara/core/services/sonara_audio_handler.dart';
+
+import '../../features/player/fake_playback_controller.dart';
+
+Track _track(String id) => Track(
+      id: id,
+      title: 'Song $id',
+      uri: '/$id.mp3',
+      artistName: 'Artist $id',
+      albumName: 'Album $id',
+    );
+
+/// Lets the broadcast from the controller's stream reach the handler's
+/// listener before assertions read the mirrored session state.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('SonaraAudioHandler', () {
+    late FakePlaybackController controller;
+    late SonaraAudioHandler handler;
+
+    setUp(() {
+      controller = FakePlaybackController();
+      handler = SonaraAudioHandler(controller);
+    });
+
+    tearDown(() async {
+      await handler.dispose();
+      await controller.dispose();
+    });
+
+    test('forwards transport commands to the controller', () async {
+      await handler.play();
+      await handler.pause();
+      await handler.skipToNext();
+      await handler.stop();
+      await handler.seek(const Duration(seconds: 12));
+
+      expect(controller.playCount, 1);
+      expect(controller.pauseCount, 1);
+      expect(controller.skipCount, 1);
+      expect(controller.stopCount, 1);
+      expect(controller.seeks, [const Duration(seconds: 12)]);
+    });
+
+    test('mirrors the current track into the media item', () async {
+      await controller.playTracks([_track('a'), _track('b')]);
+      await _settle();
+
+      final item = handler.mediaItem.value;
+      expect(item, isNotNull);
+      expect(item!.id, 'a');
+      expect(item.title, 'Song a');
+      expect(item.artist, 'Artist a');
+      expect(item.album, 'Album a');
+    });
+
+    test('reports playing state with pause/stop/skip controls when a queue '
+        'exists', () async {
+      await controller.playTracks([_track('a'), _track('b')]);
+      await _settle();
+
+      final state = handler.playbackState.value;
+      expect(state.playing, isTrue);
+      expect(state.processingState, audio.AudioProcessingState.ready);
+      expect(state.controls, contains(audio.MediaControl.pause));
+      expect(state.controls, contains(audio.MediaControl.stop));
+      expect(state.controls, contains(audio.MediaControl.skipToNext));
+    });
+
+    test('omits the skip control when nothing is queued next', () async {
+      await controller.playTracks([_track('a')]);
+      await _settle();
+
+      final state = handler.playbackState.value;
+      expect(state.controls, isNot(contains(audio.MediaControl.skipToNext)));
+    });
+
+    test('clears the media item when playback goes idle', () async {
+      await controller.playTracks([_track('a')]);
+      await _settle();
+      expect(handler.mediaItem.value, isNotNull);
+
+      controller.emit(PlaybackState.idle);
+      await _settle();
+
+      expect(handler.mediaItem.value, isNull);
+      expect(handler.playbackState.value.playing, isFalse);
+      expect(
+        handler.playbackState.value.processingState,
+        audio.AudioProcessingState.idle,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the first background-playback / Android Auto foundation using `audio_service`, kept deliberately small. `audio_service` is wired in as a **pure infrastructure adapter** that sits on top of the existing `PlaybackController` (`just_audio`) flow — the playback system is **not** rewritten, and the UI keeps depending only on `PlaybackController`, never on `audio_service`.

## Files changed

- `pubspec.yaml` — add `audio_service: ^0.18.15` (documented as services-layer only).
- `lib/core/services/sonara_audio_handler.dart` *(new)* — `SonaraAudioHandler`, the only file that imports `audio_service`. Forwards session commands to the controller and mirrors `PlaybackState` back out. Also `connectMediaSession()`, a best-effort initialiser.
- `lib/main.dart` — build the `PlaybackController` once, attach the media session, and override `playbackControllerProvider` with that shared instance so UI and session share one controller. Disposes both on scope teardown.
- `test/core/services/sonara_audio_handler_test.dart` *(new)* — handler tests using the existing `FakePlaybackController`.
- `README.md` — background playback / Android Auto status, required Android manifest/service setup, architecture notes, and limitations.

## Android service / media session behavior

- Registers a platform media session via `audio_service` so playback survives backgrounding.
- Notification & lock screen mirror the current track (title/artist/album) and expose **play/pause**, **stop**, and **skip-next** (skip only shown when the up-next queue has a track). Position updates flow through for seek/scrub.
- `SonaraAudioHandler` forwards `play`/`pause`/`stop`/`skipToNext`/`seek` to the `PlaybackController`; the controller remains the single source of truth.
- Required Android manifest entries (foreground service permissions, `AudioService`, `MediaButtonReceiver`) are documented in the README — the `android/` folder is generated locally, so nothing native is committed.

## Android Auto readiness status

- **Foundation only.** The same media session is what Android Auto attaches to, so now-playing + transport controls are reachable from a head unit.
- Does **not** yet ship a browsable media library (no folder/album/playlist nodes in the car UI) — that polish is a later PR.

## Limitations

- No browsable car/media-browser tree yet (now-playing session only).
- No skip-to-previous (queue model is forward-only for now).
- No advanced queue editing from the session.
- No MPRIS (Linux desktop) yet.
- Lock-screen artwork depends on `Track.artworkUri`, which local scanning does not populate yet.

## Tests added

- Transport commands forward to the controller (play/pause/stop/skip/seek).
- Current track is mirrored into the session media item.
- Playing state reports `ready` + pause/stop/skip controls when a queue exists.
- Skip control is omitted when nothing is queued next.
- Media item clears and state goes idle when playback stops.

> Note: `flutter`/`dart` are not available in this environment, so `flutter pub get`, `dart format`, `flutter analyze`, `flutter test`, and `flutter build apk --debug` were **not run here** — code and formatting were matched to `dart format` style by hand. CI should run the full verification suite.

## Next recommended PR

Polish offline cache, lyrics, or a playlist editor.

https://claude.ai/code/session_01Ttvh743xmHcfGxpJQGYrXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ttvh743xmHcfGxpJQGYrXc)_