### PR TITLE
Fix Jellyfin direct streaming on Android (direct-play endpoint + play-time stream probe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,11 +932,25 @@ library** (which leaves any existing catalog untouched rather than wiping it).
 playback controller opens whatever URI it's given rather than assuming a local
 file. A `JellyfinPlayableUriResolver` reads the live signed-in source, verifies
 the session (a tiny `GET /Users/Me` check), then asks the source to mint the
-authenticated `/Audio/<id>/universal` URL **at play time**. The player surfaces
-precise, friendly errors — **not signed in**, **expired session**, **server
-unreachable**, **stream unavailable** — branched on a typed error kind, not
-message text. Local file playback is untouched (it never enters the Jellyfin
-resolver).
+authenticated **direct-play** stream URL — `/Audio/<id>/stream?static=true` —
+**at play time**. `static=true` serves the original file bytes (the reliable
+"direct streaming" path the engine can open), rather than a negotiated
+transcode/HLS variant ExoPlayer may reject; auth rides in the `api_key` **query**
+(not a header), because that is what the engine itself fetches with and query
+auth survives the redirects a stripped header would not. Before the URL reaches
+the engine the source **probes** it (a one-byte ranged GET, following any
+Cloudflare/Jellyfin redirects) and checks the status + content type, so a
+Cloudflare page, an expired token, or a non-audio response becomes a precise
+message instead of the engine's opaque "couldn't play". The player surfaces
+friendly errors — **not signed in**, **expired session**, **server
+unreachable**, **a web page instead of audio (Cloudflare/Jellyfin access)**,
+**not an audio stream**, and a generic **couldn't stream** — branched on a typed
+error kind, not message text. Local and `content://` file playback are untouched
+(they never enter the Jellyfin resolver), and a downloaded track still plays from
+its cached copy; a cache miss falls straight through to streaming. Debug builds
+emit a secret-free `PlaybackDiagnostics` line (source, resolver, HTTP status,
+content type, hashed item id) to make field failures diagnosable — never the
+token, password, full URL, or `Authorization` header.
 
 **Offline downloads** let a signed-in user mark individual Jellyfin tracks for
 offline use; the bytes are fetched from Jellyfin's `/Items/<id>/Download`
@@ -956,8 +970,11 @@ tokenized URL).
 
 - **Track-level downloads only.** Album/playlist "download all" is deferred; the
   per-track seam already composes for it (see offline-downloads section above).
-- **Single server only.** One session is stored; multi-server support and
-  richer transcoding/streaming parameters come later.
+- **Single server only.** One session is stored; multi-server support comes
+  later.
+- **Direct play only (no transcoding fallback yet).** Streaming serves the
+  original file (`static=true`), which the engine decodes for the common
+  containers; a server-side transcode fallback for exotic formats is deferred.
 - **No Android Auto browsing, lyrics, or sync-conflict handling** for Jellyfin
   in this foundation.
 

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:just_audio/just_audio.dart';
 
 import '../models/playback_queue.dart';
+import '../models/playback_source.dart';
 import '../models/playback_state.dart';
 import '../models/track.dart';
 import 'local_playable_uri_resolver.dart';
@@ -146,10 +147,12 @@ class JustAudioPlaybackController implements PlaybackController {
     try {
       resolved = await _resolver.resolve(track);
     } on PlaybackResolutionException catch (error) {
+      // A resolver failure carries its own friendly, secret-free message.
       _emitError(track, error.message);
       return;
     } catch (_) {
-      _emitError(track, _genericPlaybackError);
+      // An unexpected error before we even know the source: stay generic.
+      _emitError(track, "Couldn't play this track.");
       return;
     }
 
@@ -160,16 +163,27 @@ class JustAudioPlaybackController implements PlaybackController {
 
     try {
       // setUrl handles file://, content:// (Android), and https:// URIs alike,
-      // so local files, SAF documents, and Jellyfin streams share one path.
+      // so local files, SAF documents, and Jellyfin streams share one path. The
+      // resolver guarantees this is never a bare `jellyfin:<id>` — that scheme
+      // is turned into an authenticated stream URL (or a friendly error) before
+      // it ever reaches here.
       await _player.setUrl(resolved.uri.toString());
       // play()'s future completes when playback ends, so we don't await it.
       unawaited(_player.play());
     } catch (_) {
-      _emitError(track, _genericPlaybackError);
+      // The URL resolved and (for streams) probed OK, so a failure here is the
+      // engine itself. Word it for the source the listener can see on the badge.
+      _emitError(track, _loadErrorFor(resolved.source));
     }
   }
 
-  static const String _genericPlaybackError = "Couldn't play this track.";
+  /// The generic message for an engine load failure *after* a successful
+  /// resolve, worded for the resolved [source] (a direct stream "couldn't
+  /// stream", an on-device/cached file "couldn't play").
+  static String _loadErrorFor(PlaybackSource source) =>
+      source == PlaybackSource.streamingDirect
+          ? "Couldn't stream this track."
+          : "Couldn't play this track.";
 
   /// Emits an error state for [track] carrying a friendly [message], preserving
   /// the queue context so the UI keeps showing the right track and up-next.

--- a/lib/core/services/local_playable_uri_resolver.dart
+++ b/lib/core/services/local_playable_uri_resolver.dart
@@ -1,6 +1,7 @@
 import '../models/playback_source.dart';
 import '../models/track.dart';
 import 'playable_uri_resolver.dart';
+import 'playback_diagnostics.dart';
 
 /// Resolves on-device tracks — local file paths and Android SAF `content://`
 /// document URIs — to a URI the audio engine can open.
@@ -22,6 +23,11 @@ class LocalPlayableUriResolver implements PlayableUriResolver {
 
   @override
   Future<ResolvedPlayable> resolve(Track track) async {
+    PlaybackDiagnostics.resolved(
+      source: 'local',
+      resolver: 'LocalPlayableUriResolver',
+      itemId: track.id,
+    );
     return ResolvedPlayable(
       playableUriFor(track.uri),
       PlaybackSource.localFile,

--- a/lib/core/services/offline_first_playable_uri_resolver.dart
+++ b/lib/core/services/offline_first_playable_uri_resolver.dart
@@ -2,6 +2,7 @@ import '../models/playback_source.dart';
 import '../models/track.dart';
 import 'cached_track_locator.dart';
 import 'playable_uri_resolver.dart';
+import 'playback_diagnostics.dart';
 
 /// A [PlayableUriResolver] that prefers a track's offline-cached file and falls
 /// back to another resolver (streaming) when there isn't one.
@@ -30,11 +31,18 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
   Future<ResolvedPlayable> resolve(Track track) async {
     final String? cachedPath = await _locator.cachedFilePath(track);
     if (cachedPath != null) {
+      PlaybackDiagnostics.resolved(
+        source: 'offlineCache',
+        resolver: 'OfflineFirstPlayableUriResolver',
+        itemId: track.id,
+      );
       return ResolvedPlayable(
         Uri.file(cachedPath),
         PlaybackSource.offlineCache,
       );
     }
+    // A cache miss falls straight through to streaming (or the on-device
+    // resolver) — it is never treated as "offline/unavailable" on its own.
     return _fallback.resolve(track);
   }
 }

--- a/lib/core/services/playable_uri_resolver.dart
+++ b/lib/core/services/playable_uri_resolver.dart
@@ -31,6 +31,14 @@ enum PlaybackResolutionErrorKind {
   /// The source could not be reached (offline, server down, bad address).
   serverUnreachable,
 
+  /// The source answered, but with something that isn't an audio stream (an
+  /// unexpected content type or status when the stream URL was probed).
+  invalidStream,
+
+  /// The source returned an HTML page (a Cloudflare challenge/block, login, or
+  /// reverse-proxy error page) where audio was expected.
+  serverReturnedWebPage,
+
   /// The source is reachable and authorized, but no playable URL is available
   /// for this track right now.
   streamUnavailable,

--- a/lib/core/services/playback_diagnostics.dart
+++ b/lib/core/services/playback_diagnostics.dart
@@ -1,0 +1,65 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+/// Debug-only, secret-free diagnostics for playback resolution.
+///
+/// Surfaces *why* a track resolved the way it did — its source, the resolver
+/// that handled it, and (for remote streams) the HTTP status and content type
+/// observed when the stream URL was probed — so field failures are diagnosable
+/// from a debug log. It is silent in release builds and, by construction, can
+/// only emit non-secret metadata: the API has no parameter for a token,
+/// password, full authenticated URL, or `Authorization` header, and the item id
+/// is hashed before it is ever included.
+abstract final class PlaybackDiagnostics {
+  /// Logs a resolution attempt to the `playback` developer-log channel, but
+  /// only in debug builds (this includes `flutter test`). A no-op in release.
+  static void resolved({
+    required String source,
+    required String resolver,
+    String? itemId,
+    int? statusCode,
+    String? contentType,
+  }) {
+    if (!kDebugMode) return;
+    developer.log(
+      describe(
+        source: source,
+        resolver: resolver,
+        itemId: itemId,
+        statusCode: statusCode,
+        contentType: contentType,
+      ),
+      name: 'playback',
+    );
+  }
+
+  /// Builds the one-line, secret-free description [resolved] logs. Pure and
+  /// public so a test can assert it carries the diagnostic fields and leaks no
+  /// secret (it cannot — there is no parameter for one, and the id is redacted).
+  static String describe({
+    required String source,
+    required String resolver,
+    String? itemId,
+    int? statusCode,
+    String? contentType,
+  }) {
+    return <String>[
+      'source=$source',
+      'resolver=$resolver',
+      if (itemId != null) 'item=${redactId(itemId)}',
+      if (statusCode != null) 'status=$statusCode',
+      if (contentType != null) 'contentType=${_mimeOnly(contentType)}',
+    ].join(' ');
+  }
+
+  /// A short, non-reversible tag for an item id so debug logs can correlate
+  /// attempts for one track without exposing the real id.
+  static String redactId(String id) =>
+      'id#${(id.hashCode & 0x7fffffff).toRadixString(16)}';
+
+  /// Strips any parameters (`; charset=…`) from a content type so the log shows
+  /// just the MIME type.
+  static String _mimeOnly(String contentType) =>
+      contentType.split(';').first.trim();
+}

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -127,6 +127,31 @@ class HttpJellyfinClient implements JellyfinClient {
     _checkStatus(response);
   }
 
+  @override
+  Future<JellyfinStreamProbe> probeStream(Uri url) async {
+    // A one-byte ranged GET: enough to see the real status and content type the
+    // engine will get, without downloading the track. Jellyfin honours Range on
+    // its media endpoints (it powers seeking), so this returns `206` with two
+    // bytes rather than the whole file.
+    //
+    // Auth rides in the URL's `api_key` query — exactly how the engine will
+    // fetch it — so no `Authorization` header is added here: the probe must
+    // mirror what `just_audio`/ExoPlayer actually sends, and query auth also
+    // survives the redirects (e.g. Cloudflare) a stripped header would not. The
+    // status is returned, not checked, so the caller can tell auth / web-page /
+    // non-audio apart; only a transport failure throws.
+    final http.Response response = await _send(
+      () => _client.get(url, headers: const <String, String>{
+        'Accept': '*/*',
+        'Range': 'bytes=0-1',
+      }),
+    );
+    return JellyfinStreamProbe(
+      statusCode: response.statusCode,
+      contentType: response.headers['content-type'],
+    );
+  }
+
   /// Builds the listing URL for [kind]. Artists have their own endpoint in
   /// Jellyfin; tracks and albums share `/Items` filtered by type.
   Uri _itemsUri(JellyfinSession session, JellyfinItemKind kind) {

--- a/lib/core/sources/jellyfin/jellyfin_api.dart
+++ b/lib/core/sources/jellyfin/jellyfin_api.dart
@@ -12,6 +12,55 @@ library;
 /// query string.
 enum JellyfinItemKind { audio, album, artist }
 
+/// What a tiny pre-flight request to a minted stream URL observed.
+///
+/// The playback source probes the stream URL before handing it to the audio
+/// engine so a Cloudflare page, an expired token, or a non-audio response
+/// becomes a precise, friendly error instead of an opaque engine failure. Only
+/// the (non-secret) HTTP status and content type are carried — never the URL or
+/// the token woven into it. The classification getters keep the "is this
+/// playable audio?" rules in one pure, testable place.
+class JellyfinStreamProbe {
+  const JellyfinStreamProbe({required this.statusCode, this.contentType});
+
+  /// The HTTP status the probe saw (after following any redirects).
+  final int statusCode;
+
+  /// The response's `Content-Type`, when present (parameters like `; charset`
+  /// are ignored by the classifiers below).
+  final String? contentType;
+
+  /// A 2xx response (covers `206 Partial Content` from the ranged probe).
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+
+  /// The server answered with an HTML page — a Cloudflare challenge/block, a
+  /// login page, or a reverse-proxy error page — where audio was expected.
+  bool get isHtml {
+    final String? type = _mimeType;
+    return type != null && type.startsWith('text/html');
+  }
+
+  /// The body looks like something the audio engine can open: an `audio/*`
+  /// type, the generic binary `application/octet-stream` some servers use for
+  /// media, or a missing content type (lenient — the engine sniffs the
+  /// container itself, and a 2xx with bytes is almost certainly the file).
+  bool get isAudio {
+    final String? type = _mimeType;
+    if (type == null) return true;
+    return type.startsWith('audio/') ||
+        type.startsWith('video/') ||
+        type == 'application/octet-stream';
+  }
+
+  /// The bare MIME type, lower-cased and without parameters.
+  String? get _mimeType {
+    final String? raw = contentType;
+    if (raw == null) return null;
+    final String type = raw.split(';').first.trim().toLowerCase();
+    return type.isEmpty ? null : type;
+  }
+}
+
 /// Public server info from `GET /System/Info/Public` — enough to confirm the
 /// address is a Jellyfin server and to show the user which one they reached.
 class JellyfinServerInfo {

--- a/lib/core/sources/jellyfin/jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/jellyfin_client.dart
@@ -43,4 +43,16 @@ abstract interface class JellyfinClient {
   /// [JellyfinException] ([JellyfinErrorKind.unauthorized] for an expired token,
   /// [JellyfinErrorKind.notReachable] when offline, …) on failure.
   Future<void> verifySession(JellyfinSession session);
+
+  /// Probes a minted stream [url] with a tiny ranged request to confirm the
+  /// server returns playable audio *before* the URL is handed to the audio
+  /// engine, returning the observed status and content type. Redirects (e.g.
+  /// from Cloudflare) are followed, so the result reflects the final response.
+  ///
+  /// Throws a [JellyfinException] only for transport failures
+  /// ([JellyfinErrorKind.notReachable]); a non-2xx status is returned in the
+  /// [JellyfinStreamProbe] for the caller to classify, not thrown. The [url]
+  /// carries the session token, so it must never be logged or placed in a
+  /// thrown error.
+  Future<JellyfinStreamProbe> probeStream(Uri url);
 }

--- a/lib/core/sources/jellyfin/jellyfin_exception.dart
+++ b/lib/core/sources/jellyfin/jellyfin_exception.dart
@@ -21,6 +21,17 @@ enum JellyfinErrorKind {
   /// The Jellyfin server reported a server-side error (HTTP 5xx).
   serverError,
 
+  /// A stream URL was probed and the server returned an HTML page (a Cloudflare
+  /// challenge/block, a login page, a reverse-proxy error page) where audio was
+  /// expected. Distinct from [notJellyfin] so playback can tell the user the
+  /// problem is in front of Jellyfin, not the address itself.
+  webPage,
+
+  /// A stream URL was probed and the server answered, but not with audio (an
+  /// unexpected content type or a non-2xx that isn't auth/transport/5xx). The
+  /// item likely can't be direct-streamed in its current form.
+  notAudioStream,
+
   /// Any other unexpected failure.
   unexpected,
 }
@@ -72,6 +83,17 @@ class JellyfinException implements Exception {
         'Try again in a moment.',
         kind: JellyfinErrorKind.serverError,
         statusCode: statusCode,
+      );
+
+  factory JellyfinException.webPage() => const JellyfinException(
+        'Your server returned a web page instead of audio. Check your '
+        'Cloudflare/Jellyfin access.',
+        kind: JellyfinErrorKind.webPage,
+      );
+
+  factory JellyfinException.notAudioStream() => const JellyfinException(
+        "Jellyfin didn't return an audio stream for this track.",
+        kind: JellyfinErrorKind.notAudioStream,
       );
 
   factory JellyfinException.unexpected(int statusCode) => JellyfinException(

--- a/lib/core/sources/jellyfin/jellyfin_music_source.dart
+++ b/lib/core/sources/jellyfin/jellyfin_music_source.dart
@@ -3,9 +3,11 @@ import '../../models/artist.dart';
 import '../../models/jellyfin_session.dart';
 import '../../models/track.dart';
 import '../../services/music_source.dart';
+import '../../services/playback_diagnostics.dart';
 import 'jellyfin_api.dart';
 import 'jellyfin_client.dart';
 import 'jellyfin_download_source.dart';
+import 'jellyfin_exception.dart';
 import 'jellyfin_stream_source.dart';
 import 'jellyfin_track_mapper.dart';
 
@@ -79,22 +81,67 @@ class JellyfinMusicSource
   @override
   Future<void> verifyReachable() => _client.verifySession(session);
 
-  /// Mints the authenticated streaming URL for [track] on demand.
+  /// Mints the authenticated streaming URL for [track] on demand, then probes
+  /// it so a Cloudflare page, an expired token, or a non-audio response becomes
+  /// a precise error instead of an opaque engine failure.
   ///
   /// The token is woven in here, at play time, rather than stored on the track,
-  /// so it never reaches the persisted catalog. Kept intentionally minimal
-  /// (direct play / server-chosen container); richer transcoding parameters are
-  /// a later refinement.
+  /// so it never reaches the persisted catalog. The URL targets the direct-play
+  /// stream endpoint (`/Audio/<id>/stream` with `static=true`) so the server
+  /// returns the original file bytes — what `just_audio`/ExoPlayer can open
+  /// directly — rather than negotiating a transcode/HLS variant the engine may
+  /// reject. Auth rides in the `api_key` query (not a header) because that is
+  /// what the engine fetches with, and query auth survives the redirects a
+  /// stripped header would not.
   @override
   Future<Uri?> resolvePlayableUri(Track track) async {
-    return Uri.parse('${session.baseUrl}/Audio/${_itemId(track)}/universal')
-        .replace(
-      queryParameters: <String, String>{
-        'api_key': session.accessToken,
-        'UserId': session.userId,
-        'DeviceId': session.deviceId,
-      },
+    final Uri url = _streamUri(track);
+    final JellyfinStreamProbe probe = await _client.probeStream(url);
+    // Log the (non-secret) probe outcome before classifying, so a rejected
+    // stream is still diagnosable from a debug log.
+    PlaybackDiagnostics.resolved(
+      source: 'jellyfin',
+      resolver: 'JellyfinPlayableUriResolver',
+      itemId: _itemId(track),
+      statusCode: probe.statusCode,
+      contentType: probe.contentType,
     );
+    _ensurePlayableAudio(probe);
+    return url;
+  }
+
+  /// The direct-play stream URL for [track]. `static=true` asks Jellyfin to
+  /// serve the original file as-is (no transcode), which is the reliable
+  /// "stream directly" path for an audio engine that already decodes the common
+  /// containers.
+  Uri _streamUri(Track track) =>
+      Uri.parse('${session.baseUrl}/Audio/${_itemId(track)}/stream').replace(
+        queryParameters: <String, String>{
+          'static': 'true',
+          'api_key': session.accessToken,
+          'UserId': session.userId,
+          'DeviceId': session.deviceId,
+        },
+      );
+
+  /// Turns a stream [probe] into a typed [JellyfinException] when the response
+  /// isn't playable audio, so the resolver can map it to a friendly message.
+  /// HTML is checked first: a Cloudflare/login/error page is never audio
+  /// whatever its status, and Jellyfin's own auth responses aren't HTML.
+  void _ensurePlayableAudio(JellyfinStreamProbe probe) {
+    if (probe.isHtml) {
+      throw JellyfinException.webPage();
+    }
+    final int code = probe.statusCode;
+    if (code == 401 || code == 403) {
+      throw JellyfinException.unauthorized();
+    }
+    if (code >= 500) {
+      throw JellyfinException.serverError(code);
+    }
+    if (!probe.isSuccess || !probe.isAudio) {
+      throw JellyfinException.notAudioStream();
+    }
   }
 
   /// Mints the authenticated URL to download [track]'s original file on demand.

--- a/lib/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart
@@ -33,50 +33,65 @@ class JellyfinPlayableUriResolver implements PlayableUriResolver {
     final JellyfinStreamSource? source = _source();
     if (source == null) {
       throw const PlaybackResolutionException(
-        "You're not signed in to Jellyfin. Connect to your server in Settings "
-        'to play this track.',
+        'Sign in to Jellyfin before streaming this track.',
         kind: PlaybackResolutionErrorKind.notSignedIn,
       );
     }
 
-    // Confirm the session still works before streaming, turning a 401 / network
-    // failure into a precise message rather than a generic playback error.
+    // Confirm the session still works, then mint and probe the stream URL —
+    // both can throw a typed [JellyfinException], which becomes a precise,
+    // secret-free message rather than the engine's opaque "couldn't play".
+    final Uri? uri;
     try {
       await source.verifyReachable();
+      uri = await source.resolvePlayableUri(track);
     } on JellyfinException catch (error) {
-      throw _mapVerifyFailure(error);
+      throw _mapFailure(error);
     }
 
-    final Uri? uri = await source.resolvePlayableUri(track);
     if (uri == null) {
       throw const PlaybackResolutionException(
-        "This Jellyfin track can't be streamed right now. Try syncing your "
-        'library again.',
+        "Couldn't stream this track.",
         kind: PlaybackResolutionErrorKind.streamUnavailable,
       );
     }
     return ResolvedPlayable(uri, PlaybackSource.streamingDirect);
   }
 
-  /// Maps a verification failure to a friendly, secret-free playback error.
-  /// Branches on [JellyfinErrorKind] so wording can change without breaking it.
-  PlaybackResolutionException _mapVerifyFailure(JellyfinException error) {
+  /// Maps a Jellyfin failure (from the session check or the stream probe) to a
+  /// friendly, secret-free playback error. Branches on [JellyfinErrorKind] so
+  /// wording can change without breaking it, and so a new kind is a compile
+  /// error here rather than a silent generic message.
+  PlaybackResolutionException _mapFailure(JellyfinException error) {
     switch (error.kind) {
       case JellyfinErrorKind.unauthorized:
         return const PlaybackResolutionException(
-          'Your Jellyfin session has expired. Sign out and sign in again in '
-          'Settings to keep playing.',
+          'Your Jellyfin session expired. Sign in again.',
           kind: PlaybackResolutionErrorKind.sessionExpired,
         );
-      case JellyfinErrorKind.notReachable:
+      case JellyfinErrorKind.webPage:
       case JellyfinErrorKind.notJellyfin:
+        return const PlaybackResolutionException(
+          'Your server returned a web page instead of audio. Check '
+          'Cloudflare/Jellyfin access.',
+          kind: PlaybackResolutionErrorKind.serverReturnedWebPage,
+        );
+      case JellyfinErrorKind.notAudioStream:
+        return const PlaybackResolutionException(
+          'Jellyfin did not return an audio stream.',
+          kind: PlaybackResolutionErrorKind.invalidStream,
+        );
+      case JellyfinErrorKind.notReachable:
       case JellyfinErrorKind.serverError:
+        return const PlaybackResolutionException(
+          "Couldn't reach your Jellyfin server.",
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
       case JellyfinErrorKind.invalidUrl:
       case JellyfinErrorKind.unexpected:
         return const PlaybackResolutionException(
-          "Couldn't reach your Jellyfin server. Check your connection and that "
-          'the server is online.',
-          kind: PlaybackResolutionErrorKind.serverUnreachable,
+          "Couldn't stream this track.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
         );
     }
   }

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -89,11 +89,13 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
         return 'Your Jellyfin session has expired. Sign out and sign in again '
             'to refresh it.';
       case JellyfinErrorKind.notJellyfin:
+      case JellyfinErrorKind.webPage:
         return "That server didn't respond like Jellyfin. Double-check the "
             'server address in Settings.';
       case JellyfinErrorKind.serverError:
         return 'Your Jellyfin server reported an error. Try again in a moment.';
       case JellyfinErrorKind.invalidUrl:
+      case JellyfinErrorKind.notAudioStream:
       case JellyfinErrorKind.unexpected:
         return error.message;
     }

--- a/test/core/services/playback_diagnostics_test.dart
+++ b/test/core/services/playback_diagnostics_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/playback_diagnostics.dart';
+
+void main() {
+  group('PlaybackDiagnostics.describe', () {
+    test('carries the non-secret resolution fields', () {
+      final line = PlaybackDiagnostics.describe(
+        source: 'jellyfin',
+        resolver: 'JellyfinPlayableUriResolver',
+        itemId: 'item-123',
+        statusCode: 200,
+        contentType: 'audio/mpeg',
+      );
+
+      expect(line, contains('source=jellyfin'));
+      expect(line, contains('resolver=JellyfinPlayableUriResolver'));
+      expect(line, contains('status=200'));
+      expect(line, contains('contentType=audio/mpeg'));
+    });
+
+    test('redacts the item id rather than logging it raw', () {
+      final line = PlaybackDiagnostics.describe(
+        source: 'jellyfin',
+        resolver: 'JellyfinPlayableUriResolver',
+        itemId: 'super-distinctive-item-id',
+      );
+
+      expect(line, isNot(contains('super-distinctive-item-id')));
+      expect(
+          line,
+          contains(
+              'item=${PlaybackDiagnostics.redactId('super-distinctive-item-id')}'));
+    });
+
+    test('strips content-type parameters to the bare MIME type', () {
+      final line = PlaybackDiagnostics.describe(
+        source: 'jellyfin',
+        resolver: 'r',
+        contentType: 'text/html; charset=utf-8',
+      );
+
+      expect(line, contains('contentType=text/html'));
+      expect(line, isNot(contains('charset')));
+    });
+
+    test('omits fields that were not observed', () {
+      final line = PlaybackDiagnostics.describe(
+        source: 'local',
+        resolver: 'LocalPlayableUriResolver',
+      );
+
+      expect(line, isNot(contains('status=')));
+      expect(line, isNot(contains('contentType=')));
+      expect(line, isNot(contains('item=')));
+    });
+
+    test('redactId is stable and not the raw id', () {
+      expect(PlaybackDiagnostics.redactId('abc'),
+          PlaybackDiagnostics.redactId('abc'));
+      expect(PlaybackDiagnostics.redactId('abc'), isNot('abc'));
+      expect(PlaybackDiagnostics.redactId('abc'), startsWith('id#'));
+    });
+  });
+}

--- a/test/core/sources/jellyfin/fake_jellyfin_client.dart
+++ b/test/core/sources/jellyfin/fake_jellyfin_client.dart
@@ -15,6 +15,8 @@ class FakeJellyfinClient implements JellyfinClient {
     this.authError,
     this.itemsError,
     this.verifyError,
+    this.streamProbe,
+    this.probeError,
   });
 
   JellyfinServerInfo? serverInfo;
@@ -25,6 +27,13 @@ class FakeJellyfinClient implements JellyfinClient {
   JellyfinException? itemsError;
   JellyfinException? verifyError;
 
+  /// Canned result for [probeStream]; defaults to a healthy `audio/mpeg` 200 so
+  /// tests that only care about the minted URL don't have to set it.
+  JellyfinStreamProbe? streamProbe;
+
+  /// A transport failure for [probeStream] to throw instead of returning.
+  JellyfinException? probeError;
+
   // Recorded inputs.
   String? lastBaseUrl;
   String? lastUsername;
@@ -32,6 +41,10 @@ class FakeJellyfinClient implements JellyfinClient {
   String? lastDeviceId;
   final List<JellyfinItemKind> requestedKinds = <JellyfinItemKind>[];
   int verifyCount = 0;
+
+  /// The last URL [probeStream] was asked about, so a test can prove the probe
+  /// ran against the minted stream URL.
+  Uri? lastProbedUrl;
 
   @override
   Future<JellyfinServerInfo> fetchServerInfo(String baseUrl) async {
@@ -88,5 +101,16 @@ class FakeJellyfinClient implements JellyfinClient {
     if (error != null) {
       throw error;
     }
+  }
+
+  @override
+  Future<JellyfinStreamProbe> probeStream(Uri url) async {
+    lastProbedUrl = url;
+    final JellyfinException? error = probeError;
+    if (error != null) {
+      throw error;
+    }
+    return streamProbe ??
+        const JellyfinStreamProbe(statusCode: 200, contentType: 'audio/mpeg');
   }
 }

--- a/test/core/sources/jellyfin/http_jellyfin_client_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_test.dart
@@ -305,4 +305,69 @@ void main() {
       );
     });
   });
+
+  group('probeStream', () {
+    final streamUrl =
+        Uri.parse('$_base/Audio/t1/stream?static=true&api_key=tok');
+
+    test('sends a tiny ranged GET and reports status + content type', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response('', 206, headers: <String, String>{
+          'content-type': 'audio/mpeg',
+        });
+      }));
+
+      final probe = await client.probeStream(streamUrl);
+
+      expect(probe.statusCode, 206);
+      expect(probe.contentType, 'audio/mpeg');
+      expect(probe.isAudio, isTrue);
+      expect(probe.isHtml, isFalse);
+      expect(captured!.method, 'GET');
+      // A bounded range, so the whole track isn't downloaded just to check it.
+      expect(captured!.headers['Range'], 'bytes=0-1');
+      // Auth rides in the URL (mirroring the engine); no Authorization header.
+      expect(captured!.headers.containsKey('Authorization'), isFalse);
+    });
+
+    test('returns a non-2xx status instead of throwing', () async {
+      final client = _client(MockClient((_) async => http.Response('no', 401)));
+
+      final probe = await client.probeStream(streamUrl);
+
+      expect(probe.statusCode, 401);
+    });
+
+    test('reports an HTML content type (a Cloudflare page)', () async {
+      final client = _client(MockClient((_) async => http.Response(
+            '<html>Attention Required</html>',
+            200,
+            headers: <String, String>{
+              'content-type': 'text/html; charset=utf-8'
+            },
+          )));
+
+      final probe = await client.probeStream(streamUrl);
+
+      expect(probe.isHtml, isTrue);
+      expect(probe.isAudio, isFalse);
+    });
+
+    test('maps a transport failure to "not reachable"', () async {
+      final client = _client(
+        MockClient((_) async => throw http.ClientException('offline')),
+      );
+
+      await expectLater(
+        client.probeStream(streamUrl),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.notReachable,
+        )),
+      );
+    });
+  });
 }

--- a/test/core/sources/jellyfin/jellyfin_music_source_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_music_source_test.dart
@@ -70,19 +70,27 @@ void main() {
       );
     });
 
-    test('resolvePlayableUri mints a stream URL with the token at play time',
-        () async {
-      final source = _source(FakeJellyfinClient());
+    test(
+        'resolvePlayableUri mints a direct-stream URL with the token at play '
+        'time', () async {
+      final client = FakeJellyfinClient();
+      final source = _source(client);
       const track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
 
       final uri = await source.resolvePlayableUri(track);
 
       expect(uri, isNotNull);
-      expect(uri!.path, '/Audio/t1/universal');
+      // The direct-play stream endpoint (static=true serves the original file),
+      // not the download or universal/transcode endpoint.
+      expect(uri!.path, '/Audio/t1/stream');
+      expect(uri.queryParameters['static'], 'true');
       expect(uri.host, 'music.example.com');
       expect(uri.queryParameters['api_key'], 'secret-token');
       expect(uri.queryParameters['UserId'], 'user-1');
       expect(uri.queryParameters['DeviceId'], 'device-1');
+      // The stream URL is probed before it is returned (and the probe sees the
+      // tokenized URL the engine will fetch).
+      expect(client.lastProbedUrl, uri);
     });
 
     test('resolvePlayableUri falls back to the track id when uri is unprefixed',
@@ -92,7 +100,89 @@ void main() {
 
       final uri = await source.resolvePlayableUri(track);
 
-      expect(uri!.path, '/Audio/raw-id/universal');
+      expect(uri!.path, '/Audio/raw-id/stream');
+    });
+
+    group('resolvePlayableUri probes the stream before returning it', () {
+      const track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
+
+      test('an HTML/Cloudflare page maps to a web-page error', () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(
+              statusCode: 200, contentType: 'text/html'),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.webPage,
+          )),
+        );
+      });
+
+      test('a 401 maps to unauthorized (an expired token)', () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(statusCode: 401),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.unauthorized,
+          )),
+        );
+      });
+
+      test('a non-audio content type maps to "not an audio stream"', () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(
+            statusCode: 200,
+            contentType: 'application/json',
+          ),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.notAudioStream,
+          )),
+        );
+      });
+
+      test('a 206 audio response is accepted and the URL returned', () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(
+            statusCode: 206,
+            contentType: 'audio/flac',
+          ),
+        ));
+
+        final uri = await source.resolvePlayableUri(track);
+
+        expect(uri, isNotNull);
+        expect(uri!.path, '/Audio/t1/stream');
+      });
+
+      test('a transport failure during the probe propagates', () async {
+        final source = _source(FakeJellyfinClient(
+          probeError: JellyfinException.notReachable(),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.notReachable,
+          )),
+        );
+      });
     });
 
     test('resolveDownloadUri mints a download URL with the token on demand',

--- a/test/core/sources/jellyfin/jellyfin_playable_uri_resolver_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_playable_uri_resolver_test.dart
@@ -7,12 +7,14 @@ import 'package:linthra/core/sources/jellyfin/jellyfin_playable_uri_resolver.dar
 import 'package:linthra/core/sources/jellyfin/jellyfin_stream_source.dart';
 
 /// A configurable [JellyfinStreamSource] that drives each playback outcome
-/// without a real server: verification can throw, and the minted URI can be
-/// canned or absent.
+/// without a real server: verification can throw, minting can throw (as it does
+/// when the play-time stream probe rejects the response), and the minted URI can
+/// be canned or absent.
 class _FakeStreamSource implements JellyfinStreamSource {
-  _FakeStreamSource({this.verifyError, this.streamUri});
+  _FakeStreamSource({this.verifyError, this.streamError, this.streamUri});
 
   final JellyfinException? verifyError;
+  final JellyfinException? streamError;
   final Uri? streamUri;
   int verifyCount = 0;
 
@@ -26,7 +28,13 @@ class _FakeStreamSource implements JellyfinStreamSource {
   }
 
   @override
-  Future<Uri?> resolvePlayableUri(Track track) async => streamUri;
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    final JellyfinException? error = streamError;
+    if (error != null) {
+      throw error;
+    }
+    return streamUri;
+  }
 }
 
 const _jellyfinTrack = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
@@ -45,13 +53,16 @@ void main() {
 
     test('mints the stream URL when the session verifies', () async {
       final source = _FakeStreamSource(
-        streamUri: Uri.parse('https://music.example.com/Audio/t1/universal'),
+        streamUri: Uri.parse('https://music.example.com/Audio/t1/stream'),
       );
       final resolver = JellyfinPlayableUriResolver(() => source);
 
       final resolved = await resolver.resolve(_jellyfinTrack);
 
-      expect(resolved.uri.path, '/Audio/t1/universal');
+      expect(resolved.uri.path, '/Audio/t1/stream');
+      // The URI handed to the engine is a real https URL, never `jellyfin:<id>`.
+      expect(resolved.uri.scheme, 'https');
+      expect(resolved.uri.toString(), isNot(startsWith('jellyfin:')));
       // A minted Jellyfin URL is reported as a direct stream.
       expect(resolved.source, PlaybackSource.streamingDirect);
       // The session is verified before the URL is handed to the engine.
@@ -123,6 +134,82 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('reports a web-page error when the probe sees HTML (Cloudflare)',
+        () async {
+      final source =
+          _FakeStreamSource(streamError: JellyfinException.webPage());
+      final resolver = JellyfinPlayableUriResolver(() => source);
+
+      await expectLater(
+        resolver.resolve(_jellyfinTrack),
+        throwsA(
+          isA<PlaybackResolutionException>().having(
+            (PlaybackResolutionException e) => e.kind,
+            'kind',
+            PlaybackResolutionErrorKind.serverReturnedWebPage,
+          ),
+        ),
+      );
+    });
+
+    test('reports an invalid stream when the probe sees a non-audio response',
+        () async {
+      final source =
+          _FakeStreamSource(streamError: JellyfinException.notAudioStream());
+      final resolver = JellyfinPlayableUriResolver(() => source);
+
+      await expectLater(
+        resolver.resolve(_jellyfinTrack),
+        throwsA(
+          isA<PlaybackResolutionException>().having(
+            (PlaybackResolutionException e) => e.kind,
+            'kind',
+            PlaybackResolutionErrorKind.invalidStream,
+          ),
+        ),
+      );
+    });
+
+    test('error messages match the friendly, secret-free wording', () async {
+      Future<String> messageFor(JellyfinException verifyError) async {
+        final resolver = JellyfinPlayableUriResolver(
+          () => _FakeStreamSource(verifyError: verifyError),
+        );
+        try {
+          await resolver.resolve(_jellyfinTrack);
+          fail('expected a PlaybackResolutionException');
+        } on PlaybackResolutionException catch (e) {
+          return e.message;
+        }
+      }
+
+      expect(
+        await messageFor(JellyfinException.unauthorized()),
+        'Your Jellyfin session expired. Sign in again.',
+      );
+      expect(
+        await messageFor(JellyfinException.notReachable()),
+        "Couldn't reach your Jellyfin server.",
+      );
+      expect(
+        await messageFor(JellyfinException.notAudioStream()),
+        'Jellyfin did not return an audio stream.',
+      );
+      expect(
+        await messageFor(JellyfinException.webPage()),
+        'Your server returned a web page instead of audio. Check '
+        'Cloudflare/Jellyfin access.',
+      );
+
+      final notSignedIn = JellyfinPlayableUriResolver(() => null);
+      try {
+        await notSignedIn.resolve(_jellyfinTrack);
+        fail('expected a PlaybackResolutionException');
+      } on PlaybackResolutionException catch (e) {
+        expect(e.message, 'Sign in to Jellyfin before streaming this track.');
+      }
     });
 
     test('no error message exposes the token', () async {

--- a/test/features/player/playback_resolution_test.dart
+++ b/test/features/player/playback_resolution_test.dart
@@ -123,6 +123,48 @@ void main() {
       expect(source.verifyCount, 0);
       expect(source.resolveCount, 0);
     });
+
+    test('plays a content:// local track from its document URI', () async {
+      const contentTrack = Track(
+        id: 'c1',
+        title: 'SAF One',
+        uri: 'content://media/external/audio/media/42',
+      );
+      final source = _FakeStreamSource(Uri.parse('https://stream/x'));
+      final resolver = _resolver(
+        locator: StoreCachedTrackLocator(
+          InMemoryDownloadStore(),
+          InMemoryOfflineFileStore(),
+        ),
+        source: source,
+      );
+
+      final resolved = await resolver.resolve(contentTrack);
+
+      expect(resolved.uri.scheme, 'content');
+      expect(resolved.uri, Uri.parse(contentTrack.uri));
+      expect(resolved.source, PlaybackSource.localFile);
+    });
+
+    test('never hands a bare jellyfin:<id> URI to the engine', () async {
+      // The controller plays `resolved.uri.toString()`; this proves that string
+      // is always a real, openable URL — never the opaque `jellyfin:` scheme.
+      final source = _FakeStreamSource(
+        Uri.parse('https://music.example.com/Audio/t1/stream?static=true'),
+      );
+      final resolver = _resolver(
+        locator: StoreCachedTrackLocator(
+          InMemoryDownloadStore(),
+          InMemoryOfflineFileStore(),
+        ),
+        source: source,
+      );
+
+      final resolved = await resolver.resolve(_jellyfinTrack);
+
+      expect(resolved.uri.scheme, 'https');
+      expect(resolved.uri.toString(), isNot(startsWith('jellyfin:')));
+    });
   });
 
   group('Jellyfin token safety', () {


### PR DESCRIPTION
## Summary

A signed-in user could see Jellyfin tracks, art, and metadata, but tapping an
**un-downloaded** track opened the player and showed only **"Couldn't play this
track."** — it never streamed directly. This PR makes Jellyfin tracks **stream
directly by default** (Jellyfin/Plexamp/Symfonium-style), keeps downloads
optional, and replaces the generic error with specific, friendly ones.

Scope is the streaming bugfix only — no UI redesign, no new large features, no
F-Droid/release changes, no offline-download redesign.

## Root cause

The stream URL was minted against `GET /Audio/<id>/universal` with only
`api_key`, `UserId`, `DeviceId` — **no `Container`/device-profile parameters**.
Jellyfin's *universal* endpoint needs to know which containers/codecs the client
supports to pick direct-play vs. transcode; without them it returns an error (or
an unexpected transcode/HLS response) that `just_audio` (ExoPlayer on Android)
can't open. The controller's only handling for a failed `setUrl()` was the
generic `"Couldn't play this track."`, which is exactly what surfaced. Because
the pre-stream `verifyReachable()` (`GET /Users/Me`) **succeeded**, the user
never saw the precise "session expired / unreachable" messages — the failure was
entirely at the engine load stage. Behind **Cloudflare**, an HTML
challenge/error page where audio is expected hit the same opaque failure.

## Jellyfin stream endpoint / auth behavior

- **Endpoint:** now mints the direct-play URL `GET /Audio/<id>/stream?static=true`.
  `static=true` serves the **original file bytes** (true "direct streaming"),
  which ExoPlayer decodes for the common containers — instead of negotiating a
  transcode/HLS variant the engine may reject.
- **Auth:** stays in the **`api_key` query parameter**, not an `Authorization`
  header. That is the supported way the engine itself authenticates a remote
  URL, and query auth **survives redirects** (a custom header is commonly
  stripped across a redirect, e.g. by Cloudflare). The download path is
  unchanged (`/Items/<id>/Download`).
- The token is still woven in **only at play time** and is never stored on the
  track, in the catalog, in cache, in filenames, in UI strings, or in logs.

## Play-time stream probe (the core fix)

Before the URL reaches the engine, `JellyfinMusicSource.resolvePlayableUri`
**probes** it via a new `JellyfinClient.probeStream` (a one-byte ranged
`GET`, which follows Cloudflare/Jellyfin redirects) and classifies the response:

| Probe result | Mapped error shown to the user |
|---|---|
| HTML body (Cloudflare/login/error page), any status | "Your server returned a web page instead of audio. Check Cloudflare/Jellyfin access." |
| `401` / `403` | "Your Jellyfin session expired. Sign in again." |
| `5xx` / transport failure | "Couldn't reach your Jellyfin server." |
| 2xx but not audio (wrong content type) | "Jellyfin did not return an audio stream." |
| not signed in | "Sign in to Jellyfin before streaming this track." |
| URL couldn't be built | "Couldn't stream this track." |
| `2xx`/`206` + `audio/*` (or `octet-stream`/missing) | ✅ played |

This turns every "looks like audio but isn't" case into a precise message
instead of the engine's opaque failure, and detects **401/403 separately** from
network/server errors and from HTML responses.

## Cloudflare handling

- Redirects are followed by the HTTP client (probe and engine alike).
- An HTML response (the typical Cloudflare challenge/block/error page) is
  detected by content type and reported as a web-page error — never treated as
  audio.
- The probe sends **no custom auth header** (auth is in the query), so it mirrors
  exactly what ExoPlayer will fetch through the tunnel.

## Cache-vs-stream behavior

- **Cache-first unchanged:** a downloaded track resolves to its cached `file://`
  copy (`OFFLINE CACHE`) before anything touches the network.
- **Cache miss falls *through* to streaming** (`STREAMING DIRECT`) — never to a
  "failed/offline" state. Download is never required before playback.
- Local and `content://` (SAF) playback are untouched — they never enter the
  Jellyfin resolver.

## Security / token notes

- `Track.uri` stays the token-free `jellyfin:<id>`; the authenticated URL is
  minted only at play time and is never persisted/logged/shown.
- New **debug-only** `PlaybackDiagnostics` logs only non-secret metadata —
  source, resolver chosen, HTTP status, content type, and a **hashed** item id —
  and is silent in release builds. Its API has no parameter for a token,
  password, full URL, or `Authorization` header, so it can't leak one.
- HTTP transport failures are re-raised as generic, token-free errors (a
  `ClientException` embedding the tokenized URL can't escape).

## Tests added / updated

- **Uncached** Jellyfin track → resolves to the stream URL, no download required.
- **Cached** Jellyfin track → prefers the cached file (network never consulted).
- **Cache miss** → falls through to streaming.
- **`jellyfin:<id>` is never handed to `just_audio`** — the resolver always yields
  `https`/`file`, never the `jellyfin:` scheme.
- Token is **not** persisted or shown in any error message.
- `401` → session expired; **HTML/Cloudflare** → web-page error; **non-audio** →
  invalid-stream; **transport failure** → server unreachable.
- HTTP-level probe: tiny ranged `GET`, no `Authorization` header, status +
  content type reported (non-2xx returned, not thrown).
- Local file and `content://` playback still work.
- `PlaybackDiagnostics` carries the diagnostic fields and redacts the item id.

`flutter analyze` clean, `dart format --set-exit-if-changed .` clean, and the
full suite (`flutter test`) is green (333 tests).

## Manual Android test checklist

- [ ] Install the debug APK.
- [ ] Sign in to Jellyfin via the Cloudflare HTTPS domain.
- [ ] Sync the Jellyfin library.
- [ ] Tap a Jellyfin track that is **NOT** downloaded.
- [ ] Confirm it **streams directly** (badge: `STREAMING DIRECT`).
- [ ] Turn off the server or break the token → confirm a **specific friendly
  error** (unreachable / session expired), not "Couldn't play this track."
- [ ] (If reachable through Cloudflare without Jellyfin) confirm the **web-page**
  error appears for an HTML response.
- [ ] Download the same track.
- [ ] Tap again → confirm **OFFLINE CACHE** is used.
- [ ] Remove the offline copy.
- [ ] Tap again → confirm **STREAMING DIRECT** is used again.

## Verification notes

`flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, and
`flutter test` were all run locally (green). `flutter build apk --debug` was not
run here (no Android SDK in this environment); the existing
`.github/workflows/android-debug-apk.yml` builds the debug APK in CI.

https://claude.ai/code/session_01DULLs2tbzFG4GciXp8pZVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DULLs2tbzFG4GciXp8pZVR)_