### PR TITLE
Add playlists and safe song remove/delete workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Everything below works end to end on a real Android device in the current alpha
   scanned catalog survive a restart. No broad storage permission is requested.
 - **Playback** — play local tracks with an up-next queue, plus working
   **shuffle** and **repeat** (off / all / one).
+- **Playlists** — create, rename, reorder, and delete playlists; add and remove
+  tracks (including multi-select bulk actions); play or shuffle a playlist.
+  Playlists persist locally and **sync with Jellyfin** where supported. See
+  [docs/playlists-and-delete.md](docs/playlists-and-delete.md).
+- **Safe song removal** — clearly-separated, always-confirmed actions. "Remove
+  from Linthra" (index only) and "Remove offline copy" (app-managed cache only)
+  never touch your real files or server items.
 - **Background playback** — a media notification with lock-screen, Bluetooth,
   and wired-headset transport controls.
 - **Android Auto** — browse your Library and Queue from the car screen and
@@ -85,8 +92,15 @@ This is an alpha — expect rough edges. The honest gaps today:
 - **No tag/metadata parsing yet** — tracks show their file name, and there is
   no album artwork.
 - **No browse-by-artist/album and no search** in the in-app library yet.
-- **No saved playlists** — there is an up-next queue, but no playlist creation,
-  editing, or reordering.
+- **Playlist sync is partial** — local playlists are full-featured (create,
+  edit, reorder, delete, bulk actions); Jellyfin create / add / remove / delete
+  sync, but **rename and reorder of a synced playlist stay local for now**, and
+  Subsonic/Navidrome playlist sync isn't implemented. See
+  [docs/playlists-and-delete.md](docs/playlists-and-delete.md).
+- **File/server deletion is intentionally disabled** — only the safe "Remove
+  from Linthra" and "Remove offline copy" actions ship today; deleting the real
+  device file or the Jellyfin server item is modelled but not enabled until it's
+  robust.
 - **Downloads are track-level only** — no album/playlist "download all" and no
   background download manager (downloads run inline; no resume).
 - **Single Jellyfin server** — one session at a time; no multi-server support.

--- a/docs/playlists-and-delete.md
+++ b/docs/playlists-and-delete.md
@@ -1,0 +1,168 @@
+# Playlists & safe song removal
+
+This document describes how playlists work in Linthra, how (and how far) they
+sync with Jellyfin, and the deliberately-separated model for removing or
+deleting songs. The guiding principle throughout is safety: **"remove from
+Linthra" and "delete from your source/server/device" are different actions, and
+Linthra never silently destroys your real music files or server items.**
+
+## Playlists
+
+A playlist is a user-authored, ordered collection of tracks. Each playlist
+stores stable Linthra track ids (for Jellyfin tracks these are the Jellyfin item
+ids), not copies of the tracks, so membership and order survive a library
+re-scan.
+
+What you can do:
+
+- **Create** a playlist (Playlists tab → "New playlist"). A name is required; a
+  description is optional.
+- **Rename** / re-describe a playlist (overflow menu on the row, or the playlist
+  detail screen).
+- **Delete** a playlist (always behind a confirmation).
+- **Add tracks** from a track's overflow menu ("Add to playlist"), from the Now
+  Playing actions, or via multi-select.
+- **Remove tracks** from a playlist (per-row, with an Undo snackbar, or via
+  multi-select).
+- **Reorder tracks** by dragging the handle on a row.
+- **Play** the playlist, or **Shuffle** it, from the detail screen. Tapping any
+  track plays from there and queues the rest of the playlist behind it.
+
+Playlists persist locally via `shared_preferences` (the same lightweight,
+plugin-only storage used for favourites and the offline-download set) — no
+secrets are ever written to playlist metadata.
+
+### Sync state
+
+Every playlist carries a sync state so the UI can be honest about what reached
+the server: `localOnly`, `synced`, `pendingCreate`, `pendingUpdate`,
+`pendingDelete`, or `syncFailed` (with a friendly, secret-free `lastSyncError`).
+Linthra never pretends a sync worked when the server rejected it.
+
+## Jellyfin playlist sync
+
+When you're signed in to Jellyfin you can create a playlist that mirrors to your
+server (toggle "Sync with Jellyfin" in the create dialog). Linthra also imports
+your existing Jellyfin playlists on launch and on refresh.
+
+Supported today (best-effort, server is the source of truth for synced
+playlists):
+
+- **List / import** remote playlists and their tracks.
+- **Create** a Jellyfin playlist from Linthra.
+- **Add** Jellyfin tracks to a Jellyfin playlist.
+- **Remove** tracks from a Jellyfin playlist (resolved by playlist *entry* id).
+- **Delete** a Jellyfin playlist from the server.
+
+Friendly, secret-free errors are surfaced for: not signed in, an expired
+session, an unreachable server, and unexpected/unsupported responses. A failed
+server write never throws out of an edit — the local change stands and the
+playlist's sync state flips to `syncFailed` so you can see it didn't reach the
+server.
+
+Only Jellyfin tracks can be added to a Jellyfin playlist; adding a non-Jellyfin
+track is declined with a friendly message so a synced playlist stays consistent
+with the server. Local Linthra playlists can hold tracks from any source.
+
+### Write-sync limitations (documented on purpose)
+
+- **Rename** and **reorder** of a *synced* playlist are local-only for now; they
+  are not pushed to the server, and a refresh re-adopts the server's name/order.
+- Server membership is treated as the source of truth on refresh, so a change
+  that failed to push (marked `syncFailed`) may be reconciled to the server
+  state on the next refresh.
+- Subsonic/Navidrome playlist sync is not implemented yet (its tracks can still
+  be added to local Linthra playlists).
+
+## Safe song removal / deletion
+
+Linthra separates four distinct actions. Only the first two are enabled in this
+release; the destructive file/server deletes are intentionally gated off behind
+the provider capability model until they can be done robustly and safely.
+
+| Action | What it touches | Reversible? | Enabled now |
+| --- | --- | --- | --- |
+| **Remove from Linthra library** | Linthra's local catalog/index only | Yes — a re-scan/re-sync brings it back | ✅ |
+| **Remove offline copy** | Only Linthra's app-managed cached file | Yes — re-download / stream again | ✅ (cached tracks) |
+| **Delete local file from device** | The real file on disk | No | ❌ (not wired up safely yet) |
+| **Delete from server** | The item in Jellyfin, for all devices | No | ❌ (not enabled in this release) |
+
+- **Remove from Linthra library** forgets the rows in Linthra's index. It does
+  **not** delete the original local file and does **not** delete anything on
+  Jellyfin/Navidrome. It's the safe default.
+- **Remove offline copy** deletes only the app-managed download under Linthra's
+  private cache directory. The source remains streamable. The currently-playing
+  track is never deleted out from under playback — it's skipped and reported.
+- **Delete local file** and **Delete from server** are modelled in the
+  capability matrix but **not enabled** in this release, because doing them
+  safely (SAF permissions for device files; admin permissions and irreversible
+  server removal for Jellyfin) needs more than can be verified here. They never
+  appear as actions while disabled.
+
+### Bulk actions
+
+Long-press a track (in the Library or a playlist) to enter multi-select. The
+contextual bar shows the selected count and only the actions that are **safe for
+the whole selection**:
+
+- Add to playlist
+- Remove from Linthra library
+- Remove offline copies (when at least one selected track has a managed copy)
+- Remove from playlist (inside a playlist)
+
+A destructive *delete* would only ever be offered when **every** selected track
+supports it (and, for a server delete, they're all the same provider) — so a
+mixed-source selection automatically hides any unsafe delete. Bulk removals
+always confirm with the count (e.g. "Remove 12 songs from Linthra?") and report
+a success/failure summary.
+
+## Confirmation dialogs
+
+Every destructive action confirms first, with an explicit **Cancel** and a
+clearly-labelled action button ("Remove", "Delete") — never a vague "OK".
+Examples:
+
+- Delete playlist: "Delete playlist '<name>'? This removes the playlist from
+  Linthra. Synced playlists may also be removed from the server if sync is
+  enabled."
+- Remove from Linthra: "Remove '<title>' from Linthra? This will not delete the
+  original file or server item."
+- Remove offline copy: "Remove offline copy of '<title>'? You can still stream
+  it if your server is available."
+
+## Provider capability model
+
+Per-provider capabilities (in `MusicProviderCapabilities`) drive which actions
+are shown:
+
+| Capability | Local | Jellyfin | Subsonic |
+| --- | --- | --- | --- |
+| `canRemoveFromLibrary` | ✅ | ✅ | ✅ |
+| `canRemoveOfflineCopy` | — (already local) | ✅ | ✅ |
+| `canDeleteLocalFile` | ❌ (not wired up) | ❌ | ❌ |
+| `canDeleteRemoteItem` | ❌ | ❌ (not enabled) | ❌ |
+| `canCreatePlaylist` | ✅ | ✅ | ❌ |
+| `canEditPlaylist` | ✅ | ✅ | ❌ |
+| `canDeletePlaylist` | ✅ | ✅ | ❌ |
+| `canSyncPlaylists` | ❌ | ✅ | ❌ |
+
+## Safety guarantees
+
+1. Linthra never deletes a user's file or a server item without explicit
+   confirmation — and the file/server delete actions stay disabled until they're
+   robust.
+2. Offline-cache cleanup (and "remove offline copy") only ever touches
+   app-managed files inside Linthra's private cache directory, never the user's
+   selected music-source folder.
+3. No Jellyfin token or authenticated URL is ever stored in playlist or
+   delete metadata, logged, or surfaced in an error message. Errors are friendly
+   and secret-free.
+4. The currently-playing cached file is never removed out from under playback.
+
+## Future work
+
+- Push rename/reorder of synced Jellyfin playlists to the server.
+- Safe, SAF-gated device-file deletion for local tracks.
+- Optional, clearly-confirmed Jellyfin server-item deletion for users with
+  permission.
+- Subsonic/Navidrome playlist sync.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -5,6 +5,7 @@ import '../features/downloads/downloads_screen.dart';
 import '../features/favorites/favorites_screen.dart';
 import '../features/library/library_screen.dart';
 import '../features/player/player_screen.dart';
+import '../features/playlists/playlist_detail_screen.dart';
 import '../features/playlists/playlists_screen.dart';
 import '../features/settings/settings_screen.dart';
 import '../features/shell/home_shell.dart';
@@ -39,6 +40,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: 'favorites',
                     builder: (context, state) => const FavoritesScreen(),
+                  ),
+                  GoRoute(
+                    path: 'detail/:id',
+                    builder: (context, state) => PlaylistDetailScreen(
+                      playlistId: state.pathParameters['id']!,
+                    ),
                   ),
                 ],
               ),

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -7,6 +7,14 @@ abstract final class AppRoutes {
   /// Liked tracks, reached from the Playlists tab. A child of [playlists] so it
   /// keeps the bottom nav and pops back into that tab.
   static const String favorites = '/playlists/favorites';
+
+  /// A single playlist's tracks. A child of [playlists] (so it keeps the bottom
+  /// nav and pops back into that tab); the playlist id rides as a path segment.
+  static const String playlistDetail = '/playlists/detail';
+
+  /// Builds the [playlistDetail] location for a given playlist [id].
+  static String playlistDetailPath(String id) => '$playlistDetail/$id';
+
   static const String downloads = '/downloads';
   static const String settings = '/settings';
 

--- a/lib/core/models/playlist.dart
+++ b/lib/core/models/playlist.dart
@@ -1,31 +1,137 @@
-/// A user-created, ordered collection of tracks. Stores track IDs rather than
-/// full Track objects so ordering and membership persist cheaply.
+import 'package:flutter/foundation.dart';
+
+/// Which kind of backend a playlist belongs to.
+///
+/// A playlist is either purely on-device ([local]) or mirrored to a server
+/// ([jellyfin]). The enum — rather than a free string — keeps the membership
+/// closed and the capability/sync logic exhaustive, while leaving room to add
+/// future providers (Subsonic playlists, WebDAV, …) by extending it here.
+enum PlaylistSource {
+  local,
+  jellyfin;
+
+  /// The provider id this source maps to, matching `MusicProviders.sourceId`
+  /// (`'local'`, `'jellyfin'`) so capability lookups and routing never disagree.
+  String get providerId => name;
+
+  /// Parses a stored [providerId] back to a source, defaulting to [local] for an
+  /// unknown value so an old/forward record can never crash a load.
+  static PlaylistSource fromProviderId(String? id) {
+    for (final PlaylistSource source in PlaylistSource.values) {
+      if (source.providerId == id) return source;
+    }
+    return PlaylistSource.local;
+  }
+}
+
+/// Where a playlist stands relative to its remote (server) copy.
+///
+/// Local-only playlists are always [localOnly]. A playlist that should mirror a
+/// server moves through the `pending*` states while a change is queued, lands on
+/// [synced] when the server accepted it, and on [syncFailed] when it did not —
+/// so the UI can show an honest "couldn't sync" rather than pretend success.
+enum PlaylistSyncState {
+  localOnly,
+  synced,
+  pendingCreate,
+  pendingUpdate,
+  pendingDelete,
+  syncFailed;
+
+  /// Parses a stored state name, defaulting to [localOnly] for an unknown value.
+  static PlaylistSyncState fromName(String? name) {
+    for (final PlaylistSyncState state in PlaylistSyncState.values) {
+      if (state.name == name) return state;
+    }
+    return PlaylistSyncState.localOnly;
+  }
+}
+
+/// A user-created, ordered collection of tracks.
+///
+/// Stores stable Linthra track ids (for a Jellyfin playlist these equal the
+/// Jellyfin item ids; for a local playlist they are local track ids) rather than
+/// full [Track] objects, so ordering and membership persist cheaply and survive
+/// a catalog re-scan.
+///
+/// Security invariant: a playlist is *persisted* metadata, so it must never
+/// carry a secret. [remoteId] is the non-secret server playlist id; do not add a
+/// Jellyfin token or an authenticated URL to this record, and keep
+/// [lastSyncError] a friendly, secret-free message.
+@immutable
 class Playlist {
   const Playlist({
     required this.id,
     required this.name,
-    this.trackIds = const [],
+    this.description,
+    this.source = PlaylistSource.local,
+    this.remoteId,
+    this.trackIds = const <String>[],
     this.createdAt,
+    this.updatedAt,
+    this.syncState = PlaylistSyncState.localOnly,
+    this.lastSyncError,
   });
 
+  /// Stable Linthra playlist id (an opaque local id, never a server secret).
   final String id;
+
   final String name;
+
+  /// Optional free-text description.
+  final String? description;
+
+  /// The backend this playlist belongs to.
+  final PlaylistSource source;
+
+  /// The server's playlist id once this playlist is mirrored, or `null` for a
+  /// local-only playlist (or one whose remote create has not landed yet).
+  final String? remoteId;
+
+  /// Ordered, stable track ids. Empty for a brand-new playlist.
   final List<String> trackIds;
+
   final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  /// Where this playlist stands relative to its remote copy.
+  final PlaylistSyncState syncState;
+
+  /// A friendly, secret-free explanation of the last failed sync, or `null` when
+  /// the last sync attempt succeeded (or none has run).
+  final String? lastSyncError;
 
   int get length => trackIds.length;
+
+  bool get isEmpty => trackIds.isEmpty;
+
+  /// Whether this playlist is mirrored to a server (its [source] is remote).
+  bool get isRemote => source != PlaylistSource.local;
 
   Playlist copyWith({
     String? id,
     String? name,
+    String? Function()? description,
+    PlaylistSource? source,
+    String? Function()? remoteId,
     List<String>? trackIds,
     DateTime? createdAt,
+    DateTime? updatedAt,
+    PlaylistSyncState? syncState,
+    String? Function()? lastSyncError,
   }) {
     return Playlist(
       id: id ?? this.id,
       name: name ?? this.name,
+      description: description != null ? description() : this.description,
+      source: source ?? this.source,
+      remoteId: remoteId != null ? remoteId() : this.remoteId,
       trackIds: trackIds ?? this.trackIds,
       createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      syncState: syncState ?? this.syncState,
+      lastSyncError:
+          lastSyncError != null ? lastSyncError() : this.lastSyncError,
     );
   }
 

--- a/lib/core/repositories/music_library_repository.dart
+++ b/lib/core/repositories/music_library_repository.dart
@@ -25,4 +25,14 @@ abstract interface class MusicLibraryRepository {
     required List<Album> albums,
     required List<Artist> artists,
   });
+
+  /// Removes the tracks with [trackIds] from the local catalog/index only.
+  ///
+  /// This is the "Remove from Linthra library" primitive: it deletes nothing on
+  /// disk and nothing on a server — it only forgets the rows in Linthra's own
+  /// index. The original local file or remote server item is untouched, so a
+  /// later re-scan / re-sync of that source can bring the track back. A safe,
+  /// reversible default, deliberately distinct from deleting a file or a server
+  /// item.
+  Future<void> removeTracks(List<String> trackIds);
 }

--- a/lib/core/repositories/playlist_repository.dart
+++ b/lib/core/repositories/playlist_repository.dart
@@ -1,14 +1,61 @@
 import '../models/playlist.dart';
 
-/// Persistence contract for user-created playlists.
+/// Persistence + editing contract for user-created playlists.
 ///
 /// Kept separate from [MusicLibraryRepository] because playlists are
 /// user-authored and mutable, whereas the catalog is derived from sources and
 /// rebuilt on sync. Different lifecycles, different contracts.
+///
+/// The UI reads from [playlistsStream] / [getAllPlaylists] and edits through the
+/// explicit operations below, never touching the backing store (or Jellyfin)
+/// directly — mirroring how the player reads a `PlaybackState` and never the
+/// audio engine. Editing operations persist locally first; an implementation may
+/// additionally mirror the change to a server best-effort (see
+/// [refreshFromRemote]), but a server failure never throws out of these methods.
 abstract interface class PlaylistRepository {
+  /// Emits the current playlists immediately, then on every change.
+  Stream<List<Playlist>> get playlistsStream;
+
   Future<List<Playlist>> getAllPlaylists();
   Future<Playlist?> getPlaylistById(String id);
-  Future<Playlist> createPlaylist(String name);
-  Future<void> updatePlaylist(Playlist playlist);
+
+  /// Creates a playlist and returns it. A [source] of [PlaylistSource.jellyfin]
+  /// marks it for server sync; the implementation attempts the remote create
+  /// best-effort and records the resulting [Playlist.syncState].
+  Future<Playlist> createPlaylist(
+    String name, {
+    String? description,
+    PlaylistSource source = PlaylistSource.local,
+  });
+
+  /// Renames (and optionally re-describes) the playlist with [id]. Pass a
+  /// [description] of `null` to leave the description unchanged.
+  Future<void> renamePlaylist(String id, String name, {String? description});
+
   Future<void> deletePlaylist(String id);
+
+  /// Appends [trackId] to the playlist if it is not already present (a no-op for
+  /// a duplicate, so adding the same track twice can't create a double entry).
+  Future<void> addTrack(String playlistId, String trackId);
+
+  /// Appends every id in [trackIds] not already present, preserving their order.
+  Future<void> addTracks(String playlistId, List<String> trackIds);
+
+  Future<void> removeTrack(String playlistId, String trackId);
+
+  /// Moves the track at [oldIndex] to [newIndex] within the playlist.
+  Future<void> reorderTracks(String playlistId, int oldIndex, int newIndex);
+
+  /// Records the [state] (and optional friendly, secret-free [error]) for the
+  /// playlist with [id], so the UI can show an honest sync status.
+  Future<void> markSyncState(
+    String id,
+    PlaylistSyncState state, {
+    String? error,
+  });
+
+  /// Pulls playlists from the signed-in server and reconciles them into the
+  /// local set (importing new ones, adopting server membership for synced ones).
+  /// A no-op when not signed in or no server sync is configured. Never throws.
+  Future<void> refreshFromRemote();
 }

--- a/lib/core/repositories/playlist_store.dart
+++ b/lib/core/repositories/playlist_store.dart
@@ -1,0 +1,16 @@
+import '../models/playlist.dart';
+
+/// Durable storage for the user's playlists.
+///
+/// The persistence seam under [PlaylistRepository]: it knows nothing about
+/// Jellyfin or sync — only how to load and save the full list of [Playlist]s.
+/// Splitting it out lets the backing store swap freely (in-memory for tests, a
+/// key/value document in the app), mirroring how favourites and downloads are
+/// persisted.
+///
+/// Security: only non-secret playlist metadata and stable track ids are stored
+/// here — never a token or an authenticated URL.
+abstract interface class PlaylistStore {
+  Future<List<Playlist>> load();
+  Future<void> save(List<Playlist> playlists);
+}

--- a/lib/core/services/bulk_track_actions.dart
+++ b/lib/core/services/bulk_track_actions.dart
@@ -1,0 +1,85 @@
+import '../models/track.dart';
+import '../sources/music_provider.dart';
+
+/// Which bulk actions are safe to offer for a given multi-track selection.
+///
+/// This is the single, pure place the "what can I safely do to these songs?"
+/// rules live, so the selection UI can show exactly the safe actions and the
+/// rules are trivially unit-testable. The destructive actions follow the safety
+/// principle that "remove from Linthra" and "delete from source" are different:
+/// a destructive *delete* is only offered when *every* selected track supports
+/// it (and, for a server delete, they are all the same provider), so a
+/// mixed-source selection automatically hides any unsafe delete.
+class BulkActionAvailability {
+  const BulkActionAvailability({
+    required this.canAddToPlaylist,
+    required this.canRemoveFromLibrary,
+    required this.canRemoveOfflineCopy,
+    required this.canRemoveFromPlaylist,
+    required this.canDeleteLocalFiles,
+    required this.canDeleteFromServer,
+  });
+
+  static const BulkActionAvailability none = BulkActionAvailability(
+    canAddToPlaylist: false,
+    canRemoveFromLibrary: false,
+    canRemoveOfflineCopy: false,
+    canRemoveFromPlaylist: false,
+    canDeleteLocalFiles: false,
+    canDeleteFromServer: false,
+  );
+
+  /// Add the selection to a playlist. Always available for a non-empty
+  /// selection regardless of source.
+  final bool canAddToPlaylist;
+
+  /// Remove the selection from Linthra's library/index (safe, reversible).
+  final bool canRemoveFromLibrary;
+
+  /// Remove app-managed offline copies for the selection (at least one selected
+  /// track's provider supports a managed offline copy).
+  final bool canRemoveOfflineCopy;
+
+  /// Remove the selection from the current playlist (only inside a playlist).
+  final bool canRemoveFromPlaylist;
+
+  /// Delete the underlying device files (every selected track supports it).
+  final bool canDeleteLocalFiles;
+
+  /// Delete the underlying server items (every selected track is the same
+  /// provider and that provider supports a safe server delete).
+  final bool canDeleteFromServer;
+}
+
+/// Computes the safe bulk actions for [tracks]. Pass [inPlaylist] when the
+/// selection is shown inside a playlist (so "remove from playlist" applies).
+BulkActionAvailability bulkActionsFor(
+  List<Track> tracks, {
+  required bool inPlaylist,
+}) {
+  if (tracks.isEmpty) return BulkActionAvailability.none;
+
+  final List<MusicProviderCapabilities> caps = <MusicProviderCapabilities>[
+    for (final Track track in tracks)
+      MusicProviders.capabilitiesForTrackUri(track.uri),
+  ];
+
+  final Set<String> providerIds = <String>{
+    for (final Track track in tracks)
+      MusicProviders.forTrackUri(track.uri).sourceId,
+  };
+  final bool allSameProvider = providerIds.length == 1;
+
+  return BulkActionAvailability(
+    canAddToPlaylist: true,
+    canRemoveFromLibrary:
+        caps.every((MusicProviderCapabilities c) => c.canRemoveFromLibrary),
+    canRemoveOfflineCopy:
+        caps.any((MusicProviderCapabilities c) => c.canRemoveOfflineCopy),
+    canRemoveFromPlaylist: inPlaylist,
+    canDeleteLocalFiles:
+        caps.every((MusicProviderCapabilities c) => c.canDeleteLocalFile),
+    canDeleteFromServer: allSameProvider &&
+        caps.every((MusicProviderCapabilities c) => c.canDeleteRemoteItem),
+  );
+}

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -213,6 +213,148 @@ class HttpJellyfinClient implements JellyfinClient {
     _checkStatus(response);
   }
 
+  @override
+  Future<List<JellyfinPlaylistDto>> fetchPlaylists(
+    JellyfinSession session,
+  ) async {
+    final Uri uri = JellyfinEndpoints.playlists(
+      session.baseUrl,
+      userId: session.userId,
+    );
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+    final Map<String, dynamic> json = _decodeObject(response);
+    final Object? rawItems = json['Items'];
+    if (rawItems is! List) return const <JellyfinPlaylistDto>[];
+    final List<JellyfinPlaylistDto> playlists = <JellyfinPlaylistDto>[];
+    for (final Object? entry in rawItems) {
+      if (entry is Map<String, dynamic>) {
+        final JellyfinPlaylistDto? dto = JellyfinPlaylistDto.fromJson(entry);
+        if (dto != null) playlists.add(dto);
+      }
+    }
+    return playlists;
+  }
+
+  @override
+  Future<List<JellyfinPlaylistEntry>> fetchPlaylistEntries(
+    JellyfinSession session,
+    String playlistId,
+  ) async {
+    final Uri uri = JellyfinEndpoints.playlistItems(
+      session.baseUrl,
+      playlistId: playlistId,
+      userId: session.userId,
+    );
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+    final Map<String, dynamic> json = _decodeObject(response);
+    final Object? rawItems = json['Items'];
+    if (rawItems is! List) return const <JellyfinPlaylistEntry>[];
+    final List<JellyfinPlaylistEntry> entries = <JellyfinPlaylistEntry>[];
+    for (final Object? entry in rawItems) {
+      if (entry is Map<String, dynamic>) {
+        final JellyfinPlaylistEntry? parsed =
+            JellyfinPlaylistEntry.fromJson(entry);
+        if (parsed != null) entries.add(parsed);
+      }
+    }
+    return entries;
+  }
+
+  @override
+  Future<String> createPlaylist(
+    JellyfinSession session, {
+    required String name,
+    List<String> itemIds = const <String>[],
+  }) async {
+    final Uri uri = JellyfinEndpoints.createPlaylist(
+      session.baseUrl,
+      name: name,
+      userId: session.userId,
+      itemIds: itemIds,
+    );
+    final http.Response response = await _send(
+      () => _client.post(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+    final Map<String, dynamic> json = _decodeObject(response);
+    final Object? id = json['Id'];
+    if (id is! String || id.isEmpty) {
+      throw JellyfinException.unsupportedResponse(response.statusCode);
+    }
+    return id;
+  }
+
+  @override
+  Future<void> addItemsToPlaylist(
+    JellyfinSession session,
+    String playlistId,
+    List<String> itemIds,
+  ) async {
+    if (itemIds.isEmpty) return;
+    final Uri uri = JellyfinEndpoints.addPlaylistItems(
+      session.baseUrl,
+      playlistId: playlistId,
+      userId: session.userId,
+      itemIds: itemIds,
+    );
+    final http.Response response = await _send(
+      () => _client.post(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+  }
+
+  @override
+  Future<void> removeItemsFromPlaylist(
+    JellyfinSession session,
+    String playlistId,
+    List<String> itemIds,
+  ) async {
+    if (itemIds.isEmpty) return;
+    // Jellyfin removes by *entry* id (PlaylistItemId), not media id, so resolve
+    // the entry ids for the requested media ids from the current playlist first.
+    final List<JellyfinPlaylistEntry> entries =
+        await fetchPlaylistEntries(session, playlistId);
+    final Set<String> targets = itemIds.toSet();
+    final List<String> entryIds = <String>[
+      for (final JellyfinPlaylistEntry entry in entries)
+        if (targets.contains(entry.itemId) && entry.playlistItemId != null)
+          entry.playlistItemId!,
+    ];
+    if (entryIds.isEmpty) {
+      // The server didn't expose entry ids (or the items are already gone):
+      // surface an honest "couldn't use the response" rather than a silent ok.
+      throw JellyfinException.unsupportedResponse();
+    }
+    final Uri uri = JellyfinEndpoints.removePlaylistEntries(
+      session.baseUrl,
+      playlistId: playlistId,
+      entryIds: entryIds,
+    );
+    final http.Response response = await _send(
+      () => _client.delete(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+  }
+
+  @override
+  Future<void> deletePlaylist(
+    JellyfinSession session,
+    String playlistId,
+  ) async {
+    final Uri uri =
+        JellyfinEndpoints.deleteItem(session.baseUrl, itemId: playlistId);
+    final http.Response response = await _send(
+      () => _client.delete(uri, headers: _authHeaders(session)),
+    );
+    _checkStatus(response);
+  }
+
   /// The standard headers for an authenticated JSON call: the token rides in the
   /// `Authorization` header (built in one place, never logged).
   Map<String, String> _authHeaders(JellyfinSession session) {

--- a/lib/core/sources/jellyfin/jellyfin_api.dart
+++ b/lib/core/sources/jellyfin/jellyfin_api.dart
@@ -225,3 +225,46 @@ class JellyfinItemDto {
     );
   }
 }
+
+/// A playlist item from `GET /Users/<userId>/Items?IncludeItemTypes=Playlist`.
+///
+/// Only the fields Linthra mirrors are kept: the server playlist [id] (used as
+/// the local playlist's `remoteId`) and its [name]. No token or URL is carried.
+class JellyfinPlaylistDto {
+  const JellyfinPlaylistDto({required this.id, required this.name});
+
+  final String id;
+  final String name;
+
+  /// Parses one playlist entry, or `null` when it lacks an id/name so a single
+  /// malformed entry can't break a whole listing.
+  static JellyfinPlaylistDto? fromJson(Map<String, dynamic> json) {
+    final String? id = json['Id'] as String?;
+    final String? name = json['Name'] as String?;
+    if (id == null || id.isEmpty || name == null) return null;
+    return JellyfinPlaylistDto(id: id, name: name);
+  }
+}
+
+/// One entry inside a Jellyfin playlist, from `GET /Playlists/<id>/Items`.
+///
+/// Carries both the underlying media [itemId] (what Linthra stores as a track
+/// reference) and the playlist-scoped [playlistItemId] (the *entry* id Jellyfin
+/// requires to remove that entry — distinct from the media id). The entry id is
+/// optional because some server versions omit it; removal falls back to a
+/// no-entry-id outcome the caller can treat as "couldn't remove on server".
+class JellyfinPlaylistEntry {
+  const JellyfinPlaylistEntry({required this.itemId, this.playlistItemId});
+
+  final String itemId;
+  final String? playlistItemId;
+
+  static JellyfinPlaylistEntry? fromJson(Map<String, dynamic> json) {
+    final String? id = json['Id'] as String?;
+    if (id == null || id.isEmpty) return null;
+    return JellyfinPlaylistEntry(
+      itemId: id,
+      playlistItemId: json['PlaylistItemId'] as String?,
+    );
+  }
+}

--- a/lib/core/sources/jellyfin/jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/jellyfin_client.dart
@@ -72,4 +72,43 @@ abstract interface class JellyfinClient {
     String itemId, {
     required bool favorite,
   });
+
+  /// Lists the signed-in user's playlists (id + name only).
+  Future<List<JellyfinPlaylistDto>> fetchPlaylists(JellyfinSession session);
+
+  /// Lists the ordered entries of the playlist [playlistId]. Each entry carries
+  /// the media item id and its playlist-scoped entry id.
+  Future<List<JellyfinPlaylistEntry>> fetchPlaylistEntries(
+    JellyfinSession session,
+    String playlistId,
+  );
+
+  /// Creates a playlist named [name], optionally seeded with audio [itemIds],
+  /// and returns the new server playlist id. Throws on failure.
+  Future<String> createPlaylist(
+    JellyfinSession session, {
+    required String name,
+    List<String> itemIds = const <String>[],
+  });
+
+  /// Appends audio [itemIds] to the playlist [playlistId]. Throws on failure.
+  Future<void> addItemsToPlaylist(
+    JellyfinSession session,
+    String playlistId,
+    List<String> itemIds,
+  );
+
+  /// Removes the entries holding [itemIds] from the playlist [playlistId]. The
+  /// implementation resolves each media item id to its playlist entry id first,
+  /// since Jellyfin removes by entry id. Throws on failure.
+  Future<void> removeItemsFromPlaylist(
+    JellyfinSession session,
+    String playlistId,
+    List<String> itemIds,
+  );
+
+  /// Deletes the playlist [playlistId] from the server. Requires the user to
+  /// have delete permission; a permission failure surfaces as a friendly
+  /// [JellyfinException]. Throws on failure.
+  Future<void> deletePlaylist(JellyfinSession session, String playlistId);
 }

--- a/lib/core/sources/jellyfin/jellyfin_endpoints.dart
+++ b/lib/core/sources/jellyfin/jellyfin_endpoints.dart
@@ -25,6 +25,7 @@ abstract final class JellyfinEndpoints {
   static const String _currentUserPath = '/Users/Me';
   static const String _itemsPath = '/Items';
   static const String _artistsPath = '/Artists';
+  static const String _playlistsPath = '/Playlists';
 
   // --- Query-parameter keys, named once so a typo can't split a request. ---
 
@@ -115,6 +116,88 @@ abstract final class JellyfinEndpoints {
     required String itemId,
   }) =>
       _join(baseUrl, '/Users/$userId/FavoriteItems/$itemId');
+
+  /// `GET /Items?…&IncludeItemTypes=Playlist` — the user's playlists. Images are
+  /// disabled to keep the payload small; only id + name are mapped.
+  static Uri playlists(String baseUrl, {required String userId}) =>
+      _join(baseUrl, _itemsPath).replace(
+        queryParameters: <String, String>{
+          userIdParam: userId,
+          'Recursive': 'true',
+          'IncludeItemTypes': 'Playlist',
+          'SortBy': 'SortName',
+          'SortOrder': 'Ascending',
+          'EnableImages': 'false',
+        },
+      );
+
+  /// `GET /Playlists/<playlistId>/Items` — the ordered entries of one playlist.
+  /// Each entry carries both the media `Id` and the playlist-scoped
+  /// `PlaylistItemId` (the entry id needed to remove it).
+  static Uri playlistItems(
+    String baseUrl, {
+    required String playlistId,
+    required String userId,
+  }) =>
+      _join(baseUrl, '$_playlistsPath/$playlistId/Items').replace(
+        queryParameters: <String, String>{
+          userIdParam: userId,
+          'Fields': 'ItemCounts',
+        },
+      );
+
+  /// `POST /Playlists?Name=…&Ids=…&UserId=…` — create a playlist (optionally
+  /// seeded with audio item [itemIds]). Returns `{ "Id": "<playlistId>" }`.
+  static Uri createPlaylist(
+    String baseUrl, {
+    required String name,
+    required String userId,
+    List<String> itemIds = const <String>[],
+  }) {
+    final Map<String, String> query = <String, String>{
+      'Name': name,
+      userIdParam: userId,
+      'MediaType': 'Audio',
+    };
+    if (itemIds.isNotEmpty) {
+      query['Ids'] = itemIds.join(',');
+    }
+    return _join(baseUrl, _playlistsPath).replace(queryParameters: query);
+  }
+
+  /// `POST /Playlists/<playlistId>/Items?Ids=…&UserId=…` — append audio
+  /// [itemIds] to an existing playlist.
+  static Uri addPlaylistItems(
+    String baseUrl, {
+    required String playlistId,
+    required String userId,
+    required List<String> itemIds,
+  }) =>
+      _join(baseUrl, '$_playlistsPath/$playlistId/Items').replace(
+        queryParameters: <String, String>{
+          'Ids': itemIds.join(','),
+          userIdParam: userId,
+        },
+      );
+
+  /// `DELETE /Playlists/<playlistId>/Items?EntryIds=…` — remove entries by their
+  /// playlist-scoped entry ids (the `PlaylistItemId`s, not the media ids).
+  static Uri removePlaylistEntries(
+    String baseUrl, {
+    required String playlistId,
+    required List<String> entryIds,
+  }) =>
+      _join(baseUrl, '$_playlistsPath/$playlistId/Items').replace(
+        queryParameters: <String, String>{
+          'EntryIds': entryIds.join(','),
+        },
+      );
+
+  /// `DELETE /Items/<itemId>` — delete a library item. Used to delete a playlist
+  /// (a playlist is an item); requires the user to have delete permission, so a
+  /// 401/403 is mapped to a friendly "couldn't delete" rather than retried.
+  static Uri deleteItem(String baseUrl, {required String itemId}) =>
+      _join(baseUrl, '$_itemsPath/$itemId');
 
   /// `GET /Audio/<itemId>/Lyrics` — time-synced or plain lyrics (a 404 just
   /// means the server has none).

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -18,6 +18,14 @@ class MusicProviderCapabilities {
     required this.canFavorite,
     required this.canLyrics,
     required this.canCast,
+    required this.canRemoveFromLibrary,
+    required this.canRemoveOfflineCopy,
+    required this.canDeleteLocalFile,
+    required this.canDeleteRemoteItem,
+    required this.canCreatePlaylist,
+    required this.canEditPlaylist,
+    required this.canDeletePlaylist,
+    required this.canSyncPlaylists,
   });
 
   /// Tracks can be played by resolving a stream URL at play time.
@@ -36,6 +44,41 @@ class MusicProviderCapabilities {
   /// receiver. False for on-device files a receiver can't reach.
   final bool canCast;
 
+  /// The track can be removed from Linthra's local catalog/index — a safe,
+  /// reversible action that never deletes the underlying file or server item.
+  /// True for every provider.
+  final bool canRemoveFromLibrary;
+
+  /// The provider's tracks can have an app-managed offline copy that Linthra may
+  /// safely delete (the same managed cache the download repository owns).
+  /// Whether a *specific* track actually has a copy to remove is a per-track
+  /// download-status check on top of this static capability.
+  final bool canRemoveOfflineCopy;
+
+  /// Linthra can delete the underlying file from the device for this provider's
+  /// tracks. Only meaningful for on-device files and only when platform
+  /// permissions allow it safely; left `false` until that path is robust.
+  final bool canDeleteLocalFile;
+
+  /// Linthra can delete the underlying item from the provider's server/library.
+  /// Strongly destructive (affects every device), so it is only enabled when it
+  /// can be done safely with explicit confirmation; left `false` otherwise.
+  final bool canDeleteRemoteItem;
+
+  /// A playlist of this provider's kind can be created from Linthra.
+  final bool canCreatePlaylist;
+
+  /// A playlist of this provider's kind can be edited (rename, add/remove/reorder
+  /// tracks) from Linthra.
+  final bool canEditPlaylist;
+
+  /// A playlist of this provider's kind can be deleted from Linthra.
+  final bool canDeletePlaylist;
+
+  /// Playlists can be synced with this provider's server (two-way where the API
+  /// supports it).
+  final bool canSyncPlaylists;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -44,11 +87,32 @@ class MusicProviderCapabilities {
           other.canCache == canCache &&
           other.canFavorite == canFavorite &&
           other.canLyrics == canLyrics &&
-          other.canCast == canCast);
+          other.canCast == canCast &&
+          other.canRemoveFromLibrary == canRemoveFromLibrary &&
+          other.canRemoveOfflineCopy == canRemoveOfflineCopy &&
+          other.canDeleteLocalFile == canDeleteLocalFile &&
+          other.canDeleteRemoteItem == canDeleteRemoteItem &&
+          other.canCreatePlaylist == canCreatePlaylist &&
+          other.canEditPlaylist == canEditPlaylist &&
+          other.canDeletePlaylist == canDeletePlaylist &&
+          other.canSyncPlaylists == canSyncPlaylists);
 
   @override
-  int get hashCode =>
-      Object.hash(canStream, canCache, canFavorite, canLyrics, canCast);
+  int get hashCode => Object.hash(
+        canStream,
+        canCache,
+        canFavorite,
+        canLyrics,
+        canCast,
+        canRemoveFromLibrary,
+        canRemoveOfflineCopy,
+        canDeleteLocalFile,
+        canDeleteRemoteItem,
+        canCreatePlaylist,
+        canEditPlaylist,
+        canDeletePlaylist,
+        canSyncPlaylists,
+      );
 }
 
 /// The identity + capabilities of one music provider (local files, Jellyfin,
@@ -84,6 +148,17 @@ abstract final class MusicProviders {
       canFavorite: true,
       canLyrics: false,
       canCast: false,
+      canRemoveFromLibrary: true,
+      // On-device tracks are already local — there is no separate app-managed
+      // copy to remove.
+      canRemoveOfflineCopy: false,
+      // Deleting the real on-device file is not wired up safely yet.
+      canDeleteLocalFile: false,
+      canDeleteRemoteItem: false,
+      canCreatePlaylist: true,
+      canEditPlaylist: true,
+      canDeletePlaylist: true,
+      canSyncPlaylists: false,
     ),
   );
 
@@ -97,6 +172,17 @@ abstract final class MusicProviders {
       canFavorite: true,
       canLyrics: true,
       canCast: true,
+      canRemoveFromLibrary: true,
+      canRemoveOfflineCopy: true,
+      canDeleteLocalFile: false,
+      // Server-side delete (removing the item from Jellyfin for every device)
+      // is intentionally not enabled in this release; see
+      // docs/playlists-and-delete.md.
+      canDeleteRemoteItem: false,
+      canCreatePlaylist: true,
+      canEditPlaylist: true,
+      canDeletePlaylist: true,
+      canSyncPlaylists: true,
     ),
   );
 
@@ -113,6 +199,16 @@ abstract final class MusicProviders {
       canFavorite: false,
       canLyrics: false,
       canCast: true,
+      canRemoveFromLibrary: true,
+      canRemoveOfflineCopy: true,
+      canDeleteLocalFile: false,
+      canDeleteRemoteItem: false,
+      // Subsonic/Navidrome playlists aren't synced yet; its tracks can still be
+      // added to local Linthra playlists.
+      canCreatePlaylist: false,
+      canEditPlaylist: false,
+      canDeletePlaylist: false,
+      canSyncPlaylists: false,
     ),
   );
 

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -60,4 +60,13 @@ class DriftMusicLibraryRepository implements MusicLibraryRepository {
       });
     });
   }
+
+  /// Deletes the catalog rows for [trackIds] only. This touches nothing on disk
+  /// and nothing on a server — it is purely an index removal (see
+  /// [MusicLibraryRepository.removeTracks]).
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {
+    if (trackIds.isEmpty) return;
+    await (_db.delete(_db.tracks)..where((t) => t.id.isIn(trackIds))).go();
+  }
 }

--- a/lib/data/repositories/in_memory_music_library_repository.dart
+++ b/lib/data/repositories/in_memory_music_library_repository.dart
@@ -74,4 +74,16 @@ class InMemoryMusicLibraryRepository implements MusicLibraryRepository {
     _albumsBySource[sourceId] = List<Album>.of(albums);
     _artistsBySource[sourceId] = List<Artist>.of(artists);
   }
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {
+    if (trackIds.isEmpty) return;
+    final Set<String> ids = trackIds.toSet();
+    for (final String sourceId in _tracksBySource.keys.toList()) {
+      _tracksBySource[sourceId] = <Track>[
+        for (final Track track in _tracksBySource[sourceId]!)
+          if (!ids.contains(track.id)) track,
+      ];
+    }
+  }
 }

--- a/lib/data/repositories/in_memory_playlist_store.dart
+++ b/lib/data/repositories/in_memory_playlist_store.dart
@@ -1,0 +1,21 @@
+import '../../core/models/playlist.dart';
+import '../../core/repositories/playlist_store.dart';
+
+/// An in-memory [PlaylistStore] for development and tests.
+///
+/// The whole list lives on the heap, so nothing is persisted — data is lost when
+/// the instance is dropped. That is exactly what unit tests and plugin-free dev
+/// runs want; the app overrides it with the `shared_preferences` binding.
+class InMemoryPlaylistStore implements PlaylistStore {
+  List<Playlist> _playlists = const <Playlist>[];
+
+  @override
+  Future<List<Playlist>> load() async => List<Playlist>.of(_playlists);
+
+  @override
+  Future<void> save(List<Playlist> playlists) async {
+    // Store a defensive copy so later mutation of the caller's list can't
+    // silently change what we've cached.
+    _playlists = List<Playlist>.of(playlists);
+  }
+}

--- a/lib/data/repositories/playlist_repository_provider.dart
+++ b/lib/data/repositories/playlist_repository_provider.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/playlist_repository.dart';
+import '../../core/repositories/playlist_store.dart';
+import '../../features/settings/jellyfin/jellyfin_settings_controller.dart';
+import '../../features/settings/jellyfin/jellyfin_settings_providers.dart';
+import 'in_memory_playlist_store.dart';
+import 'shared_preferences_playlist_store.dart';
+import 'synced_playlist_repository.dart';
+
+/// Durable store of the user's playlists. Defaults to in-memory so tests and dev
+/// runs need no plugins; the app overrides it with the `shared_preferences`
+/// binding below.
+final playlistStoreProvider = Provider<PlaylistStore>((ref) {
+  return InMemoryPlaylistStore();
+});
+
+/// The app's [PlaylistRepository]. The data-layer default is local-only (no
+/// Jellyfin client or session) — exactly what tests and offline use need; the
+/// composition root overrides it to sync with the signed-in server (see
+/// [jellyfinPlaylistSyncOverride]). Disposed with the scope.
+final playlistRepositoryProvider = Provider<PlaylistRepository>((ref) {
+  final SyncedPlaylistRepository repository = SyncedPlaylistRepository(
+    store: ref.watch(playlistStoreProvider),
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+});
+
+/// Production binding: persist playlists via `shared_preferences` so they
+/// survive a restart. Applied in `main`; tests keep the in-memory default.
+final sharedPreferencesPlaylistStoreOverride =
+    playlistStoreProvider.overrideWithValue(
+  const SharedPreferencesPlaylistStore(),
+);
+
+/// Production binding: sync Jellyfin-source playlists with the signed-in server.
+/// Reads the live client + session lazily (mirroring favourites), so signing
+/// in/out is picked up without rebuilding the repository. Applied in `main`;
+/// tests keep the local-only default.
+final jellyfinPlaylistSyncOverride =
+    playlistRepositoryProvider.overrideWith((ref) {
+  final SyncedPlaylistRepository repository = SyncedPlaylistRepository(
+    store: ref.watch(playlistStoreProvider),
+    client: ref.read(jellyfinClientProvider),
+    session: () =>
+        ref.read(jellyfinSettingsControllerProvider.notifier).session,
+  );
+  ref.onDispose(repository.dispose);
+  return repository;
+});

--- a/lib/data/repositories/shared_preferences_playlist_store.dart
+++ b/lib/data/repositories/shared_preferences_playlist_store.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/playlist.dart';
+import '../../core/repositories/playlist_store.dart';
+
+/// A [PlaylistStore] backed by `shared_preferences`.
+///
+/// Playlists are a small set of user-authored documents (a name, an ordered list
+/// of stable track ids, and sync bookkeeping), so a JSON key/value document is
+/// the right weight — the same reasoning favourites and the offline-download set
+/// follow. A corrupt or unrecognised record reads as "no playlists" rather than
+/// crashing the app.
+///
+/// Security: only non-secret metadata and track ids are written. The Jellyfin
+/// [remoteId] is a non-secret server id; no token or authenticated URL is stored.
+class SharedPreferencesPlaylistStore implements PlaylistStore {
+  const SharedPreferencesPlaylistStore();
+
+  static const String _key = 'playlists_v1';
+
+  @override
+  Future<List<Playlist>> load() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return const <Playlist>[];
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return const <Playlist>[];
+    }
+    if (decoded is! List) return const <Playlist>[];
+    final List<Playlist> playlists = <Playlist>[];
+    for (final Object? entry in decoded) {
+      if (entry is Map<String, dynamic>) {
+        final Playlist? playlist = _fromJson(entry);
+        if (playlist != null) playlists.add(playlist);
+      }
+    }
+    return playlists;
+  }
+
+  @override
+  Future<void> save(List<Playlist> playlists) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String raw = jsonEncode(<Map<String, dynamic>>[
+      for (final Playlist playlist in playlists) _toJson(playlist),
+    ]);
+    await prefs.setString(_key, raw);
+  }
+
+  static Map<String, dynamic> _toJson(Playlist playlist) {
+    return <String, dynamic>{
+      'id': playlist.id,
+      'name': playlist.name,
+      if (playlist.description != null) 'description': playlist.description,
+      'source': playlist.source.providerId,
+      if (playlist.remoteId != null) 'remoteId': playlist.remoteId,
+      'trackIds': playlist.trackIds,
+      if (playlist.createdAt != null)
+        'createdAt': playlist.createdAt!.toIso8601String(),
+      if (playlist.updatedAt != null)
+        'updatedAt': playlist.updatedAt!.toIso8601String(),
+      'syncState': playlist.syncState.name,
+      if (playlist.lastSyncError != null)
+        'lastSyncError': playlist.lastSyncError,
+    };
+  }
+
+  static Playlist? _fromJson(Map<String, dynamic> json) {
+    final Object? id = json['id'];
+    final Object? name = json['name'];
+    if (id is! String || id.isEmpty || name is! String) return null;
+    return Playlist(
+      id: id,
+      name: name,
+      description: json['description'] as String?,
+      source: PlaylistSource.fromProviderId(json['source'] as String?),
+      remoteId: json['remoteId'] as String?,
+      trackIds: _ids(json['trackIds']),
+      createdAt: _date(json['createdAt']),
+      updatedAt: _date(json['updatedAt']),
+      syncState: PlaylistSyncState.fromName(json['syncState'] as String?),
+      lastSyncError: json['lastSyncError'] as String?,
+    );
+  }
+
+  static List<String> _ids(Object? value) {
+    if (value is! List) return const <String>[];
+    return <String>[
+      for (final Object? id in value)
+        if (id is String && id.isNotEmpty) id,
+    ];
+  }
+
+  static DateTime? _date(Object? value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+}

--- a/lib/data/repositories/synced_playlist_repository.dart
+++ b/lib/data/repositories/synced_playlist_repository.dart
@@ -1,0 +1,438 @@
+import 'dart:async';
+
+import '../../core/models/jellyfin_session.dart';
+import '../../core/models/playlist.dart';
+import '../../core/repositories/playlist_repository.dart';
+import '../../core/repositories/playlist_store.dart';
+import '../../core/sources/jellyfin/jellyfin_api.dart';
+import '../../core/sources/jellyfin/jellyfin_client.dart';
+import '../../core/sources/jellyfin/jellyfin_exception.dart';
+
+/// The app's [PlaylistRepository]: a local, persisted set of playlists with
+/// optional best-effort Jellyfin sync layered on top.
+///
+/// Local playlists never touch a server. A playlist whose [Playlist.source] is
+/// [PlaylistSource.jellyfin] is mirrored: create, membership changes (add /
+/// remove track), and delete are pushed to the signed-in server best-effort,
+/// and [refreshFromRemote] imports server playlists and adopts server
+/// membership for already-synced ones. A server failure never throws out of an
+/// editing method — the local change stands and the playlist's
+/// [Playlist.syncState] flips to [PlaylistSyncState.syncFailed] with a friendly,
+/// secret-free [Playlist.lastSyncError], so the UI shows an honest status rather
+/// than pretending the sync worked.
+///
+/// Security: only non-secret metadata and track ids are stored or sent. The
+/// session (with its token) is read lazily through [_session] for the request —
+/// never logged or persisted here.
+class SyncedPlaylistRepository implements PlaylistRepository {
+  SyncedPlaylistRepository({
+    required PlaylistStore store,
+    JellyfinClient? client,
+    JellyfinSession? Function()? session,
+    String Function()? idGenerator,
+    DateTime Function()? now,
+  })  : _store = store,
+        _client = client,
+        _session = session,
+        _newId = idGenerator ?? _defaultIdGenerator(),
+        _now = now ?? DateTime.now;
+
+  final PlaylistStore _store;
+
+  /// The Jellyfin HTTP seam, or `null` when playlists are local-only (tests, the
+  /// data-layer default). Read lazily alongside [_session].
+  final JellyfinClient? _client;
+
+  /// Supplies the live signed-in session, or `null` when not connected. Read at
+  /// call time so signing in/out is picked up without rebuilding the repository.
+  final JellyfinSession? Function()? _session;
+
+  final String Function() _newId;
+  final DateTime Function() _now;
+
+  final StreamController<List<Playlist>> _changes =
+      StreamController<List<Playlist>>.broadcast();
+
+  List<Playlist> _playlists = <Playlist>[];
+  bool _loaded = false;
+
+  static String Function() _defaultIdGenerator() {
+    int counter = 0;
+    return () {
+      counter++;
+      final int stamp = DateTime.now().microsecondsSinceEpoch;
+      return 'pl_${stamp.toRadixString(36)}_${counter.toRadixString(36)}';
+    };
+  }
+
+  Future<void> _ensureLoaded() async {
+    if (_loaded) return;
+    _playlists = await _store.load();
+    _loaded = true;
+  }
+
+  JellyfinSession? _liveSession() => _session?.call();
+
+  bool get _canSync => _client != null && _liveSession() != null;
+
+  @override
+  Stream<List<Playlist>> get playlistsStream async* {
+    await _ensureLoaded();
+    yield _snapshot();
+    yield* _changes.stream;
+  }
+
+  @override
+  Future<List<Playlist>> getAllPlaylists() async {
+    await _ensureLoaded();
+    return _snapshot();
+  }
+
+  @override
+  Future<Playlist?> getPlaylistById(String id) async {
+    await _ensureLoaded();
+    for (final Playlist playlist in _playlists) {
+      if (playlist.id == id) return playlist;
+    }
+    return null;
+  }
+
+  @override
+  Future<Playlist> createPlaylist(
+    String name, {
+    String? description,
+    PlaylistSource source = PlaylistSource.local,
+  }) async {
+    await _ensureLoaded();
+    final DateTime now = _now();
+    final bool remote = source == PlaylistSource.jellyfin && _canSync;
+    Playlist playlist = Playlist(
+      id: _newId(),
+      name: name,
+      description: description,
+      source: remote ? PlaylistSource.jellyfin : PlaylistSource.local,
+      createdAt: now,
+      updatedAt: now,
+      syncState: remote
+          ? PlaylistSyncState.pendingCreate
+          : PlaylistSyncState.localOnly,
+    );
+    _playlists = <Playlist>[..._playlists, playlist];
+    await _persistAndEmit();
+    if (remote) {
+      playlist = await _pushCreate(playlist);
+    }
+    return playlist;
+  }
+
+  @override
+  Future<void> renamePlaylist(
+    String id,
+    String name, {
+    String? description,
+  }) async {
+    await _ensureLoaded();
+    // Rename/description are local-only for now (not pushed to the server); see
+    // docs/playlists-and-delete.md for the documented sync limitations.
+    await _mutate(
+      id,
+      (Playlist p) => p.copyWith(
+        name: name,
+        description: description != null ? () => description : null,
+        updatedAt: _now(),
+      ),
+    );
+  }
+
+  @override
+  Future<void> deletePlaylist(String id) async {
+    await _ensureLoaded();
+    final Playlist? playlist = _byId(id);
+    if (playlist == null) return;
+    _playlists = <Playlist>[
+      for (final Playlist p in _playlists)
+        if (p.id != id) p,
+    ];
+    await _persistAndEmit();
+    // Best-effort server delete for a synced playlist; a failure can't restore
+    // the local copy, so it is intentionally swallowed (the local delete stands).
+    if (playlist.isRemote && playlist.remoteId != null && _canSync) {
+      final JellyfinClient client = _client!;
+      final JellyfinSession session = _liveSession()!;
+      try {
+        await client.deletePlaylist(session, playlist.remoteId!);
+      } on JellyfinException catch (_) {
+        // Swallowed: the playlist is already gone locally. It may reappear on a
+        // later refresh if the server still has it (documented limitation).
+      }
+    }
+  }
+
+  @override
+  Future<void> addTrack(String playlistId, String trackId) =>
+      addTracks(playlistId, <String>[trackId]);
+
+  @override
+  Future<void> addTracks(String playlistId, List<String> trackIds) async {
+    await _ensureLoaded();
+    final Playlist? playlist = _byId(playlistId);
+    if (playlist == null) return;
+    final List<String> added = <String>[];
+    final List<String> updated = <String>[...playlist.trackIds];
+    for (final String trackId in trackIds) {
+      if (trackId.isEmpty || updated.contains(trackId)) continue;
+      updated.add(trackId);
+      added.add(trackId);
+    }
+    if (added.isEmpty) return;
+    await _mutate(
+      playlistId,
+      (Playlist p) => p.copyWith(trackIds: updated, updatedAt: _now()),
+    );
+    await _pushMembership(
+      playlistId,
+      (JellyfinClient client, JellyfinSession session, String remoteId) =>
+          client.addItemsToPlaylist(session, remoteId, added),
+    );
+  }
+
+  @override
+  Future<void> removeTrack(String playlistId, String trackId) async {
+    await _ensureLoaded();
+    final Playlist? playlist = _byId(playlistId);
+    if (playlist == null || !playlist.trackIds.contains(trackId)) return;
+    final List<String> updated = <String>[
+      for (final String id in playlist.trackIds)
+        if (id != trackId) id,
+    ];
+    await _mutate(
+      playlistId,
+      (Playlist p) => p.copyWith(trackIds: updated, updatedAt: _now()),
+    );
+    await _pushMembership(
+      playlistId,
+      (JellyfinClient client, JellyfinSession session, String remoteId) =>
+          client.removeItemsFromPlaylist(session, remoteId, <String>[trackId]),
+    );
+  }
+
+  @override
+  Future<void> reorderTracks(
+    String playlistId,
+    int oldIndex,
+    int newIndex,
+  ) async {
+    await _ensureLoaded();
+    final Playlist? playlist = _byId(playlistId);
+    if (playlist == null) return;
+    final List<String> ids = <String>[...playlist.trackIds];
+    if (oldIndex < 0 || oldIndex >= ids.length) return;
+    // Mirror ReorderableListView's index convention: a downward move reports a
+    // newIndex one past the intended slot once the item is removed.
+    int target = newIndex;
+    if (target > oldIndex) target -= 1;
+    target = target.clamp(0, ids.length - 1);
+    if (target == oldIndex) return;
+    final String moved = ids.removeAt(oldIndex);
+    ids.insert(target, moved);
+    // Reorder is local-only for now (Jellyfin item-move sync is a documented
+    // follow-up); a refresh of a synced playlist re-adopts the server order.
+    await _mutate(
+      playlistId,
+      (Playlist p) => p.copyWith(trackIds: ids, updatedAt: _now()),
+    );
+  }
+
+  @override
+  Future<void> markSyncState(
+    String id,
+    PlaylistSyncState state, {
+    String? error,
+  }) async {
+    await _ensureLoaded();
+    await _mutate(
+      id,
+      (Playlist p) => p.copyWith(
+        syncState: state,
+        lastSyncError: () => error,
+      ),
+    );
+  }
+
+  @override
+  Future<void> refreshFromRemote() async {
+    await _ensureLoaded();
+    final JellyfinClient? client = _client;
+    final JellyfinSession? session = _liveSession();
+    if (client == null || session == null) return;
+    final List<JellyfinPlaylistDto> remote;
+    try {
+      remote = await client.fetchPlaylists(session);
+    } on JellyfinException catch (_) {
+      // Offline or transient: keep what we have.
+      return;
+    }
+
+    final Map<String, Playlist> byRemoteId = <String, Playlist>{
+      for (final Playlist p in _playlists)
+        if (p.remoteId != null) p.remoteId!: p,
+    };
+
+    final List<Playlist> next = <Playlist>[..._playlists];
+    bool changed = false;
+    for (final JellyfinPlaylistDto dto in remote) {
+      List<String> itemIds;
+      try {
+        final List<JellyfinPlaylistEntry> entries =
+            await client.fetchPlaylistEntries(session, dto.id);
+        itemIds = <String>[
+          for (final JellyfinPlaylistEntry e in entries) e.itemId,
+        ];
+      } on JellyfinException catch (_) {
+        // Skip this playlist's membership refresh; keep the rest going.
+        continue;
+      }
+
+      final Playlist? existing = byRemoteId[dto.id];
+      if (existing == null) {
+        next.add(
+          Playlist(
+            id: _newId(),
+            name: dto.name,
+            source: PlaylistSource.jellyfin,
+            remoteId: dto.id,
+            trackIds: itemIds,
+            createdAt: _now(),
+            updatedAt: _now(),
+            syncState: PlaylistSyncState.synced,
+          ),
+        );
+        changed = true;
+      } else {
+        final int index = next.indexWhere((Playlist p) => p.id == existing.id);
+        if (index >= 0) {
+          next[index] = existing.copyWith(
+            name: dto.name,
+            trackIds: itemIds,
+            syncState: PlaylistSyncState.synced,
+            lastSyncError: () => null,
+            updatedAt: _now(),
+          );
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      _playlists = next;
+      await _persistAndEmit();
+    }
+  }
+
+  // --- Internal helpers --------------------------------------------------
+
+  /// Pushes a freshly created playlist to the server, returning the updated
+  /// playlist (with a [Playlist.remoteId] + [PlaylistSyncState.synced] on
+  /// success, or [PlaylistSyncState.syncFailed] + a friendly error on failure).
+  Future<Playlist> _pushCreate(Playlist playlist) async {
+    final JellyfinClient? client = _client;
+    final JellyfinSession? session = _liveSession();
+    if (client == null || session == null) return playlist;
+    try {
+      final String remoteId = await client.createPlaylist(
+        session,
+        name: playlist.name,
+        itemIds: playlist.trackIds,
+      );
+      return await _mutate(
+        playlist.id,
+        (Playlist p) => p.copyWith(
+          remoteId: () => remoteId,
+          syncState: PlaylistSyncState.synced,
+          lastSyncError: () => null,
+        ),
+      );
+    } on JellyfinException catch (error) {
+      return _mutate(
+        playlist.id,
+        (Playlist p) => p.copyWith(
+          syncState: PlaylistSyncState.syncFailed,
+          lastSyncError: () => error.message,
+        ),
+      );
+    }
+  }
+
+  /// Runs a best-effort membership change against the server for a synced
+  /// playlist, flipping its sync state to synced or syncFailed accordingly. A
+  /// local-only playlist (or one not yet created on the server) is left alone.
+  Future<void> _pushMembership(
+    String playlistId,
+    Future<void> Function(
+      JellyfinClient client,
+      JellyfinSession session,
+      String remoteId,
+    ) push,
+  ) async {
+    final Playlist? playlist = _byId(playlistId);
+    if (playlist == null || !playlist.isRemote || playlist.remoteId == null) {
+      return;
+    }
+    final JellyfinClient? client = _client;
+    final JellyfinSession? session = _liveSession();
+    if (client == null || session == null) return;
+    try {
+      await push(client, session, playlist.remoteId!);
+      await _mutate(
+        playlistId,
+        (Playlist p) => p.copyWith(
+          syncState: PlaylistSyncState.synced,
+          lastSyncError: () => null,
+        ),
+      );
+    } on JellyfinException catch (error) {
+      await _mutate(
+        playlistId,
+        (Playlist p) => p.copyWith(
+          syncState: PlaylistSyncState.syncFailed,
+          lastSyncError: () => error.message,
+        ),
+      );
+    }
+  }
+
+  Playlist? _byId(String id) {
+    for (final Playlist p in _playlists) {
+      if (p.id == id) return p;
+    }
+    return null;
+  }
+
+  /// Applies [transform] to the playlist with [id] (if present), persists, and
+  /// emits, returning the resulting playlist (or the unchanged one if absent).
+  Future<Playlist> _mutate(
+    String id,
+    Playlist Function(Playlist) transform,
+  ) async {
+    Playlist? result;
+    _playlists = <Playlist>[
+      for (final Playlist p in _playlists)
+        if (p.id == id) (result = transform(p)) else p,
+    ];
+    await _persistAndEmit();
+    return result ?? Playlist(id: id, name: '');
+  }
+
+  List<Playlist> _snapshot() => List<Playlist>.unmodifiable(_playlists);
+
+  Future<void> _persistAndEmit() async {
+    _emit();
+    await _store.save(_playlists);
+  }
+
+  void _emit() {
+    if (!_changes.isClosed) _changes.add(_snapshot());
+  }
+
+  Future<void> dispose() => _changes.close();
+}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -2,41 +2,150 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/dimens.dart';
+import '../../core/models/track.dart';
+import '../../core/services/bulk_track_actions.dart';
+import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
 import 'selected_folder_controller.dart';
+import 'song_actions.dart';
 import 'widgets/alphabet_track_list.dart';
 
 /// Browse tracks from the local catalog. Reads entirely from
 /// [libraryControllerProvider] and [selectedFolderControllerProvider]; it has
 /// no knowledge of where tracks are stored or which plugin picks the folder.
-class LibraryScreen extends ConsumerWidget {
+///
+/// A long-press on a row enters multi-select; the app bar then becomes a
+/// contextual selection bar offering only the actions that are safe for the
+/// current selection (mixed-source selections hide unsafe destructive actions).
+class LibraryScreen extends ConsumerStatefulWidget {
   const LibraryScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final state = ref.watch(libraryControllerProvider);
-    final selectedFolder = ref.watch(selectedFolderControllerProvider);
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Library'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.create_new_folder_outlined),
-            tooltip: 'Select music folder',
-            onPressed: () => _pickAndScan(ref),
-          ),
-        ],
+  ConsumerState<LibraryScreen> createState() => _LibraryScreenState();
+}
+
+class _LibraryScreenState extends ConsumerState<LibraryScreen> {
+  final Set<String> _selectedIds = <String>{};
+  bool _selecting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final LibraryState state = ref.watch(libraryControllerProvider);
+    final AsyncValue<String?> selectedFolder =
+        ref.watch(selectedFolderControllerProvider);
+
+    // Drop any selected ids that are no longer in the catalog (e.g. after a
+    // removal) so the count and actions stay accurate.
+    final List<Track> selected = <Track>[
+      for (final Track track in state.tracks)
+        if (_selectedIds.contains(track.id)) track,
+    ];
+
+    return PopScope(
+      canPop: !_selecting,
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (!didPop && _selecting) _exitSelection();
+      },
+      child: Scaffold(
+        appBar: _selecting
+            ? _selectionAppBar(selected)
+            : AppBar(
+                title: const Text('Library'),
+                actions: <Widget>[
+                  IconButton(
+                    icon: const Icon(Icons.create_new_folder_outlined),
+                    tooltip: 'Select music folder',
+                    onPressed: () => _pickAndScan(),
+                  ),
+                ],
+              ),
+        body: _body(state, selectedFolder.valueOrNull),
       ),
-      body: _body(ref, state, selectedFolder.valueOrNull),
     );
+  }
+
+  PreferredSizeWidget _selectionAppBar(List<Track> selected) {
+    final BulkActionAvailability actions =
+        bulkActionsFor(selected, inPlaylist: false);
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: 'Cancel selection',
+        onPressed: _exitSelection,
+      ),
+      title: Text('${selected.length} selected'),
+      actions: <Widget>[
+        if (actions.canAddToPlaylist)
+          IconButton(
+            icon: const Icon(Icons.playlist_add),
+            tooltip: 'Add to playlist',
+            onPressed: selected.isEmpty ? null : () => _addToPlaylist(selected),
+          ),
+        if (actions.canRemoveOfflineCopy)
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Remove offline copies',
+            onPressed: selected.isEmpty ? null : () => _removeOffline(selected),
+          ),
+        if (actions.canRemoveFromLibrary)
+          IconButton(
+            icon: const Icon(Icons.remove_circle_outline),
+            tooltip: 'Remove from Linthra',
+            onPressed:
+                selected.isEmpty ? null : () => _removeFromLibrary(selected),
+          ),
+      ],
+    );
+  }
+
+  void _enterSelection(Track track) {
+    setState(() {
+      _selecting = true;
+      _selectedIds
+        ..clear()
+        ..add(track.id);
+    });
+  }
+
+  void _toggle(Track track) {
+    setState(() {
+      if (!_selectedIds.add(track.id)) {
+        _selectedIds.remove(track.id);
+      }
+      if (_selectedIds.isEmpty) _selecting = false;
+    });
+  }
+
+  void _exitSelection() {
+    setState(() {
+      _selecting = false;
+      _selectedIds.clear();
+    });
+  }
+
+  Future<void> _addToPlaylist(List<Track> selected) async {
+    await showAddToPlaylistSheet(context, selected);
+    _exitSelection();
+  }
+
+  Future<void> _removeFromLibrary(List<Track> selected) async {
+    final bool removed =
+        await SongActions.removeFromLibrary(context, ref, selected);
+    if (removed) _exitSelection();
+  }
+
+  Future<void> _removeOffline(List<Track> selected) async {
+    final bool ran =
+        await SongActions.removeOfflineCopies(context, ref, selected);
+    if (ran) _exitSelection();
   }
 
   /// Open the system folder picker, persist the choice, then scan it. A
   /// cancelled pick leaves everything untouched. The UI only talks to the two
   /// controllers — never to a picker plugin or the file system directly.
-  Future<void> _pickAndScan(WidgetRef ref) async {
-    final path = await ref
+  Future<void> _pickAndScan() async {
+    final String? path = await ref
         .read(selectedFolderControllerProvider.notifier)
         .pickAndPersist();
     if (path != null) {
@@ -45,11 +154,11 @@ class LibraryScreen extends ConsumerWidget {
   }
 
   /// Re-scan the folder the user already selected, without opening the picker.
-  Future<void> _rescan(WidgetRef ref, String folder) {
+  Future<void> _rescan(String folder) {
     return ref.read(libraryControllerProvider.notifier).scanFolder(folder);
   }
 
-  Widget _body(WidgetRef ref, LibraryState state, String? selectedFolder) {
+  Widget _body(LibraryState state, String? selectedFolder) {
     switch (state.status) {
       case LibraryStatus.loading:
         return const Center(child: CircularProgressIndicator());
@@ -62,13 +171,19 @@ class LibraryScreen extends ConsumerWidget {
         if (state.isEmpty) {
           return _LibraryEmpty(
             selectedFolder: selectedFolder,
-            onPick: () => _pickAndScan(ref),
-            onRescan: selectedFolder == null
-                ? null
-                : () => _rescan(ref, selectedFolder),
+            onPick: _pickAndScan,
+            onRescan:
+                selectedFolder == null ? null : () => _rescan(selectedFolder),
           );
         }
-        return AlphabetTrackList(tracks: state.tracks);
+        return AlphabetTrackList(
+          tracks: state.tracks,
+          selectable: true,
+          selectionActive: _selecting,
+          selectedIds: _selectedIds,
+          onSelectStart: _enterSelection,
+          onSelectToggle: _toggle,
+        );
     }
   }
 }

--- a/lib/features/library/song_actions.dart
+++ b/lib/features/library/song_actions.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/track.dart';
+import '../../data/repositories/download_repository_provider.dart';
+import '../../data/repositories/music_library_repository_provider.dart';
+import '../../shared/widgets/confirm_dialog.dart';
+import '../player/player_providers.dart';
+import '../playlists/playlist_providers.dart';
+import 'library_controller.dart';
+
+/// The shared, safe song remove/delete actions used by the Library and playlist
+/// screens. Centralized so the confirmation wording, the currently-playing
+/// guard, and the success/failure summaries stay identical everywhere.
+///
+/// The two enabled actions are the safe, reversible ones the spec prefers:
+///  - "Remove from Linthra library" — forgets the catalog rows only; the
+///    original file / server item is untouched (a re-scan can bring it back).
+///  - "Remove offline copy" — deletes only Linthra's app-managed cached file;
+///    the source remains streamable.
+///
+/// Deleting the real device file or the server item is intentionally not wired
+/// here (see the provider capability model and docs/playlists-and-delete.md).
+abstract final class SongActions {
+  /// Confirms (count-aware) and removes [tracks] from Linthra's library index,
+  /// then refreshes the views. Returns whether the removal ran (false on
+  /// cancel). Never deletes a file or a server item.
+  static Future<bool> removeFromLibrary(
+    BuildContext context,
+    WidgetRef ref,
+    List<Track> tracks, {
+    String? playlistId,
+  }) async {
+    if (tracks.isEmpty) return false;
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool confirmed = await showConfirmDialog(
+      context,
+      title: 'Remove from Linthra',
+      message: tracks.length == 1
+          ? 'Remove “${tracks.first.title}” from Linthra? This will not delete '
+              'the original file or server item.'
+          : 'Remove ${tracks.length} songs from Linthra? This will not delete '
+              'the original files or server items.',
+      confirmLabel: 'Remove',
+    );
+    if (!confirmed) return false;
+
+    await ref.read(musicLibraryRepositoryProvider).removeTracks(
+      <String>[for (final Track track in tracks) track.id],
+    );
+    // Refresh the library view; if we're inside a playlist, re-resolve its
+    // tracks so a now-removed item is reflected.
+    await ref.read(libraryControllerProvider.notifier).refresh();
+    if (playlistId != null) {
+      ref.invalidate(playlistTracksProvider(playlistId));
+    }
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          tracks.length == 1
+              ? 'Removed “${tracks.first.title}” from Linthra.'
+              : 'Removed ${tracks.length} songs from Linthra.',
+        ),
+      ),
+    );
+    return true;
+  }
+
+  /// Confirms (count-aware) and removes app-managed offline copies for [tracks].
+  /// The currently-playing track is skipped (its cached file must not be deleted
+  /// out from under playback) and reported in the summary. Returns whether the
+  /// action ran (false on cancel).
+  static Future<bool> removeOfflineCopies(
+    BuildContext context,
+    WidgetRef ref,
+    List<Track> tracks,
+  ) async {
+    if (tracks.isEmpty) return false;
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool confirmed = await showConfirmDialog(
+      context,
+      title: 'Remove offline copy',
+      message: tracks.length == 1
+          ? 'Remove offline copy of “${tracks.first.title}”? You can still '
+              'stream it if your server is available.'
+          : 'Remove offline copies for ${tracks.length} songs?',
+      confirmLabel: 'Remove',
+    );
+    if (!confirmed) return false;
+
+    final String? playingId =
+        ref.read(playbackControllerProvider).state.currentTrack?.id;
+    final repository = ref.read(downloadRepositoryProvider);
+    int removed = 0;
+    int failed = 0;
+    int skipped = 0;
+    for (final Track track in tracks) {
+      // Never delete the cached file backing what's playing right now.
+      if (track.id == playingId) {
+        skipped++;
+        continue;
+      }
+      try {
+        await repository.removeDownload(track.id);
+        removed++;
+      } catch (_) {
+        failed++;
+      }
+    }
+
+    messenger.showSnackBar(
+      SnackBar(content: Text(_offlineSummary(removed, failed, skipped))),
+    );
+    return true;
+  }
+
+  static String _offlineSummary(int removed, int failed, int skipped) {
+    final StringBuffer buffer = StringBuffer()
+      ..write(
+        removed == 1
+            ? 'Removed offline copy for 1 song.'
+            : 'Removed offline copies for $removed songs.',
+      );
+    if (failed > 0) buffer.write(' $failed failed.');
+    if (skipped > 0) buffer.write(' $skipped skipped (currently playing).');
+    return buffer.toString();
+  }
+}

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -15,9 +15,32 @@ import 'track_tile.dart';
 /// Both the rows and the index work off the *same* sorted list, so a row's tap
 /// queues the rest of the library in the order the user sees — see [TrackTile].
 class AlphabetTrackList extends StatefulWidget {
-  const AlphabetTrackList({required this.tracks, super.key});
+  const AlphabetTrackList({
+    required this.tracks,
+    this.selectable = false,
+    this.selectionActive = false,
+    this.selectedIds = const <String>{},
+    this.onSelectToggle,
+    this.onSelectStart,
+    super.key,
+  });
 
   final List<Track> tracks;
+
+  /// Whether rows can enter multi-select (long-press) and toggle selection.
+  final bool selectable;
+
+  /// Whether the host is currently in selection mode.
+  final bool selectionActive;
+
+  /// Ids of the currently-selected tracks.
+  final Set<String> selectedIds;
+
+  /// Toggles a track's selection (tap while in selection mode).
+  final void Function(Track track)? onSelectToggle;
+
+  /// Starts selection with a track (long-press).
+  final void Function(Track track)? onSelectStart;
 
   @override
   State<AlphabetTrackList> createState() => _AlphabetTrackListState();
@@ -159,7 +182,21 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
             if (entry.isHeader) {
               return _SectionHeader(letter: entry.letter!);
             }
-            return TrackTile(tracks: _sorted, index: entry.trackIndex!);
+            final int trackIndex = entry.trackIndex!;
+            final Track track = _sorted[trackIndex];
+            return TrackTile(
+              tracks: _sorted,
+              index: trackIndex,
+              selectable: widget.selectable,
+              selectionActive: widget.selectionActive,
+              selected: widget.selectedIds.contains(track.id),
+              onSelectToggle: widget.onSelectToggle == null
+                  ? null
+                  : () => widget.onSelectToggle!(track),
+              onSelectStart: widget.onSelectStart == null
+                  ? null
+                  : () => widget.onSelectStart!(track),
+            );
           },
         ),
         if (showRail)

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -10,11 +10,21 @@ import '../../../data/repositories/download_repository_provider.dart';
 import '../../downloads/download_providers.dart';
 import '../../player/player_providers.dart';
 import '../../player/widgets/album_artwork.dart';
+import '../../playlists/widgets/add_to_playlist_sheet.dart';
+import '../song_actions.dart';
 
 /// The actions reachable from a track row's overflow menu. Which subset is
 /// offered is context-aware: it depends on whether the track is remote and on
 /// its current [DownloadStatus] (see `_OverflowMenu._menuItems`).
-enum _TrackAction { playNext, download, removeOffline, retryDownload, cancel }
+enum _TrackAction {
+  playNext,
+  addToPlaylist,
+  download,
+  removeOffline,
+  retryDownload,
+  cancel,
+  removeFromLibrary,
+}
 
 /// A single library track row.
 ///
@@ -27,17 +37,43 @@ enum _TrackAction { playNext, download, removeOffline, retryDownload, cancel }
 /// Tapping the row plays the tapped track and queues the rest of [tracks]
 /// behind it, then opens the now-playing screen — unchanged from before.
 ///
+/// Selection: when [selectable] is set, a long-press starts multi-select via
+/// [onSelectStart] and, while [selectionActive], a tap toggles this row via
+/// [onSelectToggle] instead of playing. Hosts that don't pass these (e.g.
+/// Favorites) keep the plain tap-to-play behaviour.
+///
 /// Source-awareness: offline/download actions only appear for *remote* tracks
 /// (resolved through [remoteTrackDownloaderProvider], the same seam the
 /// download repository uses). On-device tracks are already local, so showing
 /// "Download for offline" on them would be meaningless — they only get the
-/// queue action.
+/// queue/playlist/remove actions.
 class TrackTile extends ConsumerWidget {
-  const TrackTile({required this.tracks, required this.index, super.key});
+  const TrackTile({
+    required this.tracks,
+    required this.index,
+    this.selectable = false,
+    this.selectionActive = false,
+    this.selected = false,
+    this.onSelectToggle,
+    this.onSelectStart,
+    super.key,
+  });
 
   /// The whole visible list, so tapping one track queues the rest after it.
   final List<Track> tracks;
   final int index;
+
+  /// Whether this row participates in multi-select at all.
+  final bool selectable;
+
+  /// Whether the host is currently in selection mode (so a tap toggles).
+  final bool selectionActive;
+
+  /// Whether this row is currently selected.
+  final bool selected;
+
+  final VoidCallback? onSelectToggle;
+  final VoidCallback? onSelectStart;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -57,6 +93,7 @@ class TrackTile extends ConsumerWidget {
         : null;
 
     return ListTile(
+      selected: selectionActive && selected,
       leading: SizedBox.square(
         dimension: 48,
         child: AlbumArtwork(
@@ -80,26 +117,37 @@ class TrackTile extends ConsumerWidget {
           color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
         ),
       ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _StatusGlyph(
-            status: status,
-            isRemote: isRemote,
-            progress: downloadFraction,
-          ),
-          _OverflowMenu(
-            track: track,
-            status: status,
-            isRemote: isRemote,
-          ),
-        ],
-      ),
+      trailing: selectionActive
+          ? Checkbox(
+              value: selected,
+              onChanged:
+                  onSelectToggle == null ? null : (_) => onSelectToggle!(),
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _StatusGlyph(
+                  status: status,
+                  isRemote: isRemote,
+                  progress: downloadFraction,
+                ),
+                _OverflowMenu(
+                  track: track,
+                  status: status,
+                  isRemote: isRemote,
+                ),
+              ],
+            ),
       onTap: () {
+        if (selectionActive) {
+          onSelectToggle?.call();
+          return;
+        }
         final controller = ref.read(playbackControllerProvider);
         controller.playTracks(tracks, startIndex: index);
         context.push(AppRoutes.player);
       },
+      onLongPress: (selectable && !selectionActive) ? onSelectStart : null,
     );
   }
 
@@ -171,7 +219,8 @@ class _StatusGlyph extends StatelessWidget {
 }
 
 /// The trailing 3-dots menu. Builds a context-aware action set and dispatches
-/// the chosen one to the playback controller or download repository.
+/// the chosen one to the playback controller, download repository, or the safe
+/// remove actions.
 class _OverflowMenu extends ConsumerWidget {
   const _OverflowMenu({
     required this.track,
@@ -194,10 +243,13 @@ class _OverflowMenu extends ConsumerWidget {
   }
 
   /// Context-aware action list. Offline actions are gated on [isRemote]; the
-  /// rest depend on the track's [DownloadStatus]. The queue action is always
-  /// available.
+  /// rest depend on the track's [DownloadStatus]. The queue, add-to-playlist,
+  /// and remove-from-Linthra actions are always available.
   List<PopupMenuEntry<_TrackAction>> _menuItems() {
-    final items = <PopupMenuEntry<_TrackAction>>[];
+    final items = <PopupMenuEntry<_TrackAction>>[
+      _item(_TrackAction.playNext, Icons.queue_music, 'Play next'),
+      _item(_TrackAction.addToPlaylist, Icons.playlist_add, 'Add to playlist'),
+    ];
     if (isRemote) {
       switch (status) {
         case DownloadStatus.notDownloaded:
@@ -215,7 +267,8 @@ class _OverflowMenu extends ConsumerWidget {
           items.add(_item(_TrackAction.cancel, Icons.close, 'Cancel download'));
       }
     }
-    items.add(_item(_TrackAction.playNext, Icons.queue_music, 'Play next'));
+    items.add(_item(_TrackAction.removeFromLibrary, Icons.remove_circle_outline,
+        'Remove from Linthra'));
     return items;
   }
 
@@ -242,12 +295,19 @@ class _OverflowMenu extends ConsumerWidget {
     switch (action) {
       case _TrackAction.playNext:
         ref.read(playbackControllerProvider).playNext(track);
+      case _TrackAction.addToPlaylist:
+        await showAddToPlaylistSheet(context, <Track>[track]);
       case _TrackAction.download:
       case _TrackAction.retryDownload:
         await _download(context, ref);
-      case _TrackAction.removeOffline:
       case _TrackAction.cancel:
+        // Cancelling an in-flight/queued download is not destructive to a saved
+        // copy, so it needs no confirmation.
         await ref.read(downloadRepositoryProvider).removeDownload(track.id);
+      case _TrackAction.removeOffline:
+        await SongActions.removeOfflineCopies(context, ref, <Track>[track]);
+      case _TrackAction.removeFromLibrary:
+        await SongActions.removeFromLibrary(context, ref, <Track>[track]);
     }
   }
 

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -5,6 +5,7 @@ import '../../../app/dimens.dart';
 import '../../../core/models/track.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../shared/widgets/empty_state.dart';
+import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../favorites_providers.dart';
 import '../player_providers.dart';
 import 'lyrics_view.dart';
@@ -37,6 +38,11 @@ class NowPlayingActions extends ConsumerWidget {
           color: isFavorite ? theme.colorScheme.primary : null,
           isSelected: isFavorite,
           tooltip: isFavorite ? 'Remove from favorites' : 'Favorite',
+        ),
+        IconButton(
+          onPressed: () => showAddToPlaylistSheet(context, <Track>[track]),
+          icon: const Icon(Icons.playlist_add),
+          tooltip: 'Add to playlist',
         ),
         IconButton(
           onPressed: () => _openQueue(context),

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -1,0 +1,551 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/playlist.dart';
+import '../../core/models/track.dart';
+import '../../core/services/bulk_track_actions.dart';
+import '../../data/repositories/playlist_repository_provider.dart';
+import '../../shared/widgets/confirm_dialog.dart';
+import '../../shared/widgets/empty_state.dart';
+import '../library/song_actions.dart';
+import '../player/player_providers.dart';
+import '../player/widgets/album_artwork.dart';
+import 'playlist_providers.dart';
+import 'widgets/add_to_playlist_sheet.dart';
+import 'widgets/create_playlist_dialog.dart';
+
+/// A single playlist's tracks, with Play / Shuffle, drag-to-reorder, per-row
+/// actions, and multi-select bulk actions. Tapping a row plays the playlist
+/// from that track; reordering and removals persist through the repository.
+class PlaylistDetailScreen extends ConsumerStatefulWidget {
+  const PlaylistDetailScreen({required this.playlistId, super.key});
+
+  final String playlistId;
+
+  @override
+  ConsumerState<PlaylistDetailScreen> createState() =>
+      _PlaylistDetailScreenState();
+}
+
+class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
+  final Set<String> _selectedIds = <String>{};
+  bool _selecting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final Playlist? playlist =
+        ref.watch(playlistByIdProvider(widget.playlistId));
+    final AsyncValue<PlaylistTracks> tracksAsync =
+        ref.watch(playlistTracksProvider(widget.playlistId));
+
+    if (playlist == null) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const EmptyState(
+          icon: Icons.queue_music_outlined,
+          title: 'Playlist not found',
+          message: 'It may have been deleted.',
+        ),
+      );
+    }
+
+    final PlaylistTracks resolved =
+        tracksAsync.valueOrNull ?? PlaylistTracks.empty;
+    final List<Track> selected = <Track>[
+      for (final Track track in resolved.tracks)
+        if (_selectedIds.contains(track.id)) track,
+    ];
+
+    return PopScope(
+      canPop: !_selecting,
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (!didPop && _selecting) _exitSelection();
+      },
+      child: Scaffold(
+        appBar: _selecting
+            ? _selectionAppBar(selected)
+            : AppBar(
+                title: Text(
+                  playlist.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                actions: <Widget>[
+                  PopupMenuButton<_DetailMenuAction>(
+                    tooltip: 'Playlist actions',
+                    onSelected: (a) => _runMenu(playlist, a),
+                    itemBuilder: (context) =>
+                        const <PopupMenuEntry<_DetailMenuAction>>[
+                      PopupMenuItem<_DetailMenuAction>(
+                        value: _DetailMenuAction.rename,
+                        child: ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: Icon(Icons.edit_outlined),
+                          title: Text('Rename'),
+                        ),
+                      ),
+                      PopupMenuItem<_DetailMenuAction>(
+                        value: _DetailMenuAction.delete,
+                        child: ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: Icon(Icons.delete_outline),
+                          title: Text('Delete playlist'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+        body: tracksAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (_, __) => const EmptyState(
+            icon: Icons.error_outline,
+            title: "Couldn't load this playlist",
+            message: 'Try again in a moment.',
+          ),
+          data: (PlaylistTracks data) => _content(playlist, data),
+        ),
+      ),
+    );
+  }
+
+  Widget _content(Playlist playlist, PlaylistTracks data) {
+    if (data.tracks.isEmpty) {
+      return EmptyState(
+        icon: Icons.queue_music_outlined,
+        title: 'No songs yet',
+        message: data.missingCount > 0
+            ? '${data.missingCount} '
+                '${data.missingCount == 1 ? 'song is' : 'songs are'} '
+                'no longer in your library.'
+            : 'Add songs from your library or the Now Playing screen.',
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _Header(
+          onPlay: () => _play(data.tracks),
+          onShuffle: () => _shuffle(data.tracks),
+        ),
+        if (data.missingCount > 0)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              0,
+              AppSpacing.md,
+              AppSpacing.sm,
+            ),
+            child: Text(
+              '${data.missingCount} '
+              '${data.missingCount == 1 ? 'song is' : 'songs are'} '
+              'no longer in your library.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.6),
+                  ),
+            ),
+          ),
+        Expanded(
+          child: _selecting
+              ? _selectionList(data.tracks)
+              : _reorderableList(playlist, data),
+        ),
+      ],
+    );
+  }
+
+  /// The plain checkbox list shown while selecting (no drag-to-reorder).
+  Widget _selectionList(List<Track> tracks) {
+    return ListView.builder(
+      itemCount: tracks.length,
+      itemBuilder: (context, index) {
+        final Track track = tracks[index];
+        final bool selected = _selectedIds.contains(track.id);
+        return ListTile(
+          selected: selected,
+          leading: SizedBox.square(
+            dimension: 44,
+            child: AlbumArtwork(
+              artworkUri: track.artworkUri,
+              borderRadius:
+                  const BorderRadius.all(Radius.circular(AppRadii.sm)),
+            ),
+          ),
+          title: Text(
+            track.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          subtitle: _subtitleWidget(track),
+          trailing: Checkbox(
+            value: selected,
+            onChanged: (_) => _toggle(track),
+          ),
+          onTap: () => _toggle(track),
+        );
+      },
+    );
+  }
+
+  /// The default list: drag-to-reorder (when nothing is missing) + per-row menu.
+  Widget _reorderableList(Playlist playlist, PlaylistTracks data) {
+    final List<Track> tracks = data.tracks;
+    // Reorder maps 1:1 to stored ids only when every id resolved; if some are
+    // missing, fall back to a plain list so a drag can't scramble the order.
+    final bool canReorder = data.missingCount == 0;
+
+    if (!canReorder) {
+      return ListView.builder(
+        itemCount: tracks.length,
+        itemBuilder: (context, index) =>
+            _trackRow(playlist, tracks, index, draggable: false),
+      );
+    }
+
+    return ReorderableListView.builder(
+      buildDefaultDragHandles: false,
+      itemCount: tracks.length,
+      onReorder: (int oldIndex, int newIndex) {
+        ref.read(playlistRepositoryProvider).reorderTracks(
+              playlist.id,
+              oldIndex,
+              newIndex,
+            );
+      },
+      itemBuilder: (context, index) =>
+          _trackRow(playlist, tracks, index, draggable: true),
+    );
+  }
+
+  Widget _trackRow(
+    Playlist playlist,
+    List<Track> tracks,
+    int index, {
+    required bool draggable,
+  }) {
+    final Track track = tracks[index];
+    return ListTile(
+      key: ValueKey<String>(track.id),
+      leading: SizedBox.square(
+        dimension: 44,
+        child: AlbumArtwork(
+          artworkUri: track.artworkUri,
+          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+        ),
+      ),
+      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: _subtitleWidget(track),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          PopupMenuButton<_RowAction>(
+            icon: const Icon(Icons.more_vert),
+            tooltip: 'Track actions',
+            onSelected: (a) => _runRow(playlist, track, a),
+            itemBuilder: (context) => const <PopupMenuEntry<_RowAction>>[
+              PopupMenuItem<_RowAction>(
+                value: _RowAction.playNext,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.queue_music),
+                  title: Text('Play next'),
+                ),
+              ),
+              PopupMenuItem<_RowAction>(
+                value: _RowAction.addToPlaylist,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.playlist_add),
+                  title: Text('Add to playlist'),
+                ),
+              ),
+              PopupMenuItem<_RowAction>(
+                value: _RowAction.removeFromPlaylist,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.playlist_remove),
+                  title: Text('Remove from playlist'),
+                ),
+              ),
+            ],
+          ),
+          if (draggable)
+            ReorderableDragStartListener(
+              index: index,
+              child: const Padding(
+                padding: EdgeInsets.only(left: AppSpacing.xs),
+                child: Icon(Icons.drag_handle),
+              ),
+            ),
+        ],
+      ),
+      onTap: () => _playFrom(tracks, index),
+      onLongPress: () => _enterSelection(track),
+    );
+  }
+
+  PreferredSizeWidget _selectionAppBar(List<Track> selected) {
+    final BulkActionAvailability actions =
+        bulkActionsFor(selected, inPlaylist: true);
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: 'Cancel selection',
+        onPressed: _exitSelection,
+      ),
+      title: Text('${selected.length} selected'),
+      actions: <Widget>[
+        if (actions.canAddToPlaylist)
+          IconButton(
+            icon: const Icon(Icons.playlist_add),
+            tooltip: 'Add to playlist',
+            onPressed: selected.isEmpty ? null : () => _addToPlaylist(selected),
+          ),
+        if (actions.canRemoveFromPlaylist)
+          IconButton(
+            icon: const Icon(Icons.playlist_remove),
+            tooltip: 'Remove from playlist',
+            onPressed:
+                selected.isEmpty ? null : () => _removeFromPlaylist(selected),
+          ),
+        if (actions.canRemoveOfflineCopy)
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Remove offline copies',
+            onPressed: selected.isEmpty ? null : () => _removeOffline(selected),
+          ),
+        if (actions.canRemoveFromLibrary)
+          IconButton(
+            icon: const Icon(Icons.remove_circle_outline),
+            tooltip: 'Remove from Linthra',
+            onPressed:
+                selected.isEmpty ? null : () => _removeFromLibrary(selected),
+          ),
+      ],
+    );
+  }
+
+  // --- Playback ---------------------------------------------------------
+
+  void _play(List<Track> tracks) {
+    if (tracks.isEmpty) return;
+    ref.read(playbackControllerProvider).playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  void _shuffle(List<Track> tracks) {
+    if (tracks.isEmpty) return;
+    final controller = ref.read(playbackControllerProvider);
+    controller.setShuffleEnabled(true);
+    controller.playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  void _playFrom(List<Track> tracks, int index) {
+    ref.read(playbackControllerProvider).playTracks(tracks, startIndex: index);
+    context.push(AppRoutes.player);
+  }
+
+  // --- Selection --------------------------------------------------------
+
+  void _enterSelection(Track track) {
+    setState(() {
+      _selecting = true;
+      _selectedIds
+        ..clear()
+        ..add(track.id);
+    });
+  }
+
+  void _toggle(Track track) {
+    setState(() {
+      if (!_selectedIds.add(track.id)) {
+        _selectedIds.remove(track.id);
+      }
+      if (_selectedIds.isEmpty) _selecting = false;
+    });
+  }
+
+  void _exitSelection() {
+    setState(() {
+      _selecting = false;
+      _selectedIds.clear();
+    });
+  }
+
+  // --- Actions ----------------------------------------------------------
+
+  Future<void> _runMenu(Playlist playlist, _DetailMenuAction action) async {
+    switch (action) {
+      case _DetailMenuAction.rename:
+        await _rename(playlist);
+      case _DetailMenuAction.delete:
+        await _deletePlaylist(playlist);
+    }
+  }
+
+  Future<void> _runRow(
+    Playlist playlist,
+    Track track,
+    _RowAction action,
+  ) async {
+    switch (action) {
+      case _RowAction.playNext:
+        ref.read(playbackControllerProvider).playNext(track);
+      case _RowAction.addToPlaylist:
+        await showAddToPlaylistSheet(context, <Track>[track]);
+      case _RowAction.removeFromPlaylist:
+        await _removeOneFromPlaylist(playlist, track);
+    }
+  }
+
+  Future<void> _rename(Playlist playlist) async {
+    final PlaylistEdit? edit = await showRenamePlaylistDialog(
+      context,
+      initialName: playlist.name,
+      initialDescription: playlist.description,
+    );
+    if (edit == null) return;
+    await ref.read(playlistRepositoryProvider).renamePlaylist(
+          playlist.id,
+          edit.name,
+          description: edit.description,
+        );
+  }
+
+  Future<void> _deletePlaylist(Playlist playlist) async {
+    final NavigatorState navigator = Navigator.of(context);
+    final bool confirmed = await showConfirmDialog(
+      context,
+      title: 'Delete playlist',
+      message: 'Delete playlist “${playlist.name}”? This removes the playlist '
+          'from Linthra. Synced playlists may also be removed from the server '
+          'if sync is enabled.',
+      confirmLabel: 'Delete',
+    );
+    if (!confirmed) return;
+    await ref.read(playlistRepositoryProvider).deletePlaylist(playlist.id);
+    navigator.pop();
+  }
+
+  Future<void> _removeOneFromPlaylist(Playlist playlist, Track track) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final repository = ref.read(playlistRepositoryProvider);
+    await repository.removeTrack(playlist.id, track.id);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text('Removed “${track.title}” from playlist.'),
+        action: SnackBarAction(
+          label: 'Undo',
+          onPressed: () => repository.addTrack(playlist.id, track.id),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _removeFromPlaylist(List<Track> selected) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool confirmed = await showConfirmDialog(
+      context,
+      title: 'Remove from playlist',
+      message: selected.length == 1
+          ? 'Remove “${selected.first.title}” from this playlist?'
+          : 'Remove ${selected.length} songs from this playlist?',
+      confirmLabel: 'Remove',
+      destructive: false,
+    );
+    if (!confirmed) return;
+    final repository = ref.read(playlistRepositoryProvider);
+    for (final Track track in selected) {
+      await repository.removeTrack(widget.playlistId, track.id);
+    }
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          selected.length == 1
+              ? 'Removed 1 song from playlist.'
+              : 'Removed ${selected.length} songs from playlist.',
+        ),
+      ),
+    );
+    _exitSelection();
+  }
+
+  Future<void> _addToPlaylist(List<Track> selected) async {
+    await showAddToPlaylistSheet(context, selected);
+    _exitSelection();
+  }
+
+  Future<void> _removeFromLibrary(List<Track> selected) async {
+    final bool removed = await SongActions.removeFromLibrary(
+      context,
+      ref,
+      selected,
+      playlistId: widget.playlistId,
+    );
+    if (removed) _exitSelection();
+  }
+
+  Future<void> _removeOffline(List<Track> selected) async {
+    final bool ran =
+        await SongActions.removeOfflineCopies(context, ref, selected);
+    if (ran) _exitSelection();
+  }
+
+  Widget? _subtitleWidget(Track track) {
+    final String? subtitle = _subtitle(track);
+    if (subtitle == null) return null;
+    return Text(subtitle, maxLines: 1, overflow: TextOverflow.ellipsis);
+  }
+
+  String? _subtitle(Track track) {
+    final String? artist = track.artistName;
+    if (artist == null || artist.isEmpty) return null;
+    final String? album = track.albumName;
+    return (album == null || album.isEmpty) ? artist : '$artist • $album';
+  }
+}
+
+enum _DetailMenuAction { rename, delete }
+
+enum _RowAction { playNext, addToPlaylist, removeFromPlaylist }
+
+class _Header extends StatelessWidget {
+  const _Header({required this.onPlay, required this.onShuffle});
+
+  final VoidCallback onPlay;
+  final VoidCallback onShuffle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: FilledButton.icon(
+              onPressed: onPlay,
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('Play'),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: FilledButton.tonalIcon(
+              onPressed: onShuffle,
+              icon: const Icon(Icons.shuffle),
+              label: const Text('Shuffle'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/playlists/playlist_providers.dart
+++ b/lib/features/playlists/playlist_providers.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/playlist.dart';
+import '../../core/models/track.dart';
+import '../../data/repositories/music_library_repository_provider.dart';
+import '../../data/repositories/playlist_repository_provider.dart';
+
+/// Streams the user's playlists for the UI; emits on every change.
+final playlistsProvider = StreamProvider<List<Playlist>>((ref) {
+  return ref.watch(playlistRepositoryProvider).playlistsStream;
+});
+
+/// A single playlist by id, derived from [playlistsProvider] so it stays live as
+/// the playlist is edited. `null` while loading or when the playlist is gone.
+final playlistByIdProvider = Provider.family<Playlist?, String>((ref, id) {
+  final List<Playlist> playlists =
+      ref.watch(playlistsProvider).valueOrNull ?? const <Playlist>[];
+  for (final Playlist playlist in playlists) {
+    if (playlist.id == id) return playlist;
+  }
+  return null;
+});
+
+/// The resolved tracks of a playlist (in playlist order) plus a count of any
+/// referenced tracks no longer present in the catalog, so the detail screen can
+/// play what's available and surface missing ones honestly.
+@immutable
+class PlaylistTracks {
+  const PlaylistTracks({required this.tracks, required this.missingCount});
+
+  static const PlaylistTracks empty =
+      PlaylistTracks(tracks: <Track>[], missingCount: 0);
+
+  final List<Track> tracks;
+  final int missingCount;
+}
+
+/// Resolves a playlist's stored track ids to catalog [Track]s, preserving order
+/// and gracefully dropping (and counting) any that the catalog no longer has.
+/// Re-runs whenever the playlist changes.
+final playlistTracksProvider =
+    FutureProvider.family.autoDispose<PlaylistTracks, String>((ref, id) async {
+  final Playlist? playlist = ref.watch(playlistByIdProvider(id));
+  if (playlist == null || playlist.trackIds.isEmpty) {
+    return PlaylistTracks.empty;
+  }
+  final List<Track> all =
+      await ref.watch(musicLibraryRepositoryProvider).getAllTracks();
+  final Map<String, Track> byId = <String, Track>{
+    for (final Track track in all) track.id: track,
+  };
+  final List<Track> resolved = <Track>[];
+  int missing = 0;
+  for (final String trackId in playlist.trackIds) {
+    final Track? track = byId[trackId];
+    if (track != null) {
+      resolved.add(track);
+    } else {
+      missing++;
+    }
+  }
+  return PlaylistTracks(tracks: resolved, missingCount: missing);
+});

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -1,23 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../app/dimens.dart';
 import '../../app/routes.dart';
+import '../../core/models/playlist.dart';
+import '../../data/repositories/playlist_repository_provider.dart';
+import '../../shared/widgets/confirm_dialog.dart';
+import '../../shared/widgets/empty_state.dart';
+import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import 'playlist_providers.dart';
+import 'widgets/create_playlist_dialog.dart';
 
-/// Create and edit playlists. Playlists themselves are still a placeholder, but
-/// the user's Favorites — a smart, always-present collection of liked tracks —
-/// is reachable from here via a pinned entry at the top.
-class PlaylistsScreen extends StatelessWidget {
+/// The Playlists tab: the user's playlists, with the always-present Favorites
+/// collection pinned at the top. Playlists can be created here, and each one can
+/// be opened, renamed, or deleted (with confirmation).
+class PlaylistsScreen extends ConsumerWidget {
   const PlaylistsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final accent = theme.colorScheme.primary;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final Color accent = theme.colorScheme.primary;
+    final AsyncValue<List<Playlist>> playlists = ref.watch(playlistsProvider);
+
     return Scaffold(
       appBar: AppBar(title: const Text('Playlists')),
-      body: ListView(
-        children: [
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _create(context, ref),
+        icon: const Icon(Icons.add),
+        label: const Text('New playlist'),
+      ),
+      body: Column(
+        children: <Widget>[
           ListTile(
             leading: CircleAvatar(
               backgroundColor: accent.withValues(alpha: 0.12),
@@ -29,35 +43,156 @@ class PlaylistsScreen extends StatelessWidget {
             onTap: () => context.push(AppRoutes.favorites),
           ),
           const Divider(height: 0),
-          const Padding(
-            padding: EdgeInsets.fromLTRB(
-              AppSpacing.md,
-              AppSpacing.xl,
-              AppSpacing.md,
-              0,
-            ),
-            child: Text(
-              'No playlists yet',
-              textAlign: TextAlign.center,
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.md,
-              AppSpacing.sm,
-              AppSpacing.md,
-              AppSpacing.md,
-            ),
-            child: Text(
-              'Your playlists will appear here.',
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-              ),
+          Expanded(
+            child: playlists.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (_, __) => const _PlaylistsError(),
+              data: (List<Playlist> items) => items.isEmpty
+                  ? const EmptyState(
+                      icon: Icons.queue_music_outlined,
+                      title: 'No playlists yet',
+                      message: 'Tap “New playlist” to create one.',
+                    )
+                  : ListView.builder(
+                      padding: const EdgeInsets.only(bottom: 88),
+                      itemCount: items.length,
+                      itemBuilder: (context, index) =>
+                          _PlaylistTile(playlist: items[index]),
+                    ),
             ),
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _create(BuildContext context, WidgetRef ref) async {
+    final bool connected = ref.read(
+      jellyfinSettingsControllerProvider.select((s) => s.isConnected),
+    );
+    final PlaylistEdit? edit = await showCreatePlaylistDialog(
+      context,
+      canSyncToJellyfin: connected,
+    );
+    if (edit == null) return;
+    await ref.read(playlistRepositoryProvider).createPlaylist(
+          edit.name,
+          description: edit.description,
+          source: edit.source,
+        );
+  }
+}
+
+class _PlaylistTile extends ConsumerWidget {
+  const _PlaylistTile({required this.playlist});
+
+  final Playlist playlist;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.12),
+        child: Icon(
+          playlist.isRemote ? Icons.cloud_outlined : Icons.queue_music,
+          color: theme.colorScheme.primary,
+        ),
+      ),
+      title: Text(
+        playlist.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(_subtitle(theme)),
+      trailing: PopupMenuButton<_PlaylistMenuAction>(
+        icon: const Icon(Icons.more_vert),
+        tooltip: 'Playlist actions',
+        onSelected: (action) => _run(context, ref, action),
+        itemBuilder: (context) => const <PopupMenuEntry<_PlaylistMenuAction>>[
+          PopupMenuItem<_PlaylistMenuAction>(
+            value: _PlaylistMenuAction.rename,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.edit_outlined),
+              title: Text('Rename'),
+            ),
+          ),
+          PopupMenuItem<_PlaylistMenuAction>(
+            value: _PlaylistMenuAction.delete,
+            child: ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: Icon(Icons.delete_outline),
+              title: Text('Delete'),
+            ),
+          ),
+        ],
+      ),
+      onTap: () => context.push(AppRoutes.playlistDetailPath(playlist.id)),
+    );
+  }
+
+  String _subtitle(ThemeData theme) {
+    final String count = '${playlist.length} '
+        '${playlist.length == 1 ? 'song' : 'songs'}';
+    if (playlist.syncState == PlaylistSyncState.syncFailed) {
+      return '$count · Sync failed';
+    }
+    return count;
+  }
+
+  Future<void> _run(
+    BuildContext context,
+    WidgetRef ref,
+    _PlaylistMenuAction action,
+  ) async {
+    switch (action) {
+      case _PlaylistMenuAction.rename:
+        await _rename(context, ref);
+      case _PlaylistMenuAction.delete:
+        await _delete(context, ref);
+    }
+  }
+
+  Future<void> _rename(BuildContext context, WidgetRef ref) async {
+    final PlaylistEdit? edit = await showRenamePlaylistDialog(
+      context,
+      initialName: playlist.name,
+      initialDescription: playlist.description,
+    );
+    if (edit == null) return;
+    await ref.read(playlistRepositoryProvider).renamePlaylist(
+          playlist.id,
+          edit.name,
+          description: edit.description,
+        );
+  }
+
+  Future<void> _delete(BuildContext context, WidgetRef ref) async {
+    final bool confirmed = await showConfirmDialog(
+      context,
+      title: 'Delete playlist',
+      message: 'Delete playlist “${playlist.name}”? This removes the playlist '
+          'from Linthra. Synced playlists may also be removed from the server '
+          'if sync is enabled.',
+      confirmLabel: 'Delete',
+    );
+    if (!confirmed) return;
+    await ref.read(playlistRepositoryProvider).deletePlaylist(playlist.id);
+  }
+}
+
+enum _PlaylistMenuAction { rename, delete }
+
+class _PlaylistsError extends StatelessWidget {
+  const _PlaylistsError();
+
+  @override
+  Widget build(BuildContext context) {
+    return const EmptyState(
+      icon: Icons.error_outline,
+      title: "Couldn't load your playlists",
+      message: 'Try again in a moment.',
     );
   }
 }

--- a/lib/features/playlists/widgets/add_to_playlist_sheet.dart
+++ b/lib/features/playlists/widgets/add_to_playlist_sheet.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/playlist.dart';
+import '../../../core/models/track.dart';
+import '../../../core/sources/jellyfin/jellyfin_track_mapper.dart';
+import '../../../data/repositories/playlist_repository_provider.dart';
+import '../../../shared/widgets/empty_state.dart';
+import '../../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../playlist_providers.dart';
+import 'create_playlist_dialog.dart';
+
+/// Opens the "Add to playlist" sheet for [tracks] (one, or a bulk selection).
+/// The sheet lists existing playlists and a "New playlist" action; the actual
+/// add and any user feedback happen inside it.
+Future<void> showAddToPlaylistSheet(
+  BuildContext context,
+  List<Track> tracks,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (_) => _AddToPlaylistSheet(tracks: tracks),
+  );
+}
+
+class _AddToPlaylistSheet extends ConsumerWidget {
+  const _AddToPlaylistSheet({required this.tracks});
+
+  final List<Track> tracks;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final List<Playlist> playlists =
+        ref.watch(playlistsProvider).valueOrNull ?? const <Playlist>[];
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.7,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                0,
+                AppSpacing.lg,
+                AppSpacing.sm,
+              ),
+              child: Text(
+                tracks.length == 1
+                    ? 'Add to playlist'
+                    : 'Add ${tracks.length} songs to playlist',
+                style: theme.textTheme.titleMedium,
+              ),
+            ),
+            ListTile(
+              leading: CircleAvatar(
+                backgroundColor: theme.colorScheme.primary.withValues(
+                  alpha: 0.12,
+                ),
+                child: Icon(Icons.add, color: theme.colorScheme.primary),
+              ),
+              title: const Text('New playlist'),
+              onTap: () => _createAndAdd(context, ref),
+            ),
+            const Divider(height: 0),
+            Flexible(
+              child: playlists.isEmpty
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
+                      child: EmptyState(
+                        icon: Icons.queue_music_outlined,
+                        title: 'No playlists yet',
+                        message: 'Create one to start adding songs.',
+                      ),
+                    )
+                  : ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: playlists.length,
+                      itemBuilder: (context, index) {
+                        final Playlist playlist = playlists[index];
+                        return ListTile(
+                          leading: Icon(
+                            playlist.isRemote
+                                ? Icons.cloud_outlined
+                                : Icons.queue_music,
+                          ),
+                          title: Text(
+                            playlist.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          subtitle: Text(
+                            '${playlist.length} '
+                            '${playlist.length == 1 ? 'song' : 'songs'}',
+                          ),
+                          onTap: () => _addToExisting(context, ref, playlist),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _addToExisting(
+    BuildContext context,
+    WidgetRef ref,
+    Playlist playlist,
+  ) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final NavigatorState navigator = Navigator.of(context);
+    final List<Track> addable = _addableFor(playlist);
+    if (addable.isEmpty) {
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Only Jellyfin tracks can be added to a Jellyfin playlist.',
+          ),
+        ),
+      );
+      return;
+    }
+    await ref.read(playlistRepositoryProvider).addTracks(
+      playlist.id,
+      <String>[for (final Track track in addable) track.id],
+    );
+    navigator.pop();
+    messenger.showSnackBar(
+      SnackBar(content: Text(_addedMessage(playlist, addable.length))),
+    );
+  }
+
+  Future<void> _createAndAdd(BuildContext context, WidgetRef ref) async {
+    final bool connected = ref.read(
+      jellyfinSettingsControllerProvider.select((s) => s.isConnected),
+    );
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final NavigatorState navigator = Navigator.of(context);
+    final PlaylistEdit? edit = await showCreatePlaylistDialog(
+      context,
+      canSyncToJellyfin: connected,
+    );
+    if (edit == null) return;
+    final repository = ref.read(playlistRepositoryProvider);
+    final Playlist created = await repository.createPlaylist(
+      edit.name,
+      description: edit.description,
+      source: edit.source,
+    );
+    final List<Track> addable = _addableFor(created);
+    if (addable.isNotEmpty) {
+      await repository.addTracks(
+        created.id,
+        <String>[for (final Track track in addable) track.id],
+      );
+    }
+    navigator.pop();
+    messenger.showSnackBar(
+      SnackBar(content: Text(_addedMessage(created, addable.length))),
+    );
+  }
+
+  /// The subset of [tracks] that can be added to [playlist]: every track for a
+  /// local playlist, only Jellyfin tracks for a Jellyfin playlist (so a synced
+  /// playlist stays consistent with the server).
+  List<Track> _addableFor(Playlist playlist) {
+    if (playlist.source != PlaylistSource.jellyfin) return tracks;
+    return <Track>[
+      for (final Track track in tracks)
+        if (track.uri.startsWith(JellyfinTrackMapper.uriScheme)) track,
+    ];
+  }
+
+  String _addedMessage(Playlist playlist, int added) {
+    final int skipped = tracks.length - added;
+    final String base = added == 1
+        ? 'Added to ${playlist.name}.'
+        : 'Added $added songs to ${playlist.name}.';
+    if (skipped > 0) {
+      return '$base $skipped not added (not Jellyfin tracks).';
+    }
+    return base;
+  }
+}

--- a/lib/features/playlists/widgets/create_playlist_dialog.dart
+++ b/lib/features/playlists/widgets/create_playlist_dialog.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/playlist.dart';
+
+/// The result of the create/rename playlist dialog.
+typedef PlaylistEdit = ({
+  String name,
+  String? description,
+  PlaylistSource source,
+});
+
+/// Shows the create-playlist dialog and resolves to the entered name (+ optional
+/// description and chosen [PlaylistSource]), or `null` if cancelled or the name
+/// was blank.
+///
+/// When [canSyncToJellyfin] is true a "Sync with Jellyfin" switch is offered so
+/// the new playlist mirrors to the signed-in server; otherwise the playlist is
+/// local-only.
+Future<PlaylistEdit?> showCreatePlaylistDialog(
+  BuildContext context, {
+  bool canSyncToJellyfin = false,
+}) {
+  return showDialog<PlaylistEdit>(
+    context: context,
+    builder: (BuildContext context) => _PlaylistEditDialog(
+      title: 'New playlist',
+      confirmLabel: 'Create',
+      canSyncToJellyfin: canSyncToJellyfin,
+    ),
+  );
+}
+
+/// Shows the rename dialog seeded with [initialName]/[initialDescription], and
+/// resolves to the edited values (source is never changed by a rename).
+Future<PlaylistEdit?> showRenamePlaylistDialog(
+  BuildContext context, {
+  required String initialName,
+  String? initialDescription,
+}) {
+  return showDialog<PlaylistEdit>(
+    context: context,
+    builder: (BuildContext context) => _PlaylistEditDialog(
+      title: 'Rename playlist',
+      confirmLabel: 'Save',
+      initialName: initialName,
+      initialDescription: initialDescription,
+    ),
+  );
+}
+
+class _PlaylistEditDialog extends StatefulWidget {
+  const _PlaylistEditDialog({
+    required this.title,
+    required this.confirmLabel,
+    this.initialName,
+    this.initialDescription,
+    this.canSyncToJellyfin = false,
+  });
+
+  final String title;
+  final String confirmLabel;
+  final String? initialName;
+  final String? initialDescription;
+  final bool canSyncToJellyfin;
+
+  @override
+  State<_PlaylistEditDialog> createState() => _PlaylistEditDialogState();
+}
+
+class _PlaylistEditDialogState extends State<_PlaylistEditDialog> {
+  late final TextEditingController _name =
+      TextEditingController(text: widget.initialName ?? '');
+  late final TextEditingController _description =
+      TextEditingController(text: widget.initialDescription ?? '');
+  bool _syncToJellyfin = false;
+  bool _canSubmit = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _canSubmit = _name.text.trim().isNotEmpty;
+    _name.addListener(_onNameChanged);
+  }
+
+  void _onNameChanged() {
+    final bool canSubmit = _name.text.trim().isNotEmpty;
+    if (canSubmit != _canSubmit) {
+      setState(() => _canSubmit = canSubmit);
+    }
+  }
+
+  @override
+  void dispose() {
+    _name.removeListener(_onNameChanged);
+    _name.dispose();
+    _description.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final String name = _name.text.trim();
+    if (name.isEmpty) return;
+    final String description = _description.text.trim();
+    Navigator.of(context).pop(
+      (
+        name: name,
+        description: description.isEmpty ? null : description,
+        source:
+            _syncToJellyfin ? PlaylistSource.jellyfin : PlaylistSource.local,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          TextField(
+            controller: _name,
+            autofocus: true,
+            textCapitalization: TextCapitalization.sentences,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'My playlist',
+            ),
+            onSubmitted: (_) => _submit(),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _description,
+            textCapitalization: TextCapitalization.sentences,
+            decoration: const InputDecoration(
+              labelText: 'Description (optional)',
+            ),
+          ),
+          if (widget.canSyncToJellyfin) ...<Widget>[
+            const SizedBox(height: 8),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              value: _syncToJellyfin,
+              onChanged: (bool value) =>
+                  setState(() => _syncToJellyfin = value),
+              title: const Text('Sync with Jellyfin'),
+              subtitle: const Text('Create this playlist on your server too.'),
+            ),
+          ],
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _canSubmit ? _submit : null,
+          child: Text(widget.confirmLabel),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/favorites_repository_provider.dart';
 import 'data/repositories/jellyfin_session_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
+import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
 import 'features/downloads/download_providers.dart';
@@ -46,6 +47,8 @@ Future<void> main() async {
       secureSubsonicSessionStoreOverride,
       sharedPreferencesFavoritesStoreOverride,
       jellyfinFavoritesOverride,
+      sharedPreferencesPlaylistStoreOverride,
+      jellyfinPlaylistSyncOverride,
       jellyfinLyricsOverride,
       // Real Chromecast backend (Android/iOS only); see cast_providers.dart.
       chromecastCastServiceOverride,
@@ -94,6 +97,10 @@ Future<void> main() async {
   // reflects the server from the first frame. Best-effort and offline-tolerant:
   // the repository swallows failures and keeps any locally stored favourites.
   unawaited(container.read(favoritesRepositoryProvider).refreshFromRemote());
+
+  // Likewise import the user's Jellyfin playlists so synced playlists appear on
+  // the Playlists tab from the first frame. Best-effort and offline-tolerant.
+  unawaited(container.read(playlistRepositoryProvider).refreshFromRemote());
 
   runApp(
     UncontrolledProviderScope(

--- a/lib/shared/widgets/confirm_dialog.dart
+++ b/lib/shared/widgets/confirm_dialog.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// Shows a confirmation dialog and resolves to `true` only when the user taps
+/// the confirm action (a dismiss/back/Cancel resolves to `false`).
+///
+/// Every destructive action in Linthra routes through this so the wording is
+/// consistent: an explicit `Cancel` and a clearly-labelled action button (e.g.
+/// "Remove", "Delete", "Delete from server") — never a vague "OK". When
+/// [destructive] is true (the default) the action button is tinted with the
+/// error colour so it reads as a deliberate, irreversible-feeling choice.
+Future<bool> showConfirmDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required String confirmLabel,
+  String cancelLabel = 'Cancel',
+  bool destructive = true,
+}) async {
+  final bool? result = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext dialogContext) {
+      final ThemeData theme = Theme.of(dialogContext);
+      return AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(cancelLabel),
+          ),
+          FilledButton(
+            style: destructive
+                ? FilledButton.styleFrom(
+                    backgroundColor: theme.colorScheme.error,
+                    foregroundColor: theme.colorScheme.onError,
+                  )
+                : null,
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(confirmLabel),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? false;
+}

--- a/test/core/models/playlist_test.dart
+++ b/test/core/models/playlist_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+
+void main() {
+  group('Playlist', () {
+    test('defaults to a local, local-only, empty playlist', () {
+      const Playlist playlist = Playlist(id: '1', name: 'Mix');
+      expect(playlist.source, PlaylistSource.local);
+      expect(playlist.syncState, PlaylistSyncState.localOnly);
+      expect(playlist.trackIds, isEmpty);
+      expect(playlist.isEmpty, isTrue);
+      expect(playlist.isRemote, isFalse);
+      expect(playlist.remoteId, isNull);
+      expect(playlist.lastSyncError, isNull);
+    });
+
+    test('length reflects the track ids', () {
+      const Playlist playlist =
+          Playlist(id: '1', name: 'Mix', trackIds: <String>['a', 'b', 'c']);
+      expect(playlist.length, 3);
+      expect(playlist.isEmpty, isFalse);
+    });
+
+    test('equality is by id only', () {
+      const Playlist a = Playlist(id: '1', name: 'A');
+      const Playlist b = Playlist(id: '1', name: 'B different name');
+      const Playlist c = Playlist(id: '2', name: 'A');
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('copyWith updates scalar fields and leaves others intact', () {
+      final DateTime created = DateTime(2024, 1, 1);
+      final Playlist playlist = Playlist(
+        id: '1',
+        name: 'Mix',
+        trackIds: const <String>['a'],
+        createdAt: created,
+      );
+      final Playlist renamed = playlist.copyWith(name: 'New name');
+      expect(renamed.name, 'New name');
+      expect(renamed.id, '1');
+      expect(renamed.trackIds, <String>['a']);
+      expect(renamed.createdAt, created);
+    });
+
+    test('copyWith can set and clear nullable fields explicitly', () {
+      const Playlist playlist = Playlist(id: '1', name: 'Mix');
+      final Playlist withRemote = playlist.copyWith(
+        remoteId: () => 'srv-1',
+        description: () => 'A description',
+        lastSyncError: () => 'Could not sync',
+      );
+      expect(withRemote.remoteId, 'srv-1');
+      expect(withRemote.description, 'A description');
+      expect(withRemote.lastSyncError, 'Could not sync');
+
+      final Playlist cleared = withRemote.copyWith(
+        lastSyncError: () => null,
+        remoteId: () => null,
+      );
+      expect(cleared.lastSyncError, isNull);
+      expect(cleared.remoteId, isNull);
+      // Untouched nullable stays.
+      expect(cleared.description, 'A description');
+    });
+
+    test('PlaylistSource round-trips through providerId', () {
+      expect(PlaylistSource.local.providerId, 'local');
+      expect(PlaylistSource.jellyfin.providerId, 'jellyfin');
+      expect(
+          PlaylistSource.fromProviderId('jellyfin'), PlaylistSource.jellyfin);
+      // Unknown / null defaults to local so a forward/old record can't crash.
+      expect(PlaylistSource.fromProviderId('spotify'), PlaylistSource.local);
+      expect(PlaylistSource.fromProviderId(null), PlaylistSource.local);
+    });
+
+    test('PlaylistSyncState parses by name, defaulting to localOnly', () {
+      expect(
+        PlaylistSyncState.fromName('synced'),
+        PlaylistSyncState.synced,
+      );
+      expect(
+        PlaylistSyncState.fromName('pendingCreate'),
+        PlaylistSyncState.pendingCreate,
+      );
+      expect(
+        PlaylistSyncState.fromName('nonsense'),
+        PlaylistSyncState.localOnly,
+      );
+      expect(PlaylistSyncState.fromName(null), PlaylistSyncState.localOnly);
+    });
+  });
+}

--- a/test/core/services/bulk_track_actions_test.dart
+++ b/test/core/services/bulk_track_actions_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/bulk_track_actions.dart';
+
+Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
+
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+Track _subsonic(String id) => Track(id: id, title: id, uri: 'subsonic:$id');
+
+void main() {
+  group('bulkActionsFor', () {
+    test('empty selection offers nothing', () {
+      final BulkActionAvailability a =
+          bulkActionsFor(const <Track>[], inPlaylist: false);
+      expect(a.canAddToPlaylist, isFalse);
+      expect(a.canRemoveFromLibrary, isFalse);
+      expect(a.canRemoveOfflineCopy, isFalse);
+      expect(a.canDeleteLocalFiles, isFalse);
+      expect(a.canDeleteFromServer, isFalse);
+    });
+
+    test('a single local track: add + remove-from-library, no offline', () {
+      final BulkActionAvailability a =
+          bulkActionsFor(<Track>[_local('1')], inPlaylist: false);
+      expect(a.canAddToPlaylist, isTrue);
+      expect(a.canRemoveFromLibrary, isTrue);
+      // Local tracks have no app-managed offline copy.
+      expect(a.canRemoveOfflineCopy, isFalse);
+      // Destructive deletes are not enabled in this release.
+      expect(a.canDeleteLocalFiles, isFalse);
+      expect(a.canDeleteFromServer, isFalse);
+    });
+
+    test('Jellyfin tracks expose remove-offline', () {
+      final BulkActionAvailability a =
+          bulkActionsFor(<Track>[_jellyfin('1')], inPlaylist: false);
+      expect(a.canRemoveOfflineCopy, isTrue);
+      expect(a.canRemoveFromLibrary, isTrue);
+      // Server delete stays off (capability disabled in this release).
+      expect(a.canDeleteFromServer, isFalse);
+    });
+
+    test('remove-from-playlist only inside a playlist', () {
+      expect(
+        bulkActionsFor(<Track>[_local('1')], inPlaylist: true)
+            .canRemoveFromPlaylist,
+        isTrue,
+      );
+      expect(
+        bulkActionsFor(<Track>[_local('1')], inPlaylist: false)
+            .canRemoveFromPlaylist,
+        isFalse,
+      );
+    });
+
+    test('a mixed-source selection still allows the safe actions', () {
+      final BulkActionAvailability a = bulkActionsFor(
+        <Track>[_local('1'), _jellyfin('2'), _subsonic('3')],
+        inPlaylist: false,
+      );
+      // Safe, reversible actions are available for every source.
+      expect(a.canAddToPlaylist, isTrue);
+      expect(a.canRemoveFromLibrary, isTrue);
+      // At least one of them can have an offline copy.
+      expect(a.canRemoveOfflineCopy, isTrue);
+      // But destructive deletes are hidden for a mixed selection.
+      expect(a.canDeleteLocalFiles, isFalse);
+      expect(a.canDeleteFromServer, isFalse);
+    });
+  });
+}

--- a/test/core/sources/jellyfin/fake_jellyfin_client.dart
+++ b/test/core/sources/jellyfin/fake_jellyfin_client.dart
@@ -61,6 +61,122 @@ class FakeJellyfinClient implements JellyfinClient {
   final List<({String itemId, bool favorite})> favoriteCalls =
       <({String itemId, bool favorite})>[];
 
+  // --- Playlists ---------------------------------------------------------
+
+  /// Canned playlists for [fetchPlaylists] (id + name).
+  List<JellyfinPlaylistDto> playlists = <JellyfinPlaylistDto>[];
+
+  /// Canned entries per playlist id for [fetchPlaylistEntries], also updated by
+  /// the create/add/remove calls so a round-trip reads back consistently.
+  final Map<String, List<JellyfinPlaylistEntry>> playlistEntries =
+      <String, List<JellyfinPlaylistEntry>>{};
+
+  /// A single error every playlist call throws, for the error-mapping tests.
+  JellyfinException? playlistError;
+
+  /// The id [createPlaylist] returns (and keys new entries under).
+  String createdPlaylistId = 'remote-playlist-1';
+
+  // Recorded calls, in order.
+  final List<({String name, List<String> itemIds})> createPlaylistCalls =
+      <({String name, List<String> itemIds})>[];
+  final List<({String playlistId, List<String> itemIds})> addItemCalls =
+      <({String playlistId, List<String> itemIds})>[];
+  final List<({String playlistId, List<String> itemIds})> removeItemCalls =
+      <({String playlistId, List<String> itemIds})>[];
+  final List<String> deletedPlaylistIds = <String>[];
+
+  @override
+  Future<List<JellyfinPlaylistDto>> fetchPlaylists(
+    JellyfinSession session,
+  ) async {
+    final JellyfinException? error = playlistError;
+    if (error != null) throw error;
+    return playlists;
+  }
+
+  @override
+  Future<List<JellyfinPlaylistEntry>> fetchPlaylistEntries(
+    JellyfinSession session,
+    String playlistId,
+  ) async {
+    final JellyfinException? error = playlistError;
+    if (error != null) throw error;
+    return playlistEntries[playlistId] ?? const <JellyfinPlaylistEntry>[];
+  }
+
+  @override
+  Future<String> createPlaylist(
+    JellyfinSession session, {
+    required String name,
+    List<String> itemIds = const <String>[],
+  }) async {
+    final JellyfinException? error = playlistError;
+    if (error != null) throw error;
+    createPlaylistCalls.add((name: name, itemIds: itemIds));
+    final String id = createdPlaylistId;
+    playlistEntries[id] = <JellyfinPlaylistEntry>[
+      for (final String itemId in itemIds)
+        JellyfinPlaylistEntry(itemId: itemId, playlistItemId: 'entry-$itemId'),
+    ];
+    playlists = <JellyfinPlaylistDto>[
+      ...playlists,
+      JellyfinPlaylistDto(id: id, name: name),
+    ];
+    return id;
+  }
+
+  @override
+  Future<void> addItemsToPlaylist(
+    JellyfinSession session,
+    String playlistId,
+    List<String> itemIds,
+  ) async {
+    final JellyfinException? error = playlistError;
+    if (error != null) throw error;
+    addItemCalls.add((playlistId: playlistId, itemIds: itemIds));
+    final List<JellyfinPlaylistEntry> entries =
+        playlistEntries[playlistId] ?? <JellyfinPlaylistEntry>[];
+    playlistEntries[playlistId] = <JellyfinPlaylistEntry>[
+      ...entries,
+      for (final String itemId in itemIds)
+        JellyfinPlaylistEntry(itemId: itemId, playlistItemId: 'entry-$itemId'),
+    ];
+  }
+
+  @override
+  Future<void> removeItemsFromPlaylist(
+    JellyfinSession session,
+    String playlistId,
+    List<String> itemIds,
+  ) async {
+    final JellyfinException? error = playlistError;
+    if (error != null) throw error;
+    removeItemCalls.add((playlistId: playlistId, itemIds: itemIds));
+    final List<JellyfinPlaylistEntry> entries =
+        playlistEntries[playlistId] ?? const <JellyfinPlaylistEntry>[];
+    final Set<String> targets = itemIds.toSet();
+    playlistEntries[playlistId] = <JellyfinPlaylistEntry>[
+      for (final JellyfinPlaylistEntry entry in entries)
+        if (!targets.contains(entry.itemId)) entry,
+    ];
+  }
+
+  @override
+  Future<void> deletePlaylist(
+    JellyfinSession session,
+    String playlistId,
+  ) async {
+    final JellyfinException? error = playlistError;
+    if (error != null) throw error;
+    deletedPlaylistIds.add(playlistId);
+    playlistEntries.remove(playlistId);
+    playlists = <JellyfinPlaylistDto>[
+      for (final JellyfinPlaylistDto p in playlists)
+        if (p.id != playlistId) p,
+    ];
+  }
+
   @override
   Future<JellyfinServerInfo> fetchServerInfo(String baseUrl) async {
     lastBaseUrl = baseUrl;

--- a/test/core/sources/jellyfin/http_jellyfin_client_playlist_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_playlist_test.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/sources/jellyfin/http_jellyfin_client.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+
+const String _base = 'https://music.example.com';
+const String _token = 'tok-abc-secret';
+
+const JellyfinSession _session = JellyfinSession(
+  baseUrl: _base,
+  userId: 'user-1',
+  accessToken: _token,
+  deviceId: 'device-1',
+);
+
+HttpJellyfinClient _client(MockClient mock) =>
+    HttpJellyfinClient(httpClient: mock);
+
+http.Response _json(Object body) => http.Response(
+      jsonEncode(body),
+      200,
+      headers: const <String, String>{'content-type': 'application/json'},
+    );
+
+void main() {
+  group('fetchPlaylists', () {
+    test('lists the user playlists from /Items', () async {
+      http.Request? captured;
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        captured = request;
+        return _json(<String, dynamic>{
+          'Items': <dynamic>[
+            <String, dynamic>{'Id': 'pl-1', 'Name': 'Road Trip'},
+            <String, dynamic>{'Id': 'pl-2', 'Name': 'Focus'},
+          ],
+        });
+      }));
+
+      final List<JellyfinPlaylistDto> playlists =
+          await client.fetchPlaylists(_session);
+
+      expect(playlists.map((p) => p.name), <String>['Road Trip', 'Focus']);
+      expect(captured!.method, 'GET');
+      expect(captured!.url.path, '/Items');
+      expect(captured!.url.queryParameters['IncludeItemTypes'], 'Playlist');
+      // The token rides only in the auth header, never logged elsewhere.
+      expect(captured!.headers['Authorization'], contains(_token));
+    });
+  });
+
+  group('fetchPlaylistEntries', () {
+    test('parses item ids and entry ids', () async {
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        expect(request.url.path, '/Playlists/pl-1/Items');
+        return _json(<String, dynamic>{
+          'Items': <dynamic>[
+            <String, dynamic>{'Id': 'a', 'PlaylistItemId': 'e-a'},
+            <String, dynamic>{'Id': 'b', 'PlaylistItemId': 'e-b'},
+          ],
+        });
+      }));
+
+      final List<JellyfinPlaylistEntry> entries =
+          await client.fetchPlaylistEntries(_session, 'pl-1');
+      expect(entries.map((e) => e.itemId), <String>['a', 'b']);
+      expect(entries.first.playlistItemId, 'e-a');
+    });
+  });
+
+  group('createPlaylist', () {
+    test('POSTs to /Playlists and returns the new id', () async {
+      http.Request? captured;
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        captured = request;
+        return _json(<String, dynamic>{'Id': 'new-pl'});
+      }));
+
+      final String id = await client.createPlaylist(
+        _session,
+        name: 'My Mix',
+        itemIds: <String>['a', 'b'],
+      );
+
+      expect(id, 'new-pl');
+      expect(captured!.method, 'POST');
+      expect(captured!.url.path, '/Playlists');
+      expect(captured!.url.queryParameters['Name'], 'My Mix');
+      expect(captured!.url.queryParameters['Ids'], 'a,b');
+      expect(captured!.url.queryParameters['UserId'], 'user-1');
+    });
+  });
+
+  group('addItemsToPlaylist', () {
+    test('POSTs item ids to the playlist', () async {
+      http.Request? captured;
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        captured = request;
+        return http.Response('', 204);
+      }));
+
+      await client.addItemsToPlaylist(_session, 'pl-1', <String>['x', 'y']);
+
+      expect(captured!.method, 'POST');
+      expect(captured!.url.path, '/Playlists/pl-1/Items');
+      expect(captured!.url.queryParameters['Ids'], 'x,y');
+    });
+  });
+
+  group('removeItemsFromPlaylist', () {
+    test('resolves entry ids then DELETEs them', () async {
+      final List<http.Request> requests = <http.Request>[];
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        requests.add(request);
+        if (request.method == 'GET') {
+          return _json(<String, dynamic>{
+            'Items': <dynamic>[
+              <String, dynamic>{'Id': 'a', 'PlaylistItemId': 'e-a'},
+              <String, dynamic>{'Id': 'b', 'PlaylistItemId': 'e-b'},
+            ],
+          });
+        }
+        return http.Response('', 204);
+      }));
+
+      await client.removeItemsFromPlaylist(_session, 'pl-1', <String>['b']);
+
+      final http.Request del = requests.firstWhere((r) => r.method == 'DELETE');
+      expect(del.url.path, '/Playlists/pl-1/Items');
+      // Removes by the playlist *entry* id, not the media id.
+      expect(del.url.queryParameters['EntryIds'], 'e-b');
+    });
+  });
+
+  group('deletePlaylist', () {
+    test('DELETEs the playlist item', () async {
+      http.Request? captured;
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        captured = request;
+        return http.Response('', 204);
+      }));
+
+      await client.deletePlaylist(_session, 'pl-1');
+      expect(captured!.method, 'DELETE');
+      expect(captured!.url.path, '/Items/pl-1');
+    });
+  });
+
+  group('error mapping (secret-free)', () {
+    test('401 maps to unauthorized without leaking the token', () async {
+      final HttpJellyfinClient client = _client(
+        MockClient((_) async => http.Response('nope', 401)),
+      );
+
+      Object? caught;
+      try {
+        await client.createPlaylist(_session, name: 'X');
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<JellyfinException>());
+      final JellyfinException error = caught! as JellyfinException;
+      expect(error.kind, JellyfinErrorKind.unauthorized);
+      expect(error.message, isNot(contains(_token)));
+    });
+
+    test('a transport failure maps to notReachable, secret-free', () async {
+      final HttpJellyfinClient client = _client(
+        MockClient((_) async => throw http.ClientException('boom')),
+      );
+
+      Object? caught;
+      try {
+        await client.fetchPlaylists(_session);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<JellyfinException>());
+      final JellyfinException error = caught! as JellyfinException;
+      expect(error.kind, JellyfinErrorKind.notReachable);
+      expect(error.message, isNot(contains(_token)));
+      expect(error.message, isNot(contains('boom')));
+    });
+  });
+}

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -37,6 +37,42 @@ void main() {
       expect(MusicProviders.subsonic.serverUrlLabel, 'Server URL');
       expect(MusicProviders.local.serverUrlLabel, isNull);
     });
+
+    test('remove/delete capabilities are safe by default', () {
+      // Every provider allows the safe, reversible "remove from library".
+      expect(MusicProviders.local.capabilities.canRemoveFromLibrary, isTrue);
+      expect(MusicProviders.jellyfin.capabilities.canRemoveFromLibrary, isTrue);
+      expect(MusicProviders.subsonic.capabilities.canRemoveFromLibrary, isTrue);
+
+      // On-device tracks have no app-managed offline copy to remove; remote
+      // providers do.
+      expect(MusicProviders.local.capabilities.canRemoveOfflineCopy, isFalse);
+      expect(MusicProviders.jellyfin.capabilities.canRemoveOfflineCopy, isTrue);
+
+      // Destructive file/server deletes are not enabled in this release for any
+      // provider, so those actions stay hidden everywhere.
+      for (final caps in <MusicProviderCapabilities>[
+        MusicProviders.local.capabilities,
+        MusicProviders.jellyfin.capabilities,
+        MusicProviders.subsonic.capabilities,
+      ]) {
+        expect(caps.canDeleteLocalFile, isFalse);
+        expect(caps.canDeleteRemoteItem, isFalse);
+      }
+    });
+
+    test('playlist capabilities reflect provider support', () {
+      expect(MusicProviders.local.capabilities.canCreatePlaylist, isTrue);
+      expect(MusicProviders.local.capabilities.canSyncPlaylists, isFalse);
+
+      expect(MusicProviders.jellyfin.capabilities.canCreatePlaylist, isTrue);
+      expect(MusicProviders.jellyfin.capabilities.canEditPlaylist, isTrue);
+      expect(MusicProviders.jellyfin.capabilities.canDeletePlaylist, isTrue);
+      expect(MusicProviders.jellyfin.capabilities.canSyncPlaylists, isTrue);
+
+      // Subsonic playlists aren't synced yet.
+      expect(MusicProviders.subsonic.capabilities.canSyncPlaylists, isFalse);
+    });
   });
 
   group('MusicProviders.forTrackUri', () {

--- a/test/data/repositories/in_memory_music_library_repository_test.dart
+++ b/test/data/repositories/in_memory_music_library_repository_test.dart
@@ -108,5 +108,55 @@ void main() {
       expect(all, contains(_track('local-1')));
       expect(all, contains(_track('jellyfin-1')));
     });
+
+    test('removeTracks drops only the named ids from the index', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a'), _track('b'), _track('c')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      await repository.removeTracks(<String>['b']);
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(all, contains(_track('a')));
+      expect(all, contains(_track('c')));
+      expect(await repository.getTrackById('b'), isNull);
+    });
+
+    test('removeTracks spans sources and leaves others intact', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('local-1')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_track('jelly-1'), _track('jelly-2')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      await repository.removeTracks(<String>['jelly-1']);
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(all, contains(_track('local-1')));
+      expect(all, contains(_track('jelly-2')));
+    });
+
+    test('removeTracks with an empty list is a no-op', () async {
+      await repository.upsertCatalog(
+        sourceId: 'local',
+        tracks: <Track>[_track('a')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.removeTracks(const <String>[]);
+      expect(await repository.getAllTracks(), hasLength(1));
+    });
   });
 }

--- a/test/data/repositories/shared_preferences_playlist_store_test.dart
+++ b/test/data/repositories/shared_preferences_playlist_store_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/data/repositories/shared_preferences_playlist_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String _token = 'super-secret-token-1234567890';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SharedPreferencesPlaylistStore', () {
+    test('round-trips a list of playlists', () async {
+      const SharedPreferencesPlaylistStore store =
+          SharedPreferencesPlaylistStore();
+      final List<Playlist> playlists = <Playlist>[
+        Playlist(
+          id: 'p1',
+          name: 'Local Mix',
+          description: 'desc',
+          trackIds: const <String>['a', 'b'],
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 2),
+        ),
+        const Playlist(
+          id: 'p2',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+          remoteId: 'srv-1',
+          trackIds: <String>['x'],
+          syncState: PlaylistSyncState.synced,
+        ),
+      ];
+
+      await store.save(playlists);
+      final List<Playlist> loaded = await store.load();
+
+      expect(loaded, hasLength(2));
+      expect(loaded[0].name, 'Local Mix');
+      expect(loaded[0].description, 'desc');
+      expect(loaded[0].trackIds, <String>['a', 'b']);
+      expect(loaded[0].createdAt, DateTime(2024, 1, 1));
+      expect(loaded[1].source, PlaylistSource.jellyfin);
+      expect(loaded[1].remoteId, 'srv-1');
+      expect(loaded[1].syncState, PlaylistSyncState.synced);
+    });
+
+    test('returns empty for no stored value', () async {
+      const SharedPreferencesPlaylistStore store =
+          SharedPreferencesPlaylistStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('a corrupt record reads as no playlists', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'playlists_v1': 'not json {',
+      });
+      const SharedPreferencesPlaylistStore store =
+          SharedPreferencesPlaylistStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('never persists a token even if one leaks into a field', () async {
+      // Even if a (bug-introduced) error string carried a token, the persisted
+      // document must not contain it. Here we assert the stored JSON for a
+      // normal playlist has no token, and that lastSyncError is round-tripped
+      // verbatim (we keep errors secret-free at the source).
+      const SharedPreferencesPlaylistStore store =
+          SharedPreferencesPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Mix',
+          source: PlaylistSource.jellyfin,
+          remoteId: 'srv-1',
+        ),
+      ]);
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final String raw = prefs.getString('playlists_v1') ?? '';
+      expect(raw, isNot(contains(_token)));
+      expect(raw, contains('srv-1'));
+    });
+  });
+}

--- a/test/data/repositories/synced_playlist_repository_test.dart
+++ b/test/data/repositories/synced_playlist_repository_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/synced_playlist_repository.dart';
+
+import '../../core/sources/jellyfin/fake_jellyfin_client.dart';
+
+const String _token = 'super-secret-token-1234567890';
+
+const JellyfinSession _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: _token,
+  deviceId: 'device-1',
+);
+
+void main() {
+  group('SyncedPlaylistRepository (local)', () {
+    late InMemoryPlaylistStore store;
+    late SyncedPlaylistRepository repository;
+    late int counter;
+
+    setUp(() {
+      store = InMemoryPlaylistStore();
+      counter = 0;
+      repository = SyncedPlaylistRepository(
+        store: store,
+        idGenerator: () => 'pl-${counter++}',
+        now: () => DateTime(2024, 1, 1),
+      );
+    });
+
+    test('creates a local, local-only playlist and persists it', () async {
+      final Playlist created = await repository.createPlaylist('My Mix');
+      expect(created.name, 'My Mix');
+      expect(created.source, PlaylistSource.local);
+      expect(created.syncState, PlaylistSyncState.localOnly);
+      expect(created.createdAt, DateTime(2024, 1, 1));
+
+      // Persisted to the store.
+      expect(await store.load(), hasLength(1));
+      expect((await repository.getAllPlaylists()).single.name, 'My Mix');
+    });
+
+    test('renames a playlist', () async {
+      final Playlist created = await repository.createPlaylist('Old');
+      await repository.renamePlaylist(created.id, 'New', description: 'desc');
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.name, 'New');
+      expect(updated.description, 'desc');
+    });
+
+    test('deletes a playlist', () async {
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.deletePlaylist(created.id);
+      expect(await repository.getAllPlaylists(), isEmpty);
+      expect(await store.load(), isEmpty);
+    });
+
+    test('adds a track once (no duplicate)', () async {
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.addTrack(created.id, 't1');
+      await repository.addTrack(created.id, 't1');
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.trackIds, <String>['t1']);
+    });
+
+    test('adds multiple tracks preserving order and skipping dupes', () async {
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.addTracks(created.id, <String>['a', 'b']);
+      await repository.addTracks(created.id, <String>['b', 'c']);
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.trackIds, <String>['a', 'b', 'c']);
+    });
+
+    test('removes a track', () async {
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.addTracks(created.id, <String>['a', 'b', 'c']);
+      await repository.removeTrack(created.id, 'b');
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.trackIds, <String>['a', 'c']);
+    });
+
+    test('reorders tracks (ReorderableListView index convention)', () async {
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.addTracks(created.id, <String>['a', 'b', 'c']);
+      // Move 'a' (0) to after 'c': newIndex == length (3).
+      await repository.reorderTracks(created.id, 0, 3);
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.trackIds, <String>['b', 'c', 'a']);
+    });
+
+    test('watch stream emits the current set and every change', () async {
+      final List<List<String>> emissions = <List<String>>[];
+      final sub = repository.playlistsStream.listen(
+        (List<Playlist> ps) =>
+            emissions.add(ps.map((Playlist p) => p.name).toList()),
+      );
+      // Let the generator deliver its initial snapshot and subscribe to the
+      // change stream before mutating, so the change isn't missed.
+      await pumpEventQueue();
+      await repository.createPlaylist('First');
+      await pumpEventQueue();
+      await sub.cancel();
+      expect(emissions.first, isEmpty);
+      expect(emissions.last, <String>['First']);
+    });
+
+    test('markSyncState records the state and a secret-free error', () async {
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.markSyncState(
+        created.id,
+        PlaylistSyncState.syncFailed,
+        error: 'Something went wrong',
+      );
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.syncState, PlaylistSyncState.syncFailed);
+      expect(updated.lastSyncError, 'Something went wrong');
+    });
+
+    test('requesting a Jellyfin playlist while offline stays local', () async {
+      // No client/session configured: a jellyfin request falls back to local.
+      final Playlist created = await repository.createPlaylist(
+        'Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      expect(created.source, PlaylistSource.local);
+      expect(created.syncState, PlaylistSyncState.localOnly);
+    });
+  });
+
+  group('SyncedPlaylistRepository (Jellyfin sync)', () {
+    late InMemoryPlaylistStore store;
+    late FakeJellyfinClient client;
+    late SyncedPlaylistRepository repository;
+    late int counter;
+
+    setUp(() {
+      store = InMemoryPlaylistStore();
+      client = FakeJellyfinClient();
+      counter = 0;
+      repository = SyncedPlaylistRepository(
+        store: store,
+        client: client,
+        session: () => _session,
+        idGenerator: () => 'pl-${counter++}',
+        now: () => DateTime(2024, 1, 1),
+      );
+    });
+
+    test('creates a remote playlist and records the server id', () async {
+      client.createdPlaylistId = 'srv-9';
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      expect(client.createPlaylistCalls.single.name, 'Server Mix');
+      expect(created.source, PlaylistSource.jellyfin);
+      expect(created.remoteId, 'srv-9');
+      expect(created.syncState, PlaylistSyncState.synced);
+      expect(created.lastSyncError, isNull);
+    });
+
+    test('adds a Jellyfin track to a Jellyfin playlist on the server',
+        () async {
+      client.createdPlaylistId = 'srv-1';
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      await repository.addTrack(created.id, 'jelly-item-7');
+      expect(client.addItemCalls.single.playlistId, 'srv-1');
+      expect(client.addItemCalls.single.itemIds, <String>['jelly-item-7']);
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      expect(updated!.syncState, PlaylistSyncState.synced);
+    });
+
+    test('deletes the server playlist when deleting a synced one', () async {
+      client.createdPlaylistId = 'srv-3';
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      await repository.deletePlaylist(created.id);
+      expect(client.deletedPlaylistIds, <String>['srv-3']);
+      expect(await repository.getAllPlaylists(), isEmpty);
+    });
+
+    test('expired session maps to a friendly, secret-free sync error',
+        () async {
+      client.playlistError = JellyfinException.unauthorized();
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      expect(created.syncState, PlaylistSyncState.syncFailed);
+      expect(created.lastSyncError, isNotNull);
+      expect(created.lastSyncError, JellyfinException.unauthorized().message);
+      // The error never leaks the token, and the playlist never stores it.
+      expect(created.lastSyncError, isNot(contains(_token)));
+      expect(created.remoteId, isNull);
+    });
+
+    test('unreachable server maps to a friendly sync error', () async {
+      client.playlistError = JellyfinException.notReachable();
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      expect(created.syncState, PlaylistSyncState.syncFailed);
+      expect(created.lastSyncError, JellyfinException.notReachable().message);
+      expect(created.lastSyncError, isNot(contains(_token)));
+    });
+
+    test('a failed membership push never throws and flags syncFailed',
+        () async {
+      client.createdPlaylistId = 'srv-2';
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      // Now make the next server call fail.
+      client.playlistError = JellyfinException.notReachable();
+      await repository.addTrack(created.id, 'jelly-item-1');
+      final Playlist? updated = await repository.getPlaylistById(created.id);
+      // The local add still stands…
+      expect(updated!.trackIds, contains('jelly-item-1'));
+      // …but the sync state is honest about the failure.
+      expect(updated.syncState, PlaylistSyncState.syncFailed);
+    });
+
+    test('imports remote playlists on refresh', () async {
+      client.playlists = <JellyfinPlaylistDto>[
+        const JellyfinPlaylistDto(id: 'srv-77', name: 'From Server'),
+      ];
+      client.playlistEntries['srv-77'] = <JellyfinPlaylistEntry>[
+        const JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+        const JellyfinPlaylistEntry(itemId: 'b', playlistItemId: 'e-b'),
+      ];
+      await repository.refreshFromRemote();
+      final List<Playlist> all = await repository.getAllPlaylists();
+      expect(all, hasLength(1));
+      expect(all.single.name, 'From Server');
+      expect(all.single.remoteId, 'srv-77');
+      expect(all.single.source, PlaylistSource.jellyfin);
+      expect(all.single.trackIds, <String>['a', 'b']);
+      expect(all.single.syncState, PlaylistSyncState.synced);
+    });
+
+    test('no token is ever stored in playlist metadata', () async {
+      client.createdPlaylistId = 'srv-1';
+      final Playlist created = await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      await repository.addTrack(created.id, 'jelly-item-1');
+      for (final Playlist p in await repository.getAllPlaylists()) {
+        expect(p.remoteId, isNot(contains(_token)));
+        expect(p.id, isNot(contains(_token)));
+        expect(p.lastSyncError ?? '', isNot(contains(_token)));
+        for (final String trackId in p.trackIds) {
+          expect(trackId, isNot(contains(_token)));
+        }
+      }
+    });
+  });
+}

--- a/test/features/library/fake_music_library_repository.dart
+++ b/test/features/library/fake_music_library_repository.dart
@@ -13,10 +13,17 @@ class FakeMusicLibraryRepository implements MusicLibraryRepository {
   final List<Track> tracks;
   final Object? error;
 
+  /// Track ids passed to [removeTracks], in order, so a test can assert that a
+  /// "Remove from Linthra library" action only removed from the index.
+  final List<String> removedTrackIds = <String>[];
+
   @override
   Future<List<Track>> getAllTracks() async {
     if (error != null) throw error!;
-    return tracks;
+    return <Track>[
+      for (final Track track in tracks)
+        if (!removedTrackIds.contains(track.id)) track,
+    ];
   }
 
   @override
@@ -40,4 +47,9 @@ class FakeMusicLibraryRepository implements MusicLibraryRepository {
     required List<Album> albums,
     required List<Artist> artists,
   }) async {}
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {
+    removedTrackIds.addAll(trackIds);
+  }
 }

--- a/test/features/library/library_selection_test.dart
+++ b/test/features/library/library_selection_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+
+import 'fake_music_library_repository.dart';
+import 'fake_remote_track_downloader.dart';
+
+const List<Track> _mixed = <Track>[
+  Track(id: 'a', title: 'Song A', uri: 'file:///a.mp3'),
+  Track(id: 'b', title: 'Song B', uri: 'jellyfin:b'),
+];
+
+Future<FakeMusicLibraryRepository> _pump(
+  WidgetTester tester, {
+  List<Track> tracks = _mixed,
+}) async {
+  final FakeMusicLibraryRepository repository =
+      FakeMusicLibraryRepository(tracks: tracks);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(repository),
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return repository;
+}
+
+void main() {
+  group('Library multi-select', () {
+    testWidgets('long-press enters selection mode and shows the count',
+        (tester) async {
+      await _pump(tester);
+
+      await tester.longPress(find.text('Song A'));
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.tap(find.text('Song B'));
+      await tester.pumpAndSettle();
+      expect(find.text('2 selected'), findsOneWidget);
+    });
+
+    testWidgets('offers safe actions and hides unsafe destructive deletes',
+        (tester) async {
+      await _pump(tester);
+      await tester.longPress(find.text('Song A'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Song B'));
+      await tester.pumpAndSettle();
+
+      // Safe, reversible actions are offered.
+      expect(find.byTooltip('Add to playlist'), findsOneWidget);
+      expect(find.byTooltip('Remove from Linthra'), findsOneWidget);
+      // The Jellyfin track in the selection means offline-copy removal applies.
+      expect(find.byTooltip('Remove offline copies'), findsOneWidget);
+      // Destructive file/server deletes are never offered in this release.
+      expect(find.byTooltip('Delete from server'), findsNothing);
+      expect(find.byTooltip('Delete files'), findsNothing);
+    });
+
+    testWidgets('a local-only selection hides the offline-copy action',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'a', title: 'Song A', uri: 'file:///a.mp3'),
+        ],
+      );
+      await tester.longPress(find.text('Song A'));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Remove from Linthra'), findsOneWidget);
+      expect(find.byTooltip('Remove offline copies'), findsNothing);
+    });
+
+    testWidgets('bulk remove asks for confirmation showing the count',
+        (tester) async {
+      final FakeMusicLibraryRepository repository = await _pump(tester);
+      await tester.longPress(find.text('Song A'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Song B'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Remove from Linthra'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Remove 2 songs from Linthra?'),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Remove'), findsOneWidget);
+
+      // Confirming removes only from the index (the fake records the ids).
+      await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
+      await tester.pumpAndSettle();
+      expect(repository.removedTrackIds, containsAll(<String>['a', 'b']));
+    });
+  });
+}

--- a/test/features/library/track_tile_test.dart
+++ b/test/features/library/track_tile_test.dart
@@ -68,5 +68,84 @@ void main() {
       // No dedicated, always-visible download button on the row anymore.
       expect(find.byTooltip('Download'), findsNothing);
     });
+
+    testWidgets('overflow menu offers add-to-playlist and remove-from-Linthra',
+        (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+      ]);
+
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to playlist'), findsOneWidget);
+      expect(find.text('Remove from Linthra'), findsOneWidget);
+    });
   });
+
+  group('TrackTile selection', () {
+    testWidgets('long-press starts selection', (tester) async {
+      Track? started;
+      await _pumpSelectable(
+        tester,
+        selectionActive: false,
+        onSelectStart: (Track t) => started = t,
+      );
+
+      await tester.longPress(find.text('Song One'));
+      await tester.pumpAndSettle();
+      expect(started?.id, '1');
+    });
+
+    testWidgets('shows a checkbox and toggles while selecting', (tester) async {
+      Track? toggled;
+      await _pumpSelectable(
+        tester,
+        selectionActive: true,
+        selected: false,
+        onSelectToggle: (Track t) => toggled = t,
+      );
+
+      expect(find.byType(Checkbox), findsOneWidget);
+      await tester.tap(find.text('Song One'));
+      await tester.pumpAndSettle();
+      expect(toggled?.id, '1');
+    });
+  });
+}
+
+Future<void> _pumpSelectable(
+  WidgetTester tester, {
+  required bool selectionActive,
+  bool selected = false,
+  void Function(Track track)? onSelectStart,
+  void Function(Track track)? onSelectToggle,
+}) async {
+  const List<Track> tracks = <Track>[
+    Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+  ];
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: TrackTile(
+            tracks: tracks,
+            index: 0,
+            selectable: true,
+            selectionActive: selectionActive,
+            selected: selected,
+            onSelectStart:
+                onSelectStart == null ? null : () => onSelectStart(tracks[0]),
+            onSelectToggle:
+                onSelectToggle == null ? null : () => onSelectToggle(tracks[0]),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
 }

--- a/test/features/player/now_playing_add_to_playlist_test.dart
+++ b/test/features/player/now_playing_add_to_playlist_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/widgets/now_playing_actions.dart';
+
+void main() {
+  testWidgets('Now Playing actions include Add to playlist', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: NowPlayingActions(
+              track: Track(id: '1', title: 'Song One', uri: 'jellyfin:1'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('Add to playlist'), findsOneWidget);
+  });
+}

--- a/test/features/playlists/playlist_detail_screen_test.dart
+++ b/test/features/playlists/playlist_detail_screen_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/playlists/playlist_detail_screen.dart';
+
+import '../library/fake_music_library_repository.dart';
+import '../player/fake_playback_controller.dart';
+
+const List<Track> _tracks = <Track>[
+  Track(id: 'a', title: 'Song A', uri: 'file:///a.mp3'),
+  Track(id: 'b', title: 'Song B', uri: 'file:///b.mp3'),
+];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (_, __) => const PlaylistDetailScreen(playlistId: 'p1'),
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (_, __) => const Scaffold(body: Text('player-screen')),
+      ),
+    ],
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required InMemoryPlaylistStore store,
+  required FakePlaybackController controller,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playlistStoreProvider.overrideWithValue(store),
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: _tracks)),
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<InMemoryPlaylistStore> _seededStore() async {
+  final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+  await store.save(<Playlist>[
+    const Playlist(id: 'p1', name: 'Road Trip', trackIds: <String>['a', 'b']),
+  ]);
+  return store;
+}
+
+void main() {
+  testWidgets('renders the playlist tracks', (tester) async {
+    await _pump(
+      tester,
+      store: await _seededStore(),
+      controller: FakePlaybackController(),
+    );
+    expect(find.text('Road Trip'), findsOneWidget);
+    expect(find.text('Song A'), findsOneWidget);
+    expect(find.text('Song B'), findsOneWidget);
+  });
+
+  testWidgets('Play queues the playlist and opens the player', (tester) async {
+    final FakePlaybackController controller = FakePlaybackController();
+    await _pump(tester, store: await _seededStore(), controller: controller);
+
+    await tester.tap(find.text('Play'));
+    await tester.pumpAndSettle();
+
+    expect(controller.playedTracks.first.id, 'a');
+    // The rest of the playlist is queued behind the first track.
+    expect(controller.state.upNext.map((Track t) => t.id), <String>['b']);
+    expect(find.text('player-screen'), findsOneWidget);
+  });
+
+  testWidgets('tapping a track plays from there and queues the playlist',
+      (tester) async {
+    final FakePlaybackController controller = FakePlaybackController();
+    await _pump(tester, store: await _seededStore(), controller: controller);
+
+    await tester.tap(find.text('Song B'));
+    await tester.pumpAndSettle();
+
+    expect(controller.playedTracks.first.id, 'b');
+    expect(find.text('player-screen'), findsOneWidget);
+  });
+
+  testWidgets('long-press enters selection mode and shows the count',
+      (tester) async {
+    await _pump(
+      tester,
+      store: await _seededStore(),
+      controller: FakePlaybackController(),
+    );
+
+    await tester.longPress(find.text('Song A'));
+    await tester.pumpAndSettle();
+    expect(find.text('1 selected'), findsOneWidget);
+
+    // Selecting another track updates the count.
+    await tester.tap(find.text('Song B'));
+    await tester.pumpAndSettle();
+    expect(find.text('2 selected'), findsOneWidget);
+  });
+}

--- a/test/features/playlists/playlists_screen_test.dart
+++ b/test/features/playlists/playlists_screen_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/playlists/playlists_screen.dart';
+
+Future<void> _pump(
+  WidgetTester tester,
+  InMemoryPlaylistStore store,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playlistStoreProvider.overrideWithValue(store),
+      ],
+      child: const MaterialApp(home: PlaylistsScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('PlaylistsScreen', () {
+    testWidgets('renders the empty state when there are no playlists',
+        (tester) async {
+      await _pump(tester, InMemoryPlaylistStore());
+      expect(find.text('No playlists yet'), findsOneWidget);
+      // Favorites is always pinned at the top.
+      expect(find.text('Favorites'), findsOneWidget);
+      // The create affordance is present.
+      expect(find.widgetWithText(FloatingActionButton, 'New playlist'),
+          findsOneWidget);
+    });
+
+    testWidgets('lists existing playlists with a song count', (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Road Trip',
+          trackIds: <String>['a', 'b'],
+        ),
+      ]);
+      await _pump(tester, store);
+
+      expect(find.text('Road Trip'), findsOneWidget);
+      expect(find.text('2 songs'), findsOneWidget);
+      expect(find.text('No playlists yet'), findsNothing);
+    });
+
+    testWidgets('creating a playlist via the dialog adds it to the list',
+        (tester) async {
+      await _pump(tester, InMemoryPlaylistStore());
+
+      await tester
+          .tap(find.widgetWithText(FloatingActionButton, 'New playlist'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New playlist'), findsWidgets);
+      await tester.enterText(find.byType(TextField).first, 'Chill');
+      await tester.tap(find.widgetWithText(FilledButton, 'Create'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Chill'), findsOneWidget);
+    });
+
+    testWidgets('deleting a playlist asks for confirmation with clear labels',
+        (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Road Trip'),
+      ]);
+      await _pump(tester, store);
+
+      await tester.tap(find.byTooltip('Playlist actions'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(
+          find.textContaining('Delete playlist “Road Trip”?'), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Delete'), findsOneWidget);
+
+      // Confirm the delete and the row disappears.
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+      expect(find.text('Road Trip'), findsNothing);
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -63,6 +63,9 @@ class _RecordingRepository implements MusicLibraryRepository {
 
   @override
   Future<Track?> getTrackById(String id) async => null;
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {}
 }
 
 JellyfinItemDto _audio(String id) => JellyfinItemDto(

--- a/test/features/settings/subsonic/subsonic_sync_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_sync_controller_test.dart
@@ -55,6 +55,9 @@ class _RecordingRepository implements MusicLibraryRepository {
 
   @override
   Future<Track?> getTrackById(String id) async => null;
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {}
 }
 
 SubsonicMusicSource _source({

--- a/test/shared/widgets/confirm_dialog_test.dart
+++ b/test/shared/widgets/confirm_dialog_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/confirm_dialog.dart';
+
+void main() {
+  Future<void> pumpButton(
+    WidgetTester tester, {
+    required void Function(bool result) onResult,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) => TextButton(
+              onPressed: () async {
+                final bool result = await showConfirmDialog(
+                  context,
+                  title: 'Delete 12 files?',
+                  message: 'This cannot be undone.',
+                  confirmLabel: 'Delete',
+                );
+                onResult(result);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('shows the title, message and a Cancel + destructive action',
+      (tester) async {
+    await pumpButton(tester, onResult: (_) {});
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Delete 12 files?'), findsOneWidget);
+    expect(find.text('This cannot be undone.'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Delete'), findsOneWidget);
+    // Never a vague "OK".
+    expect(find.text('OK'), findsNothing);
+  });
+
+  testWidgets('Cancel resolves to false', (tester) async {
+    bool? result;
+    await pumpButton(tester, onResult: (bool r) => result = r);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(result, isFalse);
+  });
+
+  testWidgets('the destructive action resolves to true', (tester) async {
+    bool? result;
+    await pumpButton(tester, onResult: (bool r) => result = r);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+    await tester.pumpAndSettle();
+    expect(result, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Adds user **playlists** (create/edit/reorder/delete, multi-select bulk actions,
play/shuffle) with local persistence and best-effort **Jellyfin sync**, plus a
deliberately-separated, **always-confirmed** model for removing songs that never
deletes real files or server items.

Guiding safety principle: **"Remove from Linthra" and "Delete from
source/server/device" are different actions.** Linthra never silently deletes a
user's music file or a server item.

## Playlist UX

- **Playlists tab**: pinned Favorites entry, "No playlists yet" empty state, a
  "New playlist" FAB, per-row rename/delete (delete confirmed).
- **Playlist detail**: Play / Shuffle, tap-a-track plays from there and queues
  the playlist, drag-to-reorder, per-row "Remove from playlist" (with Undo),
  and multi-select bulk actions. Missing (no-longer-in-catalog) tracks are
  handled gracefully and surfaced honestly.
- **Add to playlist** from the track overflow menu, the Now Playing actions, and
  bulk selection. "New playlist" is reachable from the add sheet too.

## Local playlist behavior

User-authored, ordered collections of stable track ids, persisted via
`shared_preferences` (same lightweight storage as favourites/downloads — **no
drift schema change**, so no codegen needed). Full CRUD + reorder, watchable via
a broadcast stream.

## Jellyfin playlist sync

Best-effort, server-as-source-of-truth for synced playlists:
- List/import remote playlists + their tracks (on launch and refresh).
- Create a Jellyfin playlist; add tracks; remove tracks (resolved by playlist
  *entry* id); delete the server playlist.
- Only Jellyfin tracks can be added to a Jellyfin playlist (friendly decline
  otherwise). A failed server write never throws — the local change stands and
  `syncState` flips to `syncFailed` with a friendly, secret-free message.
- **Documented limitations**: rename/reorder of a synced playlist are local-only
  for now; Subsonic playlist sync is not implemented.

## Safe delete behavior

| Action | Touches | Enabled |
| --- | --- | --- |
| Remove from Linthra library | local catalog/index only | ✅ |
| Remove offline copy | app-managed cache file only | ✅ (cached tracks) |
| Delete local file from device | the real file | ❌ (not wired up safely yet) |
| Delete from server | the Jellyfin item, all devices | ❌ (not enabled) |

`MusicLibraryRepository.removeTracks` removes index rows only (reuses the
existing `Tracks` table). "Remove offline copy" reuses the existing
app-managed-cache `removeDownload`, which only ever touches files in Linthra's
private cache dir — never the user's music folder. The destructive file/server
deletes are modelled in the capability matrix but intentionally **off** until
they can be done robustly and safely (the spec explicitly permits this).

## Bulk actions

Long-press to enter multi-select (Library and playlist detail). The contextual
bar shows the count and only the actions that are safe for the whole selection.
A destructive *delete* is only offered when **every** selected track supports it
(same provider for a server delete), so **mixed-source selections hide unsafe
actions**. The **currently-playing** track is never offline-deleted out from
under playback (skipped + reported).

## Confirmation dialogs

Every destructive action confirms first with an explicit **Cancel** and a clear
destructive label ("Remove" / "Delete") — never a vague "OK". Bulk dialogs show
the count (e.g. "Remove 12 songs from Linthra?").

## Provider capability model

`MusicProviderCapabilities` gains `canRemoveFromLibrary`, `canRemoveOfflineCopy`,
`canDeleteLocalFile`, `canDeleteRemoteItem`, `canCreatePlaylist`,
`canEditPlaylist`, `canDeletePlaylist`, `canSyncPlaylists`, wired for
local/Jellyfin/Subsonic.

## Security / safety notes

- No Jellyfin token or authenticated URL is stored in playlist/delete metadata,
  logged, or surfaced in an error. Errors are friendly and secret-free (tested).
- Offline-cache removal only touches app-managed files, never the music folder.
- Currently-playing cached file is never removed unexpectedly.

## Tests added

57 new tests (792 total passing): playlist model; `SyncedPlaylistRepository`
(create/rename/delete/add/remove/reorder/watch/sync-state + Jellyfin
create/add/delete, expired-session & unreachable → friendly errors, no-token);
shared-prefs store round-trip + no-token; `removeTracks` (index-only);
`bulkActionsFor` (mixed-source hides unsafe); capability matrix; HTTP client
playlist endpoints + secret-free error mapping; confirmation dialog
(Cancel + destructive labels); playlists screen (empty/list/create/delete
confirm); playlist detail (render/play/selection); track tile (add-to-playlist
in overflow, long-press selection); library multi-select (count, mixed-source
hiding, bulk confirm with count); Now Playing add-to-playlist.

## Verification

Run against the CI-pinned Flutter **3.27.4 / Dart 3.6.2**:
- ✅ `flutter pub get`
- ✅ `dart format --set-exit-if-changed .`
- ✅ `flutter analyze` — No issues found
- ✅ `flutter test` — All 792 tests passed
- ⏭️ `flutter build apk --debug` — not run (no Android SDK in this environment)

## Manual Android checklist

1. Create a playlist.
2. Add local and Jellyfin tracks.
3. Play playlist.
4. Rename playlist.
5. Remove a track from playlist.
6. Delete playlist with confirmation.
7. Remove one track from Linthra library; confirm original file/server item remains.
8. Remove offline copy; confirm streaming still works.
9. Long-press to select multiple tracks.
10. Bulk remove from Linthra; confirm count in dialog.
11. Mixed-source selection; confirm unsafe delete actions are hidden.
12. Try deleting a currently-playing cached item; confirm it's blocked/skipped.
13. Confirm no token/sensitive URL appears in UI.

https://claude.ai/code/session_013YhUhSEWcD6B9LpTvZV7MD

---
_Generated by [Claude Code](https://claude.ai/code/session_013YhUhSEWcD6B9LpTvZV7MD)_