### PR TITLE
Make Cast a true active output + synced lyrics that follow the active session

### DIFF
--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/app_info.dart';
+import '../core/services/active_playback_controller.dart';
 import '../core/services/notification_permission.dart';
+import '../features/player/player_providers.dart';
 import 'router.dart';
 import 'theme.dart';
 
@@ -29,13 +31,36 @@ class LinthraApp extends ConsumerStatefulWidget {
   ConsumerState<LinthraApp> createState() => _LinthraAppState();
 }
 
-class _LinthraAppState extends ConsumerState<LinthraApp> {
+class _LinthraAppState extends ConsumerState<LinthraApp>
+    with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(notificationPermissionProvider).ensureGranted();
     });
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    // Returning from the background while casting: re-sync from the receiver so
+    // the position the UI shows is fresh. This never starts local playback —
+    // backgrounding/foregrounding the app must not recreate or resume the local
+    // engine while a cast session owns playback.
+    if (state == AppLifecycleState.resumed) {
+      final controller = ref.read(playbackControllerProvider);
+      if (controller is ActivePlaybackController) {
+        controller.onAppResumed();
+      }
+    }
   }
 
   @override

--- a/lib/core/models/active_playback_output.dart
+++ b/lib/core/models/active_playback_output.dart
@@ -1,0 +1,14 @@
+/// Which output is actually producing sound right now.
+///
+/// The app can play through the on-device engine ([local]) or hand off to a
+/// cast receiver ([cast], e.g. a Chromecast). Only one is ever active: when
+/// [cast] is active the phone is a remote controller and the local engine is
+/// silenced, so the two never fight over the speakers. The
+/// `ActivePlaybackController` routes commands and merges state based on this.
+enum ActivePlaybackOutput {
+  /// The on-device `just_audio` engine is the source of sound.
+  local,
+
+  /// A cast receiver is playing; the phone only controls and mirrors it.
+  cast,
+}

--- a/lib/core/models/cast_playback_status.dart
+++ b/lib/core/models/cast_playback_status.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart';
+
+import 'playback_state.dart';
+
+/// A snapshot of what a cast receiver is doing, reported back from the session.
+///
+/// This is the cast-side mirror of the playback fields in [PlaybackState]: the
+/// receiver owns the audio while casting, so its position/status/duration come
+/// from here (parsed from the receiver's `MEDIA_STATUS`) rather than from the
+/// local engine. The `ActivePlaybackController` folds these onto the unified
+/// state the UI renders, keeping the now-playing screen, mini-player, and lyrics
+/// in step with the device instead of the (paused) local engine.
+///
+/// It deliberately reuses [PlaybackStatus] so the router needs no second status
+/// vocabulary; it carries no track identity (the queue stays owned locally) and
+/// never any URL or token.
+@immutable
+class CastPlaybackStatus {
+  const CastPlaybackStatus({
+    this.status = PlaybackStatus.idle,
+    this.position = Duration.zero,
+    this.duration = Duration.zero,
+  });
+
+  /// Nothing loaded on the receiver yet.
+  static const CastPlaybackStatus idle = CastPlaybackStatus();
+
+  final PlaybackStatus status;
+  final Duration position;
+  final Duration duration;
+
+  bool get isPlaying => status == PlaybackStatus.playing;
+
+  CastPlaybackStatus copyWith({
+    PlaybackStatus? status,
+    Duration? position,
+    Duration? duration,
+  }) {
+    return CastPlaybackStatus(
+      status: status ?? this.status,
+      position: position ?? this.position,
+      duration: duration ?? this.duration,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CastPlaybackStatus &&
+          other.status == status &&
+          other.position == position &&
+          other.duration == duration);
+
+  @override
+  int get hashCode => Object.hash(status, position, duration);
+}

--- a/lib/core/models/cast_state.dart
+++ b/lib/core/models/cast_state.dart
@@ -55,6 +55,7 @@ class CastState {
     this.devices = const <CastDevice>[],
     this.connectedDevice,
     this.message,
+    this.isCasting = false,
   });
 
   /// The honest default: no cast backend wired, nothing reachable.
@@ -76,6 +77,14 @@ class CastState {
   /// authenticated URL.
   final String? message;
 
+  /// Whether a real handoff is in effect: connected *and* the current track's
+  /// media has been loaded onto the receiver, so the receiver is the active
+  /// output. False while merely connected with nothing castable loaded (e.g.
+  /// the current track is a local file), so local playback is left alone in
+  /// that case. The `ActivePlaybackController` watches this to decide when to
+  /// silence the local engine and follow the cast session.
+  final bool isCasting;
+
   /// Whether the platform can cast at all. False when no backend is wired,
   /// which is what the UI uses to show an honest unavailable state rather than
   /// an empty device picker.
@@ -93,11 +102,13 @@ class CastState {
     CastAvailability? availability,
     List<CastDevice>? devices,
     CastDevice? connectedDevice,
+    bool? isCasting,
   }) {
     return CastState(
       availability: availability ?? this.availability,
       devices: devices ?? this.devices,
       connectedDevice: connectedDevice ?? this.connectedDevice,
+      isCasting: isCasting ?? this.isCasting,
     );
   }
 
@@ -108,7 +119,8 @@ class CastState {
           other.availability == availability &&
           listEquals(other.devices, devices) &&
           other.connectedDevice == connectedDevice &&
-          other.message == message);
+          other.message == message &&
+          other.isCasting == isCasting);
 
   @override
   int get hashCode => Object.hash(
@@ -116,5 +128,6 @@ class CastState {
         Object.hashAll(devices),
         connectedDevice,
         message,
+        isCasting,
       );
 }

--- a/lib/core/models/lyrics.dart
+++ b/lib/core/models/lyrics.dart
@@ -35,6 +35,20 @@ class Lyrics {
   /// Whether any line carries a timestamp (time-synced rather than plain text).
   bool get isSynced => lines.any((LyricLine line) => line.start != null);
 
+  /// The index of the line active at [position]: the last timed line whose
+  /// [LyricLine.start] is at or before [position]. Returns -1 before the first
+  /// timed line begins, and always -1 for plain (untimed) lyrics — which are
+  /// shown without highlighting. Assumes lines are in ascending time order, as
+  /// Jellyfin returns them.
+  int activeLineIndex(Duration position) {
+    int index = -1;
+    for (int i = 0; i < lines.length; i++) {
+      final Duration? start = lines[i].start;
+      if (start != null && start <= position) index = i;
+    }
+    return index;
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import '../models/active_playback_output.dart';
+import '../models/cast_playback_status.dart';
+import '../models/cast_state.dart';
+import '../models/playback_state.dart';
+import '../models/repeat_mode.dart';
+import '../models/track.dart';
+import 'cast/cast_service.dart';
+import 'local_playback_controller.dart';
+import 'playback_controller.dart';
+
+/// The single [PlaybackController] the UI talks to, routing between the
+/// on-device engine and a cast receiver and presenting *one* unified
+/// [PlaybackState].
+///
+/// This is the seam that fixes cast desync: the now-playing screen, mini-player,
+/// and lyrics read only from here, never from `just_audio` or the cast SDK
+/// directly. It keeps a single source of truth by:
+///  - delegating the queue (current track, up-next, shuffle, repeat) to the
+///    local [LocalPlaybackController], which owns it regardless of output;
+///  - folding the receiver's position/play-state/duration onto that queue while
+///    casting, so the UI follows the *device* rather than the silenced engine;
+///  - routing transport commands (play/pause/seek) to whichever output is
+///    active, and queue commands (skip/playTracks) always to the local
+///    controller — whose track changes the cast service mirrors onto the
+///    receiver.
+///
+/// It owns the local-vs-cast switch too: when [CastState.isCasting] turns on it
+/// [LocalPlaybackController.suspend]s the engine; when it turns off it
+/// [LocalPlaybackController.resume]s **paused** at the receiver's last position,
+/// so ending a cast session (or a dropped one) never surprise-starts the phone.
+class ActivePlaybackController implements PlaybackController {
+  ActivePlaybackController({
+    required LocalPlaybackController local,
+    required CastService cast,
+  })  : _local = local,
+        _cast = cast {
+    _output = _cast.state.isCasting
+        ? ActivePlaybackOutput.cast
+        : ActivePlaybackOutput.local;
+    _castStatus = _cast.playbackStatus;
+    _lastEmitted = _merge();
+    _localSub = _local.stateStream.listen(_onLocalState);
+    _castStateSub = _cast.stateStream.listen(_onCastState);
+    _castPlaybackSub = _cast.playbackStream.listen(_onCastStatus);
+  }
+
+  final LocalPlaybackController _local;
+  final CastService _cast;
+
+  final StreamController<PlaybackState> _states =
+      StreamController<PlaybackState>.broadcast();
+  late StreamSubscription<PlaybackState> _localSub;
+  late StreamSubscription<CastState> _castStateSub;
+  late StreamSubscription<CastPlaybackStatus> _castPlaybackSub;
+
+  ActivePlaybackOutput _output = ActivePlaybackOutput.local;
+  CastPlaybackStatus _castStatus = CastPlaybackStatus.idle;
+
+  // Wall-clock anchor for the last cast status, so position can be interpolated
+  // smoothly between the receiver's (roughly once-a-second) status pushes.
+  DateTime? _castAnchoredAt;
+  Timer? _ticker;
+  bool _castWasCompleted = false;
+
+  late PlaybackState _lastEmitted;
+
+  /// Which output is producing sound right now. The UI reads this to show a
+  /// "Casting to …" affordance instead of a local source badge.
+  ActivePlaybackOutput get activeOutput => _output;
+
+  bool get _casting => _output == ActivePlaybackOutput.cast;
+
+  @override
+  PlaybackState get state => _merge();
+
+  @override
+  Stream<PlaybackState> get stateStream => _states.stream;
+
+  /// Folds the active output onto one state: the queue/track always come from
+  /// the local controller; while casting the playback fields come from the
+  /// receiver.
+  PlaybackState _merge() {
+    final PlaybackState base = _local.state;
+    if (!_casting) return base;
+    final Duration duration = _castStatus.duration > Duration.zero
+        ? _castStatus.duration
+        : (base.currentTrack?.duration ?? base.duration);
+    return base.copyWith(
+      status: _castStatus.status,
+      position: _interpolatedCastPosition(),
+      duration: duration,
+    );
+  }
+
+  /// The receiver's reported position, advanced by wall-clock time while it is
+  /// playing so progress (and lyrics) move smoothly between status pushes.
+  Duration _interpolatedCastPosition() {
+    if (_castStatus.status != PlaybackStatus.playing) {
+      return _castStatus.position;
+    }
+    final DateTime? anchor = _castAnchoredAt;
+    if (anchor == null) return _castStatus.position;
+    Duration position =
+        _castStatus.position + DateTime.now().difference(anchor);
+    final Duration duration = _castStatus.duration;
+    if (duration > Duration.zero && position > duration) position = duration;
+    return position;
+  }
+
+  void _emitMerged() {
+    final PlaybackState next = _merge();
+    if (next == _lastEmitted) return;
+    _lastEmitted = next;
+    if (!_states.isClosed) _states.add(next);
+  }
+
+  void _onLocalState(PlaybackState _) => _emitMerged();
+
+  void _onCastState(CastState state) {
+    final bool shouldCast = state.isCasting;
+    if (shouldCast && _output == ActivePlaybackOutput.local) {
+      // A handoff began: the receiver is the active output. Silence the engine
+      // so audio isn't heard twice; the queue stays owned locally.
+      _output = ActivePlaybackOutput.cast;
+      unawaited(_local.suspend());
+    } else if (!shouldCast && _output == ActivePlaybackOutput.cast) {
+      // The session ended (user disconnect or a dropped receiver). Return to the
+      // device at the receiver's last position, *paused*, so nothing
+      // surprise-starts; the user can press play to continue here.
+      final Duration resumeAt = _interpolatedCastPosition();
+      _output = ActivePlaybackOutput.local;
+      _castStatus = CastPlaybackStatus.idle;
+      _castAnchoredAt = null;
+      _castWasCompleted = false;
+      unawaited(_local.resume(at: resumeAt, play: false));
+    }
+    _syncTicker();
+    _emitMerged();
+  }
+
+  void _onCastStatus(CastPlaybackStatus status) {
+    _castStatus = status;
+    _castAnchoredAt = DateTime.now();
+    _handleCastCompletion(status);
+    _syncTicker();
+    if (_casting) _emitMerged();
+  }
+
+  /// When a cast track finishes, advance the queue the same way local playback
+  /// would: repeat-one replays on the receiver, repeat-all/off advance (wrapping
+  /// for repeat-all), and the cast service re-loads the new current track.
+  void _handleCastCompletion(CastPlaybackStatus status) {
+    final bool completed = status.status == PlaybackStatus.completed;
+    final bool wasCompleted = _castWasCompleted;
+    _castWasCompleted = completed;
+    if (!_casting || !completed || wasCompleted) return;
+
+    final PlaybackState local = _local.state;
+    switch (local.repeatMode) {
+      case RepeatMode.one:
+        unawaited(_cast.seek(Duration.zero).then((_) => _cast.play()));
+      case RepeatMode.all:
+        if (local.hasNext) {
+          unawaited(_local.skipToNext());
+        } else {
+          unawaited(_local.restartQueue());
+        }
+      case RepeatMode.off:
+        if (local.hasNext) unawaited(_local.skipToNext());
+    }
+  }
+
+  /// Runs a light ticker only while a cast track is actively playing, to push
+  /// interpolated position updates for smooth progress/lyrics.
+  void _syncTicker() {
+    final bool shouldTick =
+        _casting && _castStatus.status == PlaybackStatus.playing;
+    if (shouldTick && _ticker == null) {
+      _ticker = Timer.periodic(
+        const Duration(milliseconds: 250),
+        (_) => _emitMerged(),
+      );
+    } else if (!shouldTick && _ticker != null) {
+      _ticker!.cancel();
+      _ticker = null;
+    }
+  }
+
+  /// Re-syncs from the receiver when the app returns to the foreground while
+  /// casting. Never touches local playback.
+  void onAppResumed() {
+    if (_casting) unawaited(_cast.refresh());
+  }
+
+  // --- Transport commands route to the active output ----------------------
+
+  @override
+  Future<void> play() => _casting ? _cast.play() : _local.play();
+
+  @override
+  Future<void> pause() => _casting ? _cast.pause() : _local.pause();
+
+  @override
+  Future<void> seek(Duration position) =>
+      _casting ? _cast.seek(position) : _local.seek(position);
+
+  @override
+  Future<void> stop() => _local.stop();
+
+  // --- Queue commands always go to the local controller (the queue owner) --
+  // While casting it is suspended, so these update the current track/up-next
+  // without local audio; the cast service mirrors the change onto the receiver.
+
+  @override
+  Future<void> playTrack(Track track) => _local.playTrack(track);
+
+  @override
+  Future<void> playTracks(List<Track> tracks, {int startIndex = 0}) =>
+      _local.playTracks(tracks, startIndex: startIndex);
+
+  @override
+  void playNext(Track track) => _local.playNext(track);
+
+  @override
+  Future<void> skipToNext() => _local.skipToNext();
+
+  @override
+  Future<void> skipToPrevious() => _local.skipToPrevious();
+
+  @override
+  void clearQueue() => _local.clearQueue();
+
+  @override
+  void setShuffleEnabled(bool enabled) => _local.setShuffleEnabled(enabled);
+
+  @override
+  void setRepeatMode(RepeatMode mode) => _local.setRepeatMode(mode);
+
+  @override
+  Future<void> dispose() async {
+    _ticker?.cancel();
+    _ticker = null;
+    await _localSub.cancel();
+    await _castStateSub.cancel();
+    await _castPlaybackSub.cancel();
+    await _states.close();
+    // The local controller and cast service are owned by their own providers,
+    // which dispose them; this controller only owns its own subscriptions.
+  }
+}

--- a/lib/core/services/cast/cast_service.dart
+++ b/lib/core/services/cast/cast_service.dart
@@ -1,3 +1,4 @@
+import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 
 /// The only cast contract the UI knows about, mirroring how [PlaybackController]
@@ -19,6 +20,13 @@ abstract interface class CastService {
   /// The latest known state, for synchronous reads on first build.
   CastState get state;
 
+  /// Position/play-state of the active receiver, for the unified playback state
+  /// to follow while casting. Emits [CastPlaybackStatus.idle] when not casting.
+  Stream<CastPlaybackStatus> get playbackStream;
+
+  /// The latest known cast playback status, for synchronous reads.
+  CastPlaybackStatus get playbackStatus;
+
   /// Begins scanning for nearby cast targets. A no-op when casting is
   /// unavailable.
   Future<void> startDiscovery();
@@ -31,6 +39,19 @@ abstract interface class CastService {
 
   /// Tears down the current session and returns playback to this device.
   Future<void> disconnect();
+
+  /// Resumes playback on the receiver. A no-op when not casting.
+  Future<void> play();
+
+  /// Pauses playback on the receiver. A no-op when not casting.
+  Future<void> pause();
+
+  /// Seeks the receiver to [position]. A no-op when not casting.
+  Future<void> seek(Duration position);
+
+  /// Asks the receiver for a fresh status, to re-sync position (e.g. when the
+  /// app returns from the background). A no-op when not casting.
+  Future<void> refresh();
 
   /// Releases any resources/listeners. Call on app shutdown.
   Future<void> dispose();

--- a/lib/core/services/cast/cast_transport.dart
+++ b/lib/core/services/cast/cast_transport.dart
@@ -1,4 +1,5 @@
 import '../../models/cast_media.dart';
+import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 
 /// The low-level cast plumbing [DefaultCastService] drives, isolated behind an
@@ -28,9 +29,29 @@ abstract interface class CastSessionHandle {
   /// ready to accept [loadMedia], and `false`/closes if the session ends.
   Stream<bool> get readyStream;
 
+  /// Position/play-state updates parsed from the receiver's media status, so the
+  /// app can mirror the device (and follow its position for lyrics) instead of
+  /// the silenced local engine while casting. Carries no track identity, URL, or
+  /// token.
+  Stream<CastPlaybackStatus> get statusStream;
+
   /// Tells the receiver to fetch and play [media]. Only valid once the session
   /// is ready.
   Future<void> loadMedia(CastMedia media);
+
+  /// Resumes playback on the receiver.
+  Future<void> play();
+
+  /// Pauses playback on the receiver.
+  Future<void> pause();
+
+  /// Seeks the receiver to [position].
+  Future<void> seek(Duration position);
+
+  /// Asks the receiver for a fresh media status (used to re-sync position, e.g.
+  /// after the app returns from the background). Best-effort; a no-op when no
+  /// media is loaded.
+  Future<void> requestStatus();
 
   /// Tears the session down and returns control to this device.
   Future<void> close();

--- a/lib/core/services/cast/chromecast_cast_transport.dart
+++ b/lib/core/services/cast/chromecast_cast_transport.dart
@@ -3,7 +3,9 @@ import 'dart:async';
 import 'package:cast/cast.dart' as cast;
 
 import '../../models/cast_media.dart';
+import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
+import '../../models/playback_state.dart';
 import 'cast_transport.dart';
 
 /// The one place the `cast` package is touched. It implements [CastTransport]
@@ -64,7 +66,15 @@ class _ChromecastSessionHandle implements CastSessionHandle {
           _ready.add(false);
           _ready.close();
         }
+        _stopPolling();
       },
+      cancelOnError: false,
+    );
+    // Listen for the receiver's media status so we can mirror its position and
+    // play state back to the app while casting.
+    _messageSub = _session.messageStream.listen(
+      _onMessage,
+      onError: (_) {},
       cancelOnError: false,
     );
     // Launch the default media receiver; the device replies with a receiver
@@ -77,8 +87,19 @@ class _ChromecastSessionHandle implements CastSessionHandle {
 
   final cast.CastSession _session;
   final StreamController<bool> _ready = StreamController<bool>.broadcast();
+  final StreamController<CastPlaybackStatus> _status =
+      StreamController<CastPlaybackStatus>.broadcast();
   StreamSubscription<cast.CastSessionState>? _stateSub;
+  StreamSubscription<Map<String, dynamic>>? _messageSub;
+  Timer? _poll;
   bool? _last;
+
+  // The receiver's media session id, learned from the first MEDIA_STATUS and
+  // required to address PLAY/PAUSE/SEEK at the loaded media. Duration is carried
+  // forward because not every MEDIA_STATUS repeats it.
+  int? _mediaSessionId;
+  Duration _lastDuration = Duration.zero;
+  int _requestId = 1;
 
   @override
   Stream<bool> get readyStream async* {
@@ -90,9 +111,13 @@ class _ChromecastSessionHandle implements CastSessionHandle {
   }
 
   @override
+  Stream<CastPlaybackStatus> get statusStream => _status.stream;
+
+  @override
   Future<void> loadMedia(CastMedia media) async {
     _session.sendMessage(cast.CastSession.kNamespaceMedia, <String, dynamic>{
       'type': 'LOAD',
+      'requestId': _requestId++,
       'autoplay': true,
       'currentTime': 0,
       'media': <String, dynamic>{
@@ -111,13 +136,126 @@ class _ChromecastSessionHandle implements CastSessionHandle {
         },
       },
     });
+    // Keep position fresh between the receiver's spontaneous status pushes by
+    // polling its media status once a second.
+    _startPolling();
+  }
+
+  @override
+  Future<void> play() async => _mediaCommand('PLAY');
+
+  @override
+  Future<void> pause() async => _mediaCommand('PAUSE');
+
+  @override
+  Future<void> seek(Duration position) async {
+    final int? id = _mediaSessionId;
+    if (id == null) return;
+    _session.sendMessage(cast.CastSession.kNamespaceMedia, <String, dynamic>{
+      'type': 'SEEK',
+      'requestId': _requestId++,
+      'mediaSessionId': id,
+      'currentTime': position.inMilliseconds / 1000.0,
+    });
+  }
+
+  @override
+  Future<void> requestStatus() async {
+    if (_mediaSessionId == null) return;
+    _session.sendMessage(cast.CastSession.kNamespaceMedia, <String, dynamic>{
+      'type': 'GET_STATUS',
+      'requestId': _requestId++,
+      'mediaSessionId': _mediaSessionId,
+    });
+  }
+
+  void _mediaCommand(String type) {
+    final int? id = _mediaSessionId;
+    if (id == null) return;
+    _session.sendMessage(cast.CastSession.kNamespaceMedia, <String, dynamic>{
+      'type': type,
+      'requestId': _requestId++,
+      'mediaSessionId': id,
+    });
+  }
+
+  void _startPolling() {
+    _poll ??= Timer.periodic(
+      const Duration(seconds: 1),
+      (_) => unawaited(requestStatus()),
+    );
+  }
+
+  void _stopPolling() {
+    _poll?.cancel();
+    _poll = null;
+  }
+
+  /// Parses a receiver `MEDIA_STATUS` payload into a [CastPlaybackStatus] and
+  /// forwards it. Other message types (receiver status, etc.) are ignored.
+  void _onMessage(Map<String, dynamic> payload) {
+    if (payload['type'] != 'MEDIA_STATUS') return;
+    final Object? list = payload['status'];
+    if (list is! List || list.isEmpty) return;
+    final Object? first = list.first;
+    if (first is! Map) return;
+
+    final Object? sessionId = first['mediaSessionId'];
+    if (sessionId is int) _mediaSessionId = sessionId;
+
+    final Object? media = first['media'];
+    if (media is Map) {
+      final num? d = media['duration'] as num?;
+      if (d != null && d > 0) _lastDuration = _secondsToDuration(d);
+    }
+
+    final num? currentTime = first['currentTime'] as num?;
+    final Duration position =
+        currentTime != null ? _secondsToDuration(currentTime) : Duration.zero;
+
+    final status = CastPlaybackStatus(
+      status: _statusFor(
+        first['playerState'] as String?,
+        first['idleReason'] as String?,
+      ),
+      position: position,
+      duration: _lastDuration,
+    );
+    if (!_status.isClosed) _status.add(status);
+  }
+
+  static Duration _secondsToDuration(num seconds) =>
+      Duration(milliseconds: (seconds * 1000).round());
+
+  /// Maps the receiver's `playerState` (with `idleReason` for IDLE) onto the
+  /// app's [PlaybackStatus].
+  static PlaybackStatus _statusFor(String? playerState, String? idleReason) {
+    switch (playerState) {
+      case 'PLAYING':
+        return PlaybackStatus.playing;
+      case 'PAUSED':
+        return PlaybackStatus.paused;
+      case 'BUFFERING':
+      case 'LOADING':
+        return PlaybackStatus.loading;
+      case 'IDLE':
+        return idleReason == 'FINISHED'
+            ? PlaybackStatus.completed
+            : PlaybackStatus.idle;
+      default:
+        return PlaybackStatus.idle;
+    }
   }
 
   @override
   Future<void> close() async {
+    _stopPolling();
     await _stateSub?.cancel();
     _stateSub = null;
+    await _messageSub?.cancel();
+    _messageSub = null;
     if (!_ready.isClosed) await _ready.close();
+    if (!_status.isClosed) await _status.close();
     await cast.CastSessionManager().endSession(_session.sessionId);
   }
 }

--- a/lib/core/services/cast/default_cast_service.dart
+++ b/lib/core/services/cast/default_cast_service.dart
@@ -1,49 +1,55 @@
 import 'dart:async';
 
 import '../../models/cast_media.dart';
+import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
+import '../../models/playback_state.dart';
 import '../../models/track.dart';
 import 'cast_media_resolver.dart';
 import 'cast_service.dart';
 import 'cast_transport.dart';
 
-/// The real [CastService]: it owns cast *state* and the playback *handoff*,
-/// delegating only the network-touching plumbing (discovery, the cast session)
-/// to a [CastTransport]. That split is deliberate — every decision this class
-/// makes is unit-tested with a fake transport, while the one untestable adapter
+/// The real [CastService]: it owns cast *state*, the playback *handoff*, and the
+/// receiver's reported playback status, delegating only the network-touching
+/// plumbing (discovery, the cast session, transport commands) to a
+/// [CastTransport]. That split is deliberate — every decision this class makes
+/// is unit-tested with a fake transport, while the one untestable adapter
 /// ([ChromecastCastTransport]) stays thin.
 ///
-/// Handoff model (kept simple on purpose, since transport controls aren't yet
-/// routed to the receiver):
+/// Handoff model:
 ///  - On connect, and whenever the playing track changes while connected, it
 ///    resolves the current track to a reachable URL *at that moment* via
-///    [CastMediaResolver] and asks the receiver to play it, then pauses local
-///    playback so audio isn't heard twice.
+///    [CastMediaResolver] and asks the receiver to play it. On success it marks
+///    [CastState.isCasting] true; the `ActivePlaybackController` watches that to
+///    silence the local engine so audio isn't heard twice.
 ///  - A track with no castable URL (an on-device file) is reported as a clear,
-///    non-fatal limitation in [CastState.message]; local playback is left
-///    untouched.
-///  - On disconnect (or if the receiver drops the session) local playback
-///    resumes, so the device recovers exactly where casting left off.
+///    non-fatal limitation in [CastState.message] with [CastState.isCasting]
+///    false, so local playback is left untouched.
+///  - While casting it forwards the receiver's media status out on
+///    [playbackStream] (position / play-state / duration) and routes
+///    play/pause/seek/refresh to the session.
+///
+/// It no longer pauses or resumes the local engine itself: that decision belongs
+/// to the [ActivePlaybackController], which reacts to [CastState.isCasting]. In
+/// particular it never auto-starts local playback when a session ends — the
+/// device returns to a paused, in-sync state instead of surprise-playing.
 ///
 /// Security: the resolved URL — which may embed a Jellyfin token — lives only on
 /// the [CastMedia] passed to the transport for this one load. It is never
-/// logged, never written to [CastState], and never persisted.
+/// logged, never written to [CastState] or [CastPlaybackStatus], and never
+/// persisted.
 class DefaultCastService implements CastService {
   DefaultCastService({
     required CastTransport transport,
     required CastMediaResolver mediaResolver,
     required Track? Function() currentTrack,
     required Stream<Track?> trackChanges,
-    Future<void> Function()? onCastingStarted,
-    Future<void> Function()? onCastingStopped,
     Duration discoveryTimeout = const Duration(seconds: 5),
     Duration connectTimeout = const Duration(seconds: 12),
   })  : _transport = transport,
         _mediaResolver = mediaResolver,
         _currentTrack = currentTrack,
         _trackChanges = trackChanges,
-        _onCastingStarted = onCastingStarted,
-        _onCastingStopped = onCastingStopped,
         _discoveryTimeout = discoveryTimeout,
         _connectTimeout = connectTimeout;
 
@@ -55,26 +61,24 @@ class DefaultCastService implements CastService {
   final CastMediaResolver _mediaResolver;
   final Track? Function() _currentTrack;
   final Stream<Track?> _trackChanges;
-  final Future<void> Function()? _onCastingStarted;
-  final Future<void> Function()? _onCastingStopped;
   final Duration _discoveryTimeout;
   final Duration _connectTimeout;
 
   final StreamController<CastState> _states =
       StreamController<CastState>.broadcast();
+  final StreamController<CastPlaybackStatus> _playback =
+      StreamController<CastPlaybackStatus>.broadcast();
 
   // A real backend is present, so the starting point is idle (ready, nothing
   // discovered yet) rather than unavailable.
   CastState _state = const CastState(availability: CastAvailability.idle);
+  CastPlaybackStatus _playbackStatus = CastPlaybackStatus.idle;
 
   CastSessionHandle? _handle;
   StreamSubscription<bool>? _readySub;
+  StreamSubscription<CastPlaybackStatus>? _statusSub;
   StreamSubscription<Track?>? _trackSub;
   bool _discovering = false;
-
-  // Set only while local playback has been paused for an active handoff, so
-  // disconnect resumes it exactly once and only when it was actually paused.
-  bool _handedOff = false;
 
   @override
   CastState get state => _state;
@@ -82,10 +86,21 @@ class DefaultCastService implements CastService {
   @override
   Stream<CastState> get stateStream => _states.stream;
 
+  @override
+  CastPlaybackStatus get playbackStatus => _playbackStatus;
+
+  @override
+  Stream<CastPlaybackStatus> get playbackStream => _playback.stream;
+
   void _emit(CastState next) {
     if (next == _state) return;
     _state = next;
     if (!_states.isClosed) _states.add(next);
+  }
+
+  void _emitPlayback(CastPlaybackStatus next) {
+    _playbackStatus = next;
+    if (!_playback.isClosed) _playback.add(next);
   }
 
   @override
@@ -129,7 +144,7 @@ class DefaultCastService implements CastService {
   @override
   Future<void> connect(CastDevice device) async {
     // Tear down any prior session first so we never leak one.
-    await _teardownSession(resumeLocal: false);
+    await _teardownSession();
     _emit(CastState(
       availability: CastAvailability.connecting,
       devices: _state.devices,
@@ -170,19 +185,27 @@ class DefaultCastService implements CastService {
       onDone: _onSessionLost,
       cancelOnError: false,
     );
+    // Mirror the receiver's media status out for the unified playback state.
+    _statusSub = handle.statusStream.listen(
+      _emitPlayback,
+      onError: (_) {},
+      cancelOnError: false,
+    );
     // Cast the current track now, and re-cast whenever it changes.
     _trackSub = _trackChanges.listen((Track? track) => _handOff(device, track));
     await _handOff(device, _currentTrack());
   }
 
-  /// Resolves [track] to castable media and hands it to the receiver, pausing
-  /// local playback on success. A non-castable (on-device) track is surfaced as
-  /// a clear limitation without disturbing local playback.
+  /// Resolves [track] to castable media and hands it to the receiver. On success
+  /// it marks [CastState.isCasting] true so the engine can be silenced. A
+  /// non-castable (on-device) track is surfaced as a clear limitation without
+  /// claiming a handoff.
   Future<void> _handOff(CastDevice device, Track? track) async {
     final CastSessionHandle? handle = _handle;
     if (handle == null) return; // disconnected mid-flight
 
     if (track == null) {
+      _emitPlayback(CastPlaybackStatus.idle);
       _emit(CastState(
         availability: CastAvailability.connected,
         devices: _state.devices,
@@ -192,6 +215,7 @@ class DefaultCastService implements CastService {
     }
 
     if (!_mediaResolver.canCast(track)) {
+      _emitPlayback(CastPlaybackStatus.idle);
       _emit(CastState(
         availability: CastAvailability.connected,
         devices: _state.devices,
@@ -205,6 +229,7 @@ class DefaultCastService implements CastService {
     try {
       media = await _mediaResolver.resolve(track);
     } on CastMediaException catch (error) {
+      _emitPlayback(CastPlaybackStatus.idle);
       _emit(CastState(
         availability: CastAvailability.connected,
         devices: _state.devices,
@@ -213,6 +238,7 @@ class DefaultCastService implements CastService {
       ));
       return;
     } catch (_) {
+      _emitPlayback(CastPlaybackStatus.idle);
       _emit(CastState(
         availability: CastAvailability.connected,
         devices: _state.devices,
@@ -228,6 +254,7 @@ class DefaultCastService implements CastService {
     try {
       await handle.loadMedia(media);
     } catch (_) {
+      _emitPlayback(CastPlaybackStatus.idle);
       _emit(CastState(
         availability: CastAvailability.connected,
         devices: _state.devices,
@@ -237,33 +264,48 @@ class DefaultCastService implements CastService {
       return;
     }
 
-    // Playing on the receiver now: silence the local engine so audio isn't
-    // heard twice, and remember to resume it on disconnect.
-    if (!_handedOff) {
-      _handedOff = true;
-      await _onCastingStarted?.call();
+    // Playing on the receiver now. Marking isCasting true is the signal the
+    // ActivePlaybackController uses to silence the local engine; we report a
+    // loading status until the receiver's first MEDIA_STATUS arrives.
+    if (!_playbackStatus.isPlaying) {
+      _emitPlayback(_playbackStatus.copyWith(status: PlaybackStatus.loading));
     }
     _emit(CastState(
       availability: CastAvailability.connected,
       devices: _state.devices,
       connectedDevice: device,
+      isCasting: true,
     ));
   }
 
   @override
   Future<void> disconnect() async {
-    await _teardownSession(resumeLocal: true);
+    await _teardownSession();
     _emit(CastState(
       availability: CastAvailability.idle,
       devices: _state.devices,
     ));
   }
 
-  /// The receiver ended the session on its own (closed, network drop). Recover
-  /// to local playback and reflect that we're no longer connected.
+  @override
+  Future<void> play() async => _handle?.play();
+
+  @override
+  Future<void> pause() async => _handle?.pause();
+
+  @override
+  Future<void> seek(Duration position) async => _handle?.seek(position);
+
+  @override
+  Future<void> refresh() async => _handle?.requestStatus();
+
+  /// The receiver ended the session on its own (closed, network drop). Reflect
+  /// that we're no longer connected; the [ActivePlaybackController] reacts to
+  /// the dropped [CastState.isCasting] and returns to a paused local state
+  /// (never surprise-starting playback).
   void _onSessionLost() {
     if (_handle == null) return;
-    unawaited(_teardownSession(resumeLocal: true).then((_) {
+    unawaited(_teardownSession().then((_) {
       _emit(CastState(
         availability: CastAvailability.idle,
         devices: _state.devices,
@@ -271,20 +313,19 @@ class DefaultCastService implements CastService {
     }));
   }
 
-  /// Cancels the session listeners, closes the handle, and resumes local
-  /// playback if we had paused it for casting.
-  Future<void> _teardownSession({required bool resumeLocal}) async {
+  /// Cancels the session listeners, closes the handle, and resets the reported
+  /// playback status to idle.
+  Future<void> _teardownSession() async {
     await _readySub?.cancel();
     _readySub = null;
+    await _statusSub?.cancel();
+    _statusSub = null;
     await _trackSub?.cancel();
     _trackSub = null;
     final CastSessionHandle? handle = _handle;
     _handle = null;
     if (handle != null) await _safeClose(handle);
-    if (resumeLocal && _handedOff) {
-      await _onCastingStopped?.call();
-    }
-    _handedOff = false;
+    _emitPlayback(CastPlaybackStatus.idle);
   }
 
   Future<void> _safeClose(CastSessionHandle handle) async {
@@ -297,7 +338,8 @@ class DefaultCastService implements CastService {
 
   @override
   Future<void> dispose() async {
-    await _teardownSession(resumeLocal: false);
+    await _teardownSession();
     await _states.close();
+    await _playback.close();
   }
 }

--- a/lib/core/services/cast/unavailable_cast_service.dart
+++ b/lib/core/services/cast/unavailable_cast_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 import 'cast_service.dart';
 
@@ -22,6 +23,13 @@ class UnavailableCastService implements CastService {
       Stream<CastState>.value(state).asBroadcastStream();
 
   @override
+  CastPlaybackStatus get playbackStatus => CastPlaybackStatus.idle;
+
+  @override
+  Stream<CastPlaybackStatus> get playbackStream =>
+      const Stream<CastPlaybackStatus>.empty();
+
+  @override
   Future<void> startDiscovery() async {}
 
   @override
@@ -32,6 +40,18 @@ class UnavailableCastService implements CastService {
 
   @override
   Future<void> disconnect() async {}
+
+  @override
+  Future<void> play() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> seek(Duration position) async {}
+
+  @override
+  Future<void> refresh() async {}
 
   @override
   Future<void> dispose() async {

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -9,6 +9,7 @@ import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
 import '../models/track.dart';
 import 'local_playable_uri_resolver.dart';
+import 'local_playback_controller.dart';
 import 'playable_uri_resolver.dart';
 import 'playback_controller.dart';
 
@@ -25,7 +26,7 @@ import 'playback_controller.dart';
 /// (Jellyfin) streams all play through the same path. The default resolver
 /// handles only on-device tracks; remote resolution is composed in at the
 /// provider layer, keeping this class free of any source-specific knowledge.
-class JustAudioPlaybackController implements PlaybackController {
+class JustAudioPlaybackController implements LocalPlaybackController {
   JustAudioPlaybackController({
     AudioPlayer? player,
     PlayableUriResolver resolver = const LocalPlayableUriResolver(),
@@ -47,6 +48,11 @@ class JustAudioPlaybackController implements PlaybackController {
   PlaybackState _state = PlaybackState.idle;
   PlaybackQueue _queue = PlaybackQueue.empty;
 
+  // When true a cast receiver is the active output, so queue changes update the
+  // current track/up-next but never load or play through the engine. Set/cleared
+  // by [suspend]/[resume], driven by the ActivePlaybackController.
+  bool _suspended = false;
+
   // Shuffle and repeat are session-wide playback modes owned here (not by the
   // engine, which only ever has one source loaded at a time). They persist
   // across track changes and are mirrored onto every emitted state.
@@ -61,6 +67,10 @@ class JustAudioPlaybackController implements PlaybackController {
 
   void _wire() {
     _subscriptions.add(_player.playerStateStream.listen((playerState) {
+      // While suspended a cast receiver owns playback; ignore the (paused) local
+      // engine's events entirely, so it can never auto-advance or report stale
+      // status underneath the cast session.
+      if (_suspended) return;
       final status = _statusFor(playerState);
       // When a track finishes, what happens next depends on the repeat mode.
       if (status == PlaybackStatus.completed) {
@@ -70,9 +80,11 @@ class JustAudioPlaybackController implements PlaybackController {
       _emit(_state.copyWith(status: status));
     }));
     _subscriptions.add(_player.positionStream.listen((position) {
+      if (_suspended) return;
       _emit(_state.copyWith(position: position));
     }));
     _subscriptions.add(_player.durationStream.listen((duration) {
+      if (_suspended) return;
       if (duration != null) _emit(_state.copyWith(duration: duration));
     }));
   }
@@ -197,9 +209,30 @@ class JustAudioPlaybackController implements PlaybackController {
   /// [PlayableUriResolver]. A resolution failure carries its own friendly,
   /// secret-free message; a load failure after a successful resolve falls back
   /// to a generic one.
-  Future<void> _playCurrent() async {
+  Future<void> _playCurrent({
+    Duration startAt = Duration.zero,
+    bool autoplay = true,
+  }) async {
     final track = _queue.current;
     if (track == null) return;
+
+    if (_suspended) {
+      // A cast receiver owns the audio. Reflect only the queue/track so the UI
+      // shows what is playing; the ActivePlaybackController overrides
+      // status/position/duration from the cast session. No URI resolve (no need
+      // to mint a local stream URL) and no engine work, so the phone stays
+      // silent and the local and cast outputs never fight.
+      _emit(PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: track,
+        upNext: _queue.upNext,
+        hasPrevious: _queue.hasPrevious,
+        shuffleEnabled: _shuffleEnabled,
+        repeatMode: _repeatMode,
+      ));
+      return;
+    }
+
     // Reset position/duration up front so the UI doesn't show the previous
     // track's progress while the new one loads.
     final loading = PlaybackState(
@@ -237,8 +270,11 @@ class JustAudioPlaybackController implements PlaybackController {
       // is turned into an authenticated stream URL (or a friendly error) before
       // it ever reaches here.
       await _player.setUrl(resolved.uri.toString());
+      // Resuming on this device after casting picks up where the receiver left
+      // off, paused unless asked to play.
+      if (startAt > Duration.zero) await _player.seek(startAt);
       // play()'s future completes when playback ends, so we don't await it.
-      unawaited(_player.play());
+      if (autoplay) unawaited(_player.play());
     } catch (_) {
       // The URL resolved and (for streams) probed OK, so a failure here is the
       // engine itself. Word it for the source the listener can see on the badge.
@@ -269,7 +305,37 @@ class JustAudioPlaybackController implements PlaybackController {
   }
 
   @override
+  bool get isSuspended => _suspended;
+
+  @override
+  Future<void> suspend() async {
+    if (_suspended) return;
+    _suspended = true;
+    // Silence the engine but keep the loaded source and queue intact, so a
+    // later resume can pick up the same track instantly when nothing changed.
+    await _player.pause();
+  }
+
+  @override
+  Future<void> resume({Duration at = Duration.zero, bool play = false}) async {
+    _suspended = false;
+    // The current track may have changed during casting (skips re-cast onto the
+    // receiver), so (re)load whatever is current rather than trusting the
+    // engine's last-loaded source.
+    await _playCurrent(startAt: at, autoplay: play);
+  }
+
+  @override
+  Future<void> restartQueue() async {
+    _queue = _queue.restarted();
+    await _playCurrent();
+  }
+
+  @override
   Future<void> play() async {
+    // A cast receiver owns playback while suspended; never start local audio
+    // underneath it.
+    if (_suspended) return;
     // play()'s future completes when playback ends, so we don't await it.
     unawaited(_player.play());
   }
@@ -291,7 +357,10 @@ class JustAudioPlaybackController implements PlaybackController {
   }
 
   @override
-  Future<void> seek(Duration position) => _player.seek(position);
+  Future<void> seek(Duration position) async {
+    if (_suspended) return;
+    return _player.seek(position);
+  }
 
   @override
   Future<void> dispose() async {

--- a/lib/core/services/local_playback_controller.dart
+++ b/lib/core/services/local_playback_controller.dart
@@ -1,0 +1,28 @@
+import 'playback_controller.dart';
+
+/// A [PlaybackController] that owns an on-device audio engine and can be
+/// *suspended* so an external output (a cast receiver) becomes the only thing
+/// making sound.
+///
+/// The `ActivePlaybackController` drives this: when a cast handoff begins it
+/// calls [suspend] so the local engine goes silent while still owning the queue
+/// (skips/`playTracks` keep updating the current track and up-next, which the
+/// cast service mirrors onto the receiver — without any local audio). When
+/// casting ends it calls [resume] to load the current track at the receiver's
+/// last position, *paused by default* so the device never surprise-starts.
+abstract interface class LocalPlaybackController implements PlaybackController {
+  /// Whether the engine is currently suspended (a cast output is active).
+  bool get isSuspended;
+
+  /// Silences and pauses the local engine, leaving the queue intact. Idempotent.
+  Future<void> suspend();
+
+  /// Resumes local output: loads the current track, seeks to [at], and either
+  /// starts playing or stays paused per [play] (paused by default, so ending a
+  /// cast session never auto-starts the phone). Clears the suspended flag.
+  Future<void> resume({Duration at = Duration.zero, bool play = false});
+
+  /// Wraps the queue back to its first track and (re)loads it. Used to honour
+  /// repeat-all when a cast track finishes at the end of the queue.
+  Future<void> restartQueue();
+}

--- a/lib/features/player/cast/cast_providers.dart
+++ b/lib/features/player/cast/cast_providers.dart
@@ -40,9 +40,13 @@ final castMediaResolverProvider = Provider<CastMediaResolver>((ref) {
 /// Production binding: the real Chromecast backend, applied in `main`.
 ///
 /// It wires [DefaultCastService] to the live [ChromecastCastTransport] and to
-/// the playback controller — reading the current track, mirroring track
-/// changes, and pausing/resuming local playback around a handoff. Only Android
-/// and iOS get it; every other platform keeps the unavailable default so the
+/// the local engine — reading the current track and mirroring track changes
+/// onto the receiver. It does *not* pause or resume local playback itself: the
+/// `ActivePlaybackController` owns that, suspending the engine on handoff and
+/// resuming it paused when a session ends, so casting never surprise-starts the
+/// phone. Reading [localPlaybackControllerProvider] (the queue owner) rather
+/// than the routing controller keeps the dependency graph acyclic. Only Android
+/// and iOS get this; every other platform keeps the unavailable default so the
 /// app never claims a cast ability the platform lacks. Tests don't apply this,
 /// so they keep the inert default unless they override the service themselves.
 final chromecastCastServiceOverride = castServiceProvider.overrideWith((ref) {
@@ -54,16 +58,12 @@ final chromecastCastServiceOverride = castServiceProvider.overrideWith((ref) {
     return fallback;
   }
 
-  final controller = ref.read(playbackControllerProvider);
+  final local = ref.read(localPlaybackControllerProvider);
   final service = DefaultCastService(
     transport: ChromecastCastTransport(),
     mediaResolver: ref.read(castMediaResolverProvider),
-    currentTrack: () => controller.state.currentTrack,
-    trackChanges: controller.stateStream.map((s) => s.currentTrack).distinct(),
-    // Silence the local engine while the receiver plays, and resume it when
-    // casting ends, so the device recovers where it left off.
-    onCastingStarted: () => controller.pause(),
-    onCastingStopped: () => controller.play(),
+    currentTrack: () => local.state.currentTrack,
+    trackChanges: local.stateStream.map((s) => s.currentTrack).distinct(),
   );
   ref.onDispose(service.dispose);
   return service;

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -7,6 +7,7 @@ import '../../app/dimens.dart';
 import '../../app/routes.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/services/playback_controller.dart';
+import 'cast/cast_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
 
@@ -37,6 +38,9 @@ class MiniPlayer extends ConsumerWidget {
 
     final theme = Theme.of(context);
     final track = state.currentTrack!;
+    final bool isCasting = ref.watch(
+      castStateProvider.select((s) => s.valueOrNull?.isConnected ?? false),
+    );
     final subtitle = _subtitle(state);
 
     return Material(
@@ -92,6 +96,14 @@ class MiniPlayer extends ConsumerWidget {
                           ],
                         ),
                       ),
+                      if (isCasting) ...[
+                        Icon(
+                          Icons.cast_connected,
+                          size: 18,
+                          color: theme.colorScheme.primary,
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                      ],
                       const SizedBox(width: AppSpacing.sm),
                       _PlayPauseButton(state: state, controller: controller),
                     ],

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/playback_state.dart';
+import '../../core/services/active_playback_controller.dart';
 import '../../core/services/just_audio_playback_controller.dart';
 import '../../core/services/local_playable_uri_resolver.dart';
+import '../../core/services/local_playback_controller.dart';
 import '../../core/services/offline_first_playable_uri_resolver.dart';
 import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_controller.dart';
@@ -13,6 +15,7 @@ import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import 'cast/cast_providers.dart';
 
 /// Composes the [PlayableUriResolver] the controller resolves tracks through.
 ///
@@ -40,26 +43,42 @@ final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
   );
 });
 
-/// The single [PlaybackController] the app drives playback through.
+/// The on-device audio engine: the `just_audio`-backed [LocalPlaybackController]
+/// that owns the queue (current track, up-next, shuffle, repeat) regardless of
+/// which output is making sound.
 ///
-/// Defaults to the `just_audio`-backed implementation, wired with the routing
-/// resolver above. Tests override it with a fake so playback can be exercised
-/// without the audio plugin. Disposed with the provider scope (i.e. on app
-/// shutdown) so native resources are released.
-///
-/// Lifecycle: this is pinned for the whole app session. It reads its resolver
-/// once with [Ref.read] rather than [Ref.watch], so a rebuild of the resolver,
-/// the offline-cache locator, or the download stores can never tear the
-/// controller down. That matters because the live `AudioPlayer` and the
-/// `audio_service` media session are both bound to *this* instance: recreating
-/// it mid-playback would dispose the player (cutting the music) and leave the
-/// notification mirroring a dead controller. Navigating between tabs and
-/// changing settings touch none of that, so playback survives them. The
-/// resolver still reads the live signed-in Jellyfin source lazily at play time,
-/// so sign-in/out is picked up without rebuilding the controller.
-final playbackControllerProvider = Provider<PlaybackController>((ref) {
+/// Lifecycle: pinned for the whole app session. It reads its resolver once with
+/// [Ref.read] rather than [Ref.watch], so a rebuild of the resolver, the
+/// offline-cache locator, or the download stores can never tear it down — which
+/// would dispose the live `AudioPlayer` and cut the music. The resolver still
+/// reads the live signed-in Jellyfin source lazily at play time, so sign-in/out
+/// is picked up without rebuilding the engine.
+final localPlaybackControllerProvider =
+    Provider<LocalPlaybackController>((ref) {
   final controller = JustAudioPlaybackController(
     resolver: ref.read(playableUriResolverProvider),
+  );
+  ref.onDispose(controller.dispose);
+  return controller;
+});
+
+/// The single [PlaybackController] the UI drives playback through, routing
+/// between the local engine and a cast receiver and exposing one unified
+/// [PlaybackState].
+///
+/// The UI depends only on this — never on `just_audio` or the cast SDK — so when
+/// casting is active the now-playing screen, mini-player, and lyrics follow the
+/// receiver (position, play-state, duration) while transport commands go to the
+/// device that is actually playing. It owns the local↔cast switch, suspending
+/// the engine on handoff and resuming it *paused* when a session ends, so the
+/// phone never surprise-starts. Tests override it with a fake so playback can be
+/// exercised without the audio plugin. Pinned for the session and disposed with
+/// the scope (its subscriptions only; the engine and cast service are disposed
+/// by their own providers).
+final playbackControllerProvider = Provider<PlaybackController>((ref) {
+  final controller = ActivePlaybackController(
+    local: ref.read(localPlaybackControllerProvider),
+    cast: ref.read(castServiceProvider),
   );
   ref.onDispose(controller.dispose);
   return controller;

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -6,6 +6,7 @@ import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
 import 'cast/cast_button.dart';
+import 'cast/cast_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
 import 'widgets/now_playing_actions.dart';
@@ -168,17 +169,30 @@ class _NowPlaying extends ConsumerWidget {
   }
 }
 
-/// Under the metadata: a friendly error message when playback failed, otherwise
-/// the playback-source badge (LOCAL FILE / STREAMING DIRECT / OFFLINE CACHE)
-/// once a track has resolved. Shows nothing while a track is still loading.
-class _SourceOrError extends StatelessWidget {
+/// Under the metadata: while casting, a clear `Casting to …` indicator;
+/// otherwise a friendly error message when playback failed, or the
+/// playback-source badge (LOCAL FILE / STREAMING DIRECT / OFFLINE CACHE) once a
+/// track has resolved. Shows nothing while a track is still loading locally.
+class _SourceOrError extends ConsumerWidget {
   const _SourceOrError({required this.state});
 
   final PlaybackState state;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+
+    // While casting, the source badge would be misleading (the receiver, not
+    // this device, is playing); show where the audio is going instead.
+    final castState = ref.watch(
+      castStateProvider.select((s) => s.valueOrNull),
+    );
+    final service = ref.watch(castServiceProvider);
+    final cast = castState ?? service.state;
+    if (cast.isConnected && cast.connectedDevice != null) {
+      return _CastingIndicator(deviceName: cast.connectedDevice!.name);
+    }
+
     if (state.status == PlaybackStatus.error) {
       return Text(
         state.errorMessage ?? "Couldn't play this track",
@@ -193,5 +207,42 @@ class _SourceOrError extends StatelessWidget {
       return const SizedBox(height: 28);
     }
     return PlaybackSourceChip(source: source);
+  }
+}
+
+/// A small, on-brand `Casting to …` chip shown on Now Playing while a cast
+/// session is connected, so it's obvious the phone is a remote.
+class _CastingIndicator extends StatelessWidget {
+  const _CastingIndicator({required this.deviceName});
+
+  final String deviceName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          Icons.cast_connected,
+          size: 16,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        Flexible(
+          child: Text(
+            'Casting to $deviceName',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.primary,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.3,
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/features/player/widgets/lyrics_view.dart
+++ b/lib/features/player/widgets/lyrics_view.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/lyrics.dart';
+import '../../../shared/widgets/empty_state.dart';
+import '../lyrics_providers.dart';
+import '../player_providers.dart';
+
+/// The lyrics experience shown from Now Playing.
+///
+/// It follows the *currently playing* track (via [currentTrackLyricsProvider]),
+/// so skipping reloads the lines in place and the previous song's text never
+/// lingers. Three shapes:
+///  - no lyrics → a calm "No lyrics available yet." placeholder;
+///  - plain lyrics (no timestamps) → a static, readable list, no highlighting;
+///  - timed lyrics → a smooth synced view that highlights the current line and
+///    auto-scrolls as playback moves.
+///
+/// Critically, it only *reads* playback state — opening it never starts or
+/// restarts playback. Because it follows the unified [playbackStateProvider]
+/// position, it tracks whichever output is active: the local engine, or a cast
+/// receiver when casting.
+class LyricsView extends ConsumerWidget {
+  const LyricsView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<Lyrics?> lyrics = ref.watch(currentTrackLyricsProvider);
+
+    return lyrics.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      // Never surface raw error text (it can carry transport detail); show one
+      // calm, friendly line instead.
+      error: (_, __) => const Padding(
+        padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+        child: EmptyState(
+          icon: Icons.lyrics_outlined,
+          title: "Couldn't load lyrics",
+          message: 'Check your connection and try again.',
+        ),
+      ),
+      data: (value) {
+        if (value == null || value.isEmpty) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+            child: EmptyState(
+              icon: Icons.lyrics_outlined,
+              title: 'No lyrics available yet.',
+              message: "They'll appear here when your server has them.",
+            ),
+          );
+        }
+        return value.isSynced
+            ? _SyncedLyrics(lyrics: value)
+            : _PlainLyrics(lyrics: value);
+      },
+    );
+  }
+}
+
+/// Static lyrics with no timing: a plain, readable, scrollable list.
+class _PlainLyrics extends StatelessWidget {
+  const _PlainLyrics({required this.lyrics});
+
+  final Lyrics lyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListView.builder(
+      key: const Key('plain-lyrics'),
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+      itemCount: lyrics.lines.length,
+      itemBuilder: (context, index) {
+        final String text = lyrics.lines[index].text;
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+          // A blank line keeps its vertical rhythm rather than collapsing.
+          child: Text(
+            text.isEmpty ? ' ' : text,
+            style: theme.textTheme.bodyLarge,
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Timed lyrics: highlights the line active at the current playback position and
+/// auto-scrolls to keep it centred, with neighbouring lines softly dimmed.
+class _SyncedLyrics extends ConsumerStatefulWidget {
+  const _SyncedLyrics({required this.lyrics});
+
+  final Lyrics lyrics;
+
+  @override
+  ConsumerState<_SyncedLyrics> createState() => _SyncedLyricsState();
+}
+
+class _SyncedLyricsState extends ConsumerState<_SyncedLyrics> {
+  final ScrollController _scroll = ScrollController();
+  List<GlobalKey> _keys = const <GlobalKey>[];
+  int _activeIndex = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuildKeys();
+  }
+
+  @override
+  void didUpdateWidget(_SyncedLyrics oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new track's lyrics: reset keys and the highlight so nothing stale shows.
+    if (widget.lyrics != oldWidget.lyrics) {
+      _rebuildKeys();
+      _activeIndex = -1;
+    }
+  }
+
+  void _rebuildKeys() {
+    _keys = List<GlobalKey>.generate(
+      widget.lyrics.lines.length,
+      (_) => GlobalKey(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  /// The unified playback position, falling back to the controller's latest
+  /// state until the first stream event arrives. Reads only — never triggers
+  /// playback.
+  Duration _position() {
+    final Duration? streamed = ref.watch(
+      playbackStateProvider.select((s) => s.valueOrNull?.position),
+    );
+    return streamed ?? ref.read(playbackControllerProvider).state.position;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final int active = widget.lyrics.activeLineIndex(_position());
+
+    if (active != _activeIndex) {
+      _activeIndex = active;
+      _scheduleScrollTo(active);
+    }
+
+    return ListView.builder(
+      key: const Key('synced-lyrics'),
+      controller: _scroll,
+      // Generous vertical padding so the first and last lines can sit centred.
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xl),
+      itemCount: widget.lyrics.lines.length,
+      itemBuilder: (context, index) {
+        final LyricLine line = widget.lyrics.lines[index];
+        final bool isActive = index == active;
+        final Color color = isActive
+            ? theme.colorScheme.secondary
+            : theme.colorScheme.onSurface.withValues(alpha: 0.4);
+        return Padding(
+          key: _keys[index],
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            // Tap a timed line to jump there — routed through the controller, so
+            // it seeks whichever output is active (local or cast).
+            onTap: line.start == null
+                ? null
+                : () => ref.read(playbackControllerProvider).seek(line.start!),
+            child: AnimatedDefaultTextStyle(
+              duration: const Duration(milliseconds: 220),
+              curve: Curves.easeOut,
+              style:
+                  (theme.textTheme.titleMedium ?? const TextStyle()).copyWith(
+                color: color,
+                fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+                height: 1.35,
+              ),
+              child: Text(line.text.isEmpty ? ' ' : line.text),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// Smoothly centres the active line. Guarded so it only runs once per change
+  /// and only while the line is laid out.
+  void _scheduleScrollTo(int index) {
+    if (index < 0 || index >= _keys.length) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final BuildContext? ctx = _keys[index].currentContext;
+      if (ctx == null) return;
+      Scrollable.ensureVisible(
+        ctx,
+        alignment: 0.5,
+        duration: const Duration(milliseconds: 360),
+        curve: Curves.easeInOut,
+      );
+    });
+  }
+}

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -2,13 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
-import '../../../core/models/lyrics.dart';
 import '../../../core/models/track.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../shared/widgets/empty_state.dart';
 import '../favorites_providers.dart';
-import '../lyrics_providers.dart';
 import '../player_providers.dart';
+import 'lyrics_view.dart';
 
 /// Bottom action row on the now-playing screen: favorite · queue · lyrics.
 ///
@@ -72,24 +71,21 @@ class NowPlayingActions extends ConsumerWidget {
   }
 }
 
-/// The lyrics sheet. It follows the *currently playing* track rather than a
-/// captured one, so skipping to the next song updates the lines in place; while
-/// the new track's lyrics load it shows a spinner (never the previous song),
-/// then either the lines, a calm "no lyrics" placeholder, or a friendly
-/// "couldn't load" message on a fetch failure.
-class _LyricsSheet extends ConsumerWidget {
+/// The lyrics sheet: a tall, premium synced-lyrics panel. It follows the
+/// *currently playing* track rather than a captured one, so skipping updates the
+/// lines in place; the heavy lifting (loading / empty / plain / synced
+/// highlighting + auto-scroll) lives in [LyricsView]. Opening it only reads
+/// playback state — it never starts or restarts playback.
+class _LyricsSheet extends StatelessWidget {
   const _LyricsSheet();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final AsyncValue<Lyrics?> lyrics = ref.watch(currentTrackLyricsProvider);
 
     return SafeArea(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.sizeOf(context).height * 0.7,
-        ),
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * 0.85,
         child: Padding(
           padding: const EdgeInsets.fromLTRB(
             AppSpacing.lg,
@@ -98,74 +94,21 @@ class _LyricsSheet extends ConsumerWidget {
             AppSpacing.lg,
           ),
           child: Column(
-            mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text('Lyrics', style: theme.textTheme.titleMedium),
+              Row(
+                children: [
+                  Icon(Icons.lyrics_outlined, color: theme.colorScheme.primary),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text('Lyrics', style: theme.textTheme.titleMedium),
+                ],
+              ),
               const SizedBox(height: AppSpacing.sm),
-              Flexible(child: _content(lyrics)),
+              const Expanded(child: LyricsView()),
             ],
           ),
         ),
       ),
-    );
-  }
-
-  Widget _content(AsyncValue<Lyrics?> lyrics) {
-    return lyrics.when(
-      loading: () => const Padding(
-        padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
-        child: Center(child: CircularProgressIndicator()),
-      ),
-      // Never surface raw error text (it can carry transport detail); show one
-      // calm, friendly line instead.
-      error: (_, __) => const Padding(
-        padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
-        child: EmptyState(
-          icon: Icons.lyrics_outlined,
-          title: "Couldn't load lyrics",
-          message: 'Check your connection and try again.',
-        ),
-      ),
-      data: (value) {
-        if (value == null || value.isEmpty) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
-            child: EmptyState(
-              icon: Icons.lyrics_outlined,
-              title: 'No lyrics available yet.',
-              message: "They'll appear here when your server has them.",
-            ),
-          );
-        }
-        return _LyricsList(lyrics: value);
-      },
-    );
-  }
-}
-
-class _LyricsList extends StatelessWidget {
-  const _LyricsList({required this.lyrics});
-
-  final Lyrics lyrics;
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    return ListView.builder(
-      shrinkWrap: true,
-      itemCount: lyrics.lines.length,
-      itemBuilder: (context, index) {
-        final String text = lyrics.lines[index].text;
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-          // A blank line keeps its vertical rhythm rather than collapsing.
-          child: Text(
-            text.isEmpty ? ' ' : text,
-            style: theme.textTheme.bodyLarge,
-          ),
-        );
-      },
     );
   }
 }

--- a/test/core/models/cast_playback_status_test.dart
+++ b/test/core/models/cast_playback_status_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_playback_status.dart';
+import 'package:linthra/core/models/playback_state.dart';
+
+void main() {
+  group('CastPlaybackStatus', () {
+    test('idle is the empty default', () {
+      const status = CastPlaybackStatus.idle;
+      expect(status.status, PlaybackStatus.idle);
+      expect(status.position, Duration.zero);
+      expect(status.duration, Duration.zero);
+      expect(status.isPlaying, isFalse);
+    });
+
+    test('isPlaying reflects the status', () {
+      const playing = CastPlaybackStatus(status: PlaybackStatus.playing);
+      const paused = CastPlaybackStatus(status: PlaybackStatus.paused);
+      expect(playing.isPlaying, isTrue);
+      expect(paused.isPlaying, isFalse);
+    });
+
+    test('copyWith replaces only the given fields', () {
+      const base = CastPlaybackStatus(
+        status: PlaybackStatus.playing,
+        position: Duration(seconds: 5),
+        duration: Duration(minutes: 3),
+      );
+      final next = base.copyWith(position: const Duration(seconds: 9));
+      expect(next.status, PlaybackStatus.playing);
+      expect(next.position, const Duration(seconds: 9));
+      expect(next.duration, const Duration(minutes: 3));
+    });
+
+    test('equality compares status, position, and duration', () {
+      const a = CastPlaybackStatus(
+        status: PlaybackStatus.playing,
+        position: Duration(seconds: 5),
+        duration: Duration(minutes: 3),
+      );
+      const b = CastPlaybackStatus(
+        status: PlaybackStatus.playing,
+        position: Duration(seconds: 5),
+        duration: Duration(minutes: 3),
+      );
+      const different = CastPlaybackStatus(
+        status: PlaybackStatus.paused,
+        position: Duration(seconds: 5),
+        duration: Duration(minutes: 3),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(different)));
+    });
+  });
+}

--- a/test/core/models/cast_state_test.dart
+++ b/test/core/models/cast_state_test.dart
@@ -13,6 +13,17 @@ void main() {
       expect(state.hasError, isFalse);
       expect(state.devices, isEmpty);
       expect(state.message, isNull);
+      expect(state.isCasting, isFalse);
+    });
+
+    test('isCasting marks an active handoff and rides copyWith/equality', () {
+      const idle = CastState(availability: CastAvailability.connected);
+      final casting = idle.copyWith(isCasting: true);
+      expect(idle.isCasting, isFalse);
+      expect(casting.isCasting, isTrue);
+      // Differing only by isCasting must break equality, so the controller
+      // sees the handoff transition.
+      expect(casting, isNot(equals(idle)));
     });
 
     test('availability helpers map to the right value', () {

--- a/test/core/models/lyrics_test.dart
+++ b/test/core/models/lyrics_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+
+void main() {
+  group('Lyrics', () {
+    test('isSynced is true only when a line carries a timestamp', () {
+      const plain = Lyrics(lines: <LyricLine>[
+        LyricLine(text: 'a'),
+        LyricLine(text: 'b'),
+      ]);
+      const synced = Lyrics(lines: <LyricLine>[
+        LyricLine(text: 'a', start: Duration.zero),
+        LyricLine(text: 'b', start: Duration(seconds: 5)),
+      ]);
+      expect(plain.isSynced, isFalse);
+      expect(synced.isSynced, isTrue);
+    });
+
+    group('activeLineIndex', () {
+      const lyrics = Lyrics(lines: <LyricLine>[
+        LyricLine(text: 'one', start: Duration.zero),
+        LyricLine(text: 'two', start: Duration(seconds: 10)),
+        LyricLine(text: 'three', start: Duration(seconds: 20)),
+      ]);
+
+      test('is -1 before the first timed line begins', () {
+        const before = Lyrics(lines: <LyricLine>[
+          LyricLine(text: 'intro', start: Duration(seconds: 5)),
+          LyricLine(text: 'one', start: Duration(seconds: 10)),
+        ]);
+        expect(before.activeLineIndex(const Duration(seconds: 2)), -1);
+      });
+
+      test('returns the last line at or before the position', () {
+        expect(lyrics.activeLineIndex(const Duration(seconds: 0)), 0);
+        expect(lyrics.activeLineIndex(const Duration(seconds: 9)), 0);
+        expect(lyrics.activeLineIndex(const Duration(seconds: 10)), 1);
+        expect(lyrics.activeLineIndex(const Duration(seconds: 15)), 1);
+        expect(lyrics.activeLineIndex(const Duration(seconds: 25)), 2);
+      });
+
+      test('plain (untimed) lyrics never highlight a line', () {
+        const plain = Lyrics(lines: <LyricLine>[
+          LyricLine(text: 'a'),
+          LyricLine(text: 'b'),
+        ]);
+        expect(plain.activeLineIndex(const Duration(seconds: 30)), -1);
+      });
+    });
+  });
+}

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -1,0 +1,303 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/active_playback_output.dart';
+import 'package:linthra/core/models/cast_playback_status.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/active_playback_controller.dart';
+
+import '../../features/player/cast/fake_cast_service.dart';
+import '../../features/player/fake_playback_controller.dart';
+
+const _device = CastDevice(id: 'd1', name: 'Living Room');
+const _trackA = Track(id: 'a', title: 'Song A', uri: 'jellyfin:a');
+const _trackB = Track(id: 'b', title: 'Song B', uri: 'jellyfin:b');
+
+CastState _casting() => const CastState(
+      availability: CastAvailability.connected,
+      devices: <CastDevice>[_device],
+      connectedDevice: _device,
+      isCasting: true,
+    );
+
+CastState _disconnected() =>
+    const CastState(availability: CastAvailability.idle);
+
+/// Lets the test wait for the controller's merged state to reach a condition,
+/// without sleeping a fixed amount.
+Future<PlaybackState> _waitFor(
+  ActivePlaybackController controller,
+  bool Function(PlaybackState) predicate,
+) async {
+  if (predicate(controller.state)) return controller.state;
+  return controller.stateStream.firstWhere(predicate).timeout(
+        const Duration(seconds: 1),
+      );
+}
+
+void main() {
+  late FakePlaybackController local;
+  late FakeCastService cast;
+
+  ActivePlaybackController build() =>
+      ActivePlaybackController(local: local, cast: cast);
+
+  setUp(() {
+    local = FakePlaybackController(
+      initial: const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: _trackA,
+      ),
+    );
+    cast = FakeCastService();
+  });
+
+  tearDown(() async {
+    await cast.dispose();
+    await local.dispose();
+  });
+
+  group('local output (no cast)', () {
+    test('mirrors the local state and routes commands to local', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      expect(controller.activeOutput, ActivePlaybackOutput.local);
+      expect(controller.state.currentTrack, _trackA);
+
+      await controller.play();
+      await controller.pause();
+      await controller.seek(const Duration(seconds: 5));
+
+      expect(local.playCount, 1);
+      expect(local.pauseCount, 1);
+      expect(local.seeks, const <Duration>[Duration(seconds: 5)]);
+      // Nothing was sent to the (idle) cast service.
+      expect(cast.playCount, 0);
+      expect(cast.pauseCount, 0);
+      expect(cast.seeks, isEmpty);
+    });
+
+    test('follows the local position', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      local.emit(const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: _trackA,
+        position: Duration(seconds: 42),
+        duration: Duration(minutes: 3),
+      ));
+
+      final state = await _waitFor(
+        controller,
+        (s) => s.position == const Duration(seconds: 42),
+      );
+      expect(state.position, const Duration(seconds: 42));
+    });
+  });
+
+  group('handoff to cast', () {
+    test('suspends the local engine and switches output to cast', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      expect(controller.activeOutput, ActivePlaybackOutput.cast);
+      expect(local.suspendCount, 1);
+    });
+
+    test('play/pause/seek delegate to cast, not local', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      final int localPlaysBefore = local.playCount;
+      await controller.play();
+      await controller.pause();
+      await controller.seek(const Duration(seconds: 20));
+
+      expect(cast.playCount, 1);
+      expect(cast.pauseCount, 1);
+      expect(cast.seeks, const <Duration>[Duration(seconds: 20)]);
+      // The local engine was never told to play/seek while casting.
+      expect(local.playCount, localPlaysBefore);
+      expect(local.seeks, isEmpty);
+    });
+
+    test('merged state follows the cast position/status, keeping the track',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      cast.emitPlayback(const CastPlaybackStatus(
+        status: PlaybackStatus.paused,
+        position: Duration(seconds: 30),
+        duration: Duration(minutes: 4),
+      ));
+
+      final state = await _waitFor(
+        controller,
+        (s) => s.position == const Duration(seconds: 30),
+      );
+      // Position/status/duration come from the receiver…
+      expect(state.position, const Duration(seconds: 30));
+      expect(state.status, PlaybackStatus.paused);
+      expect(state.duration, const Duration(minutes: 4));
+      // …while the track stays owned by the local queue.
+      expect(state.currentTrack, _trackA);
+    });
+
+    test(
+        'skip advances the local queue without local audio; cast re-casts via '
+        'the track change', () async {
+      local = FakePlaybackController();
+      await local.playTracks(const <Track>[_trackA, _trackB]);
+      cast = FakeCastService();
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      final int playedBefore = local.playedTracks.length;
+
+      await controller.skipToNext();
+
+      expect(controller.state.currentTrack, _trackB);
+      // Suspended: skipping never "played" locally.
+      expect(local.playedTracks.length, playedBefore);
+    });
+  });
+
+  group('ending a cast session never surprise-starts local playback', () {
+    test('disconnect resumes the local engine paused at the cast position',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      cast.emitPlayback(const CastPlaybackStatus(
+        status: PlaybackStatus.playing,
+        position: Duration(seconds: 50),
+        duration: Duration(minutes: 3),
+      ));
+      await _waitFor(
+          controller, (s) => s.position >= const Duration(seconds: 50));
+
+      cast.emit(_disconnected());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.local);
+
+      expect(controller.activeOutput, ActivePlaybackOutput.local);
+      expect(local.resumeCount, 1);
+      // Resumed PAUSED (never auto-playing) and near where the receiver was.
+      expect(local.lastResumePlay, isFalse);
+      expect(local.lastResumeAt,
+          greaterThanOrEqualTo(const Duration(seconds: 50)));
+    });
+
+    test('a dropped receiver session does not auto-play local', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      final int localPlaysBefore = local.playCount;
+
+      // The receiver drops the session (network blip / app closed on the TV).
+      cast.emit(_disconnected());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.local);
+
+      // Resumed paused, never played.
+      expect(local.lastResumePlay, isFalse);
+      expect(local.playCount, localPlaysBefore);
+    });
+  });
+
+  group('lifecycle', () {
+    test('onAppResumed re-syncs from the receiver while casting, never local',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      final int localPlaysBefore = local.playCount;
+
+      controller.onAppResumed();
+
+      expect(cast.refreshCount, 1);
+      expect(local.playCount, localPlaysBefore);
+    });
+
+    test('onAppResumed is a no-op when not casting', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      controller.onAppResumed();
+
+      expect(cast.refreshCount, 0);
+    });
+  });
+
+  group('cast track completion advances per repeat mode', () {
+    test('repeat-one replays on the receiver', () async {
+      local = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _trackA,
+          repeatMode: RepeatMode.one,
+        ),
+      );
+      cast = FakeCastService();
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      cast.emitPlayback(
+          const CastPlaybackStatus(status: PlaybackStatus.completed));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(cast.seeks, contains(Duration.zero));
+      expect(cast.playCount, greaterThanOrEqualTo(1));
+    });
+
+    test('repeat-off advances to the next queued track', () async {
+      local = FakePlaybackController();
+      await local.playTracks(const <Track>[_trackA, _trackB]);
+      cast = FakeCastService();
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      cast.emitPlayback(
+          const CastPlaybackStatus(status: PlaybackStatus.completed));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(controller.state.currentTrack, _trackB);
+    });
+  });
+}

--- a/test/core/services/cast/default_cast_service_test.dart
+++ b/test/core/services/cast/default_cast_service_test.dart
@@ -2,14 +2,16 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/cast_media.dart';
+import 'package:linthra/core/models/cast_playback_status.dart';
 import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/cast/cast_media_resolver.dart';
 import 'package:linthra/core/services/cast/cast_transport.dart';
 import 'package:linthra/core/services/cast/default_cast_service.dart';
 
-/// A [CastSessionHandle] whose readiness and lifetime the test drives. It
-/// replays the latest readiness to each new listener, exactly like the real
+/// A [CastSessionHandle] whose readiness, status, and lifetime the test drives.
+/// It replays the latest readiness to each new listener, exactly like the real
 /// handle, so the service's `firstWhere` sees a session that became ready before
 /// it subscribed.
 class _FakeHandle implements CastSessionHandle {
@@ -18,8 +20,14 @@ class _FakeHandle implements CastSessionHandle {
   }
 
   final StreamController<bool> _ready = StreamController<bool>.broadcast();
+  final StreamController<CastPlaybackStatus> _status =
+      StreamController<CastPlaybackStatus>.broadcast();
   bool? _last;
   final List<CastMedia> loaded = <CastMedia>[];
+  int playCount = 0;
+  int pauseCount = 0;
+  final List<Duration> seeks = <Duration>[];
+  int statusRequests = 0;
   bool closed = false;
 
   void becomeReady() {
@@ -32,6 +40,10 @@ class _FakeHandle implements CastSessionHandle {
     if (!_ready.isClosed) _ready.add(false);
   }
 
+  void pushStatus(CastPlaybackStatus status) {
+    if (!_status.isClosed) _status.add(status);
+  }
+
   @override
   Stream<bool> get readyStream async* {
     if (_last != null) yield _last!;
@@ -39,12 +51,28 @@ class _FakeHandle implements CastSessionHandle {
   }
 
   @override
+  Stream<CastPlaybackStatus> get statusStream => _status.stream;
+
+  @override
   Future<void> loadMedia(CastMedia media) async => loaded.add(media);
+
+  @override
+  Future<void> play() async => playCount++;
+
+  @override
+  Future<void> pause() async => pauseCount++;
+
+  @override
+  Future<void> seek(Duration position) async => seeks.add(position);
+
+  @override
+  Future<void> requestStatus() async => statusRequests++;
 
   @override
   Future<void> close() async {
     closed = true;
     if (!_ready.isClosed) await _ready.close();
+    if (!_status.isClosed) await _status.close();
   }
 }
 
@@ -106,16 +134,12 @@ void main() {
   late _FakeResolver resolver;
   late StreamController<Track?> trackChanges;
   Track? current;
-  int pauseCount = 0;
-  int resumeCount = 0;
 
   DefaultCastService build() => DefaultCastService(
         transport: transport,
         mediaResolver: resolver,
         currentTrack: () => current,
         trackChanges: trackChanges.stream,
-        onCastingStarted: () async => pauseCount++,
-        onCastingStopped: () async => resumeCount++,
         discoveryTimeout: const Duration(milliseconds: 5),
         connectTimeout: const Duration(milliseconds: 100),
       );
@@ -125,8 +149,6 @@ void main() {
     resolver = _FakeResolver();
     trackChanges = StreamController<Track?>.broadcast();
     current = null;
-    pauseCount = 0;
-    resumeCount = 0;
   });
 
   tearDown(() async {
@@ -139,6 +161,7 @@ void main() {
       addTearDown(service.dispose);
       expect(service.state.availability, CastAvailability.idle);
       expect(service.state.isAvailable, isTrue);
+      expect(service.state.isCasting, isFalse);
     });
 
     test('populates the device list', () async {
@@ -151,17 +174,6 @@ void main() {
       expect(transport.discoverCount, 1);
       expect(service.state.availability, CastAvailability.idle);
       expect(service.state.devices, const <CastDevice>[_d1]);
-    });
-
-    test('settles to an empty idle state when nothing is found', () async {
-      transport.devices = const <CastDevice>[];
-      final service = build();
-      addTearDown(service.dispose);
-
-      await service.startDiscovery();
-
-      expect(service.state.availability, CastAvailability.idle);
-      expect(service.state.devices, isEmpty);
     });
 
     test('a discovery failure becomes a friendly error state', () async {
@@ -178,8 +190,7 @@ void main() {
   });
 
   group('connect + handoff', () {
-    test('casts the current streamable track and pauses local playback',
-        () async {
+    test('casts the current streamable track and marks isCasting', () async {
       current = _jellyfinTrack;
       final handle = _FakeHandle();
       transport.handle = handle;
@@ -190,13 +201,12 @@ void main() {
 
       expect(transport.connectRequests, const <CastDevice>[_d1]);
       expect(service.state.isConnected, isTrue);
+      expect(service.state.isCasting, isTrue);
       expect(service.state.connectedDevice, _d1);
       // The resolved, token-bearing URL reached the receiver.
       expect(handle.loaded, hasLength(1));
       expect(handle.loaded.single.url.queryParameters['api_key'], 'TOKEN');
       expect(handle.loaded.single.title, 'Streamed');
-      // Local playback was silenced so audio isn't heard twice.
-      expect(pauseCount, 1);
     });
 
     test('a local file is reported as a clear limitation, not cast', () async {
@@ -210,14 +220,14 @@ void main() {
       await service.connect(_d1);
 
       expect(service.state.isConnected, isTrue);
+      // Not a real handoff: the engine must be left alone for local files.
+      expect(service.state.isCasting, isFalse);
       expect(service.state.message, DefaultCastService.localFileLimitation);
-      // Nothing was sent to the receiver and local playback was left alone.
       expect(handle.loaded, isEmpty);
       expect(resolver.resolved, isEmpty);
-      expect(pauseCount, 0);
     });
 
-    test('a resolve failure surfaces the message but stays connected',
+    test('a resolve failure surfaces the message and does not claim casting',
         () async {
       current = _jellyfinTrack;
       resolver.error = const CastMediaException(
@@ -231,9 +241,9 @@ void main() {
       await service.connect(_d1);
 
       expect(service.state.isConnected, isTrue);
+      expect(service.state.isCasting, isFalse);
       expect(service.state.message, contains('Sign in to Jellyfin'));
       expect(transport.handle!.loaded, isEmpty);
-      expect(pauseCount, 0);
     });
 
     test('a session that never becomes ready becomes an error state', () async {
@@ -245,8 +255,8 @@ void main() {
       await service.connect(_d1);
 
       expect(service.state.hasError, isTrue);
+      expect(service.state.isCasting, isFalse);
       expect(service.state.message, contains('Living Room'));
-      expect(pauseCount, 0);
     });
 
     test('a connect failure becomes a friendly error state', () async {
@@ -277,11 +287,12 @@ void main() {
 
       expect(handle.loaded, hasLength(2));
       expect(handle.loaded.last.title, 'Next up');
+      expect(service.state.isCasting, isTrue);
     });
   });
 
-  group('disconnect + recovery', () {
-    test('disconnect closes the session and resumes local playback', () async {
+  group('receiver status', () {
+    test('forwards the receiver media status on playbackStream', () async {
       current = _jellyfinTrack;
       final handle = _FakeHandle();
       transport.handle = handle;
@@ -289,17 +300,78 @@ void main() {
       addTearDown(service.dispose);
 
       await service.connect(_d1);
-      expect(pauseCount, 1);
+
+      const status = CastPlaybackStatus(
+        status: PlaybackStatus.playing,
+        position: Duration(seconds: 12),
+        duration: Duration(minutes: 3),
+      );
+      final Future<CastPlaybackStatus> next = service.playbackStream.first;
+      handle.pushStatus(status);
+
+      expect(await next, status);
+      expect(service.playbackStatus, status);
+    });
+  });
+
+  group('transport commands route to the session', () {
+    test('play/pause/seek/refresh forward to the handle while casting',
+        () async {
+      current = _jellyfinTrack;
+      final handle = _FakeHandle();
+      transport.handle = handle;
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+
+      await service.play();
+      await service.pause();
+      await service.seek(const Duration(seconds: 30));
+      await service.refresh();
+
+      expect(handle.playCount, 1);
+      expect(handle.pauseCount, 1);
+      expect(handle.seeks, const <Duration>[Duration(seconds: 30)]);
+      expect(handle.statusRequests, 1);
+    });
+
+    test('commands are safe no-ops when not connected', () async {
+      final service = build();
+      addTearDown(service.dispose);
+
+      // Must not throw with no session.
+      await service.play();
+      await service.pause();
+      await service.seek(const Duration(seconds: 5));
+      await service.refresh();
+    });
+  });
+
+  group('disconnect + recovery (no surprise local restart)', () {
+    test('disconnect closes the session and returns to idle', () async {
+      current = _jellyfinTrack;
+      final handle = _FakeHandle();
+      transport.handle = handle;
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+      expect(service.state.isCasting, isTrue);
 
       await service.disconnect();
 
       expect(handle.closed, isTrue);
-      expect(resumeCount, 1);
       expect(service.state.availability, CastAvailability.idle);
+      expect(service.state.isCasting, isFalse);
       expect(service.state.connectedDevice, isNull);
+      // Playback status is reset; the router (not this service) decides what the
+      // device does next, and it never auto-starts local playback.
+      expect(service.playbackStatus, CastPlaybackStatus.idle);
     });
 
-    test('a receiver-dropped session recovers to local playback', () async {
+    test('a receiver-dropped session recovers to a disconnected state',
+        () async {
       current = _jellyfinTrack;
       final handle = _FakeHandle();
       transport.handle = handle;
@@ -310,40 +382,25 @@ void main() {
       handle.drop();
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
-      expect(resumeCount, 1);
       expect(service.state.availability, CastAvailability.idle);
+      expect(service.state.isCasting, isFalse);
     });
   });
 
-  group('local playback stays stable when not actively casting', () {
-    test('merely discovering never pauses local playback', () async {
+  group('security', () {
+    test('no token leaks into cast state on success or failure', () async {
       current = _jellyfinTrack;
-      transport.devices = const <CastDevice>[_d1];
+      final handle = _FakeHandle();
+      transport.handle = handle;
       final service = build();
       addTearDown(service.dispose);
 
-      await service.startDiscovery();
-
-      // Cast is available but no handoff happened, so local playback is
-      // untouched and keeps playing.
-      expect(pauseCount, 0);
-      expect(resumeCount, 0);
-    });
-
-    test('disconnecting without a handoff leaves local playback alone',
-        () async {
-      current = _localTrack;
-      resolver.castable = false;
-      transport.handle = _FakeHandle();
-      final service = build();
-      addTearDown(service.dispose);
-
-      await service.connect(_d1); // local file: limitation, no handoff
-      await service.disconnect();
-
-      // Never paused, so never force-resumed either.
-      expect(pauseCount, 0);
-      expect(resumeCount, 0);
+      await service.connect(_d1);
+      // The token rode only on the CastMedia handed to the receiver.
+      expect(handle.loaded.single.url.queryParameters['api_key'], 'TOKEN');
+      // Never in the user-facing state.
+      expect(service.state.message ?? '', isNot(contains('TOKEN')));
+      expect(service.state.message ?? '', isNot(contains('api_key')));
     });
   });
 }

--- a/test/features/player/cast/fake_cast_service.dart
+++ b/test/features/player/cast/fake_cast_service.dart
@@ -1,28 +1,45 @@
 import 'dart:async';
 
+import 'package:linthra/core/models/cast_playback_status.dart';
 import 'package:linthra/core/models/cast_state.dart';
 import 'package:linthra/core/services/cast/cast_service.dart';
 
-/// In-memory [CastService] for widget tests: starts in a caller-supplied state,
-/// records the commands it receives, and lets a test push new [CastState]s. It
-/// stands in for a future real backend so the cast UI can be exercised across
-/// availability/connected states without any SDK.
+/// In-memory [CastService] for widget/router tests: starts in a caller-supplied
+/// state, records the commands it receives, and lets a test push new
+/// [CastState]s and [CastPlaybackStatus] updates. It stands in for the real
+/// backend so the cast UI and the [ActivePlaybackController] can be exercised
+/// across availability/connected/casting states without any SDK.
 class FakeCastService implements CastService {
-  FakeCastService({CastState initial = CastState.unavailable})
-      : _state = initial;
+  FakeCastService({
+    CastState initial = CastState.unavailable,
+    CastPlaybackStatus initialPlayback = CastPlaybackStatus.idle,
+  })  : _state = initial,
+        _playback = initialPlayback;
 
   final StreamController<CastState> _states =
       StreamController<CastState>.broadcast();
+  final StreamController<CastPlaybackStatus> _playbackStates =
+      StreamController<CastPlaybackStatus>.broadcast();
   CastState _state;
+  CastPlaybackStatus _playback;
 
   int discoveryStarts = 0;
   int discoveryStops = 0;
   final List<CastDevice> connectRequests = <CastDevice>[];
   int disconnects = 0;
+  int playCount = 0;
+  int pauseCount = 0;
+  final List<Duration> seeks = <Duration>[];
+  int refreshCount = 0;
 
   void emit(CastState next) {
     _state = next;
     _states.add(next);
+  }
+
+  void emitPlayback(CastPlaybackStatus next) {
+    _playback = next;
+    _playbackStates.add(next);
   }
 
   @override
@@ -30,6 +47,12 @@ class FakeCastService implements CastService {
 
   @override
   Stream<CastState> get stateStream => _states.stream;
+
+  @override
+  CastPlaybackStatus get playbackStatus => _playback;
+
+  @override
+  Stream<CastPlaybackStatus> get playbackStream => _playbackStates.stream;
 
   @override
   Future<void> startDiscovery() async => discoveryStarts++;
@@ -44,7 +67,20 @@ class FakeCastService implements CastService {
   Future<void> disconnect() async => disconnects++;
 
   @override
+  Future<void> play() async => playCount++;
+
+  @override
+  Future<void> pause() async => pauseCount++;
+
+  @override
+  Future<void> seek(Duration position) async => seeks.add(position);
+
+  @override
+  Future<void> refresh() async => refreshCount++;
+
+  @override
   Future<void> dispose() async {
     await _states.close();
+    await _playbackStates.close();
   }
 }

--- a/test/features/player/cast_now_playing_test.dart
+++ b/test/features/player/cast_now_playing_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_playback_status.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/active_playback_controller.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import 'cast/fake_cast_service.dart';
+import 'fake_playback_controller.dart';
+
+const _track = Track(
+  id: 'a',
+  title: 'Song A',
+  uri: 'jellyfin:a',
+  artistName: 'Artist',
+);
+const _device = CastDevice(id: 'd1', name: 'Living Room');
+
+PlaybackState _playing() => const PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+    );
+
+void main() {
+  group('Now Playing reflects the cast session', () {
+    testWidgets('shows a "Casting to <device>" indicator when connected',
+        (tester) async {
+      final cast = FakeCastService(
+        initial: const CastState(
+          availability: CastAvailability.connected,
+          devices: <CastDevice>[_device],
+          connectedDevice: _device,
+          isCasting: true,
+        ),
+      );
+      addTearDown(cast.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider
+                .overrideWithValue(FakePlaybackController(initial: _playing())),
+            castServiceProvider.overrideWithValue(cast),
+          ],
+          child: const MaterialApp(home: PlayerScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Casting to Living Room'), findsOneWidget);
+      // The connected glyph is shown (the cast button uses it too).
+      expect(find.byIcon(Icons.cast_connected), findsWidgets);
+    });
+
+    testWidgets('shows the source badge (not a cast indicator) when local',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider
+                .overrideWithValue(FakePlaybackController(initial: _playing())),
+          ],
+          child: const MaterialApp(home: PlayerScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Casting to'), findsNothing);
+    });
+  });
+
+  group('opening Lyrics never starts local playback', () {
+    testWidgets('local playback: opening Lyrics does not call play',
+        (tester) async {
+      final controller = FakePlaybackController(initial: _playing());
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider.overrideWithValue(controller),
+          ],
+          child: const MaterialApp(home: PlayerScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(controller.playCount, 0);
+    });
+
+    testWidgets('while casting: opening Lyrics neither plays nor resumes local',
+        (tester) async {
+      final local = FakePlaybackController(initial: _playing());
+      final cast = FakeCastService();
+      addTearDown(cast.dispose);
+      final router = ActivePlaybackController(local: local, cast: cast);
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider.overrideWithValue(router),
+            castServiceProvider.overrideWithValue(cast),
+          ],
+          child: const MaterialApp(home: PlayerScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Hand off to the receiver (paused, so no interpolation ticker runs).
+      cast.emit(const CastState(
+        availability: CastAvailability.connected,
+        devices: <CastDevice>[_device],
+        connectedDevice: _device,
+        isCasting: true,
+      ));
+      cast.emitPlayback(const CastPlaybackStatus(
+        status: PlaybackStatus.paused,
+        position: Duration(seconds: 5),
+        duration: Duration(minutes: 3),
+      ));
+      await tester.pumpAndSettle();
+      final int playsBefore = local.playCount;
+      final int resumesBefore = local.resumeCount;
+
+      await tester.tap(find.byTooltip('Lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(local.playCount, playsBefore);
+      expect(local.resumeCount, resumesBefore);
+    });
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -5,14 +5,17 @@ import 'package:linthra/core/models/playback_queue.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
-import 'package:linthra/core/services/playback_controller.dart';
+import 'package:linthra/core/services/local_playback_controller.dart';
 
-/// In-memory [PlaybackController] for widget/provider tests.
+/// In-memory [LocalPlaybackController] for widget/provider tests.
 ///
 /// Records the calls it receives, maintains a real [PlaybackQueue] so queue
 /// flows behave like the production controller, and lets a test push arbitrary
-/// [PlaybackState]s — all without `just_audio` or any platform plugin.
-class FakePlaybackController implements PlaybackController {
+/// [PlaybackState]s — all without `just_audio` or any platform plugin. It also
+/// honours [suspend]/[resume] so it can stand in as the local engine behind an
+/// [ActivePlaybackController] in cast-routing tests: while suspended, queue
+/// changes update the current track without "playing" locally.
+class FakePlaybackController implements LocalPlaybackController {
   FakePlaybackController({PlaybackState initial = PlaybackState.idle})
       : _state = initial;
 
@@ -22,6 +25,7 @@ class FakePlaybackController implements PlaybackController {
   PlaybackQueue _queue = PlaybackQueue.empty;
   bool _shuffleEnabled = false;
   RepeatMode _repeatMode = RepeatMode.off;
+  bool _suspended = false;
 
   /// Seeded so shuffle is deterministic across test runs.
   final Random _random = Random(1);
@@ -33,6 +37,11 @@ class FakePlaybackController implements PlaybackController {
   int skipCount = 0;
   int previousCount = 0;
   int clearCount = 0;
+  int suspendCount = 0;
+  int resumeCount = 0;
+  int restartQueueCount = 0;
+  Duration? lastResumeAt;
+  bool? lastResumePlay;
   bool disposed = false;
   final List<Duration> seeks = <Duration>[];
 
@@ -129,6 +138,19 @@ class FakePlaybackController implements PlaybackController {
   void _playCurrent() {
     final track = _queue.current;
     if (track == null) return;
+    if (_suspended) {
+      // A cast output owns audio: reflect the queue/track without "playing"
+      // locally, mirroring the real controller's suspended path.
+      emit(PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: track,
+        upNext: _queue.upNext,
+        hasPrevious: _queue.hasPrevious,
+        shuffleEnabled: _shuffleEnabled,
+        repeatMode: _repeatMode,
+      ));
+      return;
+    }
     playedTracks.add(track);
     final playing = PlaybackState(
       status: PlaybackStatus.playing,
@@ -139,6 +161,31 @@ class FakePlaybackController implements PlaybackController {
       repeatMode: _repeatMode,
     );
     emit(playing);
+  }
+
+  @override
+  bool get isSuspended => _suspended;
+
+  @override
+  Future<void> suspend() async {
+    suspendCount++;
+    _suspended = true;
+  }
+
+  @override
+  Future<void> resume({Duration at = Duration.zero, bool play = false}) async {
+    resumeCount++;
+    lastResumeAt = at;
+    lastResumePlay = play;
+    _suspended = false;
+    _playCurrent();
+  }
+
+  @override
+  Future<void> restartQueue() async {
+    restartQueueCount++;
+    _queue = _queue.restarted();
+    _playCurrent();
   }
 
   @override

--- a/test/features/player/synced_lyrics_test.dart
+++ b/test/features/player/synced_lyrics_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_playback_status.dart';
+import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/active_playback_controller.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/features/player/cast/cast_providers.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import 'cast/fake_cast_service.dart';
+import 'fake_playback_controller.dart';
+
+class _FakeLyricsService implements LyricsService {
+  _FakeLyricsService(this._byId);
+  final Map<String, Lyrics?> _byId;
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async => _byId[track.id];
+}
+
+const _trackA = Track(id: 'a', title: 'Song A', uri: 'jellyfin:a');
+
+const _synced = Lyrics(lines: <LyricLine>[
+  LyricLine(text: 'line one', start: Duration.zero),
+  LyricLine(text: 'line two', start: Duration(seconds: 10)),
+  LyricLine(text: 'line three', start: Duration(seconds: 20)),
+]);
+
+const _plain = Lyrics(lines: <LyricLine>[
+  LyricLine(text: 'plain one'),
+  LyricLine(text: 'plain two'),
+]);
+
+PlaybackState _playingAt(Duration position) => PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _trackA,
+      position: position,
+      duration: const Duration(seconds: 30),
+    );
+
+/// The style of a synced lyric line. Material wraps many things in
+/// [AnimatedDefaultTextStyle], so we pick the one that *directly* wraps this
+/// line's [Text] (the synced view's own wrapper).
+TextStyle _styleOf(WidgetTester tester, String text) {
+  final candidates = tester.widgetList<AnimatedDefaultTextStyle>(
+    find.ancestor(
+      of: find.text(text),
+      matching: find.byType(AnimatedDefaultTextStyle),
+    ),
+  );
+  for (final AnimatedDefaultTextStyle w in candidates) {
+    final Widget child = w.child;
+    if (child is Text && child.data == text) return w.style;
+  }
+  return candidates.first.style;
+}
+
+Future<void> _openLyrics(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Lyrics'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('synced lyrics highlight + follow position (local)', () {
+    Future<void> pump(
+      WidgetTester tester, {
+      required FakePlaybackController controller,
+      required Lyrics lyrics,
+    }) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider.overrideWithValue(controller),
+            lyricsServiceProvider.overrideWithValue(
+              _FakeLyricsService(<String, Lyrics?>{'a': lyrics}),
+            ),
+          ],
+          child: const MaterialApp(home: PlayerScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('highlights the line active at the current position',
+        (tester) async {
+      await pump(
+        tester,
+        controller: FakePlaybackController(
+            initial: _playingAt(const Duration(seconds: 12))),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+
+      // 12s lands on "line two" (10s..20s): bold, and a distinct colour from a
+      // neighbouring (muted) line.
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w700);
+      expect(_styleOf(tester, 'line one').fontWeight, FontWeight.w500);
+      expect(
+        _styleOf(tester, 'line two').color,
+        isNot(_styleOf(tester, 'line one').color),
+      );
+    });
+
+    testWidgets('moves the highlight as the position advances', (tester) async {
+      final controller = FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)));
+      await pump(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w700);
+
+      // Advance past the third line's start.
+      controller.emit(_playingAt(const Duration(seconds: 22)));
+      await tester.pumpAndSettle();
+
+      expect(_styleOf(tester, 'line three').fontWeight, FontWeight.w700);
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w500);
+    });
+
+    testWidgets('plain lyrics render without timed highlighting',
+        (tester) async {
+      await pump(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: _plain,
+      );
+      await _openLyrics(tester);
+
+      expect(find.text('plain one'), findsOneWidget);
+      expect(find.text('plain two'), findsOneWidget);
+      // The plain (static) path is used, not the synced highlighting one.
+      expect(find.byKey(const Key('plain-lyrics')), findsOneWidget);
+      expect(find.byKey(const Key('synced-lyrics')), findsNothing);
+    });
+
+    testWidgets('shows the empty state when there are no lyrics',
+        (tester) async {
+      await pump(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: const Lyrics(lines: <LyricLine>[]),
+      );
+      await _openLyrics(tester);
+
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+    });
+  });
+
+  group('synced lyrics follow the cast position', () {
+    testWidgets('the highlight follows the receiver position while casting',
+        (tester) async {
+      final local = FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 1)));
+      final cast = FakeCastService(
+        initial: const CastState(
+          availability: CastAvailability.connected,
+          connectedDevice: CastDevice(id: 'd1', name: 'Living Room'),
+          isCasting: true,
+        ),
+      );
+      addTearDown(cast.dispose);
+      final router = ActivePlaybackController(local: local, cast: cast);
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            playbackControllerProvider.overrideWithValue(router),
+            castServiceProvider.overrideWithValue(cast),
+            lyricsServiceProvider.overrideWithValue(
+              _FakeLyricsService(<String, Lyrics?>{'a': _synced}),
+            ),
+          ],
+          child: const MaterialApp(home: PlayerScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The receiver reports a paused position at 12s → "line two" is active.
+      // (Paused so no interpolation ticker runs and the test can settle.)
+      cast.emitPlayback(const CastPlaybackStatus(
+        status: PlaybackStatus.paused,
+        position: Duration(seconds: 12),
+        duration: Duration(seconds: 30),
+      ));
+      await tester.pumpAndSettle();
+      await _openLyrics(tester);
+
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w700);
+
+      // The receiver moves on to 22s → the highlight follows to "line three".
+      cast.emitPlayback(const CastPlaybackStatus(
+        status: PlaybackStatus.paused,
+        position: Duration(seconds: 22),
+        duration: Duration(seconds: 30),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(_styleOf(tester, 'line three').fontWeight, FontWeight.w700);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

When casting to a real Chromecast, the app desynced: the receiver kept
playing but the phone could **restart local playback**, and the UI/lyrics
followed the (frozen) local engine instead of the Cast session. This makes
Cast a first-class active output — the phone becomes a remote, Spotify/Plex
style — and adds a synced-lyrics experience that follows whichever output is
playing.

## Root cause of the Cast desync

Two independent state sources fought each other:

1. The UI read **local `just_audio` state** (`playbackStateProvider` → the
   local engine), while `CastService` *separately* paused the local engine on
   handoff. So while casting, the now-playing screen, mini-player, and lyrics
   showed the paused/frozen local position — not the receiver's.
2. `CastService` auto-resumed local playback on **any** session blip
   (`onCastingStopped: () => controller.play()`, fired from `_onSessionLost`).
   Backgrounding, navigating, or a momentary cast-socket hiccup would
   **surprise-start audio on the phone** while the receiver was still playing
   → double playback + desync.

## Active playback output behavior

Introduced `ActivePlaybackController` (`PlaybackController`) — the single thing
the UI talks to. It owns an `ActivePlaybackOutput { local, cast }` and presents
**one unified `PlaybackState`**:

- queue/track/up-next/shuffle/repeat always come from the local engine (the
  queue owner), so queue logic is unchanged;
- while casting, **position / play-state / duration come from the receiver**
  (parsed from Cast `MEDIA_STATUS`, smoothly interpolated between updates).

It owns the local↔cast switch: on handoff it **suspends** the local engine
(silent, but still owns the queue); when a session ends it **resumes paused**
at the receiver's last position — never auto-playing. The UI reads only this
controller, never `just_audio` or the Cast SDK directly.

## Local vs Cast command routing

- **play / pause / seek** → routed to the active output (Cast while casting,
  else local).
- **next / previous / playTracks** → always the local queue. While casting the
  engine is suspended, so these change the current track **without local
  audio**; `CastService` mirrors the track change onto the receiver (re-`LOAD`).
- **shuffle / repeat** → local modes, coherent across outputs. A finished Cast
  track advances per repeat mode (repeat-one replays on the receiver;
  otherwise the queue advances/wraps).
- Local `just_audio` is suspended while casting, so the two never fight; no
  duplicate sessions; controllers are never recreated on navigation.
- Tokenized URLs are resolved **at cast time only**, carried on `CastMedia`
  straight to the session, never logged, never written to state, never
  persisted.

## Lifecycle behavior

- App `WidgetsBindingObserver`: on **resume** while casting it asks the
  receiver for a fresh status (re-sync position). It **never** touches local
  playback.
- Backgrounding/foregrounding, opening Lyrics/Settings/Library/Downloads, or
  navigating away from Now Playing cannot recreate or resume the local engine
  while a Cast session owns playback (nothing auto-calls `play`).
- On disconnect (user or dropped receiver) the device returns to a **paused**,
  in-sync state at the Cast position — press play to continue on this device.

## Synced lyrics behavior

- New `LyricsView`: **no lyrics** → calm placeholder; **plain** lyrics →
  static readable list; **timed** lyrics → smooth synced view that highlights
  the active line (orange accent, bold), softly dims neighbours, and
  auto-scrolls to centre the current line. Tap a timed line to seek.
- Follows the **unified** position, so it tracks local **or** Cast playback
  automatically. Reloads on track change (no stale previous-track lines).
- Opening Lyrics only *reads* state — it never starts/restarts playback.

## Jellyfin lyrics limitations

- Lyrics come only from the signed-in Jellyfin server (`/Audio/{id}/Lyrics`,
  already wired), supporting both plain and timed (`Start` ticks) lyrics.
  Local-only/signed-out tracks show the empty state. No website scraping, no
  third-party lyrics APIs — unchanged from the existing policy.

## Tests added

Cast / session sync (`active_playback_controller_test`, `default_cast_service_test`,
`cast_now_playing_test`):
- play/pause/seek delegate to Cast (not local) while casting; to local otherwise;
- opening Lyrics starts neither local play nor resume (local and casting);
- lifecycle resume re-syncs from the receiver, never local;
- Cast position/status/duration are reflected in the unified `PlaybackState`;
- disconnect / dropped session resume **paused** (no surprise local start);
- Now Playing shows the connected "Casting to <device>" state;
- local playback still works when Cast is inactive;
- Cast completion advances per repeat mode.

Lyrics (`synced_lyrics_test`, `lyrics_test`, existing `lyrics_follow_test`):
- loads for the current track and updates on track change; no stale lines;
- follows Cast position when casting and local position otherwise;
- active timed line is highlighted; highlight (auto-scroll target) moves with
  position; plain lyrics render without highlighting; empty state when none.

Security (`default_cast_service_test`, existing cast-media/resolver tests):
- no Jellyfin token in `Track.uri`, logs, UI errors, or `CastState`/`CastMedia.toString`;
- no authenticated URL persisted for Cast.

Models: `cast_playback_status_test`, `cast_state_test` (`isCasting`), `lyrics_test`.

Verification: `dart format --set-exit-if-changed .`, `flutter analyze`,
`flutter test` (597 passing) all green locally on Flutter 3.27.4. The debug
APK build runs automatically in CI (`android-debug-apk.yml`).

## Manual Android checklist

1. Start a Jellyfin track locally.
2. Connect to Chromecast.
3. Confirm playback moves to Chromecast.
4. Background the app.
5. Confirm Chromecast keeps playing.
6. Reopen app.
7. Confirm Now Playing position is still synced.
8. Open Lyrics.
9. Confirm phone does not start local playback.
10. Confirm Lyrics follows the Cast position.
11. Pause/play from the phone.
12. Confirm Chromecast responds.
13. Disconnect Cast.
14. Confirm phone does not surprise-start playback unless explicitly requested.
15. Test local playback with Cast disconnected.

## Known limitations

- Starting a **brand-new castable track while already connected but idle**
  (e.g. nothing was playing at connect time) can play ~1s locally before the
  receiver loads and the engine suspends. The common flow (connect while a
  track is playing) is blip-free because the engine is already suspended.
- **repeat-all with a single-track queue** while casting doesn't auto-replay at
  end of track (use repeat-one); multi-track repeat-all wraps correctly.
- Cast position is interpolated between ~1s receiver status polls, so it can
  drift by a fraction of a second between syncs (re-synced on poll/resume).
- Cast uses the Default Media Receiver with an `audio/mpeg` content hint
  (existing behavior); a transcoded cast profile for exotic codecs remains a
  follow-up.

https://claude.ai/code/session_01RuGE6bkFSzpdutdrMVz86H

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuGE6bkFSzpdutdrMVz86H)_