### PR TITLE
Add Android Auto browsable media library and skip-to-previous

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ Not built yet (planned, in roughly this order):
   are now routed and resolved for external storage; tag parsing,
   content-resolver SAF scanning, and a narrow Android media permission still
   pending*
-- Audio playback — *done (local playback + up-next queue); background playback
-  + media session via `audio_service` now wired in Dart **and** with the native
-  Android setup applied (foreground-service permissions, playback service,
-  media-button receiver, `AudioServiceActivity`) — Android Auto ready, not yet a
-  full car UI*
+- Audio playback — *done (local playback + up-next queue with skip
+  next/previous); background playback + media session via `audio_service` wired
+  in Dart **and** with the native Android setup applied (foreground-service
+  permissions, playback service, media-button receiver, `AudioServiceActivity`,
+  Android Auto media-app declaration); Android Auto now **browsable** (Library /
+  Queue nodes, tap-to-play) — not yet a full car UI*
 - Playlists
 - User-controlled offline downloads — *foundation done (status lifecycle,
   mark/remove offline, Wi-Fi-only seam, UI hooks); real remote byte-fetch and a
@@ -291,11 +292,12 @@ for why a narrow `READ_MEDIA_AUDIO` flow is a deliberate later step rather than
 a broad "all files" grant.
 
 > The `audio_service` native wiring (foreground-service permissions, the
-> playback `<service>`/`<receiver>`, and `MainActivity` extending
-> `AudioServiceActivity`) documented under *Background playback & Android Auto*
-> is now **applied** to the committed scaffold. `connectMediaSession` still
-> falls back gracefully if the session can't initialise (e.g. an unsupported
-> platform or a test environment), so basic playback never depends on it.
+> playback `<service>`/`<receiver>`, the Android Auto media-app declaration, and
+> `MainActivity` extending `AudioServiceActivity`) documented under *Background
+> playback & Android Auto* is now **applied** to the committed scaffold.
+> `connectMediaSession` still falls back gracefully if the session can't
+> initialise (e.g. an unsupported platform or a test environment), so basic
+> playback never depends on it.
 
 ### Building release artifacts (Android)
 
@@ -364,21 +366,46 @@ playback survives backgrounding and shows up where the OS expects it:
   **skip-next** (the skip control only appears when the up-next queue has a
   track). Position updates flow through so scrubbing/seek work from the system
   UI.
-- **Android Auto readiness.** The same session is what Android Auto and other
+- **Skip controls.** Transport exposes **skip-previous** and **skip-next**
+  alongside play/pause/stop. Each skip button only appears when the queue has a
+  track in that direction (`hasPrevious` / `hasNext`), so the controls match what
+  the queue can actually do.
+- **Android Auto — browsable.** The same session is what Android Auto and other
   media browsers attach to, so the now-playing card and transport controls are
-  reachable from the car head unit. This PR lays the **foundation** — it does
-  *not* yet ship a browsable media library (folders/albums/playlists in the car
-  UI). That polish is a later PR.
+  reachable from the car head unit. On top of that, Linthra now serves a
+  **browsable media library** so you can pick what to play from the car screen
+  (see the tree below). Selecting a track starts it and queues the rest behind
+  it, exactly like tapping a track in the in-app library.
+
+**Media tree.** The browsable hierarchy served to Android Auto is intentionally
+shallow:
+
+```
+root
+├── Library   → every catalog track (tap to play; the rest of the library
+│               becomes up-next)
+└── Queue     → the current track followed by the up-next list (tap to jump)
+```
+
+Nodes are addressed by stable IDs: the `Library` and `Queue` categories, and
+leaf IDs `library/<trackId>` and `queue/<index>` that a selection is resolved
+back through. Playlists are **not** a node yet — there is no persisted playlist
+store, so adding one would not be "safe/simple" (see limitations).
 
 **Architecture.** `audio_service` is a pure infrastructure layer.
 `LinthraAudioHandler` (`lib/core/services/linthra_audio_handler.dart`) is the
 only file that imports it: it forwards session commands
 (play/pause/stop/skip/seek) to the `PlaybackController` and mirrors the
 controller's `PlaybackState` back out as the session's playback state + media
-item. The controller (still `just_audio`-backed) stays the single source of
-truth, and **the UI continues to depend only on `PlaybackController`** — never
-on `audio_service`. Attaching the session in `main.dart` is best-effort: if it
-fails to initialise (e.g. an unsupported platform) basic playback still works.
+item. The browse tree itself is **pure Dart** — `MediaBrowserTree`
+(`lib/core/services/media_browser_tree.dart`) builds neutral `MediaNode`s from
+the `MusicLibraryRepository` (catalog) and a `PlaybackState` snapshot (the live
+queue), and the handler maps those onto `audio_service` media items. So library
+data still flows only through `MusicLibraryRepository`, playback still flows only
+through `PlaybackController`, and **the UI continues to depend only on
+`PlaybackController`** — never on `audio_service`. Attaching the session in
+`main.dart` is best-effort: if it fails to initialise (e.g. an unsupported
+platform) basic playback still works.
 
 **Native setup (applied).** The required Android wiring lives in the committed
 scaffold so the media session can run as a foreground service and be visible to
@@ -394,6 +421,11 @@ Android Auto:
   `mediaPlayback`, exposing the `MediaBrowserService` action Android Auto binds
   to) and the `<receiver>` (`com.ryanheise.audioservice.MediaButtonReceiver`)
   that handles hardware/Bluetooth/Android Auto media-button intents.
+- the manifest also declares the `com.google.android.gms.car.application`
+  meta-data pointing at `res/xml/automotive_app_desc.xml` (`<uses name="media"/>`),
+  which is what lets Android Auto list Linthra as a media app and bind to the
+  browser service to load the tree. Without it the session works but the app
+  never appears in the car's browse UI.
 - `android/app/.../MainActivity.kt` extends `AudioServiceActivity` (instead of
   the default `FlutterActivity`) so the Flutter activity binds to the session.
 
@@ -424,6 +456,11 @@ For reference, the manifest additions are:
         <action android:name="android.intent.action.MEDIA_BUTTON" />
       </intent-filter>
     </receiver>
+
+    <!-- Marks Linthra as an Android Auto media app -->
+    <meta-data
+        android:name="com.google.android.gms.car.application"
+        android:resource="@xml/automotive_app_desc" />
   </application>
 </manifest>
 ```
@@ -433,14 +470,19 @@ The notification channel id/name are configured in `connectMediaSession`
 
 **Limitations (this PR).**
 
-- No browsable car/media-browser tree yet (no folder/album/playlist nodes in
-  Android Auto) — only the now-playing session.
-- No previous-track / skip-to-previous control (the queue model is forward-only
-  for now).
-- No advanced queue editing from the session.
+- The browse tree is **flat**: `Library` is a single flat track list (no
+  album/artist/folder grouping) and there is no search-from-Auto. Large
+  libraries are not paged.
+- **No Playlists node.** Playlists have a model and a repository *interface* but
+  no persisted implementation yet, so exposing them would not be safe/simple —
+  deferred to a later PR.
+- Queue browsing is **read + jump only**: you can play from a queue position,
+  but reordering/removing queue items from the car isn't supported.
+- The car experience is **basic browsing**, not a polished/custom car UI
+  (no tabs, content style hints, or now-playing artwork tuning).
 - No MPRIS (Linux desktop media keys) yet.
-- Lock-screen artwork depends on `Track.artworkUri`, which local scanning does
-  not populate yet.
+- Lock-screen / car artwork depends on `Track.artworkUri`, which local scanning
+  does not populate yet.
 
 ### Android folder selection & known limitations
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -63,6 +63,15 @@
             </intent-filter>
         </receiver>
 
+        <!-- Declares Linthra to Android Auto as a media app so it's listed in
+             the car launcher and Auto binds to the MediaBrowserService above to
+             load the browsable tree (Library / Queue). Points at
+             res/xml/automotive_app_desc.xml, which claims only the "media"
+             capability. -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Declares Linthra as an Android Auto *media* app. Referenced from the
+     manifest via the com.google.android.gms.car.application meta-data; without
+     it Android Auto won't list the app or bind to its MediaBrowserService, so
+     the browsable tree (Library / Queue) would never appear in the car UI.
+     "media" is the only capability we claim — no messaging or other car APIs. -->
+<automotiveApp>
+    <uses name="media" />
+</automotiveApp>

--- a/lib/core/models/playback_queue.dart
+++ b/lib/core/models/playback_queue.dart
@@ -50,6 +50,9 @@ class PlaybackQueue {
   /// Whether there is at least one track after the current one.
   bool get hasNext => currentIndex >= 0 && currentIndex < tracks.length - 1;
 
+  /// Whether there is at least one track before the current one.
+  bool get hasPrevious => currentIndex > 0;
+
   bool get isEmpty => current == null;
 
   /// Advances to the next track. Returns this queue unchanged when there is no
@@ -57,6 +60,13 @@ class PlaybackQueue {
   PlaybackQueue next() {
     if (!hasNext) return this;
     return PlaybackQueue(tracks: tracks, currentIndex: currentIndex + 1);
+  }
+
+  /// Steps back to the previous track. Returns this queue unchanged when the
+  /// current track is the first, so callers can branch on [hasPrevious].
+  PlaybackQueue previous() {
+    if (!hasPrevious) return this;
+    return PlaybackQueue(tracks: tracks, currentIndex: currentIndex - 1);
   }
 
   /// Inserts [track] immediately after the current one ("play next"). With an

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -13,6 +13,7 @@ class PlaybackState {
     this.status = PlaybackStatus.idle,
     this.currentTrack,
     this.upNext = const <Track>[],
+    this.hasPrevious = false,
     this.position = Duration.zero,
     this.duration = Duration.zero,
   });
@@ -26,6 +27,11 @@ class PlaybackState {
   /// queue holds only the current track.
   final List<Track> upNext;
 
+  /// Whether a previous track exists to step back to. Stored as a flag (unlike
+  /// [hasNext], which reads off [upNext]) because the state carries no played
+  /// history — the controller derives it from the queue's current position.
+  final bool hasPrevious;
+
   final Duration position;
   final Duration duration;
 
@@ -37,6 +43,7 @@ class PlaybackState {
     PlaybackStatus? status,
     Track? currentTrack,
     List<Track>? upNext,
+    bool? hasPrevious,
     Duration? position,
     Duration? duration,
   }) {
@@ -44,6 +51,7 @@ class PlaybackState {
       status: status ?? this.status,
       currentTrack: currentTrack ?? this.currentTrack,
       upNext: upNext ?? this.upNext,
+      hasPrevious: hasPrevious ?? this.hasPrevious,
       position: position ?? this.position,
       duration: duration ?? this.duration,
     );
@@ -56,6 +64,7 @@ class PlaybackState {
           other.status == status &&
           other.currentTrack == currentTrack &&
           listEquals(other.upNext, upNext) &&
+          other.hasPrevious == hasPrevious &&
           other.position == position &&
           other.duration == duration);
 
@@ -65,6 +74,7 @@ class PlaybackState {
       status,
       currentTrack,
       Object.hashAll(upNext),
+      hasPrevious,
       position,
       duration,
     );

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -99,9 +99,16 @@ class JustAudioPlaybackController implements PlaybackController {
   }
 
   @override
+  Future<void> skipToPrevious() async {
+    if (!_queue.hasPrevious) return;
+    _queue = _queue.previous();
+    await _playCurrent();
+  }
+
+  @override
   void clearQueue() {
     _queue = _queue.cleared();
-    _emit(_state.copyWith(upNext: _queue.upNext));
+    _emit(_state.copyWith(upNext: _queue.upNext, hasPrevious: false));
   }
 
   /// Loads and plays the queue's current track, surfacing its up-next list.
@@ -114,6 +121,7 @@ class JustAudioPlaybackController implements PlaybackController {
       status: PlaybackStatus.loading,
       currentTrack: track,
       upNext: _queue.upNext,
+      hasPrevious: _queue.hasPrevious,
     );
     _emit(loading);
     try {
@@ -142,6 +150,7 @@ class JustAudioPlaybackController implements PlaybackController {
     final stopped = PlaybackState(
       currentTrack: _state.currentTrack,
       upNext: _queue.upNext,
+      hasPrevious: _queue.hasPrevious,
     );
     _emit(stopped);
   }

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -4,6 +4,8 @@ import 'package:audio_service/audio_service.dart' as audio;
 
 import '../models/playback_state.dart';
 import '../models/track.dart';
+import '../repositories/music_library_repository.dart';
+import 'media_browser_tree.dart';
 import 'playback_controller.dart';
 
 /// Bridges the app's [PlaybackController] to the platform media session via
@@ -14,10 +16,13 @@ import 'playback_controller.dart';
 /// engine: it forwards media-session commands (play/pause/stop/skip) to the
 /// controller and mirrors the controller's [PlaybackState] back out as
 /// audio_service playback state + media item, so the notification, lock screen,
-/// and Android Auto reflect what is playing. The controller stays the single
-/// source of truth and owns `just_audio`; the UI never touches this class.
+/// and Android Auto reflect what is playing. For Android Auto it also exposes a
+/// browsable tree (Library / Queue) built by [MediaBrowserTree] and turns a
+/// selected item into a [PlaybackController.playTracks] call. The controller
+/// stays the single source of truth and owns `just_audio`; the UI never touches
+/// this class.
 class LinthraAudioHandler extends audio.BaseAudioHandler {
-  LinthraAudioHandler(this._controller) {
+  LinthraAudioHandler(this._controller, this._tree) {
     _subscription = _controller.stateStream.listen(_broadcast);
     // Seed the session from the latest known state so a freshly attached
     // notification/Android Auto isn't blank before the first stream event.
@@ -25,6 +30,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   }
 
   final PlaybackController _controller;
+  final MediaBrowserTree _tree;
   late final StreamSubscription<PlaybackState> _subscription;
 
   @override
@@ -43,21 +49,68 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   Future<void> skipToNext() => _controller.skipToNext();
 
   @override
+  Future<void> skipToPrevious() => _controller.skipToPrevious();
+
+  @override
   Future<void> seek(Duration position) => _controller.seek(position);
+
+  // --- Android Auto / media browser ---------------------------------------
+
+  @override
+  Future<List<audio.MediaItem>> getChildren(
+    String parentMediaId, [
+    Map<String, dynamic>? options,
+  ]) async {
+    final nodes = await _tree.childrenOf(parentMediaId, _controller.state);
+    return nodes.map(_mediaItemForNode).toList();
+  }
+
+  @override
+  Future<void> playFromMediaId(
+    String mediaId, [
+    Map<String, dynamic>? extras,
+  ]) async {
+    final request = await _tree.resolve(mediaId, _controller.state);
+    if (request == null) return;
+    await _controller.playTracks(request.tracks,
+        startIndex: request.startIndex);
+  }
+
+  // ------------------------------------------------------------------------
 
   void _broadcast(PlaybackState state) {
     final track = state.currentTrack;
-    mediaItem.add(track == null ? null : _mediaItemFor(track, state));
+    mediaItem.add(
+      track == null
+          ? null
+          : _trackMediaItem(track, id: track.id, live: state.duration),
+    );
     playbackState.add(_playbackStateFor(state));
   }
 
-  audio.MediaItem _mediaItemFor(Track track, PlaybackState state) {
-    // Prefer the live duration the engine reported; fall back to the track's
-    // catalog duration, and omit it entirely when unknown.
-    final live = state.duration;
+  audio.MediaItem _mediaItemForNode(MediaNode node) {
+    final track = node.track;
+    if (node.playable && track != null) {
+      return _trackMediaItem(track, id: node.id);
+    }
+    return audio.MediaItem(
+      id: node.id,
+      title: node.title,
+      playable: false,
+      displaySubtitle: node.subtitle,
+    );
+  }
+
+  audio.MediaItem _trackMediaItem(
+    Track track, {
+    required String id,
+    Duration live = Duration.zero,
+  }) {
+    // Prefer the live duration the engine reported (now-playing); fall back to
+    // the track's catalog duration, and omit it entirely when unknown.
     final duration = live > Duration.zero ? live : track.duration;
     return audio.MediaItem(
-      id: track.id,
+      id: id,
       title: track.title,
       artist: track.artistName,
       album: track.albumName,
@@ -69,7 +122,11 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   audio.PlaybackState _playbackStateFor(PlaybackState state) {
     return audio.PlaybackState(
       controls: _controlsFor(state),
-      systemActions: const <audio.MediaAction>{audio.MediaAction.seek},
+      systemActions: const <audio.MediaAction>{
+        audio.MediaAction.seek,
+        audio.MediaAction.skipToNext,
+        audio.MediaAction.skipToPrevious,
+      },
       processingState: _processingStateFor(state.status),
       playing: state.isPlaying,
       updatePosition: state.position,
@@ -78,6 +135,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   List<audio.MediaControl> _controlsFor(PlaybackState state) {
     return <audio.MediaControl>[
+      if (state.hasPrevious) audio.MediaControl.skipToPrevious,
       state.isPlaying ? audio.MediaControl.pause : audio.MediaControl.play,
       audio.MediaControl.stop,
       if (state.hasNext) audio.MediaControl.skipToNext,
@@ -105,7 +163,8 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 }
 
 /// Registers [controller] with the platform media session so playback appears
-/// in the notification / lock screen and is reachable from Android Auto.
+/// in the notification / lock screen and is reachable from Android Auto, with a
+/// browsable tree backed by [library].
 ///
 /// Best-effort by design: returns `null` when `audio_service` can't initialise
 /// (a platform without the native setup, or a test environment). Playback still
@@ -113,10 +172,11 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 /// breaks basic playback.
 Future<LinthraAudioHandler?> connectMediaSession(
   PlaybackController controller,
+  MusicLibraryRepository library,
 ) async {
   try {
     return await audio.AudioService.init(
-      builder: () => LinthraAudioHandler(controller),
+      builder: () => LinthraAudioHandler(controller, MediaBrowserTree(library)),
       config: const audio.AudioServiceConfig(
         androidNotificationChannelId: 'com.linthra.audio',
         androidNotificationChannelName: 'Linthra playback',

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import '../repositories/music_library_repository.dart';
+
+/// Stable media IDs for the browsable tree exposed to Android Auto and other
+/// media browsers.
+///
+/// Category IDs are plain constants; leaf IDs encode where the item lives so a
+/// later `playFromMediaId` can be resolved back to a track without extra state:
+/// `library/<trackId>` is a catalog track, `queue/<index>` is a position in the
+/// current play queue. The two namespaces never collide (`library` vs.
+/// `library/...`).
+abstract final class MediaId {
+  /// The root the platform requests first (audio_service's `browsableRootId`).
+  static const String root = 'root';
+  static const String library = 'library';
+  static const String queue = 'queue';
+
+  static const String _libraryPrefix = 'library/';
+  static const String _queuePrefix = 'queue/';
+
+  static String libraryTrack(String trackId) => '$_libraryPrefix$trackId';
+  static String queueItem(int index) => '$_queuePrefix$index';
+
+  static bool isLibraryTrack(String id) => id.startsWith(_libraryPrefix);
+  static bool isQueueItem(String id) => id.startsWith(_queuePrefix);
+
+  static String libraryTrackId(String id) =>
+      id.substring(_libraryPrefix.length);
+
+  /// The queue position encoded in [id], or -1 when it isn't a valid number.
+  static int queueIndex(String id) =>
+      int.tryParse(id.substring(_queuePrefix.length)) ?? -1;
+}
+
+/// One node in the browsable media tree, kept free of any `audio_service` type.
+///
+/// Browsable nodes (categories) have [playable] `false`; track leaves have it
+/// `true` and carry their [track] so the handler can build a rich media item
+/// (artist, album, duration, artwork) without re-reading the catalog.
+@immutable
+class MediaNode {
+  const MediaNode({
+    required this.id,
+    required this.title,
+    this.subtitle,
+    this.playable = false,
+    this.track,
+  });
+
+  final String id;
+  final String title;
+  final String? subtitle;
+  final bool playable;
+  final Track? track;
+}
+
+/// What to play when a browsable item is selected: the [tracks] to load and the
+/// [startIndex] within them to begin at. Mirrors [PlaybackController.playTracks]
+/// so the rest of the queue becomes up-next, exactly like tapping a track in the
+/// in-app library.
+@immutable
+class MediaPlaybackRequest {
+  const MediaPlaybackRequest({required this.tracks, required this.startIndex});
+
+  final List<Track> tracks;
+  final int startIndex;
+}
+
+/// Builds the browsable media tree from the [MusicLibraryRepository] (catalog)
+/// and a [PlaybackState] snapshot (the live queue), and resolves a selected
+/// media ID back to a playback request.
+///
+/// Pure application logic with no audio backend: the handler maps its
+/// [MediaNode]s onto `audio_service` media items and drives playback through the
+/// [PlaybackController]. That keeps this fully testable with a fake repository.
+class MediaBrowserTree {
+  const MediaBrowserTree(this._library);
+
+  final MusicLibraryRepository _library;
+
+  /// The children of [parentId], for the given live [playback] snapshot.
+  /// Unknown parents yield an empty list rather than throwing, so an unexpected
+  /// browse request can never crash the media service.
+  Future<List<MediaNode>> childrenOf(
+    String parentId,
+    PlaybackState playback,
+  ) async {
+    switch (parentId) {
+      case MediaId.root:
+        return _rootNodes;
+      case MediaId.library:
+        return _libraryNodes();
+      case MediaId.queue:
+        return _queueNodes(playback);
+      default:
+        return const <MediaNode>[];
+    }
+  }
+
+  /// Resolves a selected leaf [mediaId] to what should play, or null when it
+  /// doesn't name a playable track (e.g. a stale id, or a category).
+  Future<MediaPlaybackRequest?> resolve(
+    String mediaId,
+    PlaybackState playback,
+  ) async {
+    if (MediaId.isLibraryTrack(mediaId)) {
+      final tracks = await _library.getAllTracks();
+      final trackId = MediaId.libraryTrackId(mediaId);
+      final index = tracks.indexWhere((Track t) => t.id == trackId);
+      if (index < 0) return null;
+      return MediaPlaybackRequest(tracks: tracks, startIndex: index);
+    }
+    if (MediaId.isQueueItem(mediaId)) {
+      final tracks = _currentQueue(playback);
+      final index = MediaId.queueIndex(mediaId);
+      if (index < 0 || index >= tracks.length) return null;
+      return MediaPlaybackRequest(tracks: tracks, startIndex: index);
+    }
+    return null;
+  }
+
+  static const List<MediaNode> _rootNodes = <MediaNode>[
+    MediaNode(id: MediaId.library, title: 'Library'),
+    MediaNode(id: MediaId.queue, title: 'Queue'),
+  ];
+
+  Future<List<MediaNode>> _libraryNodes() async {
+    final tracks = await _library.getAllTracks();
+    return <MediaNode>[
+      for (final Track track in tracks)
+        _trackNode(MediaId.libraryTrack(track.id), track),
+    ];
+  }
+
+  List<MediaNode> _queueNodes(PlaybackState playback) {
+    final tracks = _currentQueue(playback);
+    return <MediaNode>[
+      for (int i = 0; i < tracks.length; i++)
+        _trackNode(MediaId.queueItem(i), tracks[i]),
+    ];
+  }
+
+  /// The full live queue as a flat list: the current track followed by up-next,
+  /// matching the `queue/<index>` ids the queue nodes are built with.
+  List<Track> _currentQueue(PlaybackState playback) {
+    final current = playback.currentTrack;
+    return <Track>[if (current != null) current, ...playback.upNext];
+  }
+
+  MediaNode _trackNode(String id, Track track) {
+    return MediaNode(
+      id: id,
+      title: track.title,
+      subtitle: _subtitle(track),
+      playable: true,
+      track: track,
+    );
+  }
+
+  /// "Artist • Album", dropping whichever parts are missing.
+  static String? _subtitle(Track track) {
+    final parts = <String>[
+      if (track.artistName != null && track.artistName!.isNotEmpty)
+        track.artistName!,
+      if (track.albumName != null && track.albumName!.isNotEmpty)
+        track.albumName!,
+    ];
+    return parts.isEmpty ? null : parts.join(' • ');
+  }
+}

--- a/lib/core/services/playback_controller.dart
+++ b/lib/core/services/playback_controller.dart
@@ -31,6 +31,10 @@ abstract interface class PlaybackController {
   /// has no upcoming tracks.
   Future<void> skipToNext();
 
+  /// Steps back to the previous track in the queue, if any. A no-op when the
+  /// current track is the first one.
+  Future<void> skipToPrevious();
+
   /// Empties the up-next queue, leaving the current track playing.
   void clearQueue();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/linthra_app.dart';
-import 'core/services/just_audio_playback_controller.dart';
 import 'core/services/linthra_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
@@ -12,33 +11,33 @@ import 'features/player/player_providers.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Build the playback controller up front so the *same* instance backs both
-  // the UI (via playbackControllerProvider) and the platform media session
-  // (via audio_service). Attaching the session is best-effort: on a platform
-  // without the native setup it returns null and basic playback still works.
-  final controller = JustAudioPlaybackController();
-  final handler = await connectMediaSession(controller);
+  // One container backs the whole app so the *same* PlaybackController and
+  // MusicLibraryRepository instances drive both the UI (through providers) and
+  // the platform media session: Android Auto browses the real catalog and the
+  // notification / lock screen reflect the real controller. The running app
+  // persists its catalog to SQLite (Drift override) and its chosen folder,
+  // offline-download set, and Wi-Fi-only preference via shared_preferences;
+  // tests keep the in-memory defaults unless they opt into these bindings.
+  final container = ProviderContainer(
+    overrides: [
+      driftMusicLibraryRepositoryOverride,
+      sharedPreferencesSelectedMusicFolderRepositoryOverride,
+      sharedPreferencesDownloadStoreOverride,
+      sharedPreferencesDownloadPreferencesOverride,
+    ],
+  );
 
-  // ProviderScope hosts all Riverpod state for the app. The running app
-  // persists its catalog to SQLite via the Drift override and the chosen music
-  // folder, offline-download set, and Wi-Fi-only preference via
-  // shared_preferences; tests keep the in-memory defaults unless they opt into
-  // these bindings.
+  // Attaching the session is best-effort: on a platform without the native
+  // audio_service setup it returns null and basic playback still works. The
+  // handler mirrors the controller and outlives this scope with the container.
+  await connectMediaSession(
+    container.read(playbackControllerProvider),
+    container.read(musicLibraryRepositoryProvider),
+  );
+
   runApp(
-    ProviderScope(
-      overrides: [
-        playbackControllerProvider.overrideWith((ref) {
-          ref.onDispose(() async {
-            await handler?.dispose();
-            await controller.dispose();
-          });
-          return controller;
-        }),
-        driftMusicLibraryRepositoryOverride,
-        sharedPreferencesSelectedMusicFolderRepositoryOverride,
-        sharedPreferencesDownloadStoreOverride,
-        sharedPreferencesDownloadPreferencesOverride,
-      ],
+    UncontrolledProviderScope(
+      container: container,
       child: const LinthraApp(),
     ),
   );

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -52,6 +52,26 @@ void main() {
       expect(queue.next(), same(queue));
     });
 
+    test('previous() steps back to the prior track', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+        startIndex: 2,
+      );
+
+      final stepped = queue.previous();
+
+      expect(stepped.current, _track('b'));
+      expect(stepped.hasPrevious, isTrue);
+      expect(stepped.upNext, [_track('c')]);
+    });
+
+    test('previous() at the start returns the same queue', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')]);
+
+      expect(queue.hasPrevious, isFalse);
+      expect(queue.previous(), same(queue));
+    });
+
     test('enqueueNext() inserts right after the current track', () {
       final queue = PlaybackQueue.of([_track('a'), _track('c')]);
 

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/linthra_audio_handler.dart';
+import 'package:linthra/core/services/media_browser_tree.dart';
 
+import '../../features/library/fake_music_library_repository.dart';
 import '../../features/player/fake_playback_controller.dart';
 
 Track _track(String id) {
@@ -16,6 +18,8 @@ Track _track(String id) {
   );
 }
 
+final List<Track> _library = <Track>[_track('a'), _track('b'), _track('c')];
+
 /// Lets the broadcast from the controller's stream reach the handler's
 /// listener before assertions read the mirrored session state.
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
@@ -27,7 +31,8 @@ void main() {
 
     setUp(() {
       controller = FakePlaybackController();
-      handler = LinthraAudioHandler(controller);
+      final library = FakeMusicLibraryRepository(tracks: _library);
+      handler = LinthraAudioHandler(controller, MediaBrowserTree(library));
     });
 
     tearDown(() async {
@@ -39,12 +44,14 @@ void main() {
       await handler.play();
       await handler.pause();
       await handler.skipToNext();
+      await handler.skipToPrevious();
       await handler.stop();
       await handler.seek(const Duration(seconds: 12));
 
       expect(controller.playCount, 1);
       expect(controller.pauseCount, 1);
       expect(controller.skipCount, 1);
+      expect(controller.previousCount, 1);
       expect(controller.stopCount, 1);
       expect(controller.seeks, [const Duration(seconds: 12)]);
     });
@@ -81,6 +88,22 @@ void main() {
       expect(state.controls, isNot(contains(audio.MediaControl.skipToNext)));
     });
 
+    test('exposes skipToPrevious only once a previous track exists', () async {
+      await controller.playTracks([_track('a'), _track('b')]);
+      await _settle();
+      expect(
+        handler.playbackState.value.controls,
+        isNot(contains(audio.MediaControl.skipToPrevious)),
+      );
+
+      await controller.skipToNext();
+      await _settle();
+      expect(
+        handler.playbackState.value.controls,
+        contains(audio.MediaControl.skipToPrevious),
+      );
+    });
+
     test('clears the media item when playback goes idle', () async {
       await controller.playTracks([_track('a')]);
       await _settle();
@@ -95,6 +118,68 @@ void main() {
         handler.playbackState.value.processingState,
         audio.AudioProcessingState.idle,
       );
+    });
+
+    group('media browser', () {
+      test('root lists Library and Queue as browsable categories', () async {
+        final children = await handler.getChildren(MediaId.root);
+
+        expect(children.map((i) => i.id), [MediaId.library, MediaId.queue]);
+        expect(children.every((i) => i.playable == false), isTrue);
+      });
+
+      test('library lists every catalog track as a playable leaf', () async {
+        final children = await handler.getChildren(MediaId.library);
+
+        expect(children.map((i) => i.id), [
+          MediaId.libraryTrack('a'),
+          MediaId.libraryTrack('b'),
+          MediaId.libraryTrack('c'),
+        ]);
+        expect(children.first.title, 'Song a');
+        expect(children.first.playable, isTrue);
+      });
+
+      test('queue reflects the controller current track and up-next', () async {
+        await controller.playTracks(_library, startIndex: 1);
+        await _settle();
+
+        final children = await handler.getChildren(MediaId.queue);
+
+        // current (b) followed by up-next (c).
+        expect(children.map((i) => i.title), ['Song b', 'Song c']);
+        expect(children.map((i) => i.id), [
+          MediaId.queueItem(0),
+          MediaId.queueItem(1),
+        ]);
+      });
+
+      test('selecting a library track plays it and queues the rest', () async {
+        await handler.playFromMediaId(MediaId.libraryTrack('b'));
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'b');
+        expect(controller.state.upNext.map((t) => t.id), ['c']);
+      });
+
+      test('selecting a queue item plays from that position', () async {
+        await controller.playTracks(_library);
+        await _settle();
+
+        await handler.playFromMediaId(MediaId.queueItem(2));
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'c');
+        expect(controller.state.hasNext, isFalse);
+      });
+
+      test('an unknown media id is a no-op', () async {
+        await handler.playFromMediaId('library/missing');
+        await handler.playFromMediaId('bogus');
+        await _settle();
+
+        expect(controller.playedTracks, isEmpty);
+      });
     });
   });
 }

--- a/test/core/services/media_browser_tree_test.dart
+++ b/test/core/services/media_browser_tree_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/media_browser_tree.dart';
+
+import '../../features/library/fake_music_library_repository.dart';
+
+Track _track(String id, {String? artist, String? album}) {
+  return Track(
+    id: id,
+    title: 'Song $id',
+    uri: '/$id.mp3',
+    artistName: artist,
+    albumName: album,
+  );
+}
+
+PlaybackState _playing(Track current, {List<Track> upNext = const <Track>[]}) {
+  return PlaybackState(
+    status: PlaybackStatus.playing,
+    currentTrack: current,
+    upNext: upNext,
+  );
+}
+
+void main() {
+  group('MediaBrowserTree', () {
+    final library = <Track>[
+      _track('a', artist: 'Artist a', album: 'Album a'),
+      _track('b', artist: 'Artist b'),
+      _track('c'),
+    ];
+
+    MediaBrowserTree treeOf(List<Track> tracks) =>
+        MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks));
+
+    group('childrenOf', () {
+      test('root lists Library and Queue as browsable categories', () async {
+        final nodes =
+            await treeOf(library).childrenOf(MediaId.root, PlaybackState.idle);
+
+        expect(nodes.map((n) => n.id), [MediaId.library, MediaId.queue]);
+        expect(nodes.map((n) => n.title), ['Library', 'Queue']);
+        expect(nodes.every((n) => n.playable), isFalse);
+      });
+
+      test('library exposes every catalog track as a playable leaf', () async {
+        final nodes = await treeOf(library)
+            .childrenOf(MediaId.library, PlaybackState.idle);
+
+        expect(nodes.map((n) => n.id), [
+          MediaId.libraryTrack('a'),
+          MediaId.libraryTrack('b'),
+          MediaId.libraryTrack('c'),
+        ]);
+        expect(nodes.every((n) => n.playable), isTrue);
+        expect(nodes.first.track, library.first);
+      });
+
+      test('library track subtitle joins the present artist/album parts',
+          () async {
+        final nodes = await treeOf(library)
+            .childrenOf(MediaId.library, PlaybackState.idle);
+
+        expect(nodes[0].subtitle, 'Artist a • Album a');
+        expect(nodes[1].subtitle, 'Artist b');
+        expect(nodes[2].subtitle, isNull);
+      });
+
+      test('empty library yields no track nodes', () async {
+        final nodes = await treeOf(const <Track>[])
+            .childrenOf(MediaId.library, PlaybackState.idle);
+
+        expect(nodes, isEmpty);
+      });
+
+      test('queue lists the current track followed by up-next', () async {
+        final playback = _playing(library[0], upNext: [library[1], library[2]]);
+
+        final nodes = await treeOf(library).childrenOf(MediaId.queue, playback);
+
+        expect(nodes.map((n) => n.title), ['Song a', 'Song b', 'Song c']);
+        expect(nodes.map((n) => n.id), [
+          MediaId.queueItem(0),
+          MediaId.queueItem(1),
+          MediaId.queueItem(2),
+        ]);
+      });
+
+      test('queue is empty when nothing is playing', () async {
+        final nodes =
+            await treeOf(library).childrenOf(MediaId.queue, PlaybackState.idle);
+
+        expect(nodes, isEmpty);
+      });
+
+      test('an unknown parent id yields an empty list', () async {
+        final nodes =
+            await treeOf(library).childrenOf('nonsense', PlaybackState.idle);
+
+        expect(nodes, isEmpty);
+      });
+    });
+
+    group('resolve', () {
+      test('a library track resolves to the whole catalog at its index',
+          () async {
+        final request = await treeOf(library)
+            .resolve(MediaId.libraryTrack('b'), PlaybackState.idle);
+
+        expect(request, isNotNull);
+        expect(request!.tracks, library);
+        expect(request.startIndex, 1);
+      });
+
+      test('a missing library track resolves to null', () async {
+        final request = await treeOf(library)
+            .resolve(MediaId.libraryTrack('zzz'), PlaybackState.idle);
+
+        expect(request, isNull);
+      });
+
+      test('a queue item resolves to the live queue at its index', () async {
+        final playback = _playing(library[0], upNext: [library[1], library[2]]);
+
+        final request =
+            await treeOf(library).resolve(MediaId.queueItem(2), playback);
+
+        expect(request, isNotNull);
+        expect(request!.tracks.map((t) => t.id), ['a', 'b', 'c']);
+        expect(request.startIndex, 2);
+      });
+
+      test('an out-of-range queue index resolves to null', () async {
+        final playback = _playing(library[0]);
+
+        final request =
+            await treeOf(library).resolve(MediaId.queueItem(5), playback);
+
+        expect(request, isNull);
+      });
+
+      test('a non-numeric queue id resolves to null', () async {
+        final request = await treeOf(library)
+            .resolve('queue/not-a-number', PlaybackState.idle);
+
+        expect(request, isNull);
+      });
+
+      test('a category id is not playable', () async {
+        expect(
+          await treeOf(library).resolve(MediaId.library, PlaybackState.idle),
+          isNull,
+        );
+        expect(
+          await treeOf(library).resolve(MediaId.root, PlaybackState.idle),
+          isNull,
+        );
+      });
+    });
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -24,6 +24,7 @@ class FakePlaybackController implements PlaybackController {
   int pauseCount = 0;
   int stopCount = 0;
   int skipCount = 0;
+  int previousCount = 0;
   int clearCount = 0;
   final List<Duration> seeks = <Duration>[];
 
@@ -63,10 +64,18 @@ class FakePlaybackController implements PlaybackController {
   }
 
   @override
+  Future<void> skipToPrevious() async {
+    previousCount++;
+    if (!_queue.hasPrevious) return;
+    _queue = _queue.previous();
+    _playCurrent();
+  }
+
+  @override
   void clearQueue() {
     clearCount++;
     _queue = _queue.cleared();
-    emit(_state.copyWith(upNext: _queue.upNext));
+    emit(_state.copyWith(upNext: _queue.upNext, hasPrevious: false));
   }
 
   void _playCurrent() {
@@ -77,6 +86,7 @@ class FakePlaybackController implements PlaybackController {
       status: PlaybackStatus.playing,
       currentTrack: track,
       upNext: _queue.upNext,
+      hasPrevious: _queue.hasPrevious,
     );
     emit(playing);
   }

--- a/test/features/player/queue_behavior_test.dart
+++ b/test/features/player/queue_behavior_test.dart
@@ -51,6 +51,30 @@ void main() {
       expect(controller.state.currentTrack, _track('a'));
     });
 
+    test('skipToPrevious steps back and reports a previous track', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+      await controller.skipToNext();
+      await controller.skipToNext();
+      expect(controller.state.currentTrack, _track('c'));
+
+      await controller.skipToPrevious();
+
+      expect(controller.state.currentTrack, _track('b'));
+      expect(controller.state.hasPrevious, isTrue);
+      expect(controller.state.upNext, [_track('c')]);
+    });
+
+    test('skipToPrevious on the first track is a no-op', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b')]);
+
+      await controller.skipToPrevious();
+
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.state.hasPrevious, isFalse);
+    });
+
     test('clearQueue empties up next but keeps the current track', () async {
       final controller = FakePlaybackController();
       await controller.playTracks([_track('a'), _track('b'), _track('c')]);


### PR DESCRIPTION
## Summary

Moves Android Auto / background playback from a session-only foundation to a
**browsable** experience: the car can now browse and pick what to play, and
transport gains **skip-to-previous**. Playback stays consistent across the app
UI, notification, lock screen, and the Auto session because they're all driven
by the one `PlaybackController`.

The architecture seams are preserved: the UI never touches `audio_service`,
`LinthraAudioHandler` remains the only file that imports it, the browse logic is
**pure Dart** (`MediaBrowserTree`), library data flows only through
`MusicLibraryRepository`, and playback flows only through `PlaybackController`.

## Android Auto behavior

- The app now declares itself an Android Auto **media app** (`car.application`
  meta-data + `res/xml/automotive_app_desc.xml`), so Auto lists it and binds to
  the already-declared `MediaBrowserService`.
- Browsing serves a small tree (below). **Selecting a library track plays it and
  queues the rest of the library behind it** — the same behavior as tapping a
  track in the in-app library. Selecting a queue entry jumps to that position.
- Transport exposes **skip-previous / play-pause / stop / skip-next**; each skip
  button appears only when the queue has a track in that direction.

## Media tree structure

```
root
├── Library   → every catalog track (playable; tap to play, rest becomes up-next)
└── Queue     → current track + up-next, in order (playable; tap to jump)
```

Stable IDs: `library` / `queue` categories, leaves `library/<trackId>` and
`queue/<index>`. `getChildren` builds the nodes; `playFromMediaId` resolves a
leaf back to a `playTracks(tracks, startIndex)` call. Unknown/stale IDs are
no-ops, never crashes.

## Background playback status

- Native `audio_service` setup verified complete: `FOREGROUND_SERVICE` +
  `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions, the `mediaPlayback`
  foreground `<service>` exposing `MediaBrowserService`, the
  `MediaButtonReceiver`, `MainActivity extends AudioServiceActivity`, and now the
  Android Auto media-app declaration.
- `main` builds a single `ProviderContainer` so the **same** controller and
  repository instances back both the UI and the media session. Attaching the
  session stays best-effort (`connectMediaSession` returns null on unsupported
  platforms / tests; basic playback still works).
- State stays consistent across app UI / notification / lock screen / Auto: all
  read from the controller's `PlaybackState`.

## Limitations

- `Library` is a **flat** track list — no album/artist/folder grouping, no
  search-from-Auto, no paging for large libraries.
- **No Playlists node**: playlists have a model + repository interface but no
  persisted implementation, so a node wouldn't be safe/simple yet (deferred).
- Queue browsing is **read + jump only** — no reorder/remove from the car.
- Basic browsing only, not a polished custom car UI.
- No MPRIS (Linux desktop media keys) yet.
- Lock-screen / car artwork depends on `Track.artworkUri`, which local scanning
  doesn't populate yet.

## Tests added

- `media_browser_tree_test.dart` — root/library/queue children, subtitle
  building, empty/unknown cases, and `resolve` for library + queue leaves and
  invalid IDs (uses the fake `MusicLibraryRepository`).
- `linthra_audio_handler_test.dart` — `getChildren` for each node, tap-to-play
  via `playFromMediaId`, skip-to-previous forwarding, the skip-previous control
  appearing only with a prior track, and unknown-id no-op (uses the fake
  controller).
- `playback_queue_test.dart` / `queue_behavior_test.dart` — `previous()` /
  `hasPrevious` and `skipToPrevious` through the controller.

**Verification:** `flutter pub get`, `dart format --set-exit-if-changed .`,
`flutter analyze` (clean), `flutter test` (**152 passing**). `flutter build apk
--debug` not run locally (no Android SDK in this environment) — the existing
`android-debug-apk.yml` CI workflow covers it.

## Next recommended PR

Group the flat `Library` into **Albums / Artists / Folders** browse nodes
(persist albums/artists in the catalog first), and add a persisted
`PlaylistRepository` implementation so a **Playlists** node can be added safely.

https://claude.ai/code/session_015DuH798fKpVcjKQrMfKWri

---
_Generated by [Claude Code](https://claude.ai/code/session_015DuH798fKpVcjKQrMfKWri)_