### PR TITLE
Wire Jellyfin library sync into the Library flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,15 @@ The Settings UI talks only to `JellyfinSettingsController`/`JellyfinSettingsStat
 — never to HTTP or storage. **Passwords are never stored** (used once to obtain
 a token, then discarded) and **tokens are never logged** (the session redacts
 its token in `toString`, and a track's stored URI is a token-free
-`jellyfin:<id>`; the streaming URL is minted only at play time). What's *not*
-here yet: syncing the Jellyfin catalog into the Library and actual streaming
-playback — the source and a `jellyfinMusicSourceProvider` seam are ready for
-that next step. See **Jellyfin (self-hosted music) — setup & known limitations**
-below.
+`jellyfin:<id>`; the streaming URL is minted only at play time). **Library sync
+now works:** once signed in, a **Sync library** action pulls your Jellyfin
+artists/albums/tracks and upserts them into the same `MusicLibraryRepository`
+the Library reads from, under the stable `jellyfin` source id (driven by
+`JellyfinSyncController`/`JellyfinSyncState` over the existing
+`jellyfinMusicSourceProvider` seam). What's *not* here yet: actual streaming
+playback (Jellyfin tracks sync into the catalog, but routing their playback
+through `resolvePlayableUri` is the next step) and Jellyfin offline downloads.
+See **Jellyfin (self-hosted music) — setup & known limitations** below.
 
 Not built yet (planned, in roughly this order):
 
@@ -136,8 +140,9 @@ Not built yet (planned, in roughly this order):
 
 Self-hosted sources (Jellyfin, WebDAV, NAS) build on the local MVP. The
 **Jellyfin foundation has landed** (settings, connection test, authentication,
-encrypted session persistence, and a library source); wiring it into the
-Library and streaming playback come next.
+encrypted session persistence, and a library source), and **library sync is now
+wired in** — a signed-in user can pull their Jellyfin catalog into the Library.
+Streaming playback of those tracks comes next.
 
 ## Philosophy
 
@@ -594,7 +599,9 @@ Deliberate gaps the next PRs will close:
   empties up next but keeps the current track). When a track finishes, playback
   rolls into the next queued track. Reordering, saved playlists, shuffle, and
   repeat are not part of this foundation yet.
-- **No downloads or remote sources** (Jellyfin/WebDAV) yet.
+- **Jellyfin sync, but no remote playback yet.** A signed-in user can sync their
+  Jellyfin catalog into the Library; streaming those tracks (and WebDAV) is still
+  pending.
 
 ### Testing scanning on Android
 
@@ -669,7 +676,10 @@ including one published over HTTPS through a **Cloudflare** domain or tunnel.
    credentials needed) and shows the server name/version.
 3. **Username + password → Sign in** — authenticates and stores the resulting
    session. The password field has a show/hide toggle.
-4. **Sign out & clear** — forgets the saved session and clears the settings.
+4. **Sync library** — once signed in, pulls your Jellyfin artists/albums/tracks
+   and stores them in the local catalog so they show up in the Library. Shows a
+   spinner while it runs and a friendly result/error line when it's done.
+5. **Sign out & clear** — forgets the saved session and clears the settings.
 
 **Cloudflare notes.** A Cloudflare-proxied or Cloudflare Tunnel (`cloudflared`)
 Jellyfin is just a normal HTTPS endpoint, so it works without any special
@@ -695,19 +705,26 @@ configuration — point the URL at your public domain. Two things to know:
   authenticated streaming URL is minted only at play time, never stored.
 
 **What works now.** Configuring a server, testing the connection, signing in
-with friendly URL/connection/auth errors, and persisting the session across
-restarts. Under the hood, `JellyfinMusicSource` can already list and map
-artists/albums/tracks (and resolve a streaming URL), and is exposed via
-`jellyfinMusicSourceProvider`, but is **not yet wired into the Library UI**.
+with friendly URL/connection/auth errors, persisting the session across
+restarts, and **syncing the library**. The **Sync library** action drives
+`JellyfinSyncController`, which reads the signed-in `JellyfinMusicSource` (via
+`jellyfinMusicSourceProvider`), fetches artists/albums/tracks, and upserts them
+into `MusicLibraryRepository` under the stable `jellyfin` source id — the same
+upsert path local scanning uses. The Library reloads automatically afterward,
+so synced tracks appear alongside local ones. The sync surfaces loading /
+success / error states and friendly messages for being **not signed in**, a
+**server it couldn't reach**, an **expired/invalid session** (prompting a fresh
+sign-in), and an **empty Jellyfin library** (which leaves any existing catalog
+untouched rather than wiping it). It never logs the token and never stores an
+authenticated streaming URL — synced track URIs stay the token-free
+`jellyfin:<id>`.
 
 **Deliberate gaps the next PRs will close:**
 
-- **No Library sync or playback yet.** The source isn't fed into
-  `MusicLibraryRepository`, so Jellyfin tracks don't appear in the Library and
-  remote streaming isn't started from the UI. That's the recommended next PR:
-  add a "Sync Jellyfin library" action that calls
-  `MusicLibraryRepository.upsertCatalog(sourceId: 'jellyfin', …)` and route
-  `resolvePlayableUri` into playback.
+- **No remote streaming playback yet.** Jellyfin tracks now sync into the
+  Library, but tapping one doesn't stream it: `resolvePlayableUri` (which mints
+  the authenticated URL at play time) isn't yet routed into the playback
+  controller. That's the recommended next PR.
 - **No offline downloads from Jellyfin.** Fetching bytes for offline use slots
   into `CacheDownloadRepository._obtainOfflineCopy` later (see above).
 - **Single server only.** One session is stored; multi-server support and

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import 'jellyfin_settings_controller.dart';
 import 'jellyfin_settings_state.dart';
+import 'jellyfin_sync_controller.dart';
+import 'jellyfin_sync_state.dart';
 
 /// The Jellyfin connection card on the Settings screen.
 ///
@@ -78,10 +80,16 @@ class _JellyfinSettingsSectionState
     _passwordController.clear();
   }
 
+  Future<void> _sync() async {
+    await ref.read(jellyfinSyncControllerProvider.notifier).sync();
+  }
+
   @override
   Widget build(BuildContext context) {
     final JellyfinSettingsState state =
         ref.watch(jellyfinSettingsControllerProvider);
+    final JellyfinSyncState syncState =
+        ref.watch(jellyfinSyncControllerProvider);
     final ThemeData theme = Theme.of(context);
 
     return Card(
@@ -109,7 +117,10 @@ class _JellyfinSettingsSectionState
             if (state.isConnected)
               _ConnectedView(
                 state: state,
-                onSignOut: state.isBusy ? null : _signOut,
+                syncState: syncState,
+                onSync: (state.isBusy || syncState.isSyncing) ? null : _sync,
+                onSignOut:
+                    (state.isBusy || syncState.isSyncing) ? null : _signOut,
               )
             else
               _buildForm(theme, state),
@@ -211,9 +222,16 @@ class _JellyfinSettingsSectionState
 /// The summary shown once a session exists: which server/user, plus the action
 /// to sign out and clear the saved settings.
 class _ConnectedView extends StatelessWidget {
-  const _ConnectedView({required this.state, required this.onSignOut});
+  const _ConnectedView({
+    required this.state,
+    required this.syncState,
+    required this.onSync,
+    required this.onSignOut,
+  });
 
   final JellyfinSettingsState state;
+  final JellyfinSyncState syncState;
+  final VoidCallback? onSync;
   final VoidCallback? onSignOut;
 
   @override
@@ -256,6 +274,21 @@ class _ConnectedView extends StatelessWidget {
           ],
         ),
         const SizedBox(height: AppSpacing.md),
+        FilledButton.tonalIcon(
+          onPressed: onSync,
+          icon: syncState.isSyncing
+              ? const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.sync_outlined),
+          label: Text(syncState.isSyncing ? 'Syncing…' : 'Sync library'),
+        ),
+        if (syncState.message != null && !syncState.isSyncing) ...[
+          const SizedBox(height: AppSpacing.sm),
+          _StatusLine(message: syncState.message!, isError: syncState.isError),
+        ],
+        const SizedBox(height: AppSpacing.sm),
         OutlinedButton.icon(
           onPressed: onSignOut,
           icon: const Icon(Icons.logout_outlined),

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sources/jellyfin/jellyfin_exception.dart';
+import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
+import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../library/library_controller.dart';
+import 'jellyfin_settings_controller.dart';
+import 'jellyfin_sync_state.dart';
+
+/// Drives the "Sync Jellyfin library" action.
+///
+/// Reads the signed-in [JellyfinMusicSource] (via [jellyfinMusicSourceProvider])
+/// to fetch the catalog, then hands the results to the
+/// `MusicLibraryRepository` under the stable `jellyfin` source id — the same
+/// upsert path local scanning uses. The Library screen reads from that
+/// repository, so a refresh after the upsert makes the synced tracks appear.
+///
+/// Security: the source mints any authenticated streaming URL lazily at play
+/// time, so nothing persisted here carries a token. This controller never logs
+/// the session, and surfaces only friendly, secret-free messages through
+/// [JellyfinSyncState].
+class JellyfinSyncController extends Notifier<JellyfinSyncState> {
+  @override
+  JellyfinSyncState build() => const JellyfinSyncState();
+
+  /// Pulls artists/albums/tracks from Jellyfin and upserts them into the local
+  /// catalog. Reflects loading/success/error through [state]; never throws.
+  Future<void> sync() async {
+    final JellyfinMusicSource? source = ref.read(jellyfinMusicSourceProvider);
+    if (source == null) {
+      state = const JellyfinSyncState.error(
+        'Connect to your Jellyfin server in Settings before syncing.',
+      );
+      return;
+    }
+
+    state = const JellyfinSyncState.syncing();
+    try {
+      final tracks = await source.fetchTracks();
+      final albums = await source.fetchAlbums();
+      final artists = await source.fetchArtists();
+
+      if (tracks.isEmpty) {
+        state = const JellyfinSyncState.success(
+          trackCount: 0,
+          message: 'Your Jellyfin library looks empty — nothing to sync yet.',
+        );
+        return;
+      }
+
+      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+            sourceId: source.id,
+            tracks: tracks,
+            albums: albums,
+            artists: artists,
+          );
+      // Reload the Library so the freshly synced tracks show up immediately.
+      await ref.read(libraryControllerProvider.notifier).refresh();
+
+      state = JellyfinSyncState.success(
+        trackCount: tracks.length,
+        message: _successMessage(tracks.length),
+      );
+    } on JellyfinException catch (error) {
+      state = JellyfinSyncState.error(_friendlyMessage(error));
+    } catch (_) {
+      // A non-Jellyfin failure (e.g. the local store): keep it generic and
+      // secret-free rather than dumping a raw error.
+      state = const JellyfinSyncState.error(
+        "Something went wrong saving your Jellyfin library. Please try again.",
+      );
+    }
+  }
+
+  String _successMessage(int trackCount) {
+    final String tracks = trackCount == 1 ? '1 track' : '$trackCount tracks';
+    return 'Synced $tracks from your Jellyfin library.';
+  }
+
+  /// Turns a typed Jellyfin failure into a friendly, actionable line. Branches
+  /// on [JellyfinErrorKind] rather than message text so the wording can change
+  /// without breaking this mapping.
+  String _friendlyMessage(JellyfinException error) {
+    switch (error.kind) {
+      case JellyfinErrorKind.notReachable:
+        return "Couldn't reach your Jellyfin server. Check your connection and "
+            'that the server is online.';
+      case JellyfinErrorKind.unauthorized:
+        return 'Your Jellyfin session has expired. Sign out and sign in again '
+            'to refresh it.';
+      case JellyfinErrorKind.notJellyfin:
+        return "That server didn't respond like Jellyfin. Double-check the "
+            'server address in Settings.';
+      case JellyfinErrorKind.serverError:
+        return 'Your Jellyfin server reported an error. Try again in a moment.';
+      case JellyfinErrorKind.invalidUrl:
+      case JellyfinErrorKind.unexpected:
+        return error.message;
+    }
+  }
+}
+
+final jellyfinSyncControllerProvider =
+    NotifierProvider<JellyfinSyncController, JellyfinSyncState>(
+  JellyfinSyncController.new,
+);

--- a/lib/features/settings/jellyfin/jellyfin_sync_state.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_state.dart
@@ -1,0 +1,44 @@
+/// Where a Jellyfin library sync is in its lifecycle.
+enum JellyfinSyncStatus { idle, syncing, success, error }
+
+/// Immutable snapshot the Jellyfin settings UI renders the sync action from.
+///
+/// Like every other state object in the app, this holds only display-safe
+/// values: a status, a friendly [message], and how many tracks landed. It never
+/// carries a token, password, or streaming URL.
+class JellyfinSyncState {
+  const JellyfinSyncState({
+    this.status = JellyfinSyncStatus.idle,
+    this.message,
+    this.trackCount = 0,
+  });
+
+  const JellyfinSyncState.syncing()
+      : this(
+          status: JellyfinSyncStatus.syncing,
+          message: 'Syncing your Jellyfin library…',
+        );
+
+  const JellyfinSyncState.success({
+    required int trackCount,
+    required String message,
+  }) : this(
+          status: JellyfinSyncStatus.success,
+          trackCount: trackCount,
+          message: message,
+        );
+
+  const JellyfinSyncState.error(String message)
+      : this(status: JellyfinSyncStatus.error, message: message);
+
+  final JellyfinSyncStatus status;
+
+  /// A friendly status or error line for the UI; never contains a secret.
+  final String? message;
+
+  /// How many tracks the last successful sync stored.
+  final int trackCount;
+
+  bool get isSyncing => status == JellyfinSyncStatus.syncing;
+  bool get isError => status == JellyfinSyncStatus.error;
+}

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -1,0 +1,245 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_music_source.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
+
+import '../../../core/sources/jellyfin/fake_jellyfin_client.dart';
+
+const _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: 'secret-token',
+  deviceId: 'device-1',
+  userName: 'alice',
+  serverName: 'Home',
+);
+
+/// A recording [MusicLibraryRepository] that captures the last upsert so a test
+/// can assert what the sync stored, and can be made to throw on upsert.
+class _RecordingRepository implements MusicLibraryRepository {
+  _RecordingRepository({this.upsertError});
+
+  final Object? upsertError;
+
+  String? upsertedSourceId;
+  List<Track> upsertedTracks = const <Track>[];
+  List<Album> upsertedAlbums = const <Album>[];
+  List<Artist> upsertedArtists = const <Artist>[];
+  int upsertCount = 0;
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    upsertCount++;
+    if (upsertError != null) throw upsertError!;
+    upsertedSourceId = sourceId;
+    upsertedTracks = tracks;
+    upsertedAlbums = albums;
+    upsertedArtists = artists;
+  }
+
+  @override
+  Future<List<Track>> getAllTracks() async => upsertedTracks;
+
+  @override
+  Future<List<Album>> getAllAlbums() async => upsertedAlbums;
+
+  @override
+  Future<List<Artist>> getAllArtists() async => upsertedArtists;
+
+  @override
+  Future<Track?> getTrackById(String id) async => null;
+}
+
+JellyfinItemDto _audio(String id) => JellyfinItemDto(
+      id: id,
+      name: 'Track $id',
+      album: 'Album',
+      artists: const <String>['Artist'],
+      runTimeTicks: 1000000,
+      indexNumber: 1,
+    );
+
+/// Builds a real [JellyfinMusicSource] over a [FakeJellyfinClient] — the "fake
+/// source" for these tests, with no real HTTP or server.
+JellyfinMusicSource _source({
+  Map<JellyfinItemKind, List<JellyfinItemDto>> items =
+      const <JellyfinItemKind, List<JellyfinItemDto>>{},
+  JellyfinException? itemsError,
+}) {
+  return JellyfinMusicSource(
+    session: _session,
+    client: FakeJellyfinClient(itemsByKind: items, itemsError: itemsError),
+  );
+}
+
+ProviderContainer _container({
+  required MusicLibraryRepository repository,
+  JellyfinMusicSource? source,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      musicLibraryRepositoryProvider.overrideWithValue(repository),
+      jellyfinMusicSourceProvider.overrideWithValue(source),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('JellyfinSyncController', () {
+    test('starts idle', () {
+      final container = _container(repository: _RecordingRepository());
+      expect(
+        container.read(jellyfinSyncControllerProvider).status,
+        JellyfinSyncStatus.idle,
+      );
+    });
+
+    test('errors with a friendly message when not signed in', () async {
+      final container = _container(repository: _RecordingRepository());
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.error);
+      expect(state.message, contains('Connect to your Jellyfin server'));
+    });
+
+    test('upserts fetched tracks under the jellyfin source id', () async {
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _source(
+          items: <JellyfinItemKind, List<JellyfinItemDto>>{
+            JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a'), _audio('b')],
+            JellyfinItemKind.album: <JellyfinItemDto>[
+              const JellyfinItemDto(id: 'alb', name: 'Album'),
+            ],
+            JellyfinItemKind.artist: <JellyfinItemDto>[
+              const JellyfinItemDto(id: 'art', name: 'Artist'),
+            ],
+          },
+        ),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.success);
+      expect(state.trackCount, 2);
+      expect(state.message, contains('2 tracks'));
+      expect(repository.upsertedSourceId, 'jellyfin');
+      expect(repository.upsertedTracks, hasLength(2));
+      expect(repository.upsertedAlbums, hasLength(1));
+      expect(repository.upsertedArtists, hasLength(1));
+    });
+
+    test('never stores the access token in a synced track uri', () async {
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _source(
+          items: <JellyfinItemKind, List<JellyfinItemDto>>{
+            JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+          },
+        ),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final Track track = repository.upsertedTracks.single;
+      expect(track.uri, 'jellyfin:a');
+      expect(track.uri, isNot(contains('secret-token')));
+    });
+
+    test('reports an empty library without wiping the catalog', () async {
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _source(),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.success);
+      expect(state.trackCount, 0);
+      expect(state.message, contains('empty'));
+      // Nothing was upserted, so an existing catalog is left untouched.
+      expect(repository.upsertCount, 0);
+    });
+
+    test('maps an unreachable server to a friendly message', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.notReachable()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.error);
+      expect(state.message, contains("Couldn't reach"));
+    });
+
+    test('maps an expired token to a sign-in-again message', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.unauthorized()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.error);
+      expect(state.message, contains('session has expired'));
+    });
+
+    test('does not leak the token through an error message', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.unauthorized()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.message, isNot(contains('secret-token')));
+    });
+
+    test('surfaces a generic error when the repository upsert fails', () async {
+      final container = _container(
+        repository: _RecordingRepository(upsertError: Exception('disk full')),
+        source: _source(
+          items: <JellyfinItemKind, List<JellyfinItemDto>>{
+            JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+          },
+        ),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.error);
+      // The raw error is not surfaced to the user.
+      expect(state.message, isNot(contains('disk full')));
+      expect(state.message, contains('Please try again'));
+    });
+  });
+}


### PR DESCRIPTION
## Jellyfin sync behavior

Adds a **Sync library** action to the connected Jellyfin card in **Settings → Jellyfin**. Once signed in, it:

- Reads the signed-in `JellyfinMusicSource` via the existing `jellyfinMusicSourceProvider` seam (no new HTTP in the UI).
- Fetches tracks, albums, and artists from the server.
- Upserts them into `MusicLibraryRepository.upsertCatalog(sourceId: 'jellyfin', …)` — the same path local scanning uses — so Jellyfin tracks appear in the Library alongside local ones.
- Reloads the Library automatically so synced tracks show up immediately.

State is driven by a new `JellyfinSyncController` / `JellyfinSyncState` (Riverpod `Notifier`), keeping the widget dependent on controller state rather than raw networking. The UI shows a spinner while syncing and a friendly status/error line afterward.

Friendly messages cover:
- **Not signed in** → "Connect to your Jellyfin server in Settings before syncing."
- **Server unreachable** → "Couldn't reach your Jellyfin server…"
- **Auth expired / invalid token** → "Your Jellyfin session has expired. Sign out and sign in again…"
- **Empty Jellyfin library** → "Your Jellyfin library looks empty — nothing to sync yet." (leaves any existing catalog untouched rather than wiping it)
- Plus mappings for not-Jellyfin / server-error, and a generic secret-free fallback for local upsert failures.

## Security / token notes

- Synced track URIs stay the token-free `jellyfin:<id>`; the authenticated streaming URL is still minted lazily in `resolvePlayableUri` at play time and is **never persisted**.
- No tokens or passwords are logged; error messages branch on `JellyfinErrorKind` and never include raw exception text that could carry a secret. A test asserts the access token never appears in a synced track URI or an error message.
- No new database schema; reuses the existing `sourceId`-keyed catalog.
- No hardcoded domains.

## Files changed

- `lib/features/settings/jellyfin/jellyfin_sync_state.dart` *(new)* — idle/syncing/success/error state, secret-free.
- `lib/features/settings/jellyfin/jellyfin_sync_controller.dart` *(new)* — orchestrates fetch → upsert → Library refresh; maps failures to friendly messages.
- `lib/features/settings/jellyfin/jellyfin_settings_section.dart` — adds the **Sync library** button + status line to the connected view; disables sync/sign-out while busy.
- `test/features/settings/jellyfin/jellyfin_sync_controller_test.dart` *(new)* — see below.
- `README.md` — documents current Jellyfin sync behavior and limitations.

## Tests added

`jellyfin_sync_controller_test.dart` drives a real `JellyfinMusicSource` over the existing `FakeJellyfinClient` and a recording fake `MusicLibraryRepository`:

- starts idle
- friendly error when not signed in
- upserts fetched tracks/albums/artists under `jellyfin` source id
- never stores the access token in a synced track URI
- empty library reported without wiping the catalog (no upsert)
- unreachable server → friendly message
- expired token → sign-in-again message
- token never leaks through an error message
- generic (secret-free) message when the repository upsert fails

## Verification

- `flutter pub get` ✅
- `dart format --set-exit-if-changed .` ✅ (0 changed)
- `flutter analyze` ✅ (No issues found)
- `flutter test` ✅ (all tests pass, incl. 9 new)

## Limitations

- **No remote streaming playback yet** — Jellyfin tracks sync into the catalog, but tapping one doesn't stream it.
- No Jellyfin offline downloads.
- No Jellyfin-specific Android Auto browsing.
- Single server only; no incremental/delta sync (a full re-sync replaces the `jellyfin` catalog).

## Next recommended PR

Route Jellyfin track playback through `resolvePlayableUri` so Jellyfin tracks can stream securely (token minted at play time, never persisted).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTniFWYD8sEJrPAoi2q64g)_