### PR TITLE
docs: add store listing asset guide and screenshot capture instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,10 @@ F-Droid / Fastlane-style store metadata under
 have been captured from a running build, so none are committed. `images/` only
 contains `NEEDED-ASSETS.txt`, which documents the expected F-Droid image layout
 to fill in later. Placeholder/mock images are intentionally avoided so the
-listing never misrepresents the app.
+listing never misrepresents the app — and the default Flutter launcher icons are
+not real Linthra branding, so they are not reused as the store icon. The full
+asset checklist, exact sizes, and screenshot-capture steps are in
+[docs/listing-assets.md](./docs/listing-assets.md).
 
 The wording describes only shipped behaviour (folder selection, scanning, and
 persisted listing) as done; playback, playlists, and offline downloads are

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -116,12 +116,18 @@ Stored under `fastlane/metadata/android/en-US/`:
 - [x] `short_description.txt` — one-line summary (under F-Droid's 80-char limit).
 - [x] `full_description.txt` — long description (separates shipped vs. planned).
 - [x] `changelogs/1.txt` — placeholder notes for `versionCode` 1.
-- [ ] `images/icon.png` — 512×512 launcher/store icon.
+- [ ] `images/icon.png` — 512×512 real Linthra store icon (the launcher icons
+  under `android/app/src/main/res/mipmap-*` are still the default Flutter
+  placeholder and must not be reused here).
 - [ ] `images/featureGraphic.png` — 1024×500.
 - [ ] `images/phoneScreenshots/*.png` — 2–8 real screenshots from a device.
+- [ ] `images/sevenInchScreenshots/*.png` / `images/tenInchScreenshots/*.png` —
+  optional tablet screenshots (only if the larger layout is worth showing).
 
 No placeholder/mock images are committed on purpose; `images/` currently holds
-only `NEEDED-ASSETS.txt` documenting the expected layout. See F-Droid's
+only `NEEDED-ASSETS.txt` documenting the expected layout. Exact sizes and
+step-by-step capture instructions live in
+[docs/listing-assets.md](./listing-assets.md); see also F-Droid's
 [descriptions, graphics & screenshots guide](https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/).
 
 ## 8. Remaining blockers before submission

--- a/docs/listing-assets.md
+++ b/docs/listing-assets.md
@@ -1,0 +1,147 @@
+# Store listing assets (F-Droid / GitHub)
+
+This document describes the **image assets** a Linthra store/repository listing
+needs (app icon, feature graphic, screenshots), the exact paths and sizes they
+go in, and how to capture them from a real build.
+
+> **No real listing assets exist yet.** Nothing in this document claims an asset
+> is present. The Android launcher icons under `android/app/src/main/res/mipmap-*`
+> are still the **default Flutter placeholder icon**, not Linthra branding, so
+> they must **not** be reused as the store icon. Capture/produce real assets
+> before a listing or F-Droid submission. See also
+> [docs/fdroid-readiness.md](./fdroid-readiness.md).
+
+## 1. Where assets live
+
+F-Droid reads images from the Fastlane Supply layout already used by this repo:
+
+```
+fastlane/metadata/android/en-US/
+├── title.txt                     (present)
+├── short_description.txt         (present)
+├── full_description.txt          (present)
+├── changelogs/1.txt              (present)
+└── images/
+    ├── icon.png                  (MISSING)
+    ├── featureGraphic.png        (MISSING)
+    ├── phoneScreenshots/         (MISSING)
+    │   ├── 1.png
+    │   ├── 2.png
+    │   └── …
+    ├── sevenInchScreenshots/     (optional, MISSING)
+    │   └── 1.png …
+    └── tenInchScreenshots/       (optional, MISSING)
+        └── 1.png …
+```
+
+The same `images/` files double as the source for a GitHub listing (README
+embeds, Releases page), so they only need to be produced once.
+
+## 2. Asset checklist
+
+| Asset            | Path                                                   | Required | Status  |
+| ---------------- | ------------------------------------------------------ | -------- | ------- |
+| App icon         | `images/icon.png`                                      | Yes      | Missing |
+| Feature graphic  | `images/featureGraphic.png`                            | Yes      | Missing |
+| Phone screenshots| `images/phoneScreenshots/1.png` … (2–8)                | Yes      | Missing |
+| 7-inch tablet    | `images/sevenInchScreenshots/1.png` …                  | Optional | Missing |
+| 10-inch tablet   | `images/tenInchScreenshots/1.png` …                    | Optional | Missing |
+
+All paths are relative to `fastlane/metadata/android/en-US/`.
+
+## 3. Exact sizes and formats
+
+| Asset            | Format    | Size / constraints                                              |
+| ---------------- | --------- | --------------------------------------------------------------- |
+| App icon         | PNG       | 512×512, square. Real Linthra icon, not the default Flutter logo. |
+| Feature graphic  | PNG/JPG   | 1024×500 exactly. No essential text near edges (gets cropped).  |
+| Screenshots      | PNG/JPG   | Each side 320–3840 px; portrait phone capture is fine as-is.    |
+
+Screenshot notes:
+
+- Use **real** captures from a running build — never mockups, stock UI, or
+  upscaled placeholders.
+- 2–8 phone screenshots is the practical range; show the flows that actually
+  work today (folder selection, scan, the persisted track list).
+- Keep filenames numeric and sequential (`1.png`, `2.png`, …); ordering on the
+  listing follows the filename sort order.
+- Tablet screenshots are optional. Only add them if the layout is genuinely
+  worth showing on a larger screen — otherwise omit those folders entirely
+  rather than padding them with stretched phone captures.
+
+See F-Droid's
+[descriptions, graphics & screenshots guide](https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/)
+for the authoritative rules.
+
+## 4. How to capture screenshots
+
+Linthra is a Flutter Android app. Capture from a device or emulator running a
+debug or release build.
+
+1. **Run the app** on a connected device/emulator:
+
+   ```sh
+   flutter run
+   ```
+
+   (See the README "Getting started" / "Building a debug APK" sections.)
+
+2. **Navigate** to a screen worth showing (e.g. the track list after a scan).
+
+3. **Capture** the current screen with `adb`:
+
+   ```sh
+   # Save directly to the Fastlane phone-screenshots folder
+   adb exec-out screencap -p \
+     > fastlane/metadata/android/en-US/images/phoneScreenshots/1.png
+   ```
+
+   Repeat for each screen, incrementing the filename (`2.png`, `3.png`, …).
+
+   Alternatively, take a screenshot on the device (power + volume-down) and pull
+   it:
+
+   ```sh
+   adb pull /sdcard/Pictures/Screenshots/<file>.png \
+     fastlane/metadata/android/en-US/images/phoneScreenshots/1.png
+   ```
+
+4. **Verify dimensions** before committing (each side must be 320–3840 px):
+
+   ```sh
+   file fastlane/metadata/android/en-US/images/phoneScreenshots/*.png
+   ```
+
+For an emulator, the same `adb exec-out screencap` command works while the
+emulator is running.
+
+## 5. How to produce the icon and feature graphic
+
+- **App icon (`icon.png`, 512×512):** design a real Linthra icon. Once it
+  exists, it should also replace the default Flutter launcher icons under
+  `android/app/src/main/res/mipmap-*` (e.g. via `flutter_launcher_icons`) so the
+  installed app and the store listing match. That launcher-icon change is a
+  separate app/branding PR, not part of this listing-readiness step.
+- **Feature graphic (`featureGraphic.png`, 1024×500):** a simple branded banner
+  (logo + name on a solid/gradient background) is enough. Keep important content
+  away from the edges.
+
+## 6. Once assets exist
+
+When real assets are committed under `images/`:
+
+1. Delete `images/NEEDED-ASSETS.txt` (its only purpose is to document the gap).
+2. Tick the image rows in
+   [docs/fdroid-readiness.md](./fdroid-readiness.md) §7 (metadata checklist) and
+   clear the "No image assets" blocker in §8.
+3. Update the README "F-Droid metadata" section so it no longer lists the assets
+   as missing.
+
+## 7. Related docs
+
+- [docs/fdroid-readiness.md](./fdroid-readiness.md) — full F-Droid submission
+  checklist (identity, build, dependencies, anti-features, signing, tagging).
+- [README.md](../README.md) — project overview and the "F-Droid metadata
+  (work in progress)" section.
+- `fastlane/metadata/android/en-US/images/NEEDED-ASSETS.txt` — short in-place
+  reminder pointing back to this guide.

--- a/fastlane/metadata/android/en-US/images/NEEDED-ASSETS.txt
+++ b/fastlane/metadata/android/en-US/images/NEEDED-ASSETS.txt
@@ -1,19 +1,26 @@
-Image assets for F-Droid / Fastlane metadata are NOT included yet.
+No image assets are committed yet (on purpose).
 
-No real screenshots, feature graphic, or store icon have been captured from a
-running build, so none are committed here on purpose (placeholder/mock images
-would misrepresent the app).
+No real app icon, feature graphic, or screenshots have been captured from a
+running build, so none are included here. Placeholder/mock images are avoided so
+the listing never misrepresents the app. (The default Flutter launcher icons
+under android/app/src/main/res/mipmap-* are NOT real Linthra branding and must
+not be reused as the store icon.)
 
-When real assets are available, add them in this directory using F-Droid's
-expected layout:
+Expected F-Droid / Fastlane layout to fill in later (paths relative to this
+images/ directory):
 
-  icon.png                      512x512 (or the launcher icon)
-  featureGraphic.png            1024x500
-  phoneScreenshots/1.png        real screenshots from a device/emulator
-  phoneScreenshots/2.png        (2-8 recommended)
+  icon.png                       512x512 real Linthra app icon
+  featureGraphic.png             1024x500
+  phoneScreenshots/1.png         real screenshots from a device/emulator
+  phoneScreenshots/2.png         (2-8 recommended, numbered sequentially)
   ...
+  sevenInchScreenshots/1.png     optional 7-inch tablet screenshots
+  tenInchScreenshots/1.png       optional 10-inch tablet screenshots
 
-See: https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/
+Full asset checklist, exact sizes, and step-by-step screenshot capture
+instructions: docs/listing-assets.md
 
-Until then, this file is the only thing in images/ and can be deleted once the
-real assets land.
+F-Droid reference:
+https://f-droid.org/docs/All_About_Descriptions_Graphics_and_Screenshots/
+
+Delete this file once the real assets land.


### PR DESCRIPTION
## Summary

Prepares F-Droid / GitHub **listing readiness** (assets/docs only). No real
screenshots or graphics exist in the repo, so none are invented or committed —
instead this adds clear guidance, exact paths/sizes, and capture instructions so
the assets can be produced and dropped into the correct Fastlane/F-Droid layout
later.

No app features, no release signing, no workflow changes.

## Files changed

- **`docs/listing-assets.md`** (new) — dedicated store-listing asset guide:
  asset checklist, exact paths/sizes, screenshot capture steps, icon/feature-
  graphic production notes, and a "once assets exist" follow-up list.
- **`fastlane/metadata/android/en-US/images/NEEDED-ASSETS.txt`** — expanded the
  in-place placeholder note: adds feature graphic + optional tablet screenshot
  paths, flags that the default Flutter launcher icons are not real branding,
  and points to the new guide.
- **`docs/fdroid-readiness.md`** — §7 metadata checklist now lists optional
  tablet screenshots, notes the launcher-icon caveat, and links the new guide.
- **`README.md`** — F-Droid section links the new guide and notes the launcher
  icons are not reused as the store icon.

## Asset status

All listing image assets are **missing** (none committed, by design):

| Asset            | Path (under `fastlane/metadata/android/en-US/`) | Required | Status  |
| ---------------- | ----------------------------------------------- | -------- | ------- |
| App icon         | `images/icon.png` (512×512)                     | Yes      | Missing |
| Feature graphic  | `images/featureGraphic.png` (1024×500)          | Yes      | Missing |
| Phone screenshots| `images/phoneScreenshots/1.png` … (2–8)         | Yes      | Missing |
| 7-inch tablet    | `images/sevenInchScreenshots/1.png` …           | Optional | Missing |
| 10-inch tablet   | `images/tenInchScreenshots/1.png` …             | Optional | Missing |

Note: the Android launcher icons (`android/app/src/main/res/mipmap-*`) are still
the **default Flutter placeholder**, not Linthra branding, so they are
explicitly *not* promoted to the store icon.

## Missing assets

- Real 512×512 Linthra app icon.
- 1024×500 feature graphic.
- 2–8 real phone screenshots from a running build.
- (Optional) tablet screenshots, only if the larger layout is worth showing.

## How to capture screenshots

Run a build on a device/emulator and capture with `adb`:

```sh
flutter run
# then, on a screen worth showing (e.g. the track list after a scan):
adb exec-out screencap -p \
  > fastlane/metadata/android/en-US/images/phoneScreenshots/1.png
```

Repeat with incrementing filenames; verify each side is 320–3840 px before
committing. Full steps (including icon/feature-graphic production) are in
[`docs/listing-assets.md`](docs/listing-assets.md).

## Next recommended PR

A **branding PR** that produces the real 512×512 Linthra app icon and
regenerates the Android launcher icons (e.g. via `flutter_launcher_icons`) so
the installed app and store listing match — then commit the real `icon.png`,
`featureGraphic.png`, and captured screenshots, and tick off the image rows in
the readiness checklist.

Note: this branch is not on F-Droid and no submission has been made.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjMC5Kxx9NPA9XJS2QWfo1)_