### PR TITLE
Harden Jellyfin: server capability detection, centralized endpoints & safe diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,11 @@ Deliberate gaps the next PRs will close:
 Linthra can connect to your own [Jellyfin](https://jellyfin.org) server,
 including one published over HTTPS through a **Cloudflare** domain or tunnel.
 
+> **Compatibility reference.** Supported use cases, exact endpoints, the tested
+> version floor, Cloudflare Tunnel vs. Zero Trust, troubleshooting, and how to
+> report an issue without leaking secrets are documented in
+> [docs/jellyfin-compatibility.md](docs/jellyfin-compatibility.md).
+
 **Setup.** Open **Settings → Jellyfin** and:
 
 1. **Server URL** — enter your server address, e.g. `https://music.example.com`.
@@ -1006,13 +1011,21 @@ including one published over HTTPS through a **Cloudflare** domain or tunnel.
    `https://example.com/jellyfin` is preserved.
 2. **Test connection** — checks the address is reachable and is really a
    Jellyfin server (it reads the public `/System/Info/Public` endpoint, no
-   credentials needed) and shows the server name/version.
+   credentials needed) and shows the server name/version. The server version is
+   also classified for compatibility, and an older-than-tested server shows a
+   gentle "untested" note (it is never blocked).
 3. **Username + password → Sign in** — authenticates and stores the resulting
-   session. The password field has a show/hide toggle.
+   session. The password field has a show/hide toggle. Sign-in also records the
+   server name/version/product (reading `/System/Info/Public` if you didn't tap
+   Test first) so diagnostics show them after a restart.
 4. **Sync library** — once signed in, pulls your Jellyfin artists/albums/tracks
    and stores them in the local catalog so they show up in the Library. Shows a
    spinner while it runs and a friendly result/error line when it's done.
-5. **Sign out & clear** — forgets the saved session and clears the settings.
+5. **Copy Jellyfin diagnostics** — copies a short, **secret-free** report (app
+   version, connection state, server name/version/host-only, last error kind) to
+   the clipboard for bug reports. It never includes your password, token,
+   `Authorization` header, or any full authenticated URL.
+6. **Sign out & clear** — forgets the saved session and clears the settings.
 
 **Cloudflare notes.** A Cloudflare-proxied or Cloudflare Tunnel (`cloudflared`)
 Jellyfin is just a normal HTTPS endpoint, so it works without any special
@@ -1040,6 +1053,12 @@ configuration — point the URL at your public domain. Two things to know:
 - **Offline downloads inherit the same handling.** A downloaded track's cache
   file name is derived only from the non-secret track id; the token never lands
   in the file name, the `DownloadStore` metadata, a log, or a download error.
+- **Diagnostics are secret-free by construction.** The "Copy Jellyfin
+  diagnostics" report (and the debug `PlaybackDiagnostics` log) have no field for
+  a password, token, `Authorization` header, or full authenticated URL; the
+  server address is reduced to its **host only**, and the persisted server
+  version/product are non-secret display values. Tests assert no token reaches
+  either sink.
 
 **What works now.** Configuring a server, testing the connection, signing in
 with friendly URL/connection/auth errors, persisting the session across
@@ -1070,8 +1089,12 @@ Cloudflare page, an expired token, or a non-audio response becomes a precise
 message instead of the engine's opaque "couldn't play". The player surfaces
 friendly errors — **not signed in**, **expired session**, **server
 unreachable**, **a web page instead of audio (Cloudflare/Jellyfin access)**,
-**not an audio stream**, and a generic **couldn't stream** — branched on a typed
-error kind, not message text. Local and `content://` file playback are untouched
+**not an audio stream**, a **track that isn't available** (a 404 from the stream
+endpoint), an **unsupported server response** (an unexpected status or shape),
+and a generic **couldn't stream** — branched on a typed error kind, not message
+text (the full mapping is tabulated in the compatibility doc). All Jellyfin URLs
+are built in one place (`JellyfinEndpoints`), so the stream, download, and probe
+paths can't drift apart. Local and `content://` file playback are untouched
 (they never enter the Jellyfin resolver), and a downloaded track still plays from
 its cached copy; a cache miss falls straight through to streaming. Debug builds
 emit a secret-free `PlaybackDiagnostics` line (source, resolver, HTTP status,

--- a/docs/jellyfin-compatibility.md
+++ b/docs/jellyfin-compatibility.md
@@ -1,0 +1,177 @@
+# Jellyfin compatibility
+
+This document describes how Linthra talks to a [Jellyfin](https://jellyfin.org)
+server: which use cases are supported, the exact REST endpoints it relies on,
+how it stays robust across Jellyfin updates, and how to troubleshoot and report
+streaming problems **without leaking secrets**.
+
+It is meant to be stable reference material. The behavior here is enforced by
+the Jellyfin source under `lib/core/sources/jellyfin/` and its tests under
+`test/core/sources/jellyfin/`; if you change an endpoint or error mapping, update
+this file in the same change.
+
+## Supported use cases
+
+Linthra connects to a single self-hosted Jellyfin **music** server and supports:
+
+- **Test connection** — confirm an address is reachable and really is Jellyfin
+  (reads the public server info; no credentials needed), and read its
+  name/version/product.
+- **Sign in** — username + password are exchanged once for an access token; the
+  password is never stored.
+- **Library sync** — pull artists, albums, and tracks into the local catalog.
+- **Direct streaming** — play a synced track straight from the server (no
+  download required).
+- **Offline downloads** — cache a track's original file on device; playback then
+  prefers the local copy.
+- **Favourites** and **lyrics** — read/toggle server-side favourites and fetch
+  time-synced or plain lyrics.
+
+It targets servers reached over **HTTPS**, including those published through a
+**Cloudflare** domain or **Cloudflare Tunnel** (see below). Plain `http://` on a
+trusted LAN is also accepted.
+
+### Server version support
+
+Linthra is tested against **Jellyfin 10.8.0 and newer**. The REST endpoints it
+uses (below) are long-standing across the 10.x line, so an older server is
+labelled *untested* (and the user is gently warned) rather than blocked. The
+reported version is parsed only for this **diagnostic** classification — it never
+changes which endpoints or parameters Linthra sends. Deliberately avoiding
+version-sniffing keeps the integration robust against future server updates.
+
+## Expected server URL examples
+
+The address is normalized by `JellyfinServerUrl.normalize`:
+
+| You type | Linthra uses | Why |
+| --- | --- | --- |
+| `music.example.com` | `https://music.example.com` | A bare host defaults to **HTTPS** (the Cloudflare-proxied default). |
+| `https://music.example.com` | `https://music.example.com` | Used as-is. |
+| `http://192.168.1.10:8096` | `http://192.168.1.10:8096` | Explicit scheme + port kept (LAN). |
+| `https://example.com/jellyfin` | `https://example.com/jellyfin` | A reverse-proxy **subpath** is preserved. |
+| `https://example.com/jellyfin/` | `https://example.com/jellyfin` | A trailing slash is trimmed. |
+| `https://example.com/path?a=1#x` | `https://example.com/path` | Query/fragment are dropped. |
+
+## Cloudflare notes
+
+A Cloudflare-proxied server or a **Cloudflare Tunnel** (`cloudflared`) is just a
+normal HTTPS endpoint, so it works with no special configuration — point the URL
+at your public hostname. Two things to know:
+
+- If the domain returns a Cloudflare **error page** (HTML, or a 5xx like
+  521/522) or a challenge, Linthra reports a friendly *"doesn't look like a
+  Jellyfin server"* / *"couldn't reach the server"* / *"returned a web page
+  instead of audio"* message instead of a raw failure. This usually means the
+  tunnel is down or the hostname isn't pointed at Jellyfin.
+- **Cloudflare Access / Zero Trust** (an extra auth layer placed *in front of*
+  Jellyfin) is **not supported**. Linthra speaks only Jellyfin's own auth, so a
+  Zero Trust challenge page is returned where audio/JSON is expected. Use a
+  hostname that reaches Jellyfin directly.
+
+Streaming auth deliberately rides in the URL's `api_key` **query parameter**
+(not an `Authorization` header) because that is what the Android audio engine
+(`just_audio`/ExoPlayer) fetches with, and query auth survives the redirects a
+stripped header would not.
+
+## Endpoints Linthra relies on
+
+Every Jellyfin URL is built in **one place** — `JellyfinEndpoints`
+(`lib/core/sources/jellyfin/jellyfin_endpoints.dart`) — so paths never drift
+between call sites and the full surface is auditable here.
+
+| Purpose | Method & path | Notes |
+| --- | --- | --- |
+| Server info | `GET /System/Info/Public` | No auth. Backs Test connection + version/capability read. |
+| Sign in | `POST /Users/AuthenticateByName` | Body `{Username, Pw}`; returns the access token. |
+| Verify session | `GET /Users/Me` | Tiny authenticated check before streaming (401 ⇒ expired). |
+| List tracks | `GET /Items?IncludeItemTypes=Audio&Recursive=true&…` | Sorted; `Fields=RunTimeTicks`. |
+| List albums | `GET /Items?IncludeItemTypes=MusicAlbum&Recursive=true&…` | `Fields=ProductionYear,ChildCount`. |
+| List artists | `GET /Artists?…` | Dedicated artists endpoint. |
+| Favourite ids | `GET /Items?Filters=IsFavorite&IncludeItemTypes=Audio&…` | `EnableImages=false`. |
+| Toggle favourite | `POST` / `DELETE /Users/{userId}/FavoriteItems/{itemId}` | POST marks, DELETE clears. |
+| Lyrics | `GET /Audio/{itemId}/Lyrics` | 404 = "no lyrics", a normal outcome. |
+| Cover art | `GET /Items/{itemId}/Images/Primary` | **Token-free**; safe to cache/persist. |
+| Direct stream | `GET /Audio/{itemId}/stream?static=true&api_key=…&UserId=…&DeviceId=…` | `static=true` serves the original file (no transcode). Token in query. |
+| Download | `GET /Items/{itemId}/Download?api_key=…` | Original file for the offline cache. Token in query. |
+
+**Authentication header.** Authenticated JSON calls send the standard Jellyfin
+`Authorization: MediaBrowser Client="Linthra", Device="Linthra", DeviceId="…",
+Version="…", Token="…"` header, built once in `JellyfinAuthHeader`. The token is
+woven into a header or an `api_key` query only at request time and is **never**
+stored on a track, written to the catalog, logged, shown in the UI, or placed in
+an error.
+
+### How streaming responses are classified
+
+Before a stream URL reaches the audio engine, Linthra probes it (a one-byte
+ranged GET, following redirects) and maps the result to a precise, secret-free
+error:
+
+| Observation | Error kind | User sees |
+| --- | --- | --- |
+| 2xx + audio/octet-stream/no type | *(plays)* | — |
+| HTML body (Cloudflare/login/error page) | `webPage` | "returned a web page instead of audio" |
+| 401 / 403 | `unauthorized` | "session expired — sign in again" |
+| 404 | `streamUnavailable` | "this track isn't available right now" |
+| 5xx | `serverError` | "server reported an error" |
+| other non-2xx (400/429/…) | `unsupportedResponse` | "response Linthra couldn't use" |
+| 2xx but non-audio content type | `notAudioStream` | "didn't return an audio stream" |
+| transport failure (DNS/TLS/timeout) | `notReachable` | "couldn't reach the server" |
+
+## Compatibility notes for future Jellyfin updates
+
+- **Endpoints are centralized.** If a future server version relocates a path,
+  change it in `JellyfinEndpoints` (and this table) — nowhere else.
+- **No version-gated request behavior.** The version is read for diagnostics
+  only. Do not add `if (version >= x) useEndpointA else useEndpointB` branches;
+  prefer endpoints stable across the 10.x line.
+- **Tolerant parsing.** Unknown JSON fields are ignored, a missing `Items`
+  array reads as empty, and malformed entries are skipped, so a server that adds
+  fields won't break listing.
+- **`static=true` direct play** is the safest streaming path: it serves the
+  original bytes the engine can open, avoiding transcode/HLS negotiation that
+  varies between server versions and codecs.
+- **Bump the tested floor** (`kMinimumTestedJellyfinVersion`) only when you have
+  actually tested against, and intend to require, a newer baseline.
+
+## Safe troubleshooting steps
+
+1. **Test connection first.** It checks reachability and that the address is
+   really Jellyfin, and shows the server name/version.
+2. **"Doesn't look like a Jellyfin server"** → the hostname likely reaches
+   Cloudflare/another service, not Jellyfin (or Zero Trust is in front of it).
+3. **"Couldn't reach the server"** → server offline, tunnel down, wrong
+   address, or no connectivity.
+4. **"Session expired"** → sign out and back in to mint a fresh token.
+5. **"Returned a web page instead of audio"** → a Cloudflare challenge/error
+   page; confirm the tunnel is healthy and Zero Trust isn't gating the host.
+6. **"This track isn't available"** (404) → the item may have been moved/removed
+   or lives in a library your user can't see; re-sync the library.
+7. **Untested-version note** → streaming usually still works; upgrade the server
+   if you hit issues.
+
+## Reporting a Jellyfin issue without leaking secrets
+
+Use **Settings → Jellyfin → Copy Jellyfin diagnostics**. It puts a short,
+**secret-free** report on the clipboard, for example:
+
+```
+Linthra Jellyfin diagnostics
+App version: 0.1.0-alpha.9
+Connection: connected
+Server name: Home
+Server version: 10.9.11
+Version support: supported
+Server host: music.example.com
+Last error: none
+```
+
+What it includes: app version, connection state, server name/version/product,
+the version-support classification, the **host only** (never a full URL), and
+the **kind** of the last error.
+
+What it never includes: your **password**, the **access token**, the
+`Authorization` header, or any **full authenticated URL** (the address is
+reduced to its host so a tokenized query can't ride along). Paste it into a bug
+report as-is.

--- a/lib/core/models/jellyfin_session.dart
+++ b/lib/core/models/jellyfin_session.dart
@@ -18,6 +18,8 @@ class JellyfinSession {
     this.userName,
     this.serverId,
     this.serverName,
+    this.serverVersion,
+    this.productName,
   });
 
   /// Clean base URL of the server (no trailing slash), e.g.
@@ -45,6 +47,14 @@ class JellyfinSession {
   /// only.
   final String? serverName;
 
+  /// The server's reported version (e.g. `10.9.11`), when known. Carried so the
+  /// diagnostics report can show it after a restart. Not secret, display only.
+  final String? serverVersion;
+
+  /// The server's product name (e.g. `Jellyfin Server`), when reported. Not
+  /// secret, display/diagnostics only.
+  final String? productName;
+
   JellyfinSession copyWith({
     String? baseUrl,
     String? userId,
@@ -53,6 +63,8 @@ class JellyfinSession {
     String? userName,
     String? serverId,
     String? serverName,
+    String? serverVersion,
+    String? productName,
   }) {
     return JellyfinSession(
       baseUrl: baseUrl ?? this.baseUrl,
@@ -62,6 +74,8 @@ class JellyfinSession {
       userName: userName ?? this.userName,
       serverId: serverId ?? this.serverId,
       serverName: serverName ?? this.serverName,
+      serverVersion: serverVersion ?? this.serverVersion,
+      productName: productName ?? this.productName,
     );
   }
 
@@ -76,6 +90,8 @@ class JellyfinSession {
         if (userName != null) 'userName': userName,
         if (serverId != null) 'serverId': serverId,
         if (serverName != null) 'serverName': serverName,
+        if (serverVersion != null) 'serverVersion': serverVersion,
+        if (productName != null) 'productName': productName,
       };
 
   /// Rebuilds a session from [toJson] output, or returns `null` if any required
@@ -98,6 +114,8 @@ class JellyfinSession {
       userName: json['userName'] as String?,
       serverId: json['serverId'] as String?,
       serverName: json['serverName'] as String?,
+      serverVersion: json['serverVersion'] as String?,
+      productName: json['productName'] as String?,
     );
   }
 
@@ -111,7 +129,9 @@ class JellyfinSession {
           other.deviceId == deviceId &&
           other.userName == userName &&
           other.serverId == serverId &&
-          other.serverName == serverName);
+          other.serverName == serverName &&
+          other.serverVersion == serverVersion &&
+          other.productName == productName);
 
   @override
   int get hashCode => Object.hash(
@@ -122,6 +142,8 @@ class JellyfinSession {
         userName,
         serverId,
         serverName,
+        serverVersion,
+        productName,
       );
 
   /// Redacts the token so the session can be safely interpolated into logs or
@@ -129,5 +151,6 @@ class JellyfinSession {
   @override
   String toString() => 'JellyfinSession(baseUrl: $baseUrl, userId: $userId, '
       'userName: $userName, serverId: $serverId, serverName: $serverName, '
+      'serverVersion: $serverVersion, productName: $productName, '
       'deviceId: $deviceId, accessToken: <redacted>)';
 }

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -8,6 +8,7 @@ import '../../models/lyrics.dart';
 import 'jellyfin_api.dart';
 import 'jellyfin_auth_header.dart';
 import 'jellyfin_client.dart';
+import 'jellyfin_endpoints.dart';
 import 'jellyfin_exception.dart';
 
 /// The real [JellyfinClient], backed by `package:http`.
@@ -30,7 +31,7 @@ class HttpJellyfinClient implements JellyfinClient {
 
   @override
   Future<JellyfinServerInfo> fetchServerInfo(String baseUrl) async {
-    final Uri uri = Uri.parse('$baseUrl/System/Info/Public');
+    final Uri uri = JellyfinEndpoints.serverInfo(baseUrl);
     final http.Response response = await _send(
       () => _client.get(uri, headers: const <String, String>{
         'Accept': 'application/json',
@@ -52,7 +53,7 @@ class HttpJellyfinClient implements JellyfinClient {
     required String password,
     required String deviceId,
   }) async {
-    final Uri uri = Uri.parse('$baseUrl/Users/AuthenticateByName');
+    final Uri uri = JellyfinEndpoints.authenticateByName(baseUrl);
     final http.Response response = await _send(
       () => _client.post(
         uri,
@@ -83,7 +84,11 @@ class HttpJellyfinClient implements JellyfinClient {
     JellyfinSession session, {
     required JellyfinItemKind kind,
   }) async {
-    final Uri uri = _itemsUri(session, kind);
+    final Uri uri = JellyfinEndpoints.items(
+      session.baseUrl,
+      userId: session.userId,
+      kind: kind,
+    );
     final http.Response response = await _send(
       () => _client.get(uri, headers: <String, String>{
         'Accept': 'application/json',
@@ -117,7 +122,7 @@ class HttpJellyfinClient implements JellyfinClient {
     // `/Users/Me` is a tiny authenticated call: a 401 means the token is no
     // longer valid, a transport failure means the server is unreachable. The
     // body is irrelevant, so it is not parsed.
-    final Uri uri = Uri.parse('${session.baseUrl}/Users/Me');
+    final Uri uri = JellyfinEndpoints.currentUser(session.baseUrl);
     final http.Response response = await _send(
       () => _client.get(uri, headers: <String, String>{
         'Accept': 'application/json',
@@ -155,7 +160,7 @@ class HttpJellyfinClient implements JellyfinClient {
 
   @override
   Future<Lyrics?> fetchLyrics(JellyfinSession session, String itemId) async {
-    final Uri uri = Uri.parse('${session.baseUrl}/Audio/$itemId/Lyrics');
+    final Uri uri = JellyfinEndpoints.lyrics(session.baseUrl, itemId: itemId);
     final http.Response response = await _send(
       () => _client.get(uri, headers: _authHeaders(session)),
     );
@@ -167,14 +172,9 @@ class HttpJellyfinClient implements JellyfinClient {
 
   @override
   Future<Set<String>> fetchFavoriteIds(JellyfinSession session) async {
-    final Uri uri = Uri.parse('${session.baseUrl}/Items').replace(
-      queryParameters: <String, String>{
-        'UserId': session.userId,
-        'Recursive': 'true',
-        'IncludeItemTypes': 'Audio',
-        'Filters': 'IsFavorite',
-        'EnableImages': 'false',
-      },
+    final Uri uri = JellyfinEndpoints.favoriteAudioItems(
+      session.baseUrl,
+      userId: session.userId,
     );
     final http.Response response = await _send(
       () => _client.get(uri, headers: _authHeaders(session)),
@@ -199,8 +199,10 @@ class HttpJellyfinClient implements JellyfinClient {
     String itemId, {
     required bool favorite,
   }) async {
-    final Uri uri = Uri.parse(
-      '${session.baseUrl}/Users/${session.userId}/FavoriteItems/$itemId',
+    final Uri uri = JellyfinEndpoints.favoriteItem(
+      session.baseUrl,
+      userId: session.userId,
+      itemId: itemId,
     );
     final Map<String, String> headers = _authHeaders(session);
     final http.Response response = await _send(
@@ -242,43 +244,6 @@ class HttpJellyfinClient implements JellyfinClient {
     }
     if (lines.isEmpty) return null;
     return Lyrics(lines: lines);
-  }
-
-  /// Builds the listing URL for [kind]. Artists have their own endpoint in
-  /// Jellyfin; tracks and albums share `/Items` filtered by type.
-  Uri _itemsUri(JellyfinSession session, JellyfinItemKind kind) {
-    switch (kind) {
-      case JellyfinItemKind.audio:
-        return Uri.parse('${session.baseUrl}/Items').replace(
-          queryParameters: <String, String>{
-            'UserId': session.userId,
-            'Recursive': 'true',
-            'IncludeItemTypes': 'Audio',
-            'SortBy': 'AlbumArtist,Album,IndexNumber,SortName',
-            'SortOrder': 'Ascending',
-            'Fields': 'RunTimeTicks',
-          },
-        );
-      case JellyfinItemKind.album:
-        return Uri.parse('${session.baseUrl}/Items').replace(
-          queryParameters: <String, String>{
-            'UserId': session.userId,
-            'Recursive': 'true',
-            'IncludeItemTypes': 'MusicAlbum',
-            'SortBy': 'AlbumArtist,SortName',
-            'SortOrder': 'Ascending',
-            'Fields': 'ProductionYear,ChildCount',
-          },
-        );
-      case JellyfinItemKind.artist:
-        return Uri.parse('${session.baseUrl}/Artists').replace(
-          queryParameters: <String, String>{
-            'UserId': session.userId,
-            'SortBy': 'SortName',
-            'SortOrder': 'Ascending',
-          },
-        );
-    }
   }
 
   /// Runs a request with a timeout, turning any transport-level failure (DNS,

--- a/lib/core/sources/jellyfin/jellyfin_api.dart
+++ b/lib/core/sources/jellyfin/jellyfin_api.dart
@@ -7,6 +7,8 @@
 /// separate.
 library;
 
+import 'jellyfin_server_capabilities.dart';
+
 /// Which kind of music item to list. Maps to a Jellyfin item type / endpoint
 /// inside the client, so the source can ask for "tracks" without knowing the
 /// query string.
@@ -62,17 +64,40 @@ class JellyfinStreamProbe {
 }
 
 /// Public server info from `GET /System/Info/Public` — enough to confirm the
-/// address is a Jellyfin server and to show the user which one they reached.
+/// address is a Jellyfin server, to show the user which one they reached, and to
+/// record the server's version/product for compatibility and diagnostics.
+///
+/// The extra fields ([productName], [operatingSystem]) are optional because
+/// Jellyfin only includes them on some versions; they're used for display and
+/// the diagnostics report, never to branch request behavior.
 class JellyfinServerInfo {
   const JellyfinServerInfo({
     required this.serverName,
     required this.version,
     this.id,
+    this.productName,
+    this.operatingSystem,
   });
 
   final String serverName;
   final String version;
   final String? id;
+
+  /// The server's product name (e.g. `Jellyfin Server`), when reported.
+  final String? productName;
+
+  /// The host OS the server reports, when present (often absent in the public
+  /// info on locked-down servers).
+  final String? operatingSystem;
+
+  /// The reported [version] parsed into a comparable value, or `null` when it
+  /// has no recognizable `major.minor`.
+  JellyfinServerVersion? get parsedVersion =>
+      JellyfinServerVersion.tryParse(version);
+
+  /// How well Linthra expects to work with this server's version. Diagnostic
+  /// only — see [jellyfinServerSupportFor].
+  JellyfinServerSupport get support => jellyfinServerSupportFor(version);
 
   /// Parses the response, or returns `null` when the body lacks the fields a
   /// real Jellyfin server always sends (so the client can report "not a
@@ -85,6 +110,8 @@ class JellyfinServerInfo {
       serverName: name,
       version: version,
       id: json['Id'] as String?,
+      productName: json['ProductName'] as String?,
+      operatingSystem: json['OperatingSystem'] as String?,
     );
   }
 }

--- a/lib/core/sources/jellyfin/jellyfin_authenticator.dart
+++ b/lib/core/sources/jellyfin/jellyfin_authenticator.dart
@@ -37,8 +37,13 @@ class JellyfinAuthenticator {
     return _client.fetchServerInfo(baseUrl);
   }
 
-  /// Signs in and returns a session. [serverName], when known from a prior
-  /// [testConnection], is carried into the session for display only.
+  /// Signs in and returns a session.
+  ///
+  /// [serverInfo], when known from a prior [testConnection], is carried into the
+  /// session (server name/version/product) for display and diagnostics. When it
+  /// is absent, sign-in reads `/System/Info/Public` itself so the session still
+  /// records the server's version — best-effort, since the auth call is the real
+  /// gate and a public-info hiccup must not block a valid sign-in.
   ///
   /// Throws [JellyfinException] for a bad URL, missing username, or rejected
   /// credentials.
@@ -46,7 +51,7 @@ class JellyfinAuthenticator {
     required String rawUrl,
     required String username,
     required String password,
-    String? serverName,
+    JellyfinServerInfo? serverInfo,
   }) async {
     final String baseUrl = JellyfinServerUrl.normalize(rawUrl);
     final String trimmedUsername = username.trim();
@@ -56,6 +61,12 @@ class JellyfinAuthenticator {
         kind: JellyfinErrorKind.unauthorized,
       );
     }
+
+    // Reuse a known server info, else read it now so the session captures the
+    // version/product for diagnostics. Swallow its failure: the auth call below
+    // surfaces the real, friendly error for a bad address or down server.
+    final JellyfinServerInfo? info =
+        serverInfo ?? await _tryFetchServerInfo(baseUrl);
 
     final String deviceId = _deviceIdGenerator();
     final JellyfinAuthResult result = await _client.authenticateByName(
@@ -72,8 +83,18 @@ class JellyfinAuthenticator {
       deviceId: deviceId,
       userName: result.userName ?? trimmedUsername,
       serverId: result.serverId,
-      serverName: serverName,
+      serverName: info?.serverName,
+      serverVersion: info?.version,
+      productName: info?.productName,
     );
+  }
+
+  Future<JellyfinServerInfo?> _tryFetchServerInfo(String baseUrl) async {
+    try {
+      return await _client.fetchServerInfo(baseUrl);
+    } on JellyfinException {
+      return null;
+    }
   }
 
   static String _randomDeviceId() {

--- a/lib/core/sources/jellyfin/jellyfin_diagnostics.dart
+++ b/lib/core/sources/jellyfin/jellyfin_diagnostics.dart
@@ -1,0 +1,59 @@
+import 'jellyfin_server_capabilities.dart';
+
+/// Builds the secret-free text the "Copy Jellyfin diagnostics" action puts on
+/// the clipboard, so a user can paste it into a bug report without leaking
+/// anything sensitive.
+///
+/// Security invariant: this can only ever emit non-secret, display-safe fields.
+/// There is no parameter for a password, access token, `Authorization` header,
+/// or full authenticated URL, and the server address is reduced to its host (by
+/// [hostOnly]) so even a tokenless query string can't ride along. The
+/// [lastErrorKind] is the stable enum *name*, never a raw error string. This
+/// mirrors the same "diagnostic, never secret" rule `PlaybackDiagnostics` holds
+/// for debug logs — here for a user-facing report.
+abstract final class JellyfinDiagnostics {
+  /// Assembles the multi-line report. Every field is optional except the app
+  /// version and connection state, so the report is useful even before a
+  /// successful connection.
+  static String describe({
+    required String appVersion,
+    required String connectionState,
+    String? serverHost,
+    String? serverName,
+    String? serverVersion,
+    String? productName,
+    JellyfinServerSupport? versionSupport,
+    String? lastErrorKind,
+  }) {
+    final List<String> lines = <String>[
+      'Linthra Jellyfin diagnostics',
+      'App version: $appVersion',
+      'Connection: $connectionState',
+      if (serverName != null && serverName.isNotEmpty)
+        'Server name: $serverName',
+      if (productName != null && productName.isNotEmpty)
+        'Product: $productName',
+      if (serverVersion != null && serverVersion.isNotEmpty)
+        'Server version: $serverVersion',
+      if (versionSupport != null) 'Version support: ${versionSupport.label}',
+      if (serverHost != null && serverHost.isNotEmpty)
+        'Server host: $serverHost',
+      'Last error: ${lastErrorKind ?? 'none'}',
+    ];
+    return lines.join('\n');
+  }
+
+  /// Reduces a full server base URL to just its host (and port), dropping the
+  /// scheme, path, query, and anything else, so the diagnostics never carry a
+  /// full URL. Returns `null` when [baseUrl] is empty or has no host.
+  static String? hostOnly(String? baseUrl) {
+    if (baseUrl == null || baseUrl.isEmpty) {
+      return null;
+    }
+    final Uri? uri = Uri.tryParse(baseUrl);
+    if (uri == null || uri.host.isEmpty) {
+      return null;
+    }
+    return uri.hasPort ? '${uri.host}:${uri.port}' : uri.host;
+  }
+}

--- a/lib/core/sources/jellyfin/jellyfin_endpoints.dart
+++ b/lib/core/sources/jellyfin/jellyfin_endpoints.dart
@@ -1,0 +1,167 @@
+import 'jellyfin_api.dart';
+
+/// Every Jellyfin REST path and URL Linthra builds, in one place.
+///
+/// Centralizing the endpoints means:
+///  - the HTTP client, the music source, and the track mapper never embed raw
+///    path strings, so a path can't quietly drift between two call sites;
+///  - the exact set of endpoints Linthra depends on is auditable from this one
+///    file (kept in sync with docs/jellyfin-compatibility.md);
+///  - the token-bearing stream and download URLs are built by the same pure,
+///    tested helpers, so the "weave the token into the query, on demand, never
+///    store it" rule lives in a single spot.
+///
+/// All builders are pure: they take a clean base URL (no trailing slash, as
+/// produced by [JellyfinServerUrl.normalize]) plus the ids/params they need and
+/// return a [Uri]. Nothing here performs I/O, logs, or holds state.
+///
+/// Compatibility: these paths are stable across the Jellyfin 10.x line. If a
+/// future server version relocates one, change it here — and only here — and
+/// note it in the compatibility doc.
+abstract final class JellyfinEndpoints {
+  // --- Path templates: the only place these strings are written. ---
+  static const String _serverInfoPath = '/System/Info/Public';
+  static const String _authenticateByNamePath = '/Users/AuthenticateByName';
+  static const String _currentUserPath = '/Users/Me';
+  static const String _itemsPath = '/Items';
+  static const String _artistsPath = '/Artists';
+
+  // --- Query-parameter keys, named once so a typo can't split a request. ---
+
+  /// The access token, carried in a media URL's query (not an `Authorization`
+  /// header) so it survives the redirects a stripped header would not and
+  /// matches exactly what the audio engine fetches with.
+  static const String apiKeyParam = 'api_key';
+
+  /// `static=true` asks Jellyfin to serve the original file bytes as-is.
+  static const String staticParam = 'static';
+  static const String userIdParam = 'UserId';
+  static const String deviceIdParam = 'DeviceId';
+
+  /// `GET /System/Info/Public` — public server info. No credentials required;
+  /// backs "Test connection" and the version/capability read.
+  static Uri serverInfo(String baseUrl) => _join(baseUrl, _serverInfoPath);
+
+  /// `POST /Users/AuthenticateByName` — exchange a username + password for an
+  /// access token.
+  static Uri authenticateByName(String baseUrl) =>
+      _join(baseUrl, _authenticateByNamePath);
+
+  /// `GET /Users/Me` — the tiny authenticated call used to verify a session is
+  /// still accepted (a 401 means the token expired).
+  static Uri currentUser(String baseUrl) => _join(baseUrl, _currentUserPath);
+
+  /// The library-listing URL for one [kind] and [userId].
+  ///
+  /// Audio and albums share `/Items` filtered by type; artists have their own
+  /// `/Artists` endpoint. The sort/field choices match what Linthra maps.
+  static Uri items(
+    String baseUrl, {
+    required String userId,
+    required JellyfinItemKind kind,
+  }) {
+    switch (kind) {
+      case JellyfinItemKind.audio:
+        return _join(baseUrl, _itemsPath).replace(
+          queryParameters: <String, String>{
+            userIdParam: userId,
+            'Recursive': 'true',
+            'IncludeItemTypes': 'Audio',
+            'SortBy': 'AlbumArtist,Album,IndexNumber,SortName',
+            'SortOrder': 'Ascending',
+            'Fields': 'RunTimeTicks',
+          },
+        );
+      case JellyfinItemKind.album:
+        return _join(baseUrl, _itemsPath).replace(
+          queryParameters: <String, String>{
+            userIdParam: userId,
+            'Recursive': 'true',
+            'IncludeItemTypes': 'MusicAlbum',
+            'SortBy': 'AlbumArtist,SortName',
+            'SortOrder': 'Ascending',
+            'Fields': 'ProductionYear,ChildCount',
+          },
+        );
+      case JellyfinItemKind.artist:
+        return _join(baseUrl, _artistsPath).replace(
+          queryParameters: <String, String>{
+            userIdParam: userId,
+            'SortBy': 'SortName',
+            'SortOrder': 'Ascending',
+          },
+        );
+    }
+  }
+
+  /// `GET /Items?…&Filters=IsFavorite` — the favourite audio item ids for
+  /// [userId]. Images are disabled to keep the payload small.
+  static Uri favoriteAudioItems(String baseUrl, {required String userId}) =>
+      _join(baseUrl, _itemsPath).replace(
+        queryParameters: <String, String>{
+          userIdParam: userId,
+          'Recursive': 'true',
+          'IncludeItemTypes': 'Audio',
+          'Filters': 'IsFavorite',
+          'EnableImages': 'false',
+        },
+      );
+
+  /// `/Users/<userId>/FavoriteItems/<itemId>` — `POST` to mark, `DELETE` to
+  /// clear a favourite.
+  static Uri favoriteItem(
+    String baseUrl, {
+    required String userId,
+    required String itemId,
+  }) =>
+      _join(baseUrl, '/Users/$userId/FavoriteItems/$itemId');
+
+  /// `GET /Audio/<itemId>/Lyrics` — time-synced or plain lyrics (a 404 just
+  /// means the server has none).
+  static Uri lyrics(String baseUrl, {required String itemId}) =>
+      _join(baseUrl, '/Audio/$itemId/Lyrics');
+
+  /// `GET /Items/<itemId>/Images/Primary` — the token-free cover-art URL. Needs
+  /// no auth, so it is safe to persist on a track and cache.
+  static Uri primaryImage(String baseUrl, {required String itemId}) =>
+      _join(baseUrl, '/Items/$itemId/Images/Primary');
+
+  /// The direct-play audio stream URL: `/Audio/<id>/stream?static=true&…`.
+  ///
+  /// `static=true` requests the original file bytes (the reliable direct-stream
+  /// path `just_audio`/ExoPlayer can open) rather than a negotiated
+  /// transcode/HLS variant the engine may reject. The token rides in
+  /// [apiKeyParam]; it is woven in here, on demand, and never stored on the
+  /// track or in the catalog.
+  static Uri audioStream(
+    String baseUrl, {
+    required String itemId,
+    required String accessToken,
+    required String userId,
+    required String deviceId,
+  }) =>
+      _join(baseUrl, '/Audio/$itemId/stream').replace(
+        queryParameters: <String, String>{
+          staticParam: 'true',
+          apiKeyParam: accessToken,
+          userIdParam: userId,
+          deviceIdParam: deviceId,
+        },
+      );
+
+  /// The original-file download URL: `/Items/<id>/Download?api_key=…`, used so
+  /// the offline copy is the real source file rather than a transcode. Like
+  /// [audioStream], the token is woven in on demand and never stored.
+  static Uri download(
+    String baseUrl, {
+    required String itemId,
+    required String accessToken,
+  }) =>
+      _join(baseUrl, '/Items/$itemId/Download').replace(
+        queryParameters: <String, String>{
+          apiKeyParam: accessToken,
+        },
+      );
+
+  static Uri _join(String baseUrl, String path) => Uri.parse('$baseUrl$path');
+}

--- a/lib/core/sources/jellyfin/jellyfin_exception.dart
+++ b/lib/core/sources/jellyfin/jellyfin_exception.dart
@@ -27,10 +27,21 @@ enum JellyfinErrorKind {
   /// problem is in front of Jellyfin, not the address itself.
   webPage,
 
-  /// A stream URL was probed and the server answered, but not with audio (an
-  /// unexpected content type or a non-2xx that isn't auth/transport/5xx). The
-  /// item likely can't be direct-streamed in its current form.
+  /// A stream URL was probed and the server answered, but not with audio (a
+  /// 2xx with an unexpected content type). The item likely can't be
+  /// direct-streamed in its current form.
   notAudioStream,
+
+  /// A stream URL was probed and the server returned 404: the audio item isn't
+  /// available to stream (moved, removed, or a library the token can't reach).
+  /// Distinct from [notAudioStream] so the player can say "this track isn't
+  /// available" rather than "the server returned the wrong kind of data".
+  streamUnavailable,
+
+  /// The server answered with something Linthra can't classify or use — an
+  /// unexpected non-2xx status on a stream, or a shape an older/newer server
+  /// returned that this version doesn't understand.
+  unsupportedResponse,
 
   /// Any other unexpected failure.
   unexpected,
@@ -94,6 +105,22 @@ class JellyfinException implements Exception {
   factory JellyfinException.notAudioStream() => const JellyfinException(
         "Jellyfin didn't return an audio stream for this track.",
         kind: JellyfinErrorKind.notAudioStream,
+      );
+
+  factory JellyfinException.streamUnavailable() => const JellyfinException(
+        "This track isn't available to stream from your server right now. "
+        'It may have been moved or removed.',
+        kind: JellyfinErrorKind.streamUnavailable,
+        statusCode: 404,
+      );
+
+  factory JellyfinException.unsupportedResponse([int? statusCode]) =>
+      JellyfinException(
+        'Your Jellyfin server returned a response Linthra could not use'
+        '${statusCode != null ? ' (HTTP $statusCode)' : ''}. '
+        'It may be running an unsupported version.',
+        kind: JellyfinErrorKind.unsupportedResponse,
+        statusCode: statusCode,
       );
 
   factory JellyfinException.unexpected(int statusCode) => JellyfinException(

--- a/lib/core/sources/jellyfin/jellyfin_music_source.dart
+++ b/lib/core/sources/jellyfin/jellyfin_music_source.dart
@@ -7,6 +7,7 @@ import '../../services/playback_diagnostics.dart';
 import 'jellyfin_api.dart';
 import 'jellyfin_client.dart';
 import 'jellyfin_download_source.dart';
+import 'jellyfin_endpoints.dart';
 import 'jellyfin_exception.dart';
 import 'jellyfin_stream_source.dart';
 import 'jellyfin_track_mapper.dart';
@@ -110,24 +111,26 @@ class JellyfinMusicSource
     return url;
   }
 
-  /// The direct-play stream URL for [track]. `static=true` asks Jellyfin to
-  /// serve the original file as-is (no transcode), which is the reliable
-  /// "stream directly" path for an audio engine that already decodes the common
-  /// containers.
-  Uri _streamUri(Track track) =>
-      Uri.parse('${session.baseUrl}/Audio/${_itemId(track)}/stream').replace(
-        queryParameters: <String, String>{
-          'static': 'true',
-          'api_key': session.accessToken,
-          'UserId': session.userId,
-          'DeviceId': session.deviceId,
-        },
+  /// The direct-play stream URL for [track], built by the single
+  /// [JellyfinEndpoints.audioStream] helper so the streaming, download, and
+  /// probe paths can never drift apart. `static=true` asks Jellyfin to serve the
+  /// original file as-is (no transcode) — the reliable "stream directly" path
+  /// for an audio engine that already decodes the common containers.
+  Uri _streamUri(Track track) => JellyfinEndpoints.audioStream(
+        session.baseUrl,
+        itemId: _itemId(track),
+        accessToken: session.accessToken,
+        userId: session.userId,
+        deviceId: session.deviceId,
       );
 
   /// Turns a stream [probe] into a typed [JellyfinException] when the response
   /// isn't playable audio, so the resolver can map it to a friendly message.
-  /// HTML is checked first: a Cloudflare/login/error page is never audio
-  /// whatever its status, and Jellyfin's own auth responses aren't HTML.
+  ///
+  /// Order matters: HTML is checked first (a Cloudflare/login/error page is
+  /// never audio, whatever its status, and Jellyfin's own auth responses aren't
+  /// HTML), then auth, then a missing item (404), then server errors, then any
+  /// other non-2xx, and finally a 2xx whose body isn't audio.
   void _ensurePlayableAudio(JellyfinStreamProbe probe) {
     if (probe.isHtml) {
       throw JellyfinException.webPage();
@@ -136,10 +139,20 @@ class JellyfinMusicSource
     if (code == 401 || code == 403) {
       throw JellyfinException.unauthorized();
     }
+    if (code == 404) {
+      // The stream endpoint answered but the item isn't there — moved, removed,
+      // or a library the token can't see.
+      throw JellyfinException.streamUnavailable();
+    }
     if (code >= 500) {
       throw JellyfinException.serverError(code);
     }
-    if (!probe.isSuccess || !probe.isAudio) {
+    if (!probe.isSuccess) {
+      // Any other non-2xx (a 400/429/redirect-that-didn't-resolve): a response
+      // Linthra can't turn into a playable stream.
+      throw JellyfinException.unsupportedResponse(code);
+    }
+    if (!probe.isAudio) {
       throw JellyfinException.notAudioStream();
     }
   }
@@ -151,11 +164,10 @@ class JellyfinMusicSource
   /// token is woven in here, at download time, and never stored on the track.
   @override
   Future<Uri?> resolveDownloadUri(Track track) async {
-    return Uri.parse('${session.baseUrl}/Items/${_itemId(track)}/Download')
-        .replace(
-      queryParameters: <String, String>{
-        'api_key': session.accessToken,
-      },
+    return JellyfinEndpoints.download(
+      session.baseUrl,
+      itemId: _itemId(track),
+      accessToken: session.accessToken,
     );
   }
 

--- a/lib/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart
@@ -81,6 +81,17 @@ class JellyfinPlayableUriResolver implements PlayableUriResolver {
           'Jellyfin did not return an audio stream.',
           kind: PlaybackResolutionErrorKind.invalidStream,
         );
+      case JellyfinErrorKind.unsupportedResponse:
+        return const PlaybackResolutionException(
+          'Your Jellyfin server returned a response Linthra could not use. '
+          'It may be running an unsupported version.',
+          kind: PlaybackResolutionErrorKind.invalidStream,
+        );
+      case JellyfinErrorKind.streamUnavailable:
+        return const PlaybackResolutionException(
+          "This track isn't available to stream from your server right now.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        );
       case JellyfinErrorKind.notReachable:
       case JellyfinErrorKind.serverError:
         return const PlaybackResolutionException(

--- a/lib/core/sources/jellyfin/jellyfin_server_capabilities.dart
+++ b/lib/core/sources/jellyfin/jellyfin_server_capabilities.dart
@@ -1,0 +1,110 @@
+/// Version- and capability-awareness for a Jellyfin server.
+///
+/// This is intentionally *diagnostic only*: it parses the version string a
+/// server reports and classifies how well Linthra expects to work with it, so
+/// the user (and a bug report) can see "you're on an older, untested server".
+///
+/// It must never be used to branch request behavior — the endpoints Linthra
+/// uses (see [JellyfinEndpoints] and docs/jellyfin-compatibility.md) are stable
+/// across the Jellyfin 10.x line, so there is no need for version-sniffing
+/// hacks, and adding them would be exactly the kind of fragile coupling this
+/// hardening pass is meant to avoid.
+library;
+
+/// A parsed Jellyfin `major.minor.patch` version.
+///
+/// Pure and comparable so the support classification and any future "is this at
+/// least X" check stay unit-testable without a server. Extra build/suffix parts
+/// (e.g. `-rc1`, `+build`) are ignored.
+class JellyfinServerVersion implements Comparable<JellyfinServerVersion> {
+  const JellyfinServerVersion(this.major, [this.minor = 0, this.patch = 0]);
+
+  final int major;
+  final int minor;
+  final int patch;
+
+  /// Parses `"10.9.11"` / `"10.9"` / `"10.9.11-rc1"`, or returns `null` when the
+  /// string carries no recognizable `major.minor` version.
+  static JellyfinServerVersion? tryParse(String raw) {
+    final RegExpMatch? match =
+        RegExp(r'(\d+)\.(\d+)(?:\.(\d+))?').firstMatch(raw.trim());
+    if (match == null) {
+      return null;
+    }
+    return JellyfinServerVersion(
+      int.parse(match.group(1)!),
+      int.parse(match.group(2)!),
+      int.parse(match.group(3) ?? '0'),
+    );
+  }
+
+  @override
+  int compareTo(JellyfinServerVersion other) {
+    if (major != other.major) return major.compareTo(other.major);
+    if (minor != other.minor) return minor.compareTo(other.minor);
+    return patch.compareTo(other.patch);
+  }
+
+  bool operator >=(JellyfinServerVersion other) => compareTo(other) >= 0;
+  bool operator <(JellyfinServerVersion other) => compareTo(other) < 0;
+
+  @override
+  bool operator ==(Object other) =>
+      other is JellyfinServerVersion &&
+      other.major == major &&
+      other.minor == minor &&
+      other.patch == patch;
+
+  @override
+  int get hashCode => Object.hash(major, minor, patch);
+
+  @override
+  String toString() => '$major.$minor.$patch';
+}
+
+/// How well Linthra expects to work with a server's reported version.
+enum JellyfinServerSupport {
+  /// At or above the oldest version Linthra is tested against.
+  supported,
+
+  /// Older than the tested minimum. Linthra may still work — the endpoints it
+  /// uses are long-standing — but the combination is untested.
+  untested,
+
+  /// The version string was absent or unparseable, so support is unknown.
+  unknown;
+
+  /// A short, user-facing label for diagnostics and the settings note.
+  String get label {
+    switch (this) {
+      case JellyfinServerSupport.supported:
+        return 'supported';
+      case JellyfinServerSupport.untested:
+        return 'untested (older than recommended)';
+      case JellyfinServerSupport.unknown:
+        return 'unknown';
+    }
+  }
+}
+
+/// The oldest Jellyfin version Linthra is actively tested against.
+///
+/// This is a conservative floor, **not** a hard gate: an older server is
+/// labelled [JellyfinServerSupport.untested] (and the user is gently warned),
+/// never blocked, because the REST endpoints Linthra relies on predate it.
+const JellyfinServerVersion kMinimumTestedJellyfinVersion =
+    JellyfinServerVersion(10, 8, 0);
+
+/// Classifies a reported [version] string against [kMinimumTestedJellyfinVersion].
+JellyfinServerSupport jellyfinServerSupportFor(String? version) {
+  if (version == null || version.trim().isEmpty) {
+    return JellyfinServerSupport.unknown;
+  }
+  final JellyfinServerVersion? parsed = JellyfinServerVersion.tryParse(version);
+  if (parsed == null) {
+    return JellyfinServerSupport.unknown;
+  }
+  return parsed >= kMinimumTestedJellyfinVersion
+      ? JellyfinServerSupport.supported
+      : JellyfinServerSupport.untested;
+}

--- a/lib/core/sources/jellyfin/jellyfin_track_mapper.dart
+++ b/lib/core/sources/jellyfin/jellyfin_track_mapper.dart
@@ -2,6 +2,7 @@ import '../../models/album.dart';
 import '../../models/artist.dart';
 import '../../models/track.dart';
 import 'jellyfin_api.dart';
+import 'jellyfin_endpoints.dart';
 
 /// Converts Jellyfin wire items into Linthra's source-agnostic domain models.
 ///
@@ -72,6 +73,6 @@ abstract final class JellyfinTrackMapper {
     if (!item.hasPrimaryImage) {
       return null;
     }
-    return Uri.parse('$baseUrl/Items/${item.id}/Images/Primary');
+    return JellyfinEndpoints.primaryImage(baseUrl, itemId: item.id);
   }
 }

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -1,9 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/app_info.dart';
 import '../../../core/models/jellyfin_session.dart';
 import '../../../core/sources/jellyfin/jellyfin_api.dart';
+import '../../../core/sources/jellyfin/jellyfin_diagnostics.dart';
 import '../../../core/sources/jellyfin/jellyfin_exception.dart';
 import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
+import '../../../core/sources/jellyfin/jellyfin_server_capabilities.dart';
 import '../../../data/repositories/jellyfin_session_store_provider.dart';
 import 'jellyfin_settings_providers.dart';
 import 'jellyfin_settings_state.dart';
@@ -63,6 +66,8 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
       baseUrl: saved.baseUrl,
       username: saved.userName,
       serverName: saved.serverName,
+      serverVersion: saved.serverVersion,
+      productName: saved.productName,
       statusMessage: _connectedMessage(saved),
     );
   }
@@ -75,6 +80,8 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
       baseUrl: url,
       username: state.username,
       serverName: state.serverName,
+      serverVersion: state.serverVersion,
+      productName: state.productName,
     );
     try {
       final JellyfinServerInfo info =
@@ -85,12 +92,14 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
         username: state.username,
         serverName: info.serverName,
         serverVersion: info.version,
+        productName: info.productName,
         statusMessage:
             'Connected to ${info.serverName} (Jellyfin ${info.version}).',
       );
       return true;
     } on JellyfinException catch (error) {
-      _setFailure(error.message, url: url, username: state.username);
+      _setFailure(error.message,
+          kind: error.kind, url: url, username: state.username);
       return false;
     }
   }
@@ -109,6 +118,8 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
       baseUrl: url,
       username: username,
       serverName: state.serverName,
+      serverVersion: state.serverVersion,
+      productName: state.productName,
     );
     try {
       final JellyfinSession newSession =
@@ -116,7 +127,7 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
                 rawUrl: url,
                 username: username,
                 password: password,
-                serverName: state.serverName,
+                serverInfo: _knownServerInfo(),
               );
       await ref.read(jellyfinSessionStoreProvider).write(newSession);
       _session = newSession;
@@ -125,11 +136,14 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
         baseUrl: newSession.baseUrl,
         username: newSession.userName,
         serverName: newSession.serverName,
+        serverVersion: newSession.serverVersion,
+        productName: newSession.productName,
         statusMessage: _connectedMessage(newSession),
       );
       return true;
     } on JellyfinException catch (error) {
-      _setFailure(error.message, url: url, username: username);
+      _setFailure(error.message,
+          kind: error.kind, url: url, username: username);
       return false;
     }
   }
@@ -144,8 +158,14 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
   }
 
   /// Reports an error without dropping an existing connection: a failed test or
-  /// re-auth keeps any session that's still valid, it just surfaces the message.
-  void _setFailure(String message, {String? url, String? username}) {
+  /// re-auth keeps any session that's still valid, it just surfaces the message
+  /// (and the error [kind] for the diagnostics report).
+  void _setFailure(
+    String message, {
+    JellyfinErrorKind? kind,
+    String? url,
+    String? username,
+  }) {
     final JellyfinSession? current = _session;
     state = JellyfinSettingsState(
       phase: current != null
@@ -154,9 +174,60 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
       baseUrl: current?.baseUrl ?? url,
       username: current?.userName ?? username,
       serverName: current?.serverName ?? state.serverName,
+      serverVersion: current?.serverVersion ?? state.serverVersion,
+      productName: current?.productName ?? state.productName,
       statusMessage: current != null ? _connectedMessage(current) : null,
       errorMessage: message,
+      errorKind: kind,
     );
+  }
+
+  /// The server info already known from a prior connection test or the loaded
+  /// session, so sign-in needn't re-read it. Null when nothing is known yet.
+  JellyfinServerInfo? _knownServerInfo() {
+    final String? name = state.serverName;
+    final String? version = state.serverVersion;
+    if (name == null || name.isEmpty || version == null || version.isEmpty) {
+      return null;
+    }
+    return JellyfinServerInfo(
+      serverName: name,
+      version: version,
+      productName: state.productName,
+    );
+  }
+
+  /// A secret-free diagnostics report for the "Copy Jellyfin diagnostics"
+  /// action, assembled from display-safe state only — never the token,
+  /// password, or a full authenticated URL (the address is reduced to its host).
+  String diagnosticsReport() {
+    final String? version = state.serverVersion;
+    return JellyfinDiagnostics.describe(
+      appVersion: AppInfo.version,
+      connectionState: _connectionStateLabel(),
+      serverHost: JellyfinDiagnostics.hostOnly(state.baseUrl),
+      serverName: state.serverName,
+      serverVersion: version,
+      productName: state.productName,
+      versionSupport:
+          version != null ? jellyfinServerSupportFor(version) : null,
+      lastErrorKind: state.errorKind?.name,
+    );
+  }
+
+  String _connectionStateLabel() {
+    switch (state.phase) {
+      case JellyfinConnectionPhase.connected:
+        return 'connected';
+      case JellyfinConnectionPhase.tested:
+        return 'tested (not signed in)';
+      case JellyfinConnectionPhase.testing:
+        return 'testing';
+      case JellyfinConnectionPhase.signingIn:
+        return 'signing in';
+      case JellyfinConnectionPhase.disconnected:
+        return 'disconnected';
+    }
   }
 
   String _connectedMessage(JellyfinSession session) {

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
+import '../../../core/sources/jellyfin/jellyfin_server_capabilities.dart';
 import 'jellyfin_settings_controller.dart';
 import 'jellyfin_settings_state.dart';
 import 'jellyfin_sync_controller.dart';
@@ -84,6 +86,29 @@ class _JellyfinSettingsSectionState
     await ref.read(jellyfinSyncControllerProvider.notifier).sync();
   }
 
+  /// Copies a secret-free diagnostics report to the clipboard so the user can
+  /// paste it into a bug report. The report is assembled by the controller and,
+  /// by construction, carries no token, password, or full authenticated URL.
+  Future<void> _copyDiagnostics() async {
+    final String report = ref
+        .read(jellyfinSettingsControllerProvider.notifier)
+        .diagnosticsReport();
+    await Clipboard.setData(ClipboardData(text: report));
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Jellyfin diagnostics copied (no password or token).'),
+      ),
+    );
+  }
+
+  /// Show the diagnostics action once there's something worth reporting: a live
+  /// connection, a successful test, or a failure the user might want to share.
+  bool _showDiagnostics(JellyfinSettingsState state) =>
+      state.isConnected ||
+      state.phase == JellyfinConnectionPhase.tested ||
+      state.errorMessage != null;
+
   @override
   Widget build(BuildContext context) {
     final JellyfinSettingsState state =
@@ -130,6 +155,17 @@ class _JellyfinSettingsSectionState
             ] else if (state.statusMessage != null) ...[
               const SizedBox(height: AppSpacing.md),
               _StatusLine(message: state.statusMessage!, isError: false),
+            ],
+            if (_showDiagnostics(state)) ...[
+              const SizedBox(height: AppSpacing.xs),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  onPressed: _copyDiagnostics,
+                  icon: const Icon(Icons.bug_report_outlined, size: 18),
+                  label: const Text('Copy Jellyfin diagnostics'),
+                ),
+              ),
             ],
           ],
         ),
@@ -265,11 +301,30 @@ class _ConnectedView extends StatelessWidget {
                             theme.colorScheme.onSurface.withValues(alpha: 0.6),
                       ),
                     ),
+                  if (state.serverVersion != null &&
+                      state.serverVersion!.isNotEmpty)
+                    Text(
+                      _serverVersionLine(state),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color:
+                            theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
                 ],
               ),
             ),
           ],
         ),
+        if (state.serverVersion != null &&
+            jellyfinServerSupportFor(state.serverVersion) ==
+                JellyfinServerSupport.untested) ...[
+          const SizedBox(height: AppSpacing.sm),
+          const _StatusLine(
+            message: 'This Jellyfin version is older than Linthra is tested '
+                'against. Streaming should still work, but is untested.',
+            isError: false,
+          ),
+        ],
         const SizedBox(height: AppSpacing.md),
         FilledButton.tonalIcon(
           onPressed: onSync,
@@ -294,6 +349,16 @@ class _ConnectedView extends StatelessWidget {
       ],
     );
   }
+}
+
+/// `Jellyfin {version}` plus the product name when the server reported one.
+String _serverVersionLine(JellyfinSettingsState state) {
+  final StringBuffer line = StringBuffer('Jellyfin ${state.serverVersion}');
+  final String? product = state.productName;
+  if (product != null && product.isNotEmpty && product != 'Jellyfin Server') {
+    line.write(' · $product');
+  }
+  return line.toString();
 }
 
 /// A button label that swaps to a small spinner while its action runs.

--- a/lib/features/settings/jellyfin/jellyfin_settings_state.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_state.dart
@@ -1,3 +1,5 @@
+import '../../../core/sources/jellyfin/jellyfin_exception.dart';
+
 /// Where the Jellyfin connection is in its lifecycle.
 enum JellyfinConnectionPhase {
   /// No session and nothing in progress.
@@ -32,8 +34,10 @@ class JellyfinSettingsState {
     this.username,
     this.serverName,
     this.serverVersion,
+    this.productName,
     this.statusMessage,
     this.errorMessage,
+    this.errorKind,
   });
 
   final JellyfinConnectionPhase phase;
@@ -47,14 +51,22 @@ class JellyfinSettingsState {
   /// Friendly server name from a connection test or the saved session.
   final String? serverName;
 
-  /// Server version string from a connection test.
+  /// Server version string from a connection test or the saved session.
   final String? serverVersion;
+
+  /// Server product name (e.g. "Jellyfin Server"), when reported.
+  final String? productName;
 
   /// A friendly, non-error status line (e.g. "Connected to …").
   final String? statusMessage;
 
   /// A friendly error line, when the last action failed.
   final String? errorMessage;
+
+  /// The kind of the last failure, kept for the diagnostics report so it can
+  /// show a stable, non-secret error category. The friendly [errorMessage] is
+  /// already secret-free; the kind is even safer to surface in a bug report.
+  final JellyfinErrorKind? errorKind;
 
   bool get isConnected => phase == JellyfinConnectionPhase.connected;
 

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -96,6 +96,8 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
         return 'Your Jellyfin server reported an error. Try again in a moment.';
       case JellyfinErrorKind.invalidUrl:
       case JellyfinErrorKind.notAudioStream:
+      case JellyfinErrorKind.streamUnavailable:
+      case JellyfinErrorKind.unsupportedResponse:
       case JellyfinErrorKind.unexpected:
         return error.message;
     }

--- a/test/core/models/jellyfin_session_test.dart
+++ b/test/core/models/jellyfin_session_test.dart
@@ -9,6 +9,8 @@ const _session = JellyfinSession(
   userName: 'alice',
   serverId: 'server-1',
   serverName: 'My Server',
+  serverVersion: '10.9.11',
+  productName: 'Jellyfin Server',
 );
 
 void main() {
@@ -16,6 +18,20 @@ void main() {
     test('round-trips through toJson/fromJson', () {
       final restored = JellyfinSession.fromJson(_session.toJson());
       expect(restored, _session);
+    });
+
+    test('round-trips the server version and product for diagnostics', () {
+      final restored = JellyfinSession.fromJson(_session.toJson());
+      expect(restored!.serverVersion, '10.9.11');
+      expect(restored.productName, 'Jellyfin Server');
+    });
+
+    test('the server version/product are not secret and survive toString', () {
+      // They are display/diagnostics fields, so they may appear in toString —
+      // unlike the token, which must stay redacted.
+      final String text = _session.toString();
+      expect(text, contains('10.9.11'));
+      expect(text, isNot(contains('secret-token-value')));
     });
 
     test('fromJson returns null when a required field is missing', () {

--- a/test/core/sources/jellyfin/http_jellyfin_client_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_test.dart
@@ -31,6 +31,7 @@ void main() {
             'ServerName': 'Home',
             'Version': '10.9.0',
             'Id': 'abc',
+            'ProductName': 'Jellyfin Server',
           }),
           200,
           headers: <String, String>{'content-type': 'application/json'},
@@ -41,6 +42,7 @@ void main() {
 
       expect(info.serverName, 'Home');
       expect(info.version, '10.9.0');
+      expect(info.productName, 'Jellyfin Server');
       expect(captured!.method, 'GET');
       expect(captured!.url.path, '/System/Info/Public');
     });

--- a/test/core/sources/jellyfin/jellyfin_authenticator_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_authenticator_test.dart
@@ -59,7 +59,11 @@ void main() {
         rawUrl: 'music.example.com',
         username: 'alice',
         password: 'pw',
-        serverName: 'Home',
+        serverInfo: const JellyfinServerInfo(
+          serverName: 'Home',
+          version: '10.9.0',
+          productName: 'Jellyfin Server',
+        ),
       );
 
       expect(session.baseUrl, 'https://music.example.com');
@@ -68,9 +72,54 @@ void main() {
       expect(session.userName, 'Alice');
       expect(session.serverId, 's-1');
       expect(session.deviceId, 'dev-9');
+      // A known server info (from a prior test) is carried into the session for
+      // display and diagnostics.
       expect(session.serverName, 'Home');
+      expect(session.serverVersion, '10.9.0');
+      expect(session.productName, 'Jellyfin Server');
       // The same device id was sent to the auth call.
       expect(client.lastDeviceId, 'dev-9');
+    });
+
+    test('reads server info itself when none was supplied', () async {
+      // A user who signs in without tapping "Test connection" first: sign-in
+      // reads /System/Info/Public so the session still records the version.
+      final client = FakeJellyfinClient(
+        serverInfo: const JellyfinServerInfo(
+          serverName: 'Fetched',
+          version: '10.10.3',
+        ),
+      );
+
+      final session = await _authenticator(client).signIn(
+        rawUrl: 'music.example.com',
+        username: 'alice',
+        password: 'pw',
+      );
+
+      expect(session.serverName, 'Fetched');
+      expect(session.serverVersion, '10.10.3');
+    });
+
+    test('still signs in when reading server info fails', () async {
+      // A public-info hiccup must not block an otherwise-valid sign-in; the
+      // session just lacks the version.
+      final client = FakeJellyfinClient(
+        serverInfoError: JellyfinException.notReachable(),
+        authResult: const JellyfinAuthResult(
+          accessToken: 'tok',
+          userId: 'u-1',
+        ),
+      );
+
+      final session = await _authenticator(client).signIn(
+        rawUrl: 'music.example.com',
+        username: 'alice',
+        password: 'pw',
+      );
+
+      expect(session.accessToken, 'tok');
+      expect(session.serverVersion, isNull);
     });
 
     test('forwards the password to the client (and never returns it)',

--- a/test/core/sources/jellyfin/jellyfin_diagnostics_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_diagnostics_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_diagnostics.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_server_capabilities.dart';
+
+void main() {
+  group('JellyfinDiagnostics.hostOnly', () {
+    test('reduces a full base URL to its host', () {
+      expect(
+        JellyfinDiagnostics.hostOnly('https://music.example.com/jellyfin'),
+        'music.example.com',
+      );
+    });
+
+    test('keeps a port when present', () {
+      expect(
+        JellyfinDiagnostics.hostOnly('http://192.168.1.10:8096'),
+        '192.168.1.10:8096',
+      );
+    });
+
+    test('drops scheme, path, and query (so no token can ride along)', () {
+      final String? host = JellyfinDiagnostics.hostOnly(
+        'https://music.example.com/Audio/t1/stream?api_key=secret',
+      );
+      expect(host, 'music.example.com');
+      expect(host, isNot(contains('secret')));
+      expect(host, isNot(contains('api_key')));
+      expect(host, isNot(contains('https')));
+    });
+
+    test('returns null for empty or hostless input', () {
+      expect(JellyfinDiagnostics.hostOnly(null), isNull);
+      expect(JellyfinDiagnostics.hostOnly(''), isNull);
+    });
+  });
+
+  group('JellyfinDiagnostics.describe', () {
+    test('includes the app version, connection, server version, and host', () {
+      final String report = JellyfinDiagnostics.describe(
+        appVersion: '0.1.0-alpha.9',
+        connectionState: 'connected',
+        serverHost: 'music.example.com',
+        serverName: 'Home',
+        serverVersion: '10.9.11',
+        productName: 'Jellyfin Server',
+        versionSupport: JellyfinServerSupport.supported,
+        lastErrorKind: null,
+      );
+
+      expect(report, contains('App version: 0.1.0-alpha.9'));
+      expect(report, contains('Connection: connected'));
+      expect(report, contains('Server version: 10.9.11'));
+      expect(report, contains('Server host: music.example.com'));
+      expect(report, contains('Version support: supported'));
+      // No error → reported explicitly as none.
+      expect(report, contains('Last error: none'));
+    });
+
+    test('reports the last error kind when present', () {
+      final String report = JellyfinDiagnostics.describe(
+        appVersion: '0.1.0',
+        connectionState: 'connected',
+        lastErrorKind: 'unauthorized',
+      );
+      expect(report, contains('Last error: unauthorized'));
+    });
+
+    test('never contains a token, password, or full authenticated URL', () {
+      // Even if a caller mistakenly passed secrets, there is no field for them;
+      // and the host field is host-only. This asserts the shape stays safe.
+      final String report = JellyfinDiagnostics.describe(
+        appVersion: '0.1.0',
+        connectionState: 'connected',
+        serverHost: JellyfinDiagnostics.hostOnly(
+          'https://music.example.com/Audio/t1/stream?api_key=tok-secret',
+        ),
+        serverName: 'Home',
+        serverVersion: '10.9.11',
+      );
+
+      expect(report, isNot(contains('tok-secret')));
+      expect(report, isNot(contains('api_key')));
+      expect(report, isNot(contains('Token')));
+      expect(report, isNot(contains('password')));
+      expect(report, isNot(contains('/Audio/')));
+    });
+
+    test('omits absent optional fields', () {
+      final String report = JellyfinDiagnostics.describe(
+        appVersion: '0.1.0',
+        connectionState: 'disconnected',
+      );
+      expect(report, isNot(contains('Server name:')));
+      expect(report, isNot(contains('Server version:')));
+      expect(report, isNot(contains('Server host:')));
+      expect(report, contains('Connection: disconnected'));
+    });
+  });
+}

--- a/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_endpoints.dart';
+
+const String _base = 'https://music.example.com';
+const String _token = 'super-secret-token';
+
+void main() {
+  group('JellyfinEndpoints unauthenticated paths', () {
+    test('serverInfo targets the public info endpoint', () {
+      expect(JellyfinEndpoints.serverInfo(_base).path, '/System/Info/Public');
+    });
+
+    test('authenticateByName targets the auth endpoint', () {
+      expect(JellyfinEndpoints.authenticateByName(_base).path,
+          '/Users/AuthenticateByName');
+    });
+
+    test('currentUser targets /Users/Me', () {
+      expect(JellyfinEndpoints.currentUser(_base).path, '/Users/Me');
+    });
+
+    test('preserves a reverse-proxy subpath on the base URL', () {
+      // A server mounted under a subpath must keep it on every endpoint.
+      final Uri uri =
+          JellyfinEndpoints.serverInfo('https://example.com/jellyfin');
+      expect(uri.path, '/jellyfin/System/Info/Public');
+    });
+  });
+
+  group('JellyfinEndpoints.items', () {
+    test('audio lists from /Items filtered to Audio with the user id', () {
+      final Uri uri = JellyfinEndpoints.items(
+        _base,
+        userId: 'user-1',
+        kind: JellyfinItemKind.audio,
+      );
+      expect(uri.path, '/Items');
+      expect(uri.queryParameters['IncludeItemTypes'], 'Audio');
+      expect(uri.queryParameters['UserId'], 'user-1');
+      expect(uri.queryParameters['Recursive'], 'true');
+      expect(uri.queryParameters['Fields'], 'RunTimeTicks');
+    });
+
+    test('album lists MusicAlbum items', () {
+      final Uri uri = JellyfinEndpoints.items(
+        _base,
+        userId: 'user-1',
+        kind: JellyfinItemKind.album,
+      );
+      expect(uri.path, '/Items');
+      expect(uri.queryParameters['IncludeItemTypes'], 'MusicAlbum');
+    });
+
+    test('artist uses the dedicated /Artists endpoint', () {
+      final Uri uri = JellyfinEndpoints.items(
+        _base,
+        userId: 'user-1',
+        kind: JellyfinItemKind.artist,
+      );
+      expect(uri.path, '/Artists');
+      expect(uri.queryParameters['UserId'], 'user-1');
+    });
+  });
+
+  group('JellyfinEndpoints favourites / lyrics / artwork', () {
+    test('favoriteAudioItems filters to IsFavorite and disables images', () {
+      final Uri uri =
+          JellyfinEndpoints.favoriteAudioItems(_base, userId: 'user-1');
+      expect(uri.path, '/Items');
+      expect(uri.queryParameters['Filters'], 'IsFavorite');
+      expect(uri.queryParameters['EnableImages'], 'false');
+    });
+
+    test('favoriteItem targets the per-user favourite item path', () {
+      final Uri uri = JellyfinEndpoints.favoriteItem(
+        _base,
+        userId: 'user-1',
+        itemId: 'item-7',
+      );
+      expect(uri.path, '/Users/user-1/FavoriteItems/item-7');
+    });
+
+    test('lyrics targets the audio lyrics endpoint', () {
+      expect(
+        JellyfinEndpoints.lyrics(_base, itemId: 'item-7').path,
+        '/Audio/item-7/Lyrics',
+      );
+    });
+
+    test('primaryImage is a token-free cover-art URL', () {
+      final Uri uri = JellyfinEndpoints.primaryImage(_base, itemId: 'item-7');
+      expect(uri.path, '/Items/item-7/Images/Primary');
+      // Artwork needs no auth, so it carries no token (safe to persist/cache).
+      expect(uri.toString(), isNot(contains('api_key')));
+    });
+  });
+
+  group('JellyfinEndpoints.audioStream', () {
+    final Uri uri = JellyfinEndpoints.audioStream(
+      _base,
+      itemId: 't1',
+      accessToken: _token,
+      userId: 'user-1',
+      deviceId: 'device-1',
+    );
+
+    test('uses the direct-play stream endpoint with static=true', () {
+      expect(uri.path, '/Audio/t1/stream');
+      expect(uri.queryParameters['static'], 'true');
+      expect(uri.queryParameters['UserId'], 'user-1');
+      expect(uri.queryParameters['DeviceId'], 'device-1');
+    });
+
+    test('weaves the token into the api_key query, never the path', () {
+      expect(uri.queryParameters['api_key'], _token);
+      // The token is in the query only — never in the path the catalog/logs see.
+      expect(uri.path, isNot(contains(_token)));
+    });
+  });
+
+  group('JellyfinEndpoints.download', () {
+    final Uri uri = JellyfinEndpoints.download(
+      _base,
+      itemId: 't1',
+      accessToken: _token,
+    );
+
+    test('uses the original-file download endpoint', () {
+      expect(uri.path, '/Items/t1/Download');
+    });
+
+    test('weaves the token into the api_key query, never the path', () {
+      expect(uri.queryParameters['api_key'], _token);
+      expect(uri.path, isNot(contains(_token)));
+    });
+  });
+}

--- a/test/core/sources/jellyfin/jellyfin_music_source_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_music_source_test.dart
@@ -169,6 +169,53 @@ void main() {
         expect(uri!.path, '/Audio/t1/stream');
       });
 
+      test('a 404 maps to "stream unavailable" (track moved/removed)',
+          () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(statusCode: 404),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.streamUnavailable,
+          )),
+        );
+      });
+
+      test('a 5xx maps to a server error', () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(statusCode: 503),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.serverError,
+          )),
+        );
+      });
+
+      test('an unclassifiable non-2xx maps to "unsupported response"',
+          () async {
+        final source = _source(FakeJellyfinClient(
+          streamProbe: const JellyfinStreamProbe(statusCode: 400),
+        ));
+
+        await expectLater(
+          source.resolvePlayableUri(track),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.unsupportedResponse,
+          )),
+        );
+      });
+
       test('a transport failure during the probe propagates', () async {
         final source = _source(FakeJellyfinClient(
           probeError: JellyfinException.notReachable(),

--- a/test/core/sources/jellyfin/jellyfin_playable_uri_resolver_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_playable_uri_resolver_test.dart
@@ -172,6 +172,42 @@ void main() {
       );
     });
 
+    test('reports a stream-unavailable error on a 404 stream', () async {
+      final source =
+          _FakeStreamSource(streamError: JellyfinException.streamUnavailable());
+      final resolver = JellyfinPlayableUriResolver(() => source);
+
+      await expectLater(
+        resolver.resolve(_jellyfinTrack),
+        throwsA(
+          isA<PlaybackResolutionException>().having(
+            (PlaybackResolutionException e) => e.kind,
+            'kind',
+            PlaybackResolutionErrorKind.streamUnavailable,
+          ),
+        ),
+      );
+    });
+
+    test('reports an invalid stream on an unsupported server response',
+        () async {
+      final source = _FakeStreamSource(
+        streamError: JellyfinException.unsupportedResponse(400),
+      );
+      final resolver = JellyfinPlayableUriResolver(() => source);
+
+      await expectLater(
+        resolver.resolve(_jellyfinTrack),
+        throwsA(
+          isA<PlaybackResolutionException>().having(
+            (PlaybackResolutionException e) => e.kind,
+            'kind',
+            PlaybackResolutionErrorKind.invalidStream,
+          ),
+        ),
+      );
+    });
+
     test('error messages match the friendly, secret-free wording', () async {
       Future<String> messageFor(JellyfinException verifyError) async {
         final resolver = JellyfinPlayableUriResolver(

--- a/test/core/sources/jellyfin/jellyfin_server_capabilities_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_server_capabilities_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_server_capabilities.dart';
+
+void main() {
+  group('JellyfinServerVersion.tryParse', () {
+    test('parses major.minor.patch', () {
+      final JellyfinServerVersion? v =
+          JellyfinServerVersion.tryParse('10.9.11');
+      expect(v, isNotNull);
+      expect(v!.major, 10);
+      expect(v.minor, 9);
+      expect(v.patch, 11);
+      expect(v.toString(), '10.9.11');
+    });
+
+    test('defaults a missing patch to 0', () {
+      final JellyfinServerVersion? v = JellyfinServerVersion.tryParse('10.8');
+      expect(v, const JellyfinServerVersion(10, 8, 0));
+    });
+
+    test('ignores a build/suffix part', () {
+      expect(
+        JellyfinServerVersion.tryParse('10.10.3-rc1'),
+        const JellyfinServerVersion(10, 10, 3),
+      );
+    });
+
+    test('returns null for an unparseable string', () {
+      expect(JellyfinServerVersion.tryParse('unknown'), isNull);
+      expect(JellyfinServerVersion.tryParse(''), isNull);
+    });
+  });
+
+  group('JellyfinServerVersion comparison', () {
+    test('orders by major, then minor, then patch', () {
+      expect(
+        const JellyfinServerVersion(10, 9, 0) >=
+            const JellyfinServerVersion(10, 8, 0),
+        isTrue,
+      );
+      expect(
+        const JellyfinServerVersion(10, 8, 0) <
+            const JellyfinServerVersion(10, 9, 0),
+        isTrue,
+      );
+      expect(
+        const JellyfinServerVersion(11, 0, 0) >=
+            const JellyfinServerVersion(10, 99, 99),
+        isTrue,
+      );
+    });
+
+    test('equal versions compare equal', () {
+      expect(
+        const JellyfinServerVersion(10, 9, 1) >=
+            const JellyfinServerVersion(10, 9, 1),
+        isTrue,
+      );
+      expect(
+        const JellyfinServerVersion(10, 9, 1),
+        const JellyfinServerVersion(10, 9, 1),
+      );
+    });
+  });
+
+  group('jellyfinServerSupportFor', () {
+    test('a current version is supported', () {
+      expect(
+          jellyfinServerSupportFor('10.9.11'), JellyfinServerSupport.supported);
+      expect(
+          jellyfinServerSupportFor('10.10.0'), JellyfinServerSupport.supported);
+    });
+
+    test('a version at the tested minimum is supported', () {
+      expect(
+        jellyfinServerSupportFor(kMinimumTestedJellyfinVersion.toString()),
+        JellyfinServerSupport.supported,
+      );
+    });
+
+    test('an older version is untested', () {
+      expect(
+          jellyfinServerSupportFor('10.7.0'), JellyfinServerSupport.untested);
+    });
+
+    test('an absent or unparseable version is unknown', () {
+      expect(jellyfinServerSupportFor(null), JellyfinServerSupport.unknown);
+      expect(jellyfinServerSupportFor(''), JellyfinServerSupport.unknown);
+      expect(jellyfinServerSupportFor('???'), JellyfinServerSupport.unknown);
+    });
+
+    test('each support level has a non-empty label', () {
+      for (final JellyfinServerSupport s in JellyfinServerSupport.values) {
+        expect(s.label, isNotEmpty);
+      }
+    });
+  });
+}

--- a/test/core/sources/jellyfin/jellyfin_server_info_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_server_info_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_server_capabilities.dart';
+
+void main() {
+  group('JellyfinServerInfo.fromJson', () {
+    test('parses the public info fields', () {
+      final JellyfinServerInfo? info =
+          JellyfinServerInfo.fromJson(<String, dynamic>{
+        'ServerName': 'Home',
+        'Version': '10.9.11',
+        'Id': 'abc123',
+        'ProductName': 'Jellyfin Server',
+        'OperatingSystem': 'Linux',
+      });
+
+      expect(info, isNotNull);
+      expect(info!.serverName, 'Home');
+      expect(info.version, '10.9.11');
+      expect(info.id, 'abc123');
+      expect(info.productName, 'Jellyfin Server');
+      expect(info.operatingSystem, 'Linux');
+    });
+
+    test('tolerates the optional product/OS fields being absent', () {
+      final JellyfinServerInfo? info =
+          JellyfinServerInfo.fromJson(<String, dynamic>{
+        'ServerName': 'Home',
+        'Version': '10.9.0',
+      });
+
+      expect(info, isNotNull);
+      expect(info!.productName, isNull);
+      expect(info.operatingSystem, isNull);
+    });
+
+    test('returns null when a required field is missing', () {
+      expect(
+        JellyfinServerInfo.fromJson(<String, dynamic>{'ServerName': 'Home'}),
+        isNull,
+      );
+      expect(
+        JellyfinServerInfo.fromJson(<String, dynamic>{'Version': '10.9.0'}),
+        isNull,
+      );
+    });
+
+    test('exposes parsed version and support classification', () {
+      const JellyfinServerInfo current =
+          JellyfinServerInfo(serverName: 'Home', version: '10.9.11');
+      expect(current.parsedVersion, const JellyfinServerVersion(10, 9, 11));
+      expect(current.support, JellyfinServerSupport.supported);
+
+      const JellyfinServerInfo old =
+          JellyfinServerInfo(serverName: 'Old', version: '10.6.0');
+      expect(old.support, JellyfinServerSupport.untested);
+
+      const JellyfinServerInfo weird =
+          JellyfinServerInfo(serverName: 'Weird', version: 'custom-build');
+      expect(weird.parsedVersion, isNull);
+      expect(weird.support, JellyfinServerSupport.unknown);
+    });
+  });
+}

--- a/test/features/settings/jellyfin/fake_jellyfin_authenticator.dart
+++ b/test/features/settings/jellyfin/fake_jellyfin_authenticator.dart
@@ -23,7 +23,7 @@ class FakeJellyfinAuthenticator implements JellyfinAuthenticator {
   String? lastSignInUrl;
   String? lastUsername;
   String? lastPassword;
-  String? lastServerName;
+  JellyfinServerInfo? lastServerInfo;
 
   @override
   Future<JellyfinServerInfo> testConnection(String rawUrl) async {
@@ -41,12 +41,12 @@ class FakeJellyfinAuthenticator implements JellyfinAuthenticator {
     required String rawUrl,
     required String username,
     required String password,
-    String? serverName,
+    JellyfinServerInfo? serverInfo,
   }) async {
     lastSignInUrl = rawUrl;
     lastUsername = username;
     lastPassword = password;
-    lastServerName = serverName;
+    lastServerInfo = serverInfo;
     final JellyfinException? error = signInError;
     if (error != null) {
       throw error;
@@ -58,7 +58,9 @@ class FakeJellyfinAuthenticator implements JellyfinAuthenticator {
           accessToken: 'fake-token',
           deviceId: 'device-1',
           userName: username,
-          serverName: serverName,
+          serverName: serverInfo?.serverName,
+          serverVersion: serverInfo?.version,
+          productName: serverInfo?.productName,
         );
   }
 }

--- a/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
 import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
@@ -168,7 +169,10 @@ void main() {
         password: 'pw',
       );
 
-      expect(auth.lastServerName, 'My Server');
+      // The tested server info (name + version) is carried into sign-in so it
+      // needn't re-read it and the session records the version.
+      expect(auth.lastServerInfo?.serverName, 'My Server');
+      expect(auth.lastServerInfo?.version, '10.9.0');
     });
 
     test('does not persist anything on failure', () async {
@@ -209,6 +213,106 @@ void main() {
         container.read(jellyfinSettingsControllerProvider.notifier).session,
         isNull,
       );
+    });
+  });
+
+  group('server capability + diagnostics', () {
+    test('captures the server version and product on a successful test',
+        () async {
+      final auth = FakeJellyfinAuthenticator(
+        serverInfo: const JellyfinServerInfo(
+          serverName: 'Home',
+          version: '10.9.11',
+          productName: 'Jellyfin Server',
+        ),
+      );
+      final container = _container(authenticator: auth);
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      await container
+          .read(jellyfinSettingsControllerProvider.notifier)
+          .testConnection('music.example.com');
+
+      final state = container.read(jellyfinSettingsControllerProvider);
+      expect(state.serverVersion, '10.9.11');
+      expect(state.productName, 'Jellyfin Server');
+    });
+
+    test('persists the server version into the saved session', () async {
+      final store = InMemoryJellyfinSessionStore();
+      final auth = FakeJellyfinAuthenticator(
+        serverInfo:
+            const JellyfinServerInfo(serverName: 'Home', version: '10.9.11'),
+      );
+      final container = _container(authenticator: auth, store: store);
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.testConnection('music.example.com');
+      await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'pw',
+      );
+
+      final saved = await store.read();
+      expect(saved!.serverVersion, '10.9.11');
+    });
+
+    test('builds a secret-free diagnostics report', () async {
+      const session = JellyfinSession(
+        baseUrl: 'https://music.example.com/jellyfin',
+        userId: 'user-1',
+        accessToken: 'tok-secret-value',
+        deviceId: 'device-1',
+        userName: 'alice',
+        serverName: 'Home',
+        serverVersion: '10.9.11',
+      );
+      final container = _container(
+        store: InMemoryJellyfinSessionStore(initialSession: session),
+      );
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      final report = notifier.diagnosticsReport();
+
+      // It carries the useful, non-secret context...
+      expect(report, contains('App version:'));
+      expect(report, contains('Connection: connected'));
+      expect(report, contains('10.9.11'));
+      expect(report, contains('music.example.com'));
+      // ...and never the token, an Authorization header, or a full URL.
+      expect(report, isNot(contains('tok-secret-value')));
+      expect(report, isNot(contains('api_key')));
+      expect(report, isNot(contains('/jellyfin')));
+    });
+
+    test('records the error kind for diagnostics on a failed sign-in',
+        () async {
+      final auth = FakeJellyfinAuthenticator(
+        signInError: JellyfinException.unauthorized(),
+      );
+      final container = _container(authenticator: auth);
+      final notifier =
+          container.read(jellyfinSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'bad',
+      );
+
+      expect(
+        container.read(jellyfinSettingsControllerProvider).errorKind,
+        JellyfinErrorKind.unauthorized,
+      );
+      expect(
+          notifier.diagnosticsReport(), contains('Last error: unauthorized'));
     });
   });
 

--- a/test/features/settings/jellyfin/jellyfin_settings_section_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
@@ -127,6 +128,54 @@ void main() {
       await tester.pump();
 
       expect(find.textContaining('not accepted'), findsOneWidget);
+    });
+
+    testWidgets('copies a secret-free diagnostics report to the clipboard',
+        (tester) async {
+      final List<MethodCall> clipboardCalls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardCalls.add(call);
+          }
+          return null;
+        },
+      );
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await _pumpSection(tester, authenticator: FakeJellyfinAuthenticator());
+      await _fillForm(
+        tester,
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'pw',
+      );
+      await tester.tap(find.text('Sign in'));
+      await tester.pump();
+      await tester.pump();
+
+      // The diagnostics action appears once connected.
+      expect(find.text('Copy Jellyfin diagnostics'), findsOneWidget);
+
+      await tester.tap(find.text('Copy Jellyfin diagnostics'));
+      await tester.pump();
+
+      expect(clipboardCalls, hasLength(1));
+      final Map<dynamic, dynamic> args =
+          clipboardCalls.single.arguments as Map<dynamic, dynamic>;
+      final String copied = args['text'] as String;
+      expect(copied, contains('Linthra Jellyfin diagnostics'));
+      expect(copied, contains('App version:'));
+      // The fake session's token must never reach the clipboard.
+      expect(copied, isNot(contains('fake-token')));
+      expect(copied, isNot(contains('api_key')));
+
+      // Let the confirmation SnackBar's auto-dismiss timer fire so the test
+      // ends with no pending timers.
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
## Summary

Makes Linthra's Jellyfin integration more reliable, version-aware, and easier to maintain — no UI redesign, no new product features. The work hardens the client, centralizes streaming/URL logic, adds server capability detection, improves error mapping, and ships a secret-free diagnostics action plus a compatibility doc.

## Jellyfin compatibility improvements

- **One source of truth for endpoints.** New `JellyfinEndpoints` builds *every* Jellyfin URL/path (server info, auth, verify, items/artists, favourites, lyrics, artwork, **stream**, **download**). `HttpJellyfinClient`, `JellyfinMusicSource`, and `JellyfinTrackMapper` now call it instead of embedding raw path strings — the stream, download, and probe paths can't drift apart, and the full endpoint surface is auditable in one file.
- **Safest streaming endpoint kept.** Direct play via `/Audio/<id>/stream?static=true` (original file bytes, no transcode), with `api_key` in the query so it survives redirects and matches what `just_audio`/ExoPlayer fetches with.

## Server / version handling

- `JellyfinServerInfo` now parses **product name** and **operating system** in addition to name/version.
- New `JellyfinServerVersion` + `jellyfinServerSupportFor` parse and classify the version against a tested floor (`10.8.0`) as `supported` / `untested` / `unknown`. **Diagnostic only** — it never branches request behavior (no version-sniffing hacks).
- **Test connection and sign-in** both capture server info; the **session persists** the version/product (non-secret) so diagnostics survive a restart. The connected view shows the version and a gentle note for an untested server.

## Streaming endpoint behavior

The play-time stream probe now maps outcomes precisely:

| Observation | Error kind |
| --- | --- |
| HTML body (Cloudflare/login/error page) | `webPage` |
| 401 / 403 | `unauthorized` (session expired) |
| **404** | **`streamUnavailable`** (new) |
| 5xx | `serverError` |
| **other non-2xx (400/429/…)** | **`unsupportedResponse`** (new) |
| 2xx but non-audio content type | `notAudioStream` |
| transport failure | `notReachable` |

Two new typed kinds added end-to-end (exception → playback resolver → sync controller). Direct streaming without a prior download and offline-cache-first playback are unchanged and still covered by tests.

## Diagnostics / security notes

- New **"Copy Jellyfin diagnostics"** action (Settings → Jellyfin) copies a secret-free report: app version, connection state, server name/version/product, version-support, and **host only** + last error **kind**.
- `JellyfinDiagnostics` has **no field** for a password, token, `Authorization` header, or full authenticated URL; `hostOnly` strips scheme/path/query so a tokenized URL can't ride along. Tests assert no token reaches the clipboard or the report.
- Existing token-safety invariants are preserved: token stays out of `Track.uri`, the DB, logs, UI, cache metadata, and filenames; minted only on demand.

## Tests added

- `jellyfin_endpoints_test` — path + query construction; token in query, never path; subpath preserved.
- `jellyfin_server_capabilities_test` — version parse/compare; support classification.
- `jellyfin_server_info_test` — product/OS parsing, missing-field handling, support getter.
- `jellyfin_diagnostics_test` — report contents; host-only; never token/password/URL.
- Updated music-source (404/5xx/unsupported probe mapping), playback-resolver (new kinds), authenticator (fetch-server-info-on-sign-in + best-effort failure), session (version/product round-trip), controller (capability capture, persisted version, diagnostics report, error kind), and settings-section (clipboard) tests.

## Documentation

- New `docs/jellyfin-compatibility.md`: supported use cases, server URL examples, the endpoint table, the failure-classification table, Cloudflare Tunnel notes, **unsupported Cloudflare Access / Zero Trust**, version-support policy, troubleshooting, and how to report issues without leaking secrets. Linked from the README's Jellyfin section.

## Verification

- `flutter pub get` — ok
- `dart format --set-exit-if-changed .` — clean
- `flutter analyze` — No issues found
- `flutter test` — **508 passed** (run on Flutter 3.27.4, matching CI)

## Known limitations

- Single server / session only (unchanged).
- **Cloudflare Access / Zero Trust** in front of Jellyfin remains unsupported by design — Linthra speaks only Jellyfin's own auth.
- Version support is informational; older servers are warned, never blocked.
- Redirect-following is provided by `package:http` and documented; it isn't unit-tested via `MockClient` (which can't simulate transparent redirects).

https://claude.ai/code/session_01XYjkBYaoXa797DAGmBk5hQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYjkBYaoXa797DAGmBk5hQ)_