### PR TITLE
Add Jellyfin-aware offline downloads (Plexamp-style, user-controlled)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,31 +68,40 @@ so scanned tracks survive a restart, while tests keep the in-memory default
 UI is untouched by the swap — it still reads only `LibraryController`/the
 repository abstraction.
 
-**Offline downloads — foundation landed.** The offline-cache lifecycle now
-works end to end behind `DownloadRepository`. `CacheDownloadRepository`
-(`lib/data/repositories/`) owns the policy in one place and tracks each item's
-`DownloadStatus` (`notDownloaded → queued → downloading → downloaded`, plus
-`failed`). Two promises are enforced here, not scattered through the UI:
-**downloads are only ever user-initiated** (nothing downloads automatically),
-and the **"Wi-Fi only" preference is respected** (a request made off Wi-Fi is
-*queued* rather than run). Only the `downloaded` set is durable; the transient
-states live in memory, so a restart never resurrects a half-finished download.
+**Offline downloads — Jellyfin downloads now real (Plexamp-style).** The
+offline-cache lifecycle works end to end behind `DownloadRepository`, and
+**Jellyfin tracks are now actually fetched and cached for offline playback** —
+the model is Plexamp/Plex Pass-style but open-source and fully user-controlled:
+the whole library stays visible and streamable, and you mark exactly the tracks
+you want offline. `CacheDownloadRepository` (`lib/data/repositories/`) owns the
+policy in one place and tracks each item's `DownloadStatus`
+(`notDownloaded → queued → downloading → downloaded`, plus `failed`). Three
+promises are enforced here, not scattered through the UI:
+**downloads are only ever user-initiated** (nothing downloads automatically — no
+full-library sync), the policy is **source-aware** (a Jellyfin track has its
+bytes fetched and cached; an on-device track is already local, so it's recorded
+as available offline with no network fetch), and the **"Wi-Fi only" preference
+is respected** for remote downloads (a request made off Wi-Fi is *queued* rather
+than run). Only the `downloaded` set is durable; the transient states live in
+memory, so a restart never resurrects a half-finished download.
 
-The durable bit — *which* track IDs are cached — sits behind a small
-`DownloadStore` seam, persisted via `shared_preferences` in the app and held
-in memory in tests (same reasoning as the selected-folder store: a list of IDs
-is the wrong weight for the SQLite catalog). The "Wi-Fi only" switch is a
-`DownloadPreferences` seam, also `shared_preferences`-backed. Connectivity is
-read through a `ConnectivityService` seam; until real remote downloads land,
-the default `OptimisticConnectivityService` reports Wi-Fi (there is no network
-fetch to gate yet), and tests inject a fake to drive the mobile/offline paths.
-The UI never touches file paths: the Library row shows a per-track
-download/remove control and status, and the Downloads tab lists cached tracks
-and hosts the "Wi-Fi only" toggle — both talk only to the repository
-abstraction. **No actual bytes are fetched yet** (the only source is local
-files already on disk); the byte-fetch for remote sources slots into one
-private method without the policy changing. See **Offline downloads & known
-limitations** below.
+The durable bit — *which* tracks are cached and the file holding each one — sits
+behind a small `DownloadStore` seam (a `CachedTrack` record: non-secret track id
++ a track-id-derived file name), persisted via `shared_preferences` in the app
+and held in memory in tests. The bytes themselves live behind an
+`OfflineFileStore` seam, written to an app-private directory on disk
+(`path_provider`'s application-support location) in the app and faked in tests.
+The remote byte-fetch is a `RemoteTrackDownloader` seam, implemented for Jellyfin
+by `JellyfinTrackDownloader`, which mints the authenticated download URL **only
+at fetch time** and never stores or logs it. The "Wi-Fi only" switch is a
+`DownloadPreferences` seam, and connectivity a `ConnectivityService` seam
+(`OptimisticConnectivityService` reports Wi-Fi by default; tests inject a fake to
+drive the mobile/offline paths). The UI never touches file paths: the Library
+row shows a per-track download/remove/retry control and status, the Downloads
+tab lists cached tracks and hosts the "Wi-Fi only" toggle, and **playback
+prefers the cached file** (via an `OfflineFirstPlayableUriResolver`) before
+streaming — all talking only to download-state and resolver abstractions. See
+**Offline downloads & known limitations** below.
 
 **Jellyfin (self-hosted) — foundation landed.** The first remote source is
 wired from the Settings screen through to a `MusicSource`. A user can enter
@@ -120,9 +129,9 @@ tapping a synced Jellyfin track plays it. Playback resolves through a
 session and mints the authenticated stream URL *at play time*, so the token is
 never stored on the track, in the catalog, in logs, or in player state. The
 player shows precise, secret-free errors (not signed in / expired session /
-unreachable server / unavailable stream). What's *not* here yet: Jellyfin
-offline downloads. See **Jellyfin (self-hosted music) — setup & known
-limitations** below.
+unreachable server / unavailable stream). **Jellyfin offline downloads now work
+too** — see the offline-downloads section above and **Jellyfin (self-hosted
+music) — setup & known limitations** below.
 
 Not built yet (planned, in roughly this order):
 
@@ -140,17 +149,18 @@ Not built yet (planned, in roughly this order):
   media-app declaration); Android Auto now **browsable** (Library / Queue nodes,
   tap-to-play) — not yet a full car UI*
 - Playlists
-- User-controlled offline downloads — *foundation done (status lifecycle,
-  mark/remove offline, Wi-Fi-only seam, UI hooks); real remote byte-fetch and a
-  background download manager still pending*
+- User-controlled offline downloads — *done for tracks (Plexamp-style explicit
+  downloads: real Jellyfin byte-fetch, app-private cache, cache-first playback,
+  remove/retry); album/playlist-level "download all" and a background download
+  manager still pending*
 - Lyrics
 
 Self-hosted sources (Jellyfin, WebDAV, NAS) build on the local MVP. The
 **Jellyfin foundation has landed** (settings, connection test, authentication,
 encrypted session persistence, and a library source), **library sync is wired
-in**, and **streaming playback now works** — a signed-in user can pull their
-Jellyfin catalog into the Library and play it. Offline downloads from Jellyfin
-come next.
+in**, **streaming playback works**, and **explicit offline downloads now work**
+— a signed-in user can pull their Jellyfin catalog into the Library, play it,
+and mark individual tracks for offline use.
 
 ## Philosophy
 
@@ -698,38 +708,73 @@ filesystem fallback) and a playlist-editor foundation remain natural follow-ups.
 
 ### Offline downloads & known limitations
 
+Linthra's offline model is **Plexamp/Plex Pass-style, but open-source and fully
+user-controlled**:
+
+- **The full library stays visible.** Syncing Jellyfin shows your whole catalog;
+  nothing is hidden behind a download.
+- **Downloads are explicit.** You mark the tracks you want offline. There is **no
+  automatic full-library sync** and no surprise downloads.
+- **Streaming is the default.** An un-downloaded Jellyfin track streams normally
+  when you're online and signed in.
+- **Cached items are playable offline.** Once a track is downloaded, playback
+  **prefers the local cached file**; if it isn't cached and you're offline, the
+  player shows a friendly "couldn't reach your server" message rather than
+  failing opaquely.
+
 **How it works now.** Each Library row shows an offline-download control:
-download an absent track, see a spinner while it's in flight, and remove a
-cached one. The Downloads tab lists everything currently cached and hosts the
-**Wi-Fi only** toggle. All of this flows through `DownloadRepository`, which
-centralizes two guarantees:
+download an absent track, see a spinner while it's in flight, remove a cached
+one, or retry a failed one. The Downloads tab lists everything currently cached
+and hosts the **Wi-Fi only** toggle. All of this flows through
+`DownloadRepository`, which centralizes three guarantees:
 
 - **User-initiated only.** A track's status only ever changes in response to an
   explicit download/remove action — nothing is fetched automatically or in the
   background.
-- **Wi-Fi only is respected.** With the toggle on, a request made off Wi-Fi is
-  *queued* instead of run; with it off, downloads proceed on any connection.
+- **Source-aware.** A **Jellyfin** track has its bytes fetched (via
+  `RemoteTrackDownloader` → `JellyfinTrackDownloader`) and written to an
+  app-private offline directory (`OfflineFileStore`); an **on-device** track is
+  already local, so it's recorded as available offline with no network fetch and
+  no managed file.
+- **Wi-Fi only is respected.** For remote downloads, with the toggle on a request
+  made off Wi-Fi is *queued* instead of run; with it off, downloads proceed on
+  any connection. (Local tracks are never queued — there are no bytes to fetch.)
 
-`downloaded` is the only durable state (persisted as a set of track IDs via
-`shared_preferences`); `queued`/`downloading`/`failed` are in-memory and reset
-on restart.
+**Storage & playback.** Downloaded bytes live in an app-controlled directory
+(`path_provider`'s application-support location, not the OS cache that can be
+reclaimed). The durable metadata is a small `CachedTrack` set (track id + cache
+file name) behind `DownloadStore`, persisted via `shared_preferences`. Playback
+goes through an `OfflineFirstPlayableUriResolver`: it asks a `CachedTrackLocator`
+for a local copy first and, on a miss, falls back to the source router (Jellyfin
+streaming, or the on-device file). `downloaded` is the only durable state;
+`queued`/`downloading`/`failed` are in-memory and reset on restart.
+
+**Security (token handling).** The Jellyfin access token is **never** stored on
+`Track.uri`, in the `DownloadStore` metadata, in a cache file name, in a log, or
+in a user-facing error. A track's stored URI stays the token-free `jellyfin:<id>`;
+the authenticated **download** URL is minted only at fetch time inside
+`JellyfinTrackDownloader` (mirroring how the **stream** URL is minted at play
+time), and a transport failure is re-raised as a generic message so a
+`ClientException` carrying the tokenized URL can't escape. Cache file names are
+derived only from the non-secret track id, sanitized to filename-safe characters.
 
 Deliberate gaps the next PRs will close:
 
-- **No real downloads yet.** The only source is local files already on disk, so
-  "downloading" just records the track as offline-available. Fetching bytes from
-  a remote source (Jellyfin/WebDAV) is the follow-up; it slots into
-  `CacheDownloadRepository._obtainOfflineCopy` without changing the policy.
+- **Track-level only.** Album- and playlist-level "download all" is intentionally
+  out of scope for this PR. The seam is ready — `requestDownload(Track)` plus the
+  `RemoteTrackDownloader` compose per-track — so a batch action is additive UI
+  over the existing policy, with no architectural change.
 - **No background download manager.** Downloads run inline in response to the
-  tap; there is no worker, no Android download/notification service, and no
-  auto-flush of the queue when Wi-Fi returns (re-tap a queued track to retry).
+  tap; there is no worker, no Android download/notification service, no resume of
+  a partial transfer, and no auto-flush of the queue when Wi-Fi returns (re-tap a
+  queued track to retry).
 - **Connectivity is optimistic.** `OptimisticConnectivityService` always reports
-  Wi-Fi until `connectivity_plus` is wired alongside real remote downloads, so
-  the "Wi-Fi only" gate has nothing to block in the current local-only build —
+  Wi-Fi until `connectivity_plus` is wired in, so the "Wi-Fi only" gate currently
+  blocks only when a test (or a future real detector) reports mobile/offline —
   the seam and its tests are in place for when it does.
-- **No Drift table for downloads.** Persisting a flat ID set is a key/value job;
-  a `downloads` table (with file paths and byte progress) graduates from the
-  `DownloadStore` seam when real downloads need it.
+- **No Drift table for downloads.** Persisting a small `CachedTrack` set is a
+  key/value job; a `downloads` table (with byte progress) graduates from the
+  `DownloadStore` seam when background/resumable downloads need it.
 
 ### Jellyfin (self-hosted music) — setup & known limitations
 
@@ -772,8 +817,12 @@ configuration — point the URL at your public domain. Two things to know:
 - **The token is encrypted at rest.** It's stored via `flutter_secure_storage`
   (Android Keystore-backed), not in plaintext `shared_preferences`.
 - **Nothing logs the token or password.** `JellyfinSession.toString()` redacts
-  the token, and a track's cached URI is a token-free `jellyfin:<id>` — the
-  authenticated streaming URL is minted only at play time, never stored.
+  the token, and a track's cached URI is a token-free `jellyfin:<id>` — both the
+  authenticated streaming URL (at play time) and the download URL (at fetch time)
+  are minted only on demand, never stored.
+- **Offline downloads inherit the same handling.** A downloaded track's cache
+  file name is derived only from the non-secret track id; the token never lands
+  in the file name, the `DownloadStore` metadata, a log, or a download error.
 
 **What works now.** Configuring a server, testing the connection, signing in
 with friendly URL/connection/auth errors, persisting the session across
@@ -798,16 +847,24 @@ unreachable**, **stream unavailable** — branched on a typed error kind, not
 message text. Local file playback is untouched (it never enters the Jellyfin
 resolver).
 
+**Offline downloads** let a signed-in user mark individual Jellyfin tracks for
+offline use; the bytes are fetched from Jellyfin's `/Items/<id>/Download`
+endpoint and cached on disk, and playback then prefers the local copy. The full
+flow, storage, and token handling are covered in **Offline downloads & known
+limitations** above.
+
 **Token safety holds end to end.** A track's stored URI stays the token-free
-`jellyfin:<id>`; the authenticated stream URL is built only on demand and is
-never stored on the track, written to the catalog, logged, shown in the UI, or
-placed in player state. `JellyfinSession.toString()` redacts the token, and the
-playback error messages are asserted in tests to contain no token.
+`jellyfin:<id>`; the authenticated stream/download URLs are built only on demand
+and are never stored on the track, written to the catalog, logged, shown in the
+UI, or placed in player state. `JellyfinSession.toString()` redacts the token,
+and both the playback error messages and the download path are asserted in tests
+to contain no token (including when a transport error would otherwise echo the
+tokenized URL).
 
 **Deliberate gaps the next PRs will close:**
 
-- **No offline downloads from Jellyfin.** Fetching bytes for offline use slots
-  into `CacheDownloadRepository._obtainOfflineCopy` later (see above).
+- **Track-level downloads only.** Album/playlist "download all" is deferred; the
+  per-track seam already composes for it (see offline-downloads section above).
 - **Single server only.** One session is stored; multi-server support and
   richer transcoding/streaming parameters come later.
 - **No Android Auto browsing, lyrics, or sync-conflict handling** for Jellyfin
@@ -873,8 +930,9 @@ branch rather than `main`.
 10. Settings
 
 Later: Jellyfin (landed — settings, auth, encrypted session, a library source,
-Library sync, and streaming playback; offline downloads next), WebDAV, NAS,
-lyrics, ReplayGain, MPRIS, Android Auto, smart playlists, and more.
+Library sync, streaming playback, and explicit per-track offline downloads;
+album/playlist "download all" and a background download manager next), WebDAV,
+NAS, lyrics, ReplayGain, MPRIS, Android Auto, smart playlists, and more.
 
 ## F-Droid metadata (work in progress)
 

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -1,3 +1,5 @@
+import '../models/track.dart';
+
 /// Where a track stands in the offline-download lifecycle.
 enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
 
@@ -7,17 +9,25 @@ enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
 /// automatic. Implementations must also honor the user's "Wi-Fi only" pref
 /// (queueing rather than downloading over mobile data when set), so that
 /// promise is enforced in one place rather than scattered through the UI.
+///
+/// [requestDownload] takes the whole [Track], not just an id, so the repository
+/// can be *source-aware*: a remote (Jellyfin) track has its bytes fetched and
+/// cached, while an on-device track — already local — is recorded as available
+/// offline without any network fetch. The authenticated URL a remote fetch
+/// needs is resolved on demand, at download time, and never stored on the track.
 abstract interface class DownloadRepository {
   /// Emits whenever a track's download status changes.
   Stream<Map<String, DownloadStatus>> get statusStream;
 
   Future<DownloadStatus> statusFor(String trackId);
 
-  /// Queues an explicit download for [trackId]. Subject to the user's
-  /// connectivity preferences.
-  Future<void> requestDownload(String trackId);
+  /// Queues an explicit download for [track]. For remote tracks this is subject
+  /// to the user's connectivity preferences; on-device tracks are recorded as
+  /// already-available with no network fetch.
+  Future<void> requestDownload(Track track);
 
-  /// Removes the local copy of [trackId], freeing storage.
+  /// Removes the offline copy of [trackId], deleting any cached file and
+  /// freeing storage.
   Future<void> removeDownload(String trackId);
 
   /// Track IDs that are fully available offline.

--- a/lib/core/repositories/download_store.dart
+++ b/lib/core/repositories/download_store.dart
@@ -1,16 +1,62 @@
-/// Durable storage for the set of track IDs that are available offline.
+/// A reference to a single offline-cached track: which track it is and the file
+/// that holds its downloaded bytes (when there is one).
+///
+/// Security invariant: this is *persisted* metadata, so it must never carry a
+/// secret. [trackId] is the non-secret catalog id, and [fileName] is derived
+/// from it — never from an access token or an authenticated URL. Do not add the
+/// streaming/download URL, a Jellyfin token, or any credential to this record.
+class CachedTrack {
+  const CachedTrack({required this.trackId, this.fileName});
+
+  /// The catalog id of the cached track.
+  final String trackId;
+
+  /// The cache file holding the downloaded bytes, relative to the offline
+  /// directory — or `null` for an on-device track that is already local and so
+  /// has no managed copy of its own.
+  final String? fileName;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'trackId': trackId,
+        if (fileName != null && fileName!.isNotEmpty) 'fileName': fileName,
+      };
+
+  /// Rebuilds a record from [toJson] output, or returns `null` when the track
+  /// id is missing (a corrupt entry), so one bad record can't break loading.
+  static CachedTrack? fromJson(Map<String, dynamic> json) {
+    final String? trackId = json['trackId'] as String?;
+    if (trackId == null || trackId.isEmpty) return null;
+    final String? fileName = json['fileName'] as String?;
+    return CachedTrack(
+      trackId: trackId,
+      fileName: (fileName != null && fileName.isNotEmpty) ? fileName : null,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CachedTrack &&
+          other.trackId == trackId &&
+          other.fileName == fileName);
+
+  @override
+  int get hashCode => Object.hash(trackId, fileName);
+}
+
+/// Durable storage for the tracks that are available offline.
 ///
 /// This is the *persistence seam* under [DownloadRepository]: it knows nothing
 /// about download policy, connectivity, or the transient queued/downloading
-/// states — only which tracks are fully cached on disk and survive a restart.
-/// Splitting it out keeps the download lifecycle (policy) in one place while
-/// letting the backing store swap freely (in-memory for tests, key/value in the
-/// app, a SQLite/Drift table once real remote downloads track file paths and
-/// byte progress).
+/// states — only which tracks are cached and, for the ones with a downloaded
+/// copy, the file that holds the bytes. Splitting it out keeps the download
+/// lifecycle (policy) in one place while letting the backing store swap freely
+/// (in-memory for tests, key/value in the app, a SQLite/Drift table once
+/// downloads also track byte progress).
 abstract interface class DownloadStore {
-  /// The track IDs currently cached for offline use.
-  Future<Set<String>> loadDownloadedIds();
+  /// The tracks currently cached for offline use.
+  Future<List<CachedTrack>> loadDownloads();
 
-  /// Replaces the persisted set with [ids].
-  Future<void> saveDownloadedIds(Set<String> ids);
+  /// Replaces the persisted set with [downloads].
+  Future<void> saveDownloads(List<CachedTrack> downloads);
 }

--- a/lib/core/repositories/offline_file_store.dart
+++ b/lib/core/repositories/offline_file_store.dart
@@ -1,0 +1,28 @@
+/// Stores and retrieves the actual bytes of offline-cached tracks in an
+/// app-controlled directory.
+///
+/// This is the filesystem seam under the offline cache: it knows where cached
+/// audio lives on disk and how to read, write, and delete it, but nothing about
+/// download policy, status, or which source a track came from. Splitting it out
+/// keeps [DownloadStore] focused on the durable trackId→file metadata and lets
+/// the byte storage be faked in tests (an in-memory map) instead of touching a
+/// real filesystem or `path_provider`.
+///
+/// Security invariant: a cache file name is derived only from the *non-secret*
+/// track id. An access token or authenticated URL must never appear in a file
+/// name, a path, or anything this store persists.
+abstract interface class OfflineFileStore {
+  /// Writes [bytes] for [trackId] into the offline directory and returns the
+  /// file name (relative to that directory) they were stored under. The name is
+  /// derived from [trackId] — plus [extension] when the source reported one —
+  /// never from a token.
+  Future<String> write(String trackId, List<int> bytes, {String? extension});
+
+  /// The absolute path of a previously stored [fileName], or `null` when no
+  /// such file exists (e.g. the OS reclaimed it), so playback can fall back to
+  /// streaming rather than open a missing file.
+  Future<String?> pathFor(String fileName);
+
+  /// Deletes the cache file [fileName] if it exists; a no-op when it doesn't.
+  Future<void> delete(String fileName);
+}

--- a/lib/core/services/cached_track_locator.dart
+++ b/lib/core/services/cached_track_locator.dart
@@ -1,0 +1,14 @@
+import '../models/track.dart';
+
+/// Looks up whether a track has a usable offline copy on disk.
+///
+/// The playback layer depends on this narrow, read-only seam to *prefer* a
+/// cached file over streaming, without knowing how downloads are stored or
+/// managed. Implementations return a path only when the bytes are actually
+/// present, so a removed or reclaimed file transparently falls back to
+/// streaming.
+abstract interface class CachedTrackLocator {
+  /// The absolute path to [track]'s cached file, or `null` when it isn't
+  /// available offline (not downloaded, or the file is gone).
+  Future<String?> cachedFilePath(Track track);
+}

--- a/lib/core/services/offline_first_playable_uri_resolver.dart
+++ b/lib/core/services/offline_first_playable_uri_resolver.dart
@@ -1,0 +1,36 @@
+import '../models/track.dart';
+import 'cached_track_locator.dart';
+import 'playable_uri_resolver.dart';
+
+/// A [PlayableUriResolver] that prefers a track's offline-cached file and falls
+/// back to another resolver (streaming) when there isn't one.
+///
+/// This is the single place the "play the local copy if we have it, otherwise
+/// stream" rule lives. It wraps the source-routing resolver: a cache hit yields
+/// a `file://` URI for the downloaded bytes; a miss delegates to [_fallback],
+/// which streams from Jellyfin when online — or surfaces a friendly offline
+/// error when not. Local tracks have no managed cache file, so they fall
+/// straight through to the on-device resolver and play from their original
+/// path.
+class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
+  const OfflineFirstPlayableUriResolver({
+    required CachedTrackLocator locator,
+    required PlayableUriResolver fallback,
+  })  : _locator = locator,
+        _fallback = fallback;
+
+  final CachedTrackLocator _locator;
+  final PlayableUriResolver _fallback;
+
+  @override
+  bool handles(Track track) => _fallback.handles(track);
+
+  @override
+  Future<Uri> resolve(Track track) async {
+    final String? cachedPath = await _locator.cachedFilePath(track);
+    if (cachedPath != null) {
+      return Uri.file(cachedPath);
+    }
+    return _fallback.resolve(track);
+  }
+}

--- a/lib/core/services/remote_track_downloader.dart
+++ b/lib/core/services/remote_track_downloader.dart
@@ -1,0 +1,36 @@
+import '../models/track.dart';
+
+/// The bytes of a downloaded remote track, with an optional file-extension hint
+/// (from the server's content type) so the cache can name the file sensibly.
+class RemoteTrackData {
+  const RemoteTrackData({required this.bytes, this.fileExtension});
+
+  final List<int> bytes;
+
+  /// A lowercase extension without the dot (e.g. `mp3`, `flac`), or `null` when
+  /// the server didn't say. Used only to name the cache file.
+  final String? fileExtension;
+}
+
+/// Fetches the bytes of a *remote* track for offline caching.
+///
+/// This is the seam the download repository uses to obtain a remote source's
+/// audio without knowing anything about that source's protocol, URLs, or auth.
+/// The Jellyfin implementation lives behind it; the repository depends only on
+/// this interface, so the offline-cache policy stays source-agnostic and tests
+/// can drive downloads with a fake that returns canned bytes.
+///
+/// Security invariant: an implementation resolves any authenticated URL only at
+/// fetch time and must never return, log, or embed an access token — or that
+/// URL — in [RemoteTrackData] or in a thrown error.
+abstract interface class RemoteTrackDownloader {
+  /// Whether [track] is a remote track whose bytes must be fetched over the
+  /// network for offline use. On-device tracks return `false` — they are
+  /// already local and need no download.
+  bool isRemote(Track track);
+
+  /// Fetches [track]'s bytes for offline caching, resolving the authenticated
+  /// URL on demand. Throws when the track can't be downloaded (not signed in,
+  /// server unreachable, …); the error never carries the URL or token.
+  Future<RemoteTrackData> fetch(Track track);
+}

--- a/lib/core/sources/jellyfin/jellyfin_download_source.dart
+++ b/lib/core/sources/jellyfin/jellyfin_download_source.dart
@@ -1,0 +1,23 @@
+import '../../models/track.dart';
+
+/// The narrow capability the offline downloader needs from a signed-in Jellyfin
+/// connection: confirm the session works, then mint a *download* URL for a
+/// track's original file.
+///
+/// The mirror image of [JellyfinStreamSource] (which mints a *stream* URL).
+/// [JellyfinMusicSource] implements both; keeping this tiny lets the downloader
+/// depend on just this — not the whole source or any HTTP — and lets tests fake
+/// it to drive every download outcome without a real server.
+///
+/// Security: [resolveDownloadUri] weaves the access token into the URL on
+/// demand, at download time, and the URL is never stored on [track] or anywhere
+/// else.
+abstract interface class JellyfinDownloadSource {
+  /// Confirms the session is still valid and the server reachable. Throws a
+  /// `JellyfinException` (unauthorized / not reachable / …) when it is not.
+  Future<void> verifyReachable();
+
+  /// The authenticated URL to download [track]'s original file, or `null` when
+  /// one can't be built. The token is woven in here, on demand, never stored.
+  Future<Uri?> resolveDownloadUri(Track track);
+}

--- a/lib/core/sources/jellyfin/jellyfin_music_source.dart
+++ b/lib/core/sources/jellyfin/jellyfin_music_source.dart
@@ -5,6 +5,7 @@ import '../../models/track.dart';
 import '../../services/music_source.dart';
 import 'jellyfin_api.dart';
 import 'jellyfin_client.dart';
+import 'jellyfin_download_source.dart';
 import 'jellyfin_stream_source.dart';
 import 'jellyfin_track_mapper.dart';
 
@@ -21,7 +22,8 @@ import 'jellyfin_track_mapper.dart';
 /// `JellyfinPlayableUriResolver`, which calls [verifyReachable] then
 /// [resolvePlayableUri] at play time so the token is only ever woven into a URL
 /// on demand.
-class JellyfinMusicSource implements MusicSource, JellyfinStreamSource {
+class JellyfinMusicSource
+    implements MusicSource, JellyfinStreamSource, JellyfinDownloadSource {
   const JellyfinMusicSource({
     required this.session,
     required JellyfinClient client,
@@ -85,10 +87,8 @@ class JellyfinMusicSource implements MusicSource, JellyfinStreamSource {
   /// a later refinement.
   @override
   Future<Uri?> resolvePlayableUri(Track track) async {
-    final String itemId = track.uri.startsWith(JellyfinTrackMapper.uriScheme)
-        ? track.uri.substring(JellyfinTrackMapper.uriScheme.length)
-        : track.id;
-    return Uri.parse('${session.baseUrl}/Audio/$itemId/universal').replace(
+    return Uri.parse('${session.baseUrl}/Audio/${_itemId(track)}/universal')
+        .replace(
       queryParameters: <String, String>{
         'api_key': session.accessToken,
         'UserId': session.userId,
@@ -96,4 +96,26 @@ class JellyfinMusicSource implements MusicSource, JellyfinStreamSource {
       },
     );
   }
+
+  /// Mints the authenticated URL to download [track]'s original file on demand.
+  ///
+  /// Uses Jellyfin's `/Items/<id>/Download` endpoint so the cached copy is the
+  /// real source file rather than a transcode. Like [resolvePlayableUri], the
+  /// token is woven in here, at download time, and never stored on the track.
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async {
+    return Uri.parse('${session.baseUrl}/Items/${_itemId(track)}/Download')
+        .replace(
+      queryParameters: <String, String>{
+        'api_key': session.accessToken,
+      },
+    );
+  }
+
+  /// The Jellyfin item id behind [track]: the part after the `jellyfin:` scheme,
+  /// falling back to the track id for an unprefixed value.
+  String _itemId(Track track) =>
+      track.uri.startsWith(JellyfinTrackMapper.uriScheme)
+          ? track.uri.substring(JellyfinTrackMapper.uriScheme.length)
+          : track.id;
 }

--- a/lib/core/sources/jellyfin/jellyfin_track_downloader.dart
+++ b/lib/core/sources/jellyfin/jellyfin_track_downloader.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/track.dart';
+import '../../services/remote_track_downloader.dart';
+import 'jellyfin_download_source.dart';
+import 'jellyfin_track_mapper.dart';
+
+/// The [RemoteTrackDownloader] for Jellyfin tracks.
+///
+/// Resolves the authenticated download URL only at fetch time — through the live
+/// signed-in [JellyfinDownloadSource], read via a getter so signing in or out is
+/// picked up without a rebuild — then fetches the bytes over HTTP. The URL, and
+/// the token woven into it, never leaves [fetch]: it is not stored, not
+/// returned, and not placed in any thrown error (a transport failure is
+/// re-raised as a generic message so a `ClientException` carrying the tokenized
+/// URL can't escape).
+class JellyfinTrackDownloader implements RemoteTrackDownloader {
+  JellyfinTrackDownloader(this._source, {http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final JellyfinDownloadSource? Function() _source;
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(minutes: 5);
+
+  @override
+  bool isRemote(Track track) =>
+      track.uri.startsWith(JellyfinTrackMapper.uriScheme);
+
+  @override
+  Future<RemoteTrackData> fetch(Track track) async {
+    final JellyfinDownloadSource? source = _source();
+    if (source == null) {
+      throw StateError('Not signed in to Jellyfin.');
+    }
+
+    // Confirm the session still works before fetching; the JellyfinException
+    // this may throw is friendly and token-free by design.
+    await source.verifyReachable();
+
+    final Uri? uri = await source.resolveDownloadUri(track);
+    if (uri == null) {
+      throw StateError('No Jellyfin download URL for this track.');
+    }
+
+    final http.Response response;
+    try {
+      response = await _client.get(uri).timeout(_timeout);
+    } on Exception {
+      // Never rethrow the original error: a ClientException/SocketException can
+      // embed the tokenized URL in its message.
+      throw StateError('Jellyfin download failed.');
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(
+          'Jellyfin download failed (HTTP ${response.statusCode}).');
+    }
+
+    return RemoteTrackData(
+      bytes: response.bodyBytes,
+      fileExtension: _extensionFor(response.headers['content-type']),
+    );
+  }
+
+  /// Maps a response content type to a cache-file extension. Returns `null` for
+  /// unknown types; the player sniffs the container regardless, so the extension
+  /// is only a convenience.
+  static String? _extensionFor(String? contentType) {
+    if (contentType == null) return null;
+    final String type = contentType.split(';').first.trim().toLowerCase();
+    switch (type) {
+      case 'audio/mpeg':
+      case 'audio/mp3':
+        return 'mp3';
+      case 'audio/flac':
+      case 'audio/x-flac':
+        return 'flac';
+      case 'audio/mp4':
+      case 'audio/m4a':
+      case 'audio/x-m4a':
+        return 'm4a';
+      case 'audio/aac':
+        return 'aac';
+      case 'audio/ogg':
+      case 'application/ogg':
+        return 'ogg';
+      case 'audio/opus':
+        return 'opus';
+      case 'audio/wav':
+      case 'audio/x-wav':
+      case 'audio/wave':
+        return 'wav';
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -1,53 +1,71 @@
 import 'dart:async';
 
+import '../../core/models/track.dart';
 import '../../core/repositories/download_preferences.dart';
 import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
+import '../../core/repositories/offline_file_store.dart';
 import '../../core/services/connectivity_service.dart';
+import '../../core/services/remote_track_downloader.dart';
 
 /// The app's [DownloadRepository]: it owns the offline-cache *policy* in one
-/// place and delegates only the durable bit (which IDs are cached) to a
-/// [DownloadStore].
+/// place and delegates the moving parts to focused seams — durable metadata to
+/// a [DownloadStore], cached bytes to an [OfflineFileStore], and the remote
+/// byte-fetch to a [RemoteTrackDownloader].
 ///
-/// Two promises are enforced here so they can't be skipped by a caller:
+/// Three promises are enforced here so a caller can't skip them:
 ///  - **User-initiated only.** Nothing is ever downloaded automatically; status
 ///    changes happen solely in response to [requestDownload] / [removeDownload].
+///  - **Source-aware.** A remote (Jellyfin) track has its bytes fetched and
+///    written to the offline directory; an on-device track is already local, so
+///    it's recorded as available offline with no fetch and no managed file.
 ///  - **Wi-Fi only is respected.** When the user has set [DownloadPreferences.
-///    wifiOnly] and the connection isn't Wi-Fi, a request is *queued* rather
-///    than run, instead of silently going over mobile data.
+///    wifiOnly] and the connection isn't Wi-Fi, a *remote* request is queued
+///    rather than run, instead of silently going over mobile data.
 ///
-/// Only the `downloaded` state is durable; `queued`/`downloading`/`failed` are
+/// Only the `downloaded` set is durable; `queued`/`downloading`/`failed` are
 /// transient and live in memory, so a restart never resurrects a half-finished
 /// download (there is no background worker yet — see README).
 ///
-/// "Downloading" is trivial today because the only source is local files that
-/// are already on disk, so marking a track offline just records it. The real
-/// byte-fetch for remote sources slots in at [_obtainOfflineCopy] without
-/// touching the policy above.
+/// The authenticated URL a remote fetch needs is resolved inside the
+/// [RemoteTrackDownloader] at fetch time; this repository never sees, stores, or
+/// logs it, and a failed fetch surfaces only as the `failed` state.
 class CacheDownloadRepository implements DownloadRepository {
   CacheDownloadRepository({
     required DownloadStore store,
+    required OfflineFileStore files,
+    required RemoteTrackDownloader downloader,
     required ConnectivityService connectivity,
     required DownloadPreferences preferences,
   })  : _store = store,
+        _files = files,
+        _downloader = downloader,
         _connectivity = connectivity,
         _preferences = preferences;
 
   final DownloadStore _store;
+  final OfflineFileStore _files;
+  final RemoteTrackDownloader _downloader;
   final ConnectivityService _connectivity;
   final DownloadPreferences _preferences;
 
   final Map<String, DownloadStatus> _statuses = <String, DownloadStatus>{};
+
+  /// The durable cache references, loaded once and kept in sync with the store,
+  /// so removal can find the file to delete and seeding stays cheap.
+  final Map<String, CachedTrack> _downloads = <String, CachedTrack>{};
+
   final StreamController<Map<String, DownloadStatus>> _changes =
       StreamController<Map<String, DownloadStatus>>.broadcast();
 
   bool _loaded = false;
 
-  /// Seeds the in-memory status map from the durable set of cached IDs, once.
+  /// Seeds the in-memory state from the durable cache, once.
   Future<void> _ensureLoaded() async {
     if (_loaded) return;
-    for (final String id in await _store.loadDownloadedIds()) {
-      _statuses[id] = DownloadStatus.downloaded;
+    for (final CachedTrack cached in await _store.loadDownloads()) {
+      _downloads[cached.trackId] = cached;
+      _statuses[cached.trackId] = DownloadStatus.downloaded;
     }
     _loaded = true;
   }
@@ -68,10 +86,10 @@ class CacheDownloadRepository implements DownloadRepository {
   }
 
   @override
-  Future<void> requestDownload(String trackId) async {
+  Future<void> requestDownload(Track track) async {
     await _ensureLoaded();
     final DownloadStatus current =
-        _statuses[trackId] ?? DownloadStatus.notDownloaded;
+        _statuses[track.id] ?? DownloadStatus.notDownloaded;
     // Already done or in flight — never re-trigger. A queued or failed track,
     // by contrast, is fair game for an explicit retry.
     if (current == DownloadStatus.downloaded ||
@@ -79,27 +97,47 @@ class CacheDownloadRepository implements DownloadRepository {
       return;
     }
 
-    if (!await _allowedToDownloadNow()) {
-      _set(trackId, DownloadStatus.queued);
+    if (!_downloader.isRemote(track)) {
+      // On-device track: the bytes are already local, so there's nothing to
+      // fetch — just record it as available offline (no managed cache file).
+      await _record(CachedTrack(trackId: track.id));
+      _set(track.id, DownloadStatus.downloaded);
       return;
     }
 
-    _set(trackId, DownloadStatus.downloading);
+    // Remote track: the Wi-Fi gate only matters here, where there are bytes to
+    // pull over the network.
+    if (!await _allowedToDownloadNow()) {
+      _set(track.id, DownloadStatus.queued);
+      return;
+    }
+
+    _set(track.id, DownloadStatus.downloading);
     try {
-      await _obtainOfflineCopy(trackId);
-      await _persistDownloaded(trackId);
-      _set(trackId, DownloadStatus.downloaded);
+      final RemoteTrackData data = await _downloader.fetch(track);
+      final String fileName = await _files.write(
+        track.id,
+        data.bytes,
+        extension: data.fileExtension,
+      );
+      await _record(CachedTrack(trackId: track.id, fileName: fileName));
+      _set(track.id, DownloadStatus.downloaded);
     } catch (_) {
-      _set(trackId, DownloadStatus.failed);
+      // The error is intentionally swallowed: it may carry source-specific
+      // detail, and the UI only needs the failed state (offering a retry).
+      _set(track.id, DownloadStatus.failed);
     }
   }
 
   @override
   Future<void> removeDownload(String trackId) async {
     await _ensureLoaded();
-    final Set<String> ids = await _store.loadDownloadedIds();
-    ids.remove(trackId);
-    await _store.saveDownloadedIds(ids);
+    final CachedTrack? existing = _downloads.remove(trackId);
+    final String? fileName = existing?.fileName;
+    if (fileName != null && fileName.isNotEmpty) {
+      await _files.delete(fileName);
+    }
+    await _store.saveDownloads(_downloads.values.toList());
     // Also clears a queued/failed/downloading marker, so this doubles as cancel.
     _set(trackId, DownloadStatus.notDownloaded);
   }
@@ -123,14 +161,10 @@ class CacheDownloadRepository implements DownloadRepository {
     return await _connectivity.currentStatus() == NetworkStatus.wifi;
   }
 
-  /// Fetches/produces the offline copy for [trackId]. A no-op for local files
-  /// (the bytes are already on disk); the extension point for remote sources.
-  Future<void> _obtainOfflineCopy(String trackId) async {}
-
-  Future<void> _persistDownloaded(String trackId) async {
-    final Set<String> ids = await _store.loadDownloadedIds();
-    ids.add(trackId);
-    await _store.saveDownloadedIds(ids);
+  /// Records [cached] as downloaded and persists the updated set durably.
+  Future<void> _record(CachedTrack cached) async {
+    _downloads[cached.trackId] = cached;
+    await _store.saveDownloads(_downloads.values.toList());
   }
 
   void _set(String trackId, DownloadStatus status) {

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -1,21 +1,44 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/models/track.dart';
 import '../../core/repositories/download_preferences.dart';
 import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
+import '../../core/repositories/offline_file_store.dart';
+import '../../core/services/cached_track_locator.dart';
 import '../../core/services/connectivity_service.dart';
 import '../../core/services/optimistic_connectivity_service.dart';
+import '../../core/services/remote_track_downloader.dart';
 import 'cache_download_repository.dart';
+import 'file_system_offline_file_store.dart';
 import 'in_memory_download_preferences.dart';
 import 'in_memory_download_store.dart';
+import 'in_memory_offline_file_store.dart';
 import 'shared_preferences_download_preferences.dart';
 import 'shared_preferences_download_store.dart';
+import 'store_cached_track_locator.dart';
 
-/// Durable store of which track IDs are cached offline. Defaults to in-memory
-/// so tests and dev runs need no plugins; the app overrides it with the
-/// `shared_preferences` binding below.
+/// Durable store of which tracks are cached offline (track id + cache file).
+/// Defaults to in-memory so tests and dev runs need no plugins; the app
+/// overrides it with the `shared_preferences` binding below.
 final downloadStoreProvider = Provider<DownloadStore>((ref) {
   return InMemoryDownloadStore();
+});
+
+/// Where downloaded bytes live on disk. Defaults to an in-memory store so tests
+/// stay plugin-free; the app overrides it with the `path_provider`-backed
+/// filesystem store.
+final offlineFileStoreProvider = Provider<OfflineFileStore>((ref) {
+  return InMemoryOfflineFileStore();
+});
+
+/// Fetches bytes for remote (e.g. Jellyfin) tracks. The data layer's default
+/// handles no source — keeping it free of any source-specific or feature
+/// dependency — so the Jellyfin-backed downloader is wired in as an override at
+/// the composition root (see `jellyfinRemoteTrackDownloaderOverride`). Tests
+/// override it with a fake that returns canned bytes.
+final remoteTrackDownloaderProvider = Provider<RemoteTrackDownloader>((ref) {
+  return const _UnsupportedRemoteTrackDownloader();
 });
 
 /// The user's "Wi-Fi only" download preference. In-memory by default; the app
@@ -25,18 +48,20 @@ final downloadPreferencesProvider = Provider<DownloadPreferences>((ref) {
 });
 
 /// Network reachability used to honor the "Wi-Fi only" preference. The default
-/// optimistically reports Wi-Fi until real detection lands with remote
-/// downloads; tests inject a fake to drive the policy's mobile/offline paths.
+/// optimistically reports Wi-Fi until real detection lands; tests inject a fake
+/// to drive the policy's mobile/offline paths.
 final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
   return const OptimisticConnectivityService();
 });
 
 /// The single [DownloadRepository] the app drives offline downloads through.
-/// It composes the three seams above and centralizes the user-initiated,
-/// Wi-Fi-respecting cache policy.
+/// It composes the seams above and centralizes the user-initiated,
+/// source-aware, Wi-Fi-respecting cache policy.
 final downloadRepositoryProvider = Provider<DownloadRepository>((ref) {
   final repository = CacheDownloadRepository(
     store: ref.watch(downloadStoreProvider),
+    files: ref.watch(offlineFileStoreProvider),
+    downloader: ref.watch(remoteTrackDownloaderProvider),
     connectivity: ref.watch(connectivityServiceProvider),
     preferences: ref.watch(downloadPreferencesProvider),
   );
@@ -44,9 +69,20 @@ final downloadRepositoryProvider = Provider<DownloadRepository>((ref) {
   return repository;
 });
 
-/// Production bindings: persist the cached-ID set and the Wi-Fi-only switch via
-/// `shared_preferences` so both survive a restart. Applied in `main`; tests
-/// keep the in-memory defaults.
+/// Resolves a track to its cached-on-disk file when one exists. Read by the
+/// playback resolver to prefer the local copy over streaming. Composed from the
+/// same durable store + file store the repository writes through.
+final cachedTrackLocatorProvider = Provider<CachedTrackLocator>((ref) {
+  return StoreCachedTrackLocator(
+    ref.watch(downloadStoreProvider),
+    ref.watch(offlineFileStoreProvider),
+  );
+});
+
+/// Production bindings: persist the cached-track set and the Wi-Fi-only switch
+/// via `shared_preferences`, and store downloaded bytes on the device
+/// filesystem, so all three survive a restart. Applied in `main`; tests keep
+/// the in-memory defaults.
 final sharedPreferencesDownloadStoreOverride =
     downloadStoreProvider.overrideWithValue(
   const SharedPreferencesDownloadStore(),
@@ -56,3 +92,24 @@ final sharedPreferencesDownloadPreferencesOverride =
     downloadPreferencesProvider.overrideWithValue(
   const SharedPreferencesDownloadPreferences(),
 );
+
+final fileSystemOfflineFileStoreOverride =
+    offlineFileStoreProvider.overrideWithValue(
+  FileSystemOfflineFileStore(),
+);
+
+/// The fallback [RemoteTrackDownloader] when no source can fetch a track: it
+/// treats every track as on-device (so nothing is mistaken for a remote
+/// download) and refuses to fetch. Replaced at the composition root by the
+/// Jellyfin downloader once that source can be wired in.
+class _UnsupportedRemoteTrackDownloader implements RemoteTrackDownloader {
+  const _UnsupportedRemoteTrackDownloader();
+
+  @override
+  bool isRemote(Track track) => false;
+
+  @override
+  Future<RemoteTrackData> fetch(Track track) {
+    throw UnsupportedError('No remote downloader is configured.');
+  }
+}

--- a/lib/data/repositories/file_system_offline_file_store.dart
+++ b/lib/data/repositories/file_system_offline_file_store.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../../core/repositories/offline_file_store.dart';
+
+/// The app's [OfflineFileStore]: keeps downloaded audio in an app-private
+/// directory under the application *support* location (not the OS cache, which
+/// can be reclaimed at any time), so explicit user downloads survive restarts
+/// until the user removes them.
+///
+/// The base directory is injected so tests can point it at a temp folder; the
+/// app uses `path_provider`'s application-support directory by default.
+///
+/// Security: the cache file name is built only from the *non-secret* track id —
+/// sanitized to filename-safe characters so an odd id can't escape the offline
+/// directory — never from a token or an authenticated URL.
+class FileSystemOfflineFileStore implements OfflineFileStore {
+  FileSystemOfflineFileStore({Future<Directory> Function()? directory})
+      : _directory = directory ?? _defaultDirectory;
+
+  final Future<Directory> Function() _directory;
+
+  static Future<Directory> _defaultDirectory() async {
+    final Directory base = await getApplicationSupportDirectory();
+    return Directory(p.join(base.path, 'offline_audio'));
+  }
+
+  @override
+  Future<String> write(
+    String trackId,
+    List<int> bytes, {
+    String? extension,
+  }) async {
+    final Directory dir = await _directory();
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final String fileName = _fileNameFor(trackId, extension);
+    final File file = File(p.join(dir.path, fileName));
+    await file.writeAsBytes(bytes, flush: true);
+    return fileName;
+  }
+
+  @override
+  Future<String?> pathFor(String fileName) async {
+    final Directory dir = await _directory();
+    final File file = File(p.join(dir.path, fileName));
+    return await file.exists() ? file.path : null;
+  }
+
+  @override
+  Future<void> delete(String fileName) async {
+    final Directory dir = await _directory();
+    final File file = File(p.join(dir.path, fileName));
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  /// Builds a safe cache file name from the non-secret [trackId] (never a
+  /// token): keeps only filename-safe characters, so an odd id can't smuggle
+  /// path separators or escape the offline directory.
+  static String _fileNameFor(String trackId, String? extension) {
+    final String safeId = trackId.replaceAll(RegExp('[^A-Za-z0-9_-]'), '_');
+    final String ext = (extension != null && extension.isNotEmpty)
+        ? '.${extension.replaceAll(RegExp('[^A-Za-z0-9]'), '')}'
+        : '';
+    return '$safeId$ext';
+  }
+}

--- a/lib/data/repositories/in_memory_download_store.dart
+++ b/lib/data/repositories/in_memory_download_store.dart
@@ -2,22 +2,29 @@ import '../../core/repositories/download_store.dart';
 
 /// A non-persistent [DownloadStore] for development and tests.
 ///
-/// Keeps the cached IDs in a plain set, so they're forgotten when the instance
-/// is dropped. Default binding (mirroring the other in-memory repositories);
-/// the running app swaps in the `shared_preferences` implementation.
+/// Keeps the cached-track references in a plain map keyed by track id, so
+/// they're forgotten when the instance is dropped. Default binding (mirroring
+/// the other in-memory repositories); the running app swaps in the
+/// `shared_preferences` implementation.
 class InMemoryDownloadStore implements DownloadStore {
-  InMemoryDownloadStore({Set<String>? initialIds})
-      : _ids = <String>{...?initialIds};
+  InMemoryDownloadStore({List<CachedTrack>? initialDownloads})
+      : _downloads = <String, CachedTrack>{
+          for (final CachedTrack cached
+              in initialDownloads ?? const <CachedTrack>[])
+            cached.trackId: cached,
+        };
 
-  final Set<String> _ids;
+  final Map<String, CachedTrack> _downloads;
 
   @override
-  Future<Set<String>> loadDownloadedIds() async => <String>{..._ids};
+  Future<List<CachedTrack>> loadDownloads() async => _downloads.values.toList();
 
   @override
-  Future<void> saveDownloadedIds(Set<String> ids) async {
-    _ids
+  Future<void> saveDownloads(List<CachedTrack> downloads) async {
+    _downloads
       ..clear()
-      ..addAll(ids);
+      ..addEntries(
+        downloads.map((c) => MapEntry<String, CachedTrack>(c.trackId, c)),
+      );
   }
 }

--- a/lib/data/repositories/in_memory_offline_file_store.dart
+++ b/lib/data/repositories/in_memory_offline_file_store.dart
@@ -1,0 +1,42 @@
+import '../../core/repositories/offline_file_store.dart';
+
+/// A non-persistent [OfflineFileStore] for development and tests.
+///
+/// Holds bytes in memory keyed by a track-id-derived file name and hands out a
+/// synthetic absolute path, so the offline-cache flow can be exercised without a
+/// real filesystem or `path_provider`. The running app overrides this with
+/// [FileSystemOfflineFileStore]; no bytes ever hit disk here.
+class InMemoryOfflineFileStore implements OfflineFileStore {
+  InMemoryOfflineFileStore({String baseDirectory = '/offline_audio'})
+      : _baseDirectory = baseDirectory;
+
+  final String _baseDirectory;
+  final Map<String, List<int>> _files = <String, List<int>>{};
+
+  /// The bytes stored under [fileName], for test assertions; `null` if absent.
+  List<int>? bytesFor(String fileName) => _files[fileName];
+
+  @override
+  Future<String> write(
+    String trackId,
+    List<int> bytes, {
+    String? extension,
+  }) async {
+    final String safeId = trackId.replaceAll(RegExp('[^A-Za-z0-9_-]'), '_');
+    final String ext = (extension != null && extension.isNotEmpty)
+        ? '.${extension.replaceAll(RegExp('[^A-Za-z0-9]'), '')}'
+        : '';
+    final String fileName = '$safeId$ext';
+    _files[fileName] = List<int>.unmodifiable(bytes);
+    return fileName;
+  }
+
+  @override
+  Future<String?> pathFor(String fileName) async =>
+      _files.containsKey(fileName) ? '$_baseDirectory/$fileName' : null;
+
+  @override
+  Future<void> delete(String fileName) async {
+    _files.remove(fileName);
+  }
+}

--- a/lib/data/repositories/shared_preferences_download_store.dart
+++ b/lib/data/repositories/shared_preferences_download_store.dart
@@ -1,28 +1,58 @@
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/repositories/download_store.dart';
 
 /// A [DownloadStore] backed by `shared_preferences`.
 ///
-/// The durable part of the offline cache is just a list of track IDs, so a
-/// key/value store is the right weight here — the same reasoning the selected
-/// music folder follows. When real remote downloads need per-track file paths
-/// and byte progress, this is the seam that graduates to a Drift/SQLite table
-/// without the policy in [CacheDownloadRepository] changing.
+/// The durable part of the offline cache is a small set of track→file
+/// references, so a key/value store is the right weight here — the same
+/// reasoning the selected music folder follows. The references are kept as a
+/// single JSON document (track id + cache file name); when downloads also need
+/// byte progress, this is the seam that graduates to a Drift/SQLite table
+/// without the policy in `CacheDownloadRepository` changing.
+///
+/// Security: only the non-secret track id and a track-id-derived file name are
+/// persisted — never a token or an authenticated URL.
 class SharedPreferencesDownloadStore implements DownloadStore {
   const SharedPreferencesDownloadStore();
 
-  static const String _key = 'downloaded_track_ids';
+  // A JSON document under a v2 key. The pre-1.0 IDs-only key is intentionally
+  // not migrated (there were no remote downloads to preserve).
+  static const String _key = 'offline_downloads_v2';
 
   @override
-  Future<Set<String>> loadDownloadedIds() async {
+  Future<List<CachedTrack>> loadDownloads() async {
     final prefs = await SharedPreferences.getInstance();
-    return (prefs.getStringList(_key) ?? const <String>[]).toSet();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return const <CachedTrack>[];
+
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      // A corrupt record reads as "nothing downloaded" rather than crashing.
+      return const <CachedTrack>[];
+    }
+    if (decoded is! List) return const <CachedTrack>[];
+
+    final List<CachedTrack> downloads = <CachedTrack>[];
+    for (final Object? entry in decoded) {
+      if (entry is Map<String, dynamic>) {
+        final CachedTrack? cached = CachedTrack.fromJson(entry);
+        if (cached != null) downloads.add(cached);
+      }
+    }
+    return downloads;
   }
 
   @override
-  Future<void> saveDownloadedIds(Set<String> ids) async {
+  Future<void> saveDownloads(List<CachedTrack> downloads) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setStringList(_key, ids.toList());
+    final String raw = jsonEncode(
+      <Map<String, dynamic>>[for (final c in downloads) c.toJson()],
+    );
+    await prefs.setString(_key, raw);
   }
 }

--- a/lib/data/repositories/store_cached_track_locator.dart
+++ b/lib/data/repositories/store_cached_track_locator.dart
@@ -1,0 +1,33 @@
+import '../../core/models/track.dart';
+import '../../core/repositories/download_store.dart';
+import '../../core/repositories/offline_file_store.dart';
+import '../../core/services/cached_track_locator.dart';
+
+/// The app's [CachedTrackLocator]: answers "is this track available offline?" by
+/// reading the durable download metadata ([DownloadStore]) and confirming the
+/// bytes are still on disk ([OfflineFileStore]).
+///
+/// Reading the stores directly — rather than the download repository's
+/// in-memory state — keeps the playback read-path decoupled from download
+/// *policy*: it sees exactly what has been persisted. A track with no cache
+/// file (including any already-local on-device track) resolves to `null`, so
+/// playback falls back to its normal source.
+class StoreCachedTrackLocator implements CachedTrackLocator {
+  const StoreCachedTrackLocator(this._store, this._files);
+
+  final DownloadStore _store;
+  final OfflineFileStore _files;
+
+  @override
+  Future<String?> cachedFilePath(Track track) async {
+    String? fileName;
+    for (final CachedTrack cached in await _store.loadDownloads()) {
+      if (cached.trackId == track.id) {
+        fileName = cached.fileName;
+        break;
+      }
+    }
+    if (fileName == null || fileName.isEmpty) return null;
+    return _files.pathFor(fileName);
+  }
+}

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -2,8 +2,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/track.dart';
 import '../../core/repositories/download_repository.dart';
+import '../../core/sources/jellyfin/jellyfin_track_downloader.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
+import '../settings/jellyfin/jellyfin_settings_controller.dart';
 
 /// The live download status of a single track, for the Library row indicator.
 /// Defaults to [DownloadStatus.notDownloaded] until the repository reports
@@ -47,3 +49,17 @@ class WifiOnlyController extends AsyncNotifier<bool> {
 
 final wifiOnlyControllerProvider =
     AsyncNotifierProvider<WifiOnlyController, bool>(WifiOnlyController.new);
+
+/// Production binding: makes Jellyfin tracks downloadable for offline use by
+/// wiring the remote downloader to the live signed-in source (read through
+/// [jellyfinMusicSourceProvider], so sign-in/out is picked up without a
+/// rebuild). The token-bearing download URL is minted only at fetch time inside
+/// the downloader; nothing here stores it. Applied in `main`; tests override
+/// [remoteTrackDownloaderProvider] with their own fake.
+final jellyfinRemoteTrackDownloaderOverride =
+    remoteTrackDownloaderProvider.overrideWith((ref) {
+  // Read (not watch) the live source lazily at fetch time, mirroring the
+  // playback resolver — so the downloader is built once and signing in/out
+  // doesn't rebuild it (which would reset in-flight download state).
+  return JellyfinTrackDownloader(() => ref.read(jellyfinMusicSourceProvider));
+});

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -111,7 +111,7 @@ class _TrackTile extends ConsumerWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      trailing: _DownloadAction(trackId: track.id),
+      trailing: _DownloadAction(track: track),
       // Play the tapped track and queue the rest of the list behind it, then
       // surface the now-playing screen.
       onTap: () {
@@ -140,13 +140,13 @@ class _TrackTile extends ConsumerWidget {
 /// when cached. Progress states (queued/downloading) show as non-interactive
 /// indicators; nothing here ever starts a download on its own.
 class _DownloadAction extends ConsumerWidget {
-  const _DownloadAction({required this.trackId});
+  const _DownloadAction({required this.track});
 
-  final String trackId;
+  final Track track;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncStatus = ref.watch(trackDownloadStatusProvider(trackId));
+    final asyncStatus = ref.watch(trackDownloadStatusProvider(track.id));
     final status = asyncStatus.valueOrNull ?? DownloadStatus.notDownloaded;
     final repository = ref.read(downloadRepositoryProvider);
     final theme = Theme.of(context);
@@ -156,13 +156,13 @@ class _DownloadAction extends ConsumerWidget {
         return IconButton(
           icon: const Icon(Icons.download_outlined),
           tooltip: 'Download',
-          onPressed: () => repository.requestDownload(trackId),
+          onPressed: () => repository.requestDownload(track),
         );
       case DownloadStatus.queued:
         return IconButton(
           icon: const Icon(Icons.schedule_outlined),
           tooltip: 'Queued',
-          onPressed: () => repository.removeDownload(trackId),
+          onPressed: () => repository.removeDownload(track.id),
         );
       case DownloadStatus.downloading:
         return const SizedBox.square(
@@ -179,13 +179,13 @@ class _DownloadAction extends ConsumerWidget {
             color: theme.colorScheme.primary,
           ),
           tooltip: 'Remove download',
-          onPressed: () => repository.removeDownload(trackId),
+          onPressed: () => repository.removeDownload(track.id),
         );
       case DownloadStatus.failed:
         return IconButton(
           icon: Icon(Icons.error_outline, color: theme.colorScheme.error),
           tooltip: 'Retry download',
-          onPressed: () => repository.requestDownload(trackId),
+          onPressed: () => repository.requestDownload(track),
         );
     }
   }

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -3,24 +3,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/services/just_audio_playback_controller.dart';
 import '../../core/services/local_playable_uri_resolver.dart';
+import '../../core/services/offline_first_playable_uri_resolver.dart';
 import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
+import '../../data/repositories/download_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 
 /// Composes the [PlayableUriResolver] the controller resolves tracks through.
 ///
-/// Routes Jellyfin tracks to a resolver that mints an authenticated stream URL
-/// at play time (reading the live signed-in source, so sign-in/out is picked up
-/// without a rebuild), and everything else to the on-device resolver. The UI
-/// and controller depend only on the [PlayableUriResolver] interface, never on
-/// Jellyfin or HTTP.
+/// Offline first: a downloaded track resolves to its cached `file://` copy
+/// before anything else. On a cache miss it falls through to the source router,
+/// which mints an authenticated Jellyfin stream URL at play time (reading the
+/// live signed-in source, so sign-in/out is picked up without a rebuild) and
+/// sends everything else to the on-device resolver. The UI and controller
+/// depend only on the [PlayableUriResolver] interface, never on Jellyfin, the
+/// cache, or HTTP.
 final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
-  return RoutingPlayableUriResolver(<PlayableUriResolver>[
+  final fallback = RoutingPlayableUriResolver(<PlayableUriResolver>[
     JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
     const LocalPlayableUriResolver(),
   ]);
+  return OfflineFirstPlayableUriResolver(
+    locator: ref.watch(cachedTrackLocatorProvider),
+    fallback: fallback,
+  );
 });
 
 /// The single [PlaybackController] the app drives playback through.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/jellyfin_session_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
+import 'features/downloads/download_providers.dart';
 import 'features/player/player_providers.dart';
 
 Future<void> main() async {
@@ -18,14 +19,18 @@ Future<void> main() async {
   // notification / lock screen reflect the real controller. The running app
   // persists its catalog to SQLite (Drift override) and its chosen folder,
   // offline-download set, and Wi-Fi-only preference via shared_preferences;
-  // the Jellyfin session token is persisted in encrypted on-device storage.
-  // Tests keep the in-memory defaults unless they opt into these bindings.
+  // downloaded audio is written to an app-private directory on disk; and the
+  // Jellyfin session token is persisted in encrypted on-device storage. The
+  // Jellyfin downloader override makes remote tracks downloadable for offline
+  // use. Tests keep the in-memory defaults unless they opt into these bindings.
   final container = ProviderContainer(
     overrides: [
       driftMusicLibraryRepositoryOverride,
       sharedPreferencesSelectedMusicFolderRepositoryOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
+      fileSystemOfflineFileStoreOverride,
+      jellyfinRemoteTrackDownloaderOverride,
       secureJellyfinSessionStoreOverride,
     ],
   );

--- a/test/core/services/offline_first_playable_uri_resolver_test.dart
+++ b/test/core/services/offline_first_playable_uri_resolver_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/cached_track_locator.dart';
+import 'package:linthra/core/services/offline_first_playable_uri_resolver.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+
+/// A locator that returns a canned cached path (or null for a miss).
+class _FakeLocator implements CachedTrackLocator {
+  _FakeLocator(this._path);
+
+  final String? _path;
+  int calls = 0;
+
+  @override
+  Future<String?> cachedFilePath(Track track) async {
+    calls++;
+    return _path;
+  }
+}
+
+/// A fallback that records the track it was asked to resolve and returns a
+/// canned (streaming) URI.
+class _RecordingResolver implements PlayableUriResolver {
+  _RecordingResolver(this._uri);
+
+  final Uri _uri;
+  Track? resolved;
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<Uri> resolve(Track track) async {
+    resolved = track;
+    return _uri;
+  }
+}
+
+/// A fallback that fails the way the Jellyfin resolver does when offline.
+class _OfflineResolver implements PlayableUriResolver {
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<Uri> resolve(Track track) async {
+    throw const PlaybackResolutionException(
+      "Couldn't reach your Jellyfin server.",
+      kind: PlaybackResolutionErrorKind.serverUnreachable,
+    );
+  }
+}
+
+const _track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
+
+void main() {
+  group('OfflineFirstPlayableUriResolver', () {
+    test('prefers the cached file and does not hit the fallback', () async {
+      final locator = _FakeLocator('/offline_audio/t1.mp3');
+      final fallback = _RecordingResolver(Uri.parse('https://stream/t1'));
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: locator,
+        fallback: fallback,
+      );
+
+      final uri = await resolver.resolve(_track);
+
+      expect(uri.scheme, 'file');
+      expect(uri.toFilePath(), '/offline_audio/t1.mp3');
+      expect(fallback.resolved, isNull);
+    });
+
+    test('streams via the fallback on a cache miss', () async {
+      final fallback = _RecordingResolver(
+        Uri.parse('https://music.example.com/Audio/t1/universal'),
+      );
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator(null),
+        fallback: fallback,
+      );
+
+      final uri = await resolver.resolve(_track);
+
+      expect(uri.host, 'music.example.com');
+      expect(fallback.resolved, _track);
+    });
+
+    test('an uncached track offline surfaces the fallback offline error',
+        () async {
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator(null),
+        fallback: _OfflineResolver(),
+      );
+
+      await expectLater(
+        resolver.resolve(_track),
+        throwsA(
+          isA<PlaybackResolutionException>().having(
+            (PlaybackResolutionException e) => e.kind,
+            'kind',
+            PlaybackResolutionErrorKind.serverUnreachable,
+          ),
+        ),
+      );
+    });
+
+    test('handles delegates to the fallback', () {
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator(null),
+        fallback: _RecordingResolver(Uri.parse('https://stream/t1')),
+      );
+
+      expect(resolver.handles(_track), isTrue);
+    });
+  });
+}

--- a/test/core/sources/jellyfin/jellyfin_music_source_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_music_source_test.dart
@@ -95,6 +95,21 @@ void main() {
       expect(uri!.path, '/Audio/raw-id/universal');
     });
 
+    test('resolveDownloadUri mints a download URL with the token on demand',
+        () async {
+      final source = _source(FakeJellyfinClient());
+      const track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
+
+      final uri = await source.resolveDownloadUri(track);
+
+      expect(uri, isNotNull);
+      expect(uri!.path, '/Items/t1/Download');
+      expect(uri.host, 'music.example.com');
+      expect(uri.queryParameters['api_key'], 'secret-token');
+      // The track's own uri stays the token-free jellyfin id.
+      expect(track.uri, 'jellyfin:t1');
+    });
+
     test('verifyReachable delegates the check to the client', () async {
       final client = FakeJellyfinClient();
 

--- a/test/core/sources/jellyfin/jellyfin_track_downloader_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_track_downloader_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/remote_track_downloader.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_download_source.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_track_downloader.dart';
+
+/// A configurable [JellyfinDownloadSource] that drives each download outcome
+/// without a real server: verification can throw, and the minted URL can be
+/// canned or absent.
+class _FakeDownloadSource implements JellyfinDownloadSource {
+  _FakeDownloadSource({this.verifyError, this.downloadUri});
+
+  final JellyfinException? verifyError;
+  final Uri? downloadUri;
+  int verifyCount = 0;
+
+  @override
+  Future<void> verifyReachable() async {
+    verifyCount++;
+    final JellyfinException? error = verifyError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async => downloadUri;
+}
+
+const _track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
+
+void main() {
+  group('JellyfinTrackDownloader', () {
+    test('isRemote is true only for Jellyfin tracks', () {
+      final downloader = JellyfinTrackDownloader(() => null);
+
+      expect(downloader.isRemote(_track), isTrue);
+      expect(
+        downloader.isRemote(
+          const Track(id: '1', title: 'L', uri: '/music/x.mp3'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('verifies the session, then fetches bytes from the minted URL',
+        () async {
+      final uri = Uri.parse(
+        'https://music.example.com/Items/t1/Download?api_key=secret-token',
+      );
+      final source = _FakeDownloadSource(downloadUri: uri);
+      Uri? requested;
+      final client = MockClient((request) async {
+        requested = request.url;
+        return http.Response.bytes(
+          <int>[10, 20, 30],
+          200,
+          headers: <String, String>{'content-type': 'audio/flac'},
+        );
+      });
+      final downloader =
+          JellyfinTrackDownloader(() => source, httpClient: client);
+
+      final RemoteTrackData data = await downloader.fetch(_track);
+
+      expect(source.verifyCount, 1);
+      expect(requested, uri);
+      expect(data.bytes, <int>[10, 20, 30]);
+      expect(data.fileExtension, 'flac');
+    });
+
+    test('maps an mpeg content type to an mp3 extension', () async {
+      final source = _FakeDownloadSource(
+        downloadUri: Uri.parse('https://x/Items/t1/Download?api_key=t'),
+      );
+      final client = MockClient((request) async {
+        return http.Response.bytes(
+          <int>[1],
+          200,
+          headers: <String, String>{'content-type': 'audio/mpeg'},
+        );
+      });
+
+      final data =
+          await JellyfinTrackDownloader(() => source, httpClient: client)
+              .fetch(_track);
+
+      expect(data.fileExtension, 'mp3');
+    });
+
+    test('throws when not signed in', () async {
+      final downloader = JellyfinTrackDownloader(() => null);
+
+      await expectLater(downloader.fetch(_track), throwsA(isA<Object>()));
+    });
+
+    test('surfaces a verification failure', () async {
+      final source = _FakeDownloadSource(
+        verifyError: JellyfinException.unauthorized(),
+      );
+
+      await expectLater(
+        JellyfinTrackDownloader(() => source).fetch(_track),
+        throwsA(isA<JellyfinException>()),
+      );
+    });
+
+    test('throws when no download URL can be built', () async {
+      final source = _FakeDownloadSource(downloadUri: null);
+
+      await expectLater(
+        JellyfinTrackDownloader(() => source).fetch(_track),
+        throwsA(isA<Object>()),
+      );
+    });
+
+    test('throws on a non-2xx response', () async {
+      final source = _FakeDownloadSource(
+        downloadUri: Uri.parse('https://x/Items/t1/Download?api_key=t'),
+      );
+      final client = MockClient((request) async => http.Response('no', 404));
+
+      await expectLater(
+        JellyfinTrackDownloader(() => source, httpClient: client).fetch(_track),
+        throwsA(isA<Object>()),
+      );
+    });
+
+    test('a transport failure is re-raised without leaking the tokenized URL',
+        () async {
+      final uri = Uri.parse(
+        'https://music.example.com/Items/t1/Download?api_key=SECRET-TOKEN',
+      );
+      final source = _FakeDownloadSource(downloadUri: uri);
+      final client = MockClient((request) async {
+        // A real ClientException can embed the full (tokenized) URL.
+        throw http.ClientException('Connection failed for $uri', uri);
+      });
+      final downloader =
+          JellyfinTrackDownloader(() => source, httpClient: client);
+
+      try {
+        await downloader.fetch(_track);
+        fail('expected fetch to throw');
+      } catch (error) {
+        expect(error.toString(), isNot(contains('SECRET-TOKEN')));
+        expect(error.toString(), isNot(contains('api_key')));
+      }
+    });
+  });
+}

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -1,9 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/connectivity_service.dart';
+import 'package:linthra/core/services/remote_track_downloader.dart';
 import 'package:linthra/data/repositories/cache_download_repository.dart';
 import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
 import 'package:linthra/data/repositories/in_memory_download_store.dart';
+import 'package:linthra/data/repositories/in_memory_offline_file_store.dart';
 
 /// A connectivity stand-in whose reported status the test can flip at will.
 class _FakeConnectivity implements ConnectivityService {
@@ -18,15 +22,50 @@ class _FakeConnectivity implements ConnectivityService {
   Future<NetworkStatus> currentStatus() async => status;
 }
 
+/// A remote downloader fake: treats `jellyfin:` tracks as remote and returns
+/// canned bytes, or throws when [error] is set, so the repository's remote path
+/// can be driven without a server or HTTP.
+class _FakeRemoteDownloader implements RemoteTrackDownloader {
+  _FakeRemoteDownloader({this.error});
+
+  /// The canned bytes every successful fetch returns.
+  static const List<int> bytes = <int>[1, 2, 3, 4];
+
+  /// When set, [fetch] throws this instead of returning bytes.
+  final Object? error;
+
+  int fetchCount = 0;
+  final List<Track> fetched = <Track>[];
+
+  @override
+  bool isRemote(Track track) => track.uri.startsWith('jellyfin:');
+
+  @override
+  Future<RemoteTrackData> fetch(Track track) async {
+    fetchCount++;
+    fetched.add(track);
+    final Object? err = error;
+    if (err != null) throw err;
+    return const RemoteTrackData(bytes: bytes, fileExtension: 'mp3');
+  }
+}
+
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
 void main() {
   group('CacheDownloadRepository', () {
     late InMemoryDownloadStore store;
+    late InMemoryOfflineFileStore files;
     late InMemoryDownloadPreferences preferences;
     late _FakeConnectivity connectivity;
+    late _FakeRemoteDownloader downloader;
 
     CacheDownloadRepository build() {
       return CacheDownloadRepository(
         store: store,
+        files: files,
+        downloader: downloader,
         connectivity: connectivity,
         preferences: preferences,
       );
@@ -34,96 +73,177 @@ void main() {
 
     setUp(() {
       store = InMemoryDownloadStore();
+      files = InMemoryOfflineFileStore();
       preferences = InMemoryDownloadPreferences();
       connectivity = _FakeConnectivity(NetworkStatus.wifi);
+      downloader = _FakeRemoteDownloader();
     });
 
-    test('tracks start not downloaded', () async {
+    test('a Jellyfin track starts not downloaded', () async {
       final repository = build();
-      expect(await repository.statusFor('a'), DownloadStatus.notDownloaded);
+      expect(
+        await repository.statusFor('j1'),
+        DownloadStatus.notDownloaded,
+      );
       expect(await repository.downloadedTrackIds(), isEmpty);
     });
 
-    test('requestDownload marks a track downloaded and persists it', () async {
-      final repository = build();
-
-      await repository.requestDownload('a');
-
-      expect(await repository.statusFor('a'), DownloadStatus.downloaded);
-      expect(await repository.downloadedTrackIds(), <String>['a']);
-      expect(await store.loadDownloadedIds(), <String>{'a'});
-    });
-
-    test('removeDownload reverts status and clears persistence', () async {
-      final repository = build();
-      await repository.requestDownload('a');
-
-      await repository.removeDownload('a');
-
-      expect(await repository.statusFor('a'), DownloadStatus.notDownloaded);
-      expect(await repository.downloadedTrackIds(), isEmpty);
-      expect(await store.loadDownloadedIds(), isEmpty);
-    });
-
-    test('downloaded IDs are reloaded from the store by a fresh repository',
+    test('downloading a Jellyfin track stores a cached file reference',
         () async {
-      await build().requestDownload('a');
+      final repository = build();
 
-      // A new repository over the same store reflects the persisted state.
+      await repository.requestDownload(_jellyfin('j1'));
+
+      expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+      expect(downloader.fetchCount, 1);
+
+      final List<CachedTrack> saved = await store.loadDownloads();
+      expect(saved, hasLength(1));
+      expect(saved.single.trackId, 'j1');
+      expect(saved.single.fileName, isNotNull);
+      // The fetched bytes were written to the cache under that file name.
+      expect(files.bytesFor(saved.single.fileName!), <int>[1, 2, 3, 4]);
+    });
+
+    test('removing a downloaded Jellyfin track deletes the cached file',
+        () async {
+      final repository = build();
+      await repository.requestDownload(_jellyfin('j1'));
+      final String fileName = (await store.loadDownloads()).single.fileName!;
+
+      await repository.removeDownload('j1');
+
+      expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+      expect(await repository.downloadedTrackIds(), isEmpty);
+      expect(await store.loadDownloads(), isEmpty);
+      expect(files.bytesFor(fileName), isNull);
+    });
+
+    test('a failed remote fetch surfaces as failed and stores nothing',
+        () async {
+      downloader = _FakeRemoteDownloader(error: Exception('boom'));
+      final repository = build();
+
+      await repository.requestDownload(_jellyfin('j1'));
+
+      expect(await repository.statusFor('j1'), DownloadStatus.failed);
+      expect(await store.loadDownloads(), isEmpty);
+      expect(await repository.downloadedTrackIds(), isEmpty);
+    });
+
+    test('a failed Jellyfin track can be retried', () async {
+      downloader = _FakeRemoteDownloader(error: Exception('boom'));
+      final repository = build();
+      await repository.requestDownload(_jellyfin('j1'));
+      expect(await repository.statusFor('j1'), DownloadStatus.failed);
+
+      // A retry with a downloader that now succeeds reaches downloaded.
+      downloader = _FakeRemoteDownloader();
+      final retryRepository = CacheDownloadRepository(
+        store: store,
+        files: files,
+        downloader: downloader,
+        connectivity: connectivity,
+        preferences: preferences,
+      );
+      await retryRepository.requestDownload(_jellyfin('j1'));
+
+      expect(await retryRepository.statusFor('j1'), DownloadStatus.downloaded);
+    });
+
+    group('local tracks are treated as already local', () {
+      test('a local track is recorded without a remote fetch or cached file',
+          () async {
+        final repository = build();
+
+        await repository.requestDownload(_local('a'));
+
+        expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+        // No remote fetch happened, and no managed cache file was written.
+        expect(downloader.fetchCount, 0);
+        final List<CachedTrack> saved = await store.loadDownloads();
+        expect(saved.single.trackId, 'a');
+        expect(saved.single.fileName, isNull);
+      });
+
+      test('removing a local track clears it without touching files', () async {
+        final repository = build();
+        await repository.requestDownload(_local('a'));
+
+        await repository.removeDownload('a');
+
+        expect(await repository.statusFor('a'), DownloadStatus.notDownloaded);
+        expect(await store.loadDownloads(), isEmpty);
+      });
+    });
+
+    test('no token is stored in the track uri or the cache metadata', () async {
+      const String token = 'super-secret-token';
+      // Even if a downloader's source minted a tokenized URL, the repository
+      // only ever sees bytes — the persisted file name is derived from the id.
+      final track = _jellyfin('item-42');
+      final repository = build();
+
+      await repository.requestDownload(track);
+
+      final CachedTrack saved = (await store.loadDownloads()).single;
+      expect(saved.trackId, 'item-42');
+      expect(saved.fileName, isNot(contains(token)));
+      expect(saved.fileName, isNot(contains('api_key')));
+      // The track itself still carries only the opaque jellyfin: uri.
+      expect(track.uri, 'jellyfin:item-42');
+    });
+
+    test('downloaded references are reloaded by a fresh repository', () async {
+      await build().requestDownload(_jellyfin('j1'));
+
       final reopened = build();
-      expect(await reopened.statusFor('a'), DownloadStatus.downloaded);
-      expect(await reopened.downloadedTrackIds(), <String>['a']);
+      expect(await reopened.statusFor('j1'), DownloadStatus.downloaded);
+      expect(await reopened.downloadedTrackIds(), <String>['j1']);
     });
 
     test('statusStream seeds the current snapshot then emits changes',
         () async {
-      await build().requestDownload('a');
+      await build().requestDownload(_jellyfin('j1'));
       final repository = build();
 
       final emissions = <Map<String, DownloadStatus>>[];
       final sub = repository.statusStream.listen(emissions.add);
       await _settle();
 
-      // Seeded with the persisted snapshot.
       expect(emissions.first, <String, DownloadStatus>{
-        'a': DownloadStatus.downloaded,
+        'j1': DownloadStatus.downloaded,
       });
 
-      await repository.requestDownload('b');
+      await repository.requestDownload(_jellyfin('j2'));
       await _settle();
 
-      expect(emissions.last['b'], DownloadStatus.downloaded);
+      expect(emissions.last['j2'], DownloadStatus.downloaded);
       await sub.cancel();
     });
 
     test('a downloaded track is not re-downloaded', () async {
       final repository = build();
-      await repository.requestDownload('a');
+      await repository.requestDownload(_jellyfin('j1'));
+      expect(downloader.fetchCount, 1);
 
-      final emissions = <Map<String, DownloadStatus>>[];
-      final sub = repository.statusStream.listen(emissions.add);
-      await _settle();
-      emissions.clear();
+      await repository.requestDownload(_jellyfin('j1'));
 
-      await repository.requestDownload('a');
-      await _settle();
-
-      // No further status changes were emitted.
-      expect(emissions, isEmpty);
-      await sub.cancel();
+      // No second fetch was attempted.
+      expect(downloader.fetchCount, 1);
     });
 
-    group('Wi-Fi only policy', () {
+    group('Wi-Fi only policy (remote downloads)', () {
       test('queues instead of downloading when on mobile', () async {
         await preferences.setWifiOnly(true);
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
 
-        await repository.requestDownload('a');
+        await repository.requestDownload(_jellyfin('j1'));
 
-        expect(await repository.statusFor('a'), DownloadStatus.queued);
-        expect(await repository.downloadedTrackIds(), isEmpty);
-        expect(await store.loadDownloadedIds(), isEmpty);
+        expect(await repository.statusFor('j1'), DownloadStatus.queued);
+        expect(downloader.fetchCount, 0);
+        expect(await store.loadDownloads(), isEmpty);
       });
 
       test('downloads when on Wi-Fi', () async {
@@ -131,9 +251,9 @@ void main() {
         connectivity.status = NetworkStatus.wifi;
         final repository = build();
 
-        await repository.requestDownload('a');
+        await repository.requestDownload(_jellyfin('j1'));
 
-        expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
       });
 
       test('downloads over mobile when the preference is off', () async {
@@ -141,8 +261,19 @@ void main() {
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
 
-        await repository.requestDownload('a');
+        await repository.requestDownload(_jellyfin('j1'));
 
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+      });
+
+      test('a local track is never queued, even off Wi-Fi', () async {
+        await preferences.setWifiOnly(true);
+        connectivity.status = NetworkStatus.mobile;
+        final repository = build();
+
+        await repository.requestDownload(_local('a'));
+
+        // Already local: the Wi-Fi gate doesn't apply (no bytes to fetch).
         expect(await repository.statusFor('a'), DownloadStatus.downloaded);
       });
 
@@ -151,13 +282,13 @@ void main() {
         await preferences.setWifiOnly(true);
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
-        await repository.requestDownload('a');
-        expect(await repository.statusFor('a'), DownloadStatus.queued);
+        await repository.requestDownload(_jellyfin('j1'));
+        expect(await repository.statusFor('j1'), DownloadStatus.queued);
 
         connectivity.status = NetworkStatus.wifi;
-        await repository.requestDownload('a');
+        await repository.requestDownload(_jellyfin('j1'));
 
-        expect(await repository.statusFor('a'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
       });
     });
   });

--- a/test/data/repositories/file_system_offline_file_store_test.dart
+++ b/test/data/repositories/file_system_offline_file_store_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/file_system_offline_file_store.dart';
+
+void main() {
+  group('FileSystemOfflineFileStore', () {
+    late Directory tempDir;
+    late FileSystemOfflineFileStore store;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('linthra_offline_test');
+      store = FileSystemOfflineFileStore(directory: () async => tempDir);
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('writes bytes and resolves the file back', () async {
+      final String fileName =
+          await store.write('t1', const <int>[1, 2, 3, 4], extension: 'mp3');
+
+      expect(fileName, 't1.mp3');
+      final String? path = await store.pathFor(fileName);
+      expect(path, isNotNull);
+      expect(await File(path!).readAsBytes(), <int>[1, 2, 3, 4]);
+    });
+
+    test('the file name is derived from the id and carries no separators',
+        () async {
+      // An id with unsafe characters must not escape the offline directory.
+      final String fileName = await store.write(
+        'weird/../id with spaces',
+        const <int>[0],
+        extension: 'flac',
+      );
+
+      expect(fileName, isNot(contains('/')));
+      expect(fileName, isNot(contains(' ')));
+      expect(fileName, endsWith('.flac'));
+      // The written file lives directly under the offline directory.
+      final String? path = await store.pathFor(fileName);
+      expect(path, isNotNull);
+      expect(File(path!).parent.path, tempDir.path);
+    });
+
+    test('omits the extension when none is given', () async {
+      final String fileName = await store.write('t2', const <int>[9]);
+      expect(fileName, 't2');
+    });
+
+    test('pathFor returns null for a file that was never written', () async {
+      expect(await store.pathFor('missing.mp3'), isNull);
+    });
+
+    test('delete removes the cached file', () async {
+      final String fileName =
+          await store.write('t1', const <int>[1], extension: 'mp3');
+      expect(await store.pathFor(fileName), isNotNull);
+
+      await store.delete(fileName);
+
+      expect(await store.pathFor(fileName), isNull);
+    });
+
+    test('delete is a no-op for a missing file', () async {
+      await store.delete('missing.mp3');
+    });
+  });
+}

--- a/test/data/repositories/in_memory_download_store_test.dart
+++ b/test/data/repositories/in_memory_download_store_test.dart
@@ -1,27 +1,50 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/data/repositories/in_memory_download_store.dart';
 
 void main() {
   group('InMemoryDownloadStore', () {
     test('starts empty', () async {
-      expect(await InMemoryDownloadStore().loadDownloadedIds(), isEmpty);
+      expect(await InMemoryDownloadStore().loadDownloads(), isEmpty);
     });
 
-    test('seeds from initial IDs', () async {
-      final store = InMemoryDownloadStore(initialIds: <String>{'a', 'b'});
-      expect(await store.loadDownloadedIds(), <String>{'a', 'b'});
+    test('seeds from initial downloads', () async {
+      final store = InMemoryDownloadStore(
+        initialDownloads: const <CachedTrack>[
+          CachedTrack(trackId: 'a', fileName: 'a.mp3'),
+          CachedTrack(trackId: 'b'),
+        ],
+      );
+      expect(await store.loadDownloads(), <CachedTrack>[
+        const CachedTrack(trackId: 'a', fileName: 'a.mp3'),
+        const CachedTrack(trackId: 'b'),
+      ]);
     });
 
     test('save replaces the stored set', () async {
-      final store = InMemoryDownloadStore(initialIds: <String>{'a'});
-      await store.saveDownloadedIds(<String>{'b', 'c'});
-      expect(await store.loadDownloadedIds(), <String>{'b', 'c'});
+      final store = InMemoryDownloadStore(
+        initialDownloads: const <CachedTrack>[CachedTrack(trackId: 'a')],
+      );
+      await store.saveDownloads(const <CachedTrack>[
+        CachedTrack(trackId: 'b', fileName: 'b.flac'),
+        CachedTrack(trackId: 'c'),
+      ]);
+      expect(
+        (await store.loadDownloads()).map((c) => c.trackId).toList(),
+        <String>['b', 'c'],
+      );
     });
 
-    test('load returns a copy that callers cannot mutate', () async {
-      final store = InMemoryDownloadStore(initialIds: <String>{'a'});
-      (await store.loadDownloadedIds()).add('rogue');
-      expect(await store.loadDownloadedIds(), <String>{'a'});
+    test('load returns a list that callers cannot use to mutate the store',
+        () async {
+      final store = InMemoryDownloadStore(
+        initialDownloads: const <CachedTrack>[CachedTrack(trackId: 'a')],
+      );
+      (await store.loadDownloads()).add(const CachedTrack(trackId: 'rogue'));
+      expect(
+        (await store.loadDownloads()).map((c) => c.trackId).toList(),
+        <String>['a'],
+      );
     });
   });
 }

--- a/test/data/repositories/store_cached_track_locator_test.dart
+++ b/test/data/repositories/store_cached_track_locator_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/data/repositories/in_memory_download_store.dart';
+import 'package:linthra/data/repositories/in_memory_offline_file_store.dart';
+import 'package:linthra/data/repositories/store_cached_track_locator.dart';
+
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+void main() {
+  group('StoreCachedTrackLocator', () {
+    late InMemoryDownloadStore store;
+    late InMemoryOfflineFileStore files;
+
+    setUp(() {
+      store = InMemoryDownloadStore();
+      files = InMemoryOfflineFileStore();
+    });
+
+    StoreCachedTrackLocator build() => StoreCachedTrackLocator(store, files);
+
+    test('returns the cached path for a downloaded remote track', () async {
+      final String fileName =
+          await files.write('j1', const <int>[1, 2, 3], extension: 'mp3');
+      await store.saveDownloads(<CachedTrack>[
+        CachedTrack(trackId: 'j1', fileName: fileName),
+      ]);
+
+      final String? path = await build().cachedFilePath(_jellyfin('j1'));
+
+      expect(path, '/offline_audio/j1.mp3');
+    });
+
+    test('returns null for a track that is not downloaded', () async {
+      expect(await build().cachedFilePath(_jellyfin('nope')), isNull);
+    });
+
+    test('returns null for a track recorded without a cache file', () async {
+      // An on-device track is recorded with no file name.
+      await store.saveDownloads(const <CachedTrack>[CachedTrack(trackId: 'a')]);
+
+      expect(
+        await build().cachedFilePath(
+          const Track(id: 'a', title: 'a', uri: 'file:///a.mp3'),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null when the cache file is missing on disk', () async {
+      // Metadata points at a file that the file store doesn't have.
+      await store.saveDownloads(<CachedTrack>[
+        const CachedTrack(trackId: 'j1', fileName: 'j1.mp3'),
+      ]);
+
+      expect(await build().cachedFilePath(_jellyfin('j1')), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements a Jellyfin-aware offline cache/download model. The behavior is
**Plexamp/Plex Pass-style, but open-source and fully user-controlled**: the
whole Jellyfin library stays visible and streamable, and the user marks exactly
the tracks they want offline. Cached tracks then play from the local file;
otherwise playback streams from Jellyfin (online) or shows a friendly offline
message.

## Plexamp-style offline behavior

- **Full library stays visible.** Syncing Jellyfin shows the whole catalog —
  nothing is hidden behind a download.
- **Downloads are explicit.** The user marks individual tracks for offline use.
  **No automatic full-library sync, no surprise downloads.**
- **Streaming is the default.** An un-downloaded Jellyfin track streams normally
  when online and signed in.
- **Cached items are playable offline.** Playback prefers the local cached file;
  an uncached track while offline surfaces a friendly "couldn't reach your
  server" message instead of an opaque failure.

## What downloads, and what does not

- **Jellyfin tracks** → bytes are fetched from `/Items/<id>/Download` and cached
  on disk (`RemoteTrackDownloader` → `JellyfinTrackDownloader`).
- **On-device (local) tracks** → already local, so they're recorded as
  available offline with **no network fetch and no managed cache file**.
- **Album / playlist "download all"** → intentionally **out of scope** for this
  PR (track-level UI only). The seam is ready: `requestDownload(Track)` plus
  `RemoteTrackDownloader` compose per-track, so a batch action is additive UI
  with no architectural change.

## Architecture

UI depends on download-state/resolver providers, never on raw file paths. Jellyfin
download logic sits behind a client/source abstraction; cache policy lives in one
repository; local playback and Jellyfin streaming stay cleanly separated.

- `DownloadRepository.requestDownload(Track)` — now source-aware.
- `CacheDownloadRepository` — owns the user-initiated, source-aware,
  Wi-Fi-respecting policy.
- `RemoteTrackDownloader` / `JellyfinDownloadSource` / `JellyfinTrackDownloader`
  — remote byte-fetch behind an interface (`JellyfinMusicSource` implements the
  download source, mirroring the existing stream source).
- `OfflineFileStore` (`FileSystemOfflineFileStore` in the app,
  `InMemoryOfflineFileStore` in tests) — cached bytes.
- `DownloadStore` now persists a `CachedTrack` record (track id + cache file
  name) instead of a bare id set.
- `CachedTrackLocator` (`StoreCachedTrackLocator`) + `OfflineFirstPlayableUriResolver`
  — cache-first playback resolution.

## UI states & actions

Per-track control reflects `notDownloaded → queued → downloading → downloaded`,
plus `failed`, with **download**, **remove offline copy**, and **retry**.

## Security / token handling

- The Jellyfin token is **never** stored on `Track.uri`, in `DownloadStore`
  metadata, in a cache file name, in a log, or in a user-facing error.
- A track's stored URI stays the token-free `jellyfin:<id>`; the authenticated
  **download** URL is minted only at fetch time (like the **stream** URL at play
  time) and never persisted.
- A transport failure is re-raised as a generic message so a `ClientException`
  carrying the tokenized URL can't escape.
- Cache file names are derived only from the non-secret track id, sanitized to
  filename-safe characters (no path traversal).
- Passwords are still never persisted.

## Cache storage behavior

Downloaded bytes live in an **app-private application-support directory** (not
the OS cache, which can be reclaimed). Durable metadata is the `CachedTrack` set
behind `DownloadStore` (`shared_preferences` in the app). Only `downloaded` is
durable; `queued`/`downloading`/`failed` are in-memory and reset on restart. If
a cache file goes missing, the locator returns `null` and playback transparently
falls back to streaming.

## Limitations

- Track-level downloads only (album/playlist batch deferred — seam ready).
- No background download manager (inline, no resume, no auto-flush of the queue
  when Wi-Fi returns — re-tap a queued track to retry).
- Connectivity is still optimistic (`connectivity_plus` not yet wired); the
  Wi-Fi-only gate and its tests are in place.
- No Drift `downloads` table yet (key/value `CachedTrack` set is enough until
  byte-progress/resume is needed).

## Tests added

Fake Jellyfin source/session/download store; no real server or network.

- `CacheDownloadRepository`: Jellyfin track starts `notDownloaded`; downloading
  stores a cached file reference; removing deletes the cached file; failed fetch
  → `failed` (+ retry); local tracks recorded with no remote fetch / no file;
  no token in `Track.uri` or cache metadata; Wi-Fi-only queues remote (never
  local).
- `JellyfinTrackDownloader` (fake source + `MockClient`): verifies then fetches;
  content-type → extension; not-signed-in / verify-failure / no-URL / non-2xx;
  transport failure re-raised **without leaking the tokenized URL**.
- `OfflineFirstPlayableUriResolver`: cache hit returns the local file; miss
  streams; uncached-offline surfaces the friendly unavailable error.
- `StoreCachedTrackLocator`: returns the cached path; `null` for not-downloaded,
  local-without-file, and missing-on-disk.
- `FileSystemOfflineFileStore` (temp dir): write/resolve/delete; id-derived,
  separator-free file name.
- `JellyfinMusicSource.resolveDownloadUri`: mints the `/Items/<id>/Download` URL
  with the token on demand while the track URI stays token-free.

## Verification

- `flutter pub get` ✓
- `dart format --set-exit-if-changed .` ✓ (0 changed)
- `flutter analyze` ✓ (No issues found)
- `flutter test` ✓ (All 292 tests passed)

## Next recommended PR

Album/playlist-level "download all" UI over the existing per-track seam, then a
background/resumable download manager (work queue + notification) and wiring
`connectivity_plus` so the Wi-Fi-only gate and auto-resume act on real network
state.

https://claude.ai/code/session_01WrMhvbxmqxUYc21XcVo2dq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrMhvbxmqxUYc21XcVo2dq)_