### PR TITLE
Faster parallel offline downloads + lyrics that follow the playing track

### DIFF
--- a/lib/core/models/download_progress.dart
+++ b/lib/core/models/download_progress.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+
+/// Byte progress for a single in-flight download.
+///
+/// [totalBytes] is `null` when the server didn't report a content length, in
+/// which case progress is indeterminate ([fraction]/[percent] are `null`) and
+/// the UI shows a spinner rather than a filling bar.
+///
+/// Security note: this carries only the non-secret track id and byte counts —
+/// never a URL, token, or file path — so it is safe to surface in the UI.
+@immutable
+class DownloadProgress {
+  const DownloadProgress({
+    required this.trackId,
+    required this.receivedBytes,
+    this.totalBytes,
+  });
+
+  final String trackId;
+  final int receivedBytes;
+  final int? totalBytes;
+
+  /// Completion in the range 0.0–1.0 when the total is known, else `null`.
+  double? get fraction {
+    final int? total = totalBytes;
+    if (total == null || total <= 0) return null;
+    return (receivedBytes / total).clamp(0.0, 1.0);
+  }
+
+  /// Completion as a whole percent (0–100) when the total is known, else
+  /// `null`.
+  int? get percent {
+    final double? value = fraction;
+    return value == null ? null : (value * 100).round();
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is DownloadProgress &&
+          other.trackId == trackId &&
+          other.receivedBytes == receivedBytes &&
+          other.totalBytes == totalBytes);
+
+  @override
+  int get hashCode => Object.hash(trackId, receivedBytes, totalBytes);
+}

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -1,3 +1,4 @@
+import '../models/download_progress.dart';
 import '../models/track.dart';
 
 /// Where a track stands in the offline-download lifecycle.
@@ -40,6 +41,13 @@ abstract interface class DownloadRepository {
   Stream<Map<String, DownloadStatus>> get statusStream;
 
   Future<DownloadStatus> statusFor(String trackId);
+
+  /// Emits per-track byte progress for in-flight downloads, keyed by track id.
+  /// An entry appears while a track is downloading and is removed once it
+  /// finishes, fails, or is canceled. Best-effort: a track whose server didn't
+  /// report a content length has a null total ([DownloadProgress.fraction] is
+  /// `null`), so the UI shows an indeterminate spinner rather than a bar.
+  Stream<Map<String, DownloadProgress>> get progressStream;
 
   /// Queues an explicit download for [track]. For remote tracks this is subject
   /// to the user's connectivity preferences; on-device tracks are recorded as

--- a/lib/core/services/download_scheduler.dart
+++ b/lib/core/services/download_scheduler.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'dart:collection';
+
+/// A small, fair concurrency gate for offline downloads.
+///
+/// It lets several downloads fetch their bytes at once — which is dramatically
+/// faster than the old strictly-sequential path — while keeping a hard ceiling
+/// so the app never opens an unbounded number of network requests. Work handed
+/// to [schedule] runs immediately when a slot is free; otherwise it waits in a
+/// FIFO queue and starts as soon as an earlier task finishes (success *or*
+/// failure — a failed download must always free its slot).
+///
+/// This is deliberately a tiny, dependency-free primitive: the download
+/// *policy* (status, dedup, cache limit, Wi-Fi) stays in the repository, and
+/// the *concurrency* lives here, so each is small and testable on its own.
+class DownloadScheduler {
+  DownloadScheduler({this.maxConcurrent = defaultMaxConcurrent})
+      : assert(maxConcurrent >= 1, 'maxConcurrent must be at least 1'),
+        _permits = maxConcurrent;
+
+  /// A safe, fixed default: fast enough to feel parallel, small enough that it
+  /// never floods the network or the server with requests.
+  static const int defaultMaxConcurrent = 3;
+
+  /// The most downloads allowed to fetch their bytes at the same time.
+  final int maxConcurrent;
+
+  int _permits;
+  final Queue<Completer<void>> _waiters = Queue<Completer<void>>();
+
+  /// How many tasks are currently running (holding a slot).
+  int get activeCount => maxConcurrent - _permits;
+
+  /// How many tasks are waiting for a slot to free up.
+  int get pendingCount => _waiters.length;
+
+  /// Runs [task] once a slot is free, releasing the slot when it completes
+  /// (whether it returns or throws). Returns [task]'s result or rethrows its
+  /// error, so callers can `await` a scheduled download exactly as before.
+  Future<T> schedule<T>(Future<T> Function() task) async {
+    await _acquire();
+    try {
+      return await task();
+    } finally {
+      _release();
+    }
+  }
+
+  Future<void> _acquire() {
+    if (_permits > 0) {
+      _permits -= 1;
+      return Future<void>.value();
+    }
+    final Completer<void> waiter = Completer<void>();
+    _waiters.add(waiter);
+    return waiter.future;
+  }
+
+  void _release() {
+    if (_waiters.isNotEmpty) {
+      // Hand the slot straight to the next waiter (it stays "active"), keeping
+      // exactly [maxConcurrent] tasks running while any are queued.
+      _waiters.removeFirst().complete();
+    } else {
+      _permits += 1;
+    }
+  }
+}

--- a/lib/core/services/remote_track_downloader.dart
+++ b/lib/core/services/remote_track_downloader.dart
@@ -32,5 +32,14 @@ abstract interface class RemoteTrackDownloader {
   /// Fetches [track]'s bytes for offline caching, resolving the authenticated
   /// URL on demand. Throws when the track can't be downloaded (not signed in,
   /// server unreachable, …); the error never carries the URL or token.
-  Future<RemoteTrackData> fetch(Track track);
+  ///
+  /// [onProgress] is invoked as bytes arrive, with the running [received] count
+  /// and the [total] size when the server reported one (otherwise `null`,
+  /// meaning indeterminate). It carries byte counts only — never a URL or
+  /// token — so it is safe to surface in the UI. Implementations may omit it
+  /// (a one-shot fetch simply never calls it).
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  });
 }

--- a/lib/core/sources/jellyfin/jellyfin_track_downloader.dart
+++ b/lib/core/sources/jellyfin/jellyfin_track_downloader.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 
@@ -32,7 +33,10 @@ class JellyfinTrackDownloader implements RemoteTrackDownloader {
       track.uri.startsWith(JellyfinTrackMapper.uriScheme);
 
   @override
-  Future<RemoteTrackData> fetch(Track track) async {
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
     final JellyfinDownloadSource? source = _source();
     if (source == null) {
       throw StateError('Not signed in to Jellyfin.');
@@ -47,23 +51,45 @@ class JellyfinTrackDownloader implements RemoteTrackDownloader {
       throw StateError('No Jellyfin download URL for this track.');
     }
 
-    final http.Response response;
     try {
-      response = await _client.get(uri).timeout(_timeout);
+      // Stream the body so progress can be reported as bytes arrive. The
+      // request carries the token in its URL, but the URL never leaves this
+      // method, is never logged, and any transport error below is replaced
+      // with a generic message so it can't escape either.
+      final http.StreamedResponse response =
+          await _client.send(http.Request('GET', uri)).timeout(_timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        await response.stream.drain<void>();
+        throw StateError(
+            'Jellyfin download failed (HTTP ${response.statusCode}).');
+      }
+
+      final int? total =
+          (response.contentLength != null && response.contentLength! > 0)
+              ? response.contentLength
+              : null;
+      final BytesBuilder builder = BytesBuilder(copy: false);
+      int received = 0;
+      onProgress?.call(received, total);
+      await for (final List<int> chunk in response.stream.timeout(_timeout)) {
+        builder.add(chunk);
+        received += chunk.length;
+        onProgress?.call(received, total);
+      }
+
+      return RemoteTrackData(
+        bytes: builder.takeBytes(),
+        fileExtension: _extensionFor(response.headers['content-type']),
+      );
+    } on StateError {
+      // Our own friendly, token-free messages (bad status / not signed in):
+      // surface them as-is.
+      rethrow;
     } on Exception {
-      // Never rethrow the original error: a ClientException/SocketException can
-      // embed the tokenized URL in its message.
+      // Never rethrow the original error: a ClientException/SocketException (or
+      // a TimeoutException) can embed the tokenized URL in its message.
       throw StateError('Jellyfin download failed.');
     }
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError(
-          'Jellyfin download failed (HTTP ${response.statusCode}).');
-    }
-
-    return RemoteTrackData(
-      bytes: response.bodyBytes,
-      fileExtension: _extensionFor(response.headers['content-type']),
-    );
   }
 
   /// Maps a response content type to a cache-file extension. Returns `null` for

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import '../../core/models/download_progress.dart';
 import '../../core/models/track.dart';
 import '../../core/repositories/download_preferences.dart';
 import '../../core/repositories/download_repository.dart';
@@ -7,6 +8,7 @@ import '../../core/repositories/download_store.dart';
 import '../../core/repositories/offline_file_store.dart';
 import '../../core/services/cache_eviction_policy.dart';
 import '../../core/services/connectivity_service.dart';
+import '../../core/services/download_scheduler.dart';
 import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/remote_track_downloader.dart';
 import '../../core/services/track_prefetcher.dart';
@@ -23,6 +25,13 @@ import '../../core/services/track_prefetcher.dart';
 ///    pin). Auto-*preloaded* tracks ([prefetch]) are cached ahead of play too,
 ///    but they never take on a user-download status: they stay invisible to the
 ///    downloads UI, count toward the limit, and are the first to be evicted.
+///  - **Bounded parallelism.** Several downloads fetch their bytes at once (via
+///    a [DownloadScheduler]) so caching feels fast, but never more than the
+///    scheduler's small limit — the app never opens an unbounded number of
+///    requests. The byte fetch runs in parallel; the cache *commit* (eviction +
+///    write + metadata) is serialized, so the limit is honored even when several
+///    downloads finish at once. A repeated request for a track already
+///    downloading (or queued) is ignored, so a track is never fetched twice.
 ///  - **Source-aware.** A remote (Jellyfin) track has its bytes fetched and
 ///    written to the offline directory; an on-device track is already local, so
 ///    it's recorded as available offline with no fetch and no managed file.
@@ -54,6 +63,7 @@ class CacheDownloadRepository
     required ConnectivityService connectivity,
     required DownloadPreferences preferences,
     CacheEvictionPolicy policy = const CacheEvictionPolicy(),
+    DownloadScheduler? scheduler,
     String? Function()? currentlyPlayingTrackId,
     DateTime Function()? now,
   })  : _store = store,
@@ -62,6 +72,7 @@ class CacheDownloadRepository
         _connectivity = connectivity,
         _preferences = preferences,
         _policy = policy,
+        _scheduler = scheduler ?? DownloadScheduler(),
         _currentlyPlayingTrackId = currentlyPlayingTrackId,
         _now = now ?? DateTime.now;
 
@@ -71,6 +82,9 @@ class CacheDownloadRepository
   final ConnectivityService _connectivity;
   final DownloadPreferences _preferences;
   final CacheEvictionPolicy _policy;
+
+  /// Bounds how many remote downloads fetch their bytes at the same time.
+  final DownloadScheduler _scheduler;
 
   /// Supplies the id of the track currently playing (or `null`), so it is never
   /// evicted out from under the user. Read lazily so the repository doesn't
@@ -86,11 +100,27 @@ class CacheDownloadRepository
   /// usage is cheap to total.
   final Map<String, CachedTrack> _downloads = <String, CachedTrack>{};
 
+  /// Track ids with a user download in flight (queued for a slot or actively
+  /// fetching). Reserved synchronously at the start of [requestDownload] so two
+  /// rapid taps — or two callers — can never start the same fetch twice.
+  final Set<String> _inFlight = <String>{};
+
+  /// Live byte progress for in-flight downloads, surfaced via [progressStream].
+  final Map<String, DownloadProgress> _progress = <String, DownloadProgress>{};
+
+  /// Serializes the cache *commit* (eviction + write + metadata) across the
+  /// otherwise-parallel downloads, so the limit can't be overshot when several
+  /// finish at once. Bytes are fetched in parallel; only this step is ordered.
+  Future<void> _commitChain = Future<void>.value();
+
   final StreamController<Map<String, DownloadStatus>> _changes =
       StreamController<Map<String, DownloadStatus>>.broadcast();
 
   final StreamController<CacheSnapshot> _cacheChanges =
       StreamController<CacheSnapshot>.broadcast();
+
+  final StreamController<Map<String, DownloadProgress>> _progressChanges =
+      StreamController<Map<String, DownloadProgress>>.broadcast();
 
   bool _loaded = false;
 
@@ -143,19 +173,68 @@ class CacheDownloadRepository
   }
 
   @override
+  Stream<Map<String, DownloadProgress>> get progressStream async* {
+    yield _progressSnapshot();
+    yield* _progressChanges.stream;
+  }
+
+  @override
   Future<void> requestDownload(Track track) async {
-    await _ensureLoaded();
-    final DownloadStatus current =
-        _statuses[track.id] ?? DownloadStatus.notDownloaded;
-    // Already done or in flight — never re-trigger. A queued or failed track,
-    // by contrast, is fair game for an explicit retry.
-    if (current == DownloadStatus.downloaded ||
-        current == DownloadStatus.downloading) {
+    if (!_downloader.isRemote(track)) {
+      // On-device track: no bytes to fetch and no network gate, so record it as
+      // available offline directly.
+      await _requestOnDeviceDownload(track);
       return;
     }
 
-    // A track that was preloaded ahead of play is already cached: promote it to
-    // a user download in place, without re-fetching its bytes.
+    // Reserve the in-flight slot synchronously, before any `await`, so a second
+    // request for the same track (a double tap, or a second caller) bails out
+    // here instead of starting a duplicate fetch.
+    if (!_inFlight.add(track.id)) return;
+    try {
+      await _runRemoteRequest(track);
+    } on CacheStorageException {
+      // The cache is full with nothing safe to evict; surface the friendly,
+      // secret-free error so the UI can prompt to free space or raise the
+      // limit. Status was already reset to not-downloaded before the throw.
+      rethrow;
+    } catch (_) {
+      // Other errors may carry source-specific detail; the UI only needs the
+      // failed state (which offers a retry).
+      _set(track.id, DownloadStatus.failed);
+    } finally {
+      _inFlight.remove(track.id);
+      _clearProgress(track.id);
+    }
+  }
+
+  /// Records an on-device track as available offline: its bytes are already
+  /// local, so there is no fetch, no managed file, and no Wi-Fi gate.
+  Future<void> _requestOnDeviceDownload(Track track) async {
+    await _ensureLoaded();
+    if (_statuses[track.id] == DownloadStatus.downloaded) return;
+    _downloads[track.id] = CachedTrack(
+      trackId: track.id,
+      sourceType: _sourceTypeOf(track),
+      cachedAt: _now(),
+    );
+    await _save();
+    _statuses[track.id] = DownloadStatus.downloaded;
+    _emitStatus();
+    _emitCache();
+  }
+
+  /// Drives one remote download: skip if already cached, promote a preloaded
+  /// copy in place, honor "Wi-Fi only", then wait for a concurrency slot before
+  /// fetching the bytes and committing them under the cache limit.
+  Future<void> _runRemoteRequest(Track track) async {
+    await _ensureLoaded();
+    // Already cached — nothing to do. (A track that is downloading or queued is
+    // already in [_inFlight], so it never reaches here a second time.)
+    if (_statuses[track.id] == DownloadStatus.downloaded) return;
+
+    // A track preloaded ahead of play is already cached: promote it to a user
+    // download in place, without re-fetching its bytes.
     final CachedTrack? preloadedEntry = _downloads[track.id];
     if (preloadedEntry != null &&
         preloadedEntry.preloaded &&
@@ -168,41 +247,27 @@ class CacheDownloadRepository
       return;
     }
 
-    if (!_downloader.isRemote(track)) {
-      // On-device track: the bytes are already local, so there's nothing to
-      // fetch and no managed file — just record it as available offline.
-      _downloads[track.id] = CachedTrack(
-        trackId: track.id,
-        sourceType: _sourceTypeOf(track),
-        cachedAt: _now(),
-      );
-      await _save();
-      _statuses[track.id] = DownloadStatus.downloaded;
-      _emitStatus();
-      _emitCache();
-      return;
-    }
-
-    // Remote track: the Wi-Fi gate only matters here, where there are bytes to
-    // pull over the network.
+    // The Wi-Fi gate only matters here, where there are bytes to pull over the
+    // network. When it blocks, the track waits as "queued" for an explicit
+    // retry once on Wi-Fi (the in-flight reservation is released by the caller).
     if (!await _allowedToDownloadNow()) {
       _set(track.id, DownloadStatus.queued);
       return;
     }
 
-    _set(track.id, DownloadStatus.downloading);
-    try {
-      final RemoteTrackData data = await _downloader.fetch(track);
-      await _cacheRemote(track, data);
-    } on CacheStorageException {
-      // Space was reset below before throwing; surface the friendly error so
-      // the UI can tell the user to free space or raise the limit.
-      rethrow;
-    } catch (_) {
-      // Other errors may carry source-specific detail; the UI only needs the
-      // failed state (offering a retry).
-      _set(track.id, DownloadStatus.failed);
-    }
+    // Accepted: show "queued" until a concurrency slot frees up, then fetch.
+    _set(track.id, DownloadStatus.queued);
+    await _scheduler.schedule(() async {
+      _set(track.id, DownloadStatus.downloading);
+      final RemoteTrackData data = await _downloader.fetch(
+        track,
+        onProgress: (int received, int? total) =>
+            _reportProgress(track.id, received, total),
+      );
+      // Commit serially so concurrent downloads can't jointly overshoot the
+      // limit; the (slow) byte fetch above already ran in parallel.
+      await _commit(() => _cacheRemote(track, data));
+    });
   }
 
   /// Writes a freshly fetched remote track's bytes, evicting first to stay under
@@ -217,6 +282,16 @@ class CacheDownloadRepository
     RemoteTrackData data, {
     bool preloaded = false,
   }) async {
+    if (preloaded) {
+      final CachedTrack? existing = _downloads[track.id];
+      // A user download for the same track raced this preload (commits are
+      // serialized, so by now the winner is known). Don't clobber or duplicate
+      // a real download with a preloaded copy — let the user's copy stand.
+      if (_inFlight.contains(track.id) ||
+          (existing != null && !existing.preloaded)) {
+        return;
+      }
+    }
     final int incoming = data.bytes.length;
     final int maxBytes = await _preferences.maxCacheBytes();
     final EvictionPlan plan = _policy.plan(
@@ -272,15 +347,19 @@ class CacheDownloadRepository
     await _ensureLoaded();
     // Only remote tracks have bytes to fetch; local ones are already on disk.
     if (!_downloader.isRemote(track)) return;
-    // Already cached (download or earlier preload) or in flight — skip.
+    // Already cached (download or earlier preload), or a user download already
+    // has it in flight — skip rather than fetch the same bytes twice.
     if (_downloads.containsKey(track.id)) return;
+    if (_inFlight.contains(track.id)) return;
     if (_statuses[track.id] == DownloadStatus.downloading) return;
     // Preload is best-effort and network-heavy, so it honours "Wi-Fi only" and
     // simply skips (rather than queueing) when it can't run right now.
     if (!await _allowedToDownloadNow()) return;
     try {
       final RemoteTrackData data = await _downloader.fetch(track);
-      await _cacheRemote(track, data, preloaded: true);
+      // Share the one commit lock so a preload write can't race a user
+      // download's and overshoot the limit.
+      await _commit(() => _cacheRemote(track, data, preloaded: true));
     } catch (_) {
       // Best-effort: a failed preload caches nothing and changes no status; the
       // track still streams normally when it's reached.
@@ -370,6 +449,7 @@ class CacheDownloadRepository
   Future<void> dispose() async {
     await _changes.close();
     await _cacheChanges.close();
+    await _progressChanges.close();
   }
 
   /// The connectivity gate. With "Wi-Fi only" off, anything goes; with it on,
@@ -404,8 +484,43 @@ class CacheDownloadRepository
 
   void _emitCache() => _cacheChanges.add(_cacheSnapshot());
 
+  void _emitProgress() => _progressChanges.add(_progressSnapshot());
+
+  /// Runs [action] (a cache commit) only after any in-flight commit finishes,
+  /// so the eviction + write step is never interleaved across the otherwise
+  /// parallel downloads — which is what keeps the cache limit exact under load.
+  /// The chain itself never rejects (errors are routed to [action]'s future),
+  /// so one failed commit doesn't stall the ones behind it.
+  Future<T> _commit<T>(Future<T> Function() action) {
+    final Completer<T> result = Completer<T>();
+    _commitChain = _commitChain.then((_) async {
+      try {
+        result.complete(await action());
+      } catch (error, stackTrace) {
+        result.completeError(error, stackTrace);
+      }
+    });
+    return result.future;
+  }
+
+  void _reportProgress(String trackId, int received, int? total) {
+    _progress[trackId] = DownloadProgress(
+      trackId: trackId,
+      receivedBytes: received,
+      totalBytes: total,
+    );
+    _emitProgress();
+  }
+
+  void _clearProgress(String trackId) {
+    if (_progress.remove(trackId) != null) _emitProgress();
+  }
+
   Map<String, DownloadStatus> _snapshot() =>
       Map<String, DownloadStatus>.unmodifiable(_statuses);
+
+  Map<String, DownloadProgress> _progressSnapshot() =>
+      Map<String, DownloadProgress>.unmodifiable(_progress);
 
   CacheSnapshot _cacheSnapshot() {
     int used = 0;

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -142,7 +142,10 @@ class _UnsupportedRemoteTrackDownloader implements RemoteTrackDownloader {
   bool isRemote(Track track) => false;
 
   @override
-  Future<RemoteTrackData> fetch(Track track) {
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) {
     throw UnsupportedError('No remote downloader is configured.');
   }
 }

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/cache_size.dart';
+import '../../core/models/download_progress.dart';
 import '../../core/models/track.dart';
 import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
@@ -18,6 +19,18 @@ final trackDownloadStatusProvider =
   final repository = ref.watch(downloadRepositoryProvider);
   return repository.statusStream
       .map((statuses) => statuses[trackId] ?? DownloadStatus.notDownloaded)
+      .distinct();
+});
+
+/// The live byte progress of a single in-flight download, for the row's
+/// determinate ring. Null when the track isn't downloading (or its server
+/// didn't report a size, leaving progress indeterminate). Auto-disposed so
+/// off-screen rows drop the subscription.
+final trackDownloadProgressProvider = StreamProvider.autoDispose
+    .family<DownloadProgress?, String>((ref, trackId) {
+  final repository = ref.watch(downloadRepositoryProvider);
+  return repository.progressStream
+      .map((progress) => progress[trackId])
       .distinct();
 });
 

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -47,6 +47,14 @@ class TrackTile extends ConsumerWidget {
         ref.watch(trackDownloadStatusProvider(track.id)).valueOrNull ??
             DownloadStatus.notDownloaded;
     final isRemote = ref.watch(remoteTrackDownloaderProvider).isRemote(track);
+    // Only the actively-downloading row watches byte progress, so idle rows add
+    // no subscription. Null total (or not downloading) leaves the ring spinning.
+    final double? downloadFraction = status == DownloadStatus.downloading
+        ? ref
+            .watch(trackDownloadProgressProvider(track.id))
+            .valueOrNull
+            ?.fraction
+        : null;
 
     return ListTile(
       leading: SizedBox.square(
@@ -75,7 +83,11 @@ class TrackTile extends ConsumerWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _StatusGlyph(status: status, isRemote: isRemote),
+          _StatusGlyph(
+            status: status,
+            isRemote: isRemote,
+            progress: downloadFraction,
+          ),
           _OverflowMenu(
             track: track,
             status: status,
@@ -108,10 +120,18 @@ class TrackTile extends ConsumerWidget {
 /// overflow menu. Nothing here is tappable — it only mirrors state so the row
 /// stays quiet. Only meaningful for remote tracks; local tracks render nothing.
 class _StatusGlyph extends StatelessWidget {
-  const _StatusGlyph({required this.status, required this.isRemote});
+  const _StatusGlyph({
+    required this.status,
+    required this.isRemote,
+    this.progress,
+  });
 
   final DownloadStatus status;
   final bool isRemote;
+
+  /// Download completion in the range 0.0–1.0 when known; `null` shows an
+  /// indeterminate (spinning) ring while downloading.
+  final double? progress;
 
   @override
   Widget build(BuildContext context) {
@@ -126,9 +146,9 @@ class _StatusGlyph extends StatelessWidget {
           semanticLabel: 'Downloaded',
         );
       case DownloadStatus.downloading:
-        return const SizedBox.square(
+        return SizedBox.square(
           dimension: 16,
-          child: CircularProgressIndicator(strokeWidth: 2),
+          child: CircularProgressIndicator(strokeWidth: 2, value: progress),
         );
       case DownloadStatus.queued:
         return Icon(

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -6,6 +6,7 @@ import '../../core/services/jellyfin_lyrics_service.dart';
 import '../../core/services/lyrics_service.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
+import 'player_providers.dart';
 
 /// The lyrics backend. Defaults to "no lyrics" so tests and local-only use need
 /// no Jellyfin wiring; the app overrides it with the Jellyfin-backed service.
@@ -13,11 +14,40 @@ final lyricsServiceProvider = Provider<LyricsService>((ref) {
   return const _NoLyricsService();
 });
 
-/// Lyrics for a single track, fetched on demand and cached while the sheet is
-/// open. Auto-disposed so closing the sheet drops the request.
+/// Lyrics for a single track, keyed by the track itself (whose equality is its
+/// stable id), fetched on demand and cached while watched. Auto-disposed so a
+/// track that is no longer current drops its request.
 final trackLyricsProvider =
     FutureProvider.autoDispose.family<Lyrics?, Track>((ref, track) {
   return ref.watch(lyricsServiceProvider).lyricsFor(track);
+});
+
+/// The track playing right now, distinct by id. Selecting `currentTrack` (whose
+/// equality is id-based) means this changes only when the *track* changes — not
+/// on every position tick — so lyrics aren't refetched every second. Falls back
+/// to the controller's latest state until the first stream event arrives, so
+/// opening lyrics mid-playback resolves immediately (mirroring the player UI).
+final _currentlyPlayingTrackProvider = Provider.autoDispose<Track?>((ref) {
+  final controller = ref.watch(playbackControllerProvider);
+  final Track? streamed = ref.watch(
+    playbackStateProvider.select((state) => state.valueOrNull?.currentTrack),
+  );
+  return streamed ?? controller.state.currentTrack;
+});
+
+/// Lyrics for whatever is playing now — the seam the Now Playing lyrics view
+/// watches. It re-resolves whenever the current track changes (keyed, through
+/// [trackLyricsProvider], by the track's stable id) and reports loading during
+/// the switch, so the previous song's lines never linger. Resolves to
+/// `data(null)` when nothing is playing. The UI watches this and never calls a
+/// lyrics service directly.
+final currentTrackLyricsProvider =
+    Provider.autoDispose<AsyncValue<Lyrics?>>((ref) {
+  final Track? track = ref.watch(_currentlyPlayingTrackProvider);
+  if (track == null) {
+    return const AsyncData<Lyrics?>(null);
+  }
+  return ref.watch(trackLyricsProvider(track));
 });
 
 /// Production binding: read lyrics from the signed-in Jellyfin server. Reads the

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -67,23 +67,23 @@ class NowPlayingActions extends ConsumerWidget {
       context: context,
       showDragHandle: true,
       isScrollControlled: true,
-      builder: (_) => _LyricsSheet(track: track),
+      builder: (_) => const _LyricsSheet(),
     );
   }
 }
 
-/// The lyrics sheet: fetches the current track's lyrics and renders the lines,
-/// a calm "no lyrics" placeholder when there are none, or a friendly "couldn't
-/// load" line on a fetch failure.
+/// The lyrics sheet. It follows the *currently playing* track rather than a
+/// captured one, so skipping to the next song updates the lines in place; while
+/// the new track's lyrics load it shows a spinner (never the previous song),
+/// then either the lines, a calm "no lyrics" placeholder, or a friendly
+/// "couldn't load" message on a fetch failure.
 class _LyricsSheet extends ConsumerWidget {
-  const _LyricsSheet({required this.track});
-
-  final Track track;
+  const _LyricsSheet();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    final AsyncValue<Lyrics?> lyrics = ref.watch(trackLyricsProvider(track));
+    final AsyncValue<Lyrics?> lyrics = ref.watch(currentTrackLyricsProvider);
 
     return SafeArea(
       child: ConstrainedBox(
@@ -133,9 +133,8 @@ class _LyricsSheet extends ConsumerWidget {
             padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
             child: EmptyState(
               icon: Icons.lyrics_outlined,
-              title: 'No lyrics available',
-              message: 'This track has no lyrics, or none are synced from your '
-                  'server yet.',
+              title: 'No lyrics available yet.',
+              message: "They'll appear here when your server has them.",
             ),
           );
         }

--- a/test/core/models/download_progress_test.dart
+++ b/test/core/models/download_progress_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/download_progress.dart';
+
+void main() {
+  group('DownloadProgress', () {
+    test('computes fraction and percent when the total is known', () {
+      const progress = DownloadProgress(
+        trackId: 't1',
+        receivedBytes: 3,
+        totalBytes: 4,
+      );
+
+      expect(progress.fraction, 0.75);
+      expect(progress.percent, 75);
+    });
+
+    test('is indeterminate when the total is unknown', () {
+      const progress = DownloadProgress(trackId: 't1', receivedBytes: 10);
+
+      expect(progress.fraction, isNull);
+      expect(progress.percent, isNull);
+    });
+
+    test('clamps a fraction that would exceed 1.0', () {
+      const progress = DownloadProgress(
+        trackId: 't1',
+        receivedBytes: 9,
+        totalBytes: 4,
+      );
+
+      expect(progress.fraction, 1.0);
+      expect(progress.percent, 100);
+    });
+
+    test('treats a non-positive total as indeterminate', () {
+      const progress = DownloadProgress(
+        trackId: 't1',
+        receivedBytes: 1,
+        totalBytes: 0,
+      );
+
+      expect(progress.fraction, isNull);
+    });
+
+    test('has value equality by id and byte counts', () {
+      const a = DownloadProgress(trackId: 't', receivedBytes: 1, totalBytes: 2);
+      const b = DownloadProgress(trackId: 't', receivedBytes: 1, totalBytes: 2);
+      const c = DownloadProgress(trackId: 't', receivedBytes: 2, totalBytes: 2);
+
+      expect(a, b);
+      expect(a, isNot(c));
+    });
+  });
+}

--- a/test/core/services/download_scheduler_test.dart
+++ b/test/core/services/download_scheduler_test.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/download_scheduler.dart';
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('DownloadScheduler', () {
+    test('runs up to maxConcurrent tasks at once and queues the rest',
+        () async {
+      final scheduler = DownloadScheduler(maxConcurrent: 2);
+      final gates = <Completer<void>>[
+        Completer<void>(),
+        Completer<void>(),
+        Completer<void>(),
+      ];
+      final started = <int>[];
+
+      for (var i = 0; i < gates.length; i++) {
+        final index = i;
+        unawaited(scheduler.schedule<void>(() async {
+          started.add(index);
+          await gates[index].future;
+        }));
+      }
+      await _pump();
+
+      // Only two slots, so only the first two tasks have started.
+      expect(started, <int>[0, 1]);
+      expect(scheduler.activeCount, 2);
+      expect(scheduler.pendingCount, 1);
+
+      // Finishing one frees its slot for the queued task.
+      gates[0].complete();
+      await _pump();
+      expect(started, <int>[0, 1, 2]);
+      expect(scheduler.activeCount, 2);
+      expect(scheduler.pendingCount, 0);
+
+      gates[1].complete();
+      gates[2].complete();
+      await _pump();
+      expect(scheduler.activeCount, 0);
+    });
+
+    test('runs tasks right away when below the limit', () async {
+      final scheduler = DownloadScheduler(maxConcurrent: 3);
+      final results = <int>[];
+
+      await Future.wait(<Future<void>>[
+        scheduler.schedule<void>(() async {
+          results.add(1);
+        }),
+        scheduler.schedule<void>(() async {
+          results.add(2);
+        }),
+      ]);
+
+      expect(results, containsAll(<int>[1, 2]));
+      expect(scheduler.activeCount, 0);
+      expect(scheduler.pendingCount, 0);
+    });
+
+    test('frees the slot even when a task throws', () async {
+      final scheduler = DownloadScheduler(maxConcurrent: 1);
+
+      await expectLater(
+        scheduler.schedule<void>(() async {
+          throw StateError('boom');
+        }),
+        throwsA(isA<StateError>()),
+      );
+
+      // The failed task released its slot, so the next one still runs.
+      var ran = false;
+      await scheduler.schedule<void>(() async {
+        ran = true;
+      });
+      expect(ran, isTrue);
+      expect(scheduler.activeCount, 0);
+    });
+
+    test('preserves FIFO order for queued tasks', () async {
+      final scheduler = DownloadScheduler(maxConcurrent: 1);
+      final order = <int>[];
+
+      final futures = <Future<void>>[
+        for (var i = 0; i < 4; i++)
+          scheduler.schedule<void>(() async {
+            order.add(i);
+          }),
+      ];
+      await Future.wait(futures);
+
+      expect(order, <int>[0, 1, 2, 3]);
+    });
+  });
+}

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/download_progress.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/repositories/offline_file_store.dart';
 import 'package:linthra/core/services/connectivity_service.dart';
+import 'package:linthra/core/services/download_scheduler.dart';
 import 'package:linthra/core/services/offline_cache_manager.dart';
 import 'package:linthra/core/services/remote_track_downloader.dart';
 import 'package:linthra/data/repositories/cache_download_repository.dart';
@@ -27,28 +31,50 @@ class _FakeConnectivity implements ConnectivityService {
 /// A remote downloader fake: treats `jellyfin:` tracks as remote and returns
 /// canned bytes, or throws when [error] is set, so the repository's remote path
 /// can be driven without a server or HTTP.
+///
+/// When [gate] is set, every [fetch] awaits it before completing, so a test can
+/// hold downloads in flight and observe how many run at once ([maxActive]).
+/// [error] is mutable so a test can fail an attempt, then clear it and retry.
 class _FakeRemoteDownloader implements RemoteTrackDownloader {
-  _FakeRemoteDownloader({this.error});
+  _FakeRemoteDownloader({this.error, this.gate});
 
   /// The canned bytes every successful fetch returns.
   static const List<int> bytes = <int>[1, 2, 3, 4];
 
   /// When set, [fetch] throws this instead of returning bytes.
-  final Object? error;
+  Object? error;
+
+  /// When set, [fetch] awaits this before completing.
+  final Future<void>? gate;
 
   int fetchCount = 0;
+  int activeNow = 0;
+  int maxActive = 0;
   final List<Track> fetched = <Track>[];
 
   @override
   bool isRemote(Track track) => track.uri.startsWith('jellyfin:');
 
   @override
-  Future<RemoteTrackData> fetch(Track track) async {
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
     fetchCount++;
+    activeNow++;
+    if (activeNow > maxActive) maxActive = activeNow;
     fetched.add(track);
-    final Object? err = error;
-    if (err != null) throw err;
-    return const RemoteTrackData(bytes: bytes, fileExtension: 'mp3');
+    try {
+      onProgress?.call(2, bytes.length);
+      final Future<void>? pending = gate;
+      if (pending != null) await pending;
+      final Object? err = error;
+      if (err != null) throw err;
+      onProgress?.call(bytes.length, bytes.length);
+      return const RemoteTrackData(bytes: bytes, fileExtension: 'mp3');
+    } finally {
+      activeNow--;
+    }
   }
 }
 
@@ -514,6 +540,150 @@ void main() {
       });
     });
 
+    group('parallel downloads', () {
+      test('runs several downloads at once, bounded by the concurrency limit',
+          () async {
+        final gate = Completer<void>();
+        downloader = _FakeRemoteDownloader(gate: gate.future);
+        final repository = CacheDownloadRepository(
+          store: store,
+          files: files,
+          downloader: downloader,
+          connectivity: connectivity,
+          preferences: preferences,
+          scheduler: DownloadScheduler(maxConcurrent: 2),
+        );
+
+        final futures = <Future<void>>[
+          repository.requestDownload(_jellyfin('j1')),
+          repository.requestDownload(_jellyfin('j2')),
+          repository.requestDownload(_jellyfin('j3')),
+        ];
+
+        // Only two may fetch at once; the third waits its turn as "queued".
+        await _pumpUntil(() => downloader.fetchCount >= 2);
+        expect(downloader.fetchCount, 2);
+        expect(downloader.maxActive, 2);
+
+        final statuses = <DownloadStatus>[
+          await repository.statusFor('j1'),
+          await repository.statusFor('j2'),
+          await repository.statusFor('j3'),
+        ];
+        expect(
+          statuses.where((s) => s == DownloadStatus.downloading).length,
+          2,
+        );
+        expect(statuses.where((s) => s == DownloadStatus.queued).length, 1);
+
+        // Releasing the gate lets all three finish — still never more than two
+        // fetching at any instant.
+        gate.complete();
+        await Future.wait(futures);
+        expect(downloader.fetchCount, 3);
+        expect(downloader.maxActive, 2);
+        final List<String> ids = await repository.downloadedTrackIds();
+        ids.sort();
+        expect(ids, <String>['j1', 'j2', 'j3']);
+      });
+
+      test('a duplicate request for the same track is not started twice',
+          () async {
+        final gate = Completer<void>();
+        downloader = _FakeRemoteDownloader(gate: gate.future);
+        final repository = build();
+
+        final f1 = repository.requestDownload(_jellyfin('j1'));
+        final f2 = repository.requestDownload(_jellyfin('j1'));
+
+        // The second request bails on the in-flight guard before fetching.
+        await _pumpUntil(() => downloader.fetchCount >= 1);
+        expect(downloader.fetchCount, 1);
+
+        gate.complete();
+        await Future.wait(<Future<void>>[f1, f2]);
+
+        expect(downloader.fetchCount, 1);
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+      });
+
+      test('respects the cache limit even when downloads finish concurrently',
+          () async {
+        // Room for exactly two 4-byte downloads.
+        preferences = InMemoryDownloadPreferences(maxCacheBytes: 8);
+        final gate = Completer<void>();
+        downloader = _FakeRemoteDownloader(gate: gate.future);
+        final repository = CacheDownloadRepository(
+          store: store,
+          files: files,
+          downloader: downloader,
+          connectivity: connectivity,
+          preferences: preferences,
+          scheduler: DownloadScheduler(maxConcurrent: 3),
+        );
+
+        final futures = <Future<void>>[
+          repository.requestDownload(_jellyfin('j1')),
+          repository.requestDownload(_jellyfin('j2')),
+          repository.requestDownload(_jellyfin('j3')),
+        ];
+        // All three fetch in parallel, then commit serially once released.
+        await _pumpUntil(() => downloader.fetchCount >= 3);
+        expect(downloader.maxActive, 3);
+        gate.complete();
+        await Future.wait(futures);
+
+        // The serialized commit kept usage at the limit (never 12), evicting
+        // the least-recently-used one to make room for the third.
+        final CacheSnapshot snapshot = await repository.cacheSnapshot();
+        expect(snapshot.usedBytes, 8);
+        expect(snapshot.managedCount, 2);
+      });
+
+      test('reports byte progress while downloading, then clears it on finish',
+          () async {
+        final gate = Completer<void>();
+        downloader = _FakeRemoteDownloader(gate: gate.future);
+        final repository = build();
+
+        final emissions = <Map<String, DownloadProgress>>[];
+        final sub = repository.progressStream.listen(emissions.add);
+
+        final future = repository.requestDownload(_jellyfin('j1'));
+        await _pumpUntil(() => emissions.any((m) => m['j1'] != null));
+
+        final DownloadProgress? mid = emissions.last['j1'];
+        expect(mid, isNotNull);
+        expect(mid!.receivedBytes, 2);
+        expect(mid.totalBytes, 4);
+        expect(mid.fraction, 0.5);
+
+        gate.complete();
+        await future;
+        await _settle();
+
+        // Progress is cleared once the download finishes.
+        expect(emissions.last['j1'], isNull);
+        await sub.cancel();
+      });
+
+      test('a failed download can be retried on the same repository', () async {
+        downloader = _FakeRemoteDownloader(error: Exception('boom'));
+        final repository = build();
+        await repository.requestDownload(_jellyfin('j1'));
+        expect(await repository.statusFor('j1'), DownloadStatus.failed);
+        expect(downloader.fetchCount, 1);
+
+        // Clear the fault and retry through the same repository instance: the
+        // in-flight reservation was released, so the retry proceeds.
+        downloader.error = null;
+        await repository.requestDownload(_jellyfin('j1'));
+
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+        expect(downloader.fetchCount, 2);
+      });
+    });
+
     group('preload (prefetch)', () {
       test('caches a remote track without giving it a download status',
           () async {
@@ -691,3 +861,11 @@ void main() {
 
 /// Lets the broadcast stream deliver any pending events.
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+/// Pumps event-loop turns until [condition] holds (or a bounded number elapse),
+/// so concurrency assertions don't depend on exact async scheduling.
+Future<void> _pumpUntil(bool Function() condition) async {
+  for (var i = 0; i < 200 && !condition(); i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}

--- a/test/features/library/fake_remote_track_downloader.dart
+++ b/test/features/library/fake_remote_track_downloader.dart
@@ -12,7 +12,11 @@ class FakeRemoteTrackDownloader implements RemoteTrackDownloader {
   bool isRemote(Track track) => track.uri.startsWith('jellyfin:');
 
   @override
-  Future<RemoteTrackData> fetch(Track track) async {
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    onProgress?.call(4, 4);
     return const RemoteTrackData(
         bytes: <int>[1, 2, 3, 4], fileExtension: 'mp3');
   }

--- a/test/features/player/lyrics_follow_test.dart
+++ b/test/features/player/lyrics_follow_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/core/services/playback_controller.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import 'fake_playback_controller.dart';
+
+/// A lyrics backend returning canned, per-track lyrics — so a test can prove
+/// the lyrics view follows whatever is playing.
+class _FakeLyricsService implements LyricsService {
+  _FakeLyricsService(this._byTrackId);
+
+  final Map<String, Lyrics?> _byTrackId;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async => _byTrackId[track.id];
+}
+
+const _trackA = Track(id: 'a', title: 'Song A', uri: 'jellyfin:a');
+const _trackB = Track(id: 'b', title: 'Song B', uri: 'jellyfin:b');
+const _trackC = Track(id: 'c', title: 'Song C', uri: 'jellyfin:c');
+
+final Map<String, Lyrics?> _lyrics = <String, Lyrics?>{
+  'a': const Lyrics(lines: <LyricLine>[LyricLine(text: 'Aaa line')]),
+  'b': const Lyrics(lines: <LyricLine>[LyricLine(text: 'Bbb line')]),
+  'c': null,
+};
+
+PlaybackState _playing(Track track) =>
+    PlaybackState(status: PlaybackStatus.playing, currentTrack: track);
+
+Future<void> _pumpPlayer(
+  WidgetTester tester, {
+  required PlaybackController controller,
+  required LyricsService lyrics,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        playbackControllerProvider.overrideWithValue(controller),
+        lyricsServiceProvider.overrideWithValue(lyrics),
+      ],
+      child: const MaterialApp(home: PlayerScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openLyrics(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Lyrics'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('Lyrics follow the playing track', () {
+    testWidgets('shows lyrics for the current track', (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playing(_trackA)),
+        lyrics: _FakeLyricsService(_lyrics),
+      );
+
+      await _openLyrics(tester);
+
+      expect(find.text('Aaa line'), findsOneWidget);
+    });
+
+    testWidgets('updates when the current track changes', (tester) async {
+      final controller = FakePlaybackController(initial: _playing(_trackA));
+      await _pumpPlayer(
+        tester,
+        controller: controller,
+        lyrics: _FakeLyricsService(_lyrics),
+      );
+      await _openLyrics(tester);
+      expect(find.text('Aaa line'), findsOneWidget);
+
+      // Skipping to the next track re-resolves the lyrics in place.
+      controller.emit(_playing(_trackB));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Bbb line'), findsOneWidget);
+      expect(find.text('Aaa line'), findsNothing);
+    });
+
+    testWidgets('shows the empty state when the track has no lyrics',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playing(_trackC)),
+        lyrics: _FakeLyricsService(_lyrics),
+      );
+
+      await _openLyrics(tester);
+
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+    });
+
+    testWidgets('does not show stale lyrics from the previous track',
+        (tester) async {
+      final controller = FakePlaybackController(initial: _playing(_trackA));
+      await _pumpPlayer(
+        tester,
+        controller: controller,
+        lyrics: _FakeLyricsService(_lyrics),
+      );
+      await _openLyrics(tester);
+      expect(find.text('Aaa line'), findsOneWidget);
+
+      // Moving to a track with no lyrics must clear the previous song's lines.
+      controller.emit(_playing(_trackC));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Aaa line'), findsNothing);
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -225,7 +225,7 @@ void main() {
 
       // The default lyrics backend returns none (local track, no Jellyfin), so
       // it shows a calm placeholder rather than a blank sheet.
-      expect(find.text('No lyrics available'), findsOneWidget);
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
     });
 
     testWidgets('the favorite button toggles the heart', (tester) async {


### PR DESCRIPTION
## Summary

Two focused improvements after real Android testing:

1. **Caching feels much faster** — downloads now run a few at a time instead of one‑by‑one, with live progress, dedup, and retry — while staying safe and bounded.
2. **Lyrics follow the playing song** — the Now Playing lyrics view re‑resolves whenever the track changes and shows a clean empty state when there are none.

No Chromecast work, no F‑Droid/release changes, no unrelated UI redesign, no logo changes.

---

## A. Download speed / concurrency behavior

- New **`DownloadScheduler`** (`lib/core/services/download_scheduler.dart`) — a tiny, fair, dependency‑free concurrency gate. Up to **3** downloads (default, injectable) fetch their bytes at once; the rest wait FIFO and start the moment a slot frees (on success **or** failure). It never opens an unbounded number of requests.
- Concurrency lives in the scheduler/repository, **never in widgets**. The cache policy stays centralized in `CacheDownloadRepository`.
- **Queue states** surface on the library row glyph (already wired): `queued` → `downloading` → `downloaded` / `failed`. Cancel is `removeDownload` (resets to not‑downloaded), as before.
- **Dedup**: a remote request reserves an in‑flight slot *synchronously* (`Set.add`) before any `await`, so a double‑tap or a second caller can never start the same fetch twice.
- **Progress**: the Jellyfin downloader now streams the response body and reports `received`/`total`; the repo exposes a `progressStream`, and the library row shows a **determinate** ring (percent) when the size is known, falling back to a spinner when it isn’t. New `DownloadProgress` model carries only byte counts + track id.
- **Retry**: a `failed` download is retryable on the same repository instance (the in‑flight reservation is released on failure).
- **Playback is never blocked**: downloads are off the playback path; the scheduler bounds them. Preload and manual downloads stay separate (preload is single‑flight via the existing `PlaybackPreloader`; both share the cache‑commit lock).

## Cache‑limit behavior under parallel downloads

- The **byte fetch runs in parallel** (the slow part); the **cache commit** (eviction → write → metadata) is **serialized** behind a commit lock. So even when several downloads finish at the same instant, the eviction policy always sees up‑to‑date state and the size limit is never overshot.
- Pinned / “Keep offline” and the currently‑playing track are still never evicted (eviction policy unchanged). A user download that won’t fit even after evicting everything safe still fails with the friendly `CacheStorageException`.

## B. Lyrics follow the current track

- New `currentTrackLyricsProvider` + a private current‑track selector (`lib/features/player/lyrics_providers.dart`). It watches the **currently playing** track (distinct by stable id, so it doesn’t refetch on every position tick) and re‑resolves lyrics through the existing `trackLyricsProvider`/`LyricsService` whenever the track changes.
- The Now Playing lyrics sheet no longer captures the track at open time — it follows playback. On a track change it shows a spinner during the switch (**never** the previous song’s lines), then the new lyrics or a clean empty state: **“No lyrics available yet.”**
- UI watches the provider; it never calls a lyrics service directly. The `Lyrics`/`LyricLine` model already supports optional per‑line timestamps, so **synced lyrics later need no model change**. Lyrics still come only from Jellyfin’s safe `/Audio/{id}/Lyrics` API — no scraping, no third‑party lyrics APIs.

## Security / token notes

- Jellyfin tokens stay out of `Track.uri` (only the `jellyfin:<id>` scheme), out of cache metadata (`sourceType` is the URI scheme only), and out of filenames (derived from the non‑secret id).
- The streaming downloader resolves the tokenized URL only at fetch time; it’s never stored, never logged, and any transport error (which could embed the URL) is replaced with a generic `StateError`.
- Progress (`DownloadProgress`) carries only the track id and byte counts. UI errors stay generic (`CacheStorageException` message is friendly and secret‑free).

## Tests added

- `download_scheduler_test.dart`: bounded concurrency (up to the limit, queues the rest), runs immediately under the limit, frees the slot on throw, FIFO order.
- `download_progress_test.dart`: fraction/percent, indeterminate when total unknown, clamping, equality.
- `cache_download_repository_test.dart` (new group): parallel downloads bounded by the limit; duplicate request not started twice; **cache limit respected under concurrent downloads**; byte‑progress reported then cleared; failed‑then‑retry on the same repository.
- `lyrics_follow_test.dart`: shows current‑track lyrics; updates when the track changes; empty state when none; **does not show stale previous‑track lyrics**.
- Existing Wi‑Fi‑only, no‑token‑leak, eviction, and preload tests are unchanged and still apply.

## ⚠️ Verification not run in this environment

Flutter/Dart is **not installed** in the remote execution container, so I could not run the checks locally. Please run before merging (CI will also run them):

```
flutter pub get
dart format --set-exit-if-changed .   # may need `dart format .` once for whitespace
flutter analyze
flutter test
flutter build apk --debug
```

Code was written to the repo’s strict lints (`flutter_lints` + `strict-casts`/`strict-raw-types`, `unawaited_futures`, `directives_ordering`, etc.); the most likely follow‑up is a one‑shot `dart format .` for whitespace.

## Known limitations

- Concurrency limit is a fixed default (3), injectable for tests — no Settings UI for it (kept out of scope to avoid UI redesign).
- Manual downloads share the scheduler; a preload is single‑flight on its own, so the absolute ceiling is *N + 1* concurrent fetches (still bounded). A late preload that raced a user download is skipped at commit so it can’t clobber the real download.
- Progress is best‑effort: when the server reports no `Content‑Length`, the ring is indeterminate.
- Synced/timed lyrics are not rendered yet (model is ready; UI shows plain lines).

## Manual Android checklist

- [ ] Start several Jellyfin downloads at once.
- [ ] Confirm multiple tracks download faster but not unlimited (≤3 active).
- [ ] Confirm duplicate taps don’t duplicate a download.
- [ ] Confirm playback continues while caching.
- [ ] Confirm Wi‑Fi‑only still queues on mobile.
- [ ] Play a track and open Lyrics.
- [ ] Skip to next track and confirm Lyrics updates (no stale lines).
- [ ] Confirm the empty state on a track with no lyrics.

https://claude.ai/code/session_01X1jNwQua3wXe7v7RJzdFnq

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1jNwQua3wXe7v7RJzdFnq)_