### PR TITLE
Add initial F-Droid/Fastlane metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,32 @@ branch rather than `main`.
 Later: Jellyfin, WebDAV, NAS, lyrics, ReplayGain, MPRIS, Android Auto, smart
 playlists, and more.
 
+## F-Droid metadata (work in progress)
+
+Linthra is **not** on F-Droid yet, and no submission has been made. As
+groundwork for a possible future submission, the repository now carries
+F-Droid / Fastlane-style store metadata under
+`fastlane/metadata/android/en-US/`:
+
+- `title.txt` — app name.
+- `short_description.txt` — one-line summary (kept under F-Droid's 80-char
+  limit).
+- `full_description.txt` — long description that deliberately separates what
+  works today from what is still planned.
+- `changelogs/1.txt` — placeholder release notes for `versionCode` 1 (the
+  current `0.1.0+1`); replaced with real notes once a published version exists.
+
+**Known missing assets.** No real screenshots, feature graphic, or store icon
+have been captured from a running build, so none are committed. `images/` only
+contains `NEEDED-ASSETS.txt`, which documents the expected F-Droid image layout
+to fill in later. Placeholder/mock images are intentionally avoided so the
+listing never misrepresents the app.
+
+The wording describes only shipped behaviour (folder selection, scanning, and
+persisted listing) as done; playback, playlists, and offline downloads are
+described as planned. There are no claims of F-Droid availability and no
+marketing language that overpromises.
+
 ## License
 
 [MPL-2.0](./LICENSE)

--- a/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,8 @@
+Initial development build (0.1.0).
+
+Early-stage. Working today: select a music folder, scan it, and list the
+discovered tracks; the selection and catalog persist across restarts. Audio
+playback, playlists, and offline downloads are still in progress.
+
+This is a placeholder changelog for the first versionCode and will be replaced
+with real release notes once a published version exists.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,43 @@
+Linthra is an open-source, local-first music player for people who own their
+music. Your library lives on your device, and you stay in control of it.
+
+Linthra is early-stage software and under active development. The sections
+below clearly separate what works today from what is planned, so nothing here
+overpromises.
+
+What Linthra is about:
+
+* Local-first — your music files stay on your device; the app reads from a
+  local catalog rather than depending on a remote service.
+* User-owned music — Linthra plays the files you already have. There is no
+  store, no account, and no requirement to use anyone's cloud.
+* Privacy-focused — no telemetry and no forced sync. The app does not phone
+  home or upload your library.
+* Open-source — released under the Mozilla Public License 2.0. Anyone can
+  read, audit, build, and contribute to the code.
+
+Working today:
+
+* Pick a folder of music using the native Android folder picker.
+* Scan that folder and build a local catalog of your tracks.
+* The chosen folder and the scanned tracks are saved on the device, so they
+  survive an app restart.
+
+Planned (not finished yet):
+
+* Audio playback with a background media session (notification and lock-screen
+  controls).
+* Browsing by artist and album, plus search and album artwork.
+* Playlist creation and editing.
+* Explicit, user-initiated offline downloads with a "Wi-Fi only" option — never
+  automatic. The groundwork for this download policy already exists in the code,
+  but no remote sources are wired up yet.
+* Additional sources (such as Jellyfin, WebDAV, and NAS) behind a single
+  interface.
+
+Platforms:
+
+* Android first. Linux desktop is planned later, from the same codebase.
+
+Linthra is built to respect the people who use it: no lock-in, no surprise
+network activity, and no downloads you did not ask for.

--- a/fastlane/metadata/android/en-US/images/NEEDED-ASSETS.txt
+++ b/fastlane/metadata/android/en-US/images/NEEDED-ASSETS.txt
@@ -1,0 +1,19 @@
+Image assets for F-Droid / Fastlane metadata are NOT included yet.
+
+No real screenshots, feature graphic, or store icon have been captured from a
+running build, so none are committed here on purpose (placeholder/mock images
+would misrepresent the app).
+
+When real assets are available, add them in this directory using F-Droid's
+expected layout:
+
+  icon.png                      512x512 (or the launcher icon)
+  featureGraphic.png            1024x500
+  phoneScreenshots/1.png        real screenshots from a device/emulator
+  phoneScreenshots/2.png        (2-8 recommended)
+  ...
+
+See: https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/
+
+Until then, this file is the only thing in images/ and can be deleted once the
+real assets land.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Open-source, local-first music player for music you own. No forced sync.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Linthra


### PR DESCRIPTION
## Summary

Groundwork for a possible **future** F-Droid submission. Metadata only — no app features, no release-workflow changes, and no submission to F-Droid.

## Metadata files added

Under `fastlane/metadata/android/en-US/`:

- `title.txt` — `Linthra`
- `short_description.txt` — one-line summary (72 chars, under F-Droid's 80-char limit)
- `full_description.txt` — long description
- `changelogs/1.txt` — placeholder release notes for `versionCode` 1 (current `0.1.0+1`)
- `images/NEEDED-ASSETS.txt` — documents the expected F-Droid image layout (no images committed)

Plus a new **F-Droid metadata (work in progress)** section in `README.md`.

## Wording choices

- The description **separates shipped behaviour from planned features**. Only folder selection, scanning, and persisted listing are described as working today; **playback, playlists, and offline downloads are described as planned** (they are not finished in the code).
- Emphasizes the requested themes: open-source (MPL-2.0), local-first, user-owned music files, privacy, no telemetry, no forced sync, no automatic downloads, Android-first with Linux later. Playlists and the offline/cache work appear in the "planned" list to avoid false claims.
- No claim of F-Droid availability. No marketing fluff that overpromises.

## Known missing assets / screenshots

- **No real screenshots, feature graphic, or store icon** are included. None have been captured from a running build, so committing placeholder/mock images would misrepresent the app. `images/` contains only `NEEDED-ASSETS.txt` describing what to add later (`icon.png`, `featureGraphic.png 1024x500`, `phoneScreenshots/`).

## Next recommended PR

- Capture **real screenshots** from a running build plus a feature graphic and store icon, and drop them into `images/` per the documented layout. This is the main blocker before any F-Droid listing would look complete.
- (Later, separate work) verify the F-Droid build recipe / reproducible-build requirements and signing story before any actual submission.


---
_Generated by [Claude Code](https://claude.ai/code/session_0156aAKfWrkJi8qyfheDLQSL)_