### PR TITLE
Add Navidrome/Subsonic provider and Cast device-volume control

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,22 @@ Everything below works end to end on a real Android device in the current alpha
 - **Jellyfin (self-hosted)** — connect to your own server, test the connection,
   sign in, sync your library, and **stream** tracks. Works with HTTPS /
   Cloudflare-proxied domains.
+- **Navidrome / Subsonic (self-hosted)** — connect to your own
+  Subsonic-compatible server, test the connection, sign in, **sync** your
+  library, and **stream / cache / cast** tracks. Auth uses the Subsonic
+  token+salt scheme, so your password is never stored — only a derived token is
+  kept (encrypted). Favorites and lyrics are follow-ups; see
+  [docs/providers.md](docs/providers.md).
 - **Smart offline cache** — mark individual Jellyfin tracks for offline use
   (Plexamp-style explicit downloads), with a **"Wi-Fi only"** option, a
   configurable cache size limit, "Keep offline" pinning, and optional smart
   pre-caching of upcoming tracks. Cached tracks play fully offline.
 - **Synced lyrics** — fetch a Jellyfin track's lyrics into a sheet; favorites
   also sync with your Jellyfin server.
-- **Chromecast foundation** — discover Cast devices, connect, and hand off the
-  current Jellyfin stream to the receiver, using a pure-Dart Cast protocol (no
-  Google Play Services).
+- **Chromecast** — discover Cast devices, connect, and hand off the current
+  Jellyfin/Subsonic stream to the receiver, using a pure-Dart Cast protocol (no
+  Google Play Services). When connected, the Cast sheet shows a **Cast volume**
+  control (slider + mute) that drives the *device's* volume.
 
 ## Known limitations
 
@@ -83,6 +90,9 @@ This is an alpha — expect rough edges. The honest gaps today:
 - **Downloads are track-level only** — no album/playlist "download all" and no
   background download manager (downloads run inline; no resume).
 - **Single Jellyfin server** — one session at a time; no multi-server support.
+- **Subsonic favorites & lyrics** — Navidrome/Subsonic streaming, offline cache,
+  and casting work, but favorites, lyrics, and cover art are documented
+  follow-ups (see [docs/providers.md](docs/providers.md)).
 - **Direct play only** — no server-side transcoding fallback for exotic
   formats; Cloudflare Access / Zero Trust in front of Jellyfin is not supported.
 - **On-device files can't be cast** — a Cast receiver can't reach a local file,
@@ -195,18 +205,19 @@ and the offline-downloads section below.
 ## Roadmap
 
 **Working now:** local scanning + playback, background playback & media session,
-Android Auto browsing, shuffle/repeat, Jellyfin connect/sync/stream, explicit
-offline downloads with a smart cache, synced favorites & lyrics, and a
-Chromecast foundation.
+Android Auto browsing, shuffle/repeat, Jellyfin and Navidrome/Subsonic
+connect/sync/stream, explicit offline downloads with a smart cache, synced
+favorites & lyrics (Jellyfin), and Chromecast with device-volume control.
 
 **Next up (roughly in order):**
 
 1. Tag/metadata parsing and album artwork.
 2. Browse by artist/album, and search.
-3. Playlist creation, editing, and queue reordering.
-4. Album/playlist "download all" and a background download manager.
-5. Real connectivity detection for the "Wi-Fi only" gate.
-6. More sources behind the same interface — WebDAV, NAS.
+3. Subsonic favorites, lyrics, and cover art.
+4. Playlist creation, editing, and queue reordering.
+5. Album/playlist "download all" and a background download manager.
+6. Real connectivity detection for the "Wi-Fi only" gate.
+7. More sources behind the same interface — WebDAV, NAS.
 
 **Later:** local-file lyrics (`.lrc`/tags), ReplayGain, MPRIS, smart playlists,
 Linux desktop, and richer Android Auto (album/artist grouping, search) and
@@ -321,11 +332,15 @@ lib/
 
 - **`MusicSource`** (`core/services/music_source.dart`) — a media backend.
   `LocalMusicSource` shipped first; `JellyfinMusicSource`
-  (`core/sources/jellyfin/`) now implements the same contract over a
-  `JellyfinClient` (HTTP behind one interface), with `JellyfinAuthenticator`
-  for sign-in and `JellyfinSessionStore` for the encrypted token —
-  authentication, persistence, and library fetching kept separate.
-  `WebDavMusicSource` slots in the same way later.
+  (`core/sources/jellyfin/`) and `SubsonicMusicSource` (`core/sources/subsonic/`,
+  for Navidrome and other Subsonic-compatible servers) now implement the same
+  contract over their own HTTP clients, each with a separate authenticator,
+  encrypted session store, and library fetcher — authentication, persistence,
+  and library fetching kept apart. A small **capability model**
+  (`core/sources/music_provider.dart`) declares what each provider supports
+  (`canStream`/`canCache`/`canFavorite`/`canLyrics`/`canCast`) so the UI offers
+  only the actions that work. `WebDavMusicSource` slots in the same way later;
+  see [docs/providers.md](docs/providers.md).
 - **`MusicLibraryRepository`** (`core/repositories/`) — the local SQLite cache
   the UI reads from. Sources *sync into* it; the UI never talks to a source
   directly. This is what keeps the app fast and fully offline.
@@ -353,7 +368,10 @@ lib/
   keep `UnavailableCastService`, so the button stays honest. The
   network-touching transport is isolated so all of casting's decision-making is
   unit-tested with a fake; the resolved URL (with any token) is never logged or
-  persisted.
+  persisted. When connected, `CastService` also exposes the receiver's **device
+  volume** (`setVolume`/`volumeUp`/`volumeDown`/`setMuted`, surfaced in
+  `CastState` as `volume`/`muted`/`supportsVolumeControl`); the Cast sheet shows
+  a "Cast volume" slider, and a failed volume command never interrupts playback.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
   user-initiated, "Wi-Fi only"-respecting download policy in one place.
   `CacheDownloadRepository` implements it today over a `DownloadStore`
@@ -831,13 +849,21 @@ own.
   Google Play Services or proprietary Cast SDK**, so the F-Droid build keeps
   casting (see [docs](docs/dependency-license-audit.md#casting-chromecast--real-cast-without-google-play-services)).
   The handoff resolves the current track's stream URL **only at cast time**
-  (Jellyfin's authenticated URL, token woven in on demand and **never logged or
-  persisted**), tells the receiver to fetch it, and pauses local audio so it
-  isn't heard twice; disconnecting (or the receiver dropping) resumes local
-  playback. **On-device files can't be cast** — a receiver can't reach a
-  `file://` path — so those surface a clear limitation in the sheet rather than
-  failing silently. The sheet shows every state honestly: searching, available
-  devices, connecting, connected, the local-file notice, and error/no-devices.
+  (Jellyfin's or Subsonic's authenticated URL, the credential woven in on demand
+  and **never logged or persisted**), tells the receiver to fetch it, and pauses
+  local audio so it isn't heard twice; disconnecting (or the receiver dropping)
+  resumes local playback. **On-device files can't be cast** — a receiver can't
+  reach a `file://` path — so those surface a clear limitation in the sheet
+  rather than failing silently. The sheet shows every state honestly: searching,
+  available devices, connecting, connected, the local-file notice, and
+  error/no-devices.
+- **Cast volume.** While connected, the Cast sheet shows a clearly labelled
+  **Cast volume** slider plus mute, driving the *device's* own volume (not the
+  phone's media volume) and following the receiver's reported level live. It's
+  all behind `CastService` (`setVolume`/`volumeUp`/`volumeDown`/`setMuted`), with
+  `CastState` exposing `volume`/`muted`/`supportsVolumeControl`; a device that
+  reports a fixed volume shows an honest disabled state, and a failed volume
+  command surfaces a calm notice **without ever interrupting playback**.
   Architecturally the UI still only touches `CastService`/`CastState`; the real
   `DefaultCastService` owns state + handoff and is fully unit-tested behind a
   faked `CastTransport`, while the thin `ChromecastCastTransport` (the only code

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,129 @@
+# Music providers
+
+Linthra is a **self-hosted / user-owned** music player. It plays music you
+already have — on your device or on a server you run — and is built around one
+extension point, the **`MusicSource`** (`lib/core/services/music_source.dart`),
+so new backends slot in without touching the UI or storage layers.
+
+Each provider declares what it can do through a small **capability model**
+(`lib/core/sources/music_provider.dart`), so the UI only ever offers actions a
+source actually supports:
+
+| Capability     | Meaning                                                        |
+| -------------- | -------------------------------------------------------------- |
+| `canStream`    | Tracks play by resolving a stream URL at play time.            |
+| `canCache`     | Tracks can be downloaded for offline use (token-free cache).   |
+| `canFavorite`  | Favorites can be toggled and reflected.                        |
+| `canLyrics`    | Lyrics can be fetched for the source's tracks.                 |
+| `canCast`      | A track's playback URL is network-reachable, so it can cast.   |
+
+A track carries an opaque `scheme:` URI (`subsonic:<id>`, `jellyfin:<id>`, or a
+file path) and **never** an authenticated URL — stream/download URLs are minted
+on demand at play/download time and discarded, so no secret reaches the
+persisted catalog.
+
+## Provider matrix
+
+| Provider              | sourceId   | Stream | Cache | Favorite | Lyrics | Cast |
+| --------------------- | ---------- | :----: | :---: | :------: | :----: | :--: |
+| On this device        | `local`    |   ✅   |  —    |    ✅    |   —    |  —   |
+| Jellyfin              | `jellyfin` |   ✅   |  ✅   |    ✅    |   ✅   |  ✅  |
+| Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜    |   🔜   |  ✅  |
+
+✅ implemented · 🔜 planned follow-up · — not applicable
+
+## Local files
+
+Pick a folder with the Android Storage Access Framework picker and scan it.
+Tracks play from their on-device path. The chosen folder and the scanned catalog
+survive a restart. No broad storage permission is requested. On-device files
+cannot be cast (a receiver can't reach a file on your phone).
+
+## Jellyfin
+
+Connect to your own Jellyfin server, test the connection, sign in, sync your
+library, and stream — including over an HTTPS/Cloudflare-proxied domain.
+Favorites and synced lyrics work; tracks can be marked for offline use and cast
+to a Chromecast. The access token is stored encrypted on-device; the password is
+never persisted. See [jellyfin-compatibility.md](jellyfin-compatibility.md).
+
+## Navidrome / Subsonic
+
+Linthra speaks the **Subsonic-compatible REST API**, so it works with
+[Navidrome](https://www.navidrome.org/) and other Subsonic-compatible servers.
+
+### What works now
+
+- **Configure** a server (`Settings → Navidrome / Subsonic`): server URL,
+  username, password. HTTPS reverse-proxy / self-hosted domains are supported;
+  no personal domain is hardcoded.
+- **Test connection** and **sign in** — both verify the credentials against the
+  server's `ping` endpoint.
+- **Sync library** (“Sync Navidrome library”): artists, albums, and tracks are
+  fetched (walking the ID3 album lists) and upserted into the local catalog
+  under the `subsonic` source id.
+- **Stream** a track: tapping an uncached Subsonic track streams it directly,
+  resolving the URL at play time. A cached copy is preferred automatically.
+- **Offline cache**: a Subsonic track can be downloaded for offline use (the
+  original file via `download.view`).
+- **Cast**: a Subsonic track casts to a Chromecast as a live stream.
+
+### Authentication & security (token+salt)
+
+Subsonic's modern auth sends, on every request,
+`u=<user>&t=<token>&s=<salt>` where `token = md5(password + salt)`. Linthra
+computes **one** random salt and its token at sign-in and stores **only those**
+(encrypted on-device, via `flutter_secure_storage`). The password is used to
+derive the token and then **discarded — never persisted, never logged**. This
+mirrors how Jellyfin stores a derived access token rather than the password.
+
+Concretely, Linthra:
+
+- never stores the plaintext password;
+- never logs the password, salt, or token;
+- never stores an authenticated stream/download URL in `Track.uri` or the
+  database (the URI is the opaque `subsonic:<id>`);
+- never puts a credential in a cache filename or cache metadata (the cache file
+  extension comes from the response content type, not the URL);
+- never surfaces a credential or credentialed URL in a UI error message;
+- resolves stream/download URLs **only at play/download time**.
+
+### What remains (follow-ups)
+
+These are declared **unsupported** in the capability model today, so their
+actions stay hidden/disabled rather than failing:
+
+- **Favorites** — Subsonic exposes `star`/`unstar`/`getStarred2`; wiring them
+  through Linthra's favorites repository is a follow-up.
+- **Lyrics** — `getLyrics`/`getLyricsBySongId` (OpenSubsonic) is a follow-up.
+- **Cover art** — `getCoverArt` requires the auth query, so a cover URL would
+  embed the credential, and artwork is persisted in the catalog. To keep the
+  security invariant, Subsonic tracks have no `artworkUri` yet; token-free
+  cover-art resolution (resolved on demand, like stream URLs) is a follow-up.
+- **Per-track cast content type** — the cast receiver is sent a generic
+  `audio/mpeg` hint; an exact per-track type / transcode profile is a follow-up.
+- **In-app browse/search by artist/album** — the synced catalog lists tracks;
+  richer browsing is shared work across all providers.
+
+## Future provider possibilities
+
+The `MusicSource` seam is designed so more **self-hosted / user-owned** backends
+can be added the same way Jellyfin and Subsonic were:
+
+- **WebDAV** — play from a WebDAV share (Nextcloud, etc.).
+- **SMB / NAS** — browse and stream from a network file share.
+- **DLNA / UPnP** — discover and play from a media server on the LAN.
+
+Each would implement `MusicSource` (and the narrow stream/download seams),
+declare its capabilities, and add a settings section — with the same rule that
+credentials are stored securely and never woven into a persisted URI.
+
+## Non-goals
+
+Linthra stays focused on music you own or host yourself. It does **not**, and
+will not:
+
+- play from **Spotify** or other closed streaming services;
+- **bypass DRM** of any kind;
+- perform **unauthorized downloads**;
+- **rip** or extract content from closed streaming services.

--- a/lib/core/models/cast_state.dart
+++ b/lib/core/models/cast_state.dart
@@ -56,6 +56,9 @@ class CastState {
     this.connectedDevice,
     this.message,
     this.isCasting = false,
+    this.volume,
+    this.muted = false,
+    this.supportsVolumeControl = false,
   });
 
   /// The honest default: no cast backend wired, nothing reachable.
@@ -85,6 +88,23 @@ class CastState {
   /// silence the local engine and follow the cast session.
   final bool isCasting;
 
+  /// The connected receiver's volume on the `0.0–1.0` scale, or null when not
+  /// connected or the device hasn't reported one yet. This is the *device*
+  /// volume (a Chromecast's own level), not the phone's media volume.
+  final double? volume;
+
+  /// Whether the connected receiver is muted. Only meaningful while connected.
+  final bool muted;
+
+  /// Whether the connected receiver allows volume control. False when not
+  /// connected, when the device reports a fixed volume, or before its first
+  /// status arrives — the volume UI shows an honest disabled state in that case.
+  final bool supportsVolumeControl;
+
+  /// Whether a device volume level is known (connected and reported), so the UI
+  /// can render the current level.
+  bool get hasVolume => volume != null;
+
   /// Whether the platform can cast at all. False when no backend is wired,
   /// which is what the UI uses to show an honest unavailable state rather than
   /// an empty device picker.
@@ -103,12 +123,19 @@ class CastState {
     List<CastDevice>? devices,
     CastDevice? connectedDevice,
     bool? isCasting,
+    double? volume,
+    bool? muted,
+    bool? supportsVolumeControl,
   }) {
     return CastState(
       availability: availability ?? this.availability,
       devices: devices ?? this.devices,
       connectedDevice: connectedDevice ?? this.connectedDevice,
       isCasting: isCasting ?? this.isCasting,
+      volume: volume ?? this.volume,
+      muted: muted ?? this.muted,
+      supportsVolumeControl:
+          supportsVolumeControl ?? this.supportsVolumeControl,
     );
   }
 
@@ -120,7 +147,10 @@ class CastState {
           listEquals(other.devices, devices) &&
           other.connectedDevice == connectedDevice &&
           other.message == message &&
-          other.isCasting == isCasting);
+          other.isCasting == isCasting &&
+          other.volume == volume &&
+          other.muted == muted &&
+          other.supportsVolumeControl == supportsVolumeControl);
 
   @override
   int get hashCode => Object.hash(
@@ -129,5 +159,8 @@ class CastState {
         connectedDevice,
         message,
         isCasting,
+        volume,
+        muted,
+        supportsVolumeControl,
       );
 }

--- a/lib/core/models/cast_volume.dart
+++ b/lib/core/models/cast_volume.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+
+/// The volume of a connected cast receiver, as reported by (and set on) the
+/// device — not the phone's media volume.
+///
+/// Emitted by a [CastSessionHandle] as the receiver's status changes and folded
+/// by [DefaultCastService] into [CastState] (its `volume`, `muted`, and
+/// `supportsVolumeControl`). [level] is the Cast `0.0–1.0` scale. [controllable]
+/// is false when the receiver reports a fixed volume (Cast `controlType: fixed`),
+/// so the UI can show an honest disabled state instead of a slider that does
+/// nothing.
+@immutable
+class CastVolume {
+  const CastVolume({
+    required this.level,
+    required this.muted,
+    this.controllable = true,
+  });
+
+  /// The honest "we don't know the device volume" value: not controllable and
+  /// unmuted at zero, used before the first receiver status arrives.
+  static const CastVolume unknown =
+      CastVolume(level: 0, muted: false, controllable: false);
+
+  /// Device volume on the Cast `0.0–1.0` scale.
+  final double level;
+
+  /// Whether the receiver is muted.
+  final bool muted;
+
+  /// Whether the receiver allows volume changes (false for a fixed-volume
+  /// device).
+  final bool controllable;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CastVolume &&
+          other.level == level &&
+          other.muted == muted &&
+          other.controllable == controllable);
+
+  @override
+  int get hashCode => Object.hash(level, muted, controllable);
+
+  @override
+  String toString() =>
+      'CastVolume(level: $level, muted: $muted, controllable: $controllable)';
+}

--- a/lib/core/models/subsonic_session.dart
+++ b/lib/core/models/subsonic_session.dart
@@ -1,0 +1,139 @@
+/// An authenticated Subsonic/Navidrome session: everything needed to make
+/// further authorized requests, kept in one immutable value so it can be
+/// persisted as a unit and passed to the source.
+///
+/// Security — the token+salt model: Subsonic's modern auth sends, on every
+/// request, `u=<user>&t=<token>&s=<salt>` where `token = md5(password + salt)`.
+/// Linthra computes a single random [salt] and its [token] once at sign-in and
+/// stores **only those**; the user's password is used to derive the token and
+/// is then discarded, never persisted. That mirrors how [JellyfinSession]
+/// stores a derived access token rather than the password. The (salt, token)
+/// pair is a credential — it is persisted only through the `SubsonicSessionStore`
+/// (the production binding is encrypted on-device) and must never be logged or
+/// shown. [toString] redacts both so an accidental interpolation can't leak it.
+class SubsonicSession {
+  const SubsonicSession({
+    required this.baseUrl,
+    required this.username,
+    required this.salt,
+    required this.token,
+    this.serverType,
+    this.serverVersion,
+    this.apiVersion,
+  });
+
+  /// Clean base URL of the server (no trailing slash), e.g.
+  /// `https://music.example.com`. The `/rest/*.view` API paths append to this.
+  final String baseUrl;
+
+  /// The authenticated user's name. Sent on every request as `u=`.
+  final String username;
+
+  /// The per-session random salt sent as `s=`. Not a secret on its own, but is
+  /// half of the credential, so it is treated as sensitive and redacted in
+  /// [toString].
+  final String salt;
+
+  /// `md5(password + salt)`, sent as `t=`. The secret — never log this. The
+  /// password it was derived from is never stored.
+  final String token;
+
+  /// The server product, when reported (OpenSubsonic `type`, e.g. `navidrome`).
+  /// Display/diagnostics only.
+  final String? serverType;
+
+  /// The server's own version (OpenSubsonic `serverVersion`), when reported.
+  /// Display/diagnostics only.
+  final String? serverVersion;
+
+  /// The Subsonic API version the server reported (`version`), when known.
+  /// Display/diagnostics only.
+  final String? apiVersion;
+
+  SubsonicSession copyWith({
+    String? baseUrl,
+    String? username,
+    String? salt,
+    String? token,
+    String? serverType,
+    String? serverVersion,
+    String? apiVersion,
+  }) {
+    return SubsonicSession(
+      baseUrl: baseUrl ?? this.baseUrl,
+      username: username ?? this.username,
+      salt: salt ?? this.salt,
+      token: token ?? this.token,
+      serverType: serverType ?? this.serverType,
+      serverVersion: serverVersion ?? this.serverVersion,
+      apiVersion: apiVersion ?? this.apiVersion,
+    );
+  }
+
+  /// Serializes for the session store. The salt and token are included because
+  /// the only caller is the (encrypted) store; do not route this through any
+  /// plaintext sink.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'baseUrl': baseUrl,
+        'username': username,
+        'salt': salt,
+        'token': token,
+        if (serverType != null) 'serverType': serverType,
+        if (serverVersion != null) 'serverVersion': serverVersion,
+        if (apiVersion != null) 'apiVersion': apiVersion,
+      };
+
+  /// Rebuilds a session from [toJson] output, or returns `null` if any required
+  /// field is missing/blank (e.g. a partially written or corrupted record), so
+  /// the app treats it as "not signed in" rather than crashing.
+  static SubsonicSession? fromJson(Map<String, dynamic> json) {
+    final String? baseUrl = json['baseUrl'] as String?;
+    final String? username = json['username'] as String?;
+    final String? salt = json['salt'] as String?;
+    final String? token = json['token'] as String?;
+    if (baseUrl == null || baseUrl.isEmpty) return null;
+    if (username == null || username.isEmpty) return null;
+    if (salt == null || salt.isEmpty) return null;
+    if (token == null || token.isEmpty) return null;
+    return SubsonicSession(
+      baseUrl: baseUrl,
+      username: username,
+      salt: salt,
+      token: token,
+      serverType: json['serverType'] as String?,
+      serverVersion: json['serverVersion'] as String?,
+      apiVersion: json['apiVersion'] as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SubsonicSession &&
+          other.baseUrl == baseUrl &&
+          other.username == username &&
+          other.salt == salt &&
+          other.token == token &&
+          other.serverType == serverType &&
+          other.serverVersion == serverVersion &&
+          other.apiVersion == apiVersion);
+
+  @override
+  int get hashCode => Object.hash(
+        baseUrl,
+        username,
+        salt,
+        token,
+        serverType,
+        serverVersion,
+        apiVersion,
+      );
+
+  /// Redacts the credential (salt + token) so the session can be safely
+  /// interpolated into logs or error messages without leaking the secret.
+  @override
+  String toString() => 'SubsonicSession(baseUrl: $baseUrl, '
+      'username: $username, serverType: $serverType, '
+      'serverVersion: $serverVersion, apiVersion: $apiVersion, '
+      'salt: <redacted>, token: <redacted>)';
+}

--- a/lib/core/repositories/subsonic_session_store.dart
+++ b/lib/core/repositories/subsonic_session_store.dart
@@ -1,0 +1,23 @@
+import '../models/subsonic_session.dart';
+
+/// Persists the single Subsonic/Navidrome [SubsonicSession] across app restarts.
+///
+/// Deliberately separate from authentication (which *produces* a session) and
+/// from library fetching (which *uses* one): this contract owns only the storage
+/// of the signed-in session, so the credential (salt + token) has exactly one
+/// persistence path that can be made secure in isolation.
+///
+/// The production binding encrypts on-device; tests and dev use an in-memory
+/// implementation. The user's password is never given to this store — only the
+/// session (derived salt + token + server + user) is.
+abstract interface class SubsonicSessionStore {
+  /// The persisted session, or `null` if the user isn't signed in (or the
+  /// stored record was missing/corrupt).
+  Future<SubsonicSession?> read();
+
+  /// Persists [session], replacing any previous one.
+  Future<void> write(SubsonicSession session);
+
+  /// Forgets the signed-in session (sign out).
+  Future<void> clear();
+}

--- a/lib/core/services/cast/cast_service.dart
+++ b/lib/core/services/cast/cast_service.dart
@@ -49,6 +49,24 @@ abstract interface class CastService {
   /// Seeks the receiver to [position]. A no-op when not casting.
   Future<void> seek(Duration position);
 
+  /// Sets the connected receiver's volume to [volume] (clamped to `0.0–1.0`).
+  /// Controls the *device* volume, not the phone's media volume. A no-op when
+  /// not connected or the device doesn't support volume control; a failure is
+  /// swallowed (surfaced via [CastState.message]) and never breaks playback.
+  Future<void> setVolume(double volume);
+
+  /// Nudges the connected receiver's volume up by one step. A no-op when not
+  /// connected or unsupported.
+  Future<void> volumeUp();
+
+  /// Nudges the connected receiver's volume down by one step. A no-op when not
+  /// connected or unsupported.
+  Future<void> volumeDown();
+
+  /// Mutes ([muted] true) or unmutes the connected receiver. A no-op when not
+  /// connected or unsupported; a failure never breaks playback.
+  Future<void> setMuted(bool muted);
+
   /// Asks the receiver for a fresh status, to re-sync position (e.g. when the
   /// app returns from the background). A no-op when not casting.
   Future<void> refresh();

--- a/lib/core/services/cast/cast_transport.dart
+++ b/lib/core/services/cast/cast_transport.dart
@@ -1,6 +1,7 @@
 import '../../models/cast_media.dart';
 import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
+import '../../models/cast_volume.dart';
 
 /// The low-level cast plumbing [DefaultCastService] drives, isolated behind an
 /// interface so the orchestration logic (discovery → state, connect → handoff,
@@ -35,6 +36,11 @@ abstract interface class CastSessionHandle {
   /// token.
   Stream<CastPlaybackStatus> get statusStream;
 
+  /// The receiver's device volume, parsed from its receiver status, so the app
+  /// can show and follow the *device* volume (not the phone's). Emits whenever
+  /// the device reports a change. Carries no track identity, URL, or token.
+  Stream<CastVolume> get volumeStream;
+
   /// Tells the receiver to fetch and play [media]. Only valid once the session
   /// is ready.
   Future<void> loadMedia(CastMedia media);
@@ -47,6 +53,14 @@ abstract interface class CastSessionHandle {
 
   /// Seeks the receiver to [position].
   Future<void> seek(Duration position);
+
+  /// Sets the receiver's device volume to [level] (`0.0–1.0`). Targets the
+  /// platform receiver, not the media app, so it changes the device's own
+  /// volume.
+  Future<void> setVolume(double level);
+
+  /// Mutes ([muted] true) or unmutes the receiver's device volume.
+  Future<void> setMuted(bool muted);
 
   /// Asks the receiver for a fresh media status (used to re-sync position, e.g.
   /// after the app returns from the background). Best-effort; a no-op when no

--- a/lib/core/services/cast/chromecast_cast_transport.dart
+++ b/lib/core/services/cast/chromecast_cast_transport.dart
@@ -5,6 +5,7 @@ import 'package:cast/cast.dart' as cast;
 import '../../models/cast_media.dart';
 import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
+import '../../models/cast_volume.dart';
 import '../../models/playback_state.dart';
 import 'cast_transport.dart';
 
@@ -83,12 +84,18 @@ class _ChromecastSessionHandle implements CastSessionHandle {
       'type': 'LAUNCH',
       'appId': mediaReceiverAppId,
     });
+    // Ask the platform receiver for its status so the device's current volume is
+    // known promptly (the LAUNCH reply also carries it, but this is belt-and-
+    // suspenders for receivers that omit volume on launch).
+    _requestReceiverStatus();
   }
 
   final cast.CastSession _session;
   final StreamController<bool> _ready = StreamController<bool>.broadcast();
   final StreamController<CastPlaybackStatus> _status =
       StreamController<CastPlaybackStatus>.broadcast();
+  final StreamController<CastVolume> _volume =
+      StreamController<CastVolume>.broadcast();
   StreamSubscription<cast.CastSessionState>? _stateSub;
   StreamSubscription<Map<String, dynamic>>? _messageSub;
   Timer? _poll;
@@ -112,6 +119,9 @@ class _ChromecastSessionHandle implements CastSessionHandle {
 
   @override
   Stream<CastPlaybackStatus> get statusStream => _status.stream;
+
+  @override
+  Stream<CastVolume> get volumeStream => _volume.stream;
 
   @override
   Future<void> loadMedia(CastMedia media) async {
@@ -169,6 +179,45 @@ class _ChromecastSessionHandle implements CastSessionHandle {
     });
   }
 
+  @override
+  Future<void> setVolume(double level) async {
+    _sendToReceiver(<String, dynamic>{
+      'type': 'SET_VOLUME',
+      'volume': <String, dynamic>{'level': level.clamp(0.0, 1.0)},
+    });
+  }
+
+  @override
+  Future<void> setMuted(bool muted) async {
+    _sendToReceiver(<String, dynamic>{
+      'type': 'SET_VOLUME',
+      'volume': <String, dynamic>{'muted': muted},
+    });
+  }
+
+  /// Asks the platform receiver for its current status (which carries device
+  /// volume).
+  void _requestReceiverStatus() {
+    _sendToReceiver(<String, dynamic>{'type': 'GET_STATUS'});
+  }
+
+  /// Sends a message on the receiver namespace addressed to the platform
+  /// receiver (`receiver-0`), not the media app.
+  ///
+  /// `CastSession.sendMessage` targets the media app's transport id once the
+  /// app has launched, but volume/receiver-status commands must reach the
+  /// platform receiver — so this goes through the socket with an explicit
+  /// `receiver-0` destination (the virtual connection to it was opened when the
+  /// session connected).
+  void _sendToReceiver(Map<String, dynamic> payload) {
+    _session.socket.sendMessage(
+      cast.CastSession.kNamespaceReceiver,
+      _session.sessionId,
+      'receiver-0',
+      <String, dynamic>{'requestId': _requestId++, ...payload},
+    );
+  }
+
   void _mediaCommand(String type) {
     final int? id = _mediaSessionId;
     if (id == null) return;
@@ -191,10 +240,19 @@ class _ChromecastSessionHandle implements CastSessionHandle {
     _poll = null;
   }
 
-  /// Parses a receiver `MEDIA_STATUS` payload into a [CastPlaybackStatus] and
-  /// forwards it. Other message types (receiver status, etc.) are ignored.
+  /// Routes an incoming receiver message: media status drives playback, receiver
+  /// status carries the device volume. Other types are ignored.
   void _onMessage(Map<String, dynamic> payload) {
-    if (payload['type'] != 'MEDIA_STATUS') return;
+    switch (payload['type']) {
+      case 'MEDIA_STATUS':
+        _onMediaStatus(payload);
+      case 'RECEIVER_STATUS':
+        _onReceiverStatus(payload);
+    }
+  }
+
+  /// Parses a `MEDIA_STATUS` payload into a [CastPlaybackStatus] and forwards it.
+  void _onMediaStatus(Map<String, dynamic> payload) {
     final Object? list = payload['status'];
     if (list is! List || list.isEmpty) return;
     final Object? first = list.first;
@@ -222,6 +280,27 @@ class _ChromecastSessionHandle implements CastSessionHandle {
       duration: _lastDuration,
     );
     if (!_status.isClosed) _status.add(status);
+  }
+
+  /// Parses the device volume out of a `RECEIVER_STATUS` payload and forwards a
+  /// [CastVolume]. A `controlType` of `fixed` marks the device as not
+  /// volume-controllable, so the UI can disable its slider. Carries no track
+  /// identity, URL, or token.
+  void _onReceiverStatus(Map<String, dynamic> payload) {
+    final Object? status = payload['status'];
+    if (status is! Map) return;
+    final Object? volume = status['volume'];
+    if (volume is! Map) return;
+    final num? level = volume['level'] as num?;
+    if (level == null) return;
+    final Object? muted = volume['muted'];
+    final Object? controlType = volume['controlType'];
+    final CastVolume next = CastVolume(
+      level: level.toDouble().clamp(0.0, 1.0),
+      muted: muted is bool ? muted : false,
+      controllable: controlType != 'fixed',
+    );
+    if (!_volume.isClosed) _volume.add(next);
   }
 
   static Duration _secondsToDuration(num seconds) =>
@@ -256,6 +335,7 @@ class _ChromecastSessionHandle implements CastSessionHandle {
     _messageSub = null;
     if (!_ready.isClosed) await _ready.close();
     if (!_status.isClosed) await _status.close();
+    if (!_volume.isClosed) await _volume.close();
     await cast.CastSessionManager().endSession(_session.sessionId);
   }
 }

--- a/lib/core/services/cast/default_cast_service.dart
+++ b/lib/core/services/cast/default_cast_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import '../../models/cast_media.dart';
 import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
+import '../../models/cast_volume.dart';
 import '../../models/playback_state.dart';
 import '../../models/track.dart';
 import 'cast_media_resolver.dart';
@@ -54,8 +55,14 @@ class DefaultCastService implements CastService {
         _connectTimeout = connectTimeout;
 
   static const String localFileLimitation =
-      'This track is a local file. Casting plays streamed (Jellyfin) tracks '
-      'only — a receiver can\'t reach files on this device.';
+      'This track is a local file. Casting plays streamed (Jellyfin/Subsonic) '
+      "tracks only — a receiver can't reach files on this device.";
+
+  static const String volumeCommandFailed =
+      "Couldn't change the cast volume. Playback is unaffected.";
+
+  /// How far one volume nudge moves the device level (10%).
+  static const double _volumeStep = 0.1;
 
   final CastTransport _transport;
   final CastMediaResolver _mediaResolver;
@@ -77,8 +84,14 @@ class DefaultCastService implements CastService {
   CastSessionHandle? _handle;
   StreamSubscription<bool>? _readySub;
   StreamSubscription<CastPlaybackStatus>? _statusSub;
+  StreamSubscription<CastVolume>? _volumeSub;
   StreamSubscription<Track?>? _trackSub;
   bool _discovering = false;
+
+  /// The connected receiver's last-reported volume, kept so every connected
+  /// state build carries it (it belongs to the device and persists across track
+  /// changes within a session). Null until the receiver reports one.
+  CastVolume? _volume;
 
   @override
   CastState get state => _state;
@@ -101,6 +114,28 @@ class DefaultCastService implements CastService {
   void _emitPlayback(CastPlaybackStatus next) {
     _playbackStatus = next;
     if (!_playback.isClosed) _playback.add(next);
+  }
+
+  /// Builds a `connected` state for [device] that always carries the current
+  /// device [_volume], so a track change or volume update never drops the
+  /// receiver's known level. [message] is transient (not preserved by the next
+  /// build) and defaults to none.
+  CastState _connected(
+    CastDevice device, {
+    String? message,
+    bool isCasting = false,
+  }) {
+    final CastVolume? v = _volume;
+    return CastState(
+      availability: CastAvailability.connected,
+      devices: _state.devices,
+      connectedDevice: device,
+      message: message,
+      isCasting: isCasting,
+      volume: v?.level,
+      muted: v?.muted ?? false,
+      supportsVolumeControl: v?.controllable ?? false,
+    );
   }
 
   @override
@@ -191,6 +226,12 @@ class DefaultCastService implements CastService {
       onError: (_) {},
       cancelOnError: false,
     );
+    // Follow the receiver's device volume so the sheet can show and track it.
+    _volumeSub = handle.volumeStream.listen(
+      _onVolume,
+      onError: (_) {},
+      cancelOnError: false,
+    );
     // Cast the current track now, and re-cast whenever it changes.
     _trackSub = _trackChanges.listen((Track? track) => _handOff(device, track));
     await _handOff(device, _currentTrack());
@@ -206,22 +247,13 @@ class DefaultCastService implements CastService {
 
     if (track == null) {
       _emitPlayback(CastPlaybackStatus.idle);
-      _emit(CastState(
-        availability: CastAvailability.connected,
-        devices: _state.devices,
-        connectedDevice: device,
-      ));
+      _emit(_connected(device));
       return;
     }
 
     if (!_mediaResolver.canCast(track)) {
       _emitPlayback(CastPlaybackStatus.idle);
-      _emit(CastState(
-        availability: CastAvailability.connected,
-        devices: _state.devices,
-        connectedDevice: device,
-        message: localFileLimitation,
-      ));
+      _emit(_connected(device, message: localFileLimitation));
       return;
     }
 
@@ -230,21 +262,11 @@ class DefaultCastService implements CastService {
       media = await _mediaResolver.resolve(track);
     } on CastMediaException catch (error) {
       _emitPlayback(CastPlaybackStatus.idle);
-      _emit(CastState(
-        availability: CastAvailability.connected,
-        devices: _state.devices,
-        connectedDevice: device,
-        message: error.message,
-      ));
+      _emit(_connected(device, message: error.message));
       return;
     } catch (_) {
       _emitPlayback(CastPlaybackStatus.idle);
-      _emit(CastState(
-        availability: CastAvailability.connected,
-        devices: _state.devices,
-        connectedDevice: device,
-        message: "Couldn't cast this track.",
-      ));
+      _emit(_connected(device, message: "Couldn't cast this track."));
       return;
     }
 
@@ -255,12 +277,8 @@ class DefaultCastService implements CastService {
       await handle.loadMedia(media);
     } catch (_) {
       _emitPlayback(CastPlaybackStatus.idle);
-      _emit(CastState(
-        availability: CastAvailability.connected,
-        devices: _state.devices,
-        connectedDevice: device,
-        message: "Couldn't start playback on ${device.name}.",
-      ));
+      _emit(_connected(device,
+          message: "Couldn't start playback on ${device.name}."));
       return;
     }
 
@@ -270,11 +288,20 @@ class DefaultCastService implements CastService {
     if (!_playbackStatus.isPlaying) {
       _emitPlayback(_playbackStatus.copyWith(status: PlaybackStatus.loading));
     }
-    _emit(CastState(
-      availability: CastAvailability.connected,
-      devices: _state.devices,
-      connectedDevice: device,
-      isCasting: true,
+    _emit(_connected(device, isCasting: true));
+  }
+
+  /// Folds a fresh receiver [volume] into the connected state, keeping the
+  /// current notice and casting flag. Ignored when not connected (a stray
+  /// update after disconnect must not resurrect a connected state).
+  void _onVolume(CastVolume volume) {
+    _volume = volume;
+    final CastDevice? device = _state.connectedDevice;
+    if (device == null || !_state.isConnected) return;
+    _emit(_connected(
+      device,
+      message: _state.message,
+      isCasting: _state.isCasting,
     ));
   }
 
@@ -295,6 +322,57 @@ class DefaultCastService implements CastService {
 
   @override
   Future<void> seek(Duration position) async => _handle?.seek(position);
+
+  @override
+  Future<void> setVolume(double volume) async {
+    final CastSessionHandle? handle = _handle;
+    // Only act on a live, volume-capable session; otherwise a safe no-op.
+    if (handle == null || !_state.supportsVolumeControl) return;
+    final double level = volume.clamp(0.0, 1.0);
+    try {
+      await handle.setVolume(level);
+      // The receiver confirms with a status push that updates [_volume]; no
+      // optimistic write is needed.
+    } catch (_) {
+      // A failed volume command must never break playback — surface a calm
+      // notice and leave the session/handoff untouched.
+      _emitVolumeError();
+    }
+  }
+
+  @override
+  Future<void> volumeUp() => _nudgeVolume(_volumeStep);
+
+  @override
+  Future<void> volumeDown() => _nudgeVolume(-_volumeStep);
+
+  Future<void> _nudgeVolume(double delta) {
+    final double base = _volume?.level ?? 0.0;
+    return setVolume(base + delta);
+  }
+
+  @override
+  Future<void> setMuted(bool muted) async {
+    final CastSessionHandle? handle = _handle;
+    if (handle == null || !_state.supportsVolumeControl) return;
+    try {
+      await handle.setMuted(muted);
+    } catch (_) {
+      _emitVolumeError();
+    }
+  }
+
+  /// Surfaces a friendly volume-command failure as a transient notice, without
+  /// touching playback or the handoff. A no-op when not connected.
+  void _emitVolumeError() {
+    final CastDevice? device = _state.connectedDevice;
+    if (device == null || !_state.isConnected) return;
+    _emit(_connected(
+      device,
+      message: volumeCommandFailed,
+      isCasting: _state.isCasting,
+    ));
+  }
 
   @override
   Future<void> refresh() async => _handle?.requestStatus();
@@ -320,8 +398,13 @@ class DefaultCastService implements CastService {
     _readySub = null;
     await _statusSub?.cancel();
     _statusSub = null;
+    await _volumeSub?.cancel();
+    _volumeSub = null;
     await _trackSub?.cancel();
     _trackSub = null;
+    // The device volume belongs to the session; forget it so the next connect
+    // starts from "unknown" rather than a stale level.
+    _volume = null;
     final CastSessionHandle? handle = _handle;
     _handle = null;
     if (handle != null) await _safeClose(handle);

--- a/lib/core/services/cast/routing_cast_media_resolver.dart
+++ b/lib/core/services/cast/routing_cast_media_resolver.dart
@@ -1,0 +1,37 @@
+import '../../models/cast_media.dart';
+import '../../models/track.dart';
+import 'cast_media_resolver.dart';
+
+/// A [CastMediaResolver] that delegates to the first member able to cast a
+/// track, so multiple remote sources (Jellyfin, Subsonic/Navidrome) can be cast
+/// through one resolver.
+///
+/// Mirrors `RoutingPlayableUriResolver`: each source contributes its own
+/// resolver, composed here. [canCast] is true when any member can cast the
+/// track; [resolve] uses the first member that can. A track no member can cast
+/// (an on-device file) yields `canCast == false`, so the caller shows a clear
+/// limitation rather than attempting it.
+class RoutingCastMediaResolver implements CastMediaResolver {
+  const RoutingCastMediaResolver(this._resolvers);
+
+  final List<CastMediaResolver> _resolvers;
+
+  @override
+  bool canCast(Track track) =>
+      _resolvers.any((CastMediaResolver r) => r.canCast(track));
+
+  @override
+  Future<CastMedia> resolve(Track track) async {
+    for (final CastMediaResolver resolver in _resolvers) {
+      if (resolver.canCast(track)) {
+        return resolver.resolve(track);
+      }
+    }
+    // `async` so this surfaces as a rejected future, not a synchronous throw,
+    // for callers that `await`.
+    throw const CastMediaException(
+      "Couldn't cast this track.",
+      kind: CastMediaErrorKind.unavailable,
+    );
+  }
+}

--- a/lib/core/services/cast/unavailable_cast_service.dart
+++ b/lib/core/services/cast/unavailable_cast_service.dart
@@ -51,6 +51,18 @@ class UnavailableCastService implements CastService {
   Future<void> seek(Duration position) async {}
 
   @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> volumeUp() async {}
+
+  @override
+  Future<void> volumeDown() async {}
+
+  @override
+  Future<void> setMuted(bool muted) async {}
+
+  @override
   Future<void> refresh() async {}
 
   @override

--- a/lib/core/services/local_playable_uri_resolver.dart
+++ b/lib/core/services/local_playable_uri_resolver.dart
@@ -14,11 +14,15 @@ import 'playback_diagnostics.dart';
 class LocalPlayableUriResolver implements PlayableUriResolver {
   const LocalPlayableUriResolver();
 
+  /// Remote schemes this on-device resolver must NOT claim, so their own
+  /// resolvers (composed ahead of this one) handle them. Anything else is
+  /// treated as an on-device file path or `content://` document.
+  static const Set<String> _remoteSchemes = <String>{'jellyfin', 'subsonic'};
+
   @override
   bool handles(Track track) {
     final Uri? uri = Uri.tryParse(track.uri);
-    // Anything that isn't a known remote scheme is treated as on-device.
-    return (uri?.scheme.toLowerCase() ?? '') != 'jellyfin';
+    return !_remoteSchemes.contains(uri?.scheme.toLowerCase() ?? '');
   }
 
   @override

--- a/lib/core/services/routing_remote_track_downloader.dart
+++ b/lib/core/services/routing_remote_track_downloader.dart
@@ -1,0 +1,34 @@
+import '../models/track.dart';
+import 'remote_track_downloader.dart';
+
+/// A [RemoteTrackDownloader] that delegates to the first member that recognizes
+/// a track as its own, so multiple remote sources (Jellyfin, Subsonic/Navidrome)
+/// can be downloaded for offline use through one downloader.
+///
+/// Mirrors `RoutingPlayableUriResolver`/`RoutingCastMediaResolver`: each source
+/// contributes its own downloader, composed here. [isRemote] is true when any
+/// member claims the track; [fetch] uses the first member that does. An
+/// on-device track (no member claims it) reports `isRemote == false`, so the
+/// download policy skips it — it is already local.
+class RoutingRemoteTrackDownloader implements RemoteTrackDownloader {
+  RoutingRemoteTrackDownloader(this._downloaders);
+
+  final List<RemoteTrackDownloader> _downloaders;
+
+  @override
+  bool isRemote(Track track) =>
+      _downloaders.any((RemoteTrackDownloader d) => d.isRemote(track));
+
+  @override
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    for (final RemoteTrackDownloader downloader in _downloaders) {
+      if (downloader.isRemote(track)) {
+        return downloader.fetch(track, onProgress: onProgress);
+      }
+    }
+    throw StateError('No remote downloader can fetch this track.');
+  }
+}

--- a/lib/core/sources/audio_file_extension.dart
+++ b/lib/core/sources/audio_file_extension.dart
@@ -1,0 +1,40 @@
+/// Maps a response `Content-Type` to a cache-file extension.
+///
+/// Shared by the remote downloaders (Jellyfin, Subsonic) so the on-disk cache
+/// names a downloaded file sensibly. Returns `null` for unknown types; the audio
+/// engine sniffs the container regardless, so the extension is only a
+/// convenience — never relied on for correctness, and (security) it carries no
+/// token, since a content type isn't a credential.
+abstract final class AudioFileExtension {
+  /// The lowercase extension (without the dot) for [contentType], or `null` when
+  /// the type is absent or unrecognized.
+  static String? forContentType(String? contentType) {
+    if (contentType == null) return null;
+    final String type = contentType.split(';').first.trim().toLowerCase();
+    switch (type) {
+      case 'audio/mpeg':
+      case 'audio/mp3':
+        return 'mp3';
+      case 'audio/flac':
+      case 'audio/x-flac':
+        return 'flac';
+      case 'audio/mp4':
+      case 'audio/m4a':
+      case 'audio/x-m4a':
+        return 'm4a';
+      case 'audio/aac':
+        return 'aac';
+      case 'audio/ogg':
+      case 'application/ogg':
+        return 'ogg';
+      case 'audio/opus':
+        return 'opus';
+      case 'audio/wav':
+      case 'audio/x-wav':
+      case 'audio/wave':
+        return 'wav';
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/core/sources/jellyfin/jellyfin_track_downloader.dart
+++ b/lib/core/sources/jellyfin/jellyfin_track_downloader.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 
 import '../../models/track.dart';
 import '../../services/remote_track_downloader.dart';
+import '../audio_file_extension.dart';
 import 'jellyfin_download_source.dart';
 import 'jellyfin_track_mapper.dart';
 
@@ -79,7 +80,8 @@ class JellyfinTrackDownloader implements RemoteTrackDownloader {
 
       return RemoteTrackData(
         bytes: builder.takeBytes(),
-        fileExtension: _extensionFor(response.headers['content-type']),
+        fileExtension:
+            AudioFileExtension.forContentType(response.headers['content-type']),
       );
     } on StateError {
       // Our own friendly, token-free messages (bad status / not signed in):
@@ -89,39 +91,6 @@ class JellyfinTrackDownloader implements RemoteTrackDownloader {
       // Never rethrow the original error: a ClientException/SocketException (or
       // a TimeoutException) can embed the tokenized URL in its message.
       throw StateError('Jellyfin download failed.');
-    }
-  }
-
-  /// Maps a response content type to a cache-file extension. Returns `null` for
-  /// unknown types; the player sniffs the container regardless, so the extension
-  /// is only a convenience.
-  static String? _extensionFor(String? contentType) {
-    if (contentType == null) return null;
-    final String type = contentType.split(';').first.trim().toLowerCase();
-    switch (type) {
-      case 'audio/mpeg':
-      case 'audio/mp3':
-        return 'mp3';
-      case 'audio/flac':
-      case 'audio/x-flac':
-        return 'flac';
-      case 'audio/mp4':
-      case 'audio/m4a':
-      case 'audio/x-m4a':
-        return 'm4a';
-      case 'audio/aac':
-        return 'aac';
-      case 'audio/ogg':
-      case 'application/ogg':
-        return 'ogg';
-      case 'audio/opus':
-        return 'opus';
-      case 'audio/wav':
-      case 'audio/x-wav':
-      case 'audio/wave':
-        return 'wav';
-      default:
-        return null;
     }
   }
 }

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+
+import 'jellyfin/jellyfin_track_mapper.dart';
+import 'subsonic/subsonic_track_mapper.dart';
+
+/// What a music provider can do, so the UI can show only the actions a given
+/// source actually supports rather than offering ones that would silently fail.
+///
+/// This is the capability model the roadmap calls for: each provider declares
+/// its abilities once, here, and features read them (e.g. a cast affordance is
+/// only meaningful when [canCast]). Keeping it a plain value makes the matrix
+/// trivial to unit-test and a single source of truth as providers are added.
+@immutable
+class MusicProviderCapabilities {
+  const MusicProviderCapabilities({
+    required this.canStream,
+    required this.canCache,
+    required this.canFavorite,
+    required this.canLyrics,
+    required this.canCast,
+  });
+
+  /// Tracks can be played by resolving a stream URL at play time.
+  final bool canStream;
+
+  /// Tracks can be downloaded for offline use safely (a token-free cache file).
+  final bool canCache;
+
+  /// Favorites can be toggled and reflected for this provider.
+  final bool canFavorite;
+
+  /// Lyrics can be fetched for this provider's tracks.
+  final bool canLyrics;
+
+  /// A track's playback URL is network-reachable, so it can be handed to a Cast
+  /// receiver. False for on-device files a receiver can't reach.
+  final bool canCast;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MusicProviderCapabilities &&
+          other.canStream == canStream &&
+          other.canCache == canCache &&
+          other.canFavorite == canFavorite &&
+          other.canLyrics == canLyrics &&
+          other.canCast == canCast);
+
+  @override
+  int get hashCode =>
+      Object.hash(canStream, canCache, canFavorite, canLyrics, canCast);
+}
+
+/// The identity + capabilities of one music provider (local files, Jellyfin,
+/// Subsonic/Navidrome). The [serverUrlLabel] is the field label a settings
+/// section shows for the server address, or null for the on-device source which
+/// has no server.
+@immutable
+class MusicProvider {
+  const MusicProvider({
+    required this.sourceId,
+    required this.displayName,
+    required this.serverUrlLabel,
+    required this.capabilities,
+  });
+
+  final String sourceId;
+  final String displayName;
+  final String? serverUrlLabel;
+  final MusicProviderCapabilities capabilities;
+}
+
+/// The registry of known providers and the lookup from a [Track.uri] to the
+/// provider that owns it. The lookup keys off the same `scheme:` prefixes the
+/// resolvers use, so capabilities and routing can never disagree.
+abstract final class MusicProviders {
+  static const MusicProvider local = MusicProvider(
+    sourceId: 'local',
+    displayName: 'On this device',
+    serverUrlLabel: null,
+    capabilities: MusicProviderCapabilities(
+      canStream: true,
+      canCache: false,
+      canFavorite: true,
+      canLyrics: false,
+      canCast: false,
+    ),
+  );
+
+  static const MusicProvider jellyfin = MusicProvider(
+    sourceId: 'jellyfin',
+    displayName: 'Jellyfin',
+    serverUrlLabel: 'Server URL',
+    capabilities: MusicProviderCapabilities(
+      canStream: true,
+      canCache: true,
+      canFavorite: true,
+      canLyrics: true,
+      canCast: true,
+    ),
+  );
+
+  /// Subsonic/Navidrome. Streaming, offline caching, and casting are
+  /// implemented; favorites and lyrics are documented follow-ups, so they are
+  /// declared unsupported here and their actions stay hidden/disabled.
+  static const MusicProvider subsonic = MusicProvider(
+    sourceId: 'subsonic',
+    displayName: 'Navidrome / Subsonic',
+    serverUrlLabel: 'Server URL',
+    capabilities: MusicProviderCapabilities(
+      canStream: true,
+      canCache: true,
+      canFavorite: false,
+      canLyrics: false,
+      canCast: true,
+    ),
+  );
+
+  /// The provider that owns [trackUri], by its `scheme:` prefix. Anything not a
+  /// known remote scheme is an on-device ([local]) track.
+  static MusicProvider forTrackUri(String trackUri) {
+    if (trackUri.startsWith(JellyfinTrackMapper.uriScheme)) return jellyfin;
+    if (trackUri.startsWith(SubsonicTrackMapper.uriScheme)) return subsonic;
+    return local;
+  }
+
+  /// The capabilities of the provider that owns [trackUri].
+  static MusicProviderCapabilities capabilitiesForTrackUri(String trackUri) =>
+      forTrackUri(trackUri).capabilities;
+}

--- a/lib/core/sources/subsonic/http_subsonic_client.dart
+++ b/lib/core/sources/subsonic/http_subsonic_client.dart
@@ -1,0 +1,262 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/subsonic_session.dart';
+import 'subsonic_api.dart';
+import 'subsonic_auth.dart';
+import 'subsonic_client.dart';
+import 'subsonic_endpoints.dart';
+import 'subsonic_exception.dart';
+
+/// The real [SubsonicClient], backed by `package:http`.
+///
+/// The only file in the app that constructs Subsonic URLs and parses the
+/// `subsonic-response` envelope. Standard HTTPS already works through a reverse
+/// proxy/Cloudflare, so there's nothing proxy-specific here beyond turning an
+/// HTML/5xx error page into a friendly [SubsonicErrorKind.notSubsonic] /
+/// [SubsonicErrorKind.serverError].
+///
+/// Every failure becomes a [SubsonicException]; the username/salt/token are
+/// never written to an exception, so a leaked error string can't expose them.
+class HttpSubsonicClient implements SubsonicClient {
+  HttpSubsonicClient({http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(seconds: 20);
+
+  /// Subsonic caps `getAlbumList2` page size at 500; a generous page-count cap
+  /// stops a runaway loop if a server ever ignores the offset.
+  static const int _albumPageSize = 500;
+  static const int _maxAlbumPages = 200;
+
+  @override
+  Future<SubsonicServerInfo> ping(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+  }) async {
+    final Uri uri = SubsonicEndpoints.ping(
+      baseUrl,
+      username: username,
+      credentials: credentials,
+    );
+    final SubsonicEnvelope envelope = await _get(uri);
+    return SubsonicServerInfo(
+      apiVersion: envelope.version,
+      type: envelope.type,
+      serverVersion: envelope.serverVersion,
+    );
+  }
+
+  @override
+  Future<void> verifySession(SubsonicSession session) async {
+    final Uri uri = SubsonicEndpoints.ping(
+      session.baseUrl,
+      username: session.username,
+      credentials: _credentials(session),
+    );
+    await _get(uri);
+  }
+
+  @override
+  Future<List<SubsonicArtistDto>> getArtists(SubsonicSession session) async {
+    final Uri uri = SubsonicEndpoints.getArtists(
+      session.baseUrl,
+      username: session.username,
+      credentials: _credentials(session),
+    );
+    final SubsonicEnvelope envelope = await _get(uri);
+
+    // Shape: artists.index[].artist[]
+    final List<SubsonicArtistDto> artists = <SubsonicArtistDto>[];
+    final Object? root = envelope.data['artists'];
+    final Object? indexes = root is Map<String, dynamic> ? root['index'] : null;
+    if (indexes is List) {
+      for (final Object? index in indexes) {
+        if (index is! Map<String, dynamic>) continue;
+        final Object? list = index['artist'];
+        if (list is! List) continue;
+        for (final Object? entry in list) {
+          if (entry is Map<String, dynamic>) {
+            final SubsonicArtistDto? dto = SubsonicArtistDto.fromJson(entry);
+            if (dto != null) artists.add(dto);
+          }
+        }
+      }
+    }
+    return artists;
+  }
+
+  @override
+  Future<List<SubsonicAlbumDto>> getAlbums(SubsonicSession session) async {
+    final SubsonicCredentials credentials = _credentials(session);
+    final List<SubsonicAlbumDto> albums = <SubsonicAlbumDto>[];
+    // Walk pages until one comes back short of a full page (the last page).
+    for (int page = 0; page < _maxAlbumPages; page++) {
+      final Uri uri = SubsonicEndpoints.getAlbumList2(
+        session.baseUrl,
+        username: session.username,
+        credentials: credentials,
+        size: _albumPageSize,
+        offset: page * _albumPageSize,
+      );
+      final SubsonicEnvelope envelope = await _get(uri);
+      final Object? root = envelope.data['albumList2'];
+      final Object? list = root is Map<String, dynamic> ? root['album'] : null;
+      if (list is! List || list.isEmpty) break;
+      for (final Object? entry in list) {
+        if (entry is Map<String, dynamic>) {
+          final SubsonicAlbumDto? dto = SubsonicAlbumDto.fromJson(entry);
+          if (dto != null) albums.add(dto);
+        }
+      }
+      if (list.length < _albumPageSize) break;
+    }
+    return albums;
+  }
+
+  @override
+  Future<List<SubsonicSongDto>> getAlbumSongs(
+    SubsonicSession session,
+    String albumId,
+  ) async {
+    final Uri uri = SubsonicEndpoints.getAlbum(
+      session.baseUrl,
+      username: session.username,
+      credentials: _credentials(session),
+      albumId: albumId,
+    );
+    final SubsonicEnvelope envelope = await _get(uri);
+    final Object? root = envelope.data['album'];
+    final Object? list = root is Map<String, dynamic> ? root['song'] : null;
+    if (list is! List) return const <SubsonicSongDto>[];
+    final List<SubsonicSongDto> songs = <SubsonicSongDto>[];
+    for (final Object? entry in list) {
+      if (entry is Map<String, dynamic>) {
+        final SubsonicSongDto? dto = SubsonicSongDto.fromJson(entry);
+        if (dto != null) songs.add(dto);
+      }
+    }
+    return songs;
+  }
+
+  @override
+  Future<SubsonicStreamProbe> probeStream(Uri url) async {
+    // A one-byte ranged GET: enough to see the real status and content type the
+    // engine will get, without downloading the track. The credential rides in
+    // the URL's query — exactly how the engine will fetch — so no extra header
+    // is added. The status is returned, not checked, so the caller can tell
+    // auth / web-page / non-audio apart; only a transport failure throws.
+    final http.Response response = await _send(
+      () => _client.get(url, headers: const <String, String>{
+        'Accept': '*/*',
+        'Range': 'bytes=0-1',
+      }),
+    );
+    return SubsonicStreamProbe(
+      statusCode: response.statusCode,
+      contentType: response.headers['content-type'],
+    );
+  }
+
+  SubsonicCredentials _credentials(SubsonicSession session) =>
+      SubsonicCredentials(salt: session.salt, token: session.token);
+
+  /// Performs a JSON `GET`, then decodes and validates the `subsonic-response`
+  /// envelope — throwing a friendly [SubsonicException] for a transport failure,
+  /// a non-2xx status, a non-Subsonic body, or a Subsonic error code.
+  Future<SubsonicEnvelope> _get(Uri uri) async {
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: const <String, String>{
+        'Accept': 'application/json',
+      }),
+    );
+    _checkStatus(response);
+    final SubsonicEnvelope? envelope =
+        SubsonicEnvelope.fromJson(_decodeObject(response));
+    if (envelope == null) {
+      throw SubsonicException.notSubsonic();
+    }
+    if (!envelope.isOk) {
+      throw _mapErrorCode(envelope.errorCode);
+    }
+    return envelope;
+  }
+
+  /// Runs a request with a timeout, turning any transport-level failure (DNS,
+  /// refused connection, TLS handshake, timeout) into a single friendly "not
+  /// reachable" error without leaking low-level details (which could include the
+  /// credential-bearing URL).
+  Future<http.Response> _send(Future<http.Response> Function() request) async {
+    try {
+      return await request().timeout(_timeout);
+    } on TimeoutException {
+      throw SubsonicException.notReachable();
+    } on http.ClientException {
+      throw SubsonicException.notReachable();
+    } on Exception {
+      // SocketException / HandshakeException and friends: all "can't reach it".
+      throw SubsonicException.notReachable();
+    }
+  }
+
+  /// Maps an HTTP status to a [SubsonicException]. 2xx passes (the envelope is
+  /// inspected next); everything else throws before the body is parsed, so error
+  /// handling never depends on — or echoes — response content.
+  void _checkStatus(http.Response response) {
+    final int code = response.statusCode;
+    if (code >= 200 && code < 300) return;
+    if (code == 401 || code == 403) {
+      throw SubsonicException.unauthorized();
+    }
+    if (code >= 500) {
+      throw SubsonicException.serverError(code);
+    }
+    // Other 4xx (wrong path, proxy 4xx, …): the address probably isn't a
+    // Subsonic API root.
+    throw SubsonicException.notSubsonic();
+  }
+
+  /// Maps a Subsonic error [code] (returned inside a 200 response) to a typed,
+  /// friendly exception. Credentials errors re-prompt; "not found" is a
+  /// stream-unavailable; an incompatible version is unsupported.
+  SubsonicException _mapErrorCode(int? code) {
+    switch (code) {
+      case 40: // wrong username or password
+      case 41: // token auth not supported for LDAP
+      case 44: // invalid API key
+      case 45: // API key not authorized
+      case 50: // user not authorized for the operation
+        return SubsonicException.unauthorized();
+      case 70: // requested data not found
+        return SubsonicException.streamUnavailable();
+      case 20: // incompatible client version
+      case 30: // incompatible server version
+        return SubsonicException.unsupportedResponse();
+      default:
+        return SubsonicException.serverError();
+    }
+  }
+
+  /// Decodes a JSON object body, or throws [SubsonicErrorKind.notSubsonic] when
+  /// the body isn't JSON (e.g. an HTML error page) or isn't an object.
+  Map<String, dynamic> _decodeObject(http.Response response) {
+    Object? decoded;
+    try {
+      // Decode the raw bytes as UTF-8 rather than `response.body` (which falls
+      // back to latin1 without a charset and would mangle non-ASCII titles).
+      final String text = utf8.decode(response.bodyBytes, allowMalformed: true);
+      decoded = jsonDecode(text);
+    } on FormatException {
+      throw SubsonicException.notSubsonic();
+    }
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    throw SubsonicException.notSubsonic();
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_api.dart
+++ b/lib/core/sources/subsonic/subsonic_api.dart
@@ -1,0 +1,236 @@
+/// Wire models for the Subsonic REST API (and OpenSubsonic extensions).
+///
+/// These mirror the JSON shapes a Subsonic-compatible server (such as
+/// Navidrome) returns and live behind [SubsonicClient]; nothing outside the
+/// Subsonic source should touch them. Mapping them to Linthra's
+/// [Track]/[Album]/[Artist] is the `SubsonicTrackMapper`'s job, keeping HTTP
+/// parsing and domain mapping separate.
+///
+/// Only the fields Linthra maps today are kept; the rest of each (large) item
+/// payload is ignored.
+library;
+
+/// The `subsonic-response` envelope every Subsonic API call returns.
+///
+/// A request can fail with a Subsonic error *inside a 200 response* (e.g.
+/// `status: "failed"` with `error.code: 40` for bad credentials), so the client
+/// must inspect this rather than rely on the HTTP status alone. The [data] map
+/// is the envelope itself, from which the typed parsers below pull their fields.
+class SubsonicEnvelope {
+  const SubsonicEnvelope({
+    required this.status,
+    required this.data,
+    this.errorCode,
+    this.errorMessage,
+    this.version,
+    this.type,
+    this.serverVersion,
+  });
+
+  /// `"ok"` or `"failed"`.
+  final String status;
+
+  /// The full `subsonic-response` object, so a parser can read its data fields.
+  final Map<String, dynamic> data;
+
+  /// The Subsonic error code when [status] is `failed` (e.g. 40 = wrong
+  /// credentials, 70 = not found), or `null` on success.
+  final int? errorCode;
+
+  /// The server's error text. Not shown verbatim to the user (it could change
+  /// across servers); the client maps [errorCode] to a friendly message.
+  final String? errorMessage;
+
+  /// The Subsonic API version the server speaks (`version`).
+  final String? version;
+
+  /// OpenSubsonic server product (`type`, e.g. `navidrome`), when present.
+  final String? type;
+
+  /// OpenSubsonic server version (`serverVersion`), when present.
+  final String? serverVersion;
+
+  bool get isOk => status == 'ok';
+
+  /// Parses the top-level body, or returns `null` when it isn't a
+  /// `subsonic-response` envelope (so the client can report "not a Subsonic
+  /// server" rather than surfacing a half-empty object).
+  static SubsonicEnvelope? fromJson(Map<String, dynamic> json) {
+    final Object? raw = json['subsonic-response'];
+    if (raw is! Map<String, dynamic>) return null;
+    final Object? status = raw['status'];
+    if (status is! String) return null;
+    final Object? error = raw['error'];
+    return SubsonicEnvelope(
+      status: status,
+      data: raw,
+      errorCode: error is Map<String, dynamic> ? error['code'] as int? : null,
+      errorMessage:
+          error is Map<String, dynamic> ? error['message'] as String? : null,
+      version: raw['version'] as String?,
+      type: raw['type'] as String?,
+      serverVersion: raw['serverVersion'] as String?,
+    );
+  }
+}
+
+/// Public server identity from a successful `ping`: enough to confirm the
+/// address is a Subsonic-compatible server and to record its product/version
+/// for display and diagnostics.
+class SubsonicServerInfo {
+  const SubsonicServerInfo({
+    this.apiVersion,
+    this.type,
+    this.serverVersion,
+  });
+
+  /// The Subsonic API version (`version`), e.g. `1.16.1`.
+  final String? apiVersion;
+
+  /// OpenSubsonic product (`type`, e.g. `navidrome`), when reported.
+  final String? type;
+
+  /// OpenSubsonic server version (`serverVersion`), when reported.
+  final String? serverVersion;
+
+  /// A friendly product label for the UI ("Navidrome", "Subsonic", …),
+  /// title-casing the reported [type] when one exists.
+  String get displayProduct {
+    final String? t = type;
+    if (t == null || t.isEmpty) return 'Subsonic';
+    return t[0].toUpperCase() + t.substring(1);
+  }
+}
+
+/// What a tiny pre-flight request to a minted stream URL observed.
+///
+/// The source probes the stream URL before handing it to the audio engine so a
+/// reverse-proxy/Cloudflare page or a non-audio response becomes a precise,
+/// friendly error instead of an opaque engine failure. Only the (non-secret)
+/// HTTP status and content type are carried — never the URL or the token woven
+/// into it. Mirrors `JellyfinStreamProbe`.
+class SubsonicStreamProbe {
+  const SubsonicStreamProbe({required this.statusCode, this.contentType});
+
+  final int statusCode;
+  final String? contentType;
+
+  bool get isSuccess => statusCode >= 200 && statusCode < 300;
+
+  /// The server answered with an HTML page (a Cloudflare/login/reverse-proxy
+  /// page) where audio was expected.
+  bool get isHtml {
+    final String? type = _mimeType;
+    return type != null && type.startsWith('text/html');
+  }
+
+  /// The body looks like something the audio engine can open (an `audio/*`
+  /// type, the generic binary `application/octet-stream` some servers use, or a
+  /// missing content type — lenient, since the engine sniffs the container).
+  bool get isAudio {
+    final String? type = _mimeType;
+    if (type == null) return true;
+    return type.startsWith('audio/') ||
+        type.startsWith('video/') ||
+        type == 'application/octet-stream';
+  }
+
+  String? get _mimeType {
+    final String? raw = contentType;
+    if (raw == null) return null;
+    final String type = raw.split(';').first.trim().toLowerCase();
+    return type.isEmpty ? null : type;
+  }
+}
+
+/// An artist from `getArtists` (the ID3 browsing endpoint).
+class SubsonicArtistDto {
+  const SubsonicArtistDto({
+    required this.id,
+    required this.name,
+    this.albumCount = 0,
+  });
+
+  final String id;
+  final String name;
+  final int albumCount;
+
+  static SubsonicArtistDto? fromJson(Map<String, dynamic> json) {
+    final String? id = json['id'] as String?;
+    final String? name = json['name'] as String?;
+    if (id == null || id.isEmpty || name == null) return null;
+    return SubsonicArtistDto(
+      id: id,
+      name: name,
+      albumCount: (json['albumCount'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+/// An album from `getAlbumList2` (the ID3 album list).
+class SubsonicAlbumDto {
+  const SubsonicAlbumDto({
+    required this.id,
+    required this.name,
+    this.artist,
+    this.songCount = 0,
+    this.year,
+  });
+
+  final String id;
+  final String name;
+  final String? artist;
+  final int songCount;
+  final int? year;
+
+  static SubsonicAlbumDto? fromJson(Map<String, dynamic> json) {
+    final String? id = json['id'] as String?;
+    final String? name = json['name'] as String?;
+    if (id == null || id.isEmpty || name == null) return null;
+    return SubsonicAlbumDto(
+      id: id,
+      name: name,
+      artist: json['artist'] as String?,
+      songCount: (json['songCount'] as num?)?.toInt() ?? 0,
+      year: (json['year'] as num?)?.toInt(),
+    );
+  }
+}
+
+/// A song/track from `getAlbum` (an album's child list).
+class SubsonicSongDto {
+  const SubsonicSongDto({
+    required this.id,
+    required this.title,
+    this.album,
+    this.artist,
+    this.track,
+    this.durationSeconds,
+  });
+
+  final String id;
+  final String title;
+  final String? album;
+  final String? artist;
+
+  /// The track number within its album, when present.
+  final int? track;
+
+  /// Duration in whole seconds, when present (Subsonic reports `duration` in
+  /// seconds, unlike Jellyfin's 100-ns ticks).
+  final int? durationSeconds;
+
+  static SubsonicSongDto? fromJson(Map<String, dynamic> json) {
+    final String? id = json['id'] as String?;
+    final String? title = json['title'] as String?;
+    if (id == null || id.isEmpty || title == null) return null;
+    return SubsonicSongDto(
+      id: id,
+      title: title,
+      album: json['album'] as String?,
+      artist: json['artist'] as String?,
+      track: (json['track'] as num?)?.toInt(),
+      durationSeconds: (json['duration'] as num?)?.toInt(),
+    );
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_auth.dart
+++ b/lib/core/sources/subsonic/subsonic_auth.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+
+/// The salt + token pair that authenticates a Subsonic request, derived once
+/// from the password and then carried instead of it.
+///
+/// Subsonic's modern auth (API 1.13.0+) sends `t=<token>&s=<salt>` where
+/// `token = md5(password + salt)`, so the plaintext password never travels and
+/// never needs to be stored. Linthra computes one pair at sign-in and keeps
+/// only it — see [SubsonicSession].
+class SubsonicCredentials {
+  const SubsonicCredentials({required this.salt, required this.token});
+
+  /// The random salt, sent as the `s=` query parameter.
+  final String salt;
+
+  /// `md5(password + salt)`, the secret sent as the `t=` query parameter. Never
+  /// log this.
+  final String token;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SubsonicCredentials &&
+          other.salt == salt &&
+          other.token == token);
+
+  @override
+  int get hashCode => Object.hash(salt, token);
+
+  /// Redacts the token (and salt) so a credential can't leak through a log.
+  @override
+  String toString() =>
+      'SubsonicCredentials(salt: <redacted>, token: <redacted>)';
+}
+
+/// Derives Subsonic [SubsonicCredentials] from a password, the one place the
+/// token+salt scheme is implemented.
+///
+/// Pure and side-effect-free (apart from generating a random salt), so it is
+/// trivially unit-testable: a fixed [saltGenerator] yields a deterministic
+/// token whose value can be asserted against a known `md5(password + salt)`.
+/// The password is used only to compute the token here and is never held,
+/// copied, or logged.
+abstract final class SubsonicAuth {
+  /// Computes the (salt, token) pair for [password]. A fresh secure-random salt
+  /// is generated unless [saltGenerator] is supplied (tests inject a fixed one).
+  static SubsonicCredentials credentials(
+    String password, {
+    String Function()? saltGenerator,
+  }) {
+    final String salt = (saltGenerator ?? _randomSalt)();
+    return SubsonicCredentials(salt: salt, token: tokenFor(password, salt));
+  }
+
+  /// `md5(password + salt)` as a lowercase hex string — exactly what a Subsonic
+  /// server recomputes from its stored password to verify a request.
+  static String tokenFor(String password, String salt) {
+    return md5.convert(utf8.encode('$password$salt')).toString();
+  }
+
+  static String _randomSalt() {
+    final Random rng = Random.secure();
+    final List<int> bytes = List<int>.generate(16, (_) => rng.nextInt(256));
+    return bytes.map((int b) => b.toRadixString(16).padLeft(2, '0')).join();
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_authenticator.dart
+++ b/lib/core/sources/subsonic/subsonic_authenticator.dart
@@ -1,0 +1,106 @@
+import '../../models/subsonic_session.dart';
+import 'subsonic_api.dart';
+import 'subsonic_auth.dart';
+import 'subsonic_client.dart';
+import 'subsonic_exception.dart';
+import 'subsonic_server_url.dart';
+
+/// Turns a raw address + credentials into a usable [SubsonicSession].
+///
+/// The "authentication" concern, kept separate from settings storage (the
+/// `SubsonicSessionStore`) and from library fetching (the
+/// `SubsonicMusicSource`): it validates the URL, derives the salt+token from
+/// the password, and asks the [SubsonicClient] to ping. It does not persist
+/// anything — the controller decides whether/where to store the session — so
+/// this stays a pure coordinator that's trivial to test with a fake client.
+///
+/// The password is used only to compute the token (via [SubsonicAuth]) and is
+/// never held, copied into the session, or logged. The session carries only the
+/// derived (salt, token).
+class SubsonicAuthenticator {
+  SubsonicAuthenticator(
+    this._client, {
+    String Function()? saltGenerator,
+  }) : _saltGenerator = saltGenerator;
+
+  final SubsonicClient _client;
+
+  /// Injectable so tests can assert a deterministic token; production uses a
+  /// fresh secure-random salt per sign-in (the [SubsonicAuth] default).
+  final String Function()? _saltGenerator;
+
+  /// Validates [rawUrl] + credentials and confirms they reach a Subsonic server
+  /// that accepts them, returning its info. Throws [SubsonicException] on a bad
+  /// URL, unreachable/non-Subsonic server, or rejected credentials.
+  ///
+  /// Unlike Jellyfin's anonymous server-info probe, Subsonic's `ping` requires
+  /// credentials, so a successful test also confirms sign-in will work.
+  Future<SubsonicServerInfo> testConnection({
+    required String rawUrl,
+    required String username,
+    required String password,
+  }) async {
+    final String baseUrl = SubsonicServerUrl.normalize(rawUrl);
+    final String trimmedUsername = _requireUsername(username);
+    _requirePassword(password);
+    final SubsonicCredentials credentials =
+        SubsonicAuth.credentials(password, saltGenerator: _saltGenerator);
+    return _client.ping(
+      baseUrl,
+      username: trimmedUsername,
+      credentials: credentials,
+    );
+  }
+
+  /// Signs in and returns a session that stores only the derived (salt, token).
+  ///
+  /// Throws [SubsonicException] for a bad URL, missing credentials, or rejected
+  /// credentials.
+  Future<SubsonicSession> signIn({
+    required String rawUrl,
+    required String username,
+    required String password,
+  }) async {
+    final String baseUrl = SubsonicServerUrl.normalize(rawUrl);
+    final String trimmedUsername = _requireUsername(username);
+    _requirePassword(password);
+    final SubsonicCredentials credentials =
+        SubsonicAuth.credentials(password, saltGenerator: _saltGenerator);
+
+    final SubsonicServerInfo info = await _client.ping(
+      baseUrl,
+      username: trimmedUsername,
+      credentials: credentials,
+    );
+
+    return SubsonicSession(
+      baseUrl: baseUrl,
+      username: trimmedUsername,
+      salt: credentials.salt,
+      token: credentials.token,
+      serverType: info.type,
+      serverVersion: info.serverVersion,
+      apiVersion: info.apiVersion,
+    );
+  }
+
+  String _requireUsername(String username) {
+    final String trimmed = username.trim();
+    if (trimmed.isEmpty) {
+      throw const SubsonicException(
+        'Enter your username.',
+        kind: SubsonicErrorKind.unauthorized,
+      );
+    }
+    return trimmed;
+  }
+
+  void _requirePassword(String password) {
+    if (password.isEmpty) {
+      throw const SubsonicException(
+        'Enter your password.',
+        kind: SubsonicErrorKind.unauthorized,
+      );
+    }
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
@@ -1,0 +1,100 @@
+import '../../models/cast_media.dart';
+import '../../models/track.dart';
+import '../../services/cast/cast_media_resolver.dart';
+import '../../services/playback_diagnostics.dart';
+import 'subsonic_exception.dart';
+import 'subsonic_stream_source.dart';
+import 'subsonic_track_mapper.dart';
+
+/// Resolves Subsonic/Navidrome tracks into [CastMedia] for a receiver to stream.
+///
+/// Reuses the same [SubsonicStreamSource] seam the audio engine's resolver uses
+/// ([SubsonicStreamSource.verifyReachable] then
+/// [SubsonicStreamSource.resolvePlayableUri]), so the cast URL is minted on
+/// demand at cast time, with the salt+token woven in by the source and never
+/// stored on the track or in the catalog. The receiver fetches that URL
+/// directly, so a Subsonic track casts as a live stream — including one that
+/// also has an offline copy, since a receiver can't read the on-device file but
+/// can reach the server.
+///
+/// The minted URL is placed only on the returned [CastMedia], which is handed
+/// straight to the cast session and never logged or persisted. The only thing
+/// logged here is the secret-free [PlaybackDiagnostics] line.
+class SubsonicCastMediaResolver implements CastMediaResolver {
+  const SubsonicCastMediaResolver(this._source);
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final SubsonicStreamSource? Function() _source;
+
+  /// A best-effort MIME hint for the receiver. The stream serves a broadly
+  /// compatible audio format; an exact per-track content type is a follow-up.
+  static const String _defaultContentType = 'audio/mpeg';
+
+  @override
+  bool canCast(Track track) =>
+      track.uri.startsWith(SubsonicTrackMapper.uriScheme);
+
+  @override
+  Future<CastMedia> resolve(Track track) async {
+    final SubsonicStreamSource? source = _source();
+    if (source == null) {
+      throw const CastMediaException(
+        'Sign in to your Subsonic/Navidrome server before casting this track.',
+        kind: CastMediaErrorKind.notSignedIn,
+      );
+    }
+
+    final Uri? uri;
+    try {
+      await source.verifyReachable();
+      uri = await source.resolvePlayableUri(track);
+    } on SubsonicException catch (error) {
+      throw _mapFailure(error);
+    }
+    if (uri == null) {
+      throw const CastMediaException(
+        "Couldn't cast this track.",
+        kind: CastMediaErrorKind.unavailable,
+      );
+    }
+
+    // Secret-free: the diagnostics API cannot carry the credential or full URL.
+    PlaybackDiagnostics.resolved(
+      source: 'subsonicCast',
+      resolver: 'SubsonicCastMediaResolver',
+      itemId: track.id,
+    );
+
+    return CastMedia(
+      url: uri,
+      contentType: _defaultContentType,
+      title: track.title,
+      artist: track.artistName,
+      album: track.albumName,
+    );
+  }
+
+  /// Maps a Subsonic failure to a friendly, secret-free cast error. A rejected
+  /// session is worth distinguishing ("sign in again"); everything else
+  /// collapses to a generic "couldn't cast".
+  CastMediaException _mapFailure(SubsonicException error) {
+    switch (error.kind) {
+      case SubsonicErrorKind.unauthorized:
+        return const CastMediaException(
+          'Your Subsonic session was rejected. Sign in again to cast.',
+          kind: CastMediaErrorKind.notSignedIn,
+        );
+      case SubsonicErrorKind.notSubsonic:
+      case SubsonicErrorKind.streamUnavailable:
+      case SubsonicErrorKind.unsupportedResponse:
+      case SubsonicErrorKind.notReachable:
+      case SubsonicErrorKind.serverError:
+      case SubsonicErrorKind.invalidUrl:
+      case SubsonicErrorKind.unexpected:
+        return const CastMediaException(
+          "Couldn't cast this track from your music server.",
+          kind: CastMediaErrorKind.unavailable,
+        );
+    }
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_client.dart
+++ b/lib/core/sources/subsonic/subsonic_client.dart
@@ -1,0 +1,52 @@
+import '../../models/subsonic_session.dart';
+import 'subsonic_api.dart';
+import 'subsonic_auth.dart';
+
+/// The single seam through which Linthra talks HTTP to a Subsonic-compatible
+/// server (such as Navidrome).
+///
+/// Every request goes through this interface, so the rest of the app
+/// (authenticator, source, settings) depends only on it — never on `http`,
+/// URLs, the auth query, or JSON. That keeps networking swappable and lets
+/// tests drive the whole feature with a fake client and canned responses.
+///
+/// Implementations throw a [SubsonicException] (with a friendly message and a
+/// [SubsonicErrorKind]) for every failure — including a Subsonic error returned
+/// *inside a 200 response* — and must never put the password, salt, or token
+/// into an exception, log, or any other output.
+abstract interface class SubsonicClient {
+  /// Confirms [baseUrl] is a reachable Subsonic server that accepts the given
+  /// credentials, returning its public info. Backs "Test connection" and the
+  /// credential check at sign-in.
+  Future<SubsonicServerInfo> ping(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+  });
+
+  /// Confirms [session] is still accepted by the server (its credential is
+  /// valid and the server reachable) without fetching anything large. Backs the
+  /// pre-stream check the playback resolver runs.
+  Future<void> verifySession(SubsonicSession session);
+
+  /// The ID3 artist index for the signed-in user.
+  Future<List<SubsonicArtistDto>> getArtists(SubsonicSession session);
+
+  /// The full ID3 album list, paginated internally so the caller gets every
+  /// album in one call.
+  Future<List<SubsonicAlbumDto>> getAlbums(SubsonicSession session);
+
+  /// The songs of one album.
+  Future<List<SubsonicSongDto>> getAlbumSongs(
+    SubsonicSession session,
+    String albumId,
+  );
+
+  /// Probes a minted stream [url] with a tiny ranged request to confirm the
+  /// server returns playable audio *before* the URL is handed to the audio
+  /// engine, returning the observed status and content type. The [url] carries
+  /// the credential, so it must never be logged or placed in a thrown error;
+  /// only a transport failure throws (a non-2xx status is returned for the
+  /// caller to classify).
+  Future<SubsonicStreamProbe> probeStream(Uri url);
+}

--- a/lib/core/sources/subsonic/subsonic_endpoints.dart
+++ b/lib/core/sources/subsonic/subsonic_endpoints.dart
@@ -1,0 +1,126 @@
+import '../../app_info.dart';
+import 'subsonic_auth.dart';
+
+/// Every Subsonic REST path and URL Linthra builds, in one place.
+///
+/// Centralizing the endpoints means the HTTP client, the source, and the mapper
+/// never embed raw path strings, and — crucially — the token-bearing URLs are
+/// built by the same pure helpers, so the "weave the salt+token into the query,
+/// on demand, never store it" rule lives in a single, auditable spot.
+///
+/// All builders are pure: they take a clean base URL (no trailing slash, as
+/// produced by [SubsonicServerUrl.normalize]) plus the username, credentials,
+/// and ids they need, and return a [Uri]. Nothing here performs I/O, logs, or
+/// holds state.
+///
+/// Auth: Subsonic carries credentials in the query string of *every* request
+/// (`u`, `t`, `s`, `v`, `c`, `f`), including the binary stream/download URLs the
+/// audio engine and the offline downloader fetch — which is exactly why those
+/// URLs must be minted on demand here and never persisted on a [Track].
+abstract final class SubsonicEndpoints {
+  /// The Subsonic API version Linthra targets. 1.16.1 covers the token+salt
+  /// auth and the ID3 browsing endpoints used here.
+  static const String apiVersion = '1.16.1';
+
+  // --- Query-parameter keys, named once so a typo can't split a request. ---
+  static const String userParam = 'u';
+  static const String tokenParam = 't';
+  static const String saltParam = 's';
+  static const String versionParam = 'v';
+  static const String clientParam = 'c';
+  static const String formatParam = 'f';
+  static const String idParam = 'id';
+
+  /// `GET /rest/ping.view` — confirms the address is a reachable
+  /// Subsonic-compatible server and that the credentials are accepted.
+  static Uri ping(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+  }) =>
+      _build(baseUrl, 'ping', username, credentials);
+
+  /// `GET /rest/getArtists.view` — the ID3 artist index.
+  static Uri getArtists(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+  }) =>
+      _build(baseUrl, 'getArtists', username, credentials);
+
+  /// `GET /rest/getAlbumList2.view` — one page of the ID3 album list, sorted
+  /// alphabetically. Paginated by [size]/[offset] so the source can walk the
+  /// whole library.
+  static Uri getAlbumList2(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required int size,
+    required int offset,
+  }) =>
+      _build(baseUrl, 'getAlbumList2', username, credentials, extra: {
+        'type': 'alphabeticalByName',
+        'size': '$size',
+        'offset': '$offset',
+      });
+
+  /// `GET /rest/getAlbum.view?id=` — one album with its child songs.
+  static Uri getAlbum(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String albumId,
+  }) =>
+      _build(baseUrl, 'getAlbum', username, credentials,
+          extra: {idParam: albumId});
+
+  /// The audio stream URL for a song: `/rest/stream.view?id=…` plus auth.
+  ///
+  /// The server serves a playable stream (transcoding to a broadly compatible
+  /// format when its policy says so). The salt+token ride in the query; they
+  /// are woven in here, on demand, and never stored on the track or in the
+  /// catalog.
+  static Uri stream(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String songId,
+  }) =>
+      _build(baseUrl, 'stream', username, credentials,
+          extra: {idParam: songId});
+
+  /// The original-file download URL: `/rest/download.view?id=…` plus auth, so
+  /// the offline copy is the real source file rather than a transcode. Like
+  /// [stream], the credential is woven in on demand and never stored.
+  static Uri download(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String songId,
+  }) =>
+      _build(baseUrl, 'download', username, credentials,
+          extra: {idParam: songId});
+
+  /// Builds `/rest/<method>.view` with the standard auth + format query and any
+  /// method-specific [extra] parameters. The single place the salt+token are
+  /// woven into a URL.
+  static Uri _build(
+    String baseUrl,
+    String method,
+    String username,
+    SubsonicCredentials credentials, {
+    Map<String, String> extra = const <String, String>{},
+  }) {
+    return Uri.parse('$baseUrl/rest/$method.view').replace(
+      queryParameters: <String, String>{
+        userParam: username,
+        tokenParam: credentials.token,
+        saltParam: credentials.salt,
+        versionParam: apiVersion,
+        clientParam: AppInfo.name,
+        formatParam: 'json',
+        ...extra,
+      },
+    );
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_exception.dart
+++ b/lib/core/sources/subsonic/subsonic_exception.dart
@@ -1,0 +1,112 @@
+/// The category of a [SubsonicException].
+///
+/// Lets the UI react to the *kind* of failure (re-prompt for credentials on
+/// [unauthorized], suggest checking the address on
+/// [notReachable]/[notSubsonic]) without fragile matching on message text.
+enum SubsonicErrorKind {
+  /// The address the user typed isn't a usable http(s) URL.
+  invalidUrl,
+
+  /// The server couldn't be reached at all (DNS, connection refused, TLS
+  /// handshake, or timeout). Often a wrong address or an offline tunnel.
+  notReachable,
+
+  /// The server answered but rejected the credentials (Subsonic error 40/41/44,
+  /// or HTTP 401/403).
+  unauthorized,
+
+  /// Something answered, but it isn't a Subsonic-compatible server (non-Subsonic
+  /// body, missing fields, or a reverse-proxy/Cloudflare error page).
+  notSubsonic,
+
+  /// The server reported a server-side error (HTTP 5xx, or a generic Subsonic
+  /// error code).
+  serverError,
+
+  /// The requested item isn't available (a Subsonic "not found" error, code 70).
+  streamUnavailable,
+
+  /// The server answered with something Linthra can't classify or use.
+  unsupportedResponse,
+
+  /// Any other unexpected failure.
+  unexpected,
+}
+
+/// The single typed error the Subsonic layer throws.
+///
+/// Mirrors [JellyfinException]: callers get a friendly, user-facing [message]
+/// plus a [kind] to branch on, instead of a raw HTTP/socket failure or a
+/// Subsonic error code.
+///
+/// Security invariant: a message must NEVER contain the password, the salt, or
+/// the token. Do not add the request URL (which carries `t=`/`s=`) or any auth
+/// query parameter to a message — the factories below intentionally carry only
+/// a safe, generic explanation.
+class SubsonicException implements Exception {
+  const SubsonicException(
+    this.message, {
+    this.kind = SubsonicErrorKind.unexpected,
+    this.statusCode,
+  });
+
+  /// The typed address-format failure. The caller supplies a specific reason
+  /// since only it knows what was wrong with the input.
+  const SubsonicException.invalidUrl(this.message)
+      : kind = SubsonicErrorKind.invalidUrl,
+        statusCode = null;
+
+  factory SubsonicException.notReachable() => const SubsonicException(
+        "Couldn't reach the server. Check the address and that you're online. "
+        'If your server is behind a reverse proxy or Cloudflare, make sure it '
+        'is running.',
+        kind: SubsonicErrorKind.notReachable,
+      );
+
+  factory SubsonicException.unauthorized() => const SubsonicException(
+        'Your username or password was not accepted by the server.',
+        kind: SubsonicErrorKind.unauthorized,
+      );
+
+  factory SubsonicException.notSubsonic() => const SubsonicException(
+        "That address responded, but it doesn't look like a Subsonic-compatible "
+        'server (such as Navidrome). Double-check the URL — point it at the '
+        'server root, not a sub-page.',
+        kind: SubsonicErrorKind.notSubsonic,
+      );
+
+  factory SubsonicException.serverError([int? statusCode]) => SubsonicException(
+        'Your music server reported an error'
+        '${statusCode != null ? ' (HTTP $statusCode)' : ''}. '
+        'Try again in a moment.',
+        kind: SubsonicErrorKind.serverError,
+        statusCode: statusCode,
+      );
+
+  factory SubsonicException.streamUnavailable() => const SubsonicException(
+        "This track isn't available from your server right now. "
+        'It may have been moved or removed.',
+        kind: SubsonicErrorKind.streamUnavailable,
+      );
+
+  factory SubsonicException.unsupportedResponse([int? statusCode]) =>
+      SubsonicException(
+        'Your music server returned a response Linthra could not use'
+        '${statusCode != null ? ' (HTTP $statusCode)' : ''}. '
+        'It may be running an unsupported version.',
+        kind: SubsonicErrorKind.unsupportedResponse,
+        statusCode: statusCode,
+      );
+
+  /// A user-facing explanation safe to show in the UI.
+  final String message;
+
+  /// What broadly went wrong, for the UI to branch on.
+  final SubsonicErrorKind kind;
+
+  /// The HTTP status code, when the failure came from a transport response.
+  final int? statusCode;
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/sources/subsonic/subsonic_music_source.dart
+++ b/lib/core/sources/subsonic/subsonic_music_source.dart
@@ -1,0 +1,167 @@
+import '../../models/album.dart';
+import '../../models/artist.dart';
+import '../../models/subsonic_session.dart';
+import '../../models/track.dart';
+import '../../services/music_source.dart';
+import '../../services/playback_diagnostics.dart';
+import 'subsonic_api.dart';
+import 'subsonic_auth.dart';
+import 'subsonic_client.dart';
+import 'subsonic_endpoints.dart';
+import 'subsonic_exception.dart';
+import 'subsonic_stream_source.dart';
+import 'subsonic_track_mapper.dart';
+
+/// A [MusicSource] backed by a signed-in Subsonic-compatible server (Navidrome,
+/// etc.).
+///
+/// The Subsonic counterpart to `JellyfinMusicSource`: it implements the same
+/// `MusicSource` contract, so the rest of the app treats a Subsonic library
+/// identically to a Jellyfin or on-device one. Discovery (listing items) is
+/// delegated to a [SubsonicClient] and mapping to [SubsonicTrackMapper], keeping
+/// this class a thin orchestrator.
+///
+/// Like the other sources, it does not persist anything itself — the
+/// `MusicLibraryRepository` syncs these results into the offline cache the UI
+/// reads from. Streaming/casting/downloading are wired through the narrow
+/// [SubsonicStreamSource] seam, which mints a credential-bearing URL only on
+/// demand at play/download time so the salt+token never reach the catalog.
+///
+/// Subsonic has no single "all songs" endpoint, so [fetchTracks] walks every
+/// album (`getAlbumList2` then `getAlbum`) and flattens the songs — the standard
+/// ID3 enumeration.
+class SubsonicMusicSource implements MusicSource, SubsonicStreamSource {
+  const SubsonicMusicSource({
+    required this.session,
+    required SubsonicClient client,
+  }) : _client = client;
+
+  /// The session this source reads on behalf of (server URL, user, credential).
+  final SubsonicSession session;
+
+  final SubsonicClient _client;
+
+  /// The stable source id under which Subsonic tracks are stored. A single id
+  /// covers any Subsonic-compatible server (the [displayName] reflects the
+  /// specific product, e.g. Navidrome).
+  static const String sourceId = 'subsonic';
+
+  @override
+  String get id => sourceId;
+
+  @override
+  String get displayName {
+    final String? type = session.serverType;
+    if (type != null && type.isNotEmpty) {
+      return type[0].toUpperCase() + type.substring(1);
+    }
+    return 'Subsonic';
+  }
+
+  @override
+  Future<List<Track>> fetchTracks() async {
+    final List<SubsonicAlbumDto> albums = await _client.getAlbums(session);
+    final List<Track> tracks = <Track>[];
+    for (final SubsonicAlbumDto album in albums) {
+      final List<SubsonicSongDto> songs =
+          await _client.getAlbumSongs(session, album.id);
+      for (final SubsonicSongDto song in songs) {
+        tracks.add(SubsonicTrackMapper.toTrack(song));
+      }
+    }
+    return tracks;
+  }
+
+  @override
+  Future<List<Album>> fetchAlbums() async {
+    final List<SubsonicAlbumDto> albums = await _client.getAlbums(session);
+    return <Album>[
+      for (final SubsonicAlbumDto album in albums)
+        SubsonicTrackMapper.toAlbum(album),
+    ];
+  }
+
+  @override
+  Future<List<Artist>> fetchArtists() async {
+    final List<SubsonicArtistDto> artists = await _client.getArtists(session);
+    return <Artist>[
+      for (final SubsonicArtistDto artist in artists)
+        SubsonicTrackMapper.toArtist(artist),
+    ];
+  }
+
+  @override
+  Future<void> verifyReachable() => _client.verifySession(session);
+
+  /// Mints the stream URL for [track] on demand, then probes it so a proxy page,
+  /// a rejected credential, or a non-audio response becomes a precise error
+  /// instead of an opaque engine failure. The credential is woven in here, at
+  /// play time, never stored on the track.
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    final Uri url = SubsonicEndpoints.stream(
+      session.baseUrl,
+      username: session.username,
+      credentials: _credentials,
+      songId: _songId(track),
+    );
+    final SubsonicStreamProbe probe = await _client.probeStream(url);
+    PlaybackDiagnostics.resolved(
+      source: 'subsonic',
+      resolver: 'SubsonicPlayableUriResolver',
+      itemId: _songId(track),
+      statusCode: probe.statusCode,
+      contentType: probe.contentType,
+    );
+    _ensurePlayableAudio(probe);
+    return url;
+  }
+
+  /// Mints the original-file download URL for [track] on demand. No probe: the
+  /// downloader reads the response status itself, mirroring Jellyfin.
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async {
+    return SubsonicEndpoints.download(
+      session.baseUrl,
+      username: session.username,
+      credentials: _credentials,
+      songId: _songId(track),
+    );
+  }
+
+  /// Turns a stream [probe] into a typed [SubsonicException] when the response
+  /// isn't playable audio. Order mirrors Jellyfin: HTML first (a proxy/login
+  /// page is never audio), then auth, then a missing item, then server errors,
+  /// then any other non-2xx, and finally a 2xx whose body isn't audio.
+  void _ensurePlayableAudio(SubsonicStreamProbe probe) {
+    if (probe.isHtml) {
+      throw SubsonicException.notSubsonic();
+    }
+    final int code = probe.statusCode;
+    if (code == 401 || code == 403) {
+      throw SubsonicException.unauthorized();
+    }
+    if (code == 404) {
+      throw SubsonicException.streamUnavailable();
+    }
+    if (code >= 500) {
+      throw SubsonicException.serverError(code);
+    }
+    if (!probe.isSuccess) {
+      throw SubsonicException.unsupportedResponse(code);
+    }
+    if (!probe.isAudio) {
+      throw SubsonicException.unsupportedResponse();
+    }
+  }
+
+  SubsonicCredentials get _credentials =>
+      SubsonicCredentials(salt: session.salt, token: session.token);
+
+  /// The Subsonic song id behind [track]: the part after the `subsonic:` scheme,
+  /// falling back to the track id for an unprefixed value.
+  String _songId(Track track) =>
+      track.uri.startsWith(SubsonicTrackMapper.uriScheme)
+          ? track.uri.substring(SubsonicTrackMapper.uriScheme.length)
+          : track.id;
+}

--- a/lib/core/sources/subsonic/subsonic_playable_uri_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_playable_uri_resolver.dart
@@ -1,0 +1,99 @@
+import '../../models/playback_source.dart';
+import '../../models/track.dart';
+import '../../services/playable_uri_resolver.dart';
+import 'subsonic_exception.dart';
+import 'subsonic_stream_source.dart';
+import 'subsonic_track_mapper.dart';
+
+/// Resolves Subsonic/Navidrome tracks to authenticated streaming URLs at play
+/// time.
+///
+/// The salt+token is woven into the URL here, on demand by the
+/// [SubsonicStreamSource], and never stored on the track or in the catalog.
+/// Before minting, this verifies the session is still valid and the server
+/// reachable, so the player can show a precise, friendly error instead of an
+/// opaque audio-engine failure. The minted URL is returned to the controller
+/// and handed to the engine — never logged, never placed in [Track].
+///
+/// The current signed-in source is read through a getter so signing in or out
+/// is reflected without rebuilding the controller; the resolver depends only on
+/// the narrow [SubsonicStreamSource], never on Riverpod or HTTP.
+class SubsonicPlayableUriResolver implements PlayableUriResolver {
+  const SubsonicPlayableUriResolver(this._source);
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final SubsonicStreamSource? Function() _source;
+
+  @override
+  bool handles(Track track) =>
+      track.uri.startsWith(SubsonicTrackMapper.uriScheme);
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    final SubsonicStreamSource? source = _source();
+    if (source == null) {
+      throw const PlaybackResolutionException(
+        'Sign in to your Subsonic/Navidrome server before streaming this track.',
+        kind: PlaybackResolutionErrorKind.notSignedIn,
+      );
+    }
+
+    final Uri? uri;
+    try {
+      await source.verifyReachable();
+      uri = await source.resolvePlayableUri(track);
+    } on SubsonicException catch (error) {
+      throw _mapFailure(error);
+    }
+
+    if (uri == null) {
+      throw const PlaybackResolutionException(
+        "Couldn't stream this track.",
+        kind: PlaybackResolutionErrorKind.streamUnavailable,
+      );
+    }
+    return ResolvedPlayable(uri, PlaybackSource.streamingDirect);
+  }
+
+  /// Maps a Subsonic failure to a friendly, secret-free playback error. Branches
+  /// on [SubsonicErrorKind] so wording can change without breaking it, and so a
+  /// new kind is a compile error here rather than a silent generic message.
+  PlaybackResolutionException _mapFailure(SubsonicException error) {
+    switch (error.kind) {
+      case SubsonicErrorKind.unauthorized:
+        return const PlaybackResolutionException(
+          'Your Subsonic session was rejected. Sign in again.',
+          kind: PlaybackResolutionErrorKind.sessionExpired,
+        );
+      case SubsonicErrorKind.notSubsonic:
+        return const PlaybackResolutionException(
+          'Your server returned a web page instead of audio. Check your '
+          'reverse proxy / Cloudflare access.',
+          kind: PlaybackResolutionErrorKind.serverReturnedWebPage,
+        );
+      case SubsonicErrorKind.streamUnavailable:
+        return const PlaybackResolutionException(
+          "This track isn't available from your server right now.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        );
+      case SubsonicErrorKind.unsupportedResponse:
+        return const PlaybackResolutionException(
+          'Your music server returned a response Linthra could not use. '
+          'It may be running an unsupported version.',
+          kind: PlaybackResolutionErrorKind.invalidStream,
+        );
+      case SubsonicErrorKind.notReachable:
+      case SubsonicErrorKind.serverError:
+        return const PlaybackResolutionException(
+          "Couldn't reach your music server.",
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
+      case SubsonicErrorKind.invalidUrl:
+      case SubsonicErrorKind.unexpected:
+        return const PlaybackResolutionException(
+          "Couldn't stream this track.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        );
+    }
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_server_url.dart
+++ b/lib/core/sources/subsonic/subsonic_server_url.dart
@@ -1,0 +1,85 @@
+import 'subsonic_exception.dart';
+
+/// Validates and normalizes the server address the user types into the
+/// Subsonic/Navidrome settings.
+///
+/// Intentionally pure string logic with no HTTP: it is the one place that
+/// decides what a "valid Subsonic address" looks like, so the connection test
+/// and sign-in agree, and so the rules stay unit-testable without a network.
+/// The design choices mirror the self-hosted, reverse-proxied case Linthra
+/// targets:
+///  - A bare host (`music.example.com`) defaults to **https**, because a
+///    self-hosted server is usually reached over TLS and users rarely type the
+///    scheme.
+///  - A subpath is preserved (`example.com/navidrome`), since reverse proxies
+///    often mount the server under one; the `/rest/*.view` API paths append to
+///    whatever base survives here.
+///  - A trailing slash, query, and fragment are stripped so the result is a
+///    clean base to append to.
+abstract final class SubsonicServerUrl {
+  /// Returns a clean base URL (no trailing slash) for [input], or throws a
+  /// [SubsonicException] of kind [SubsonicErrorKind.invalidUrl] with a friendly
+  /// reason when the address can't be used.
+  static String normalize(String input) {
+    final String trimmed = input.trim();
+    if (trimmed.isEmpty) {
+      throw const SubsonicException.invalidUrl(
+        'Enter your server address, e.g. https://music.example.com',
+      );
+    }
+
+    // No scheme typed → assume https (the common self-hosted default).
+    final String withScheme =
+        trimmed.contains('://') ? trimmed : 'https://$trimmed';
+
+    final Uri? uri = Uri.tryParse(withScheme);
+    if (uri == null) {
+      throw const SubsonicException.invalidUrl(
+        "That doesn't look like a valid web address.",
+      );
+    }
+
+    final String scheme = uri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      throw const SubsonicException.invalidUrl(
+        'The address must start with https:// (or http:// on a local network).',
+      );
+    }
+
+    if (uri.host.isEmpty) {
+      throw const SubsonicException.invalidUrl(
+        'The address is missing a server name, e.g. music.example.com',
+      );
+    }
+
+    final StringBuffer base = StringBuffer()
+      ..write(scheme)
+      ..write('://')
+      ..write(uri.host);
+    if (uri.hasPort) {
+      base
+        ..write(':')
+        ..write(uri.port);
+    }
+    base.write(_trimTrailingSlashes(uri.path));
+    return base.toString();
+  }
+
+  /// Like [normalize] but returns `null` instead of throwing, for callers that
+  /// only need a yes/no (e.g. enabling a button) and don't want the reason.
+  static String? tryNormalize(String input) {
+    try {
+      return normalize(input);
+    } on SubsonicException {
+      return null;
+    }
+  }
+
+  static String _trimTrailingSlashes(String path) {
+    int end = path.length;
+    while (end > 0 && path[end - 1] == '/') {
+      end--;
+    }
+    return path.substring(0, end);
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_stream_source.dart
+++ b/lib/core/sources/subsonic/subsonic_stream_source.dart
@@ -1,0 +1,26 @@
+import '../../models/track.dart';
+
+/// The narrow capability the playback resolver, cast resolver, and offline
+/// downloader need from a signed-in Subsonic connection: confirm the session
+/// still works, then mint a stream or download URL on demand.
+///
+/// [SubsonicMusicSource] implements it; keeping it tiny lets each consumer
+/// depend on just this (not the whole source or any HTTP) and lets tests fake
+/// the source directly to drive every outcome — expired session, unreachable
+/// server, unavailable stream — without a real server.
+///
+/// Security: the URLs carry the salt+token in their query, so they are minted
+/// here on demand, at play/download time, and never stored on [track].
+abstract interface class SubsonicStreamSource {
+  /// Confirms the session is still valid and the server reachable. Throws a
+  /// `SubsonicException` (unauthorized / not reachable / …) when it is not.
+  Future<void> verifyReachable();
+
+  /// The authenticated stream URL for [track], or `null` when one cannot be
+  /// built. The credential is woven in here, on demand, never stored on [track].
+  Future<Uri?> resolvePlayableUri(Track track);
+
+  /// The authenticated URL to download [track]'s original file, or `null` when
+  /// one can't be built. The credential is woven in on demand, never stored.
+  Future<Uri?> resolveDownloadUri(Track track);
+}

--- a/lib/core/sources/subsonic/subsonic_track_downloader.dart
+++ b/lib/core/sources/subsonic/subsonic_track_downloader.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/track.dart';
+import '../../services/remote_track_downloader.dart';
+import '../audio_file_extension.dart';
+import 'subsonic_stream_source.dart';
+import 'subsonic_track_mapper.dart';
+
+/// The [RemoteTrackDownloader] for Subsonic/Navidrome tracks.
+///
+/// Resolves the authenticated original-file download URL only at fetch time —
+/// through the live signed-in [SubsonicStreamSource], read via a getter so
+/// signing in or out is picked up without a rebuild — then fetches the bytes
+/// over HTTP. The URL, and the salt+token woven into it, never leave [fetch]:
+/// not stored, not returned, and not placed in any thrown error (a transport
+/// failure is re-raised as a generic message so a `ClientException` carrying the
+/// credentialed URL can't escape).
+class SubsonicTrackDownloader implements RemoteTrackDownloader {
+  SubsonicTrackDownloader(this._source, {http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final SubsonicStreamSource? Function() _source;
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(minutes: 5);
+
+  @override
+  bool isRemote(Track track) =>
+      track.uri.startsWith(SubsonicTrackMapper.uriScheme);
+
+  @override
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    final SubsonicStreamSource? source = _source();
+    if (source == null) {
+      throw StateError('Not signed in to your Subsonic server.');
+    }
+
+    // Confirm the session still works before fetching; the SubsonicException
+    // this may throw is friendly and credential-free by design.
+    await source.verifyReachable();
+
+    final Uri? uri = await source.resolveDownloadUri(track);
+    if (uri == null) {
+      throw StateError('No download URL for this track.');
+    }
+
+    try {
+      // Stream the body so progress can be reported as bytes arrive. The request
+      // carries the credential in its URL, but the URL never leaves this method,
+      // is never logged, and any transport error below is replaced with a
+      // generic message so it can't escape either.
+      final http.StreamedResponse response =
+          await _client.send(http.Request('GET', uri)).timeout(_timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        await response.stream.drain<void>();
+        throw StateError('Download failed (HTTP ${response.statusCode}).');
+      }
+
+      final int? total =
+          (response.contentLength != null && response.contentLength! > 0)
+              ? response.contentLength
+              : null;
+      final BytesBuilder builder = BytesBuilder(copy: false);
+      int received = 0;
+      onProgress?.call(received, total);
+      await for (final List<int> chunk in response.stream.timeout(_timeout)) {
+        builder.add(chunk);
+        received += chunk.length;
+        onProgress?.call(received, total);
+      }
+
+      return RemoteTrackData(
+        bytes: builder.takeBytes(),
+        fileExtension:
+            AudioFileExtension.forContentType(response.headers['content-type']),
+      );
+    } on StateError {
+      // Our own friendly, credential-free messages (bad status / not signed in):
+      // surface them as-is.
+      rethrow;
+    } on Exception {
+      // Never rethrow the original error: a ClientException/SocketException (or
+      // a TimeoutException) can embed the credentialed URL in its message.
+      throw StateError('Download failed.');
+    }
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_track_mapper.dart
+++ b/lib/core/sources/subsonic/subsonic_track_mapper.dart
@@ -1,0 +1,62 @@
+import '../../models/album.dart';
+import '../../models/artist.dart';
+import '../../models/track.dart';
+import 'subsonic_api.dart';
+
+/// Converts Subsonic wire items into Linthra's source-agnostic domain models.
+///
+/// Kept separate from both the HTTP client (which only parses JSON) and the
+/// source (which only orchestrates), so the field-by-field mapping is pure and
+/// unit-testable.
+///
+/// Two deliberate choices:
+///  - A track's [Track.uri] is the opaque `subsonic:<id>`, NOT a streaming URL.
+///    The real stream/download URLs carry the salt+token, so building them
+///    lazily in `SubsonicMusicSource` keeps the credential out of the persisted
+///    catalog.
+///  - [Track.artworkUri] is intentionally left null. Subsonic cover art
+///    (`getCoverArt`) requires the auth query, so a cover URL would embed the
+///    credential — and `artworkUri` is persisted in the catalog. Token-free
+///    cover-art resolution is a documented follow-up (see docs/providers.md).
+abstract final class SubsonicTrackMapper {
+  /// Prefix marking a [Track.uri] as a Subsonic item rather than a file path or
+  /// a Jellyfin item.
+  static const String uriScheme = 'subsonic:';
+
+  static Track toTrack(SubsonicSongDto song) {
+    return Track(
+      id: song.id,
+      title: song.title,
+      uri: '$uriScheme${song.id}',
+      artistName: song.artist,
+      albumName: song.album,
+      duration: _durationFromSeconds(song.durationSeconds),
+      trackNumber: song.track,
+    );
+  }
+
+  static Album toAlbum(SubsonicAlbumDto album) {
+    return Album(
+      id: album.id,
+      title: album.name,
+      artistName: album.artist,
+      year: album.year,
+      trackCount: album.songCount,
+    );
+  }
+
+  static Artist toArtist(SubsonicArtistDto artist) {
+    return Artist(
+      id: artist.id,
+      name: artist.name,
+      albumCount: artist.albumCount,
+    );
+  }
+
+  /// Subsonic reports a song's duration in whole seconds; absent or zero maps to
+  /// [Duration.zero].
+  static Duration _durationFromSeconds(int? seconds) {
+    if (seconds == null || seconds <= 0) return Duration.zero;
+    return Duration(seconds: seconds);
+  }
+}

--- a/lib/data/repositories/in_memory_subsonic_session_store.dart
+++ b/lib/data/repositories/in_memory_subsonic_session_store.dart
@@ -1,0 +1,28 @@
+import '../../core/models/subsonic_session.dart';
+import '../../core/repositories/subsonic_session_store.dart';
+
+/// A non-persistent [SubsonicSessionStore] for development and tests.
+///
+/// Holds the session in a single field, so it's forgotten when the instance is
+/// dropped. This is the default binding (mirroring the other repositories); the
+/// running app swaps in [SecureSubsonicSessionStore] so the credential survives
+/// restarts in encrypted storage.
+class InMemorySubsonicSessionStore implements SubsonicSessionStore {
+  InMemorySubsonicSessionStore({SubsonicSession? initialSession})
+      : _session = initialSession;
+
+  SubsonicSession? _session;
+
+  @override
+  Future<SubsonicSession?> read() async => _session;
+
+  @override
+  Future<void> write(SubsonicSession session) async {
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    _session = null;
+  }
+}

--- a/lib/data/repositories/secure_subsonic_session_store.dart
+++ b/lib/data/repositories/secure_subsonic_session_store.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../../core/models/subsonic_session.dart';
+import '../../core/repositories/subsonic_session_store.dart';
+
+/// A [SubsonicSessionStore] backed by `flutter_secure_storage`.
+///
+/// The session is serialized to JSON and written to platform-encrypted storage
+/// (Android Keystore-backed) under a single key, so the credential (salt +
+/// token) is never at rest in plaintext (unlike `shared_preferences`). This is
+/// the production binding; it's intentionally never touched by tests, which use
+/// the in-memory store so they stay free of platform channels.
+///
+/// A malformed/partial record reads back as `null` (treated as "signed out")
+/// rather than throwing, so a storage glitch can't wedge the app at launch.
+class SecureSubsonicSessionStore implements SubsonicSessionStore {
+  const SecureSubsonicSessionStore({
+    FlutterSecureStorage storage = const FlutterSecureStorage(),
+  }) : _storage = storage;
+
+  final FlutterSecureStorage _storage;
+
+  static const String _key = 'subsonic_session_v1';
+
+  @override
+  Future<SubsonicSession?> read() async {
+    final String? raw = await _storage.read(key: _key);
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    try {
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return SubsonicSession.fromJson(decoded);
+      }
+      return null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> write(SubsonicSession session) async {
+    await _storage.write(key: _key, value: jsonEncode(session.toJson()));
+  }
+
+  @override
+  Future<void> clear() async {
+    await _storage.delete(key: _key);
+  }
+}

--- a/lib/data/repositories/subsonic_session_store_provider.dart
+++ b/lib/data/repositories/subsonic_session_store_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/subsonic_session_store.dart';
+import 'in_memory_subsonic_session_store.dart';
+import 'secure_subsonic_session_store.dart';
+
+/// The single [SubsonicSessionStore] the app reads/writes the Subsonic session
+/// through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins (no `flutter_secure_storage`). The running app overrides
+/// this with [secureSubsonicSessionStoreOverride] so the credential persists, at
+/// rest, in encrypted storage.
+final subsonicSessionStoreProvider = Provider<SubsonicSessionStore>((ref) {
+  return InMemorySubsonicSessionStore();
+});
+
+/// Production binding: persists the session credential in encrypted on-device
+/// storage. Applied in `main`.
+final secureSubsonicSessionStoreOverride =
+    subsonicSessionStoreProvider.overrideWithValue(
+  const SecureSubsonicSessionStore(),
+);

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -7,10 +7,14 @@ import '../../core/repositories/download_preferences.dart';
 import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
 import '../../core/services/offline_cache_manager.dart';
+import '../../core/services/remote_track_downloader.dart';
+import '../../core/services/routing_remote_track_downloader.dart';
 import '../../core/sources/jellyfin/jellyfin_track_downloader.dart';
+import '../../core/sources/subsonic/subsonic_track_downloader.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/subsonic/subsonic_settings_controller.dart';
 
 /// The live download status of a single track, for the Library row indicator.
 /// Defaults to [DownloadStatus.notDownloaded] until the repository reports
@@ -200,16 +204,20 @@ final precacheCountProvider =
   PrecacheCountController.new,
 );
 
-/// Production binding: makes Jellyfin tracks downloadable for offline use by
-/// wiring the remote downloader to the live signed-in source (read through
-/// [jellyfinMusicSourceProvider], so sign-in/out is picked up without a
-/// rebuild). The token-bearing download URL is minted only at fetch time inside
-/// the downloader; nothing here stores it. Applied in `main`; tests override
-/// [remoteTrackDownloaderProvider] with their own fake.
-final jellyfinRemoteTrackDownloaderOverride =
+/// Production binding: makes remote (Jellyfin and Subsonic/Navidrome) tracks
+/// downloadable for offline use by routing the remote downloader across both
+/// sources, each wired to its live signed-in source (read lazily, so sign-in/out
+/// is picked up without a rebuild). The credential-bearing download URL is
+/// minted only at fetch time inside each downloader; nothing here stores it.
+/// Applied in `main`; tests override [remoteTrackDownloaderProvider] with their
+/// own fake.
+final remoteTrackDownloaderOverride =
     remoteTrackDownloaderProvider.overrideWith((ref) {
-  // Read (not watch) the live source lazily at fetch time, mirroring the
+  // Read (not watch) the live sources lazily at fetch time, mirroring the
   // playback resolver — so the downloader is built once and signing in/out
   // doesn't rebuild it (which would reset in-flight download state).
-  return JellyfinTrackDownloader(() => ref.read(jellyfinMusicSourceProvider));
+  return RoutingRemoteTrackDownloader(<RemoteTrackDownloader>[
+    JellyfinTrackDownloader(() => ref.read(jellyfinMusicSourceProvider)),
+    SubsonicTrackDownloader(() => ref.read(subsonicMusicSourceProvider)),
+  ]);
 });

--- a/lib/features/player/cast/cast_devices_sheet.dart
+++ b/lib/features/player/cast/cast_devices_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -187,6 +189,10 @@ class _Body extends ConsumerWidget {
         // file that can't be cast).
         if (state.isConnected && state.message != null)
           _Notice(message: state.message!),
+        // Cast device volume — only while connected, since it controls the
+        // receiver's own volume (not the phone's).
+        if (state.isConnected)
+          CastVolumeControls(state: state, service: service),
         for (final device in devices)
           ListTile(
             leading: Icon(
@@ -206,6 +212,107 @@ class _Body extends ConsumerWidget {
                 : () => service.connect(device),
           ),
       ],
+    );
+  }
+}
+
+/// Cast device volume controls, shown in the sheet while connected.
+///
+/// Drives the receiver's *own* volume entirely through [CastService] — never a
+/// cast SDK directly — so a command failure can't break playback (the service
+/// swallows it and surfaces a calm notice). It follows live volume updates from
+/// [CastState] (which the sheet watches) while tracking the in-progress drag
+/// locally, mirroring [PlaybackProgressBar]. When the device doesn't support
+/// volume control ([CastState.supportsVolumeControl] false) the slider and mute
+/// are disabled with an honest note rather than hidden, so the section stays
+/// stable.
+class CastVolumeControls extends StatefulWidget {
+  const CastVolumeControls({
+    required this.state,
+    required this.service,
+    super.key,
+  });
+
+  final CastState state;
+  final CastService service;
+
+  @override
+  State<CastVolumeControls> createState() => _CastVolumeControlsState();
+}
+
+class _CastVolumeControlsState extends State<CastVolumeControls> {
+  /// The in-progress drag level (0–1), or null when not dragging — so live
+  /// device updates don't fight the user's finger.
+  double? _dragValue;
+
+  void _onChanged(double value) => setState(() => _dragValue = value);
+
+  void _onChangeEnd(double value) {
+    unawaited(widget.service.setVolume(value));
+    setState(() => _dragValue = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool supported = widget.state.supportsVolumeControl;
+    final bool muted = widget.state.muted;
+    final double level = (widget.state.volume ?? 0.0).clamp(0.0, 1.0);
+    // While muted, show the slider at zero so the visual matches what's heard.
+    final double effective = muted ? 0.0 : level;
+    final double sliderValue = _dragValue ?? effective;
+
+    final Color muteColor = supported
+        ? theme.colorScheme.onSurface
+        : theme.colorScheme.onSurface.withValues(alpha: 0.38);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.sm,
+        AppSpacing.lg,
+        AppSpacing.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Cast volume',
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+            ),
+          ),
+          Row(
+            children: [
+              IconButton(
+                onPressed: supported
+                    ? () => unawaited(widget.service.setMuted(!muted))
+                    : null,
+                color: muteColor,
+                icon: Icon(muted ? Icons.volume_off : Icons.volume_up),
+                tooltip: muted ? 'Unmute' : 'Mute',
+              ),
+              Expanded(
+                child: Slider(
+                  value: sliderValue,
+                  onChanged: supported ? _onChanged : null,
+                  onChangeEnd: supported ? _onChangeEnd : null,
+                ),
+              ),
+            ],
+          ),
+          if (!supported)
+            Padding(
+              padding: const EdgeInsets.only(left: AppSpacing.sm),
+              child: Text(
+                "This device doesn't support volume control from Linthra.",
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/player/cast/cast_providers.dart
+++ b/lib/features/player/cast/cast_providers.dart
@@ -6,9 +6,12 @@ import '../../../core/services/cast/cast_media_resolver.dart';
 import '../../../core/services/cast/cast_service.dart';
 import '../../../core/services/cast/chromecast_cast_transport.dart';
 import '../../../core/services/cast/default_cast_service.dart';
+import '../../../core/services/cast/routing_cast_media_resolver.dart';
 import '../../../core/services/cast/unavailable_cast_service.dart';
 import '../../../core/sources/jellyfin/jellyfin_cast_media_resolver.dart';
+import '../../../core/sources/subsonic/subsonic_cast_media_resolver.dart';
 import '../../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../../settings/subsonic/subsonic_settings_controller.dart';
 import '../player_providers.dart';
 
 /// The single [CastService] the app drives casting through.
@@ -30,11 +33,16 @@ final castStateProvider = StreamProvider<CastState>((ref) {
 });
 
 /// Resolves the current track into a castable URL on demand at cast time.
-/// Jellyfin tracks mint an authenticated stream URL (the receiver fetches it
-/// directly); on-device files report [CastMediaResolver.canCast] false so the
-/// service can show a clear limitation instead of failing.
+/// Jellyfin and Subsonic tracks each mint an authenticated stream URL (the
+/// receiver fetches it directly); on-device files report
+/// [CastMediaResolver.canCast] false so the service can show a clear limitation
+/// instead of failing. Composed so multiple remote sources cast through one
+/// resolver.
 final castMediaResolverProvider = Provider<CastMediaResolver>((ref) {
-  return JellyfinCastMediaResolver(() => ref.read(jellyfinMusicSourceProvider));
+  return RoutingCastMediaResolver(<CastMediaResolver>[
+    JellyfinCastMediaResolver(() => ref.read(jellyfinMusicSourceProvider)),
+    SubsonicCastMediaResolver(() => ref.read(subsonicMusicSourceProvider)),
+  ]);
 });
 
 /// Production binding: the real Chromecast backend, applied in `main`.

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -13,8 +13,10 @@ import '../../core/services/playback_controller.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/services/smart_precache_service.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
+import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'cast/cast_providers.dart';
 
 /// Composes the [PlayableUriResolver] the controller resolves tracks through.
@@ -29,6 +31,7 @@ import 'cast/cast_providers.dart';
 final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
   final fallback = RoutingPlayableUriResolver(<PlayableUriResolver>[
     JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
+    SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
     const LocalPlayableUriResolver(),
   ]);
   return OfflineFirstPlayableUriResolver(

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import '../../shared/widgets/linthra_logo_mark.dart';
 import 'cache/cache_settings_section.dart';
 import 'jellyfin/jellyfin_settings_section.dart';
 import 'precache/precache_settings_section.dart';
+import 'subsonic/subsonic_settings_section.dart';
 
 /// Settings. Hosts the connection/source and offline-storage options, plus a
 /// quiet brand/about footer. Theme and other options will join them here.
@@ -20,6 +21,8 @@ class SettingsScreen extends StatelessWidget {
         padding: const EdgeInsets.all(AppSpacing.md),
         children: const [
           JellyfinSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          SubsonicSettingsSection(),
           SizedBox(height: AppSpacing.md),
           CacheSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/lib/features/settings/subsonic/subsonic_settings_controller.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_controller.dart
@@ -1,0 +1,214 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/subsonic_session.dart';
+import '../../../core/sources/subsonic/subsonic_api.dart';
+import '../../../core/sources/subsonic/subsonic_exception.dart';
+import '../../../core/sources/subsonic/subsonic_music_source.dart';
+import '../../../data/repositories/subsonic_session_store_provider.dart';
+import 'subsonic_settings_providers.dart';
+import 'subsonic_settings_state.dart';
+
+/// Drives the Subsonic/Navidrome settings screen: loads any saved session,
+/// tests a connection, signs in, and clears settings.
+///
+/// The single coordinator between the three separated concerns — the
+/// authenticator (auth), the session store (persistence), and the source
+/// (library access) — so the UI only ever talks to this controller and its
+/// [SubsonicSettingsState], never to HTTP or storage.
+///
+/// The live [session] (with its salt+token) is kept privately for building the
+/// source; it is never exposed through the public [state], never logged, and the
+/// password handed to [signIn]/[testConnection] is forwarded once (to derive the
+/// token) and never retained.
+class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
+  SubsonicSession? _session;
+  late final Future<void> _initialLoad;
+
+  /// The live signed-in session, or `null` when not connected. Used to build a
+  /// [SubsonicMusicSource]; callers must not log it.
+  SubsonicSession? get session => _session;
+
+  @override
+  SubsonicSettingsState build() {
+    _initialLoad = _loadPersisted();
+    return const SubsonicSettingsState();
+  }
+
+  /// Completes once the persisted session has been loaded (or confirmed absent).
+  /// `main` awaits this at startup so a synced Subsonic track can stream on the
+  /// first tap. Idempotent.
+  Future<void> ensureLoaded() => _initialLoad;
+
+  Future<void> _loadPersisted() async {
+    final SubsonicSession? saved;
+    try {
+      saved = await ref.read(subsonicSessionStoreProvider).read();
+    } catch (_) {
+      // A storage hiccup must not break startup or playback; stay disconnected.
+      return;
+    }
+    if (saved == null) {
+      return;
+    }
+    _session = saved;
+    state = SubsonicSettingsState(
+      phase: SubsonicConnectionPhase.connected,
+      baseUrl: saved.baseUrl,
+      username: saved.username,
+      serverType: saved.serverType,
+      serverVersion: saved.serverVersion,
+      apiVersion: saved.apiVersion,
+      statusMessage: _connectedMessage(saved.username, saved.serverType),
+    );
+  }
+
+  /// Tests that [url] + credentials reach a Subsonic server that accepts them.
+  /// Returns whether it succeeded; details land in [state]. The password is
+  /// forwarded once (to derive the token) and never stored.
+  Future<bool> testConnection({
+    required String url,
+    required String username,
+    required String password,
+  }) async {
+    state = SubsonicSettingsState(
+      phase: SubsonicConnectionPhase.testing,
+      baseUrl: url,
+      username: username,
+    );
+    try {
+      final SubsonicServerInfo info =
+          await ref.read(subsonicAuthenticatorProvider).testConnection(
+                rawUrl: url,
+                username: username,
+                password: password,
+              );
+      state = SubsonicSettingsState(
+        phase: SubsonicConnectionPhase.tested,
+        baseUrl: url,
+        username: username,
+        serverType: info.type,
+        serverVersion: info.serverVersion,
+        apiVersion: info.apiVersion,
+        statusMessage: 'Connected to ${info.displayProduct}'
+            '${info.serverVersion != null ? ' ${info.serverVersion}' : ''}.',
+      );
+      return true;
+    } on SubsonicException catch (error) {
+      _setFailure(error.message,
+          kind: error.kind, url: url, username: username);
+      return false;
+    }
+  }
+
+  /// Signs in with [url] + [username] + [password], persists the resulting
+  /// session (only its derived salt+token), and flips to connected. Returns
+  /// whether it succeeded.
+  Future<bool> signIn({
+    required String url,
+    required String username,
+    required String password,
+  }) async {
+    state = SubsonicSettingsState(
+      phase: SubsonicConnectionPhase.signingIn,
+      baseUrl: url,
+      username: username,
+    );
+    try {
+      final SubsonicSession newSession =
+          await ref.read(subsonicAuthenticatorProvider).signIn(
+                rawUrl: url,
+                username: username,
+                password: password,
+              );
+      await ref.read(subsonicSessionStoreProvider).write(newSession);
+      _session = newSession;
+      state = SubsonicSettingsState(
+        phase: SubsonicConnectionPhase.connected,
+        baseUrl: newSession.baseUrl,
+        username: newSession.username,
+        serverType: newSession.serverType,
+        serverVersion: newSession.serverVersion,
+        apiVersion: newSession.apiVersion,
+        statusMessage:
+            _connectedMessage(newSession.username, newSession.serverType),
+      );
+      return true;
+    } on SubsonicException catch (error) {
+      _setFailure(error.message,
+          kind: error.kind, url: url, username: username);
+      return false;
+    }
+  }
+
+  /// Clears the saved session and resets to the disconnected state.
+  Future<void> clear() async {
+    await ref.read(subsonicSessionStoreProvider).clear();
+    _session = null;
+    state = const SubsonicSettingsState(
+      statusMessage: 'Signed out. Your Subsonic settings were cleared.',
+    );
+  }
+
+  /// Reports an error without dropping an existing connection: a failed test or
+  /// re-auth keeps any session that's still valid, it just surfaces the message.
+  void _setFailure(
+    String message, {
+    SubsonicErrorKind? kind,
+    String? url,
+    String? username,
+  }) {
+    final SubsonicSession? current = _session;
+    state = SubsonicSettingsState(
+      phase: current != null
+          ? SubsonicConnectionPhase.connected
+          : SubsonicConnectionPhase.disconnected,
+      baseUrl: current?.baseUrl ?? url,
+      username: current?.username ?? username,
+      serverType: current?.serverType ?? state.serverType,
+      serverVersion: current?.serverVersion ?? state.serverVersion,
+      apiVersion: current?.apiVersion ?? state.apiVersion,
+      statusMessage: current != null
+          ? _connectedMessage(current.username, current.serverType)
+          : null,
+      errorMessage: message,
+      errorKind: kind,
+    );
+  }
+
+  String _connectedMessage(String username, String? serverType) {
+    final String where = (serverType != null && serverType.isNotEmpty)
+        ? ' on ${serverType[0].toUpperCase()}${serverType.substring(1)}'
+        : '';
+    return 'Signed in as $username$where.';
+  }
+}
+
+final subsonicSettingsControllerProvider =
+    NotifierProvider<SubsonicSettingsController, SubsonicSettingsState>(
+  SubsonicSettingsController.new,
+);
+
+/// The Subsonic library source for the current session, or `null` when not
+/// connected.
+///
+/// The seam that syncs the Subsonic catalog into the `MusicLibraryRepository`
+/// (via `SubsonicSyncController`) and that the playback/cast/download paths read
+/// to mint URLs at use time. It rebuilds when the connection toggles, reading
+/// the live session from the controller.
+final subsonicMusicSourceProvider = Provider<SubsonicMusicSource?>((ref) {
+  final bool connected = ref.watch(
+    subsonicSettingsControllerProvider.select((s) => s.isConnected),
+  );
+  if (!connected) {
+    return null;
+  }
+  final SubsonicSession? session =
+      ref.read(subsonicSettingsControllerProvider.notifier).session;
+  if (session == null) {
+    return null;
+  }
+  return SubsonicMusicSource(
+    session: session,
+    client: ref.read(subsonicClientProvider),
+  );
+});

--- a/lib/features/settings/subsonic/subsonic_settings_providers.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_providers.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sources/subsonic/http_subsonic_client.dart';
+import '../../../core/sources/subsonic/subsonic_authenticator.dart';
+import '../../../core/sources/subsonic/subsonic_client.dart';
+
+/// The HTTP seam for all Subsonic networking.
+///
+/// Defaults to the real [HttpSubsonicClient]; tests override it with a fake
+/// client that returns canned responses, so the whole settings/auth flow can be
+/// exercised without a server. This is the single place production wires the
+/// concrete client — `main` needs no override because the default is already the
+/// real one.
+final subsonicClientProvider = Provider<SubsonicClient>((ref) {
+  return HttpSubsonicClient();
+});
+
+/// Coordinates URL validation + the token+salt auth on top of
+/// [subsonicClientProvider].
+///
+/// The settings controller depends on this rather than on the client directly,
+/// keeping authentication (produce a session) separate from the controller's
+/// orchestration (when to test, sign in, persist, clear).
+final subsonicAuthenticatorProvider = Provider<SubsonicAuthenticator>((ref) {
+  return SubsonicAuthenticator(ref.watch(subsonicClientProvider));
+});

--- a/lib/features/settings/subsonic/subsonic_settings_section.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_section.dart
@@ -1,0 +1,397 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/sources/music_provider.dart';
+import 'subsonic_settings_controller.dart';
+import 'subsonic_settings_state.dart';
+import 'subsonic_sync_controller.dart';
+import 'subsonic_sync_state.dart';
+
+/// The Navidrome/Subsonic connection card on the Settings screen.
+///
+/// Owns the text fields (URL / username / password) but nothing else: every
+/// action is forwarded to [SubsonicSettingsController], and everything rendered
+/// comes from [SubsonicSettingsState]. The widget never touches HTTP or storage
+/// directly, and the password is cleared from memory as soon as it's used.
+///
+/// Subsonic's `ping` requires credentials, so both "Test connection" and "Sign
+/// in" need all three fields — a successful test confirms sign-in will work.
+class SubsonicSettingsSection extends ConsumerStatefulWidget {
+  const SubsonicSettingsSection({super.key});
+
+  @override
+  ConsumerState<SubsonicSettingsSection> createState() =>
+      _SubsonicSettingsSectionState();
+}
+
+class _SubsonicSettingsSectionState
+    extends ConsumerState<SubsonicSettingsSection> {
+  final TextEditingController _urlController = TextEditingController();
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _urlController.addListener(_onFieldChanged);
+    _usernameController.addListener(_onFieldChanged);
+    _passwordController.addListener(_onFieldChanged);
+  }
+
+  void _onFieldChanged() => setState(() {});
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  /// All three fields are required because Subsonic authenticates `ping` itself.
+  bool get _canSubmit =>
+      _urlController.text.trim().isNotEmpty &&
+      _usernameController.text.trim().isNotEmpty &&
+      _passwordController.text.isNotEmpty;
+
+  Future<void> _test() async {
+    FocusScope.of(context).unfocus();
+    await ref.read(subsonicSettingsControllerProvider.notifier).testConnection(
+          url: _urlController.text,
+          username: _usernameController.text,
+          password: _passwordController.text,
+        );
+  }
+
+  Future<void> _signIn() async {
+    FocusScope.of(context).unfocus();
+    final bool ok =
+        await ref.read(subsonicSettingsControllerProvider.notifier).signIn(
+              url: _urlController.text,
+              username: _usernameController.text,
+              password: _passwordController.text,
+            );
+    // Don't keep the password in memory once it's been exchanged for a token.
+    if (ok) {
+      _passwordController.clear();
+    }
+  }
+
+  Future<void> _signOut() async {
+    await ref.read(subsonicSettingsControllerProvider.notifier).clear();
+    _urlController.clear();
+    _usernameController.clear();
+    _passwordController.clear();
+  }
+
+  Future<void> _sync() async {
+    await ref.read(subsonicSyncControllerProvider.notifier).sync();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SubsonicSettingsState state =
+        ref.watch(subsonicSettingsControllerProvider);
+    final SubsonicSyncState syncState =
+        ref.watch(subsonicSyncControllerProvider);
+    final ThemeData theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.dns_outlined, color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Navidrome / Subsonic',
+                    style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Stream from your own Navidrome or other Subsonic-compatible '
+              'server, including one behind an HTTPS reverse proxy. Your '
+              'password is never stored — only a derived token is kept.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            const _CapabilityChips(),
+            const SizedBox(height: AppSpacing.md),
+            if (state.isConnected)
+              _ConnectedView(
+                state: state,
+                syncState: syncState,
+                onSync: (state.isBusy || syncState.isSyncing) ? null : _sync,
+                onSignOut:
+                    (state.isBusy || syncState.isSyncing) ? null : _signOut,
+              )
+            else
+              _buildForm(state),
+            if (state.errorMessage != null) ...[
+              const SizedBox(height: AppSpacing.md),
+              _StatusLine(message: state.errorMessage!, isError: true),
+            ] else if (state.statusMessage != null) ...[
+              const SizedBox(height: AppSpacing.md),
+              _StatusLine(message: state.statusMessage!, isError: false),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildForm(SubsonicSettingsState state) {
+    final bool busy = state.isBusy;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextField(
+          controller: _urlController,
+          enabled: !busy,
+          keyboardType: TextInputType.url,
+          autocorrect: false,
+          textInputAction: TextInputAction.next,
+          decoration: const InputDecoration(
+            labelText: 'Server URL',
+            hintText: 'https://music.example.com',
+            prefixIcon: Icon(Icons.dns_outlined),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        TextField(
+          controller: _usernameController,
+          enabled: !busy,
+          autocorrect: false,
+          textInputAction: TextInputAction.next,
+          decoration: const InputDecoration(
+            labelText: 'Username',
+            prefixIcon: Icon(Icons.person_outline),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        TextField(
+          controller: _passwordController,
+          enabled: !busy,
+          obscureText: _obscurePassword,
+          textInputAction: TextInputAction.done,
+          onSubmitted: (_canSubmit && !busy) ? (_) => _signIn() : null,
+          decoration: InputDecoration(
+            labelText: 'Password',
+            prefixIcon: const Icon(Icons.lock_outline),
+            suffixIcon: IconButton(
+              icon: Icon(
+                _obscurePassword
+                    ? Icons.visibility_outlined
+                    : Icons.visibility_off_outlined,
+              ),
+              tooltip: _obscurePassword ? 'Show password' : 'Hide password',
+              onPressed: () =>
+                  setState(() => _obscurePassword = !_obscurePassword),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: (_canSubmit && !busy) ? _test : null,
+                child: _ButtonLabel(
+                  label: 'Test connection',
+                  busy: state.phase == SubsonicConnectionPhase.testing,
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: FilledButton(
+                onPressed: (_canSubmit && !busy) ? _signIn : null,
+                child: _ButtonLabel(
+                  label: 'Sign in',
+                  busy: state.phase == SubsonicConnectionPhase.signingIn,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Capability-based action chips: one per ability the Subsonic provider
+/// actually supports, so unimplemented actions (favorites, lyrics) simply don't
+/// appear rather than being offered and failing.
+class _CapabilityChips extends StatelessWidget {
+  const _CapabilityChips();
+
+  @override
+  Widget build(BuildContext context) {
+    final MusicProviderCapabilities caps = MusicProviders.subsonic.capabilities;
+    final List<({IconData icon, String label})> supported = [
+      if (caps.canStream) (icon: Icons.play_circle_outline, label: 'Streaming'),
+      if (caps.canCache)
+        (icon: Icons.download_for_offline_outlined, label: 'Offline'),
+      if (caps.canCast) (icon: Icons.cast, label: 'Cast'),
+      if (caps.canFavorite) (icon: Icons.favorite_border, label: 'Favorites'),
+      if (caps.canLyrics) (icon: Icons.lyrics_outlined, label: 'Lyrics'),
+    ];
+    return Wrap(
+      spacing: AppSpacing.sm,
+      runSpacing: AppSpacing.xs,
+      children: [
+        for (final cap in supported)
+          Chip(
+            visualDensity: VisualDensity.compact,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            avatar: Icon(cap.icon, size: 16),
+            label: Text(cap.label),
+          ),
+      ],
+    );
+  }
+}
+
+/// The summary shown once a session exists: which server/user, plus the sync
+/// action and sign-out.
+class _ConnectedView extends StatelessWidget {
+  const _ConnectedView({
+    required this.state,
+    required this.syncState,
+    required this.onSync,
+    required this.onSignOut,
+  });
+
+  final SubsonicSettingsState state;
+  final SubsonicSyncState syncState;
+  final VoidCallback? onSync;
+  final VoidCallback? onSignOut;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.check_circle_outline, color: theme.colorScheme.primary),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(state.productLabel, style: theme.textTheme.titleSmall),
+                  if (state.username != null && state.username!.isNotEmpty)
+                    Text(
+                      'Signed in as ${state.username}',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  if (state.baseUrl != null)
+                    Text(
+                      state.baseUrl!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color:
+                            theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  if (state.serverVersion != null &&
+                      state.serverVersion!.isNotEmpty)
+                    Text(
+                      '${state.productLabel} ${state.serverVersion}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color:
+                            theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+        FilledButton.tonalIcon(
+          onPressed: onSync,
+          icon: syncState.isSyncing
+              ? const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.sync_outlined),
+          label:
+              Text(syncState.isSyncing ? 'Syncing…' : 'Sync Navidrome library'),
+        ),
+        if (syncState.message != null && !syncState.isSyncing) ...[
+          const SizedBox(height: AppSpacing.sm),
+          _StatusLine(message: syncState.message!, isError: syncState.isError),
+        ],
+        const SizedBox(height: AppSpacing.sm),
+        OutlinedButton.icon(
+          onPressed: onSignOut,
+          icon: const Icon(Icons.logout_outlined),
+          label: const Text('Sign out & clear'),
+        ),
+      ],
+    );
+  }
+}
+
+/// A button label that swaps to a small spinner while its action runs.
+class _ButtonLabel extends StatelessWidget {
+  const _ButtonLabel({required this.label, required this.busy});
+
+  final String label;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!busy) {
+      return Text(label);
+    }
+    return const SizedBox.square(
+      dimension: 18,
+      child: CircularProgressIndicator(strokeWidth: 2),
+    );
+  }
+}
+
+/// A friendly one-line status or error message under the form.
+class _StatusLine extends StatelessWidget {
+  const _StatusLine({required this.message, required this.isError});
+
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color color =
+        isError ? theme.colorScheme.error : theme.colorScheme.primary;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          isError ? Icons.error_outline : Icons.info_outline,
+          size: 18,
+          color: color,
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/subsonic/subsonic_settings_state.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_state.dart
@@ -1,0 +1,86 @@
+import '../../../core/sources/subsonic/subsonic_exception.dart';
+
+/// Where the Subsonic/Navidrome connection is in its lifecycle.
+enum SubsonicConnectionPhase {
+  /// No session and nothing in progress.
+  disconnected,
+
+  /// A connection test is running.
+  testing,
+
+  /// A connection test just succeeded (server reachable, credentials accepted);
+  /// not signed in / persisted yet.
+  tested,
+
+  /// Sign-in is running.
+  signingIn,
+
+  /// Signed in — a session exists.
+  connected,
+}
+
+/// Immutable snapshot the Subsonic settings UI renders from.
+///
+/// The screen reads this and never reaches into HTTP, the authenticator, or the
+/// session store directly — the controller is the only thing that mutates it.
+///
+/// Security: this state intentionally holds NO secret. There is no token, salt,
+/// or password field; only display-safe values (server URL, username, server
+/// product/version) live here, so nothing sensitive can leak through the widget
+/// tree or a state dump.
+class SubsonicSettingsState {
+  const SubsonicSettingsState({
+    this.phase = SubsonicConnectionPhase.disconnected,
+    this.baseUrl,
+    this.username,
+    this.serverType,
+    this.serverVersion,
+    this.apiVersion,
+    this.statusMessage,
+    this.errorMessage,
+    this.errorKind,
+  });
+
+  final SubsonicConnectionPhase phase;
+
+  /// Last connected/tested base URL, used to prefill the field. Not secret.
+  final String? baseUrl;
+
+  /// Connected (or last-entered) username, for prefill/display. Not secret.
+  final String? username;
+
+  /// Server product (e.g. `navidrome`) from a test or the saved session.
+  final String? serverType;
+
+  /// Server version (OpenSubsonic `serverVersion`), when reported.
+  final String? serverVersion;
+
+  /// Subsonic API version the server speaks, when reported.
+  final String? apiVersion;
+
+  /// A friendly, non-error status line (e.g. "Connected to …").
+  final String? statusMessage;
+
+  /// A friendly error line, when the last action failed.
+  final String? errorMessage;
+
+  /// The kind of the last failure, kept for the UI to branch on. The friendly
+  /// [errorMessage] is already secret-free.
+  final SubsonicErrorKind? errorKind;
+
+  bool get isConnected => phase == SubsonicConnectionPhase.connected;
+
+  /// True while a network action is in flight, so the UI can disable inputs and
+  /// show a spinner.
+  bool get isBusy =>
+      phase == SubsonicConnectionPhase.testing ||
+      phase == SubsonicConnectionPhase.signingIn;
+
+  /// A friendly product label for display, title-casing the reported [serverType]
+  /// (e.g. "Navidrome") or falling back to "Subsonic".
+  String get productLabel {
+    final String? t = serverType;
+    if (t == null || t.isEmpty) return 'Subsonic';
+    return t[0].toUpperCase() + t.substring(1);
+  }
+}

--- a/lib/features/settings/subsonic/subsonic_sync_controller.dart
+++ b/lib/features/settings/subsonic/subsonic_sync_controller.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sources/subsonic/subsonic_exception.dart';
+import '../../../core/sources/subsonic/subsonic_music_source.dart';
+import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../library/library_controller.dart';
+import 'subsonic_settings_controller.dart';
+import 'subsonic_sync_state.dart';
+
+/// Drives the "Sync Navidrome library" action.
+///
+/// Reads the signed-in [SubsonicMusicSource] (via [subsonicMusicSourceProvider])
+/// to fetch the catalog, then hands the results to the `MusicLibraryRepository`
+/// under the stable `subsonic` source id — the same upsert path local scanning
+/// and Jellyfin use. The Library screen reads from that repository, so a refresh
+/// after the upsert makes the synced tracks appear.
+///
+/// Security: the source mints any authenticated stream/download URL lazily at
+/// use time, so nothing persisted here carries a credential. This controller
+/// never logs the session, and surfaces only friendly, secret-free messages.
+class SubsonicSyncController extends Notifier<SubsonicSyncState> {
+  @override
+  SubsonicSyncState build() => const SubsonicSyncState();
+
+  /// Pulls artists/albums/tracks from the server and upserts them into the local
+  /// catalog. Reflects loading/success/error through [state]; never throws.
+  Future<void> sync() async {
+    final SubsonicMusicSource? source = ref.read(subsonicMusicSourceProvider);
+    if (source == null) {
+      state = const SubsonicSyncState.error(
+        'Connect to your Subsonic/Navidrome server in Settings before syncing.',
+      );
+      return;
+    }
+
+    state = const SubsonicSyncState.syncing();
+    try {
+      final tracks = await source.fetchTracks();
+      final albums = await source.fetchAlbums();
+      final artists = await source.fetchArtists();
+
+      if (tracks.isEmpty) {
+        state = const SubsonicSyncState.success(
+          trackCount: 0,
+          message: 'Your library looks empty — nothing to sync yet.',
+        );
+        return;
+      }
+
+      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+            sourceId: source.id,
+            tracks: tracks,
+            albums: albums,
+            artists: artists,
+          );
+      await ref.read(libraryControllerProvider.notifier).refresh();
+
+      state = SubsonicSyncState.success(
+        trackCount: tracks.length,
+        message: _successMessage(tracks.length),
+      );
+    } on SubsonicException catch (error) {
+      state = SubsonicSyncState.error(_friendlyMessage(error));
+    } catch (_) {
+      state = const SubsonicSyncState.error(
+        'Something went wrong saving your library. Please try again.',
+      );
+    }
+  }
+
+  String _successMessage(int trackCount) {
+    final String tracks = trackCount == 1 ? '1 track' : '$trackCount tracks';
+    return 'Synced $tracks from your library.';
+  }
+
+  /// Turns a typed Subsonic failure into a friendly, actionable line. Branches
+  /// on [SubsonicErrorKind] rather than message text.
+  String _friendlyMessage(SubsonicException error) {
+    switch (error.kind) {
+      case SubsonicErrorKind.notReachable:
+        return "Couldn't reach your music server. Check your connection and "
+            'that the server is online.';
+      case SubsonicErrorKind.unauthorized:
+        return 'Your session was rejected. Sign out and sign in again to '
+            'refresh it.';
+      case SubsonicErrorKind.notSubsonic:
+        return "That server didn't respond like Subsonic. Double-check the "
+            'server address in Settings.';
+      case SubsonicErrorKind.serverError:
+        return 'Your music server reported an error. Try again in a moment.';
+      case SubsonicErrorKind.invalidUrl:
+      case SubsonicErrorKind.streamUnavailable:
+      case SubsonicErrorKind.unsupportedResponse:
+      case SubsonicErrorKind.unexpected:
+        return error.message;
+    }
+  }
+}
+
+final subsonicSyncControllerProvider =
+    NotifierProvider<SubsonicSyncController, SubsonicSyncState>(
+  SubsonicSyncController.new,
+);

--- a/lib/features/settings/subsonic/subsonic_sync_state.dart
+++ b/lib/features/settings/subsonic/subsonic_sync_state.dart
@@ -1,0 +1,44 @@
+/// Where a Subsonic/Navidrome library sync is in its lifecycle.
+enum SubsonicSyncStatus { idle, syncing, success, error }
+
+/// Immutable snapshot the Subsonic settings UI renders the sync action from.
+///
+/// Like every other state object in the app, this holds only display-safe
+/// values: a status, a friendly [message], and how many tracks landed. It never
+/// carries a token, salt, password, or streaming URL.
+class SubsonicSyncState {
+  const SubsonicSyncState({
+    this.status = SubsonicSyncStatus.idle,
+    this.message,
+    this.trackCount = 0,
+  });
+
+  const SubsonicSyncState.syncing()
+      : this(
+          status: SubsonicSyncStatus.syncing,
+          message: 'Syncing your library…',
+        );
+
+  const SubsonicSyncState.success({
+    required int trackCount,
+    required String message,
+  }) : this(
+          status: SubsonicSyncStatus.success,
+          trackCount: trackCount,
+          message: message,
+        );
+
+  const SubsonicSyncState.error(String message)
+      : this(status: SubsonicSyncStatus.error, message: message);
+
+  final SubsonicSyncStatus status;
+
+  /// A friendly status or error line for the UI; never contains a secret.
+  final String? message;
+
+  /// How many tracks the last successful sync stored.
+  final int trackCount;
+
+  bool get isSyncing => status == SubsonicSyncStatus.syncing;
+  bool get isError => status == SubsonicSyncStatus.error;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,12 +10,14 @@ import 'data/repositories/favorites_repository_provider.dart';
 import 'data/repositories/jellyfin_session_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
+import 'data/repositories/subsonic_session_store_provider.dart';
 import 'features/downloads/download_providers.dart';
 import 'features/player/cast/cast_providers.dart';
 import 'features/player/favorites_providers.dart';
 import 'features/player/lyrics_providers.dart';
 import 'features/player/player_providers.dart';
 import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
+import 'features/settings/subsonic/subsonic_settings_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -27,9 +29,10 @@ Future<void> main() async {
   // persists its catalog to SQLite (Drift override) and its chosen folder,
   // offline-download set, and Wi-Fi-only preference via shared_preferences;
   // downloaded audio is written to an app-private directory on disk; and the
-  // Jellyfin session token is persisted in encrypted on-device storage. The
-  // Jellyfin downloader override makes remote tracks downloadable for offline
-  // use. Tests keep the in-memory defaults unless they opt into these bindings.
+  // Jellyfin and Subsonic/Navidrome session credentials are each persisted in
+  // encrypted on-device storage. The remote downloader override makes both
+  // Jellyfin and Subsonic tracks downloadable for offline use. Tests keep the
+  // in-memory defaults unless they opt into these bindings.
   final container = ProviderContainer(
     overrides: [
       driftMusicLibraryRepositoryOverride,
@@ -37,9 +40,10 @@ Future<void> main() async {
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
       fileSystemOfflineFileStoreOverride,
-      jellyfinRemoteTrackDownloaderOverride,
+      remoteTrackDownloaderOverride,
       currentlyPlayingTrackIdOverride,
       secureJellyfinSessionStoreOverride,
+      secureSubsonicSessionStoreOverride,
       sharedPreferencesFavoritesStoreOverride,
       jellyfinFavoritesOverride,
       jellyfinLyricsOverride,
@@ -71,6 +75,16 @@ Future<void> main() async {
   try {
     await container
         .read(jellyfinSettingsControllerProvider.notifier)
+        .ensureLoaded();
+  } catch (_) {
+    // Ignore: the user can still connect in Settings.
+  }
+
+  // Likewise warm any persisted Subsonic/Navidrome session so a synced Subsonic
+  // track can stream on the first tap. Best-effort and secret-free.
+  try {
+    await container
+        .read(subsonicSettingsControllerProvider.notifier)
         .ensureLoaded();
   } catch (_) {
     // Ignore: the user can still connect in Settings.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,12 @@ dependencies:
   # the rest of the app depends on the JellyfinClient interface, never on http
   # directly. The Dart-team package, so it stays small and dependency-light.
   http: ^1.2.0
+  # MD5 hashing for the Subsonic/Navidrome token+salt auth scheme
+  # (token = md5(password + salt)). Used only by SubsonicAuth so a Subsonic
+  # session can authenticate every request without ever persisting the
+  # plaintext password — only the derived (salt, token) is stored, encrypted.
+  # A Dart-team package (BSD-3, MIT-compatible), small and dependency-light.
+  crypto: ^3.0.3
   # Runtime permission requests. Used only by
   # PermissionHandlerNotificationPermission to ask for POST_NOTIFICATIONS on
   # Android 13+ so the audio_service media notification can appear; the rest of

--- a/test/core/models/subsonic_session_test.dart
+++ b/test/core/models/subsonic_session_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+
+void main() {
+  const session = SubsonicSession(
+    baseUrl: 'https://music.example.com',
+    username: 'alice',
+    salt: 'abc123salt',
+    token: 'deadbeefdeadbeefdeadbeefdeadbeef',
+    serverType: 'navidrome',
+    serverVersion: '0.52.0',
+    apiVersion: '1.16.1',
+  );
+
+  group('SubsonicSession serialization', () {
+    test('round-trips through toJson/fromJson', () {
+      final restored = SubsonicSession.fromJson(session.toJson());
+      expect(restored, session);
+    });
+
+    test('fromJson returns null when a required field is missing', () {
+      expect(
+        SubsonicSession.fromJson(<String, dynamic>{
+          'baseUrl': 'https://x',
+          'username': 'a',
+          // no salt/token
+        }),
+        isNull,
+      );
+      expect(
+        SubsonicSession.fromJson(<String, dynamic>{
+          'baseUrl': '',
+          'username': 'a',
+          'salt': 's',
+          'token': 't',
+        }),
+        isNull,
+      );
+    });
+  });
+
+  group('security', () {
+    test('toString redacts the salt and token', () {
+      final String text = session.toString();
+      expect(text, isNot(contains('abc123salt')));
+      expect(text, isNot(contains('deadbeefdeadbeefdeadbeefdeadbeef')));
+      expect(text, contains('<redacted>'));
+      // Non-secret display fields are fine to show.
+      expect(text, contains('music.example.com'));
+      expect(text, contains('alice'));
+    });
+
+    test('has no password field at all (only the derived credential)', () {
+      // The serialized form carries the salt+token, never a password key.
+      expect(session.toJson().containsKey('password'), isFalse);
+    });
+  });
+}

--- a/test/core/services/cast/default_cast_service_test.dart
+++ b/test/core/services/cast/default_cast_service_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/cast_media.dart';
 import 'package:linthra/core/models/cast_playback_status.dart';
 import 'package:linthra/core/models/cast_state.dart';
+import 'package:linthra/core/models/cast_volume.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/cast/cast_media_resolver.dart';
@@ -22,12 +23,20 @@ class _FakeHandle implements CastSessionHandle {
   final StreamController<bool> _ready = StreamController<bool>.broadcast();
   final StreamController<CastPlaybackStatus> _status =
       StreamController<CastPlaybackStatus>.broadcast();
+  final StreamController<CastVolume> _volume =
+      StreamController<CastVolume>.broadcast();
   bool? _last;
   final List<CastMedia> loaded = <CastMedia>[];
   int playCount = 0;
   int pauseCount = 0;
   final List<Duration> seeks = <Duration>[];
   int statusRequests = 0;
+  final List<double> volumes = <double>[];
+  final List<bool> mutes = <bool>[];
+
+  /// When set, [setVolume]/[setMuted] throw it, so a test can drive a failed
+  /// volume command.
+  Object? volumeError;
   bool closed = false;
 
   void becomeReady() {
@@ -44,6 +53,10 @@ class _FakeHandle implements CastSessionHandle {
     if (!_status.isClosed) _status.add(status);
   }
 
+  void pushVolume(CastVolume volume) {
+    if (!_volume.isClosed) _volume.add(volume);
+  }
+
   @override
   Stream<bool> get readyStream async* {
     if (_last != null) yield _last!;
@@ -52,6 +65,9 @@ class _FakeHandle implements CastSessionHandle {
 
   @override
   Stream<CastPlaybackStatus> get statusStream => _status.stream;
+
+  @override
+  Stream<CastVolume> get volumeStream => _volume.stream;
 
   @override
   Future<void> loadMedia(CastMedia media) async => loaded.add(media);
@@ -66,6 +82,18 @@ class _FakeHandle implements CastSessionHandle {
   Future<void> seek(Duration position) async => seeks.add(position);
 
   @override
+  Future<void> setVolume(double level) async {
+    if (volumeError != null) throw volumeError!;
+    volumes.add(level);
+  }
+
+  @override
+  Future<void> setMuted(bool muted) async {
+    if (volumeError != null) throw volumeError!;
+    mutes.add(muted);
+  }
+
+  @override
   Future<void> requestStatus() async => statusRequests++;
 
   @override
@@ -73,6 +101,7 @@ class _FakeHandle implements CastSessionHandle {
     closed = true;
     if (!_ready.isClosed) await _ready.close();
     if (!_status.isClosed) await _status.close();
+    if (!_volume.isClosed) await _volume.close();
   }
 }
 
@@ -401,6 +430,142 @@ void main() {
       // Never in the user-facing state.
       expect(service.state.message ?? '', isNot(contains('TOKEN')));
       expect(service.state.message ?? '', isNot(contains('api_key')));
+    });
+  });
+
+  group('device volume', () {
+    Future<DefaultCastService> connectedService(_FakeHandle handle) async {
+      current = _jellyfinTrack;
+      transport.handle = handle;
+      final service = build();
+      addTearDown(service.dispose);
+      await service.connect(_d1);
+      return service;
+    }
+
+    Future<void> settle() =>
+        Future<void>.delayed(const Duration(milliseconds: 5));
+
+    test('a receiver volume update folds into the cast state', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+
+      handle.pushVolume(const CastVolume(level: 0.4, muted: false));
+      await settle();
+
+      expect(service.state.volume, 0.4);
+      expect(service.state.muted, isFalse);
+      expect(service.state.supportsVolumeControl, isTrue);
+      // Folding volume must not disturb the handoff.
+      expect(service.state.isCasting, isTrue);
+    });
+
+    test('setVolume forwards a clamped level to the session', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(const CastVolume(level: 0.5, muted: false));
+      await settle();
+
+      await service.setVolume(1.5);
+
+      expect(handle.volumes, <double>[1.0]);
+    });
+
+    test('setMuted forwards to the session', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(const CastVolume(level: 0.5, muted: false));
+      await settle();
+
+      await service.setMuted(true);
+
+      expect(handle.mutes, <bool>[true]);
+    });
+
+    test('volumeUp / volumeDown nudge from the current level', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(const CastVolume(level: 0.5, muted: false));
+      await settle();
+
+      await service.volumeUp();
+      await service.volumeDown();
+
+      expect(handle.volumes, hasLength(2));
+      expect(handle.volumes[0], closeTo(0.6, 1e-9));
+      expect(handle.volumes[1], closeTo(0.4, 1e-9));
+    });
+
+    test('volume commands are safe no-ops when not connected', () async {
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.setVolume(0.5);
+      await service.setMuted(true);
+      await service.volumeUp();
+      await service.volumeDown();
+      // No throw, nothing connected to forward to.
+    });
+
+    test('volume commands are no-ops on a fixed-volume device', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(
+        const CastVolume(level: 0.5, muted: false, controllable: false),
+      );
+      await settle();
+      expect(service.state.supportsVolumeControl, isFalse);
+
+      await service.setVolume(0.8);
+      await service.setMuted(true);
+
+      expect(handle.volumes, isEmpty);
+      expect(handle.mutes, isEmpty);
+    });
+
+    test('a failed volume command surfaces a notice but never stops playback',
+        () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(const CastVolume(level: 0.5, muted: false));
+      await settle();
+      expect(service.state.isCasting, isTrue);
+
+      handle.volumeError = Exception('receiver rejected SET_VOLUME');
+      await service.setVolume(0.7);
+
+      // Playback/handoff is untouched, and the raw error never leaks.
+      expect(service.state.isCasting, isTrue);
+      expect(service.state.message, DefaultCastService.volumeCommandFailed);
+      expect(service.state.message, isNot(contains('Exception')));
+    });
+
+    test('the device volume survives a track change mid-session', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(const CastVolume(level: 0.5, muted: false));
+      await settle();
+
+      const next = Track(id: 'j2', title: 'Next up', uri: 'jellyfin:j2');
+      current = next;
+      trackChanges.add(next);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(service.state.volume, 0.5);
+      expect(service.state.supportsVolumeControl, isTrue);
+    });
+
+    test('disconnect clears the device volume', () async {
+      final handle = _FakeHandle();
+      final service = await connectedService(handle);
+      handle.pushVolume(const CastVolume(level: 0.5, muted: false));
+      await settle();
+      expect(service.state.supportsVolumeControl, isTrue);
+
+      await service.disconnect();
+
+      expect(service.state.volume, isNull);
+      expect(service.state.supportsVolumeControl, isFalse);
     });
   });
 }

--- a/test/core/services/local_playable_uri_resolver_test.dart
+++ b/test/core/services/local_playable_uri_resolver_test.dart
@@ -31,14 +31,18 @@ void main() {
       expect(resolved.source, PlaybackSource.localFile);
     });
 
-    test('handles on-device tracks but not Jellyfin tracks', () {
+    test('handles on-device tracks but not remote (Jellyfin/Subsonic) ones',
+        () {
       const file = Track(id: '1', title: 'One', uri: '/music/song.mp3');
       const content = Track(id: '2', title: 'Two', uri: 'content://x/y');
       const jellyfin = Track(id: 't1', title: 'J', uri: 'jellyfin:t1');
+      const subsonic = Track(id: 's1', title: 'S', uri: 'subsonic:s1');
 
       expect(resolver.handles(file), isTrue);
       expect(resolver.handles(content), isTrue);
+      // Remote tracks are left to their own resolvers, composed ahead of this.
       expect(resolver.handles(jellyfin), isFalse);
+      expect(resolver.handles(subsonic), isFalse);
     });
   });
 }

--- a/test/core/services/routing_remote_track_downloader_test.dart
+++ b/test/core/services/routing_remote_track_downloader_test.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/remote_track_downloader.dart';
+import 'package:linthra/core/services/routing_remote_track_downloader.dart';
+
+/// A downloader that claims one scheme and returns canned bytes.
+class _FakeDownloader implements RemoteTrackDownloader {
+  _FakeDownloader(this.scheme, this.tag);
+
+  final String scheme;
+  final String tag;
+  final List<String> fetched = <String>[];
+
+  @override
+  bool isRemote(Track track) => track.uri.startsWith(scheme);
+
+  @override
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    fetched.add(track.id);
+    return RemoteTrackData(
+        bytes: Uint8List.fromList(<int>[1]), fileExtension: tag);
+  }
+}
+
+void main() {
+  late _FakeDownloader jellyfin;
+  late _FakeDownloader subsonic;
+  late RoutingRemoteTrackDownloader router;
+
+  setUp(() {
+    jellyfin = _FakeDownloader('jellyfin:', 'j');
+    subsonic = _FakeDownloader('subsonic:', 's');
+    router = RoutingRemoteTrackDownloader(<RemoteTrackDownloader>[
+      jellyfin,
+      subsonic,
+    ]);
+  });
+
+  test('isRemote is true when any member claims the track', () {
+    expect(
+      router.isRemote(const Track(id: 's1', title: 'x', uri: 'subsonic:s1')),
+      isTrue,
+    );
+    expect(
+      router.isRemote(const Track(id: 'j1', title: 'x', uri: 'jellyfin:j1')),
+      isTrue,
+    );
+    expect(
+      router.isRemote(const Track(id: 'l', title: 'x', uri: '/music/a.mp3')),
+      isFalse,
+    );
+  });
+
+  test('fetch routes to the member that owns the scheme', () async {
+    final data = await router
+        .fetch(const Track(id: 's1', title: 'x', uri: 'subsonic:s1'));
+
+    expect(data.fileExtension, 's');
+    expect(subsonic.fetched, <String>['s1']);
+    expect(jellyfin.fetched, isEmpty);
+  });
+
+  test('throws for a track no member can fetch', () {
+    expect(
+      () => router.fetch(const Track(id: 'l', title: 'x', uri: '/a.mp3')),
+      throwsA(isA<StateError>()),
+    );
+  });
+}

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/music_provider.dart';
+
+void main() {
+  group('MusicProviders capabilities', () {
+    test('local: plays and favorites on-device, but cannot cast', () {
+      final caps = MusicProviders.local.capabilities;
+      expect(caps.canStream, isTrue);
+      expect(caps.canFavorite, isTrue);
+      expect(caps.canCast, isFalse);
+      expect(caps.canCache, isFalse);
+    });
+
+    test('jellyfin: full capabilities', () {
+      final caps = MusicProviders.jellyfin.capabilities;
+      expect(caps.canStream, isTrue);
+      expect(caps.canCache, isTrue);
+      expect(caps.canFavorite, isTrue);
+      expect(caps.canLyrics, isTrue);
+      expect(caps.canCast, isTrue);
+    });
+
+    test('subsonic: stream/cache/cast implemented; favorites & lyrics are not',
+        () {
+      final caps = MusicProviders.subsonic.capabilities;
+      expect(caps.canStream, isTrue);
+      expect(caps.canCache, isTrue);
+      expect(caps.canCast, isTrue);
+      // Declared unsupported so their actions stay hidden/disabled.
+      expect(caps.canFavorite, isFalse);
+      expect(caps.canLyrics, isFalse);
+    });
+
+    test('identity fields', () {
+      expect(MusicProviders.subsonic.sourceId, 'subsonic');
+      expect(MusicProviders.subsonic.displayName, 'Navidrome / Subsonic');
+      expect(MusicProviders.subsonic.serverUrlLabel, 'Server URL');
+      expect(MusicProviders.local.serverUrlLabel, isNull);
+    });
+  });
+
+  group('MusicProviders.forTrackUri', () {
+    test('routes by scheme', () {
+      expect(MusicProviders.forTrackUri('subsonic:abc'),
+          same(MusicProviders.subsonic));
+      expect(MusicProviders.forTrackUri('jellyfin:abc'),
+          same(MusicProviders.jellyfin));
+      expect(MusicProviders.forTrackUri('/music/song.mp3'),
+          same(MusicProviders.local));
+      expect(MusicProviders.forTrackUri('content://media/x'),
+          same(MusicProviders.local));
+    });
+
+    test('capabilitiesForTrackUri matches the resolved provider', () {
+      expect(
+        MusicProviders.capabilitiesForTrackUri('subsonic:1'),
+        MusicProviders.subsonic.capabilities,
+      );
+    });
+  });
+}

--- a/test/core/sources/subsonic/fake_subsonic_client.dart
+++ b/test/core/sources/subsonic/fake_subsonic_client.dart
@@ -1,0 +1,102 @@
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_auth.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_client.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+
+/// A configurable [SubsonicClient] that returns canned responses (or throws)
+/// and records what it was asked, so the source/authenticator/controllers can
+/// be tested without a real server or HTTP.
+class FakeSubsonicClient implements SubsonicClient {
+  FakeSubsonicClient({
+    this.serverInfo,
+    this.pingError,
+    this.verifyError,
+    this.artists = const <SubsonicArtistDto>[],
+    this.albums = const <SubsonicAlbumDto>[],
+    this.songsByAlbum = const <String, List<SubsonicSongDto>>{},
+    this.listError,
+    this.streamProbe,
+    this.probeError,
+  });
+
+  SubsonicServerInfo? serverInfo;
+  SubsonicException? pingError;
+  SubsonicException? verifyError;
+  List<SubsonicArtistDto> artists;
+  List<SubsonicAlbumDto> albums;
+  Map<String, List<SubsonicSongDto>> songsByAlbum;
+  SubsonicException? listError;
+
+  /// Canned probe; defaults to a healthy `audio/mpeg` 200.
+  SubsonicStreamProbe? streamProbe;
+  SubsonicException? probeError;
+
+  // Recorded inputs.
+  String? lastBaseUrl;
+  String? lastUsername;
+  SubsonicCredentials? lastCredentials;
+  int verifyCount = 0;
+  final List<String> requestedAlbumIds = <String>[];
+  Uri? lastProbedUrl;
+
+  @override
+  Future<SubsonicServerInfo> ping(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastUsername = username;
+    lastCredentials = credentials;
+    final SubsonicException? error = pingError;
+    if (error != null) throw error;
+    return serverInfo ??
+        const SubsonicServerInfo(
+          apiVersion: '1.16.1',
+          type: 'navidrome',
+          serverVersion: '0.52.0',
+        );
+  }
+
+  @override
+  Future<void> verifySession(SubsonicSession session) async {
+    verifyCount++;
+    final SubsonicException? error = verifyError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<List<SubsonicArtistDto>> getArtists(SubsonicSession session) async {
+    final SubsonicException? error = listError;
+    if (error != null) throw error;
+    return artists;
+  }
+
+  @override
+  Future<List<SubsonicAlbumDto>> getAlbums(SubsonicSession session) async {
+    final SubsonicException? error = listError;
+    if (error != null) throw error;
+    return albums;
+  }
+
+  @override
+  Future<List<SubsonicSongDto>> getAlbumSongs(
+    SubsonicSession session,
+    String albumId,
+  ) async {
+    requestedAlbumIds.add(albumId);
+    final SubsonicException? error = listError;
+    if (error != null) throw error;
+    return songsByAlbum[albumId] ?? const <SubsonicSongDto>[];
+  }
+
+  @override
+  Future<SubsonicStreamProbe> probeStream(Uri url) async {
+    lastProbedUrl = url;
+    final SubsonicException? error = probeError;
+    if (error != null) throw error;
+    return streamProbe ??
+        const SubsonicStreamProbe(statusCode: 200, contentType: 'audio/mpeg');
+  }
+}

--- a/test/core/sources/subsonic/http_subsonic_client_test.dart
+++ b/test/core/sources/subsonic/http_subsonic_client_test.dart
@@ -1,0 +1,217 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/subsonic/http_subsonic_client.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_auth.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+
+const String _base = 'https://music.example.com';
+const _session = SubsonicSession(
+  baseUrl: _base,
+  username: 'alice',
+  salt: 'salt1',
+  token: 'tok1',
+);
+const _credentials = SubsonicCredentials(salt: 'salt1', token: 'tok1');
+
+HttpSubsonicClient _client(MockClient mock) =>
+    HttpSubsonicClient(httpClient: mock);
+
+http.Response _ok(Map<String, dynamic> data) => http.Response(
+      jsonEncode(<String, dynamic>{
+        'subsonic-response': <String, dynamic>{'status': 'ok', ...data},
+      }),
+      200,
+      headers: const <String, String>{'content-type': 'application/json'},
+    );
+
+http.Response _failed(int code, String message) => http.Response(
+      jsonEncode(<String, dynamic>{
+        'subsonic-response': <String, dynamic>{
+          'status': 'failed',
+          'error': <String, dynamic>{'code': code, 'message': message},
+        },
+      }),
+      200,
+      headers: const <String, String>{'content-type': 'application/json'},
+    );
+
+void main() {
+  group('ping', () {
+    test('parses server info and sends the auth + format query', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _ok(<String, dynamic>{
+          'version': '1.16.1',
+          'type': 'navidrome',
+          'serverVersion': '0.52.0',
+        });
+      }));
+
+      final info = await client.ping(
+        _base,
+        username: 'alice',
+        credentials: _credentials,
+      );
+
+      expect(info.apiVersion, '1.16.1');
+      expect(info.type, 'navidrome');
+      expect(info.serverVersion, '0.52.0');
+      expect(info.displayProduct, 'Navidrome');
+
+      expect(captured!.url.path, '/rest/ping.view');
+      final q = captured!.url.queryParameters;
+      expect(q['u'], 'alice');
+      expect(q['t'], 'tok1');
+      expect(q['s'], 'salt1');
+      expect(q['v'], '1.16.1');
+      expect(q['c'], 'Linthra');
+      expect(q['f'], 'json');
+    });
+
+    test('maps Subsonic error 40 to unauthorized', () async {
+      final client = _client(
+        MockClient((_) async => _failed(40, 'Wrong username or password')),
+      );
+      expect(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.unauthorized)),
+      );
+    });
+
+    test('maps Subsonic error 70 to streamUnavailable', () async {
+      final client = _client(MockClient((_) async => _failed(70, 'Not found')));
+      expect(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>().having(
+            (e) => e.kind, 'kind', SubsonicErrorKind.streamUnavailable)),
+      );
+    });
+
+    test('treats an HTML/non-Subsonic body as notSubsonic', () async {
+      final client = _client(
+        MockClient((_) async => http.Response('<html>nope</html>', 200)),
+      );
+      expect(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.notSubsonic)),
+      );
+    });
+
+    test('maps a transport failure to notReachable', () async {
+      final client = _client(
+        MockClient((_) async => throw http.ClientException('refused')),
+      );
+      expect(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.notReachable)),
+      );
+    });
+  });
+
+  group('library listing', () {
+    test('getArtists flattens the index → artist lists', () async {
+      final client = _client(MockClient((_) async {
+        return _ok(<String, dynamic>{
+          'artists': <String, dynamic>{
+            'index': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'name': 'K',
+                'artist': <Map<String, dynamic>>[
+                  <String, dynamic>{'id': 'ar-1', 'name': 'Kavinsky'},
+                ],
+              },
+              <String, dynamic>{
+                'name': 'M',
+                'artist': <Map<String, dynamic>>[
+                  <String, dynamic>{
+                    'id': 'ar-2',
+                    'name': 'M83',
+                    'albumCount': 5
+                  },
+                ],
+              },
+            ],
+          },
+        });
+      }));
+
+      final artists = await client.getArtists(_session);
+
+      expect(artists.map((a) => a.id), <String>['ar-1', 'ar-2']);
+      expect(artists.last.albumCount, 5);
+    });
+
+    test('getAlbums parses albumList2 and requests the right type', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _ok(<String, dynamic>{
+          'albumList2': <String, dynamic>{
+            'album': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'id': 'al-1',
+                'name': 'Drive',
+                'artist': 'Kavinsky',
+                'songCount': 12,
+                'year': 2011,
+              },
+            ],
+          },
+        });
+      }));
+
+      final albums = await client.getAlbums(_session);
+
+      expect(albums.single.id, 'al-1');
+      expect(albums.single.songCount, 12);
+      expect(captured!.url.path, '/rest/getAlbumList2.view');
+      expect(captured!.url.queryParameters['type'], 'alphabeticalByName');
+    });
+
+    test('getAlbumSongs parses the album child list', () async {
+      final client = _client(MockClient((_) async {
+        return _ok(<String, dynamic>{
+          'album': <String, dynamic>{
+            'song': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'id': 's1',
+                'title': 'Nightcall',
+                'artist': 'Kavinsky',
+                'duration': 256,
+                'track': 1,
+              },
+            ],
+          },
+        });
+      }));
+
+      final songs = await client.getAlbumSongs(_session, 'al-1');
+
+      expect(songs.single.id, 's1');
+      expect(songs.single.durationSeconds, 256);
+    });
+  });
+
+  group('probeStream', () {
+    test('returns the observed status and content type', () async {
+      final client = _client(MockClient((_) async => http.Response(
+            'data',
+            206,
+            headers: const <String, String>{'content-type': 'audio/mpeg'},
+          )));
+
+      final probe = await client.probeStream(Uri.parse('$_base/rest/stream'));
+
+      expect(probe.statusCode, 206);
+      expect(probe.isAudio, isTrue);
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_auth_test.dart
+++ b/test/core/sources/subsonic/subsonic_auth_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_auth.dart';
+
+void main() {
+  group('SubsonicAuth.tokenFor', () {
+    test('is md5(password + salt) — known MD5 vectors', () {
+      // md5('a') = 0cc175b9c0f1b6a831c399e269772661
+      expect(
+          SubsonicAuth.tokenFor('a', ''), '0cc175b9c0f1b6a831c399e269772661');
+      expect(
+          SubsonicAuth.tokenFor('', 'a'), '0cc175b9c0f1b6a831c399e269772661');
+      // md5('ab') = 187ef4436122d1cc2f40dc2b92f0eba0 (password+salt is concat)
+      expect(
+          SubsonicAuth.tokenFor('a', 'b'), '187ef4436122d1cc2f40dc2b92f0eba0');
+      expect(
+          SubsonicAuth.tokenFor('ab', ''), '187ef4436122d1cc2f40dc2b92f0eba0');
+    });
+
+    test('is a 32-char lowercase hex digest', () {
+      final String token = SubsonicAuth.tokenFor('hunter2', 'abc123');
+      expect(token, hasLength(32));
+      expect(token, matches(RegExp(r'^[0-9a-f]{32}$')));
+    });
+
+    test('changes with the password', () {
+      expect(
+        SubsonicAuth.tokenFor('one', 'salt'),
+        isNot(SubsonicAuth.tokenFor('two', 'salt')),
+      );
+    });
+  });
+
+  group('SubsonicAuth.credentials', () {
+    test('uses the injected salt and derives the matching token', () {
+      final creds = SubsonicAuth.credentials(
+        'hunter2',
+        saltGenerator: () => 'fixedsalt',
+      );
+      expect(creds.salt, 'fixedsalt');
+      expect(creds.token, SubsonicAuth.tokenFor('hunter2', 'fixedsalt'));
+    });
+
+    test('generates a fresh random salt by default', () {
+      final a = SubsonicAuth.credentials('pw');
+      final b = SubsonicAuth.credentials('pw');
+      expect(a.salt, isNot(b.salt));
+      expect(a.salt, isNotEmpty);
+    });
+  });
+
+  group('security', () {
+    test('toString redacts the salt and token', () {
+      final creds = SubsonicAuth.credentials(
+        'hunter2',
+        saltGenerator: () => 'fixedsalt',
+      );
+      final String text = creds.toString();
+      expect(text, isNot(contains('fixedsalt')));
+      expect(text, isNot(contains(creds.token)));
+      expect(text, contains('<redacted>'));
+    });
+
+    test('the plaintext password never appears in the credential', () {
+      final creds = SubsonicAuth.credentials(
+        'super-secret-password',
+        saltGenerator: () => 'fixedsalt',
+      );
+      expect(creds.salt, isNot(contains('super-secret-password')));
+      expect(creds.token, isNot(contains('super-secret-password')));
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_authenticator_test.dart
+++ b/test/core/sources/subsonic/subsonic_authenticator_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_auth.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_authenticator.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+
+import 'fake_subsonic_client.dart';
+
+void main() {
+  late FakeSubsonicClient client;
+
+  SubsonicAuthenticator auth() => SubsonicAuthenticator(
+        client,
+        saltGenerator: () => 'fixedsalt',
+      );
+
+  setUp(() => client = FakeSubsonicClient());
+
+  group('testConnection', () {
+    test('normalizes the URL and pings with derived credentials', () async {
+      final info = await auth().testConnection(
+        rawUrl: 'music.example.com',
+        username: ' alice ',
+        password: 'hunter2',
+      );
+
+      expect(info.type, 'navidrome');
+      expect(client.lastBaseUrl, 'https://music.example.com');
+      expect(client.lastUsername, 'alice');
+      // The token is md5(password + salt) for the fixed salt — never the
+      // password itself.
+      expect(client.lastCredentials!.salt, 'fixedsalt');
+      expect(
+        client.lastCredentials!.token,
+        SubsonicAuth.tokenFor('hunter2', 'fixedsalt'),
+      );
+      expect(client.lastCredentials!.token, isNot(contains('hunter2')));
+    });
+
+    test('surfaces a rejected credential as unauthorized', () async {
+      client.pingError = SubsonicException.unauthorized();
+      expect(
+        () => auth().testConnection(
+          rawUrl: 'music.example.com',
+          username: 'alice',
+          password: 'wrong',
+        ),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.unauthorized)),
+      );
+    });
+
+    test('rejects an empty username/password before any network call',
+        () async {
+      await expectLater(
+        auth().testConnection(
+            rawUrl: 'music.example.com', username: '  ', password: 'x'),
+        throwsA(isA<SubsonicException>()),
+      );
+      await expectLater(
+        auth().testConnection(
+            rawUrl: 'music.example.com', username: 'a', password: ''),
+        throwsA(isA<SubsonicException>()),
+      );
+      expect(client.lastBaseUrl, isNull); // never reached the client
+    });
+  });
+
+  group('signIn', () {
+    test('produces a session that stores only the derived credential',
+        () async {
+      client.serverInfo = const SubsonicServerInfo(
+        apiVersion: '1.16.1',
+        type: 'navidrome',
+        serverVersion: '0.52.0',
+      );
+
+      final session = await auth().signIn(
+        rawUrl: 'https://music.example.com/',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(session.baseUrl, 'https://music.example.com');
+      expect(session.username, 'alice');
+      expect(session.salt, 'fixedsalt');
+      expect(session.token, SubsonicAuth.tokenFor('hunter2', 'fixedsalt'));
+      expect(session.serverType, 'navidrome');
+      expect(session.serverVersion, '0.52.0');
+      // The password is not anywhere in the session.
+      expect(session.toJson().values.contains('hunter2'), isFalse);
+    });
+
+    test('throws on a bad URL before deriving anything', () {
+      expect(
+        () => auth().signIn(rawUrl: '', username: 'a', password: 'b'),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.invalidUrl)),
+      );
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_cast_media_resolver_test.dart
+++ b/test/core/sources/subsonic/subsonic_cast_media_resolver_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/cast/cast_media_resolver.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_cast_media_resolver.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_stream_source.dart';
+
+class _FakeStreamSource implements SubsonicStreamSource {
+  _FakeStreamSource({this.uri, this.verifyError});
+
+  Uri? uri;
+  SubsonicException? verifyError;
+
+  @override
+  Future<void> verifyReachable() async {
+    if (verifyError != null) throw verifyError!;
+  }
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async => uri;
+
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async => uri;
+}
+
+const _track = Track(
+  id: 's1',
+  title: 'One',
+  uri: 'subsonic:s1',
+  artistName: 'Kavinsky',
+  albumName: 'Drive',
+);
+
+void main() {
+  test('canCast is true for subsonic tracks only', () {
+    final resolver = SubsonicCastMediaResolver(() => _FakeStreamSource());
+    expect(resolver.canCast(_track), isTrue);
+    expect(
+      resolver.canCast(const Track(id: 'l', title: 'x', uri: '/a.mp3')),
+      isFalse,
+    );
+  });
+
+  test('resolves castable media from the minted stream URL', () async {
+    final source = _FakeStreamSource(
+      uri: Uri.parse(
+          'https://music.example.com/rest/stream.view?id=s1&t=tok&s=salt'),
+    );
+    final resolver = SubsonicCastMediaResolver(() => source);
+
+    final media = await resolver.resolve(_track);
+
+    expect(media.url.queryParameters['id'], 's1');
+    expect(media.title, 'One');
+    expect(media.artist, 'Kavinsky');
+    expect(media.album, 'Drive');
+    expect(media.contentType, 'audio/mpeg');
+  });
+
+  test('throws notSignedIn when no source is connected', () async {
+    final resolver = SubsonicCastMediaResolver(() => null);
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<CastMediaException>()
+          .having((e) => e.kind, 'kind', CastMediaErrorKind.notSignedIn)),
+    );
+  });
+
+  test('maps an expired session to a sign-in-again cast error', () async {
+    final resolver = SubsonicCastMediaResolver(
+      () => _FakeStreamSource(verifyError: SubsonicException.unauthorized()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<CastMediaException>()
+          .having((e) => e.kind, 'kind', CastMediaErrorKind.notSignedIn)),
+    );
+  });
+}

--- a/test/core/sources/subsonic/subsonic_music_source_test.dart
+++ b/test/core/sources/subsonic/subsonic_music_source_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_music_source.dart';
+
+import 'fake_subsonic_client.dart';
+
+const _session = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'fixedsalt',
+  token: 'tok-abc',
+  serverType: 'navidrome',
+);
+
+void main() {
+  late FakeSubsonicClient client;
+
+  SubsonicMusicSource source() =>
+      SubsonicMusicSource(session: _session, client: client);
+
+  setUp(() => client = FakeSubsonicClient());
+
+  test('id is the stable "subsonic"; displayName reflects the product', () {
+    expect(source().id, 'subsonic');
+    expect(source().displayName, 'Navidrome');
+  });
+
+  group('fetchTracks', () {
+    test('walks every album and flattens its songs into tracks', () async {
+      client.albums = const <SubsonicAlbumDto>[
+        SubsonicAlbumDto(id: 'al-1', name: 'A'),
+        SubsonicAlbumDto(id: 'al-2', name: 'B'),
+      ];
+      client.songsByAlbum = const <String, List<SubsonicSongDto>>{
+        'al-1': <SubsonicSongDto>[
+          SubsonicSongDto(id: 's1', title: 'One'),
+          SubsonicSongDto(id: 's2', title: 'Two'),
+        ],
+        'al-2': <SubsonicSongDto>[SubsonicSongDto(id: 's3', title: 'Three')],
+      };
+
+      final tracks = await source().fetchTracks();
+
+      expect(client.requestedAlbumIds, <String>['al-1', 'al-2']);
+      expect(tracks.map((t) => t.id), <String>['s1', 's2', 's3']);
+      // Every track uri is token-free.
+      for (final Track t in tracks) {
+        expect(t.uri, startsWith('subsonic:'));
+        expect(t.uri, isNot(contains('tok-abc')));
+        expect(t.uri, isNot(contains('fixedsalt')));
+      }
+    });
+  });
+
+  group('resolvePlayableUri', () {
+    test('mints the stream URL with the credential only at play time',
+        () async {
+      const track = Track(id: 's1', title: 'One', uri: 'subsonic:s1');
+
+      final uri = await source().resolvePlayableUri(track);
+
+      expect(uri, isNotNull);
+      expect(uri!.path, endsWith('/rest/stream.view'));
+      expect(uri.queryParameters['id'], 's1');
+      // The credential is woven into the *resolved* URL (at play time)…
+      expect(uri.queryParameters['t'], 'tok-abc');
+      expect(uri.queryParameters['s'], 'fixedsalt');
+      expect(uri.queryParameters['u'], 'alice');
+      // …and the probe ran against exactly that URL.
+      expect(client.lastProbedUrl, uri);
+    });
+
+    test('classifies a rejected stream as unauthorized', () async {
+      client.streamProbe = const SubsonicStreamProbe(statusCode: 401);
+      const track = Track(id: 's1', title: 'One', uri: 'subsonic:s1');
+      expect(
+        () => source().resolvePlayableUri(track),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.unauthorized)),
+      );
+    });
+
+    test('classifies an HTML proxy page as not-Subsonic', () async {
+      client.streamProbe =
+          const SubsonicStreamProbe(statusCode: 200, contentType: 'text/html');
+      const track = Track(id: 's1', title: 'One', uri: 'subsonic:s1');
+      expect(
+        () => source().resolvePlayableUri(track),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.notSubsonic)),
+      );
+    });
+  });
+
+  group('resolveDownloadUri', () {
+    test('mints the original-file download URL with the credential', () async {
+      const track = Track(id: 's1', title: 'One', uri: 'subsonic:s1');
+
+      final uri = await source().resolveDownloadUri(track);
+
+      expect(uri!.path, endsWith('/rest/download.view'));
+      expect(uri.queryParameters['id'], 's1');
+      expect(uri.queryParameters['t'], 'tok-abc');
+    });
+  });
+
+  test('verifyReachable delegates to the client', () async {
+    await source().verifyReachable();
+    expect(client.verifyCount, 1);
+  });
+}

--- a/test/core/sources/subsonic/subsonic_playable_uri_resolver_test.dart
+++ b/test/core/sources/subsonic/subsonic_playable_uri_resolver_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_stream_source.dart';
+
+/// A configurable [SubsonicStreamSource] for resolver tests.
+class _FakeStreamSource implements SubsonicStreamSource {
+  _FakeStreamSource({this.uri, this.verifyError, this.resolveError});
+
+  Uri? uri;
+  SubsonicException? verifyError;
+  SubsonicException? resolveError;
+
+  @override
+  Future<void> verifyReachable() async {
+    if (verifyError != null) throw verifyError!;
+  }
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    if (resolveError != null) throw resolveError!;
+    return uri;
+  }
+
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async => uri;
+}
+
+const _track = Track(id: 's1', title: 'One', uri: 'subsonic:s1');
+
+void main() {
+  test('handles only subsonic: tracks', () {
+    final resolver = SubsonicPlayableUriResolver(() => _FakeStreamSource());
+    expect(resolver.handles(_track), isTrue);
+    expect(
+      resolver.handles(const Track(id: 'j', title: 'x', uri: 'jellyfin:j')),
+      isFalse,
+    );
+    expect(
+      resolver.handles(const Track(id: 'l', title: 'x', uri: '/music/a.mp3')),
+      isFalse,
+    );
+  });
+
+  test('resolves to a streaming-direct playable', () async {
+    final source = _FakeStreamSource(
+      uri: Uri.parse('https://music.example.com/rest/stream.view?id=s1&t=tok'),
+    );
+    final resolver = SubsonicPlayableUriResolver(() => source);
+
+    final resolved = await resolver.resolve(_track);
+
+    expect(resolved.source, PlaybackSource.streamingDirect);
+    expect(resolved.uri.queryParameters['id'], 's1');
+  });
+
+  test('reports a friendly "not signed in" when no source is connected',
+      () async {
+    final resolver = SubsonicPlayableUriResolver(() => null);
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having(
+          (e) => e.kind, 'kind', PlaybackResolutionErrorKind.notSignedIn)),
+    );
+  });
+
+  test('maps an unauthorized failure to sessionExpired', () async {
+    final resolver = SubsonicPlayableUriResolver(
+      () => _FakeStreamSource(verifyError: SubsonicException.unauthorized()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having(
+          (e) => e.kind, 'kind', PlaybackResolutionErrorKind.sessionExpired)),
+    );
+  });
+
+  test('maps an HTML/proxy page to serverReturnedWebPage', () async {
+    final resolver = SubsonicPlayableUriResolver(
+      () => _FakeStreamSource(resolveError: SubsonicException.notSubsonic()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having((e) => e.kind, 'kind',
+          PlaybackResolutionErrorKind.serverReturnedWebPage)),
+    );
+  });
+
+  test('no resolution error message leaks a token', () async {
+    final resolver = SubsonicPlayableUriResolver(
+      () => _FakeStreamSource(verifyError: SubsonicException.unauthorized()),
+    );
+    try {
+      await resolver.resolve(_track);
+      fail('expected a PlaybackResolutionException');
+    } on PlaybackResolutionException catch (e) {
+      expect(e.message, isNot(contains('tok')));
+      expect(e.message, isNot(contains('=')));
+    }
+  });
+}

--- a/test/core/sources/subsonic/subsonic_server_url_test.dart
+++ b/test/core/sources/subsonic/subsonic_server_url_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_server_url.dart';
+
+void main() {
+  group('SubsonicServerUrl.normalize', () {
+    test('defaults a bare host to https', () {
+      expect(
+        SubsonicServerUrl.normalize('music.example.com'),
+        'https://music.example.com',
+      );
+    });
+
+    test('keeps an explicit http scheme (local network)', () {
+      expect(
+        SubsonicServerUrl.normalize('http://192.168.1.10:4533'),
+        'http://192.168.1.10:4533',
+      );
+    });
+
+    test('preserves a reverse-proxy subpath', () {
+      expect(
+        SubsonicServerUrl.normalize('https://example.com/navidrome'),
+        'https://example.com/navidrome',
+      );
+    });
+
+    test('strips a trailing slash, query, and fragment', () {
+      expect(
+        SubsonicServerUrl.normalize('https://music.example.com/?x=1#y'),
+        'https://music.example.com',
+      );
+    });
+
+    test('keeps a non-default port', () {
+      expect(
+        SubsonicServerUrl.normalize('music.example.com:4533'),
+        'https://music.example.com:4533',
+      );
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(
+        SubsonicServerUrl.normalize('  music.example.com  '),
+        'https://music.example.com',
+      );
+    });
+
+    test('rejects an empty address', () {
+      expect(
+        () => SubsonicServerUrl.normalize('   '),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.invalidUrl)),
+      );
+    });
+
+    test('rejects a non-http scheme', () {
+      expect(
+        () => SubsonicServerUrl.normalize('ftp://music.example.com'),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.invalidUrl)),
+      );
+    });
+
+    test('tryNormalize returns null instead of throwing', () {
+      expect(SubsonicServerUrl.tryNormalize(''), isNull);
+      expect(
+        SubsonicServerUrl.tryNormalize('music.example.com'),
+        'https://music.example.com',
+      );
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_track_downloader_test.dart
+++ b/test/core/sources/subsonic/subsonic_track_downloader_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_stream_source.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_track_downloader.dart';
+
+class _FakeStreamSource implements SubsonicStreamSource {
+  _FakeStreamSource({this.downloadUri});
+
+  Uri? downloadUri;
+
+  @override
+  Future<void> verifyReachable() async {}
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async => downloadUri;
+
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async => downloadUri;
+}
+
+const _track = Track(id: 's1', title: 'One', uri: 'subsonic:s1');
+final _downloadUri = Uri.parse(
+  'https://music.example.com/rest/download.view?id=s1&t=secret-token&s=salt1',
+);
+
+void main() {
+  test('isRemote is true only for subsonic tracks', () {
+    final downloader = SubsonicTrackDownloader(() => _FakeStreamSource());
+    expect(downloader.isRemote(_track), isTrue);
+    expect(
+      downloader.isRemote(const Track(id: 'l', title: 'x', uri: '/a.mp3')),
+      isFalse,
+    );
+  });
+
+  test('fetches the bytes and infers the extension from the content type',
+      () async {
+    final mock = MockClient((http.Request request) async {
+      return http.Response(
+        'audio-bytes',
+        200,
+        headers: const <String, String>{'content-type': 'audio/flac'},
+      );
+    });
+    final downloader = SubsonicTrackDownloader(
+      () => _FakeStreamSource(downloadUri: _downloadUri),
+      httpClient: mock,
+    );
+
+    final data = await downloader.fetch(_track);
+
+    expect(utf8.decode(data.bytes), 'audio-bytes');
+    expect(data.fileExtension, 'flac');
+  });
+
+  test('throws a generic, token-free error on a transport failure', () async {
+    final mock = MockClient(
+      (_) async =>
+          throw http.ClientException('failed talking to $_downloadUri'),
+    );
+    final downloader = SubsonicTrackDownloader(
+      () => _FakeStreamSource(downloadUri: _downloadUri),
+      httpClient: mock,
+    );
+
+    await expectLater(
+      downloader.fetch(_track),
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          isNot(contains('secret-token')),
+        ),
+      ),
+    );
+  });
+
+  test('throws when not signed in', () async {
+    final downloader = SubsonicTrackDownloader(() => null);
+    await expectLater(downloader.fetch(_track), throwsA(isA<StateError>()));
+  });
+}

--- a/test/core/sources/subsonic/subsonic_track_mapper_test.dart
+++ b/test/core/sources/subsonic/subsonic_track_mapper_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_track_mapper.dart';
+
+void main() {
+  group('SubsonicTrackMapper.toTrack', () {
+    test('maps a song to a token-free subsonic: uri', () {
+      const song = SubsonicSongDto(
+        id: 'song-42',
+        title: 'Nightcall',
+        album: 'Drive',
+        artist: 'Kavinsky',
+        track: 3,
+        durationSeconds: 256,
+      );
+
+      final track = SubsonicTrackMapper.toTrack(song);
+
+      expect(track.id, 'song-42');
+      expect(track.uri, 'subsonic:song-42');
+      expect(track.title, 'Nightcall');
+      expect(track.artistName, 'Kavinsky');
+      expect(track.albumName, 'Drive');
+      expect(track.trackNumber, 3);
+      expect(track.duration, const Duration(seconds: 256));
+    });
+
+    test('never embeds a credential or artwork URL (auth-bearing)', () {
+      const song = SubsonicSongDto(id: 's1', title: 'x');
+      final track = SubsonicTrackMapper.toTrack(song);
+
+      // The uri is the opaque id only — no query, no token/salt.
+      expect(track.uri, 'subsonic:s1');
+      expect(track.uri, isNot(contains('?')));
+      expect(track.uri, isNot(contains('token')));
+      expect(track.uri, isNot(contains('=')));
+      // Cover art needs auth params, so artwork is intentionally not persisted.
+      expect(track.artworkUri, isNull);
+    });
+
+    test('maps zero/absent duration to zero', () {
+      expect(
+        SubsonicTrackMapper.toTrack(
+          const SubsonicSongDto(id: 's', title: 't'),
+        ).duration,
+        Duration.zero,
+      );
+    });
+  });
+
+  group('SubsonicTrackMapper album/artist', () {
+    test('maps an album', () {
+      const dto = SubsonicAlbumDto(
+        id: 'al-1',
+        name: 'Drive',
+        artist: 'Kavinsky',
+        songCount: 12,
+        year: 2011,
+      );
+      final album = SubsonicTrackMapper.toAlbum(dto);
+      expect(album.id, 'al-1');
+      expect(album.title, 'Drive');
+      expect(album.artistName, 'Kavinsky');
+      expect(album.trackCount, 12);
+      expect(album.year, 2011);
+      expect(album.artworkUri, isNull);
+    });
+
+    test('maps an artist', () {
+      const dto =
+          SubsonicArtistDto(id: 'ar-1', name: 'Kavinsky', albumCount: 2);
+      final artist = SubsonicTrackMapper.toArtist(dto);
+      expect(artist.id, 'ar-1');
+      expect(artist.name, 'Kavinsky');
+      expect(artist.albumCount, 2);
+      expect(artist.artworkUri, isNull);
+    });
+  });
+}

--- a/test/features/player/cast/cast_devices_sheet_test.dart
+++ b/test/features/player/cast/cast_devices_sheet_test.dart
@@ -138,4 +138,123 @@ void main() {
       expect(service.discoveryStarts, before + 1);
     });
   });
+
+  group('Cast volume controls', () {
+    CastState connected({
+      double? volume,
+      bool muted = false,
+      bool supportsVolumeControl = false,
+    }) =>
+        CastState(
+          availability: CastAvailability.connected,
+          devices: const <CastDevice>[_device],
+          connectedDevice: _device,
+          volume: volume,
+          muted: muted,
+          supportsVolumeControl: supportsVolumeControl,
+        );
+
+    testWidgets('hidden when no device is connected', (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(
+          initial: const CastState(
+            availability: CastAvailability.idle,
+            devices: <CastDevice>[_device],
+          ),
+        ),
+      );
+
+      expect(find.text('Cast volume'), findsNothing);
+      expect(find.byType(Slider), findsNothing);
+    });
+
+    testWidgets('renders a slider when connected and supported',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(
+          initial: connected(volume: 0.4, supportsVolumeControl: true),
+        ),
+      );
+
+      expect(find.text('Cast volume'), findsOneWidget);
+      final slider = tester.widget<Slider>(find.byType(Slider));
+      expect(slider.value, 0.4);
+      expect(slider.onChanged, isNotNull);
+    });
+
+    testWidgets('slider release calls CastService.setVolume', (tester) async {
+      final service = FakeCastService(
+        initial: connected(volume: 0.2, supportsVolumeControl: true),
+      );
+      await _pumpSheet(tester, service);
+
+      // Invoke the slider's commit callback directly — a deterministic stand-in
+      // for a drag-and-release at that level.
+      tester.widget<Slider>(find.byType(Slider)).onChangeEnd!(0.75);
+      await tester.pump();
+
+      expect(service.volumeRequests, <double>[0.75]);
+    });
+
+    testWidgets('mute button calls CastService.setMuted', (tester) async {
+      final service = FakeCastService(
+        initial: connected(volume: 0.5, supportsVolumeControl: true),
+      );
+      await _pumpSheet(tester, service);
+
+      await tester.tap(find.byIcon(Icons.volume_up));
+      await tester.pump();
+
+      expect(service.muteRequests, <bool>[true]);
+    });
+
+    testWidgets('unsupported control shows a friendly disabled state',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(initial: connected(supportsVolumeControl: false)),
+      );
+
+      // The section is still present and stable, but the slider is disabled and
+      // an honest note explains why.
+      expect(find.text('Cast volume'), findsOneWidget);
+      expect(
+        find.textContaining("doesn't support volume control"),
+        findsOneWidget,
+      );
+      expect(tester.widget<Slider>(find.byType(Slider)).onChanged, isNull);
+    });
+
+    testWidgets('a CastState volume update refreshes the slider',
+        (tester) async {
+      final service = FakeCastService(
+        initial: connected(volume: 0.3, supportsVolumeControl: true),
+      );
+      await _pumpSheet(tester, service);
+      expect(tester.widget<Slider>(find.byType(Slider)).value, 0.3);
+
+      service.emit(connected(volume: 0.9, supportsVolumeControl: true));
+      // One frame for the StreamProvider to deliver the event, one to rebuild.
+      await tester.pump();
+      await tester.pump();
+
+      expect(tester.widget<Slider>(find.byType(Slider)).value, 0.9);
+    });
+
+    testWidgets('a muted receiver shows the muted icon and a zeroed slider',
+        (tester) async {
+      await _pumpSheet(
+        tester,
+        FakeCastService(
+          initial:
+              connected(volume: 0.6, muted: true, supportsVolumeControl: true),
+        ),
+      );
+
+      expect(find.byIcon(Icons.volume_off), findsOneWidget);
+      expect(tester.widget<Slider>(find.byType(Slider)).value, 0.0);
+    });
+  });
 }

--- a/test/features/player/cast/fake_cast_service.dart
+++ b/test/features/player/cast/fake_cast_service.dart
@@ -31,6 +31,14 @@ class FakeCastService implements CastService {
   int pauseCount = 0;
   final List<Duration> seeks = <Duration>[];
   int refreshCount = 0;
+  final List<double> volumeRequests = <double>[];
+  int volumeUpCount = 0;
+  int volumeDownCount = 0;
+  final List<bool> muteRequests = <bool>[];
+
+  /// When set, [setVolume]/[setMuted] throw it, so a test can assert that a
+  /// failed volume command doesn't break playback.
+  Object? commandError;
 
   void emit(CastState next) {
     _state = next;
@@ -74,6 +82,24 @@ class FakeCastService implements CastService {
 
   @override
   Future<void> seek(Duration position) async => seeks.add(position);
+
+  @override
+  Future<void> setVolume(double volume) async {
+    volumeRequests.add(volume);
+    if (commandError != null) throw commandError!;
+  }
+
+  @override
+  Future<void> volumeUp() async => volumeUpCount++;
+
+  @override
+  Future<void> volumeDown() async => volumeDownCount++;
+
+  @override
+  Future<void> setMuted(bool muted) async {
+    muteRequests.add(muted);
+    if (commandError != null) throw commandError!;
+  }
 
   @override
   Future<void> refresh() async => refreshCount++;

--- a/test/features/settings/subsonic/subsonic_settings_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_settings_controller_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/data/repositories/in_memory_subsonic_session_store.dart';
+import 'package:linthra/data/repositories/subsonic_session_store_provider.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_settings_controller.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_settings_providers.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_settings_state.dart';
+
+import '../../../core/sources/subsonic/fake_subsonic_client.dart';
+
+const _session = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'salt1',
+  token: 'tok1',
+  serverType: 'navidrome',
+  serverVersion: '0.52.0',
+);
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+ProviderContainer _container({
+  FakeSubsonicClient? client,
+  InMemorySubsonicSessionStore? store,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      subsonicClientProvider.overrideWithValue(client ?? FakeSubsonicClient()),
+      subsonicSessionStoreProvider
+          .overrideWithValue(store ?? InMemorySubsonicSessionStore()),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('load', () {
+    test('starts disconnected when nothing is persisted', () async {
+      final container = _container();
+      container.read(subsonicSettingsControllerProvider);
+      await _settle();
+      expect(
+        container.read(subsonicSettingsControllerProvider).phase,
+        SubsonicConnectionPhase.disconnected,
+      );
+    });
+
+    test('ensureLoaded readies the signed-in source', () async {
+      final container = _container(
+        store: InMemorySubsonicSessionStore(initialSession: _session),
+      );
+
+      await container
+          .read(subsonicSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      expect(
+        container.read(subsonicSettingsControllerProvider).phase,
+        SubsonicConnectionPhase.connected,
+      );
+      expect(container.read(subsonicMusicSourceProvider), isNotNull);
+    });
+  });
+
+  group('testConnection', () {
+    test('reports the reached product on success', () async {
+      final container = _container();
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.testConnection(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(ok, isTrue);
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(state.phase, SubsonicConnectionPhase.tested);
+      expect(state.statusMessage, contains('Navidrome'));
+    });
+
+    test('surfaces a friendly error on failure', () async {
+      final container = _container(
+        client: FakeSubsonicClient(pingError: SubsonicException.unauthorized()),
+      );
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.testConnection(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'wrong',
+      );
+
+      expect(ok, isFalse);
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(state.phase, SubsonicConnectionPhase.disconnected);
+      expect(state.errorMessage, isNotNull);
+    });
+  });
+
+  group('signIn', () {
+    test('persists a credential-only session and never leaks the password',
+        () async {
+      final store = InMemorySubsonicSessionStore();
+      final client = FakeSubsonicClient();
+      final container = _container(client: client, store: store);
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'hunter2',
+      );
+
+      expect(ok, isTrue);
+      final state = container.read(subsonicSettingsControllerProvider);
+      expect(state.phase, SubsonicConnectionPhase.connected);
+      expect(state.username, 'alice');
+
+      final saved = await store.read();
+      expect(saved, isNotNull);
+      // The stored session carries the derived token+salt, never the password.
+      expect(saved!.token, client.lastCredentials!.token);
+      expect(saved.toJson().values.contains('hunter2'), isFalse);
+      // Nor does the displayed state.
+      expect(state.statusMessage, isNot(contains('hunter2')));
+      expect(state.errorMessage ?? '', isNot(contains('hunter2')));
+    });
+
+    test('does not persist anything on failure', () async {
+      final store = InMemorySubsonicSessionStore();
+      final container = _container(
+        client: FakeSubsonicClient(pingError: SubsonicException.unauthorized()),
+        store: store,
+      );
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.signIn(
+        url: 'music.example.com',
+        username: 'alice',
+        password: 'bad',
+      );
+
+      expect(ok, isFalse);
+      expect(await store.read(), isNull);
+      expect(
+        container.read(subsonicSettingsControllerProvider).phase,
+        SubsonicConnectionPhase.disconnected,
+      );
+    });
+  });
+
+  group('clear', () {
+    test('wipes the stored session and resets to disconnected', () async {
+      final store = InMemorySubsonicSessionStore(initialSession: _session);
+      final container = _container(store: store);
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.clear();
+
+      expect(await store.read(), isNull);
+      expect(
+        container.read(subsonicSettingsControllerProvider).phase,
+        SubsonicConnectionPhase.disconnected,
+      );
+      expect(notifier.session, isNull);
+    });
+  });
+
+  group('subsonicMusicSourceProvider', () {
+    test('is null when disconnected and a source once connected', () async {
+      final container = _container();
+      container.read(subsonicSettingsControllerProvider);
+      await _settle();
+      expect(container.read(subsonicMusicSourceProvider), isNull);
+
+      await container.read(subsonicSettingsControllerProvider.notifier).signIn(
+            url: 'music.example.com',
+            username: 'alice',
+            password: 'pw',
+          );
+
+      final source = container.read(subsonicMusicSourceProvider);
+      expect(source, isNotNull);
+      expect(source!.id, 'subsonic');
+    });
+  });
+}

--- a/test/features/settings/subsonic/subsonic_settings_section_test.dart
+++ b/test/features/settings/subsonic/subsonic_settings_section_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_subsonic_session_store.dart';
+import 'package:linthra/data/repositories/subsonic_session_store_provider.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_settings_providers.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_settings_section.dart';
+
+import '../../../core/sources/subsonic/fake_subsonic_client.dart';
+
+Future<void> _pump(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        subsonicClientProvider.overrideWithValue(FakeSubsonicClient()),
+        subsonicSessionStoreProvider
+            .overrideWithValue(InMemorySubsonicSessionStore()),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(child: SubsonicSettingsSection()),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('renders the connection form with all three fields',
+      (tester) async {
+    await _pump(tester);
+
+    expect(find.text('Navidrome / Subsonic'), findsOneWidget);
+    expect(find.text('Server URL'), findsOneWidget);
+    expect(find.text('Username'), findsOneWidget);
+    expect(find.text('Password'), findsOneWidget);
+    expect(find.text('Sign in'), findsOneWidget);
+    expect(find.text('Test connection'), findsOneWidget);
+  });
+
+  testWidgets('shows capability chips only for implemented features',
+      (tester) async {
+    await _pump(tester);
+
+    // Implemented → shown.
+    expect(find.text('Streaming'), findsOneWidget);
+    expect(find.text('Offline'), findsOneWidget);
+    expect(find.text('Cast'), findsOneWidget);
+    // Not implemented for Subsonic yet → hidden (capability-based visibility).
+    expect(find.text('Favorites'), findsNothing);
+    expect(find.text('Lyrics'), findsNothing);
+  });
+
+  testWidgets('Sign in is disabled until all three fields are filled',
+      (tester) async {
+    await _pump(tester);
+
+    FilledButton signIn() => tester.widget<FilledButton>(
+          find.widgetWithText(FilledButton, 'Sign in'),
+        );
+    expect(signIn().onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField).at(0), 'music.example.com');
+    await tester.enterText(find.byType(TextField).at(1), 'alice');
+    await tester.enterText(find.byType(TextField).at(2), 'hunter2');
+    await tester.pump();
+
+    expect(signIn().onPressed, isNotNull);
+  });
+}

--- a/test/features/settings/subsonic/subsonic_sync_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_sync_controller_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_music_source.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_settings_controller.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_sync_controller.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_sync_state.dart';
+
+import '../../../core/sources/subsonic/fake_subsonic_client.dart';
+
+const _session = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'salt1',
+  token: 'secret-token',
+);
+
+class _RecordingRepository implements MusicLibraryRepository {
+  _RecordingRepository({this.upsertError});
+
+  final Object? upsertError;
+
+  String? upsertedSourceId;
+  List<Track> upsertedTracks = const <Track>[];
+  int upsertCount = 0;
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    upsertCount++;
+    if (upsertError != null) throw upsertError!;
+    upsertedSourceId = sourceId;
+    upsertedTracks = tracks;
+  }
+
+  @override
+  Future<List<Track>> getAllTracks() async => upsertedTracks;
+
+  @override
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
+
+  @override
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
+
+  @override
+  Future<Track?> getTrackById(String id) async => null;
+}
+
+SubsonicMusicSource _source({
+  List<SubsonicAlbumDto> albums = const <SubsonicAlbumDto>[],
+  Map<String, List<SubsonicSongDto>> songsByAlbum =
+      const <String, List<SubsonicSongDto>>{},
+  SubsonicException? listError,
+}) {
+  return SubsonicMusicSource(
+    session: _session,
+    client: FakeSubsonicClient(
+      albums: albums,
+      songsByAlbum: songsByAlbum,
+      listError: listError,
+    ),
+  );
+}
+
+ProviderContainer _container({
+  required MusicLibraryRepository repository,
+  SubsonicMusicSource? source,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      musicLibraryRepositoryProvider.overrideWithValue(repository),
+      subsonicMusicSourceProvider.overrideWithValue(source),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('SubsonicSyncController', () {
+    test('errors with a friendly message when not signed in', () async {
+      final container = _container(repository: _RecordingRepository());
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      final state = container.read(subsonicSyncControllerProvider);
+      expect(state.status, SubsonicSyncStatus.error);
+      expect(state.message, contains('Connect to your Subsonic'));
+    });
+
+    test('upserts fetched tracks under the subsonic source id', () async {
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _source(
+          albums: const <SubsonicAlbumDto>[
+            SubsonicAlbumDto(id: 'al', name: 'A')
+          ],
+          songsByAlbum: const <String, List<SubsonicSongDto>>{
+            'al': <SubsonicSongDto>[
+              SubsonicSongDto(id: 's1', title: 'One'),
+              SubsonicSongDto(id: 's2', title: 'Two'),
+            ],
+          },
+        ),
+      );
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      final state = container.read(subsonicSyncControllerProvider);
+      expect(state.status, SubsonicSyncStatus.success);
+      expect(state.trackCount, 2);
+      expect(repository.upsertedSourceId, 'subsonic');
+      expect(repository.upsertedTracks, hasLength(2));
+    });
+
+    test('never stores a credential in a synced track uri', () async {
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _source(
+          albums: const <SubsonicAlbumDto>[
+            SubsonicAlbumDto(id: 'al', name: 'A')
+          ],
+          songsByAlbum: const <String, List<SubsonicSongDto>>{
+            'al': <SubsonicSongDto>[SubsonicSongDto(id: 's1', title: 'One')],
+          },
+        ),
+      );
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      final Track track = repository.upsertedTracks.single;
+      expect(track.uri, 'subsonic:s1');
+      expect(track.uri, isNot(contains('secret-token')));
+      expect(track.uri, isNot(contains('salt1')));
+    });
+
+    test('reports an empty library without wiping the catalog', () async {
+      final repository = _RecordingRepository();
+      final container = _container(repository: repository, source: _source());
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      final state = container.read(subsonicSyncControllerProvider);
+      expect(state.status, SubsonicSyncStatus.success);
+      expect(state.trackCount, 0);
+      expect(repository.upsertCount, 0);
+    });
+
+    test('maps an unreachable server to a friendly message', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(listError: SubsonicException.notReachable()),
+      );
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      final state = container.read(subsonicSyncControllerProvider);
+      expect(state.status, SubsonicSyncStatus.error);
+      expect(state.message, contains("Couldn't reach"));
+    });
+
+    test('does not leak the credential through an error message', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(listError: SubsonicException.unauthorized()),
+      );
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      expect(
+        container.read(subsonicSyncControllerProvider).message,
+        isNot(contains('secret-token')),
+      );
+    });
+
+    test('surfaces a generic error when the repository upsert fails', () async {
+      final container = _container(
+        repository: _RecordingRepository(upsertError: Exception('disk full')),
+        source: _source(
+          albums: const <SubsonicAlbumDto>[
+            SubsonicAlbumDto(id: 'al', name: 'A')
+          ],
+          songsByAlbum: const <String, List<SubsonicSongDto>>{
+            'al': <SubsonicSongDto>[SubsonicSongDto(id: 's1', title: 'One')],
+          },
+        ),
+      );
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      final state = container.read(subsonicSyncControllerProvider);
+      expect(state.status, SubsonicSyncStatus.error);
+      expect(state.message, isNot(contains('disk full')));
+      expect(state.message, contains('Please try again'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two self-hosted improvements in one PR, keeping Linthra focused on user-owned music:

1. **Navidrome / Subsonic provider** — a clean Subsonic-compatible integration alongside Jellyfin.
2. **Chromecast device-volume control** — adjust the receiver's own volume from the app.

Jellyfin, local files, and existing Cast playback are unchanged.

---

## Part A — Navidrome / Subsonic

### Status: streaming, offline cache & casting work end-to-end

New `subsonic` source under `lib/core/sources/subsonic/`, mirroring the Jellyfin architecture with concerns kept apart (settings model · HTTP client · auth/session · music source · capabilities · UI section).

**What works now**
- Configure a Subsonic-compatible server (Navidrome, …) in `Settings → Navidrome / Subsonic`: URL, username, password. HTTPS reverse-proxy/self-hosted domains supported; no personal domain hardcoded.
- **Test connection** and **sign in** (both verify credentials via `ping`).
- **Sync Navidrome library** — artists/albums/tracks fetched (walking the ID3 album lists) and upserted under the `subsonic` source id.
- **Stream** an uncached track directly (URL resolved at play time); a cached copy is preferred automatically.
- **Offline cache** a track (original file via `download.view`).
- **Cast** a track to a Chromecast as a live stream.

**Follow-ups (declared unsupported, so hidden/disabled — not faked)**
- Favorites (`star`/`unstar`), lyrics (`getLyrics`), cover art (`getCoverArt` needs auth params, so it's a follow-up to resolve token-free), per-track cast content type, and in-app browse/search.

### Provider capability model
`lib/core/sources/music_provider.dart` declares each provider's `canStream` / `canCache` / `canFavorite` / `canLyrics` / `canCast`, so the UI offers only supported actions (the Settings section renders capability chips for the implemented ones).

| Provider | Stream | Cache | Favorite | Lyrics | Cast |
| --- | :-: | :-: | :-: | :-: | :-: |
| local | ✅ | — | ✅ | — | — |
| jellyfin | ✅ | ✅ | ✅ | ✅ | ✅ |
| subsonic | ✅ | ✅ | 🔜 | 🔜 | ✅ |

### Security / token notes
- **Token+salt auth** — `token = md5(password + salt)`. Linthra computes one random salt + token at sign-in and stores **only those** (encrypted via `flutter_secure_storage`). The **password is never persisted or logged**.
- `Track.uri` is the opaque `subsonic:<id>` — **no authenticated URL** in the track or database.
- Stream/download URLs (carrying salt+token) are minted **only at play/download time**; never logged, never persisted, never put in cache filenames/metadata or UI errors.
- `SubsonicSession` / `SubsonicCredentials` redact the salt+token in `toString`.

---

## Part B — Cast device volume

- `CastService` gains `setVolume` / `volumeUp` / `volumeDown` / `setMuted`; `CastState` exposes `volume` / `muted` / `supportsVolumeControl`.
- Volume rides over the Cast **receiver** namespace (addressed to `receiver-0`, not the media app) and the UI follows the device's reported level live.
- **"Cast volume" slider + mute** in the Cast bottom sheet, shown **only when connected**. No controls when nothing is connected; the Cast button is otherwise unchanged.
- A **fixed-volume device** shows an honest disabled state with a note.
- A **failed volume command** surfaces a calm notice and **never interrupts playback**.
- All behind `CastService`/`CastTransport` — widgets never touch the cast SDK. The `ChromecastCastTransport` parses `RECEIVER_STATUS` for the device volume and sends `SET_VOLUME`.

---

## Tests added (suite: 623 → 726, all green)

**Subsonic:** server-URL normalization · token+salt auth (known MD5 vectors, redaction, no password) · session round-trip/redaction · authenticator (test/sign-in, empty creds, derived token) · HTTP client (envelope + error-code mapping, listing, probe, transport failure) · track mapper (token-free URI, null artwork) · music source (album walk, play-time URL minting, probe classification) · playback & cast resolvers · downloader (no token leak) · capability matrix · settings & sync controllers · settings section (capability-chip visibility) · routing downloader · local resolver excludes `subsonic`.

**Cast volume:** state folding from the transport · `setVolume`/`setMuted`/`volumeUp`/`volumeDown` · clamp · no-ops when disconnected/fixed-volume · failure leaves playback untouched · disconnect clears volume · sheet renders/hides slider, calls the service, reflects updates, and shows the disabled state.

**Verification run in this sandbox (Flutter 3.27.4 / Dart 3.6.2, matching CI):**
- `flutter pub get` ✅
- `dart format --set-exit-if-changed .` ✅ clean
- `flutter analyze` ✅ no issues
- `flutter test` ✅ 726 passed
- `flutter build apk --debug` — **not run** (no Android SDK in this sandbox; the project's `android-debug-apk` CI workflow builds it).

---

## Manual Android / self-hosted checklist
- [ ] Connect to Jellyfin and confirm existing playback still works.
- [ ] Configure a Navidrome/Subsonic server, **Test connection**, **Sign in**.
- [ ] **Sync** the library and confirm tracks list.
- [ ] Stream a Subsonic track (uncached → streams; cached → plays offline).
- [ ] Connect to a Chromecast, open the Cast sheet, adjust **Cast volume**, confirm the device volume changes; mute/unmute.
- [ ] Confirm playback continues if a volume command fails.

## Known limitations
- Subsonic favorites, lyrics, and cover art are follow-ups (capability-gated today).
- On-device files still can't be cast (a receiver can't reach a local file).
- Single session per provider; direct-play streaming only.

See [`docs/providers.md`](docs/providers.md) for the full provider write-up and explicit non-goals (no Spotify, no DRM bypass, no unauthorized downloads).

https://claude.ai/code/session_012Fh2u5U6ugViuSbANFK2Y8

---
_Generated by [Claude Code](https://claude.ai/code/session_012Fh2u5U6ugViuSbANFK2Y8)_