### PR TITLE
Rename app from Sonara to Linthra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Sonara
+# Linthra
 
 A modern, **local-first**, privacy-focused music player for people who own
-their music. Sonara is a clean alternative to bloated streaming apps — your
+their music. Linthra is a clean alternative to bloated streaming apps — your
 library lives on your device, and downloads are always under your explicit
 control.
 
@@ -54,7 +54,7 @@ testing.
 
 **Drift/SQLite persistence** has now landed for tracks.
 `DriftMusicLibraryRepository` (`lib/data/repositories/`) is the persistent
-catalog the UI will read from, backed by `SonaraDatabase`
+catalog the UI will read from, backed by `LinthraDatabase`
 (`lib/data/database/`). At schema **v1** only the `tracks` table is persisted:
 `getAllTracks`, `getTrackById`, and `upsertCatalog` are real, while
 `getAllAlbums`/`getAllArtists` return empty lists for now. Domain models
@@ -155,7 +155,7 @@ Jellyfin/WebDAV roadmap possible without rewriting the UI.
 lib/
   main.dart                 entry point; hosts the Riverpod ProviderScope
   app/                      app-level wiring
-    sonara_app.dart         root MaterialApp.router widget
+    linthra_app.dart         root MaterialApp.router widget
     router.dart             go_router config (Riverpod provider)
     routes.dart             route path constants
     theme.dart              dark-first ThemeData
@@ -171,7 +171,7 @@ lib/
     sources/                concrete MusicSource implementations:
                             local/ (LocalMusicSource + file scanning)
   data/                     concrete repository implementations + storage
-    database/               SonaraDatabase (Drift) + tables/ (tracks_table.dart)
+    database/               LinthraDatabase (Drift) + tables/ (tracks_table.dart)
     mappers/                domain <-> Drift row conversion (track_mapper.dart)
     repositories/           drift_music_library_repository.dart (persistent),
                             in_memory_music_library_repository.dart (dev/tests)
@@ -194,7 +194,7 @@ lib/
   [`PlaybackQueue`](lib/core/models/playback_queue.dart) model (current track +
   upcoming tracks) and exposes `playTracks`, `playNext`, `skipToNext`, and
   `clearQueue`; the UI reads the queue from `PlaybackState` and never edits it
-  directly. `SonaraAudioHandler` wraps it for background audio / the platform
+  directly. `LinthraAudioHandler` wraps it for background audio / the platform
   media session (notification, lock screen, Android Auto) without touching
   feature code; MPRIS can attach the same way later.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
@@ -226,7 +226,7 @@ flutter run
 
 ### Building a debug APK (Android)
 
-To install and test Sonara on an Android phone:
+To install and test Linthra on an Android phone:
 
 ```bash
 # Generate the Android scaffold (skip if android/ already exists locally)
@@ -249,7 +249,7 @@ this stage — there are no native build, signing, or publishing steps in CI.
 
 ### Background playback & Android Auto
 
-Sonara registers a platform **media session** through `audio_service` so
+Linthra registers a platform **media session** through `audio_service` so
 playback survives backgrounding and shows up where the OS expects it:
 
 - **Notification & lock screen.** A media notification mirrors the current
@@ -264,7 +264,7 @@ playback survives backgrounding and shows up where the OS expects it:
   UI). That polish is a later PR.
 
 **Architecture.** `audio_service` is a pure infrastructure layer.
-`SonaraAudioHandler` (`lib/core/services/sonara_audio_handler.dart`) is the
+`LinthraAudioHandler` (`lib/core/services/linthra_audio_handler.dart`) is the
 only file that imports it: it forwards session commands
 (play/pause/stop/skip/seek) to the `PlaybackController` and mirrors the
 controller's `PlaybackState` back out as the session's playback state + media
@@ -308,7 +308,7 @@ Android Auto, add to `android/app/src/main/AndroidManifest.xml`:
 
 The main activity should extend `AudioServiceActivity` (per the `audio_service`
 README) so the session binds correctly. The notification channel id/name are
-configured in `connectMediaSession` (`com.sonara.audio` / "Sonara playback").
+configured in `connectMediaSession` (`com.linthra.audio` / "Linthra playback").
 
 **Limitations (this PR).**
 
@@ -385,7 +385,7 @@ Deliberate gaps the next PRs will close:
 2. Put a few audio files under a folder on shared storage, e.g.
    `/storage/emulated/0/Music`.
 3. In **Library**, tap the folder icon and pick that folder. The chooser
-   returns a `content://…/tree/primary:Music` URI; Sonara resolves it to the
+   returns a `content://…/tree/primary:Music` URI; Linthra resolves it to the
    path and scans it.
 4. Picking a folder from a provider that has no filesystem mapping (for example
    a cloud "Documents" provider) is expected to show the Library error state

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -7,8 +7,8 @@ import 'theme.dart';
 
 /// Root widget. Dark mode is the primary experience; the light theme follows
 /// the system setting when the user opts out of dark.
-class SonaraApp extends ConsumerWidget {
-  const SonaraApp({super.key});
+class LinthraApp extends ConsumerWidget {
+  const LinthraApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'colors.dart';
 import 'dimens.dart';
 
-/// Builds the light and dark [ThemeData] for Sonara. Both share the same
+/// Builds the light and dark [ThemeData] for Linthra. Both share the same
 /// shape language and accent so the product feels cohesive across modes.
 abstract final class AppTheme {
   static ThemeData get dark => _build(

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -1,5 +1,5 @@
 /// Static, build-time app metadata.
 abstract final class AppInfo {
-  static const String name = 'Sonara';
+  static const String name = 'Linthra';
   static const String tagline = 'Your music, beautifully yours.';
 }

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -3,7 +3,7 @@ enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
 
 /// Tracks which library items are available offline.
 ///
-/// Downloads in Sonara are always *explicit and user-initiated* — never
+/// Downloads in Linthra are always *explicit and user-initiated* — never
 /// automatic. Implementations must also honor the user's "Wi-Fi only" pref
 /// (queueing rather than downloading over mobile data when set), so that
 /// promise is enforced in one place rather than scattered through the UI.

--- a/lib/core/repositories/music_library_repository.dart
+++ b/lib/core/repositories/music_library_repository.dart
@@ -6,7 +6,7 @@ import '../models/track.dart';
 ///
 /// Critical separation of concerns: the UI always reads from the repository
 /// (backed by SQLite), never directly from a [MusicSource]. Sources *sync into*
-/// the repository on demand. This is what makes Sonara work fully offline and
+/// the repository on demand. This is what makes Linthra work fully offline and
 /// keeps remote latency out of the render path.
 ///
 /// The concrete implementation (e.g. a `drift`-backed one) is added when the

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -16,8 +16,8 @@ import 'playback_controller.dart';
 /// audio_service playback state + media item, so the notification, lock screen,
 /// and Android Auto reflect what is playing. The controller stays the single
 /// source of truth and owns `just_audio`; the UI never touches this class.
-class SonaraAudioHandler extends audio.BaseAudioHandler {
-  SonaraAudioHandler(this._controller) {
+class LinthraAudioHandler extends audio.BaseAudioHandler {
+  LinthraAudioHandler(this._controller) {
     _subscription = _controller.stateStream.listen(_broadcast);
     // Seed the session from the latest known state so a freshly attached
     // notification/Android Auto isn't blank before the first stream event.
@@ -111,15 +111,15 @@ class SonaraAudioHandler extends audio.BaseAudioHandler {
 /// (a platform without the native setup, or a test environment). Playback still
 /// works through the controller in that case, so a missing media session never
 /// breaks basic playback.
-Future<SonaraAudioHandler?> connectMediaSession(
+Future<LinthraAudioHandler?> connectMediaSession(
   PlaybackController controller,
 ) async {
   try {
     return await audio.AudioService.init(
-      builder: () => SonaraAudioHandler(controller),
+      builder: () => LinthraAudioHandler(controller),
       config: const audio.AudioServiceConfig(
-        androidNotificationChannelId: 'com.sonara.audio',
-        androidNotificationChannelName: 'Sonara playback',
+        androidNotificationChannelId: 'com.linthra.audio',
+        androidNotificationChannelName: 'Linthra playback',
         androidNotificationOngoing: true,
       ),
     );

--- a/lib/core/services/music_source.dart
+++ b/lib/core/services/music_source.dart
@@ -2,7 +2,7 @@ import '../models/album.dart';
 import '../models/artist.dart';
 import '../models/track.dart';
 
-/// A backend that *provides* media to Sonara.
+/// A backend that *provides* media to Linthra.
 ///
 /// This is the core extension point for the project's roadmap. The MVP ships a
 /// `LocalMusicSource` (scans on-device files); future `JellyfinMusicSource`,

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -77,7 +77,7 @@ class ContentUriAudioFileScanner implements AudioFileScanner {
     if (path == null) {
       throw FolderScanException(
         "This folder can't be scanned yet. It was shared through Android's "
-        'Storage Access Framework, which Sonara cannot walk directly on this '
+        'Storage Access Framework, which Linthra cannot walk directly on this '
         'device. Try selecting a folder on your phone or SD card storage.',
         folder: folder,
       );

--- a/lib/core/sources/local/audio_file_types.dart
+++ b/lib/core/sources/local/audio_file_types.dart
@@ -1,6 +1,6 @@
 import 'package:path/path.dart' as p;
 
-/// The audio file extensions Sonara's local scanner recognizes.
+/// The audio file extensions Linthra's local scanner recognizes.
 ///
 /// Kept small and centralized on purpose: supporting a new container format
 /// later is a one-line change here that the rest of the scanner picks up for

--- a/lib/data/database/linthra_database.dart
+++ b/lib/data/database/linthra_database.dart
@@ -7,7 +7,7 @@ import 'package:path_provider/path_provider.dart';
 
 import 'tables/tracks_table.dart';
 
-part 'sonara_database.g.dart';
+part 'linthra_database.g.dart';
 
 /// The app's local SQLite database — the offline-first catalog the UI reads
 /// from. Kept deliberately outside the UI and feature layers; repositories in
@@ -17,12 +17,12 @@ part 'sonara_database.g.dart';
 /// [schemaVersion] and add a `MigrationStrategy`; we are not pre-building that
 /// machinery while there is nothing to migrate from.
 @DriftDatabase(tables: [Tracks])
-class SonaraDatabase extends _$SonaraDatabase {
-  SonaraDatabase() : super(_openConnection());
+class LinthraDatabase extends _$LinthraDatabase {
+  LinthraDatabase() : super(_openConnection());
 
   /// Builds a database over a caller-supplied executor. Used by tests to run
   /// against an in-memory SQLite instance (`NativeDatabase.memory()`).
-  SonaraDatabase.forTesting(super.executor);
+  LinthraDatabase.forTesting(super.executor);
 
   @override
   int get schemaVersion => 1;
@@ -31,7 +31,7 @@ class SonaraDatabase extends _$SonaraDatabase {
 QueryExecutor _openConnection() {
   return LazyDatabase(() async {
     final Directory dir = await getApplicationDocumentsDirectory();
-    final File file = File(p.join(dir.path, 'sonara.sqlite'));
+    final File file = File(p.join(dir.path, 'linthra.sqlite'));
     return NativeDatabase.createInBackground(file);
   });
 }

--- a/lib/data/database/linthra_database.g.dart
+++ b/lib/data/database/linthra_database.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'sonara_database.dart';
+part of 'linthra_database.dart';
 
 // ignore_for_file: type=lint
 class $TracksTable extends Tracks with TableInfo<$TracksTable, TrackRow> {
@@ -482,9 +482,9 @@ class TracksCompanion extends UpdateCompanion<TrackRow> {
   }
 }
 
-abstract class _$SonaraDatabase extends GeneratedDatabase {
-  _$SonaraDatabase(QueryExecutor e) : super(e);
-  $SonaraDatabaseManager get managers => $SonaraDatabaseManager(this);
+abstract class _$LinthraDatabase extends GeneratedDatabase {
+  _$LinthraDatabase(QueryExecutor e) : super(e);
+  $LinthraDatabaseManager get managers => $LinthraDatabaseManager(this);
   late final $TracksTable tracks = $TracksTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -519,7 +519,7 @@ typedef $$TracksTableUpdateCompanionBuilder = TracksCompanion Function({
 });
 
 class $$TracksTableFilterComposer
-    extends Composer<_$SonaraDatabase, $TracksTable> {
+    extends Composer<_$LinthraDatabase, $TracksTable> {
   $$TracksTableFilterComposer({
     required super.$db,
     required super.$table,
@@ -556,7 +556,7 @@ class $$TracksTableFilterComposer
 }
 
 class $$TracksTableOrderingComposer
-    extends Composer<_$SonaraDatabase, $TracksTable> {
+    extends Composer<_$LinthraDatabase, $TracksTable> {
   $$TracksTableOrderingComposer({
     required super.$db,
     required super.$table,
@@ -593,7 +593,7 @@ class $$TracksTableOrderingComposer
 }
 
 class $$TracksTableAnnotationComposer
-    extends Composer<_$SonaraDatabase, $TracksTable> {
+    extends Composer<_$LinthraDatabase, $TracksTable> {
   $$TracksTableAnnotationComposer({
     required super.$db,
     required super.$table,
@@ -630,7 +630,7 @@ class $$TracksTableAnnotationComposer
 }
 
 class $$TracksTableTableManager extends RootTableManager<
-    _$SonaraDatabase,
+    _$LinthraDatabase,
     $TracksTable,
     TrackRow,
     $$TracksTableFilterComposer,
@@ -638,10 +638,10 @@ class $$TracksTableTableManager extends RootTableManager<
     $$TracksTableAnnotationComposer,
     $$TracksTableCreateCompanionBuilder,
     $$TracksTableUpdateCompanionBuilder,
-    (TrackRow, BaseReferences<_$SonaraDatabase, $TracksTable, TrackRow>),
+    (TrackRow, BaseReferences<_$LinthraDatabase, $TracksTable, TrackRow>),
     TrackRow,
     PrefetchHooks Function()> {
-  $$TracksTableTableManager(_$SonaraDatabase db, $TracksTable table)
+  $$TracksTableTableManager(_$LinthraDatabase db, $TracksTable table)
       : super(TableManagerState(
           db: db,
           table: table,
@@ -707,7 +707,7 @@ class $$TracksTableTableManager extends RootTableManager<
 }
 
 typedef $$TracksTableProcessedTableManager = ProcessedTableManager<
-    _$SonaraDatabase,
+    _$LinthraDatabase,
     $TracksTable,
     TrackRow,
     $$TracksTableFilterComposer,
@@ -715,13 +715,13 @@ typedef $$TracksTableProcessedTableManager = ProcessedTableManager<
     $$TracksTableAnnotationComposer,
     $$TracksTableCreateCompanionBuilder,
     $$TracksTableUpdateCompanionBuilder,
-    (TrackRow, BaseReferences<_$SonaraDatabase, $TracksTable, TrackRow>),
+    (TrackRow, BaseReferences<_$LinthraDatabase, $TracksTable, TrackRow>),
     TrackRow,
     PrefetchHooks Function()>;
 
-class $SonaraDatabaseManager {
-  final _$SonaraDatabase _db;
-  $SonaraDatabaseManager(this._db);
+class $LinthraDatabaseManager {
+  final _$LinthraDatabase _db;
+  $LinthraDatabaseManager(this._db);
   $$TracksTableTableManager get tracks =>
       $$TracksTableTableManager(_db, _db.tracks);
 }

--- a/lib/data/database/linthra_database_provider.dart
+++ b/lib/data/database/linthra_database_provider.dart
@@ -1,12 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'sonara_database.dart';
+import 'linthra_database.dart';
 
-/// The app-wide [SonaraDatabase]. The underlying SQLite connection is opened
+/// The app-wide [LinthraDatabase]. The underlying SQLite connection is opened
 /// lazily on first query and closed when the provider is disposed, so nothing
 /// touches the disk until the catalog is actually read or written.
-final sonaraDatabaseProvider = Provider<SonaraDatabase>((ref) {
-  final db = SonaraDatabase();
+final linthraDatabaseProvider = Provider<LinthraDatabase>((ref) {
+  final db = LinthraDatabase();
   ref.onDispose(db.close);
   return db;
 });

--- a/lib/data/mappers/track_mapper.dart
+++ b/lib/data/mappers/track_mapper.dart
@@ -1,7 +1,7 @@
 import 'package:drift/drift.dart';
 
 import '../../core/models/track.dart';
-import '../database/sonara_database.dart';
+import '../database/linthra_database.dart';
 
 /// Explicit, one-way conversions between the [Track] domain model and its
 /// persisted form. Kept tiny and dumb on purpose: no IO, no defaults beyond

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -4,7 +4,7 @@ import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../core/repositories/music_library_repository.dart';
-import '../database/sonara_database.dart';
+import '../database/linthra_database.dart';
 import '../mappers/track_mapper.dart';
 
 /// SQLite-backed [MusicLibraryRepository] using Drift. This is the persistent
@@ -16,7 +16,7 @@ import '../mappers/track_mapper.dart';
 class DriftMusicLibraryRepository implements MusicLibraryRepository {
   DriftMusicLibraryRepository(this._db);
 
-  final SonaraDatabase _db;
+  final LinthraDatabase _db;
 
   @override
   Future<List<Track>> getAllTracks() async {

--- a/lib/data/repositories/music_library_repository_provider.dart
+++ b/lib/data/repositories/music_library_repository_provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/repositories/music_library_repository.dart';
-import '../database/sonara_database_provider.dart';
+import '../database/linthra_database_provider.dart';
 import 'drift_music_library_repository.dart';
 import 'in_memory_music_library_repository.dart';
 
@@ -17,8 +17,8 @@ final musicLibraryRepositoryProvider = Provider<MusicLibraryRepository>((ref) {
 
 /// Production binding: a Drift/SQLite-backed repository so scanned tracks
 /// survive app restarts. Applied in `main`; tests can apply it over an
-/// in-memory database by also overriding [sonaraDatabaseProvider].
+/// in-memory database by also overriding [linthraDatabaseProvider].
 final driftMusicLibraryRepositoryOverride =
     musicLibraryRepositoryProvider.overrideWith(
-  (ref) => DriftMusicLibraryRepository(ref.watch(sonaraDatabaseProvider)),
+  (ref) => DriftMusicLibraryRepository(ref.watch(linthraDatabaseProvider)),
 );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'app/sonara_app.dart';
+import 'app/linthra_app.dart';
 import 'core/services/just_audio_playback_controller.dart';
-import 'core/services/sonara_audio_handler.dart';
+import 'core/services/linthra_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
@@ -39,7 +39,7 @@ Future<void> main() async {
         sharedPreferencesDownloadStoreOverride,
         sharedPreferencesDownloadPreferencesOverride,
       ],
-      child: const SonaraApp(),
+      child: const LinthraApp(),
     ),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: sonara
+name: linthra
 description: A modern, local-first, privacy-focused music player.
 publish_to: "none"
 version: 0.1.0+1
@@ -29,7 +29,7 @@ dependencies:
   # just_audio directly.
   just_audio: ^0.9.42
   # Background playback + platform media session (notification, lock screen,
-  # Android Auto). Used only by SonaraAudioHandler in the services layer, which
+  # Android Auto). Used only by LinthraAudioHandler in the services layer, which
   # forwards session commands to PlaybackController and mirrors its state out.
   # The UI never depends on audio_service directly.
   audio_service: ^0.18.15
@@ -47,7 +47,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   # Drift code generation. Run via the manual "Generate Drift files" workflow;
-  # produces the *.g.dart files that back SonaraDatabase.
+  # produces the *.g.dart files that back LinthraDatabase.
   drift_dev: ^2.18.0
   build_runner: ^2.4.13
 

--- a/test/app_smoke_test.dart
+++ b/test/app_smoke_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/app/sonara_app.dart';
+import 'package:linthra/app/linthra_app.dart';
 
 void main() {
   testWidgets('App boots to the Library screen', (tester) async {
-    await tester.pumpWidget(const ProviderScope(child: SonaraApp()));
+    await tester.pumpWidget(const ProviderScope(child: LinthraApp()));
     await tester.pumpAndSettle();
 
     // The persistent shell and its bottom navigation render.

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/playback_queue.dart';
-import 'package:sonara/core/models/track.dart';
+import 'package:linthra/core/models/playback_queue.dart';
+import 'package:linthra/core/models/track.dart';
 
 Track _track(String id) => Track(id: id, title: 'Song $id', uri: '/$id.mp3');
 

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -1,8 +1,8 @@
 import 'package:audio_service/audio_service.dart' as audio;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/playback_state.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/services/sonara_audio_handler.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/linthra_audio_handler.dart';
 
 import '../../features/player/fake_playback_controller.dart';
 
@@ -21,13 +21,13 @@ Track _track(String id) {
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
 
 void main() {
-  group('SonaraAudioHandler', () {
+  group('LinthraAudioHandler', () {
     late FakePlaybackController controller;
-    late SonaraAudioHandler handler;
+    late LinthraAudioHandler handler;
 
     setUp(() {
       controller = FakePlaybackController();
-      handler = SonaraAudioHandler(controller);
+      handler = LinthraAudioHandler(controller);
     });
 
     tearDown(() async {

--- a/test/core/sources/local/audio_file_scanner_test.dart
+++ b/test/core/sources/local/audio_file_scanner_test.dart
@@ -1,14 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 
 void main() {
   group('IoAudioFileScanner', () {
     late Directory root;
 
     setUp(() async {
-      root = await Directory.systemTemp.createTemp('sonara_scan_test');
+      root = await Directory.systemTemp.createTemp('linthra_scan_test');
     });
 
     tearDown(() async {

--- a/test/core/sources/local/audio_file_types_test.dart
+++ b/test/core/sources/local/audio_file_types_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_types.dart';
+import 'package:linthra/core/sources/local/audio_file_types.dart';
 
 void main() {
   group('AudioFileTypes.isSupported', () {

--- a/test/core/sources/local/content_uri_audio_file_scanner_test.dart
+++ b/test/core/sources/local/content_uri_audio_file_scanner_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
-import 'package:sonara/core/sources/local/folder_scan_exception.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/folder_scan_exception.dart';
 
 /// Records the folder it was asked to scan and returns a fixed list, so we can
 /// assert the content scanner resolved the URI to a path before delegating.

--- a/test/core/sources/local/folder_location_test.dart
+++ b/test/core/sources/local/folder_location_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/folder_location.dart';
+import 'package:linthra/core/sources/local/folder_location.dart';
 
 void main() {
   group('FolderLocation', () {

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
-import 'package:sonara/core/sources/local/local_music_source.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/local_music_source.dart';
 
 /// Returns a fixed list of paths and records the folder it was asked to scan,
 /// so the source can be tested without touching a real file system.

--- a/test/core/sources/local/local_track_mapper_test.dart
+++ b/test/core/sources/local/local_track_mapper_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/local_track_mapper.dart';
+import 'package:linthra/core/sources/local/local_track_mapper.dart';
 
 void main() {
   group('LocalTrackMapper.fromPath', () {

--- a/test/core/sources/local/platform_audio_file_scanner_test.dart
+++ b/test/core/sources/local/platform_audio_file_scanner_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 
 /// Records that it was called and with which folder, so we can assert the
 /// router picked this backend.

--- a/test/core/sources/local/saf_tree_uri_resolver_test.dart
+++ b/test/core/sources/local/saf_tree_uri_resolver_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/sources/local/saf_tree_uri_resolver.dart';
+import 'package:linthra/core/sources/local/saf_tree_uri_resolver.dart';
 
 void main() {
   const resolver = SafTreeUriResolver();

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/repositories/download_repository.dart';
-import 'package:sonara/core/services/connectivity_service.dart';
-import 'package:sonara/data/repositories/cache_download_repository.dart';
-import 'package:sonara/data/repositories/in_memory_download_preferences.dart';
-import 'package:sonara/data/repositories/in_memory_download_store.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/services/connectivity_service.dart';
+import 'package:linthra/data/repositories/cache_download_repository.dart';
+import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
+import 'package:linthra/data/repositories/in_memory_download_store.dart';
 
 /// A connectivity stand-in whose reported status the test can flip at will.
 class _FakeConnectivity implements ConnectivityService {

--- a/test/data/repositories/drift_music_library_repository_test.dart
+++ b/test/data/repositories/drift_music_library_repository_test.dart
@@ -1,10 +1,10 @@
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/database/sonara_database.dart';
-import 'package:sonara/data/repositories/drift_music_library_repository.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/database/linthra_database.dart';
+import 'package:linthra/data/repositories/drift_music_library_repository.dart';
 
 Track _track(String id, {int durationMs = 0, String? artworkUri}) => Track(
       id: id,
@@ -19,11 +19,11 @@ Track _track(String id, {int durationMs = 0, String? artworkUri}) => Track(
 
 void main() {
   group('DriftMusicLibraryRepository', () {
-    late SonaraDatabase db;
+    late LinthraDatabase db;
     late DriftMusicLibraryRepository repository;
 
     setUp(() {
-      db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      db = LinthraDatabase.forTesting(NativeDatabase.memory());
       repository = DriftMusicLibraryRepository(db);
     });
 

--- a/test/data/repositories/drift_repository_wiring_test.dart
+++ b/test/data/repositories/drift_repository_wiring_test.dart
@@ -1,24 +1,24 @@
 import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/database/sonara_database.dart';
-import 'package:sonara/data/database/sonara_database_provider.dart';
-import 'package:sonara/data/repositories/drift_music_library_repository.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_controller.dart';
-import 'package:sonara/features/library/library_state.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/database/linthra_database.dart';
+import 'package:linthra/data/database/linthra_database_provider.dart';
+import 'package:linthra/data/repositories/drift_music_library_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/library_state.dart';
 
 void main() {
   group('driftMusicLibraryRepositoryOverride', () {
     test('binds the repository provider to the Drift implementation', () {
-      final db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      final db = LinthraDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       final container = ProviderContainer(
         overrides: [
-          sonaraDatabaseProvider.overrideWithValue(db),
+          linthraDatabaseProvider.overrideWithValue(db),
           driftMusicLibraryRepositoryOverride,
         ],
       );
@@ -32,11 +32,11 @@ void main() {
 
     test('catalog persists through the controller via the Drift binding',
         () async {
-      final db = SonaraDatabase.forTesting(NativeDatabase.memory());
+      final db = LinthraDatabase.forTesting(NativeDatabase.memory());
       addTearDown(db.close);
       final container = ProviderContainer(
         overrides: [
-          sonaraDatabaseProvider.overrideWithValue(db),
+          linthraDatabaseProvider.overrideWithValue(db),
           driftMusicLibraryRepositoryOverride,
         ],
       );

--- a/test/data/repositories/in_memory_download_store_test.dart
+++ b/test/data/repositories/in_memory_download_store_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/data/repositories/in_memory_download_store.dart';
+import 'package:linthra/data/repositories/in_memory_download_store.dart';
 
 void main() {
   group('InMemoryDownloadStore', () {

--- a/test/data/repositories/in_memory_music_library_repository_test.dart
+++ b/test/data/repositories/in_memory_music_library_repository_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 
 Track _track(String id) => Track(id: id, title: 'Track $id', uri: id);
 

--- a/test/data/repositories/in_memory_selected_music_folder_repository_test.dart
+++ b/test/data/repositories/in_memory_selected_music_folder_repository_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
 
 void main() {
   group('InMemorySelectedMusicFolderRepository', () {

--- a/test/features/downloads/download_action_test.dart
+++ b/test/features/downloads/download_action_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_screen.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
 
 import '../library/fake_music_library_repository.dart';
 

--- a/test/features/library/fake_audio_file_scanner.dart
+++ b/test/features/library/fake_audio_file_scanner.dart
@@ -1,4 +1,4 @@
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 
 /// Returns a fixed list of file paths, or throws [error] when one is set, so a
 /// scan can be driven without a real file system.

--- a/test/features/library/fake_folder_picker_service.dart
+++ b/test/features/library/fake_folder_picker_service.dart
@@ -1,4 +1,4 @@
-import 'package:sonara/core/services/folder_picker_service.dart';
+import 'package:linthra/core/services/folder_picker_service.dart';
 
 /// Returns a fixed folder (or `null` to simulate cancellation) so the
 /// pick-and-scan flow can be driven without a real OS folder dialog.

--- a/test/features/library/fake_music_library_repository.dart
+++ b/test/features/library/fake_music_library_repository.dart
@@ -1,7 +1,7 @@
-import 'package:sonara/core/models/album.dart';
-import 'package:sonara/core/models/artist.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
 
 /// A minimal [MusicLibraryRepository] for driving controller/widget tests.
 ///

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/repositories/music_library_repository.dart';
-import 'package:sonara/core/sources/local/audio_file_scanner.dart';
-import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_controller.dart';
-import 'package:sonara/features/library/library_providers.dart';
-import 'package:sonara/features/library/library_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/library_state.dart';
 
 import 'fake_audio_file_scanner.dart';
 import 'fake_music_library_repository.dart';

--- a/test/features/library/library_playback_test.dart
+++ b/test/features/library/library_playback_test.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:sonara/app/routes.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_screen.dart';
-import 'package:sonara/features/player/player_providers.dart';
-import 'package:sonara/features/player/player_screen.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
 
 import '../player/fake_playback_controller.dart';
 import 'fake_music_library_repository.dart';

--- a/test/features/library/library_screen_test.dart
+++ b/test/features/library/library_screen_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/data/repositories/in_memory_music_library_repository.dart';
-import 'package:sonara/data/repositories/music_library_repository_provider.dart';
-import 'package:sonara/features/library/library_providers.dart';
-import 'package:sonara/features/library/library_screen.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/library_screen.dart';
 
 import 'fake_audio_file_scanner.dart';
 import 'fake_folder_picker_service.dart';

--- a/test/features/library/selected_folder_controller_test.dart
+++ b/test/features/library/selected_folder_controller_test.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/data/repositories/in_memory_selected_music_folder_repository.dart';
-import 'package:sonara/data/repositories/selected_music_folder_repository_provider.dart';
-import 'package:sonara/features/library/library_providers.dart';
-import 'package:sonara/features/library/selected_folder_controller.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/selected_folder_controller.dart';
 
 import 'fake_folder_picker_service.dart';
 

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:sonara/core/models/playback_queue.dart';
-import 'package:sonara/core/models/playback_state.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/services/playback_controller.dart';
+import 'package:linthra/core/models/playback_queue.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_controller.dart';
 
 /// In-memory [PlaybackController] for widget/provider tests.
 ///

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/playback_state.dart';
-import 'package:sonara/core/models/track.dart';
-import 'package:sonara/core/services/playback_controller.dart';
-import 'package:sonara/features/player/player_providers.dart';
-import 'package:sonara/features/player/player_screen.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_controller.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
 
 import 'fake_playback_controller.dart';
 

--- a/test/features/player/queue_behavior_test.dart
+++ b/test/features/player/queue_behavior_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonara/core/models/track.dart';
+import 'package:linthra/core/models/track.dart';
 
 import 'fake_playback_controller.dart';
 


### PR DESCRIPTION
## Rename summary

`Sonara` conflicts with an existing music-related iOS app, so the project is being renamed to the new official name **Linthra**. This is a **rename-only** PR: no features added, no architecture refactored, and no feature behavior (playback, scanner, Drift, Library, folder picker, queue, playlists, downloads, lyrics, offline cache, Android Auto, Android build) intentionally changed.

Applied case-aware replacements across the codebase:
- `SONARA` → `LINTHRA`
- `Sonara` → `Linthra`
- `sonara` → `linthra`

## Package / app identity

- **Dart package name:** `sonara` → `linthra` (`pubspec.yaml`)
- **All `package:` imports:** `package:sonara/...` → `package:linthra/...`
- **App display name:** `AppInfo.name` `'Sonara'` → `'Linthra'`
- Repo/project name: Linthra
- Future app ID `io.github.thezupzup.linthra` — see follow-up below (no Android native module is committed in this repo yet).

## Files changed

46 files changed. Notable renames (history preserved via `git mv`):

| Old | New |
| --- | --- |
| `lib/app/sonara_app.dart` | `lib/app/linthra_app.dart` |
| `lib/core/services/sonara_audio_handler.dart` | `lib/core/services/linthra_audio_handler.dart` |
| `lib/data/database/sonara_database.dart` | `lib/data/database/linthra_database.dart` |
| `lib/data/database/sonara_database.g.dart` | `lib/data/database/linthra_database.g.dart` |
| `lib/data/database/sonara_database_provider.dart` | `lib/data/database/linthra_database_provider.dart` |
| `test/core/services/sonara_audio_handler_test.dart` | `test/core/services/linthra_audio_handler_test.dart` |

Renamed identifiers: `SonaraApp` → `LinthraApp`, `SonaraAudioHandler` → `LinthraAudioHandler`, `SonaraDatabase` → `LinthraDatabase`, `$SonaraDatabaseManager`/`_$SonaraDatabase` → `…Linthra…`, `sonaraDatabaseProvider` → `linthraDatabaseProvider`. Drift `part`/`part of` directives updated to the new file names. README/docs and app-facing doc comments updated. Test expectations and test IDs that mentioned `sonara` updated.

## Package / import changes

- `pubspec.yaml`: `name: sonara` → `name: linthra`.
- 83 `package:sonara/...` import statements (mostly in `test/`) → `package:linthra/...`.
- Relative `part`/`import` references to the renamed database/app/handler files updated.

## Intentionally NOT changed

- **Database schema:** the Drift table (`Tracks` / `tracks`) and all columns are untouched — `schemaVersion` stays `1`. Drift codegen output (`*.g.dart`) was hand-edited for the class/file rename only, not regenerated.
- **Persistence keys:** `SharedPreferences` keys (`selected_music_folder`, `downloaded_track_ids`, `downloads_wifi_only`) are brand-neutral and were left alone, so existing preferences are preserved.
- **Architecture & feature behavior:** no changes to playback, scanner, Library, folder picker, queue, playlists, downloads, lyrics, offline cache logic, Android Auto bridging, or CI logic.

## Behavioral side-effects of the rename (benign)

- **Offline cache file:** `sonara.sqlite` → `linthra.sqlite`. On any existing install the old cache file is no longer read; the catalog is a derived cache and rebuilds automatically on the next folder scan (no user data is lost). Renamed for a clean rename; flag if you'd prefer to keep the old filename or add a one-time migration instead.
- **Android notification channel ID:** `com.sonara.audio` → `com.linthra.audio` (channel name `'Sonara playback'` → `'Linthra playback'`). On an existing install this registers a fresh notification channel — cosmetic only.

## Verification status

Flutter/Dart is **not available** in this environment, so the following were **not run locally** and are expected to run in GitHub Actions CI:
- `flutter pub get`
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test`

Note: replacing `sonara` (6 chars) with `linthra` (7 chars) lengthens some lines, so `dart format` may want to reflow a few near the 80-column limit — CI will catch this and I can push a format fix if it flags anything.

## Known follow-up

- **Android native package ID:** this repo does not currently commit an `android/` native module (no `AndroidManifest.xml`, Gradle `applicationId`, or Kotlin/Java package dirs are present). The future app ID `io.github.thezupzup.linthra` will need to be set when the native Android project is generated/committed; it is not part of this PR.
- Optional: a one-time migration to carry an existing `sonara.sqlite` cache over to `linthra.sqlite`, if preserving pre-rename caches matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S434G1VuRumq2zwq6Re1VZ)_