### PR TITLE
Rename app from Sonara to Halcyon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Sonara
+# Halcyon
 
 A modern, **local-first**, privacy-focused music player for people who own
-their music. Sonara is a clean alternative to bloated streaming apps — your
+their music. Halcyon is a clean alternative to bloated streaming apps — your
 library lives on your device, and downloads are always under your explicit
 control.
 
@@ -54,7 +54,7 @@ testing.
 
 **Drift/SQLite persistence** has now landed for tracks.
 `DriftMusicLibraryRepository` (`lib/data/repositories/`) is the persistent
-catalog the UI will read from, backed by `SonaraDatabase`
+catalog the UI will read from, backed by `HalcyonDatabase`
 (`lib/data/database/`). At schema **v1** only the `tracks` table is persisted:
 `getAllTracks`, `getTrackById`, and `upsertCatalog` are real, while
 `getAllAlbums`/`getAllArtists` return empty lists for now. Domain models
@@ -155,7 +155,7 @@ Jellyfin/WebDAV roadmap possible without rewriting the UI.
 lib/
   main.dart                 entry point; hosts the Riverpod ProviderScope
   app/                      app-level wiring
-    sonara_app.dart         root MaterialApp.router widget
+    halcyon_app.dart         root MaterialApp.router widget
     router.dart             go_router config (Riverpod provider)
     routes.dart             route path constants
     theme.dart              dark-first ThemeData
@@ -171,7 +171,7 @@ lib/
     sources/                concrete MusicSource implementations:
                             local/ (LocalMusicSource + file scanning)
   data/                     concrete repository implementations + storage
-    database/               SonaraDatabase (Drift) + tables/ (tracks_table.dart)
+    database/               HalcyonDatabase (Drift) + tables/ (tracks_table.dart)
     mappers/                domain <-> Drift row conversion (track_mapper.dart)
     repositories/           drift_music_library_repository.dart (persistent),
                             in_memory_music_library_repository.dart (dev/tests)
@@ -194,7 +194,7 @@ lib/
   [`PlaybackQueue`](lib/core/models/playback_queue.dart) model (current track +
   upcoming tracks) and exposes `playTracks`, `playNext`, `skipToNext`, and
   `clearQueue`; the UI reads the queue from `PlaybackState` and never edits it
-  directly. `SonaraAudioHandler` wraps it for background audio / the platform
+  directly. `HalcyonAudioHandler` wraps it for background audio / the platform
   media session (notification, lock screen, Android Auto) without touching
   feature code; MPRIS can attach the same way later.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
@@ -226,7 +226,7 @@ flutter run
 
 ### Building a debug APK (Android)
 
-To install and test Sonara on an Android phone:
+To install and test Halcyon on an Android phone:
 
 ```bash
 # Generate the Android scaffold (skip if android/ already exists locally)
@@ -249,7 +249,7 @@ this stage — there are no native build, signing, or publishing steps in CI.
 
 ### Background playback & Android Auto
 
-Sonara registers a platform **media session** through `audio_service` so
+Halcyon registers a platform **media session** through `audio_service` so
 playback survives backgrounding and shows up where the OS expects it:
 
 - **Notification & lock screen.** A media notification mirrors the current
@@ -264,7 +264,7 @@ playback survives backgrounding and shows up where the OS expects it:
   UI). That polish is a later PR.
 
 **Architecture.** `audio_service` is a pure infrastructure layer.
-`SonaraAudioHandler` (`lib/core/services/sonara_audio_handler.dart`) is the
+`HalcyonAudioHandler` (`lib/core/services/halcyon_audio_handler.dart`) is the
 only file that imports it: it forwards session commands
 (play/pause/stop/skip/seek) to the `PlaybackController` and mirrors the
 controller's `PlaybackState` back out as the session's playback state + media
@@ -308,7 +308,7 @@ Android Auto, add to `android/app/src/main/AndroidManifest.xml`:
 
 The main activity should extend `AudioServiceActivity` (per the `audio_service`
 README) so the session binds correctly. The notification channel id/name are
-configured in `connectMediaSession` (`com.sonara.audio` / "Sonara playback").
+configured in `connectMediaSession` (`com.halcyon.audio` / "Halcyon playback").
 
 **Limitations (this PR).**
 
@@ -385,7 +385,7 @@ Deliberate gaps the next PRs will close:
 2. Put a few audio files under a folder on shared storage, e.g.
    `/storage/emulated/0/Music`.
 3. In **Library**, tap the folder icon and pick that folder. The chooser
-   returns a `content://…/tree/primary:Music` URI; Sonara resolves it to the
+   returns a `content://…/tree/primary:Music` URI; Halcyon resolves it to the
    path and scans it.
 4. Picking a folder from a provider that has no filesystem mapping (for example
    a cloud "Documents" provider) is expected to show the Library error state

--- a/lib/app/halcyon_app.dart
+++ b/lib/app/halcyon_app.dart
@@ -7,8 +7,8 @@ import 'theme.dart';
 
 /// Root widget. Dark mode is the primary experience; the light theme follows
 /// the system setting when the user opts out of dark.
-class SonaraApp extends ConsumerWidget {
-  const SonaraApp({super.key});
+class HalcyonApp extends ConsumerWidget {
+  const HalcyonApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'colors.dart';
 import 'dimens.dart';
 
-/// Builds the light and dark [ThemeData] for Sonara. Both share the same
+/// Builds the light and dark [ThemeData] for Halcyon. Both share the same
 /// shape language and accent so the product feels cohesive across modes.
 abstract final class AppTheme {
   static ThemeData get dark => _build(

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -1,5 +1,5 @@
 /// Static, build-time app metadata.
 abstract final class AppInfo {
-  static const String name = 'Sonara';
+  static const String name = 'Halcyon';
   static const String tagline = 'Your music, beautifully yours.';
 }

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -3,7 +3,7 @@ enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
 
 /// Tracks which library items are available offline.
 ///
-/// Downloads in Sonara are always *explicit and user-initiated* — never
+/// Downloads in Halcyon are always *explicit and user-initiated* — never
 /// automatic. Implementations must also honor the user's "Wi-Fi only" pref
 /// (queueing rather than downloading over mobile data when set), so that
 /// promise is enforced in one place rather than scattered through the UI.

--- a/lib/core/repositories/music_library_repository.dart
+++ b/lib/core/repositories/music_library_repository.dart
@@ -6,7 +6,7 @@ import '../models/track.dart';
 ///
 /// Critical separation of concerns: the UI always reads from the repository
 /// (backed by SQLite), never directly from a [MusicSource]. Sources *sync into*
-/// the repository on demand. This is what makes Sonara work fully offline and
+/// the repository on demand. This is what makes Halcyon work fully offline and
 /// keeps remote latency out of the render path.
 ///
 /// The concrete implementation (e.g. a `drift`-backed one) is added when the

--- a/lib/core/services/halcyon_audio_handler.dart
+++ b/lib/core/services/halcyon_audio_handler.dart
@@ -16,8 +16,8 @@ import 'playback_controller.dart';
 /// audio_service playback state + media item, so the notification, lock screen,
 /// and Android Auto reflect what is playing. The controller stays the single
 /// source of truth and owns `just_audio`; the UI never touches this class.
-class SonaraAudioHandler extends audio.BaseAudioHandler {
-  SonaraAudioHandler(this._controller) {
+class HalcyonAudioHandler extends audio.BaseAudioHandler {
+  HalcyonAudioHandler(this._controller) {
     _subscription = _controller.stateStream.listen(_broadcast);
     // Seed the session from the latest known state so a freshly attached
     // notification/Android Auto isn't blank before the first stream event.
@@ -111,15 +111,15 @@ class SonaraAudioHandler extends audio.BaseAudioHandler {
 /// (a platform without the native setup, or a test environment). Playback still
 /// works through the controller in that case, so a missing media session never
 /// breaks basic playback.
-Future<SonaraAudioHandler?> connectMediaSession(
+Future<HalcyonAudioHandler?> connectMediaSession(
   PlaybackController controller,
 ) async {
   try {
     return await audio.AudioService.init(
-      builder: () => SonaraAudioHandler(controller),
+      builder: () => HalcyonAudioHandler(controller),
       config: const audio.AudioServiceConfig(
-        androidNotificationChannelId: 'com.sonara.audio',
-        androidNotificationChannelName: 'Sonara playback',
+        androidNotificationChannelId: 'com.halcyon.audio',
+        androidNotificationChannelName: 'Halcyon playback',
         androidNotificationOngoing: true,
       ),
     );

--- a/lib/core/services/music_source.dart
+++ b/lib/core/services/music_source.dart
@@ -2,7 +2,7 @@ import '../models/album.dart';
 import '../models/artist.dart';
 import '../models/track.dart';
 
-/// A backend that *provides* media to Sonara.
+/// A backend that *provides* media to Halcyon.
 ///
 /// This is the core extension point for the project's roadmap. The MVP ships a
 /// `LocalMusicSource` (scans on-device files); future `JellyfinMusicSource`,

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -77,7 +77,7 @@ class ContentUriAudioFileScanner implements AudioFileScanner {
     if (path == null) {
       throw FolderScanException(
         "This folder can't be scanned yet. It was shared through Android's "
-        'Storage Access Framework, which Sonara cannot walk directly on this '
+        'Storage Access Framework, which Halcyon cannot walk directly on this '
         'device. Try selecting a folder on your phone or SD card storage.',
         folder: folder,
       );

--- a/lib/core/sources/local/audio_file_types.dart
+++ b/lib/core/sources/local/audio_file_types.dart
@@ -1,6 +1,6 @@
 import 'package:path/path.dart' as p;
 
-/// The audio file extensions Sonara's local scanner recognizes.
+/// The audio file extensions Halcyon's local scanner recognizes.
 ///
 /// Kept small and centralized on purpose: supporting a new container format
 /// later is a one-line change here that the rest of the scanner picks up for

--- a/lib/data/database/halcyon_database.dart
+++ b/lib/data/database/halcyon_database.dart
@@ -7,7 +7,7 @@ import 'package:path_provider/path_provider.dart';
 
 import 'tables/tracks_table.dart';
 
-part 'sonara_database.g.dart';
+part 'halcyon_database.g.dart';
 
 /// The app's local SQLite database — the offline-first catalog the UI reads
 /// from. Kept deliberately outside the UI and feature layers; repositories in
@@ -17,12 +17,12 @@ part 'sonara_database.g.dart';
 /// [schemaVersion] and add a `MigrationStrategy`; we are not pre-building that
 /// machinery while there is nothing to migrate from.
 @DriftDatabase(tables: [Tracks])
-class SonaraDatabase extends _$SonaraDatabase {
-  SonaraDatabase() : super(_openConnection());
+class HalcyonDatabase extends _$HalcyonDatabase {
+  HalcyonDatabase() : super(_openConnection());
 
   /// Builds a database over a caller-supplied executor. Used by tests to run
   /// against an in-memory SQLite instance (`NativeDatabase.memory()`).
-  SonaraDatabase.forTesting(super.executor);
+  HalcyonDatabase.forTesting(super.executor);
 
   @override
   int get schemaVersion => 1;
@@ -31,7 +31,7 @@ class SonaraDatabase extends _$SonaraDatabase {
 QueryExecutor _openConnection() {
   return LazyDatabase(() async {
     final Directory dir = await getApplicationDocumentsDirectory();
-    final File file = File(p.join(dir.path, 'sonara.sqlite'));
+    final File file = File(p.join(dir.path, 'halcyon.sqlite'));
     return NativeDatabase.createInBackground(file);
   });
 }

--- a/lib/data/database/halcyon_database.g.dart
+++ b/lib/data/database/halcyon_database.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'sonara_database.dart';
+part of 'halcyon_database.dart';
 
 // ignore_for_file: type=lint
 class $TracksTable extends Tracks with TableInfo<$TracksTable, TrackRow> {
@@ -482,9 +482,9 @@ class TracksCompanion extends UpdateCompanion<TrackRow> {
   }
 }
 
-abstract class _$SonaraDatabase extends GeneratedDatabase {
-  _$SonaraDatabase(QueryExecutor e) : super(e);
-  $SonaraDatabaseManager get managers => $SonaraDatabaseManager(this);
+abstract class _$HalcyonDatabase extends GeneratedDatabase {
+  _$HalcyonDatabase(QueryExecutor e) : super(e);
+  $HalcyonDatabaseManager get managers => $HalcyonDatabaseManager(this);
   late final $TracksTable tracks = $TracksTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -519,7 +519,7 @@ typedef $$TracksTableUpdateCompanionBuilder = TracksCompanion Function({
 });
 
 class $$TracksTableFilterComposer
-    extends Composer<_$SonaraDatabase, $TracksTable> {
+    extends Composer<_$HalcyonDatabase, $TracksTable> {
   $$TracksTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -556,7 +556,7 @@ class $$TracksTableFilterComposer
 }
 
 class $$TracksTableOrderingComposer
-    extends Composer<_$SonaraDatabase, $TracksTable> {
+    extends Composer<_$HalcyonDatabase, $TracksTable> {
   $$TracksTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -593,7 +593,7 @@ class $$TracksTableOrderingComposer
 }
 
 class $$TracksTableAnnotationComposer
-    extends Composer<_$SonaraDatabase, $TracksTable> {
+    extends Composer<_$HalcyonDatabase, $TracksTable> {
   $$TracksTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -630,7 +630,7 @@ class $$TracksTableAnnotationComposer
 }
 
 class $$TracksTableTableManager extends RootTableManager<
-    _$SonaraDatabase,
+    _$HalcyonDatabase,
     $TracksTable,
     TrackRow,
     $$TracksTableFilterComposer,
@@ -638,10 +638,10 @@ class $$TracksTableTableManager extends RootTableManager<
     $$TracksTableAnnotationComposer,
     $$TracksTableCreateCompanionBuilder,
     $$TracksTableUpdateCompanionBuilder,
-    (TrackRow, BaseReferences<_$SonaraDatabase, $TracksTable, TrackRow>),
+    (TrackRow, BaseReferences<_$HalcyonDatabase, $TracksTable, TrackRow>),
     TrackRow,
     PrefetchHooks Function()> {
-  $$TracksTableTableManager(_$SonaraDatabase db, $TracksTable table)
+  $$TracksTableTableManager(_$HalcyonDatabase db, $TracksTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -707,7 +707,7 @@ class $$TracksTableTableManager extends RootTableManager<
 }
 
 typedef $$TracksTableProcessedTableManager = ProcessedTableManager<
-    _$SonaraDatabase,
+    _$HalcyonDatabase,
     $TracksTable,
     TrackRow,
     $$TracksTableFilterComposer,
@@ -715,13 +715,13 @@ typedef $$TracksTableProcessedTableManager = ProcessedTableManager<
     $$TracksTableAnnotationComposer,
     $$TracksTableCreateCompanionBuilder,
     $$TracksTableUpdateCompanionBuilder,
-    (TrackRow, BaseReferences<_$SonaraDatabase, $TracksTable, TrackRow>),
+    (TrackRow, BaseReferences<_$HalcyonDatabase, $TracksTable, TrackRow>),
     TrackRow,
     PrefetchHooks Function()>;
 
-class $SonaraDatabaseManager {
-  final _$SonaraDatabase _db;
-  $SonaraDatabaseManager(this._db);
+class $HalcyonDatabaseManager {
+  final _$HalcyonDatabase _db;
+  $HalcyonDatabaseManager(this._db);
   $$TracksTableTableManager get tracks =>
       $$TracksTableTableManager(_db, _db.tracks);
 }

--- a/lib/data/database/halcyon_database_provider.dart
+++ b/lib/data/database/halcyon_database_provider.dart
@@ -1,12 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'sonara_database.dart';
+import 'halcyon_database.dart';
 
-/// The app-wide [SonaraDatabase]. The underlying SQLite connection is opened
+/// The app-wide [HalcyonDatabase]. The underlying SQLite connection is opened
 /// lazily on first query and closed when the provider is disposed, so nothing
 /// touches the disk until the catalog is actually read or written.
-final sonaraDatabaseProvider = Provider<SonaraDatabase>((ref) {
-  final db = SonaraDatabase();
+final halcyonDatabaseProvider = Provider<HalcyonDatabase>((ref) {
+  final db = HalcyonDatabase();
   ref.onDispose(db.close);
   return db;
 });

--- a/lib/data/mappers/track_mapper.dart
+++ b/lib/data/mappers/track_mapper.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart';
 
 import '../../core/models/track.dart';
-import '../database/sonara_database.dart';
+import '../database/halcyon_database.dart';
 
 /// Explicit, one-way conversions between the [Track] domain model and its
 /// persisted form. Kept tiny and dumb on purpose: no IO, no defaults beyond

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -4,7 +4,7 @@ import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../core/repositories/music_library_repository.dart';
-import '../database/sonara_database.dart';
+import '../database/halcyon_database.dart';
 import '../mappers/track_mapper.dart';
 
 /// SQLite-backed [MusicLibraryRepository] using Drift. This is the persistent
@@ -16,7 +16,7 @@ import '../mappers/track_mapper.dart';
 class DriftMusicLibraryRepository implements MusicLibraryRepository {
   DriftMusicLibraryRepository(this._db);
 
-  final SonaraDatabase _db;
+  final HalcyonDatabase _db;
 
   @override
   Future<List<Track>> getAllTracks() async {

--- a/lib/data/repositories/music_library_repository_provider.dart
+++ b/lib/data/repositories/music_library_repository_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/repositories/music_library_repository.dart';
-import '../database/sonara_database_provider.dart';
+import '../database/halcyon_database_provider.dart';
 import 'drift_music_library_repository.dart';
 import 'in_memory_music_library_repository.dart';
 
@@ -17,8 +17,8 @@ final musicLibraryRepositoryProvider = Provider<MusicLibraryRepository>((ref) {
 
 /// Production binding: a Drift/SQLite-backed repository so scanned tracks
 /// survive app restarts. Applied in `main`; tests can apply it over an
-/// in-memory database by also overriding [sonaraDatabaseProvider].
+/// in-memory database by also overriding [halcyonDatabaseProvider].
 final driftMusicLibraryRepositoryOverride =
     musicLibraryRepositoryProvider.overrideWith(
-  (ref) => DriftMusicLibraryRepository(ref.watch(sonaraDatabaseProvider)),
+  (ref) => DriftMusicLibraryRepository(ref.watch(halcyonDatabaseProvider)),
 );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'app/sonara_app.dart';
+import 'app/halcyon_app.dart';
 import 'core/services/just_audio_playback_controller.dart';
-import 'core/services/sonara_audio_handler.dart';
+import 'core/services/halcyon_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
@@ -39,7 +39,7 @@ Future<void> main() async {
         sharedPreferencesDownloadStoreOverride,
         sharedPreferencesDownloadPreferencesOverride,
       ],
-      child: const SonaraApp(),
+      child: const HalcyonApp(),
     ),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: sonara
+name: halcyon
 description: A modern, local-first, privacy-focused music player.
 publish_to: "none"
 version: 0.1.0+1
@@ -29,7 +29,7 @@ dependencies:
   # just_audio directly.
   just_audio: ^0.9.42
   # Background playback + platform media session (notification, lock screen,
-  # Android Auto). Used only by SonaraAudioHandler in the services layer, which
+  # Android Auto). Used only by HalcyonAudioHandler in the services layer, which
   # forwards session commands to PlaybackController and mirrors its state out.
   # The UI never depends on audio_service directly.
   audio_service: ^0.18.15
@@ -47,7 +47,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   # Drift code generation. Run via the manual "Generate Drift files" workflow;
-  # produces the *.g.dart files that back SonaraDatabase.
+  # produces the *.g.dart files that back HalcyonDatabase.
   drift_dev: ^2.18.0
   build_runner: ^2.4.13
 

--- a/test/app_smoke_test.dart
+++ b/test/app_smoke_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/app/sonara_app.dart';
+import 'package:halcyon/app/halcyon_app.dart';
 
 void main() {
   testWidgets('App boots to the Library screen', (tester) async {
-    await tester.pumpWidget(const ProviderScope(child: SonaraApp()));
+    await tester.pumpWidget(const ProviderScope(child: HalcyonApp()));
     await tester.pumpAndSettle();
 
     // The persistent shell and its bottom navigation render.

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/playback_queue.dart';
-import 'package:sonara/core/models/track.dart';
+import 'package:halcyon/core/models/playback_queue.dart';
+import 'package:halcyon/core/models/track.dart';
 
 Track _track(String id) => Track(id: id, title: 'Song $id', uri: '/$id.mp3');
 

--- a/test/core/services/halcyon_audio_handler_test.dart
+++ b/test/core/services/halcyon_audio_handler_test.dart
@@ -1,8 +1,8 @@
 import 'package:audio_service/audio_service.dart' as audio;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/playback_state.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/services/sonara_audio_handler.dart';
+import 'package:halcyon/core/models/playback_state.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/core/services/halcyon_audio_handler.dart';
 
 import '../../features/player/fake_playback_controller.dart';
 
@@ -21,13 +21,13 @@ Track _track(String id) {
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
 
 void main() {
-  group('SonaraAudioHandler', () {
+  group('HalcyonAudioHandler', () {
     late FakePlaybackController controller;
-    late SonaraAudioHandler handler;
+    late HalcyonAudioHandler handler;
 
     setUp(() {
       controller = FakePlaybackController();
-      handler = SonaraAudioHandler(controller);
+      handler = HalcyonAudioHandler(controller);
     });
 
     tearDown(() async {

--- a/test/core/sources/local/audio_file_scanner_test.dart
+++ b/test/core/sources/local/audio_file_scanner_test.dart
@@ -1,14 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:halcyon/core/sources/local/audio_file_scanner.dart';
 
 void main() {
   group('IoAudioFileScanner', () {
     late Directory root;
 
     setUp(() async {
-      root = await Directory.systemTemp.createTemp('sonara_scan_test');
+      root = await Directory.systemTemp.createTemp('halcyon_scan_test');
     });
 
     tearDown(() async {

--- a/test/core/sources/local/audio_file_types_test.dart
+++ b/test/core/sources/local/audio_file_types_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_types.dart';
+import 'package:halcyon/core/sources/local/audio_file_types.dart';
 
 void main() {
   group('AudioFileTypes.isSupported', () {

--- a/test/core/sources/local/content_uri_audio_file_scanner_test.dart
+++ b/test/core/sources/local/content_uri_audio_file_scanner_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
-import 'package:sonara/core/sources/local/folder_scan_exception.dart';
+import 'package:halcyon/core/sources/local/audio_file_scanner.dart';
+import 'package:halcyon/core/sources/local/folder_scan_exception.dart';
 
 /// Records the folder it was asked to scan and returns a fixed list, so we can
 /// assert the content scanner resolved the URI to a path before delegating.

--- a/test/core/sources/local/folder_location_test.dart
+++ b/test/core/sources/local/folder_location_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/folder_location.dart';
+import 'package:halcyon/core/sources/local/folder_location.dart';
 
 void main() {
   group('FolderLocation', () {

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
-import 'package:sonara/core/sources/local/local_music_source.dart';
+import 'package:halcyon/core/sources/local/audio_file_scanner.dart';
+import 'package:halcyon/core/sources/local/local_music_source.dart';
 
 /// Returns a fixed list of paths and records the folder it was asked to scan,
 /// so the source can be tested without touching a real file system.

--- a/test/core/sources/local/local_track_mapper_test.dart
+++ b/test/core/sources/local/local_track_mapper_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/local_track_mapper.dart';
+import 'package:halcyon/core/sources/local/local_track_mapper.dart';
 
 void main() {
   group('LocalTrackMapper.fromPath', () {

--- a/test/core/sources/local/platform_audio_file_scanner_test.dart
+++ b/test/core/sources/local/platform_audio_file_scanner_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:halcyon/core/sources/local/audio_file_scanner.dart';
 
 /// Records that it was called and with which folder, so we can assert the
 /// router picked this backend.

--- a/test/core/sources/local/saf_tree_uri_resolver_test.dart
+++ b/test/core/sources/local/saf_tree_uri_resolver_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/saf_tree_uri_resolver.dart';
+import 'package:halcyon/core/sources/local/saf_tree_uri_resolver.dart';
 
 void main() {
   const resolver = SafTreeUriResolver();

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/repositories/download_repository.dart';
-import 'package:sonara/core/services/connectivity_service.dart';
-import 'package:sonara/data/repositories/cache_download_repository.dart';
-import 'package:sonara/data/repositories/in_memory_download_preferences.dart';
-import 'package:sonara/data/repositories/in_memory_download_store.dart';
+import 'package:halcyon/core/repositories/download_repository.dart';
+import 'package:halcyon/core/services/connectivity_service.dart';
+import 'package:halcyon/data/repositories/cache_download_repository.dart';
+import 'package:halcyon/data/repositories/in_memory_download_preferences.dart';
+import 'package:halcyon/data/repositories/in_memory_download_store.dart';
 
 /// A connectivity stand-in whose reported status the test can flip at will.
 class _FakeConnectivity implements ConnectivityService {

--- a/test/data/repositories/drift_music_library_repository_test.dart
+++ b/test/data/repositories/drift_music_library_repository_test.dart
@@ -1,10 +1,10 @@
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/database/sonara_database.dart';
-import 'package:sonara/data/repositories/drift_music_library_repository.dart';
+import 'package:halcyon/core/models/album.dart';
+import 'package:halcyon/core/models/artist.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/data/database/halcyon_database.dart';
+import 'package:halcyon/data/repositories/drift_music_library_repository.dart';
 
 Track _track(String id, {int durationMs = 0, String? artworkUri}) => Track(
       id: id,
@@ -19,11 +19,11 @@ Track _track(String id, {int durationMs = 0, String? artworkUri}) => Track(
 
 void main() {
   group('DriftMusicLibraryRepository', () {
-    late SonaraDatabase db;
+    late HalcyonDatabase db;
     late DriftMusicLibraryRepository repository;
 
     setUp(() {
-      db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      db = HalcyonDatabase.forTesting(NativeDatabase.memory());
       repository = DriftMusicLibraryRepository(db);
     });
 

--- a/test/data/repositories/drift_repository_wiring_test.dart
+++ b/test/data/repositories/drift_repository_wiring_test.dart
@@ -1,24 +1,24 @@
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/database/sonara_database.dart';
-import 'package:sonara/data/database/sonara_database_provider.dart';
-import 'package:sonara/data/repositories/drift_music_library_repository.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_controller.dart';
-import 'package:sonara/features/library/library_state.dart';
+import 'package:halcyon/core/models/album.dart';
+import 'package:halcyon/core/models/artist.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/data/database/halcyon_database.dart';
+import 'package:halcyon/data/database/halcyon_database_provider.dart';
+import 'package:halcyon/data/repositories/drift_music_library_repository.dart';
+import 'package:halcyon/data/repositories/music_library_repository_provider.dart';
+import 'package:halcyon/features/library/library_controller.dart';
+import 'package:halcyon/features/library/library_state.dart';
 
 void main() {
   group('driftMusicLibraryRepositoryOverride', () {
     test('binds the repository provider to the Drift implementation', () {
-      final db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      final db = HalcyonDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       final container = ProviderContainer(
         overrides: [
-          sonaraDatabaseProvider.overrideWithValue(db),
+          halcyonDatabaseProvider.overrideWithValue(db),
           driftMusicLibraryRepositoryOverride,
         ],
       );
@@ -32,11 +32,11 @@ void main() {
 
     test('catalog persists through the controller via the Drift binding',
         () async {
-      final db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      final db = HalcyonDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       final container = ProviderContainer(
         overrides: [
-          sonaraDatabaseProvider.overrideWithValue(db),
+          halcyonDatabaseProvider.overrideWithValue(db),
           driftMusicLibraryRepositoryOverride,
         ],
       );

--- a/test/data/repositories/in_memory_download_store_test.dart
+++ b/test/data/repositories/in_memory_download_store_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/data/repositories/in_memory_download_store.dart';
+import 'package:halcyon/data/repositories/in_memory_download_store.dart';
 
 void main() {
   group('InMemoryDownloadStore', () {

--- a/test/data/repositories/in_memory_music_library_repository_test.dart
+++ b/test/data/repositories/in_memory_music_library_repository_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
+import 'package:halcyon/core/models/album.dart';
+import 'package:halcyon/core/models/artist.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/data/repositories/in_memory_music_library_repository.dart';
 
 Track _track(String id) => Track(id: id, title: 'Track $id', uri: id);
 

--- a/test/data/repositories/in_memory_selected_music_folder_repository_test.dart
+++ b/test/data/repositories/in_memory_selected_music_folder_repository_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:halcyon/data/repositories/in_memory_selected_music_folder_repository.dart';
 
 void main() {
   group('InMemorySelectedMusicFolderRepository', () {

--- a/test/features/downloads/download_action_test.dart
+++ b/test/features/downloads/download_action_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_screen.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/data/repositories/music_library_repository_provider.dart';
+import 'package:halcyon/features/library/library_screen.dart';
 
 import '../library/fake_music_library_repository.dart';
 

--- a/test/features/library/fake_audio_file_scanner.dart
+++ b/test/features/library/fake_audio_file_scanner.dart
@@ -1,4 +1,4 @@
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:halcyon/core/sources/local/audio_file_scanner.dart';
 
 /// Returns a fixed list of file paths, or throws [error] when one is set, so a
 /// scan can be driven without a real file system.

--- a/test/features/library/fake_folder_picker_service.dart
+++ b/test/features/library/fake_folder_picker_service.dart
@@ -1,4 +1,4 @@
-import 'package:sonara/core/services/folder_picker_service.dart';
+import 'package:halcyon/core/services/folder_picker_service.dart';
 
 /// Returns a fixed folder (or `null` to simulate cancellation) so the
 /// pick-and-scan flow can be driven without a real OS folder dialog.

--- a/test/features/library/fake_music_library_repository.dart
+++ b/test/features/library/fake_music_library_repository.dart
@@ -1,7 +1,7 @@
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/repositories/music_library_repository.dart';
+import 'package:halcyon/core/models/album.dart';
+import 'package:halcyon/core/models/artist.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/core/repositories/music_library_repository.dart';
 
 /// A minimal [MusicLibraryRepository] for driving controller/widget tests.
 ///

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/repositories/music_library_repository.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
-import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_controller.dart';
-import 'package:sonara/features/library/library_providers.dart';
-import 'package:sonara/features/library/library_state.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/core/repositories/music_library_repository.dart';
+import 'package:halcyon/core/sources/local/audio_file_scanner.dart';
+import 'package:halcyon/data/repositories/in_memory_music_library_repository.dart';
+import 'package:halcyon/data/repositories/music_library_repository_provider.dart';
+import 'package:halcyon/features/library/library_controller.dart';
+import 'package:halcyon/features/library/library_providers.dart';
+import 'package:halcyon/features/library/library_state.dart';
 
 import 'fake_audio_file_scanner.dart';
 import 'fake_music_library_repository.dart';

--- a/test/features/library/library_playback_test.dart
+++ b/test/features/library/library_playback_test.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:sonara/app/routes.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_screen.dart';
-import 'package:sonara/features/player/player_providers.dart';
-import 'package:sonara/features/player/player_screen.dart';
+import 'package:halcyon/app/routes.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/data/repositories/music_library_repository_provider.dart';
+import 'package:halcyon/features/library/library_screen.dart';
+import 'package:halcyon/features/player/player_providers.dart';
+import 'package:halcyon/features/player/player_screen.dart';
 
 import '../player/fake_playback_controller.dart';
 import 'fake_music_library_repository.dart';

--- a/test/features/library/library_screen_test.dart
+++ b/test/features/library/library_screen_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_providers.dart';
-import 'package:sonara/features/library/library_screen.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/data/repositories/in_memory_music_library_repository.dart';
+import 'package:halcyon/data/repositories/music_library_repository_provider.dart';
+import 'package:halcyon/features/library/library_providers.dart';
+import 'package:halcyon/features/library/library_screen.dart';
 
 import 'fake_audio_file_scanner.dart';
 import 'fake_folder_picker_service.dart';

--- a/test/features/library/selected_folder_controller_test.dart
+++ b/test/features/library/selected_folder_controller_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/data/repositories/in_memory_selected_music_folder_repository.dart';
-import 'package:sonara/data/repositories/selected_music_folder_repository_provider.dart';
-import 'package:sonara/features/library/library_providers.dart';
-import 'package:sonara/features/library/selected_folder_controller.dart';
+import 'package:halcyon/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:halcyon/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:halcyon/features/library/library_providers.dart';
+import 'package:halcyon/features/library/selected_folder_controller.dart';
 
 import 'fake_folder_picker_service.dart';
 

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:sonara/core/models/playback_queue.dart';
-import 'package:sonara/core/models/playback_state.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/services/playback_controller.dart';
+import 'package:halcyon/core/models/playback_queue.dart';
+import 'package:halcyon/core/models/playback_state.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/core/services/playback_controller.dart';
 
 /// In-memory [PlaybackController] for widget/provider tests.
 ///

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/playback_state.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/services/playback_controller.dart';
-import 'package:sonara/features/player/player_providers.dart';
-import 'package:sonara/features/player/player_screen.dart';
+import 'package:halcyon/core/models/playback_state.dart';
+import 'package:halcyon/core/models/track.dart';
+import 'package:halcyon/core/services/playback_controller.dart';
+import 'package:halcyon/features/player/player_providers.dart';
+import 'package:halcyon/features/player/player_screen.dart';
 
 import 'fake_playback_controller.dart';
 

--- a/test/features/player/queue_behavior_test.dart
+++ b/test/features/player/queue_behavior_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
+import 'package:halcyon/core/models/track.dart';
 
 import 'fake_playback_controller.dart';
 


### PR DESCRIPTION
## Rename summary

Renames the music player from **Sonara** to **Halcyon** (Sonara conflicts with an existing music-related iOS app). This is a focused, rename-only change — every `Sonara`/`sonara`/`SONARA` occurrence becomes `Halcyon`/`halcyon`/`HALCYON`, with no behavioral changes.

What was renamed:
- **Dart package name**: `sonara` → `halcyon` (`pubspec.yaml`), and every `package:sonara/...` import in tests updated to `package:halcyon/...`.
- **App display name**: `AppInfo.name` `'Sonara'` → `'Halcyon'`.
- **Internal identifiers**: `SonaraApp` → `HalcyonApp`, `SonaraAudioHandler` → `HalcyonAudioHandler`, `SonaraDatabase` → `HalcyonDatabase`, `sonaraDatabaseProvider` → `halcyonDatabaseProvider`.
- **File renames** (via `git mv`, history preserved):
  - `lib/app/sonara_app.dart` → `lib/app/halcyon_app.dart`
  - `lib/core/services/sonara_audio_handler.dart` → `lib/core/services/halcyon_audio_handler.dart`
  - `lib/data/database/sonara_database.dart` → `halcyon_database.dart`
  - `lib/data/database/sonara_database.g.dart` → `halcyon_database.g.dart`
  - `lib/data/database/sonara_database_provider.dart` → `halcyon_database_provider.dart`
  - `test/core/services/sonara_audio_handler_test.dart` → `halcyon_audio_handler_test.dart`
- **Generated Drift file**: the `.g.dart` was hand-edited (not regenerated) to track the `SonaraDatabase` → `HalcyonDatabase` class rename (`_$HalcyonDatabase`, `$HalcyonDatabaseManager`, `part of` directive). No schema or table changes.
- **Runtime identifiers**: SQLite filename `sonara.sqlite` → `halcyon.sqlite`; media-session notification channel id `com.sonara.audio` → `com.halcyon.audio` and channel name `Sonara playback` → `Halcyon playback`.
- **Docs & comments**: `README.md` and app-facing/brand comments updated.

## Files changed

46 files, 156 insertions / 156 deletions: `README.md`, `pubspec.yaml`, 6 renamed files (listed above), plus mechanical text updates across `lib/` and `test/`. No file was changed beyond the name substitution.

## What was intentionally NOT changed

- No features added; no architecture, refactoring, or layering changes.
- No changes to playback, scanner, Drift queries, Library, folder picker, queue, playlists, downloads, or Android Auto logic.
- Drift files were **not regenerated** — only the class-name references in the existing `.g.dart` were edited to match the rename.
- Database **schema** unchanged (still `schemaVersion = 1`, same tables/columns).
- CI workflows (`.github/workflows/`) contained no `sonara` references and were left untouched.

## Verification status

⚠️ Flutter/Dart SDK is **not available** in this execution environment, so the requested commands could not be run here:
- `flutter pub get` — not run (no SDK)
- `dart format --set-exit-if-changed .` — not run (no SDK)
- `flutter analyze` — not run (no SDK)
- `flutter test` — not run (no SDK)

Manual consistency checks that were performed:
- No remaining `Sonara`/`sonara`/`SONARA` references anywhere in the tree.
- No dangling `package:sonara/...` imports and no references to the old file names.
- `part`/`part of` directives and Drift class names (`_$HalcyonDatabase`, `$HalcyonDatabaseManager`) are consistent between `halcyon_database.dart` and `halcyon_database.g.dart`.

Please run the four verification commands in a Flutter-enabled environment before merging.

## Known follow-ups

- **Android/iOS native package IDs are not in this repo** (no `android/`, `ios/`, etc. directories are committed/generated yet). The suggested final app ID `io.github.thezupzup.halcyon` should be applied when native projects are generated. At that time, consider aligning the audio notification channel id (currently a mechanical rename to `com.halcyon.audio`) with the final app-ID namespace.
- The on-disk SQLite file moved from `sonara.sqlite` to `halcyon.sqlite`; existing local installs (pre-release) would start with a fresh local catalog and re-scan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QMyx6zhqzDNAJ4eg7YJnm6)_