### PR TITLE
ci: auto-build Android release artifacts on v* tags

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -1,25 +1,45 @@
 name: Android Release Build
 
-# Builds the Android release artifacts (APK + AAB) and attaches them to the
-# workflow run. This is a build-only foundation for future GitHub Releases /
-# F-Droid distribution: it does NOT create a GitHub release, publish to any
-# store, or submit to F-Droid, and it runs only when you trigger it manually.
+# Builds the Android release artifacts (APK + AAB) and makes them available as
+# workflow artifacts. When triggered by a version tag, it can additionally
+# attach the *release-signed* artifacts to a matching GitHub Release (if one
+# already exists). It never creates a GitHub Release, writes release notes,
+# publishes to a store, or submits to F-Droid.
 #
-# Signing: this workflow can produce either a real release-signed build or a
-# debug-key build, controlled by the `signed` input below.
+# Triggers:
 #
-#   * signed = false (default): no signing secrets are read; the release build
-#     falls back to the debug signing config in android/app/build.gradle. The
-#     artifacts are DEBUG-KEY SIGNED — fine for previews and smoke-testing a
-#     release build, but NOT suitable for store or F-Droid distribution. They
-#     are uploaded with a `-debug-signed` name so they cannot be mistaken for a
-#     real release.
+#   * workflow_dispatch (manual): produces test builds. The `signed` input
+#     chooses real release signing vs. a debug-key build, exactly as before.
 #
-#   * signed = true: the workflow decodes a keystore from the LINTHRA_KEYSTORE_*
-#     repository secrets and signs the build with it. If any required secret is
-#     missing the run fails fast with a clear error (it does NOT silently fall
-#     back to the debug key). See docs/release-signing.md for the required
-#     secrets and how to generate / rotate the keystore.
+#   * push of a tag matching `v*` (e.g. v0.1.0-alpha.1): an automatic release
+#     build. Tag builds attempt release signing and, if the signing secrets are
+#     present, attach the signed APK/AAB to an existing GitHub Release for that
+#     tag.
+#
+# Why not also `release: [published]`? Creating a Release in the GitHub UI on a
+# new tag also pushes that tag, which already fires the `push` trigger above.
+# Listening to both would build the same commit twice. We listen only to the
+# tag push and look up the Release from inside that run, so there is exactly one
+# build per tag and release notes stay manually authored.
+#
+# Signing (unchanged behavior for manual runs):
+#
+#   * Manual run, signed = false (default): no signing secrets are read; the
+#     build falls back to the debug signing config in android/app/build.gradle.
+#     Artifacts are DEBUG-KEY SIGNED — fine for previews, NOT for distribution —
+#     and are uploaded with a `-debug-signed` name.
+#
+#   * Manual run, signed = true: decodes the keystore from the LINTHRA_KEYSTORE_*
+#     secrets and signs with it. If any required secret is missing the run fails
+#     fast (it does NOT silently fall back to the debug key).
+#
+#   * Tag push: signed if the LINTHRA_* secrets are configured (-> release-signed,
+#     eligible for Release attachment). If the secrets are missing, the run does
+#     NOT pretend to be a real release: it builds DEBUG-KEY signed artifacts,
+#     labels them `-debug-signed`, emits a loud warning, and does NOT attach them
+#     to any Release.
+#
+# See docs/release-signing.md for the required secrets and keystore handling.
 on:
   workflow_dispatch:
     inputs:
@@ -27,9 +47,13 @@ on:
         description: "Sign with the release keystore (requires LINTHRA_* secrets). If false, builds are debug-signed and labeled as such."
         type: boolean
         default: false
+  push:
+    tags:
+      - "v*"
 
-# Read-only is all this needs: artifacts are shared via upload-artifact rather
-# than by writing to the repo or creating a release.
+# Default to read-only. Building and sharing artifacts via upload-artifact needs
+# nothing more. The separate attach-release job below requests `contents: write`
+# only for itself, and only to upload assets to an existing GitHub Release.
 permissions:
   contents: read
 
@@ -45,28 +69,57 @@ jobs:
       LINTHRA_KEYSTORE_PASSWORD: ${{ secrets.LINTHRA_KEYSTORE_PASSWORD }}
       LINTHRA_KEY_ALIAS: ${{ secrets.LINTHRA_KEY_ALIAS }}
       LINTHRA_KEY_PASSWORD: ${{ secrets.LINTHRA_KEY_PASSWORD }}
+    outputs:
+      signing: ${{ steps.mode.outputs.signing }}
+      trigger: ${{ steps.mode.outputs.trigger }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate signing secrets
-        if: ${{ inputs.signed }}
+      # Decide, in one place, how this run should sign and how to label it.
+      #   trigger: manual | tag
+      #   signing: release-signed | debug-signed
+      # Manual signed=true with missing secrets fails fast (preserves the old
+      # behavior). A tag with missing secrets degrades to clearly-labeled
+      # debug-signed artifacts (never silently passed off as a real release).
+      - name: Determine build mode
+        id: mode
         env:
           LINTHRA_KEYSTORE_BASE64: ${{ secrets.LINTHRA_KEYSTORE_BASE64 }}
         run: |
-          missing=()
-          [ -z "$LINTHRA_KEYSTORE_BASE64" ] && missing+=("LINTHRA_KEYSTORE_BASE64")
-          [ -z "$LINTHRA_KEYSTORE_PASSWORD" ] && missing+=("LINTHRA_KEYSTORE_PASSWORD")
-          [ -z "$LINTHRA_KEY_ALIAS" ] && missing+=("LINTHRA_KEY_ALIAS")
-          [ -z "$LINTHRA_KEY_PASSWORD" ] && missing+=("LINTHRA_KEY_PASSWORD")
-          if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error::Signed release requested but these secrets are missing: ${missing[*]}. See docs/release-signing.md."
-            exit 1
+          have_secrets=true
+          for v in "$LINTHRA_KEYSTORE_BASE64" "$LINTHRA_KEYSTORE_PASSWORD" "$LINTHRA_KEY_ALIAS" "$LINTHRA_KEY_PASSWORD"; do
+            [ -z "$v" ] && have_secrets=false
+          done
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            trigger=manual
+            want_signed="${{ inputs.signed }}"
+          else
+            trigger=tag
+            want_signed=true
           fi
-          echo "All required signing secrets are present."
+
+          if [ "$want_signed" = "true" ]; then
+            if [ "$have_secrets" = "true" ]; then
+              signing=release-signed
+            elif [ "$trigger" = "manual" ]; then
+              echo "::error::Signed release requested but signing secrets are missing (need LINTHRA_KEYSTORE_BASE64, LINTHRA_KEYSTORE_PASSWORD, LINTHRA_KEY_ALIAS, LINTHRA_KEY_PASSWORD). See docs/release-signing.md."
+              exit 1
+            else
+              echo "::warning::Tag build but signing secrets are missing; producing DEBUG-KEY signed artifacts (labeled -debug-signed). These are NOT a real release and will NOT be attached to any GitHub Release. Configure the LINTHRA_* secrets to get release-signed builds. See docs/release-signing.md."
+              signing=debug-signed
+            fi
+          else
+            signing=debug-signed
+          fi
+
+          echo "trigger=$trigger" >> "$GITHUB_OUTPUT"
+          echo "signing=$signing" >> "$GITHUB_OUTPUT"
+          echo "Trigger: $trigger | Signing: $signing"
 
       - name: Decode release keystore
-        if: ${{ inputs.signed }}
+        if: ${{ steps.mode.outputs.signing == 'release-signed' }}
         env:
           LINTHRA_KEYSTORE_BASE64: ${{ secrets.LINTHRA_KEYSTORE_BASE64 }}
         run: |
@@ -98,50 +151,76 @@ jobs:
       - name: Build release AAB
         run: flutter build appbundle --release
 
-      # Distinguish real release-signed artifacts from debug-signed previews so
-      # the wrong build can never be mistaken for a publishable release.
-      - name: Determine artifact label
-        id: label
-        run: |
-          if [ "${{ inputs.signed }}" = "true" ]; then
-            echo "suffix=release-signed" >> "$GITHUB_OUTPUT"
-          else
-            echo "suffix=debug-signed" >> "$GITHUB_OUTPUT"
-          fi
-
+      # The artifact name carries the signing label so a debug-signed build can
+      # never be mistaken for a publishable release.
       - name: Upload release APK
         uses: actions/upload-artifact@v4
         with:
-          name: linthra-${{ steps.label.outputs.suffix }}-apk
+          name: linthra-${{ steps.mode.outputs.signing }}-apk
           path: build/app/outputs/flutter-apk/app-release.apk
           if-no-files-found: error
 
       - name: Upload release AAB
         uses: actions/upload-artifact@v4
         with:
-          name: linthra-${{ steps.label.outputs.suffix }}-aab
+          name: linthra-${{ steps.mode.outputs.signing }}-aab
           path: build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
 
       - name: Build summary
         run: |
-          if [ "${{ inputs.signed }}" = "true" ]; then
-            {
-              echo "## Linthra release build"
-              echo ""
+          {
+            echo "## Linthra release build"
+            echo ""
+            echo "**Trigger:** ${{ steps.mode.outputs.trigger }}${{ github.event_name == 'push' && format(' (tag {0})', github.ref_name) || '' }}"
+            echo ""
+            if [ "${{ steps.mode.outputs.signing }}" = "release-signed" ]; then
               echo "**Signing:** release-signed with the configured keystore."
               echo ""
               echo "Artifacts: \`linthra-release-signed-apk\`, \`linthra-release-signed-aab\`."
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "## Linthra release build"
-              echo ""
-              echo "**Signing:** DEBUG-KEY signed (not a real release)."
-              echo ""
-              echo "Re-run with \`signed = true\` and the LINTHRA_* secrets configured to"
-              echo "produce a release-signed build. See docs/release-signing.md."
+              if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
+                echo ""
+                echo "These signed artifacts will be attached to the GitHub Release for this tag if one exists."
+              fi
+            else
+              echo "**Signing:** DEBUG-KEY signed (NOT a real release)."
               echo ""
               echo "Artifacts: \`linthra-debug-signed-apk\`, \`linthra-debug-signed-aab\`."
-            } >> "$GITHUB_STEP_SUMMARY"
+              echo ""
+              echo "Configure the LINTHRA_* secrets (and, for manual runs, set \`signed = true\`) to"
+              echo "produce a release-signed build. See docs/release-signing.md."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Attaches the release-signed artifacts to an EXISTING GitHub Release for the
+  # pushed tag. This is the only job that needs write access, so it is the only
+  # one granted `contents: write`. It never creates a Release and never writes
+  # release notes — if no Release exists yet, it leaves a notice and the signed
+  # artifacts remain downloadable from the build job.
+  attach-release:
+    name: Attach signed artifacts to GitHub Release
+    needs: build-release
+    if: ${{ github.event_name == 'push' && needs.build-release.outputs.signing == 'release-signed' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Attach to GitHub Release (if one exists)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          apk="artifacts/linthra-release-signed-apk/app-release.apk"
+          aab="artifacts/linthra-release-signed-aab/app-release.aab"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub Release '$TAG' exists; uploading signed artifacts."
+            gh release upload "$TAG" "$apk" "$aab" --clobber --repo "$GITHUB_REPOSITORY"
+            echo "Attached release-signed APK/AAB to Release '$TAG'."
+          else
+            echo "::notice::No GitHub Release exists for tag '$TAG' yet, so nothing was attached. The release-signed APK/AAB are available as workflow artifacts. Create the Release (with your own notes) and re-run this workflow, or attach the artifacts manually."
           fi

--- a/README.md
+++ b/README.md
@@ -318,10 +318,11 @@ flutter install              # installs the last debug build
 ```
 
 The debug APK is unsigned and meant for local testing only. Release builds and
-optional release signing are handled separately by the manual **Android Release
-Build** workflow (see [Building release artifacts](#building-release-artifacts-android)
-and [docs/release-signing.md](./docs/release-signing.md)); nothing is published
-to a store or F-Droid, and no GitHub Release is created automatically.
+optional release signing are handled separately by the **Android Release
+Build** workflow — manual for test builds, automatic on `v*` tags (see
+[Building release artifacts](#building-release-artifacts-android) and
+[docs/release-signing.md](./docs/release-signing.md)); nothing is published to a
+store or F-Droid, and no GitHub Release is created or written automatically.
 
 #### Downloading a debug APK from CI
 
@@ -440,24 +441,48 @@ rather than a broad "all files" grant.
 
 The **Android Release Build** workflow
 (`.github/workflows/android-release-build.yml`) builds the Android **release**
-artifacts so we can validate a release build ahead of any GitHub Releases /
-F-Droid distribution. It is a build-only foundation:
+artifacts. It runs **manually** for test builds and **automatically on version
+tags** so a tagged release builds its APK/AAB without anyone clicking *Run
+workflow*. It still never publishes to a store or F-Droid and never writes
+release notes.
 
-- **How to run it:** open the repo's **Actions** tab → **Android Release
-  Build** → **Run workflow**. It is **manual only** (`workflow_dispatch`) — it
-  never runs on a push or PR. A `signed` input controls whether the build is
-  release-signed (see [Signing status](#signing-status-important) below).
+- **Manual test builds:** open the repo's **Actions** tab → **Android Release
+  Build** → **Run workflow** (`workflow_dispatch`). A `signed` input controls
+  whether the build is release-signed (see
+  [Signing status](#signing-status-important) below). This behavior is
+  unchanged.
+- **Automatic tag builds:** pushing a tag matching `v*` (e.g. `v0.1.0-alpha.1`)
+  triggers the workflow automatically:
+
+  ```bash
+  git tag -a v0.1.0-alpha.1 -m "Linthra 0.1.0-alpha.1"
+  git push origin v0.1.0-alpha.1
+  ```
+
+  Creating a Release in the GitHub UI on a *new* tag also creates+pushes that
+  tag, which starts the same build — so you can write the Release notes first
+  and let the build attach to it (see below). The workflow listens only to the
+  tag push (not to `release: published`) so a tag never builds twice.
 - **What it builds:** `flutter build apk --release` and
   `flutter build appbundle --release`.
 - **Artifacts** (names reflect how the build was signed, so a preview can't be
   mistaken for a real release):
-  - `signed = false` (default): `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
-  - `signed = true`: `linthra-release-signed-apk` / `linthra-release-signed-aab`.
+  - Manual `signed = false` (default), or any build where signing secrets are
+    absent: `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
+  - Manual `signed = true`, or a tag build with the signing secrets present:
+    `linthra-release-signed-apk` / `linthra-release-signed-aab`.
   - Each contains `app-release.apk` (`build/app/outputs/flutter-apk/app-release.apk`)
     or `app-release.aab` (`build/app/outputs/bundle/release/app-release.aab`).
+- **Release attachment (tag builds only):** when a tag build is
+  **release-signed** *and* a GitHub Release already exists for that tag, the
+  signed APK/AAB are attached to the Release automatically. The workflow never
+  creates a Release or writes notes — those stay manual. If no Release exists
+  yet, nothing is attached and the signed artifacts remain downloadable from the
+  run.
 - **Download:** open the completed run and grab the artifacts from the run's
   **Artifacts** section (GitHub serves each as a `.zip`; unzip to get the
-  APK/AAB).
+  APK/AAB). For a published Release, download the attached APK/AAB directly from
+  the Release page.
 
 Build the same artifacts locally with:
 
@@ -476,25 +501,36 @@ material is present does it sign with the release key; otherwise it falls back t
 the **debug** key so `flutter run --release` still works. **No signing keys or
 secrets are committed** to the repo.
 
-- Run the workflow with **`signed = false`** (default) → **debug-key signed**
+- Manual run with **`signed = false`** (default) → **debug-key signed**
   artifacts, labeled `…-debug-signed-…`. Fine for previewing a release build,
   **not** suitable for store or F-Droid distribution.
-- Run with **`signed = true`** → the workflow decodes a keystore from the
+- Manual run with **`signed = true`** → the workflow decodes a keystore from the
   `LINTHRA_*` repository secrets and produces **release-signed** artifacts
   (labeled `…-release-signed-…`). If a required secret is missing, the run
   **fails fast** rather than silently producing a debug-signed build.
+- **Tag build** (`v*` push) → attempts release signing automatically:
+  - If the `LINTHRA_*` secrets are present → **release-signed** artifacts,
+    eligible for Release attachment.
+  - If the secrets are missing → the run does **not** pretend to be a real
+    release: it emits a loud warning, builds **debug-key signed** artifacts
+    labeled `…-debug-signed-…`, and does **not** attach them to any Release.
 
-The keystore secrets are not configured in this repository yet, so a real
-release-signed build requires setting them up first. Full details — required
+The keystore secrets are not configured in this repository yet, so until they
+are, tag builds fall back to debug-signed artifacts. Configure them (see
+[docs/release-signing.md](./docs/release-signing.md)) to get release-signed tag
+builds. Full details — required
 secrets, how to generate/rotate a keystore, and how this relates to F-Droid (which
 signs its own builds) — are in [docs/release-signing.md](./docs/release-signing.md).
 
 #### Limitations & next steps
 
-- The workflow **does not** create a GitHub release, upload anything to a store,
-  or submit to F-Droid. It only produces downloadable build artifacts.
+- The workflow **does not** create a GitHub Release, write release notes, upload
+  anything to a store, or submit to F-Droid. It produces downloadable build
+  artifacts and, for a release-signed tag build, attaches them to a Release you
+  created manually.
 - Release signing **secrets are not yet provisioned**, so until they are, builds
-  fall back to the debug key (and are labeled accordingly).
+  (including tag builds) fall back to the debug key (and are labeled
+  accordingly).
 - **Next steps:** provision the `LINTHRA_*` keystore secrets
   ([docs/release-signing.md](./docs/release-signing.md)), then follow the manual
   release/tagging and GitHub-Release flow in
@@ -926,10 +962,11 @@ flutter test                         # widget/unit tests
 CI pins **Flutter 3.27.x (stable)** for reproducible results; using a matching
 SDK locally avoids spurious `dart format` diffs from formatter changes in newer
 Dart releases. The automatic `ci.yml` workflow is **code-quality only**. Native
-builds and optional release signing live in **separate, manual** workflows
-(**Android Debug APK**, **Android Release Build**); nothing publishes to a store
-or F-Droid. See [Building release artifacts](#building-release-artifacts-android)
-and [docs/release-process.md](./docs/release-process.md).
+builds and optional release signing live in **separate** workflows (**Android
+Debug APK**, and **Android Release Build** — manual for test builds, automatic
+on `v*` tags); nothing publishes to a store or F-Droid. See
+[Building release artifacts](#building-release-artifacts-android) and
+[docs/release-process.md](./docs/release-process.md).
 
 ### Generating Drift files in CI
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,10 +4,12 @@ This is the canonical reference for how Linthra cuts a release: versioning,
 git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
 docs reference this document rather than restating the plan.
 
-> **No release has been cut and nothing here publishes automatically.** Linthra
+> **No release has been cut and nothing here publishes to a store.** Linthra
 > has no tagged release yet, is **not** on F-Droid, and no APK/AAB has been
-> published. Every step below is manual and operator-initiated. This document
-> describes the intended process; it does not perform it.
+> published. Pushing a `v*` tag now builds the release artifacts automatically
+> (and attaches them to a matching GitHub Release if one exists), but **creating
+> the Release and writing its notes stays manual** — and nothing is published to
+> any store or to F-Droid. This document describes the intended process.
 
 ## 1. Versioning model
 
@@ -75,30 +77,51 @@ Before creating a release tag:
    [dependency & license audit](./dependency-license-audit.md).
 6. Create the annotated tag (§2).
 
-## 4. GitHub Releases (manual)
+## 4. GitHub Releases (notes manual, artifact build automatic)
 
-Publishing a GitHub Release is **optional and entirely manual** — there is no
-workflow that creates one automatically, by design.
+Publishing a GitHub Release — and **writing its notes** — stays **manual and
+operator-initiated**. No workflow creates a Release or authors notes for you.
 
-The building block is the **Android Release Build** workflow
-(`.github/workflows/android-release-build.yml`), which is `workflow_dispatch`
-only and just produces downloadable artifacts (it does **not** create a Release,
-publish to a store, or submit to F-Droid). See
+What *is* automated is the **artifact build**: the **Android Release Build**
+workflow (`.github/workflows/android-release-build.yml`) runs automatically when
+a `v*` tag is pushed, builds the APK/AAB, and — if the build is release-signed
+and a GitHub Release already exists for that tag — attaches the signed APK/AAB
+to it. It never creates a Release, writes notes, publishes to a store, or
+submits to F-Droid. The workflow listens only to the tag `push` (not to
+`release: published`), so a tag builds exactly once. See
 [docs/release-signing.md](./release-signing.md) for the signing details.
 
-To publish a GitHub Release for a tag:
+### Recommended flow (notes written first, build attaches automatically)
 
-1. Ensure the release tag exists (§2) and generated files are current (§3).
-2. Run **Android Release Build** with **`signed = true`** (requires the
-   `LINTHRA_*` keystore secrets — see
-   [release-signing.md §2](./release-signing.md#2-required-github-secrets-ci)).
-   This yields `linthra-release-signed-apk` / `linthra-release-signed-aab`.
-   - A `signed = false` run produces **`linthra-debug-signed-*`** artifacts.
-     Those are previews only and **must never** be attached to a Release.
-3. Download the **release-signed** artifacts from the run.
-4. Create the GitHub Release against the `vX.Y.Z` tag (GitHub UI, or `gh release
-   create`) and attach the signed APK/AAB. Write release notes (the Fastlane
-   changelog from §3 is a good basis).
+1. Ensure generated files are current (§3) and `pubspec.yaml` matches the tag.
+2. Make sure the `LINTHRA_*` keystore secrets are configured (see
+   [release-signing.md §2](./release-signing.md#2-required-github-secrets-ci)),
+   otherwise the tag build will fall back to debug-signed artifacts that are
+   **not** attached to the Release.
+3. In the GitHub UI, **create the Release** against a **new** tag `vX.Y.Z`,
+   write the notes (the Fastlane changelog from §3 is a good basis), and mark it
+   **pre-release** for `-alpha`/`-beta` tags. Creating the Release on a new tag
+   also creates and pushes that tag.
+4. That tag push triggers **Android Release Build** automatically. When it
+   finishes, the **release-signed** `app-release.apk` / `app-release.aab` are
+   attached to the Release. Done.
+
+### Alternative flow (tag from git first)
+
+1. Push the annotated tag from git (§2). The build starts automatically and the
+   **release-signed** artifacts are produced as workflow artifacts. Because no
+   Release exists yet, nothing is attached.
+2. Create the GitHub Release for the tag and write its notes, then either
+   **re-run** the workflow for that tag (it will now find the Release and
+   attach) or download the artifacts from the original run and attach them
+   manually.
+
+> A `signed = false` manual run, or any build without the signing secrets,
+> produces **`linthra-debug-signed-*`** artifacts. Those are previews only and
+> **must never** be attached to a Release.
+
+Manual `workflow_dispatch` runs remain available for ad-hoc test builds and are
+unchanged.
 
 > **Signature note.** A GitHub-Release APK is signed with **our** release key,
 > while an F-Droid build of the same version is signed with **F-Droid's** key.
@@ -123,14 +146,16 @@ F-Droid does **not** consume our signed artifacts. When/if Linthra is submitted:
 | ------ | ---------- |
 | Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
 | Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
-| Release APK/AAB build | **Manual only** (`android-release-build.yml`, `workflow_dispatch`). |
+| Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
+| Attaching signed APK/AAB to a Release | **Automatic** on a `v*` tag build, **only if** the build is release-signed and a Release already exists. |
 | Drift code generation | **Manual only** (`generate-drift.yml`, `workflow_dispatch`). |
-| Creating a git tag | **Manual** (operator runs `git tag`). |
-| Creating a GitHub Release | **Manual** (operator, §4). |
+| Creating a git tag | **Manual** (operator runs `git tag`, or creates a Release on a new tag). |
+| Creating a GitHub Release / writing notes | **Manual** (operator, §4). |
 | Publishing to a store / F-Droid | **Not done by this repo.** |
 
-Nothing in CI publishes a release, signs a store build automatically, or submits
-to F-Droid.
+CI builds release artifacts on a tag and can attach them to a Release you
+created, but it never creates a Release, writes notes, signs a store build, or
+submits to F-Droid.
 
 ## 7. Remaining blockers before a first release
 

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -58,17 +58,30 @@ file at runtime and never writes it into the repository.
 
 ## 3. Running the release workflow
 
-The **Android Release Build** workflow is manual only (`workflow_dispatch`). It
-does not create a GitHub Release, publish to any store, or submit to F-Droid.
+The **Android Release Build** workflow runs **manually** (`workflow_dispatch`)
+for test builds and **automatically on `v*` tags** for release builds. It does
+not create a GitHub Release, write notes, publish to any store, or submit to
+F-Droid.
 
-- **Unsigned preview (default):** run with `signed = false`. Artifacts are
-  uploaded as `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
-- **Real release-signed build:** run with `signed = true` (requires the secrets
-  above). Artifacts are uploaded as `linthra-release-signed-apk` /
-  `linthra-release-signed-aab`.
+- **Manual unsigned preview (default):** run with `signed = false`. Artifacts
+  are uploaded as `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
+- **Manual release-signed build:** run with `signed = true` (requires the
+  secrets above; the run **fails fast** if any are missing). Artifacts are
+  uploaded as `linthra-release-signed-apk` / `linthra-release-signed-aab`.
+- **Automatic tag build (`v*` push):** attempts release signing.
+  - If all the secrets above are present → **release-signed** artifacts, and if
+    a GitHub Release already exists for the tag they are attached to it.
+  - If any secret is missing → the run does **not** silently fake a release: it
+    logs a warning, builds **debug-signed** artifacts (`linthra-debug-signed-*`),
+    and attaches nothing to any Release. Configure the secrets to get a real
+    release-signed tag build.
 
 The artifact names and the run summary always state which key signed the build,
-so a debug-signed preview can never be confused with a release.
+so a debug-signed build can never be confused with a release.
+
+> **Minimal permissions.** The build job runs with `contents: read`. Only the
+> separate Release-attachment job is granted `contents: write`, and only to
+> upload assets to an existing Release — it never creates one or edits notes.
 
 ## 4. Generating a keystore locally
 
@@ -139,11 +152,12 @@ freely once published — plan rotation carefully.
   F-Droid repository, F-Droid builds from source on its own infrastructure and
   signs the APK with **F-Droid's** signing key, not ours. Our release keystore
   is therefore not used by, and not given to, F-Droid.
-- **GitHub Releases signing is separate.** Any APK/AAB we attach to a GitHub
-  Release (a future, manual step — not done by this PR) would be signed with
-  *our* release key. That means the F-Droid build and a GitHub-Release build of
-  the same version have **different signatures** and cannot be cross-installed
-  as updates of each other. This is expected; document it clearly for users.
+- **GitHub Releases signing is separate.** Any APK/AAB attached to a GitHub
+  Release (built on a `v*` tag and attached automatically when release-signed)
+  is signed with *our* release key. That means the F-Droid build and a
+  GitHub-Release build of the same version have **different signatures** and
+  cannot be cross-installed as updates of each other. This is expected; document
+  it clearly for users.
 - **Reproducible builds (optional, advanced).** F-Droid supports verifying that
   a developer-signed binary matches what it builds from source, but that
   requires a reproducible build setup and is explicitly out of scope here.
@@ -153,7 +167,9 @@ freely once published — plan rotation carefully.
 
 ## 7. What is intentionally out of scope
 
-- Creating GitHub Releases automatically (the release workflow stays manual).
+- Creating GitHub Releases or writing release notes automatically (the workflow
+  only *attaches* signed artifacts to a Release you created; it never creates
+  one). Building the artifacts on a `v*` tag *is* automated.
 - Publishing to the Play Store.
 - Submitting to F-Droid.
 - Committing any keystore, password, or `key.properties`.


### PR DESCRIPTION
## Summary

Makes GitHub build the Android release artifacts automatically when a version tag is pushed, so a tagged release no longer requires manually running **Android Release Build**. Manual `workflow_dispatch` is preserved unchanged. No app code changes — workflow + docs only.

## Trigger changes

- **Added** `push: tags: ["v*"]` — pushing e.g. `v0.1.0-alpha.1` builds the APK/AAB automatically.
- **Kept** `workflow_dispatch` with the existing `signed` boolean input for test builds.
- **Deliberately did NOT add** `release: [published]`. Creating a Release on a new tag also pushes that tag, which already fires the `push` trigger — listening to both would build the same commit twice. We listen only to the tag push and look up the Release from within that run, so there is exactly one build per tag.

## Artifact behavior

- Builds `flutter pub get` → `flutter build apk --release` → `flutter build appbundle --release` (unchanged).
- Uploads both artifacts via `upload-artifact`, named by signing mode:
  - `linthra-release-signed-apk` / `linthra-release-signed-aab`, or
  - `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.

## Release attachment behavior

- A new, separate `attach-release` job runs **only on tag pushes** and **only when the build is release-signed**.
- It attaches the signed APK/AAB to an **existing** GitHub Release for the tag using `gh release upload --clobber`.
- It **never creates a Release and never writes notes** — if no Release exists yet, it logs a notice and the signed artifacts stay available as workflow artifacts. Release notes remain manually authored.
- **Minimal permissions:** the build job runs with `contents: read`; only the attach job is granted `contents: write`, and only to upload assets.

## Signing behavior

- **Manual `signed = false`** (default): debug-key signed, labeled `-debug-signed` (unchanged).
- **Manual `signed = true`**: decodes the `LINTHRA_*` keystore secrets and signs; **fails fast** if any secret is missing (unchanged).
- **Tag push**: attempts release signing automatically.
  - Secrets present → release-signed, eligible for Release attachment.
  - Secrets missing → does **not** fake a real release: emits a loud warning, builds clearly labeled `-debug-signed` artifacts, and attaches nothing.
- No signing keys committed, no secrets invented, no Play Store / F-Droid publishing.

## What remains manual

- Creating the GitHub Release and writing its notes.
- Creating the git tag (push it, or create a Release on a new tag).
- Configuring the `LINTHRA_*` signing secrets (see `docs/release-signing.md`).
- Any store / F-Droid distribution (still out of scope).

## Docs updated

- `README.md` — tag trigger, how to tag, where to download, signed vs debug-signed, attachment.
- `docs/release-process.md` — recommended (notes-first) and alternative flows, automation table.
- `docs/release-signing.md` — tag-build signing behavior, minimal-permissions note.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open(...))"` → YAML valid.
- Manual dispatch path (`signed` input, fail-fast on missing secrets, artifact names) preserved.
- No app/source code changes (only the workflow and three docs).

https://claude.ai/code/session_01JyhS1gd6QrjaXyv36bXssL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyhS1gd6QrjaXyv36bXssL)_