### PR TITLE
Stabilize Linthra for real-device Android testing (friendly errors, offline-cache notes, test checklist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,29 @@ it covers the paths that only behave correctly on real hardware:
 6. **Friendly playback errors.** With Jellyfin signed out, try to play a synced
    Jellyfin track and confirm the Now Playing status line shows a precise,
    friendly message (e.g. "not signed in"), not an opaque engine error.
+7. **Download a Jellyfin track for offline.** Signed in and online, tap the
+   download icon on a synced Jellyfin track in the Library. It should show a
+   spinner, then a filled "downloaded" icon. The track should also appear on the
+   **Downloads** tab.
+8. **Play a cached track fully offline.** Enable **airplane mode** (or stop the
+   server). Play the downloaded track — it should play from the **local cached
+   file** with no network error. Then try an *un-downloaded* Jellyfin track and
+   confirm you get the friendly "couldn't reach your server" message, never a
+   raw failure or a silent hang.
+9. **Remove a download.** Back online or off, remove the download (Downloads tab
+   trash icon, or the Library row's "remove" action). It should **disappear from
+   the Downloads tab immediately** and the Library row should revert to the
+   "download" action.
+10. **Retry a failed download.** Start a Jellyfin download, then kill the server
+    or connection mid-fetch so it fails. The Library row should show an **error
+    icon with a "Retry download" tooltip**; tapping it re-attempts the download
+    (it succeeds once the server is reachable again).
+11. **Wi-Fi-only gate.** On the Downloads tab, turn on **Wi-Fi only**, switch to
+    mobile data (or a future real detector), and start a download — it should be
+    **queued** rather than run over mobile data. (See the connectivity note in
+    *Offline downloads & known limitations*.)
+12. **No secrets on screen.** Throughout, confirm no error, status line, or
+    track subtitle ever shows a Jellyfin token, `api_key`, password, or raw URL.
 
 See *Testing scanning on Android* below for the SAF-specific detail, and the
 *Limitations still remaining* list at the end of this section.

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -31,7 +31,14 @@ class DownloadsScreen extends ConsumerWidget {
   Widget _list(AsyncValue<List<Track>> downloaded) {
     return downloaded.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, _) => Center(child: Text('$error')),
+      // Never surface raw exception text (it can carry paths or store detail);
+      // show one calm, friendly line instead.
+      error: (_, __) => const EmptyState(
+        icon: Icons.error_outline,
+        title: "Couldn't load downloads",
+        message:
+            'Something went wrong reading your downloads. Try again later.',
+      ),
       data: (tracks) {
         if (tracks.isEmpty) {
           return const EmptyState(

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -58,14 +58,20 @@ class LibraryController extends Notifier<LibraryState> {
       "Couldn't scan that folder. Try selecting it again, or pick a different "
       'folder.';
 
+  static const String _loadFailedMessage =
+      "Couldn't open your music library. Try again, or rescan your music "
+      'folder.';
+
   Future<void> _load() async {
     state = const LibraryState.loading();
     try {
       final tracks =
           await ref.read(musicLibraryRepositoryProvider).getAllTracks();
       state = LibraryState.loaded(tracks);
-    } catch (error) {
-      state = LibraryState.error(error.toString());
+    } catch (_) {
+      // Don't leak raw store/exception text (file paths, SQL, errno) to the
+      // UI; show one friendly, actionable line instead.
+      state = const LibraryState.error(_loadFailedMessage);
     }
   }
 }

--- a/test/features/downloads/downloads_screen_test.dart
+++ b/test/features/downloads/downloads_screen_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/downloads/downloads_screen.dart';
+
+import '../library/fake_music_library_repository.dart';
+
+void main() {
+  group('DownloadsScreen', () {
+    Future<void> pump(WidgetTester tester, FakeMusicLibraryRepository repo) {
+      return tester.pumpWidget(
+        ProviderScope(
+          // Default download providers are plugin-free (in-memory store +
+          // optimistic connectivity), so the screen works without overrides.
+          overrides: [
+            musicLibraryRepositoryProvider.overrideWithValue(repo),
+          ],
+          child: const MaterialApp(home: DownloadsScreen()),
+        ),
+      );
+    }
+
+    testWidgets('shows the empty state when nothing is downloaded', (
+      tester,
+    ) async {
+      await pump(tester, FakeMusicLibraryRepository());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Nothing downloaded'), findsOneWidget);
+    });
+
+    testWidgets('shows a friendly, leak-free error when the library throws', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        FakeMusicLibraryRepository(
+          error: Exception('FileSystemException: /data/.../db errno = 13'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("Couldn't load downloads"), findsOneWidget);
+      // The raw exception text must never reach the UI.
+      expect(find.textContaining('errno'), findsNothing);
+      expect(find.textContaining('Exception'), findsNothing);
+    });
+
+    testWidgets('removing a download drops it from the list', (tester) async {
+      const track = Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3');
+      await pump(
+        tester,
+        FakeMusicLibraryRepository(tracks: const <Track>[track]),
+      );
+      await tester.pumpAndSettle();
+
+      // Mark the on-device track as downloaded so it appears in the list.
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(DownloadsScreen)),
+      );
+      await container.read(downloadRepositoryProvider).requestDownload(track);
+      await tester.pumpAndSettle();
+      expect(find.text('Song One'), findsOneWidget);
+
+      // Removing it must update the UI state: the row disappears.
+      await tester.tap(find.byTooltip('Remove download'));
+      await tester.pumpAndSettle();
+      expect(find.text('Song One'), findsNothing);
+      expect(find.text('Nothing downloaded'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/library/library_controller_test.dart
+++ b/test/features/library/library_controller_test.dart
@@ -90,16 +90,24 @@ void main() {
       expect(state.isEmpty, isTrue);
     });
 
-    test('surfaces an error when the repository throws', () async {
+    test('surfaces a friendly, leak-free error when the repository throws',
+        () async {
+      // A raw store failure (a corrupt-db or filesystem error on device) must
+      // not leak its text — the user sees one clean, actionable line instead.
       final container = _containerWith(
-        FakeMusicLibraryRepository(error: Exception('boom')),
+        FakeMusicLibraryRepository(
+          error: Exception('FileSystemException: /data/.../db errno = 13'),
+        ),
       );
 
       await container.read(libraryControllerProvider.notifier).refresh();
 
       final state = container.read(libraryControllerProvider);
       expect(state.status, LibraryStatus.error);
-      expect(state.errorMessage, contains('boom'));
+      expect(state.errorMessage, contains("Couldn't open your music library"));
+      // The raw exception text never reaches the UI.
+      expect(state.errorMessage, isNot(contains('errno')));
+      expect(state.errorMessage, isNot(contains('Exception')));
     });
 
     test('scanFolder persists discovered tracks and reloads', () async {


### PR DESCRIPTION
## Summary

A bug-fix/polish pass to get Linthra ready for real Android device testing ahead of the first alpha APK. No new features, no F-Droid submission, no release publishing, no UI redesign.

After inspecting every subsystem in scope (local folder scan, Android SAF scan, local playback, Jellyfin login/sync/streaming, the Plexamp-style offline cache/download path, the Wi-Fi-only preference, background playback/`audio_service`, Android Auto/media session, the debug-APK workflow, and the README test checklist), the codebase was found to already handle most requested behaviors correctly. This PR closes the two genuine gaps — UI surfaces that still rendered raw exception text — and strengthens the docs and tests.

## Real-device issues addressed

- **Friendly error messages (items 1 & 6).** Two places still surfaced raw `error.toString()` to the UI, which on a real device can leak file paths, `errno` codes, or store/SQL detail:
  - `LibraryController._load` (`lib/features/library/library_controller.dart`) now shows *"Couldn't open your music library. Try again, or rescan your music folder."* instead of the raw exception. The existing scan-failure path was already friendly; this brings the library **load** path in line.
  - `DownloadsScreen` (`lib/features/downloads/downloads_screen.dart`) now renders a calm `EmptyState` (*"Couldn't load downloads"*) instead of `Text('$error')`.

## Offline cache behavior confirmed

Verified against the existing implementation (no changes needed — already correct):

- **Cached tracks prefer the local file (item 2).** `OfflineFirstPlayableUriResolver` checks `CachedTrackLocator.cachedFilePath` first and returns a `file://` URI on a hit; only a miss falls through to streaming. `StoreCachedTrackLocator` also confirms the bytes are still on disk via `OfflineFileStore.pathFor`, so a reclaimed file transparently falls back to streaming.
- **Uncached tracks stream only when online + valid session (item 3).** `JellyfinPlayableUriResolver` calls `verifyReachable()` before minting a stream URL, throwing precise, friendly errors for not-signed-in / session-expired / server-unreachable / stream-unavailable.
- **Cache removal updates UI state (item 4).** `removeDownload` deletes the file, updates the durable store, and broadcasts `notDownloaded` on `statusStream`; `downloadedTracksProvider` and the per-row `trackDownloadStatusProvider` recompute immediately. Now covered by a new Downloads-screen widget test.
- **Failed-download retry is clear (item 5).** A failed download shows an error icon with a *"Retry download"* tooltip in the Library row; tapping it re-runs `requestDownload`. `requestDownload` allows retry from `failed`/`queued` but never re-triggers `downloaded`/`downloading`. Already covered by repository tests.

## Jellyfin / security notes (item 6)

Audited the whole token/password lifecycle; **no leaks found**, and no code changes were required:

- **`Track.uri`** stays the token-free `jellyfin:<itemId>` scheme; the authenticated stream/download URL is minted on demand at play/fetch time and never stored.
- **Database rows** persist only the opaque `uri` (no token/api_key/password column).
- **Cache metadata & filenames** are derived only from the non-secret track id, sanitized to filename-safe characters; no token in `CachedTrack` or on disk.
- **Logs**: no `print`/`debugPrint`/`log` calls in `lib/`. The Jellyfin downloader re-wraps transport failures as a generic message so a `ClientException` carrying the tokenized URL can't escape.
- **UI errors** branch on typed error kinds, never raw HTTP bodies. The two raw-text surfaces fixed here were the last gaps; both are now leak-free and asserted by tests.

## Manual Android test checklist

The README's *Manual smoke test on a real Android phone* section is extended (steps 7–12) to cover the offline path that only behaves correctly on hardware: download a Jellyfin track, play a cached track fully offline (airplane mode), confirm the friendly offline error for uncached tracks, remove a download and confirm immediate UI update, retry a failed download, exercise the Wi-Fi-only gate, and verify no secrets ever appear on screen.

## Tests

- New `test/features/downloads/downloads_screen_test.dart`: empty state, friendly+leak-free error on library failure, and removal dropping the row from the Downloads list.
- Updated `test/features/library/library_controller_test.dart`: the load-failure test now asserts the message is friendly and contains no raw `errno`/`Exception` text.

## Verification

Run locally against Flutter 3.27.4 (the CI-pinned version):

- `flutter pub get` — ok
- `dart format --set-exit-if-changed .` — clean (0 changed)
- `flutter analyze` — No issues found
- `flutter test` — **All 295 tests passed**
- `flutter build apk --debug` — not run here (no Android SDK in this environment); covered by the existing `android-debug-build` CI workflow.

## Remaining limitations (unchanged, out of scope)

- Track-level downloads only — no album/playlist "download all".
- No background download manager: downloads run inline, no worker/resume, no auto-flush of the queued set when Wi-Fi returns (re-tap to retry).
- Connectivity is optimistic (`OptimisticConnectivityService` reports Wi-Fi) until `connectivity_plus` is wired in, so the Wi-Fi-only gate only blocks when a detector reports mobile/offline.
- Downloads metadata is a key/value `DownloadStore`, not a Drift table (no byte-level progress yet).
- A cached file reclaimed by the OS still shows as "downloaded" while transparently falling back to streaming.

## Next recommended PR

Wire `connectivity_plus` into a real `ConnectivityService` so the Wi-Fi-only gate is enforced on-device and queued downloads auto-flush when Wi-Fi returns — the seam and tests are already in place. (A background/resumable download manager is the larger follow-on after that.)

https://claude.ai/code/session_01KEMKJXsX5ji65AqNz7VSfc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEMKJXsX5ji65AqNz7VSfc)_