### PR TITLE
Prepare v0.1.0-alpha.1 alpha release (versioning, changelog, notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,18 @@ control.
 
 ## Status
 
-**Early-stage, but Library v1 is wired end to end.** Alongside the project
+**First alpha: `0.1.0-alpha.1`.** Linthra is now a manually testable Android
+build. Local scanning, local playback, background playback with a media
+notification, an Android Auto browse foundation, Jellyfin connect/sync/stream,
+and explicit user-initiated offline downloads all work end to end. It is still
+early software with honest, documented limitations — see the per-feature
+"known limitations" sections below and the
+[v0.1.0-alpha.1 release notes](./docs/release-notes/v0.1.0-alpha.1.md). It is
+**not** on F-Droid yet, and nothing is published automatically.
+
+**Library v1 and beyond, wired end to end.** Alongside the project
 structure, dark-first theming, navigation, app shell, core domain models, and
-the service/repository *interfaces*, the Library feature now works as a real
+the service/repository *interfaces*, the Library feature works as a real
 vertical slice.
 
 **Library v1.** The Library screen can scan a local folder, persist the
@@ -492,6 +501,12 @@ signs its own builds) — are in [docs/release-signing.md](./docs/release-signin
   [docs/release-process.md](./docs/release-process.md). F-Droid readiness is
   tracked separately in [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
 
+> **First alpha (`v0.1.0-alpha.1`).** The draft GitHub-Release body — what
+> works, known limitations, sideload instructions, and the manual release
+> steps — lives in
+> [docs/release-notes/v0.1.0-alpha.1.md](./docs/release-notes/v0.1.0-alpha.1.md).
+> It is a draft only; cutting the tag and publishing the Release stay manual.
+
 ### Background playback & Android Auto
 
 Linthra registers a platform **media session** through `audio_service` so
@@ -954,8 +969,9 @@ branch rather than `main`.
 
 Later: Jellyfin (landed — settings, auth, encrypted session, a library source,
 Library sync, streaming playback, and explicit per-track offline downloads;
-album/playlist "download all" and a background download manager next), WebDAV,
-NAS, lyrics, ReplayGain, MPRIS, Android Auto, smart playlists, and more.
+album/playlist "download all" and a background download manager next), Android
+Auto (foundation landed — browsable Library/Queue; album/artist grouping and
+search next), WebDAV, NAS, lyrics, ReplayGain, MPRIS, smart playlists, and more.
 
 ## F-Droid metadata (work in progress)
 
@@ -969,8 +985,8 @@ F-Droid / Fastlane-style store metadata under
   limit).
 - `full_description.txt` — long description that deliberately separates what
   works today from what is still planned.
-- `changelogs/1.txt` — placeholder release notes for `versionCode` 1 (the
-  current `0.1.0+1`); replaced with real notes once a published version exists.
+- `changelogs/1.txt` — release notes for `versionCode` 1 (the current
+  `0.1.0-alpha.1+1`), shown by F-Droid if/when the app is listed.
 
 **Branding (real, committed).** Linthra now has a genuine app icon — four
 rounded white equalizer bars on the brand violet gradient — generated
@@ -991,10 +1007,11 @@ avoided so the listing never misrepresents the app. The full asset checklist,
 exact sizes, and screenshot-capture steps are in
 [docs/listing-assets.md](./docs/listing-assets.md).
 
-The wording describes only shipped behaviour (folder selection, scanning,
-playback, persisted listing) as done; playlists and offline downloads are
-described as planned. There are no claims of F-Droid availability and no
-marketing language that overpromises.
+The wording describes only shipped behaviour (folder selection, scanning, local
+and Jellyfin playback, background playback, Android Auto browsing, and explicit
+offline downloads) as done; tag parsing, artwork, playlists, and batch
+downloads are described as planned. There are no claims of F-Droid availability
+and no marketing language that overpromises.
 
 ### Release & F-Droid documentation
 

--- a/docs/release-notes/v0.1.0-alpha.1.md
+++ b/docs/release-notes/v0.1.0-alpha.1.md
@@ -1,0 +1,132 @@
+# Linthra v0.1.0-alpha.1 — release notes (draft)
+
+> **Draft, not published.** This is the GitHub Release body to use when the
+> `v0.1.0-alpha.1` tag is cut. Nothing here publishes automatically; see
+> [docs/release-process.md](../release-process.md) for the manual steps.
+
+**Linthra is a modern, local-first, privacy-focused music player for people who
+own their music.** This is the **first manually testable alpha** — an Android
+APK you can sideload and try end to end. It is early software: the sections
+below separate what works today from the known limitations, honestly.
+
+- **Version:** `0.1.0-alpha.1` (`versionName`), `versionCode` 1
+- **Platform:** Android (Linux desktop planned later, same codebase)
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+
+## What works in this alpha
+
+- **Local scanning.** Pick a folder with the native Android folder chooser; the
+  Storage Access Framework (SAF) tree is walked through the content resolver
+  (no broad storage permission), and the discovered tracks are listed. The
+  chosen folder and the scanned catalog persist across restarts. Desktop/Linux
+  selections scan a real filesystem path.
+- **Local playback.** Tap a track to play it; the rest of the visible list
+  becomes the up-next queue, with play / pause / next / stop on the Now Playing
+  screen.
+- **Background playback & media notification.** Playback survives backgrounding
+  via a foreground media session: a media notification mirrors the track with
+  transport controls, plus lock-screen, Bluetooth, and wired-headset buttons.
+  On Android 13+ the app asks once for the notification permission.
+- **Android Auto foundation.** The same media session exposes a browsable
+  **Library** and **Queue** to Android Auto, so you can pick what to play from
+  the car screen. The tree is intentionally shallow (flat track list + current
+  queue).
+- **Jellyfin connection / sync / streaming.** Connect to your own Jellyfin
+  server (including HTTPS via a Cloudflare domain or tunnel), test the
+  connection, sign in, sync your artists/albums/tracks into the local catalog,
+  and stream them. The session token is stored encrypted (Android
+  Keystore-backed); passwords are never persisted, and the token never appears
+  in URIs, logs, errors, or cache file names.
+- **Explicit offline cache / downloads.** Mark individual Jellyfin tracks for
+  offline use; the bytes are fetched to an app-private directory and playback
+  then prefers the local copy. Downloads are **always user-initiated** — there
+  is no automatic full-library sync — and a **"Wi-Fi only"** toggle can queue
+  remote downloads off Wi-Fi.
+
+## Known limitations (honest)
+
+**Android SAF / device-specific**
+
+- Cross-restart re-scanning depends on the picker granting a *persistable* URI
+  permission; if it didn't, re-pick the folder.
+- No runtime `READ_MEDIA_AUDIO` flow yet, and `MANAGE_EXTERNAL_STORAGE` is
+  intentionally **not** requested. On Android 11+ the filesystem-path fallback
+  can be unreadable under scoped storage — prefer a folder picked through the
+  SAF chooser.
+- The native SAF traversal is verifiable only on a real device/emulator; the
+  Dart seams are fully unit-tested but the manual smoke test on hardware is the
+  real check (see the README checklist).
+- **No tag/metadata parsing yet.** Tracks show a title derived from the file
+  name and fall back to the path when artist/album tags are absent; no album
+  artwork.
+
+**Jellyfin**
+
+- **Single server only** — one session is stored; no multi-server support.
+- **Cloudflare Access / Zero Trust is not supported** — Linthra speaks only to
+  Jellyfin's own auth, so use a hostname that reaches Jellyfin directly.
+- No lyrics, no sync-conflict handling, and no richer transcoding/streaming
+  parameters yet.
+
+**Offline cache**
+
+- **Track-level downloads only** — no album/playlist "download all".
+- **No background download manager** — downloads run inline; there is no worker,
+  no resume of a partial transfer, and no auto-flush of the queue when Wi-Fi
+  returns (re-tap a queued track to retry).
+- **Connectivity is optimistic** — until `connectivity_plus` is wired in, the
+  app assumes Wi-Fi, so the "Wi-Fi only" gate only blocks when a detector
+  reports mobile/offline.
+- Only `downloaded` is durable; `queued` / `downloading` / `failed` reset on
+  restart.
+
+**Playlists & queue**
+
+- No saved playlists yet (model + repository interface exist, no persisted
+  store). The queue is play-from-here + jump only — no reorder, shuffle, or
+  repeat.
+
+**Distribution**
+
+- **Not on F-Droid yet** — no submission has been made. This alpha is a
+  sideloadable APK only. A GitHub-Release APK is signed with **our** key while a
+  future F-Droid build would be signed with **F-Droid's** key, so the two can't
+  cross-update; don't mix sources.
+
+## Install (sideload)
+
+1. Download the `app-release.apk` attached to this release (or build it
+   yourself — see the README).
+2. On your Android device, allow installing from unknown sources if prompted,
+   then open the APK. Or, with the device connected over ADB:
+   ```bash
+   adb install -r app-release.apk
+   ```
+3. On first launch (Android 13+), tap **Allow** on the notification prompt so
+   the media notification and its controls can appear.
+
+See the **Manual smoke test on a real Android phone** checklist in the README
+for a full walkthrough of every path worth exercising in this alpha.
+
+## Manual release steps (operator)
+
+These are **not** automated — nothing publishes on its own.
+
+1. Confirm CI is green and generated Drift files are current on the commit.
+2. Verify `pubspec.yaml` is `0.1.0-alpha.1+1` and `versionCode` is monotonic.
+3. Tag the release commit:
+   ```bash
+   git tag -a v0.1.0-alpha.1 -m "Linthra 0.1.0-alpha.1"
+   git push origin v0.1.0-alpha.1
+   ```
+4. Run the **Android Release Build** workflow with `signed = true` (requires the
+   `LINTHRA_*` keystore secrets — see
+   [docs/release-signing.md](../release-signing.md)) and download the
+   `linthra-release-signed-apk` / `-aab` artifacts. A `signed = false` run
+   produces debug-signed previews that must **not** be attached to a release.
+5. Create the GitHub Release against the `v0.1.0-alpha.1` tag, mark it a
+   **pre-release**, paste this document as the body, and attach the signed
+   APK/AAB.
+
+Full reference: [docs/release-process.md](../release-process.md).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -14,7 +14,7 @@ docs reference this document rather than restating the plan.
 `pubspec.yaml` is the **single source of truth** for the version:
 
 ```
-version: x.y.z+<versionCode>      # currently 0.1.0+1
+version: x.y.z+<versionCode>      # currently 0.1.0-alpha.1+1
 ```
 
 - **`versionName` = `x.y.z`** — the human-facing [SemVer](https://semver.org/)
@@ -31,7 +31,9 @@ bumping `pubspec.yaml` is enough.
   decrease it — Android refuses to install an update with an equal/lower code,
   and F-Droid relies on it to order versions.
 - `versionName` follows SemVer. Pre-1.0, treat `0.y.z` as "still early; the API
-  and feature set can change between minor versions."
+  and feature set can change between minor versions." A SemVer pre-release
+  suffix (e.g. `0.1.0-alpha.1`) marks an explicitly unstable build; the matching
+  tag is `vX.Y.Z-suffix` and the GitHub Release should be marked **pre-release**.
 
 ## 2. Tagging
 
@@ -58,7 +60,10 @@ Before creating a release tag:
 1. **Bump the version** in `pubspec.yaml` (`versionName` and `versionCode`).
 2. **Add a changelog** for the new `versionCode` at
    `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` (e.g.
-   `1.txt` for `0.1.0+1`). Keep it short and factual; this is what F-Droid shows.
+   `1.txt` for `0.1.0-alpha.1+1`). Keep it short and factual; this is what
+   F-Droid shows. A longer GitHub-Release body can live under
+   `docs/release-notes/vX.Y.Z*.md` (see the
+   [v0.1.0-alpha.1 draft](./release-notes/v0.1.0-alpha.1.md)).
 3. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
    schema at the tagged commit — run the
    [Generate Drift files workflow](../README.md#generating-drift-files-in-ci) or
@@ -136,8 +141,12 @@ to F-Droid.
 2. **A `vX.Y.Z` tag** exists — none does yet.
 3. **Decide the `pubspec.lock` policy** for reproducible release builds
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
-4. **Feature-maturity call:** decide whether `0.1.0` (library scan only; playback
-   not shipped) is the version to release, or whether to wait.
+4. **Feature-maturity call — made for the alpha.** `0.1.0-alpha.1` ships local
+   scanning + playback, background playback / media notification, an Android
+   Auto browse foundation, Jellyfin connect/sync/stream, and explicit offline
+   downloads. It is published as a sideloadable, pre-release alpha (no F-Droid
+   submission yet). See
+   [docs/release-notes/v0.1.0-alpha.1.md](./release-notes/v0.1.0-alpha.1.md).
 
 See [fdroid-readiness.md §8](./fdroid-readiness.md#8-remaining-blockers-before-submission)
 for the full F-Droid blocker list.

--- a/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,8 +1,18 @@
-Initial development build (0.1.0).
+Linthra 0.1.0-alpha.1 — first manually testable alpha.
 
-Early-stage. Working today: select a music folder, scan it, and list the
-discovered tracks; the selection and catalog persist across restarts. Audio
-playback, playlists, and offline downloads are still in progress.
+Working in this build:
+- Pick a local folder, scan it (Storage Access Framework on Android), and
+  list the discovered tracks; the choice and catalog persist across restarts.
+- Local audio playback with an up-next queue.
+- Background playback with a media notification and lock-screen / Bluetooth /
+  headset controls.
+- Android Auto: a browsable Library and Queue from the car screen.
+- Jellyfin: connect to your own server, sign in, sync your library, and
+  stream tracks. The session token is stored encrypted; passwords are never
+  saved.
+- Explicit, user-initiated offline downloads of Jellyfin tracks, with a
+  "Wi-Fi only" option. Nothing downloads automatically.
 
-This is a placeholder changelog for the first versionCode and will be replaced
-with real release notes once a published version exists.
+Alpha, so expect rough edges. Known limits: no tag/metadata parsing yet
+(tracks show file names), track-level downloads only, single Jellyfin server,
+optimistic connectivity detection, and no saved playlists. Not on F-Droid yet.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,9 +1,8 @@
 Linthra is an open-source, local-first music player for people who own their
 music. Your library lives on your device, and you stay in control of it.
 
-Linthra is early-stage software and under active development. The sections
-below clearly separate what works today from what is planned, so nothing here
-overpromises.
+Linthra is early-stage software in its first alpha. The sections below clearly
+separate what works today from what is planned, so nothing here overpromises.
 
 What Linthra is about:
 
@@ -12,28 +11,32 @@ What Linthra is about:
 * User-owned music — Linthra plays the files you already have. There is no
   store, no account, and no requirement to use anyone's cloud.
 * Privacy-focused — no telemetry and no forced sync. The app does not phone
-  home or upload your library.
+  home or upload your library, and offline downloads only ever happen when you
+  ask for them.
 * Open-source — released under the Mozilla Public License 2.0. Anyone can
   read, audit, build, and contribute to the code.
 
 Working today:
 
-* Pick a folder of music using the native Android folder picker.
-* Scan that folder and build a local catalog of your tracks.
-* The chosen folder and the scanned tracks are saved on the device, so they
-  survive an app restart.
+* Pick a folder of music using the native Android folder picker, scan it, and
+  list your tracks. The chosen folder and the scanned catalog survive a
+  restart.
+* Play your local tracks, with an up-next queue.
+* Background playback with a media notification and lock-screen, Bluetooth, and
+  wired-headset controls.
+* Android Auto: browse your Library and Queue from the car screen.
+* Connect to your own Jellyfin server, sign in, sync your library, and stream
+  tracks. The session token is stored encrypted and passwords are never saved.
+* Explicit, user-initiated offline downloads of Jellyfin tracks, with a
+  "Wi-Fi only" option — never automatic.
 
 Planned (not finished yet):
 
-* Audio playback with a background media session (notification and lock-screen
-  controls).
-* Browsing by artist and album, plus search and album artwork.
-* Playlist creation and editing.
-* Explicit, user-initiated offline downloads with a "Wi-Fi only" option — never
-  automatic. The groundwork for this download policy already exists in the code,
-  but no remote sources are wired up yet.
-* Additional sources (such as Jellyfin, WebDAV, and NAS) behind a single
-  interface.
+* Tag/metadata parsing and album artwork (tracks currently show file names).
+* Browsing by artist and album, plus search.
+* Playlist creation and editing, plus queue reorder/shuffle/repeat.
+* Album- and playlist-level "download all" and a background download manager.
+* Additional sources (such as WebDAV and NAS) behind the same interface.
 
 Platforms:
 

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -6,5 +6,5 @@ abstract final class AppInfo {
   /// App version, kept in step with `pubspec.yaml`. Sent (informationally) to
   /// Jellyfin as the client version in the auth header so the server can label
   /// this device in its dashboard.
-  static const String version = '0.1.0';
+  static const String version = '0.1.0-alpha.1';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: linthra
 description: A modern, local-first, privacy-focused music player.
 publish_to: "none"
-version: 0.1.0+1
+version: 0.1.0-alpha.1+1
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepares Linthra **v0.1.0-alpha.1** as a manually testable Android APK release. Versioning, changelog, and release-notes only — **no app features change, and nothing is published automatically.**

### Version changes
- `pubspec.yaml`: `0.1.0+1` → `0.1.0-alpha.1+1`. `versionCode` stays **1** — it is monotonic because no prior release was ever published, so this is the real first release at code 1.
- `lib/core/app_info.dart`: `AppInfo.version` → `0.1.0-alpha.1` (kept in step; sent informationally to Jellyfin as the client version — the existing auth-header test reads it dynamically, so it stays green).

### Release notes summary
- Replaced the placeholder F-Droid changelog (`fastlane/.../changelogs/1.txt`) with real, short alpha notes.
- Added a draft GitHub-Release body at `docs/release-notes/v0.1.0-alpha.1.md` (what works, known limitations, sideload steps, manual release steps).
- Updated `fastlane/.../full_description.txt` to move shipped features (playback, background playback, Android Auto, Jellyfin, offline downloads) from "planned" into "working today".
- Updated README **Status**, the F-Droid metadata section, the MVP roadmap, and `docs/release-process.md` (version examples, SemVer pre-release guidance, and the now-resolved "feature-maturity" blocker).

### What works (documented)
Local scanning (SAF) · local playback · background playback + media notification · Android Auto browse foundation (Library/Queue) · Jellyfin connect/sync/streaming (encrypted token, passwords never saved) · explicit, user-initiated offline downloads with "Wi-Fi only".

### Known limitations (documented honestly)
- **Android/SAF:** persistable-URI dependence for re-scan; no `READ_MEDIA_AUDIO` flow and no `MANAGE_EXTERNAL_STORAGE`; native SAF walk only verifiable on a device; no tag parsing / artwork yet.
- **Jellyfin:** single server only; no Cloudflare Access/Zero Trust; no lyrics/sync-conflict handling.
- **Offline cache:** track-level only; no background download manager/resume; optimistic connectivity; only `downloaded` is durable.
- **Distribution:** not on F-Droid yet; GitHub-Release key ≠ F-Droid key (don't mix sources).

### Manual release steps (not automated)
Tag `v0.1.0-alpha.1` → run **Android Release Build** with `signed = true` → download `linthra-release-signed-*` → create a **pre-release** GitHub Release using `docs/release-notes/v0.1.0-alpha.1.md` as the body and attach the signed APK/AAB. Full detail in that doc and `docs/release-process.md`.

### Verification (run locally on Flutter 3.27.4, the pinned CI version)
- `flutter pub get` — ok
- `dart format --set-exit-if-changed .` — 0 changed
- `flutter analyze` — no issues
- `flutter test` — **295 passed**
- Android debug/release workflow instructions reviewed for accuracy.

### Next recommended PR
Tag-and-publish the alpha: cut the `v0.1.0-alpha.1` tag, run the signed Android Release Build, and create the pre-release GitHub Release with the attached APK/AAB — plus capture real device screenshots for the listing (`fastlane/.../images/NEEDED-ASSETS.txt`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MwHGTc51UGH2RSMUqEhGHY)_