### PR TITLE
Disk preloading, Jellyfin-synced favorites & working lyrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ The notification channel id/name are configured in `connectMediaSession`
 - Lock-screen / car artwork depends on `Track.artworkUri`, which local scanning
   does not populate yet.
 
-### Now Playing controls — shuffle, repeat & casting
+### Now Playing controls — shuffle, repeat, favorite, lyrics & casting
 
 The Now Playing screen drives every transport action through
 `PlaybackController`/`PlaybackState`; the widgets hold no playback logic of their
@@ -735,6 +735,20 @@ own.
   start, without re-resolving its URL — so a stream isn't re-fetched each loop).
   Next/previous keep working normally in every mode. The glyph switches to
   `repeat_one` for repeat-one and is tinted/selected whenever repeat is active.
+- **Favorite (working).** The heart toggles a favourite through a
+  `FavoritesRepository`. For a **Jellyfin** track the change is synced to the
+  server (`POST`/`DELETE …/FavoriteItems/<id>`), so it follows the user across
+  clients; for a **local** track it's stored on-device. Either way the UI updates
+  optimistically from a single favourite-id set, and a failed server push keeps
+  the local intent and reconciles on the next refresh (the signed-in user's
+  server favourites are pulled at startup). Only non-secret ids are stored or
+  sent — never a token.
+- **Lyrics (working for Jellyfin).** The lyrics button fetches the track's
+  lyrics from the signed-in Jellyfin server (`GET /Audio/<id>/Lyrics`) behind a
+  `LyricsService` seam and shows the lines in a sheet. A track with no lyrics, a
+  local track, or being signed out shows a calm "No lyrics available" placeholder
+  (and a fetch failure a friendly "couldn't load" line) — never a blank sheet. A
+  local `.lrc`/tag reader can slot in behind the same seam later.
 - **Cast / Chromecast — UI placeholder with architecture seam (not live yet).**
   A cast control sits in the Now Playing header. **Casting is *not* implemented
   in this build** and the app never pretends otherwise: the shipped
@@ -870,24 +884,28 @@ user-controlled**:
   failing opaquely.
 - **The cache stays under a size limit.** You set a maximum (presets of 1, 2, 4,
   8, 16 GB or a custom value; **4 GB by default**), so Linthra never fills your
-  phone unexpectedly. When a new download would exceed the limit, it frees space
-  by removing the **least-recently-played, unpinned, not-currently-playing**
-  tracks first. Pin a track ("Keep offline") to protect it. If nothing safe can
-  be freed, the download is refused with a friendly "not enough cache space"
-  message instead of deleting something you wanted.
+  phone unexpectedly. Both your downloads **and** any preloaded upcoming tracks
+  (see below) count toward this one limit. When a new download would exceed it,
+  space is freed by removing **preloaded tracks first**, then the
+  **least-recently-played, unpinned, not-currently-playing** downloads. Pin a
+  track ("Keep offline") to protect it. If nothing safe can be freed, the
+  download is refused with a friendly "not enough cache space" message instead of
+  deleting something you wanted.
 
 **How it works now.** Each Library row shows an offline-download control:
 download an absent track, see a spinner while it's in flight, remove a cached
 one, or retry a failed one. The **Downloads** tab lists everything currently
 cached — with each track's **size** and a **Keep offline** pin — shows how much
-of the limit is in use, and hosts the **Wi-Fi only** toggle. **Settings →
+of the limit is in use, and hosts the **Wi-Fi only** and **Preload upcoming
+tracks** toggles. **Settings →
 Offline cache** shows used / max / free space and the **Change limit** and
 **Clear cache** (clear unpinned, or clear all) actions. The download lifecycle
 flows through `DownloadRepository`, which centralizes three guarantees:
 
-- **User-initiated only.** A track's status only ever changes in response to an
-  explicit download/remove action — nothing is fetched automatically or in the
-  background.
+- **Downloads are user-initiated.** A track's *download status* only ever changes
+  in response to an explicit download/remove action. (Preloading, below, also
+  caches bytes automatically — but a preloaded track never takes on a download
+  status, never shows as a download, and is evicted before any download.)
 - **Source-aware.** A **Jellyfin** track has its bytes fetched (via
   `RemoteTrackDownloader` → `JellyfinTrackDownloader`) and written to an
   app-private offline directory (`OfflineFileStore`); an **on-device** track is
@@ -896,6 +914,22 @@ flows through `DownloadRepository`, which centralizes three guarantees:
 - **Wi-Fi only is respected.** For remote downloads, with the toggle on a request
   made off Wi-Fi is *queued* instead of run; with it off, downloads proceed on
   any connection. (Local tracks are never queued — there are no bytes to fetch.)
+
+**Preloading upcoming tracks.** As playback moves, Linthra warms the next few
+queued tracks into the same cache ahead of time, so the upcoming songs start
+instantly (and play offline) instead of buffering a fresh stream at each track
+change. A `PlaybackPreloader` watches `PlaybackState` and, when the playing
+track changes, asks a `TrackPrefetcher` (the `CacheDownloadRepository` again) to
+cache the next few `upNext` entries — which is the **queue order** in normal
+playback and the **shuffled order** when shuffle is on, since the controller
+keeps `upNext` in effective play order. It is deliberately well-behaved: only
+remote, not-yet-cached tracks are fetched; it **honours "Wi-Fi only"** (skipping
+rather than queueing off Wi-Fi); it stays under the cache limit and **evicts
+preloads before any download**; a preload that won't fit or fails is silently
+skipped (the track still streams when reached); and it never blocks or
+interrupts what's playing. Preloaded tracks count toward cache usage but never
+appear as downloads. Toggle it off with **Downloads → Preload upcoming tracks**
+(on by default).
 
 **Storage & playback.** Downloaded bytes live in an app-controlled directory
 (`path_provider`'s application-support location, not the OS cache that can be
@@ -942,10 +976,11 @@ Deliberate gaps the next PRs will close:
   out of scope for this PR. The seam is ready — `requestDownload(Track)` plus the
   `RemoteTrackDownloader` compose per-track — so a batch action is additive UI
   over the existing policy, with no architectural change.
-- **No background download manager.** Downloads run inline in response to the
-  tap; there is no worker, no Android download/notification service, no resume of
-  a partial transfer, and no auto-flush of the queue when Wi-Fi returns (re-tap a
-  queued track to retry).
+- **No background download manager.** Downloads (and preloads) run inline; there
+  is no worker, no Android download/notification service, no resume of a partial
+  transfer, and no auto-flush of the queue when Wi-Fi returns (re-tap a queued
+  track to retry). Preloading runs as a foreground side effect of playback, not a
+  scheduled background job.
 - **Eviction is inline, not a background sweeper.** Space is freed only when a
   new download needs it (and stale metadata only on load); there is no periodic
   reconciliation against the directory's actual on-disk size, and a remote track
@@ -1066,8 +1101,9 @@ tokenized URL).
 - **Direct play only (no transcoding fallback yet).** Streaming serves the
   original file (`static=true`), which the engine decodes for the common
   containers; a server-side transcode fallback for exotic formats is deferred.
-- **No Android Auto browsing, lyrics, or sync-conflict handling** for Jellyfin
-  in this foundation.
+- **No Android Auto browsing or sync-conflict handling** for Jellyfin in this
+  foundation. (Lyrics and favourites now sync from Jellyfin — see **Now Playing
+  controls** above.)
 
 ## Continuous integration
 
@@ -1130,12 +1166,13 @@ branch rather than `main`.
 10. Settings
 
 Later: Jellyfin (landed — settings, auth, encrypted session, a library source,
-Library sync, streaming playback, and explicit per-track offline downloads;
+Library sync, streaming playback, explicit per-track offline downloads,
+preloading of upcoming tracks, server-synced favourites, and lyrics;
 album/playlist "download all" and a background download manager next), Android
 Auto (foundation landed — browsable Library/Queue; album/artist grouping and
 search next), Chromecast/casting (UI + `CastService` architecture seam landed;
-live device discovery and playback handoff next), WebDAV, NAS, lyrics,
-ReplayGain, MPRIS, smart playlists, and more.
+live device discovery and playback handoff next), WebDAV, NAS, local-file lyrics
+(`.lrc`/tags), ReplayGain, MPRIS, smart playlists, and more.
 
 ## F-Droid metadata (work in progress)
 

--- a/lib/core/models/lyrics.dart
+++ b/lib/core/models/lyrics.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+
+/// One line of a track's lyrics, with an optional timestamp for synced lyrics.
+@immutable
+class LyricLine {
+  const LyricLine({required this.text, this.start});
+
+  /// The line's text. May be empty — a deliberate blank line between stanzas.
+  final String text;
+
+  /// When this line begins, for time-synced lyrics; `null` for plain lyrics.
+  final Duration? start;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is LyricLine && other.text == text && other.start == start);
+
+  @override
+  int get hashCode => Object.hash(text, start);
+}
+
+/// A track's lyrics: an ordered list of [lines]. Source-agnostic so the UI
+/// renders the same whether the lines came from Jellyfin or, later, a local
+/// `.lrc`/tag reader.
+@immutable
+class Lyrics {
+  const Lyrics({required this.lines});
+
+  final List<LyricLine> lines;
+
+  bool get isEmpty => lines.isEmpty;
+  bool get isNotEmpty => lines.isNotEmpty;
+
+  /// Whether any line carries a timestamp (time-synced rather than plain text).
+  bool get isSynced => lines.any((LyricLine line) => line.start != null);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Lyrics && listEquals(other.lines, lines));
+
+  @override
+  int get hashCode => Object.hashAll(lines);
+}

--- a/lib/core/repositories/download_preferences.dart
+++ b/lib/core/repositories/download_preferences.dart
@@ -19,4 +19,11 @@ abstract interface class DownloadPreferences {
   Future<int> maxCacheBytes();
 
   Future<void> setMaxCacheBytes(int bytes);
+
+  /// Whether upcoming queued tracks are preloaded into the cache ahead of play.
+  /// Defaults to `true`. Preloads are bounded by [maxCacheBytes] and skipped
+  /// (not queued) when "Wi-Fi only" is on and the connection isn't Wi-Fi.
+  Future<bool> preloadEnabled();
+
+  Future<void> setPreloadEnabled(bool value);
 }

--- a/lib/core/repositories/download_store.dart
+++ b/lib/core/repositories/download_store.dart
@@ -17,6 +17,7 @@ class CachedTrack {
     this.cachedAt,
     this.lastAccessedAt,
     this.pinned = false,
+    this.preloaded = false,
   });
 
   /// The catalog id of the cached track.
@@ -47,6 +48,13 @@ class CachedTrack {
   /// never evicted automatically and survive "clear unpinned".
   final bool pinned;
 
+  /// Whether this entry was *auto-preloaded* (prefetched ahead of play) rather
+  /// than explicitly downloaded by the user. Preloaded entries count toward the
+  /// cache budget but never appear as user downloads, and are evicted before any
+  /// user download when space is needed (see [CacheEvictionPolicy]). Cleared
+  /// when the user explicitly downloads the same track, promoting it.
+  final bool preloaded;
+
   /// Whether this record points at app-managed downloaded bytes (vs. an
   /// on-device track that is merely marked available offline).
   bool get isManaged => fileName != null && fileName!.isNotEmpty;
@@ -58,6 +66,7 @@ class CachedTrack {
     DateTime? cachedAt,
     DateTime? lastAccessedAt,
     bool? pinned,
+    bool? preloaded,
   }) {
     return CachedTrack(
       trackId: trackId,
@@ -67,6 +76,7 @@ class CachedTrack {
       cachedAt: cachedAt ?? this.cachedAt,
       lastAccessedAt: lastAccessedAt ?? this.lastAccessedAt,
       pinned: pinned ?? this.pinned,
+      preloaded: preloaded ?? this.preloaded,
     );
   }
 
@@ -80,6 +90,7 @@ class CachedTrack {
         if (lastAccessedAt != null)
           'lastAccessedAt': lastAccessedAt!.millisecondsSinceEpoch,
         if (pinned) 'pinned': true,
+        if (preloaded) 'preloaded': true,
       };
 
   /// Rebuilds a record from [toJson] output, or returns `null` when the track
@@ -100,6 +111,7 @@ class CachedTrack {
       cachedAt: _asDate(json['cachedAt']),
       lastAccessedAt: _asDate(json['lastAccessedAt']),
       pinned: json['pinned'] == true,
+      preloaded: json['preloaded'] == true,
     );
   }
 
@@ -125,7 +137,8 @@ class CachedTrack {
           other.sizeBytes == sizeBytes &&
           other.cachedAt == cachedAt &&
           other.lastAccessedAt == lastAccessedAt &&
-          other.pinned == pinned);
+          other.pinned == pinned &&
+          other.preloaded == preloaded);
 
   @override
   int get hashCode => Object.hash(
@@ -136,6 +149,7 @@ class CachedTrack {
         cachedAt,
         lastAccessedAt,
         pinned,
+        preloaded,
       );
 }
 

--- a/lib/core/repositories/favorites_repository.dart
+++ b/lib/core/repositories/favorites_repository.dart
@@ -1,0 +1,30 @@
+import '../models/track.dart';
+
+/// Tracks the user's favourites and keeps them in sync with the source.
+///
+/// Favourites on **Jellyfin** tracks are synced to the server (the server is the
+/// source of truth there, so they follow the user across clients); favourites on
+/// **local-folder** tracks are kept on-device. The UI reads [favoritesStream] /
+/// [isFavorite] and toggles through [setFavorite], never touching Jellyfin or
+/// storage directly — mirroring how the player reads a [PlaybackState] and never
+/// the audio engine.
+abstract interface class FavoritesRepository {
+  /// Emits the current favourite track-id set immediately, then on every change.
+  Stream<Set<String>> get favoritesStream;
+
+  /// Whether [trackId] is currently a favourite. A synchronous best-effort read
+  /// of the in-memory mirror (empty until the first load); the stream is what
+  /// the UI should bind to.
+  bool isFavorite(String trackId);
+
+  /// Marks (or unmarks) [track] as a favourite. Updates immediately and, for a
+  /// Jellyfin track while signed in, pushes the change to the server. Never
+  /// throws: a failed server push keeps the local intent and reconciles on the
+  /// next [refreshFromRemote].
+  Future<void> setFavorite(Track track, bool favorite);
+
+  /// Pulls the signed-in user's server favourites and adopts them as the remote
+  /// set (server is the source of truth there), leaving local-track favourites
+  /// untouched. A no-op when not signed in. Never throws.
+  Future<void> refreshFromRemote();
+}

--- a/lib/core/repositories/favorites_store.dart
+++ b/lib/core/repositories/favorites_store.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+/// The persisted favourite sets, split by source so a remote refresh can replace
+/// the server-owned set without disturbing favourites on local-only tracks.
+@immutable
+class FavoritesData {
+  const FavoritesData({
+    this.localIds = const <String>{},
+    this.remoteIds = const <String>{},
+  });
+
+  static const FavoritesData empty = FavoritesData();
+
+  /// Favourite track ids that live only on this device (local-folder tracks).
+  final Set<String> localIds;
+
+  /// Favourite Jellyfin item ids, mirrored from and pushed to the server.
+  final Set<String> remoteIds;
+
+  FavoritesData copyWith({Set<String>? localIds, Set<String>? remoteIds}) {
+    return FavoritesData(
+      localIds: localIds ?? this.localIds,
+      remoteIds: remoteIds ?? this.remoteIds,
+    );
+  }
+}
+
+/// Durable storage for the user's favourites.
+///
+/// The persistence seam under [FavoritesRepository]: it knows nothing about
+/// Jellyfin or sync — only which track ids are favourited, split into the
+/// device-local set and the (server-mirrored) remote set. Splitting it out lets
+/// the backing store swap freely (in-memory for tests, key/value in the app).
+///
+/// Security: only non-secret track/item ids are stored here — never a token.
+abstract interface class FavoritesStore {
+  Future<FavoritesData> load();
+  Future<void> save(FavoritesData data);
+}

--- a/lib/core/services/cache_eviction_policy.dart
+++ b/lib/core/services/cache_eviction_policy.dart
@@ -28,9 +28,11 @@ class EvictionPlan {
 ///    are never evicted (they hold no app-managed bytes).
 ///  - The currently playing track is never evicted.
 ///  - Pinned ("Keep offline") tracks are never evicted.
-///  - Among the rest, least-recently-used goes first (oldest [CachedTrack.
-///    lastAccessedAt]; never-played counts as oldest), tie-broken by oldest
-///    [CachedTrack.cachedAt] then track id for determinism.
+///  - Auto-preloaded tracks go before any user download: a prefetched copy is a
+///    convenience, so it's sacrificed first to keep what the user chose to keep.
+///  - Among entries of the same kind, least-recently-used goes first (oldest
+///    [CachedTrack.lastAccessedAt]; never-played counts as oldest), tie-broken by
+///    oldest [CachedTrack.cachedAt] then track id for determinism.
 ///  - If even evicting every eligible track wouldn't make room, nothing is
 ///    evicted and the plan reports it doesn't fit.
 class CacheEvictionPolicy {
@@ -82,6 +84,8 @@ class CacheEvictionPolicy {
   }
 
   static int _leastRecentlyUsedFirst(CachedTrack a, CachedTrack b) {
+    // Auto-preloaded entries are evicted before any user download.
+    if (a.preloaded != b.preloaded) return a.preloaded ? -1 : 1;
     final int byAccess = _compareNullableOldestFirst(
       a.lastAccessedAt,
       b.lastAccessedAt,

--- a/lib/core/services/jellyfin_lyrics_service.dart
+++ b/lib/core/services/jellyfin_lyrics_service.dart
@@ -1,0 +1,33 @@
+import '../models/jellyfin_session.dart';
+import '../models/lyrics.dart';
+import '../models/track.dart';
+import '../sources/jellyfin/jellyfin_client.dart';
+import '../sources/jellyfin/jellyfin_track_mapper.dart';
+import 'lyrics_service.dart';
+
+/// A [LyricsService] backed by a signed-in Jellyfin server.
+///
+/// Only Jellyfin tracks (the `jellyfin:<id>` scheme) are looked up; a local
+/// track or being signed out returns `null` so the UI shows "no lyrics". The
+/// session (with its token) is read lazily through [_session] so signing in/out
+/// is picked up without a rebuild, mirroring the streaming/download path.
+class JellyfinLyricsService implements LyricsService {
+  JellyfinLyricsService({
+    required JellyfinClient client,
+    required JellyfinSession? Function() session,
+  })  : _client = client,
+        _session = session;
+
+  final JellyfinClient _client;
+  final JellyfinSession? Function() _session;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async {
+    if (!track.uri.startsWith(JellyfinTrackMapper.uriScheme)) return null;
+    final JellyfinSession? session = _session();
+    if (session == null) return null;
+    final String itemId =
+        track.uri.substring(JellyfinTrackMapper.uriScheme.length);
+    return _client.fetchLyrics(session, itemId);
+  }
+}

--- a/lib/core/services/lyrics_service.dart
+++ b/lib/core/services/lyrics_service.dart
@@ -1,0 +1,15 @@
+import '../models/lyrics.dart';
+import '../models/track.dart';
+
+/// Fetches a track's lyrics, hiding the source from the UI.
+///
+/// The shipped implementation reads lyrics from a signed-in Jellyfin server for
+/// remote tracks; a local track (or being signed out) yields `null`, and the UI
+/// shows an honest "no lyrics" state. A future local `.lrc`/tag reader slots in
+/// behind this same seam without the player changing.
+abstract interface class LyricsService {
+  /// The lyrics for [track], or `null` when none are available. May throw a
+  /// [JellyfinException] for a fetch failure (offline, expired session) so the
+  /// UI can tell "couldn't load" apart from "no lyrics".
+  Future<Lyrics?> lyricsFor(Track track);
+}

--- a/lib/core/services/playback_preloader.dart
+++ b/lib/core/services/playback_preloader.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import '../repositories/download_preferences.dart';
+import 'track_prefetcher.dart';
+
+/// Warms the next few queued tracks into the offline cache as playback moves,
+/// so the upcoming songs play instantly (and offline) instead of buffering a
+/// fresh stream at each track change.
+///
+/// It listens to the [PlaybackState] stream and, each time the *playing track*
+/// changes, asks a [TrackPrefetcher] to cache the next [aheadCount] entries of
+/// the up-next list. Because the controller keeps `upNext` in effective play
+/// order, this preloads the queue order in normal playback and the shuffled
+/// order when shuffle is on — no special-casing needed.
+///
+/// Everything that bounds it lives downstream: the prefetcher skips local and
+/// already-cached tracks, honours "Wi-Fi only", stays under the cache limit
+/// (evicting preloads first), and never throws. This class only decides *what*
+/// to preload and *when*, and does so off the playback path — a preload never
+/// blocks or interrupts what's playing.
+class PlaybackPreloader {
+  PlaybackPreloader({
+    required Stream<PlaybackState> playbackStates,
+    required TrackPrefetcher prefetcher,
+    required DownloadPreferences preferences,
+    int aheadCount = defaultAheadCount,
+  })  : _prefetcher = prefetcher,
+        _preferences = preferences,
+        _aheadCount = aheadCount {
+    _subscription = playbackStates.listen(_onState);
+  }
+
+  /// How many upcoming tracks to keep warmed ahead of the current one. Small on
+  /// purpose: enough for seamless next/auto-advance without hoarding the cache.
+  static const int defaultAheadCount = 3;
+
+  final TrackPrefetcher _prefetcher;
+  final DownloadPreferences _preferences;
+  final int _aheadCount;
+  late final StreamSubscription<PlaybackState> _subscription;
+
+  String? _lastTrackId;
+  List<Track>? _pendingUpNext;
+  bool _running = false;
+
+  void _onState(PlaybackState state) {
+    final String? id = state.currentTrack?.id;
+    // Only react when the playing track changes, not on every position tick.
+    if (id == _lastTrackId) return;
+    _lastTrackId = id;
+    if (id == null) return;
+    // Remember the latest up-next and drain; a pass already running will pick
+    // this up when it finishes, so the freshest queue always wins.
+    _pendingUpNext = state.upNext;
+    unawaited(_drain());
+  }
+
+  Future<void> _drain() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (_pendingUpNext != null) {
+        final List<Track> upNext = _pendingUpNext!;
+        _pendingUpNext = null;
+        await _preloadUpcoming(upNext);
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> _preloadUpcoming(List<Track> upNext) async {
+    if (upNext.isEmpty) return;
+    if (!await _preferences.preloadEnabled()) return;
+    final int count = upNext.length < _aheadCount ? upNext.length : _aheadCount;
+    for (int i = 0; i < count; i++) {
+      // Sequential on purpose: one warm fetch at a time keeps preload off the
+      // critical path and lets the cache limit settle between writes.
+      await _prefetcher.prefetch(upNext[i]);
+    }
+  }
+
+  Future<void> dispose() => _subscription.cancel();
+}

--- a/lib/core/services/track_prefetcher.dart
+++ b/lib/core/services/track_prefetcher.dart
@@ -1,0 +1,20 @@
+import '../models/track.dart';
+
+/// Caches an upcoming track ahead of play ("preload").
+///
+/// This is the seam the [PlaybackPreloader] drives so the player feature can ask
+/// for the next queued tracks to be warmed into the offline cache without
+/// knowing anything about the download policy, connectivity, or the filesystem —
+/// the [CacheDownloadRepository] implements it alongside the user-download
+/// lifecycle so both share one limit and one eviction policy.
+///
+/// A preload is *best-effort and never user-visible as a download*: it caches a
+/// remote track's bytes (skipping local tracks, which are already on disk),
+/// honours the user's "Wi-Fi only" and "preload" preferences, stays under the
+/// cache limit (evicting other preloads first), and silently does nothing on any
+/// failure — the track still streams normally when it's reached.
+abstract interface class TrackPrefetcher {
+  /// Warms [track] into the offline cache if it isn't already cached and the
+  /// current connection/preferences allow it. Never throws.
+  Future<void> prefetch(Track track);
+}

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -222,8 +222,8 @@ class HttpJellyfinClient implements JellyfinClient {
   }
 
   /// Parses Jellyfin's `/Audio/<id>/Lyrics` body into [Lyrics], or `null` when
-  /// it carries no usable lines. Each entry is `{ "Text": "…", "Start": <ticks>
-  /// }`, where `Start` is in 100-nanosecond ticks (synced) or absent (plain).
+  /// it carries no usable lines. Each entry is a `Text` string plus an optional
+  /// `Start` in 100-nanosecond ticks (synced) — or no `Start` at all (plain).
   static Lyrics? _parseLyrics(Map<String, dynamic> json) {
     final Object? raw = json['Lyrics'];
     if (raw is! List) return null;

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../../models/jellyfin_session.dart';
+import '../../models/lyrics.dart';
 import 'jellyfin_api.dart';
 import 'jellyfin_auth_header.dart';
 import 'jellyfin_client.dart';
@@ -150,6 +151,97 @@ class HttpJellyfinClient implements JellyfinClient {
       statusCode: response.statusCode,
       contentType: response.headers['content-type'],
     );
+  }
+
+  @override
+  Future<Lyrics?> fetchLyrics(JellyfinSession session, String itemId) async {
+    final Uri uri = Uri.parse('${session.baseUrl}/Audio/$itemId/Lyrics');
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _authHeaders(session)),
+    );
+    // No lyrics on the server is a normal outcome, not an error.
+    if (response.statusCode == 404) return null;
+    _checkStatus(response);
+    return _parseLyrics(_decodeObject(response));
+  }
+
+  @override
+  Future<Set<String>> fetchFavoriteIds(JellyfinSession session) async {
+    final Uri uri = Uri.parse('${session.baseUrl}/Items').replace(
+      queryParameters: <String, String>{
+        'UserId': session.userId,
+        'Recursive': 'true',
+        'IncludeItemTypes': 'Audio',
+        'Filters': 'IsFavorite',
+        'EnableImages': 'false',
+      },
+    );
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+    final Map<String, dynamic> json = _decodeObject(response);
+    final Object? rawItems = json['Items'];
+    if (rawItems is! List) return <String>{};
+    final Set<String> ids = <String>{};
+    for (final Object? entry in rawItems) {
+      if (entry is Map<String, dynamic>) {
+        final Object? id = entry['Id'];
+        if (id is String && id.isNotEmpty) ids.add(id);
+      }
+    }
+    return ids;
+  }
+
+  @override
+  Future<void> setFavorite(
+    JellyfinSession session,
+    String itemId, {
+    required bool favorite,
+  }) async {
+    final Uri uri = Uri.parse(
+      '${session.baseUrl}/Users/${session.userId}/FavoriteItems/$itemId',
+    );
+    final Map<String, String> headers = _authHeaders(session);
+    final http.Response response = await _send(
+      () => favorite
+          ? _client.post(uri, headers: headers)
+          : _client.delete(uri, headers: headers),
+    );
+    _checkStatus(response);
+  }
+
+  /// The standard headers for an authenticated JSON call: the token rides in the
+  /// `Authorization` header (built in one place, never logged).
+  Map<String, String> _authHeaders(JellyfinSession session) {
+    return <String, String>{
+      'Accept': 'application/json',
+      'Authorization':
+          JellyfinAuthHeader.forToken(session.deviceId, session.accessToken),
+    };
+  }
+
+  /// Parses Jellyfin's `/Audio/<id>/Lyrics` body into [Lyrics], or `null` when
+  /// it carries no usable lines. Each entry is `{ "Text": "…", "Start": <ticks>
+  /// }`, where `Start` is in 100-nanosecond ticks (synced) or absent (plain).
+  static Lyrics? _parseLyrics(Map<String, dynamic> json) {
+    final Object? raw = json['Lyrics'];
+    if (raw is! List) return null;
+    final List<LyricLine> lines = <LyricLine>[];
+    for (final Object? entry in raw) {
+      if (entry is! Map<String, dynamic>) continue;
+      final Object? text = entry['Text'];
+      if (text is! String) continue;
+      final int? ticks = (entry['Start'] as num?)?.toInt();
+      lines.add(LyricLine(
+        text: text,
+        start: (ticks != null && ticks >= 0)
+            ? Duration(microseconds: ticks ~/ 10)
+            : null,
+      ));
+    }
+    if (lines.isEmpty) return null;
+    return Lyrics(lines: lines);
   }
 
   /// Builds the listing URL for [kind]. Artists have their own endpoint in

--- a/lib/core/sources/jellyfin/jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/jellyfin_client.dart
@@ -1,4 +1,5 @@
 import '../../models/jellyfin_session.dart';
+import '../../models/lyrics.dart';
 import 'jellyfin_api.dart';
 
 /// The single seam through which Linthra talks HTTP to a Jellyfin server.
@@ -55,4 +56,20 @@ abstract interface class JellyfinClient {
   /// carries the session token, so it must never be logged or placed in a
   /// thrown error.
   Future<JellyfinStreamProbe> probeStream(Uri url);
+
+  /// Fetches lyrics for the audio item [itemId], or `null` when the server has
+  /// none (a 404 — a normal outcome, not an error). Throws a [JellyfinException]
+  /// for transport or auth failures.
+  Future<Lyrics?> fetchLyrics(JellyfinSession session, String itemId);
+
+  /// The audio item ids the signed-in user has marked as favourites.
+  Future<Set<String>> fetchFavoriteIds(JellyfinSession session);
+
+  /// Marks (when [favorite]) or unmarks the audio item [itemId] as a favourite
+  /// for the signed-in user. Throws a [JellyfinException] on failure.
+  Future<void> setFavorite(
+    JellyfinSession session,
+    String itemId, {
+    required bool favorite,
+  });
 }

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -9,6 +9,7 @@ import '../../core/services/cache_eviction_policy.dart';
 import '../../core/services/connectivity_service.dart';
 import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/remote_track_downloader.dart';
+import '../../core/services/track_prefetcher.dart';
 
 /// The app's [DownloadRepository] *and* [OfflineCacheManager]: it owns the
 /// offline-cache *policy* in one place and delegates the moving parts to focused
@@ -17,9 +18,11 @@ import '../../core/services/remote_track_downloader.dart';
 /// the (pure) eviction decision to a [CacheEvictionPolicy].
 ///
 /// Promises enforced here so a caller can't skip them:
-///  - **User-initiated only.** Nothing is ever downloaded automatically; status
-///    changes happen solely in response to [requestDownload] / [removeDownload]
-///    (or an explicit clear / pin).
+///  - **Downloads are user-initiated.** A track's download *status* changes only
+///    in response to [requestDownload] / [removeDownload] (or an explicit clear /
+///    pin). Auto-*preloaded* tracks ([prefetch]) are cached ahead of play too,
+///    but they never take on a user-download status: they stay invisible to the
+///    downloads UI, count toward the limit, and are the first to be evicted.
 ///  - **Source-aware.** A remote (Jellyfin) track has its bytes fetched and
 ///    written to the offline directory; an on-device track is already local, so
 ///    it's recorded as available offline with no fetch and no managed file.
@@ -43,7 +46,7 @@ import '../../core/services/remote_track_downloader.dart';
 /// id-derived file name, the source's URI scheme, a byte size, timestamps, and
 /// the pinned flag — never a token or URL.
 class CacheDownloadRepository
-    implements DownloadRepository, OfflineCacheManager {
+    implements DownloadRepository, OfflineCacheManager, TrackPrefetcher {
   CacheDownloadRepository({
     required DownloadStore store,
     required OfflineFileStore files,
@@ -116,7 +119,11 @@ class CacheDownloadRepository
       } else {
         _downloads[cached.trackId] = cached;
       }
-      _statuses[cached.trackId] = DownloadStatus.downloaded;
+      // A preloaded entry is cached and playable, but never a *download*: it
+      // stays out of the status map so the downloads UI doesn't show it.
+      if (!cached.preloaded) {
+        _statuses[cached.trackId] = DownloadStatus.downloaded;
+      }
     }
     if (changed) await _save();
     _loaded = true;
@@ -144,6 +151,20 @@ class CacheDownloadRepository
     // by contrast, is fair game for an explicit retry.
     if (current == DownloadStatus.downloaded ||
         current == DownloadStatus.downloading) {
+      return;
+    }
+
+    // A track that was preloaded ahead of play is already cached: promote it to
+    // a user download in place, without re-fetching its bytes.
+    final CachedTrack? preloadedEntry = _downloads[track.id];
+    if (preloadedEntry != null &&
+        preloadedEntry.preloaded &&
+        preloadedEntry.isManaged) {
+      _downloads[track.id] = preloadedEntry.copyWith(preloaded: false);
+      await _save();
+      _statuses[track.id] = DownloadStatus.downloaded;
+      _emitStatus();
+      _emitCache();
       return;
     }
 
@@ -184,10 +205,18 @@ class CacheDownloadRepository
     }
   }
 
-  /// Writes a freshly fetched remote download, evicting first to stay under the
-  /// limit. Throws [CacheStorageException] (after resetting status) when it
-  /// can't fit even after evicting everything safe to remove.
-  Future<void> _cacheRemote(Track track, RemoteTrackData data) async {
+  /// Writes a freshly fetched remote track's bytes, evicting first to stay under
+  /// the limit. A user download ([preloaded] `false`) takes on the `downloaded`
+  /// status; a [preloaded] one is cached but stays out of the status map.
+  ///
+  /// Throws [CacheStorageException] (after resetting status) when a user
+  /// download can't fit even after evicting everything safe to remove; a preload
+  /// that can't fit returns quietly (it's best-effort).
+  Future<void> _cacheRemote(
+    Track track,
+    RemoteTrackData data, {
+    bool preloaded = false,
+  }) async {
     final int incoming = data.bytes.length;
     final int maxBytes = await _preferences.maxCacheBytes();
     final EvictionPlan plan = _policy.plan(
@@ -199,14 +228,16 @@ class CacheDownloadRepository
     );
 
     if (!plan.fits) {
+      if (preloaded) return;
       _set(track.id, DownloadStatus.notDownloaded);
       throw const CacheStorageException();
     }
 
+    bool evictedAStatus = false;
     for (final CachedTrack victim in plan.evict) {
       await _deleteManagedFile(victim);
       _downloads.remove(victim.trackId);
-      _statuses.remove(victim.trackId);
+      if (_statuses.remove(victim.trackId) != null) evictedAStatus = true;
     }
 
     final String fileName = await _files.write(
@@ -221,12 +252,39 @@ class CacheDownloadRepository
       sourceType: _sourceTypeOf(track),
       sizeBytes: incoming,
       cachedAt: now,
-      lastAccessedAt: now,
+      // A preload hasn't been played yet, so it has no access time — which also
+      // keeps it ahead of played tracks of its own kind in eviction order.
+      lastAccessedAt: preloaded ? null : now,
+      preloaded: preloaded,
     );
     await _save();
-    _statuses[track.id] = DownloadStatus.downloaded;
-    _emitStatus();
+    if (!preloaded) {
+      _statuses[track.id] = DownloadStatus.downloaded;
+    }
+    // A preload changes only cache usage; a user download (or an eviction that
+    // dropped a download) also changes download status.
+    if (!preloaded || evictedAStatus) _emitStatus();
     _emitCache();
+  }
+
+  @override
+  Future<void> prefetch(Track track) async {
+    await _ensureLoaded();
+    // Only remote tracks have bytes to fetch; local ones are already on disk.
+    if (!_downloader.isRemote(track)) return;
+    // Already cached (download or earlier preload) or in flight — skip.
+    if (_downloads.containsKey(track.id)) return;
+    if (_statuses[track.id] == DownloadStatus.downloading) return;
+    // Preload is best-effort and network-heavy, so it honours "Wi-Fi only" and
+    // simply skips (rather than queueing) when it can't run right now.
+    if (!await _allowedToDownloadNow()) return;
+    try {
+      final RemoteTrackData data = await _downloader.fetch(track);
+      await _cacheRemote(track, data, preloaded: true);
+    } catch (_) {
+      // Best-effort: a failed preload caches nothing and changes no status; the
+      // track still streams normally when it's reached.
+    }
   }
 
   @override

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -10,6 +10,7 @@ import '../../core/services/connectivity_service.dart';
 import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/optimistic_connectivity_service.dart';
 import '../../core/services/remote_track_downloader.dart';
+import '../../core/services/track_prefetcher.dart';
 import 'cache_download_repository.dart';
 import 'file_system_offline_file_store.dart';
 import 'in_memory_download_preferences.dart';
@@ -90,6 +91,14 @@ final downloadRepositoryProvider = Provider<DownloadRepository>((ref) {
 /// backed by the *same* instance as [downloadRepositoryProvider] so a cleared
 /// or pinned track stays consistent with download status.
 final offlineCacheManagerProvider = Provider<OfflineCacheManager>((ref) {
+  return ref.watch(_cacheDownloadRepositoryProvider);
+});
+
+/// The preload surface (warm an upcoming track ahead of play), backed by the
+/// *same* instance as [downloadRepositoryProvider] so preloads share the one
+/// cache limit and eviction policy with user downloads. Driven by the
+/// `PlaybackPreloader`, never by the UI directly.
+final trackPrefetcherProvider = Provider<TrackPrefetcher>((ref) {
   return ref.watch(_cacheDownloadRepositoryProvider);
 });
 

--- a/lib/data/repositories/favorites_repository_provider.dart
+++ b/lib/data/repositories/favorites_repository_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/favorites_repository.dart';
+import '../../core/repositories/favorites_store.dart';
+import 'in_memory_favorites_store.dart';
+import 'jellyfin_synced_favorites_repository.dart';
+import 'shared_preferences_favorites_store.dart';
+
+/// Durable store of the user's favourite track ids. Defaults to in-memory so
+/// tests and dev runs need no plugins; the app overrides it with the
+/// `shared_preferences` binding below.
+final favoritesStoreProvider = Provider<FavoritesStore>((ref) {
+  return InMemoryFavoritesStore();
+});
+
+/// The app's [FavoritesRepository]. The data-layer default is local-only (no
+/// Jellyfin client or session) — exactly what tests and offline use need; the
+/// composition root overrides it to sync with the signed-in server (see
+/// `jellyfinFavoritesOverride`). Disposed with the scope.
+final favoritesRepositoryProvider = Provider<FavoritesRepository>((ref) {
+  final repository = JellyfinSyncedFavoritesRepository(
+    store: ref.watch(favoritesStoreProvider),
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+});
+
+/// Production binding: persist favourites via `shared_preferences` so they
+/// survive a restart. Applied in `main`; tests keep the in-memory default.
+final sharedPreferencesFavoritesStoreOverride =
+    favoritesStoreProvider.overrideWithValue(
+  const SharedPreferencesFavoritesStore(),
+);

--- a/lib/data/repositories/in_memory_download_preferences.dart
+++ b/lib/data/repositories/in_memory_download_preferences.dart
@@ -6,11 +6,14 @@ class InMemoryDownloadPreferences implements DownloadPreferences {
   InMemoryDownloadPreferences({
     bool wifiOnly = false,
     int maxCacheBytes = CacheSize.defaultLimit,
+    bool preloadEnabled = true,
   })  : _wifiOnly = wifiOnly,
-        _maxCacheBytes = maxCacheBytes;
+        _maxCacheBytes = maxCacheBytes,
+        _preloadEnabled = preloadEnabled;
 
   bool _wifiOnly;
   int _maxCacheBytes;
+  bool _preloadEnabled;
 
   @override
   Future<bool> wifiOnly() async => _wifiOnly;
@@ -26,5 +29,13 @@ class InMemoryDownloadPreferences implements DownloadPreferences {
   @override
   Future<void> setMaxCacheBytes(int bytes) async {
     _maxCacheBytes = bytes;
+  }
+
+  @override
+  Future<bool> preloadEnabled() async => _preloadEnabled;
+
+  @override
+  Future<void> setPreloadEnabled(bool value) async {
+    _preloadEnabled = value;
   }
 }

--- a/lib/data/repositories/in_memory_favorites_store.dart
+++ b/lib/data/repositories/in_memory_favorites_store.dart
@@ -1,0 +1,17 @@
+import '../../core/repositories/favorites_store.dart';
+
+/// A non-persistent [FavoritesStore] for development and tests.
+class InMemoryFavoritesStore implements FavoritesStore {
+  InMemoryFavoritesStore([FavoritesData initial = FavoritesData.empty])
+      : _data = initial;
+
+  FavoritesData _data;
+
+  @override
+  Future<FavoritesData> load() async => _data;
+
+  @override
+  Future<void> save(FavoritesData data) async {
+    _data = data;
+  }
+}

--- a/lib/data/repositories/jellyfin_synced_favorites_repository.dart
+++ b/lib/data/repositories/jellyfin_synced_favorites_repository.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import '../../core/models/jellyfin_session.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/favorites_repository.dart';
+import '../../core/repositories/favorites_store.dart';
+import '../../core/sources/jellyfin/jellyfin_client.dart';
+import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
+
+/// The app's [FavoritesRepository]: an optimistic local mirror with Jellyfin
+/// sync layered on top.
+///
+/// Favourites live in a [FavoritesStore] split into device-local ids (local
+/// tracks) and remote ids (Jellyfin item ids). A toggle updates the right set
+/// immediately, emits, and persists; for a Jellyfin track while signed in it
+/// then pushes to the server best-effort. [refreshFromRemote] adopts the
+/// server's set as the remote truth, leaving local-track favourites alone, so
+/// favourites set on another client show up here.
+///
+/// Security: only non-secret track/item ids are stored or sent. The session
+/// (with its token) is read lazily through [_session] for the request header —
+/// never logged or persisted here. Local-track favourites are never sent
+/// anywhere.
+class JellyfinSyncedFavoritesRepository implements FavoritesRepository {
+  JellyfinSyncedFavoritesRepository({
+    required FavoritesStore store,
+    JellyfinClient? client,
+    JellyfinSession? Function()? session,
+  })  : _store = store,
+        _client = client,
+        _session = session;
+
+  final FavoritesStore _store;
+
+  /// The Jellyfin HTTP seam, or `null` when favourites are local-only (tests,
+  /// the data-layer default). Read lazily alongside [_session].
+  final JellyfinClient? _client;
+
+  /// Supplies the live signed-in session, or `null` when not connected. Read at
+  /// call time so signing in/out is picked up without rebuilding the repository.
+  final JellyfinSession? Function()? _session;
+
+  final StreamController<Set<String>> _changes =
+      StreamController<Set<String>>.broadcast();
+
+  FavoritesData _data = FavoritesData.empty;
+  bool _loaded = false;
+
+  Future<void> _ensureLoaded() async {
+    if (_loaded) return;
+    _data = await _store.load();
+    _loaded = true;
+  }
+
+  Set<String> get _all => <String>{..._data.localIds, ..._data.remoteIds};
+
+  @override
+  Stream<Set<String>> get favoritesStream async* {
+    await _ensureLoaded();
+    yield _all;
+    yield* _changes.stream;
+  }
+
+  @override
+  bool isFavorite(String trackId) =>
+      _data.localIds.contains(trackId) || _data.remoteIds.contains(trackId);
+
+  @override
+  Future<void> setFavorite(Track track, bool favorite) async {
+    await _ensureLoaded();
+    final bool remote = _isRemote(track);
+    if (remote) {
+      final Set<String> ids = <String>{..._data.remoteIds};
+      if (favorite) {
+        ids.add(track.id);
+      } else {
+        ids.remove(track.id);
+      }
+      _data = _data.copyWith(remoteIds: ids);
+    } else {
+      final Set<String> ids = <String>{..._data.localIds};
+      if (favorite) {
+        ids.add(track.id);
+      } else {
+        ids.remove(track.id);
+      }
+      _data = _data.copyWith(localIds: ids);
+    }
+    _emit();
+    await _store.save(_data);
+
+    // Push to the server best-effort; a failure keeps the optimistic local
+    // state, which the next refresh reconciles. Never throws out of here.
+    if (remote) {
+      final JellyfinClient? client = _client;
+      final JellyfinSession? session = _session?.call();
+      if (client != null && session != null) {
+        try {
+          await client.setFavorite(session, track.id, favorite: favorite);
+        } catch (_) {
+          // Ignore: optimistic local state stands; refresh reconciles later.
+        }
+      }
+    }
+  }
+
+  @override
+  Future<void> refreshFromRemote() async {
+    await _ensureLoaded();
+    final JellyfinClient? client = _client;
+    final JellyfinSession? session = _session?.call();
+    if (client == null || session == null) return;
+    try {
+      final Set<String> serverIds = await client.fetchFavoriteIds(session);
+      // Skip the emit/save when nothing actually changed, to avoid churn.
+      if (serverIds.length == _data.remoteIds.length &&
+          serverIds.containsAll(_data.remoteIds)) {
+        return;
+      }
+      _data = _data.copyWith(remoteIds: serverIds);
+      _emit();
+      await _store.save(_data);
+    } catch (_) {
+      // Offline or transient: keep what we have.
+    }
+  }
+
+  void _emit() {
+    if (!_changes.isClosed) _changes.add(_all);
+  }
+
+  static bool _isRemote(Track track) =>
+      track.uri.startsWith(JellyfinTrackMapper.uriScheme);
+
+  Future<void> dispose() => _changes.close();
+}

--- a/lib/data/repositories/shared_preferences_download_preferences.dart
+++ b/lib/data/repositories/shared_preferences_download_preferences.dart
@@ -11,6 +11,7 @@ class SharedPreferencesDownloadPreferences implements DownloadPreferences {
 
   static const String _wifiOnlyKey = 'downloads_wifi_only';
   static const String _maxCacheBytesKey = 'downloads_max_cache_bytes';
+  static const String _preloadEnabledKey = 'downloads_preload_enabled';
 
   @override
   Future<bool> wifiOnly() async {
@@ -36,5 +37,17 @@ class SharedPreferencesDownloadPreferences implements DownloadPreferences {
   Future<void> setMaxCacheBytes(int bytes) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_maxCacheBytesKey, CacheSize.clamp(bytes));
+  }
+
+  @override
+  Future<bool> preloadEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_preloadEnabledKey) ?? true;
+  }
+
+  @override
+  Future<void> setPreloadEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_preloadEnabledKey, value);
   }
 }

--- a/lib/data/repositories/shared_preferences_favorites_store.dart
+++ b/lib/data/repositories/shared_preferences_favorites_store.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/favorites_store.dart';
+
+/// A [FavoritesStore] backed by `shared_preferences`.
+///
+/// Favourites are a small set of non-secret track ids, so a key/value document
+/// is the right weight (the same reasoning the offline-download set follows).
+/// Stored as `{ "local": [...], "remote": [...] }` so the device-local
+/// favourites and the server-mirrored ones survive a restart and can be
+/// reconciled independently.
+class SharedPreferencesFavoritesStore implements FavoritesStore {
+  const SharedPreferencesFavoritesStore();
+
+  static const String _key = 'favorites_v1';
+
+  @override
+  Future<FavoritesData> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return FavoritesData.empty;
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      // A corrupt record reads as "no favourites" rather than crashing.
+      return FavoritesData.empty;
+    }
+    if (decoded is! Map<String, dynamic>) return FavoritesData.empty;
+    return FavoritesData(
+      localIds: _ids(decoded['local']),
+      remoteIds: _ids(decoded['remote']),
+    );
+  }
+
+  @override
+  Future<void> save(FavoritesData data) async {
+    final prefs = await SharedPreferences.getInstance();
+    final String raw = jsonEncode(<String, dynamic>{
+      'local': data.localIds.toList(),
+      'remote': data.remoteIds.toList(),
+    });
+    await prefs.setString(_key, raw);
+  }
+
+  static Set<String> _ids(Object? value) {
+    if (value is! List) return <String>{};
+    return <String>{
+      for (final Object? id in value)
+        if (id is String && id.isNotEmpty) id,
+    };
+  }
+}

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -89,6 +89,26 @@ class WifiOnlyController extends AsyncNotifier<bool> {
 final wifiOnlyControllerProvider =
     AsyncNotifierProvider<WifiOnlyController, bool>(WifiOnlyController.new);
 
+/// Owns the "Preload upcoming tracks" switch: loads the persisted value and
+/// writes changes back through [DownloadPreferences]. When on, the player warms
+/// the next few queued tracks into the cache ahead of play.
+class PreloadEnabledController extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() {
+    return ref.read(downloadPreferencesProvider).preloadEnabled();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    await ref.read(downloadPreferencesProvider).setPreloadEnabled(value);
+    state = AsyncData<bool>(value);
+  }
+}
+
+final preloadEnabledControllerProvider =
+    AsyncNotifierProvider<PreloadEnabledController, bool>(
+  PreloadEnabledController.new,
+);
+
 /// Production binding: makes Jellyfin tracks downloadable for offline use by
 /// wiring the remote downloader to the live signed-in source (read through
 /// [jellyfinMusicSourceProvider], so sign-in/out is picked up without a

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -27,6 +27,7 @@ class DownloadsScreen extends ConsumerWidget {
         children: [
           const _CacheUsageHeader(),
           const _WifiOnlyToggle(),
+          const _PreloadToggle(),
           const Divider(height: 1),
           Expanded(child: _list(downloaded)),
         ],
@@ -124,6 +125,28 @@ class _WifiOnlyToggle extends ConsumerWidget {
 
   void _set(WidgetRef ref, bool value) {
     ref.read(wifiOnlyControllerProvider.notifier).setWifiOnly(value);
+  }
+}
+
+class _PreloadToggle extends ConsumerWidget {
+  const _PreloadToggle();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final preload = ref.watch(preloadEnabledControllerProvider);
+    return SwitchListTile(
+      secondary: const Icon(Icons.bolt_outlined),
+      title: const Text('Preload upcoming tracks'),
+      subtitle: const Text(
+        'Cache the next few queued tracks ahead of play, within your limit',
+      ),
+      value: preload.valueOrNull ?? true,
+      onChanged: preload.isLoading ? null : (value) => _set(ref, value),
+    );
+  }
+
+  void _set(WidgetRef ref, bool value) {
+    ref.read(preloadEnabledControllerProvider.notifier).setEnabled(value);
   }
 }
 

--- a/lib/features/player/favorites_providers.dart
+++ b/lib/features/player/favorites_providers.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/favorites_repository_provider.dart';
+import '../../data/repositories/jellyfin_synced_favorites_repository.dart';
+import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/jellyfin/jellyfin_settings_providers.dart';
+
+/// Streams the favourite track-id set for the UI.
+final favoriteIdsProvider = StreamProvider<Set<String>>((ref) {
+  return ref.watch(favoritesRepositoryProvider).favoritesStream;
+});
+
+/// Whether a single track is currently a favourite — for the heart toggle. It
+/// recomputes whenever the favourites set changes, so the icon stays live.
+final isFavoriteProvider = Provider.family<bool, String>((ref, trackId) {
+  final Set<String> ids =
+      ref.watch(favoriteIdsProvider).valueOrNull ?? const <String>{};
+  return ids.contains(trackId);
+});
+
+/// Production binding: syncs favourites with the signed-in Jellyfin server.
+/// Reads the live client + session lazily (mirroring the downloader override),
+/// so signing in/out is picked up without rebuilding the repository. Applied in
+/// `main`; tests keep the local-only default.
+final jellyfinFavoritesOverride =
+    favoritesRepositoryProvider.overrideWith((ref) {
+  final repository = JellyfinSyncedFavoritesRepository(
+    store: ref.watch(favoritesStoreProvider),
+    client: ref.read(jellyfinClientProvider),
+    session: () =>
+        ref.read(jellyfinSettingsControllerProvider.notifier).session,
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+});

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/lyrics.dart';
+import '../../core/models/track.dart';
+import '../../core/services/jellyfin_lyrics_service.dart';
+import '../../core/services/lyrics_service.dart';
+import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/jellyfin/jellyfin_settings_providers.dart';
+
+/// The lyrics backend. Defaults to "no lyrics" so tests and local-only use need
+/// no Jellyfin wiring; the app overrides it with the Jellyfin-backed service.
+final lyricsServiceProvider = Provider<LyricsService>((ref) {
+  return const _NoLyricsService();
+});
+
+/// Lyrics for a single track, fetched on demand and cached while the sheet is
+/// open. Auto-disposed so closing the sheet drops the request.
+final trackLyricsProvider =
+    FutureProvider.autoDispose.family<Lyrics?, Track>((ref, track) {
+  return ref.watch(lyricsServiceProvider).lyricsFor(track);
+});
+
+/// Production binding: read lyrics from the signed-in Jellyfin server. Reads the
+/// live client + session lazily so signing in/out is picked up without a
+/// rebuild. Applied in `main`; tests keep the no-lyrics default.
+final jellyfinLyricsOverride = lyricsServiceProvider.overrideWith((ref) {
+  return JellyfinLyricsService(
+    client: ref.read(jellyfinClientProvider),
+    session: () =>
+        ref.read(jellyfinSettingsControllerProvider.notifier).session,
+  );
+});
+
+/// The honest local-only default: no lyrics source wired, so every track
+/// resolves to "none" and the UI shows a calm placeholder.
+class _NoLyricsService implements LyricsService {
+  const _NoLyricsService();
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async => null;
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -8,6 +8,7 @@ import '../../core/services/local_playable_uri_resolver.dart';
 import '../../core/services/offline_first_playable_uri_resolver.dart';
 import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_controller.dart';
+import '../../core/services/playback_preloader.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
@@ -69,6 +70,25 @@ final playbackControllerProvider = Provider<PlaybackController>((ref) {
 final playbackStateProvider = StreamProvider<PlaybackState>((ref) {
   final controller = ref.watch(playbackControllerProvider);
   return controller.stateStream;
+});
+
+/// Warms the next few queued tracks into the offline cache as playback moves,
+/// so upcoming songs play instantly and offline (bounded by the cache limit,
+/// and honouring "Wi-Fi only" / the preload preference).
+///
+/// Pinned for the session like the controller: it reads the controller's state
+/// stream and the cache/prefs seams once with [Ref.read], so a rebuild of the
+/// download stores or preferences can't tear it down mid-session. It does its
+/// work as a side effect of listening, so `main` instantiates it once after
+/// startup; nothing in the UI reads its value.
+final playbackPreloaderProvider = Provider<PlaybackPreloader>((ref) {
+  final preloader = PlaybackPreloader(
+    playbackStates: ref.read(playbackControllerProvider).stateStream,
+    prefetcher: ref.read(trackPrefetcherProvider),
+    preferences: ref.read(downloadPreferencesProvider),
+  );
+  ref.onDispose(preloader.dispose);
+  return preloader;
 });
 
 /// Production binding: lets the cache eviction policy see the currently playing

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -161,7 +161,7 @@ class _NowPlaying extends ConsumerWidget {
           const SizedBox(height: AppSpacing.xs),
           PlaybackControls(state: state),
           const SizedBox(height: AppSpacing.sm),
-          const NowPlayingActions(),
+          NowPlayingActions(track: track),
         ],
       ),
     );

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -2,27 +2,42 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
+import '../../../core/models/lyrics.dart';
 import '../../../core/models/track.dart';
+import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../shared/widgets/empty_state.dart';
+import '../favorites_providers.dart';
+import '../lyrics_providers.dart';
 import '../player_providers.dart';
 
 /// Bottom action row on the now-playing screen: favorite · queue · lyrics.
 ///
-/// Favorite and lyrics are honest placeholders — they give feedback but don't
-/// pretend to persist or fetch anything. Queue opens the live up-next list in a
-/// sheet, keeping the main screen artwork-focused.
+/// All three are live: favorite toggles a heart synced through the
+/// [FavoritesRepository] (to Jellyfin for remote tracks, on-device for local
+/// ones), queue opens the up-next list, and lyrics fetches the track's lyrics
+/// from the source — falling back to an honest "no lyrics" state when there are
+/// none (or for a local track / when signed out).
 class NowPlayingActions extends ConsumerWidget {
-  const NowPlayingActions({super.key});
+  const NowPlayingActions({super.key, required this.track});
+
+  final Track track;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final bool isFavorite = ref.watch(isFavoriteProvider(track.id));
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         IconButton(
-          onPressed: () => _comingSoon(context, 'Favorites are coming soon.'),
-          icon: const Icon(Icons.favorite_border),
-          tooltip: 'Favorite',
+          onPressed: () => ref
+              .read(favoritesRepositoryProvider)
+              .setFavorite(track, !isFavorite),
+          icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
+          color: isFavorite ? theme.colorScheme.primary : null,
+          isSelected: isFavorite,
+          tooltip: isFavorite ? 'Remove from favorites' : 'Favorite',
         ),
         IconButton(
           onPressed: () => _openQueue(context),
@@ -38,12 +53,6 @@ class NowPlayingActions extends ConsumerWidget {
     );
   }
 
-  void _comingSoon(BuildContext context, String message) {
-    ScaffoldMessenger.of(context)
-      ..hideCurrentSnackBar()
-      ..showSnackBar(SnackBar(content: Text(message)));
-  }
-
   void _openQueue(BuildContext context) {
     showModalBottomSheet<void>(
       context: context,
@@ -57,16 +66,107 @@ class NowPlayingActions extends ConsumerWidget {
     showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
-      builder: (_) => const SafeArea(
+      isScrollControlled: true,
+      builder: (_) => _LyricsSheet(track: track),
+    );
+  }
+}
+
+/// The lyrics sheet: fetches the current track's lyrics and renders the lines,
+/// a calm "no lyrics" placeholder when there are none, or a friendly "couldn't
+/// load" line on a fetch failure.
+class _LyricsSheet extends ConsumerWidget {
+  const _LyricsSheet({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final AsyncValue<Lyrics?> lyrics = ref.watch(trackLyricsProvider(track));
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.7,
+        ),
         child: Padding(
-          padding: EdgeInsets.only(bottom: AppSpacing.xl),
-          child: EmptyState(
-            icon: Icons.lyrics_outlined,
-            title: 'No lyrics available yet.',
-            message: 'Lyrics support is coming in a future update.',
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            0,
+            AppSpacing.lg,
+            AppSpacing.lg,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text('Lyrics', style: theme.textTheme.titleMedium),
+              const SizedBox(height: AppSpacing.sm),
+              Flexible(child: _content(lyrics)),
+            ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _content(AsyncValue<Lyrics?> lyrics) {
+    return lyrics.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      // Never surface raw error text (it can carry transport detail); show one
+      // calm, friendly line instead.
+      error: (_, __) => const Padding(
+        padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+        child: EmptyState(
+          icon: Icons.lyrics_outlined,
+          title: "Couldn't load lyrics",
+          message: 'Check your connection and try again.',
+        ),
+      ),
+      data: (value) {
+        if (value == null || value.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+            child: EmptyState(
+              icon: Icons.lyrics_outlined,
+              title: 'No lyrics available',
+              message: 'This track has no lyrics, or none are synced from your '
+                  'server yet.',
+            ),
+          );
+        }
+        return _LyricsList(lyrics: value);
+      },
+    );
+  }
+}
+
+class _LyricsList extends StatelessWidget {
+  const _LyricsList({required this.lyrics});
+
+  final Lyrics lyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: lyrics.lines.length,
+      itemBuilder: (context, index) {
+        final String text = lyrics.lines[index].text;
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+          // A blank line keeps its vertical rhythm rather than collapsing.
+          child: Text(
+            text.isEmpty ? ' ' : text,
+            style: theme.textTheme.bodyLarge,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/settings/cache/cache_settings_section.dart
+++ b/lib/features/settings/cache/cache_settings_section.dart
@@ -46,9 +46,10 @@ class CacheSettingsSection extends ConsumerWidget {
             ),
             const SizedBox(height: AppSpacing.xs),
             Text(
-              'Downloads stay under your limit. When it fills, the '
-              'least-recently-played unpinned tracks are removed first — pinned '
-              'tracks and the track playing now are kept.',
+              'Downloads and preloaded upcoming tracks stay under your limit. '
+              'When it fills, preloaded then least-recently-played unpinned '
+              'tracks are removed first — pinned tracks and the track playing '
+              'now are kept.',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,18 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/linthra_app.dart';
 import 'core/services/linthra_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
+import 'data/repositories/favorites_repository_provider.dart';
 import 'data/repositories/jellyfin_session_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'features/downloads/download_providers.dart';
+import 'features/player/favorites_providers.dart';
+import 'features/player/lyrics_providers.dart';
 import 'features/player/player_providers.dart';
 import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
 
@@ -34,6 +39,9 @@ Future<void> main() async {
       jellyfinRemoteTrackDownloaderOverride,
       currentlyPlayingTrackIdOverride,
       secureJellyfinSessionStoreOverride,
+      sharedPreferencesFavoritesStoreOverride,
+      jellyfinFavoritesOverride,
+      jellyfinLyricsOverride,
     ],
   );
 
@@ -44,6 +52,12 @@ Future<void> main() async {
     container.read(playbackControllerProvider),
     container.read(musicLibraryRepositoryProvider),
   );
+
+  // Start the upcoming-track preloader: as playback advances it warms the next
+  // queued tracks into the offline cache (under the same limit, honouring
+  // "Wi-Fi only" and the preload preference). Instantiating it wires the
+  // listener; it has no value the UI reads.
+  container.read(playbackPreloaderProvider);
 
   // Warm the persisted Jellyfin session before the first frame so a synced
   // remote track can stream on the first tap — without it, playback would race
@@ -58,6 +72,11 @@ Future<void> main() async {
   } catch (_) {
     // Ignore: the user can still connect in Settings.
   }
+
+  // With the session loaded, pull the user's Jellyfin favourites so the heart
+  // reflects the server from the first frame. Best-effort and offline-tolerant:
+  // the repository swallows failures and keeps any locally stored favourites.
+  unawaited(container.read(favoritesRepositoryProvider).refreshFromRemote());
 
   runApp(
     UncontrolledProviderScope(

--- a/test/core/services/cache_eviction_policy_test.dart
+++ b/test/core/services/cache_eviction_policy_test.dart
@@ -157,8 +157,8 @@ void main() {
         cached: <CachedTrack>[
           // The user download is older, but a preload is sacrificed first.
           _managed('download', size: 100, accessed: DateTime(2024, 1, 1)),
-          _managed('preload', size: 100, accessed: DateTime(2024, 6, 1),
-              preloaded: true),
+          _managed('preload',
+              size: 100, accessed: DateTime(2024, 6, 1), preloaded: true),
         ],
         incomingBytes: 100,
         maxBytes: 250,
@@ -171,10 +171,10 @@ void main() {
     test('evicts older preloads first among several preloads', () {
       final plan = policy.plan(
         cached: <CachedTrack>[
-          _managed('p-new', size: 100, cached: DateTime(2024, 6, 1),
-              preloaded: true),
-          _managed('p-old', size: 100, cached: DateTime(2024, 1, 1),
-              preloaded: true),
+          _managed('p-new',
+              size: 100, cached: DateTime(2024, 6, 1), preloaded: true),
+          _managed('p-old',
+              size: 100, cached: DateTime(2024, 1, 1), preloaded: true),
           _managed('download', size: 100, accessed: DateTime(2024, 1, 1)),
         ],
         incomingBytes: 100,

--- a/test/core/services/cache_eviction_policy_test.dart
+++ b/test/core/services/cache_eviction_policy_test.dart
@@ -9,6 +9,7 @@ CachedTrack _managed(
   DateTime? accessed,
   DateTime? cached,
   bool pinned = false,
+  bool preloaded = false,
 }) {
   return CachedTrack(
     trackId: id,
@@ -17,6 +18,7 @@ CachedTrack _managed(
     lastAccessedAt: accessed,
     cachedAt: cached,
     pinned: pinned,
+    preloaded: preloaded,
   );
 }
 
@@ -148,6 +150,39 @@ void main() {
       // Only the managed remote track counts (100) and is the sole candidate.
       expect(plan.fits, isTrue);
       expect(plan.evict.map((e) => e.trackId), <String>['remote']);
+    });
+
+    test('evicts a preloaded track before any user download', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          // The user download is older, but a preload is sacrificed first.
+          _managed('download', size: 100, accessed: DateTime(2024, 1, 1)),
+          _managed('preload', size: 100, accessed: DateTime(2024, 6, 1),
+              preloaded: true),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250,
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict.map((e) => e.trackId), <String>['preload']);
+    });
+
+    test('evicts older preloads first among several preloads', () {
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('p-new', size: 100, cached: DateTime(2024, 6, 1),
+              preloaded: true),
+          _managed('p-old', size: 100, cached: DateTime(2024, 1, 1),
+              preloaded: true),
+          _managed('download', size: 100, accessed: DateTime(2024, 1, 1)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 250, // need to free 2 of 3
+      );
+
+      // Both preloads go (oldest first) before the user download is touched.
+      expect(plan.evict.map((e) => e.trackId), <String>['p-old', 'p-new']);
     });
 
     test('a re-download replaces its own copy rather than evicting others', () {

--- a/test/core/services/jellyfin_lyrics_service_test.dart
+++ b/test/core/services/jellyfin_lyrics_service_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/jellyfin_lyrics_service.dart';
+
+import '../sources/jellyfin/fake_jellyfin_client.dart';
+
+const _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: 'tok',
+  deviceId: 'device-1',
+);
+
+void main() {
+  group('JellyfinLyricsService', () {
+    late FakeJellyfinClient client;
+
+    setUp(() => client = FakeJellyfinClient());
+
+    JellyfinLyricsService build({JellyfinSession? session}) =>
+        JellyfinLyricsService(client: client, session: () => session);
+
+    test('fetches lyrics for a Jellyfin track by its item id', () async {
+      client.lyrics = const Lyrics(
+        lines: <LyricLine>[LyricLine(text: 'la la')],
+      );
+      final service = build(session: _session);
+
+      final lyrics = await service.lyricsFor(
+        const Track(id: 'item-7', title: 'Song', uri: 'jellyfin:item-7'),
+      );
+
+      expect(client.lastLyricsItemId, 'item-7');
+      expect(lyrics?.lines.single.text, 'la la');
+    });
+
+    test('returns null for a local track without hitting the server', () async {
+      final service = build(session: _session);
+
+      final lyrics = await service.lyricsFor(
+        const Track(id: '1', title: 'Local', uri: 'file:///1.mp3'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.lastLyricsItemId, isNull);
+    });
+
+    test('returns null when signed out', () async {
+      final service = build(session: null);
+
+      final lyrics = await service.lyricsFor(
+        const Track(id: 'item-7', title: 'Song', uri: 'jellyfin:item-7'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.lastLyricsItemId, isNull);
+    });
+  });
+}

--- a/test/core/services/playback_preloader_test.dart
+++ b/test/core/services/playback_preloader_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_preloader.dart';
+import 'package:linthra/core/services/track_prefetcher.dart';
+import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
+
+/// Records the ids it was asked to warm, in order.
+class _RecordingPrefetcher implements TrackPrefetcher {
+  final List<String> prefetched = <String>[];
+
+  @override
+  Future<void> prefetch(Track track) async {
+    prefetched.add(track.id);
+  }
+}
+
+Track _t(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+PlaybackState _playing(Track current, List<Track> upNext) => PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: current,
+      upNext: upNext,
+    );
+
+/// Drains the microtask chain the listener + prefetch awaits run on.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('PlaybackPreloader', () {
+    late StreamController<PlaybackState> states;
+    late _RecordingPrefetcher prefetcher;
+    late InMemoryDownloadPreferences preferences;
+
+    setUp(() {
+      states = StreamController<PlaybackState>.broadcast();
+      prefetcher = _RecordingPrefetcher();
+      preferences = InMemoryDownloadPreferences();
+    });
+
+    PlaybackPreloader build({int aheadCount = 3}) => PlaybackPreloader(
+          playbackStates: states.stream,
+          prefetcher: prefetcher,
+          preferences: preferences,
+          aheadCount: aheadCount,
+        );
+
+    test('warms the next few upcoming tracks when the track changes', () async {
+      final preloader = build(aheadCount: 2);
+
+      states.add(_playing(_t('a'), <Track>[_t('b'), _t('c'), _t('d')]));
+      await _settle();
+
+      // Only the first two upcoming tracks, in queue order.
+      expect(prefetcher.prefetched, <String>['b', 'c']);
+      await preloader.dispose();
+    });
+
+    test('does nothing while the preload preference is off', () async {
+      preferences = InMemoryDownloadPreferences(preloadEnabled: false);
+      final preloader = build();
+
+      states.add(_playing(_t('a'), <Track>[_t('b'), _t('c')]));
+      await _settle();
+
+      expect(prefetcher.prefetched, isEmpty);
+      await preloader.dispose();
+    });
+
+    test('reacts to a track change, not to every state update', () async {
+      final preloader = build(aheadCount: 1);
+
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+      // A position-only update keeps the same playing track.
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+
+      expect(prefetcher.prefetched, <String>['b']);
+      await preloader.dispose();
+    });
+
+    test('re-preloads against the new queue after advancing', () async {
+      final preloader = build(aheadCount: 1);
+
+      states.add(_playing(_t('a'), <Track>[_t('b'), _t('c')]));
+      await _settle();
+      states.add(_playing(_t('b'), <Track>[_t('c'), _t('d')]));
+      await _settle();
+
+      expect(prefetcher.prefetched, <String>['b', 'c']);
+      await preloader.dispose();
+    });
+
+    test('does nothing with an empty up-next list', () async {
+      final preloader = build();
+
+      states.add(_playing(_t('a'), const <Track>[]));
+      await _settle();
+
+      expect(prefetcher.prefetched, isEmpty);
+      await preloader.dispose();
+    });
+  });
+}

--- a/test/core/sources/jellyfin/fake_jellyfin_client.dart
+++ b/test/core/sources/jellyfin/fake_jellyfin_client.dart
@@ -1,4 +1,5 @@
 import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/lyrics.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_client.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
@@ -45,6 +46,20 @@ class FakeJellyfinClient implements JellyfinClient {
   /// The last URL [probeStream] was asked about, so a test can prove the probe
   /// ran against the minted stream URL.
   Uri? lastProbedUrl;
+
+  /// Canned lyrics for [fetchLyrics]; `null` models "no lyrics" (a 404).
+  Lyrics? lyrics;
+  JellyfinException? lyricsError;
+  String? lastLyricsItemId;
+
+  /// Canned favourite ids for [fetchFavoriteIds] (also updated by [setFavorite]
+  /// so a round-trip reads back consistently).
+  Set<String> favoriteIds = <String>{};
+  JellyfinException? favoritesError;
+
+  /// Recorded favourite toggles in order, as (itemId, favorite) pairs.
+  final List<({String itemId, bool favorite})> favoriteCalls =
+      <({String itemId, bool favorite})>[];
 
   @override
   Future<JellyfinServerInfo> fetchServerInfo(String baseUrl) async {
@@ -112,5 +127,42 @@ class FakeJellyfinClient implements JellyfinClient {
     }
     return streamProbe ??
         const JellyfinStreamProbe(statusCode: 200, contentType: 'audio/mpeg');
+  }
+
+  @override
+  Future<Lyrics?> fetchLyrics(JellyfinSession session, String itemId) async {
+    lastLyricsItemId = itemId;
+    final JellyfinException? error = lyricsError;
+    if (error != null) {
+      throw error;
+    }
+    return lyrics;
+  }
+
+  @override
+  Future<Set<String>> fetchFavoriteIds(JellyfinSession session) async {
+    final JellyfinException? error = favoritesError;
+    if (error != null) {
+      throw error;
+    }
+    return favoriteIds;
+  }
+
+  @override
+  Future<void> setFavorite(
+    JellyfinSession session,
+    String itemId, {
+    required bool favorite,
+  }) async {
+    final JellyfinException? error = favoritesError;
+    if (error != null) {
+      throw error;
+    }
+    favoriteCalls.add((itemId: itemId, favorite: favorite));
+    if (favorite) {
+      favoriteIds = <String>{...favoriteIds, itemId};
+    } else {
+      favoriteIds = <String>{...favoriteIds}..remove(itemId);
+    }
   }
 }

--- a/test/core/sources/jellyfin/http_jellyfin_client_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_test.dart
@@ -370,4 +370,83 @@ void main() {
       );
     });
   });
+
+  group('fetchLyrics', () {
+    test('parses synced + plain lines and targets the lyrics endpoint',
+        () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'Lyrics': <Map<String, dynamic>>[
+              <String, dynamic>{'Text': 'First line', 'Start': 10000000},
+              <String, dynamic>{'Text': 'Second line'},
+            ],
+          }),
+          200,
+          headers: <String, String>{'content-type': 'application/json'},
+        );
+      }));
+
+      final lyrics = await client.fetchLyrics(_session, 'item-7');
+
+      expect(captured!.method, 'GET');
+      expect(captured!.url.path, '/Audio/item-7/Lyrics');
+      expect(
+        lyrics!.lines.map((line) => line.text),
+        <String>['First line', 'Second line'],
+      );
+      // 10,000,000 ticks (100-ns units) is exactly one second.
+      expect(lyrics.lines.first.start, const Duration(seconds: 1));
+      expect(lyrics.lines.last.start, isNull);
+      expect(lyrics.isSynced, isTrue);
+    });
+
+    test('returns null when the server has no lyrics (404)', () async {
+      final client = _client(MockClient((_) async => http.Response('', 404)));
+
+      expect(await client.fetchLyrics(_session, 'item-7'), isNull);
+    });
+  });
+
+  group('favorites', () {
+    test('fetchFavoriteIds lists favourite audio item ids', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode(<String, dynamic>{
+            'Items': <Map<String, dynamic>>[
+              <String, dynamic>{'Id': 'a'},
+              <String, dynamic>{'Id': 'b'},
+            ],
+          }),
+          200,
+          headers: <String, String>{'content-type': 'application/json'},
+        );
+      }));
+
+      final ids = await client.fetchFavoriteIds(_session);
+
+      expect(ids, <String>{'a', 'b'});
+      expect(captured!.url.queryParameters['Filters'], 'IsFavorite');
+    });
+
+    test('setFavorite POSTs to mark and DELETEs to clear', () async {
+      final List<http.Request> requests = <http.Request>[];
+      final client = _client(MockClient((http.Request request) async {
+        requests.add(request);
+        return http.Response('', 200);
+      }));
+
+      await client.setFavorite(_session, 'item-7', favorite: true);
+      await client.setFavorite(_session, 'item-7', favorite: false);
+
+      expect(requests[0].method, 'POST');
+      expect(requests[0].url.path, '/Users/user-1/FavoriteItems/item-7');
+      expect(requests[1].method, 'DELETE');
+      expect(requests[1].url.path, '/Users/user-1/FavoriteItems/item-7');
+    });
+  });
 }

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -605,9 +605,10 @@ void main() {
         // The preload is sacrificed; the user download survives.
         expect(await repository.statusFor('keep'), DownloadStatus.downloaded);
         expect(await repository.statusFor('new'), DownloadStatus.downloaded);
-        final List<String> ids =
-            (await store.loadDownloads()).map((c) => c.trackId).toList()
-              ..sort();
+        final List<String> ids = (await store.loadDownloads())
+            .map((c) => c.trackId)
+            .toList()
+          ..sort();
         expect(ids, <String>['keep', 'new']);
       });
     });

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -514,6 +514,104 @@ void main() {
       });
     });
 
+    group('preload (prefetch)', () {
+      test('caches a remote track without giving it a download status',
+          () async {
+        final repository = build();
+
+        await repository.prefetch(_jellyfin('j1'));
+
+        // Invisible as a download, but cached and counted toward usage.
+        expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect(await repository.downloadedTrackIds(), isEmpty);
+        final CachedTrack saved = (await store.loadDownloads()).single;
+        expect(saved.trackId, 'j1');
+        expect(saved.preloaded, isTrue);
+        expect(saved.fileName, isNotNull);
+        expect((await repository.cacheSnapshot()).usedBytes, 4);
+      });
+
+      test('skips a local track (already on disk)', () async {
+        final repository = build();
+
+        await repository.prefetch(_local('a'));
+
+        expect(downloader.fetchCount, 0);
+        expect(await store.loadDownloads(), isEmpty);
+      });
+
+      test('skips a track that is already downloaded', () async {
+        final repository = build();
+        await repository.requestDownload(_jellyfin('j1'));
+        expect(downloader.fetchCount, 1);
+
+        await repository.prefetch(_jellyfin('j1'));
+
+        expect(downloader.fetchCount, 1);
+      });
+
+      test('is best-effort: a failed fetch caches nothing and never throws',
+          () async {
+        downloader = _FakeRemoteDownloader(error: Exception('boom'));
+        final repository = build();
+
+        await repository.prefetch(_jellyfin('j1'));
+
+        expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect(await store.loadDownloads(), isEmpty);
+      });
+
+      test('respects "Wi-Fi only" and skips (without queueing) on mobile',
+          () async {
+        await preferences.setWifiOnly(true);
+        connectivity.status = NetworkStatus.mobile;
+        final repository = build();
+
+        await repository.prefetch(_jellyfin('j1'));
+
+        expect(downloader.fetchCount, 0);
+        expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect(await store.loadDownloads(), isEmpty);
+      });
+
+      test('an explicit download promotes a preloaded copy without re-fetching',
+          () async {
+        final repository = build();
+        await repository.prefetch(_jellyfin('j1'));
+        expect(downloader.fetchCount, 1);
+
+        await repository.requestDownload(_jellyfin('j1'));
+
+        // Promoted in place: now a real download, still only one fetch total.
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+        expect(downloader.fetchCount, 1);
+        expect((await store.loadDownloads()).single.preloaded, isFalse);
+      });
+
+      test('a preloaded track is evicted before a user download', () async {
+        // Room for two 4-byte entries; a third forces one out.
+        preferences = InMemoryDownloadPreferences(maxCacheBytes: 10);
+        final repository = CacheDownloadRepository(
+          store: store,
+          files: files,
+          downloader: downloader,
+          connectivity: connectivity,
+          preferences: preferences,
+        );
+        await repository.requestDownload(_jellyfin('keep')); // user download
+        await repository.prefetch(_jellyfin('warm')); // preload
+        await repository.requestDownload(_jellyfin('new')); // forces eviction
+
+        // The preload is sacrificed; the user download survives.
+        expect(await repository.statusFor('keep'), DownloadStatus.downloaded);
+        expect(await repository.statusFor('new'), DownloadStatus.downloaded);
+        final List<String> ids =
+            (await store.loadDownloads()).map((c) => c.trackId).toList()
+              ..sort();
+        expect(ids, <String>['keep', 'new']);
+      });
+    });
+
     group('manual cache controls', () {
       test('clear all removes every managed file and its metadata', () async {
         final spy = _SpyOfflineFileStore(files);

--- a/test/data/repositories/jellyfin_synced_favorites_repository_test.dart
+++ b/test/data/repositories/jellyfin_synced_favorites_repository_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/favorites_store.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/data/repositories/in_memory_favorites_store.dart';
+import 'package:linthra/data/repositories/jellyfin_synced_favorites_repository.dart';
+
+import '../../core/sources/jellyfin/fake_jellyfin_client.dart';
+
+const _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: 'tok',
+  deviceId: 'device-1',
+);
+
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('JellyfinSyncedFavoritesRepository', () {
+    late InMemoryFavoritesStore store;
+    late FakeJellyfinClient client;
+
+    setUp(() {
+      store = InMemoryFavoritesStore();
+      client = FakeJellyfinClient();
+    });
+
+    JellyfinSyncedFavoritesRepository build({JellyfinSession? session}) {
+      return JellyfinSyncedFavoritesRepository(
+        store: store,
+        client: client,
+        session: () => session,
+      );
+    }
+
+    test('favoriting a Jellyfin track pushes to the server and persists',
+        () async {
+      final repo = build(session: _session);
+
+      await repo.setFavorite(_jellyfin('j1'), true);
+
+      expect(repo.isFavorite('j1'), isTrue);
+      expect(
+        client.favoriteCalls,
+        <({String itemId, bool favorite})>[(itemId: 'j1', favorite: true)],
+      );
+      // Persisted under the (server-owned) remote set.
+      expect((await store.load()).remoteIds, <String>{'j1'});
+    });
+
+    test('unfavoriting a Jellyfin track deletes it on the server', () async {
+      final repo = build(session: _session);
+      await repo.setFavorite(_jellyfin('j1'), true);
+
+      await repo.setFavorite(_jellyfin('j1'), false);
+
+      expect(repo.isFavorite('j1'), isFalse);
+      expect(client.favoriteCalls.last, (itemId: 'j1', favorite: false));
+    });
+
+    test('a local track is stored on-device and never sent to the server',
+        () async {
+      final repo = build(session: _session);
+
+      await repo.setFavorite(_local('a'), true);
+
+      expect(repo.isFavorite('a'), isTrue);
+      expect(client.favoriteCalls, isEmpty);
+      final loaded = await store.load();
+      expect(loaded.localIds, <String>{'a'});
+      expect(loaded.remoteIds, isEmpty);
+    });
+
+    test('favoritesStream emits the union of local and remote favourites',
+        () async {
+      final repo = build(session: _session);
+      final emissions = <Set<String>>[];
+      final sub = repo.favoritesStream.listen(emissions.add);
+      await _settle();
+
+      await repo.setFavorite(_local('a'), true);
+      await repo.setFavorite(_jellyfin('j1'), true);
+      await _settle();
+
+      expect(emissions.last, <String>{'a', 'j1'});
+      await sub.cancel();
+    });
+
+    test('refreshFromRemote adopts the server set, keeping local favourites',
+        () async {
+      final repo = build(session: _session);
+      await repo.setFavorite(_local('a'), true);
+      // The server reports j9 as a favourite (set on another client).
+      client.favoriteIds = <String>{'j9'};
+
+      await repo.refreshFromRemote();
+
+      expect(repo.isFavorite('a'), isTrue); // local kept
+      expect(repo.isFavorite('j9'), isTrue); // remote adopted
+    });
+
+    test('a server push failure keeps the optimistic local favourite',
+        () async {
+      client.favoritesError = JellyfinException.notReachable();
+      final repo = build(session: _session);
+
+      await repo.setFavorite(_jellyfin('j1'), true);
+
+      // Still favourited locally despite the failed push.
+      expect(repo.isFavorite('j1'), isTrue);
+      expect((await store.load()).remoteIds, <String>{'j1'});
+    });
+
+    test('without a session, favourites stay purely local', () async {
+      final repo = build(session: null);
+
+      await repo.setFavorite(_jellyfin('j1'), true);
+      await repo.refreshFromRemote();
+
+      expect(repo.isFavorite('j1'), isTrue);
+      expect(client.favoriteCalls, isEmpty);
+    });
+
+    test('loads persisted favourites from the store on first read', () async {
+      store = InMemoryFavoritesStore(
+        const FavoritesData(localIds: <String>{'a'}, remoteIds: <String>{'j1'}),
+      );
+      final repo = build(session: _session);
+
+      // The synchronous mirror is empty until the first stream read loads it.
+      final ids = await repo.favoritesStream.first;
+
+      expect(ids, <String>{'a', 'j1'});
+    });
+  });
+}

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -214,7 +214,7 @@ void main() {
       expect(find.text("Couldn't play this track"), findsNothing);
     });
 
-    testWidgets('shows the Lyrics empty state', (tester) async {
+    testWidgets('shows the Lyrics empty state with no source', (tester) async {
       await _pumpScreen(tester, _playing());
 
       // The entry point is visible on the player.
@@ -223,8 +223,24 @@ void main() {
       await tester.tap(find.byTooltip('Lyrics'));
       await tester.pumpAndSettle();
 
-      // No lyrics source yet, so it shows a calm placeholder rather than blank.
-      expect(find.text('No lyrics available yet.'), findsOneWidget);
+      // The default lyrics backend returns none (local track, no Jellyfin), so
+      // it shows a calm placeholder rather than a blank sheet.
+      expect(find.text('No lyrics available'), findsOneWidget);
+    });
+
+    testWidgets('the favorite button toggles the heart', (tester) async {
+      await _pumpScreen(tester, _playing());
+
+      // Starts unfavorited: outline heart, "Favorite" tooltip.
+      expect(find.byTooltip('Favorite'), findsOneWidget);
+      expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Favorite'));
+      await tester.pumpAndSettle();
+
+      // Now favorited: filled heart, updated tooltip (local-only default store).
+      expect(find.byTooltip('Remove from favorites'), findsOneWidget);
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
     });
 
     testWidgets('reacts to state pushed on the stream', (tester) async {


### PR DESCRIPTION
## Summary

Implements the requested checklist. Two items already shipped (**Cast** — clean `UnavailableCastService` foundation; **Smart cache** — the GB-limited, LRU-evicting offline cache from #49), so this PR adds the genuinely-missing pieces: **preloading**, **lyrics**, and **favorites**.

Two design forks were confirmed with the requester up front:
- **Préchargement → on disk** (into the offline cache, bounded by the GB limit) rather than in-memory buffering.
- **Favoris → synced with Jellyfin** (server is source of truth for remote tracks; local tracks stored on-device).

### 1. Preloading upcoming tracks (disk)
- New `PlaybackPreloader` watches `PlaybackState`; when the playing track changes it warms the next few `upNext` tracks into the cache via a new `TrackPrefetcher` seam on `CacheDownloadRepository`. Because `upNext` is the *effective* play order, this preloads **queue order** normally and **shuffle order** when shuffle is on.
- Preloads share the **one cache limit and eviction policy** with downloads, are **evicted first** (a new `preloaded` flag on `CachedTrack`; `CacheEvictionPolicy` sacrifices preloads before any download), **honour "Wi-Fi only"**, **never appear as downloads**, and are **best-effort** (a preload that won't fit or fails is silently skipped — the track still streams).
- An explicit download **promotes** a preloaded copy without re-fetching. Toggle via **Downloads → Preload upcoming tracks** (on by default).

### 2. Favorites synced with Jellyfin
- `FavoritesRepository` (optimistic local mirror + Jellyfin sync). Remote tracks `POST`/`DELETE …/FavoriteItems/<id>` and are pulled at startup; local-track favourites are stored on-device, split-set in `FavoritesStore`. A failed server push keeps the local intent and reconciles on the next refresh. The Now Playing heart toggles live.

### 3. Lyrics (Jellyfin)
- Lyrics button fetches `GET /Audio/<id>/Lyrics` behind a `LyricsService` seam and renders the lines, with honest **"No lyrics available"** / **"Couldn't load lyrics"** states for local tracks, signed-out, or empty results.

### Notes
- New Jellyfin endpoints go through the existing `JellyfinClient` seam (real + fake updated). Only **non-secret ids** are stored or sent — never a token.
- README updated to keep the offline / now-playing docs **honest** about automatic preloading (it explicitly relaxes the prior "no automatic downloads" wording for preloads, which never show as downloads and are evicted first) and the now-working buttons.
- The container here has no Flutter/Dart toolchain, so `dart format` / `flutter analyze` / `flutter test` were **not run locally** — relying on CI. New unit/widget tests cover the eviction-priority rule, prefetch/promote/Wi-Fi behavior, the preloader, the favorites repo, the lyrics service, and the new HTTP endpoints.

## Test plan
- [ ] CI green: `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test`
- [ ] Sign in to Jellyfin, play a queue → next tracks are cached ahead (Downloads cache-usage rises) without showing as downloads; transitions are instant
- [ ] Enable Wi-Fi only on mobile → preloading pauses; cache never exceeds the limit (preloads evicted first)
- [ ] Toggle Favorite on a Jellyfin track → reflected on the server / other clients; favorite a local track → persists on-device
- [ ] Open Lyrics for a track with lyrics on Jellyfin → lines show; for a local track / no lyrics → "No lyrics available"
- [ ] Toggle off **Preload upcoming tracks** → no automatic caching

https://claude.ai/code/session_01FLzR11GneaUU9RtNBLJLwf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLzR11GneaUU9RtNBLJLwf)_