### PR TITLE
Fix Library alphabet fast scroller overlapping track rows

### DIFF
--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -5,7 +5,7 @@ import '../../../core/models/track.dart';
 import 'track_tile.dart';
 
 /// A track list with first-letter section grouping and an A–Z fast-scroll
-/// index down the trailing edge, so large libraries stay navigable.
+/// index pinned to the trailing edge, so large libraries stay navigable.
 ///
 /// Tracks are sorted by title (case-insensitive) and grouped under a header for
 /// each leading letter; titles that don't start with a letter fall under '#'.
@@ -29,6 +29,10 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
   static const double _headerExtent = 36;
   static const double _trackExtent = 64;
 
+  /// Width of the trailing A–Z rail. The list reserves this much right-side
+  /// padding so rows (and the 3-dot overflow menu) never sit under the rail.
+  static const double _railWidth = 28;
+
   final ScrollController _controller = ScrollController();
 
   late List<Track> _sorted;
@@ -36,10 +40,19 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
   late List<String> _letters;
   late Map<String, double> _letterOffsets;
 
+  /// The section the list is currently parked at — highlighted in the rail and
+  /// shown in the scrub bubble. Tracks both manual scrolling and rail drags.
+  String? _activeLetter;
+
+  /// True while the user is touching/dragging the rail, which surfaces the
+  /// larger active-letter bubble.
+  bool _scrubbing = false;
+
   @override
   void initState() {
     super.initState();
     _rebuildIndex();
+    _controller.addListener(_syncActiveLetter);
   }
 
   @override
@@ -52,6 +65,7 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
 
   @override
   void dispose() {
+    _controller.removeListener(_syncActiveLetter);
     _controller.dispose();
     super.dispose();
   }
@@ -80,6 +94,7 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
       _entries.add(_Entry.track(i));
       offset += _trackExtent;
     }
+    _activeLetter = _letters.isNotEmpty ? _letters.first : null;
   }
 
   /// The leading index character for [title]: an uppercase letter, or '#' for
@@ -91,21 +106,51 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
     return RegExp('[A-Z]').hasMatch(first) ? first : '#';
   }
 
+  /// Keeps [_activeLetter] in step with normal list scrolling so the rail
+  /// highlight reflects where the user actually is, not just where they tapped.
+  void _syncActiveLetter() {
+    if (!_controller.hasClients) return;
+    final letter = _letterForOffset(_controller.offset);
+    if (letter != null && letter != _activeLetter) {
+      setState(() => _activeLetter = letter);
+    }
+  }
+
+  /// The last section whose header sits at or above [offset] — i.e. the section
+  /// currently scrolled to the top of the viewport.
+  String? _letterForOffset(double offset) {
+    String? result;
+    for (final entry in _letterOffsets.entries) {
+      if (entry.value <= offset + 1) {
+        result = entry.key;
+      } else {
+        break;
+      }
+    }
+    return result ?? (_letters.isNotEmpty ? _letters.first : null);
+  }
+
   void _jumpToLetter(String letter) {
     final offset = _letterOffsets[letter];
     if (offset == null || !_controller.hasClients) return;
     final max = _controller.position.maxScrollExtent;
     _controller.jumpTo(offset.clamp(0.0, max));
+    if (letter != _activeLetter) {
+      setState(() => _activeLetter = letter);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
+    final showRail = _letters.length >= 2;
     return Stack(
       children: [
         ListView.builder(
           key: const Key('library_track_list'),
           controller: _controller,
-          padding: const EdgeInsets.only(right: AppSpacing.md),
+          // Reserve room for the rail so rows never render beneath it.
+          padding:
+              EdgeInsets.only(right: showRail ? _railWidth : AppSpacing.md),
           itemCount: _entries.length,
           itemExtentBuilder: (index, _) =>
               _entries[index].isHeader ? _headerExtent : _trackExtent,
@@ -117,13 +162,27 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
             return TrackTile(tracks: _sorted, index: entry.trackIndex!);
           },
         ),
-        Align(
-          alignment: Alignment.centerRight,
-          child: _AlphabetIndex(
-            letters: _letters,
-            onSelected: _jumpToLetter,
+        if (showRail)
+          Positioned(
+            top: 0,
+            bottom: 0,
+            right: 0,
+            width: _railWidth,
+            child: _AlphabetIndex(
+              letters: _letters,
+              activeLetter: _activeLetter,
+              onSelected: _jumpToLetter,
+              onScrubChanged: (scrubbing) =>
+                  setState(() => _scrubbing = scrubbing),
+            ),
           ),
-        ),
+        if (showRail && _scrubbing && _activeLetter != null)
+          Positioned(
+            right: _railWidth + AppSpacing.sm,
+            top: 0,
+            bottom: 0,
+            child: Center(child: _ScrubBubble(letter: _activeLetter!)),
+          ),
       ],
     );
   }
@@ -170,13 +229,51 @@ class _SectionHeader extends StatelessWidget {
   }
 }
 
-/// The A–Z scrubber rail. Renders only the letters present and maps a tap or
-/// vertical drag to the nearest letter, jumping the list to that section.
+/// The big translucent letter shown beside the rail while the user is
+/// scrubbing, so the target section is legible even under a fingertip.
+class _ScrubBubble extends StatelessWidget {
+  const _ScrubBubble({required this.letter});
+
+  final String letter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: 48,
+      height: 48,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary,
+        borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
+      ),
+      child: Text(
+        letter,
+        style: theme.textTheme.titleLarge?.copyWith(
+          color: theme.colorScheme.onPrimary,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+/// The A–Z scrubber rail, pinned to the trailing edge at a fixed [width]. It
+/// renders only the letters present and maps a tap or vertical drag to the
+/// nearest letter, jumping the list to that section. The active letter is
+/// drawn in the accent colour; the rest stay subtle.
 class _AlphabetIndex extends StatelessWidget {
-  const _AlphabetIndex({required this.letters, required this.onSelected});
+  const _AlphabetIndex({
+    required this.letters,
+    required this.activeLetter,
+    required this.onSelected,
+    required this.onScrubChanged,
+  });
 
   final List<String> letters;
+  final String? activeLetter;
   final ValueChanged<String> onSelected;
+  final ValueChanged<bool> onScrubChanged;
 
   void _handle(Offset localPosition, double height) {
     if (letters.isEmpty || height <= 0) return;
@@ -186,7 +283,6 @@ class _AlphabetIndex extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (letters.length < 2) return const SizedBox.shrink();
     final theme = Theme.of(context);
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -198,28 +294,32 @@ class _AlphabetIndex extends StatelessWidget {
           key: const Key('library_alphabet_index'),
           behavior: HitTestBehavior.opaque,
           onTapDown: (d) => _handle(d.localPosition, height),
-          onVerticalDragStart: (d) => _handle(d.localPosition, height),
+          onVerticalDragStart: (d) {
+            onScrubChanged(true);
+            _handle(d.localPosition, height);
+          },
           onVerticalDragUpdate: (d) => _handle(d.localPosition, height),
+          onVerticalDragEnd: (_) => onScrubChanged(false),
+          onVerticalDragCancel: () => onScrubChanged(false),
           child: SizedBox(
             height: height > 0 ? height : null,
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (final letter in letters)
-                      Text(
-                        letter,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.onSurface
-                              .withValues(alpha: 0.45),
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
+            child: Column(
+              mainAxisSize: height > 0 ? MainAxisSize.max : MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                for (final letter in letters)
+                  Text(
+                    letter,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: letter == activeLetter
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurface.withValues(alpha: 0.45),
+                      fontWeight: letter == activeLetter
+                          ? FontWeight.bold
+                          : FontWeight.w600,
+                    ),
+                  ),
+              ],
             ),
           ),
         );

--- a/test/features/library/alphabet_track_list_test.dart
+++ b/test/features/library/alphabet_track_list_test.dart
@@ -16,14 +16,22 @@ List<Track> _alphabetTracks() {
   ];
 }
 
-Future<void> _pump(WidgetTester tester, List<Track> tracks) async {
+Future<void> _pump(
+  WidgetTester tester,
+  List<Track> tracks, {
+  double width = 400,
+  double height = 500,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       child: MaterialApp(
         home: Scaffold(
-          body: SizedBox(
-            height: 500,
-            child: AlphabetTrackList(tracks: tracks),
+          body: Center(
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: AlphabetTrackList(tracks: tracks),
+            ),
           ),
         ),
       ),
@@ -44,6 +52,38 @@ void main() {
       expect(find.text('Z Track'), findsNothing);
     });
 
+    testWidgets('pins the index to the trailing edge as a narrow rail', (
+      tester,
+    ) async {
+      await _pump(tester, _alphabetTracks());
+
+      final railRect =
+          tester.getRect(find.byKey(const Key('library_alphabet_index')));
+      final listRect =
+          tester.getRect(find.byKey(const Key('library_track_list')));
+
+      // Anchored to the right edge of the list, not floating in the centre.
+      expect(railRect.right, closeTo(listRect.right, 1));
+      expect(railRect.left, greaterThan(listRect.center.dx));
+      // And it's a slim touch target, not a wide overlay over the rows.
+      expect(railRect.width, lessThanOrEqualTo(32));
+    });
+
+    testWidgets('rows keep their text and overflow menu beside the rail', (
+      tester,
+    ) async {
+      await _pump(tester, _alphabetTracks());
+
+      expect(find.text('A Track'), findsOneWidget);
+      expect(find.byIcon(Icons.more_vert), findsWidgets);
+
+      // The overflow menu sits to the left of the rail, never under it.
+      final railRect =
+          tester.getRect(find.byKey(const Key('library_alphabet_index')));
+      final menuRect = tester.getRect(find.byIcon(Icons.more_vert).first);
+      expect(menuRect.right, lessThanOrEqualTo(railRect.left + 1));
+    });
+
     testWidgets('tapping the index jumps the list to that section', (
       tester,
     ) async {
@@ -57,6 +97,16 @@ void main() {
 
       expect(find.text('Z Track'), findsOneWidget);
       expect(find.text('A Track'), findsNothing);
+    });
+
+    testWidgets('lays out without overflow on a narrow phone width', (
+      tester,
+    ) async {
+      await _pump(tester, _alphabetTracks(), width: 280);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const Key('library_alphabet_index')), findsOneWidget);
+      expect(find.byType(TrackTile), findsWidgets);
     });
 
     testWidgets('hides the rail when there are too few sections', (


### PR DESCRIPTION
## Root cause

On a real device the A–Z fast-scroll index rendered in the **middle** of the Library list, overlapping song titles/subtitles.

In `_AlphabetIndex` the rail was a `SizedBox(height: …)` with **no width constraint**, wrapping a `Center`. Inside the `Align(centerRight)` of the `Stack`, that `SizedBox` received loose width constraints (`0 … stackWidth`) and passed them straight through. `Center` then expanded to fill the *full* available width, so the letter `Column` was centred horizontally across the whole screen instead of hugging the right edge. The `Align(centerRight)` had nothing narrow to align, so the visual result was a centred rail laid over the rows.

## Layout fix

- **Pin the rail to the trailing edge** with `Positioned(right: 0, top: 0, bottom: 0, width: 28)` — a fixed, narrow rail instead of a width-unbounded `Align` child.
- **Reserve right-side padding** on the `ListView` equal to the rail width, so track artwork, title, subtitle, and the 3-dot overflow menu never render beneath the rail.
- **Fill height for linear mapping**: the rail uses a full-height `Column` with `spaceEvenly` so a tap/drag still maps linearly across the list; the hit area matches the mapped height.
- **Active letter indicator**: the current section is drawn in the accent (primary) colour and bolded. It stays in sync with normal scrolling via a `ScrollController` listener (`_syncActiveLetter` → `_letterForOffset`), not just on tap.
- **Scrub bubble**: while dragging the rail, a larger translucent accent bubble shows the target letter beside the rail so it's legible under a fingertip.
- Rail only renders when there are ≥ 2 sections (unchanged behaviour); section headers stay left-aligned with the list content.
- Bottom nav / mini-player are handled by the `Scaffold` (the body is already inset above `bottomNavigationBar`), so the full-height rail never sits under them.

## Manual / screenshot verification note

I could not run the app on an emulator in this environment (no Android device/emulator available), so the visual was validated through widget tests that assert geometry (rail right edge == list right edge, rail width ≤ 32, overflow menu left of the rail) rather than a fresh device screenshot. The fix directly addresses the centred-rail behaviour shown in the reported screenshot. Recommend a quick on-device sanity check before merging.

## Tests added/updated (`alphabet_track_list_test.dart`)

1. Alphabet index is present.
2. Index is pinned to the trailing/right edge as a narrow rail (right edge aligns to the list, width ≤ 32, left edge past centre).
3. Track row text + overflow menu still render, and the menu sits to the left of the rail.
4. Tapping the index still jumps to the section (existing).
5. Lays out without overflow on a narrow (280px) phone width.
6. Rail hidden when there are too few sections (existing).

All 423 tests pass; `flutter analyze` clean; `dart format` clean (verified against the CI-pinned Flutter 3.27.4).

## Known limitations

- The scrub bubble is centred vertically beside the rail rather than tracking the fingertip's vertical position; it's a readability aid, not a precise position marker.
- With a very large number of distinct first letters on an unusually short viewport, `spaceEvenly` could in theory crowd letters; not observed at typical phone heights.
- No device screenshot captured (see verification note above).

## Scope

Library fast-scroller layout only — no playback, Jellyfin, cache/download, or release-workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtLWBuvBbFRYgZZLoGxw1C)_