### PR TITLE
Stabilize alpha playback: pinned controller, Jellyfin streaming, mini-player, lyrics entry

### DIFF
--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/playback_state.dart';
+import '../../core/services/playback_controller.dart';
+import 'player_providers.dart';
+
+/// A compact, persistent now-playing bar shown above the bottom navigation on
+/// every main screen (Library / Playlists / Downloads / Settings).
+///
+/// It renders from [playbackStateProvider] — the same single
+/// [PlaybackController] the full [PlayerScreen] and the media session use — so
+/// it never owns playback state of its own and never disappears when switching
+/// tabs. When nothing is loaded it collapses to zero height. Tapping it opens
+/// the full now-playing screen; the play/pause button delegates straight to the
+/// controller.
+class MiniPlayer extends ConsumerWidget {
+  const MiniPlayer({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(playbackControllerProvider);
+    final state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+
+    // Collapse entirely when there is nothing to show, so screens without a
+    // loaded track look exactly as they did before.
+    if (!state.hasTrack) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final track = state.currentTrack!;
+    final subtitle = _subtitle(state);
+
+    return Material(
+      color: theme.colorScheme.surfaceContainerHigh,
+      child: InkWell(
+        onTap: () => context.push(AppRoutes.player),
+        child: Container(
+          height: 64,
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          decoration: BoxDecoration(
+            border: Border(
+              top: BorderSide(
+                color: theme.colorScheme.outlineVariant,
+                width: 0.5,
+              ),
+            ),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.music_note, color: theme.colorScheme.primary),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      track.title,
+                      style: theme.textTheme.titleSmall,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (subtitle != null)
+                      Text(
+                        subtitle,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurface
+                              .withValues(alpha: 0.6),
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              _PlayPauseButton(state: state, controller: controller),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Artist • album when present; falls back to artist or album alone, and to
+  /// nothing when the track carries no metadata.
+  static String? _subtitle(PlaybackState state) {
+    final track = state.currentTrack!;
+    final parts = <String>[
+      if (track.artistName != null && track.artistName!.isNotEmpty)
+        track.artistName!,
+      if (track.albumName != null && track.albumName!.isNotEmpty)
+        track.albumName!,
+    ];
+    return parts.isEmpty ? null : parts.join(' • ');
+  }
+}
+
+/// The mini-player's transport control: a spinner while a track loads, then a
+/// play/pause toggle that forwards to the controller.
+class _PlayPauseButton extends StatelessWidget {
+  const _PlayPauseButton({required this.state, required this.controller});
+
+  final PlaybackState state;
+  final PlaybackController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.status == PlaybackStatus.loading) {
+      return const SizedBox.square(
+        dimension: 24,
+        child: Padding(
+          padding: EdgeInsets.all(AppSpacing.xs),
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    final playing = state.isPlaying;
+    return IconButton(
+      onPressed: playing ? controller.pause : controller.play,
+      icon: Icon(playing ? Icons.pause : Icons.play_arrow),
+      tooltip: playing ? 'Pause' : 'Play',
+    );
+  }
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -35,11 +35,22 @@ final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
 ///
 /// Defaults to the `just_audio`-backed implementation, wired with the routing
 /// resolver above. Tests override it with a fake so playback can be exercised
-/// without the audio plugin. Disposed with the provider scope so native
-/// resources are released on shutdown.
+/// without the audio plugin. Disposed with the provider scope (i.e. on app
+/// shutdown) so native resources are released.
+///
+/// Lifecycle: this is pinned for the whole app session. It reads its resolver
+/// once with [Ref.read] rather than [Ref.watch], so a rebuild of the resolver,
+/// the offline-cache locator, or the download stores can never tear the
+/// controller down. That matters because the live `AudioPlayer` and the
+/// `audio_service` media session are both bound to *this* instance: recreating
+/// it mid-playback would dispose the player (cutting the music) and leave the
+/// notification mirroring a dead controller. Navigating between tabs and
+/// changing settings touch none of that, so playback survives them. The
+/// resolver still reads the live signed-in Jellyfin source lazily at play time,
+/// so sign-in/out is picked up without rebuilding the controller.
 final playbackControllerProvider = Provider<PlaybackController>((ref) {
   final controller = JustAudioPlaybackController(
-    resolver: ref.watch(playableUriResolverProvider),
+    resolver: ref.read(playableUriResolverProvider),
   );
   ref.onDispose(controller.dispose);
   return controller;

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -113,7 +113,42 @@ class _TrackInfo extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.lg),
         _Controls(state: state),
+        const SizedBox(height: AppSpacing.md),
+        const _LyricsButton(),
       ],
+    );
+  }
+}
+
+/// Visible entry point for lyrics. Lyrics aren't sourced yet, so tapping opens a
+/// calm empty state rather than nothing — the button stays put for when a real
+/// lyrics source lands in a later change. No lyrics are fetched or scraped.
+class _LyricsButton extends StatelessWidget {
+  const _LyricsButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: () => _showLyrics(context),
+      icon: const Icon(Icons.lyrics_outlined),
+      label: const Text('Lyrics'),
+    );
+  }
+
+  void _showLyrics(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) => const SafeArea(
+        child: Padding(
+          padding: EdgeInsets.only(bottom: AppSpacing.xl),
+          child: EmptyState(
+            icon: Icons.lyrics_outlined,
+            title: 'No lyrics available yet.',
+            message: 'Lyrics support is coming in a future update.',
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -21,6 +21,7 @@ import 'jellyfin_settings_state.dart';
 /// the password handed to [signIn] is forwarded once and never retained.
 class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
   JellyfinSession? _session;
+  late final Future<void> _initialLoad;
 
   /// The live signed-in session, or `null` when not connected. Used to build a
   /// [JellyfinMusicSource]; callers must not log it.
@@ -29,14 +30,30 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
   @override
   JellyfinSettingsState build() {
     // Load any persisted session in the background; until it lands the UI shows
-    // the disconnected state, then flips to connected if one is found.
-    _loadPersisted();
+    // the disconnected state, then flips to connected if one is found. The
+    // future is retained so startup can await it (see [ensureLoaded]).
+    _initialLoad = _loadPersisted();
     return const JellyfinSettingsState();
   }
 
+  /// Completes once the persisted session has been loaded (or confirmed absent).
+  ///
+  /// `main` awaits this at startup so the signed-in source is ready *before* the
+  /// user can tap play. Without it, the first Jellyfin stream after launch could
+  /// race the background load, see no session, and fail with "not signed in" —
+  /// which made streaming look like it required a prior download. Idempotent:
+  /// repeated calls return the same in-flight/completed load.
+  Future<void> ensureLoaded() => _initialLoad;
+
   Future<void> _loadPersisted() async {
-    final JellyfinSession? saved =
-        await ref.read(jellyfinSessionStoreProvider).read();
+    final JellyfinSession? saved;
+    try {
+      saved = await ref.read(jellyfinSessionStoreProvider).read();
+    } catch (_) {
+      // A storage hiccup must not break startup or playback; stay disconnected
+      // and let the user reconnect in Settings. No secret is involved here.
+      return;
+    }
     if (saved == null) {
       return;
     }

--- a/lib/features/shell/home_shell.dart
+++ b/lib/features/shell/home_shell.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../player/mini_player.dart';
+
 /// The persistent app frame: hosts the active tab and the bottom navigation
 /// bar. Tab state is owned by go_router's [StatefulNavigationShell], so each
 /// tab keeps its own stack and scroll position across switches.
@@ -44,10 +46,19 @@ class HomeShell extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: navigationShell,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: _onDestinationSelected,
-        destinations: _destinations,
+      // The mini-player rides just above the navigation bar so it stays visible
+      // on every tab (and collapses to nothing when no track is loaded). The
+      // full PlayerScreen is pushed above this shell, so the two never overlap.
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const MiniPlayer(),
+          NavigationBar(
+            selectedIndex: navigationShell.currentIndex,
+            onDestinationSelected: _onDestinationSelected,
+            destinations: _destinations,
+          ),
+        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'features/downloads/download_providers.dart';
 import 'features/player/player_providers.dart';
+import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -42,6 +43,20 @@ Future<void> main() async {
     container.read(playbackControllerProvider),
     container.read(musicLibraryRepositoryProvider),
   );
+
+  // Warm the persisted Jellyfin session before the first frame so a synced
+  // remote track can stream on the first tap — without it, playback would race
+  // the background session load and could fail with "not signed in", making
+  // streaming look like it required downloading first. Best-effort: the loader
+  // already swallows storage errors, but guard here too so a failure never
+  // blocks launch. No token is read into the UI or logged.
+  try {
+    await container
+        .read(jellyfinSettingsControllerProvider.notifier)
+        .ensureLoaded();
+  } catch (_) {
+    // Ignore: the user can still connect in Settings.
+  }
 
   runApp(
     UncontrolledProviderScope(

--- a/test/app/notification_permission_request_test.dart
+++ b/test/app/notification_permission_request_test.dart
@@ -2,6 +2,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/linthra_app.dart';
 import 'package:linthra/core/services/notification_permission.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../features/player/fake_playback_controller.dart';
 
 /// Records how many times the app asked for the notification permission, so a
 /// test can assert the first-launch request fires exactly once without a real
@@ -23,6 +26,8 @@ void main() {
       ProviderScope(
         overrides: [
           notificationPermissionProvider.overrideWithValue(permission),
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
         ],
         child: const LinthraApp(),
       ),

--- a/test/app_smoke_test.dart
+++ b/test/app_smoke_test.dart
@@ -2,10 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/linthra_app.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import 'features/player/fake_playback_controller.dart';
 
 void main() {
   testWidgets('App boots to the Library screen', (tester) async {
-    await tester.pumpWidget(const ProviderScope(child: LinthraApp()));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          // The persistent shell hosts the mini-player, which reads the
+          // playback controller; use the fake so the smoke test never touches
+          // the audio plugin.
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
+        ],
+        child: const LinthraApp(),
+      ),
+    );
     await tester.pumpAndSettle();
 
     // The persistent shell and its bottom navigation render.

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -26,6 +26,7 @@ class FakePlaybackController implements PlaybackController {
   int skipCount = 0;
   int previousCount = 0;
   int clearCount = 0;
+  bool disposed = false;
   final List<Duration> seeks = <Duration>[];
 
   /// Pushes [next] to listeners and updates the synchronous [state].
@@ -113,6 +114,7 @@ class FakePlaybackController implements PlaybackController {
 
   @override
   Future<void> dispose() async {
+    disposed = true;
     await _states.close();
   }
 }

--- a/test/features/player/mini_player_test.dart
+++ b/test/features/player/mini_player_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/mini_player.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import 'fake_playback_controller.dart';
+
+const _track = Track(
+  id: '1',
+  title: 'Song One',
+  uri: '/music/song1.mp3',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: [
+      // A stand-in main screen that hosts the mini-player exactly as the shell
+      // does: pinned above the (here, omitted) navigation bar.
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const Scaffold(
+          body: SizedBox.expand(),
+          bottomNavigationBar: MiniPlayer(),
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (_, __) => const PlayerScreen(),
+      ),
+    ],
+  );
+}
+
+Future<void> _pump(WidgetTester tester, FakePlaybackController controller) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+}
+
+void main() {
+  group('MiniPlayer', () {
+    testWidgets('is hidden when nothing is playing', (tester) async {
+      await _pump(tester, FakePlaybackController());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MiniPlayer), findsOneWidget);
+      // Nothing loaded: it collapses, showing no track text or controls.
+      expect(find.text('Song One'), findsNothing);
+      expect(find.byTooltip('Play'), findsNothing);
+    });
+
+    testWidgets('appears with title and artist when a track is active', (
+      tester,
+    ) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+      await _pump(tester, controller);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.text('Artist A • Album B'), findsOneWidget);
+      // While playing it offers a Pause control.
+      expect(find.byTooltip('Pause'), findsOneWidget);
+    });
+
+    testWidgets('play/pause delegates to the controller', (tester) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.paused,
+          currentTrack: _track,
+        ),
+      );
+      await _pump(tester, controller);
+      await tester.pumpAndSettle();
+
+      // Paused: the toggle resumes playback through the controller.
+      await tester.tap(find.byTooltip('Play'));
+      expect(controller.playCount, 1);
+
+      // Reflect the resumed state and confirm the toggle now pauses.
+      controller.emit(
+        const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Pause'));
+      expect(controller.pauseCount, 1);
+    });
+
+    testWidgets('tapping the bar opens the full player screen', (tester) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+      await _pump(tester, controller);
+      await tester.pumpAndSettle();
+
+      // Tap the body (the title), not the play/pause button.
+      await tester.tap(find.text('Song One'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Now Playing'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/player/playback_controller_lifecycle_test.dart
+++ b/test/features/player/playback_controller_lifecycle_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+/// Locks in the playback-lifecycle guarantee from the alpha bug report: the
+/// single [PlaybackController] must be pinned for the app session, so navigating
+/// between tabs/screens and changing settings can never recreate or dispose it
+/// (which would dispose the live `AudioPlayer` and cut the music). These tests
+/// drive the *real* `playbackControllerProvider`; on a non-mobile test host the
+/// `just_audio` engine constructs without touching any platform channel.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('playback controller lifecycle', () {
+    test('is read once and survives a resolver/locator rebuild', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final first = container.read(playbackControllerProvider);
+
+      // Invalidate the resolution chain the controller depends on — the kind of
+      // churn navigation and settings changes can trigger. With read-once
+      // wiring this must NOT rebuild the controller.
+      container.invalidate(cachedTrackLocatorProvider);
+      container.invalidate(playableUriResolverProvider);
+
+      final second = container.read(playbackControllerProvider);
+
+      expect(
+        identical(first, second),
+        isTrue,
+        reason: 'the controller must not be recreated when its resolver '
+            'dependencies rebuild',
+      );
+    });
+
+    test('survives a download-store rebuild (e.g. a download completing)', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final first = container.read(playbackControllerProvider);
+
+      // These feed the offline-cache locator, which feeds the resolver. A
+      // watch-based controller would be torn down by this cascade; a read-based
+      // one is untouched.
+      container.invalidate(downloadStoreProvider);
+      container.invalidate(offlineFileStoreProvider);
+
+      final second = container.read(playbackControllerProvider);
+
+      expect(identical(first, second), isTrue);
+    });
+
+    test('the same instance backs the provider on every read', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final reads = List.generate(
+        5,
+        (_) => container.read(playbackControllerProvider),
+      );
+
+      expect(reads.every((c) => identical(c, reads.first)), isTrue);
+    });
+  });
+}

--- a/test/features/player/playback_resolution_test.dart
+++ b/test/features/player/playback_resolution_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/core/services/local_playable_uri_resolver.dart';
+import 'package:linthra/core/services/offline_first_playable_uri_resolver.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/routing_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_stream_source.dart';
+import 'package:linthra/data/repositories/in_memory_download_store.dart';
+import 'package:linthra/data/repositories/in_memory_offline_file_store.dart';
+import 'package:linthra/data/repositories/store_cached_track_locator.dart';
+
+/// A signed-in Jellyfin stream source that mints a canned URL at play time and
+/// records whether it was consulted, so a test can prove a cached track never
+/// hits the network.
+class _FakeStreamSource implements JellyfinStreamSource {
+  _FakeStreamSource(this._uri);
+
+  final Uri _uri;
+  int verifyCount = 0;
+  int resolveCount = 0;
+
+  @override
+  Future<void> verifyReachable() async => verifyCount++;
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    resolveCount++;
+    return _uri;
+  }
+}
+
+const _jellyfinTrack = Track(id: 't1', title: 'Remote One', uri: 'jellyfin:t1');
+const _localTrack = Track(id: 'l1', title: 'Local One', uri: '/music/one.mp3');
+
+/// Builds the exact resolver `playableUriResolverProvider` composes: offline
+/// first, then source routing (Jellyfin, then on-device).
+OfflineFirstPlayableUriResolver _resolver({
+  required StoreCachedTrackLocator locator,
+  required JellyfinStreamSource source,
+}) {
+  return OfflineFirstPlayableUriResolver(
+    locator: locator,
+    fallback: RoutingPlayableUriResolver(<PlayableUriResolver>[
+      JellyfinPlayableUriResolver(() => source),
+      const LocalPlayableUriResolver(),
+    ]),
+  );
+}
+
+void main() {
+  group('composed playback resolution', () {
+    test('streams a Jellyfin track directly when it is not cached', () async {
+      final source = _FakeStreamSource(
+        Uri.parse('https://music.example.com/Audio/t1/universal'),
+      );
+      final resolver = _resolver(
+        // Nothing cached: an empty download store.
+        locator: StoreCachedTrackLocator(
+          InMemoryDownloadStore(),
+          InMemoryOfflineFileStore(),
+        ),
+        source: source,
+      );
+
+      final uri = await resolver.resolve(_jellyfinTrack);
+
+      // It streamed (no download required) straight from Jellyfin.
+      expect(uri.scheme, 'https');
+      expect(uri.path, '/Audio/t1/universal');
+      expect(source.verifyCount, 1);
+      expect(source.resolveCount, 1);
+    });
+
+    test('prefers the cached file for a downloaded Jellyfin track', () async {
+      final files = InMemoryOfflineFileStore();
+      final fileName =
+          await files.write('t1', <int>[1, 2, 3], extension: 'mp3');
+      final source = _FakeStreamSource(Uri.parse('https://stream/t1'));
+      final resolver = _resolver(
+        locator: StoreCachedTrackLocator(
+          InMemoryDownloadStore(
+            initialDownloads: <CachedTrack>[
+              CachedTrack(trackId: 't1', fileName: fileName),
+            ],
+          ),
+          files,
+        ),
+        source: source,
+      );
+
+      final uri = await resolver.resolve(_jellyfinTrack);
+
+      // Cache hit: a local file, and the network source was never touched.
+      expect(uri.scheme, 'file');
+      expect(uri.toFilePath(), '/offline_audio/t1.mp3');
+      expect(source.verifyCount, 0);
+      expect(source.resolveCount, 0);
+    });
+
+    test('plays a local track from its on-device path', () async {
+      final source = _FakeStreamSource(Uri.parse('https://stream/x'));
+      final resolver = _resolver(
+        locator: StoreCachedTrackLocator(
+          InMemoryDownloadStore(),
+          InMemoryOfflineFileStore(),
+        ),
+        source: source,
+      );
+
+      final uri = await resolver.resolve(_localTrack);
+
+      expect(uri.scheme, 'file');
+      expect(uri.toFilePath(), '/music/one.mp3');
+      // A local track never consults the Jellyfin source.
+      expect(source.verifyCount, 0);
+      expect(source.resolveCount, 0);
+    });
+  });
+}

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -155,6 +155,27 @@ void main() {
       expect(find.text("Couldn't play this track"), findsNothing);
     });
 
+    testWidgets('shows a Lyrics entry that opens a calm empty state', (
+      tester,
+    ) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(id: '1', title: 'Song One', uri: '/s.mp3'),
+        ),
+      );
+      await _pumpScreen(tester, controller);
+
+      // The entry point is visible on the player.
+      expect(find.text('Lyrics'), findsOneWidget);
+
+      await tester.tap(find.text('Lyrics'));
+      await tester.pumpAndSettle();
+
+      // No lyrics source yet, so it shows a calm placeholder rather than blank.
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+    });
+
     testWidgets('reacts to state pushed on the stream', (tester) async {
       final controller = FakePlaybackController();
       await _pumpScreen(tester, controller);

--- a/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
@@ -53,6 +53,27 @@ void main() {
       );
     });
 
+    test('ensureLoaded readies the signed-in source before first play',
+        () async {
+      // Mirrors what `main` awaits at startup: after ensureLoaded() resolves,
+      // the persisted session is live and the Jellyfin source is available, so
+      // the first remote track can stream without racing the background load
+      // (the bug that made streaming look like it required downloading first).
+      final container = _container(
+        store: InMemoryJellyfinSessionStore(initialSession: _session),
+      );
+
+      await container
+          .read(jellyfinSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      expect(
+        container.read(jellyfinSettingsControllerProvider).phase,
+        JellyfinConnectionPhase.connected,
+      );
+      expect(container.read(jellyfinMusicSourceProvider), isNotNull);
+    });
+
     test('loads a persisted session as connected', () async {
       final container = _container(
         store: InMemoryJellyfinSessionStore(initialSession: _session),


### PR DESCRIPTION
## Summary

Fixes the real-device playback issues found in the first Android alpha so Linthra behaves like a proper music player: playback survives navigation/settings, Jellyfin tracks stream directly without needing a download first, a persistent Now Playing mini-player is always available, and there is a visible lyrics entry point.

Scope kept to bugfix + playback UX stabilization. No release/F-Droid work, no UI redesign, no new providers, no album/playlist download-all.

## Root cause of playback cutting

The single `PlaybackController` is meant to be app-wide, but its provider was wired to **rebuild reactively**:

```
playbackControllerProvider  -> ref.watch(playableUriResolverProvider)
playableUriResolverProvider -> ref.watch(cachedTrackLocatorProvider)
cachedTrackLocatorProvider  -> ref.watch(downloadStore / offlineFileStore)
```

Because the controller `watch`ed that chain, any rebuild of the resolver, the offline-cache locator, or the download stores would **dispose the live `AudioPlayer` and build a new controller mid-playback** — cutting the music. It also desynced the `audio_service` media session, because `connectMediaSession` binds the notification/lock-screen handler to one controller instance read at startup; a recreated controller leaves the session mirroring a dead one.

**Fix:** the controller now reads its resolver **once** (`ref.read`) instead of subscribing. It is pinned for the whole app session, so navigating tabs/screens and changing settings can never tear it down. The resolver still reads the live signed-in Jellyfin source lazily at play time, so sign-in/out is picked up without rebuilding the controller. The UI, the media session, and `just_audio` all share the one instance.

## Jellyfin streaming behavior

Direct streaming was already composed (offline-first → stream fallback), but on a cold launch the **first** remote play could race the asynchronous persisted-session load: `jellyfinMusicSourceProvider` saw no session yet and the play failed with "You're not signed in to Jellyfin." A downloaded track played fine (cache hit needs no session), which is why streaming *looked* like it required downloading first.

**Fix:** the persisted session is warmed at startup. `JellyfinSettingsController.ensureLoaded()` exposes the initial load as an awaitable, idempotent future, and `main` awaits it (best-effort) before the first frame, so the source is ready before the user can tap play.

Resulting behavior:
- A Jellyfin track **streams directly by default**; download/offline cache is optional.
- If a track **is** cached, playback prefers the local file.
- If it is **not** cached, it streams from Jellyfin when online and signed in.
- `Track.uri` stays the opaque `jellyfin:<itemId>`; the tokenized stream URL is minted only at play time and never stored on the track, in the DB, in cache file names, in UI errors, or in logs.

## Mini-player behavior

A compact, persistent Now Playing bar (`MiniPlayer`) rides just above the bottom navigation on every main screen (Library / Playlists / Downloads / Settings):
- shows track title and artist • album when available;
- play/pause button that delegates straight to the controller (spinner while loading);
- tap anywhere on the bar opens the full `PlayerScreen`;
- collapses to zero height when nothing is loaded, so empty screens look unchanged;
- does not disappear when switching tabs (it lives in the persistent shell). The full `PlayerScreen` is pushed above the shell, so the two never overlap.

## Lyrics placeholder behavior

`PlayerScreen` now has a visible **Lyrics** entry. Tapping it opens a calm empty state — “No lyrics available yet.” No lyrics are fetched or scraped; a real lyrics source is left for a later PR.

## Tests

Added/updated (all green, 307 passing):
- controller is **not** recreated/disposed when the resolver, locator, or download stores rebuild (real provider, read-once semantics);
- Jellyfin track **streams** when not cached; **prefers the cache** when downloaded; local file playback still works (composed resolver);
- `ensureLoaded` readies the signed-in source before first play;
- mini-player appears when a track is active, hides when idle, play/pause delegates to the controller, tap opens the player;
- `PlayerScreen` shows the lyrics empty state.

## Security checks

- no token in `Track.uri` (stays `jellyfin:<itemId>`);
- no token in database rows or cached file names (`CachedTrack` carries id + derived file name only);
- no token in UI errors (friendly, secret-free `PlaybackResolutionException`s) — covered by existing tests;
- no token logged (URLs minted at play/fetch time, never logged); the session warm-up reads no secret into the UI.

## Verification

- [x] `flutter pub get`
- [x] `dart format --set-exit-if-changed .` — 0 changed
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 307 passed
- [ ] `flutter build apk --debug` — **not run here**: the Android SDK host (`dl.google.com`) is outside this environment's network allowlist, so the SDK/NDK can't be installed. No native/Gradle/manifest code changed; the `android-debug-apk` CI workflow builds the APK with the full toolchain.

## Android test checklist (for on-device verification)

- [ ] Start a local track, switch tabs and open Settings — music keeps playing, mini-player stays visible.
- [ ] Change a setting (e.g. Jellyfin sync / Wi-Fi-only toggle) while playing — music does not stop.
- [ ] Background the app while playing — audio continues; notification controls work.
- [ ] Fresh launch (signed in to Jellyfin, library synced), tap a **non-downloaded** Jellyfin track — it streams without a download.
- [ ] Download a Jellyfin track, then play it offline — plays from the cached file.
- [ ] Tap the mini-player — opens full Now Playing; play/pause in the mini-player matches the engine.
- [ ] Open Lyrics on the player — shows the calm empty state.

## Remaining limitations

- Lyrics are a placeholder only (no source yet).
- Streaming uses Jellyfin's `/Audio/{id}/universal` endpoint (server-chosen container); richer transcoding controls are a later refinement.
- No album/playlist “download all” yet; mini-player shows no artwork (icon only) to keep it light and test-friendly.
- APK build validated by CI, not in this PR's environment.

https://claude.ai/code/session_01Rhz4Batj3JraNj5V72wDLL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rhz4Batj3JraNj5V72wDLL)_