### PR TITLE
Smart offline cache manager with a user-configurable size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,12 +868,22 @@ user-controlled**:
   **prefers the local cached file**; if it isn't cached and you're offline, the
   player shows a friendly "couldn't reach your server" message rather than
   failing opaquely.
+- **The cache stays under a size limit.** You set a maximum (presets of 1, 2, 4,
+  8, 16 GB or a custom value; **4 GB by default**), so Linthra never fills your
+  phone unexpectedly. When a new download would exceed the limit, it frees space
+  by removing the **least-recently-played, unpinned, not-currently-playing**
+  tracks first. Pin a track ("Keep offline") to protect it. If nothing safe can
+  be freed, the download is refused with a friendly "not enough cache space"
+  message instead of deleting something you wanted.
 
 **How it works now.** Each Library row shows an offline-download control:
 download an absent track, see a spinner while it's in flight, remove a cached
-one, or retry a failed one. The Downloads tab lists everything currently cached
-and hosts the **Wi-Fi only** toggle. All of this flows through
-`DownloadRepository`, which centralizes three guarantees:
+one, or retry a failed one. The **Downloads** tab lists everything currently
+cached — with each track's **size** and a **Keep offline** pin — shows how much
+of the limit is in use, and hosts the **Wi-Fi only** toggle. **Settings →
+Offline cache** shows used / max / free space and the **Change limit** and
+**Clear cache** (clear unpinned, or clear all) actions. The download lifecycle
+flows through `DownloadRepository`, which centralizes three guarantees:
 
 - **User-initiated only.** A track's status only ever changes in response to an
   explicit download/remove action — nothing is fetched automatically or in the
@@ -889,12 +899,30 @@ and hosts the **Wi-Fi only** toggle. All of this flows through
 
 **Storage & playback.** Downloaded bytes live in an app-controlled directory
 (`path_provider`'s application-support location, not the OS cache that can be
-reclaimed). The durable metadata is a small `CachedTrack` set (track id + cache
-file name) behind `DownloadStore`, persisted via `shared_preferences`. Playback
-goes through an `OfflineFirstPlayableUriResolver`: it asks a `CachedTrackLocator`
-for a local copy first and, on a miss, falls back to the source router (Jellyfin
-streaming, or the on-device file). `downloaded` is the only durable state;
+reclaimed). The durable metadata is a small `CachedTrack` set behind
+`DownloadStore`, persisted via `shared_preferences`; each record carries the
+non-secret track id, the id-derived cache file name, the source's URI scheme,
+the byte size, `cachedAt`/`lastAccessedAt` timestamps, and a `pinned` flag — the
+signals the cache manager cleans up by. Playback goes through an
+`OfflineFirstPlayableUriResolver`: it asks a `CachedTrackLocator` for a local
+copy first and, on a miss, falls back to the source router (Jellyfin streaming,
+or the on-device file); a cache **hit refreshes `lastAccessedAt`** so eviction
+keeps what you actually listen to. `downloaded` is the only durable state;
 `queued`/`downloading`/`failed` are in-memory and reset on restart.
+
+**Smart cache management.** The limit and eviction live in one place. The
+`CacheDownloadRepository` also implements an `OfflineCacheManager` (usage stream,
+pin, note-played, clear), and delegates the *what to evict* decision to a pure,
+exhaustively tested `CacheEvictionPolicy` — never the UI, which only calls the
+manager. What can and can't be deleted is a hard line: only **app-managed cache
+files** in the offline directory are ever removed (by id-derived file name);
+the user's **local source files** in their music folder are never passed to the
+file store, so they can't be touched. The **currently playing** track and
+**pinned** tracks are never auto-evicted. A managed file the OS reclaimed is
+detected on load — its stale metadata is pruned and playback falls back to
+streaming rather than opening a missing file. "Clear all" removes everything
+(pinned included); "Clear unpinned" keeps what you pinned. The maximum size is a
+`DownloadPreferences` value (also `shared_preferences`), clamped to a sane range.
 
 **Security (token handling).** The Jellyfin access token is **never** stored on
 `Track.uri`, in the `DownloadStore` metadata, in a cache file name, in a log, or
@@ -904,6 +932,9 @@ the authenticated **download** URL is minted only at fetch time inside
 time), and a transport failure is re-raised as a generic message so a
 `ClientException` carrying the tokenized URL can't escape. Cache file names are
 derived only from the non-secret track id, sanitized to filename-safe characters.
+The richer metadata the cache manager adds is likewise non-secret: the stored
+**source type is the bare URI scheme** (`jellyfin` / `file`), never the full URL,
+and the "not enough cache space" error carries no path, URL, or token.
 
 Deliberate gaps the next PRs will close:
 
@@ -915,6 +946,10 @@ Deliberate gaps the next PRs will close:
   tap; there is no worker, no Android download/notification service, no resume of
   a partial transfer, and no auto-flush of the queue when Wi-Fi returns (re-tap a
   queued track to retry).
+- **Eviction is inline, not a background sweeper.** Space is freed only when a
+  new download needs it (and stale metadata only on load); there is no periodic
+  reconciliation against the directory's actual on-disk size, and a remote track
+  larger than the whole limit can't be cached at all.
 - **Connectivity is optimistic.** `OptimisticConnectivityService` always reports
   Wi-Fi until `connectivity_plus` is wired in, so the "Wi-Fi only" gate currently
   blocks only when a test (or a future real detector) reports mobile/offline —

--- a/lib/core/models/cache_size.dart
+++ b/lib/core/models/cache_size.dart
@@ -1,0 +1,66 @@
+/// Cache-size presets, the default limit, and byte formatting — the small,
+/// pure pieces the cache settings UI and persistence share.
+///
+/// Sizes are in bytes throughout the cache layer so there is one unit; the
+/// presets and [formatBytes] are the only place the GB/MB labels live.
+abstract final class CacheSize {
+  const CacheSize._();
+
+  static const int bytesPerKb = 1024;
+  static const int bytesPerMb = 1024 * bytesPerKb;
+  static const int bytesPerGb = 1024 * bytesPerMb;
+
+  /// Convert a whole-GB value to bytes.
+  static int gigabytes(num gb) => (gb * bytesPerGb).round();
+
+  /// The preset limits offered in Settings, in bytes: 1, 2, 4, 8, 16 GB.
+  static const List<int> presets = <int>[
+    1 * bytesPerGb,
+    2 * bytesPerGb,
+    4 * bytesPerGb,
+    8 * bytesPerGb,
+    16 * bytesPerGb,
+  ];
+
+  /// A sane default that won't fill a phone unexpectedly while still holding a
+  /// good amount of offline music.
+  static const int defaultLimit = 4 * bytesPerGb;
+
+  /// Guard rails for a custom value so the field can't be set to something
+  /// nonsensical (0, negative, or larger than any phone).
+  static const int minLimit = 256 * bytesPerMb;
+  static const int maxLimit = 512 * bytesPerGb;
+
+  /// Clamp [bytes] into the supported range.
+  static int clamp(int bytes) {
+    if (bytes < minLimit) return minLimit;
+    if (bytes > maxLimit) return maxLimit;
+    return bytes;
+  }
+
+  /// Whether [bytes] is one of the named [presets] (so the picker can mark it
+  /// selected rather than treating it as a custom value).
+  static bool isPreset(int bytes) => presets.contains(bytes);
+
+  /// A short, human-friendly size label (e.g. `4 GB`, `1.5 GB`, `512 MB`,
+  /// `0 B`). Whole numbers drop the decimal; otherwise one decimal place.
+  static String formatBytes(int bytes) {
+    if (bytes < bytesPerKb) return '$bytes B';
+    final double value;
+    final String unit;
+    if (bytes >= bytesPerGb) {
+      value = bytes / bytesPerGb;
+      unit = 'GB';
+    } else if (bytes >= bytesPerMb) {
+      value = bytes / bytesPerMb;
+      unit = 'MB';
+    } else {
+      value = bytes / bytesPerKb;
+      unit = 'KB';
+    }
+    final String text = value == value.roundToDouble()
+        ? value.toStringAsFixed(0)
+        : value.toStringAsFixed(1);
+    return '$text $unit';
+  }
+}

--- a/lib/core/repositories/download_preferences.dart
+++ b/lib/core/repositories/download_preferences.dart
@@ -1,12 +1,22 @@
-/// The user's download preferences.
+import '../models/cache_size.dart';
+
+/// The user's download/offline preferences.
 ///
-/// Right now this is just the "Wi-Fi only" switch, kept behind an interface so
-/// the [DownloadRepository] can consult it without binding to a storage plugin.
-/// When set, downloads that would run over mobile data are queued instead of
-/// started — the policy lives in the repository, this only remembers the choice.
+/// These are kept behind an interface so the [DownloadRepository] and cache
+/// manager can consult them without binding to a storage plugin. The policy
+/// lives in the repository; this only remembers the choices:
+///  - "Wi-Fi only": downloads that would run over mobile data are queued.
+///  - "Max cache size": the byte ceiling the offline cache is kept under, with
+///    least-recently-used eviction once a new download would exceed it.
 abstract interface class DownloadPreferences {
   /// Whether downloads should only run on Wi-Fi. Defaults to `false`.
   Future<bool> wifiOnly();
 
   Future<void> setWifiOnly(bool value);
+
+  /// The maximum total size of the offline cache in bytes. Defaults to
+  /// [CacheSize.defaultLimit] when the user hasn't chosen one.
+  Future<int> maxCacheBytes();
+
+  Future<void> setMaxCacheBytes(int bytes);
 }

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -3,6 +3,26 @@ import '../models/track.dart';
 /// Where a track stands in the offline-download lifecycle.
 enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
 
+/// Thrown by [DownloadRepository.requestDownload] when a download can't be
+/// cached because the cache is at its limit and nothing safe is left to evict
+/// (everything remaining is pinned or currently playing, or the track is larger
+/// than the whole limit).
+///
+/// The [message] is friendly and secret-free by design — it never carries a
+/// URL, token, or file path — so the UI can show it verbatim.
+class CacheStorageException implements Exception {
+  const CacheStorageException([
+    this.message =
+        'Not enough cache space. Free up space or raise the cache limit '
+            'in Settings, then try again.',
+  ]);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 /// Tracks which library items are available offline.
 ///
 /// Downloads in Linthra are always *explicit and user-initiated* — never
@@ -24,6 +44,10 @@ abstract interface class DownloadRepository {
   /// Queues an explicit download for [track]. For remote tracks this is subject
   /// to the user's connectivity preferences; on-device tracks are recorded as
   /// already-available with no network fetch.
+  ///
+  /// To stay under the user's cache limit, a remote download may first evict
+  /// least-recently-used, unpinned, not-currently-playing tracks. If even then
+  /// there isn't room, it throws [CacheStorageException] and caches nothing.
   Future<void> requestDownload(Track track);
 
   /// Removes the offline copy of [trackId], deleting any cached file and

--- a/lib/core/repositories/download_store.dart
+++ b/lib/core/repositories/download_store.dart
@@ -1,12 +1,23 @@
-/// A reference to a single offline-cached track: which track it is and the file
-/// that holds its downloaded bytes (when there is one).
+/// A reference to a single offline-cached track: which track it is, the file
+/// that holds its downloaded bytes (when there is one), and the small bits of
+/// metadata the cache manager needs to clean up intelligently.
 ///
 /// Security invariant: this is *persisted* metadata, so it must never carry a
 /// secret. [trackId] is the non-secret catalog id, and [fileName] is derived
-/// from it — never from an access token or an authenticated URL. Do not add the
-/// streaming/download URL, a Jellyfin token, or any credential to this record.
+/// from it — never from an access token or an authenticated URL. [sourceType]
+/// is the track's non-secret URI scheme (e.g. `jellyfin`, `file`), never the
+/// full URL. Do not add the streaming/download URL, a Jellyfin token, or any
+/// credential to this record.
 class CachedTrack {
-  const CachedTrack({required this.trackId, this.fileName});
+  const CachedTrack({
+    required this.trackId,
+    this.fileName,
+    this.sourceType,
+    this.sizeBytes = 0,
+    this.cachedAt,
+    this.lastAccessedAt,
+    this.pinned = false,
+  });
 
   /// The catalog id of the cached track.
   final String trackId;
@@ -16,21 +27,92 @@ class CachedTrack {
   /// has no managed copy of its own.
   final String? fileName;
 
+  /// The non-secret URI scheme the track came from (`jellyfin`, `file`, …),
+  /// kept so the cache can show/group by source. Never the full URL.
+  final String? sourceType;
+
+  /// The size of the managed cache file in bytes, captured at download time.
+  /// `0` for an on-device track (no managed bytes), so only app-managed
+  /// downloads count toward the cache budget.
+  final int sizeBytes;
+
+  /// When the bytes were first cached. `null` for legacy/on-device records.
+  final DateTime? cachedAt;
+
+  /// When the track was last played from cache — the signal least-recently-used
+  /// eviction sorts on. `null` means never accessed (treated as oldest).
+  final DateTime? lastAccessedAt;
+
+  /// Whether the user pinned this track ("Keep offline"). Pinned tracks are
+  /// never evicted automatically and survive "clear unpinned".
+  final bool pinned;
+
+  /// Whether this record points at app-managed downloaded bytes (vs. an
+  /// on-device track that is merely marked available offline).
+  bool get isManaged => fileName != null && fileName!.isNotEmpty;
+
+  CachedTrack copyWith({
+    String? fileName,
+    String? sourceType,
+    int? sizeBytes,
+    DateTime? cachedAt,
+    DateTime? lastAccessedAt,
+    bool? pinned,
+  }) {
+    return CachedTrack(
+      trackId: trackId,
+      fileName: fileName ?? this.fileName,
+      sourceType: sourceType ?? this.sourceType,
+      sizeBytes: sizeBytes ?? this.sizeBytes,
+      cachedAt: cachedAt ?? this.cachedAt,
+      lastAccessedAt: lastAccessedAt ?? this.lastAccessedAt,
+      pinned: pinned ?? this.pinned,
+    );
+  }
+
   Map<String, dynamic> toJson() => <String, dynamic>{
         'trackId': trackId,
-        if (fileName != null && fileName!.isNotEmpty) 'fileName': fileName,
+        if (isManaged) 'fileName': fileName,
+        if (sourceType != null && sourceType!.isNotEmpty)
+          'sourceType': sourceType,
+        if (sizeBytes > 0) 'sizeBytes': sizeBytes,
+        if (cachedAt != null) 'cachedAt': cachedAt!.millisecondsSinceEpoch,
+        if (lastAccessedAt != null)
+          'lastAccessedAt': lastAccessedAt!.millisecondsSinceEpoch,
+        if (pinned) 'pinned': true,
       };
 
   /// Rebuilds a record from [toJson] output, or returns `null` when the track
   /// id is missing (a corrupt entry), so one bad record can't break loading.
+  /// Records written by an earlier version (id + file name only) load cleanly:
+  /// the new fields fall back to their defaults.
   static CachedTrack? fromJson(Map<String, dynamic> json) {
     final String? trackId = json['trackId'] as String?;
     if (trackId == null || trackId.isEmpty) return null;
     final String? fileName = json['fileName'] as String?;
+    final String? sourceType = json['sourceType'] as String?;
     return CachedTrack(
       trackId: trackId,
       fileName: (fileName != null && fileName.isNotEmpty) ? fileName : null,
+      sourceType:
+          (sourceType != null && sourceType.isNotEmpty) ? sourceType : null,
+      sizeBytes: _asInt(json['sizeBytes']),
+      cachedAt: _asDate(json['cachedAt']),
+      lastAccessedAt: _asDate(json['lastAccessedAt']),
+      pinned: json['pinned'] == true,
     );
+  }
+
+  static int _asInt(Object? value) {
+    if (value is int) return value < 0 ? 0 : value;
+    return 0;
+  }
+
+  static DateTime? _asDate(Object? value) {
+    if (value is int) {
+      return DateTime.fromMillisecondsSinceEpoch(value);
+    }
+    return null;
   }
 
   @override
@@ -38,21 +120,34 @@ class CachedTrack {
       identical(this, other) ||
       (other is CachedTrack &&
           other.trackId == trackId &&
-          other.fileName == fileName);
+          other.fileName == fileName &&
+          other.sourceType == sourceType &&
+          other.sizeBytes == sizeBytes &&
+          other.cachedAt == cachedAt &&
+          other.lastAccessedAt == lastAccessedAt &&
+          other.pinned == pinned);
 
   @override
-  int get hashCode => Object.hash(trackId, fileName);
+  int get hashCode => Object.hash(
+        trackId,
+        fileName,
+        sourceType,
+        sizeBytes,
+        cachedAt,
+        lastAccessedAt,
+        pinned,
+      );
 }
 
 /// Durable storage for the tracks that are available offline.
 ///
 /// This is the *persistence seam* under [DownloadRepository]: it knows nothing
 /// about download policy, connectivity, or the transient queued/downloading
-/// states — only which tracks are cached and, for the ones with a downloaded
-/// copy, the file that holds the bytes. Splitting it out keeps the download
-/// lifecycle (policy) in one place while letting the backing store swap freely
-/// (in-memory for tests, key/value in the app, a SQLite/Drift table once
-/// downloads also track byte progress).
+/// states — only which tracks are cached and the metadata the cache manager
+/// cleans up by (file, size, timestamps, pinned). Splitting it out keeps the
+/// download lifecycle (policy) in one place while letting the backing store
+/// swap freely (in-memory for tests, key/value in the app, a SQLite/Drift
+/// table once downloads also track byte progress).
 abstract interface class DownloadStore {
   /// The tracks currently cached for offline use.
   Future<List<CachedTrack>> loadDownloads();

--- a/lib/core/repositories/offline_file_store.dart
+++ b/lib/core/repositories/offline_file_store.dart
@@ -23,6 +23,11 @@ abstract interface class OfflineFileStore {
   /// streaming rather than open a missing file.
   Future<String?> pathFor(String fileName);
 
+  /// The size in bytes of [fileName] on disk, or `null` when it no longer
+  /// exists — used to total cache usage and to detect (and prune) metadata
+  /// pointing at a file the OS reclaimed.
+  Future<int?> sizeFor(String fileName);
+
   /// Deletes the cache file [fileName] if it exists; a no-op when it doesn't.
   Future<void> delete(String fileName);
 }

--- a/lib/core/services/cache_eviction_policy.dart
+++ b/lib/core/services/cache_eviction_policy.dart
@@ -1,0 +1,103 @@
+import '../repositories/download_store.dart';
+
+/// What to evict (and whether the incoming download fits at all) for one
+/// download request — the output of [CacheEvictionPolicy].
+class EvictionPlan {
+  const EvictionPlan({required this.evict, required this.fits});
+
+  /// The tracks to delete to make room, least-recently-used first. Empty when
+  /// nothing needs to go (or when [fits] is `false`, since freeing space that
+  /// still wouldn't be enough only loses the user's downloads for nothing).
+  final List<CachedTrack> evict;
+
+  /// Whether the incoming bytes fit once [evict] is removed. `false` means
+  /// "Not enough cache space" — the caller should refuse and keep what's there.
+  final bool fits;
+
+  static const EvictionPlan empty =
+      EvictionPlan(evict: <CachedTrack>[], fits: true);
+}
+
+/// Decides, purely, what to evict so a new download stays under the cache
+/// limit. No I/O and no app state — it takes the current cache metadata and
+/// returns a plan — which keeps the rules exhaustively testable and the
+/// repository free of branching policy logic.
+///
+/// Rules, in order:
+///  - On-device tracks and zero-byte records don't count toward the budget and
+///    are never evicted (they hold no app-managed bytes).
+///  - The currently playing track is never evicted.
+///  - Pinned ("Keep offline") tracks are never evicted.
+///  - Among the rest, least-recently-used goes first (oldest [CachedTrack.
+///    lastAccessedAt]; never-played counts as oldest), tie-broken by oldest
+///    [CachedTrack.cachedAt] then track id for determinism.
+///  - If even evicting every eligible track wouldn't make room, nothing is
+///    evicted and the plan reports it doesn't fit.
+class CacheEvictionPolicy {
+  const CacheEvictionPolicy();
+
+  EvictionPlan plan({
+    required Iterable<CachedTrack> cached,
+    required int incomingBytes,
+    required int maxBytes,
+    String? protectTrackId,
+    String? incomingTrackId,
+  }) {
+    int used = 0;
+    final List<CachedTrack> candidates = <CachedTrack>[];
+    for (final CachedTrack track in cached) {
+      // A re-download replaces its own old copy, so it doesn't count as
+      // already-used space and can't evict itself.
+      if (track.trackId == incomingTrackId) continue;
+      used += track.sizeBytes;
+      final bool evictable = track.isManaged &&
+          track.sizeBytes > 0 &&
+          !track.pinned &&
+          track.trackId != protectTrackId;
+      if (evictable) candidates.add(track);
+    }
+
+    if (used + incomingBytes <= maxBytes) return EvictionPlan.empty;
+
+    // A single track larger than the whole limit can never fit, even in an
+    // empty cache — refuse without evicting anything.
+    if (incomingBytes > maxBytes) {
+      return const EvictionPlan(evict: <CachedTrack>[], fits: false);
+    }
+
+    candidates.sort(_leastRecentlyUsedFirst);
+
+    final List<CachedTrack> evict = <CachedTrack>[];
+    int freed = 0;
+    for (final CachedTrack track in candidates) {
+      if (used - freed + incomingBytes <= maxBytes) break;
+      evict.add(track);
+      freed += track.sizeBytes;
+    }
+
+    final bool fits = used - freed + incomingBytes <= maxBytes;
+    return fits
+        ? EvictionPlan(evict: evict, fits: true)
+        : const EvictionPlan(evict: <CachedTrack>[], fits: false);
+  }
+
+  static int _leastRecentlyUsedFirst(CachedTrack a, CachedTrack b) {
+    final int byAccess = _compareNullableOldestFirst(
+      a.lastAccessedAt,
+      b.lastAccessedAt,
+    );
+    if (byAccess != 0) return byAccess;
+    final int byCached = _compareNullableOldestFirst(a.cachedAt, b.cachedAt);
+    if (byCached != 0) return byCached;
+    return a.trackId.compareTo(b.trackId);
+  }
+
+  /// Orders two timestamps oldest-first, treating `null` (never accessed) as
+  /// older than any real time so it's evicted before played tracks.
+  static int _compareNullableOldestFirst(DateTime? a, DateTime? b) {
+    if (a == null && b == null) return 0;
+    if (a == null) return -1;
+    if (b == null) return 1;
+    return a.compareTo(b);
+  }
+}

--- a/lib/core/services/offline_cache_manager.dart
+++ b/lib/core/services/offline_cache_manager.dart
@@ -1,0 +1,61 @@
+import '../repositories/download_store.dart';
+
+/// An immutable view of the offline cache for the UI: how much app-managed
+/// space is in use and the per-track metadata behind it.
+///
+/// [usedBytes] counts only app-managed downloaded bytes — on-device tracks
+/// marked available offline hold no managed bytes and don't count. The maximum
+/// limit is *not* here: it lives in [DownloadPreferences] (the user can change
+/// it independently), and the UI composes the two to show "used of max".
+class CacheSnapshot {
+  const CacheSnapshot({
+    required this.usedBytes,
+    required this.entries,
+  });
+
+  static const CacheSnapshot empty =
+      CacheSnapshot(usedBytes: 0, entries: <CachedTrack>[]);
+
+  /// Total bytes held in app-managed cache files.
+  final int usedBytes;
+
+  /// Every offline entry (managed downloads and on-device markers alike).
+  final List<CachedTrack> entries;
+
+  /// How many entries hold app-managed bytes (i.e. real downloads).
+  int get managedCount => entries.where((CachedTrack e) => e.isManaged).length;
+}
+
+/// The cache-maintenance surface the UI drives, kept separate from the
+/// download *lifecycle* ([DownloadRepository.requestDownload] / status).
+///
+/// Everything that frees or pins app-managed files goes through here so the UI
+/// never deletes files or computes eviction itself — it just asks the manager,
+/// which owns the policy and the filesystem. The same instance backs the
+/// download repository, so a cleared/pinned track is reflected in download
+/// status too.
+abstract interface class OfflineCacheManager {
+  /// Emits the current [CacheSnapshot] immediately, then again on every change
+  /// (download, removal, eviction, pin, play, or clear).
+  Stream<CacheSnapshot> get cacheStream;
+
+  /// The current snapshot, for a one-off read.
+  Future<CacheSnapshot> cacheSnapshot();
+
+  /// Pins or unpins a track ("Keep offline"). Pinned tracks are never evicted
+  /// automatically and survive [clearUnpinned]. A no-op for an unknown track.
+  Future<void> setPinned(String trackId, bool pinned);
+
+  /// Records that [trackId] was just played from cache, refreshing its
+  /// least-recently-used position. A no-op for a track that isn't cached.
+  Future<void> notePlayed(String trackId);
+
+  /// Removes every offline entry: deletes all app-managed cache files and the
+  /// metadata, pinned items included. Never touches the user's local source
+  /// files (those have no app-managed file).
+  Future<void> clearAll();
+
+  /// Removes only unpinned offline entries, deleting their app-managed cache
+  /// files. Pinned ("Keep offline") tracks are preserved.
+  Future<void> clearUnpinned();
+}

--- a/lib/core/services/offline_first_playable_uri_resolver.dart
+++ b/lib/core/services/offline_first_playable_uri_resolver.dart
@@ -18,11 +18,18 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
   const OfflineFirstPlayableUriResolver({
     required CachedTrackLocator locator,
     required PlayableUriResolver fallback,
+    void Function(String trackId)? onCacheHit,
   })  : _locator = locator,
-        _fallback = fallback;
+        _fallback = fallback,
+        _onCacheHit = onCacheHit;
 
   final CachedTrackLocator _locator;
   final PlayableUriResolver _fallback;
+
+  /// Called with the track id on a cache hit, so the cache manager can refresh
+  /// its least-recently-used position. Fire-and-forget: a failure here must
+  /// never stop playback, so it isn't awaited.
+  final void Function(String trackId)? _onCacheHit;
 
   @override
   bool handles(Track track) => _fallback.handles(track);
@@ -36,6 +43,7 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
         resolver: 'OfflineFirstPlayableUriResolver',
         itemId: track.id,
       );
+      _onCacheHit?.call(track.id);
       return ResolvedPlayable(
         Uri.file(cachedPath),
         PlaybackSource.offlineCache,

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -5,75 +5,125 @@ import '../../core/repositories/download_preferences.dart';
 import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
 import '../../core/repositories/offline_file_store.dart';
+import '../../core/services/cache_eviction_policy.dart';
 import '../../core/services/connectivity_service.dart';
+import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/remote_track_downloader.dart';
 
-/// The app's [DownloadRepository]: it owns the offline-cache *policy* in one
-/// place and delegates the moving parts to focused seams — durable metadata to
-/// a [DownloadStore], cached bytes to an [OfflineFileStore], and the remote
-/// byte-fetch to a [RemoteTrackDownloader].
+/// The app's [DownloadRepository] *and* [OfflineCacheManager]: it owns the
+/// offline-cache *policy* in one place and delegates the moving parts to focused
+/// seams — durable metadata to a [DownloadStore], cached bytes to an
+/// [OfflineFileStore], the remote byte-fetch to a [RemoteTrackDownloader], and
+/// the (pure) eviction decision to a [CacheEvictionPolicy].
 ///
-/// Three promises are enforced here so a caller can't skip them:
+/// Promises enforced here so a caller can't skip them:
 ///  - **User-initiated only.** Nothing is ever downloaded automatically; status
-///    changes happen solely in response to [requestDownload] / [removeDownload].
+///    changes happen solely in response to [requestDownload] / [removeDownload]
+///    (or an explicit clear / pin).
 ///  - **Source-aware.** A remote (Jellyfin) track has its bytes fetched and
 ///    written to the offline directory; an on-device track is already local, so
 ///    it's recorded as available offline with no fetch and no managed file.
-///  - **Wi-Fi only is respected.** When the user has set [DownloadPreferences.
-///    wifiOnly] and the connection isn't Wi-Fi, a *remote* request is queued
-///    rather than run, instead of silently going over mobile data.
+///  - **Wi-Fi only is respected.** A *remote* request is queued (not run) when
+///    the user set "Wi-Fi only" and the connection isn't Wi-Fi.
+///  - **Stays under the cache limit.** Before writing a remote download, the
+///    policy evicts least-recently-used, unpinned, not-currently-playing tracks
+///    to make room; if it still won't fit, the download is refused with a
+///    friendly [CacheStorageException] and nothing is cached.
 ///
-/// Only the `downloaded` set is durable; `queued`/`downloading`/`failed` are
-/// transient and live in memory, so a restart never resurrects a half-finished
-/// download (there is no background worker yet — see README).
+/// Safety: only app-managed cache files (in the offline directory) are ever
+/// deleted — by file name derived from the non-secret track id. The user's
+/// local source files (an on-device track's own path) are never passed to the
+/// file store, so they can't be deleted here. A managed file the OS reclaimed
+/// is detected on load and its stale metadata pruned, so playback falls back to
+/// streaming instead of opening a missing file.
 ///
 /// The authenticated URL a remote fetch needs is resolved inside the
 /// [RemoteTrackDownloader] at fetch time; this repository never sees, stores, or
-/// logs it, and a failed fetch surfaces only as the `failed` state.
-class CacheDownloadRepository implements DownloadRepository {
+/// logs it. Persisted metadata carries only the non-secret track id, a
+/// id-derived file name, the source's URI scheme, a byte size, timestamps, and
+/// the pinned flag — never a token or URL.
+class CacheDownloadRepository
+    implements DownloadRepository, OfflineCacheManager {
   CacheDownloadRepository({
     required DownloadStore store,
     required OfflineFileStore files,
     required RemoteTrackDownloader downloader,
     required ConnectivityService connectivity,
     required DownloadPreferences preferences,
+    CacheEvictionPolicy policy = const CacheEvictionPolicy(),
+    String? Function()? currentlyPlayingTrackId,
+    DateTime Function()? now,
   })  : _store = store,
         _files = files,
         _downloader = downloader,
         _connectivity = connectivity,
-        _preferences = preferences;
+        _preferences = preferences,
+        _policy = policy,
+        _currentlyPlayingTrackId = currentlyPlayingTrackId,
+        _now = now ?? DateTime.now;
 
   final DownloadStore _store;
   final OfflineFileStore _files;
   final RemoteTrackDownloader _downloader;
   final ConnectivityService _connectivity;
   final DownloadPreferences _preferences;
+  final CacheEvictionPolicy _policy;
+
+  /// Supplies the id of the track currently playing (or `null`), so it is never
+  /// evicted out from under the user. Read lazily so the repository doesn't
+  /// depend on the playback layer at construction.
+  final String? Function()? _currentlyPlayingTrackId;
+
+  final DateTime Function() _now;
 
   final Map<String, DownloadStatus> _statuses = <String, DownloadStatus>{};
 
   /// The durable cache references, loaded once and kept in sync with the store,
-  /// so removal can find the file to delete and seeding stays cheap.
+  /// so removal can find the file to delete, eviction can sort by metadata, and
+  /// usage is cheap to total.
   final Map<String, CachedTrack> _downloads = <String, CachedTrack>{};
 
   final StreamController<Map<String, DownloadStatus>> _changes =
       StreamController<Map<String, DownloadStatus>>.broadcast();
 
+  final StreamController<CacheSnapshot> _cacheChanges =
+      StreamController<CacheSnapshot>.broadcast();
+
   bool _loaded = false;
 
-  /// Seeds the in-memory state from the durable cache, once.
+  /// Seeds the in-memory state from the durable cache, once. Along the way it
+  /// self-heals: a managed entry whose file is gone is dropped (stale metadata),
+  /// and a managed entry missing its byte size (e.g. written by an earlier
+  /// version) is backfilled from disk, so usage and eviction are accurate.
   Future<void> _ensureLoaded() async {
     if (_loaded) return;
+    bool changed = false;
     for (final CachedTrack cached in await _store.loadDownloads()) {
-      _downloads[cached.trackId] = cached;
+      if (cached.isManaged) {
+        final int? size = await _files.sizeFor(cached.fileName!);
+        if (size == null) {
+          // The managed file is gone; drop the record so it isn't counted and
+          // playback falls back to streaming.
+          changed = true;
+          continue;
+        }
+        CachedTrack entry = cached;
+        if (cached.sizeBytes == 0 && size > 0) {
+          entry = cached.copyWith(sizeBytes: size);
+          changed = true;
+        }
+        _downloads[entry.trackId] = entry;
+      } else {
+        _downloads[cached.trackId] = cached;
+      }
       _statuses[cached.trackId] = DownloadStatus.downloaded;
     }
+    if (changed) await _save();
     _loaded = true;
   }
 
   @override
   Stream<Map<String, DownloadStatus>> get statusStream async* {
-    // Seed each listener with the current snapshot so the UI can render a
-    // correct first frame, then forward live changes.
     await _ensureLoaded();
     yield _snapshot();
     yield* _changes.stream;
@@ -99,9 +149,16 @@ class CacheDownloadRepository implements DownloadRepository {
 
     if (!_downloader.isRemote(track)) {
       // On-device track: the bytes are already local, so there's nothing to
-      // fetch — just record it as available offline (no managed cache file).
-      await _record(CachedTrack(trackId: track.id));
-      _set(track.id, DownloadStatus.downloaded);
+      // fetch and no managed file — just record it as available offline.
+      _downloads[track.id] = CachedTrack(
+        trackId: track.id,
+        sourceType: _sourceTypeOf(track),
+        cachedAt: _now(),
+      );
+      await _save();
+      _statuses[track.id] = DownloadStatus.downloaded;
+      _emitStatus();
+      _emitCache();
       return;
     }
 
@@ -115,44 +172,147 @@ class CacheDownloadRepository implements DownloadRepository {
     _set(track.id, DownloadStatus.downloading);
     try {
       final RemoteTrackData data = await _downloader.fetch(track);
-      final String fileName = await _files.write(
-        track.id,
-        data.bytes,
-        extension: data.fileExtension,
-      );
-      await _record(CachedTrack(trackId: track.id, fileName: fileName));
-      _set(track.id, DownloadStatus.downloaded);
+      await _cacheRemote(track, data);
+    } on CacheStorageException {
+      // Space was reset below before throwing; surface the friendly error so
+      // the UI can tell the user to free space or raise the limit.
+      rethrow;
     } catch (_) {
-      // The error is intentionally swallowed: it may carry source-specific
-      // detail, and the UI only needs the failed state (offering a retry).
+      // Other errors may carry source-specific detail; the UI only needs the
+      // failed state (offering a retry).
       _set(track.id, DownloadStatus.failed);
     }
+  }
+
+  /// Writes a freshly fetched remote download, evicting first to stay under the
+  /// limit. Throws [CacheStorageException] (after resetting status) when it
+  /// can't fit even after evicting everything safe to remove.
+  Future<void> _cacheRemote(Track track, RemoteTrackData data) async {
+    final int incoming = data.bytes.length;
+    final int maxBytes = await _preferences.maxCacheBytes();
+    final EvictionPlan plan = _policy.plan(
+      cached: _downloads.values,
+      incomingBytes: incoming,
+      maxBytes: maxBytes,
+      protectTrackId: _currentlyPlayingTrackId?.call(),
+      incomingTrackId: track.id,
+    );
+
+    if (!plan.fits) {
+      _set(track.id, DownloadStatus.notDownloaded);
+      throw const CacheStorageException();
+    }
+
+    for (final CachedTrack victim in plan.evict) {
+      await _deleteManagedFile(victim);
+      _downloads.remove(victim.trackId);
+      _statuses.remove(victim.trackId);
+    }
+
+    final String fileName = await _files.write(
+      track.id,
+      data.bytes,
+      extension: data.fileExtension,
+    );
+    final DateTime now = _now();
+    _downloads[track.id] = CachedTrack(
+      trackId: track.id,
+      fileName: fileName,
+      sourceType: _sourceTypeOf(track),
+      sizeBytes: incoming,
+      cachedAt: now,
+      lastAccessedAt: now,
+    );
+    await _save();
+    _statuses[track.id] = DownloadStatus.downloaded;
+    _emitStatus();
+    _emitCache();
   }
 
   @override
   Future<void> removeDownload(String trackId) async {
     await _ensureLoaded();
     final CachedTrack? existing = _downloads.remove(trackId);
-    final String? fileName = existing?.fileName;
-    if (fileName != null && fileName.isNotEmpty) {
-      await _files.delete(fileName);
-    }
-    await _store.saveDownloads(_downloads.values.toList());
+    await _deleteManagedFile(existing);
+    await _save();
     // Also clears a queued/failed/downloading marker, so this doubles as cancel.
     _set(trackId, DownloadStatus.notDownloaded);
+    _emitCache();
   }
 
   @override
   Future<List<String>> downloadedTrackIds() async {
     await _ensureLoaded();
     return _statuses.entries
-        .where((e) => e.value == DownloadStatus.downloaded)
-        .map((e) => e.key)
+        .where((MapEntry<String, DownloadStatus> e) =>
+            e.value == DownloadStatus.downloaded)
+        .map((MapEntry<String, DownloadStatus> e) => e.key)
         .toList();
   }
 
-  /// Releases the change stream. Call when the owning provider is disposed.
-  Future<void> dispose() => _changes.close();
+  @override
+  Stream<CacheSnapshot> get cacheStream async* {
+    await _ensureLoaded();
+    yield _cacheSnapshot();
+    yield* _cacheChanges.stream;
+  }
+
+  @override
+  Future<CacheSnapshot> cacheSnapshot() async {
+    await _ensureLoaded();
+    return _cacheSnapshot();
+  }
+
+  @override
+  Future<void> setPinned(String trackId, bool pinned) async {
+    await _ensureLoaded();
+    final CachedTrack? existing = _downloads[trackId];
+    if (existing == null || existing.pinned == pinned) return;
+    _downloads[trackId] = existing.copyWith(pinned: pinned);
+    await _save();
+    _emitCache();
+  }
+
+  @override
+  Future<void> notePlayed(String trackId) async {
+    await _ensureLoaded();
+    final CachedTrack? existing = _downloads[trackId];
+    if (existing == null) return;
+    _downloads[trackId] = existing.copyWith(lastAccessedAt: _now());
+    await _save();
+    _emitCache();
+  }
+
+  @override
+  Future<void> clearAll() => _clear(keepPinned: false);
+
+  @override
+  Future<void> clearUnpinned() => _clear(keepPinned: true);
+
+  /// Removes offline entries (optionally keeping pinned ones), deleting their
+  /// app-managed cache files. On-device markers carry no managed file, so the
+  /// user's local source files are never touched.
+  Future<void> _clear({required bool keepPinned}) async {
+    await _ensureLoaded();
+    final List<CachedTrack> victims = _downloads.values
+        .where((CachedTrack c) => !(keepPinned && c.pinned))
+        .toList();
+    if (victims.isEmpty) return;
+    for (final CachedTrack victim in victims) {
+      await _deleteManagedFile(victim);
+      _downloads.remove(victim.trackId);
+      _statuses.remove(victim.trackId);
+    }
+    await _save();
+    _emitStatus();
+    _emitCache();
+  }
+
+  /// Releases the change streams. Call when the owning provider is disposed.
+  Future<void> dispose() async {
+    await _changes.close();
+    await _cacheChanges.close();
+  }
 
   /// The connectivity gate. With "Wi-Fi only" off, anything goes; with it on,
   /// only a Wi-Fi connection clears a download to start now.
@@ -161,11 +321,17 @@ class CacheDownloadRepository implements DownloadRepository {
     return await _connectivity.currentStatus() == NetworkStatus.wifi;
   }
 
-  /// Records [cached] as downloaded and persists the updated set durably.
-  Future<void> _record(CachedTrack cached) async {
-    _downloads[cached.trackId] = cached;
-    await _store.saveDownloads(_downloads.values.toList());
+  /// Deletes the app-managed cache file behind [entry], if any. A `null` entry
+  /// or an on-device record (no managed file) is a safe no-op — the file store
+  /// is only ever asked to delete files it created in the offline directory.
+  Future<void> _deleteManagedFile(CachedTrack? entry) async {
+    final String? fileName = entry?.fileName;
+    if (fileName != null && fileName.isNotEmpty) {
+      await _files.delete(fileName);
+    }
   }
+
+  Future<void> _save() => _store.saveDownloads(_downloads.values.toList());
 
   void _set(String trackId, DownloadStatus status) {
     if (status == DownloadStatus.notDownloaded) {
@@ -173,9 +339,33 @@ class CacheDownloadRepository implements DownloadRepository {
     } else {
       _statuses[trackId] = status;
     }
-    _changes.add(_snapshot());
+    _emitStatus();
   }
+
+  void _emitStatus() => _changes.add(_snapshot());
+
+  void _emitCache() => _cacheChanges.add(_cacheSnapshot());
 
   Map<String, DownloadStatus> _snapshot() =>
       Map<String, DownloadStatus>.unmodifiable(_statuses);
+
+  CacheSnapshot _cacheSnapshot() {
+    int used = 0;
+    for (final CachedTrack c in _downloads.values) {
+      used += c.sizeBytes;
+    }
+    return CacheSnapshot(
+      usedBytes: used,
+      entries: List<CachedTrack>.unmodifiable(_downloads.values),
+    );
+  }
+
+  /// The track's non-secret URI scheme (`jellyfin`, `file`, …), never the full
+  /// URL — safe to persist as the cached track's source type.
+  static String? _sourceTypeOf(Track track) {
+    final int colon = track.uri.indexOf(':');
+    if (colon <= 0) return null;
+    final String scheme = track.uri.substring(0, colon).toLowerCase();
+    return scheme.isEmpty ? null : scheme;
+  }
 }

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -7,6 +7,7 @@ import '../../core/repositories/download_store.dart';
 import '../../core/repositories/offline_file_store.dart';
 import '../../core/services/cached_track_locator.dart';
 import '../../core/services/connectivity_service.dart';
+import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/optimistic_connectivity_service.dart';
 import '../../core/services/remote_track_downloader.dart';
 import 'cache_download_repository.dart';
@@ -54,19 +55,42 @@ final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
   return const OptimisticConnectivityService();
 });
 
-/// The single [DownloadRepository] the app drives offline downloads through.
-/// It composes the seams above and centralizes the user-initiated,
-/// source-aware, Wi-Fi-respecting cache policy.
-final downloadRepositoryProvider = Provider<DownloadRepository>((ref) {
+/// Supplies the id of the currently playing track so the cache policy never
+/// evicts it. The data layer defaults to "nothing playing" (keeping it free of
+/// any playback dependency); the app overrides this to read the live
+/// [PlaybackController] (see `currentlyPlayingTrackIdOverride`). The closure is
+/// read lazily at eviction time, so wiring it never rebuilds the repository.
+final currentlyPlayingTrackIdProvider =
+    Provider<String? Function()?>((ref) => null);
+
+/// The single [CacheDownloadRepository] the app drives offline downloads
+/// through. It composes the seams above and centralizes the user-initiated,
+/// source-aware, Wi-Fi-respecting, limit-bounded cache policy. Held as the
+/// concrete type so the cache-manager provider can expose the same instance.
+final _cacheDownloadRepositoryProvider =
+    Provider<CacheDownloadRepository>((ref) {
   final repository = CacheDownloadRepository(
     store: ref.watch(downloadStoreProvider),
     files: ref.watch(offlineFileStoreProvider),
     downloader: ref.watch(remoteTrackDownloaderProvider),
     connectivity: ref.watch(connectivityServiceProvider),
     preferences: ref.watch(downloadPreferencesProvider),
+    currentlyPlayingTrackId: ref.watch(currentlyPlayingTrackIdProvider),
   );
   ref.onDispose(repository.dispose);
   return repository;
+});
+
+/// The download lifecycle surface (request/remove/status) the UI uses.
+final downloadRepositoryProvider = Provider<DownloadRepository>((ref) {
+  return ref.watch(_cacheDownloadRepositoryProvider);
+});
+
+/// The cache-maintenance surface (usage stream, pin, clear, note-played),
+/// backed by the *same* instance as [downloadRepositoryProvider] so a cleared
+/// or pinned track stays consistent with download status.
+final offlineCacheManagerProvider = Provider<OfflineCacheManager>((ref) {
+  return ref.watch(_cacheDownloadRepositoryProvider);
 });
 
 /// Resolves a track to its cached-on-disk file when one exists. Read by the

--- a/lib/data/repositories/file_system_offline_file_store.dart
+++ b/lib/data/repositories/file_system_offline_file_store.dart
@@ -51,6 +51,13 @@ class FileSystemOfflineFileStore implements OfflineFileStore {
   }
 
   @override
+  Future<int?> sizeFor(String fileName) async {
+    final Directory dir = await _directory();
+    final File file = File(p.join(dir.path, fileName));
+    return await file.exists() ? await file.length() : null;
+  }
+
+  @override
   Future<void> delete(String fileName) async {
     final Directory dir = await _directory();
     final File file = File(p.join(dir.path, fileName));

--- a/lib/data/repositories/in_memory_download_preferences.dart
+++ b/lib/data/repositories/in_memory_download_preferences.dart
@@ -1,10 +1,16 @@
+import '../../core/models/cache_size.dart';
 import '../../core/repositories/download_preferences.dart';
 
 /// A non-persistent [DownloadPreferences] for development and tests.
 class InMemoryDownloadPreferences implements DownloadPreferences {
-  InMemoryDownloadPreferences({bool wifiOnly = false}) : _wifiOnly = wifiOnly;
+  InMemoryDownloadPreferences({
+    bool wifiOnly = false,
+    int maxCacheBytes = CacheSize.defaultLimit,
+  })  : _wifiOnly = wifiOnly,
+        _maxCacheBytes = maxCacheBytes;
 
   bool _wifiOnly;
+  int _maxCacheBytes;
 
   @override
   Future<bool> wifiOnly() async => _wifiOnly;
@@ -12,5 +18,13 @@ class InMemoryDownloadPreferences implements DownloadPreferences {
   @override
   Future<void> setWifiOnly(bool value) async {
     _wifiOnly = value;
+  }
+
+  @override
+  Future<int> maxCacheBytes() async => _maxCacheBytes;
+
+  @override
+  Future<void> setMaxCacheBytes(int bytes) async {
+    _maxCacheBytes = bytes;
   }
 }

--- a/lib/data/repositories/in_memory_offline_file_store.dart
+++ b/lib/data/repositories/in_memory_offline_file_store.dart
@@ -36,6 +36,9 @@ class InMemoryOfflineFileStore implements OfflineFileStore {
       _files.containsKey(fileName) ? '$_baseDirectory/$fileName' : null;
 
   @override
+  Future<int?> sizeFor(String fileName) async => _files[fileName]?.length;
+
+  @override
   Future<void> delete(String fileName) async {
     _files.remove(fileName);
   }

--- a/lib/data/repositories/shared_preferences_download_preferences.dart
+++ b/lib/data/repositories/shared_preferences_download_preferences.dart
@@ -1,24 +1,40 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../core/models/cache_size.dart';
 import '../../core/repositories/download_preferences.dart';
 
-/// A [DownloadPreferences] backed by `shared_preferences`. The "Wi-Fi only"
-/// switch is a single bool, so it lives next to the other small user choices in
-/// the key/value store rather than in the SQLite catalog.
+/// A [DownloadPreferences] backed by `shared_preferences`. Both choices are
+/// small scalars (a bool and an int), so they live next to the other small user
+/// choices in the key/value store rather than in the SQLite catalog.
 class SharedPreferencesDownloadPreferences implements DownloadPreferences {
   const SharedPreferencesDownloadPreferences();
 
-  static const String _key = 'downloads_wifi_only';
+  static const String _wifiOnlyKey = 'downloads_wifi_only';
+  static const String _maxCacheBytesKey = 'downloads_max_cache_bytes';
 
   @override
   Future<bool> wifiOnly() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_key) ?? false;
+    return prefs.getBool(_wifiOnlyKey) ?? false;
   }
 
   @override
   Future<void> setWifiOnly(bool value) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_key, value);
+    await prefs.setBool(_wifiOnlyKey, value);
+  }
+
+  @override
+  Future<int> maxCacheBytes() async {
+    final prefs = await SharedPreferences.getInstance();
+    final int? stored = prefs.getInt(_maxCacheBytesKey);
+    if (stored == null) return CacheSize.defaultLimit;
+    return CacheSize.clamp(stored);
+  }
+
+  @override
+  Future<void> setMaxCacheBytes(int bytes) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_maxCacheBytesKey, CacheSize.clamp(bytes));
   }
 }

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -1,7 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/models/cache_size.dart';
 import '../../core/models/track.dart';
 import '../../core/repositories/download_repository.dart';
+import '../../core/repositories/download_store.dart';
+import '../../core/services/offline_cache_manager.dart';
 import '../../core/sources/jellyfin/jellyfin_track_downloader.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
@@ -32,6 +35,42 @@ final downloadedTracksProvider = StreamProvider<List<Track>>((ref) async* {
     yield tracks.where((t) => downloadedIds.contains(t.id)).toList();
   }
 });
+
+/// Live offline-cache usage + per-track metadata (size, pinned, timestamps),
+/// re-emitted whenever the cache changes. Powers the Settings cache card and
+/// the per-row size/pin affordances on the Downloads screen.
+final cacheSnapshotProvider = StreamProvider<CacheSnapshot>((ref) {
+  return ref.watch(offlineCacheManagerProvider).cacheStream;
+});
+
+/// The cached-track metadata keyed by track id, for quick per-row lookups.
+final cacheEntriesByIdProvider = Provider<Map<String, CachedTrack>>((ref) {
+  final snapshot = ref.watch(cacheSnapshotProvider).valueOrNull;
+  if (snapshot == null) return const <String, CachedTrack>{};
+  return <String, CachedTrack>{
+    for (final entry in snapshot.entries) entry.trackId: entry,
+  };
+});
+
+/// Owns the "Maximum cache size" limit: loads the persisted value and writes
+/// changes back through [DownloadPreferences]. Clamped to the supported range.
+class MaxCacheBytesController extends AsyncNotifier<int> {
+  @override
+  Future<int> build() {
+    return ref.read(downloadPreferencesProvider).maxCacheBytes();
+  }
+
+  Future<void> setLimit(int bytes) async {
+    final int clamped = CacheSize.clamp(bytes);
+    await ref.read(downloadPreferencesProvider).setMaxCacheBytes(clamped);
+    state = AsyncData<int>(clamped);
+  }
+}
+
+final maxCacheBytesControllerProvider =
+    AsyncNotifierProvider<MaxCacheBytesController, int>(
+  MaxCacheBytesController.new,
+);
 
 /// Owns the "Wi-Fi only downloads" switch: loads the persisted value and writes
 /// changes back through [DownloadPreferences].

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -2,14 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/dimens.dart';
+import '../../core/models/cache_size.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/download_store.dart';
+import '../../core/services/offline_cache_manager.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../shared/widgets/empty_state.dart';
 import 'download_providers.dart';
 
 /// Manage explicit, user-controlled downloads. Lists the tracks the user has
-/// marked for offline use and exposes the "Wi-Fi only" preference. Downloads
-/// are always user-initiated — never automatic.
+/// marked for offline use — with their cache size and a "Keep offline" pin —
+/// shows how much cache is in use, and exposes the "Wi-Fi only" preference.
+/// Downloads are always user-initiated — never automatic.
 class DownloadsScreen extends ConsumerWidget {
   const DownloadsScreen({super.key});
 
@@ -20,6 +24,7 @@ class DownloadsScreen extends ConsumerWidget {
       appBar: AppBar(title: const Text('Downloads')),
       body: Column(
         children: [
+          const _CacheUsageHeader(),
           const _WifiOnlyToggle(),
           const Divider(height: 1),
           Expanded(child: _list(downloaded)),
@@ -53,6 +58,54 @@ class DownloadsScreen extends ConsumerWidget {
   }
 }
 
+/// A slim "used of limit" header. The full controls (change limit, clear) live
+/// on the Settings screen; this is a glanceable status line.
+class _CacheUsageHeader extends ConsumerWidget {
+  const _CacheUsageHeader();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final int maxBytes =
+        ref.watch(maxCacheBytesControllerProvider).valueOrNull ??
+            CacheSize.defaultLimit;
+    final CacheSnapshot snapshot =
+        ref.watch(cacheSnapshotProvider).valueOrNull ?? CacheSnapshot.empty;
+    final double fraction =
+        maxBytes <= 0 ? 0 : (snapshot.usedBytes / maxBytes).clamp(0.0, 1.0);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.md,
+        AppSpacing.md,
+        AppSpacing.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            '${CacheSize.formatBytes(snapshot.usedBytes)} of '
+            '${CacheSize.formatBytes(maxBytes)} cache used',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(AppRadii.pill),
+            child: LinearProgressIndicator(
+              value: fraction,
+              minHeight: 6,
+              backgroundColor: theme.colorScheme.surfaceContainerHighest,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _WifiOnlyToggle extends ConsumerWidget {
   const _WifiOnlyToggle();
 
@@ -80,10 +133,14 @@ class _DownloadedList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final Map<String, CachedTrack> entries =
+        ref.watch(cacheEntriesByIdProvider);
     return ListView.builder(
       itemCount: tracks.length,
       itemBuilder: (context, index) {
         final track = tracks[index];
+        final CachedTrack? entry = entries[track.id];
+        final bool pinned = entry?.pinned ?? false;
         return ListTile(
           leading: const Icon(Icons.music_note_outlined),
           title: Text(
@@ -91,22 +148,41 @@ class _DownloadedList extends ConsumerWidget {
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
-          subtitle: _subtitle(track),
-          trailing: IconButton(
-            icon: const Icon(Icons.delete_outline),
-            tooltip: 'Remove download',
-            padding: const EdgeInsets.all(AppSpacing.sm),
-            onPressed: () =>
-                ref.read(downloadRepositoryProvider).removeDownload(track.id),
+          subtitle: _subtitle(track, entry),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: Icon(pinned ? Icons.push_pin : Icons.push_pin_outlined),
+                color: pinned ? Theme.of(context).colorScheme.primary : null,
+                tooltip: pinned ? 'Unpin' : 'Keep offline',
+                onPressed: () => ref
+                    .read(offlineCacheManagerProvider)
+                    .setPinned(track.id, !pinned),
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                tooltip: 'Remove download',
+                onPressed: () => ref
+                    .read(downloadRepositoryProvider)
+                    .removeDownload(track.id),
+              ),
+            ],
           ),
         );
       },
     );
   }
 
-  static Widget? _subtitle(Track track) {
-    final artist = track.artistName;
-    if (artist == null || artist.isEmpty) return null;
-    return Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis);
+  static Widget? _subtitle(Track track, CachedTrack? entry) {
+    final String? artist = track.artistName;
+    final bool hasArtist = artist != null && artist.isNotEmpty;
+    final bool hasSize = entry != null && entry.sizeBytes > 0;
+    if (!hasArtist && !hasSize) return null;
+    final String text = <String>[
+      if (hasArtist) artist,
+      if (hasSize) CacheSize.formatBytes(entry.sizeBytes),
+    ].join('  •  ');
+    return Text(text, maxLines: 1, overflow: TextOverflow.ellipsis);
   }
 }

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -166,7 +166,7 @@ class _OverflowMenu extends ConsumerWidget {
     return PopupMenuButton<_TrackAction>(
       icon: const Icon(Icons.more_vert),
       tooltip: 'More actions',
-      onSelected: (action) => _run(ref, action),
+      onSelected: (action) => _run(context, ref, action),
       itemBuilder: (context) => _menuItems(),
     );
   }
@@ -212,16 +212,33 @@ class _OverflowMenu extends ConsumerWidget {
     );
   }
 
-  void _run(WidgetRef ref, _TrackAction action) {
+  Future<void> _run(
+    BuildContext context,
+    WidgetRef ref,
+    _TrackAction action,
+  ) async {
     switch (action) {
       case _TrackAction.playNext:
         ref.read(playbackControllerProvider).playNext(track);
       case _TrackAction.download:
       case _TrackAction.retryDownload:
-        ref.read(downloadRepositoryProvider).requestDownload(track);
+        await _download(context, ref);
       case _TrackAction.removeOffline:
       case _TrackAction.cancel:
-        ref.read(downloadRepositoryProvider).removeDownload(track.id);
+        await ref.read(downloadRepositoryProvider).removeDownload(track.id);
+    }
+  }
+
+  /// Starts the download, surfacing the one user-facing failure that isn't a
+  /// transient "failed" status: a full cache with nothing safe to evict. The
+  /// message is friendly and secret-free; other errors fall through to the
+  /// row's "failed" indicator (with a retry action).
+  Future<void> _download(BuildContext context, WidgetRef ref) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(downloadRepositoryProvider).requestDownload(track);
+    } on CacheStorageException catch (error) {
+      messenger.showSnackBar(SnackBar(content: Text(error.message)));
     }
   }
 }

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/playback_state.dart';
@@ -28,6 +30,12 @@ final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
   return OfflineFirstPlayableUriResolver(
     locator: ref.watch(cachedTrackLocatorProvider),
     fallback: fallback,
+    // On a cache hit, refresh the track's least-recently-used position so
+    // eviction keeps what's actually listened to. Read lazily (no build-time
+    // dependency on the cache manager) and never awaited — a metadata write
+    // must not block or break playback.
+    onCacheHit: (trackId) =>
+        unawaited(ref.read(offlineCacheManagerProvider).notePlayed(trackId)),
   );
 });
 
@@ -62,3 +70,13 @@ final playbackStateProvider = StreamProvider<PlaybackState>((ref) {
   final controller = ref.watch(playbackControllerProvider);
   return controller.stateStream;
 });
+
+/// Production binding: lets the cache eviction policy see the currently playing
+/// track so it's never deleted to make room. The closure reads the controller's
+/// latest state lazily at eviction time, so applying this override doesn't tie
+/// the download repository to the controller's lifecycle. Applied in `main`;
+/// tests keep the data-layer default (nothing playing).
+final currentlyPlayingTrackIdOverride =
+    currentlyPlayingTrackIdProvider.overrideWith(
+  (ref) => () => ref.read(playbackControllerProvider).state.currentTrack?.id,
+);

--- a/lib/features/settings/cache/cache_settings_section.dart
+++ b/lib/features/settings/cache/cache_settings_section.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/cache_size.dart';
+import '../../../core/services/offline_cache_manager.dart';
+import '../../../data/repositories/download_repository_provider.dart';
+import '../../downloads/download_providers.dart';
+
+/// The offline-cache card on the Settings screen.
+///
+/// Shows how much app-managed space is in use against the user's limit, and
+/// exposes the two controls: change the limit, and clear the cache. The widget
+/// never deletes files or computes eviction itself — every action is forwarded
+/// to the [OfflineCacheManager] / preferences, which own that policy.
+class CacheSettingsSection extends ConsumerWidget {
+  const CacheSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final int maxBytes =
+        ref.watch(maxCacheBytesControllerProvider).valueOrNull ??
+            CacheSize.defaultLimit;
+    final CacheSnapshot snapshot =
+        ref.watch(cacheSnapshotProvider).valueOrNull ?? CacheSnapshot.empty;
+
+    final int used = snapshot.usedBytes;
+    final int available = used >= maxBytes ? 0 : maxBytes - used;
+    final double fraction =
+        maxBytes <= 0 ? 0 : (used / maxBytes).clamp(0.0, 1.0);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.sd_storage_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Offline cache', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Downloads stay under your limit. When it fills, the '
+              'least-recently-played unpinned tracks are removed first — pinned '
+              'tracks and the track playing now are kept.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(AppRadii.pill),
+              child: LinearProgressIndicator(
+                value: fraction,
+                minHeight: 8,
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '${CacheSize.formatBytes(used)} of '
+                  '${CacheSize.formatBytes(maxBytes)} used',
+                  style: theme.textTheme.bodyMedium,
+                ),
+                Text(
+                  '${CacheSize.formatBytes(available)} free',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: () => _changeLimit(context, ref, maxBytes),
+                    icon: const Icon(Icons.tune_outlined),
+                    label: const Text('Change limit'),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: snapshot.entries.isEmpty
+                        ? null
+                        : () => _clearCache(context, ref),
+                    icon: const Icon(Icons.delete_sweep_outlined),
+                    label: const Text('Clear cache'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _changeLimit(
+    BuildContext context,
+    WidgetRef ref,
+    int currentBytes,
+  ) async {
+    final int? chosen = await showDialog<int>(
+      context: context,
+      builder: (_) => _CacheLimitDialog(currentBytes: currentBytes),
+    );
+    if (chosen != null) {
+      await ref.read(maxCacheBytesControllerProvider.notifier).setLimit(chosen);
+    }
+  }
+
+  Future<void> _clearCache(BuildContext context, WidgetRef ref) async {
+    final _ClearChoice? choice = await showDialog<_ClearChoice>(
+      context: context,
+      builder: (_) => const _ClearCacheDialog(),
+    );
+    if (choice == null) return;
+    final manager = ref.read(offlineCacheManagerProvider);
+    switch (choice) {
+      case _ClearChoice.unpinned:
+        await manager.clearUnpinned();
+      case _ClearChoice.all:
+        await manager.clearAll();
+    }
+  }
+}
+
+/// The "Change limit" dialog: the named presets plus a custom value in GB.
+class _CacheLimitDialog extends StatefulWidget {
+  const _CacheLimitDialog({required this.currentBytes});
+
+  final int currentBytes;
+
+  @override
+  State<_CacheLimitDialog> createState() => _CacheLimitDialogState();
+}
+
+class _CacheLimitDialogState extends State<_CacheLimitDialog> {
+  late bool _custom;
+  late final TextEditingController _customController;
+  late int _selectedPreset;
+
+  @override
+  void initState() {
+    super.initState();
+    _custom = !CacheSize.isPreset(widget.currentBytes);
+    _selectedPreset = CacheSize.isPreset(widget.currentBytes)
+        ? widget.currentBytes
+        : CacheSize.defaultLimit;
+    final double gb = widget.currentBytes / CacheSize.bytesPerGb;
+    final String gbText = gb == gb.roundToDouble()
+        ? gb.toStringAsFixed(0)
+        : gb.toStringAsFixed(1);
+    _customController = TextEditingController(text: gbText);
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    super.dispose();
+  }
+
+  int? get _resolvedBytes {
+    if (!_custom) return _selectedPreset;
+    final double? gb = double.tryParse(_customController.text.trim());
+    if (gb == null || gb <= 0) return null;
+    return CacheSize.clamp(CacheSize.gigabytes(gb));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Maximum cache size'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final int preset in CacheSize.presets)
+              RadioListTile<int>(
+                contentPadding: EdgeInsets.zero,
+                title: Text(CacheSize.formatBytes(preset)),
+                value: preset,
+                groupValue: _custom ? null : _selectedPreset,
+                onChanged: (value) => setState(() {
+                  _custom = false;
+                  if (value != null) _selectedPreset = value;
+                }),
+              ),
+            RadioListTile<bool>(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Custom'),
+              value: true,
+              groupValue: _custom,
+              onChanged: (_) => setState(() => _custom = true),
+            ),
+            if (_custom)
+              Padding(
+                padding: const EdgeInsets.only(left: AppSpacing.md),
+                child: TextField(
+                  controller: _customController,
+                  autofocus: true,
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  onChanged: (_) => setState(() {}),
+                  decoration: const InputDecoration(
+                    labelText: 'Size',
+                    suffixText: 'GB',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _resolvedBytes == null
+              ? null
+              : () => Navigator.of(context).pop(_resolvedBytes),
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+}
+
+enum _ClearChoice { unpinned, all }
+
+/// The "Clear cache" dialog: free unpinned downloads, or everything.
+class _ClearCacheDialog extends StatelessWidget {
+  const _ClearCacheDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Clear offline cache'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: const Icon(Icons.cleaning_services_outlined),
+            title: const Text('Clear unpinned'),
+            subtitle: const Text('Keep tracks you marked "Keep offline"'),
+            onTap: () => Navigator.of(context).pop(_ClearChoice.unpinned),
+          ),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            leading: const Icon(Icons.delete_forever_outlined),
+            title: const Text('Clear all'),
+            subtitle: const Text('Remove every offline download'),
+            onTap: () => Navigator.of(context).pop(_ClearChoice.all),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 
 import '../../app/dimens.dart';
+import 'cache/cache_settings_section.dart';
 import 'jellyfin/jellyfin_settings_section.dart';
 
-/// Settings. Hosts the connection/source options; the Jellyfin section is the
-/// first real entry. Theme, downloads, and other options will join it here.
+/// Settings. Hosts the connection/source and offline-storage options. Theme and
+/// other options will join them here.
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
@@ -16,6 +17,8 @@ class SettingsScreen extends StatelessWidget {
         padding: const EdgeInsets.all(AppSpacing.md),
         children: const [
           JellyfinSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          CacheSettingsSection(),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ Future<void> main() async {
       sharedPreferencesDownloadPreferencesOverride,
       fileSystemOfflineFileStoreOverride,
       jellyfinRemoteTrackDownloaderOverride,
+      currentlyPlayingTrackIdOverride,
       secureJellyfinSessionStoreOverride,
     ],
   );

--- a/test/core/models/cache_size_test.dart
+++ b/test/core/models/cache_size_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cache_size.dart';
+
+void main() {
+  group('CacheSize', () {
+    test('offers the expected presets and a sane default', () {
+      expect(CacheSize.presets, <int>[
+        1 * CacheSize.bytesPerGb,
+        2 * CacheSize.bytesPerGb,
+        4 * CacheSize.bytesPerGb,
+        8 * CacheSize.bytesPerGb,
+        16 * CacheSize.bytesPerGb,
+      ]);
+      expect(CacheSize.defaultLimit, 4 * CacheSize.bytesPerGb);
+      expect(CacheSize.isPreset(CacheSize.defaultLimit), isTrue);
+      expect(CacheSize.isPreset(CacheSize.defaultLimit + 1), isFalse);
+    });
+
+    test('gigabytes converts to bytes', () {
+      expect(CacheSize.gigabytes(2), 2 * CacheSize.bytesPerGb);
+      expect(CacheSize.gigabytes(1.5), (1.5 * CacheSize.bytesPerGb).round());
+    });
+
+    test('clamp keeps values within the supported range', () {
+      expect(CacheSize.clamp(0), CacheSize.minLimit);
+      expect(CacheSize.clamp(CacheSize.maxLimit + 1), CacheSize.maxLimit);
+      expect(CacheSize.clamp(CacheSize.defaultLimit), CacheSize.defaultLimit);
+    });
+
+    group('formatBytes', () {
+      test('formats bytes, KB, MB and GB', () {
+        expect(CacheSize.formatBytes(0), '0 B');
+        expect(CacheSize.formatBytes(512), '512 B');
+        expect(CacheSize.formatBytes(CacheSize.bytesPerKb), '1 KB');
+        expect(CacheSize.formatBytes(CacheSize.bytesPerMb), '1 MB');
+        expect(CacheSize.formatBytes(512 * CacheSize.bytesPerMb), '512 MB');
+        expect(CacheSize.formatBytes(4 * CacheSize.bytesPerGb), '4 GB');
+      });
+
+      test('shows one decimal for fractional sizes', () {
+        expect(
+          CacheSize.formatBytes((1.5 * CacheSize.bytesPerGb).round()),
+          '1.5 GB',
+        );
+      });
+    });
+  });
+}

--- a/test/core/services/cache_eviction_policy_test.dart
+++ b/test/core/services/cache_eviction_policy_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/core/services/cache_eviction_policy.dart';
+
+/// A managed cache entry (has a file + size), the only kind eviction considers.
+CachedTrack _managed(
+  String id, {
+  int size = 100,
+  DateTime? accessed,
+  DateTime? cached,
+  bool pinned = false,
+}) {
+  return CachedTrack(
+    trackId: id,
+    fileName: '$id.mp3',
+    sizeBytes: size,
+    lastAccessedAt: accessed,
+    cachedAt: cached,
+    pinned: pinned,
+  );
+}
+
+void main() {
+  const CacheEvictionPolicy policy = CacheEvictionPolicy();
+
+  group('CacheEvictionPolicy', () {
+    test('fits with no eviction when there is room', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[_managed('a', size: 100)],
+        incomingBytes: 100,
+        maxBytes: 1000,
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict, isEmpty);
+    });
+
+    test('evicts the least-recently-used track first', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('old', size: 100, accessed: DateTime(2024, 1, 1)),
+          _managed('new', size: 100, accessed: DateTime(2024, 6, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250, // room for two 100s; a third needs one evicted
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict.map((e) => e.trackId), <String>['old']);
+    });
+
+    test('a never-played track is treated as oldest', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('played', size: 100, accessed: DateTime(2024, 1, 1)),
+          _managed('never', size: 100), // no lastAccessedAt
+        ],
+        incomingBytes: 100,
+        maxBytes: 250,
+      );
+
+      expect(plan.evict.map((e) => e.trackId), <String>['never']);
+    });
+
+    test('evicts several, least-recently-used first, until it fits', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('a', size: 100, accessed: DateTime(2024, 1, 1)),
+          _managed('b', size: 100, accessed: DateTime(2024, 2, 1)),
+          _managed('c', size: 100, accessed: DateTime(2024, 3, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250, // used 300 + 100 = 400; must free to <= 250 → drop 2
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict.map((e) => e.trackId), <String>['a', 'b']);
+    });
+
+    test('never evicts a pinned track', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('pinned',
+              size: 100, accessed: DateTime(2024, 1, 1), pinned: true),
+          _managed('loose', size: 100, accessed: DateTime(2024, 6, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250,
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict.map((e) => e.trackId), <String>['loose']);
+    });
+
+    test('never evicts the currently playing track', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('playing', size: 100, accessed: DateTime(2024, 1, 1)),
+          _managed('other', size: 100, accessed: DateTime(2024, 6, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250,
+        protectTrackId: 'playing',
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict.map((e) => e.trackId), <String>['other']);
+    });
+
+    test('does not fit when only pinned/playing tracks remain', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('pinned', size: 100, pinned: true),
+          _managed('playing', size: 100),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250, // used 200 + 100 = 300 > 250, nothing safe to drop
+        protectTrackId: 'playing',
+      );
+
+      expect(plan.fits, isFalse);
+      // Nothing is evicted when it still wouldn't fit.
+      expect(plan.evict, isEmpty);
+    });
+
+    test('a track larger than the whole limit never fits and evicts nothing',
+        () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[_managed('a', size: 100)],
+        incomingBytes: 5000,
+        maxBytes: 1000,
+      );
+
+      expect(plan.fits, isFalse);
+      expect(plan.evict, isEmpty);
+    });
+
+    test('on-device entries do not count and are never evicted', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          const CachedTrack(trackId: 'local'), // no file, size 0
+          _managed('remote', size: 100, accessed: DateTime(2024, 1, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 150,
+      );
+
+      // Only the managed remote track counts (100) and is the sole candidate.
+      expect(plan.fits, isTrue);
+      expect(plan.evict.map((e) => e.trackId), <String>['remote']);
+    });
+
+    test('a re-download replaces its own copy rather than evicting others', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('a', size: 100, accessed: DateTime(2024, 1, 1)),
+          _managed('b', size: 100, accessed: DateTime(2024, 6, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 200,
+        incomingTrackId: 'a', // 'a' is being re-downloaded
+      );
+
+      // 'a' doesn't count as existing use, so b(100) + a(100) = 200 fits.
+      expect(plan.fits, isTrue);
+      expect(plan.evict, isEmpty);
+    });
+  });
+}

--- a/test/core/services/offline_first_playable_uri_resolver_test.dart
+++ b/test/core/services/offline_first_playable_uri_resolver_test.dart
@@ -72,6 +72,32 @@ void main() {
       expect(fallback.resolved, isNull);
     });
 
+    test('notifies onCacheHit with the track id on a cache hit', () async {
+      final hits = <String>[];
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator('/offline_audio/t1.mp3'),
+        fallback: _RecordingResolver(Uri.parse('https://stream/t1')),
+        onCacheHit: hits.add,
+      );
+
+      await resolver.resolve(_track);
+
+      expect(hits, <String>['t1']);
+    });
+
+    test('does not notify onCacheHit on a cache miss', () async {
+      final hits = <String>[];
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator(null),
+        fallback: _RecordingResolver(Uri.parse('https://stream/t1')),
+        onCacheHit: hits.add,
+      );
+
+      await resolver.resolve(_track);
+
+      expect(hits, isEmpty);
+    });
+
     test('streams via the fallback on a cache miss', () async {
       final fallback = _RecordingResolver(
         Uri.parse('https://music.example.com/Audio/t1/universal'),

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/core/repositories/offline_file_store.dart';
 import 'package:linthra/core/services/connectivity_service.dart';
+import 'package:linthra/core/services/offline_cache_manager.dart';
 import 'package:linthra/core/services/remote_track_downloader.dart';
 import 'package:linthra/data/repositories/cache_download_repository.dart';
 import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
@@ -47,6 +49,33 @@ class _FakeRemoteDownloader implements RemoteTrackDownloader {
     final Object? err = error;
     if (err != null) throw err;
     return const RemoteTrackData(bytes: bytes, fileExtension: 'mp3');
+  }
+}
+
+/// Wraps an in-memory file store and records every delete, so a test can prove
+/// the cache only ever deletes app-managed files (never a local source file).
+class _SpyOfflineFileStore implements OfflineFileStore {
+  _SpyOfflineFileStore(this._inner);
+
+  final InMemoryOfflineFileStore _inner;
+  final List<String> deleted = <String>[];
+
+  List<int>? bytesFor(String fileName) => _inner.bytesFor(fileName);
+
+  @override
+  Future<String> write(String trackId, List<int> bytes, {String? extension}) =>
+      _inner.write(trackId, bytes, extension: extension);
+
+  @override
+  Future<String?> pathFor(String fileName) => _inner.pathFor(fileName);
+
+  @override
+  Future<int?> sizeFor(String fileName) => _inner.sizeFor(fileName);
+
+  @override
+  Future<void> delete(String fileName) {
+    deleted.add(fileName);
+    return _inner.delete(fileName);
   }
 }
 
@@ -289,6 +318,273 @@ void main() {
         await repository.requestDownload(_jellyfin('j1'));
 
         expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+      });
+    });
+
+    group('cache metadata', () {
+      test('a download records size, timestamps and source type', () async {
+        final repository = build();
+
+        await repository.requestDownload(_jellyfin('j1'));
+
+        final CachedTrack saved = (await store.loadDownloads()).single;
+        // Each canned fetch returns 4 bytes.
+        expect(saved.sizeBytes, 4);
+        expect(saved.cachedAt, isNotNull);
+        expect(saved.lastAccessedAt, isNotNull);
+        // The non-secret URI scheme, never the full URL/token.
+        expect(saved.sourceType, 'jellyfin');
+        expect(saved.pinned, isFalse);
+      });
+
+      test('cacheSnapshot totals only app-managed bytes', () async {
+        final repository = build();
+        await repository.requestDownload(_jellyfin('j1')); // 4 managed bytes
+        await repository.requestDownload(_local('a')); // on-device, 0 bytes
+
+        final CacheSnapshot snapshot = await repository.cacheSnapshot();
+        expect(snapshot.usedBytes, 4);
+        expect(snapshot.entries, hasLength(2));
+        expect(snapshot.managedCount, 1);
+      });
+
+      test('a managed entry missing its size is backfilled from disk on load',
+          () async {
+        // Simulate a record written by an earlier version: file present, but
+        // no sizeBytes recorded.
+        final String fileName = await files
+            .write('j1', const <int>[1, 2, 3, 4, 5], extension: 'mp3');
+        await store.saveDownloads(<CachedTrack>[
+          CachedTrack(trackId: 'j1', fileName: fileName),
+        ]);
+
+        final repository = build();
+        final CacheSnapshot snapshot = await repository.cacheSnapshot();
+
+        expect(snapshot.usedBytes, 5);
+        expect((await store.loadDownloads()).single.sizeBytes, 5);
+      });
+
+      test('stale metadata for a missing file is pruned on load', () async {
+        final String present =
+            await files.write('here', const <int>[1, 2, 3], extension: 'mp3');
+        await store.saveDownloads(<CachedTrack>[
+          CachedTrack(trackId: 'here', fileName: present, sizeBytes: 3),
+          // Points at a file the store doesn't have (OS reclaimed it).
+          const CachedTrack(
+              trackId: 'gone', fileName: 'gone.mp3', sizeBytes: 9),
+        ]);
+
+        final repository = build();
+
+        expect(await repository.statusFor('here'), DownloadStatus.downloaded);
+        expect(
+            await repository.statusFor('gone'), DownloadStatus.notDownloaded);
+        // The prune is persisted, so the stale record doesn't linger.
+        final List<CachedTrack> remaining = await store.loadDownloads();
+        expect(remaining.map((c) => c.trackId), <String>['here']);
+      });
+    });
+
+    group('cache limit and eviction', () {
+      // A clock that advances one minute per call, so cachedAt/lastAccessedAt
+      // are distinct and least-recently-used ordering is deterministic.
+      DateTime Function() incrementingClock() {
+        int tick = 0;
+        return () => DateTime(2024, 1, 1).add(Duration(minutes: tick++));
+      }
+
+      CacheDownloadRepository buildLimited({
+        required int maxBytes,
+        String? Function()? currentlyPlaying,
+        DateTime Function()? now,
+      }) {
+        preferences = InMemoryDownloadPreferences(maxCacheBytes: maxBytes);
+        return CacheDownloadRepository(
+          store: store,
+          files: files,
+          downloader: downloader,
+          connectivity: connectivity,
+          preferences: preferences,
+          currentlyPlayingTrackId: currentlyPlaying,
+          now: now,
+        );
+      }
+
+      test('downloading under the limit succeeds without eviction', () async {
+        // Room for two 4-byte downloads.
+        final repository = buildLimited(maxBytes: 10);
+
+        await repository.requestDownload(_jellyfin('j1'));
+        await repository.requestDownload(_jellyfin('j2'));
+
+        final List<String> ids = await repository.downloadedTrackIds();
+        ids.sort();
+        expect(ids, <String>['j1', 'j2']);
+        expect((await repository.cacheSnapshot()).usedBytes, 8);
+      });
+
+      test('downloading over the limit evicts the least-recently-used track',
+          () async {
+        final repository = buildLimited(maxBytes: 10, now: incrementingClock());
+
+        await repository.requestDownload(_jellyfin('j1')); // oldest
+        await repository.requestDownload(_jellyfin('j2'));
+        await repository.requestDownload(_jellyfin('j3')); // forces eviction
+
+        expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect(await repository.statusFor('j2'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('j3'), DownloadStatus.downloaded);
+        // The evicted file's bytes are gone from disk.
+        expect(files.bytesFor('j1.mp3'), isNull);
+      });
+
+      test('playing a track refreshes it so a stale one is evicted instead',
+          () async {
+        final repository = buildLimited(maxBytes: 10, now: incrementingClock());
+
+        await repository.requestDownload(_jellyfin('j1'));
+        await repository.requestDownload(_jellyfin('j2'));
+        // j1 was just played, so j2 is now the least-recently-used.
+        await repository.notePlayed('j1');
+        await repository.requestDownload(_jellyfin('j3'));
+
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('j2'), DownloadStatus.notDownloaded);
+        expect(await repository.statusFor('j3'), DownloadStatus.downloaded);
+      });
+
+      test('pinned tracks are never evicted automatically', () async {
+        final repository = buildLimited(maxBytes: 10, now: incrementingClock());
+
+        await repository.requestDownload(_jellyfin('j1')); // oldest
+        await repository.setPinned('j1', true);
+        await repository.requestDownload(_jellyfin('j2'));
+        await repository.requestDownload(_jellyfin('j3')); // forces eviction
+
+        // j1 is pinned, so the unpinned j2 goes instead.
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('j2'), DownloadStatus.notDownloaded);
+        expect(await repository.statusFor('j3'), DownloadStatus.downloaded);
+      });
+
+      test('the currently playing track is never evicted', () async {
+        final repository = buildLimited(
+          maxBytes: 10,
+          currentlyPlaying: () => 'j1',
+          now: incrementingClock(),
+        );
+
+        await repository.requestDownload(_jellyfin('j1')); // oldest + playing
+        await repository.requestDownload(_jellyfin('j2'));
+        await repository.requestDownload(_jellyfin('j3')); // forces eviction
+
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('j2'), DownloadStatus.notDownloaded);
+        expect(await repository.statusFor('j3'), DownloadStatus.downloaded);
+      });
+
+      test('refuses with a friendly, secret-free error when nothing is safe',
+          () async {
+        // Room for one 4-byte track only.
+        final repository = buildLimited(maxBytes: 4);
+        await repository.requestDownload(_jellyfin('j1'));
+        await repository.setPinned('j1', true);
+
+        Object? caught;
+        try {
+          await repository.requestDownload(_jellyfin('j2'));
+        } catch (error) {
+          caught = error;
+        }
+
+        expect(caught, isA<CacheStorageException>());
+        // The error never carries a URL, token, or path.
+        final String message = (caught! as CacheStorageException).message;
+        expect(message.toLowerCase(), isNot(contains('http')));
+        expect(message.toLowerCase(), isNot(contains('token')));
+        expect(message, isNot(contains('/')));
+
+        // j2 was not cached and j1 (pinned) was left untouched.
+        expect(await repository.statusFor('j2'), DownloadStatus.notDownloaded);
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+        expect((await store.loadDownloads()).map((c) => c.trackId),
+            <String>['j1']);
+        expect(files.bytesFor('j1.mp3'), isNotNull);
+      });
+    });
+
+    group('manual cache controls', () {
+      test('clear all removes every managed file and its metadata', () async {
+        final spy = _SpyOfflineFileStore(files);
+        final repository = CacheDownloadRepository(
+          store: store,
+          files: spy,
+          downloader: downloader,
+          connectivity: connectivity,
+          preferences: preferences,
+        );
+        await repository.requestDownload(_jellyfin('j1'));
+        await repository.requestDownload(_jellyfin('j2'));
+        await repository.setPinned('j1', true);
+
+        await repository.clearAll();
+
+        // Pinned items included: clear-all is the nuclear option.
+        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await store.loadDownloads(), isEmpty);
+        expect(spy.bytesFor('j1.mp3'), isNull);
+        expect(spy.bytesFor('j2.mp3'), isNull);
+      });
+
+      test('clear unpinned preserves pinned tracks', () async {
+        final repository = build();
+        await repository.requestDownload(_jellyfin('keep'));
+        await repository.requestDownload(_jellyfin('drop'));
+        await repository.setPinned('keep', true);
+
+        await repository.clearUnpinned();
+
+        expect(await repository.statusFor('keep'), DownloadStatus.downloaded);
+        expect(
+            await repository.statusFor('drop'), DownloadStatus.notDownloaded);
+        expect(files.bytesFor('keep.mp3'), isNotNull);
+        expect(files.bytesFor('drop.mp3'), isNull);
+      });
+
+      test('clearing never deletes a local source file', () async {
+        final spy = _SpyOfflineFileStore(files);
+        final repository = CacheDownloadRepository(
+          store: store,
+          files: spy,
+          downloader: downloader,
+          connectivity: connectivity,
+          preferences: preferences,
+        );
+        await repository.requestDownload(_jellyfin('remote'));
+        await repository.requestDownload(_local('song')); // local source file
+
+        await repository.clearAll();
+
+        // Only the app-managed remote file was ever handed to delete(); the
+        // local track has no managed file, so its source is never touched.
+        expect(spy.deleted, <String>['remote.mp3']);
+        expect(spy.deleted.any((f) => f.contains('song')), isFalse);
+      });
+
+      test('cacheStream emits the current snapshot then changes', () async {
+        final repository = build();
+        final snapshots = <CacheSnapshot>[];
+        final sub = repository.cacheStream.listen(snapshots.add);
+        await _settle();
+
+        expect(snapshots.first.usedBytes, 0);
+
+        await repository.requestDownload(_jellyfin('j1'));
+        await _settle();
+
+        expect(snapshots.last.usedBytes, 4);
+        await sub.cancel();
       });
     });
   });

--- a/test/data/repositories/download_preferences_max_cache_test.dart
+++ b/test/data/repositories/download_preferences_max_cache_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cache_size.dart';
+import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
+import 'package:linthra/data/repositories/shared_preferences_download_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('maxCacheBytes preference', () {
+    test('in-memory defaults to the sane default and round-trips a value',
+        () async {
+      final prefs = InMemoryDownloadPreferences();
+      expect(await prefs.maxCacheBytes(), CacheSize.defaultLimit);
+
+      await prefs.setMaxCacheBytes(2 * CacheSize.bytesPerGb);
+      expect(await prefs.maxCacheBytes(), 2 * CacheSize.bytesPerGb);
+    });
+
+    group('shared_preferences', () {
+      setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+      test('defaults to the sane default when never set', () async {
+        const prefs = SharedPreferencesDownloadPreferences();
+        expect(await prefs.maxCacheBytes(), CacheSize.defaultLimit);
+      });
+
+      test('persists a chosen limit across instances', () async {
+        const prefs = SharedPreferencesDownloadPreferences();
+        await prefs.setMaxCacheBytes(8 * CacheSize.bytesPerGb);
+
+        // A fresh instance reads the same persisted value.
+        const reopened = SharedPreferencesDownloadPreferences();
+        expect(await reopened.maxCacheBytes(), 8 * CacheSize.bytesPerGb);
+      });
+
+      test('clamps an out-of-range value into the supported range', () async {
+        const prefs = SharedPreferencesDownloadPreferences();
+        await prefs.setMaxCacheBytes(1);
+
+        expect(await prefs.maxCacheBytes(), CacheSize.minLimit);
+      });
+    });
+  });
+}

--- a/test/data/repositories/file_system_offline_file_store_test.dart
+++ b/test/data/repositories/file_system_offline_file_store_test.dart
@@ -56,6 +56,25 @@ void main() {
       expect(await store.pathFor('missing.mp3'), isNull);
     });
 
+    test('sizeFor returns the byte length on disk', () async {
+      final String fileName =
+          await store.write('t1', const <int>[1, 2, 3, 4, 5], extension: 'mp3');
+
+      expect(await store.sizeFor(fileName), 5);
+    });
+
+    test('sizeFor returns null for a file that was never written', () async {
+      expect(await store.sizeFor('missing.mp3'), isNull);
+    });
+
+    test('sizeFor returns null after the file is deleted', () async {
+      final String fileName =
+          await store.write('t1', const <int>[1, 2], extension: 'mp3');
+      await store.delete(fileName);
+
+      expect(await store.sizeFor(fileName), isNull);
+    });
+
     test('delete removes the cached file', () async {
       final String fileName =
           await store.write('t1', const <int>[1], extension: 'mp3');

--- a/test/features/settings/cache/cache_settings_section_test.dart
+++ b/test/features/settings/cache/cache_settings_section_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/features/settings/cache/cache_settings_section.dart';
+
+import '../../library/fake_remote_track_downloader.dart';
+
+void main() {
+  group('CacheSettingsSection', () {
+    Future<ProviderContainer> pump(WidgetTester tester) async {
+      final container = ProviderContainer(
+        // Plugin-free defaults; only the remote downloader is faked so a
+        // jellyfin: track counts as a managed download.
+        overrides: [
+          remoteTrackDownloaderProvider
+              .overrideWithValue(FakeRemoteTrackDownloader()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: CacheSettingsSection()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets('shows usage against the default 4 GB limit', (tester) async {
+      await pump(tester);
+
+      expect(find.text('Offline cache'), findsOneWidget);
+      expect(find.textContaining('of 4 GB used'), findsOneWidget);
+      expect(find.textContaining('0 B of'), findsOneWidget);
+    });
+
+    testWidgets('changing the limit updates the displayed maximum', (
+      tester,
+    ) async {
+      await pump(tester);
+
+      await tester.tap(find.text('Change limit'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('8 GB'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('of 8 GB used'), findsOneWidget);
+    });
+
+    testWidgets('clear all empties the cache', (tester) async {
+      final container = await pump(tester);
+
+      // A download so there's something to clear (Clear cache is disabled when
+      // the cache is empty).
+      await container.read(downloadRepositoryProvider).requestDownload(
+            const Track(id: 'j1', title: 'Song', uri: 'jellyfin:j1'),
+          );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('4 B of'), findsOneWidget);
+
+      await tester.tap(find.text('Clear cache'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear all'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('0 B of'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an intelligent, fully user-controlled offline cache manager on top of the existing Plexamp-style downloads. The cache is kept under a size limit you choose, with safe least-recently-used eviction — open-source and user-owned, no Plex Pass required. Downloads stay explicit; nothing is fetched automatically.

## Smart cache behavior

- Downloads still work exactly as before (explicit, source-aware, Wi-Fi-only respected), but a remote download now **makes room first** so the cache stays under your limit.
- Playing a cached track refreshes its "last played" position, so eviction keeps what you actually listen to.
- A cached file the OS reclaimed is detected on load: its stale metadata is pruned and playback falls back to streaming rather than opening a missing file.

## Default cache limit

- Presets: **1, 2, 4, 8, 16 GB**, plus a **custom** value (GB).
- **Default: 4 GB** — conservative enough not to fill a phone, large enough for a real offline set.
- Persisted via `shared_preferences` (`DownloadPreferences.maxCacheBytes`), clamped to a sane range (256 MB–512 GB).

## Cache eviction policy

Centralized in a pure, exhaustively tested `CacheEvictionPolicy`; the repository applies it, the UI never computes it. When a new download would exceed the limit:

1. The **currently playing** track is never evicted.
2. **Pinned** ("Keep offline") tracks are never auto-evicted.
3. Among the rest, **least-recently-played first** (never-played counts as oldest; ties broken by oldest cached time, then id).
4. If freeing all eligible tracks still wouldn't fit (everything is pinned/playing, or the track is larger than the whole limit), **nothing is deleted** and the download is refused with a friendly, secret-free **"Not enough cache space"** error.

## Pinned / Keep offline behavior

- Pin a download from the Downloads list ("Keep offline"). Pinned tracks survive auto-eviction and **"Clear unpinned"**.
- Only an explicit **"Clear all"** removes pinned items.

## What can and cannot be deleted

- **Can:** app-managed cache files in the app-private offline directory, addressed only by an id-derived file name.
- **Cannot:** the user's **local source files** in their music folder — their paths are never passed to the file store, so an on-device track's bytes can't be deleted. Clearing an on-device "available offline" marker drops only the marker.

## Settings UI changes

- **Settings → Offline cache** card: used / max / free space with a progress bar, **Change limit** (presets + custom), and **Clear cache** (Clear unpinned / Clear all).
- **Downloads** screen: per-track **size**, a **Keep offline** pin toggle, remove, and a slim **"X of Y used"** usage header.
- Library "Download for offline" now surfaces the "Not enough cache space" message as a snackbar.

## Security

- No Jellyfin token or authenticated URL is ever stored in cache metadata, file names, logs, or UI errors. The stored `sourceType` is the bare URI scheme (`jellyfin` / `file`), never the full URL. The "not enough space" error carries no path/URL/token.

## Architecture

- `CacheDownloadRepository` implements both `DownloadRepository` (lifecycle) and a new `OfflineCacheManager` (usage stream, pin, note-played, clear) — same instance behind both providers, so status and cache state stay consistent.
- Eviction is a pure `CacheEvictionPolicy`; `CachedTrack` gained `sourceType`, `sizeBytes`, `cachedAt`, `lastAccessedAt`, `pinned` (backward-compatible JSON; legacy records load and backfill size from disk).
- `OfflineFileStore` gained `sizeFor`; the playback resolver gained an `onCacheHit` hook (wired lazily, no provider cycle, never blocks playback).

## Tests added

Pure policy (LRU, pinned/playing protection, not-enough-space, oversized, on-device exclusion, re-download), `CacheSize` formatting/presets/clamp, cache-limit persistence (in-memory + `shared_preferences`), `OfflineFileStore.sizeFor`, resolver `onCacheHit`, and repository integration: size/timestamp/source metadata, usage totals, size backfill, stale-metadata prune, download under/over the limit, LRU eviction, play-refresh, pinned/playing not evicted, not-enough-space refusal, clear all / clear unpinned, **local source files never deleted** (delete-spy), token never in metadata, and a Settings cache-card widget test. Full suite: **420 passing**.

## Verification

- `flutter pub get` ✅
- `dart format --set-exit-if-changed .` ✅ (0 changed)
- `flutter analyze` ✅ (no issues)
- `flutter test` ✅ (420 passed)

## Known limitations

- **Eviction is inline, not a background sweeper** — space is freed only when a new download needs it (and stale metadata only on load); there's no periodic reconciliation against the directory's real on-disk size.
- A remote track **larger than the whole limit** can't be cached at all (reported, not silently truncated).
- Still no background download manager / resume; queued downloads don't auto-flush when Wi-Fi returns (re-tap to retry) — unchanged from the previous PR.
- Connectivity is still optimistic (`connectivity_plus` not yet wired).

## Next recommended PR

Album/playlist-level **"download all"** that reuses this per-track policy (the seam is ready), and/or a background download + eviction worker with resumable transfers backed by a Drift `downloads` table (graduating from the `DownloadStore` key/value seam).

## Manual Android test checklist

- [ ] Set the cache limit to a small value in Settings → Offline cache.
- [ ] Download several Jellyfin tracks; confirm the cache size updates.
- [ ] Confirm old unpinned tracks are evicted when the limit is reached.
- [ ] Pin a track ("Keep offline") and confirm it survives eviction / "Clear unpinned".
- [ ] Confirm the currently playing track is not deleted under pressure.
- [ ] Confirm "Not enough cache space" appears when only pinned/playing remain.
- [ ] Clear cache (all / unpinned) from Settings.
- [ ] Confirm local music-folder files are never deleted.
- [ ] Confirm Jellyfin streaming still works after cache cleanup.

https://claude.ai/code/session_01U3mUsDhpJoMjcUw5LnLNjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3mUsDhpJoMjcUw5LnLNjc)_