### PR TITLE
Add debug APK build workflow for Android testing

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -1,0 +1,48 @@
+name: Android Debug APK
+
+# Builds an unsigned debug APK for manual on-device testing.
+# This is for testing only: it does not sign release builds, create
+# GitHub releases, or publish anything.
+on:
+  workflow_dispatch:
+  pull_request:
+
+# Read-only access is all this build needs; the APK is shared via the
+# upload-artifact action rather than by writing to the repo.
+permissions:
+  contents: read
+
+jobs:
+  build-debug-apk:
+    name: Build debug APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # Keep this Flutter version in sync with .github/workflows/ci.yml.
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.27.4
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build debug APK
+        run: flutter build apk --debug
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: linthra-debug-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -251,6 +251,33 @@ The debug APK is unsigned and meant for local testing only. **Release signing,
 store-ready bundles, and APK publishing are intentionally out of scope** for
 this stage — there are no native build, signing, or publishing steps in CI.
 
+#### Downloading a debug APK from CI
+
+If you don't have a local Flutter/Android toolchain, the
+**Android Debug APK** workflow (`.github/workflows/android-debug-apk.yml`)
+builds the same `flutter build apk --debug` output on GitHub and attaches it as
+a downloadable artifact.
+
+- **How to run it:** open the repo's **Actions** tab → **Android Debug APK** →
+  **Run workflow** (the `workflow_dispatch` trigger). It also runs
+  automatically on pull requests.
+- **Artifact:** `linthra-debug-apk`, containing
+  `app-debug.apk` (built from `build/app/outputs/flutter-apk/app-debug.apk`).
+- **Download:** open the completed workflow run and grab `linthra-debug-apk`
+  from the run's **Artifacts** section. GitHub serves it as a `.zip`; unzip it
+  to get `app-debug.apk`.
+- **Install manually:** copy the APK to an Android device and open it (you may
+  need to allow "install from unknown sources"), or with the device connected
+  over ADB run:
+
+  ```bash
+  adb install -r app-debug.apk
+  ```
+
+This artifact is an **unsigned debug build for testing only** — it is not
+signed for release, not published to any store or F-Droid, and no GitHub
+release is created.
+
 **Android identity & permissions.** The app ships with a stable application ID
 **`io.github.thezupzup.linthra`** (also the Kotlin/Gradle `namespace`) and the
 display name **Linthra** — both chosen for future F-Droid / GitHub Releases


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds an **unsigned debug APK** for manual Android testing, so testers can grab a ready-to-install build without a local Flutter/Android toolchain.

- New workflow: `.github/workflows/android-debug-apk.yml`
- Triggers: `workflow_dispatch` (manual) and `pull_request`
- Sets up JDK 17 (Temurin) and Flutter `3.27.4` (stable) — kept in sync with `.github/workflows/ci.yml`
- Runs `flutter pub get` then `flutter build apk --debug`
- Uploads the result as a workflow artifact
- `permissions: contents: read` only

## Artifact

- **Name:** `linthra-debug-apk`
- **Path built:** `build/app/outputs/flutter-apk/app-debug.apk`
- GitHub serves the artifact as a `.zip`; unzip to get `app-debug.apk`.

## How to run it

- **Manual:** Actions tab → **Android Debug APK** → **Run workflow** (`workflow_dispatch`).
- **Automatic:** runs on every pull request.

## How to install the APK manually

1. Download the `linthra-debug-apk` artifact from the completed run and unzip it.
2. Copy `app-debug.apk` to an Android device and open it (allow "install from unknown sources" if prompted), **or** with the device connected over ADB:
   ```bash
   adb install -r app-debug.apk
   ```

## Limitations

- Debug build only — **not** signed for release.
- No release signing, no F-Droid metadata, no Play Store publishing.
- No GitHub release is created and nothing is published automatically.
- No app code changes; README updated with download/install instructions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8fCZDywcx2haVunKJwF2o)_