### PR TITLE
Add secret-free diagnostics export to Settings

### DIFF
--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -154,8 +154,15 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
 - ☐ Subsonic/Navidrome connect: test, sign in, sign out & clear.
 - ☐ Sign out resets the sync status line (no stale "Synced N tracks" after
   signing back in). *(Fixed this release.)*
-- ☐ "Copy diagnostics" after a **failed** test of a different address does not
-  report the previously-seen server. *(Fixed this release.)*
+- ☐ "Copy Jellyfin diagnostics" after a **failed** test of a different address
+  does not report the previously-seen server. *(Fixed this release.)*
+- ☐ **Diagnostics card**: "Copy diagnostics" copies the app snapshot to the
+  clipboard and shows the "no passwords, tokens, or URLs" confirmation; pasting
+  it shows app version, connection state, server **host only**, counts, and
+  feature status — and **no** token, password, `Authorization` header, or full
+  authenticated URL (see §12).
+- ☐ "Save diagnostics" writes the same snapshot and confirms with a **redacted**
+  location (basename only, never the private app directory path).
 - ☐ Cache settings: change the limit (persists); clear cache (confirms first).
 - ☐ Pre-cache settings: toggle + count persist.
 - ☐ Version display matches the build; about/privacy links present.
@@ -176,6 +183,41 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
 - ☐ Dark theme is consistent; the violet + warm-orange palette is consistent.
 - ☐ Loading / error / empty states are friendly everywhere.
 - ☐ Destructive actions (delete playlist, clear cache) confirm first.
+
+---
+
+## Reporting a bug (for testers and users)
+
+When something goes wrong, attach a diagnostics snapshot so it can be triaged
+without a back-and-forth — and without you having to share anything sensitive.
+
+**How to copy diagnostics**
+
+1. Open **Settings ▸ Diagnostics**.
+2. Tap **Copy diagnostics** (or **Save diagnostics** to write a
+   `linthra-diagnostics.txt` file). A confirmation appears.
+3. Paste it into your bug report.
+
+The snapshot is **secret-free by design**: it carries the app version, Android
+version and device model (when available), the Jellyfin/Subsonic connection
+state and **server host only**, the library track count, cache used/limit, the
+current playback output, the last safe error kind, and feature status (Cast,
+Android Auto, offline cache, smart pre-cache). It **never** includes your
+password, any token, an `Authorization` header, or a full authenticated URL — so
+it is safe to paste into a public issue.
+
+**What to include in a bug report**
+
+- The pasted **diagnostics** snapshot (above).
+- **What you did** — the exact steps to reproduce, in order.
+- **What you expected** vs. **what happened**.
+- **How often** it happens (every time / sometimes / once).
+- Your **server type** (Jellyfin / Navidrome / Subsonic) if it's connection-,
+  sync-, streaming-, or cast-related.
+- A screenshot or screen recording if it's a UI/layout issue.
+
+Please **do not** paste raw `logcat` output, your server URL with credentials,
+or any token — the diagnostics snapshot already has the safe details needed.
 
 ---
 

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -1,0 +1,175 @@
+import '../models/cache_size.dart';
+
+/// An immutable, display-safe snapshot of everything the diagnostics report can
+/// show. Built by the collector from live app state and rendered by
+/// [AppDiagnostics.report].
+///
+/// Security: by construction this object can only ever hold non-secret,
+/// report-safe values. There is no field for a password, token, `Authorization`
+/// header, salt, or a full authenticated URL. The server addresses are reduced
+/// to host[:port] by [AppDiagnostics.hostOnly] when rendered, the last error is
+/// a stable enum *name* (never a raw error string that could carry a path or
+/// server response), and any device-supplied free text is omitted rather than
+/// risk leaking a private path. This mirrors the "diagnostic, never secret" rule
+/// the per-source `JellyfinDiagnostics`/`PlaybackDiagnostics` already hold.
+class AppDiagnosticsData {
+  const AppDiagnosticsData({
+    required this.appVersion,
+    this.androidVersion,
+    this.deviceModel,
+    this.jellyfinState,
+    this.jellyfinHost,
+    this.subsonicState,
+    this.subsonicHost,
+    this.libraryTrackCount,
+    this.cacheUsedBytes,
+    this.cacheLimitBytes,
+    this.playbackOutput,
+    this.lastErrorKind,
+    this.castAvailable = false,
+    this.castConnected = false,
+    this.androidAutoSupported = false,
+    this.offlineCacheEnabled = false,
+    this.smartPrecacheEnabled,
+  });
+
+  /// The app `versionName` (e.g. `0.1.0-alpha.15`). Always present.
+  final String appVersion;
+
+  /// The Android OS version string, when running on Android. Null elsewhere.
+  final String? androidVersion;
+
+  /// The device model, when a platform source for it is available. Null
+  /// otherwise — never a guess.
+  final String? deviceModel;
+
+  /// The Jellyfin connection state label (e.g. `connected`), when Jellyfin has
+  /// been touched at all. Null when there is nothing to report.
+  final String? jellyfinState;
+
+  /// The Jellyfin server address. Rendered host-only; never a full URL.
+  final String? jellyfinHost;
+
+  /// The Subsonic/Navidrome connection state label, when present. Null when the
+  /// user has never used Subsonic.
+  final String? subsonicState;
+
+  /// The Subsonic/Navidrome server address. Rendered host-only.
+  final String? subsonicHost;
+
+  /// How many tracks are in the local catalog, when known.
+  final int? libraryTrackCount;
+
+  /// App-managed cache bytes in use, when known.
+  final int? cacheUsedBytes;
+
+  /// The configured cache limit in bytes, when known.
+  final int? cacheLimitBytes;
+
+  /// Which output is producing sound now: `local`, `cast`, or `android auto`.
+  /// Null when nothing is playing / not known.
+  final String? playbackOutput;
+
+  /// The stable name of the last safe error kind (an enum name), when one
+  /// occurred. Never a raw error message.
+  final String? lastErrorKind;
+
+  final bool castAvailable;
+  final bool castConnected;
+  final bool androidAutoSupported;
+  final bool offlineCacheEnabled;
+
+  /// Whether smart pre-cache is on, when the preference is known. Null when not
+  /// loaded.
+  final bool? smartPrecacheEnabled;
+}
+
+/// Builds the secret-free text the Settings ▸ Diagnostics "Copy"/"Save" actions
+/// produce, so a user can paste it into a bug report without leaking anything
+/// sensitive.
+///
+/// Security invariant: every field is rendered from the display-safe
+/// [AppDiagnosticsData], and the two server-address fields are always passed
+/// through [hostOnly] here — so even if a caller mistakenly handed in a full
+/// authenticated URL, only its host[:port] can ever reach the output. There is
+/// no parameter for a password, token, `Authorization` header, or raw server
+/// response.
+abstract final class AppDiagnostics {
+  /// Assembles the multi-line report. Only [AppDiagnosticsData.appVersion] is
+  /// guaranteed present; every other line is emitted only when its value is
+  /// known, so the report is useful even before a connection or a library sync.
+  static String report(AppDiagnosticsData data) {
+    final String? jellyfinHost = hostOnly(data.jellyfinHost);
+    final String? subsonicHost = hostOnly(data.subsonicHost);
+    final String? cache = _cacheLine(data);
+    final List<String> lines = <String>[
+      'Linthra diagnostics',
+      'App version: ${data.appVersion}',
+      if (_has(data.androidVersion)) 'Android: ${data.androidVersion}',
+      if (_has(data.deviceModel)) 'Device: ${data.deviceModel}',
+      if (data.jellyfinState != null) 'Jellyfin: ${data.jellyfinState}',
+      if (jellyfinHost != null) 'Jellyfin host: $jellyfinHost',
+      if (data.subsonicState != null) 'Subsonic: ${data.subsonicState}',
+      if (subsonicHost != null) 'Subsonic host: $subsonicHost',
+      if (data.libraryTrackCount != null)
+        'Library tracks: ${data.libraryTrackCount}',
+      if (cache != null) cache,
+      if (data.playbackOutput != null)
+        'Playback output: ${data.playbackOutput}',
+      'Last error: ${data.lastErrorKind ?? 'none'}',
+      'Cast available: ${_yesNo(data.castAvailable)}',
+      'Cast connected: ${_yesNo(data.castConnected)}',
+      'Android Auto supported: ${_yesNo(data.androidAutoSupported)}',
+      'Offline cache: ${_enabledDisabled(data.offlineCacheEnabled)}',
+      if (data.smartPrecacheEnabled != null)
+        'Smart pre-cache: ${_enabledDisabled(data.smartPrecacheEnabled!)}',
+    ];
+    return lines.join('\n');
+  }
+
+  static String? _cacheLine(AppDiagnosticsData data) {
+    final int? used = data.cacheUsedBytes;
+    final int? limit = data.cacheLimitBytes;
+    if (used == null || limit == null) return null;
+    return 'Cache: ${CacheSize.formatBytes(used)} of '
+        '${CacheSize.formatBytes(limit)}';
+  }
+
+  static bool _has(String? value) => value != null && value.isNotEmpty;
+
+  /// Reduces a server address to just its host (and port), dropping the scheme,
+  /// path, query, userinfo, and fragment — so a full authenticated URL can never
+  /// carry a token, an `api_key` query, or a `user:pass@` prefix into the
+  /// report. Accepts a bare host (`music.example.com[:8096]`) too, returning it
+  /// reduced. Returns null when [value] is empty or has no host.
+  static String? hostOnly(String? value) {
+    if (value == null) return null;
+    final String trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    Uri? uri = Uri.tryParse(trimmed);
+    if (uri == null || uri.host.isEmpty) {
+      // No scheme present: re-parse as a bare authority so a value like
+      // `music.example.com:8096` (or one with a stray path) still reduces.
+      uri = Uri.tryParse('//$trimmed');
+    }
+    if (uri == null || uri.host.isEmpty) return null;
+    return uri.hasPort ? '${uri.host}:${uri.port}' : uri.host;
+  }
+
+  /// Redacts a local filesystem path to just its basename behind a `…/` marker,
+  /// so a diagnostic that must mention a file never reveals the private,
+  /// user-identifying directory tree leading to it. Returns null for null/empty.
+  static String? redactPath(String? path) {
+    if (path == null) return null;
+    final String trimmed = path.trim();
+    if (trimmed.isEmpty) return null;
+    final int slash = trimmed.lastIndexOf(RegExp(r'[/\\]'));
+    if (slash < 0) return trimmed;
+    final String basename = trimmed.substring(slash + 1);
+    return basename.isEmpty ? '…' : '…/$basename';
+  }
+
+  static String _yesNo(bool value) => value ? 'yes' : 'no';
+
+  static String _enabledDisabled(bool value) => value ? 'enabled' : 'disabled';
+}

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -1,0 +1,148 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/app_info.dart';
+import '../../../core/diagnostics/app_diagnostics.dart';
+import '../../../core/models/active_playback_output.dart';
+import '../../../core/models/cast_state.dart';
+import '../../../core/services/active_playback_controller.dart';
+import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../downloads/download_providers.dart';
+import '../../player/cast/cast_providers.dart';
+import '../../player/player_providers.dart';
+import '../jellyfin/jellyfin_settings_controller.dart';
+import '../jellyfin/jellyfin_settings_state.dart';
+import '../subsonic/subsonic_settings_controller.dart';
+import '../subsonic/subsonic_settings_state.dart';
+
+/// Gathers the live, display-safe app state into an [AppDiagnosticsData] and
+/// renders it through [AppDiagnostics].
+///
+/// It only ever reads already-secret-free values — the settings *states* (which
+/// hold no token/password by design), host-only addresses, counts, and feature
+/// flags — so nothing sensitive can be assembled here in the first place. The
+/// rendering step ([AppDiagnostics.report]) is the second guard: it forces both
+/// server addresses through `hostOnly`.
+class DiagnosticsCollector {
+  DiagnosticsCollector(this._ref);
+
+  final Ref _ref;
+
+  /// Builds the secret-free report text for the Copy/Save actions. Reads the
+  /// library track count asynchronously; everything else is read synchronously
+  /// from the current provider state.
+  Future<String> buildReport() async {
+    return AppDiagnostics.report(await _collect());
+  }
+
+  Future<AppDiagnosticsData> _collect() async {
+    final JellyfinSettingsState jellyfin =
+        _ref.read(jellyfinSettingsControllerProvider);
+    final SubsonicSettingsState subsonic =
+        _ref.read(subsonicSettingsControllerProvider);
+    final CastState cast = _ref.read(castServiceProvider).state;
+
+    return AppDiagnosticsData(
+      appVersion: AppInfo.version,
+      androidVersion: _androidVersion(),
+      // No device-model plugin is bundled, so this stays null rather than a
+      // guess; the report omits the line entirely when absent.
+      deviceModel: null,
+      jellyfinState: _jellyfinStateLabel(jellyfin.phase),
+      jellyfinHost: jellyfin.baseUrl,
+      subsonicState: _subsonicStateLabel(subsonic),
+      subsonicHost: subsonic.baseUrl,
+      libraryTrackCount: await _libraryTrackCount(),
+      cacheUsedBytes: _cacheUsedBytes(),
+      cacheLimitBytes: _cacheLimitBytes(),
+      playbackOutput: _playbackOutput(),
+      lastErrorKind: jellyfin.errorKind?.name ?? subsonic.errorKind?.name,
+      castAvailable: cast.isAvailable,
+      castConnected: cast.isConnected,
+      androidAutoSupported: _androidAutoSupported(),
+      // Offline caching/downloads are always available in the app; there is no
+      // user switch that turns the cache off.
+      offlineCacheEnabled: true,
+      smartPrecacheEnabled: _ref.read(smartPrecacheEnabledProvider).valueOrNull,
+    );
+  }
+
+  String? _androidVersion() =>
+      Platform.isAndroid ? Platform.operatingSystemVersion : null;
+
+  bool _androidAutoSupported() => Platform.isAndroid;
+
+  String _jellyfinStateLabel(JellyfinConnectionPhase phase) {
+    switch (phase) {
+      case JellyfinConnectionPhase.connected:
+        return 'connected';
+      case JellyfinConnectionPhase.tested:
+        return 'tested (not signed in)';
+      case JellyfinConnectionPhase.testing:
+        return 'testing';
+      case JellyfinConnectionPhase.signingIn:
+        return 'signing in';
+      case JellyfinConnectionPhase.disconnected:
+        return 'disconnected';
+    }
+  }
+
+  /// Subsonic is optional, so it is only reported once the user has touched it
+  /// (a connection in progress, established, or at least an address entered).
+  String? _subsonicStateLabel(SubsonicSettingsState state) {
+    final bool present = state.phase != SubsonicConnectionPhase.disconnected ||
+        (state.baseUrl != null && state.baseUrl!.isNotEmpty);
+    if (!present) return null;
+    switch (state.phase) {
+      case SubsonicConnectionPhase.connected:
+        return 'connected';
+      case SubsonicConnectionPhase.tested:
+        return 'tested (not signed in)';
+      case SubsonicConnectionPhase.testing:
+        return 'testing';
+      case SubsonicConnectionPhase.signingIn:
+        return 'signing in';
+      case SubsonicConnectionPhase.disconnected:
+        return 'disconnected';
+    }
+  }
+
+  Future<int?> _libraryTrackCount() async {
+    try {
+      final tracks =
+          await _ref.read(musicLibraryRepositoryProvider).getAllTracks();
+      return tracks.length;
+    } catch (_) {
+      // A storage hiccup must not break the report; just omit the count.
+      return null;
+    }
+  }
+
+  int? _cacheUsedBytes() =>
+      _ref.read(cacheSnapshotProvider).valueOrNull?.usedBytes;
+
+  int? _cacheLimitBytes() =>
+      _ref.read(maxCacheBytesControllerProvider).valueOrNull;
+
+  String? _playbackOutput() {
+    final controller = _ref.read(playbackControllerProvider);
+    if (controller is! ActivePlaybackController) return null;
+    switch (controller.activeOutput) {
+      case ActivePlaybackOutput.local:
+        return 'local';
+      case ActivePlaybackOutput.cast:
+        return 'cast';
+    }
+  }
+}
+
+/// Builds the secret-free diagnostics report text on demand.
+typedef DiagnosticsReportBuilder = Future<String> Function();
+
+/// The report builder the Diagnostics section invokes. Production wires it to a
+/// live [DiagnosticsCollector]; tests override it with a stub so the widget can
+/// be exercised without the playback/cast plugins behind the collector.
+final diagnosticsReportBuilderProvider = Provider<DiagnosticsReportBuilder>(
+  (ref) => DiagnosticsCollector(ref).buildReport,
+);

--- a/lib/features/settings/diagnostics/diagnostics_settings_section.dart
+++ b/lib/features/settings/diagnostics/diagnostics_settings_section.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/diagnostics/app_diagnostics.dart';
+import 'diagnostics_collector.dart';
+
+/// The Diagnostics card on the Settings screen.
+///
+/// Lets a user copy (or save) a secret-free snapshot of the app's state to paste
+/// into a bug report. The text is assembled by [DiagnosticsCollector] and, by
+/// construction, carries no password, token, `Authorization` header, or full
+/// authenticated URL — only host-only addresses, counts, and feature flags.
+class DiagnosticsSettingsSection extends ConsumerStatefulWidget {
+  const DiagnosticsSettingsSection({super.key});
+
+  @override
+  ConsumerState<DiagnosticsSettingsSection> createState() =>
+      _DiagnosticsSettingsSectionState();
+}
+
+class _DiagnosticsSettingsSectionState
+    extends ConsumerState<DiagnosticsSettingsSection> {
+  bool _busy = false;
+
+  Future<void> _copy() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final String report =
+          await ref.read(diagnosticsReportBuilderProvider)();
+      await Clipboard.setData(ClipboardData(text: report));
+      _showSnack('Diagnostics copied (no passwords, tokens, or URLs).');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _save() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final String report =
+          await ref.read(diagnosticsReportBuilderProvider)();
+      final Directory dir = await getApplicationDocumentsDirectory();
+      final File file = File('${dir.path}/linthra-diagnostics.txt');
+      await file.writeAsString(report, flush: true);
+      // Show only the redacted basename — never the private app directory path.
+      _showSnack('Saved to ${AppDiagnostics.redactPath(file.path)}.');
+    } catch (_) {
+      _showSnack("Couldn't save diagnostics. Try Copy instead.");
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _showSnack(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.bug_report_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Diagnostics', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Copy a safe snapshot of the app to paste into a bug report. It '
+              'never includes your password, tokens, or full server URLs — just '
+              'versions, connection state, server host, counts, and feature '
+              'status.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton.tonalIcon(
+                    onPressed: _busy ? null : _copy,
+                    icon: const Icon(Icons.copy_outlined),
+                    label: const Text('Copy diagnostics'),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _busy ? null : _save,
+                    icon: const Icon(Icons.save_alt_outlined),
+                    label: const Text('Save diagnostics'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/diagnostics/diagnostics_settings_section.dart
+++ b/lib/features/settings/diagnostics/diagnostics_settings_section.dart
@@ -31,8 +31,7 @@ class _DiagnosticsSettingsSectionState
     if (_busy) return;
     setState(() => _busy = true);
     try {
-      final String report =
-          await ref.read(diagnosticsReportBuilderProvider)();
+      final String report = await ref.read(diagnosticsReportBuilderProvider)();
       await Clipboard.setData(ClipboardData(text: report));
       _showSnack('Diagnostics copied (no passwords, tokens, or URLs).');
     } finally {
@@ -44,8 +43,7 @@ class _DiagnosticsSettingsSectionState
     if (_busy) return;
     setState(() => _busy = true);
     try {
-      final String report =
-          await ref.read(diagnosticsReportBuilderProvider)();
+      final String report = await ref.read(diagnosticsReportBuilderProvider)();
       final Directory dir = await getApplicationDocumentsDirectory();
       final File file = File('${dir.path}/linthra-diagnostics.txt');
       await file.writeAsString(report, flush: true);

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -4,6 +4,7 @@ import '../../app/dimens.dart';
 import '../../core/app_info.dart';
 import '../../shared/widgets/linthra_logo_mark.dart';
 import 'cache/cache_settings_section.dart';
+import 'diagnostics/diagnostics_settings_section.dart';
 import 'jellyfin/jellyfin_settings_section.dart';
 import 'precache/precache_settings_section.dart';
 import 'subsonic/subsonic_settings_section.dart';
@@ -27,6 +28,8 @@ class SettingsScreen extends StatelessWidget {
           CacheSettingsSection(),
           SizedBox(height: AppSpacing.md),
           PrecacheSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          DiagnosticsSettingsSection(),
           SizedBox(height: AppSpacing.md),
           _AboutCard(),
         ],

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/app_diagnostics.dart';
+import 'package:linthra/core/models/cache_size.dart';
+
+void main() {
+  group('AppDiagnostics.hostOnly', () {
+    test('reduces a full base URL to its host', () {
+      expect(
+        AppDiagnostics.hostOnly('https://music.example.com/jellyfin'),
+        'music.example.com',
+      );
+    });
+
+    test('keeps a port when present', () {
+      expect(
+        AppDiagnostics.hostOnly('http://192.168.1.10:8096'),
+        '192.168.1.10:8096',
+      );
+    });
+
+    test('reduces a bare host (no scheme), keeping its port', () {
+      expect(AppDiagnostics.hostOnly('music.example.com'), 'music.example.com');
+      expect(
+        AppDiagnostics.hostOnly('music.example.com:8096'),
+        'music.example.com:8096',
+      );
+    });
+
+    test('drops scheme, path, query, and userinfo so no secret rides along',
+        () {
+      final String? host = AppDiagnostics.hostOnly(
+        'https://user:pass@music.example.com/Audio/t1/stream?api_key=secret',
+      );
+      expect(host, 'music.example.com');
+      expect(host, isNot(contains('secret')));
+      expect(host, isNot(contains('api_key')));
+      expect(host, isNot(contains('pass')));
+      expect(host, isNot(contains('https')));
+    });
+
+    test('returns null for null or empty input', () {
+      expect(AppDiagnostics.hostOnly(null), isNull);
+      expect(AppDiagnostics.hostOnly(''), isNull);
+      expect(AppDiagnostics.hostOnly('   '), isNull);
+    });
+  });
+
+  group('AppDiagnostics.redactPath', () {
+    test('reduces a private path to its basename behind a marker', () {
+      expect(
+        AppDiagnostics.redactPath('/data/user/0/com.linthra/files/diag.txt'),
+        '…/diag.txt',
+      );
+    });
+
+    test('redacts so the private directory tree never appears', () {
+      final String? redacted =
+          AppDiagnostics.redactPath('/home/alice/secret-folder/diag.txt');
+      expect(redacted, '…/diag.txt');
+      expect(redacted, isNot(contains('alice')));
+      expect(redacted, isNot(contains('secret-folder')));
+    });
+
+    test('returns null for null/empty', () {
+      expect(AppDiagnostics.redactPath(null), isNull);
+      expect(AppDiagnostics.redactPath(''), isNull);
+    });
+  });
+
+  group('AppDiagnostics.report', () {
+    test('includes the requested diagnostic fields', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0-alpha.15',
+          androidVersion: 'Android 14 (API 34)',
+          deviceModel: 'Pixel 7',
+          jellyfinState: 'connected',
+          jellyfinHost: 'music.example.com',
+          subsonicState: 'disconnected',
+          subsonicHost: 'navi.example.com',
+          libraryTrackCount: 1234,
+          cacheUsedBytes: 2 * CacheSize.bytesPerGb,
+          cacheLimitBytes: 4 * CacheSize.bytesPerGb,
+          playbackOutput: 'cast',
+          lastErrorKind: 'unauthorized',
+          castAvailable: true,
+          castConnected: true,
+          androidAutoSupported: true,
+          offlineCacheEnabled: true,
+          smartPrecacheEnabled: false,
+        ),
+      );
+
+      expect(report, contains('Linthra diagnostics'));
+      expect(report, contains('App version: 0.1.0-alpha.15'));
+      expect(report, contains('Android: Android 14 (API 34)'));
+      expect(report, contains('Device: Pixel 7'));
+      expect(report, contains('Jellyfin: connected'));
+      expect(report, contains('Jellyfin host: music.example.com'));
+      expect(report, contains('Subsonic: disconnected'));
+      expect(report, contains('Subsonic host: navi.example.com'));
+      expect(report, contains('Library tracks: 1234'));
+      expect(report, contains('Cache: 2 GB of 4 GB'));
+      expect(report, contains('Playback output: cast'));
+      expect(report, contains('Last error: unauthorized'));
+      expect(report, contains('Cast available: yes'));
+      expect(report, contains('Cast connected: yes'));
+      expect(report, contains('Android Auto supported: yes'));
+      expect(report, contains('Offline cache: enabled'));
+      expect(report, contains('Smart pre-cache: disabled'));
+    });
+
+    test('omits absent optional fields but always reports app version', () {
+      final String report =
+          AppDiagnostics.report(const AppDiagnosticsData(appVersion: '0.1.0'));
+
+      expect(report, contains('App version: 0.1.0'));
+      expect(report, isNot(contains('Android:')));
+      expect(report, isNot(contains('Device:')));
+      expect(report, isNot(contains('Jellyfin:')));
+      expect(report, isNot(contains('Jellyfin host:')));
+      expect(report, isNot(contains('Subsonic:')));
+      expect(report, isNot(contains('Library tracks:')));
+      expect(report, isNot(contains('Cache:')));
+      expect(report, isNot(contains('Playback output:')));
+      expect(report, isNot(contains('Smart pre-cache:')));
+      // No error → reported explicitly as none.
+      expect(report, contains('Last error: none'));
+      // Booleans default to the safe/off side.
+      expect(report, contains('Cast available: no'));
+      expect(report, contains('Offline cache: disabled'));
+    });
+
+    test(
+        'never emits a token, password, or full authenticated URL even when a '
+        'caller mistakenly passes one as a host', () {
+      // The two host fields are forced through hostOnly by report(), so even a
+      // full authenticated URL handed in cannot leak its token/credentials.
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          jellyfinState: 'connected',
+          jellyfinHost:
+              'https://user:hunter2@music.example.com/Audio/t1/stream'
+                  '?api_key=tok-secret',
+          subsonicState: 'connected',
+          subsonicHost:
+              'https://navi.example.com/rest/stream.view?u=bob&p=enc:abcdef'
+                  '&t=md5tok&s=salt123',
+          lastErrorKind: 'unauthorized',
+        ),
+      );
+
+      expect(report, contains('Jellyfin host: music.example.com'));
+      expect(report, contains('Subsonic host: navi.example.com'));
+      // None of the secret material survives.
+      expect(report, isNot(contains('tok-secret')));
+      expect(report, isNot(contains('api_key')));
+      expect(report, isNot(contains('hunter2')));
+      expect(report, isNot(contains('md5tok')));
+      expect(report, isNot(contains('salt123')));
+      expect(report, isNot(contains('enc:')));
+      expect(report, isNot(contains('/Audio/')));
+      expect(report, isNot(contains('/rest/')));
+      expect(report.toLowerCase(), isNot(contains('password')));
+      expect(report.toLowerCase(), isNot(contains('authorization')));
+      expect(report.toLowerCase(), isNot(contains('bearer')));
+    });
+  });
+}

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -140,13 +140,12 @@ void main() {
         const AppDiagnosticsData(
           appVersion: '0.1.0',
           jellyfinState: 'connected',
-          jellyfinHost:
-              'https://user:hunter2@music.example.com/Audio/t1/stream'
-                  '?api_key=tok-secret',
+          jellyfinHost: 'https://user:hunter2@music.example.com/Audio/t1/stream'
+              '?api_key=tok-secret',
           subsonicState: 'connected',
           subsonicHost:
               'https://navi.example.com/rest/stream.view?u=bob&p=enc:abcdef'
-                  '&t=md5tok&s=salt123',
+              '&t=md5tok&s=salt123',
           lastErrorKind: 'unauthorized',
         ),
       );

--- a/test/features/settings/diagnostics/diagnostics_settings_section_test.dart
+++ b/test/features/settings/diagnostics/diagnostics_settings_section_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/diagnostics/diagnostics_collector.dart';
+import 'package:linthra/features/settings/diagnostics/diagnostics_settings_section.dart';
+
+const String _fakeReport = 'Linthra diagnostics\n'
+    'App version: 0.1.0-test\n'
+    'Jellyfin host: music.example.com\n'
+    'Last error: none';
+
+Future<void> _pumpSection(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        diagnosticsReportBuilderProvider.overrideWithValue(
+          () async => _fakeReport,
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: DiagnosticsSettingsSection()),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('DiagnosticsSettingsSection', () {
+    testWidgets('shows the Copy and Save actions', (tester) async {
+      await _pumpSection(tester);
+      expect(find.text('Diagnostics'), findsOneWidget);
+      expect(find.text('Copy diagnostics'), findsOneWidget);
+      expect(find.text('Save diagnostics'), findsOneWidget);
+    });
+
+    testWidgets('Copy puts the secret-free report on the clipboard',
+        (tester) async {
+      final List<MethodCall> clipboardCalls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardCalls.add(call);
+          }
+          return null;
+        },
+      );
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await _pumpSection(tester);
+
+      await tester.tap(find.text('Copy diagnostics'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(clipboardCalls, hasLength(1));
+      final Map<dynamic, dynamic> args =
+          clipboardCalls.single.arguments as Map<dynamic, dynamic>;
+      final String copied = args['text'] as String;
+      expect(copied, _fakeReport);
+      expect(copied, contains('App version:'));
+      expect(copied, isNot(contains('api_key')));
+
+      // The confirmation SnackBar appears.
+      expect(
+        find.textContaining('Diagnostics copied'),
+        findsOneWidget,
+      );
+
+      // Let the SnackBar's auto-dismiss timer fire so no timers are pending.
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **Settings ▸ Diagnostics** card so alpha testers can attach a safe app snapshot to bug reports without leaking secrets.

- **Copy diagnostics** — puts a secret-free report on the clipboard.
- **Save diagnostics** — writes the same report to `linthra-diagnostics.txt` and confirms with a **redacted** path (basename only).
- The report includes: app version; Android version and device model (when available); Jellyfin/Subsonic connection state and **server host only**; library track count; cache used/limit; current playback output (local/cast); last safe error kind; and Cast / Android Auto / offline-cache / smart-pre-cache status.

## Security

By construction the report can only emit display-safe values — there is no field for a password, token, `Authorization` header, salt, or full URL. As a second guard, both server addresses are always forced through a host-only reducer at render time, so even a full authenticated URL handed in cannot leak its token/credentials. The last error is a stable enum *name*, never a raw error string. Saved-file paths are shown redacted.

## Implementation

- `lib/core/diagnostics/app_diagnostics.dart` — pure, testable report builder + `hostOnly`/`redactPath` helpers.
- `lib/features/settings/diagnostics/diagnostics_collector.dart` — gathers live state and exposes a `diagnosticsReportBuilderProvider` (function-typed so the widget is testable without playback/cast plugins).
- `lib/features/settings/diagnostics/diagnostics_settings_section.dart` — the card; wired into `settings_screen.dart`.

## Tests

- `test/core/diagnostics/app_diagnostics_test.dart` — host-only/path redaction, field rendering, omission of absent fields, and **proof no secret leaks** even when a full authenticated URL (with token/userinfo/query secrets) is passed as a host.
- `test/features/settings/diagnostics/diagnostics_settings_section_test.dart` — Copy puts the report on the clipboard and shows the confirmation.

## Docs

- `docs/manual-test-checklist.md` — Settings checklist items for the Diagnostics card, plus a new **Reporting a bug** section: how to copy diagnostics and what to include.

## Test plan

> Note: this environment has no Flutter/Dart SDK, so the commands below were **not** run here and should be run by a reviewer.

- [ ] `flutter pub get`
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] Manual: Settings ▸ Diagnostics ▸ Copy, paste, confirm no token/password/URL.

https://claude.ai/code/session_01MrJHzkMXdg9dzV5YGYPSKT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrJHzkMXdg9dzV5YGYPSKT)_