### PR TITLE
docs: polish README for public alpha and add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report something that doesn't work in the Linthra alpha.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing Linthra! This is alpha software, so rough edges are
+        expected — clear reports help a lot.
+
+        **Tip:** open **Settings → Diagnostics → Copy diagnostics** in the app
+        and paste the result below. It's secret-free by construction (no
+        password, token, or full server URL — just versions, connection state,
+        server host, counts, and feature flags).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+      placeholder: I tapped a synced Jellyfin track and expected it to play, but…
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps so it can be reproduced.
+      placeholder: |
+        1. Go to Settings → Jellyfin and sign in
+        2. Sync the library
+        3. Tap a track
+        4. See the error
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: Paste the output of Settings → Diagnostics → Copy diagnostics.
+      render: text
+    validations:
+      required: false
+  - type: dropdown
+    id: install-source
+    attributes:
+      label: Install source
+      options:
+        - GitHub Releases APK
+        - Obtainium
+        - Self-built APK (flutter build)
+        - Other / not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: setup
+    attributes:
+      label: What were you using?
+      options:
+        - label: Local files
+        - label: Jellyfin
+        - label: Navidrome / Subsonic
+        - label: Android Auto
+        - label: Chromecast / Cast
+        - label: Offline cache / downloads
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs (optional)
+      description: |
+        For playback or Android Auto issues, a logcat capture often helps.
+        Linthra's own log lines are secret-free by design:
+        `adb logcat | grep -i linthra`
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Jellyfin setup & troubleshooting
+    url: https://github.com/thezupzup/linthra/blob/main/docs/jellyfin-compatibility.md
+    about: Connection, Cloudflare, and "how to report without leaking secrets" notes.
+  - name: Android Auto troubleshooting
+    url: https://github.com/thezupzup/linthra/blob/main/docs/android-auto.md
+    about: Why a sideloaded build may not appear, and how to test on a head unit.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an improvement or a missing capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a look at the [Roadmap](../../README.md#roadmap) first — some of
+        this may already be planned.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case, not just the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What would you like Linthra to do?
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Linthra is **not on F-Droid** and **not production-stable** yet.
 - [Known limitations](#known-limitations)
 - [Install](#install)
 - [Connect your Jellyfin server](#connect-your-jellyfin-server)
+- [Cast to a speaker or TV](#cast-to-a-speaker-or-tv)
+- [Offline cache, in short](#offline-cache-in-short)
+- [Reporting bugs &amp; feedback](#reporting-bugs--feedback)
 - [Privacy &amp; security](#privacy--security)
 - [Roadmap](#roadmap)
 - [Project status](#project-status)
@@ -153,6 +156,12 @@ GitHub Releases and keeps them updated — a great fit for alpha sideloading.
 3. On first launch (Android 13+), tap **Allow** on the notification prompt so
    the media notification and its controls can appear.
 
+> **Using Android Auto?** Android Auto only lists media apps installed from the
+> Play Store unless you enable sideloaded ones: in the Android Auto settings, tap
+> the version number to unlock **Developer settings**, then turn on **Unknown
+> sources**. Without this, Linthra works on the phone but won't appear on the car
+> screen. Full steps are in [docs/android-auto.md](docs/android-auto.md).
+
 ### Build it yourself
 
 Linthra is a standard Flutter app (the committed `android/` scaffold means no
@@ -193,6 +202,91 @@ Full setup notes, supported endpoints, compatibility, and troubleshooting are in
 [Jellyfin (self-hosted music) — setup &amp; known limitations](#jellyfin-self-hosted-music--setup--known-limitations)
 and [docs/jellyfin-compatibility.md](docs/jellyfin-compatibility.md).
 
+## Cast to a speaker or TV
+
+Linthra can hand a Jellyfin or Navidrome/Subsonic stream off to a **Chromecast**
+device (a Cast-enabled speaker, TV, or display) on your network. It uses a
+pure-Dart implementation of the Google Cast v2 protocol — **no Google Play
+Services and no proprietary Cast SDK** — so casting works the same on a
+sideloaded or F-Droid-style build.
+
+1. Be on the **same Wi-Fi network** as the Cast device.
+2. Start playing a **streamed** track (Jellyfin or Subsonic).
+3. Tap the **cast icon** in the Now Playing header to open the device sheet.
+4. Pick a device. Linthra resolves the stream at cast time, plays it on the
+   receiver, and pauses local audio so you don't hear it twice.
+5. While connected, the sheet shows a **Cast volume** slider and mute that drive
+   the *device's* own volume. Disconnecting (or the receiver dropping) resumes
+   local playback, paused.
+
+**Good to know:**
+
+- **On-device (local) files can't be cast** — a receiver can't reach a file on
+  your phone, so only network streams hand off. The sheet says so plainly rather
+  than failing silently.
+- Discovery uses mDNS, so a device only appears if it's reachable on your LAN
+  (some guest/isolated networks block this).
+
+Architecture and token-handling details are in
+[Now Playing controls — casting](#now-playing-controls--shuffle-repeat-favorite-lyrics--casting).
+
+## Offline cache, in short
+
+Linthra's offline model is **explicit and user-controlled** — Plexamp-style, but
+open-source, with no surprise downloads:
+
+- Your **whole synced library stays visible**; nothing is hidden behind a
+  download.
+- **Streaming is the default.** You tap the download icon on the tracks you want
+  available offline; only those are fetched.
+- **Cached tracks play with no network** — airplane mode, dead tunnel, anywhere.
+- A **size limit** (4 GB by default; presets up to 16 GB or a custom value) keeps
+  the cache from filling your phone. When it's full, Linthra evicts pre-cached
+  and least-recently-played, unpinned tracks first — never something you
+  **pinned** with "Keep offline".
+- Optional **smart pre-cache** warms the next few queued tracks so they start
+  instantly; it honours the "Wi-Fi only" toggle and the same size limit.
+
+The full mechanics, eviction policy, and token handling are in
+[Offline downloads &amp; known limitations](#offline-downloads--known-limitations).
+
+## Reporting bugs &amp; feedback
+
+This is an alpha, and **focused bug reports are the most useful thing a tester
+can send.** Please file issues on the
+[GitHub issue tracker](https://github.com/thezupzup/linthra/issues).
+
+**Attach diagnostics.** Linthra has a built-in, **secret-free** diagnostics
+export — open **Settings → Diagnostics** and tap **Copy diagnostics** (or **Save
+diagnostics** to write `linthra-diagnostics.txt`), then paste it into the report.
+The snapshot includes the app version, Android version, Jellyfin/Subsonic
+connection state and **server host only**, library track count, cache used/limit,
+current playback output, the last error kind, and which features are
+available/enabled. By construction it contains **no password, token,
+`Authorization` header, or full server URL** — so it's safe to share publicly.
+
+A good report includes:
+
+1. **What you did** — the steps to reproduce, ideally numbered.
+2. **What you expected** vs. **what happened**.
+3. **The diagnostics block** from Settings → Diagnostics (above).
+4. **Install source** — GitHub Releases APK, Obtainium, or a self-built APK — and
+   whether it was debug- or release-signed (shown on the Release asset name).
+5. **Your setup** — local files, Jellyfin, and/or Navidrome/Subsonic; and whether
+   Android Auto or Cast was involved.
+
+**Advanced (optional) logs.** For playback or Android Auto issues, a logcat
+capture from a USB-connected device often pinpoints the cause. Linthra's own log
+lines are tagged and **secret-free by design** (tokens and URLs are never
+logged):
+
+```bash
+adb logcat | grep -i linthra
+```
+
+There is **no telemetry or crash reporting** — nothing is collected unless you
+choose to send it.
+
 ## Privacy &amp; security
 
 Linthra is built to respect the people who use it:
@@ -210,7 +304,9 @@ Linthra is built to respect the people who use it:
   token and then discarded — it is **never stored**. The session token is
   encrypted at rest (`flutter_secure_storage`, Android Keystore-backed), is
   **never logged** or shown in the UI, and authenticated stream/download URLs are
-  minted only on demand. Diagnostics are secret-free by construction.
+  minted only on demand. The **Settings → Diagnostics** export (see
+  [Reporting bugs &amp; feedback](#reporting-bugs--feedback)) is secret-free by
+  construction — it can carry a host name and counts, never a token or password.
 
 More detail lives in the
 [Jellyfin security notes](#jellyfin-self-hosted-music--setup--known-limitations)
@@ -219,16 +315,18 @@ and the offline-downloads section below.
 ## Roadmap
 
 **Working now:** local scanning + playback, background playback & media session,
-Android Auto browsing, shuffle/repeat, Jellyfin and Navidrome/Subsonic
+Android Auto browsing, shuffle/repeat, playlists (create/edit/reorder/delete,
+with partial Jellyfin sync), safe song removal, Jellyfin and Navidrome/Subsonic
 connect/sync/stream, explicit offline downloads with a smart cache, synced
-favorites & lyrics (Jellyfin), and Chromecast with device-volume control.
+favorites & lyrics (Jellyfin), Chromecast with device-volume control, and a
+secret-free diagnostics export.
 
 **Next up (roughly in order):**
 
 1. Tag/metadata parsing and album artwork.
 2. Browse by artist/album, and search.
 3. Subsonic favorites, lyrics, and cover art.
-4. Playlist creation, editing, and queue reordering.
+4. Full playlist sync (rename/reorder of synced playlists; Subsonic playlists).
 5. Album/playlist "download all" and a background download manager.
 6. Real connectivity detection for the "Wi-Fi only" gate.
 7. More sources behind the same interface — WebDAV, NAS.


### PR DESCRIPTION
## Summary

Polishes the project presentation for the public alpha so testers can install and report useful feedback. README/docs and issue templates only — no app features, no UI changes.

### README
- **Cast to a speaker or TV** — new reader-facing setup section (was buried in the Now Playing deep-dive).
- **Offline cache, in short** — concise summary section linking to the full mechanics.
- **Reporting bugs & feedback** — new section centered on the secret-free **Settings → Diagnostics** export (Copy/Save), what a good report includes, install-source detail, and optional `adb logcat` for advanced cases. Notes there is no telemetry.
- **Install** — surfaces the Android Auto *Unknown sources* requirement for sideloaded builds (Developer settings → Unknown sources) so it isn't missed.
- **Roadmap** — refreshed so landed playlists, safe song removal, and the diagnostics export are listed as working; "Next up" now reflects remaining playlist-sync gaps instead of playlist creation.
- **Privacy** — points to the Settings → Diagnostics export and reiterates it's secret-free by construction.
- Updated table of contents for the new sections.

### Issue templates
- `bug_report.yml` — prompts for steps, expected/actual, the diagnostics block, install source, what was in use, and optional logs.
- `feature_request.yml` and `config.yml` (links to Jellyfin/Android Auto docs).

### Honest-alpha guardrails kept
No claims of Play Store / F-Droid availability or production stability; debug-signed alpha caveats retained. Screenshots remain a documented gap (real captures only) per `docs/listing-assets.md` — none fabricated.

## Test plan
- [ ] Render README on GitHub; confirm new TOC anchors resolve (Cast, Offline cache, Reporting bugs).
- [ ] Confirm issue templates appear under **New issue** with the diagnostics field.

https://claude.ai/code/session_018LX2e14n2anpLaFdmP2xiT

---
_Generated by [Claude Code](https://claude.ai/code/session_018LX2e14n2anpLaFdmP2xiT)_