### PR TITLE
Premium Now Playing screen + visible direct-stream source badges

### DIFF
--- a/lib/core/models/playback_source.dart
+++ b/lib/core/models/playback_source.dart
@@ -1,0 +1,31 @@
+/// Where the audio the player is currently feeding the engine actually comes
+/// from. Decoupled from any audio package and from the source layer so the UI
+/// can show an honest "what am I hearing" badge without reaching into the
+/// resolver, the cache, or Jellyfin.
+///
+/// The value is decided by the [PlayableUriResolver] at play time (a cache hit
+/// is [offlineCache], a minted Jellyfin URL is [streamingDirect], an on-device
+/// path is [localFile]) and carried on the player's state.
+enum PlaybackSource {
+  /// An on-device file (or Android SAF document) playing from its own path.
+  localFile,
+
+  /// A remote (Jellyfin/NAS) track streaming live from the authenticated
+  /// session — no download required.
+  streamingDirect,
+
+  /// A remote track playing from its downloaded, on-disk copy.
+  offlineCache;
+
+  /// Short, all-caps badge text for the now-playing source indicator.
+  String get label {
+    switch (this) {
+      case PlaybackSource.localFile:
+        return 'LOCAL FILE';
+      case PlaybackSource.streamingDirect:
+        return 'STREAMING DIRECT';
+      case PlaybackSource.offlineCache:
+        return 'OFFLINE CACHE';
+    }
+  }
+}

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import 'playback_source.dart';
 import 'track.dart';
 
 /// High-level playback status, deliberately decoupled from any audio package.
@@ -16,6 +17,7 @@ class PlaybackState {
     this.hasPrevious = false,
     this.position = Duration.zero,
     this.duration = Duration.zero,
+    this.source,
     this.errorMessage,
   });
 
@@ -23,6 +25,12 @@ class PlaybackState {
 
   final PlaybackStatus status;
   final Track? currentTrack;
+
+  /// Where [currentTrack]'s audio is coming from (local file, direct stream, or
+  /// offline cache), as decided by the resolver at play time. Null until a track
+  /// resolves, and cleared when playback stops or errors — so the UI only shows
+  /// a source badge for audio actually loaded.
+  final PlaybackSource? source;
 
   /// Tracks queued to play after [currentTrack], in play order. Empty when the
   /// queue holds only the current track.
@@ -53,6 +61,7 @@ class PlaybackState {
     bool? hasPrevious,
     Duration? position,
     Duration? duration,
+    PlaybackSource? source,
   }) {
     return PlaybackState(
       status: status ?? this.status,
@@ -61,6 +70,7 @@ class PlaybackState {
       hasPrevious: hasPrevious ?? this.hasPrevious,
       position: position ?? this.position,
       duration: duration ?? this.duration,
+      source: source ?? this.source,
     );
   }
 
@@ -74,6 +84,7 @@ class PlaybackState {
           other.hasPrevious == hasPrevious &&
           other.position == position &&
           other.duration == duration &&
+          other.source == source &&
           other.errorMessage == errorMessage);
 
   @override
@@ -85,6 +96,7 @@ class PlaybackState {
       hasPrevious,
       position,
       duration,
+      source,
       errorMessage,
     );
   }

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -142,9 +142,9 @@ class JustAudioPlaybackController implements PlaybackController {
     );
     _emit(loading);
 
-    final Uri uri;
+    final ResolvedPlayable resolved;
     try {
-      uri = await _resolver.resolve(track);
+      resolved = await _resolver.resolve(track);
     } on PlaybackResolutionException catch (error) {
       _emitError(track, error.message);
       return;
@@ -153,10 +153,15 @@ class JustAudioPlaybackController implements PlaybackController {
       return;
     }
 
+    // Record where the audio is coming from so the UI can show an honest
+    // source badge. It rides along on every later position/status update via
+    // copyWith until the next track loads (which resets it).
+    _emit(_state.copyWith(source: resolved.source));
+
     try {
       // setUrl handles file://, content:// (Android), and https:// URIs alike,
       // so local files, SAF documents, and Jellyfin streams share one path.
-      await _player.setUrl(uri.toString());
+      await _player.setUrl(resolved.uri.toString());
       // play()'s future completes when playback ends, so we don't await it.
       unawaited(_player.play());
     } catch (_) {

--- a/lib/core/services/local_playable_uri_resolver.dart
+++ b/lib/core/services/local_playable_uri_resolver.dart
@@ -1,3 +1,4 @@
+import '../models/playback_source.dart';
 import '../models/track.dart';
 import 'playable_uri_resolver.dart';
 
@@ -20,7 +21,12 @@ class LocalPlayableUriResolver implements PlayableUriResolver {
   }
 
   @override
-  Future<Uri> resolve(Track track) async => playableUriFor(track.uri);
+  Future<ResolvedPlayable> resolve(Track track) async {
+    return ResolvedPlayable(
+      playableUriFor(track.uri),
+      PlaybackSource.localFile,
+    );
+  }
 
   /// Maps a stored on-device [trackUri] to a playable URI: a `content://` URI
   /// (an Android SAF document) is opened as-is; everything else is treated as a

--- a/lib/core/services/offline_first_playable_uri_resolver.dart
+++ b/lib/core/services/offline_first_playable_uri_resolver.dart
@@ -1,3 +1,4 @@
+import '../models/playback_source.dart';
 import '../models/track.dart';
 import 'cached_track_locator.dart';
 import 'playable_uri_resolver.dart';
@@ -26,10 +27,13 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
   bool handles(Track track) => _fallback.handles(track);
 
   @override
-  Future<Uri> resolve(Track track) async {
+  Future<ResolvedPlayable> resolve(Track track) async {
     final String? cachedPath = await _locator.cachedFilePath(track);
     if (cachedPath != null) {
-      return Uri.file(cachedPath);
+      return ResolvedPlayable(
+        Uri.file(cachedPath),
+        PlaybackSource.offlineCache,
+      );
     }
     return _fallback.resolve(track);
   }

--- a/lib/core/services/playable_uri_resolver.dart
+++ b/lib/core/services/playable_uri_resolver.dart
@@ -1,4 +1,20 @@
+import '../models/playback_source.dart';
 import '../models/track.dart';
+
+/// The outcome of resolving a [Track]: the URI the audio engine should open and
+/// where those bytes come from.
+///
+/// Carrying the [source] alongside the [uri] lets the player show an honest
+/// "LOCAL FILE / STREAMING DIRECT / OFFLINE CACHE" badge without re-deriving it
+/// (a `file://` URI alone can't tell an on-device track from a downloaded remote
+/// one). The resolver that actually produces the URI is the one that knows, so
+/// it reports both together.
+class ResolvedPlayable {
+  const ResolvedPlayable(this.uri, this.source);
+
+  final Uri uri;
+  final PlaybackSource source;
+}
 
 /// Why resolving a [Track] to a playable URI failed.
 ///
@@ -50,7 +66,7 @@ abstract interface class PlayableUriResolver {
   /// Whether this resolver can produce a URI for [track].
   bool handles(Track track);
 
-  /// Resolves [track] to a playable URI, or throws a
+  /// Resolves [track] to a playable URI and its source, or throws a
   /// [PlaybackResolutionException] with a friendly, secret-free message.
-  Future<Uri> resolve(Track track);
+  Future<ResolvedPlayable> resolve(Track track);
 }

--- a/lib/core/services/routing_playable_uri_resolver.dart
+++ b/lib/core/services/routing_playable_uri_resolver.dart
@@ -18,7 +18,7 @@ class RoutingPlayableUriResolver implements PlayableUriResolver {
       _resolvers.any((PlayableUriResolver r) => r.handles(track));
 
   @override
-  Future<Uri> resolve(Track track) async {
+  Future<ResolvedPlayable> resolve(Track track) async {
     for (final PlayableUriResolver resolver in _resolvers) {
       if (resolver.handles(track)) {
         return resolver.resolve(track);

--- a/lib/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart
@@ -1,3 +1,4 @@
+import '../../models/playback_source.dart';
 import '../../models/track.dart';
 import '../../services/playable_uri_resolver.dart';
 import 'jellyfin_exception.dart';
@@ -28,7 +29,7 @@ class JellyfinPlayableUriResolver implements PlayableUriResolver {
       track.uri.startsWith(JellyfinTrackMapper.uriScheme);
 
   @override
-  Future<Uri> resolve(Track track) async {
+  Future<ResolvedPlayable> resolve(Track track) async {
     final JellyfinStreamSource? source = _source();
     if (source == null) {
       throw const PlaybackResolutionException(
@@ -54,7 +55,7 @@ class JellyfinPlayableUriResolver implements PlayableUriResolver {
         kind: PlaybackResolutionErrorKind.streamUnavailable,
       );
     }
-    return uri;
+    return ResolvedPlayable(uri, PlaybackSource.streamingDirect);
   }
 
   /// Maps a verification failure to a friendly, secret-free playback error.

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -7,6 +7,7 @@ import '../../app/routes.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/services/playback_controller.dart';
 import 'player_providers.dart';
+import 'widgets/album_artwork.dart';
 
 /// A compact, persistent now-playing bar shown above the bottom navigation on
 /// every main screen (Library / Playlists / Downloads / Settings).
@@ -53,7 +54,13 @@ class MiniPlayer extends ConsumerWidget {
           ),
           child: Row(
             children: [
-              Icon(Icons.music_note, color: theme.colorScheme.primary),
+              SizedBox.square(
+                dimension: 44,
+                child: AlbumArtwork(
+                  artworkUri: track.artworkUri,
+                  borderRadius: BorderRadius.circular(AppRadii.sm),
+                ),
+              ),
               const SizedBox(width: AppSpacing.md),
               Expanded(
                 child: Column(

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -6,10 +6,18 @@ import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
 import 'player_providers.dart';
+import 'widgets/album_artwork.dart';
+import 'widgets/now_playing_actions.dart';
+import 'widgets/now_playing_background.dart';
+import 'widgets/playback_controls.dart';
+import 'widgets/playback_progress_bar.dart';
+import 'widgets/track_metadata.dart';
 
-/// Full-screen now-playing view. Renders from [playbackStateProvider] and
-/// drives playback through the [PlaybackController]; it never touches the audio
-/// engine directly. Pushed above the shell via AppRoutes.player.
+/// Full-screen now-playing view. Renders from [playbackStateProvider] and drives
+/// playback through the [PlaybackController]; it never touches the audio engine,
+/// Jellyfin, or the cache directly. Layout is composed from small widgets
+/// (background, artwork, metadata, progress, controls, actions) so this file
+/// stays a thin orchestrator. Pushed above the shell via AppRoutes.player.
 class PlayerScreen extends ConsumerWidget {
   const PlayerScreen({super.key});
 
@@ -18,16 +26,69 @@ class PlayerScreen extends ConsumerWidget {
     final controller = ref.watch(playbackControllerProvider);
     final state =
         ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+    final Track? track = state.currentTrack;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Now Playing')),
-      body: state.hasTrack ? _NowPlaying(state: state) : const _Nothing(),
+      body: Stack(
+        children: [
+          Positioned.fill(
+            child: NowPlayingBackground(artworkUri: track?.artworkUri),
+          ),
+          SafeArea(
+            child: Column(
+              children: [
+                const _Header(),
+                Expanded(
+                  child: track == null
+                      ? const _EmptyNowPlaying()
+                      : _NowPlaying(state: state, track: track),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
 
-class _Nothing extends StatelessWidget {
-  const _Nothing();
+/// Top bar: a collapse affordance and a calm "Now Playing" caption. Transparent
+/// so the blurred artwork shows through.
+class _Header extends StatelessWidget {
+  const _Header();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: () => Navigator.of(context).maybePop(),
+            icon: const Icon(Icons.keyboard_arrow_down),
+            tooltip: 'Close',
+          ),
+          Expanded(
+            child: Text(
+              'Now Playing',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.85),
+              ),
+            ),
+          ),
+          // Balances the leading button so the title stays centered.
+          const SizedBox(width: 48),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyNowPlaying extends StatelessWidget {
+  const _EmptyNowPlaying();
 
   @override
   Widget build(BuildContext context) {
@@ -39,241 +100,80 @@ class _Nothing extends StatelessWidget {
   }
 }
 
-/// Lays out the now-playing block above an optional "Up next" section. The
-/// centered track info stays vertically centered when the queue is empty, and
-/// shares the screen with the queue list when there are upcoming tracks.
-class _NowPlaying extends StatelessWidget {
-  const _NowPlaying({required this.state});
+class _NowPlaying extends ConsumerWidget {
+  const _NowPlaying({required this.state, required this.track});
 
   final PlaybackState state;
+  final Track track;
 
   @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        // The now-playing block keeps the larger share so the controls stay
-        // on screen even when the queue list is shown beneath it.
-        Expanded(
-          flex: 2,
-          child: Center(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(AppSpacing.xl),
-              child: _TrackInfo(state: state),
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.sm,
+        AppSpacing.lg,
+        AppSpacing.md,
+      ),
+      child: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: AlbumArtwork(artworkUri: track.artworkUri),
+              ),
             ),
           ),
-        ),
-        if (state.hasNext) Expanded(child: _UpNext(tracks: state.upNext)),
-      ],
-    );
-  }
-}
-
-class _TrackInfo extends StatelessWidget {
-  const _TrackInfo({required this.state});
-
-  final PlaybackState state;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final track = state.currentTrack!;
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.7);
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(Icons.music_note, size: 96, color: theme.colorScheme.primary),
-        const SizedBox(height: AppSpacing.xl),
-        Text(
-          track.title,
-          style: theme.textTheme.headlineSmall,
-          textAlign: TextAlign.center,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-        if (track.artistName != null && track.artistName!.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.lg),
+          TrackMetadata(
+            title: track.title,
+            artistName: track.artistName,
+            albumName: track.albumName,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          _SourceOrError(state: state),
           const SizedBox(height: AppSpacing.sm),
-          Text(
-            track.artistName!,
-            style: theme.textTheme.titleMedium?.copyWith(color: muted),
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+          PlaybackProgressBar(
+            position: state.position,
+            duration: state.duration,
+            onSeek: (position) =>
+                ref.read(playbackControllerProvider).seek(position),
           ),
+          const SizedBox(height: AppSpacing.xs),
+          PlaybackControls(state: state),
+          const SizedBox(height: AppSpacing.sm),
+          const NowPlayingActions(),
         ],
-        const SizedBox(height: AppSpacing.lg),
-        Text(
-          _statusText(state),
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: state.status == PlaybackStatus.error
-                ? theme.colorScheme.error
-                : theme.colorScheme.onSurface.withValues(alpha: 0.6),
-          ),
-          textAlign: TextAlign.center,
-        ),
-        const SizedBox(height: AppSpacing.lg),
-        _Controls(state: state),
-        const SizedBox(height: AppSpacing.md),
-        const _LyricsButton(),
-      ],
-    );
-  }
-}
-
-/// Visible entry point for lyrics. Lyrics aren't sourced yet, so tapping opens a
-/// calm empty state rather than nothing — the button stays put for when a real
-/// lyrics source lands in a later change. No lyrics are fetched or scraped.
-class _LyricsButton extends StatelessWidget {
-  const _LyricsButton();
-
-  @override
-  Widget build(BuildContext context) {
-    return TextButton.icon(
-      onPressed: () => _showLyrics(context),
-      icon: const Icon(Icons.lyrics_outlined),
-      label: const Text('Lyrics'),
-    );
-  }
-
-  void _showLyrics(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (context) => const SafeArea(
-        child: Padding(
-          padding: EdgeInsets.only(bottom: AppSpacing.xl),
-          child: EmptyState(
-            icon: Icons.lyrics_outlined,
-            title: 'No lyrics available yet.',
-            message: 'Lyrics support is coming in a future update.',
-          ),
-        ),
       ),
     );
   }
 }
 
-class _Controls extends ConsumerWidget {
-  const _Controls({required this.state});
+/// Under the metadata: a friendly error message when playback failed, otherwise
+/// the playback-source badge (LOCAL FILE / STREAMING DIRECT / OFFLINE CACHE)
+/// once a track has resolved. Shows nothing while a track is still loading.
+class _SourceOrError extends StatelessWidget {
+  const _SourceOrError({required this.state});
 
   final PlaybackState state;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final controller = ref.read(playbackControllerProvider);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        IconButton.filled(
-          iconSize: 48,
-          onPressed: state.isPlaying ? controller.pause : controller.play,
-          icon: Icon(state.isPlaying ? Icons.pause : Icons.play_arrow),
-          tooltip: state.isPlaying ? 'Pause' : 'Play',
-        ),
-        const SizedBox(width: AppSpacing.lg),
-        IconButton.filledTonal(
-          iconSize: 48,
-          onPressed: state.hasNext ? controller.skipToNext : null,
-          icon: const Icon(Icons.skip_next),
-          tooltip: 'Next',
-        ),
-        const SizedBox(width: AppSpacing.lg),
-        IconButton.filledTonal(
-          iconSize: 48,
-          onPressed: controller.stop,
-          icon: const Icon(Icons.stop),
-          tooltip: 'Stop',
-        ),
-      ],
-    );
-  }
-}
-
-/// The "Up next" section: a header with a Clear action and the upcoming tracks
-/// in play order. Only built when the queue has upcoming tracks.
-class _UpNext extends ConsumerWidget {
-  const _UpNext({required this.tracks});
-
-  final List<Track> tracks;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final controller = ref.read(playbackControllerProvider);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            AppSpacing.sm,
-            AppSpacing.sm,
-            AppSpacing.sm,
-          ),
-          child: Row(
-            children: [
-              Text('Up next', style: theme.textTheme.titleSmall),
-              const Spacer(),
-              TextButton(
-                onPressed: controller.clearQueue,
-                child: const Text('Clear'),
-              ),
-            ],
-          ),
-        ),
-        Expanded(
-          child: ListView.builder(
-            itemCount: tracks.length,
-            itemBuilder: (context, index) => _UpNextTile(track: tracks[index]),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _UpNextTile extends StatelessWidget {
-  const _UpNextTile({required this.track});
-
-  final Track track;
-
-  @override
   Widget build(BuildContext context) {
-    final artist = track.artistName;
-    return ListTile(
-      dense: true,
-      leading: const Icon(Icons.queue_music_outlined),
-      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
-      subtitle: artist == null || artist.isEmpty
-          ? null
-          : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
-    );
-  }
-}
-
-/// The status line under the track. On error it shows the state's specific,
-/// friendly [PlaybackState.errorMessage] (e.g. "session has expired") when one
-/// is set, falling back to a generic line.
-String _statusText(PlaybackState state) {
-  if (state.status == PlaybackStatus.error) {
-    return state.errorMessage ?? "Couldn't play this track";
-  }
-  return _statusLabel(state.status);
-}
-
-String _statusLabel(PlaybackStatus status) {
-  switch (status) {
-    case PlaybackStatus.idle:
-      return 'Stopped';
-    case PlaybackStatus.loading:
-      return 'Loading…';
-    case PlaybackStatus.playing:
-      return 'Playing';
-    case PlaybackStatus.paused:
-      return 'Paused';
-    case PlaybackStatus.completed:
-      return 'Finished';
-    case PlaybackStatus.error:
-      return "Couldn't play this track";
+    final theme = Theme.of(context);
+    if (state.status == PlaybackStatus.error) {
+      return Text(
+        state.errorMessage ?? "Couldn't play this track",
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+        textAlign: TextAlign.center,
+      );
+    }
+    final source = state.source;
+    if (source == null) {
+      return const SizedBox(height: 28);
+    }
+    return PlaybackSourceChip(source: source);
   }
 }

--- a/lib/features/player/widgets/album_artwork.dart
+++ b/lib/features/player/widgets/album_artwork.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+
+/// The single place album artwork is turned into pixels.
+///
+/// This is the app's *artwork resolver seam*: every artwork render goes through
+/// [_imageProviderFor], so if a source ever needs signed/tokenized image URLs
+/// they can be resolved here — at display time — without persisting a token or
+/// changing call sites. Today Jellyfin's primary-image URL needs no token
+/// (it is built token-free in the track mapper and stored as `Track.artworkUri`)
+/// and local tracks carry none, so a plain [NetworkImage] is enough.
+///
+/// It fills whatever box the parent gives it (wrap in a `SizedBox`/`AspectRatio`
+/// to size it) and degrades gracefully: a missing URL, a load error, or a slow
+/// fetch all show the same calm placeholder, so the layout never jumps or shows
+/// broken-image glyphs — the UI stays beautiful with no artwork at all.
+class AlbumArtwork extends StatelessWidget {
+  const AlbumArtwork({
+    required this.artworkUri,
+    this.borderRadius = const BorderRadius.all(Radius.circular(AppRadii.md)),
+    super.key,
+  });
+
+  final Uri? artworkUri;
+  final BorderRadius borderRadius;
+
+  static ImageProvider _imageProviderFor(Uri uri) =>
+      NetworkImage(uri.toString());
+
+  @override
+  Widget build(BuildContext context) {
+    final Uri? uri = artworkUri;
+    return ClipRRect(
+      borderRadius: borderRadius,
+      child: uri == null
+          ? const _ArtworkPlaceholder()
+          : Image(
+              image: _imageProviderFor(uri),
+              fit: BoxFit.cover,
+              width: double.infinity,
+              height: double.infinity,
+              gaplessPlayback: true,
+              errorBuilder: (_, __, ___) => const _ArtworkPlaceholder(),
+              frameBuilder: (context, child, frame, wasSync) {
+                if (wasSync || frame != null) return child;
+                return const _ArtworkPlaceholder();
+              },
+            ),
+    );
+  }
+}
+
+/// A calm stand-in shown whenever there is no artwork (or it can't load): a soft
+/// surface tint with a centered note glyph, sized to the available box.
+class _ArtworkPlaceholder extends StatelessWidget {
+  const _ArtworkPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final double shortest = constraints.biggest.shortestSide;
+        final double iconSize = (shortest.isFinite ? shortest : 96.0) * 0.4;
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                theme.colorScheme.surfaceContainerHighest,
+                theme.colorScheme.surfaceContainerHigh,
+              ],
+            ),
+          ),
+          child: Center(
+            child: Icon(
+              Icons.music_note,
+              size: iconSize.clamp(20.0, 96.0),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.35),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/track.dart';
+import '../../../shared/widgets/empty_state.dart';
+import '../player_providers.dart';
+
+/// Bottom action row on the now-playing screen: favorite · queue · lyrics.
+///
+/// Favorite and lyrics are honest placeholders — they give feedback but don't
+/// pretend to persist or fetch anything. Queue opens the live up-next list in a
+/// sheet, keeping the main screen artwork-focused.
+class NowPlayingActions extends ConsumerWidget {
+  const NowPlayingActions({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        IconButton(
+          onPressed: () => _comingSoon(context, 'Favorites are coming soon.'),
+          icon: const Icon(Icons.favorite_border),
+          tooltip: 'Favorite',
+        ),
+        IconButton(
+          onPressed: () => _openQueue(context),
+          icon: const Icon(Icons.queue_music_outlined),
+          tooltip: 'Queue',
+        ),
+        IconButton(
+          onPressed: () => _openLyrics(context),
+          icon: const Icon(Icons.lyrics_outlined),
+          tooltip: 'Lyrics',
+        ),
+      ],
+    );
+  }
+
+  void _comingSoon(BuildContext context, String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _openQueue(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (_) => const _QueueSheet(),
+    );
+  }
+
+  void _openLyrics(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) => const SafeArea(
+        child: Padding(
+          padding: EdgeInsets.only(bottom: AppSpacing.xl),
+          child: EmptyState(
+            icon: Icons.lyrics_outlined,
+            title: 'No lyrics available yet.',
+            message: 'Lyrics support is coming in a future update.',
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The queue sheet: the playing track followed by the live up-next list, with a
+/// Clear action. Watches playback state so it stays current while open.
+class _QueueSheet extends ConsumerWidget {
+  const _QueueSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final controller = ref.watch(playbackControllerProvider);
+    final state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+    final upNext = state.upNext;
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.6,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                0,
+                AppSpacing.sm,
+                AppSpacing.sm,
+              ),
+              child: Row(
+                children: [
+                  Text('Up next', style: theme.textTheme.titleMedium),
+                  const Spacer(),
+                  if (upNext.isNotEmpty)
+                    TextButton(
+                      onPressed: controller.clearQueue,
+                      child: const Text('Clear'),
+                    ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: upNext.isEmpty
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+                      child: EmptyState(
+                        icon: Icons.queue_music_outlined,
+                        title: 'Nothing up next',
+                        message: 'Tracks you queue will appear here.',
+                      ),
+                    )
+                  : ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: upNext.length,
+                      itemBuilder: (context, index) =>
+                          _QueueTile(track: upNext[index]),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QueueTile extends StatelessWidget {
+  const _QueueTile({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context) {
+    final artist = track.artistName;
+    return ListTile(
+      dense: true,
+      leading: const Icon(Icons.queue_music_outlined),
+      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: artist == null || artist.isEmpty
+          ? null
+          : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
+  }
+}

--- a/lib/features/player/widgets/now_playing_background.dart
+++ b/lib/features/player/widgets/now_playing_background.dart
@@ -1,0 +1,84 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// The full-bleed backdrop behind the now-playing content.
+///
+/// When artwork is available it shows a heavily blurred, dimmed copy of it so
+/// the screen feels like it belongs to the song; otherwise it falls back to a
+/// calm accent-tinted gradient. Either way a dark scrim is layered on top so the
+/// title, slider, and controls stay legible. Artwork that fails to load quietly
+/// drops back to the gradient — the background is decorative and never blocks
+/// playback.
+class NowPlayingBackground extends StatelessWidget {
+  const NowPlayingBackground({required this.artworkUri, super.key});
+
+  final Uri? artworkUri;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Uri? uri = artworkUri;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _Gradient(theme: theme),
+        if (uri != null)
+          ImageFiltered(
+            imageFilter: ui.ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+            child: Image(
+              image: NetworkImage(uri.toString()),
+              fit: BoxFit.cover,
+              gaplessPlayback: true,
+              // A failed/decoding image leaves just the gradient showing.
+              errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+              frameBuilder: (context, child, frame, wasSync) {
+                if (wasSync || frame != null) return child;
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        // Scrim: darken toward the bottom where the controls live.
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                theme.colorScheme.surface.withValues(alpha: 0.30),
+                theme.colorScheme.surface.withValues(alpha: 0.70),
+                theme.colorScheme.surface.withValues(alpha: 0.92),
+              ],
+              stops: const [0.0, 0.55, 1.0],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Gradient extends StatelessWidget {
+  const _Gradient({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Color.alphaBlend(
+              theme.colorScheme.primary.withValues(alpha: 0.35),
+              theme.colorScheme.surface,
+            ),
+            theme.colorScheme.surface,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/playback_controls.dart
+++ b/lib/features/player/widgets/playback_controls.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/playback_state.dart';
+import '../../../core/services/playback_controller.dart';
+import '../player_providers.dart';
+
+/// The transport row: shuffle · previous · play/pause · next · repeat.
+///
+/// Shuffle and repeat are deliberately disabled placeholders — they hold their
+/// place in the layout for when those modes land, but never pretend to work.
+/// Previous/next reflect the live queue (disabled at the ends) and delegate to
+/// the existing queue controls; play/pause forwards straight to the controller
+/// and shows a spinner while a track loads.
+class PlaybackControls extends ConsumerWidget {
+  const PlaybackControls({required this.state, super.key});
+
+  final PlaybackState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.read(playbackControllerProvider);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        // Disabled placeholder until shuffle lands; holds its place in the row.
+        const IconButton(
+          onPressed: null,
+          icon: Icon(Icons.shuffle),
+          tooltip: 'Shuffle',
+        ),
+        IconButton(
+          iconSize: 36,
+          onPressed: state.hasPrevious ? controller.skipToPrevious : null,
+          icon: const Icon(Icons.skip_previous),
+          tooltip: 'Previous',
+        ),
+        _PlayPauseButton(state: state, controller: controller),
+        IconButton(
+          iconSize: 36,
+          onPressed: state.hasNext ? controller.skipToNext : null,
+          icon: const Icon(Icons.skip_next),
+          tooltip: 'Next',
+        ),
+        // Disabled placeholder until repeat lands.
+        const IconButton(
+          onPressed: null,
+          icon: Icon(Icons.repeat),
+          tooltip: 'Repeat',
+        ),
+      ],
+    );
+  }
+}
+
+/// The dominant control: a large filled circle that toggles play/pause and
+/// shows a spinner while the next track resolves/buffers.
+class _PlayPauseButton extends StatelessWidget {
+  const _PlayPauseButton({required this.state, required this.controller});
+
+  final PlaybackState state;
+  final PlaybackController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (state.status == PlaybackStatus.loading) {
+      return Container(
+        width: 72,
+        height: 72,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primary,
+          shape: BoxShape.circle,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: CircularProgressIndicator(
+            strokeWidth: 2.5,
+            valueColor:
+                AlwaysStoppedAnimation<Color>(theme.colorScheme.onPrimary),
+          ),
+        ),
+      );
+    }
+
+    final playing = state.isPlaying;
+    return SizedBox(
+      width: 72,
+      height: 72,
+      child: IconButton.filled(
+        iconSize: 40,
+        onPressed: playing ? controller.pause : controller.play,
+        icon: Icon(playing ? Icons.pause : Icons.play_arrow),
+        tooltip: playing ? 'Pause' : 'Play',
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+
+/// Seekable progress bar showing the current position and total duration.
+///
+/// Robust to an unknown duration (common at the very start of a stream or for a
+/// live source): when [duration] is zero the slider sits stable and disabled and
+/// the total reads `--:--`, so the UI never breaks or jumps. While the user
+/// drags, the thumb and the elapsed label follow the finger; the actual
+/// [onSeek] fires once on release, so playback isn't spammed mid-drag.
+class PlaybackProgressBar extends StatefulWidget {
+  const PlaybackProgressBar({
+    required this.position,
+    required this.duration,
+    required this.onSeek,
+    super.key,
+  });
+
+  final Duration position;
+  final Duration duration;
+
+  /// Called with the target position when a seek completes. The bar still
+  /// renders progress when this is null, just without seeking.
+  final ValueChanged<Duration>? onSeek;
+
+  @override
+  State<PlaybackProgressBar> createState() => _PlaybackProgressBarState();
+}
+
+class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
+  /// The in-progress drag position in milliseconds, or null when not dragging.
+  double? _dragMs;
+
+  void _onChanged(double value) => setState(() => _dragMs = value);
+
+  void _onChangeEnd(double value) {
+    widget.onSeek?.call(Duration(milliseconds: value.round()));
+    setState(() => _dragMs = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final int totalMs = widget.duration.inMilliseconds;
+    final bool hasDuration = totalMs > 0;
+    final bool canSeek = hasDuration && widget.onSeek != null;
+
+    final int posMs = hasDuration
+        ? widget.position.inMilliseconds.clamp(0, totalMs).toInt()
+        : 0;
+    final double sliderValue = _dragMs ?? posMs.toDouble();
+    final double elapsedMs = _dragMs ?? posMs.toDouble();
+
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Column(
+      children: [
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 3,
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
+            inactiveTrackColor:
+                theme.colorScheme.onSurface.withValues(alpha: 0.18),
+          ),
+          child: Slider(
+            value: sliderValue,
+            max: hasDuration ? totalMs.toDouble() : 1.0,
+            onChanged: canSeek ? _onChanged : null,
+            onChangeEnd: canSeek ? _onChangeEnd : null,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _format(Duration(milliseconds: elapsedMs.round())),
+                style: theme.textTheme.labelMedium?.copyWith(color: muted),
+              ),
+              Text(
+                hasDuration ? _format(widget.duration) : '--:--',
+                style: theme.textTheme.labelMedium?.copyWith(color: muted),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// `m:ss`, widening to `h:mm:ss` past an hour.
+  static String _format(Duration d) {
+    final int totalSeconds = d.inSeconds;
+    final int hours = totalSeconds ~/ 3600;
+    final int minutes = (totalSeconds % 3600) ~/ 60;
+    final int seconds = totalSeconds % 60;
+    final String ss = seconds.toString().padLeft(2, '0');
+    if (hours > 0) {
+      final String mm = minutes.toString().padLeft(2, '0');
+      return '$hours:$mm:$ss';
+    }
+    return '$minutes:$ss';
+  }
+}

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/playback_source.dart';
+
+/// Title / artist / album block for the now-playing screen.
+///
+/// Only renders the lines it actually has, so a track with no artist or album
+/// stays clean rather than showing blank rows. Text is centered and clipped to
+/// keep the layout stable under long titles.
+class TrackMetadata extends StatelessWidget {
+  const TrackMetadata({
+    required this.title,
+    this.artistName,
+    this.albumName,
+    super.key,
+  });
+
+  final String title;
+  final String? artistName;
+  final String? albumName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.72);
+    final fainter = theme.colorScheme.onSurface.withValues(alpha: 0.55);
+    final hasArtist = artistName != null && artistName!.isNotEmpty;
+    final hasAlbum = albumName != null && albumName!.isNotEmpty;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        if (hasArtist) ...[
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            artistName!,
+            style: theme.textTheme.titleMedium?.copyWith(color: muted),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+        if (hasAlbum) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            albumName!,
+            style: theme.textTheme.bodyMedium?.copyWith(color: fainter),
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// A small badge that states where the audio is coming from: LOCAL FILE,
+/// STREAMING DIRECT, or OFFLINE CACHE. Its text comes from
+/// [PlaybackSource.label] so the wording stays in one place.
+class PlaybackSourceChip extends StatelessWidget {
+  const PlaybackSourceChip({required this.source, super.key});
+
+  final PlaybackSource source;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.xs + 2,
+      ),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withValues(alpha: 0.55),
+        borderRadius: BorderRadius.circular(AppRadii.pill),
+        border: Border.all(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.12),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            _iconFor(source),
+            size: 14,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: AppSpacing.xs + 2),
+          Text(
+            source.label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              letterSpacing: 0.8,
+              fontWeight: FontWeight.w700,
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static IconData _iconFor(PlaybackSource source) {
+    switch (source) {
+      case PlaybackSource.localFile:
+        return Icons.smartphone_outlined;
+      case PlaybackSource.streamingDirect:
+        return Icons.cloud_outlined;
+      case PlaybackSource.offlineCache:
+        return Icons.offline_pin_outlined;
+    }
+  }
+}

--- a/test/core/services/local_playable_uri_resolver_test.dart
+++ b/test/core/services/local_playable_uri_resolver_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/local_playable_uri_resolver.dart';
 
@@ -6,13 +7,14 @@ void main() {
   group('LocalPlayableUriResolver', () {
     const resolver = LocalPlayableUriResolver();
 
-    test('resolves a filesystem path to a file URI', () async {
+    test('resolves a filesystem path to a local-file source', () async {
       const track = Track(id: '1', title: 'One', uri: '/music/song.mp3');
 
-      final uri = await resolver.resolve(track);
+      final resolved = await resolver.resolve(track);
 
-      expect(uri, Uri.file('/music/song.mp3'));
-      expect(uri.scheme, 'file');
+      expect(resolved.uri, Uri.file('/music/song.mp3'));
+      expect(resolved.uri.scheme, 'file');
+      expect(resolved.source, PlaybackSource.localFile);
     });
 
     test('passes a content:// URI through unchanged', () async {
@@ -20,12 +22,13 @@ void main() {
           'tree/primary%3AMusic/document/primary%3AMusic%2FOne.mp3';
       const track = Track(id: raw, title: 'One', uri: raw);
 
-      final uri = await resolver.resolve(track);
+      final resolved = await resolver.resolve(track);
 
-      expect(uri.scheme, 'content');
+      expect(resolved.uri.scheme, 'content');
       // Compare parsed URIs (not strings) so the assertion doesn't depend on
       // Dart's percent-encoding normalization of the content URI.
-      expect(uri, Uri.parse(raw));
+      expect(resolved.uri, Uri.parse(raw));
+      expect(resolved.source, PlaybackSource.localFile);
     });
 
     test('handles on-device tracks but not Jellyfin tracks', () {

--- a/test/core/services/offline_first_playable_uri_resolver_test.dart
+++ b/test/core/services/offline_first_playable_uri_resolver_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/cached_track_locator.dart';
 import 'package:linthra/core/services/offline_first_playable_uri_resolver.dart';
@@ -19,7 +20,7 @@ class _FakeLocator implements CachedTrackLocator {
 }
 
 /// A fallback that records the track it was asked to resolve and returns a
-/// canned (streaming) URI.
+/// canned (streaming) result.
 class _RecordingResolver implements PlayableUriResolver {
   _RecordingResolver(this._uri);
 
@@ -30,9 +31,9 @@ class _RecordingResolver implements PlayableUriResolver {
   bool handles(Track track) => true;
 
   @override
-  Future<Uri> resolve(Track track) async {
+  Future<ResolvedPlayable> resolve(Track track) async {
     resolved = track;
-    return _uri;
+    return ResolvedPlayable(_uri, PlaybackSource.streamingDirect);
   }
 }
 
@@ -42,7 +43,7 @@ class _OfflineResolver implements PlayableUriResolver {
   bool handles(Track track) => true;
 
   @override
-  Future<Uri> resolve(Track track) async {
+  Future<ResolvedPlayable> resolve(Track track) async {
     throw const PlaybackResolutionException(
       "Couldn't reach your Jellyfin server.",
       kind: PlaybackResolutionErrorKind.serverUnreachable,
@@ -62,10 +63,12 @@ void main() {
         fallback: fallback,
       );
 
-      final uri = await resolver.resolve(_track);
+      final resolved = await resolver.resolve(_track);
 
-      expect(uri.scheme, 'file');
-      expect(uri.toFilePath(), '/offline_audio/t1.mp3');
+      expect(resolved.uri.scheme, 'file');
+      expect(resolved.uri.toFilePath(), '/offline_audio/t1.mp3');
+      // A cache hit is reported as the offline-cache source.
+      expect(resolved.source, PlaybackSource.offlineCache);
       expect(fallback.resolved, isNull);
     });
 
@@ -78,9 +81,11 @@ void main() {
         fallback: fallback,
       );
 
-      final uri = await resolver.resolve(_track);
+      final resolved = await resolver.resolve(_track);
 
-      expect(uri.host, 'music.example.com');
+      expect(resolved.uri.host, 'music.example.com');
+      // The fallback's source (a direct stream) is passed straight through.
+      expect(resolved.source, PlaybackSource.streamingDirect);
       expect(fallback.resolved, _track);
     });
 

--- a/test/core/services/routing_playable_uri_resolver_test.dart
+++ b/test/core/services/routing_playable_uri_resolver_test.dart
@@ -1,66 +1,90 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/playable_uri_resolver.dart';
 import 'package:linthra/core/services/routing_playable_uri_resolver.dart';
 
-/// A resolver that claims a fixed set of URI prefixes and returns a canned URI,
-/// so routing can be asserted without any real source.
+/// A resolver that claims a fixed set of URI prefixes and returns a canned
+/// result, so routing can be asserted without any real source.
 class _StubResolver implements PlayableUriResolver {
-  _StubResolver(this.prefix, this.result);
+  _StubResolver(this.prefix, this.result, this.source);
 
   final String prefix;
   final Uri result;
+  final PlaybackSource source;
   bool resolved = false;
 
   @override
   bool handles(Track track) => track.uri.startsWith(prefix);
 
   @override
-  Future<Uri> resolve(Track track) async {
+  Future<ResolvedPlayable> resolve(Track track) async {
     resolved = true;
-    return result;
+    return ResolvedPlayable(result, source);
   }
 }
 
 void main() {
   group('RoutingPlayableUriResolver', () {
     test('delegates to the first resolver that handles the track', () async {
-      final jellyfin = _StubResolver('jellyfin:', Uri.parse('https://j/x'));
-      final local = _StubResolver('/', Uri.file('/music/song.mp3'));
+      final jellyfin = _StubResolver(
+        'jellyfin:',
+        Uri.parse('https://j/x'),
+        PlaybackSource.streamingDirect,
+      );
+      final local = _StubResolver(
+        '/',
+        Uri.file('/music/song.mp3'),
+        PlaybackSource.localFile,
+      );
       final router = RoutingPlayableUriResolver(<PlayableUriResolver>[
         jellyfin,
         local,
       ]);
 
-      final uri = await router.resolve(
+      final resolved = await router.resolve(
         const Track(id: 't1', title: 'J', uri: 'jellyfin:t1'),
       );
 
-      expect(uri, Uri.parse('https://j/x'));
+      expect(resolved.uri, Uri.parse('https://j/x'));
+      expect(resolved.source, PlaybackSource.streamingDirect);
       expect(jellyfin.resolved, isTrue);
       expect(local.resolved, isFalse);
     });
 
     test('falls through to a later resolver', () async {
-      final jellyfin = _StubResolver('jellyfin:', Uri.parse('https://j/x'));
-      final local = _StubResolver('/', Uri.file('/music/song.mp3'));
+      final jellyfin = _StubResolver(
+        'jellyfin:',
+        Uri.parse('https://j/x'),
+        PlaybackSource.streamingDirect,
+      );
+      final local = _StubResolver(
+        '/',
+        Uri.file('/music/song.mp3'),
+        PlaybackSource.localFile,
+      );
       final router = RoutingPlayableUriResolver(<PlayableUriResolver>[
         jellyfin,
         local,
       ]);
 
-      final uri = await router.resolve(
+      final resolved = await router.resolve(
         const Track(id: '1', title: 'L', uri: '/music/song.mp3'),
       );
 
-      expect(uri, Uri.file('/music/song.mp3'));
+      expect(resolved.uri, Uri.file('/music/song.mp3'));
+      expect(resolved.source, PlaybackSource.localFile);
       expect(local.resolved, isTrue);
       expect(jellyfin.resolved, isFalse);
     });
 
     test('throws when no resolver handles the track', () async {
       final router = RoutingPlayableUriResolver(<PlayableUriResolver>[
-        _StubResolver('jellyfin:', Uri.parse('https://j/x')),
+        _StubResolver(
+          'jellyfin:',
+          Uri.parse('https://j/x'),
+          PlaybackSource.streamingDirect,
+        ),
       ]);
 
       await expectLater(

--- a/test/core/sources/jellyfin/jellyfin_playable_uri_resolver_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_playable_uri_resolver_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/playable_uri_resolver.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
@@ -48,9 +49,11 @@ void main() {
       );
       final resolver = JellyfinPlayableUriResolver(() => source);
 
-      final uri = await resolver.resolve(_jellyfinTrack);
+      final resolved = await resolver.resolve(_jellyfinTrack);
 
-      expect(uri.path, '/Audio/t1/universal');
+      expect(resolved.uri.path, '/Audio/t1/universal');
+      // A minted Jellyfin URL is reported as a direct stream.
+      expect(resolved.source, PlaybackSource.streamingDirect);
       // The session is verified before the URL is handed to the engine.
       expect(source.verifyCount, 1);
     });

--- a/test/features/library/library_playback_test.dart
+++ b/test/features/library/library_playback_test.dart
@@ -52,9 +52,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(controller.playedTracks.single.id, '1');
-    // The now-playing screen is shown for the tapped track.
+    // The now-playing screen is shown for the tapped track, reflecting the
+    // playing state with a Pause control.
     expect(find.text('Now Playing'), findsOneWidget);
-    expect(find.text('Playing'), findsOneWidget);
+    expect(find.byTooltip('Pause'), findsOneWidget);
   });
 
   testWidgets('tapping a track queues the rest of the list as up next', (
@@ -88,7 +89,11 @@ void main() {
       controller.state.upNext.map((t) => t.id).toList(),
       ['2', '3'],
     );
-    // The player surfaces the queued tracks in its Up next section.
+    // The player surfaces the queued tracks in its Up next queue sheet.
+    await tester.tap(find.byTooltip('Queue'));
+    await tester.pumpAndSettle();
     expect(find.text('Up next'), findsOneWidget);
+    expect(find.text('Song Two'), findsOneWidget);
+    expect(find.text('Song Three'), findsOneWidget);
   });
 }

--- a/test/features/player/playback_resolution_test.dart
+++ b/test/features/player/playback_resolution_test.dart
@@ -129,7 +129,8 @@ void main() {
     const baseUrl = 'https://music.example.com';
     const token = 'super-secret-token';
 
-    test('no token leaks into the track uri, artwork, source label, or cache '
+    test(
+        'no token leaks into the track uri, artwork, source label, or cache '
         'filename', () async {
       // The mapped track is the persisted identity the UI and database see.
       final track = JellyfinTrackMapper.toTrack(

--- a/test/features/player/playback_resolution_test.dart
+++ b/test/features/player/playback_resolution_test.dart
@@ -1,12 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/local_playable_uri_resolver.dart';
 import 'package:linthra/core/services/offline_first_playable_uri_resolver.dart';
 import 'package:linthra/core/services/playable_uri_resolver.dart';
 import 'package:linthra/core/services/routing_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_stream_source.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_track_mapper.dart';
 import 'package:linthra/data/repositories/in_memory_download_store.dart';
 import 'package:linthra/data/repositories/in_memory_offline_file_store.dart';
 import 'package:linthra/data/repositories/store_cached_track_locator.dart';
@@ -64,11 +67,12 @@ void main() {
         source: source,
       );
 
-      final uri = await resolver.resolve(_jellyfinTrack);
+      final resolved = await resolver.resolve(_jellyfinTrack);
 
       // It streamed (no download required) straight from Jellyfin.
-      expect(uri.scheme, 'https');
-      expect(uri.path, '/Audio/t1/universal');
+      expect(resolved.uri.scheme, 'https');
+      expect(resolved.uri.path, '/Audio/t1/universal');
+      expect(resolved.source, PlaybackSource.streamingDirect);
       expect(source.verifyCount, 1);
       expect(source.resolveCount, 1);
     });
@@ -90,11 +94,12 @@ void main() {
         source: source,
       );
 
-      final uri = await resolver.resolve(_jellyfinTrack);
+      final resolved = await resolver.resolve(_jellyfinTrack);
 
       // Cache hit: a local file, and the network source was never touched.
-      expect(uri.scheme, 'file');
-      expect(uri.toFilePath(), '/offline_audio/t1.mp3');
+      expect(resolved.uri.scheme, 'file');
+      expect(resolved.uri.toFilePath(), '/offline_audio/t1.mp3');
+      expect(resolved.source, PlaybackSource.offlineCache);
       expect(source.verifyCount, 0);
       expect(source.resolveCount, 0);
     });
@@ -109,13 +114,55 @@ void main() {
         source: source,
       );
 
-      final uri = await resolver.resolve(_localTrack);
+      final resolved = await resolver.resolve(_localTrack);
 
-      expect(uri.scheme, 'file');
-      expect(uri.toFilePath(), '/music/one.mp3');
+      expect(resolved.uri.scheme, 'file');
+      expect(resolved.uri.toFilePath(), '/music/one.mp3');
+      expect(resolved.source, PlaybackSource.localFile);
       // A local track never consults the Jellyfin source.
       expect(source.verifyCount, 0);
       expect(source.resolveCount, 0);
+    });
+  });
+
+  group('Jellyfin token safety', () {
+    const baseUrl = 'https://music.example.com';
+    const token = 'super-secret-token';
+
+    test('no token leaks into the track uri, artwork, source label, or cache '
+        'filename', () async {
+      // The mapped track is the persisted identity the UI and database see.
+      final track = JellyfinTrackMapper.toTrack(
+        const JellyfinItemDto(id: 't1', name: 'One', hasPrimaryImage: true),
+        baseUrl: baseUrl,
+      );
+      expect(track.uri, 'jellyfin:t1');
+      expect(track.uri, isNot(contains(token)));
+      expect(track.artworkUri.toString(), isNot(contains(token)));
+      expect(track.artworkUri.toString(), isNot(contains('api_key')));
+
+      // The tokenized stream URL is minted only at play time; the source the UI
+      // renders is a plain enum label with no secret in it.
+      final source = _FakeStreamSource(
+        Uri.parse('$baseUrl/Audio/t1/universal?api_key=$token'),
+      );
+      final resolver = _resolver(
+        locator: StoreCachedTrackLocator(
+          InMemoryDownloadStore(),
+          InMemoryOfflineFileStore(),
+        ),
+        source: source,
+      );
+      final resolved = await resolver.resolve(track);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(resolved.source.label, isNot(contains(token)));
+
+      // A downloaded copy is named from the track id, never the tokenized URL.
+      final files = InMemoryOfflineFileStore();
+      final fileName =
+          await files.write(track.id, <int>[1, 2, 3], extension: 'mp3');
+      expect(fileName, isNot(contains(token)));
+      expect(fileName, isNot(contains('api_key')));
     });
   });
 }

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/playback_controller.dart';
 import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/features/player/widgets/album_artwork.dart';
+import 'package:linthra/features/player/widgets/now_playing_background.dart';
 
 import 'fake_playback_controller.dart';
 
@@ -24,44 +27,101 @@ Future<void> _pumpScreen(
   await tester.pumpAndSettle();
 }
 
+/// A local track with full metadata but no artwork, so widget tests never reach
+/// for the network (artwork falls back to the placeholder).
+const _localTrack = Track(
+  id: '1',
+  title: 'Song One',
+  uri: '/music/song1.mp3',
+  artistName: 'Artist A',
+  albumName: 'Album B',
+);
+
+FakePlaybackController _playing({
+  Track track = _localTrack,
+  PlaybackSource source = PlaybackSource.localFile,
+  List<Track> upNext = const <Track>[],
+  bool hasPrevious = false,
+  Duration position = Duration.zero,
+  Duration duration = Duration.zero,
+}) {
+  return FakePlaybackController(
+    initial: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: track,
+      source: source,
+      upNext: upNext,
+      hasPrevious: hasPrevious,
+      position: position,
+      duration: duration,
+    ),
+  );
+}
+
 void main() {
   group('PlayerScreen', () {
-    testWidgets('shows the empty state when nothing is loaded', (tester) async {
+    testWidgets('shows the empty state with no track', (tester) async {
       await _pumpScreen(tester, FakePlaybackController());
 
       expect(find.text('Nothing playing'), findsOneWidget);
     });
 
-    testWidgets('shows the current track title, artist, and Playing status', (
-      tester,
-    ) async {
-      final controller = FakePlaybackController(
-        initial: const PlaybackState(
-          status: PlaybackStatus.playing,
-          currentTrack: Track(
-            id: '1',
-            title: 'Song One',
-            uri: '/music/song1.mp3',
-            artistName: 'Artist A',
-          ),
-        ),
-      );
-      await _pumpScreen(tester, controller);
+    testWidgets('renders the title, artist, and album', (tester) async {
+      await _pumpScreen(tester, _playing());
 
       expect(find.text('Song One'), findsOneWidget);
       expect(find.text('Artist A'), findsOneWidget);
-      expect(find.text('Playing'), findsOneWidget);
+      expect(find.text('Album B'), findsOneWidget);
       // While playing, the toggle offers Pause.
       expect(find.byTooltip('Pause'), findsOneWidget);
     });
 
-    testWidgets('the play/pause button delegates to the controller', (
-      tester,
-    ) async {
+    testWidgets('falls back to placeholder artwork', (tester) async {
+      await _pumpScreen(tester, _playing());
+
+      // The background and artwork widgets render even without an artwork URI,
+      // and no broken-image exception is thrown.
+      expect(find.byType(NowPlayingBackground), findsOneWidget);
+      expect(find.byType(AlbumArtwork), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('shows the LOCAL FILE badge', (tester) async {
+      await _pumpScreen(tester, _playing(source: PlaybackSource.localFile));
+
+      expect(find.text('LOCAL FILE'), findsOneWidget);
+    });
+
+    testWidgets('shows the STREAMING DIRECT badge', (tester) async {
+      await _pumpScreen(
+        tester,
+        _playing(
+          track: const Track(id: 't1', title: 'Remote', uri: 'jellyfin:t1'),
+          source: PlaybackSource.streamingDirect,
+        ),
+      );
+
+      expect(find.text('STREAMING DIRECT'), findsOneWidget);
+    });
+
+    testWidgets('shows the OFFLINE CACHE badge', (tester) async {
+      await _pumpScreen(
+        tester,
+        _playing(
+          track: const Track(id: 't1', title: 'Remote', uri: 'jellyfin:t1'),
+          source: PlaybackSource.offlineCache,
+        ),
+      );
+
+      expect(find.text('OFFLINE CACHE'), findsOneWidget);
+    });
+
+    testWidgets('play/pause delegates to the controller', (tester) async {
       final controller = FakePlaybackController(
         initial: const PlaybackState(
           status: PlaybackStatus.paused,
-          currentTrack: Track(id: '1', title: 'Song One', uri: '/s.mp3'),
+          currentTrack: _localTrack,
+          source: PlaybackSource.localFile,
         ),
       );
       await _pumpScreen(tester, controller);
@@ -69,47 +129,29 @@ void main() {
       // Paused: tapping the toggle resumes playback.
       await tester.tap(find.byTooltip('Play'));
       expect(controller.playCount, 1);
-
-      // Stop is always available.
-      await tester.tap(find.byTooltip('Stop'));
-      expect(controller.stopCount, 1);
     });
 
-    testWidgets('shows the Up next list and an enabled Next button', (
-      tester,
-    ) async {
-      final controller = FakePlaybackController(
-        initial: const PlaybackState(
-          status: PlaybackStatus.playing,
-          currentTrack: Track(id: '1', title: 'Song One', uri: '/1.mp3'),
-          upNext: <Track>[
-            Track(id: '2', title: 'Song Two', uri: '/2.mp3'),
-            Track(id: '3', title: 'Song Three', uri: '/3.mp3'),
-          ],
-        ),
+    testWidgets('Next delegates to the controller', (tester) async {
+      final controller = _playing(
+        upNext: const <Track>[Track(id: '2', title: 'Song Two', uri: '/2.mp3')],
       );
       await _pumpScreen(tester, controller);
-
-      expect(find.text('Up next'), findsOneWidget);
-      expect(find.text('Song Two'), findsOneWidget);
-      expect(find.text('Song Three'), findsOneWidget);
 
       await tester.tap(find.byTooltip('Next'));
       expect(controller.skipCount, 1);
     });
 
-    testWidgets('hides Up next and disables Next when the queue is empty', (
-      tester,
-    ) async {
-      final controller = FakePlaybackController(
-        initial: const PlaybackState(
-          status: PlaybackStatus.playing,
-          currentTrack: Track(id: '1', title: 'Only Song', uri: '/1.mp3'),
-        ),
-      );
+    testWidgets('Previous delegates to the controller', (tester) async {
+      final controller = _playing(hasPrevious: true);
       await _pumpScreen(tester, controller);
 
-      expect(find.text('Up next'), findsNothing);
+      await tester.tap(find.byTooltip('Previous'));
+      expect(controller.previousCount, 1);
+    });
+
+    testWidgets('disables Next with an empty queue', (tester) async {
+      await _pumpScreen(tester, _playing());
+
       final next = tester.widget<IconButton>(
         find.ancestor(
           of: find.byIcon(Icons.skip_next),
@@ -119,23 +161,39 @@ void main() {
       expect(next.onPressed, isNull);
     });
 
-    testWidgets('Clear delegates to the controller', (tester) async {
-      final controller = FakePlaybackController(
-        initial: const PlaybackState(
-          status: PlaybackStatus.playing,
-          currentTrack: Track(id: '1', title: 'Song One', uri: '/1.mp3'),
-          upNext: <Track>[Track(id: '2', title: 'Song Two', uri: '/2.mp3')],
-        ),
+    testWidgets('the slider seeks via the controller', (tester) async {
+      final controller = _playing(duration: const Duration(minutes: 3));
+      await _pumpScreen(tester, controller);
+
+      // Tapping the slider commits a seek to roughly its center.
+      await tester.tap(find.byType(Slider));
+      await tester.pumpAndSettle();
+
+      expect(controller.seeks, isNotEmpty);
+      expect(controller.seeks.first, greaterThan(Duration.zero));
+    });
+
+    testWidgets('the queue button opens up-next', (tester) async {
+      final controller = _playing(
+        upNext: const <Track>[
+          Track(id: '2', title: 'Song Two', uri: '/2.mp3'),
+          Track(id: '3', title: 'Song Three', uri: '/3.mp3'),
+        ],
       );
       await _pumpScreen(tester, controller);
+
+      await tester.tap(find.byTooltip('Queue'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Up next'), findsOneWidget);
+      expect(find.text('Song Two'), findsOneWidget);
+      expect(find.text('Song Three'), findsOneWidget);
 
       await tester.tap(find.text('Clear'));
       expect(controller.clearCount, 1);
     });
 
-    testWidgets('shows the specific error message on a playback error', (
-      tester,
-    ) async {
+    testWidgets('shows the specific playback error', (tester) async {
       final controller = FakePlaybackController(
         initial: const PlaybackState(
           status: PlaybackStatus.error,
@@ -155,21 +213,13 @@ void main() {
       expect(find.text("Couldn't play this track"), findsNothing);
     });
 
-    testWidgets('shows a Lyrics entry that opens a calm empty state', (
-      tester,
-    ) async {
-      final controller = FakePlaybackController(
-        initial: const PlaybackState(
-          status: PlaybackStatus.playing,
-          currentTrack: Track(id: '1', title: 'Song One', uri: '/s.mp3'),
-        ),
-      );
-      await _pumpScreen(tester, controller);
+    testWidgets('shows the Lyrics empty state', (tester) async {
+      await _pumpScreen(tester, _playing());
 
       // The entry point is visible on the player.
-      expect(find.text('Lyrics'), findsOneWidget);
+      expect(find.byTooltip('Lyrics'), findsOneWidget);
 
-      await tester.tap(find.text('Lyrics'));
+      await tester.tap(find.byTooltip('Lyrics'));
       await tester.pumpAndSettle();
 
       // No lyrics source yet, so it shows a calm placeholder rather than blank.
@@ -185,12 +235,13 @@ void main() {
         const PlaybackState(
           status: PlaybackStatus.playing,
           currentTrack: Track(id: '1', title: 'Live Track', uri: '/l.mp3'),
+          source: PlaybackSource.localFile,
         ),
       );
       await tester.pumpAndSettle();
 
       expect(find.text('Live Track'), findsOneWidget);
-      expect(find.text('Playing'), findsOneWidget);
+      expect(find.byTooltip('Pause'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

Rebuilds the now-playing experience into a polished, artwork-focused screen and makes the playback source visible and honest. Direct Jellyfin/NAS streaming already worked through the offline-first resolver chain; this PR surfaces it, polishes the UI, and locks the behavior in with tests.

No architecture rewrite: the UI still depends only on `PlaybackController` / `PlaybackState`, never on `just_audio` or Jellyfin HTTP.

## Now Playing UI

`PlayerScreen` is now a thin orchestrator over small, single-purpose widgets in `lib/features/player/widgets/`:

- **Background** (`NowPlayingBackground`) — heavily blurred + dimmed copy of the artwork, with an accent-tinted **gradient fallback** when there's no art (or it fails to load).
- **Artwork** (`AlbumArtwork`) — large rounded album art with a calm placeholder; the single artwork seam (see below). Reused as the mini-player thumbnail.
- **Metadata** (`TrackMetadata`) — title / artist / album, only rendering lines it has.
- **Source badge** (`PlaybackSourceChip`) — `LOCAL FILE` · `STREAMING DIRECT` · `OFFLINE CACHE`.
- **Progress** (`PlaybackProgressBar`) — position/duration + seekable slider; stays stable and shows `--:--` when duration is unknown.
- **Controls** (`PlaybackControls`) — shuffle (disabled placeholder) · previous · play/pause (spinner while loading) · next · repeat (disabled placeholder). Stop dropped from the screen (still in the controller + media notification).
- **Actions** (`NowPlayingActions`) — favorite (placeholder), queue (opens up-next in a sheet), lyrics (opens a calm empty state).

Header keeps a "Now Playing" caption and a collapse affordance.

## Direct Jellyfin/NAS streaming

Tapping a track resolves through `OfflineFirstPlayableUriResolver` → routing (`Jellyfin`, then on-device):

- **Cached** → plays the local `file://` copy (`OFFLINE CACHE`).
- **Not cached** → mints an authenticated stream URL at play time and streams it (`STREAMING DIRECT`) — **no download required**.
- **Local** → plays from its on-device path (`LOCAL FILE`).

Download/offline cache stays optional. Friendly, kind-specific errors remain for not-signed-in / expired session / unreachable server / unavailable stream.

## How the source reaches the UI

`PlayableUriResolver.resolve` now returns a `ResolvedPlayable { uri, source }`. The resolver that produces the URI is the one that knows the source (a `file://` URI alone can't distinguish an on-device track from a downloaded remote one), so it reports both. The controller stores `source` on `PlaybackState`, where it rides along on later position/status updates and is reset when the next track loads or playback stops/errors.

## Artwork

- Uses `Track.artworkUri` when present (Jellyfin's primary-image URL is token-free and already stored by the mapper).
- All artwork loading goes through one seam (`AlbumArtwork._imageProviderFor`), so a future token-signed image resolver has exactly one place to live — without persisting tokens.
- Missing/failed/slow artwork degrades to a clean placeholder; the screen stays beautiful with no art.

## Token / security notes

- No authenticated stream URL or token is stored on `Track.uri`, in the database, or in cache filenames; it's minted only at play time and never logged or shown.
- The visible source is a plain enum label, never a URL.
- Errors stay generic and secret-free.
- Covered by a dedicated "Jellyfin token safety" test plus the existing resolver/source token tests.

## Tests

- `player_screen_test.dart` (rewritten): renders title/artist/album; fallback artwork/background; `LOCAL FILE` / `STREAMING DIRECT` / `OFFLINE CACHE` badges; play/pause, next, previous delegation; slider seek; queue sheet + Clear; lyrics empty state; specific error message; reacts to stream.
- `playback_resolution_test.dart`: direct streaming without download, cache preference, local path, **+ new token-safety test** (uri/artwork/source label/cache filename carry no token).
- Resolver/Jellyfin unit tests updated to the `ResolvedPlayable` contract and assert the reported source.

> [!NOTE]
> No Flutter SDK is available in this cloud environment, so `flutter pub get` / `dart format --set-exit-if-changed .` / `flutter analyze` / `flutter test` / `flutter build apk --debug` were **not run here**. Code was written to match the repo's style and lint rules (`prefer_const_constructors`, `directives_ordering`, ≤80-col code lines, etc.); please let CI run the full verification.

## Manual Android checklist

1. Install debug APK.
2. Sign in to Jellyfin through the Cloudflare domain.
3. Sync the Jellyfin library.
4. Tap a Jellyfin track that is **not** downloaded → confirm it streams directly (`STREAMING DIRECT`).
5. Download that track.
6. Tap it again → confirm it plays from offline cache (`OFFLINE CACHE`).
7. Open Now Playing → verify artwork / blurred background / controls / progress.
8. Navigate to Settings while music plays.
9. Return to Now Playing → confirm music did not stop.
10. Background the app → confirm the media notification continues.

## Known limitations

- Shuffle, repeat, and favorite are visible but **disabled/placeholder** (no behavior yet).
- Lyrics is an entry point only ("No lyrics available yet."); no source/scraping.
- Layout is portrait-optimized; very short landscape heights aren't specially handled.
- Artwork uses Flutter's built-in `Image` (no disk cache / `cached_network_image`).

https://claude.ai/code/session_015hwAm5M7GraaUaTPMGh3UH

---
_Generated by [Claude Code](https://claude.ai/code/session_015hwAm5M7GraaUaTPMGh3UH)_