### PR TITLE
Add manual Android release build workflow (build-only foundation)

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -1,0 +1,66 @@
+name: Android Release Build
+
+# Builds the Android release artifacts (APK + AAB) and attaches them to the
+# workflow run. This is a build-only foundation for future GitHub Releases /
+# F-Droid distribution: it does NOT create a GitHub release, publish to any
+# store, or submit to F-Droid, and it runs only when you trigger it manually.
+#
+# Signing status: no release signing secrets are configured in this repo, so
+# the release build falls back to the debug signing config declared in
+# android/app/build.gradle (`signingConfig = signingConfigs.debug`). The
+# resulting artifacts are therefore DEBUG-KEY SIGNED, not release signed — fine
+# for previews and smoke-testing a release build, but NOT suitable for store or
+# F-Droid distribution. Wiring real release signing (via repository secrets) is
+# the recommended next step and is intentionally out of scope here.
+on:
+  workflow_dispatch:
+
+# Read-only is all this needs: artifacts are shared via upload-artifact rather
+# than by writing to the repo or creating a release.
+permissions:
+  contents: read
+
+jobs:
+  build-release:
+    name: Build release APK + AAB
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # Keep this Flutter version in sync with .github/workflows/ci.yml.
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.27.4
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build release APK
+        run: flutter build apk --release
+
+      - name: Build release AAB
+        run: flutter build appbundle --release
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: linthra-release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error
+
+      - name: Upload release AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: linthra-release-aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -295,6 +295,63 @@ a broad "all files" grant.
 > back gracefully when it is absent, so the debug build still runs and basic
 > playback works; wiring the media session is the recommended next PR.
 
+### Building release artifacts (Android)
+
+The **Android Release Build** workflow
+(`.github/workflows/android-release-build.yml`) builds the Android **release**
+artifacts so we can validate a release build ahead of any GitHub Releases /
+F-Droid distribution. It is a build-only foundation:
+
+- **How to run it:** open the repo's **Actions** tab → **Android Release
+  Build** → **Run workflow**. It is **manual only** (`workflow_dispatch`) — it
+  never runs on a push or PR.
+- **What it builds:** `flutter build apk --release` and
+  `flutter build appbundle --release`.
+- **Artifacts:**
+  - `linthra-release-apk` → `app-release.apk`
+    (`build/app/outputs/flutter-apk/app-release.apk`)
+  - `linthra-release-aab` → `app-release.aab`
+    (`build/app/outputs/bundle/release/app-release.aab`)
+- **Download:** open the completed run and grab the artifacts from the run's
+  **Artifacts** section (GitHub serves each as a `.zip`; unzip to get the
+  APK/AAB).
+
+Build the same artifacts locally with:
+
+```bash
+flutter pub get
+flutter build apk --release        # → build/app/outputs/flutter-apk/app-release.apk
+flutter build appbundle --release  # → build/app/outputs/bundle/release/app-release.aab
+```
+
+#### Signing status (important)
+
+**These release artifacts are debug-key signed, not release signed.** No
+release signing secrets are configured in this repository, so the release build
+falls back to the debug signing config declared in `android/app/build.gradle`
+(`signingConfig = signingConfigs.debug`). That makes the artifacts useful for
+previewing/smoke-testing a release build, but they are **not** suitable for
+store or F-Droid distribution, and **no signing keys are committed** to the
+repo.
+
+Real release signing (a keystore supplied via repository secrets, with the
+`android/app/build.gradle` release `signingConfig` reading those secrets) is
+**intentionally out of scope** for this foundation and is the recommended next
+step — see below.
+
+#### Limitations & next steps
+
+- The workflow **does not** create a GitHub release, upload anything to a store,
+  or submit to F-Droid. It only produces downloadable build artifacts.
+- It does **not** add release signing; artifacts remain debug-key signed until a
+  signing config backed by secrets is added.
+- **Recommended next PR:** add release signing — provision a release keystore,
+  store it and its credentials as repository secrets, decode it during the
+  workflow, and update the release `signingConfig` in
+  `android/app/build.gradle` to use it. With real signing in place, a separate
+  follow-up can wire **GitHub Releases** publishing and, later, F-Droid
+  readiness.
+
 ### Background playback & Android Auto
 
 Linthra registers a platform **media session** through `audio_service` so


### PR DESCRIPTION
## Summary

Adds a build-only foundation for future GitHub Releases / F-Droid distribution. No app features, no publishing, no signing keys.

### Workflow behavior
- New workflow `.github/workflows/android-release-build.yml`.
- **Trigger:** `workflow_dispatch` only — never runs on push or PR.
- **Permissions:** `contents: read` (read-only).
- Runs `flutter build apk --release` and `flutter build appbundle --release` on Flutter 3.27.4 / JDK 17 (matching existing CI).

### Artifact output
- `linthra-release-apk` → `app-release.apk` (`build/app/outputs/flutter-apk/app-release.apk`)
- `linthra-release-aab` → `app-release.aab` (`build/app/outputs/bundle/release/app-release.aab`)
- Both uploaded via `actions/upload-artifact@v4` with `if-no-files-found: error`.

### Signing status
- **Debug-key signed, NOT release signed.** No release signing secrets are configured, so the build falls back to the debug signing config already declared in `android/app/build.gradle` (`signingConfig = signingConfigs.debug`).
- Suitable for previewing/smoke-testing a release build; **not** suitable for store or F-Droid distribution.
- **No signing keys are committed**, and no secrets were invented.

### Limitations
- Does **not** create a GitHub release, publish to any store, or submit to F-Droid.
- Does **not** add release signing — artifacts remain debug-key signed.
- No app features changed; only the workflow and README.

### Next recommended PR
Add real release signing: provision a release keystore, store it + credentials as repository secrets, decode it during the workflow, and update the release `signingConfig` in `android/app/build.gradle` to use it. With real signing in place, a follow-up can wire GitHub Releases publishing and, later, F-Droid readiness.

## Changes
- Add `.github/workflows/android-release-build.yml`.
- Document release builds, signing status, limitations, and next steps in `README.md`.

## Test plan
- [x] YAML validated (`yaml.safe_load`).
- [ ] Manually dispatch **Android Release Build** from the Actions tab and confirm both artifacts appear on the run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sh31AKQ8wuy98HPNBKTsJ7)_