### PR TITLE
docs: tighten F-Droid listing screenshot asset guidance

### DIFF
--- a/docs/listing-assets.md
+++ b/docs/listing-assets.md
@@ -55,7 +55,7 @@ All paths are relative to `fastlane/metadata/android/en-US/`.
 | ---------------- | --------- | --------------------------------------------------------------- |
 | App icon         | PNG       | 512×512, square. Real Linthra icon, not the default Flutter logo. |
 | Feature graphic  | PNG/JPG   | 1024×500 exactly. No essential text near edges (gets cropped).  |
-| Screenshots      | PNG/JPG   | Each side 320–3840 px; portrait phone capture is fine as-is.    |
+| Screenshots      | PNG/JPG   | Each side 320–3840 px; aspect ratio between 1:2 and 2:1; portrait phone capture is fine as-is. |
 
 Screenshot notes:
 
@@ -63,8 +63,12 @@ Screenshot notes:
   upscaled placeholders.
 - 2–8 phone screenshots is the practical range; show the flows that actually
   work today (folder selection, scan, the persisted track list).
+- F-Droid rejects screenshots whose aspect ratio is outside 1:2–2:1, so a raw
+  capture from an unusually tall/narrow device may need cropping (not stretching).
 - Keep filenames numeric and sequential (`1.png`, `2.png`, …); ordering on the
-  listing follows the filename sort order.
+  listing follows the filename **string** sort order, so `10.png` sorts before
+  `2.png`. Stay under 10 screenshots, or zero-pad (`01.png`, `02.png`, …) to keep
+  the intended order.
 - Tablet screenshots are optional. Only add them if the layout is genuinely
   worth showing on a larger screen — otherwise omit those folders entirely
   rather than padding them with stretched phone captures.


### PR DESCRIPTION
## Summary

Listing-readiness PR (assets/docs only). On inspection, the bulk of F-Droid/GitHub asset readiness was **already in place** on this branch from prior PRs (#25 metadata, #26 readiness checklist, #27 listing-assets guide). Rather than churn that work, this PR closes two genuine accuracy gaps in the existing screenshot guidance.

No app features, no signing changes, no workflow changes, no F-Droid submission. No real assets are added and no asset existence is claimed.

## Files changed

- `docs/listing-assets.md` — added the F-Droid screenshot aspect-ratio constraint and a numeric-filename sort-order caveat (6 insertions, 2 deletions).

## What this PR adds

1. **Screenshot aspect ratio** — F-Droid rejects screenshots whose aspect ratio is outside **1:2–2:1**. This was missing from the size/format table and notes; a raw capture from a very tall/narrow device may need cropping (not stretching).
2. **Filename sort-order pitfall** — listing order follows *string* sort, so `10.png` sorts before `2.png`. Guidance: stay under 10 screenshots or zero-pad (`01.png`, `02.png`, …).

## Asset status (unchanged by this PR)

Everything required for honest listing readiness already exists and remains accurate:

- ✅ Asset checklist — `docs/listing-assets.md` §2, `docs/fdroid-readiness.md` §7
- ✅ Screenshot capture instructions (adb) — `docs/listing-assets.md` §4
- ✅ Exact expected paths/sizes — `docs/listing-assets.md` §1, §3
- ✅ README + readiness cross-links — README "F-Droid metadata" section
- ✅ Metadata does not falsely claim assets exist — `images/NEEDED-ASSETS.txt`

## Missing assets (still missing — intentionally not faked)

| Asset | Path (under `fastlane/metadata/android/en-US/`) | Required | Status |
| --- | --- | --- | --- |
| App icon | `images/icon.png` | Yes | Missing |
| Feature graphic | `images/featureGraphic.png` | Yes | Missing |
| Phone screenshots | `images/phoneScreenshots/1.png` … (2–8) | Yes | Missing |
| 7-inch tablet | `images/sevenInchScreenshots/*.png` | Optional | Missing |
| 10-inch tablet | `images/tenInchScreenshots/*.png` | Optional | Missing |

No real screenshots/icons exist in the repo (the only PNGs are the default Flutter launcher icons under `android/app/src/main/res/mipmap-*`, which are explicitly **not** Linthra branding and must not be reused). No placeholders were added.

## Exact icon/screenshot requirements

- **Icon:** PNG, 512×512, square — a real Linthra icon, not the Flutter logo.
- **Feature graphic:** PNG/JPG, exactly 1024×500, important content away from edges.
- **Screenshots:** PNG/JPG, each side 320–3840 px, aspect ratio 1:2–2:1, numeric sequential filenames.

## How to capture screenshots

Run a debug/release build, navigate to a screen worth showing, then:

```sh
adb exec-out screencap -p > fastlane/metadata/android/en-US/images/phoneScreenshots/1.png
```

Full step-by-step in `docs/listing-assets.md` §4.

## Next recommended PR

A real-branding PR: design the Linthra app icon, generate launcher icons (e.g. `flutter_launcher_icons`) to replace the default Flutter mipmaps, add `icon.png`/`featureGraphic.png`, capture real phone screenshots, then delete `images/NEEDED-ASSETS.txt` and tick the image rows in `docs/fdroid-readiness.md` §7.

## Verification

Markdown/docs review only — no code changed, so no code test required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7voTrT4Tj6atKwFhGtfUZ)_