### PR TITLE
Polish library list: cleaner rows, alphabet fast-scroll, overflow menu

### DIFF
--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -1,17 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
-import '../../app/routes.dart';
-import '../../core/models/track.dart';
-import '../../core/repositories/download_repository.dart';
-import '../../data/repositories/download_repository_provider.dart';
-import '../downloads/download_providers.dart';
-import '../player/player_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
 import 'selected_folder_controller.dart';
+import 'widgets/alphabet_track_list.dart';
 
 /// Browse tracks from the local catalog. Reads entirely from
 /// [libraryControllerProvider] and [selectedFolderControllerProvider]; it has
@@ -74,119 +68,7 @@ class LibraryScreen extends ConsumerWidget {
                 : () => _rescan(ref, selectedFolder),
           );
         }
-        return _TrackList(tracks: state.tracks);
-    }
-  }
-}
-
-class _TrackList extends StatelessWidget {
-  const _TrackList({required this.tracks});
-
-  final List<Track> tracks;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView.builder(
-      itemCount: tracks.length,
-      itemBuilder: (context, index) => _TrackTile(tracks: tracks, index: index),
-    );
-  }
-}
-
-class _TrackTile extends ConsumerWidget {
-  const _TrackTile({required this.tracks, required this.index});
-
-  /// The whole visible list, so tapping one track queues the rest after it.
-  final List<Track> tracks;
-  final int index;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final track = tracks[index];
-    return ListTile(
-      leading: const Icon(Icons.music_note_outlined),
-      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
-      subtitle: Text(
-        _subtitle(track),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-      trailing: _DownloadAction(track: track),
-      // Play the tapped track and queue the rest of the list behind it, then
-      // surface the now-playing screen.
-      onTap: () {
-        final controller = ref.read(playbackControllerProvider);
-        controller.playTracks(tracks, startIndex: index);
-        context.push(AppRoutes.player);
-      },
-    );
-  }
-
-  /// Prefer human-readable artist/album metadata; fall back to the raw
-  /// uri/path when a track has no tags yet.
-  static String _subtitle(Track track) {
-    final parts = <String>[
-      if (track.artistName != null && track.artistName!.isNotEmpty)
-        track.artistName!,
-      if (track.albumName != null && track.albumName!.isNotEmpty)
-        track.albumName!,
-    ];
-    return parts.isEmpty ? track.uri : parts.join(' • ');
-  }
-}
-
-/// The per-row offline-download control. Reflects the track's [DownloadStatus]
-/// and offers the matching user-initiated action — download when absent, remove
-/// when cached. Progress states (queued/downloading) show as non-interactive
-/// indicators; nothing here ever starts a download on its own.
-class _DownloadAction extends ConsumerWidget {
-  const _DownloadAction({required this.track});
-
-  final Track track;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final asyncStatus = ref.watch(trackDownloadStatusProvider(track.id));
-    final status = asyncStatus.valueOrNull ?? DownloadStatus.notDownloaded;
-    final repository = ref.read(downloadRepositoryProvider);
-    final theme = Theme.of(context);
-
-    switch (status) {
-      case DownloadStatus.notDownloaded:
-        return IconButton(
-          icon: const Icon(Icons.download_outlined),
-          tooltip: 'Download',
-          onPressed: () => repository.requestDownload(track),
-        );
-      case DownloadStatus.queued:
-        return IconButton(
-          icon: const Icon(Icons.schedule_outlined),
-          tooltip: 'Queued',
-          onPressed: () => repository.removeDownload(track.id),
-        );
-      case DownloadStatus.downloading:
-        return const SizedBox.square(
-          dimension: 24,
-          child: Padding(
-            padding: EdgeInsets.all(AppSpacing.xs),
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        );
-      case DownloadStatus.downloaded:
-        return IconButton(
-          icon: Icon(
-            Icons.download_done_outlined,
-            color: theme.colorScheme.primary,
-          ),
-          tooltip: 'Remove download',
-          onPressed: () => repository.removeDownload(track.id),
-        );
-      case DownloadStatus.failed:
-        return IconButton(
-          icon: Icon(Icons.error_outline, color: theme.colorScheme.error),
-          tooltip: 'Retry download',
-          onPressed: () => repository.requestDownload(track),
-        );
+        return AlphabetTrackList(tracks: state.tracks);
     }
   }
 }

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/track.dart';
+import 'track_tile.dart';
+
+/// A track list with first-letter section grouping and an A–Z fast-scroll
+/// index down the trailing edge, so large libraries stay navigable.
+///
+/// Tracks are sorted by title (case-insensitive) and grouped under a header for
+/// each leading letter; titles that don't start with a letter fall under '#'.
+/// The vertical index rail mirrors exactly the letters present and jumps the
+/// list to a section on tap or drag (a contacts-app style scrubber).
+///
+/// Both the rows and the index work off the *same* sorted list, so a row's tap
+/// queues the rest of the library in the order the user sees — see [TrackTile].
+class AlphabetTrackList extends StatefulWidget {
+  const AlphabetTrackList({required this.tracks, super.key});
+
+  final List<Track> tracks;
+
+  @override
+  State<AlphabetTrackList> createState() => _AlphabetTrackListState();
+}
+
+class _AlphabetTrackListState extends State<AlphabetTrackList> {
+  /// Fixed extents let the index compute an exact scroll offset for any letter
+  /// without measuring laid-out widgets.
+  static const double _headerExtent = 36;
+  static const double _trackExtent = 64;
+
+  final ScrollController _controller = ScrollController();
+
+  late List<Track> _sorted;
+  late List<_Entry> _entries;
+  late List<String> _letters;
+  late Map<String, double> _letterOffsets;
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuildIndex();
+  }
+
+  @override
+  void didUpdateWidget(AlphabetTrackList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.tracks, widget.tracks)) {
+      _rebuildIndex();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// (Re)derives the sorted list, the flat header/track entry list, and the
+  /// per-letter scroll offsets from the current tracks.
+  void _rebuildIndex() {
+    _sorted = [...widget.tracks]
+      ..sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
+
+    _entries = <_Entry>[];
+    _letters = <String>[];
+    _letterOffsets = <String, double>{};
+
+    double offset = 0;
+    String? current;
+    for (var i = 0; i < _sorted.length; i++) {
+      final letter = _indexKey(_sorted[i].title);
+      if (letter != current) {
+        current = letter;
+        _letters.add(letter);
+        _letterOffsets[letter] = offset;
+        _entries.add(_Entry.header(letter));
+        offset += _headerExtent;
+      }
+      _entries.add(_Entry.track(i));
+      offset += _trackExtent;
+    }
+  }
+
+  /// The leading index character for [title]: an uppercase letter, or '#' for
+  /// anything that doesn't begin with a letter (digits, symbols, empty).
+  static String _indexKey(String title) {
+    final trimmed = title.trimLeft();
+    if (trimmed.isEmpty) return '#';
+    final first = trimmed[0].toUpperCase();
+    return RegExp('[A-Z]').hasMatch(first) ? first : '#';
+  }
+
+  void _jumpToLetter(String letter) {
+    final offset = _letterOffsets[letter];
+    if (offset == null || !_controller.hasClients) return;
+    final max = _controller.position.maxScrollExtent;
+    _controller.jumpTo(offset.clamp(0.0, max));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        ListView.builder(
+          key: const Key('library_track_list'),
+          controller: _controller,
+          padding: const EdgeInsets.only(right: AppSpacing.md),
+          itemCount: _entries.length,
+          itemExtentBuilder: (index, _) =>
+              _entries[index].isHeader ? _headerExtent : _trackExtent,
+          itemBuilder: (context, i) {
+            final entry = _entries[i];
+            if (entry.isHeader) {
+              return _SectionHeader(letter: entry.letter!);
+            }
+            return TrackTile(tracks: _sorted, index: entry.trackIndex!);
+          },
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: _AlphabetIndex(
+            letters: _letters,
+            onSelected: _jumpToLetter,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A flat-list entry: either a section header (carrying its [letter]) or a
+/// track (carrying its index into the sorted track list).
+class _Entry {
+  const _Entry.header(this.letter) : trackIndex = null;
+  const _Entry.track(this.trackIndex) : letter = null;
+
+  final String? letter;
+  final int? trackIndex;
+
+  bool get isHeader => letter != null;
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.letter});
+
+  final String letter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.xs,
+      ),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          letter,
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.primary,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The A–Z scrubber rail. Renders only the letters present and maps a tap or
+/// vertical drag to the nearest letter, jumping the list to that section.
+class _AlphabetIndex extends StatelessWidget {
+  const _AlphabetIndex({required this.letters, required this.onSelected});
+
+  final List<String> letters;
+  final ValueChanged<String> onSelected;
+
+  void _handle(Offset localPosition, double height) {
+    if (letters.isEmpty || height <= 0) return;
+    final fraction = (localPosition.dy / height).clamp(0.0, 0.999);
+    onSelected(letters[(fraction * letters.length).floor()]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (letters.length < 2) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Fill the available height so a tap/drag maps linearly across the
+        // whole list, and the hit area matches the height used for mapping.
+        final double height =
+            constraints.hasBoundedHeight ? constraints.maxHeight : 0;
+        return GestureDetector(
+          key: const Key('library_alphabet_index'),
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (d) => _handle(d.localPosition, height),
+          onVerticalDragStart: (d) => _handle(d.localPosition, height),
+          onVerticalDragUpdate: (d) => _handle(d.localPosition, height),
+          child: SizedBox(
+            height: height > 0 ? height : null,
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (final letter in letters)
+                      Text(
+                        letter,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../app/dimens.dart';
+import '../../../app/routes.dart';
+import '../../../core/models/track.dart';
+import '../../../core/repositories/download_repository.dart';
+import '../../../data/repositories/download_repository_provider.dart';
+import '../../downloads/download_providers.dart';
+import '../../player/player_providers.dart';
+import '../../player/widgets/album_artwork.dart';
+
+/// The actions reachable from a track row's overflow menu. Which subset is
+/// offered is context-aware: it depends on whether the track is remote and on
+/// its current [DownloadStatus] (see `_OverflowMenu._menuItems`).
+enum _TrackAction { playNext, download, removeOffline, retryDownload, cancel }
+
+/// A single library track row.
+///
+/// The row is deliberately calm: artwork (or a placeholder), the title, and a
+/// clean artist • album subtitle. Per-track actions live behind a trailing
+/// 3-dots overflow menu rather than a dedicated button, so the list stays
+/// uncluttered. Download state is still surfaced — but only as a subtle leading
+/// glyph next to the menu, never as a large control.
+///
+/// Tapping the row plays the tapped track and queues the rest of [tracks]
+/// behind it, then opens the now-playing screen — unchanged from before.
+///
+/// Source-awareness: offline/download actions only appear for *remote* tracks
+/// (resolved through [remoteTrackDownloaderProvider], the same seam the
+/// download repository uses). On-device tracks are already local, so showing
+/// "Download for offline" on them would be meaningless — they only get the
+/// queue action.
+class TrackTile extends ConsumerWidget {
+  const TrackTile({required this.tracks, required this.index, super.key});
+
+  /// The whole visible list, so tapping one track queues the rest after it.
+  final List<Track> tracks;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final track = tracks[index];
+    final theme = Theme.of(context);
+    final status =
+        ref.watch(trackDownloadStatusProvider(track.id)).valueOrNull ??
+            DownloadStatus.notDownloaded;
+    final isRemote = ref.watch(remoteTrackDownloaderProvider).isRemote(track);
+
+    return ListTile(
+      leading: SizedBox.square(
+        dimension: 48,
+        child: AlbumArtwork(
+          artworkUri: track.artworkUri,
+          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+        ),
+      ),
+      title: Text(
+        track.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.titleMedium,
+      ),
+      subtitle: Text(
+        _subtitle(track),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _StatusGlyph(status: status, isRemote: isRemote),
+          _OverflowMenu(
+            track: track,
+            status: status,
+            isRemote: isRemote,
+          ),
+        ],
+      ),
+      onTap: () {
+        final controller = ref.read(playbackControllerProvider);
+        controller.playTracks(tracks, startIndex: index);
+        context.push(AppRoutes.player);
+      },
+    );
+  }
+
+  /// Prefer human-readable artist/album metadata; fall back to the raw
+  /// uri/path when a track has no tags yet.
+  static String _subtitle(Track track) {
+    final parts = <String>[
+      if (track.artistName != null && track.artistName!.isNotEmpty)
+        track.artistName!,
+      if (track.albumName != null && track.albumName!.isNotEmpty)
+        track.albumName!,
+    ];
+    return parts.isEmpty ? track.uri : parts.join(' • ');
+  }
+}
+
+/// The subtle, non-interactive download-state hint shown just before the
+/// overflow menu. Nothing here is tappable — it only mirrors state so the row
+/// stays quiet. Only meaningful for remote tracks; local tracks render nothing.
+class _StatusGlyph extends StatelessWidget {
+  const _StatusGlyph({required this.status, required this.isRemote});
+
+  final DownloadStatus status;
+  final bool isRemote;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isRemote) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    switch (status) {
+      case DownloadStatus.downloaded:
+        return Icon(
+          Icons.download_done,
+          size: 18,
+          color: theme.colorScheme.primary,
+          semanticLabel: 'Downloaded',
+        );
+      case DownloadStatus.downloading:
+        return const SizedBox.square(
+          dimension: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        );
+      case DownloadStatus.queued:
+        return Icon(
+          Icons.schedule,
+          size: 18,
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+          semanticLabel: 'Queued',
+        );
+      case DownloadStatus.failed:
+        return Icon(
+          Icons.error_outline,
+          size: 18,
+          color: theme.colorScheme.error,
+          semanticLabel: 'Download failed',
+        );
+      case DownloadStatus.notDownloaded:
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+/// The trailing 3-dots menu. Builds a context-aware action set and dispatches
+/// the chosen one to the playback controller or download repository.
+class _OverflowMenu extends ConsumerWidget {
+  const _OverflowMenu({
+    required this.track,
+    required this.status,
+    required this.isRemote,
+  });
+
+  final Track track;
+  final DownloadStatus status;
+  final bool isRemote;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PopupMenuButton<_TrackAction>(
+      icon: const Icon(Icons.more_vert),
+      tooltip: 'More actions',
+      onSelected: (action) => _run(ref, action),
+      itemBuilder: (context) => _menuItems(),
+    );
+  }
+
+  /// Context-aware action list. Offline actions are gated on [isRemote]; the
+  /// rest depend on the track's [DownloadStatus]. The queue action is always
+  /// available.
+  List<PopupMenuEntry<_TrackAction>> _menuItems() {
+    final items = <PopupMenuEntry<_TrackAction>>[];
+    if (isRemote) {
+      switch (status) {
+        case DownloadStatus.notDownloaded:
+          items.add(_item(_TrackAction.download, Icons.download_outlined,
+              'Download for offline'));
+        case DownloadStatus.queued:
+        case DownloadStatus.downloading:
+          items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
+        case DownloadStatus.downloaded:
+          items.add(_item(_TrackAction.removeOffline, Icons.delete_outline,
+              'Remove offline copy'));
+        case DownloadStatus.failed:
+          items.add(_item(
+              _TrackAction.retryDownload, Icons.refresh, 'Retry download'));
+          items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
+      }
+    }
+    items.add(_item(_TrackAction.playNext, Icons.queue_music, 'Play next'));
+    return items;
+  }
+
+  PopupMenuItem<_TrackAction> _item(
+    _TrackAction action,
+    IconData icon,
+    String label,
+  ) {
+    return PopupMenuItem<_TrackAction>(
+      value: action,
+      child: ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: Icon(icon),
+        title: Text(label),
+      ),
+    );
+  }
+
+  void _run(WidgetRef ref, _TrackAction action) {
+    switch (action) {
+      case _TrackAction.playNext:
+        ref.read(playbackControllerProvider).playNext(track);
+      case _TrackAction.download:
+      case _TrackAction.retryDownload:
+        ref.read(downloadRepositoryProvider).requestDownload(track);
+      case _TrackAction.removeOffline:
+      case _TrackAction.cancel:
+        ref.read(downloadRepositoryProvider).removeDownload(track.id);
+    }
+  }
+}

--- a/test/features/downloads/download_action_test.dart
+++ b/test/features/downloads/download_action_test.dart
@@ -2,26 +2,30 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/features/library/library_screen.dart';
 
 import '../library/fake_music_library_repository.dart';
+import '../library/fake_remote_track_downloader.dart';
 
+/// The per-track offline actions now live behind the trailing 3-dots overflow
+/// menu (the dedicated download button was removed). These tests open that menu
+/// and verify the context-aware, source-aware action set.
 void main() {
-  group('Library download action', () {
-    Future<void> pump(WidgetTester tester) async {
+  group('Library overflow download actions', () {
+    Future<void> pump(WidgetTester tester, List<Track> tracks) async {
       await tester.pumpWidget(
         ProviderScope(
           // Default download providers are plugin-free (in-memory store +
-          // optimistic connectivity), so the row action works without overrides.
+          // optimistic connectivity); only the remote downloader is faked so a
+          // `jellyfin:` track counts as remote/offline-capable.
           overrides: [
             musicLibraryRepositoryProvider.overrideWithValue(
-              FakeMusicLibraryRepository(
-                tracks: const <Track>[
-                  Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
-                ],
-              ),
+              FakeMusicLibraryRepository(tracks: tracks),
             ),
+            remoteTrackDownloaderProvider
+                .overrideWithValue(FakeRemoteTrackDownloader()),
           ],
           child: const MaterialApp(home: LibraryScreen()),
         ),
@@ -29,28 +33,53 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    testWidgets('a not-downloaded row offers a download action', (
-      tester,
-    ) async {
-      await pump(tester);
-      expect(find.byTooltip('Download'), findsOneWidget);
-      expect(find.byTooltip('Remove download'), findsNothing);
+    Future<void> openMenu(WidgetTester tester) async {
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a remote track offers Download for offline', (tester) async {
+      await pump(tester, const <Track>[
+        Track(id: '1', title: 'Remote Song', uri: 'jellyfin:1'),
+      ]);
+
+      await openMenu(tester);
+      expect(find.text('Download for offline'), findsOneWidget);
+      expect(find.text('Remove offline copy'), findsNothing);
+      expect(find.text('Play next'), findsOneWidget);
     });
 
-    testWidgets('downloading then removing toggles the row action', (
+    testWidgets('downloading a remote track flips to Remove offline copy', (
       tester,
     ) async {
-      await pump(tester);
+      await pump(tester, const <Track>[
+        Track(id: '1', title: 'Remote Song', uri: 'jellyfin:1'),
+      ]);
 
-      await tester.tap(find.byTooltip('Download'));
+      await openMenu(tester);
+      await tester.tap(find.text('Download for offline'));
       await tester.pumpAndSettle();
-      expect(find.byTooltip('Remove download'), findsOneWidget);
-      expect(find.byTooltip('Download'), findsNothing);
 
-      await tester.tap(find.byTooltip('Remove download'));
-      await tester.pumpAndSettle();
-      expect(find.byTooltip('Download'), findsOneWidget);
-      expect(find.byTooltip('Remove download'), findsNothing);
+      await openMenu(tester);
+      expect(find.text('Remove offline copy'), findsOneWidget);
+      expect(find.text('Download for offline'), findsNothing);
+
+      // The subtle downloaded glyph is now visible on the row.
+      expect(find.byIcon(Icons.download_done), findsOneWidget);
+    });
+
+    testWidgets('a local track exposes no remote-download actions', (
+      tester,
+    ) async {
+      await pump(tester, const <Track>[
+        Track(id: '1', title: 'Local Song', uri: 'file:///s1.mp3'),
+      ]);
+
+      await openMenu(tester);
+      expect(find.text('Download for offline'), findsNothing);
+      expect(find.text('Remove offline copy'), findsNothing);
+      // Only the queue action remains for local files.
+      expect(find.text('Play next'), findsOneWidget);
     });
   });
 }

--- a/test/features/library/alphabet_track_list_test.dart
+++ b/test/features/library/alphabet_track_list_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/library/widgets/alphabet_track_list.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+
+List<Track> _alphabetTracks() {
+  return [
+    for (var code = 'A'.codeUnitAt(0); code <= 'Z'.codeUnitAt(0); code++)
+      Track(
+        id: '$code',
+        title: '${String.fromCharCode(code)} Track',
+        uri: 'file:///$code.mp3',
+      ),
+  ];
+}
+
+Future<void> _pump(WidgetTester tester, List<Track> tracks) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 500,
+            child: AlphabetTrackList(tracks: tracks),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('AlphabetTrackList', () {
+    testWidgets('renders rows and the A–Z index rail', (tester) async {
+      await _pump(tester, _alphabetTracks());
+
+      expect(find.byType(TrackTile), findsWidgets);
+      expect(find.byKey(const Key('library_alphabet_index')), findsOneWidget);
+      // The first section is visible; a far-down one is not yet built.
+      expect(find.text('A Track'), findsOneWidget);
+      expect(find.text('Z Track'), findsNothing);
+    });
+
+    testWidgets('tapping the index jumps the list to that section', (
+      tester,
+    ) async {
+      await _pump(tester, _alphabetTracks());
+
+      // Tap near the bottom of the rail to jump to the last letter ('Z').
+      final rail = find.byKey(const Key('library_alphabet_index'));
+      final rect = tester.getRect(rail);
+      await tester.tapAt(Offset(rect.center.dx, rect.bottom - 2));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Z Track'), findsOneWidget);
+      expect(find.text('A Track'), findsNothing);
+    });
+
+    testWidgets('hides the rail when there are too few sections', (
+      tester,
+    ) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Alpha', uri: 'file:///a.mp3'),
+        Track(id: '2', title: 'Another', uri: 'file:///b.mp3'),
+      ]);
+
+      // Only one section ('A') → no rail to render.
+      expect(find.byKey(const Key('library_alphabet_index')), findsNothing);
+    });
+  });
+}

--- a/test/features/library/fake_remote_track_downloader.dart
+++ b/test/features/library/fake_remote_track_downloader.dart
@@ -1,0 +1,19 @@
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/remote_track_downloader.dart';
+
+/// A plugin-free [RemoteTrackDownloader] for widget tests.
+///
+/// Treats any `jellyfin:` track as remote (mirroring the real Jellyfin
+/// downloader) and returns canned bytes on fetch, so the Library row's
+/// offline actions can be exercised without a server. A local (`file://`)
+/// track stays local, exactly as in production.
+class FakeRemoteTrackDownloader implements RemoteTrackDownloader {
+  @override
+  bool isRemote(Track track) => track.uri.startsWith('jellyfin:');
+
+  @override
+  Future<RemoteTrackData> fetch(Track track) async {
+    return const RemoteTrackData(
+        bytes: <int>[1, 2, 3, 4], fileExtension: 'mp3');
+  }
+}

--- a/test/features/library/library_playback_test.dart
+++ b/test/features/library/library_playback_test.dart
@@ -85,9 +85,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(controller.state.currentTrack?.id, '1');
+    // The list is sorted by title, so after "Song One" comes "Song Three"
+    // then "Song Two" — the up-next queue follows that visible order.
     expect(
       controller.state.upNext.map((t) => t.id).toList(),
-      ['2', '3'],
+      ['3', '2'],
     );
     // The player surfaces the queued tracks in its Up next queue sheet.
     await tester.tap(find.byTooltip('Queue'));

--- a/test/features/library/track_tile_test.dart
+++ b/test/features/library/track_tile_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+
+import 'fake_remote_track_downloader.dart';
+
+Future<void> _pump(WidgetTester tester, List<Track> tracks) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: ListView(
+            children: [
+              for (var i = 0; i < tracks.length; i++)
+                TrackTile(tracks: tracks, index: i),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('TrackTile', () {
+    testWidgets('shows the title and a clean artist • album subtitle', (
+      tester,
+    ) async {
+      await _pump(tester, const <Track>[
+        Track(
+          id: '1',
+          title: 'Song One',
+          uri: 'file:///s1.mp3',
+          artistName: 'Artist A',
+          albumName: 'Album X',
+        ),
+      ]);
+
+      expect(find.text('Song One'), findsOneWidget);
+      expect(find.text('Artist A • Album X'), findsOneWidget);
+    });
+
+    testWidgets('falls back to the uri when metadata is missing', (
+      tester,
+    ) async {
+      await _pump(tester, const <Track>[
+        Track(id: '2', title: 'Song Two', uri: 'file:///s2.mp3'),
+      ]);
+
+      expect(find.text('Song Two'), findsOneWidget);
+      expect(find.text('file:///s2.mp3'), findsOneWidget);
+    });
+
+    testWidgets('exposes a trailing overflow menu', (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+      ]);
+
+      expect(find.byTooltip('More actions'), findsOneWidget);
+      // No dedicated, always-visible download button on the row anymore.
+      expect(find.byTooltip('Download'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Library/list UI polish only — no Chromecast, no playback-architecture or backend changes, no release-workflow changes.

### Library UI improvements
- Track rows are cleaner and quieter: artwork thumbnail (reusing `AlbumArtwork`, with the same calm placeholder), a clear title, and a single-line `artist • album` subtitle that falls back to the uri when a track has no tags.
- Long titles/subtitles stay readable (single line, ellipsis).
- Download state is still visible but subtle — a small leading glyph beside the menu (`download_done` when cached, a tiny spinner while downloading, a queued/error glyph otherwise) instead of a large button.

### Scrolling / navigation behavior
- Tracks are grouped into sections by first letter (`#` for non-letters) and sorted by title.
- A contacts-app style **A–Z fast-scroll index** runs down the trailing edge; tapping or dragging it jumps the list to that section. The rail mirrors only the letters actually present and hides itself when there's just one section.
- Implementation note / limitation: section offsets are computed from fixed row/header extents (via `itemExtentBuilder`) so the jump is exact without measuring laid-out widgets. This means rows use a uniform height rather than intrinsic sizing.

### Overflow menu actions
- The dedicated per-row download button is **removed**.
- Each row now has a trailing 3-dots overflow menu (`More actions`) with a context-aware, source-aware action set:
  - Remote, not downloaded → **Download for offline**
  - Remote, queued/downloading → **Cancel download**
  - Remote, downloaded → **Remove offline copy**
  - Remote, failed → **Retry download** + **Cancel download**
  - All tracks → **Play next** (enqueues via the existing `playNext`)
- **Local tracks expose no remote-download actions** — they're already on-device, so they only get the queue action.
- Row tap behavior is unchanged: it plays the tapped track, queues the rest of the (now sorted) list behind it, and opens Now Playing.

### Download action changes
- Per-track offline control moved from an always-visible icon button into the overflow menu, routed through the same `DownloadRepository` / `remoteTrackDownloaderProvider` seams as before.

### Tests added / updated
- `track_tile_test.dart`: title + `artist • album` subtitle render, uri fallback, overflow menu present, old download button gone.
- `download_action_test.dart` (rewritten): remote track offers Download; downloading flips to Remove offline copy and shows the downloaded glyph; local track exposes no remote-download actions.
- `alphabet_track_list_test.dart`: rows + A–Z rail render; tapping the rail jumps to the right section; rail hidden with too few sections.
- `library_playback_test.dart`: up-next expectation updated for the new title-sorted order.
- Added `fake_remote_track_downloader.dart` test helper.

## Verification
- `flutter pub get`
- `dart format --set-exit-if-changed .` — clean
- `flutter analyze` — no issues
- `flutter test` — all passing

## Next recommended PR
Enable shuffle/repeat and add a Chromecast foundation.

https://claude.ai/code/session_01BUnNoiwBNSM6kg2fmE8sjP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUnNoiwBNSM6kg2fmE8sjP)_