### PR TITLE
Stabilize real-device Android testing (notifications, INTERNET, friendly scan errors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,15 +331,60 @@ This artifact is an **unsigned debug build for testing only** — it is not
 signed for release, not published to any store or F-Droid, and no GitHub
 release is created.
 
+#### Manual smoke test on a real Android phone
+
+After installing the debug APK on a physical device (most useful on **Android
+13+**, where the runtime notification permission applies), walk this checklist —
+it covers the paths that only behave correctly on real hardware:
+
+1. **First launch & notification prompt.** Cold-start the app. On Android 13+ a
+   **"Allow notifications?"** system prompt should appear shortly after the UI
+   loads. Tap **Allow** (the media notification depends on it). If you tap
+   **Don't allow**, playback still works but no notification appears — re-enable
+   it later under *Settings → Apps → Linthra → Notifications*.
+2. **Pick a folder & scan.** Library tab → folder icon → choose a folder with a
+   few audio files (e.g. `Music`). It should list the tracks. Pick a folder a
+   provider can't traverse (or an empty one) and confirm you get a **clear,
+   friendly message or "No music found"**, never a raw error or an indefinite
+   spinner.
+3. **Play a local track.** Tap a track. It should start, and the **Now Playing**
+   screen should show title/artist and working play/pause/next/stop.
+4. **Background playback & notification.** Background the app (Home button). Audio
+   should keep playing and a **media notification** should show the track with
+   working transport controls. Lock the phone and confirm lock-screen controls
+   work. Headset/Bluetooth play-pause buttons should work too.
+5. **Jellyfin (optional).** Settings → Jellyfin → enter your server URL → **Test
+   connection** → sign in → **Sync library** → play a synced track. Confirm
+   streaming works over the network. Try a wrong URL / offline server and
+   confirm you get a **friendly error** (unreachable / not-a-Jellyfin-server /
+   expired session), not a raw failure.
+6. **Friendly playback errors.** With Jellyfin signed out, try to play a synced
+   Jellyfin track and confirm the Now Playing status line shows a precise,
+   friendly message (e.g. "not signed in"), not an opaque engine error.
+
+See *Testing scanning on Android* below for the SAF-specific detail, and the
+*Limitations still remaining* list at the end of this section.
+
 **Android identity & permissions.** The app ships with a stable application ID
 **`io.github.thezupzup.linthra`** (also the Kotlin/Gradle `namespace`) and the
 display name **Linthra** — both chosen for future F-Droid / GitHub Releases
-distribution. Permissions are kept deliberately minimal: the production
-manifest declares **no** permissions, and `INTERNET` is added only in the
-`debug`/`profile` manifests (Flutter needs it for hot reload). No storage
-permissions are requested — see *Android folder selection & known limitations*
-for why a narrow `READ_MEDIA_AUDIO` flow is a deliberate later step rather than
-a broad "all files" grant.
+distribution. Permissions are kept deliberately minimal. The production manifest
+declares only:
+
+- **`FOREGROUND_SERVICE`** / **`FOREGROUND_SERVICE_MEDIA_PLAYBACK`** — so
+  `audio_service` can keep playing while backgrounded (Android 14+ requires the
+  typed `mediaPlayback` grant).
+- **`POST_NOTIFICATIONS`** — required on Android 13+ for the media notification
+  (and its transport controls) to appear; it is a *runtime* permission the app
+  asks for once on first launch (see *Background playback* below).
+- **`INTERNET`** — needed to reach a self-hosted Jellyfin server (connection
+  test, sign-in, library sync, and streaming). The `debug`/`profile` manifests
+  also add it for Flutter's tooling; the manifest merger de-duplicates.
+
+**No storage permission is requested** — folder access uses the Storage Access
+Framework grant the user picks. See *Android folder selection & known
+limitations* for why a narrow `READ_MEDIA_AUDIO` flow is a deliberate later step
+rather than a broad "all files" grant.
 
 > The `audio_service` native wiring (foreground-service permissions, the
 > playback `<service>`/`<receiver>`, the Android Auto media-app declaration, and
@@ -469,11 +514,19 @@ platform) basic playback still works.
 scaffold so the media session can run as a foreground service and be visible to
 Android Auto:
 
-- `android/app/src/main/AndroidManifest.xml` declares two minimal permissions —
+- `android/app/src/main/AndroidManifest.xml` declares the playback permissions —
   `FOREGROUND_SERVICE` (run the playback service in the foreground so audio
   continues while backgrounded) and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` (the
   typed-foreground grant Android 14+/API 34 requires for a `mediaPlayback`
-  service). No storage or network permissions are added.
+  service) — plus `POST_NOTIFICATIONS` (Android 13+ runtime permission, without
+  which the notification is silently suppressed). `INTERNET` is also declared
+  for Jellyfin; no storage permission is added.
+- **Notification permission prompt.** On Android 13+ the media notification only
+  shows once the user grants `POST_NOTIFICATIONS`. `LinthraApp` asks for it once
+  on first launch (after the first frame, via the `NotificationPermission` seam
+  → `permission_handler`). The request is best-effort: if it's denied, playback
+  still works but the notification / lock-screen controls won't appear until the
+  permission is enabled in system settings.
 - the same manifest declares the audio_service playback `<service>`
   (`com.ryanheise.audioservice.AudioService`, `foregroundServiceType`
   `mediaPlayback`, exposing the `MediaBrowserService` action Android Auto binds
@@ -494,6 +547,10 @@ For reference, the manifest additions are:
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission
       android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+  <!-- Android 13+ runtime permission for the media notification. -->
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <!-- Reaching a self-hosted Jellyfin server. -->
+  <uses-permission android:name="android.permission.INTERNET" />
 
   <application ...>
     <!-- audio_service playback service -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,22 @@
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
+    <!-- POST_NOTIFICATIONS: required on Android 13+ (API 33) for the
+         audio_service media notification (and its transport controls) to appear
+         at all. It is a runtime permission the user must grant; the app asks
+         once on first launch (see NotificationPermission). Without it the
+         service still runs but the notification / lock-screen controls are
+         silently suppressed on modern devices. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!-- INTERNET: needed to reach a self-hosted Jellyfin server (connection
+         test, sign-in, library sync, and streaming). Declared here so a
+         release build can stream too; the debug/profile manifests also add it
+         for Flutter's tooling, and the manifest merger de-duplicates. No
+         storage permission is declared — folder access uses the Storage Access
+         Framework grant the user picks. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="Linthra"
         android:name="${applicationName}"

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -2,16 +2,44 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/app_info.dart';
+import '../core/services/notification_permission.dart';
 import 'router.dart';
 import 'theme.dart';
 
+/// The notification-permission seam the app asks through on first launch.
+///
+/// Defaults to the `permission_handler`-backed request (a no-op off Android and
+/// when already granted); tests override it with a fake so pumping the app
+/// never triggers a real OS prompt.
+final notificationPermissionProvider = Provider<NotificationPermission>((ref) {
+  return const PermissionHandlerNotificationPermission();
+});
+
 /// Root widget. Dark mode is the primary experience; the light theme follows
 /// the system setting when the user opts out of dark.
-class LinthraApp extends ConsumerWidget {
+///
+/// On first build it asks for the notification permission once, after the first
+/// frame, so the Android 13+ `POST_NOTIFICATIONS` prompt has an attached
+/// activity and the media notification can actually appear. The request is
+/// best-effort and never blocks the UI.
+class LinthraApp extends ConsumerStatefulWidget {
   const LinthraApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<LinthraApp> createState() => _LinthraAppState();
+}
+
+class _LinthraAppState extends ConsumerState<LinthraApp> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(notificationPermissionProvider).ensureGranted();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final router = ref.watch(appRouterProvider);
     return MaterialApp.router(
       title: AppInfo.name,

--- a/lib/core/services/notification_permission.dart
+++ b/lib/core/services/notification_permission.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:permission_handler/permission_handler.dart';
+
+/// Asks the OS for the notification permission the media session needs.
+///
+/// On Android 13+ (API 33) the `POST_NOTIFICATIONS` permission is required
+/// before `audio_service` can show its playback notification — without it the
+/// foreground service still runs but the notification and its transport
+/// controls are silently suppressed. This is the single seam the app calls so
+/// the request stays testable (UI/tests inject a fake) and the rest of the app
+/// never touches `permission_handler` directly.
+abstract interface class NotificationPermission {
+  /// Requests the notification permission if it isn't already granted.
+  ///
+  /// Best-effort and safe to call more than once: a no-op where the permission
+  /// doesn't apply (older Android, other platforms) and when already granted.
+  /// Never throws — a platform that can't service the request is treated as
+  /// "nothing to do" so startup is never blocked by it.
+  Future<void> ensureGranted();
+}
+
+/// The production [NotificationPermission], backed by `permission_handler`.
+///
+/// Only meaningful on Android: elsewhere there is no `POST_NOTIFICATIONS`
+/// runtime gate, so it returns immediately. Any plugin failure is swallowed so
+/// a permission hiccup can never crash or stall app start; playback still works
+/// without the notification.
+class PermissionHandlerNotificationPermission
+    implements NotificationPermission {
+  const PermissionHandlerNotificationPermission();
+
+  @override
+  Future<void> ensureGranted() async {
+    if (!Platform.isAndroid) {
+      return;
+    }
+    try {
+      final PermissionStatus status = await Permission.notification.status;
+      // Only prompt when it can still be granted. A permanently-denied grant is
+      // left alone: re-prompting does nothing and the user can enable it from
+      // system settings.
+      if (status.isDenied) {
+        await Permission.notification.request();
+      }
+    } catch (_) {
+      // A platform/plugin that can't service the request is non-fatal: the app
+      // runs without the notification rather than failing to start.
+    }
+  }
+}
+
+/// A [NotificationPermission] that does nothing.
+///
+/// For tests and any context that must not trigger a real OS prompt.
+class NoopNotificationPermission implements NotificationPermission {
+  const NoopNotificationPermission();
+
+  @override
+  Future<void> ensureGranted() async {}
+}

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/sources/local/folder_scan_exception.dart';
 import '../../core/sources/local/local_music_source.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
 import 'library_providers.dart';
@@ -41,10 +42,21 @@ class LibraryController extends Notifier<LibraryState> {
         artists: artists,
       );
       await _load();
-    } catch (error) {
-      state = LibraryState.error(error.toString());
+    } on FolderScanException catch (error) {
+      // The scanning layer already phrased a clear, secret-free message
+      // (unreachable SAF tree, unreadable scoped-storage path, …); show it.
+      state = LibraryState.error(error.message);
+    } catch (_) {
+      // Anything else is an unexpected scan failure — a raw `dart:io`
+      // permission error or a plugin fault. Don't leak its text (errno codes,
+      // paths) to the user; show one friendly, actionable line instead.
+      state = const LibraryState.error(_scanFailedMessage);
     }
   }
+
+  static const String _scanFailedMessage =
+      "Couldn't scan that folder. Try selecting it again, or pick a different "
+      'folder.';
 
   Future<void> _load() async {
     state = const LibraryState.loading();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,12 @@ dependencies:
   # the rest of the app depends on the JellyfinClient interface, never on http
   # directly. The Dart-team package, so it stays small and dependency-light.
   http: ^1.2.0
+  # Runtime permission requests. Used only by
+  # PermissionHandlerNotificationPermission to ask for POST_NOTIFICATIONS on
+  # Android 13+ so the audio_service media notification can appear; the rest of
+  # the app depends on the NotificationPermission interface, never on
+  # permission_handler directly.
+  permission_handler: ^11.3.1
   # Encrypted on-device storage for the Jellyfin session token (Android
   # Keystore / EncryptedSharedPreferences under the hood). Used only by
   # SecureJellyfinSessionStore, behind the JellyfinSessionStore interface, so

--- a/test/app/notification_permission_request_test.dart
+++ b/test/app/notification_permission_request_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/linthra_app.dart';
+import 'package:linthra/core/services/notification_permission.dart';
+
+/// Records how many times the app asked for the notification permission, so a
+/// test can assert the first-launch request fires exactly once without a real
+/// OS prompt.
+class _RecordingNotificationPermission implements NotificationPermission {
+  int calls = 0;
+
+  @override
+  Future<void> ensureGranted() async {
+    calls += 1;
+  }
+}
+
+void main() {
+  testWidgets('requests the notification permission once on first launch',
+      (tester) async {
+    final permission = _RecordingNotificationPermission();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          notificationPermissionProvider.overrideWithValue(permission),
+        ],
+        child: const LinthraApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(permission.calls, 1);
+
+    // A rebuild (e.g. a frame later) does not re-prompt: the request is tied to
+    // the one-time post-first-frame callback, not to build.
+    await tester.pump();
+    expect(permission.calls, 1);
+  });
+}

--- a/test/core/services/notification_permission_test.dart
+++ b/test/core/services/notification_permission_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/notification_permission.dart';
+
+void main() {
+  group('PermissionHandlerNotificationPermission', () {
+    test('is a no-op (never throws) off Android', () async {
+      // The test host is not Android, so the request short-circuits before ever
+      // touching the plugin channel. This guards the early-return so startup is
+      // never blocked or crashed by the permission request on other platforms.
+      const permission = PermissionHandlerNotificationPermission();
+      await expectLater(permission.ensureGranted(), completes);
+    });
+  });
+
+  group('NoopNotificationPermission', () {
+    test('does nothing and completes', () async {
+      const permission = NoopNotificationPermission();
+      await expectLater(permission.ensureGranted(), completes);
+    });
+  });
+}

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 import 'package:linthra/core/sources/local/directory_readability.dart';
+import 'package:linthra/core/sources/local/folder_scan_exception.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
@@ -127,10 +128,15 @@ void main() {
       expect(await repository.getAllTracks(), hasLength(2));
     });
 
-    test('scanFolder surfaces an error when scanning fails', () async {
+    test('scanFolder shows a friendly message for an unexpected scan failure',
+        () async {
+      // A raw scanner failure (a dart:io permission error on device, say) must
+      // not leak its text — the user sees one clean, actionable line instead.
       final container = _scanContainer(
         repository: InMemoryMusicLibraryRepository(),
-        scanner: FakeAudioFileScanner(error: Exception('no such folder')),
+        scanner: FakeAudioFileScanner(
+          error: Exception('FileSystemException: errno = 13'),
+        ),
       );
 
       await container
@@ -139,7 +145,36 @@ void main() {
 
       final state = container.read(libraryControllerProvider);
       expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains('no such folder'));
+      expect(state.errorMessage, contains("Couldn't scan that folder"));
+      // The raw exception text never reaches the UI.
+      expect(state.errorMessage, isNot(contains('errno')));
+      expect(state.errorMessage, isNot(contains('Exception')));
+    });
+
+    test('scanFolder surfaces a FolderScanException message verbatim',
+        () async {
+      // A typed scan error already carries a curated, secret-free message, so
+      // it should pass through unchanged rather than be replaced by the generic
+      // fallback.
+      final container = _scanContainer(
+        repository: InMemoryMusicLibraryRepository(),
+        scanner: FakeAudioFileScanner(
+          error: const FolderScanException(
+            'This folder is on a provider Linthra cannot read yet.',
+          ),
+        ),
+      );
+
+      await container
+          .read(libraryControllerProvider.notifier)
+          .scanFolder('/missing');
+
+      final state = container.read(libraryControllerProvider);
+      expect(state.status, LibraryStatus.error);
+      expect(
+        state.errorMessage,
+        'This folder is on a provider Linthra cannot read yet.',
+      );
     });
 
     test('scanFolder scans a content URI through the SAF lister', () async {


### PR DESCRIPTION
## Summary

Focused bug-fix / smoke-test polish so the current app is actually testable on a real Android phone after installing the debug APK. No new major features.

## Real-device issues addressed

1. **Media notification didn't appear on Android 13+ (`POST_NOTIFICATIONS`).** `audio_service` is configured with an ongoing notification, but on API 33+ the notification (and its lock-screen / transport controls) is silently suppressed without the runtime `POST_NOTIFICATIONS` grant. Now declared in the manifest and requested **once on first launch** via a small `NotificationPermission` seam (`permission_handler`-backed; no-op off Android, best-effort, never blocks startup).
2. **Jellyfin would fail in release builds (`INTERNET`).** `INTERNET` was only in the `debug`/`profile` manifests, so connection test / sign-in / sync / streaming worked in the debug APK but would break in a release build. Now declared in the production manifest too (merger de-duplicates). Still **no storage permission** — folder access stays SAF-based.
3. **Folder-scan failures could leak raw error text.** Only `FolderScanException` was curated; an unexpected `dart:io` permission error (e.g. `errno = 13`) or plugin fault surfaced its raw `toString()` to the user. The controller now maps unexpected failures to one friendly, actionable line while passing typed `FolderScanException` messages through verbatim.
4. **README**: corrected the permissions description, added the notification-prompt note, refreshed the manifest reference block, and added a manual real-device smoke checklist (below).

Playback / background-service wiring and the Jellyfin streaming error mapping were already solid on review, so they're left as-is.

## Manual Android test checklist (run on a real phone, ideally Android 13+)

- [ ] **First launch** shows the **"Allow notifications?"** prompt; tapping Allow lets the media notification appear.
- [ ] **Pick a folder & scan** lists tracks; an unscannable/empty folder shows a **friendly message**, never a raw error or endless spinner.
- [ ] **Play a local track**; Now Playing shows title/artist with working play/pause/next/stop.
- [ ] **Background the app** → audio keeps playing, **media notification** + lock-screen controls work; headset/Bluetooth buttons work.
- [ ] **Jellyfin (optional)**: test connection → sign in → sync → stream; wrong URL / offline server yields a **friendly error**.
- [ ] **Friendly playback error**: signed-out Jellyfin track shows a precise message, not an engine error.

## Verification

- `flutter pub get` ✅
- `dart format --set-exit-if-changed .` ✅ (0 changed)
- `flutter analyze` ✅ (no issues)
- `flutter test` ✅ (263 tests, +4 new)
- `flutter build apk --debug` — **not run here**: no Android SDK in the sandbox. The existing **Android Debug APK** CI workflow builds it. Manifest validated as well-formed XML.

## Limitations still remaining

- Notification permission is requested but **not re-prompted** if the user declines; they must re-enable it in system settings (standard Android behavior).
- No `READ_MEDIA_AUDIO` runtime flow — the SAF content-resolver path needs no storage permission, but the filesystem-fallback path can still be blocked by scoped storage (surfaces a clear error).
- No tag/metadata parsing; lock-screen/car artwork depends on `Track.artworkUri`, which local scanning doesn't populate.
- Debug APK build couldn't be exercised in this environment (SDK unavailable); relies on CI.

## Next recommended PR

Add a narrow **`READ_MEDIA_AUDIO`** runtime-permission flow (mirroring the `NotificationPermission` seam) for the filesystem-fallback scan path, and surface a settings affordance to re-request notifications when previously denied.

https://claude.ai/code/session_01DPbAJnnLHy5FUsZEzeWxbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPbAJnnLHy5FUsZEzeWxbv)_