### PR TITLE
Complete smart pre-cache test plan: no tight-loop retry + never blocks playback

### DIFF
--- a/test/core/services/smart_precache_service_test.dart
+++ b/test/core/services/smart_precache_service_test.dart
@@ -10,12 +10,33 @@ import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
 
 /// Records the ids it was asked to warm, in order. (The real prefetcher dedups
 /// and bounds; here we only assert *what* the service decides to pre-cache.)
+///
+/// It records the attempt and returns without "caching" anything, which — from
+/// the service's vantage point — is indistinguishable from a *failed* pre-cache:
+/// the real prefetcher swallows fetch errors and returns having cached nothing.
+/// So asserting on [prefetched] also proves the service doesn't re-attempt a
+/// track that never succeeds.
 class _RecordingPrefetcher implements TrackPrefetcher {
   final List<String> prefetched = <String>[];
 
   @override
   Future<void> prefetch(Track track) async {
     prefetched.add(track.id);
+  }
+}
+
+/// A prefetcher whose calls block on [gate] until a test opens it, so a test can
+/// hold a pre-cache "in progress" and assert the service keeps accepting new
+/// playback states meanwhile — i.e. pre-cache runs off the playback path and
+/// never blocks it.
+class _GatedPrefetcher implements TrackPrefetcher {
+  final List<String> started = <String>[];
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<void> prefetch(Track track) async {
+    started.add(track.id);
+    await gate.future;
   }
 }
 
@@ -205,6 +226,64 @@ void main() {
       await _settle();
 
       expect(prefetcher.prefetched, <String>['b']);
+      await service.dispose();
+    });
+
+    test('a track that fails to cache is not retried in a tight loop',
+        () async {
+      // The prefetcher records each attempt and returns having cached nothing —
+      // exactly how the real one behaves when a fetch fails (it swallows the
+      // error). So a track that keeps "failing" stays uncached and therefore
+      // remains an eligible up-next candidate.
+      preferences = InMemoryDownloadPreferences(precacheCount: 1);
+      final service = build();
+
+      // Emit the same what-to-cache inputs many times, as the rapid position /
+      // status ticks during playback would. The service keys off the playing
+      // track, queue, shuffle and repeat — none of which changed — so it must
+      // not hammer the failing track on every tick.
+      for (int i = 0; i < 6; i++) {
+        states.add(_playing(_t('a'), <Track>[_t('b')]));
+        await _settle();
+      }
+
+      // One attempt total, despite six emissions and a persistent failure.
+      expect(prefetcher.prefetched, <String>['b']);
+      await service.dispose();
+    });
+
+    test('a slow pre-cache never blocks playback advancing', () async {
+      // Playback (and the player feature) never await the service: it observes
+      // the state stream and warms tracks as a side effect. Proven here by
+      // wedging a pre-cache mid-flight and showing newer states still flow in.
+      // (Playback itself resolves independently and streams an uncached track
+      // immediately — see offline_first_playable_uri_resolver_test.)
+      preferences = InMemoryDownloadPreferences(precacheCount: 1);
+      final gated = _GatedPrefetcher();
+      final service = SmartPrecacheService(
+        playbackStates: states.stream,
+        prefetcher: gated,
+        preferences: preferences,
+      );
+
+      // Start playing 'a'; the service begins warming 'b' and that fetch blocks.
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+      expect(gated.started, <String>['b']);
+
+      // Playback advances to 'b' while 'b''s pre-cache is still in flight.
+      // Delivering the new state must not deadlock on the stuck pre-cache.
+      states.add(_playing(_t('b'), <Track>[_t('c')]));
+      await _settle();
+      // Still one warm at a time, so 'c' hasn't started — but nothing hung.
+      expect(gated.started, <String>['b']);
+
+      // Once the in-flight pre-cache finishes, the service catches up to the
+      // latest queue and warms 'c'.
+      gated.gate.complete();
+      await _settle();
+      expect(gated.started, <String>['b', 'c']);
+
       await service.dispose();
     });
 


### PR DESCRIPTION
## What this PR changes

The user-controlled smart pre-cache for upcoming Jellyfin tracks already landed on `main` (#59). Reviewing it against the feature's full test plan, two named guarantees had no dedicated **service-level** coverage. This PR adds those two tests — **test-only, no behaviour change** — so the guarantees are regression-proof.

New tests in `test/core/services/smart_precache_service_test.dart`:

1. **A track that fails to cache is not retried in a tight loop.** The prefetcher records each attempt and returns having cached nothing (exactly how the real one behaves when a fetch fails — it swallows the error), so the track stays an eligible candidate. Re-emitting the same what-to-cache inputs six times (as rapid position/status ticks would) yields **one** attempt, not six.
2. **A slow pre-cache never blocks playback advancing.** A pre-cache is wedged mid-flight (a gated prefetcher); a newer playback state is then delivered and is accepted without deadlocking, and the service catches up to the latest queue once the in-flight warm completes.

The "playback starts immediately even when nothing is cached" half of guarantee (2) was already covered by `offline_first_playable_uri_resolver_test` (*streams via the fallback on a cache miss*); the new test references it and adds the complementary "the pre-cache service itself is non-blocking" assertion.

## The feature these tests cover (context — already on `main` via #59)

**Smart pre-cache behaviour.** Linthra streams immediately from Jellyfin and, in the background, warms a small, user-chosen number of upcoming queue tracks into the offline cache so the next songs start instantly (and offline). `SmartPrecacheService` observes the unified `PlaybackState` and reacts only when *what to cache* changes (playing track, up-next, shuffle, repeat) — never on every position tick. Warming is sequential (effective concurrency 1), best-effort, non-blocking, remote-only, de-duplicated, and never throws.

**Smart pre-cache vs Keep offline.** Smart pre-cache is **automatic and evictable** — pre-cached entries are the first to go when space is needed and never appear as user downloads. **Keep offline** (a manual download/pin) is **protected** and never auto-evicted. They share one cache, one limit, and one eviction policy (`CacheDownloadRepository` + `CacheEvictionPolicy`).

**Queue / shuffle.** The controller keeps `upNext` in effective play order, so pre-cache warms the **queue order** normally and the **shuffled order** when shuffle is on, with no special-casing. Under **repeat-one** it warms nothing extra (the current track loops); under **repeat-all** it warms only the next small window. Already-cached tracks are skipped; local files are skipped (already on disk).

**Settings (Settings → Smart pre-cache).** On/off toggle and an upcoming-count picker (1 / 3 / 5 / 10), with copy explaining the automatic-vs-protected distinction and that it stays within the cache limit. The count is persisted and sanitised to the offered options. "Wi-Fi only" already exists on the Downloads screen, so it isn't duplicated; pre-cache honours it.

**Cache-limit behaviour.** Pre-cache checks for room *before* spending data and skips silently when the cache is full of pinned/playing tracks (nothing safe to evict). The exact fit is re-checked at commit, where commits are serialised so concurrent warms/downloads can't jointly overshoot the limit. Eviction never removes the **currently playing track**, **pinned** tracks, **local source files**, or zero-byte/on-device records; only app-managed cache files are deleted. A *manual* download that can't fit still surfaces a friendly `CacheStorageException`.

**Security / tokens.** No Jellyfin token or authenticated stream/download URL is stored, logged, or put in a filename. The download URL is minted only at fetch time inside `JellyfinTrackDownloader` and never escapes it; transport errors are re-raised as generic, token-free messages. Persisted `CachedTrack` metadata carries only the non-secret track id, an id-derived file name, the URI *scheme*, a byte size, timestamps, and the pinned flag. Smart pre-cache uses the **same** safe Jellyfin download path as manual downloads.

## Tests

Full smart pre-cache test plan, with the two added here marked **(new)**:

| # | Guarantee | Location |
|---|-----------|----------|
| 1 | disabled does nothing | `smart_precache_service_test` |
| 2 | enabled warms next N | `smart_precache_service_test` |
| 3 | shuffle uses shuffled/upcoming order | `smart_precache_service_test` |
| 4 | local files skipped | `cache_download_repository_test` |
| 5 | duplicate downloads avoided | `cache_download_repository_test` |
| 6 | cache size limit respected | `cache_download_repository_test` |
| 7 | Wi-Fi-only respected | `cache_download_repository_test` |
| 8 | repeat-one not aggressive | `smart_precache_service_test` |
| 9 | pinned/keep-offline not evicted | `cache_download_repository_test` |
| 10 | currently-playing not evicted | `cache_download_repository_test` |
| 11 | **failed track not retried in a tight loop** | `smart_precache_service_test` **(new)** |
| 12 | no token in metadata/logs/errors | `cache_download_repository_test`, `jellyfin_track_downloader_test` |
| 13 | settings UI exposes the controls | `precache_settings_section_test` |
| 14 | **pre-cache non-blocking** (+ uncached streams immediately) | `smart_precache_service_test` **(new)**, `offline_first_playable_uri_resolver_test` |

## Verification

- `flutter pub get` — ok
- `dart format --set-exit-if-changed .` — clean (0 changed)
- `flutter analyze` — No issues found
- `flutter test` — **623 passing** (+2)
- `flutter build apk --debug` — **not run here**: no Android SDK in this environment, and the change is test-only (it can't affect the Android build). CI (`subosito/flutter-action`, Flutter 3.27.4 — matched locally) covers the APK build.

## Manual Android checklist (for the feature on `main`)

1. Stream a Jellyfin track.
2. Enable Smart pre-cache.
3. Confirm playback starts immediately.
4. Confirm upcoming tracks begin caching in the background.
5. Enable shuffle and confirm pre-cache follows the upcoming shuffled queue.
6. Set a small cache limit and confirm cleanup behaves safely (pre-cached → LRU unpinned removed first).
7. Pin / Keep offline a track and confirm it is not evicted.
8. Confirm local files are never deleted.
9. Confirm no huge full-library download starts.
10. Confirm Jellyfin streaming still works with smart pre-cache disabled.

## Known limitations

- **Background behaviour.** Pre-cache continues while the app is backgrounded but stays within the same conservative bounds (sequential, count-capped, cache-limited, Wi-Fi-gated, best-effort) — there is no separate background throttle. This keeps the next track ready without a runaway download.
- A pre-cache that fails for a track still upcoming may be re-attempted once on the next queue change (by design — a fresh chance when conditions change), but never in a busy loop (covered by test #11).
- Pre-cache is intentionally modest and best-effort; on a flaky connection the next track may still fall back to streaming, which starts immediately regardless.

https://claude.ai/code/session_01MFu52mk4Qp7dCzirfJLjkm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFu52mk4Qp7dCzirfJLjkm)_