### PR TITLE
docs: Google Play closed-testing readiness (readiness, privacy, listing, data safety)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,9 @@ discover it.
 - **Feature deep-dives:** background playback & Android Auto, Now Playing
   controls, folder selection, offline downloads, and Jellyfin — all detailed in
   the sections below.
-- **Release & F-Droid planning:** [docs/](./docs) (release process, signing,
-  F-Droid readiness, dependency/license audit, Jellyfin compatibility).
+- **Release, F-Droid & Google Play planning:** [docs/](./docs) (release process,
+  signing, F-Droid readiness, dependency/license audit, Jellyfin compatibility,
+  and [Google Play closed-testing readiness](#google-play-closed-testing-work-in-progress)).
 
 ## Philosophy
 
@@ -1362,6 +1363,30 @@ Planning/readiness docs (none of these publish or submit anything):
 > **Status:** Linthra is **not** on F-Droid and no submission has been made. The
 > remaining blockers before a submission would be possible are listed in
 > [docs/fdroid-readiness.md §8](./docs/fdroid-readiness.md#8-remaining-blockers-before-submission).
+
+## Google Play closed testing (work in progress)
+
+Linthra is **not** on Google Play, and no submission has been made. As
+groundwork for a first **internal / closed testing** (alpha) submission — **not**
+a production launch — the repository carries Play-oriented planning docs. None of
+them publish or submit anything.
+
+- [docs/play-store-readiness.md](./docs/play-store-readiness.md) — Play
+  readiness checklist: identity, AAB vs APK, Play App Signing, testing tracks,
+  required assets, blockers, the recommended submission path, versioning, and a
+  permissions review.
+- [docs/privacy-policy.md](./docs/privacy-policy.md) — privacy policy **draft**
+  (needs review and a public URL before submission).
+- [docs/google-play-listing.md](./docs/google-play-listing.md) — store listing
+  **draft**: short/full description, features, what-works-today, alpha
+  limitations, keywords, and a screenshot checklist.
+- [docs/google-play-data-safety.md](./docs/google-play-data-safety.md) — Data
+  Safety form prep (no ads, no analytics, no data sold; on-device storage and
+  the user's own Jellyfin server).
+
+> **Status:** alpha only. The blockers before closed testing — and the much
+> longer list before production — are in
+> [docs/play-store-readiness.md §9](./docs/play-store-readiness.md#9-known-blockers-before-production).
 
 ## License
 

--- a/docs/google-play-data-safety.md
+++ b/docs/google-play-data-safety.md
@@ -1,0 +1,133 @@
+# Google Play Data Safety prep (draft)
+
+> **Draft for review.** This documents the **likely** answers for Google Play's
+> **Data Safety** form, based on how Linthra behaves today. It has not been
+> legally reviewed. Re-check every answer against the shipped build in the Play
+> Console before submitting, and keep it consistent with
+> [docs/privacy-policy.md](./privacy-policy.md). See
+> [docs/play-store-readiness.md](./play-store-readiness.md).
+
+## How to read this
+
+Google Play's Data Safety form distinguishes:
+
+- **Collected** — user data transmitted **off the device** to the developer or a
+  third party the developer works with.
+- **Shared** — user data transferred to a **third party**.
+
+The key fact for Linthra: **the Linthra project operates no backend.** There is
+no Linthra account and no Linthra server. The app only talks to sources **the
+user** configures (their own Jellyfin server) and to the user's own local files
+and local-network Cast devices. So the Linthra developer does not receive any
+user data.
+
+> **Nuance to confirm in the Console.** When a user connects their **own**
+> Jellyfin server, data (credentials, library requests) is sent to **that
+> server**, which the user controls and the developer has no access to. Whether
+> Google's form treats "data sent to a user-designated server the developer
+> can't access" as developer *collection* is a judgment call; the honest
+> position is that **the developer collects nothing**. Decide the exact form
+> answers in the Play Console using Google's current definitions, and make sure
+> they match the privacy policy.
+
+## Summary of likely disclosures
+
+- **Ads:** none. Linthra contains **no advertising SDK** and shows no ads.
+- **Third-party analytics / crash reporting:** **none present.** There is no
+  analytics, telemetry, or crash-reporting SDK in the app. (Verify against
+  `pubspec.yaml` at submission time — see the dependency list below.)
+- **Data sold:** **no.** Linthra does not sell user data.
+- **Data shared with third parties:** **no** (the developer has no backend; data
+  the user sends to their own Jellyfin server is not shared with the developer
+  or anyone else by Linthra).
+- **Data collected by the developer:** **none** (no Linthra backend; see nuance
+  above for the user's own server).
+- **App functionality / local app activity:** stored **on the device** for the
+  app to work (library, settings, cache).
+- **Encryption in transit:** traffic to a Jellyfin server is encrypted **when
+  the user's server uses HTTPS** (the user controls this).
+- **Data deletion:** the user can sign out/clear settings, clear the cache, or
+  uninstall to remove locally stored data.
+
+## Data types handled (and where)
+
+Everything below is stored **locally on the device**. None of it is sent to the
+Linthra developer (there is no developer backend).
+
+| Data | Purpose | Where stored | Leaves device? |
+| ---- | ------- | ------------ | -------------- |
+| Jellyfin **server URL** | Connect to the user's chosen server | Encrypted secure storage (Android Keystore-backed) | Only to the user's own server, only if configured |
+| Jellyfin **username** + server identity | Display the signed-in account; auth | Encrypted secure storage | Sent to the user's own server during auth |
+| Jellyfin **session token** | Keep the user signed in | Encrypted secure storage (never plaintext, never logged) | Sent to the user's own server as the auth header |
+| Jellyfin **password** | One-time sign-in only | **Not stored** — used once then discarded | Sent once to the user's own server to obtain a token |
+| **Music library metadata** (track/album/artist) | Browse/play, work offline | Local SQLite database on device | No |
+| **Offline cache / downloaded tracks** | User-requested offline playback | Local app file storage on device | No (downloaded *from* the user's server on request) |
+| **App settings** (selected folder, cache size, download prefs) | App functionality | Local Android preference storage | No |
+
+Notes for the form:
+
+- The **server URL, username, and session token** are the only
+  account/credential-style data, and they live in **encrypted** on-device
+  storage. The **password is never stored.**
+- The user-selected **music folder** uses Android's Storage Access Framework
+  grant; Linthra requests **no** broad storage / "all files" permission.
+
+## Security practices (Data Safety "Security practices" section)
+
+- **Encrypted in transit:** traffic to a Jellyfin server is encrypted **when the
+  user's server uses HTTPS**. Because the user supplies the server URL, Linthra
+  cannot guarantee HTTPS for every user — answer this question honestly
+  ("encrypted in transit when the configured server uses HTTPS") rather than an
+  unqualified "yes."
+- **Encrypted at rest:** the Jellyfin session (URL, username, token) is stored in
+  Android Keystore-backed encrypted storage.
+- **Data deletion mechanism:** users can **sign out & clear** the Jellyfin
+  session, **clear the offline cache**, and **uninstall** the app to remove
+  locally stored data. There is no server-side data to request deletion of,
+  because there is no Linthra server.
+
+## Casting / Google dependencies — implications
+
+- Casting uses a **pure-Dart Cast v2 protocol** implementation (`cast`) with
+  **mDNS** discovery (`bonsoir`, via AOSP `NsdManager`). It does **not** use
+  Google Play Services or the proprietary Google Cast SDK, so casting introduces
+  **no Google data-collection SDK**.
+- Cast traffic goes to a device on the user's **local network** that the user
+  selects — not through any Linthra or Google cloud service.
+- The `AndroidManifest.xml` entry `com.google.android.gms.car.application` is a
+  **metadata declaration** that lets Android Auto recognize Linthra as a media
+  app (it points at `automotive_app_desc.xml`). It does **not** link the GMS
+  Cast/Car SDK and does not collect data.
+- See [docs/dependency-license-audit.md](./dependency-license-audit.md) for the
+  full dependency/anti-feature review.
+
+## Dependencies relevant to Data Safety
+
+For verifying "no analytics / no ads" at submission time, the shipped runtime
+dependencies (from `pubspec.yaml`) are: `flutter_riverpod`, `go_router`, `path`,
+`drift`, `sqlite3_flutter_libs`, `path_provider`, `just_audio`, `audio_service`,
+`file_picker`, `shared_preferences`, `http`, `permission_handler`,
+`flutter_secure_storage`, `cast`, `bonsoir`. **None** is an ads, analytics,
+telemetry, or crash-reporting SDK. If any future dependency adds such behavior,
+the Data Safety form (and the privacy policy) must be updated.
+
+## Before submitting — checklist
+
+- [ ] Re-confirm no ads / analytics / crash SDK was added since this was
+      written (check `pubspec.yaml`).
+- [ ] Decide the "collection vs. user's own server" framing per Google's current
+      definitions, and keep it consistent with the privacy policy.
+- [ ] Answer "encrypted in transit" with the HTTPS qualification, not an
+      unqualified yes.
+- [ ] Describe the data-deletion options (sign out & clear, clear cache,
+      uninstall).
+- [ ] Provide the published **privacy policy URL** in the listing.
+
+## Related docs
+
+- [docs/privacy-policy.md](./privacy-policy.md) — must stay consistent with this
+  form.
+- [docs/play-store-readiness.md](./play-store-readiness.md) — overall readiness.
+- [docs/dependency-license-audit.md](./dependency-license-audit.md) — dependency
+  and anti-feature review.
+</content>

--- a/docs/google-play-listing.md
+++ b/docs/google-play-listing.md
@@ -1,0 +1,197 @@
+# Google Play store listing (draft)
+
+> **Draft for review.** This is a draft of the Google Play store listing copy
+> for Linthra's **closed testing / alpha**. It deliberately separates what works
+> today from what is planned, and makes **no** claim that Linthra is on Google
+> Play or F-Droid (it is not, and no submission has been made). Review and trim
+> to Play's limits before pasting into the Play Console. See
+> [docs/play-store-readiness.md](./play-store-readiness.md).
+
+The repo already carries reusable listing text under
+`fastlane/metadata/android/en-US/` (`short_description.txt`,
+`full_description.txt`). This document is the Play-Console-oriented version and
+should stay consistent with those files.
+
+## 1. Short description
+
+Play limit: **80 characters.** Suggested:
+
+```
+Open-source, local-first music player for music you own. No forced sync.
+```
+
+(72 characters — matches `fastlane/.../short_description.txt`.)
+
+## 2. Full description
+
+Play limit: **4000 characters.** Suggested draft (keep the "works today" vs
+"planned" split honest):
+
+```
+Linthra is an open-source, local-first music player for people who own their
+music. Your library lives on your device, and you stay in control of it.
+
+Linthra is early-stage alpha software. This listing separates what works today
+from what is planned, so nothing here overpromises.
+
+WHAT LINTHRA IS ABOUT
+• Local-first — your music files stay on your device; the app reads from a
+  local catalog rather than depending on a remote service.
+• Music you own — Linthra plays files you already have. No store, no account,
+  no requirement to use anyone's cloud.
+• Privacy-focused — no ads, no telemetry, no forced sync. The app does not
+  phone home or upload your library, and offline downloads only happen when you
+  ask for them.
+• Open source — released under the Mozilla Public License 2.0; anyone can read,
+  audit, build, and contribute.
+
+WORKS TODAY
+• Pick a folder of music with the Android folder picker, scan it, and browse
+  your tracks. Your folder and scanned library survive a restart.
+• Play your local tracks with an up-next queue, plus shuffle and repeat.
+• Background playback with a media notification and lock-screen, Bluetooth, and
+  wired-headset controls.
+• Android Auto: browse your Library and Queue from the car screen.
+• Connect to your own Jellyfin server, sign in, sync your library, and stream.
+  The session token is stored encrypted and your password is never saved.
+• Explicit, user-initiated offline downloads with a smart cache and a size
+  limit you set, plus a "Wi-Fi only" option — never automatic.
+• Cast to Chromecast-compatible devices on your local network.
+
+PLANNED (NOT FINISHED YET)
+• Tag/metadata parsing and album artwork (tracks currently show file names).
+• Browsing by artist and album, plus search.
+• Playlist creation and editing, and queue reorder.
+• Album- and playlist-level "download all" and a background download manager.
+• Additional sources such as WebDAV and NAS, behind the same interface.
+
+SELF-HOSTED FRIENDLY
+Linthra works great with a self-hosted Jellyfin server you run yourself — on a
+home server or NAS. The server is entirely optional and entirely yours; Linthra
+bundles no server and runs no cloud service of its own.
+
+NO SURPRISES
+No ads. No account. No forced sync. No surprise downloads — Linthra never
+downloads your library in the background; downloads happen only when you ask,
+and a "Wi-Fi only" option is respected.
+
+Linthra is alpha software with honest, documented limitations. Expect rough
+edges, and please share feedback.
+```
+
+If this exceeds 4000 characters after edits, trim the "Planned" section first.
+
+## 3. Feature list (for the listing / promo copy)
+
+- Local-first library: scan a folder, browse, and play music you own.
+- Background playback with media notification and lock-screen / Bluetooth /
+  headset controls.
+- Up-next queue, shuffle, and repeat.
+- Android Auto browsing (Library and Queue).
+- Optional Jellyfin connection: sign in, sync, and stream from **your** server.
+- Explicit offline downloads with a smart, size-limited cache and a "Wi-Fi
+  only" option.
+- Casting to Chromecast-compatible devices on the local network.
+- Open source (MPL-2.0), no ads, no telemetry, no forced sync.
+
+## 4. What works today
+
+Use this as the truthful baseline; do not list planned items as if shipped.
+
+- Folder selection (Android folder picker), scanning, and a persisted track
+  list.
+- Local playback with an up-next queue, shuffle, and repeat.
+- Background playback + media session (notification, lock screen, Bluetooth,
+  wired headset).
+- Android Auto: browse Library and Queue.
+- Jellyfin: connect, sign in (token stored encrypted; password never saved),
+  sync, stream, and synced favorites/lyrics.
+- Explicit offline downloads with a smart cache and a configurable size limit.
+- Chromecast/Cast foundation to local-network devices.
+
+## 5. Known alpha limitations
+
+Be upfront in the listing and/or release notes:
+
+- Tracks currently show **file names**; tag/metadata parsing and **album
+  artwork** are not implemented yet.
+- No browse-by-artist/album and **no search** yet.
+- **No playlist** creation/editing yet; queue reordering is limited.
+- No album/playlist "download all" or background download manager yet.
+- The "Wi-Fi only" gate relies on basic connectivity handling; robust
+  connectivity detection is still planned.
+- Some Android 11+ scoped-storage folders may be unreadable; the app surfaces a
+  clear error rather than a silent empty library.
+- Alpha overall — expect rough edges and changing behavior between versions.
+
+## 6. Suggested keywords
+
+For the title/short description and ASO thinking (Play has no separate keyword
+field — weave naturally, do not keyword-stuff):
+
+`music player`, `local music`, `offline music`, `Jellyfin`, `self-hosted`,
+`open source`, `privacy`, `no ads`, `Chromecast`, `Android Auto`, `NAS`,
+`media player`, `audio player`.
+
+> Use third-party names like **Jellyfin**, **Chromecast**, **Android Auto**, and
+> **NAS** only to describe genuine compatibility — never in a way that implies
+> endorsement or affiliation. Do **not** describe Linthra as a clone of, or
+> drop-in replacement for, any specific commercial app.
+
+## 7. Screenshot checklist
+
+Play requires **2–8 phone screenshots**; they must be **real** captures from a
+running build (see [docs/listing-assets.md](./listing-assets.md) for sizes and
+`adb` capture steps). Suggested set, showing only what works today:
+
+- [ ] Library / track list after a scan.
+- [ ] Now Playing screen (with shuffle/repeat/favorite controls).
+- [ ] Background-playback media notification or lock-screen controls.
+- [ ] Jellyfin connect / signed-in Settings screen (no secrets visible).
+- [ ] Offline cache / downloads settings (size limit, clear cache).
+- [ ] (Optional) Cast device picker.
+- [ ] (Optional) Android Auto browse, if cleanly capturable.
+
+Do **not** ship mock or upscaled screenshots. Capture from a real device or
+emulator.
+
+## 8. "No surprise downloads" messaging
+
+A core promise worth stating plainly in the listing and release notes:
+
+> Linthra never downloads your library in the background. Offline downloads are
+> always something **you** start, with a size limit you set and an optional
+> "Wi-Fi only" restriction. There is no forced full-library sync.
+
+## 9. Jellyfin / NAS / self-hosted positioning
+
+- Position Linthra as a **player for music you own**, that **optionally** works
+  with a **self-hosted Jellyfin server** (e.g. on a home server or NAS).
+- The Jellyfin connection is **optional and user-configured**: Linthra bundles
+  no server, promotes no hosted service, and runs **no cloud service of its
+  own**.
+- Frame self-hosting as a benefit for people who want their library on their own
+  hardware — not as a requirement. The local-first core works without any
+  server.
+
+## 10. Things to avoid in the listing
+
+- **Do not** call Linthra a "Plexamp clone" (or a clone/replacement of any
+  specific commercial product).
+- **Do not** overclaim production stability — it is alpha; say so.
+- **Do not** claim availability on F-Droid or Google Play before it is actually
+  published there.
+- **Do not** use third-party trademark names (Jellyfin, Chromecast, Android
+  Auto, NAS vendors) in a confusing way that implies affiliation or endorsement.
+
+## 11. Related docs
+
+- [docs/play-store-readiness.md](./play-store-readiness.md) — overall Play
+  readiness and submission path.
+- [docs/google-play-data-safety.md](./google-play-data-safety.md) — Data Safety
+  form prep.
+- [docs/privacy-policy.md](./privacy-policy.md) — privacy policy draft.
+- [docs/listing-assets.md](./listing-assets.md) — image asset sizes and capture.
+- `fastlane/metadata/android/en-US/` — the canonical short/full description and
+  changelog text.
+</content>

--- a/docs/play-store-readiness.md
+++ b/docs/play-store-readiness.md
@@ -1,0 +1,295 @@
+# Google Play readiness checklist
+
+This document tracks what Linthra needs before it can go through **Google Play
+closed testing** and, much later, production. It is a planning aid, **not** a
+claim of availability.
+
+> **Linthra is _not_ on Google Play, and no submission has been made.** This
+> checklist exists so that a first **internal / closed testing** submission is
+> straightforward and accurate. Linthra is still an **alpha** and must not be
+> published to the production track yet.
+
+For F-Droid the parallel document is
+[docs/fdroid-readiness.md](./fdroid-readiness.md); the two stores share the same
+identity, version source, and assets but differ on signing and submission.
+
+## 1. Current status
+
+- **Stage:** early alpha. Current version `0.1.0-alpha.9+9` (see `pubspec.yaml`).
+- **Distribution:** sideloadable pre-release APK/AAB attached to GitHub
+  Releases. **Not** on Google Play, **not** on F-Droid; nothing publishes
+  automatically.
+- **Groundwork in place:**
+  - Stable application ID `io.github.thezupzup.linthra` and MPL-2.0 license.
+  - A real Linthra app/launcher icon (adaptive + legacy) plus a 512×512 store
+    icon and a 1024×500 feature graphic under
+    `fastlane/metadata/android/en-US/images/`.
+  - A release workflow that already builds an **AAB** (`flutter build appbundle
+    --release`) as well as an APK — see
+    [docs/release-process.md](./release-process.md) and
+    `.github/workflows/android-release-build.yml`.
+  - Release signing is **wired** (env vars / `android/key.properties`) but the
+    real keystore/secrets are **not yet provisioned** — see
+    [docs/release-signing.md](./release-signing.md).
+  - Fastlane-style listing text (`title.txt`, `short_description.txt`,
+    `full_description.txt`, per-`versionCode` changelogs).
+- **Not ready for production.** See
+  [§9 Known blockers before production](#9-known-blockers-before-production).
+
+## 2. App identity
+
+| Field            | Value                            |
+| ---------------- | -------------------------------- |
+| Name             | Linthra                          |
+| App ID           | `io.github.thezupzup.linthra`    |
+| License          | MPL-2.0                          |
+
+- The App ID is set as both the Android `namespace` and `applicationId` in
+  `android/app/build.gradle`. On Google Play the **package name is permanent**
+  once an app is created — it can never be changed for that listing, so it must
+  be correct at first upload. It already matches the F-Droid plan and the
+  GitHub-Release artifacts.
+- License is declared in [`LICENSE`](../LICENSE) (Mozilla Public License 2.0).
+  Play does not require a specific license, but Linthra remains open source.
+
+## 3. Release artifact
+
+| Artifact | Built by                              | Use on Play                          |
+| -------- | ------------------------------------- | ------------------------------------ |
+| **AAB**  | `flutter build appbundle --release`   | **Required.** Google Play accepts only Android App Bundles for new apps; Play generates per-device APKs from it. |
+| APK      | `flutter build apk --release`         | **Not** uploaded to Play. Useful for GitHub Releases / direct sideload testing and for quick on-device checks. |
+
+The release workflow already produces both and labels them with the version and
+signing mode (e.g. `linthra-v0.1.0-alpha.9-release-signed.aab`). For Play, take
+the **release-signed `.aab`** from a `v*` tag build (or a `signed = true` manual
+run) and upload it to the chosen testing track.
+
+## 4. Signing
+
+Two distinct keys are involved once Play App Signing is used. Do not confuse
+them.
+
+### Google Play App Signing (recommended)
+
+- When you enrol an app in **Play App Signing**, Google holds the **app signing
+  key** (the key end users' installs are signed with) in its own infrastructure.
+  You never see it and cannot lose it.
+- You sign each upload with your **upload key** and submit that. Google
+  re-signs with the app signing key before distributing.
+- For the **first** app you can either let Google generate the app signing key,
+  or upload one you generated. Letting Google generate it is the low-risk
+  default for a new listing.
+- The **upload key** is exactly the release keystore this repo already supports
+  (see below). If the upload key is ever lost, Google can reset it — unlike the
+  app signing key, which is permanent.
+
+### Release keystore (the upload key)
+
+- Linthra's release build reads signing material from environment variables or a
+  git-ignored `android/key.properties`, falling back to the **debug** key when
+  none is present. Full details, secret names, and `keytool` generation steps
+  are in [docs/release-signing.md](./release-signing.md).
+- For Play, generate a release keystore (see release-signing.md §4) and use it
+  as the **upload key**. Keep it backed up; reuse it for every upload.
+- **Debug-signed builds must never be uploaded to Play**, not even to internal
+  testing — they are clearly labeled `-debug-signed` by CI precisely so they
+  are not mistaken for a real build.
+
+### Do not commit secrets
+
+- Keystores (`*.keystore`, `*.jks`) and `android/key.properties` are
+  git-ignored. **Never** commit a keystore, a password, or `key.properties`, and
+  never paste a real password into code, CI YAML, a commit message, or this doc.
+- In CI the keystore is provided base64-encoded via the `LINTHRA_KEYSTORE_BASE64`
+  secret and decoded to a temp file at runtime (release-signing.md §2).
+
+## 5. Testing tracks
+
+Google Play offers a ladder of tracks. Use them in order; do not jump to
+production.
+
+| Track                | Audience                                  | Use for Linthra |
+| -------------------- | ----------------------------------------- | --------------- |
+| **Internal testing** | Up to 100 testers you list by email; fastest review/propagation. | **Start here.** Smoke-test the uploaded AAB, store listing, and Data Safety form end to end. |
+| **Closed testing**   | Invited testers via email lists or Google Groups. | **The goal of this prep.** Gather real feedback from a small trusted group on real devices. |
+| **Open testing**     | Anyone with the opt-in link; public.      | Optional, later — only once closed testing is stable and feedback is addressed. |
+| **Production**       | Public on the Play Store.                 | **Not yet.** Only after real closed/open feedback and the blockers in §9 are cleared. |
+
+> **Newer-account testing requirement.** Personal Google Play developer
+> accounts created after Nov 2023 must run a **closed test with at least 12
+> testers opted in for 14+ days** before they can apply for production access.
+> If this account is subject to that rule, closed testing is not optional — it
+> is the path to production. Verify the exact current requirement in the Play
+> Console before planning timelines.
+
+## 6. Required assets
+
+Google Play listing assets (managed in the Play Console; the repo already holds
+reusable copies under `fastlane/metadata/android/en-US/images/`):
+
+| Asset                 | Play requirement                                   | Status  |
+| --------------------- | -------------------------------------------------- | ------- |
+| **App icon**          | 512×512 PNG, 32-bit with alpha.                    | Present (`images/icon.png`). |
+| **Feature graphic**   | 1024×500 PNG/JPG. Required to publish on any track.| Present (`images/featureGraphic.png`). |
+| **Phone screenshots** | 2–8, each side 320–3840 px, 16:9 or 9:16-ish.      | **Missing** — must be captured from a real build. |
+| **7-inch tablet**     | Optional.                                          | Missing (optional). |
+| **10-inch tablet**    | Optional.                                          | Missing (optional). |
+
+- Screenshots are the **only missing image asset** and the main asset blocker.
+  Capture them from a **real** running build — never mockups or upscaled
+  placeholders. Exact sizes and `adb` capture steps are in
+  [docs/listing-assets.md](./listing-assets.md).
+- The icon and feature graphic are generated deterministically from one source
+  design (`tool/branding/`), so the Play and F-Droid copies never drift.
+
+## 7. Data Safety checklist
+
+Google Play requires a **Data Safety** form for every app. A Linthra-specific
+draft of the likely answers lives in
+[docs/google-play-data-safety.md](./google-play-data-safety.md). Before
+submission:
+
+- [ ] Confirm **no ads** SDK is present (none today).
+- [ ] Confirm **no third-party analytics / crash-reporting** SDK is present
+      (none today — verify against `pubspec.yaml` at submission time).
+- [ ] Declare the Jellyfin **server URL + credentials/session token** as data
+      stored **on the device** (encrypted), not collected by us — Linthra runs
+      no server of its own.
+- [ ] Declare **no data sold** and **no data shared** with third parties.
+- [ ] State that traffic to a Jellyfin server is **encrypted in transit when the
+      user's server uses HTTPS** (the user controls this).
+- [ ] Re-check the form whenever a dependency is added (a new SDK can change the
+      honest answers).
+
+## 8. Privacy policy checklist
+
+Google Play requires a **privacy policy URL** for the listing (and always for
+apps that handle account/credential data). A draft is in
+[docs/privacy-policy.md](./privacy-policy.md). Before submission:
+
+- [ ] Review the draft for accuracy against the current build.
+- [ ] Publish it at a **stable public URL** (e.g. GitHub Pages, the repo's
+      rendered Markdown, or a project site) and paste that URL into the Play
+      Console listing.
+- [ ] Keep the policy and the Data Safety form **consistent** — Play checks that
+      they do not contradict each other.
+- [ ] Update the policy if data handling changes.
+
+## 9. Known blockers before production
+
+These do **not** all block *closed testing*, but they block a *production*
+launch. Items marked **(closed-testing blocker)** must be done before even
+internal/closed testing.
+
+1. **Real screenshots** captured from a running build **(closed-testing
+   blocker)** — see [docs/listing-assets.md](./listing-assets.md).
+2. **Release/upload keystore provisioned** and Play App Signing enrolled
+   **(closed-testing blocker)** — see
+   [docs/release-signing.md](./release-signing.md). A debug-signed build cannot
+   be uploaded to any track.
+3. **Privacy policy published at a public URL** **(closed-testing blocker)** —
+   draft in [docs/privacy-policy.md](./privacy-policy.md).
+4. **Data Safety form completed** in the Play Console **(closed-testing
+   blocker)** — draft in [docs/google-play-data-safety.md](./google-play-data-safety.md).
+5. **Target API level** meets Play's current minimum. Linthra inherits
+   `targetSdk` from `flutter.targetSdkVersion` (`android/app/build.gradle`), so
+   the effective value depends on the pinned Flutter SDK. Play raises the
+   minimum target each year — **verify the built AAB's `targetSdkVersion` meets
+   the current Play requirement** before upload, and bump the Flutter SDK if
+   needed.
+6. **Alpha feature maturity.** Tag parsing/artwork, artist/album browse, search,
+   playlists, and batch downloads are still planned (see the README roadmap).
+   This is fine for closed testing but is a judgment-call blocker for a
+   production launch.
+7. **Closed-test tester count / duration**, if the account is subject to the
+   newer testing requirement (§5).
+8. **Content rating questionnaire** completed in the Play Console (Play requires
+   it before publishing on any public track).
+
+## 10. Recommended first submission path
+
+1. **Internal testing first.** Upload the release-signed AAB, complete the store
+   listing, Data Safety form, content rating, and privacy-policy URL. Add
+   yourself and a few trusted emails as internal testers and verify the whole
+   flow on a real device — install, sign in to a Jellyfin server, play, cache,
+   cast.
+2. **Closed testing next.** Promote the build to a closed track, invite a small
+   trusted group, and gather real feedback. If the account is subject to the
+   newer rule (§5), run this for the required tester count / duration.
+3. **Open testing (optional).** Only once closed testing is stable.
+4. **Production only after real feedback.** Do not promote to production until
+   the §9 blockers are cleared and closed/open testing has surfaced and resolved
+   real-world issues. Linthra is alpha software; ship it as such.
+
+## 11. Versioning for Play uploads
+
+Play enforces a **strictly increasing `versionCode`** per package: an upload
+with an equal or lower code than any previous upload (on any track) is rejected.
+Linthra's versioning model already supports this safely:
+
+- `pubspec.yaml` is the **single source of truth**:
+  `version: x.y.z+<versionCode>` (currently `0.1.0-alpha.9+9`). Android reads
+  both `versionName` and `versionCode` from Flutter — they are not hard-coded in
+  Gradle.
+- The in-app About/Settings string (`AppInfo.version` in
+  `lib/core/app_info.dart`) mirrors the `versionName`. A CI test
+  (`test/core/app_info_version_test.dart`) **fails the build if the two drift**,
+  so the displayed version can never silently diverge from the shipped one. This
+  guard already exists; **no new versioning code is needed for Play.**
+
+**Per-upload checklist (in addition to
+[release-process.md §3](./release-process.md#3-pre-tag-checklist)):**
+
+- [ ] `versionCode` is **strictly greater** than every code ever uploaded to
+      Play — across **all** tracks, not just the current one. Once a code is
+      consumed by an upload it can never be reused, even if that upload is
+      discarded.
+- [ ] `versionName` and `AppInfo.version` are bumped together in the same commit
+      (the drift test enforces this).
+- [ ] A matching changelog exists at
+      `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
+
+## 12. Permissions review
+
+Linthra's `AndroidManifest.xml` declares a deliberately small permission set.
+Play's Data Safety and review process expects each to be justified.
+
+| Permission | Why Linthra needs it |
+| ---------- | -------------------- |
+| `INTERNET` | Reach the **user-configured** Jellyfin server (connection test, sign-in, library sync, streaming) and run the Cast session to a chosen device. No server is bundled or contacted unless the user configures one. |
+| `FOREGROUND_SERVICE` | Run the `audio_service` playback service in the foreground so audio keeps playing while the app is backgrounded. |
+| `FOREGROUND_SERVICE_MEDIA_PLAYBACK` | The typed-foreground-service grant required on Android 14+ (API 34) for a `mediaPlayback` service; without it the playback service cannot start on new devices. |
+| `POST_NOTIFICATIONS` | Android 13+ runtime permission for the media notification and its lock-screen / transport controls. Requested once on first launch; denial only suppresses the notification, playback still works. |
+| `CHANGE_WIFI_MULTICAST_STATE` | Receive multicast Wi-Fi packets for **mDNS** (`_googlecast._tcp`) so Chromecast devices on the **local network** can be discovered. Grants no internet or storage access of its own. |
+
+Notes:
+
+- **No storage/media permissions are declared.** Local folder access uses the
+  Storage Access Framework folder grant the user picks — no
+  `READ_MEDIA_AUDIO`, no `MANAGE_EXTERNAL_STORAGE`. This keeps the Play "all
+  files access" declaration unnecessary.
+- **Cast uses no Google Play Services / Google Cast SDK.** It is a pure-Dart
+  Cast v2 implementation (`cast` + `bonsoir` over AOSP `NsdManager`). The
+  manifest's `com.google.android.gms.car.application` entry is **only a
+  metadata declaration** that tells Android Auto Linthra is a media app
+  (pointing at `automotive_app_desc.xml`); it does **not** link the GMS Cast or
+  Car SDK. See [docs/dependency-license-audit.md](./dependency-license-audit.md).
+- The same permission rationale, with more F-Droid framing, is in
+  [docs/fdroid-readiness.md §5](./fdroid-readiness.md#5-anti-features-review).
+
+## 13. Related docs
+
+- [docs/privacy-policy.md](./privacy-policy.md) — privacy policy draft.
+- [docs/google-play-listing.md](./google-play-listing.md) — store listing draft.
+- [docs/google-play-data-safety.md](./google-play-data-safety.md) — Data Safety
+  form prep.
+- [docs/release-process.md](./release-process.md) — versioning, tagging, and the
+  release-build workflow.
+- [docs/release-signing.md](./release-signing.md) — keystore, CI secrets,
+  rotation, and Play App Signing notes.
+- [docs/listing-assets.md](./listing-assets.md) — icon, feature graphic, and
+  screenshot capture.
+- [docs/fdroid-readiness.md](./fdroid-readiness.md) — the parallel F-Droid
+  checklist.
+</content>
+</invoke>

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,144 @@
+# Linthra Privacy Policy
+
+> **Draft for review.** This is a draft privacy policy for Linthra. It is
+> written to be honest about how the current app behaves, but it has **not** been
+> legally reviewed. Review it for accuracy against the shipped build, and have it
+> reviewed as appropriate, before publishing it at a public URL and linking it
+> from a Google Play listing. See
+> [docs/play-store-readiness.md](./play-store-readiness.md).
+
+_Last updated: see this file's git history._
+
+## Overview
+
+Linthra is an **open-source Android music player**. It is licensed under the
+Mozilla Public License 2.0 and its source code is public at
+<https://github.com/thezupzup/linthra>.
+
+In plain terms:
+
+- Linthra **does not include ads**.
+- Linthra **does not sell your data**.
+- Linthra **does not intentionally track you**. There is no analytics,
+  telemetry, or crash-reporting SDK in the app.
+- Linthra **does not operate a central cloud service**. There is no Linthra
+  account and no Linthra server. The app talks only to the music sources **you**
+  configure (such as your own Jellyfin server) and to your own local files.
+
+Because Linthra has no backend, most of your data simply never leaves your
+device unless **you** point the app at a server you control.
+
+## What data Linthra handles, and where it is stored
+
+All of the following is stored **locally on your device**. None of it is sent to
+the Linthra project or to any third party operated by us.
+
+### Jellyfin connection details (only if you connect a server)
+
+If you choose to connect Linthra to a [Jellyfin](https://jellyfin.org/) media
+server, the app stores what it needs to keep you signed in:
+
+- the **server URL** you entered;
+- your **username** (as returned by the server) and the server's identifying
+  details;
+- a **session token** issued by your server.
+
+These are stored together in the device's **encrypted** secure storage
+(Android Keystore-backed), so the session token is not kept in plaintext.
+
+Your **password is never stored.** It is sent once to your Jellyfin server to
+obtain a session token, then discarded from memory.
+
+This information is used **only** to talk to the server you configured. Linthra
+does not transmit it anywhere else.
+
+### Music library metadata
+
+Metadata about your music (track, album, and artist information from your local
+folders and/or your Jellyfin library) may be stored in a **local database on
+your device** so the app can show your library quickly and work offline. This
+data stays on the device.
+
+### Offline cache and downloads
+
+Tracks you explicitly download, and tracks the app pre-caches to play smoothly,
+are stored as files in Linthra's **local storage on your device**, within a
+size limit you control. Downloads are always **user-initiated** — Linthra does
+not silently download your library. A "Wi-Fi only" option is available for
+remote downloads.
+
+### App settings
+
+Your preferences (such as the selected local music folder, cache size limit, and
+download settings) are stored locally on the device using standard Android
+preference storage.
+
+## Network activity
+
+Linthra makes network connections only in these situations, all under your
+control:
+
+- **Talking to your Jellyfin server.** When you have configured a server,
+  Linthra contacts **that server** (and only that server) to test the
+  connection, sign in, sync your library, stream music, and download tracks you
+  request. If your server uses **HTTPS**, this traffic is **encrypted in
+  transit**; whether HTTPS is used is determined by **your** server
+  configuration.
+- **Casting to a device on your local network.** When you choose to cast,
+  Linthra discovers and communicates with Cast/Chromecast-compatible devices on
+  your **local network**. This uses a local-network protocol implementation and
+  does **not** route your media through any Linthra or Google cloud service for
+  this purpose.
+
+Linthra does **not** phone home, upload your library, or send usage data
+anywhere.
+
+## Permissions
+
+Linthra requests a minimal set of Android permissions, each tied to a feature:
+
+- **Internet** — to reach the Jellyfin server you configure and to run a Cast
+  session. Without a configured server, the app does not need to use the
+  network for its local-first features.
+- **Foreground service / media playback** — to keep audio playing in the
+  background and show media controls in the notification and on the lock screen.
+- **Notifications** (Android 13+) — to show the media-playback notification and
+  its controls. If you deny it, playback still works without the notification.
+- **Local-network multicast** — to discover Cast/Chromecast devices on your
+  local network when you choose to cast.
+
+Linthra does **not** request broad storage ("all files") access. Access to your
+local music folder uses Android's Storage Access Framework, where **you** pick
+the folder to grant.
+
+## Your choices and control
+
+- You can **sign out** of a Jellyfin server in Settings, which clears the saved
+  server details and session token from the device ("Sign out & clear").
+- You can **clear the offline cache** (downloaded and pre-cached tracks) in
+  Settings.
+- You can **uninstall** Linthra, which removes the app's locally stored data
+  from your device per Android's normal app-removal behavior.
+
+## Children's privacy
+
+Linthra is a general-purpose music player and is not directed at children. It
+does not knowingly collect personal information from anyone, as it has no
+backend that collects data.
+
+## Changes to this policy
+
+Because Linthra is open source, changes to data handling are visible in the
+project's source history. If this policy changes, the updated version will be
+published in the repository and at the URL linked from any store listing.
+
+## Contact / reporting a security issue
+
+Linthra is a community open-source project. For questions about this policy, or
+to report a privacy or security issue, please open an issue (or use any security
+reporting mechanism provided) on the project's GitHub repository:
+
+- **GitHub:** <https://github.com/thezupzup/linthra/issues>
+
+Please do not include secrets (such as passwords or tokens) in a public issue.
+</content>


### PR DESCRIPTION
## Summary

Prepares Linthra for **Google Play closed testing / alpha readiness**. This is
**documentation only** — no app features, no production publishing, and nothing
that submits to any store. Linthra stays an alpha (`0.1.0-alpha.9+9`).

Inspected before writing: `pubspec.yaml`, `android/app/build.gradle`,
`android/build.gradle`, `AndroidManifest.xml`, `lib/core/app_info.dart`, the
release workflow, fastlane metadata, `README.md`, and the existing
`docs/release-process.md` / `docs/release-signing.md` / `docs/fdroid-readiness.md`
/ `docs/listing-assets.md`. Storage behavior was confirmed in code
(`SecureJellyfinSessionStore`, `JellyfinSession`) to keep the privacy/data-safety
docs accurate.

## New docs

### Play Store readiness — `docs/play-store-readiness.md`
Current status; app identity (Linthra / `io.github.thezupzup.linthra` / MPL-2.0);
**AAB required for Play, APK for GitHub/sideload testing** (the release workflow
already builds both); **Google Play App Signing** vs the release **upload**
keystore, with a "never commit secrets" note; testing tracks
(internal → closed → open → production); required assets; Data Safety + privacy
checklists; blockers before production; the recommended submission path; a Play
**versionCode** checklist (§E); and a **permissions review** (§F).

### Privacy policy draft — `docs/privacy-policy.md`
Honest draft, marked **for review**: open-source Android music player; **no ads**,
**no data sold**, **no intentional tracking**, **no central cloud service**;
connects only to a **user-configured Jellyfin server**; server URL / username /
**session token stored encrypted on-device** (password **never** stored); library
metadata and offline cache stored locally; Cast talks to local-network devices
only when the user casts; **sign-out & clear / clear cache / uninstall** controls;
contact via the GitHub repo.

### Store listing draft — `docs/google-play-listing.md`
Short description (≤80 chars), full description (works-today vs planned split),
feature list, alpha limitations, suggested keywords, a **real**-screenshot
checklist, "no surprise downloads" messaging, and Jellyfin/NAS/self-hosted
positioning. Explicitly **avoids** clone comparisons, production-stability
overclaims, premature F-Droid/Play availability claims, and confusing trademark
use.

### Data Safety prep — `docs/google-play-data-safety.md`
Likely form answers grounded in the code: developer collects nothing (no backend);
**no ads**, **no third-party analytics/crash SDK** (verified against
`pubspec.yaml`); **no data sold/shared**; server URL/username/token in **encrypted**
secure storage; **encrypted in transit when the user's Jellyfin server uses
HTTPS** (qualified, not an unconditional "yes"); local storage/cache behavior; and
the Cast note — **pure-Dart Cast, no GMS Cast SDK** (the
`com.google.android.gms.car.application` manifest entry is only an Android Auto
metadata declaration).

### README
New "Google Play closed testing (work in progress)" section linking all four docs,
plus a pointer from the deeper-docs list.

## Remaining blockers before closed testing
1. **Real screenshots** captured from a running build (the only missing image
   asset).
2. **Release/upload keystore provisioned** + Play App Signing enrolled (debug-
   signed builds can't be uploaded).
3. **Privacy policy published at a public URL** and linked in the Console.
4. **Data Safety form** completed in the Console.
5. **Target API level** — verify the built AAB's `targetSdkVersion` (inherited
   from `flutter.targetSdkVersion`) meets Play's current minimum.
6. **Content rating** questionnaire.
7. If the account is subject to the **newer testing requirement**, a closed test
   with ≥12 testers for 14+ days before production access.

## Intentionally **not** changed
- No app features or behavior changes.
- **No version bump** — the existing `test/core/app_info_version_test.dart` drift
  guard plus `release-process.md` already keep `AppInfo.version` ↔ `pubspec.yaml`
  honest; §E only adds a Play **versionCode** checklist (no new code).
- No new permissions; §F documents the existing minimal set.
- No keystore, secret, or `key.properties` (none committed; verified).
- Nothing published or submitted to any store; no fastlane metadata rewritten
  (the new listing doc stays consistent with the existing files).

## Verification
- Markdown/docs review; all internal cross-references resolve to existing files
  and headings.
- Secret scan of the new docs — none found.
- `flutter analyze` / `test` not applicable — **no code changes** (docs + README
  only).

https://claude.ai/code/session_01SAZUM1hzK8LEvG1eH54FUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAZUM1hzK8LEvG1eH54FUx)_