### PR TITLE
Attach build artifacts to GitHub pre-releases for alpha tags

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -2,44 +2,56 @@ name: Android Release Build
 
 # Builds the Android release artifacts (APK + AAB) and makes them available as
 # workflow artifacts. When triggered by a version tag, it can additionally
-# attach the *release-signed* artifacts to a matching GitHub Release (if one
-# already exists). It never creates a GitHub Release, writes release notes,
-# publishes to a store, or submits to F-Droid.
+# attach the built artifacts to a matching GitHub Release. It never publishes to
+# a store or submits to F-Droid, and it never writes production release notes.
 #
 # Triggers:
 #
 #   * workflow_dispatch (manual): produces test builds. The `signed` input
 #     chooses real release signing vs. a debug-key build, exactly as before.
+#     Manual runs never touch any GitHub Release.
 #
 #   * push of a tag matching `v*` (e.g. v0.1.0-alpha.1): an automatic release
-#     build. Tag builds attempt release signing and, if the signing secrets are
-#     present, attach the signed APK/AAB to an existing GitHub Release for that
-#     tag.
+#     build. There is exactly one build per tag (we listen only to the tag push,
+#     not to `release: published`, so the same commit is never built twice).
 #
-# Why not also `release: [published]`? Creating a Release in the GitHub UI on a
-# new tag also pushes that tag, which already fires the `push` trigger above.
-# Listening to both would build the same commit twice. We listen only to the
-# tag push and look up the Release from inside that run, so there is exactly one
-# build per tag and release notes stay manually authored.
+# Tag behavior (alpha/pre-release vs. stable):
 #
-# Signing (unchanged behavior for manual runs):
+#   * Pre-release tags — any tag containing `alpha`, `beta`, or `rc`
+#     (e.g. v0.1.0-alpha.1): attach the built APK/AAB to a GitHub *pre-release*.
+#     If no Release exists for the tag yet, one is CREATED as a pre-release.
+#     These tags may attach release-signed OR clearly-labeled debug-signed
+#     artifacts — debug-signed builds are for TESTING ONLY and are named and
+#     described as such (never passed off as a production release).
+#
+#   * Stable tags — e.g. v1.0.0 (no alpha/beta/rc): REQUIRE release signing.
+#     If the LINTHRA_* signing secrets are missing the run FAILS fast rather
+#     than attaching a debug-signed build. Stable assets are only attached to a
+#     Release that already exists (notes stay manually authored); the workflow
+#     does not auto-create stable Releases.
+#
+# Signing:
 #
 #   * Manual run, signed = false (default): no signing secrets are read; the
 #     build falls back to the debug signing config in android/app/build.gradle.
 #     Artifacts are DEBUG-KEY SIGNED — fine for previews, NOT for distribution —
-#     and are uploaded with a `-debug-signed` name.
+#     and are labeled `-debug-signed`.
 #
 #   * Manual run, signed = true: decodes the keystore from the LINTHRA_KEYSTORE_*
 #     secrets and signs with it. If any required secret is missing the run fails
 #     fast (it does NOT silently fall back to the debug key).
 #
-#   * Tag push: signed if the LINTHRA_* secrets are configured (-> release-signed,
-#     eligible for Release attachment). If the secrets are missing, the run does
-#     NOT pretend to be a real release: it builds DEBUG-KEY signed artifacts,
-#     labels them `-debug-signed`, emits a loud warning, and does NOT attach them
-#     to any Release.
+#   * Tag push: signed if the LINTHRA_* secrets are configured (-> release-signed).
+#     If the secrets are missing: a pre-release tag degrades to clearly-labeled
+#     debug-signed artifacts (for testing only); a stable tag fails fast.
 #
-# See docs/release-signing.md for the required secrets and keystore handling.
+# Artifact naming carries both the version (tag) and the signing label so a
+# debug-signed build can never be mistaken for a production release, e.g.
+#   linthra-v0.1.0-alpha.1-debug-signed.apk / .aab
+#   linthra-v0.1.0-alpha.1-release-signed.apk / .aab
+#
+# See docs/release-signing.md for the required secrets and keystore handling,
+# and docs/release-process.md for the overall release flow.
 on:
   workflow_dispatch:
     inputs:
@@ -53,7 +65,7 @@ on:
 
 # Default to read-only. Building and sharing artifacts via upload-artifact needs
 # nothing more. The separate attach-release job below requests `contents: write`
-# only for itself, and only to upload assets to an existing GitHub Release.
+# only for itself, and only to create a pre-release / upload Release assets.
 permissions:
   contents: read
 
@@ -72,16 +84,24 @@ jobs:
     outputs:
       signing: ${{ steps.mode.outputs.signing }}
       trigger: ${{ steps.mode.outputs.trigger }}
+      prerelease: ${{ steps.mode.outputs.prerelease }}
+      asset_base: ${{ steps.mode.outputs.asset_base }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Decide, in one place, how this run should sign and how to label it.
-      #   trigger: manual | tag
-      #   signing: release-signed | debug-signed
+      # Decide, in one place, how this run should sign, whether the tag is a
+      # pre-release, and how to label/name the artifacts.
+      #   trigger:    manual | tag
+      #   signing:    release-signed | debug-signed
+      #   prerelease: true | false  (only meaningful for tag builds)
+      #   asset_base: file-name stem for the produced APK/AAB
+      #
       # Manual signed=true with missing secrets fails fast (preserves the old
-      # behavior). A tag with missing secrets degrades to clearly-labeled
-      # debug-signed artifacts (never silently passed off as a real release).
+      # behavior). A STABLE tag with missing secrets also fails fast. A
+      # PRE-RELEASE tag (alpha/beta/rc) with missing secrets degrades to
+      # clearly-labeled debug-signed artifacts (never passed off as a real
+      # production release).
       - name: Determine build mode
         id: mode
         env:
@@ -92,12 +112,18 @@ jobs:
             [ -z "$v" ] && have_secrets=false
           done
 
+          prerelease=false
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             trigger=manual
             want_signed="${{ inputs.signed }}"
           else
             trigger=tag
             want_signed=true
+            tag="${{ github.ref_name }}"
+            # A SemVer pre-release: any tag containing alpha, beta, or rc.
+            if printf '%s' "$tag" | grep -qiE '(alpha|beta|rc)'; then
+              prerelease=true
+            fi
           fi
 
           if [ "$want_signed" = "true" ]; then
@@ -106,17 +132,28 @@ jobs:
             elif [ "$trigger" = "manual" ]; then
               echo "::error::Signed release requested but signing secrets are missing (need LINTHRA_KEYSTORE_BASE64, LINTHRA_KEYSTORE_PASSWORD, LINTHRA_KEY_ALIAS, LINTHRA_KEY_PASSWORD). See docs/release-signing.md."
               exit 1
-            else
-              echo "::warning::Tag build but signing secrets are missing; producing DEBUG-KEY signed artifacts (labeled -debug-signed). These are NOT a real release and will NOT be attached to any GitHub Release. Configure the LINTHRA_* secrets to get release-signed builds. See docs/release-signing.md."
+            elif [ "$prerelease" = "true" ]; then
+              echo "::warning::Pre-release tag but signing secrets are missing; producing DEBUG-KEY signed artifacts (labeled -debug-signed). These are FOR TESTING ONLY, not a production release, and will be attached to a GitHub PRE-RELEASE labeled as such. Configure the LINTHRA_* secrets to get release-signed builds. See docs/release-signing.md."
               signing=debug-signed
+            else
+              echo "::error::Stable tag '${{ github.ref_name }}' requires release signing, but the signing secrets are missing (need LINTHRA_KEYSTORE_BASE64, LINTHRA_KEYSTORE_PASSWORD, LINTHRA_KEY_ALIAS, LINTHRA_KEY_PASSWORD). Stable releases must not ship debug-signed artifacts. Configure the secrets, or use an alpha/beta/rc tag for a testing pre-release. See docs/release-signing.md."
+              exit 1
             fi
           else
             signing=debug-signed
           fi
 
+          if [ "$trigger" = "tag" ]; then
+            asset_base="linthra-${{ github.ref_name }}-${signing}"
+          else
+            asset_base="linthra-${signing}"
+          fi
+
           echo "trigger=$trigger" >> "$GITHUB_OUTPUT"
           echo "signing=$signing" >> "$GITHUB_OUTPUT"
-          echo "Trigger: $trigger | Signing: $signing"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "asset_base=$asset_base" >> "$GITHUB_OUTPUT"
+          echo "Trigger: $trigger | Signing: $signing | Pre-release: $prerelease | Asset base: $asset_base"
 
       - name: Decode release keystore
         if: ${{ steps.mode.outputs.signing == 'release-signed' }}
@@ -151,20 +188,29 @@ jobs:
       - name: Build release AAB
         run: flutter build appbundle --release
 
-      # The artifact name carries the signing label so a debug-signed build can
-      # never be mistaken for a publishable release.
+      # Give the outputs descriptive, self-documenting names that carry the
+      # version (tag) and the signing label, so a debug-signed build can never
+      # be mistaken for a production release once downloaded or attached.
+      - name: Stage named artifacts
+        run: |
+          mkdir -p dist
+          base="${{ steps.mode.outputs.asset_base }}"
+          cp build/app/outputs/flutter-apk/app-release.apk "dist/${base}.apk"
+          cp build/app/outputs/bundle/release/app-release.aab "dist/${base}.aab"
+          ls -l dist
+
       - name: Upload release APK
         uses: actions/upload-artifact@v4
         with:
           name: linthra-${{ steps.mode.outputs.signing }}-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
+          path: dist/${{ steps.mode.outputs.asset_base }}.apk
           if-no-files-found: error
 
       - name: Upload release AAB
         uses: actions/upload-artifact@v4
         with:
           name: linthra-${{ steps.mode.outputs.signing }}-aab
-          path: build/app/outputs/bundle/release/app-release.aab
+          path: dist/${{ steps.mode.outputs.asset_base }}.aab
           if-no-files-found: error
 
       - name: Build summary
@@ -174,33 +220,45 @@ jobs:
             echo ""
             echo "**Trigger:** ${{ steps.mode.outputs.trigger }}${{ github.event_name == 'push' && format(' (tag {0})', github.ref_name) || '' }}"
             echo ""
+            echo "**Artifacts:** \`${{ steps.mode.outputs.asset_base }}.apk\`, \`${{ steps.mode.outputs.asset_base }}.aab\`"
+            echo ""
             if [ "${{ steps.mode.outputs.signing }}" = "release-signed" ]; then
               echo "**Signing:** release-signed with the configured keystore."
-              echo ""
-              echo "Artifacts: \`linthra-release-signed-apk\`, \`linthra-release-signed-aab\`."
               if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
                 echo ""
-                echo "These signed artifacts will be attached to the GitHub Release for this tag if one exists."
+                if [ "${{ steps.mode.outputs.prerelease }}" = "true" ]; then
+                  echo "These release-signed artifacts will be attached to a GitHub **pre-release** for this tag (created if it does not exist)."
+                else
+                  echo "These release-signed artifacts will be attached to the GitHub Release for this tag if one exists."
+                fi
               fi
             else
-              echo "**Signing:** DEBUG-KEY signed (NOT a real release)."
+              echo "**Signing:** DEBUG-KEY signed — FOR TESTING ONLY, NOT a production release."
               echo ""
-              echo "Artifacts: \`linthra-debug-signed-apk\`, \`linthra-debug-signed-aab\`."
-              echo ""
+              if [ "${{ steps.mode.outputs.trigger }}" = "tag" ] && [ "${{ steps.mode.outputs.prerelease }}" = "true" ]; then
+                echo "These debug-signed artifacts will be attached to a GitHub **pre-release** for this tag (created if it does not exist), clearly labeled as testing-only builds."
+                echo ""
+              fi
               echo "Configure the LINTHRA_* secrets (and, for manual runs, set \`signed = true\`) to"
               echo "produce a release-signed build. See docs/release-signing.md."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Attaches the release-signed artifacts to an EXISTING GitHub Release for the
-  # pushed tag. This is the only job that needs write access, so it is the only
-  # one granted `contents: write`. It never creates a Release and never writes
-  # release notes — if no Release exists yet, it leaves a notice and the signed
-  # artifacts remain downloadable from the build job.
+  # Attaches the built artifacts to a GitHub Release for the pushed tag. This is
+  # the only job that needs write access, so it is the only one granted
+  # `contents: write`.
+  #
+  #   * Pre-release tags (alpha/beta/rc): CREATE a pre-release if none exists,
+  #     then upload/replace the APK/AAB. Debug-signed artifacts are attached with
+  #     a clear "testing only" label and the Release is marked as a pre-release.
+  #
+  #   * Stable tags: only attach (upload/replace) to a Release that already
+  #     exists. The workflow never auto-creates a stable Release or writes its
+  #     production notes.
   attach-release:
-    name: Attach signed artifacts to GitHub Release
+    name: Attach artifacts to GitHub Release
     needs: build-release
-    if: ${{ github.event_name == 'push' && needs.build-release.outputs.signing == 'release-signed' }}
+    if: ${{ github.event_name == 'push' && (needs.build-release.outputs.signing == 'release-signed' || needs.build-release.outputs.prerelease == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -210,17 +268,67 @@ jobs:
         with:
           path: artifacts
 
-      - name: Attach to GitHub Release (if one exists)
+      - name: Attach to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+          SIGNING: ${{ needs.build-release.outputs.signing }}
+          PRERELEASE: ${{ needs.build-release.outputs.prerelease }}
         run: |
-          apk="artifacts/linthra-release-signed-apk/app-release.apk"
-          aab="artifacts/linthra-release-signed-aab/app-release.aab"
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "GitHub Release '$TAG' exists; uploading signed artifacts."
-            gh release upload "$TAG" "$apk" "$aab" --clobber --repo "$GITHUB_REPOSITORY"
-            echo "Attached release-signed APK/AAB to Release '$TAG'."
-          else
-            echo "::notice::No GitHub Release exists for tag '$TAG' yet, so nothing was attached. The release-signed APK/AAB are available as workflow artifacts. Create the Release (with your own notes) and re-run this workflow, or attach the artifacts manually."
+          set -euo pipefail
+
+          apk="$(find artifacts -name '*.apk' -print -quit)"
+          aab="$(find artifacts -name '*.aab' -print -quit)"
+          if [ -z "$apk" ] || [ -z "$aab" ]; then
+            echo "::error::Could not locate built APK/AAB among downloaded artifacts."
+            exit 1
           fi
+          echo "APK: $apk"
+          echo "AAB: $aab"
+
+          release_exists=false
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            release_exists=true
+          fi
+
+          if [ "$release_exists" = "true" ]; then
+            echo "GitHub Release '$TAG' exists; uploading/replacing assets."
+            gh release upload "$TAG" "$apk" "$aab" --clobber --repo "$GITHUB_REPOSITORY"
+            echo "Attached $SIGNING APK/AAB to Release '$TAG'."
+            exit 0
+          fi
+
+          if [ "$PRERELEASE" != "true" ]; then
+            # Stable tag with no Release yet: do not auto-create. Notes are manual.
+            echo "::notice::No GitHub Release exists for stable tag '$TAG' yet, so nothing was attached. The release-signed APK/AAB are available as workflow artifacts. Create the Release (with your own notes) and re-run this workflow, or attach the artifacts manually."
+            exit 0
+          fi
+
+          # Pre-release tag with no Release yet: create one (marked pre-release)
+          # with a clear, honest body and attach the artifacts. Notes are
+          # written to a file (no heredocs, to keep this YAML block valid).
+          notes_file="$RUNNER_TEMP/release-notes.md"
+          if [ "$SIGNING" = "debug-signed" ]; then
+            {
+              printf '%s\n\n' '> **Pre-release / testing build — DEBUG-SIGNED.**'
+              printf '%s\n' 'The attached APK/AAB are **DEBUG-KEY signed** and are **for testing only**.'
+              printf '%s\n\n' 'They are **not** a production release, **not** release-signed, and must **not** be distributed as such.'
+            } > "$notes_file"
+          else
+            {
+              printf '%s\n\n' '**Pre-release build — release-signed.**'
+              printf '%s\n\n' 'The attached APK/AAB are release-signed with the project keystore. This is a pre-release for testing / early access.'
+            } > "$notes_file"
+          fi
+          {
+            printf '%s\n' 'This Release was created automatically by the Android Release Build workflow on a pre-release tag. Edit these notes to describe the build.'
+            printf '%s\n' 'Nothing here is published to the Play Store or F-Droid (F-Droid builds and signs separately).'
+          } >> "$notes_file"
+
+          echo "No GitHub Release for pre-release tag '$TAG'; creating one (pre-release)."
+          gh release create "$TAG" "$apk" "$aab" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --prerelease \
+            --notes-file "$notes_file"
+          echo "Created pre-release '$TAG' and attached $SIGNING APK/AAB."

--- a/README.md
+++ b/README.md
@@ -322,7 +322,8 @@ optional release signing are handled separately by the **Android Release
 Build** workflow — manual for test builds, automatic on `v*` tags (see
 [Building release artifacts](#building-release-artifacts-android) and
 [docs/release-signing.md](./docs/release-signing.md)); nothing is published to a
-store or F-Droid, and no GitHub Release is created or written automatically.
+store or F-Droid. Alpha/beta/rc tags may auto-create a GitHub **pre-release** and
+attach artifacts to it, but production release notes are never written for you.
 
 #### Downloading a debug APK from CI
 
@@ -444,13 +445,13 @@ The **Android Release Build** workflow
 artifacts. It runs **manually** for test builds and **automatically on version
 tags** so a tagged release builds its APK/AAB without anyone clicking *Run
 workflow*. It still never publishes to a store or F-Droid and never writes
-release notes.
+production release notes.
 
 - **Manual test builds:** open the repo's **Actions** tab → **Android Release
   Build** → **Run workflow** (`workflow_dispatch`). A `signed` input controls
   whether the build is release-signed (see
-  [Signing status](#signing-status-important) below). This behavior is
-  unchanged.
+  [Signing status](#signing-status-important) below). Manual runs never touch
+  any GitHub Release.
 - **Automatic tag builds:** pushing a tag matching `v*` (e.g. `v0.1.0-alpha.1`)
   triggers the workflow automatically:
 
@@ -465,20 +466,28 @@ release notes.
   tag push (not to `release: published`) so a tag never builds twice.
 - **What it builds:** `flutter build apk --release` and
   `flutter build appbundle --release`.
-- **Artifacts** (names reflect how the build was signed, so a preview can't be
-  mistaken for a real release):
-  - Manual `signed = false` (default), or any build where signing secrets are
-    absent: `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
-  - Manual `signed = true`, or a tag build with the signing secrets present:
-    `linthra-release-signed-apk` / `linthra-release-signed-aab`.
-  - Each contains `app-release.apk` (`build/app/outputs/flutter-apk/app-release.apk`)
-    or `app-release.aab` (`build/app/outputs/bundle/release/app-release.aab`).
-- **Release attachment (tag builds only):** when a tag build is
-  **release-signed** *and* a GitHub Release already exists for that tag, the
-  signed APK/AAB are attached to the Release automatically. The workflow never
-  creates a Release or writes notes — those stay manual. If no Release exists
-  yet, nothing is attached and the signed artifacts remain downloadable from the
-  run.
+- **Artifacts** are named with both the version (tag) and the signing label, so
+  a debug-signed preview can never be mistaken for a production release:
+  - Tag builds: `linthra-<tag>-<signing>.apk` / `.aab`, e.g.
+    `linthra-v0.1.0-alpha.1-debug-signed.apk` or
+    `linthra-v0.1.0-alpha.1-release-signed.aab`.
+  - Manual builds (no tag): `linthra-<signing>.apk` / `.aab`.
+  - The build job uploads each as a workflow artifact
+    (`linthra-<signing>-apk` / `linthra-<signing>-aab`) from
+    `build/app/outputs/flutter-apk/app-release.apk` and
+    `build/app/outputs/bundle/release/app-release.aab`.
+- **Release attachment (tag builds only):**
+  - **Pre-release tags** — any tag containing `alpha`, `beta`, or `rc` — attach
+    their APK/AAB to a GitHub **pre-release**. If no Release exists for the tag,
+    one is **created as a pre-release** automatically. These tags may attach
+    release-signed *or* clearly-labeled **debug-signed** artifacts; debug-signed
+    builds are for **testing only** and are named and described as such.
+  - **Stable tags** — e.g. `v1.0.0` — **require release signing**. If the
+    `LINTHRA_*` secrets are missing the run **fails fast** rather than attaching
+    a debug-signed build. Stable assets are only uploaded to a Release that
+    **already exists** (notes stay manual); stable Releases are never
+    auto-created.
+  - When a Release already exists, assets are uploaded/replaced (`--clobber`).
 - **Download:** open the completed run and grab the artifacts from the run's
   **Artifacts** section (GitHub serves each as a `.zip`; unzip to get the
   APK/AAB). For a published Release, download the attached APK/AAB directly from
@@ -511,12 +520,19 @@ secrets are committed** to the repo.
 - **Tag build** (`v*` push) → attempts release signing automatically:
   - If the `LINTHRA_*` secrets are present → **release-signed** artifacts,
     eligible for Release attachment.
-  - If the secrets are missing → the run does **not** pretend to be a real
-    release: it emits a loud warning, builds **debug-key signed** artifacts
-    labeled `…-debug-signed-…`, and does **not** attach them to any Release.
+  - If the secrets are missing on a **pre-release** tag (`alpha`/`beta`/`rc`) →
+    the run does **not** pretend to be a production release: it emits a loud
+    warning and builds **debug-key signed** artifacts labeled `…-debug-signed`,
+    which are attached to a GitHub **pre-release** clearly marked as
+    testing-only.
+  - If the secrets are missing on a **stable** tag (e.g. `v1.0.0`) → the run
+    **fails fast**. Stable releases must be release-signed; debug-signed
+    artifacts are never attached to a stable Release.
 
 The keystore secrets are not configured in this repository yet, so until they
-are, tag builds fall back to debug-signed artifacts. Configure them (see
+are, **pre-release** tag builds fall back to clearly-labeled debug-signed
+artifacts (attached to a pre-release for testing), and **stable** tag builds
+fail until signing is provisioned. Configure the secrets (see
 [docs/release-signing.md](./docs/release-signing.md)) to get release-signed tag
 builds. Full details — required
 secrets, how to generate/rotate a keystore, and how this relates to F-Droid (which
@@ -524,13 +540,14 @@ signs its own builds) — are in [docs/release-signing.md](./docs/release-signin
 
 #### Limitations & next steps
 
-- The workflow **does not** create a GitHub Release, write release notes, upload
-  anything to a store, or submit to F-Droid. It produces downloadable build
-  artifacts and, for a release-signed tag build, attaches them to a Release you
-  created manually.
-- Release signing **secrets are not yet provisioned**, so until they are, builds
-  (including tag builds) fall back to the debug key (and are labeled
-  accordingly).
+- The workflow **does not** upload anything to a store or submit to F-Droid, and
+  it does **not** write production release notes. For **pre-release** tags it can
+  create a GitHub pre-release and attach (debug- or release-signed) artifacts to
+  it, with auto-generated placeholder notes you should edit. For **stable** tags
+  it only attaches release-signed artifacts to a Release you created manually.
+- Release signing **secrets are not yet provisioned**, so until they are,
+  pre-release tag builds fall back to clearly-labeled debug-signed artifacts
+  (for testing only) and stable tag builds fail until signing is configured.
 - **Next steps:** provision the `LINTHRA_*` keystore secrets
   ([docs/release-signing.md](./docs/release-signing.md)), then follow the manual
   release/tagging and GitHub-Release flow in

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,10 +6,11 @@ docs reference this document rather than restating the plan.
 
 > **No release has been cut and nothing here publishes to a store.** Linthra
 > has no tagged release yet, is **not** on F-Droid, and no APK/AAB has been
-> published. Pushing a `v*` tag now builds the release artifacts automatically
-> (and attaches them to a matching GitHub Release if one exists), but **creating
-> the Release and writing its notes stays manual** — and nothing is published to
-> any store or to F-Droid. This document describes the intended process.
+> published. Pushing a `v*` tag now builds the release artifacts automatically.
+> For **alpha/beta/rc** tags the build can create a GitHub **pre-release** and
+> attach the APK/AAB to it; for **stable** tags it only attaches to a Release you
+> created. **Writing the release notes stays manual** — and nothing is published
+> to any store or to F-Droid. This document describes the intended process.
 
 ## 1. Versioning model
 
@@ -77,51 +78,73 @@ Before creating a release tag:
    [dependency & license audit](./dependency-license-audit.md).
 6. Create the annotated tag (§2).
 
-## 4. GitHub Releases (notes manual, artifact build automatic)
+## 4. GitHub Releases (notes manual, artifact build & attachment automatic)
 
-Publishing a GitHub Release — and **writing its notes** — stays **manual and
-operator-initiated**. No workflow creates a Release or authors notes for you.
-
-What *is* automated is the **artifact build**: the **Android Release Build**
-workflow (`.github/workflows/android-release-build.yml`) runs automatically when
-a `v*` tag is pushed, builds the APK/AAB, and — if the build is release-signed
-and a GitHub Release already exists for that tag — attaches the signed APK/AAB
-to it. It never creates a Release, writes notes, publishes to a store, or
-submits to F-Droid. The workflow listens only to the tag `push` (not to
-`release: published`), so a tag builds exactly once. See
+Pushing a `v*` tag starts the build. The **Android Release Build** workflow
+(`.github/workflows/android-release-build.yml`) runs automatically on a `v*`
+tag, builds the APK/AAB, and attaches them to a GitHub Release. **Writing the
+release notes stays manual** — the workflow never authors production notes,
+publishes to a store, or submits to F-Droid. It listens only to the tag `push`
+(not to `release: published`), so a tag builds exactly once. See
 [docs/release-signing.md](./release-signing.md) for the signing details.
 
-### Recommended flow (notes written first, build attaches automatically)
+The attachment behavior depends on whether the tag is a **pre-release**:
+
+- **Alpha/beta/rc tags** (any tag containing `alpha`, `beta`, or `rc`, e.g.
+  `v0.1.0-alpha.1`) may attach **debug-signed** *or* **release-signed**
+  artifacts to a GitHub **pre-release**. If no Release exists for the tag yet,
+  the workflow **creates one as a pre-release** with placeholder notes (edit
+  them afterwards). Debug-signed artifacts are clearly named and labeled as
+  **testing-only** builds — never as a production release.
+- **Stable tags** (e.g. `v1.0.0`) **require release signing**. If the
+  `LINTHRA_*` secrets are missing, the tag build **fails fast** rather than
+  shipping a debug-signed build. Stable assets are only uploaded to a Release
+  that **already exists**; the workflow does not auto-create stable Releases.
+
+Artifacts are named with the version and signing label, e.g.
+`linthra-v0.1.0-alpha.1-debug-signed.apk` or
+`linthra-v0.1.0-alpha.1-release-signed.aab`.
+
+### Recommended flow for an alpha/beta/rc pre-release (fully automatic)
 
 1. Ensure generated files are current (§3) and `pubspec.yaml` matches the tag.
-2. Make sure the `LINTHRA_*` keystore secrets are configured (see
-   [release-signing.md §2](./release-signing.md#2-required-github-secrets-ci)),
-   otherwise the tag build will fall back to debug-signed artifacts that are
-   **not** attached to the Release.
-3. In the GitHub UI, **create the Release** against a **new** tag `vX.Y.Z`,
-   write the notes (the Fastlane changelog from §3 is a good basis), and mark it
-   **pre-release** for `-alpha`/`-beta` tags. Creating the Release on a new tag
-   also creates and pushes that tag.
+2. (Optional but recommended) configure the `LINTHRA_*` keystore secrets (see
+   [release-signing.md §2](./release-signing.md#2-required-github-secrets-ci))
+   so the attached artifacts are release-signed. Without them, the pre-release
+   gets clearly-labeled **debug-signed** artifacts for testing only.
+3. Push the annotated tag (§2), e.g. `v0.1.0-alpha.1`. The build runs, and a
+   GitHub **pre-release** is created (if absent) with the APK/AAB attached.
+4. Edit the auto-created pre-release notes (the Fastlane changelog from §3 is a
+   good basis). Done.
+
+### Recommended flow for a stable release (notes written first)
+
+1. Ensure generated files are current (§3) and `pubspec.yaml` matches the tag.
+2. Configure the `LINTHRA_*` keystore secrets — **required** for stable tags
+   (the tag build fails without them).
+3. In the GitHub UI, **create the Release** against a **new** stable tag
+   `vX.Y.Z`, write the notes. Creating the Release on a new tag also creates and
+   pushes that tag.
 4. That tag push triggers **Android Release Build** automatically. When it
-   finishes, the **release-signed** `app-release.apk` / `app-release.aab` are
-   attached to the Release. Done.
+   finishes, the **release-signed** APK/AAB are attached to the Release. Done.
 
 ### Alternative flow (tag from git first)
 
-1. Push the annotated tag from git (§2). The build starts automatically and the
-   **release-signed** artifacts are produced as workflow artifacts. Because no
-   Release exists yet, nothing is attached.
+1. Push the annotated tag from git (§2). For a stable tag with no Release yet,
+   the **release-signed** artifacts are produced as workflow artifacts but
+   nothing is attached.
 2. Create the GitHub Release for the tag and write its notes, then either
    **re-run** the workflow for that tag (it will now find the Release and
    attach) or download the artifacts from the original run and attach them
    manually.
 
 > A `signed = false` manual run, or any build without the signing secrets,
-> produces **`linthra-debug-signed-*`** artifacts. Those are previews only and
-> **must never** be attached to a Release.
+> produces **debug-signed** artifacts. Those are previews/testing builds only.
+> They may be attached to an alpha/beta/rc **pre-release** (clearly labeled), but
+> **must never** be attached to a stable Release.
 
-Manual `workflow_dispatch` runs remain available for ad-hoc test builds and are
-unchanged.
+Manual `workflow_dispatch` runs remain available for ad-hoc test builds; they
+never touch any GitHub Release.
 
 > **Signature note.** A GitHub-Release APK is signed with **our** release key,
 > while an F-Droid build of the same version is signed with **F-Droid's** key.
@@ -147,15 +170,17 @@ F-Droid does **not** consume our signed artifacts. When/if Linthra is submitted:
 | Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
 | Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
-| Attaching signed APK/AAB to a Release | **Automatic** on a `v*` tag build, **only if** the build is release-signed and a Release already exists. |
+| Attaching APK/AAB to a Release | **Automatic** on a `v*` tag build. Alpha/beta/rc tags attach (debug- or release-signed) to a **pre-release**; stable tags attach **release-signed** assets to an existing Release only. |
+| Creating a GitHub **pre-release** (alpha/beta/rc) | **Automatic** on the tag build if no Release exists yet (placeholder notes; edit afterwards). |
+| Creating a stable GitHub Release | **Manual** (operator, §4); never auto-created. |
 | Drift code generation | **Manual only** (`generate-drift.yml`, `workflow_dispatch`). |
 | Creating a git tag | **Manual** (operator runs `git tag`, or creates a Release on a new tag). |
-| Creating a GitHub Release / writing notes | **Manual** (operator, §4). |
+| Writing production release notes | **Manual** (operator, §4). |
 | Publishing to a store / F-Droid | **Not done by this repo.** |
 
-CI builds release artifacts on a tag and can attach them to a Release you
-created, but it never creates a Release, writes notes, signs a store build, or
-submits to F-Droid.
+CI builds release artifacts on a tag and attaches them: it can auto-create a
+**pre-release** for alpha/beta/rc tags, but it never auto-creates a stable
+Release, writes production notes, signs a store build, or submits to F-Droid.
 
 ## 7. Remaining blockers before a first release
 

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -60,28 +60,34 @@ file at runtime and never writes it into the repository.
 
 The **Android Release Build** workflow runs **manually** (`workflow_dispatch`)
 for test builds and **automatically on `v*` tags** for release builds. It does
-not create a GitHub Release, write notes, publish to any store, or submit to
-F-Droid.
+not publish to any store, submit to F-Droid, or write production release notes.
 
-- **Manual unsigned preview (default):** run with `signed = false`. Artifacts
-  are uploaded as `linthra-debug-signed-apk` / `linthra-debug-signed-aab`.
+Artifacts are named with the version (tag) and signing label, e.g.
+`linthra-v0.1.0-alpha.1-debug-signed.apk` or
+`linthra-v0.1.0-alpha.1-release-signed.aab`, so a debug-signed build can never
+be confused with a production release. They are uploaded as workflow artifacts
+(`linthra-<signing>-apk` / `linthra-<signing>-aab`).
+
+- **Manual unsigned preview (default):** run with `signed = false` →
+  debug-signed artifacts. Manual runs never touch any GitHub Release.
 - **Manual release-signed build:** run with `signed = true` (requires the
-  secrets above; the run **fails fast** if any are missing). Artifacts are
-  uploaded as `linthra-release-signed-apk` / `linthra-release-signed-aab`.
-- **Automatic tag build (`v*` push):** attempts release signing.
-  - If all the secrets above are present → **release-signed** artifacts, and if
-    a GitHub Release already exists for the tag they are attached to it.
-  - If any secret is missing → the run does **not** silently fake a release: it
-    logs a warning, builds **debug-signed** artifacts (`linthra-debug-signed-*`),
-    and attaches nothing to any Release. Configure the secrets to get a real
-    release-signed tag build.
-
-The artifact names and the run summary always state which key signed the build,
-so a debug-signed build can never be confused with a release.
+  secrets above; the run **fails fast** if any are missing) → release-signed
+  artifacts.
+- **Automatic tag build (`v*` push):** attempts release signing, with behavior
+  that depends on whether the tag is a pre-release:
+  - **Alpha/beta/rc tags** (containing `alpha`, `beta`, or `rc`): attach the
+    APK/AAB to a GitHub **pre-release**, creating one if it does not exist. If
+    the secrets are present the artifacts are **release-signed**; if any secret
+    is missing the run logs a warning and attaches clearly-labeled
+    **debug-signed** (testing-only) artifacts instead of faking a release.
+  - **Stable tags** (e.g. `v1.0.0`): **require release signing**. If any secret
+    is missing the run **fails fast**. Release-signed assets are uploaded only
+    to a Release that already exists; stable Releases are never auto-created.
 
 > **Minimal permissions.** The build job runs with `contents: read`. Only the
 > separate Release-attachment job is granted `contents: write`, and only to
-> upload assets to an existing Release — it never creates one or edits notes.
+> create a pre-release (alpha/beta/rc) or upload/replace Release assets. It
+> never writes production release notes for you.
 
 ## 4. Generating a keystore locally
 
@@ -152,12 +158,14 @@ freely once published — plan rotation carefully.
   F-Droid repository, F-Droid builds from source on its own infrastructure and
   signs the APK with **F-Droid's** signing key, not ours. Our release keystore
   is therefore not used by, and not given to, F-Droid.
-- **GitHub Releases signing is separate.** Any APK/AAB attached to a GitHub
-  Release (built on a `v*` tag and attached automatically when release-signed)
-  is signed with *our* release key. That means the F-Droid build and a
-  GitHub-Release build of the same version have **different signatures** and
-  cannot be cross-installed as updates of each other. This is expected; document
-  it clearly for users.
+- **GitHub Releases signing is separate.** A **release-signed** APK/AAB attached
+  to a GitHub Release (built on a `v*` tag) is signed with *our* release key.
+  That means the F-Droid build and a release-signed GitHub-Release build of the
+  same version have **different signatures** and cannot be cross-installed as
+  updates of each other. This is expected; document it clearly for users.
+  (Debug-signed artifacts attached to an alpha/beta/rc pre-release are signed
+  with the Android **debug** key and are for testing only — never for F-Droid or
+  any store.)
 - **Reproducible builds (optional, advanced).** F-Droid supports verifying that
   a developer-signed binary matches what it builds from source, but that
   requires a reproducible build setup and is explicitly out of scope here.
@@ -167,9 +175,10 @@ freely once published — plan rotation carefully.
 
 ## 7. What is intentionally out of scope
 
-- Creating GitHub Releases or writing release notes automatically (the workflow
-  only *attaches* signed artifacts to a Release you created; it never creates
-  one). Building the artifacts on a `v*` tag *is* automated.
+- Writing production release notes automatically. For alpha/beta/rc tags the
+  workflow may *create* a GitHub **pre-release** with placeholder notes and
+  attach artifacts; for stable tags it only attaches to a Release you created.
+  Building the artifacts on a `v*` tag *is* automated.
 - Publishing to the Play Store.
 - Submitting to F-Droid.
 - Committing any keystore, password, or `key.properties`.


### PR DESCRIPTION
## Root cause

The Android Release Build workflow built APK/AAB on `v*` tags but only the `attach-release` job uploaded them to a GitHub Release, and that job ran **only** when `signing == release-signed` and **only** when a Release already existed. As a result, the alpha flow (debug-signed tag builds) produced workflow artifacts that were never attached to any Release, and if no Release existed yet, nothing was attached at all. Cutting an alpha required manually creating the Release and attaching files by hand.

## New release attachment behavior

`.github/workflows/android-release-build.yml`:

- Still triggers on manual `workflow_dispatch` and on `v*` tag pushes (one build per tag — we listen to the tag push, not `release: published`, so no duplicate builds).
- The build job now classifies a tag as a **pre-release** when it contains `alpha`, `beta`, or `rc`, computes a descriptive `asset_base`, and stages the outputs under that name.
- The `attach-release` job now runs for any tag build that has attachable artifacts (`release-signed`, or any pre-release tag). It:
  - uploads/replaces assets (`--clobber`) when a Release already exists;
  - **creates a GitHub pre-release automatically** (with honest placeholder notes) for alpha/beta/rc tags when no Release exists;
  - leaves a notice (no auto-create) for stable tags with no Release.
- No Play Store / F-Droid publishing, and no production release notes are written for you.

## Alpha vs stable behavior

| Tag kind | Secrets present | Result |
| --- | --- | --- |
| `alpha`/`beta`/`rc` | yes | release-signed artifacts attached to a pre-release (created if absent) |
| `alpha`/`beta`/`rc` | no | warning + **debug-signed** artifacts attached to a pre-release, clearly labeled testing-only |
| stable (`v1.0.0`) | yes | release-signed artifacts attached to an existing Release only |
| stable (`v1.0.0`) | no | **fails fast** — stable releases must be release-signed |

Debug-signed builds are never passed off as production releases; the auto-created pre-release body states they are DEBUG-KEY signed and for testing only.

## Artifact naming

Names carry both the version (tag) and the signing label:

- `linthra-v0.1.0-alpha.1-debug-signed.apk` / `.aab`
- `linthra-v0.1.0-alpha.1-release-signed.apk` / `.aab`
- Manual (no tag) builds: `linthra-<signing>.apk` / `.aab`

Workflow artifacts are uploaded as `linthra-<signing>-apk` / `linthra-<signing>-aab` containing the named file.

## Permissions used

- Top-level: `contents: read` (build job needs nothing more).
- `attach-release` job: `contents: write`, scoped to that job only — used to create a pre-release and upload/replace Release assets. No other scopes added.

## Docs updated

- `README.md` — tag/attachment behavior, artifact naming, alpha vs stable, signing status.
- `docs/release-process.md` — pre-release vs stable flows, automation table.
- `docs/release-signing.md` — tag-build signing matrix, permissions note, F-Droid separation, out-of-scope list.

Docs explain: pushing a `v*` tag starts the build; alpha/beta/rc tags can attach debug-signed artifacts to a GitHub pre-release; stable releases require release signing; F-Droid builds/signs separately; debug-signed APKs are for testing only.

## Remaining manual steps

- Provision the `LINTHRA_*` keystore secrets to get release-signed builds (required for stable tags; recommended for alphas).
- Edit the auto-created pre-release notes to describe the build.
- For **stable** releases: create the GitHub Release (with notes) yourself — it is never auto-created; the workflow only attaches release-signed assets to it.
- Publishing to a store / submitting to F-Droid remains out of scope and manual.

No app code, features, or secrets were added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbSZCSjq7FGWDbaC2Js5DE)_