### PR TITLE
docs: F-Droid/release readiness audit, recipe & process notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,11 @@ flutter run --debug          # hot-reloadable dev session
 flutter install              # installs the last debug build
 ```
 
-The debug APK is unsigned and meant for local testing only. **Release signing,
-store-ready bundles, and APK publishing are intentionally out of scope** for
-this stage — there are no native build, signing, or publishing steps in CI.
+The debug APK is unsigned and meant for local testing only. Release builds and
+optional release signing are handled separately by the manual **Android Release
+Build** workflow (see [Building release artifacts](#building-release-artifacts-android)
+and [docs/release-signing.md](./docs/release-signing.md)); nothing is published
+to a store or F-Droid, and no GitHub Release is created automatically.
 
 #### Downloading a debug APK from CI
 
@@ -343,14 +345,16 @@ F-Droid distribution. It is a build-only foundation:
 
 - **How to run it:** open the repo's **Actions** tab → **Android Release
   Build** → **Run workflow**. It is **manual only** (`workflow_dispatch`) — it
-  never runs on a push or PR.
+  never runs on a push or PR. A `signed` input controls whether the build is
+  release-signed (see [Signing status](#signing-status-important) below).
 - **What it builds:** `flutter build apk --release` and
   `flutter build appbundle --release`.
-- **Artifacts:**
-  - `linthra-release-apk` → `app-release.apk`
-    (`build/app/outputs/flutter-apk/app-release.apk`)
-  - `linthra-release-aab` → `app-release.aab`
-    (`build/app/outputs/bundle/release/app-release.aab`)
+- **Artifacts** (names reflect how the build was signed, so a preview can't be
+  mistaken for a real release):
+  - `signed = false` (default): `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
+  - `signed = true`: `linthra-release-signed-apk` / `linthra-release-signed-aab`.
+  - Each contains `app-release.apk` (`build/app/outputs/flutter-apk/app-release.apk`)
+    or `app-release.aab` (`build/app/outputs/bundle/release/app-release.aab`).
 - **Download:** open the completed run and grab the artifacts from the run's
   **Artifacts** section (GitHub serves each as a `.zip`; unzip to get the
   APK/AAB).
@@ -365,31 +369,37 @@ flutter build appbundle --release  # → build/app/outputs/bundle/release/app-re
 
 #### Signing status (important)
 
-**These release artifacts are debug-key signed, not release signed.** No
-release signing secrets are configured in this repository, so the release build
-falls back to the debug signing config declared in `android/app/build.gradle`
-(`signingConfig = signingConfigs.debug`). That makes the artifacts useful for
-previewing/smoke-testing a release build, but they are **not** suitable for
-store or F-Droid distribution, and **no signing keys are committed** to the
-repo.
+Release signing is **wired up but not yet provisioned**. `android/app/build.gradle`
+resolves a release signing config from environment variables (used by CI) or a
+git-ignored `android/key.properties` (local). **Only if** complete signing
+material is present does it sign with the release key; otherwise it falls back to
+the **debug** key so `flutter run --release` still works. **No signing keys or
+secrets are committed** to the repo.
 
-Real release signing (a keystore supplied via repository secrets, with the
-`android/app/build.gradle` release `signingConfig` reading those secrets) is
-**intentionally out of scope** for this foundation and is the recommended next
-step — see below.
+- Run the workflow with **`signed = false`** (default) → **debug-key signed**
+  artifacts, labeled `…-debug-signed-…`. Fine for previewing a release build,
+  **not** suitable for store or F-Droid distribution.
+- Run with **`signed = true`** → the workflow decodes a keystore from the
+  `LINTHRA_*` repository secrets and produces **release-signed** artifacts
+  (labeled `…-release-signed-…`). If a required secret is missing, the run
+  **fails fast** rather than silently producing a debug-signed build.
+
+The keystore secrets are not configured in this repository yet, so a real
+release-signed build requires setting them up first. Full details — required
+secrets, how to generate/rotate a keystore, and how this relates to F-Droid (which
+signs its own builds) — are in [docs/release-signing.md](./docs/release-signing.md).
 
 #### Limitations & next steps
 
 - The workflow **does not** create a GitHub release, upload anything to a store,
   or submit to F-Droid. It only produces downloadable build artifacts.
-- It does **not** add release signing; artifacts remain debug-key signed until a
-  signing config backed by secrets is added.
-- **Recommended next PR:** add release signing — provision a release keystore,
-  store it and its credentials as repository secrets, decode it during the
-  workflow, and update the release `signingConfig` in
-  `android/app/build.gradle` to use it. With real signing in place, a separate
-  follow-up can wire **GitHub Releases** publishing and, later, F-Droid
-  readiness.
+- Release signing **secrets are not yet provisioned**, so until they are, builds
+  fall back to the debug key (and are labeled accordingly).
+- **Next steps:** provision the `LINTHRA_*` keystore secrets
+  ([docs/release-signing.md](./docs/release-signing.md)), then follow the manual
+  release/tagging and GitHub-Release flow in
+  [docs/release-process.md](./docs/release-process.md). F-Droid readiness is
+  tracked separately in [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
 
 ### Background playback & Android Auto
 
@@ -722,8 +732,11 @@ flutter test                         # widget/unit tests
 
 CI pins **Flutter 3.27.x (stable)** for reproducible results; using a matching
 SDK locally avoids spurious `dart format` diffs from formatter changes in newer
-Dart releases. This is code-quality CI only — there are no native build,
-signing, or store-publishing steps yet.
+Dart releases. The automatic `ci.yml` workflow is **code-quality only**. Native
+builds and optional release signing live in **separate, manual** workflows
+(**Android Debug APK**, **Android Release Build**); nothing publishes to a store
+or F-Droid. See [Building release artifacts](#building-release-artifacts-android)
+and [docs/release-process.md](./docs/release-process.md).
 
 ### Generating Drift files in CI
 
@@ -794,12 +807,29 @@ persisted listing) as done; playback, playlists, and offline downloads are
 described as planned. There are no claims of F-Droid availability and no
 marketing language that overpromises.
 
-For the full submission checklist — app identity, build requirements,
-dependency and anti-feature review, release/tagging plan, and remaining
-blockers — see [docs/fdroid-readiness.md](./docs/fdroid-readiness.md). The
-F-Droid build recipe planning (expected metadata fields, build-source/toolchain
-expectations, reproducible-build notes, and a draft recipe snippet) lives in
-[docs/fdroid-build-recipe.md](./docs/fdroid-build-recipe.md).
+### Release & F-Droid documentation
+
+Planning/readiness docs (none of these publish or submit anything):
+
+- [docs/fdroid-readiness.md](./docs/fdroid-readiness.md) — full F-Droid
+  submission checklist: app identity, build requirements, dependency &
+  anti-feature review, release/tagging plan, and remaining blockers.
+- [docs/fdroid-build-recipe.md](./docs/fdroid-build-recipe.md) — F-Droid build
+  recipe planning: expected metadata fields, build-source/toolchain
+  expectations, reproducible-build notes, and a draft recipe snippet.
+- [docs/dependency-license-audit.md](./docs/dependency-license-audit.md) —
+  per-dependency licenses, native/bundled-component review, and the
+  network/anti-feature assessment.
+- [docs/release-process.md](./docs/release-process.md) — canonical versioning,
+  tagging, and (manual) GitHub-Release process.
+- [docs/release-signing.md](./docs/release-signing.md) — how release builds are
+  signed, required CI secrets, and keystore generation/rotation.
+- [docs/listing-assets.md](./docs/listing-assets.md) — store icon, feature
+  graphic, and screenshot checklist with capture instructions.
+
+> **Status:** Linthra is **not** on F-Droid and no submission has been made. The
+> remaining blockers before a submission would be possible are listed in
+> [docs/fdroid-readiness.md §8](./docs/fdroid-readiness.md#8-remaining-blockers-before-submission).
 
 ## License
 

--- a/docs/dependency-license-audit.md
+++ b/docs/dependency-license-audit.md
@@ -1,0 +1,177 @@
+# Dependency & license audit
+
+This document audits Linthra's declared dependencies and their licenses, so a
+future F-Droid submission (and any GitHub-Release distribution) can state the
+project's licensing accurately. It is a planning/compliance aid.
+
+> **Linthra is _not_ on F-Droid and has _not_ been submitted.** Nothing here
+> publishes or submits anything. This audit records the licensing posture of the
+> code as it stands; see the [F-Droid readiness checklist](./fdroid-readiness.md)
+> for the overall submission status and blockers.
+
+## 1. Project license
+
+Linthra is licensed under the **Mozilla Public License 2.0** (`MPL-2.0`), an
+[FSF/OSI-approved free license](https://www.gnu.org/licenses/license-list.html)
+accepted by F-Droid. The full text is in [`LICENSE`](../LICENSE), and the SPDX
+identifier F-Droid expects is `MPL-2.0`.
+
+MPL-2.0 is a file-level (weak) copyleft. It combines cleanly with the permissive
+(MIT / BSD) dependencies listed below: those licenses impose only attribution
+and license-notice requirements, with no terms that conflict with shipping them
+alongside MPL-2.0 code.
+
+## 2. How this audit was produced (and its limits)
+
+- **Scope:** the **direct** dependencies declared in
+  [`pubspec.yaml`](../pubspec.yaml). Licenses below are the ones each package
+  publishes on [pub.dev](https://pub.dev) / in its bundled `LICENSE` file.
+- **Not yet run mechanically:** a full **transitive** dependency walk was not
+  generated for this document (the Dart/Flutter toolchain and a resolved
+  `pubspec.lock` were not available in the environment that produced it, and
+  `pubspec.lock` is currently git-ignored — see
+  [reproducibility notes](./fdroid-build-recipe.md#4-reproducibility-notes)).
+  Confirming the complete transitive set is still an open item (§6).
+- **To reproduce / extend this audit** with the toolchain available:
+
+  ```sh
+  flutter pub get
+  flutter pub deps --style=compact     # full transitive dependency tree
+  # Optional: collect every bundled LICENSE into one report
+  dart pub global activate pana
+  pana --no-warning .                  # includes a license check
+  # or generate an in-app/exported license list:
+  #   dart run flutter_oss_licenses:generate
+  ```
+
+  Cross-check the generated list against this table and resolve any package that
+  is **not** a recognised free-software license or that pulls in proprietary /
+  Google-only binaries.
+
+## 3. Runtime dependencies (shipped in the APK)
+
+All entries below are permissive free-software licenses (MIT or BSD-3-Clause),
+compatible with MPL-2.0 and acceptable to F-Droid.
+
+| Package                  | Constraint   | Publisher (pub.dev) | License        | Purpose in Linthra |
+| ------------------------ | ------------ | ------------------- | -------------- | ------------------ |
+| `flutter` (SDK)          | (SDK)        | flutter.dev         | BSD-3-Clause   | Framework. |
+| `flutter_riverpod`       | `^2.6.1`     | (rrousselGit)       | MIT            | State management. |
+| `go_router`              | `^14.6.2`    | flutter.dev         | BSD-3-Clause   | Navigation/routing. |
+| `path`                   | `^1.9.0`     | dart.dev            | BSD-3-Clause   | Path parsing for the scanner. |
+| `drift`                  | `^2.18.0`    | simonbinder.eu      | MIT            | Typed SQLite query layer. |
+| `sqlite3_flutter_libs`   | `^0.5.20`    | simonbinder.eu      | MIT            | Bundles the native SQLite engine (see §5). |
+| `path_provider`          | `^2.1.4`     | flutter.dev         | BSD-3-Clause   | Locates the on-device DB file. |
+| `just_audio`             | `^0.9.42`    | ryanheise.com       | MIT            | Local audio playback engine. |
+| `audio_service`          | `^0.18.15`   | ryanheise.com       | MIT            | Background playback / media session. |
+| `file_picker`            | `^8.1.4`     | (miguelpruivo)      | MIT            | Native folder chooser (SAF). |
+| `shared_preferences`     | `^2.3.3`     | flutter.dev         | BSD-3-Clause   | Persists the selected folder. |
+| `http`                   | `^1.2.0`     | dart.dev            | BSD-3-Clause   | HTTP client for the optional Jellyfin source (§7). |
+| `flutter_secure_storage` | `^9.2.2`     | (juliansteenbakker) | BSD-3-Clause   | Encrypted store for the Jellyfin session token (§7). |
+
+> The `http` and `flutter_secure_storage` entries were added with the Jellyfin
+> source foundation and are the two newest runtime dependencies; both are
+> permissive (BSD-3-Clause) Dart/Flutter-ecosystem packages.
+
+## 4. Dev / build-only dependencies (NOT shipped in the APK)
+
+These run only during development, analysis, or code generation and are not part
+of the released artifact, so they do not affect the APK's license. They are
+listed for completeness.
+
+| Package         | Constraint   | Publisher | License        | Purpose |
+| --------------- | ------------ | --------- | -------------- | ------- |
+| `flutter_lints` | `^5.0.0`     | flutter.dev | BSD-3-Clause | Lint rule set. |
+| `flutter_test`  | (SDK)        | flutter.dev | BSD-3-Clause | Test framework. |
+| `drift_dev`     | `^2.18.0`    | simonbinder.eu | MIT       | Drift code generation. |
+| `build_runner`  | `^2.4.13`    | dart.dev  | BSD-3-Clause   | Runs the code generators. |
+
+## 5. Native / bundled components
+
+F-Droid requires every shipped component to be free software and buildable from
+source (no prebuilt proprietary blobs).
+
+- **SQLite** (via `sqlite3_flutter_libs`): the SQLite amalgamation is in the
+  **public domain** and is compiled from source as part of the build — not a
+  prebuilt closed binary. The Dart wrapper packages are MIT.
+- **Android Keystore / EncryptedSharedPreferences** (used by
+  `flutter_secure_storage`): part of the **AOSP** platform, not Google Play
+  Services. No proprietary dependency is introduced.
+- **No Google Play Services / Firebase / GMS.** None of the direct dependencies
+  require Google Play Services, Firebase, or other proprietary Google libraries.
+  The Android Auto declaration uses the standard `MediaBrowserService` /
+  `media-session` APIs from `audio_service` (AOSP media APIs), not a proprietary
+  car SDK. _(Confirm there is no transitive GMS pull-in as part of §6.)_
+
+## 6. Anti-features / non-free check
+
+Mapped to F-Droid's [anti-features](https://f-droid.org/docs/Anti-Features/):
+
+| Concern                    | Status | Notes |
+| -------------------------- | ------ | ----- |
+| Ads                        | None   | No advertising libraries or code. |
+| Tracking / analytics       | None   | No telemetry, analytics, or crash-reporting SDK is present. |
+| Proprietary dependencies   | None found in **direct** deps | All direct deps are MIT/BSD-3-Clause; transitive set still to be confirmed mechanically (§2). |
+| Non-free network services  | See §7 | Local-first core needs no network; Jellyfin is optional and user-configured. |
+
+## 7. Network use & the optional Jellyfin source
+
+Linthra is **local-first**: the core (folder selection, scanning, the persisted
+catalog) works with **no network access at all**. The production
+`AndroidManifest.xml` declares no `INTERNET` permission of its own; `INTERNET`
+appears only in the debug/profile manifests (for Flutter hot reload).
+
+A **Jellyfin** source foundation has since landed (server settings, sign-in,
+encrypted session token, a library source behind an interface). It is the reason
+`http` and `flutter_secure_storage` are dependencies. F-Droid implications:
+
+- **Optional and user-configured.** No Jellyfin server is bundled, promoted, or
+  required; the user supplies their own server URL and credentials. The app does
+  not depend on any specific hosted service.
+- **Jellyfin is free software.** The Jellyfin server is itself
+  free/open-source, and Linthra only speaks plain HTTP(S) to it via the
+  permissive `http` package.
+- **Anti-feature judgement:** because the non-local source is optional,
+  user-supplied, and points at free software, it does not obviously warrant the
+  `NonFreeNet` anti-feature. This should still be **reviewed at submission time**
+  — if any future source defaults to or promotes a non-free hosted service, it
+  must be reassessed (the [readiness doc](./fdroid-readiness.md#5-anti-features-review)
+  carries the same caveat).
+- When the Jellyfin client begins making real network calls, the production
+  manifest will need an `INTERNET` permission; that is a normal, expected
+  permission for a user-opted-in remote source and is not an anti-feature by
+  itself.
+
+## 8. Summary
+
+- **Project license:** MPL-2.0 (free, F-Droid-accepted).
+- **Direct dependencies:** all MIT or BSD-3-Clause — permissive, free, and
+  MPL-2.0-compatible. No copyleft conflicts, no proprietary direct deps.
+- **Native bits:** SQLite (public domain, built from source) and Android Keystore
+  (AOSP). No Google Play Services / Firebase in the direct dependency set.
+- **Bottom line:** nothing in the **declared** dependency set blocks F-Droid on
+  licensing grounds. The remaining work is mechanical verification of the full
+  transitive tree (§6 below).
+
+## 9. Outstanding before submission
+
+1. **Run the mechanical transitive audit** (§2 commands) and confirm every
+   transitive package is free software with no Google-only / proprietary binary
+   pull-in. This is the last open piece of the dependency blocker tracked in
+   [fdroid-readiness.md §8](./fdroid-readiness.md#8-remaining-blockers-before-submission).
+2. **Decide the `pubspec.lock` policy** for releases so the audited dependency
+   set is pinned at the tagged commit (see
+   [fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
+3. **Re-run this audit whenever a dependency is added or bumped**, and update the
+   tables above.
+
+## 10. Related docs
+
+- [docs/fdroid-readiness.md](./fdroid-readiness.md) — overall F-Droid submission
+  checklist and blockers.
+- [docs/fdroid-build-recipe.md](./fdroid-build-recipe.md) — build recipe and
+  reproducible-build notes.
+- [docs/release-process.md](./release-process.md) — release/tagging and
+  GitHub-Release process.
+- [docs/release-signing.md](./release-signing.md) — how release builds are
+  signed.

--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -57,6 +57,8 @@ Linthra is a Flutter (Dart) application targeting Android.
 | Dart SDK constraint | `>=3.6.0 <4.0.0` (`pubspec.yaml`), satisfied by Flutter 3.27.4. |
 | Java / JDK | **JDK 17** (Temurin in CI) — matches the bundled Gradle wrapper. |
 | Gradle | **8.3**, declared in `android/gradle/wrapper/gradle-wrapper.properties` (`gradle-8.3-all.zip`). |
+| Android Gradle Plugin | **8.1.0**, declared in `android/settings.gradle`. |
+| Kotlin Gradle plugin | **1.8.22**, declared in `android/settings.gradle`. |
 | Android SDK | `compileSdk`, `minSdk`, `targetSdk`, `versionCode`, and `versionName` all come from Flutter (`flutter.*` in `android/app/build.gradle`); they follow the pinned Flutter version rather than being hard-coded. |
 | Gradle wrapper committed? | **Partly.** `gradle-wrapper.properties` is committed; **`gradle-wrapper.jar` is _not_ committed.** F-Droid's build server can regenerate/restore the wrapper jar, but the recipe must account for this (e.g. `gradle` build type, or a prebuild that runs `flutter build` which provisions the wrapper). Worth re-checking before submission. |
 | Generated files committed? | **Yes for Drift.** `lib/data/database/linthra_database.g.dart` is committed. This means `build_runner` is **not** required during the F-Droid build (see §4). |
@@ -97,10 +99,11 @@ the schema at the tagged commit (§4).
    deliberately (it is out of scope for this documentation PR).
 4. **Dependency source review.** Every runtime dependency must be free software
    and buildable from source on F-Droid's infrastructure — no Google Play
-   Services, Firebase, or proprietary blobs. The current dependency list and its
-   open-source status are tracked in
-   [fdroid-readiness.md §4](./fdroid-readiness.md). A transitive-dependency
-   audit is still an open blocker (§6).
+   Services, Firebase, or proprietary blobs. The per-package licenses and the
+   native/bundled-component review are in
+   [dependency-license-audit.md](./dependency-license-audit.md): all direct deps
+   are permissive (MIT/BSD-3-Clause). A mechanical **transitive** audit is still
+   an open blocker (§6).
 5. **Toolchain pinning.** Reproducibility depends on the F-Droid build using the
    same Flutter (3.27.4), Dart (3.6.x), JDK (17), and Gradle (8.3) versions the
    project builds with. Keep the CI pin and any recipe-side pin in sync; a
@@ -109,8 +112,10 @@ the schema at the tagged commit (§4).
 
 ## 5. Release / tagging plan
 
-F-Droid builds from a git tag. The plan (consistent with
-[fdroid-readiness.md §6](./fdroid-readiness.md)):
+F-Droid builds from a git tag. Summary below; the canonical, step-by-step
+process (and the GitHub-Release flow) is in
+[docs/release-process.md](./release-process.md), and it is consistent with
+[fdroid-readiness.md §6](./fdroid-readiness.md):
 
 1. **Single source of truth:** `pubspec.yaml` `version: x.y.z+<versionCode>`
    (currently `0.1.0+1`). `versionName` = `x.y.z`, `versionCode` = the integer

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -55,25 +55,35 @@ Linthra is a Flutter (Dart) application targeting Android.
 Runtime dependencies (from `pubspec.yaml`), all open source and commonly
 accepted on F-Droid:
 
-| Package                  | Purpose                                  | Notes |
-| ------------------------ | ---------------------------------------- | ----- |
-| `flutter_riverpod`       | State management                         | OK |
-| `go_router`              | Navigation                               | OK |
-| `path`                   | Cross-platform path parsing              | OK |
-| `drift`                  | Typed SQLite query layer                 | OK (codegen) |
-| `sqlite3_flutter_libs`   | Native SQLite engine                     | OK (native build) |
-| `path_provider`          | Locates on-device DB file                | OK |
-| `just_audio`             | Local audio playback engine              | OK |
-| `audio_service`          | Background playback / media session      | OK |
-| `file_picker`            | Native folder chooser                    | OK |
-| `shared_preferences`     | Persists selected folder                 | OK |
+| Package                  | Purpose                                  | License | Notes |
+| ------------------------ | ---------------------------------------- | ------- | ----- |
+| `flutter_riverpod`       | State management                         | MIT | OK |
+| `go_router`              | Navigation                               | BSD-3-Clause | OK |
+| `path`                   | Cross-platform path parsing              | BSD-3-Clause | OK |
+| `drift`                  | Typed SQLite query layer                 | MIT | OK (codegen) |
+| `sqlite3_flutter_libs`   | Native SQLite engine                     | MIT | OK (native build; SQLite is public domain) |
+| `path_provider`          | Locates on-device DB file                | BSD-3-Clause | OK |
+| `just_audio`             | Local audio playback engine              | MIT | OK |
+| `audio_service`          | Background playback / media session      | MIT | OK |
+| `file_picker`            | Native folder chooser                    | MIT | OK |
+| `shared_preferences`     | Persists selected folder                 | BSD-3-Clause | OK |
+| `http`                   | HTTP client for the optional Jellyfin source | BSD-3-Clause | OK (network is opt-in; see §5) |
+| `flutter_secure_storage` | Encrypted Jellyfin session-token store   | BSD-3-Clause | OK (Android Keystore; AOSP, not GMS) |
 
 Dev-only dependencies (`flutter_lints`, `flutter_test`, `drift_dev`,
 `build_runner`) are not shipped in the APK.
 
+The full per-package license breakdown, the native/bundled-component review, and
+the methodology live in [docs/dependency-license-audit.md](./dependency-license-audit.md).
+All direct dependencies are permissive (MIT / BSD-3-Clause) and MPL-2.0
+compatible.
+
 **Action items:**
-- Confirm no transitive dependency pulls in Google Play Services, Firebase, or
-  other non-free components (run an audit before submission).
+- **Mechanical transitive audit still pending.** The direct-dependency license
+  review is done (audit doc above); a tool-driven walk of the full transitive
+  tree (`flutter pub deps`, license collector) confirming no Google Play
+  Services / Firebase / proprietary pull-in has not yet been run. See
+  [audit §6 & §9](./dependency-license-audit.md#6-anti-features--non-free-check).
 - Verify each plugin builds cleanly on the F-Droid build server (some Flutter
   plugins need specific recipe tweaks).
 
@@ -86,13 +96,22 @@ where applicable. Current assessment:
 | ------------------------- | -------- | ----- |
 | Ads                       | **No**   | No advertising of any kind. |
 | Tracking / analytics      | **No**   | No telemetry, analytics, or crash reporting SDKs. |
-| Non-free network services | **No**   | Local-first; no required remote services today. |
-| Non-free dependencies     | No (TBC) | To be confirmed by the dependency audit above. |
+| Non-free network services | **No** (optional Jellyfin source — see below) | Local-first core needs no network. The optional Jellyfin source is user-configured and points at free software. |
+| Non-free dependencies     | No (TBC) | Direct deps cleared (all MIT/BSD-3-Clause); transitive walk still to be confirmed by the audit above. |
 
-> **Future caveat:** if optional online providers (e.g. metadata lookup or
-> streaming sources) are added later, each must be reviewed individually and may
-> warrant the `NonFreeNet` anti-feature. The local-first core must remain fully
-> functional without them.
+> **Optional Jellyfin source.** A Jellyfin source foundation has landed (server
+> settings, sign-in, encrypted session token, a library source). It is optional
+> and entirely user-configured — no server is bundled, promoted, or required, and
+> the local-first core works with no network at all. The Jellyfin server is
+> itself free software, and Linthra only speaks HTTP(S) to it via the permissive
+> `http` package, so it does not obviously warrant the `NonFreeNet`
+> anti-feature. This is reviewed in detail in
+> [dependency-license-audit.md §7](./dependency-license-audit.md#7-network-use--the-optional-jellyfin-source).
+>
+> **Future caveat:** any further online provider must be reviewed individually
+> and may warrant `NonFreeNet` if it defaults to or promotes a non-free hosted
+> service. The local-first core must remain fully functional without any remote
+> source.
 
 ### Android storage / permissions status
 
@@ -114,7 +133,9 @@ where applicable. Current assessment:
 
 ## 6. Release / tagging plan
 
-F-Droid builds from a git tag. Plan:
+F-Droid builds from a git tag. Summary (the canonical, step-by-step process —
+including the GitHub-Release flow — is in
+[docs/release-process.md](./release-process.md)):
 
 1. Keep version in `pubspec.yaml` as the single source of truth
    (`version: x.y.z+<versionCode>`; currently `0.1.0+1`).
@@ -156,8 +177,13 @@ step-by-step capture instructions live in
    [docs/release-signing.md](./release-signing.md)). F-Droid signs its own
    builds, so this matters mainly for GitHub-Release artifacts. Remaining work:
    configure the actual release secrets and decide the GitHub-Release flow.
-2. **No image assets.** Icon, feature graphic, and screenshots are missing.
-3. **Dependency audit.** Confirm no non-free / Google-only transitive deps.
+2. **No image assets.** Icon, feature graphic, and screenshots are missing (see
+   [docs/listing-assets.md](./listing-assets.md)).
+3. **Dependency audit (partly done).** The direct-dependency license review is
+   complete — all MIT/BSD-3-Clause, MPL-2.0 compatible
+   ([docs/dependency-license-audit.md](./dependency-license-audit.md)). Still
+   open: a mechanical walk of the full transitive tree confirming no non-free /
+   Google-only components.
 4. **Reproducible build verification.** Confirm the app builds on F-Droid's
    build server, including Drift codegen as a prebuild step.
 5. **No tagged release yet.** A `vX.Y.Z` tag must exist for F-Droid to build.
@@ -166,11 +192,16 @@ step-by-step capture instructions live in
 
 ## 9. Suggested order before F-Droid submission
 
-1. Run the dependency audit (§4) and resolve any non-free findings.
-2. Sort out release signing config (§8.1).
+1. Finish the dependency audit (§4): the direct-dep license review is done
+   ([audit doc](./dependency-license-audit.md)); run the mechanical transitive
+   walk and resolve any non-free findings.
+2. Sort out release signing config (§8.1; see
+   [docs/release-signing.md](./release-signing.md)).
 3. Verify a clean release build, including codegen (§3, §8.4).
-4. Capture and commit real image assets (§7).
-5. Finalize the version and cut a `vX.Y.Z` tag with a matching changelog (§6).
+4. Capture and commit real image assets (§7; see
+   [docs/listing-assets.md](./listing-assets.md)).
+5. Finalize the version and cut a `vX.Y.Z` tag with a matching changelog (§6;
+   full steps in [docs/release-process.md](./release-process.md)).
 6. Prepare the F-Droid `metadata/<appid>.yml` build recipe and submit a merge
    request to [fdroiddata](https://gitlab.com/fdroid/fdroiddata).
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,154 @@
+# Release process (versioning, tagging & GitHub Releases)
+
+This is the canonical reference for how Linthra cuts a release: versioning,
+git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
+docs reference this document rather than restating the plan.
+
+> **No release has been cut and nothing here publishes automatically.** Linthra
+> has no tagged release yet, is **not** on F-Droid, and no APK/AAB has been
+> published. Every step below is manual and operator-initiated. This document
+> describes the intended process; it does not perform it.
+
+## 1. Versioning model
+
+`pubspec.yaml` is the **single source of truth** for the version:
+
+```
+version: x.y.z+<versionCode>      # currently 0.1.0+1
+```
+
+- **`versionName` = `x.y.z`** — the human-facing [SemVer](https://semver.org/)
+  string.
+- **`versionCode` = the integer after `+`** — Android's internal build number.
+
+Android reads both from Flutter (`flutter.versionName` / `flutter.versionCode`
+in `android/app/build.gradle`); they are **not** hard-coded in Gradle, so
+bumping `pubspec.yaml` is enough.
+
+**Rules:**
+
+- `versionCode` **must increase monotonically** on every release. Never reuse or
+  decrease it — Android refuses to install an update with an equal/lower code,
+  and F-Droid relies on it to order versions.
+- `versionName` follows SemVer. Pre-1.0, treat `0.y.z` as "still early; the API
+  and feature set can change between minor versions."
+
+## 2. Tagging
+
+F-Droid (and our own release tracking) builds from a **git tag**.
+
+- **Format:** an **annotated** tag `vX.Y.Z` (e.g. `v0.1.0`) on the exact commit
+  to be released:
+
+  ```sh
+  git tag -a v0.1.0 -m "Linthra 0.1.0"
+  git push origin v0.1.0
+  ```
+
+- The tag's `vX.Y.Z` must match `pubspec.yaml`'s `versionName`. This keeps the
+  F-Droid `UpdateCheckMode: Tags ^v[0-9.]+$` / `AutoUpdateMode: Version v%v`
+  recommendation (see [fdroid-build-recipe.md §2](./fdroid-build-recipe.md#2-expected-f-droid-metadata-repo-fields))
+  working without false positives.
+- Tag only commits where CI is green **and** generated files are current (§3).
+
+## 3. Pre-tag checklist
+
+Before creating a release tag:
+
+1. **Bump the version** in `pubspec.yaml` (`versionName` and `versionCode`).
+2. **Add a changelog** for the new `versionCode` at
+   `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` (e.g.
+   `1.txt` for `0.1.0+1`). Keep it short and factual; this is what F-Droid shows.
+3. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
+   schema at the tagged commit — run the
+   [Generate Drift files workflow](../README.md#generating-drift-files-in-ci) or
+   `dart run build_runner build --delete-conflicting-outputs` locally, and commit
+   the result. The committed output means the F-Droid build needs no `build_runner`
+   prebuild (see [fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
+4. **CI is green** (`flutter analyze`, `flutter test`, formatting) on the commit.
+5. **Confirm licensing** is still accurate if dependencies changed — re-run the
+   [dependency & license audit](./dependency-license-audit.md).
+6. Create the annotated tag (§2).
+
+## 4. GitHub Releases (manual)
+
+Publishing a GitHub Release is **optional and entirely manual** — there is no
+workflow that creates one automatically, by design.
+
+The building block is the **Android Release Build** workflow
+(`.github/workflows/android-release-build.yml`), which is `workflow_dispatch`
+only and just produces downloadable artifacts (it does **not** create a Release,
+publish to a store, or submit to F-Droid). See
+[docs/release-signing.md](./release-signing.md) for the signing details.
+
+To publish a GitHub Release for a tag:
+
+1. Ensure the release tag exists (§2) and generated files are current (§3).
+2. Run **Android Release Build** with **`signed = true`** (requires the
+   `LINTHRA_*` keystore secrets — see
+   [release-signing.md §2](./release-signing.md#2-required-github-secrets-ci)).
+   This yields `linthra-release-signed-apk` / `linthra-release-signed-aab`.
+   - A `signed = false` run produces **`linthra-debug-signed-*`** artifacts.
+     Those are previews only and **must never** be attached to a Release.
+3. Download the **release-signed** artifacts from the run.
+4. Create the GitHub Release against the `vX.Y.Z` tag (GitHub UI, or `gh release
+   create`) and attach the signed APK/AAB. Write release notes (the Fastlane
+   changelog from §3 is a good basis).
+
+> **Signature note.** A GitHub-Release APK is signed with **our** release key,
+> while an F-Droid build of the same version is signed with **F-Droid's** key.
+> The two cannot be cross-installed as updates of each other. This is expected;
+> call it out in the release notes so users don't mix sources. See
+> [release-signing.md §6](./release-signing.md#6-f-droid-signing-considerations).
+
+## 5. F-Droid relationship
+
+F-Droid does **not** consume our signed artifacts. When/if Linthra is submitted:
+
+- F-Droid builds **from source** at the `vX.Y.Z` tag on its own infrastructure
+  and signs with **F-Droid's** key.
+- The recipe tracks new releases via the `vX.Y.Z` tags this process creates.
+- The full submission flow, metadata fields, and draft recipe live in
+  [docs/fdroid-build-recipe.md](./fdroid-build-recipe.md); overall status and
+  blockers live in [docs/fdroid-readiness.md](./fdroid-readiness.md).
+
+## 6. What is automated vs. manual
+
+| Action | Automated? |
+| ------ | ---------- |
+| Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
+| Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
+| Release APK/AAB build | **Manual only** (`android-release-build.yml`, `workflow_dispatch`). |
+| Drift code generation | **Manual only** (`generate-drift.yml`, `workflow_dispatch`). |
+| Creating a git tag | **Manual** (operator runs `git tag`). |
+| Creating a GitHub Release | **Manual** (operator, §4). |
+| Publishing to a store / F-Droid | **Not done by this repo.** |
+
+Nothing in CI publishes a release, signs a store build automatically, or submits
+to F-Droid.
+
+## 7. Remaining blockers before a first release
+
+1. **Real release signing secrets** are configured (`LINTHRA_*`) if a
+   GitHub-Release artifact is wanted — see
+   [release-signing.md](./release-signing.md). (Not needed for F-Droid itself,
+   which signs its own builds.)
+2. **A `vX.Y.Z` tag** exists — none does yet.
+3. **Decide the `pubspec.lock` policy** for reproducible release builds
+   ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
+4. **Feature-maturity call:** decide whether `0.1.0` (library scan only; playback
+   not shipped) is the version to release, or whether to wait.
+
+See [fdroid-readiness.md §8](./fdroid-readiness.md#8-remaining-blockers-before-submission)
+for the full F-Droid blocker list.
+
+## 8. Related docs
+
+- [docs/release-signing.md](./release-signing.md) — signing keys, CI secrets,
+  rotation.
+- [docs/fdroid-readiness.md](./fdroid-readiness.md) — F-Droid submission checklist.
+- [docs/fdroid-build-recipe.md](./fdroid-build-recipe.md) — F-Droid build recipe.
+- [docs/dependency-license-audit.md](./dependency-license-audit.md) — dependency
+  licensing.
+- [docs/listing-assets.md](./listing-assets.md) — store icon / feature graphic /
+  screenshots.


### PR DESCRIPTION
## Summary

Bundles the remaining F-Droid / GitHub-release readiness documentation and a
round of metadata cleanup into one focused, **docs-only** PR. No app code,
workflows, screenshots, signing keys, or secrets are touched, and nothing is
submitted to F-Droid or published.

> Linthra is **not** on F-Droid and no submission has been made. Every doc here
> is a planning aid and says so explicitly.

## Docs changed

**New**
- `docs/dependency-license-audit.md` — per-dependency licenses, native/bundled
  component review, network/anti-feature assessment, and methodology.
- `docs/release-process.md` — canonical versioning, tagging, and the **manual**
  GitHub-Release flow; what's automated vs. manual; F-Droid relationship.

**Updated**
- `docs/fdroid-readiness.md` — added `http` + `flutter_secure_storage` to the
  dependency table (they were **missing** — added with the Jellyfin foundation),
  reflected the optional Jellyfin source in the anti-features review, refined the
  dependency-audit blocker (direct done / transitive pending), and cross-linked
  the new docs.
- `docs/fdroid-build-recipe.md` — recorded AGP `8.1.0` / Kotlin `1.8.22` in the
  toolchain table, pointed the dependency review at the new audit doc, and
  cross-linked the release-process doc.
- `README.md` — **corrected stale release content**: artifact names now match
  the actual workflow (`linthra-debug-signed-*` / `linthra-release-signed-*`,
  not the old `linthra-release-*`); the "signing status" / "limitations" text
  now reflects that release signing is wired up (via env vars / `key.properties`
  + the `signed` workflow input) rather than "out of scope / next PR"; the CI
  blurb no longer claims "no native build steps"; and a new **Release & F-Droid
  documentation** index links every release/F-Droid doc.

## F-Droid readiness summary

- **Identity/license:** stable app ID `io.github.thezupzup.linthra`, `MPL-2.0`
  (F-Droid-accepted). ✅
- **Build/toolchain:** Flutter 3.27.4, Dart 3.6.x, JDK 17, Gradle 8.3, AGP 8.1.0,
  Kotlin 1.8.22; Drift `*.g.dart` committed (no `build_runner` prebuild needed). ✅
- **Anti-features:** no ads, no analytics/telemetry. Jellyfin is an optional,
  user-configured source pointing at free software — assessed as **not**
  obviously `NonFreeNet`, to re-confirm at submission. ✅ (documented)
- **Signing:** wired but **secrets not provisioned**; F-Droid signs its own
  builds regardless. ⚠️
- **Assets:** icon / feature graphic / screenshots still missing (no fakes
  added, by design). ❌
- **Release:** no `vX.Y.Z` tag yet. ❌

## Dependency / license notes

All **direct** dependencies are permissive and MPL-2.0-compatible:

- **MIT:** `flutter_riverpod`, `drift`, `sqlite3_flutter_libs`, `just_audio`,
  `audio_service`, `file_picker` (+ `drift_dev` dev-only).
- **BSD-3-Clause:** `flutter`, `go_router`, `path`, `path_provider`,
  `shared_preferences`, `http`, `flutter_secure_storage` (+ `flutter_lints`,
  `flutter_test`, `build_runner` dev-only).
- Native bits: bundled **SQLite** is public-domain and built from source;
  `flutter_secure_storage` uses **Android Keystore** (AOSP, not GMS). No Google
  Play Services / Firebase in the direct set.

Licenses are from each package's pub.dev listing; the Dart/Flutter toolchain
wasn't available in this environment, so a **mechanical transitive walk** wasn't
run — the doc records the exact commands to run it before submission.

**Fastlane metadata review:** reviewed and accurate — `short_description.txt` is
73 chars (under F-Droid's 80), `full_description.txt` cleanly separates shipped
vs. planned (Jellyfin listed as planned), `changelogs/1.txt` is a clearly
labeled placeholder. No changes needed.

## Remaining blockers before F-Droid submission

1. **Mechanical transitive dependency audit** — confirm the full tree is free /
   no Google-only binaries (direct-dep review is done).
2. **Real image assets** — store icon, feature graphic, 2–8 screenshots.
3. **Release signing secrets** (`LINTHRA_*`) — only needed for GitHub-Release
   artifacts; F-Droid signs its own builds.
4. **Reproducible-build verification** on F-Droid infra + decide `pubspec.lock`
   policy for releases.
5. **No tagged release yet** — a `vX.Y.Z` tag must exist.
6. **Feature-maturity call** — submit at the current library-only stage or wait
   for playback.

## Next recommended PR

Capture and commit **real listing assets** (icon, feature graphic, screenshots
from a running build, per `docs/listing-assets.md`) and run the mechanical
transitive dependency audit — the two blockers that are pure groundwork and
don't depend on cutting a release.

## Test plan

- [x] All relative doc links resolve (verified; no broken `./*.md` targets).
- [x] README artifact names / signing status match
      `.github/workflows/android-release-build.yml` + `docs/release-signing.md`.
- [x] Dependency table matches `pubspec.yaml` (incl. `http`,
      `flutter_secure_storage`).
- [x] No code, workflows, secrets, keys, or screenshots changed (docs + README
      only).

https://claude.ai/code/session_01SjMkQczuUzBrH7YgpfSFKN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjMkQczuUzBrH7YgpfSFKN)_