### PR TITLE
Working shuffle/repeat controls + Chromecast/cast foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,14 @@ Not built yet (planned, in roughly this order):
   scoped-storage friendly, no broad permission); tag parsing and a narrow
   Android media permission still pending*
 - Audio playback — *done (local + **Jellyfin streaming** playback, behind a
-  `PlayableUriResolver`, plus an up-next queue with skip next/previous);
-  background playback + media session via `audio_service` wired in Dart **and**
-  with the native Android setup applied (foreground-service permissions,
-  playback service, media-button receiver, `AudioServiceActivity`, Android Auto
-  media-app declaration); Android Auto now **browsable** (Library / Queue nodes,
-  tap-to-play) — not yet a full car UI*
+  `PlayableUriResolver`, plus an up-next queue with skip next/previous and
+  **working shuffle and repeat (off / all / one)**); background playback + media
+  session via `audio_service` wired in Dart **and** with the native Android setup
+  applied (foreground-service permissions, playback service, media-button
+  receiver, `AudioServiceActivity`, Android Auto media-app declaration); Android
+  Auto now **browsable** (Library / Queue nodes, tap-to-play) — not yet a full
+  car UI. A **cast/Chromecast control** is present in Now Playing as a UI +
+  architecture-seam foundation (no live device handoff yet — see below)*
 - Playlists
 - User-controlled offline downloads — *done for tracks (Plexamp-style explicit
   downloads: real Jellyfin byte-fetch, app-private cache, cache-first playback,
@@ -262,11 +264,22 @@ lib/
 - **`PlaybackController`** (`core/services/playback_controller.dart`) — playback
   *and* the up-next queue, fully decoupled from `just_audio`. It owns a pure
   [`PlaybackQueue`](lib/core/models/playback_queue.dart) model (current track +
-  upcoming tracks) and exposes `playTracks`, `playNext`, `skipToNext`, and
-  `clearQueue`; the UI reads the queue from `PlaybackState` and never edits it
-  directly. `LinthraAudioHandler` wraps it for background audio / the platform
-  media session (notification, lock screen, Android Auto) without touching
+  upcoming tracks) and exposes `playTracks`, `playNext`, `skipToNext`,
+  `clearQueue`, and the **shuffle/repeat modes** (`setShuffleEnabled`,
+  `setRepeatMode`); shuffle reorders the queue in place (keeping the current
+  track playing) and repeat (off / all / one) is consulted when a track
+  finishes. The UI reads the queue, `shuffleEnabled`, and `repeatMode` from
+  `PlaybackState` and never edits them directly. `LinthraAudioHandler` wraps it
+  for background audio / the platform media session (notification, lock screen,
+  Android Auto), mirroring shuffle/repeat into the session, without touching
   feature code; MPRIS can attach the same way later.
+- **`CastService`** (`core/services/cast/cast_service.dart`) — the seam for
+  remote playback handoff (Chromecast/Cast SDK, AirPlay, …). The UI renders a
+  `CastState` and drives discovery/connection through this interface, never a
+  cast SDK directly — mirroring how the audio engine is hidden behind
+  `PlaybackController`. The shipped `UnavailableCastService` reports
+  "unavailable" and no-ops, so the cast button is honest today; a live backend
+  slots in by overriding one provider, with no player-UI changes.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
   user-initiated, "Wi-Fi only"-respecting download policy in one place.
   `CacheDownloadRepository` implements it today over a `DownloadStore`
@@ -700,6 +713,47 @@ The notification channel id/name are configured in `connectMediaSession`
 - Lock-screen / car artwork depends on `Track.artworkUri`, which local scanning
   does not populate yet.
 
+### Now Playing controls — shuffle, repeat & casting
+
+The Now Playing screen drives every transport action through
+`PlaybackController`/`PlaybackState`; the widgets hold no playback logic of their
+own.
+
+- **Shuffle (working).** The shuffle button toggles a playback *mode* on the
+  controller. Turning it on reorders the current queue with the playing track
+  kept at the front (so the music never skips), and remembers the original order;
+  turning it off restores that order with the current track still current. The
+  mode persists, so a queue loaded while shuffle is on starts shuffled. State
+  lives in `PlaybackState.shuffleEnabled`, and the button shows its on/off state
+  with the accent colour + selected styling. The reordering itself is a pure
+  `PlaybackQueue.shuffled()`/`unshuffled()` transform, unit-tested without an
+  audio engine.
+- **Repeat / loop (working).** The repeat button cycles **off → repeat all →
+  repeat one → off**. When a track finishes the controller consults
+  `PlaybackState.repeatMode`: *off* plays to the end and stops, *all* wraps from
+  the last track back to the first, and *one* replays the current track (from the
+  start, without re-resolving its URL — so a stream isn't re-fetched each loop).
+  Next/previous keep working normally in every mode. The glyph switches to
+  `repeat_one` for repeat-one and is tinted/selected whenever repeat is active.
+- **Cast / Chromecast — UI placeholder with architecture seam (not live yet).**
+  A cast control sits in the Now Playing header. **Casting is *not* implemented
+  in this build** and the app never pretends otherwise: the shipped
+  `UnavailableCastService` reports `CastAvailability.unavailable`, the button is
+  shown but visibly muted ("Cast (coming soon)"), and opening it shows an honest
+  "Casting isn't available yet" sheet rather than a fake or empty device list.
+  What *is* here is the full seam for a future backend — a `CastService`
+  interface, a `CastState` model (availability / discovered devices / connected
+  device), a provider, and a device-picker sheet that already handles discovery,
+  connect, and disconnect. Wiring real Chromecast support later (e.g. a Cast SDK
+  package) means implementing `CastService` and overriding one provider, with **no
+  changes to the player UI**. No cast SDK dependency is added in this PR, keeping
+  the build safe and small.
+
+Both shuffle and repeat are also mirrored into the `audio_service` media session
+(`shuffleMode`/`repeatMode`), and the session forwards the system's
+shuffle/repeat actions back to the controller, so the modes stay coherent
+between the in-app screen, the notification, and Android Auto.
+
 ### Android folder selection & known limitations
 
 **How scanning works now.** Tap the folder icon in the Library app bar → the
@@ -766,12 +820,14 @@ Deliberate gaps the next PRs will close:
   already read, or use the content-resolver follow-up above.
 - **No tag/metadata parsing.** Tracks show their title (derived from the file
   name) and fall back to the file path when artist/album tags are absent.
-- **Basic up-next queue, no playlists.** Tapping a track in the Library plays it
-  and queues the rest of the visible list behind it; the Now Playing screen shows
-  the current track, an **Up next** list, a **Next** button, and **Clear** (which
-  empties up next but keeps the current track). When a track finishes, playback
-  rolls into the next queued track. Reordering, saved playlists, shuffle, and
-  repeat are not part of this foundation yet.
+- **Up-next queue with shuffle & repeat, no playlists.** Tapping a track in the
+  Library plays it and queues the rest of the visible list behind it; the Now
+  Playing screen shows the current track, an **Up next** list, a **Next** button,
+  **Clear** (which empties up next but keeps the current track), and working
+  **shuffle** and **repeat** controls. When a track finishes, playback follows
+  the repeat mode (roll into the next track, wrap the queue, or replay the
+  current one). Manual reordering and saved playlists are not part of this
+  foundation yet.
 - **Jellyfin streaming works; WebDAV pending.** A signed-in user can sync their
   Jellyfin catalog into the Library and stream it (see the Jellyfin section
   below). Other remote sources (WebDAV/NAS) are still pending.
@@ -1042,7 +1098,9 @@ Later: Jellyfin (landed — settings, auth, encrypted session, a library source,
 Library sync, streaming playback, and explicit per-track offline downloads;
 album/playlist "download all" and a background download manager next), Android
 Auto (foundation landed — browsable Library/Queue; album/artist grouping and
-search next), WebDAV, NAS, lyrics, ReplayGain, MPRIS, smart playlists, and more.
+search next), Chromecast/casting (UI + `CastService` architecture seam landed;
+live device discovery and playback handoff next), WebDAV, NAS, lyrics,
+ReplayGain, MPRIS, smart playlists, and more.
 
 ## F-Droid metadata (work in progress)
 

--- a/lib/core/models/cast_state.dart
+++ b/lib/core/models/cast_state.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/foundation.dart';
+
+/// How far along the cast subsystem is, independent of any cast SDK.
+///
+/// [unavailable] is the honest default in this build: no cast backend is wired
+/// yet, so the UI shows a cast affordance but never pretends a device is
+/// reachable. The remaining values are the seam a real backend
+/// (Chromecast/Cast SDK, AirPlay, …) fills in once it lands.
+enum CastAvailability {
+  /// No cast backend is present, so casting cannot be started at all.
+  unavailable,
+
+  /// A backend exists and is ready, but no discovery/connection is in progress.
+  idle,
+
+  /// Actively scanning for nearby cast devices.
+  discovering,
+
+  /// A device was picked and a session is being established.
+  connecting,
+
+  /// Connected to a device; playback should be handed off to it.
+  connected,
+}
+
+/// A discoverable cast target (e.g. a Chromecast). Identity is its [id] so the
+/// UI can highlight the connected device regardless of list reordering.
+@immutable
+class CastDevice {
+  const CastDevice({required this.id, required this.name});
+
+  final String id;
+  final String name;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is CastDevice && other.id == id);
+
+  @override
+  int get hashCode => id.hashCode;
+}
+
+/// An immutable snapshot of the cast subsystem the UI renders from, mirroring
+/// the shape of [PlaybackState]: the UI reads this and drives a [CastService],
+/// never a cast SDK directly. That keeps the now-playing screen identical
+/// whether casting is a stubbed foundation (today) or a live backend (later).
+@immutable
+class CastState {
+  const CastState({
+    this.availability = CastAvailability.unavailable,
+    this.devices = const <CastDevice>[],
+    this.connectedDevice,
+  });
+
+  /// The honest default: no cast backend wired, nothing reachable.
+  static const CastState unavailable = CastState();
+
+  final CastAvailability availability;
+
+  /// Devices found so far while discovering. Empty until a backend reports any.
+  final List<CastDevice> devices;
+
+  /// The device a session is established with, or null when not connected.
+  final CastDevice? connectedDevice;
+
+  /// Whether the platform can cast at all. False in this build (no backend),
+  /// which is what the UI uses to show an honest "coming soon" state rather than
+  /// an empty device picker.
+  bool get isAvailable => availability != CastAvailability.unavailable;
+
+  bool get isConnected => availability == CastAvailability.connected;
+
+  bool get isDiscovering => availability == CastAvailability.discovering;
+
+  CastState copyWith({
+    CastAvailability? availability,
+    List<CastDevice>? devices,
+    CastDevice? connectedDevice,
+  }) {
+    return CastState(
+      availability: availability ?? this.availability,
+      devices: devices ?? this.devices,
+      connectedDevice: connectedDevice ?? this.connectedDevice,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CastState &&
+          other.availability == availability &&
+          listEquals(other.devices, devices) &&
+          other.connectedDevice == connectedDevice);
+
+  @override
+  int get hashCode =>
+      Object.hash(availability, Object.hashAll(devices), connectedDevice);
+}

--- a/lib/core/models/playback_queue.dart
+++ b/lib/core/models/playback_queue.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 
 import 'track.dart';
@@ -7,9 +9,18 @@ import 'track.dart';
 /// This is the pure queue model the [PlaybackController] keeps behind its
 /// state. Every mutation returns a new instance, so transitions are trivial to
 /// test in isolation — no audio engine required.
+///
+/// Shuffle lives here too: [tracks] is always the *effective* play order, so
+/// `current`/`upNext`/`next`/`previous` never need to know about shuffle. When
+/// shuffled, [originalOrder] remembers the pre-shuffle order so [unshuffled] can
+/// restore it with the current track kept in place.
 @immutable
 class PlaybackQueue {
-  const PlaybackQueue({this.tracks = const <Track>[], this.currentIndex = -1});
+  const PlaybackQueue({
+    this.tracks = const <Track>[],
+    this.currentIndex = -1,
+    this.originalOrder,
+  });
 
   static const PlaybackQueue empty = PlaybackQueue();
 
@@ -32,6 +43,14 @@ class PlaybackQueue {
   /// Position of the current track within [tracks], or -1 when nothing is
   /// queued.
   final int currentIndex;
+
+  /// The play order before shuffle was applied, or null when not shuffled.
+  /// Carried so [unshuffled] can restore the original order; never read by the
+  /// normal playback getters, which always work off the effective [tracks].
+  final List<Track>? originalOrder;
+
+  /// Whether the queue is currently in shuffled order.
+  bool get isShuffled => originalOrder != null;
 
   /// The track playing now, or null when the queue is empty.
   Track? get current {
@@ -59,29 +78,88 @@ class PlaybackQueue {
   /// next track, so callers can branch on [hasNext] before playing.
   PlaybackQueue next() {
     if (!hasNext) return this;
-    return PlaybackQueue(tracks: tracks, currentIndex: currentIndex + 1);
+    return PlaybackQueue(
+      tracks: tracks,
+      currentIndex: currentIndex + 1,
+      originalOrder: originalOrder,
+    );
   }
 
   /// Steps back to the previous track. Returns this queue unchanged when the
   /// current track is the first, so callers can branch on [hasPrevious].
   PlaybackQueue previous() {
     if (!hasPrevious) return this;
-    return PlaybackQueue(tracks: tracks, currentIndex: currentIndex - 1);
+    return PlaybackQueue(
+      tracks: tracks,
+      currentIndex: currentIndex - 1,
+      originalOrder: originalOrder,
+    );
+  }
+
+  /// Wraps back to the first track in the effective order, keeping the queue
+  /// (and its shuffle) intact. Used by repeat-all when the last track finishes.
+  PlaybackQueue restarted() {
+    if (isEmpty) return this;
+    return PlaybackQueue(
+      tracks: tracks,
+      currentIndex: 0,
+      originalOrder: originalOrder,
+    );
   }
 
   /// Inserts [track] immediately after the current one ("play next"). With an
-  /// empty queue it becomes the current track.
+  /// empty queue it becomes the current track. When shuffled, the track is also
+  /// appended to [originalOrder] so it survives a later unshuffle.
   PlaybackQueue enqueueNext(Track track) {
     if (current == null) return PlaybackQueue.single(track);
     final updated = List<Track>.of(tracks)..insert(currentIndex + 1, track);
-    return PlaybackQueue(tracks: updated, currentIndex: currentIndex);
+    final updatedOriginal = originalOrder == null
+        ? null
+        : (List<Track>.of(originalOrder!)..add(track));
+    return PlaybackQueue(
+      tracks: updated,
+      currentIndex: currentIndex,
+      originalOrder: updatedOriginal,
+    );
   }
 
-  /// Drops every upcoming track, keeping only the one playing now.
+  /// Drops every upcoming track, keeping only the one playing now. The result
+  /// is a plain single-track queue (no shuffle to restore).
   PlaybackQueue cleared() {
     final track = current;
     if (track == null) return empty;
     return PlaybackQueue.single(track);
+  }
+
+  /// Returns a shuffled copy: the current track stays current (moved to the
+  /// front so playback continues uninterrupted) and every other track is
+  /// randomised after it. The pre-shuffle order is remembered in
+  /// [originalOrder]. A no-op on an empty queue, and re-shuffling keeps the
+  /// first remembered order so [unshuffled] still restores the true original.
+  PlaybackQueue shuffled([Random? random]) {
+    final track = current;
+    if (track == null) return this;
+    final original = originalOrder ?? List<Track>.of(tracks);
+    final rest = List<Track>.of(tracks)..removeAt(currentIndex);
+    rest.shuffle(random);
+    return PlaybackQueue(
+      tracks: <Track>[track, ...rest],
+      currentIndex: 0,
+      originalOrder: original,
+    );
+  }
+
+  /// Restores the pre-shuffle order, keeping the current track current. A no-op
+  /// when the queue was not shuffled.
+  PlaybackQueue unshuffled() {
+    final original = originalOrder;
+    if (original == null) return this;
+    final track = current;
+    final index = track == null ? -1 : original.indexOf(track);
+    return PlaybackQueue(
+      tracks: List<Track>.of(original),
+      currentIndex: index < 0 ? (original.isEmpty ? -1 : 0) : index,
+    );
   }
 
   @override
@@ -89,8 +167,13 @@ class PlaybackQueue {
       identical(this, other) ||
       (other is PlaybackQueue &&
           other.currentIndex == currentIndex &&
-          listEquals(other.tracks, tracks));
+          listEquals(other.tracks, tracks) &&
+          listEquals(other.originalOrder, originalOrder));
 
   @override
-  int get hashCode => Object.hash(currentIndex, Object.hashAll(tracks));
+  int get hashCode => Object.hash(
+        currentIndex,
+        Object.hashAll(tracks),
+        originalOrder == null ? null : Object.hashAll(originalOrder!),
+      );
 }

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'playback_source.dart';
+import 'repeat_mode.dart';
 import 'track.dart';
 
 /// High-level playback status, deliberately decoupled from any audio package.
@@ -18,6 +19,8 @@ class PlaybackState {
     this.position = Duration.zero,
     this.duration = Duration.zero,
     this.source,
+    this.shuffleEnabled = false,
+    this.repeatMode = RepeatMode.off,
     this.errorMessage,
   });
 
@@ -44,6 +47,16 @@ class PlaybackState {
   final Duration position;
   final Duration duration;
 
+  /// Whether shuffle is on. A playback *mode* owned by the controller, so it
+  /// persists across track changes and is re-applied to any new queue — not a
+  /// property of a single track. The UI renders the shuffle button from this.
+  final bool shuffleEnabled;
+
+  /// The active repeat behaviour (off / repeat all / repeat one). Like
+  /// [shuffleEnabled] this is a controller-owned mode the UI renders the repeat
+  /// button from; the controller consults it when a track finishes.
+  final RepeatMode repeatMode;
+
   /// A friendly, secret-free explanation shown when [status] is
   /// [PlaybackStatus.error]. Deliberately *not* carried by [copyWith]: it is set
   /// only on a freshly built error state and clears on the next state change, so
@@ -62,6 +75,8 @@ class PlaybackState {
     Duration? position,
     Duration? duration,
     PlaybackSource? source,
+    bool? shuffleEnabled,
+    RepeatMode? repeatMode,
   }) {
     return PlaybackState(
       status: status ?? this.status,
@@ -71,6 +86,8 @@ class PlaybackState {
       position: position ?? this.position,
       duration: duration ?? this.duration,
       source: source ?? this.source,
+      shuffleEnabled: shuffleEnabled ?? this.shuffleEnabled,
+      repeatMode: repeatMode ?? this.repeatMode,
     );
   }
 
@@ -85,6 +102,8 @@ class PlaybackState {
           other.position == position &&
           other.duration == duration &&
           other.source == source &&
+          other.shuffleEnabled == shuffleEnabled &&
+          other.repeatMode == repeatMode &&
           other.errorMessage == errorMessage);
 
   @override
@@ -97,6 +116,8 @@ class PlaybackState {
       position,
       duration,
       source,
+      shuffleEnabled,
+      repeatMode,
       errorMessage,
     );
   }

--- a/lib/core/models/repeat_mode.dart
+++ b/lib/core/models/repeat_mode.dart
@@ -1,0 +1,28 @@
+/// How playback behaves when the current track (or the whole queue) finishes.
+///
+/// Kept in the model layer, decoupled from any audio package, so both the
+/// [PlaybackController] and the UI share one definition. The cycling order the
+/// repeat button steps through also lives here ([next]) rather than in a widget,
+/// keeping playback policy out of presentation code.
+enum RepeatMode {
+  /// Play to the end of the queue and stop.
+  off,
+
+  /// At the end of the queue, wrap back to the first track.
+  all,
+
+  /// Replay the current track indefinitely.
+  one;
+
+  /// The mode the repeat button advances to: off → all → one → off.
+  RepeatMode get next {
+    switch (this) {
+      case RepeatMode.off:
+        return RepeatMode.all;
+      case RepeatMode.all:
+        return RepeatMode.one;
+      case RepeatMode.one:
+        return RepeatMode.off;
+    }
+  }
+}

--- a/lib/core/services/cast/cast_service.dart
+++ b/lib/core/services/cast/cast_service.dart
@@ -1,0 +1,37 @@
+import '../../models/cast_state.dart';
+
+/// The only cast contract the UI knows about, mirroring how [PlaybackController]
+/// hides the audio engine. The now-playing screen renders a cast affordance from
+/// a [CastState] and drives discovery/connection through this interface, never
+/// touching a cast SDK directly.
+///
+/// This is the seam a real backend (Google Cast / Chromecast, AirPlay, a remote
+/// Jellyfin "play on device", …) implements later. The shipped default,
+/// [UnavailableCastService], reports [CastAvailability.unavailable] and no-ops
+/// every command, so the UI shows an honest "not yet" state instead of faking a
+/// device. Swapping in a live backend wires casting end to end without changing
+/// the player UI.
+abstract interface class CastService {
+  /// Emits a new [CastState] whenever availability, the discovered devices, or
+  /// the connected device changes.
+  Stream<CastState> get stateStream;
+
+  /// The latest known state, for synchronous reads on first build.
+  CastState get state;
+
+  /// Begins scanning for nearby cast targets. A no-op when casting is
+  /// unavailable.
+  Future<void> startDiscovery();
+
+  /// Stops scanning (e.g. when the device picker closes).
+  Future<void> stopDiscovery();
+
+  /// Establishes a session with [device] and hands playback off to it.
+  Future<void> connect(CastDevice device);
+
+  /// Tears down the current session and returns playback to this device.
+  Future<void> disconnect();
+
+  /// Releases any resources/listeners. Call on app shutdown.
+  Future<void> dispose();
+}

--- a/lib/core/services/cast/unavailable_cast_service.dart
+++ b/lib/core/services/cast/unavailable_cast_service.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import '../../models/cast_state.dart';
+import 'cast_service.dart';
+
+/// The shipped [CastService]: casting is **not implemented** in this build, so
+/// it honestly reports [CastAvailability.unavailable] and no-ops every command.
+///
+/// It exists so the now-playing screen can show a real cast button backed by a
+/// real (if inert) service today, and so swapping in a Chromecast/Cast SDK
+/// implementation later is a one-line provider change with no UI edits. It never
+/// invents devices or pretends to connect.
+class UnavailableCastService implements CastService {
+  final StreamController<CastState> _states =
+      StreamController<CastState>.broadcast();
+
+  @override
+  CastState get state => CastState.unavailable;
+
+  @override
+  Stream<CastState> get stateStream =>
+      Stream<CastState>.value(state).asBroadcastStream();
+
+  @override
+  Future<void> startDiscovery() async {}
+
+  @override
+  Future<void> stopDiscovery() async {}
+
+  @override
+  Future<void> connect(CastDevice device) async {}
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+}

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:just_audio/just_audio.dart';
 
 import '../models/playback_queue.dart';
 import '../models/playback_source.dart';
 import '../models/playback_state.dart';
+import '../models/repeat_mode.dart';
 import '../models/track.dart';
 import 'local_playable_uri_resolver.dart';
 import 'playable_uri_resolver.dart';
@@ -27,13 +29,16 @@ class JustAudioPlaybackController implements PlaybackController {
   JustAudioPlaybackController({
     AudioPlayer? player,
     PlayableUriResolver resolver = const LocalPlayableUriResolver(),
+    Random? random,
   })  : _player = player ?? AudioPlayer(),
-        _resolver = resolver {
+        _resolver = resolver,
+        _random = random ?? Random() {
     _wire();
   }
 
   final AudioPlayer _player;
   final PlayableUriResolver _resolver;
+  final Random _random;
   final StreamController<PlaybackState> _states =
       StreamController<PlaybackState>.broadcast();
   final List<StreamSubscription<void>> _subscriptions =
@@ -41,6 +46,12 @@ class JustAudioPlaybackController implements PlaybackController {
 
   PlaybackState _state = PlaybackState.idle;
   PlaybackQueue _queue = PlaybackQueue.empty;
+
+  // Shuffle and repeat are session-wide playback modes owned here (not by the
+  // engine, which only ever has one source loaded at a time). They persist
+  // across track changes and are mirrored onto every emitted state.
+  bool _shuffleEnabled = false;
+  RepeatMode _repeatMode = RepeatMode.off;
 
   @override
   PlaybackState get state => _state;
@@ -51,9 +62,9 @@ class JustAudioPlaybackController implements PlaybackController {
   void _wire() {
     _subscriptions.add(_player.playerStateStream.listen((playerState) {
       final status = _statusFor(playerState);
-      // When a track finishes, roll into the next one if the queue has more.
-      if (status == PlaybackStatus.completed && _queue.hasNext) {
-        skipToNext();
+      // When a track finishes, what happens next depends on the repeat mode.
+      if (status == PlaybackStatus.completed) {
+        _onCompleted();
         return;
       }
       _emit(_state.copyWith(status: status));
@@ -93,7 +104,11 @@ class JustAudioPlaybackController implements PlaybackController {
 
   @override
   Future<void> playTracks(List<Track> tracks, {int startIndex = 0}) {
-    _queue = PlaybackQueue.of(tracks, startIndex: startIndex);
+    var queue = PlaybackQueue.of(tracks, startIndex: startIndex);
+    // Shuffle is a persistent mode: a queue loaded while it's on starts
+    // shuffled, with the chosen track kept as the one that plays first.
+    if (_shuffleEnabled) queue = queue.shuffled(_random);
+    _queue = queue;
     return _playCurrent();
   }
 
@@ -124,6 +139,58 @@ class JustAudioPlaybackController implements PlaybackController {
     _emit(_state.copyWith(upNext: _queue.upNext, hasPrevious: false));
   }
 
+  @override
+  void setShuffleEnabled(bool enabled) {
+    if (enabled == _shuffleEnabled) return;
+    _shuffleEnabled = enabled;
+    // Reorder in place: the current track keeps playing; only the up-next list
+    // (and whether a previous track now exists) changes — no reload.
+    _queue = enabled ? _queue.shuffled(_random) : _queue.unshuffled();
+    _emit(_state.copyWith(
+      upNext: _queue.upNext,
+      hasPrevious: _queue.hasPrevious,
+      shuffleEnabled: _shuffleEnabled,
+    ));
+  }
+
+  @override
+  void setRepeatMode(RepeatMode mode) {
+    if (mode == _repeatMode) return;
+    _repeatMode = mode;
+    _emit(_state.copyWith(repeatMode: _repeatMode));
+  }
+
+  /// Decides what to play when the current track finishes, per [_repeatMode]:
+  /// repeat-one replays the same track, repeat-all advances (wrapping past the
+  /// end), and off advances until the queue runs out and then settles on
+  /// [PlaybackStatus.completed].
+  void _onCompleted() {
+    switch (_repeatMode) {
+      case RepeatMode.one:
+        unawaited(_replayCurrent());
+      case RepeatMode.all:
+        if (_queue.hasNext) {
+          skipToNext();
+        } else {
+          _queue = _queue.restarted();
+          unawaited(_playCurrent());
+        }
+      case RepeatMode.off:
+        if (_queue.hasNext) {
+          skipToNext();
+        } else {
+          _emit(_state.copyWith(status: PlaybackStatus.completed));
+        }
+    }
+  }
+
+  /// Replays the current track from the start without re-resolving its URI, so
+  /// repeat-one never re-mints a stream URL or re-hits the cache each loop.
+  Future<void> _replayCurrent() async {
+    await _player.seek(Duration.zero);
+    unawaited(_player.play());
+  }
+
   /// Loads and plays the queue's current track, surfacing its up-next list.
   ///
   /// Resolution (local path / content URI / remote stream) happens through the
@@ -140,6 +207,8 @@ class JustAudioPlaybackController implements PlaybackController {
       currentTrack: track,
       upNext: _queue.upNext,
       hasPrevious: _queue.hasPrevious,
+      shuffleEnabled: _shuffleEnabled,
+      repeatMode: _repeatMode,
     );
     _emit(loading);
 
@@ -193,6 +262,8 @@ class JustAudioPlaybackController implements PlaybackController {
       currentTrack: track,
       upNext: _queue.upNext,
       hasPrevious: _queue.hasPrevious,
+      shuffleEnabled: _shuffleEnabled,
+      repeatMode: _repeatMode,
       errorMessage: message,
     ));
   }
@@ -213,6 +284,8 @@ class JustAudioPlaybackController implements PlaybackController {
       currentTrack: _state.currentTrack,
       upNext: _queue.upNext,
       hasPrevious: _queue.hasPrevious,
+      shuffleEnabled: _shuffleEnabled,
+      repeatMode: _repeatMode,
     );
     _emit(stopped);
   }

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:audio_service/audio_service.dart' as audio;
 
 import '../models/playback_state.dart';
+import '../models/repeat_mode.dart';
 import '../models/track.dart';
 import '../repositories/music_library_repository.dart';
 import 'media_browser_tree.dart';
@@ -53,6 +54,17 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   @override
   Future<void> seek(Duration position) => _controller.seek(position);
+
+  @override
+  Future<void> setShuffleMode(audio.AudioServiceShuffleMode shuffleMode) async {
+    _controller
+        .setShuffleEnabled(shuffleMode != audio.AudioServiceShuffleMode.none);
+  }
+
+  @override
+  Future<void> setRepeatMode(audio.AudioServiceRepeatMode repeatMode) async {
+    _controller.setRepeatMode(_repeatModeFrom(repeatMode));
+  }
 
   // --- Android Auto / media browser ---------------------------------------
 
@@ -126,11 +138,40 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         audio.MediaAction.seek,
         audio.MediaAction.skipToNext,
         audio.MediaAction.skipToPrevious,
+        audio.MediaAction.setShuffleMode,
+        audio.MediaAction.setRepeatMode,
       },
       processingState: _processingStateFor(state.status),
       playing: state.isPlaying,
       updatePosition: state.position,
+      shuffleMode: state.shuffleEnabled
+          ? audio.AudioServiceShuffleMode.all
+          : audio.AudioServiceShuffleMode.none,
+      repeatMode: _repeatModeTo(state.repeatMode),
     );
+  }
+
+  static RepeatMode _repeatModeFrom(audio.AudioServiceRepeatMode mode) {
+    switch (mode) {
+      case audio.AudioServiceRepeatMode.none:
+        return RepeatMode.off;
+      case audio.AudioServiceRepeatMode.one:
+        return RepeatMode.one;
+      case audio.AudioServiceRepeatMode.all:
+      case audio.AudioServiceRepeatMode.group:
+        return RepeatMode.all;
+    }
+  }
+
+  static audio.AudioServiceRepeatMode _repeatModeTo(RepeatMode mode) {
+    switch (mode) {
+      case RepeatMode.off:
+        return audio.AudioServiceRepeatMode.none;
+      case RepeatMode.all:
+        return audio.AudioServiceRepeatMode.all;
+      case RepeatMode.one:
+        return audio.AudioServiceRepeatMode.one;
+    }
   }
 
   List<audio.MediaControl> _controlsFor(PlaybackState state) {

--- a/lib/core/services/playback_controller.dart
+++ b/lib/core/services/playback_controller.dart
@@ -1,4 +1,5 @@
 import '../models/playback_state.dart';
+import '../models/repeat_mode.dart';
 import '../models/track.dart';
 
 /// The only playback contract the UI knows about.
@@ -37,6 +38,16 @@ abstract interface class PlaybackController {
 
   /// Empties the up-next queue, leaving the current track playing.
   void clearQueue();
+
+  /// Turns shuffle on or off. Shuffle is a playback mode, not a one-shot: it
+  /// reorders the current queue (keeping the current track playing) and stays in
+  /// effect for any queue loaded afterwards. The new state is reflected in
+  /// [PlaybackState.shuffleEnabled].
+  void setShuffleEnabled(bool enabled);
+
+  /// Sets the repeat behaviour (off / repeat all / repeat one). Consulted when a
+  /// track finishes; the new mode is reflected in [PlaybackState.repeatMode].
+  void setRepeatMode(RepeatMode mode);
 
   Future<void> play();
   Future<void> pause();

--- a/lib/features/player/cast/cast_button.dart
+++ b/lib/features/player/cast/cast_button.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'cast_devices_sheet.dart';
+import 'cast_providers.dart';
+
+/// The now-playing cast affordance. Renders from [castStateProvider] and opens
+/// the [CastDevicesSheet]; it never talks to a cast SDK directly.
+///
+/// Honest by design: with the shipped [UnavailableCastService] the button is
+/// visible but muted, signalling casting is a foundation rather than live. When
+/// connected it switches to the filled cast-connected glyph. Tapping always
+/// opens the sheet, which states the real status for the current backend.
+class CastButton extends ConsumerWidget {
+  const CastButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final service = ref.watch(castServiceProvider);
+    final state = ref.watch(castStateProvider).valueOrNull ?? service.state;
+
+    final Color color;
+    if (state.isConnected) {
+      color = theme.colorScheme.primary;
+    } else if (state.isAvailable) {
+      color = theme.colorScheme.onSurface.withValues(alpha: 0.85);
+    } else {
+      // Unavailable: present but visibly inactive, so it never implies casting
+      // works today.
+      color = theme.colorScheme.onSurface.withValues(alpha: 0.38);
+    }
+
+    return IconButton(
+      onPressed: () => _openSheet(context),
+      icon: Icon(state.isConnected ? Icons.cast_connected : Icons.cast),
+      color: color,
+      isSelected: state.isConnected,
+      tooltip: state.isAvailable ? 'Cast' : 'Cast (coming soon)',
+    );
+  }
+
+  void _openSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (_) => const CastDevicesSheet(),
+    );
+  }
+}

--- a/lib/features/player/cast/cast_devices_sheet.dart
+++ b/lib/features/player/cast/cast_devices_sheet.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/cast_state.dart';
+import '../../../core/services/cast/cast_service.dart';
+import '../../../shared/widgets/empty_state.dart';
+import 'cast_providers.dart';
+
+/// The cast target picker, opened from the now-playing [CastButton].
+///
+/// It renders honestly from [castStateProvider]: when casting is unavailable
+/// (the shipped default — no cast backend wired yet) it shows a calm
+/// foundation/"coming soon" state rather than an empty or fake device list.
+/// When a real backend lands, the same sheet lists discovered devices and lets
+/// the user connect/disconnect — no UI changes needed. Discovery is started
+/// while the sheet is open and stopped when it closes.
+class CastDevicesSheet extends ConsumerStatefulWidget {
+  const CastDevicesSheet({super.key});
+
+  @override
+  ConsumerState<CastDevicesSheet> createState() => _CastDevicesSheetState();
+}
+
+class _CastDevicesSheetState extends ConsumerState<CastDevicesSheet> {
+  // Captured in initState because `ref` can't be used from dispose().
+  late final CastService _service;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = ref.read(castServiceProvider);
+    // Only meaningful once a real backend exists; the default service no-ops.
+    if (_service.state.isAvailable) {
+      // Defer so we don't kick off async work during the first build.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _service.startDiscovery();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _service.stopDiscovery();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final service = ref.watch(castServiceProvider);
+    final state = ref.watch(castStateProvider).valueOrNull ?? service.state;
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.6,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                0,
+                AppSpacing.lg,
+                AppSpacing.sm,
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.cast, color: theme.colorScheme.primary),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text('Cast', style: theme.textTheme.titleMedium),
+                ],
+              ),
+            ),
+            Flexible(child: _Body(state: state)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Body extends ConsumerWidget {
+  const _Body({required this.state});
+
+  final CastState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!state.isAvailable) {
+      return const Padding(
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.sm,
+          AppSpacing.lg,
+          AppSpacing.xl,
+        ),
+        child: EmptyState(
+          icon: Icons.cast,
+          title: 'Casting isn\'t available yet',
+          message: 'Streaming to Chromecast and other cast devices is on the '
+              'roadmap. The control is here; the device handoff lands in a '
+              'future update.',
+        ),
+      );
+    }
+
+    final service = ref.read(castServiceProvider);
+    final devices = state.devices;
+    if (devices.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.sm,
+          AppSpacing.lg,
+          AppSpacing.xl,
+        ),
+        child: EmptyState(
+          icon: Icons.cast,
+          title: state.isDiscovering
+              ? 'Searching for devices…'
+              : 'No devices found',
+          message: state.isDiscovering
+              ? 'Looking for cast devices on your network.'
+              : 'Make sure a cast device is on the same network.',
+        ),
+      );
+    }
+
+    return ListView(
+      shrinkWrap: true,
+      children: [
+        for (final device in devices)
+          ListTile(
+            leading: Icon(
+              state.connectedDevice == device
+                  ? Icons.cast_connected
+                  : Icons.cast,
+            ),
+            title: Text(device.name),
+            trailing: state.connectedDevice == device
+                ? TextButton(
+                    onPressed: service.disconnect,
+                    child: const Text('Disconnect'),
+                  )
+                : null,
+            onTap: state.connectedDevice == device
+                ? null
+                : () => service.connect(device),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/player/cast/cast_providers.dart
+++ b/lib/features/player/cast/cast_providers.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/cast_state.dart';
+import '../../../core/services/cast/cast_service.dart';
+import '../../../core/services/cast/unavailable_cast_service.dart';
+
+/// The single [CastService] the app drives casting through.
+///
+/// Defaults to [UnavailableCastService] — casting is a UI + architecture
+/// foundation in this build, not a live backend. A real Chromecast/Cast SDK
+/// implementation slots in by overriding only this provider; the cast button
+/// and device sheet are unchanged. Disposed with the provider scope so any
+/// future backend releases its resources on shutdown.
+final castServiceProvider = Provider<CastService>((ref) {
+  final service = UnavailableCastService();
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// Streams [CastState] for the UI. Until the first event arrives, callers fall
+/// back to the service's synchronous [CastService.state].
+final castStateProvider = StreamProvider<CastState>((ref) {
+  return ref.watch(castServiceProvider).stateStream;
+});

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -5,6 +5,7 @@ import '../../app/dimens.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
+import 'cast/cast_button.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
 import 'widgets/now_playing_actions.dart';
@@ -52,8 +53,8 @@ class PlayerScreen extends ConsumerWidget {
   }
 }
 
-/// Top bar: a collapse affordance and a calm "Now Playing" caption. Transparent
-/// so the blurred artwork shows through.
+/// Top bar: a collapse affordance, a calm "Now Playing" caption, and the cast
+/// button. Transparent so the blurred artwork shows through.
 class _Header extends StatelessWidget {
   const _Header();
 
@@ -79,8 +80,9 @@ class _Header extends StatelessWidget {
               ),
             ),
           ),
-          // Balances the leading button so the title stays centered.
-          const SizedBox(width: 48),
+          // Trailing cast control; ~48dp wide, balancing the leading button so
+          // the title stays centered.
+          const CastButton(),
         ],
       ),
     );

--- a/lib/features/player/widgets/playback_controls.dart
+++ b/lib/features/player/widgets/playback_controls.dart
@@ -3,13 +3,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/models/playback_state.dart';
+import '../../../core/models/repeat_mode.dart';
 import '../../../core/services/playback_controller.dart';
 import '../player_providers.dart';
 
 /// The transport row: shuffle · previous · play/pause · next · repeat.
 ///
-/// Shuffle and repeat are deliberately disabled placeholders — they hold their
-/// place in the layout for when those modes land, but never pretend to work.
+/// Shuffle and repeat are live, controller-driven modes (read from
+/// [PlaybackState], toggled/cycled through the [PlaybackController]); the active
+/// state is shown with the accent colour and the button's selected styling.
 /// Previous/next reflect the live queue (disabled at the ends) and delegate to
 /// the existing queue controls; play/pause forwards straight to the controller
 /// and shows a spinner while a track loads.
@@ -25,12 +27,7 @@ class PlaybackControls extends ConsumerWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        // Disabled placeholder until shuffle lands; holds its place in the row.
-        const IconButton(
-          onPressed: null,
-          icon: Icon(Icons.shuffle),
-          tooltip: 'Shuffle',
-        ),
+        _ShuffleButton(state: state, controller: controller),
         IconButton(
           iconSize: 36,
           onPressed: state.hasPrevious ? controller.skipToPrevious : null,
@@ -44,14 +41,67 @@ class PlaybackControls extends ConsumerWidget {
           icon: const Icon(Icons.skip_next),
           tooltip: 'Next',
         ),
-        // Disabled placeholder until repeat lands.
-        const IconButton(
-          onPressed: null,
-          icon: Icon(Icons.repeat),
-          tooltip: 'Repeat',
-        ),
+        _RepeatButton(state: state, controller: controller),
       ],
     );
+  }
+}
+
+/// Toggles shuffle. Tinted with the accent colour and shown selected while on,
+/// so the active state reads at a glance.
+class _ShuffleButton extends StatelessWidget {
+  const _ShuffleButton({required this.state, required this.controller});
+
+  final PlaybackState state;
+  final PlaybackController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final enabled = state.shuffleEnabled;
+    return IconButton(
+      onPressed: () => controller.setShuffleEnabled(!enabled),
+      icon: const Icon(Icons.shuffle),
+      isSelected: enabled,
+      color: enabled ? theme.colorScheme.primary : null,
+      tooltip: enabled ? 'Shuffle on' : 'Shuffle',
+    );
+  }
+}
+
+/// Cycles repeat off → all → one → off. The glyph switches to repeat-one in
+/// that mode, and the button is tinted/selected whenever repeat is active.
+class _RepeatButton extends StatelessWidget {
+  const _RepeatButton({required this.state, required this.controller});
+
+  final PlaybackState state;
+  final PlaybackController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mode = state.repeatMode;
+    final active = mode != RepeatMode.off;
+    return IconButton(
+      onPressed: () => controller.setRepeatMode(mode.next),
+      icon: Icon(
+        mode == RepeatMode.one ? Icons.repeat_one : Icons.repeat,
+      ),
+      isSelected: active,
+      color: active ? theme.colorScheme.primary : null,
+      tooltip: _tooltipFor(mode),
+    );
+  }
+
+  static String _tooltipFor(RepeatMode mode) {
+    switch (mode) {
+      case RepeatMode.off:
+        return 'Repeat';
+      case RepeatMode.all:
+        return 'Repeat all';
+      case RepeatMode.one:
+        return 'Repeat one';
+    }
   }
 }
 

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_queue.dart';
 import 'package:linthra/core/models/track.dart';
@@ -109,6 +111,107 @@ void main() {
       expect(a, b);
       expect(a.hashCode, b.hashCode);
       expect(a, isNot(b.next()));
+    });
+
+    test('restarted() wraps back to the first track keeping the queue', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+        startIndex: 2,
+      );
+
+      final restarted = queue.restarted();
+
+      expect(restarted.current, _track('a'));
+      expect(restarted.upNext, [_track('b'), _track('c')]);
+      expect(restarted.hasPrevious, isFalse);
+    });
+
+    test('restarted() on an empty queue stays empty', () {
+      expect(PlaybackQueue.empty.restarted(), PlaybackQueue.empty);
+    });
+  });
+
+  group('PlaybackQueue shuffle', () {
+    test('shuffled() keeps the current track current and shuffles the rest',
+        () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c'), _track('d')],
+        startIndex: 1,
+      );
+
+      // A fixed seed keeps this deterministic across runs.
+      final shuffled = queue.shuffled(Random(7));
+
+      // The track that was playing keeps playing and moves to the front.
+      expect(shuffled.current, _track('b'));
+      expect(shuffled.currentIndex, 0);
+      expect(shuffled.isShuffled, isTrue);
+      expect(shuffled.hasPrevious, isFalse);
+      // Every track is preserved, just reordered.
+      expect(
+        shuffled.tracks.toSet(),
+        {_track('a'), _track('b'), _track('c'), _track('d')},
+      );
+      expect(shuffled.tracks.length, 4);
+    });
+
+    test('shuffled() on an empty queue is a no-op', () {
+      expect(PlaybackQueue.empty.shuffled(Random(1)), PlaybackQueue.empty);
+      expect(PlaybackQueue.empty.isShuffled, isFalse);
+    });
+
+    test('unshuffled() restores the original order, keeping the current track',
+        () {
+      final original = [_track('a'), _track('b'), _track('c'), _track('d')];
+      final queue = PlaybackQueue.of(original, startIndex: 2);
+
+      final restored = queue.shuffled(Random(3)).unshuffled();
+
+      expect(restored.isShuffled, isFalse);
+      expect(restored.tracks, original);
+      // 'c' was current before shuffling and is still current after restoring.
+      expect(restored.current, _track('c'));
+      expect(restored.currentIndex, 2);
+    });
+
+    test('unshuffled() on a non-shuffled queue returns the same queue', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')]);
+
+      expect(queue.unshuffled(), same(queue));
+    });
+
+    test('next()/previous() preserve the shuffled order', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+      ).shuffled(Random(5));
+
+      final advanced = queue.next();
+      expect(advanced.isShuffled, isTrue);
+      expect(advanced.tracks, queue.tracks);
+
+      final back = advanced.previous();
+      expect(back.isShuffled, isTrue);
+      expect(back.current, queue.current);
+    });
+
+    test('enqueueNext() while shuffled survives a later unshuffle', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')])
+          .shuffled(Random(2))
+          .enqueueNext(_track('z'));
+
+      final restored = queue.unshuffled();
+
+      // The queued track is still present once the original order is restored.
+      expect(restored.tracks, contains(_track('z')));
+    });
+
+    test('equality distinguishes a shuffled queue from a plain one', () {
+      final plain = PlaybackQueue.of([_track('a'), _track('b')]);
+      final shuffled = plain.shuffled(Random(1));
+
+      // A single-front-track + remembered original order is not the plain queue.
+      expect(shuffled, isNot(plain));
+      expect(shuffled.isShuffled, isTrue);
     });
   });
 }

--- a/test/core/models/repeat_mode_test.dart
+++ b/test/core/models/repeat_mode_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+
+void main() {
+  group('RepeatMode', () {
+    test('next cycles off -> all -> one -> off', () {
+      expect(RepeatMode.off.next, RepeatMode.all);
+      expect(RepeatMode.all.next, RepeatMode.one);
+      expect(RepeatMode.one.next, RepeatMode.off);
+    });
+
+    test('cycling three times returns to the start', () {
+      var mode = RepeatMode.off;
+      mode = mode.next;
+      mode = mode.next;
+      mode = mode.next;
+      expect(mode, RepeatMode.off);
+    });
+
+    test('supports off, all, and one', () {
+      expect(
+          RepeatMode.values,
+          containsAll(<RepeatMode>[
+            RepeatMode.off,
+            RepeatMode.all,
+            RepeatMode.one,
+          ]));
+    });
+  });
+}

--- a/test/core/services/cast/unavailable_cast_service_test.dart
+++ b/test/core/services/cast/unavailable_cast_service_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/services/cast/unavailable_cast_service.dart';
+
+void main() {
+  group('UnavailableCastService', () {
+    test('reports the unavailable state', () {
+      final service = UnavailableCastService();
+      addTearDown(service.dispose);
+
+      expect(service.state, CastState.unavailable);
+      expect(service.state.isAvailable, isFalse);
+      expect(service.state.isConnected, isFalse);
+      expect(service.state.devices, isEmpty);
+    });
+
+    test('the stream emits the unavailable state', () async {
+      final service = UnavailableCastService();
+      addTearDown(service.dispose);
+
+      await expectLater(service.stateStream, emits(CastState.unavailable));
+    });
+
+    test('every command is a safe no-op (never fakes a connection)', () async {
+      final service = UnavailableCastService();
+      addTearDown(service.dispose);
+
+      await service.startDiscovery();
+      await service.connect(const CastDevice(id: 'x', name: 'Nope'));
+      await service.disconnect();
+      await service.stopDiscovery();
+
+      // Nothing changed: still unavailable, still nothing connected.
+      expect(service.state, CastState.unavailable);
+      expect(service.state.connectedDevice, isNull);
+    });
+  });
+}

--- a/test/core/services/just_audio_playback_controller_test.dart
+++ b/test/core/services/just_audio_playback_controller_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+
+/// Exercises the real `just_audio`-backed controller's shuffle/repeat *state
+/// plumbing* without driving playback. Like the lifecycle test, this constructs
+/// the real controller; on a non-mobile test host the engine is built but no
+/// platform channel is touched, because shuffle/repeat are pure state mutations
+/// that never call into the player.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('JustAudioPlaybackController shuffle/repeat state', () {
+    test('defaults: shuffle off, repeat off', () {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      expect(controller.state.shuffleEnabled, isFalse);
+      expect(controller.state.repeatMode, RepeatMode.off);
+    });
+
+    test('setShuffleEnabled toggles and emits the new state', () async {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      final emitted = <bool>[];
+      final sub =
+          controller.stateStream.listen((s) => emitted.add(s.shuffleEnabled));
+
+      controller.setShuffleEnabled(true);
+      expect(controller.state.shuffleEnabled, isTrue);
+
+      controller.setShuffleEnabled(false);
+      expect(controller.state.shuffleEnabled, isFalse);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(emitted, containsAllInOrder(<bool>[true, false]));
+      await sub.cancel();
+    });
+
+    test('a redundant setShuffleEnabled does not emit', () async {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      var emissions = 0;
+      final sub = controller.stateStream.listen((_) => emissions++);
+
+      controller.setShuffleEnabled(false); // already false: no-op
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emissions, 0);
+      await sub.cancel();
+    });
+
+    test('setRepeatMode updates and emits the mode', () async {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      final emitted = <RepeatMode>[];
+      final sub =
+          controller.stateStream.listen((s) => emitted.add(s.repeatMode));
+
+      controller.setRepeatMode(RepeatMode.all);
+      expect(controller.state.repeatMode, RepeatMode.all);
+
+      controller.setRepeatMode(RepeatMode.one);
+      expect(controller.state.repeatMode, RepeatMode.one);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        emitted,
+        containsAllInOrder(<RepeatMode>[RepeatMode.all, RepeatMode.one]),
+      );
+      await sub.cancel();
+    });
+  });
+}

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -1,6 +1,7 @@
 import 'package:audio_service/audio_service.dart' as audio;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/linthra_audio_handler.dart';
 import 'package:linthra/core/services/media_browser_tree.dart';
@@ -179,6 +180,45 @@ void main() {
         await _settle();
 
         expect(controller.playedTracks, isEmpty);
+      });
+    });
+
+    group('shuffle & repeat', () {
+      test('forwards setShuffleMode to the controller', () async {
+        await handler.setShuffleMode(audio.AudioServiceShuffleMode.all);
+        expect(controller.state.shuffleEnabled, isTrue);
+
+        await handler.setShuffleMode(audio.AudioServiceShuffleMode.none);
+        expect(controller.state.shuffleEnabled, isFalse);
+      });
+
+      test('forwards setRepeatMode to the controller', () async {
+        await handler.setRepeatMode(audio.AudioServiceRepeatMode.all);
+        expect(controller.state.repeatMode, RepeatMode.all);
+
+        await handler.setRepeatMode(audio.AudioServiceRepeatMode.one);
+        expect(controller.state.repeatMode, RepeatMode.one);
+
+        await handler.setRepeatMode(audio.AudioServiceRepeatMode.none);
+        expect(controller.state.repeatMode, RepeatMode.off);
+      });
+
+      test('mirrors the controller shuffle/repeat into the session', () async {
+        await controller.playTracks([_track('a'), _track('b')]);
+        controller.setShuffleEnabled(true);
+        controller.setRepeatMode(RepeatMode.one);
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.shuffleMode, audio.AudioServiceShuffleMode.all);
+        expect(state.repeatMode, audio.AudioServiceRepeatMode.one);
+        expect(
+          state.systemActions,
+          containsAll(<audio.MediaAction>{
+            audio.MediaAction.setShuffleMode,
+            audio.MediaAction.setRepeatMode,
+          }),
+        );
       });
     });
   });

--- a/test/features/player/cast/cast_button_test.dart
+++ b/test/features/player/cast/cast_button_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/features/player/cast/cast_button.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+
+import 'fake_cast_service.dart';
+
+Future<void> _pump(WidgetTester tester, FakeCastService service) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [castServiceProvider.overrideWithValue(service)],
+      child: const MaterialApp(
+        home: Scaffold(body: Center(child: CastButton())),
+      ),
+    ),
+  );
+}
+
+IconButton _button(WidgetTester tester) =>
+    tester.widget<IconButton>(find.byType(IconButton));
+
+void main() {
+  group('CastButton', () {
+    testWidgets('renders a cast icon', (tester) async {
+      await _pump(tester, FakeCastService());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.cast), findsOneWidget);
+    });
+
+    testWidgets('is shown but marked "coming soon" when unavailable', (
+      tester,
+    ) async {
+      await _pump(tester, FakeCastService());
+      await tester.pumpAndSettle();
+
+      // Honest: the control is present but its tooltip signals it isn't live.
+      expect(find.byTooltip('Cast (coming soon)'), findsOneWidget);
+      expect(_button(tester).isSelected, isFalse);
+    });
+
+    testWidgets('opens the device sheet with an honest unavailable state', (
+      tester,
+    ) async {
+      await _pump(tester, FakeCastService());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(CastButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Casting isn\'t available yet'), findsOneWidget);
+    });
+
+    testWidgets('shows the connected glyph when connected', (tester) async {
+      const device = CastDevice(id: 'd1', name: 'Living Room');
+      await _pump(
+        tester,
+        FakeCastService(
+          initial: const CastState(
+            availability: CastAvailability.connected,
+            devices: <CastDevice>[device],
+            connectedDevice: device,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.cast_connected), findsOneWidget);
+      expect(find.byTooltip('Cast'), findsOneWidget);
+      expect(_button(tester).isSelected, isTrue);
+    });
+
+    testWidgets('lists discovered devices and connects on tap (the seam)', (
+      tester,
+    ) async {
+      const device = CastDevice(id: 'd1', name: 'Living Room');
+      final service = FakeCastService(
+        initial: const CastState(
+          availability: CastAvailability.idle,
+          devices: <CastDevice>[device],
+        ),
+      );
+      await _pump(tester, service);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(CastButton));
+      await tester.pumpAndSettle();
+
+      // The sheet starts discovery while open and lists the device.
+      expect(service.discoveryStarts, 1);
+      expect(find.text('Living Room'), findsOneWidget);
+
+      await tester.tap(find.text('Living Room'));
+      expect(service.connectRequests, <CastDevice>[device]);
+    });
+  });
+}

--- a/test/features/player/cast/fake_cast_service.dart
+++ b/test/features/player/cast/fake_cast_service.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/services/cast/cast_service.dart';
+
+/// In-memory [CastService] for widget tests: starts in a caller-supplied state,
+/// records the commands it receives, and lets a test push new [CastState]s. It
+/// stands in for a future real backend so the cast UI can be exercised across
+/// availability/connected states without any SDK.
+class FakeCastService implements CastService {
+  FakeCastService({CastState initial = CastState.unavailable})
+      : _state = initial;
+
+  final StreamController<CastState> _states =
+      StreamController<CastState>.broadcast();
+  CastState _state;
+
+  int discoveryStarts = 0;
+  int discoveryStops = 0;
+  final List<CastDevice> connectRequests = <CastDevice>[];
+  int disconnects = 0;
+
+  void emit(CastState next) {
+    _state = next;
+    _states.add(next);
+  }
+
+  @override
+  CastState get state => _state;
+
+  @override
+  Stream<CastState> get stateStream => _states.stream;
+
+  @override
+  Future<void> startDiscovery() async => discoveryStarts++;
+
+  @override
+  Future<void> stopDiscovery() async => discoveryStops++;
+
+  @override
+  Future<void> connect(CastDevice device) async => connectRequests.add(device);
+
+  @override
+  Future<void> disconnect() async => disconnects++;
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:linthra/core/models/playback_queue.dart';
 import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/playback_controller.dart';
 
@@ -18,6 +20,11 @@ class FakePlaybackController implements PlaybackController {
       StreamController<PlaybackState>.broadcast();
   PlaybackState _state;
   PlaybackQueue _queue = PlaybackQueue.empty;
+  bool _shuffleEnabled = false;
+  RepeatMode _repeatMode = RepeatMode.off;
+
+  /// Seeded so shuffle is deterministic across test runs.
+  final Random _random = Random(1);
 
   final List<Track> playedTracks = <Track>[];
   int playCount = 0;
@@ -46,7 +53,9 @@ class FakePlaybackController implements PlaybackController {
 
   @override
   Future<void> playTracks(List<Track> tracks, {int startIndex = 0}) async {
-    _queue = PlaybackQueue.of(tracks, startIndex: startIndex);
+    var queue = PlaybackQueue.of(tracks, startIndex: startIndex);
+    if (_shuffleEnabled) queue = queue.shuffled(_random);
+    _queue = queue;
     _playCurrent();
   }
 
@@ -79,6 +88,44 @@ class FakePlaybackController implements PlaybackController {
     emit(_state.copyWith(upNext: _queue.upNext, hasPrevious: false));
   }
 
+  @override
+  void setShuffleEnabled(bool enabled) {
+    if (enabled == _shuffleEnabled) return;
+    _shuffleEnabled = enabled;
+    _queue = enabled ? _queue.shuffled(_random) : _queue.unshuffled();
+    emit(_state.copyWith(
+      upNext: _queue.upNext,
+      hasPrevious: _queue.hasPrevious,
+      shuffleEnabled: _shuffleEnabled,
+    ));
+  }
+
+  @override
+  void setRepeatMode(RepeatMode mode) {
+    if (mode == _repeatMode) return;
+    _repeatMode = mode;
+    emit(_state.copyWith(repeatMode: _repeatMode));
+  }
+
+  /// Test seam mirroring the production controller's completion handling: drives
+  /// what plays when the current track finishes, honouring the repeat mode.
+  void completeCurrent() {
+    switch (_repeatMode) {
+      case RepeatMode.one:
+        _playCurrent();
+      case RepeatMode.all:
+        _queue = _queue.hasNext ? _queue.next() : _queue.restarted();
+        _playCurrent();
+      case RepeatMode.off:
+        if (_queue.hasNext) {
+          _queue = _queue.next();
+          _playCurrent();
+        } else {
+          emit(_state.copyWith(status: PlaybackStatus.completed));
+        }
+    }
+  }
+
   void _playCurrent() {
     final track = _queue.current;
     if (track == null) return;
@@ -88,6 +135,8 @@ class FakePlaybackController implements PlaybackController {
       currentTrack: track,
       upNext: _queue.upNext,
       hasPrevious: _queue.hasPrevious,
+      shuffleEnabled: _shuffleEnabled,
+      repeatMode: _repeatMode,
     );
     emit(playing);
   }

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/playback_controller.dart';
 import 'package:linthra/features/player/player_providers.dart';
@@ -242,6 +243,88 @@ void main() {
 
       expect(find.text('Live Track'), findsOneWidget);
       expect(find.byTooltip('Pause'), findsOneWidget);
+    });
+
+    testWidgets('shuffle button reflects state and toggles it', (tester) async {
+      final controller = _playing();
+      await _pumpScreen(tester, controller);
+
+      // Off by default.
+      expect(
+        tester
+            .widget<IconButton>(find.widgetWithIcon(IconButton, Icons.shuffle))
+            .isSelected,
+        isFalse,
+      );
+
+      await tester.tap(find.byIcon(Icons.shuffle));
+      await tester.pumpAndSettle();
+
+      // The state flipped and the button now reads as selected.
+      expect(controller.state.shuffleEnabled, isTrue);
+      expect(
+        tester
+            .widget<IconButton>(find.widgetWithIcon(IconButton, Icons.shuffle))
+            .isSelected,
+        isTrue,
+      );
+    });
+
+    testWidgets('repeat button cycles off -> all -> one -> off',
+        (tester) async {
+      final controller = _playing();
+      await _pumpScreen(tester, controller);
+
+      // Off: plain repeat glyph, not selected.
+      expect(find.byIcon(Icons.repeat), findsOneWidget);
+      expect(find.byIcon(Icons.repeat_one), findsNothing);
+      expect(
+        tester
+            .widget<IconButton>(find.widgetWithIcon(IconButton, Icons.repeat))
+            .isSelected,
+        isFalse,
+      );
+
+      // -> repeat all: still the repeat glyph, now selected.
+      await tester.tap(find.byIcon(Icons.repeat));
+      await tester.pumpAndSettle();
+      expect(controller.state.repeatMode, RepeatMode.all);
+      expect(
+        tester
+            .widget<IconButton>(find.widgetWithIcon(IconButton, Icons.repeat))
+            .isSelected,
+        isTrue,
+      );
+
+      // -> repeat one: glyph switches to repeat_one.
+      await tester.tap(find.byIcon(Icons.repeat));
+      await tester.pumpAndSettle();
+      expect(controller.state.repeatMode, RepeatMode.one);
+      expect(find.byIcon(Icons.repeat_one), findsOneWidget);
+
+      // -> off: back to the plain glyph.
+      await tester.tap(find.byIcon(Icons.repeat_one));
+      await tester.pumpAndSettle();
+      expect(controller.state.repeatMode, RepeatMode.off);
+      expect(find.byIcon(Icons.repeat), findsOneWidget);
+    });
+
+    testWidgets('renders the cast button in the header', (tester) async {
+      await _pumpScreen(tester, _playing());
+
+      // Default cast backend is unavailable, so the (honest) cast glyph shows.
+      expect(find.byIcon(Icons.cast), findsOneWidget);
+      expect(find.byTooltip('Cast (coming soon)'), findsOneWidget);
+    });
+
+    testWidgets('cast button opens an honest unavailable sheet',
+        (tester) async {
+      await _pumpScreen(tester, _playing());
+
+      await tester.tap(find.byIcon(Icons.cast));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Casting isn\'t available yet'), findsOneWidget);
     });
   });
 }

--- a/test/features/player/shuffle_repeat_test.dart
+++ b/test/features/player/shuffle_repeat_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+
+import 'fake_playback_controller.dart';
+
+Track _track(String id) => Track(id: id, title: 'Song $id', uri: '/$id.mp3');
+
+void main() {
+  group('shuffle through the controller', () {
+    test('toggling shuffle on exposes the state and keeps the current track',
+        () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+      expect(controller.state.shuffleEnabled, isFalse);
+
+      controller.setShuffleEnabled(true);
+
+      expect(controller.state.shuffleEnabled, isTrue);
+      // The track that was playing keeps playing.
+      expect(controller.state.currentTrack, _track('a'));
+      // The same set of upcoming tracks remains, just reordered.
+      expect(
+        {...controller.state.upNext, controller.state.currentTrack},
+        {_track('a'), _track('b'), _track('c')},
+      );
+    });
+
+    test('toggling shuffle off restores order and clears the state', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+
+      controller.setShuffleEnabled(true);
+      controller.setShuffleEnabled(false);
+
+      expect(controller.state.shuffleEnabled, isFalse);
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.state.upNext, [_track('b'), _track('c')]);
+    });
+
+    test('a queue loaded while shuffle is on starts shuffled', () async {
+      final controller = FakePlaybackController();
+      controller.setShuffleEnabled(true);
+
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+
+      expect(controller.state.shuffleEnabled, isTrue);
+      expect(
+        {...controller.state.upNext, controller.state.currentTrack},
+        {_track('a'), _track('b'), _track('c')},
+      );
+    });
+  });
+
+  group('repeat through the controller', () {
+    test('setRepeatMode exposes the mode in state', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a')]);
+      expect(controller.state.repeatMode, RepeatMode.off);
+
+      controller.setRepeatMode(RepeatMode.all);
+      expect(controller.state.repeatMode, RepeatMode.all);
+
+      controller.setRepeatMode(RepeatMode.one);
+      expect(controller.state.repeatMode, RepeatMode.one);
+    });
+
+    test('repeat off stops at the end of the queue', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b')]);
+
+      controller.completeCurrent(); // a -> b
+      expect(controller.state.currentTrack, _track('b'));
+
+      controller.completeCurrent(); // b is last; with repeat off, stop
+      expect(controller.state.currentTrack, _track('b'));
+      expect(controller.state.status.name, 'completed');
+    });
+
+    test('repeat all wraps from the last track back to the first', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b')]);
+      controller.setRepeatMode(RepeatMode.all);
+
+      controller.completeCurrent(); // a -> b
+      expect(controller.state.currentTrack, _track('b'));
+
+      controller.completeCurrent(); // b is last; wrap back to a
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.state.upNext, [_track('b')]);
+    });
+
+    test('repeat one replays the same track when it finishes', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b')]);
+      controller.setRepeatMode(RepeatMode.one);
+
+      controller.completeCurrent();
+      controller.completeCurrent();
+
+      // Still on the first track, having played it three times in total.
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.playedTracks, [_track('a'), _track('a'), _track('a')]);
+    });
+
+    test('next/previous still advance normally regardless of repeat mode',
+        () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+      controller.setRepeatMode(RepeatMode.one);
+
+      await controller.skipToNext();
+      expect(controller.state.currentTrack, _track('b'));
+
+      await controller.skipToPrevious();
+      expect(controller.state.currentTrack, _track('a'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Makes the shuffle and repeat transport controls actually work, and adds an honest Chromecast/cast **foundation** (UI + architecture seam, not a live backend). All playback logic lives in `PlaybackController`/`PlaybackState`; the widgets just render and delegate.

## Shuffle behavior

- Shuffle is a persistent **playback mode** on the controller (`setShuffleEnabled`), exposed as `PlaybackState.shuffleEnabled`.
- Turning it **on** reorders the current queue with the playing track kept at the **front** (music never skips) and remembers the original order. Turning it **off** restores that order with the current track still current.
- The mode persists across track changes, so a queue loaded while shuffle is on starts shuffled.
- Reordering is a pure `PlaybackQueue.shuffled()` / `unshuffled()` transform — unit-tested with no audio engine. The current track is preserved through every toggle.
- The button reflects state with the accent colour + Material `isSelected` styling.

## Repeat behavior

- Repeat cycles **off → repeat all → repeat one → off** (`setRepeatMode`, exposed as `PlaybackState.repeatMode`).
- On track completion the controller consults the mode:
  - **off** — play to the end of the queue and stop.
  - **all** — wrap from the last track back to the first.
  - **one** — replay the current track from the start, **without re-resolving its URL** (a stream isn't re-fetched each loop).
- Next/previous keep working normally in every mode.
- The glyph switches to `repeat_one` for repeat-one and is tinted/selected whenever repeat is active.
- Both shuffle and repeat are **mirrored into the `audio_service` media session** (`shuffleMode`/`repeatMode`), and the session forwards the system's shuffle/repeat actions back to the controller, so modes stay coherent across the in-app screen, the notification, and Android Auto.

## Cast / Chromecast status

**UI placeholder with architecture seam — not live yet, and the app never pretends otherwise.**

- A cast control sits in the Now Playing header. The shipped `UnavailableCastService` reports `CastAvailability.unavailable`, so the button is visible but **muted** ("Cast (coming soon)"), and opening it shows an honest *"Casting isn't available yet"* sheet rather than a fake or empty device list.
- The full seam is in place for a future backend: a `CastService` interface, a `CastState` model (availability / discovered devices / connected device), a provider, and a device-picker sheet that already handles discovery, connect, and disconnect.
- Wiring real Chromecast later (e.g. a Cast SDK package) = implement `CastService` + override one provider, **with no player-UI changes**.
- **No cast SDK dependency is added** in this PR, keeping the build safe and small.

## Limitations

- Casting does no real device discovery or playback handoff yet (foundation only).
- Repeat-one's gapless replay uses seek-to-zero + play rather than a native gapless loop (the app loads one source at a time rather than a `just_audio` playlist).
- Manual queue reordering and saved playlists remain out of scope (unchanged).
- Lock-screen / car artwork still depends on `Track.artworkUri`, which local scanning doesn't populate yet (unchanged).

## Tests added

- `playback_queue_test.dart` — shuffle/unshuffle (current-track preserved, order restored), `restarted()` wrap, shuffle survives next/previous/enqueue, equality.
- `repeat_mode_test.dart` — cycling off → all → one → off.
- `shuffle_repeat_test.dart` — controller shuffle toggles + state; repeat cycling; completion respects each repeat mode (stop / wrap / replay); next/previous coherent.
- `just_audio_playback_controller_test.dart` — real controller shuffle/repeat state plumbing + emission (no engine playback).
- `player_screen_test.dart` — UI reflects shuffle state; repeat glyph cycles; cast button renders; cast sheet shows the honest unavailable state.
- `cast_button_test.dart` + `fake_cast_service.dart` — renders, muted "coming soon" when unavailable, opens honest sheet, connected glyph, and the device-list/connect seam.
- `unavailable_cast_service_test.dart` — reports unavailable, emits it, commands are safe no-ops.
- `linthra_audio_handler_test.dart` — forwards/mirrors shuffle & repeat in the media session.

## Verification

- `flutter pub get` ✅
- `dart format --set-exit-if-changed .` ✅ (clean)
- `flutter analyze` ✅ (no issues)
- `flutter test` ✅ (379 passed; +39 new)

Run locally against Flutter **3.27.4** (matching CI).

## Next recommended PR

Implement a real `CastService` backed by a maintained Flutter Cast SDK: device discovery, session connect/disconnect, and `PlaybackController` ↔ cast playback handoff — slotting in behind the seam this PR establishes, with the existing cast button/sheet unchanged.

## Test plan

- [ ] On a device/emulator: play a multi-track queue, toggle shuffle on/off — current track keeps playing, up-next reorders/restores.
- [ ] Cycle repeat through off/all/one; let tracks finish and confirm stop / wrap / replay; confirm next/previous still behave.
- [ ] Confirm the notification/Android Auto reflect shuffle & repeat.
- [ ] Tap the cast button — confirm the honest "coming soon" sheet (no fake devices).

https://claude.ai/code/session_01BvcvjkqF2tsKt2XpdjFhSD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvcvjkqF2tsKt2XpdjFhSD)_