### PR TITLE
Add Library tabs (Songs/Albums/Artists) with search

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Everything below works end to end on a real Android device in the current alpha
 - **Local library** — pick a folder with the native Android picker (Storage
   Access Framework), scan it, and list your tracks. The chosen folder and the
   scanned catalog survive a restart. No broad storage permission is requested.
+- **Library browsing & search** — browse across **Songs**, **Albums**, and
+  **Artists** tabs, with a search box that filters the active tab (by title,
+  artist, or album) — case- and accent-insensitive. Open an album or artist to
+  play or shuffle it. See [docs/library.md](docs/library.md).
 - **Playback** — play local tracks with an up-next queue, plus working
   **shuffle** and **repeat** (off / all / one).
 - **Playlists** — create, rename, reorder, and delete playlists; add and remove
@@ -92,9 +96,11 @@ Everything below works end to end on a real Android device in the current alpha
 
 This is an alpha — expect rough edges. The honest gaps today:
 
-- **No tag/metadata parsing yet** — tracks show their file name, and there is
-  no album artwork.
-- **No browse-by-artist/album and no search** in the in-app library yet.
+- **No local tag/metadata parsing yet** — local files show their file name, and
+  there is no album artwork for them. Because album/artist tags aren't read,
+  local tracks group under **Unknown Album** / **Unknown Artist** in the Albums
+  and Artists tabs. Jellyfin/Subsonic tracks carry real album/artist names and
+  artwork, so they group properly. See [docs/library.md](docs/library.md).
 - **Playlist sync is partial** — local playlists are full-featured (create,
   edit, reorder, delete, bulk actions); Jellyfin create / add / remove / delete
   sync, but **rename and reorder of a synced playlist stay local for now**, and

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,0 +1,111 @@
+# Library browsing & search
+
+Linthra's Library is the home screen. It reads entirely from the local,
+offline-first catalog (the SQLite track table that scans and server syncs write
+into) — never from the network on the render path — so browsing stays instant
+and works fully offline.
+
+## Tabs
+
+The Library is organised into three tabs:
+
+- **Songs** — every track in your catalog. Sorted by title (A–Z), with the A–Z
+  fast-scroll rail pinned to the right edge for large libraries. Long-press a
+  row to multi-select (add to playlist, remove from Linthra, remove offline
+  copies). Tapping a song plays it and queues the rest of the visible list.
+- **Albums** — tracks grouped into albums. Each row shows the album artwork (or
+  a placeholder), the album title, the album artist, and the track count.
+  Tapping an album opens its detail view.
+- **Artists** — tracks grouped by artist. Each row shows an avatar placeholder,
+  the artist name, and the album/track counts. Tapping an artist opens its
+  detail view.
+
+The mini-player and bottom navigation stay put while you browse — switching
+tabs or searching never interrupts playback.
+
+### Album detail
+
+Shows the album's tracks in album order (by track number where available, then
+title). Includes **Play** and **Shuffle** buttons that queue the whole album,
+and tapping any track plays it and queues the rest of *that album*.
+
+### Artist detail
+
+Shows the artist's albums (each opening its own album detail) and all their
+tracks. Includes **Play all** and **Shuffle all**, which queue only that
+artist's tracks. The Albums section is shown when the artist has more than one
+album; a single-album artist just lists its songs.
+
+## Search
+
+A single search box sits above the tabs and filters whatever tab is active:
+
+- **Songs** — matches title, artist, or album.
+- **Albums** — matches album title or album artist.
+- **Artists** — matches artist name.
+
+Search is **case-insensitive** and, where practical, **accent-insensitive** —
+typing `beyonce` finds *Beyoncé*, and `motley` finds *Mötley*. (Folding uses a
+small built-in Latin diacritics table, so it adds no dependency and never
+touches the network.)
+
+- An empty query shows the full tab.
+- A query with no matches shows a friendly **"No results found."** state.
+- A **clear** (×) button resets the search.
+- **Switching tabs clears the query** — a search meant for one tab never
+  silently hides another tab's contents.
+- Searching only filters what's shown; it **never changes playback**. Whatever
+  is playing keeps playing, and the mini-player keeps working.
+
+### Fast-scroll rail
+
+The A–Z fast-scroller is kept on the **Songs** tab, where an alphabetical track
+list benefits from it. It hides automatically when there are too few sections
+(for example, while a search narrows the list to a handful of results), so it
+never gets in the way. The Albums and Artists tabs are short, grouped lists and
+don't use the rail.
+
+## How grouping works
+
+Albums and artists are **derived from the track catalog** rather than stored as
+separate rows. Grouping keys are built from the tracks' own album/artist names
+(folded for case and accents), so:
+
+- the same album title by two different artists stays distinct (two "Greatest
+  Hits" don't merge), and
+- case/accent differences in tags don't split one album into two.
+
+This is source-uniform: it works the same for Jellyfin/Subsonic tracks and
+local files.
+
+## Jellyfin / Subsonic metadata
+
+Tracks synced from a Jellyfin or Subsonic/Navidrome server carry real album and
+artist names and a token-free cover-art URL, so they group into proper albums
+and artists with artwork. No authenticated URL or token is ever stored on a
+track or surfaced in the Library — a Jellyfin track's stored reference is an
+opaque `jellyfin:<id>`, and stream URLs (which carry the access token) are minted
+only at play time.
+
+## Known limitations
+
+- **Metadata quality depends on the source.** Grouping is only as good as the
+  album/artist tags the source provides.
+- **Local files may lack album/artist tags.** Linthra does not parse on-device
+  tag metadata yet, so local tracks usually have no album or artist and fold
+  into a single **Unknown Album** / **Unknown Artist**. Local files that *do*
+  arrive with album/artist set (e.g. via a future tag-parsing step) will group
+  normally.
+- **Artwork may be missing** for some tracks (notably local files); a calm
+  placeholder is shown instead, and the layout never jumps.
+- **No stable source album/artist IDs yet.** Grouping uses folded names because
+  source album/artist IDs (e.g. Jellyfin's `AlbumId`) aren't persisted on a
+  track today. Persisting them — for sharper disambiguation and richer
+  album/artist art — is a follow-up.
+
+## Future
+
+- Playlists / favorites integration from album & artist views.
+- Genre browsing.
+- Advanced filters and sort options (by year, recently added, duration).
+- Local tag/metadata parsing so on-device files get real album/artist/artwork.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,8 @@ import 'package:go_router/go_router.dart';
 
 import '../features/downloads/downloads_screen.dart';
 import '../features/favorites/favorites_screen.dart';
+import '../features/library/album_detail_screen.dart';
+import '../features/library/artist_detail_screen.dart';
 import '../features/library/library_screen.dart';
 import '../features/player/player_screen.dart';
 import '../features/playlists/playlist_detail_screen.dart';
@@ -28,6 +30,20 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: AppRoutes.library,
                 builder: (context, state) => const LibraryScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'album/:id',
+                    builder: (context, state) => AlbumDetailScreen(
+                      albumId: state.pathParameters['id']!,
+                    ),
+                  ),
+                  GoRoute(
+                    path: 'artist/:id',
+                    builder: (context, state) => ArtistDetailScreen(
+                      artistId: state.pathParameters['id']!,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -2,6 +2,24 @@
 /// navigation targets are discoverable and refactor-safe.
 abstract final class AppRoutes {
   static const String library = '/library';
+
+  /// One album's tracks, reached from the Library's Albums tab. A child of
+  /// [library] so it keeps the bottom nav and pops back into that tab; the
+  /// derived album id rides as a path segment.
+  static const String albumDetail = '/library/album';
+
+  /// Builds the [albumDetail] location for a derived album [id].
+  static String albumDetailPath(String id) =>
+      '$albumDetail/${Uri.encodeComponent(id)}';
+
+  /// One artist's catalog, reached from the Library's Artists tab. A child of
+  /// [library] for the same reasons as [albumDetail].
+  static const String artistDetail = '/library/artist';
+
+  /// Builds the [artistDetail] location for a derived artist [id].
+  static String artistDetailPath(String id) =>
+      '$artistDetail/${Uri.encodeComponent(id)}';
+
   static const String playlists = '/playlists';
 
   /// Liked tracks, reached from the Playlists tab. A child of [playlists] so it

--- a/lib/core/models/artist.dart
+++ b/lib/core/models/artist.dart
@@ -4,12 +4,14 @@ class Artist {
     required this.id,
     required this.name,
     this.albumCount = 0,
+    this.trackCount = 0,
     this.artworkUri,
   });
 
   final String id;
   final String name;
   final int albumCount;
+  final int trackCount;
   final Uri? artworkUri;
 
   @override

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/album.dart';
+import '../../core/models/track.dart';
+import '../../shared/widgets/empty_state.dart';
+import '../player/player_providers.dart';
+import '../player/widgets/album_artwork.dart';
+import 'library_controller.dart';
+import 'library_grouping.dart';
+import 'library_state.dart';
+import 'widgets/track_tile.dart';
+
+/// One album's tracks, in album order, with Play / Shuffle and tap-to-play.
+///
+/// Reads the same derived grouping the Albums tab uses, so it stays in sync
+/// with the catalog: tapping a track plays it and queues the rest of *this
+/// album*, never the whole library. Reuses [TrackTile], so per-track actions
+/// and download state look identical to the main library.
+class AlbumDetailScreen extends ConsumerWidget {
+  const AlbumDetailScreen({required this.albumId, super.key});
+
+  final String albumId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final LibraryState state = ref.watch(libraryControllerProvider);
+
+    if (state.status == LibraryStatus.loading) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final Album? album = albumById(state.tracks, albumId);
+    final List<Track> tracks = tracksForAlbum(state.tracks, albumId);
+    if (album == null || tracks.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const EmptyState(
+          icon: Icons.album_outlined,
+          title: 'Album not found',
+          message: 'It may have been removed from your library.',
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(album.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
+      body: CustomScrollView(
+        slivers: <Widget>[
+          SliverToBoxAdapter(
+            child: _AlbumHeader(
+              album: album,
+              trackCount: tracks.length,
+              onPlay: () => _play(context, ref, tracks),
+              onShuffle: () => _shuffle(context, ref, tracks),
+            ),
+          ),
+          SliverList.builder(
+            itemCount: tracks.length,
+            itemBuilder: (context, index) =>
+                TrackTile(tracks: tracks, index: index),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _play(BuildContext context, WidgetRef ref, List<Track> tracks) {
+    ref.read(playbackControllerProvider).playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  void _shuffle(BuildContext context, WidgetRef ref, List<Track> tracks) {
+    final controller = ref.read(playbackControllerProvider);
+    controller.setShuffleEnabled(true);
+    controller.playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+}
+
+class _AlbumHeader extends StatelessWidget {
+  const _AlbumHeader({
+    required this.album,
+    required this.trackCount,
+    required this.onPlay,
+    required this.onShuffle,
+  });
+
+  final Album album;
+  final int trackCount;
+  final VoidCallback onPlay;
+  final VoidCallback onShuffle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color onSurface = theme.colorScheme.onSurface;
+    final String count = trackCount == 1 ? '1 song' : '$trackCount songs';
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              SizedBox.square(
+                dimension: 120,
+                child: AlbumArtwork(artworkUri: album.artworkUri),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      album.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    if (album.artistName != null &&
+                        album.artistName!.isNotEmpty) ...<Widget>[
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        album.artistName!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          color: onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      count,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: FilledButton.icon(
+                  onPressed: onPlay,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('Play'),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: onShuffle,
+                  icon: const Icon(Icons.shuffle),
+                  label: const Text('Shuffle'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import '../../core/models/track.dart';
+import '../../shared/widgets/empty_state.dart';
+import '../player/player_providers.dart';
+import 'library_controller.dart';
+import 'library_grouping.dart';
+import 'library_state.dart';
+import 'widgets/album_tile.dart';
+import 'widgets/track_tile.dart';
+
+/// One artist's catalog: their albums (each opening its album detail) and all
+/// their tracks, with Play all / Shuffle all.
+///
+/// Reads the same derived grouping the Artists tab uses. Playing from here
+/// queues only this artist's tracks; tapping a single track queues the artist's
+/// tracks from that point. Reuses [TrackTile] and [AlbumTile] so rows match the
+/// rest of the library.
+class ArtistDetailScreen extends ConsumerWidget {
+  const ArtistDetailScreen({required this.artistId, super.key});
+
+  final String artistId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final LibraryState state = ref.watch(libraryControllerProvider);
+
+    if (state.status == LibraryStatus.loading) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final Artist? artist = artistById(state.tracks, artistId);
+    final List<Track> tracks = tracksForArtist(state.tracks, artistId);
+    if (artist == null || tracks.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const EmptyState(
+          icon: Icons.person_outline,
+          title: 'Artist not found',
+          message: 'They may have been removed from your library.',
+        ),
+      );
+    }
+
+    final List<Album> albums = albumsForArtist(state.tracks, artistId);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(artist.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
+      body: CustomScrollView(
+        slivers: <Widget>[
+          SliverToBoxAdapter(
+            child: _ArtistHeader(
+              artist: artist,
+              albumCount: albums.length,
+              trackCount: tracks.length,
+              onPlay: () => _play(context, ref, tracks),
+              onShuffle: () => _shuffle(context, ref, tracks),
+            ),
+          ),
+          if (albums.length > 1) ...<Widget>[
+            const SliverToBoxAdapter(child: _SectionHeader(label: 'Albums')),
+            SliverList.builder(
+              itemCount: albums.length,
+              itemBuilder: (context, index) {
+                final Album album = albums[index];
+                return AlbumTile(
+                  album: album,
+                  onTap: () => _openAlbum(context, album.id),
+                );
+              },
+            ),
+          ],
+          const SliverToBoxAdapter(child: _SectionHeader(label: 'Songs')),
+          SliverList.builder(
+            itemCount: tracks.length,
+            itemBuilder: (context, index) =>
+                TrackTile(tracks: tracks, index: index),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openAlbum(BuildContext context, String albumId) {
+    context.push(AppRoutes.albumDetailPath(albumId));
+  }
+
+  void _play(BuildContext context, WidgetRef ref, List<Track> tracks) {
+    ref.read(playbackControllerProvider).playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  void _shuffle(BuildContext context, WidgetRef ref, List<Track> tracks) {
+    final controller = ref.read(playbackControllerProvider);
+    controller.setShuffleEnabled(true);
+    controller.playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+}
+
+class _ArtistHeader extends StatelessWidget {
+  const _ArtistHeader({
+    required this.artist,
+    required this.albumCount,
+    required this.trackCount,
+    required this.onPlay,
+    required this.onShuffle,
+  });
+
+  final Artist artist;
+  final int albumCount;
+  final int trackCount;
+  final VoidCallback onPlay;
+  final VoidCallback onShuffle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color onSurface = theme.colorScheme.onSurface;
+    final String songs = trackCount == 1 ? '1 song' : '$trackCount songs';
+    final String summary = albumCount > 0
+        ? '${albumCount == 1 ? '1 album' : '$albumCount albums'} • $songs'
+        : songs;
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              CircleAvatar(
+                radius: 36,
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                backgroundImage: artist.artworkUri == null
+                    ? null
+                    : NetworkImage(artist.artworkUri!.toString()),
+                child: artist.artworkUri == null
+                    ? Icon(
+                        Icons.person,
+                        size: 36,
+                        color: onSurface.withValues(alpha: 0.35),
+                      )
+                    : null,
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      artist.name,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      summary,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: FilledButton.icon(
+                  onPressed: onPlay,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('Play all'),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: onShuffle,
+                  icon: const Icon(Icons.shuffle),
+                  label: const Text('Shuffle all'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.md,
+        AppSpacing.md,
+        AppSpacing.xs,
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/library/library_browse_providers.dart
+++ b/lib/features/library/library_browse_providers.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import 'library_controller.dart';
+import 'library_grouping.dart';
+
+/// Albums derived from the loaded track catalog, recomputed whenever the
+/// library reloads (scan, sync, or a removal). The Albums tab and the artist
+/// detail read from here so grouping lives in exactly one place.
+final libraryAlbumsProvider = Provider<List<Album>>((ref) {
+  return groupAlbums(ref.watch(libraryControllerProvider).tracks);
+});
+
+/// Artists derived from the loaded track catalog. See [libraryAlbumsProvider].
+final libraryArtistsProvider = Provider<List<Artist>>((ref) {
+  return groupArtists(ref.watch(libraryControllerProvider).tracks);
+});

--- a/lib/features/library/library_grouping.dart
+++ b/lib/features/library/library_grouping.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import '../../core/models/track.dart';
+import 'library_search.dart' show foldText;
+
+/// Derives [Album] and [Artist] groupings from the flat track catalog.
+///
+/// Why derive instead of persist: the only stable, offline catalog Linthra
+/// keeps is the track table — album/artist *IDs* from a source (e.g. Jellyfin's
+/// `AlbumId`) are not stored on a [Track] today, so there are no stable IDs to
+/// group by. Grouping here by the tracks' own metadata is therefore the honest,
+/// source-uniform approach: it works identically for Jellyfin tracks (which
+/// carry real album/artist names) and local files (which usually carry neither,
+/// and so fold into a single "Unknown Album" / "Unknown Artist"). Persisting
+/// source album/artist IDs for sharper grouping is a documented follow-up.
+///
+/// Grouping keys are built from [foldText], so case and accents never split one
+/// album/artist into two. Album identity is (album title + artist) so two
+/// different artists' "Greatest Hits" stay distinct; tracks with no album fold
+/// into one "Unknown Album" regardless of artist. All ordering uses total
+/// comparators (every tie broken down to the stable id), so a given catalog
+/// always produces the exact same order — sorting is predictable and stable.
+
+/// Display label for tracks with no album metadata.
+const String kUnknownAlbum = 'Unknown Album';
+
+/// Display label for tracks with no artist metadata.
+const String kUnknownArtist = 'Unknown Artist';
+
+const String _unknownAlbumId = 'unknown-album';
+const String _unknownArtistId = 'unknown-artist';
+
+String _encode(String key) =>
+    base64Url.encode(utf8.encode(key)).replaceAll('=', '');
+
+/// Joins (album, artist) into a key that is injective on the pair: the album's
+/// length is prefixed, so the album portion is read by length and a separator
+/// inside a title can never make ("a b", "c") collide with ("a", "b c").
+String _albumKey(String album, String artist) =>
+    '${album.length}|$album|$artist';
+
+/// The stable album id [track] belongs to. Tracks with no album title share the
+/// single [_unknownAlbumId]; otherwise the id is `al-` + a base64url encoding of
+/// the (title, artist) key. Every character is URL-safe (so the id can ride in
+/// a route path untouched) and the `al-` prefix can never produce the unknown
+/// sentinel, so the two never collide.
+String albumIdForTrack(Track track) {
+  final String album = foldText(track.albumName ?? '');
+  if (album.isEmpty) return _unknownAlbumId;
+  final String artist = foldText(track.artistName ?? '');
+  return 'al-${_encode(_albumKey(album, artist))}';
+}
+
+/// The stable artist id [track] belongs to. Tracks with no artist share the
+/// single [_unknownArtistId]; otherwise the id is `ar-` + a base64url encoding
+/// of the folded name. See [albumIdForTrack] for the URL-safety guarantees.
+String artistIdForTrack(Track track) {
+  final String artist = foldText(track.artistName ?? '');
+  if (artist.isEmpty) return _unknownArtistId;
+  return 'ar-${_encode(artist)}';
+}
+
+/// All albums in [tracks], sorted by title then artist (then id), ascending.
+List<Album> groupAlbums(List<Track> tracks) {
+  final Map<String, _AlbumAgg> byId = <String, _AlbumAgg>{};
+  for (final Track track in tracks) {
+    byId.putIfAbsent(albumIdForTrack(track), () => _AlbumAgg()).add(track);
+  }
+  final List<Album> albums = <Album>[
+    for (final MapEntry<String, _AlbumAgg> e in byId.entries)
+      e.value.toAlbum(e.key),
+  ];
+  albums.sort(_albumCompare);
+  return albums;
+}
+
+/// All artists in [tracks], sorted by name (then id), ascending.
+List<Artist> groupArtists(List<Track> tracks) {
+  final Map<String, _ArtistAgg> byId = <String, _ArtistAgg>{};
+  for (final Track track in tracks) {
+    byId.putIfAbsent(artistIdForTrack(track), () => _ArtistAgg()).add(track);
+  }
+  final List<Artist> artists = <Artist>[
+    for (final MapEntry<String, _ArtistAgg> e in byId.entries)
+      e.value.toArtist(e.key),
+  ];
+  artists.sort(_artistCompare);
+  return artists;
+}
+
+/// The album with [albumId] in [tracks], or null when no track belongs to it.
+Album? albumById(List<Track> tracks, String albumId) {
+  for (final Album album in groupAlbums(tracks)) {
+    if (album.id == albumId) return album;
+  }
+  return null;
+}
+
+/// The artist with [artistId] in [tracks], or null when none matches.
+Artist? artistById(List<Track> tracks, String artistId) {
+  for (final Artist artist in groupArtists(tracks)) {
+    if (artist.id == artistId) return artist;
+  }
+  return null;
+}
+
+/// Tracks on the album [albumId], in playable album order: by track number
+/// (numbered first, ascending), then title, then id. No disc number is stored
+/// on a [Track], so numbering is the finest order available.
+List<Track> tracksForAlbum(List<Track> tracks, String albumId) {
+  final List<Track> result = <Track>[
+    for (final Track t in tracks)
+      if (albumIdForTrack(t) == albumId) t,
+  ];
+  result.sort(_trackInAlbumCompare);
+  return result;
+}
+
+/// Tracks by the artist [artistId], grouped by album then album order, so an
+/// artist's catalog reads album-by-album.
+List<Track> tracksForArtist(List<Track> tracks, String artistId) {
+  final List<Track> result = <Track>[
+    for (final Track t in tracks)
+      if (artistIdForTrack(t) == artistId) t,
+  ];
+  result.sort(_trackForArtistCompare);
+  return result;
+}
+
+/// Albums by the artist [artistId], sorted like [groupAlbums].
+List<Album> albumsForArtist(List<Track> tracks, String artistId) {
+  return groupAlbums(<Track>[
+    for (final Track t in tracks)
+      if (artistIdForTrack(t) == artistId) t,
+  ]);
+}
+
+int _albumCompare(Album a, Album b) {
+  final int byTitle = foldText(a.title).compareTo(foldText(b.title));
+  if (byTitle != 0) return byTitle;
+  final int byArtist =
+      foldText(a.artistName ?? '').compareTo(foldText(b.artistName ?? ''));
+  if (byArtist != 0) return byArtist;
+  return a.id.compareTo(b.id);
+}
+
+int _artistCompare(Artist a, Artist b) {
+  final int byName = foldText(a.name).compareTo(foldText(b.name));
+  if (byName != 0) return byName;
+  return a.id.compareTo(b.id);
+}
+
+int _trackInAlbumCompare(Track a, Track b) {
+  final int? an = a.trackNumber;
+  final int? bn = b.trackNumber;
+  if (an != null && bn != null && an != bn) return an.compareTo(bn);
+  if (an != null && bn == null) return -1;
+  if (an == null && bn != null) return 1;
+  final int byTitle = foldText(a.title).compareTo(foldText(b.title));
+  if (byTitle != 0) return byTitle;
+  return a.id.compareTo(b.id);
+}
+
+int _trackForArtistCompare(Track a, Track b) {
+  final int byAlbum =
+      foldText(a.albumName ?? '').compareTo(foldText(b.albumName ?? ''));
+  if (byAlbum != 0) return byAlbum;
+  return _trackInAlbumCompare(a, b);
+}
+
+/// Accumulates one album's display fields as its tracks are seen. The first
+/// non-empty title/artist/artwork wins, so a stray untagged track in the group
+/// can't blank out a name the others provide.
+class _AlbumAgg {
+  String? _title;
+  String? _artist;
+  Uri? _artwork;
+  int _count = 0;
+
+  void add(Track track) {
+    _count++;
+    final String? album = track.albumName;
+    if ((_title == null || _title!.isEmpty) &&
+        album != null &&
+        album.isNotEmpty) {
+      _title = album;
+    }
+    final String? artist = track.artistName;
+    if ((_artist == null || _artist!.isEmpty) &&
+        artist != null &&
+        artist.isNotEmpty) {
+      _artist = artist;
+    }
+    _artwork ??= track.artworkUri;
+  }
+
+  Album toAlbum(String id) {
+    return Album(
+      id: id,
+      title: (_title == null || _title!.isEmpty) ? kUnknownAlbum : _title!,
+      artistName: (_artist != null && _artist!.isNotEmpty) ? _artist : null,
+      artworkUri: _artwork,
+      trackCount: _count,
+    );
+  }
+}
+
+/// Accumulates one artist's display fields and how many distinct albums and
+/// tracks they have.
+class _ArtistAgg {
+  String? _name;
+  Uri? _artwork;
+  final Set<String> _albumIds = <String>{};
+  int _trackCount = 0;
+
+  void add(Track track) {
+    _trackCount++;
+    final String? artist = track.artistName;
+    if ((_name == null || _name!.isEmpty) &&
+        artist != null &&
+        artist.isNotEmpty) {
+      _name = artist;
+    }
+    _artwork ??= track.artworkUri;
+    _albumIds.add(albumIdForTrack(track));
+  }
+
+  Artist toArtist(String id) {
+    return Artist(
+      id: id,
+      name: (_name == null || _name!.isEmpty) ? kUnknownArtist : _name!,
+      albumCount: _albumIds.length,
+      trackCount: _trackCount,
+      artworkUri: _artwork,
+    );
+  }
+}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -1,23 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../core/services/bulk_track_actions.dart';
+import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
+import 'library_browse_providers.dart';
 import 'library_controller.dart';
+import 'library_search.dart';
 import 'library_state.dart';
 import 'selected_folder_controller.dart';
 import 'song_actions.dart';
+import 'widgets/album_tile.dart';
 import 'widgets/alphabet_track_list.dart';
+import 'widgets/artist_tile.dart';
+import 'widgets/library_search_field.dart';
 
-/// Browse tracks from the local catalog. Reads entirely from
-/// [libraryControllerProvider] and [selectedFolderControllerProvider]; it has
-/// no knowledge of where tracks are stored or which plugin picks the folder.
+/// Browse the local catalog across three tabs — Songs, Albums, Artists — with a
+/// single search box that filters whichever tab is showing. Reads entirely from
+/// [libraryControllerProvider] (the flat track catalog) plus the derived
+/// [libraryAlbumsProvider]/[libraryArtistsProvider]; it has no knowledge of
+/// where tracks are stored or which plugin picks the folder.
 ///
-/// A long-press on a row enters multi-select; the app bar then becomes a
-/// contextual selection bar offering only the actions that are safe for the
-/// current selection (mixed-source selections hide unsafe destructive actions).
+/// Songs keeps the long-press multi-select and the A–Z fast-scroller from
+/// before. Switching tabs clears the query, so a search meant for one tab never
+/// silently hides another's contents. Search only filters what is shown — it
+/// never touches playback, so the mini-player keeps playing while browsing.
 class LibraryScreen extends ConsumerStatefulWidget {
   const LibraryScreen({super.key});
 
@@ -25,9 +38,48 @@ class LibraryScreen extends ConsumerStatefulWidget {
   ConsumerState<LibraryScreen> createState() => _LibraryScreenState();
 }
 
-class _LibraryScreenState extends ConsumerState<LibraryScreen> {
+class _LibraryScreenState extends ConsumerState<LibraryScreen>
+    with SingleTickerProviderStateMixin {
   final Set<String> _selectedIds = <String>{};
   bool _selecting = false;
+
+  late final TabController _tabController;
+  final TextEditingController _searchController = TextEditingController();
+  String _query = '';
+  int _lastTabIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+    _tabController.addListener(_onTabChanged);
+  }
+
+  @override
+  void dispose() {
+    _tabController.removeListener(_onTabChanged);
+    _tabController.dispose();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  /// Clears the search once per real tab change. A query that filters songs is
+  /// meaningless against albums/artists, so resetting on switch keeps each tab
+  /// honest about what it's showing.
+  void _onTabChanged() {
+    if (_tabController.index == _lastTabIndex) return;
+    _lastTabIndex = _tabController.index;
+    if (_query.isNotEmpty) _clearSearch();
+  }
+
+  void _onQueryChanged(String value) => setState(() => _query = value);
+
+  void _clearSearch() {
+    setState(() {
+      _query = '';
+      _searchController.clear();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,28 +94,160 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
         if (_selectedIds.contains(track.id)) track,
     ];
 
-    return PopScope(
-      canPop: !_selecting,
-      onPopInvokedWithResult: (bool didPop, _) {
-        if (!didPop && _selecting) _exitSelection();
-      },
-      child: Scaffold(
-        appBar: _selecting
-            ? _selectionAppBar(selected)
-            : AppBar(
-                title: const Text('Library'),
-                actions: <Widget>[
-                  IconButton(
-                    icon: const Icon(Icons.create_new_folder_outlined),
-                    tooltip: 'Select music folder',
-                    onPressed: () => _pickAndScan(),
-                  ),
-                ],
-              ),
-        body: _body(state, selectedFolder.valueOrNull),
+    if (_selecting) {
+      return PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (bool didPop, _) {
+          if (!didPop) _exitSelection();
+        },
+        child: Scaffold(
+          appBar: _selectionAppBar(selected),
+          body: _songsList(_filteredSongs(state)),
+        ),
+      );
+    }
+
+    // Tabs and search only appear once there's a loaded, non-empty catalog to
+    // browse; loading, error, and the folder-pick empty state take the whole
+    // body (and no tabs), exactly as before.
+    final bool browsing =
+        state.status == LibraryStatus.loaded && state.tracks.isNotEmpty;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Library'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.create_new_folder_outlined),
+            tooltip: 'Select music folder',
+            onPressed: _pickAndScan,
+          ),
+        ],
+        bottom: browsing ? _tabBar() : null,
       ),
+      body: browsing
+          ? _browseBody(state)
+          : _statusBody(state, selectedFolder.valueOrNull),
     );
   }
+
+  PreferredSizeWidget _tabBar() {
+    final ThemeData theme = Theme.of(context);
+    return TabBar(
+      key: const Key('library_tabs'),
+      controller: _tabController,
+      indicatorColor: theme.colorScheme.secondary,
+      indicatorSize: TabBarIndicatorSize.label,
+      labelColor: theme.colorScheme.secondary,
+      unselectedLabelColor: theme.colorScheme.onSurfaceVariant,
+      tabs: const <Widget>[
+        Tab(text: 'Songs'),
+        Tab(text: 'Albums'),
+        Tab(text: 'Artists'),
+      ],
+    );
+  }
+
+  /// Loading / error / folder-pick states, shown full-body without tabs.
+  Widget _statusBody(LibraryState state, String? selectedFolder) {
+    switch (state.status) {
+      case LibraryStatus.loading:
+        return const Center(child: CircularProgressIndicator());
+      case LibraryStatus.error:
+        return _LibraryError(
+          message: state.errorMessage,
+          onRetry: () => ref.read(libraryControllerProvider.notifier).refresh(),
+        );
+      case LibraryStatus.loaded:
+        return _LibraryEmpty(
+          selectedFolder: selectedFolder,
+          onPick: _pickAndScan,
+          onRescan:
+              selectedFolder == null ? null : () => _rescan(selectedFolder),
+        );
+    }
+  }
+
+  /// Search box + the three browse tabs. Only built when there's content.
+  Widget _browseBody(LibraryState state) {
+    return Column(
+      children: <Widget>[
+        LibrarySearchField(
+          controller: _searchController,
+          onChanged: _onQueryChanged,
+          onClear: _clearSearch,
+        ),
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: <Widget>[
+              _songsTab(state),
+              _albumsTab(),
+              _artistsTab(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  // --- Tabs -------------------------------------------------------------
+
+  Widget _songsTab(LibraryState state) {
+    final List<Track> filtered = _filteredSongs(state);
+    if (filtered.isEmpty) return const _NoResults();
+    return _songsList(filtered);
+  }
+
+  Widget _albumsTab() {
+    final List<Album> filtered =
+        filterAlbums(ref.watch(libraryAlbumsProvider), _query);
+    if (filtered.isEmpty) return const _NoResults();
+    return ListView.builder(
+      key: const Key('library_album_list'),
+      itemCount: filtered.length,
+      itemBuilder: (context, index) {
+        final Album album = filtered[index];
+        return AlbumTile(
+          album: album,
+          onTap: () => context.push(AppRoutes.albumDetailPath(album.id)),
+        );
+      },
+    );
+  }
+
+  Widget _artistsTab() {
+    final List<Artist> filtered =
+        filterArtists(ref.watch(libraryArtistsProvider), _query);
+    if (filtered.isEmpty) return const _NoResults();
+    return ListView.builder(
+      key: const Key('library_artist_list'),
+      itemCount: filtered.length,
+      itemBuilder: (context, index) {
+        final Artist artist = filtered[index];
+        return ArtistTile(
+          artist: artist,
+          onTap: () => context.push(AppRoutes.artistDetailPath(artist.id)),
+        );
+      },
+    );
+  }
+
+  List<Track> _filteredSongs(LibraryState state) =>
+      filterTracks(state.tracks, _query);
+
+  Widget _songsList(List<Track> tracks) {
+    return AlphabetTrackList(
+      tracks: tracks,
+      selectable: true,
+      selectionActive: _selecting,
+      selectedIds: _selectedIds,
+      onSelectStart: _enterSelection,
+      onSelectToggle: _toggle,
+    );
+  }
+
+  // --- Selection --------------------------------------------------------
 
   PreferredSizeWidget _selectionAppBar(List<Track> selected) {
     final BulkActionAvailability actions =
@@ -141,6 +325,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
     if (ran) _exitSelection();
   }
 
+  // --- Scan -------------------------------------------------------------
+
   /// Open the system folder picker, persist the choice, then scan it. A
   /// cancelled pick leaves everything untouched. The UI only talks to the two
   /// controllers — never to a picker plugin or the file system directly.
@@ -157,34 +343,20 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
   Future<void> _rescan(String folder) {
     return ref.read(libraryControllerProvider.notifier).scanFolder(folder);
   }
+}
 
-  Widget _body(LibraryState state, String? selectedFolder) {
-    switch (state.status) {
-      case LibraryStatus.loading:
-        return const Center(child: CircularProgressIndicator());
-      case LibraryStatus.error:
-        return _LibraryError(
-          message: state.errorMessage,
-          onRetry: () => ref.read(libraryControllerProvider.notifier).refresh(),
-        );
-      case LibraryStatus.loaded:
-        if (state.isEmpty) {
-          return _LibraryEmpty(
-            selectedFolder: selectedFolder,
-            onPick: _pickAndScan,
-            onRescan:
-                selectedFolder == null ? null : () => _rescan(selectedFolder),
-          );
-        }
-        return AlphabetTrackList(
-          tracks: state.tracks,
-          selectable: true,
-          selectionActive: _selecting,
-          selectedIds: _selectedIds,
-          onSelectStart: _enterSelection,
-          onSelectToggle: _toggle,
-        );
-    }
+/// The "no search matches" state, shown when a query filters every row out of
+/// the active tab. Deliberately friendly and identical across tabs.
+class _NoResults extends StatelessWidget {
+  const _NoResults();
+
+  @override
+  Widget build(BuildContext context) {
+    return const EmptyState(
+      icon: Icons.search_off,
+      title: 'No results found.',
+      message: 'Try a different search.',
+    );
   }
 }
 

--- a/lib/features/library/library_search.dart
+++ b/lib/features/library/library_search.dart
@@ -1,0 +1,145 @@
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import '../../core/models/track.dart';
+
+/// Pure, dependency-free text matching for the Library search box.
+///
+/// All comparisons run through [foldText] so search is case-insensitive and,
+/// where practical, accent-insensitive: typing "beyonce" finds "Beyoncé" and
+/// "amelie" finds "Amélie". The folding is intentionally small and offline (a
+/// fixed Latin diacritics table rather than a Unicode-normalization package), so
+/// it adds no dependency and never reaches the network — there is nothing here
+/// that could expose a token or an authenticated URL.
+
+/// Common single-codepoint Latin diacritics mapped to their unaccented base, so
+/// folding stays a cheap table lookup. Keys are lower-case; callers lower-case
+/// first. Anything not listed passes through unchanged.
+const Map<String, String> _diacritics = <String, String>{
+  'á': 'a',
+  'à': 'a',
+  'â': 'a',
+  'ä': 'a',
+  'ã': 'a',
+  'å': 'a',
+  'ā': 'a',
+  'ă': 'a',
+  'ą': 'a',
+  'ç': 'c',
+  'ć': 'c',
+  'č': 'c',
+  'ċ': 'c',
+  'ď': 'd',
+  'đ': 'd',
+  'é': 'e',
+  'è': 'e',
+  'ê': 'e',
+  'ë': 'e',
+  'ē': 'e',
+  'ė': 'e',
+  'ę': 'e',
+  'ě': 'e',
+  'ğ': 'g',
+  'í': 'i',
+  'ì': 'i',
+  'î': 'i',
+  'ï': 'i',
+  'ī': 'i',
+  'į': 'i',
+  'ı': 'i',
+  'ł': 'l',
+  'ľ': 'l',
+  'ñ': 'n',
+  'ń': 'n',
+  'ň': 'n',
+  'ó': 'o',
+  'ò': 'o',
+  'ô': 'o',
+  'ö': 'o',
+  'õ': 'o',
+  'ø': 'o',
+  'ō': 'o',
+  'ő': 'o',
+  'ŕ': 'r',
+  'ř': 'r',
+  'š': 's',
+  'ś': 's',
+  'ş': 's',
+  'ș': 's',
+  'ť': 't',
+  'ț': 't',
+  'ú': 'u',
+  'ù': 'u',
+  'û': 'u',
+  'ü': 'u',
+  'ū': 'u',
+  'ů': 'u',
+  'ű': 'u',
+  'ý': 'y',
+  'ÿ': 'y',
+  'ž': 'z',
+  'ź': 'z',
+  'ż': 'z',
+  'ß': 'ss',
+  'œ': 'oe',
+  'æ': 'ae',
+};
+
+/// Lower-cases [input], strips common diacritics, and collapses runs of
+/// whitespace to a single space (trimmed). The result is the canonical form
+/// used both for matching and for stable grouping keys, so "  The   Café " and
+/// "the cafe" fold to the same value.
+String foldText(String input) {
+  final String lower = input.toLowerCase();
+  final StringBuffer out = StringBuffer();
+  bool lastWasSpace = false;
+  for (int i = 0; i < lower.length; i++) {
+    final String ch = lower[i];
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+      if (!lastWasSpace) {
+        out.write(' ');
+        lastWasSpace = true;
+      }
+      continue;
+    }
+    lastWasSpace = false;
+    out.write(_diacritics[ch] ?? ch);
+  }
+  return out.toString().trim();
+}
+
+bool _contains(String? field, String foldedQuery) =>
+    field != null && field.isNotEmpty && foldText(field).contains(foldedQuery);
+
+/// Songs matching [query] by title, artist, or album. An empty query returns
+/// [tracks] unchanged (no allocation of a filtered copy is implied by callers).
+List<Track> filterTracks(List<Track> tracks, String query) {
+  final String q = foldText(query);
+  if (q.isEmpty) return tracks;
+  return <Track>[
+    for (final Track t in tracks)
+      if (_contains(t.title, q) ||
+          _contains(t.artistName, q) ||
+          _contains(t.albumName, q))
+        t,
+  ];
+}
+
+/// Albums matching [query] by album title or album artist.
+List<Album> filterAlbums(List<Album> albums, String query) {
+  final String q = foldText(query);
+  if (q.isEmpty) return albums;
+  return <Album>[
+    for (final Album a in albums)
+      if (_contains(a.title, q) || _contains(a.artistName, q)) a,
+  ];
+}
+
+/// Artists matching [query] by name.
+List<Artist> filterArtists(List<Artist> artists, String query) {
+  final String q = foldText(query);
+  if (q.isEmpty) return artists;
+  return <Artist>[
+    for (final Artist a in artists)
+      if (_contains(a.name, q)) a,
+  ];
+}

--- a/lib/features/library/widgets/album_tile.dart
+++ b/lib/features/library/widgets/album_tile.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/album.dart';
+import '../../player/widgets/album_artwork.dart';
+
+/// One row in the Albums list: cover (or the shared placeholder), album title,
+/// and an artist • track-count subtitle. Long titles/artists ellipsize so a row
+/// never overflows on a narrow phone.
+class AlbumTile extends StatelessWidget {
+  const AlbumTile({required this.album, this.onTap, super.key});
+
+  final Album album;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListTile(
+      leading: SizedBox.square(
+        dimension: 48,
+        child: AlbumArtwork(
+          artworkUri: album.artworkUri,
+          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+        ),
+      ),
+      title: Text(
+        album.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: Text(
+        _subtitle(album),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: onTap,
+    );
+  }
+
+  static String _subtitle(Album album) {
+    final String count = _countLabel(album.trackCount);
+    final String? artist = album.artistName;
+    if (artist == null || artist.isEmpty) return count;
+    return '$artist • $count';
+  }
+
+  static String _countLabel(int count) =>
+      count == 1 ? '1 song' : '$count songs';
+}

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/artist.dart';
+
+/// One row in the Artists list: a circular avatar (artwork or a placeholder
+/// glyph), the artist name, and an album/track-count subtitle. Long names
+/// ellipsize so a row never overflows on a narrow phone.
+class ArtistTile extends StatelessWidget {
+  const ArtistTile({required this.artist, this.onTap, super.key});
+
+  final Artist artist;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ListTile(
+      leading: _ArtistAvatar(artworkUri: artist.artworkUri),
+      title: Text(
+        artist.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: Text(
+        _subtitle(artist),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: onTap,
+    );
+  }
+
+  static String _subtitle(Artist artist) {
+    final String songs =
+        artist.trackCount == 1 ? '1 song' : '${artist.trackCount} songs';
+    if (artist.albumCount <= 0) return songs;
+    final String albums =
+        artist.albumCount == 1 ? '1 album' : '${artist.albumCount} albums';
+    return '$albums • $songs';
+  }
+}
+
+/// A circular artist avatar: the artwork when present, otherwise a calm tinted
+/// circle with a person glyph (the "optional avatar placeholder").
+class _ArtistAvatar extends StatelessWidget {
+  const _ArtistAvatar({required this.artworkUri});
+
+  final Uri? artworkUri;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Uri? uri = artworkUri;
+    return SizedBox.square(
+      dimension: 48,
+      child: ClipOval(
+        child: uri == null
+            ? _placeholder(theme)
+            : Image(
+                image: NetworkImage(uri.toString()),
+                fit: BoxFit.cover,
+                gaplessPlayback: true,
+                errorBuilder: (_, __, ___) => _placeholder(theme),
+                frameBuilder: (context, child, frame, wasSync) {
+                  if (wasSync || frame != null) return child;
+                  return _placeholder(theme);
+                },
+              ),
+      ),
+    );
+  }
+
+  Widget _placeholder(ThemeData theme) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+      ),
+      child: Icon(
+        Icons.person,
+        color: theme.colorScheme.onSurface.withValues(alpha: 0.35),
+      ),
+    );
+  }
+}

--- a/lib/features/library/widgets/library_search_field.dart
+++ b/lib/features/library/widgets/library_search_field.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+
+/// The Library search box. A thin, themed wrapper over [TextField] that filters
+/// the active tab as the user types and offers a clear button once there's text.
+///
+/// It owns no state — the host screen holds the query and the controller — so a
+/// tab switch can clear it from the outside. It only ever reports plain typed
+/// text upward; it never reads or renders a URL or token.
+class LibrarySearchField extends StatelessWidget {
+  const LibrarySearchField({
+    required this.controller,
+    required this.onChanged,
+    required this.onClear,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool hasText = controller.text.isNotEmpty;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.sm,
+      ),
+      child: TextField(
+        key: const Key('library_search_field'),
+        controller: controller,
+        onChanged: onChanged,
+        textInputAction: TextInputAction.search,
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: 'Search songs, albums, artists',
+          prefixIcon: const Icon(Icons.search),
+          suffixIcon: hasText
+              ? IconButton(
+                  key: const Key('library_search_clear'),
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Clear search',
+                  onPressed: onClear,
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/library/album_detail_screen_test.dart
+++ b/test/features/library/album_detail_screen_test.dart
@@ -98,8 +98,8 @@ void main() {
       await _openAlbum(tester, 'Discovery');
 
       // The header's Play action confirms we're on the detail screen.
-      expect(find.widgetWithText(FilledButton, 'Play'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, 'Shuffle'), findsOneWidget);
+      expect(find.text('Play'), findsOneWidget);
+      expect(find.text('Shuffle'), findsOneWidget);
       // Only this album's tracks are listed.
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsOneWidget);
@@ -110,7 +110,7 @@ void main() {
       final FakePlaybackController controller = await _pump(tester);
       await _openAlbum(tester, 'Discovery');
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Play'));
+      await tester.tap(find.text('Play'));
       await tester.pumpAndSettle();
 
       expect(controller.state.currentTrack?.id, '1');
@@ -140,7 +140,7 @@ void main() {
       );
       await _openAlbum(tester, 'Unknown Album');
 
-      expect(find.widgetWithText(FilledButton, 'Play'), findsOneWidget);
+      expect(find.text('Play'), findsOneWidget);
       expect(find.text('Untagged'), findsOneWidget);
     });
   });

--- a/test/features/library/album_detail_screen_test.dart
+++ b/test/features/library/album_detail_screen_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+const List<Track> _tracks = <Track>[
+  Track(
+    id: '1',
+    title: 'Alpha',
+    uri: 'jellyfin:1',
+    artistName: 'Daft Punk',
+    albumName: 'Discovery',
+    trackNumber: 1,
+  ),
+  Track(
+    id: '2',
+    title: 'Beta',
+    uri: 'jellyfin:2',
+    artistName: 'Daft Punk',
+    albumName: 'Discovery',
+    trackNumber: 2,
+  ),
+  Track(
+    id: '3',
+    title: 'Gamma',
+    uri: 'jellyfin:3',
+    artistName: 'Adele',
+    albumName: '25',
+    trackNumber: 1,
+  ),
+];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/library/album/:id',
+        builder: (_, GoRouterState s) =>
+            AlbumDetailScreen(albumId: s.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/library/artist/:id',
+        builder: (_, GoRouterState s) =>
+            ArtistDetailScreen(artistId: s.pathParameters['id']!),
+      ),
+      GoRoute(path: AppRoutes.player, builder: (_, __) => const PlayerScreen()),
+    ],
+  );
+}
+
+Future<FakePlaybackController> _pump(
+  WidgetTester tester, {
+  List<Track> tracks = _tracks,
+}) async {
+  final FakePlaybackController controller = FakePlaybackController();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+Future<void> _openAlbum(WidgetTester tester, String title) async {
+  await tester.tap(find.text('Albums'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(title));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('AlbumDetailScreen', () {
+    testWidgets('tapping an album opens its detail listing its tracks',
+        (tester) async {
+      await _pump(tester);
+      await _openAlbum(tester, 'Discovery');
+
+      // The header's Play action confirms we're on the detail screen.
+      expect(find.widgetWithText(FilledButton, 'Play'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Shuffle'), findsOneWidget);
+      // Only this album's tracks are listed.
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsNothing);
+    });
+
+    testWidgets('Play queues the album tracks in order', (tester) async {
+      final FakePlaybackController controller = await _pump(tester);
+      await _openAlbum(tester, 'Discovery');
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Play'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack?.id, '1');
+      expect(controller.state.upNext.map((Track t) => t.id), <String>['2']);
+    });
+
+    testWidgets('tapping a track plays it and queues the rest of the album',
+        (tester) async {
+      final FakePlaybackController controller = await _pump(tester);
+      await _openAlbum(tester, 'Discovery');
+
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+
+      // Started at Beta; nothing after it on this album.
+      expect(controller.state.currentTrack?.id, '2');
+      expect(controller.state.upNext, isEmpty);
+    });
+
+    testWidgets('an album with missing metadata shows Unknown Album',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'x', title: 'Untagged', uri: 'file:///x.mp3'),
+        ],
+      );
+      await _openAlbum(tester, 'Unknown Album');
+
+      expect(find.widgetWithText(FilledButton, 'Play'), findsOneWidget);
+      expect(find.text('Untagged'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -98,8 +98,8 @@ void main() {
       await _pump(tester);
       await _openArtist(tester, 'Daft Punk');
 
-      expect(find.widgetWithText(FilledButton, 'Play all'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, 'Shuffle all'), findsOneWidget);
+      expect(find.text('Play all'), findsOneWidget);
+      expect(find.text('Shuffle all'), findsOneWidget);
       // Albums section (the artist has two albums) and songs section.
       expect(find.text('Albums'), findsOneWidget);
       expect(find.text('Songs'), findsOneWidget);
@@ -114,7 +114,7 @@ void main() {
       final FakePlaybackController controller = await _pump(tester);
       await _openArtist(tester, 'Daft Punk');
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Play all'));
+      await tester.tap(find.text('Play all'));
       await tester.pumpAndSettle();
 
       // Two tracks by Daft Punk; album order puts Discovery before Homework.
@@ -131,7 +131,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Now on the album detail: its Play action and only its track.
-      expect(find.widgetWithText(FilledButton, 'Play'), findsOneWidget);
+      expect(find.text('Play'), findsOneWidget);
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsNothing);
     });
@@ -146,10 +146,10 @@ void main() {
       );
       await _openArtist(tester, 'Unknown Artist');
 
-      expect(find.widgetWithText(FilledButton, 'Play all'), findsOneWidget);
+      expect(find.text('Play all'), findsOneWidget);
       expect(find.text('Untagged'), findsOneWidget);
 
-      await tester.tap(find.widgetWithText(FilledButton, 'Play all'));
+      await tester.tap(find.text('Play all'));
       await tester.pumpAndSettle();
       expect(controller.state.currentTrack?.id, 'x');
     });

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/artist_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/album_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+const List<Track> _tracks = <Track>[
+  Track(
+    id: '1',
+    title: 'Alpha',
+    uri: 'jellyfin:1',
+    artistName: 'Daft Punk',
+    albumName: 'Discovery',
+    trackNumber: 1,
+  ),
+  Track(
+    id: '2',
+    title: 'Beta',
+    uri: 'jellyfin:2',
+    artistName: 'Daft Punk',
+    albumName: 'Homework',
+    trackNumber: 1,
+  ),
+  Track(
+    id: '3',
+    title: 'Gamma',
+    uri: 'jellyfin:3',
+    artistName: 'Adele',
+    albumName: '25',
+    trackNumber: 1,
+  ),
+];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/library/album/:id',
+        builder: (_, GoRouterState s) =>
+            AlbumDetailScreen(albumId: s.pathParameters['id']!),
+      ),
+      GoRoute(
+        path: '/library/artist/:id',
+        builder: (_, GoRouterState s) =>
+            ArtistDetailScreen(artistId: s.pathParameters['id']!),
+      ),
+      GoRoute(path: AppRoutes.player, builder: (_, __) => const PlayerScreen()),
+    ],
+  );
+}
+
+Future<FakePlaybackController> _pump(
+  WidgetTester tester, {
+  List<Track> tracks = _tracks,
+}) async {
+  final FakePlaybackController controller = FakePlaybackController();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+Future<void> _openArtist(WidgetTester tester, String name) async {
+  await tester.tap(find.text('Artists'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(name));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ArtistDetailScreen', () {
+    testWidgets('tapping an artist opens detail listing albums and tracks',
+        (tester) async {
+      await _pump(tester);
+      await _openArtist(tester, 'Daft Punk');
+
+      expect(find.widgetWithText(FilledButton, 'Play all'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Shuffle all'), findsOneWidget);
+      // Albums section (the artist has two albums) and songs section.
+      expect(find.text('Albums'), findsOneWidget);
+      expect(find.text('Songs'), findsOneWidget);
+      expect(find.byType(AlbumTile), findsNWidgets(2));
+      // This artist's tracks, not the other artist's.
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsNothing);
+    });
+
+    testWidgets('Play all queues the artist tracks', (tester) async {
+      final FakePlaybackController controller = await _pump(tester);
+      await _openArtist(tester, 'Daft Punk');
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Play all'));
+      await tester.pumpAndSettle();
+
+      // Two tracks by Daft Punk; album order puts Discovery before Homework.
+      expect(controller.state.currentTrack?.id, '1');
+      expect(controller.state.upNext.map((Track t) => t.id), <String>['2']);
+    });
+
+    testWidgets('tapping an album in the artist detail opens that album',
+        (tester) async {
+      await _pump(tester);
+      await _openArtist(tester, 'Daft Punk');
+
+      await tester.tap(find.text('Discovery'));
+      await tester.pumpAndSettle();
+
+      // Now on the album detail: its Play action and only its track.
+      expect(find.widgetWithText(FilledButton, 'Play'), findsOneWidget);
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsNothing);
+    });
+
+    testWidgets('an artist with missing metadata shows Unknown Artist',
+        (tester) async {
+      final FakePlaybackController controller = await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'x', title: 'Untagged', uri: 'file:///x.mp3'),
+        ],
+      );
+      await _openArtist(tester, 'Unknown Artist');
+
+      expect(find.widgetWithText(FilledButton, 'Play all'), findsOneWidget);
+      expect(find.text('Untagged'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Play all'));
+      await tester.pumpAndSettle();
+      expect(controller.state.currentTrack?.id, 'x');
+    });
+  });
+}

--- a/test/features/library/library_browse_test.dart
+++ b/test/features/library/library_browse_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/album_tile.dart';
+import 'package:linthra/features/library/widgets/artist_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+// No artworkUri anywhere, so these widget tests never reach for the network —
+// artwork falls back to the placeholder (mirrors the player screen tests).
+List<Track> _sampleTracks() => const <Track>[
+      Track(
+        id: '1',
+        title: 'Alpha',
+        uri: 'jellyfin:1',
+        artistName: 'Daft Punk',
+        albumName: 'Discovery',
+      ),
+      Track(
+        id: '2',
+        title: 'Beta',
+        uri: 'jellyfin:2',
+        artistName: 'Daft Punk',
+        albumName: 'Discovery',
+      ),
+      Track(
+        id: '3',
+        title: 'Gamma',
+        uri: 'jellyfin:3',
+        artistName: 'Adele',
+        albumName: '25',
+      ),
+    ];
+
+Future<void> _pump(
+  WidgetTester tester, {
+  List<Track>? tracks,
+  FakePlaybackController? playback,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: tracks ?? _sampleTracks()),
+        ),
+        if (playback != null)
+          playbackControllerProvider.overrideWithValue(playback),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _enter(WidgetTester tester, String text) async {
+  await tester.enterText(
+    find.byKey(const Key('library_search_field')),
+    text,
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('Library search', () {
+    testWidgets('the search bar renders once the catalog is loaded',
+        (tester) async {
+      await _pump(tester);
+      expect(find.byKey(const Key('library_search_field')), findsOneWidget);
+    });
+
+    testWidgets('typing filters songs by title', (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'alpha');
+
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsNothing);
+      expect(find.text('Gamma'), findsNothing);
+    });
+
+    testWidgets('typing filters songs by artist', (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'adele');
+
+      // Only Gamma is by Adele.
+      expect(find.text('Gamma'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
+    });
+
+    testWidgets('typing filters songs by album', (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'discovery');
+
+      // Alpha and Beta are both on Discovery; Gamma (album "25") is hidden.
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsNothing);
+    });
+
+    testWidgets('a query with no matches shows the empty state',
+        (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'zzzzz');
+
+      expect(find.text('No results found.'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
+    });
+
+    testWidgets('clearing the search restores the full list', (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'alpha');
+      expect(find.text('Beta'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('library_search_clear')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsOneWidget);
+    });
+
+    testWidgets('searching never touches playback', (tester) async {
+      final Track playing = _sampleTracks().first;
+      final FakePlaybackController controller = FakePlaybackController(
+        initial: PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: playing,
+        ),
+      );
+      await _pump(tester, playback: controller);
+
+      await _enter(tester, 'gamma');
+
+      // Filtering the list started nothing and changed nothing about playback.
+      expect(controller.playedTracks, isEmpty);
+      expect(controller.playCount, 0);
+      expect(controller.state.currentTrack?.id, '1');
+      expect(controller.state.isPlaying, isTrue);
+    });
+
+    testWidgets('search does not expose tokens or authenticated URLs',
+        (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'alpha');
+
+      expect(find.textContaining('api_key'), findsNothing);
+      expect(find.textContaining('AccessToken'), findsNothing);
+      // The row shows friendly metadata, not the opaque uri.
+      expect(find.text('Daft Punk • Discovery'), findsOneWidget);
+    });
+  });
+
+  group('Library tabs', () {
+    testWidgets('the Songs tab renders the tracks', (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Songs'), findsOneWidget);
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsOneWidget);
+    });
+
+    testWidgets('the Albums tab renders grouped albums with title/artist/count',
+        (tester) async {
+      await _pump(tester);
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlbumTile), findsNWidgets(2));
+      expect(find.text('Discovery'), findsOneWidget);
+      expect(find.text('25'), findsOneWidget);
+      // Album row subtitle: artist + track count.
+      expect(find.text('Daft Punk • 2 songs'), findsOneWidget);
+    });
+
+    testWidgets('the Artists tab renders grouped artists with name/count',
+        (tester) async {
+      await _pump(tester);
+      await tester.tap(find.text('Artists'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ArtistTile), findsNWidgets(2));
+      expect(find.text('Daft Punk'), findsOneWidget);
+      expect(find.text('Adele'), findsOneWidget);
+      // Artist row subtitle: album + track count.
+      expect(find.text('1 album • 2 songs'), findsOneWidget);
+    });
+
+    testWidgets('switching tabs clears the active search', (tester) async {
+      await _pump(tester);
+      await _enter(tester, 'alpha');
+      expect(find.text('Beta'), findsNothing);
+
+      // Move to Albums (clears the query), then back to Songs.
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Songs'));
+      await tester.pumpAndSettle();
+
+      // The full song list is back — the query did not survive the switch.
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsOneWidget);
+    });
+
+    testWidgets('missing album/artist metadata groups under Unknown',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'x', title: 'Untagged', uri: 'file:///x.mp3'),
+        ],
+      );
+
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+      expect(find.text('Unknown Album'), findsOneWidget);
+
+      await tester.tap(find.text('Artists'));
+      await tester.pumpAndSettle();
+      expect(find.text('Unknown Artist'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/library/library_grouping_test.dart
+++ b/test/features/library/library_grouping_test.dart
@@ -1,0 +1,218 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/library/library_grouping.dart';
+
+/// A track shaped like the Jellyfin mapper's output: an opaque `jellyfin:<id>`
+/// uri (never a stream URL) and a token-free primary-image artwork URL.
+Track _jelly(
+  String id, {
+  required String title,
+  String? artist,
+  String? album,
+  int? trackNumber,
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: artist,
+      albumName: album,
+      trackNumber: trackNumber,
+      artworkUri: Uri.parse('https://media.example/Items/$id/Images/Primary'),
+    );
+
+/// A track shaped like the local scanner's output: a file path for both id and
+/// uri, the file name as title, and no album/artist tags.
+Track _local(String path) =>
+    Track(id: path, title: path.split('/').last, uri: path);
+
+void main() {
+  group('album grouping — Jellyfin tracks', () {
+    test('groups tracks that share an album + artist into one album', () {
+      final List<Album> albums = groupAlbums(<Track>[
+        _jelly('1', title: 'One', artist: 'Adele', album: '25', trackNumber: 1),
+        _jelly('2', title: 'Two', artist: 'Adele', album: '25', trackNumber: 2),
+      ]);
+
+      expect(albums, hasLength(1));
+      expect(albums.single.title, '25');
+      expect(albums.single.artistName, 'Adele');
+      expect(albums.single.trackCount, 2);
+      // Artwork comes from a track, which is the token-free primary image URL.
+      expect(albums.single.artworkUri, isNotNull);
+    });
+
+    test('same album title by different artists stays distinct', () {
+      final List<Album> albums = groupAlbums(<Track>[
+        _jelly('1', title: 'a', artist: 'Queen', album: 'Greatest Hits'),
+        _jelly('2', title: 'b', artist: 'ABBA', album: 'Greatest Hits'),
+      ]);
+
+      expect(albums, hasLength(2));
+      expect(
+        albums.map((Album a) => a.artistName).toSet(),
+        <String>{'Queen', 'ABBA'},
+      );
+    });
+
+    test('case and accents do not split one album', () {
+      final List<Album> albums = groupAlbums(<Track>[
+        _jelly('1', title: 'a', artist: 'Sigur Rós', album: 'Takk'),
+        _jelly('2', title: 'b', artist: 'Sigur Ros', album: 'takk'),
+      ]);
+
+      expect(albums, hasLength(1));
+      expect(albums.single.trackCount, 2);
+    });
+  });
+
+  group('album grouping — local tracks', () {
+    test('untagged local files fold into a single Unknown Album', () {
+      final List<Album> albums = groupAlbums(<Track>[
+        _local('/music/a.mp3'),
+        _local('/music/b.mp3'),
+        _local('/music/c.flac'),
+      ]);
+
+      expect(albums, hasLength(1));
+      expect(albums.single.title, kUnknownAlbum);
+      expect(albums.single.title, 'Unknown Album');
+      expect(albums.single.artistName, isNull);
+      expect(albums.single.trackCount, 3);
+    });
+  });
+
+  group('artist grouping — Jellyfin tracks', () {
+    test('groups by artist and counts distinct albums and tracks', () {
+      final List<Artist> artists = groupArtists(<Track>[
+        _jelly('1', title: 'a', artist: 'Radiohead', album: 'OK Computer'),
+        _jelly('2', title: 'b', artist: 'Radiohead', album: 'OK Computer'),
+        _jelly('3', title: 'c', artist: 'Radiohead', album: 'In Rainbows'),
+      ]);
+
+      expect(artists, hasLength(1));
+      expect(artists.single.name, 'Radiohead');
+      expect(artists.single.albumCount, 2);
+      expect(artists.single.trackCount, 3);
+    });
+  });
+
+  group('artist grouping — local tracks', () {
+    test('untagged local files fold into a single Unknown Artist', () {
+      final List<Artist> artists = groupArtists(<Track>[
+        _local('/music/a.mp3'),
+        _local('/music/b.mp3'),
+      ]);
+
+      expect(artists, hasLength(1));
+      expect(artists.single.name, kUnknownArtist);
+      expect(artists.single.name, 'Unknown Artist');
+      expect(artists.single.trackCount, 2);
+    });
+  });
+
+  group('sorting', () {
+    test('albums sort by title then artist, and are deterministic', () {
+      List<Track> input() => <Track>[
+            _jelly('1', title: 'a', artist: 'Z', album: 'Banana'),
+            _jelly('2', title: 'b', artist: 'A', album: 'apple'),
+            _jelly('3', title: 'c', artist: 'B', album: 'Apple'),
+          ];
+
+      final List<String> first =
+          groupAlbums(input()).map((Album a) => a.title).toList();
+      final List<Album> reordered = groupAlbums(input().reversed.toList());
+
+      // Title ascending, case-insensitive; the two "Apple"s order by artist.
+      expect(first, <String>['apple', 'Apple', 'Banana']);
+      // Same input (in any order) always produces the same order.
+      expect(reordered.map((Album a) => a.title).toList(), first);
+    });
+
+    test('artists sort by name ascending and deterministically', () {
+      List<Track> input() => <Track>[
+            _jelly('1', title: 'a', artist: 'Tame Impala'),
+            _jelly('2', title: 'b', artist: 'ABBA'),
+            _jelly('3', title: 'c', artist: 'glass animals'),
+          ];
+
+      final List<String> names =
+          groupArtists(input()).map((Artist a) => a.name).toList();
+      expect(names, <String>['ABBA', 'glass animals', 'Tame Impala']);
+      expect(
+        groupArtists(input().reversed.toList()).map((Artist a) => a.name),
+        names,
+      );
+    });
+
+    test('album tracks order by track number, numbered before unnumbered', () {
+      final List<Track> all = <Track>[
+        _jelly('x', title: 'No number', artist: 'A', album: 'LP'),
+        _jelly('1', title: 'First', artist: 'A', album: 'LP', trackNumber: 1),
+        _jelly('2', title: 'Second', artist: 'A', album: 'LP', trackNumber: 2),
+      ];
+      final String id = albumIdForTrack(all[1]);
+
+      expect(
+        tracksForAlbum(all, id).map((Track t) => t.title),
+        <String>['First', 'Second', 'No number'],
+      );
+    });
+  });
+
+  group('lookups', () {
+    test('albumById / artistById find the derived group, or null', () {
+      final List<Track> tracks = <Track>[
+        _jelly('1', title: 'a', artist: 'Muse', album: 'Drones'),
+      ];
+      final String albumId = albumIdForTrack(tracks.first);
+      final String artistId = artistIdForTrack(tracks.first);
+
+      expect(albumById(tracks, albumId)?.title, 'Drones');
+      expect(artistById(tracks, artistId)?.name, 'Muse');
+      expect(albumById(tracks, 'nope'), isNull);
+      expect(artistById(tracks, 'nope'), isNull);
+    });
+
+    test('albumsForArtist returns only that artist\'s albums', () {
+      final List<Track> tracks = <Track>[
+        _jelly('1', title: 'a', artist: 'Muse', album: 'Drones'),
+        _jelly('2', title: 'b', artist: 'Muse', album: 'Origin'),
+        _jelly('3', title: 'c', artist: 'Other', album: 'Misc'),
+      ];
+      final String artistId = artistIdForTrack(tracks.first);
+
+      expect(
+        albumsForArtist(tracks, artistId).map((Album a) => a.title),
+        <String>['Drones', 'Origin'],
+      );
+    });
+  });
+
+  group('privacy', () {
+    test('derived album/artist metadata carries no token or auth URL', () {
+      final List<Track> tracks = <Track>[
+        _jelly('1', title: 'a', artist: 'Artist', album: 'Album'),
+      ];
+      final Album album = groupAlbums(tracks).single;
+      final Artist artist = groupArtists(tracks).single;
+
+      final List<String> exposed = <String>[
+        album.title,
+        album.artistName ?? '',
+        album.id,
+        album.artworkUri?.toString() ?? '',
+        artist.name,
+        artist.id,
+        artist.artworkUri?.toString() ?? '',
+      ];
+      for (final String value in exposed) {
+        expect(value.toLowerCase(), isNot(contains('api_key')));
+        expect(value.toLowerCase(), isNot(contains('token')));
+        expect(value, isNot(contains('AccessToken')));
+      }
+    });
+  });
+}

--- a/test/features/library/library_search_test.dart
+++ b/test/features/library/library_search_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/library/library_search.dart';
+
+Track _track(
+  String id, {
+  String? title,
+  String? artist,
+  String? album,
+}) =>
+    Track(
+      id: id,
+      title: title ?? 'Track $id',
+      uri: 'file:///$id.mp3',
+      artistName: artist,
+      albumName: album,
+    );
+
+void main() {
+  group('foldText', () {
+    test('lower-cases and trims', () {
+      expect(foldText('  Hello World  '), 'hello world');
+    });
+
+    test('collapses internal whitespace', () {
+      expect(foldText('a\t b\n c'), 'a b c');
+    });
+
+    test('strips common Latin diacritics', () {
+      expect(foldText('Beyoncé'), 'beyonce');
+      expect(foldText('Amélie'), 'amelie');
+      expect(foldText('Mötley Crüe'), 'motley crue');
+      expect(foldText('Sigur Rós'), 'sigur ros');
+    });
+
+    test('expands ligatures', () {
+      expect(foldText('Straße'), 'strasse');
+    });
+  });
+
+  group('filterTracks', () {
+    final List<Track> tracks = <Track>[
+      _track('1', title: 'Levitating', artist: 'Dua Lipa', album: 'Future'),
+      _track('2', title: 'Blinding Lights', artist: 'The Weeknd'),
+      _track('3', title: 'Café del Mar', artist: 'Energy 52', album: 'Ibiza'),
+    ];
+
+    test('empty query returns the same list instance', () {
+      expect(filterTracks(tracks, ''), same(tracks));
+      expect(filterTracks(tracks, '   '), same(tracks));
+    });
+
+    test('matches by title, case-insensitively', () {
+      final List<Track> result = filterTracks(tracks, 'levit');
+      expect(result.map((Track t) => t.id), <String>['1']);
+    });
+
+    test('matches by artist', () {
+      final List<Track> result = filterTracks(tracks, 'weeknd');
+      expect(result.map((Track t) => t.id), <String>['2']);
+    });
+
+    test('matches by album', () {
+      final List<Track> result = filterTracks(tracks, 'future');
+      expect(result.map((Track t) => t.id), <String>['1']);
+    });
+
+    test('matches accent-insensitively', () {
+      // Typing the unaccented form still finds the accented title.
+      final List<Track> result = filterTracks(tracks, 'cafe');
+      expect(result.map((Track t) => t.id), <String>['3']);
+    });
+
+    test('no match yields an empty list', () {
+      expect(filterTracks(tracks, 'zzz'), isEmpty);
+    });
+  });
+
+  group('filterAlbums', () {
+    final List<Album> albums = <Album>[
+      const Album(id: 'a', title: 'Random Access Memories', artistName: 'Daft'),
+      const Album(id: 'b', title: 'Discovery', artistName: 'Daft Punk'),
+    ];
+
+    test('matches by album title', () {
+      expect(
+        filterAlbums(albums, 'discovery').map((Album a) => a.id),
+        <String>['b'],
+      );
+    });
+
+    test('matches by album artist', () {
+      expect(
+        filterAlbums(albums, 'daft').map((Album a) => a.id),
+        <String>['a', 'b'],
+      );
+    });
+  });
+
+  group('filterArtists', () {
+    final List<Artist> artists = <Artist>[
+      const Artist(id: 'a', name: 'Tame Impala'),
+      const Artist(id: 'b', name: 'Glass Animals'),
+    ];
+
+    test('matches by name', () {
+      expect(
+        filterArtists(artists, 'tame').map((Artist a) => a.id),
+        <String>['a'],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Reworks the Library into a clean tabbed experience — **Songs**, **Albums**, **Artists** — with a search box that filters the active tab. Albums and artists are derived from the existing track catalog, so it works fully offline and needs no schema migration. Album and artist detail screens reuse the existing track row and playback queueing.

Scope was kept to library browsing/search UI, album/artist views, and the focused repository/grouping helpers they need. No playback-architecture, Jellyfin-auth, cache/download, Cast/Android-Auto, release-workflow, or theme changes.

## Library browsing changes

- **Tabbed Library**: `Songs` / `Albums` / `Artists`, styled in the existing dark purple + warm-orange theme (orange tab indicator/label). Loading, error, and the folder-pick empty state still take the whole body without tabs, exactly as before.
- The **mini-player and bottom navigation are untouched** — they live in the shell, above the Library screen.
- **Songs** keeps its long-press multi-select (add to playlist / remove from Linthra / remove offline copies) and the **A–Z fast scroller** (which auto-hides when a list has too few sections, e.g. a narrow search result).
- Album/artist **detail screens** are child routes of the Library tab, so they keep the bottom nav and pop back into Library.

## Search behavior

- One search box filters whichever tab is active: Songs by title/artist/album, Albums by album title/artist, Artists by name.
- **Case-insensitive** and, where practical, **accent-insensitive** (a small built-in Latin diacritics table — no new dependency, no network). `beyonce` → *Beyoncé*.
- Empty query shows the full tab; no matches shows a friendly **“No results found.”**; a **clear (×)** button resets it.
- **Switching tabs clears the query** (chosen as the "clears it intentionally" option) so a song query never silently hides albums/artists.
- **Search never touches playback** — it only filters what's shown.

## Albums tab

- Rows show artwork (or the shared placeholder), title, album artist, and track count. Tapping opens album detail.
- Album detail: artwork + title + artist + count, **Play** / **Shuffle**, and tracks in album order (track number, then title). Tapping a track plays it and **queues the rest of that album**.

## Artists tab

- Rows show an avatar placeholder, name, and album/track counts. Tapping opens artist detail.
- Artist detail: **Play all** / **Shuffle all**, an **Albums** section (each opening its album detail) when the artist has more than one album, and a **Songs** section. Playing queues only that artist's tracks.

## Playback queue behavior

- Playing a song from search results queues the filtered list; from an album queues the album; from an artist queues that artist's tracks.
- Current playback never restarts on browse/search — playback methods are only called when the user taps play/shuffle/a row. Cast/Android Auto behavior is unchanged.

## Data / grouping

- Albums/artists are **derived from the persisted tracks** via a pure, tested grouping module (`library_grouping.dart`), keyed on folded (case/accent-normalized) album/artist names. Same-named albums by different artists stay distinct; missing metadata folds into **Unknown Album** / **Unknown Artist**.
- Source album/artist **IDs aren't stored on a track today**, so grouping uses folded names (the sanctioned path given the "if already stored" guidance). Derived IDs are URL-safe (`al-…` / `ar-…` base64url) so they ride in the route path unambiguously. Persisting source IDs for sharper grouping is documented as a follow-up.
- `Artist` gained a `trackCount` field (additive, default 0) for the artist row/detail counts.

## Tests added

- `library_search_test.dart` — folding (case/accents/whitespace) + filter-by-title/artist/album.
- `library_grouping_test.dart` — album/artist grouping for Jellyfin-style and local-style tracks, stable/deterministic ordering, Unknown fallbacks, lookups, and a privacy check that derived metadata carries no token/auth URL.
- `library_browse_test.dart` — search bar renders, typing filters by title/artist/album, empty state, clear restores, search doesn't change playback, tab rendering with row title/artist/count, switching clears search, Unknown grouping.
- `album_detail_screen_test.dart` / `artist_detail_screen_test.dart` — open detail, list tracks, Play/Play-all queues the right context, tap-a-track queues from there, tap-album-from-artist, Unknown fallbacks.

Existing library/playback/repository/mapper tests were checked for compatibility (selection, tap-to-play queue order, folder pick, smoke boot, in-memory/Drift repos all unchanged).

## Verification

⚠️ **The Flutter/Dart SDK is not available in this execution environment**, so I could not run `flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test`, or `flutter build apk --debug` here. Please run the CI gates. I hand-formatted to dart_style conventions (2-space, ≤80-col code lines, trailing-comma splits, hoisted locals to avoid ambiguous wraps) and audited against the repo's enabled lints (`prefer_const_constructors`, `prefer_final_locals`, `directives_ordering`, `always_declare_return_types`, `unawaited_futures`, strict casts/raw-types), but the formatter/analyzer should confirm.

## Known limitations

- Metadata quality depends on the source; grouping is only as good as the tags.
- Local files have no album/artist tags yet → they group under Unknown Album / Unknown Artist. (Local tag parsing is a separate follow-up.)
- Artwork may be missing for some local files (placeholder shown).
- No stable source album/artist IDs persisted yet (follow-up).

## Manual Android checklist

1. Open Library.
2. Search for a song title.
3. Search for an artist.
4. Search for an album.
5. Clear search.
6. Open Albums tab.
7. Open an album and play it.
8. Open Artists tab.
9. Open an artist and play tracks.
10. Confirm current music keeps playing while browsing.
11. Confirm mini-player still works.
12. Confirm no layout overlap on a narrow phone.

https://claude.ai/code/session_012qffCev49nsqZ73YNKLZg6

---
_Generated by [Claude Code](https://claude.ai/code/session_012qffCev49nsqZ73YNKLZg6)_