### PR TITLE
Fix version drift: in-app version now matches the release (0.1.0-alpha.9)

### DIFF
--- a/docs/release-notes/v0.1.0-alpha.9.md
+++ b/docs/release-notes/v0.1.0-alpha.9.md
@@ -1,0 +1,61 @@
+# Linthra v0.1.0-alpha.9 — release notes
+
+**Linthra is a modern, local-first, privacy-focused music player for people who
+own their music.** This is the latest sideloadable Android alpha — still early
+software, but with several rounds of features and fixes since the first alpha.
+
+- **Version:** `0.1.0-alpha.9` (`versionName`), `versionCode` 9
+- **Platform:** Android (Linux desktop planned later, same codebase)
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+
+## What changed since v0.1.0-alpha.1
+
+- **Shuffle & repeat.** Working shuffle and repeat playback controls.
+- **Cast foundation.** Chromecast / cast groundwork behind the playback layer.
+- **Smart offline cache.** An offline cache manager with a user-configurable
+  size limit and eviction policy.
+- **Jellyfin favorites & lyrics.** Favorites stay in sync with Jellyfin, and
+  track lyrics now display.
+- **Smoother playback.** Disk preloading of upcoming tracks.
+- **Brand & theme refresh.** A violet + warm orange identity and a refined
+  equalizer icon.
+- **Library fast-scroller fix.** The alphabet fast scroller no longer overlaps
+  track rows.
+- **Version display fix.** Settings/About now shows the real app version. Older
+  alpha builds were stuck displaying `0.1.0-alpha.1` because the in-app string
+  was a second, hand-maintained source that had drifted from `pubspec.yaml`.
+  The version now lives in `pubspec.yaml` as the single source of truth, with a
+  CI test (`test/core/app_info_version_test.dart`) that fails if the in-app
+  string drifts again.
+
+For the full baseline feature set and the honest list of known limitations, see
+the [v0.1.0-alpha.1 notes](./v0.1.0-alpha.1.md); they still describe the core
+of the app. This alpha remains a **sideloadable APK only — not on F-Droid yet**.
+
+## Install (sideload)
+
+1. Download the `app-release.apk` attached to this release (or build it
+   yourself — see the README).
+2. On your Android device, allow installing from unknown sources if prompted,
+   then open the APK. Or, with the device connected over ADB:
+   ```bash
+   adb install -r app-release.apk
+   ```
+3. On first launch (Android 13+), tap **Allow** on the notification prompt so
+   the media notification and its controls can appear.
+
+## Releasing the next alpha without drift
+
+Follow [docs/release-process.md §3](../release-process.md#3-pre-tag-checklist).
+In short, for `0.1.0-alpha.10`:
+
+1. Bump `version:` in `pubspec.yaml` to `0.1.0-alpha.10+10` (versionName **and**
+   the monotonic `+versionCode`).
+2. Sync `AppInfo.version` in `lib/core/app_info.dart` to `0.1.0-alpha.10`
+   (the drift test enforces this).
+3. Add `fastlane/metadata/android/en-US/changelogs/10.txt` and a
+   `docs/release-notes/v0.1.0-alpha.10.md`.
+4. Land it with CI green, then push the annotated tag `v0.1.0-alpha.10`.
+
+Full reference: [docs/release-process.md](../release-process.md).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -4,20 +4,21 @@ This is the canonical reference for how Linthra cuts a release: versioning,
 git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
 docs reference this document rather than restating the plan.
 
-> **No release has been cut and nothing here publishes to a store.** Linthra
-> has no tagged release yet, is **not** on F-Droid, and no APK/AAB has been
-> published. Pushing a `v*` tag now builds the release artifacts automatically.
-> For **alpha/beta/rc** tags the build can create a GitHub **pre-release** and
-> attach the APK/AAB to it; for **stable** tags it only attaches to a Release you
-> created. **Writing the release notes stays manual** — and nothing is published
-> to any store or to F-Droid. This document describes the intended process.
+> **Sideloadable alphas only; nothing here publishes to a store.** Linthra has
+> tagged pre-release alphas (latest `v0.1.0-alpha.9`) attached to GitHub
+> Releases as sideloadable APKs/AABs, but is **not** on F-Droid. Pushing a `v*`
+> tag builds the release artifacts automatically. For **alpha/beta/rc** tags the
+> build can create a GitHub **pre-release** and attach the APK/AAB to it; for
+> **stable** tags it only attaches to a Release you created. **Writing the
+> release notes stays manual** — and nothing is published to any store or to
+> F-Droid.
 
 ## 1. Versioning model
 
 `pubspec.yaml` is the **single source of truth** for the version:
 
 ```
-version: x.y.z+<versionCode>      # currently 0.1.0-alpha.1+1
+version: x.y.z+<versionCode>      # currently 0.1.0-alpha.9+9
 ```
 
 - **`versionName` = `x.y.z`** — the human-facing [SemVer](https://semver.org/)
@@ -26,7 +27,19 @@ version: x.y.z+<versionCode>      # currently 0.1.0-alpha.1+1
 
 Android reads both from Flutter (`flutter.versionName` / `flutter.versionCode`
 in `android/app/build.gradle`); they are **not** hard-coded in Gradle, so
-bumping `pubspec.yaml` is enough.
+bumping `pubspec.yaml` is enough for the installed APK's version.
+
+**The in-app version display has its own copy.** The Settings/About screen and
+the Jellyfin client-version header read `AppInfo.version` in
+`lib/core/app_info.dart`, a `const` string. It must mirror the `versionName`
+part of `pubspec.yaml` (without the `+versionCode`). This second copy is what
+drifted in earlier alphas — the APK shipped `alpha.9` while Settings still said
+`alpha.1`. To keep it honest, `test/core/app_info_version_test.dart` reads
+`pubspec.yaml` and **fails CI if `AppInfo.version` does not match**, so the two
+must be bumped together in the same commit. (Runtime package-metadata lookup via
+a plugin was deliberately not used: `AppInfo.version` is a `const` consumed
+synchronously, and a test-guarded mirror keeps the change small and dependency-
+free.)
 
 **Rules:**
 
@@ -61,22 +74,31 @@ F-Droid (and our own release tracking) builds from a **git tag**.
 Before creating a release tag:
 
 1. **Bump the version** in `pubspec.yaml` (`versionName` and `versionCode`).
-2. **Add a changelog** for the new `versionCode` at
+   The `versionCode` **must** be strictly greater than every previous build's
+   (the current release is `+9`, so the next is `+10`).
+2. **Sync the in-app version.** Set `AppInfo.version` in
+   `lib/core/app_info.dart` to the new `versionName` (no `+versionCode`). The
+   drift test (`test/core/app_info_version_test.dart`) fails CI if you forget,
+   so do this in the same commit as step 1.
+3. **Add a changelog** for the new `versionCode` at
    `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` (e.g.
-   `1.txt` for `0.1.0-alpha.1+1`). Keep it short and factual; this is what
-   F-Droid shows. A longer GitHub-Release body can live under
+   `9.txt` for `0.1.0-alpha.9+9`). Keep it short and factual; this is what
+   F-Droid shows. A longer GitHub-Release body lives under
    `docs/release-notes/vX.Y.Z*.md` (see the
-   [v0.1.0-alpha.1 draft](./release-notes/v0.1.0-alpha.1.md)).
-3. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
+   [v0.1.0-alpha.9 notes](./release-notes/v0.1.0-alpha.9.md)). The
+   `vX.Y.Z` in the file name and the version inside it must match the tag and
+   `pubspec.yaml`.
+4. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
    schema at the tagged commit — run the
    [Generate Drift files workflow](../README.md#generating-drift-files-in-ci) or
    `dart run build_runner build --delete-conflicting-outputs` locally, and commit
    the result. The committed output means the F-Droid build needs no `build_runner`
    prebuild (see [fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
-4. **CI is green** (`flutter analyze`, `flutter test`, formatting) on the commit.
-5. **Confirm licensing** is still accurate if dependencies changed — re-run the
+5. **CI is green** (`flutter analyze`, `flutter test`, formatting) on the
+   commit — this includes the version-drift test from step 2.
+6. **Confirm licensing** is still accurate if dependencies changed — re-run the
    [dependency & license audit](./dependency-license-audit.md).
-6. Create the annotated tag (§2).
+7. Create the annotated tag (§2).
 
 ## 4. GitHub Releases (notes manual, artifact build & attachment automatic)
 
@@ -188,7 +210,8 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
    GitHub-Release artifact is wanted — see
    [release-signing.md](./release-signing.md). (Not needed for F-Droid itself,
    which signs its own builds.)
-2. **A `vX.Y.Z` tag** exists — none does yet.
+2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.9` have been
+   cut; F-Droid submission itself is still pending the other blockers.
 3. **Decide the `pubspec.lock` policy** for reproducible release builds
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
 4. **Feature-maturity call — made for the alpha.** `0.1.0-alpha.1` ships local

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,17 @@
+Linthra 0.1.0-alpha.9 — cumulative alpha since alpha.1.
+
+New since the first alpha:
+- Working shuffle and repeat playback controls.
+- Chromecast / cast foundation.
+- Smart offline cache manager with a user-configurable size limit.
+- Brand & theme refresh (violet + warm orange identity, refined equalizer
+  icon).
+- Library alphabet fast-scroller fix (no longer overlaps track rows).
+- Disk preloading for smoother playback, Jellyfin-synced favorites, and
+  working lyrics.
+
+Fixed:
+- Settings/About now reports the correct version (it was stuck at alpha.1
+  through earlier alpha builds).
+
+Still an alpha — expect rough edges. Not on F-Droid yet.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -3,8 +3,13 @@ abstract final class AppInfo {
   static const String name = 'Linthra';
   static const String tagline = 'Your music, beautifully yours.';
 
-  /// App version, kept in step with `pubspec.yaml`. Sent (informationally) to
-  /// Jellyfin as the client version in the auth header so the server can label
-  /// this device in its dashboard.
-  static const String version = '0.1.0-alpha.1';
+  /// App `versionName`, mirroring the `x.y.z(-suffix)` part of `pubspec.yaml`'s
+  /// `version` (the `+versionCode` is Android-only and not shown here). Used for
+  /// the Settings/About display and sent (informationally) to Jellyfin as the
+  /// client version in the auth header so the server can label this device.
+  ///
+  /// `pubspec.yaml` is the single source of truth; this constant must match it.
+  /// `test/core/app_info_version_test.dart` fails CI if the two ever drift, so
+  /// bump both in the same commit (see docs/release-process.md §3).
+  static const String version = '0.1.0-alpha.9';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: linthra
 description: A modern, local-first, privacy-focused music player.
 publish_to: "none"
-version: 0.1.0-alpha.1+1
+version: 0.1.0-alpha.9+9
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/test/core/app_info_version_test.dart
+++ b/test/core/app_info_version_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/app_info.dart';
+
+/// Guards against version drift between the two places a version string lives:
+/// `pubspec.yaml` (the single source of truth, which also drives Android's
+/// `versionName`/`versionCode` via Flutter) and [AppInfo.version] (what the
+/// Settings/About screen shows and what is sent to Jellyfin). Before this test
+/// existed the app shipped `alpha.9` while still displaying `alpha.1`.
+void main() {
+  // `version: x.y.z(-suffix)(+buildNumber)` — capture the SemVer part only;
+  // the `+versionCode` is Android-internal and intentionally not in AppInfo.
+  final versionLine = RegExp(r'^version:\s*([^\s+]+)', multiLine: true);
+
+  ({String name, int? code}) readPubspecVersion() {
+    final pubspec = File('pubspec.yaml').readAsStringSync();
+    final match =
+        RegExp(r'^version:\s*(\S+)', multiLine: true).firstMatch(pubspec);
+    expect(match, isNotNull, reason: 'pubspec.yaml has no `version:` line');
+    final raw = match!.group(1)!;
+    final plus = raw.indexOf('+');
+    final name = plus == -1 ? raw : raw.substring(0, plus);
+    final code = plus == -1 ? null : int.tryParse(raw.substring(plus + 1));
+    return (name: name, code: code);
+  }
+
+  test('AppInfo.version matches the versionName in pubspec.yaml', () {
+    final pubspec = readPubspecVersion();
+    expect(
+      AppInfo.version,
+      pubspec.name,
+      reason: 'AppInfo.version (${AppInfo.version}) drifted from pubspec.yaml '
+          '(${pubspec.name}). Bump both in the same commit — see '
+          'docs/release-process.md §3.',
+    );
+  });
+
+  test('pubspec.yaml carries an integer Android versionCode', () {
+    final pubspec = readPubspecVersion();
+    expect(
+      pubspec.code,
+      isNotNull,
+      reason: 'pubspec.yaml `version:` must end in `+<versionCode>` so Android '
+          'gets a monotonic build number.',
+    );
+    expect(pubspec.code, greaterThan(0));
+  });
+
+  test('AppInfo.version is a SemVer string without a build suffix', () {
+    // No `+buildNumber` should leak into the user-facing version.
+    expect(AppInfo.version, isNot(contains('+')));
+    expect(versionLine.hasMatch('version: ${AppInfo.version}'), isTrue);
+  });
+}


### PR DESCRIPTION
## Root cause

The app had **two** version strings:

- `pubspec.yaml` `version:` — the single source of truth that drives Android's `versionName`/`versionCode` via Flutter.
- `AppInfo.version` in `lib/core/app_info.dart` — a hand-maintained `const` that the **Settings/About** screen displays (and that is sent to Jellyfin as the client-version header).

Across alpha.2 → alpha.9, **neither** was bumped: `pubspec.yaml` stayed at `0.1.0-alpha.1+1` and `AppInfo.version` stayed at `0.1.0-alpha.1`. So every release built `versionCode` 1 and the installed app kept showing `Version 0.1.0-alpha.1` even though the GitHub release/tag was `v0.1.0-alpha.9`.

## Version source of truth

`pubspec.yaml` remains the single source of truth. `AppInfo.version` is a small mirror of its `versionName` (the in-app display can't read the build config synchronously without adding a plugin, and the `const` is consumed synchronously). To stop the mirror from drifting again, a new CI test reads `pubspec.yaml` and **fails if `AppInfo.version` doesn't match** — so the two must be bumped together in the same commit. No new runtime dependency was added.

## Files changed

- `pubspec.yaml` — `version: 0.1.0-alpha.9+9`.
- `lib/core/app_info.dart` — `version = '0.1.0-alpha.9'` + doc comment pointing at the source of truth and the drift test.
- `test/core/app_info_version_test.dart` *(new)* — drift guard: `AppInfo.version` matches the `versionName` in `pubspec.yaml`, `pubspec.yaml` carries a positive integer `versionCode`, and `AppInfo.version` has no `+build` suffix.
- `fastlane/metadata/android/en-US/changelogs/9.txt` *(new)* — F-Droid-style changelog for `versionCode` 9.
- `docs/release-notes/v0.1.0-alpha.9.md` *(new)* — GitHub-Release body.
- `docs/release-process.md` — documents the `AppInfo` sync step and the drift test in the pre-tag checklist; refreshed stale "no release cut yet" notes.

## New app version / versionCode

- **versionName:** `0.1.0-alpha.9`
- **versionCode:** `9` (monotonic — previous builds shipped `1`, so this is safely greater; never reset backwards)

## Releasing the next alpha without drift (e.g. alpha.10)

Per `docs/release-process.md §3`:

1. `pubspec.yaml` → `0.1.0-alpha.10+10` (versionName **and** monotonic `+versionCode`).
2. `lib/core/app_info.dart` → `AppInfo.version = '0.1.0-alpha.10'` (the drift test enforces this).
3. Add `fastlane/metadata/android/en-US/changelogs/10.txt` and `docs/release-notes/v0.1.0-alpha.10.md`.
4. Land with CI green, then push the annotated tag `v0.1.0-alpha.10` (triggers the Android release build).

## Verification

- `dart format --set-exit-if-changed` — verified locally on the changed Dart files (Dart 3.6.2, matching CI's Flutter 3.27.4).
- Version-parsing logic confirmed against the real `pubspec.yaml` → `versionName=0.1.0-alpha.9`, `versionCode=9`.
- `flutter pub get` / `flutter analyze` / `flutter test` run in CI (no Flutter SDK in the authoring environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPJa3e9br2huGjkS5ftQ4o)_