### PR TITLE
Add Favorites library view

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../features/downloads/downloads_screen.dart';
+import '../features/favorites/favorites_screen.dart';
 import '../features/library/library_screen.dart';
 import '../features/player/player_screen.dart';
 import '../features/playlists/playlists_screen.dart';
@@ -34,6 +35,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: AppRoutes.playlists,
                 builder: (context, state) => const PlaylistsScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'favorites',
+                    builder: (context, state) => const FavoritesScreen(),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -3,6 +3,10 @@
 abstract final class AppRoutes {
   static const String library = '/library';
   static const String playlists = '/playlists';
+
+  /// Liked tracks, reached from the Playlists tab. A child of [playlists] so it
+  /// keeps the bottom nav and pops back into that tab.
+  static const String favorites = '/playlists/favorites';
   static const String downloads = '/downloads';
   static const String settings = '/settings';
 

--- a/lib/features/favorites/favorites_controller.dart
+++ b/lib/features/favorites/favorites_controller.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/track.dart';
+import '../../data/repositories/music_library_repository_provider.dart';
+import '../player/favorites_providers.dart';
+
+/// The favourited tracks to show in the Favorites view.
+///
+/// Joins the favourite id set (from [favoriteIdsProvider] — local-folder
+/// favourites plus the Jellyfin server's set, which is the source of truth for
+/// remote tracks) against the offline catalog, so every liked track that's in
+/// the library appears whether it's local or Jellyfin. Re-resolves whenever the
+/// favourite set changes, keeping the list live as hearts toggle.
+final favoriteTracksProvider = FutureProvider<List<Track>>((ref) async {
+  final Set<String> ids = await ref.watch(favoriteIdsProvider.future);
+  if (ids.isEmpty) return const <Track>[];
+  final List<Track> tracks =
+      await ref.watch(musicLibraryRepositoryProvider).getAllTracks();
+  return <Track>[
+    for (final Track track in tracks)
+      if (ids.contains(track.id)) track,
+  ];
+});

--- a/lib/features/favorites/favorites_screen.dart
+++ b/lib/features/favorites/favorites_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/dimens.dart';
+import '../../shared/widgets/empty_state.dart';
+import '../library/widgets/alphabet_track_list.dart';
+import 'favorites_controller.dart';
+
+/// The Favorites library view: every track the user has liked, local or
+/// Jellyfin. Reads entirely from [favoriteTracksProvider] and reuses the same
+/// [AlphabetTrackList]/`TrackTile` rows as the main library, so tapping a
+/// favourite plays it and queues the rest behind it — unchanged from the
+/// library. Shows an honest empty state when nothing is favourited yet.
+class FavoritesScreen extends ConsumerWidget {
+  const FavoritesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final favorites = ref.watch(favoriteTracksProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Favorites')),
+      body: favorites.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const _FavoritesError(),
+        data: (tracks) => tracks.isEmpty
+            ? const EmptyState(
+                icon: Icons.favorite_border,
+                title: 'No favorites yet',
+                message: 'Tap the heart on a track to add it here.',
+              )
+            : AlphabetTrackList(tracks: tracks),
+      ),
+    );
+  }
+}
+
+class _FavoritesError extends StatelessWidget {
+  const _FavoritesError();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              "Couldn't load your favorites",
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -1,19 +1,62 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
-import '../../shared/widgets/empty_state.dart';
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
 
-/// Create and edit playlists. Placeholder until the playlists feature lands.
+/// Create and edit playlists. Playlists themselves are still a placeholder, but
+/// the user's Favorites — a smart, always-present collection of liked tracks —
+/// is reachable from here via a pinned entry at the top.
 class PlaylistsScreen extends StatelessWidget {
   const PlaylistsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = theme.colorScheme.primary;
     return Scaffold(
       appBar: AppBar(title: const Text('Playlists')),
-      body: const EmptyState(
-        icon: Icons.queue_music_outlined,
-        title: 'No playlists yet',
-        message: 'Your playlists will appear here.',
+      body: ListView(
+        children: [
+          ListTile(
+            leading: CircleAvatar(
+              backgroundColor: accent.withValues(alpha: 0.12),
+              child: Icon(Icons.favorite, color: accent),
+            ),
+            title: const Text('Favorites'),
+            subtitle: const Text('Tracks you’ve liked'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.favorites),
+          ),
+          const Divider(height: 0),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              AppSpacing.xl,
+              AppSpacing.md,
+              0,
+            ),
+            child: Text(
+              'No playlists yet',
+              textAlign: TextAlign.center,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              AppSpacing.sm,
+              AppSpacing.md,
+              AppSpacing.md,
+            ),
+            child: Text(
+              'Your playlists will appear here.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/features/favorites/favorites_screen_test.dart
+++ b/test/features/favorites/favorites_screen_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/favorites_store.dart';
+import 'package:linthra/data/repositories/favorites_repository_provider.dart';
+import 'package:linthra/data/repositories/in_memory_favorites_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/favorites/favorites_screen.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import '../library/fake_music_library_repository.dart';
+import '../player/fake_playback_controller.dart';
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.favorites,
+    routes: [
+      GoRoute(
+        path: AppRoutes.favorites,
+        builder: (_, __) => const FavoritesScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (_, __) => const PlayerScreen(),
+      ),
+    ],
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<Track> tracks,
+  required FavoritesData favorites,
+  FakePlaybackController? playback,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        favoritesStoreProvider
+            .overrideWithValue(InMemoryFavoritesStore(favorites)),
+        if (playback != null)
+          playbackControllerProvider.overrideWithValue(playback),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('FavoritesScreen', () {
+    testWidgets('lists only favourited tracks, local and Jellyfin', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'local1', title: 'Alpha', uri: 'file:///a.mp3'),
+          Track(id: 'remote1', title: 'Bravo', uri: 'jellyfin:remote1'),
+          Track(id: 'other', title: 'Charlie', uri: 'file:///c.mp3'),
+        ],
+        favorites: const FavoritesData(
+          localIds: {'local1'},
+          remoteIds: {'remote1'},
+        ),
+      );
+
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Bravo'), findsOneWidget);
+      // A non-favourited track from the catalog is not shown.
+      expect(find.text('Charlie'), findsNothing);
+    });
+
+    testWidgets('shows an empty state when nothing is favourited', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'local1', title: 'Alpha', uri: 'file:///a.mp3'),
+        ],
+        favorites: FavoritesData.empty,
+      );
+
+      expect(find.text('No favorites yet'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
+    });
+
+    testWidgets('tapping a favourite plays it and queues the rest', (
+      tester,
+    ) async {
+      final controller = FakePlaybackController();
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'a', title: 'Alpha', uri: 'file:///a.mp3'),
+          Track(id: 'b', title: 'Bravo', uri: 'file:///b.mp3'),
+          Track(id: 'c', title: 'Charlie', uri: 'file:///c.mp3'),
+        ],
+        favorites: const FavoritesData(localIds: {'a', 'b', 'c'}),
+        playback: controller,
+      );
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      // The tapped track plays and the rest of the list (sorted by title)
+      // follows it in the up-next queue.
+      expect(controller.state.currentTrack?.id, 'a');
+      expect(
+        controller.state.upNext.map((t) => t.id).toList(),
+        ['b', 'c'],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a **Favorites** screen that lists every liked track, reached from a pinned entry at the top of the **Playlists** tab.
- Joins the favourite id set (`favoriteIdsProvider`) against the offline catalog, so both **local-folder favourites** and **Jellyfin server favourites** appear. For remote tracks the server set is already the source of truth (via the repository's `refreshFromRemote`); local-only favourites are kept too.
- Reuses the existing `AlphabetTrackList` / `TrackTile` rows and overflow menu — so tapping a favourite **plays it and queues the rest**, consistent with the main library and the purple/orange theme.
- Honest **empty state** when nothing is favourited.

## Changes
- `lib/features/favorites/favorites_controller.dart` — `favoriteTracksProvider` joining favourite ids with the catalog; re-resolves live as hearts toggle.
- `lib/features/favorites/favorites_screen.dart` — loading / error / empty / list states.
- `lib/features/playlists/playlists_screen.dart` — Favorites entry tile navigating to the screen.
- `lib/app/routes.dart` + `lib/app/router.dart` — `/playlists/favorites` as a child route (keeps bottom nav, pops back into the tab).

## Scope
Favorites UI and library filtering only — no Cast, lyrics, cache, or release-workflow changes.

## Test plan
- [ ] `flutter pub get`
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] `flutter test`

Added `test/features/favorites/favorites_screen_test.dart` covering favourite list rendering (local + Jellyfin), the empty state, and the play-and-queue-the-rest behaviour.

> Note: the Flutter/Dart SDK is not available in the execution environment, so the verification commands above could not be run here. They should be run in CI / locally.

https://claude.ai/code/session_01RShfSWyZqShcXz9Cy4XyzA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RShfSWyZqShcXz9Cy4XyzA)_