### PR TITLE
Apply native Android audio_service setup for background playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,10 @@ Not built yet (planned, in roughly this order):
   content-resolver SAF scanning, and a narrow Android media permission still
   pending*
 - Audio playback — *done (local playback + up-next queue); background playback
-  + media session foundation via `audio_service` now wired (Android Auto
-  readiness, not yet a full car UI)*
+  + media session via `audio_service` now wired in Dart **and** with the native
+  Android setup applied (foreground-service permissions, playback service,
+  media-button receiver, `AudioServiceActivity`) — Android Auto ready, not yet a
+  full car UI*
 - Playlists
 - User-controlled offline downloads — *foundation done (status lifecycle,
   mark/remove offline, Wi-Fi-only seam, UI hooks); real remote byte-fetch and a
@@ -291,9 +293,9 @@ a broad "all files" grant.
 > The `audio_service` native wiring (foreground-service permissions, the
 > playback `<service>`/`<receiver>`, and `MainActivity` extending
 > `AudioServiceActivity`) documented under *Background playback & Android Auto*
-> is **not yet applied** to the committed scaffold. `connectMediaSession` falls
-> back gracefully when it is absent, so the debug build still runs and basic
-> playback works; wiring the media session is the recommended next PR.
+> is now **applied** to the committed scaffold. `connectMediaSession` still
+> falls back gracefully if the session can't initialise (e.g. an unsupported
+> platform or a test environment), so basic playback never depends on it.
 
 ### Building release artifacts (Android)
 
@@ -378,9 +380,24 @@ truth, and **the UI continues to depend only on `PlaybackController`** — never
 on `audio_service`. Attaching the session in `main.dart` is best-effort: if it
 fails to initialise (e.g. an unsupported platform) basic playback still works.
 
-**Required native setup** (the `android/` folder is generated locally, see
-above). For the media session to run as a foreground service and be visible to
-Android Auto, add to `android/app/src/main/AndroidManifest.xml`:
+**Native setup (applied).** The required Android wiring lives in the committed
+scaffold so the media session can run as a foreground service and be visible to
+Android Auto:
+
+- `android/app/src/main/AndroidManifest.xml` declares two minimal permissions —
+  `FOREGROUND_SERVICE` (run the playback service in the foreground so audio
+  continues while backgrounded) and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` (the
+  typed-foreground grant Android 14+/API 34 requires for a `mediaPlayback`
+  service). No storage or network permissions are added.
+- the same manifest declares the audio_service playback `<service>`
+  (`com.ryanheise.audioservice.AudioService`, `foregroundServiceType`
+  `mediaPlayback`, exposing the `MediaBrowserService` action Android Auto binds
+  to) and the `<receiver>` (`com.ryanheise.audioservice.MediaButtonReceiver`)
+  that handles hardware/Bluetooth/Android Auto media-button intents.
+- `android/app/.../MainActivity.kt` extends `AudioServiceActivity` (instead of
+  the default `FlutterActivity`) so the Flutter activity binds to the session.
+
+For reference, the manifest additions are:
 
 ```xml
 <manifest ...>
@@ -411,9 +428,8 @@ Android Auto, add to `android/app/src/main/AndroidManifest.xml`:
 </manifest>
 ```
 
-The main activity should extend `AudioServiceActivity` (per the `audio_service`
-README) so the session binds correctly. The notification channel id/name are
-configured in `connectMediaSession` (`com.linthra.audio` / "Linthra playback").
+The notification channel id/name are configured in `connectMediaSession`
+(`com.linthra.audio` / "Linthra playback").
 
 **Limitations (this PR).**
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Background playback / media-session permissions for audio_service.
+         Kept deliberately minimal: only what a foreground media-playback
+         service needs. No storage or network permissions are added here.
+
+         FOREGROUND_SERVICE: lets audio_service run its playback service in the
+         foreground so audio keeps playing while the app is backgrounded.
+         FOREGROUND_SERVICE_MEDIA_PLAYBACK: the typed-foreground-service grant
+         required on Android 14+ (API 34) for a service of type
+         "mediaPlayback"; without it the service cannot start on new devices. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission
+        android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application
         android:label="Linthra"
         android:name="${applicationName}"
@@ -25,6 +38,31 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <!-- audio_service playback service. Runs as a foreground service of
+             type "mediaPlayback" so audio survives backgrounding, and exposes
+             the MediaBrowserService action that Android Auto / other media
+             browsers bind to. The class is provided by the audio_service
+             plugin; we only declare it. -->
+        <service
+            android:name="com.ryanheise.audioservice.AudioService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService" />
+            </intent-filter>
+        </service>
+
+        <!-- Media button receiver (also provided by audio_service). Handles
+             hardware/Bluetooth/headset transport buttons and the media-button
+             intents Android Auto and the system route to the session. -->
+        <receiver
+            android:name="com.ryanheise.audioservice.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -1,5 +1,9 @@
 package io.github.thezupzup.linthra
 
-import io.flutter.embedding.android.FlutterActivity
+import com.ryanheise.audioservice.AudioServiceActivity
 
-class MainActivity: FlutterActivity()
+// Extends AudioServiceActivity (instead of the default FlutterActivity) so the
+// single Flutter activity binds to the audio_service media session correctly.
+// This is the activity audio_service expects to host the engine; using the
+// plain FlutterActivity would leave the background service unable to attach.
+class MainActivity : AudioServiceActivity()


### PR DESCRIPTION
## Summary

Applies the native Android wiring that the existing `audio_service` Dart
integration needs to run as a real foreground media session and be reachable
from Android Auto. The Dart side (`LinthraAudioHandler`, `connectMediaSession`)
was already in place; previously the README noted the native setup was **not
yet applied**. This PR closes that gap. No playback rewrite, no queue changes,
no UI changes.

## Native files changed

- **`android/app/src/main/AndroidManifest.xml`**
  - Added two `<uses-permission>` entries (see below).
  - Declared the audio_service playback `<service>`
    (`com.ryanheise.audioservice.AudioService`, `foregroundServiceType="mediaPlayback"`,
    exposing the `android.media.browse.MediaBrowserService` action).
  - Declared the `<receiver>` (`com.ryanheise.audioservice.MediaButtonReceiver`)
    for `android.intent.action.MEDIA_BUTTON`.
- **`android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt`**
  - Now extends `AudioServiceActivity` instead of `FlutterActivity` so the
    Flutter activity binds to the media session.
- **`README.md`**
  - Flipped the "native setup not yet applied" callout to "applied", updated
    the *Background playback & Android Auto* section to describe the wired
    files, and refreshed the roadmap status line.

## Permissions added and why

| Permission | Why |
| --- | --- |
| `FOREGROUND_SERVICE` | Lets audio_service run its playback service in the foreground so audio continues while the app is backgrounded. |
| `FOREGROUND_SERVICE_MEDIA_PLAYBACK` | The typed-foreground-service grant Android 14+ (API 34) requires for a `mediaPlayback` service; without it the service cannot start on new devices. |

No storage (`READ_MEDIA_AUDIO`/all-files) or network permissions were added —
those remain deliberately out of scope.

## Android Auto / background playback status

- Background playback + notification/lock-screen media session: **wired**
  (Dart + native). `connectMediaSession` still falls back gracefully if the
  session can't initialise, so basic playback never depends on it.
- Android Auto: **ready at the session level** — the now-playing card and
  transport controls bind through the declared MediaBrowserService. No browsable
  car library (folders/albums/playlists) yet.

## Limitations

- No browsable car/media-browser tree (no folder/album/playlist nodes in
  Android Auto) — only the now-playing session.
- No skip-to-previous control (queue is forward-only for now).
- Verification commands (`flutter pub get`, `dart format`, `flutter analyze`,
  `flutter test`, `flutter build apk --debug`) could **not** be run here — the
  Flutter/Dart SDK is not installed in this environment. Changes are limited to
  native Android files (manifest XML validated as well-formed) and the README;
  no Dart sources were touched, so analyze/format/test results are unaffected by
  this PR. CI should run the full suite.

## Next recommended PR

Add the browsable Android Auto media library (`getChildren`/`onLoadChildren`
nodes for folders/albums/playlists) and a skip-to-previous control once the
queue model supports backward navigation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKTEwshSS5FR1FDBXUhVTu)_