### PR TITLE
Detect unreadable resolved SAF paths on Android scoped storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,14 @@ than a filesystem path. Scanning now routes each selection through a single seam
   then walks that path. Folders selected this way are stored as ordinary file
   paths, so playback resolution is unchanged.
 
+  Before walking, the scanner probes the resolved path for readability
+  (`DirectoryReadability`). On Android 11+ a path the SAF URI resolves to is
+  often **not** readable through `dart:io` — picking a folder in the system
+  chooser does not by itself grant read access under scoped storage. When the
+  path resolves but cannot be listed, the scan now raises a clear
+  `FolderScanException` ("Android is not letting it read that location…")
+  instead of returning an empty list that would look like "no music found".
+
 How a selection is addressed (path vs `content://`) is decided once by
 `FolderLocation`; nothing downstream re-parses the string, and the UI never
 sees any of it.
@@ -460,11 +468,13 @@ Deliberate gaps the next PRs will close:
   the common `com.android.externalstorage.documents` provider. Other SAF
   providers (downloads, media, cloud/document providers) don't expose a stable
   path, so a selection from one of those surfaces a clear `FolderScanException`
-  in the Library error state instead of a silent empty list. The full
-  follow-up is reading a SAF tree through Android's content resolver (via a
-  native plugin), which also covers devices where scoped storage hides a
-  resolved path behind the framework. The routing and error seams are in place
-  for it.
+  in the Library error state instead of a silent empty list. On Android 11+,
+  even an external-storage path that resolves cleanly may be unreadable under
+  scoped storage; the `DirectoryReadability` probe now turns that into the same
+  clear error rather than a silent empty library. The full follow-up is reading
+  a SAF tree through Android's content resolver (via a native plugin), which is
+  what actually lifts the scoped-storage restriction for picked folders. The
+  routing, readability, and error seams are all in place for it.
 - **No runtime storage permissions yet.** No `READ_MEDIA_AUDIO` request flow is
   wired up, and **`MANAGE_EXTERNAL_STORAGE` is intentionally *not* requested** —
   it is an "all files access" permission Google restricts on the Play Store and
@@ -490,11 +500,16 @@ Deliberate gaps the next PRs will close:
 2. Put a few audio files under a folder on shared storage, e.g.
    `/storage/emulated/0/Music`.
 3. In **Library**, tap the folder icon and pick that folder. The chooser
-   returns a `content://…/tree/primary:Music` URI; Linthra resolves it to the
-   path and scans it.
-4. Picking a folder from a provider that has no filesystem mapping (for example
-   a cloud "Documents" provider) is expected to show the Library error state
-   with a clear message — that's the documented limitation, not a crash.
+   returns a `content://…/tree/primary:Music` URI; Linthra resolves it to a
+   path and, if that path is readable on the device, scans it.
+4. On Android 11+ the resolved path is frequently **not** readable under scoped
+   storage (the system chooser grants access to the SAF tree, not to the
+   underlying filesystem path). In that case the Library shows a clear error
+   explaining Android blocked the read — that's the documented limitation, not
+   a crash or a silent empty library.
+5. Picking a folder from a provider that has no filesystem mapping (for example
+   a cloud "Documents" provider) likewise shows the Library error state with a
+   clear message.
 
 The next PR is expected to be a playlist-editor foundation or Android SAF
 content-resolver folder scanning; a narrow `READ_MEDIA_AUDIO` permission flow

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -94,6 +94,24 @@ where applicable. Current assessment:
 > warrant the `NonFreeNet` anti-feature. The local-first core must remain fully
 > functional without them.
 
+### Android storage / permissions status
+
+- **No storage permissions are declared** in `AndroidManifest.xml`. Folder
+  selection uses the Storage Access Framework via the system folder chooser
+  (`file_picker`'s `ACTION_OPEN_DOCUMENT_TREE`), which needs no manifest
+  permission.
+- **`MANAGE_EXTERNAL_STORAGE` is intentionally not used.** It is an
+  "all files access" permission Google restricts and F-Droid users distrust; it
+  is the opposite of the scoped-storage approach this project prefers. It must
+  not be added without an explicit, documented justification.
+- **Known limitation:** a SAF folder is resolved to a filesystem path and walked
+  with `dart:io`. On Android 11+ that path is frequently unreadable under scoped
+  storage; the scanner now surfaces a clear in-app error in that case
+  (`DirectoryReadability` probe + `FolderScanException`) rather than a silent
+  empty library. Lifting the restriction needs content-resolver SAF traversal
+  (native plugin); a narrow `READ_MEDIA_AUDIO` request is a separate future
+  option. Neither permission is requested today.
+
 ## 6. Release / tagging plan
 
 F-Droid builds from a git tag. Plan:

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'directory_readability.dart';
 import 'folder_location.dart';
 import 'folder_scan_exception.dart';
 import 'saf_tree_uri_resolver.dart';
@@ -56,29 +57,51 @@ class IoAudioFileScanner implements AudioFileScanner {
 ///
 /// This is the Android-capable scanner. It does not touch `dart:io` itself: it
 /// resolves the URI with a [SafTreeUriResolver] and hands the resulting path to
-/// an injected [AudioFileScanner] (the real one is [IoAudioFileScanner]). When
-/// the URI maps to no reachable path, it throws [FolderScanException] so the
-/// user sees a clear message instead of an empty library. Walking SAF trees
-/// that scoped storage only exposes through the content resolver is the
-/// documented native follow-up.
+/// an injected [AudioFileScanner] (the real one is [IoAudioFileScanner]).
+///
+/// Two cases throw [FolderScanException] so the user sees a clear message
+/// instead of a silently empty library:
+///
+/// 1. The URI maps to no reachable path at all (cloud/document providers).
+/// 2. The URI resolves to a path that this app is not allowed to read on this
+///    device — the Android 11+ scoped-storage case, detected up front with a
+///    [DirectoryReadability] probe. Without the probe a `dart:io` walk of an
+///    unreadable directory just returns nothing, which looks like "no music
+///    found" rather than the permission problem it is.
+///
+/// Walking SAF trees that scoped storage only exposes through the content
+/// resolver is the documented native follow-up.
 class ContentUriAudioFileScanner implements AudioFileScanner {
   const ContentUriAudioFileScanner({
     AudioFileScanner filesystemScanner = const IoAudioFileScanner(),
     SafTreeUriResolver resolver = const SafTreeUriResolver(),
+    DirectoryReadability readability = const IoDirectoryReadability(),
   })  : _filesystemScanner = filesystemScanner,
-        _resolver = resolver;
+        _resolver = resolver,
+        _readability = readability;
 
   final AudioFileScanner _filesystemScanner;
   final SafTreeUriResolver _resolver;
+  final DirectoryReadability _readability;
 
   @override
-  Future<List<String>> listFiles(String folder) {
+  Future<List<String>> listFiles(String folder) async {
     final String? path = _resolver.resolveToPath(folder);
     if (path == null) {
       throw FolderScanException(
         "This folder can't be scanned yet. It was shared through Android's "
         'Storage Access Framework, which Linthra cannot walk directly on this '
         'device. Try selecting a folder on your phone or SD card storage.',
+        folder: folder,
+      );
+    }
+    if (!await _readability.canList(path)) {
+      throw FolderScanException(
+        'Linthra resolved this folder to "$path", but Android is not letting '
+        'it read that location. Picking a folder through the system chooser '
+        'does not by itself grant read access on Android 11+, where shared '
+        'storage is sandboxed. Choose a folder the app can already read, or '
+        'wait for the upcoming Storage Access Framework support.',
         folder: folder,
       );
     }

--- a/lib/core/sources/local/directory_readability.dart
+++ b/lib/core/sources/local/directory_readability.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+/// Answers one question for the SAF scanner: can this app actually *list* the
+/// directory at [path] on this device right now?
+///
+/// This seam exists because [SafTreeUriResolver] can map an Android SAF tree
+/// URI to a filesystem path (e.g. `primary:Music` → `/storage/emulated/0/Music`)
+/// that the app is then not allowed to read under Android's scoped storage. A
+/// plain `dart:io` walk of such a path simply returns nothing, which looks like
+/// an empty library rather than the permission problem it actually is. Probing
+/// readability first lets [ContentUriAudioFileScanner] tell those two cases
+/// apart and raise a clear [FolderScanException] for the unreadable one.
+///
+/// Kept behind an interface so the SAF scanner stays unit-testable without a
+/// real device: tests inject a fake that reports "readable"/"not readable".
+abstract interface class DirectoryReadability {
+  /// Whether the directory at [path] exists and can be listed by this app.
+  ///
+  /// Returns `false` for a missing directory and for one that exists but cannot
+  /// be read (the scoped-storage case); an existing but *empty* directory is
+  /// reported as readable.
+  Future<bool> canList(String path);
+}
+
+/// The production [DirectoryReadability], backed by `dart:io`.
+class IoDirectoryReadability implements DirectoryReadability {
+  const IoDirectoryReadability();
+
+  @override
+  Future<bool> canList(String path) async {
+    final Directory directory = Directory(path);
+    try {
+      if (!await directory.exists()) {
+        return false;
+      }
+      // Touch the listing: an existing-but-unreadable directory (the scoped
+      // storage case) only fails here, not on exists(). An empty but readable
+      // directory completes the loop without yielding and is reported readable.
+      await for (final FileSystemEntity _ in directory.list(
+        followLinks: false,
+      )) {
+        break;
+      }
+      return true;
+    } on FileSystemException {
+      return false;
+    }
+  }
+}

--- a/test/core/sources/local/content_uri_audio_file_scanner_test.dart
+++ b/test/core/sources/local/content_uri_audio_file_scanner_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/directory_readability.dart';
 import 'package:linthra/core/sources/local/folder_scan_exception.dart';
 
 /// Records the folder it was asked to scan and returns a fixed list, so we can
@@ -17,25 +18,48 @@ class _RecordingScanner implements AudioFileScanner {
   }
 }
 
+/// A [DirectoryReadability] with a fixed answer, so the scoped-storage probe
+/// can be exercised without a real device.
+class _FakeReadability implements DirectoryReadability {
+  _FakeReadability(this._readable);
+
+  final bool _readable;
+  String? probedPath;
+
+  @override
+  Future<bool> canList(String path) async {
+    probedPath = path;
+    return _readable;
+  }
+}
+
 void main() {
   group('ContentUriAudioFileScanner', () {
     test('resolves a SAF tree URI to a path and delegates the walk', () async {
       final filesystem = _RecordingScanner(<String>[
         '/storage/emulated/0/Music/One.mp3',
       ]);
-      final scanner = ContentUriAudioFileScanner(filesystemScanner: filesystem);
+      final readability = _FakeReadability(true);
+      final scanner = ContentUriAudioFileScanner(
+        filesystemScanner: filesystem,
+        readability: readability,
+      );
 
       final files = await scanner.listFiles(
         'content://com.android.externalstorage.documents/tree/primary%3AMusic',
       );
 
+      expect(readability.probedPath, '/storage/emulated/0/Music');
       expect(filesystem.requestedFolder, '/storage/emulated/0/Music');
       expect(files, <String>['/storage/emulated/0/Music/One.mp3']);
     });
 
     test('throws a useful error for an unresolvable provider', () async {
       final filesystem = _RecordingScanner(const <String>[]);
-      final scanner = ContentUriAudioFileScanner(filesystemScanner: filesystem);
+      final scanner = ContentUriAudioFileScanner(
+        filesystemScanner: filesystem,
+        readability: _FakeReadability(true),
+      );
 
       expect(
         () => scanner.listFiles(
@@ -44,6 +68,36 @@ void main() {
         throwsA(isA<FolderScanException>()),
       );
       // The walk is never attempted when the URI can't be resolved.
+      expect(filesystem.requestedFolder, isNull);
+    });
+
+    test('throws a useful error when the resolved path is not readable',
+        () async {
+      // The external-storage URI resolves to a real path, but scoped storage
+      // blocks reading it. The scanner must surface a clear error instead of
+      // delegating a walk that would silently return nothing.
+      final filesystem = _RecordingScanner(const <String>[]);
+      final readability = _FakeReadability(false);
+      final scanner = ContentUriAudioFileScanner(
+        filesystemScanner: filesystem,
+        readability: readability,
+      );
+
+      await expectLater(
+        () => scanner.listFiles(
+          'content://com.android.externalstorage.documents/tree/'
+          'primary%3AMusic',
+        ),
+        throwsA(
+          isA<FolderScanException>().having(
+            (e) => e.message,
+            'message',
+            contains('not letting it read'),
+          ),
+        ),
+      );
+      expect(readability.probedPath, '/storage/emulated/0/Music');
+      // The walk is skipped when the resolved path can't be read.
       expect(filesystem.requestedFolder, isNull);
     });
   });

--- a/test/core/sources/local/directory_readability_test.dart
+++ b/test/core/sources/local/directory_readability_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/directory_readability.dart';
+
+void main() {
+  group('IoDirectoryReadability', () {
+    const readability = IoDirectoryReadability();
+
+    test('reports a populated directory as readable', () async {
+      final dir = await Directory.systemTemp.createTemp('linthra_readable_');
+      addTearDown(() => dir.delete(recursive: true));
+      await File('${dir.path}/One.mp3').writeAsString('x');
+
+      expect(await readability.canList(dir.path), isTrue);
+    });
+
+    test('reports an empty but readable directory as readable', () async {
+      final dir = await Directory.systemTemp.createTemp('linthra_empty_');
+      addTearDown(() => dir.delete(recursive: true));
+
+      expect(await readability.canList(dir.path), isTrue);
+    });
+
+    test('reports a missing directory as not readable', () async {
+      final dir = await Directory.systemTemp.createTemp('linthra_missing_');
+      final missing = '${dir.path}/does-not-exist';
+      await dir.delete(recursive: true);
+
+      expect(await readability.canList(missing), isFalse);
+    });
+  });
+}

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/directory_readability.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/features/library/library_controller.dart';
@@ -13,6 +14,20 @@ import 'fake_audio_file_scanner.dart';
 import 'fake_music_library_repository.dart';
 
 Track _track(String id) => Track(id: id, title: 'Track $id', uri: 'file://$id');
+
+/// Reports every resolved SAF path as readable, standing in for the on-device
+/// scoped-storage probe so the content-URI walk runs in tests.
+class _AlwaysReadable implements DirectoryReadability {
+  @override
+  Future<bool> canList(String path) async => true;
+}
+
+/// Reports every resolved SAF path as unreadable, simulating Android 11+ scoped
+/// storage blocking a folder the SAF URI resolved to.
+class _NeverReadable implements DirectoryReadability {
+  @override
+  Future<bool> canList(String path) async => false;
+}
 
 ProviderContainer _containerWith(FakeMusicLibraryRepository repository) {
   final container = ProviderContainer(
@@ -135,9 +150,12 @@ void main() {
       );
       // Wire the fake into the content scanner's walk: a content URI routes to
       // ContentUriAudioFileScanner, which resolves the URI to a path and then
-      // delegates that path to its filesystem scanner.
-      final contentScanner =
-          ContentUriAudioFileScanner(filesystemScanner: filesystem);
+      // delegates that path to its filesystem scanner. A fake readability probe
+      // stands in for the on-device scoped-storage check.
+      final contentScanner = ContentUriAudioFileScanner(
+        filesystemScanner: filesystem,
+        readability: _AlwaysReadable(),
+      );
       final container = _scanContainer(
         repository: repository,
         scanner: PlatformAudioFileScanner(contentUriScanner: contentScanner),
@@ -172,6 +190,34 @@ void main() {
       final state = container.read(libraryControllerProvider);
       expect(state.status, LibraryStatus.error);
       expect(state.errorMessage, contains('Storage Access Framework'));
+    });
+
+    test(
+        'scanFolder surfaces a clean error when a resolved content URI is '
+        'unreadable', () async {
+      // The external-storage URI resolves to a real path, but scoped storage
+      // blocks reading it. The Library should show a clear, actionable error
+      // rather than an empty "no music found" library.
+      final contentScanner = ContentUriAudioFileScanner(
+        filesystemScanner: FakeAudioFileScanner(
+          files: <String>['/storage/emulated/0/Music/One.mp3'],
+        ),
+        readability: _NeverReadable(),
+      );
+      final container = _scanContainer(
+        repository: InMemoryMusicLibraryRepository(),
+        scanner: PlatformAudioFileScanner(contentUriScanner: contentScanner),
+      );
+
+      const folderUri = 'content://com.android.externalstorage.documents/tree/'
+          'primary%3AMusic';
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder(folderUri);
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.error);
+      expect(state.errorMessage, contains('not letting it read'));
     });
   });
 }


### PR DESCRIPTION
## Summary

The SAF/content-URI routing seam (`PlatformAudioFileScanner` → `ContentUriAudioFileScanner` → `SafTreeUriResolver`) already exists. This PR closes the one documented real-device gap left in it.

`SafTreeUriResolver` maps a `content://…/tree/primary:Music` selection to a filesystem path (`/storage/emulated/0/Music`). On **Android 11+ scoped storage**, picking a folder in the system chooser grants access to the SAF *tree*, not to that underlying path — so the `dart:io` walk just returns nothing. The user saw an empty "no music found" library instead of the permission problem it actually is.

This adds a small, injectable `DirectoryReadability` probe. `ContentUriAudioFileScanner` now checks the resolved path is listable **before** walking it, and raises a clear `FolderScanException` when it isn't. No native plugin, no new permission, no scanner rewrite.

## Files changed

- `lib/core/sources/local/directory_readability.dart` (new) — `DirectoryReadability` interface + `IoDirectoryReadability` (`dart:io`) production impl. The single new place that decides "can this app list this directory right now?".
- `lib/core/sources/local/audio_file_scanner.dart` — `ContentUriAudioFileScanner` takes an injected `DirectoryReadability` (defaults to `IoDirectoryReadability`) and throws a clear error for the resolve-but-unreadable case.
- `test/core/sources/local/directory_readability_test.dart` (new) — exercises the real `dart:io` probe (populated / empty-but-readable / missing).
- `test/core/sources/local/content_uri_audio_file_scanner_test.dart` — fake-readability injection + new unreadable-path case.
- `test/features/library/library_controller_test.dart` — end-to-end test that the Library surfaces the unreadable-path error state; fake readability for the existing content-URI routing test.
- `README.md`, `docs/fdroid-readiness.md` — updated Android storage status.

## Android SAF / content:// behavior

1. **No filesystem mapping** (downloads / media / cloud providers) → clear `FolderScanException` (unchanged).
2. **Resolves to a path that is readable** → walked as before; folder stored as an ordinary path so playback is unchanged.
3. **Resolves to a path that is *not* readable** (Android 11+ scoped storage) → **new:** clear `FolderScanException` ("Android is not letting it read that location…") instead of a silent empty library.

## Linux/desktop behavior

Unchanged. Filesystem-path selections route straight to `IoAudioFileScanner` via `PlatformAudioFileScanner` and never touch the readability probe.

## Permissions / storage notes

- **No new permissions.** `AndroidManifest.xml` still declares none; selection stays SAF-based (`ACTION_OPEN_DOCUMENT_TREE`).
- **`MANAGE_EXTERNAL_STORAGE` deliberately not added** — restricted "all files access", contrary to the scoped-storage approach this project prefers.
- A narrow `READ_MEDIA_AUDIO` flow remains a separate future option; not requested here.

## Tests added

- `IoDirectoryReadability`: populated → readable, empty → readable, missing → not readable.
- `ContentUriAudioFileScanner`: resolves + delegates when readable; throws when the resolved path is unreadable (walk skipped).
- `LibraryController`: scan surfaces the unreadable-path error state end-to-end.
- Existing filesystem-path scan, content-URI detection, and unscannable-provider tests retained.

## Known limitations

- The probe converts the scoped-storage failure into a clear error; it does **not** make the folder scannable. Actually reading a SAF tree under scoped storage needs content-resolver traversal via a native plugin — still the documented follow-up.
- No tag/metadata parsing yet.
- **Verification note:** Flutter/Dart are not installed in this environment, so `flutter pub get` / `dart format` / `flutter analyze` / `flutter test` / `flutter build apk --debug` could not be run here. The change is intentionally pure-Dart + fake-driven tests; please run the suite in CI/locally to confirm.

## Next recommended PR

Native content-resolver SAF traversal (e.g. a `DocumentFile`-backed enumerator behind the existing `AudioFileScanner` seam) so picked folders are actually scannable on Android 11+, optionally paired with a narrow `READ_MEDIA_AUDIO` request flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fvbbo9uw4TAp9Z82cN2SQo)_