### PR TITLE
Add safe release signing strategy and docs

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -5,15 +5,28 @@ name: Android Release Build
 # F-Droid distribution: it does NOT create a GitHub release, publish to any
 # store, or submit to F-Droid, and it runs only when you trigger it manually.
 #
-# Signing status: no release signing secrets are configured in this repo, so
-# the release build falls back to the debug signing config declared in
-# android/app/build.gradle (`signingConfig = signingConfigs.debug`). The
-# resulting artifacts are therefore DEBUG-KEY SIGNED, not release signed — fine
-# for previews and smoke-testing a release build, but NOT suitable for store or
-# F-Droid distribution. Wiring real release signing (via repository secrets) is
-# the recommended next step and is intentionally out of scope here.
+# Signing: this workflow can produce either a real release-signed build or a
+# debug-key build, controlled by the `signed` input below.
+#
+#   * signed = false (default): no signing secrets are read; the release build
+#     falls back to the debug signing config in android/app/build.gradle. The
+#     artifacts are DEBUG-KEY SIGNED — fine for previews and smoke-testing a
+#     release build, but NOT suitable for store or F-Droid distribution. They
+#     are uploaded with a `-debug-signed` name so they cannot be mistaken for a
+#     real release.
+#
+#   * signed = true: the workflow decodes a keystore from the LINTHRA_KEYSTORE_*
+#     repository secrets and signs the build with it. If any required secret is
+#     missing the run fails fast with a clear error (it does NOT silently fall
+#     back to the debug key). See docs/release-signing.md for the required
+#     secrets and how to generate / rotate the keystore.
 on:
   workflow_dispatch:
+    inputs:
+      signed:
+        description: "Sign with the release keystore (requires LINTHRA_* secrets). If false, builds are debug-signed and labeled as such."
+        type: boolean
+        default: false
 
 # Read-only is all this needs: artifacts are shared via upload-artifact rather
 # than by writing to the repo or creating a release.
@@ -24,9 +37,43 @@ jobs:
   build-release:
     name: Build release APK + AAB
     runs-on: ubuntu-latest
+    # These are harmless when empty (unsigned builds): the Gradle config treats
+    # absent/empty values as "no release signing" and falls back to the debug
+    # key. The keystore file path (LINTHRA_KEYSTORE_PATH) is only exported by the
+    # decode step below, and only when signing is requested.
+    env:
+      LINTHRA_KEYSTORE_PASSWORD: ${{ secrets.LINTHRA_KEYSTORE_PASSWORD }}
+      LINTHRA_KEY_ALIAS: ${{ secrets.LINTHRA_KEY_ALIAS }}
+      LINTHRA_KEY_PASSWORD: ${{ secrets.LINTHRA_KEY_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Validate signing secrets
+        if: ${{ inputs.signed }}
+        env:
+          LINTHRA_KEYSTORE_BASE64: ${{ secrets.LINTHRA_KEYSTORE_BASE64 }}
+        run: |
+          missing=()
+          [ -z "$LINTHRA_KEYSTORE_BASE64" ] && missing+=("LINTHRA_KEYSTORE_BASE64")
+          [ -z "$LINTHRA_KEYSTORE_PASSWORD" ] && missing+=("LINTHRA_KEYSTORE_PASSWORD")
+          [ -z "$LINTHRA_KEY_ALIAS" ] && missing+=("LINTHRA_KEY_ALIAS")
+          [ -z "$LINTHRA_KEY_PASSWORD" ] && missing+=("LINTHRA_KEY_PASSWORD")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Signed release requested but these secrets are missing: ${missing[*]}. See docs/release-signing.md."
+            exit 1
+          fi
+          echo "All required signing secrets are present."
+
+      - name: Decode release keystore
+        if: ${{ inputs.signed }}
+        env:
+          LINTHRA_KEYSTORE_BASE64: ${{ secrets.LINTHRA_KEYSTORE_BASE64 }}
+        run: |
+          keystore_path="$RUNNER_TEMP/linthra-release.keystore"
+          echo "$LINTHRA_KEYSTORE_BASE64" | base64 -d > "$keystore_path"
+          echo "LINTHRA_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
+          echo "Release keystore decoded to a temporary path."
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -51,16 +98,50 @@ jobs:
       - name: Build release AAB
         run: flutter build appbundle --release
 
+      # Distinguish real release-signed artifacts from debug-signed previews so
+      # the wrong build can never be mistaken for a publishable release.
+      - name: Determine artifact label
+        id: label
+        run: |
+          if [ "${{ inputs.signed }}" = "true" ]; then
+            echo "suffix=release-signed" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=debug-signed" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload release APK
         uses: actions/upload-artifact@v4
         with:
-          name: linthra-release-apk
+          name: linthra-${{ steps.label.outputs.suffix }}-apk
           path: build/app/outputs/flutter-apk/app-release.apk
           if-no-files-found: error
 
       - name: Upload release AAB
         uses: actions/upload-artifact@v4
         with:
-          name: linthra-release-aab
+          name: linthra-${{ steps.label.outputs.suffix }}-aab
           path: build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
+
+      - name: Build summary
+        run: |
+          if [ "${{ inputs.signed }}" = "true" ]; then
+            {
+              echo "## Linthra release build"
+              echo ""
+              echo "**Signing:** release-signed with the configured keystore."
+              echo ""
+              echo "Artifacts: \`linthra-release-signed-apk\`, \`linthra-release-signed-aab\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Linthra release build"
+              echo ""
+              echo "**Signing:** DEBUG-KEY signed (not a real release)."
+              echo ""
+              echo "Re-run with \`signed = true\` and the LINTHRA_* secrets configured to"
+              echo "produce a release-signed build. See docs/release-signing.md."
+              echo ""
+              echo "Artifacts: \`linthra-debug-signed-apk\`, \`linthra-debug-signed-aab\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,6 +5,44 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+// Release signing material is NEVER committed (see android/.gitignore). It is
+// supplied at build time via either:
+//   * environment variables — used by CI, which decodes a keystore from the
+//     LINTHRA_KEYSTORE_BASE64 secret and sets LINTHRA_KEYSTORE_PATH, or
+//   * a git-ignored android/key.properties file — for local release builds.
+// Environment variables take precedence over key.properties. If no complete
+// signing config is found, release builds fall back to the debug key so that
+// `flutter run --release` keeps working. Debug-signed artifacts are NOT real
+// releases and must not be distributed as such. See docs/release-signing.md.
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.withInputStream { keystoreProperties.load(it) }
+}
+
+def resolveSigningValue = { String envKey, String propKey ->
+    def value = System.getenv(envKey)
+    if (value == null || value.isEmpty()) {
+        value = keystoreProperties.getProperty(propKey)
+    }
+    return value
+}
+
+def releaseStoreFilePath = resolveSigningValue("LINTHRA_KEYSTORE_PATH", "storeFile")
+def releaseStorePassword = resolveSigningValue("LINTHRA_KEYSTORE_PASSWORD", "storePassword")
+def releaseKeyAlias = resolveSigningValue("LINTHRA_KEY_ALIAS", "keyAlias")
+def releaseKeyPassword = resolveSigningValue("LINTHRA_KEY_PASSWORD", "keyPassword")
+
+def hasReleaseSigning = releaseStoreFilePath != null && !releaseStoreFilePath.isEmpty() &&
+    file(releaseStoreFilePath).exists() && releaseStorePassword != null &&
+    releaseKeyAlias != null && releaseKeyPassword != null
+
+if (hasReleaseSigning) {
+    logger.lifecycle("Linthra: release build will be signed with the configured release keystore.")
+} else {
+    logger.lifecycle("Linthra: no release signing config found; release build falls back to the DEBUG key (not a real release).")
+}
+
 android {
     namespace = "io.github.thezupzup.linthra"
     compileSdk = flutter.compileSdkVersion
@@ -28,11 +66,24 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasReleaseSigning) {
+            release {
+                storeFile = file(releaseStoreFilePath)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            // Use the real release signing config when complete signing material
+            // is available (env vars or key.properties); otherwise fall back to
+            // the debug key so `flutter run --release` still works. Debug-signed
+            // release builds are clearly labeled by CI and must not be shipped.
+            signingConfig = hasReleaseSigning ? signingConfigs.release : signingConfigs.debug
         }
     }
 }

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -132,10 +132,12 @@ step-by-step capture instructions live in
 
 ## 8. Remaining blockers before submission
 
-1. **Release signing.** `android/app/build.gradle` still signs release builds
-   with the debug key (`signingConfig = signingConfigs.debug`). F-Droid signs
-   its own builds, but the project should remove the debug-key fallback / set up
-   a proper release signing story before publishing.
+1. **Release signing.** Release signing can now be supplied via env vars /
+   `android/key.properties`, with CI decoding a keystore from secrets; builds
+   fall back to the debug key only when no signing material is present (see
+   [docs/release-signing.md](./release-signing.md)). F-Droid signs its own
+   builds, so this matters mainly for GitHub-Release artifacts. Remaining work:
+   configure the actual release secrets and decide the GitHub-Release flow.
 2. **No image assets.** Icon, feature graphic, and screenshots are missing.
 3. **Dependency audit.** Confirm no non-free / Google-only transitive deps.
 4. **Reproducible build verification.** Confirm the app builds on F-Droid's

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,162 @@
+# Release signing
+
+How Linthra's Android release builds are signed, what secrets the CI workflow
+needs, how to generate a keystore locally, how to rotate it, and how all of
+this relates to F-Droid.
+
+> **No signing keys or secrets live in this repository.** Keystores
+> (`*.keystore`, `*.jks`) and `android/key.properties` are git-ignored. Never
+> commit them, never paste a real password into code, CI YAML, or a commit
+> message.
+
+## 1. How signing is wired
+
+`android/app/build.gradle` resolves the release signing config at build time
+from one of two sources, in this order of precedence:
+
+1. **Environment variables** — used by CI. The release workflow decodes a
+   keystore from a secret and exports its path.
+2. **`android/key.properties`** — a git-ignored file for local release builds.
+
+| Purpose          | Environment variable        | `key.properties` key |
+| ---------------- | --------------------------- | -------------------- |
+| Keystore file    | `LINTHRA_KEYSTORE_PATH`     | `storeFile`          |
+| Keystore password| `LINTHRA_KEYSTORE_PASSWORD` | `storePassword`      |
+| Key alias        | `LINTHRA_KEY_ALIAS`         | `keyAlias`           |
+| Key password     | `LINTHRA_KEY_PASSWORD`      | `keyPassword`        |
+
+If — and only if — all four values are present **and** the keystore file
+exists, the release build is signed with that key. Otherwise the build falls
+back to the **debug** key so `flutter run --release` still works. Debug-signed
+release builds are **not** real releases and must never be distributed as such.
+
+## 2. Required GitHub Secrets (CI)
+
+Configure these under **Settings → Secrets and variables → Actions** before
+running the release workflow with `signed = true`:
+
+| Secret                      | Contents                                              |
+| --------------------------- | ----------------------------------------------------- |
+| `LINTHRA_KEYSTORE_BASE64`   | The keystore file, base64-encoded (see below).        |
+| `LINTHRA_KEYSTORE_PASSWORD` | The keystore (store) password.                        |
+| `LINTHRA_KEY_ALIAS`         | The key alias inside the keystore.                    |
+| `LINTHRA_KEY_PASSWORD`      | The password for that key.                            |
+
+The workflow only reads these when triggered with `signed = true`. If any are
+missing in that case, the run **fails fast** with a clear error rather than
+silently producing a debug-signed build.
+
+Encode the keystore for the `LINTHRA_KEYSTORE_BASE64` secret:
+
+```sh
+base64 -w0 linthra-release.keystore   # Linux
+base64 linthra-release.keystore       # macOS (no -w flag)
+```
+
+Copy the output into the secret value. The CI job decodes it to a temporary
+file at runtime and never writes it into the repository.
+
+## 3. Running the release workflow
+
+The **Android Release Build** workflow is manual only (`workflow_dispatch`). It
+does not create a GitHub Release, publish to any store, or submit to F-Droid.
+
+- **Unsigned preview (default):** run with `signed = false`. Artifacts are
+  uploaded as `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
+- **Real release-signed build:** run with `signed = true` (requires the secrets
+  above). Artifacts are uploaded as `linthra-release-signed-apk` /
+  `linthra-release-signed-aab`.
+
+The artifact names and the run summary always state which key signed the build,
+so a debug-signed preview can never be confused with a release.
+
+## 4. Generating a keystore locally
+
+A release keystore is a long-lived secret. Generate it once, back it up
+securely (a password manager or offline encrypted storage), and reuse it for
+every release — Android will reject an update signed by a different key.
+
+```sh
+keytool -genkey -v \
+  -keystore linthra-release.keystore \
+  -alias linthra \
+  -keyalg RSA -keysize 4096 \
+  -validity 10000 \
+  -storetype PKCS12
+```
+
+`keytool` will prompt for the keystore password, the key password, and your
+distinguished-name details. Record the alias and both passwords in your
+password manager.
+
+For a **local** release build, create `android/key.properties` (git-ignored):
+
+```properties
+storeFile=/absolute/path/to/linthra-release.keystore
+storePassword=…
+keyAlias=linthra
+keyPassword=…
+```
+
+Then build:
+
+```sh
+flutter build apk --release
+flutter build appbundle --release
+```
+
+Do not commit `android/key.properties` or the keystore. Both are already
+covered by `android/.gitignore` (`key.properties`, `**/*.keystore`,
+`**/*.jks`).
+
+## 5. Rotating the key
+
+Rotate if the key may be compromised, or as routine hygiene. Note that for a
+given app **identity on a store**, the signing key generally cannot be changed
+freely once published — plan rotation carefully.
+
+1. Generate a **new** keystore with the steps in §4 (use a fresh file name,
+   alias, and passwords; keep the old one until rotation is verified).
+2. Update the GitHub Secrets:
+   - re-encode the new keystore and replace `LINTHRA_KEYSTORE_BASE64`;
+   - update `LINTHRA_KEYSTORE_PASSWORD`, `LINTHRA_KEY_ALIAS`, and
+     `LINTHRA_KEY_PASSWORD`.
+3. Update any local `android/key.properties` to point at the new keystore.
+4. Run the release workflow with `signed = true` and verify the artifact is
+   signed by the new key (`apksigner verify --print-certs app-release.apk` or
+   `keytool -printcert -jarfile app-release.apk`).
+5. Securely archive or destroy the old keystore once the new one is confirmed.
+6. If the app is published anywhere, follow that channel's key-rotation
+   procedure:
+   - **Play Store:** if Play App Signing is enabled, rotate the *upload* key via
+     the Play Console; the app signing key is managed by Google.
+   - **F-Droid:** F-Droid signs with its own key (see §6) — rotating our key
+     does not change F-Droid-distributed artifacts.
+
+## 6. F-Droid signing considerations
+
+- **F-Droid signs builds itself.** When an app is distributed through the main
+  F-Droid repository, F-Droid builds from source on its own infrastructure and
+  signs the APK with **F-Droid's** signing key, not ours. Our release keystore
+  is therefore not used by, and not given to, F-Droid.
+- **GitHub Releases signing is separate.** Any APK/AAB we attach to a GitHub
+  Release (a future, manual step — not done by this PR) would be signed with
+  *our* release key. That means the F-Droid build and a GitHub-Release build of
+  the same version have **different signatures** and cannot be cross-installed
+  as updates of each other. This is expected; document it clearly for users.
+- **Reproducible builds (optional, advanced).** F-Droid supports verifying that
+  a developer-signed binary matches what it builds from source, but that
+  requires a reproducible build setup and is explicitly out of scope here.
+- **Never ship debug-signed artifacts as releases.** Debug-key builds exist
+  only for previews/smoke tests. The CI workflow labels them `-debug-signed`
+  precisely so they are never mistaken for a real release.
+
+## 7. What is intentionally out of scope
+
+- Creating GitHub Releases automatically (the release workflow stays manual).
+- Publishing to the Play Store.
+- Submitting to F-Droid.
+- Committing any keystore, password, or `key.properties`.
+
+See [docs/fdroid-readiness.md](./fdroid-readiness.md) for the broader
+distribution checklist.


### PR DESCRIPTION
## Summary

Adds a safe, secret-free foundation for Android release signing. Release builds can now be signed from environment variables or a git-ignored `key.properties`, with the manual CI workflow able to decode a keystore from repository secrets. When no signing material is present, builds fall back to the debug key and are **clearly labeled** so they can never be mistaken for a real release. No keys, passwords, or secrets are committed.

## Files changed

- `android/app/build.gradle` — resolve release signing config from env vars (CI) or `key.properties` (local); fall back to debug key when incomplete.
- `.github/workflows/android-release-build.yml` — add a `signed` input, validate/decode keystore secrets, fail fast on missing secrets, label artifacts by signing status.
- `docs/release-signing.md` — new doc: signing wiring, required secrets, keystore generation, key rotation, F-Droid considerations.
- `docs/fdroid-readiness.md` — update the release-signing blocker to point at the new signing story.

## Signing strategy

`build.gradle` resolves four values, **env vars taking precedence** over `android/key.properties`:

| Purpose           | Env var                     | `key.properties` |
| ----------------- | --------------------------- | ---------------- |
| Keystore file     | `LINTHRA_KEYSTORE_PATH`     | `storeFile`      |
| Keystore password | `LINTHRA_KEYSTORE_PASSWORD` | `storePassword`  |
| Key alias         | `LINTHRA_KEY_ALIAS`         | `keyAlias`       |
| Key password      | `LINTHRA_KEY_PASSWORD`      | `keyPassword`    |

A real release signing config is used **only** when all four are present and the keystore file exists; otherwise the build uses the debug key.

## Required secrets (CI, only when `signed = true`)

- `LINTHRA_KEYSTORE_BASE64` — base64-encoded keystore
- `LINTHRA_KEYSTORE_PASSWORD`
- `LINTHRA_KEY_ALIAS`
- `LINTHRA_KEY_PASSWORD`

If any are missing when `signed = true`, the run **fails with a clear error** rather than silently producing a debug-signed build.

## Artifact behavior

- `signed = false` (default): debug-key build, uploaded as `linthra-debug-signed-apk` / `-aab`.
- `signed = true`: release-signed build, uploaded as `linthra-release-signed-apk` / `-aab`.
- The run summary always states which key signed the build.

## What remains manual

- Triggering the workflow (`workflow_dispatch` only — no automatic builds).
- Configuring the `LINTHRA_*` repository secrets.
- Generating/backing up the keystore (documented).
- Creating any GitHub Release (none is created automatically).
- No Play Store publishing, no F-Droid submission.

## Safety

- No keystore, password, or `key.properties` is committed (already covered by `android/.gitignore`).
- PR CI requires **no secrets**; the signing path is gated behind the manual `signed` input.
- Existing CI (`ci.yml`) is untouched and unaffected — no Dart code changed.

## Next recommended PR

Define the manual **GitHub Release** flow (tag-driven, manual approval) that attaches the release-signed APK/AAB, with user-facing notes on the F-Droid vs GitHub-Release signature difference.

https://claude.ai/code/session_01DMV1B2ah95TkikSa9X4qEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMV1B2ah95TkikSa9X4qEP)_