### PR TITLE
Sync Jellyfin playlists & favourites on every library sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,8 +1293,11 @@ including one published over HTTPS through a **Cloudflare** domain or tunnel.
    server name/version/product (reading `/System/Info/Public` if you didn't tap
    Test first) so diagnostics show them after a restart.
 4. **Sync library** — once signed in, pulls your Jellyfin artists/albums/tracks
-   and stores them in the local catalog so they show up in the Library. Shows a
-   spinner while it runs and a friendly result/error line when it's done.
+   **and your playlists and liked/favourite tracks** into the local catalog so
+   they show up in Library, Playlists, and Favorites. Shows a spinner while it
+   runs and a friendly result line ("Synced 42 tracks, 3 playlists and 9
+   favorites from your Jellyfin library.") — with honest partial-failure notes
+   when only playlists or favourites couldn't load.
 5. **Copy Jellyfin diagnostics** — copies a short, **secret-free** report (app
    version, connection state, server name/version/host-only, last error kind) to
    the clipboard for bug reports. It never includes your password, token,
@@ -1347,6 +1350,21 @@ for being **not signed in**, a **server it couldn't reach**, an
 **expired/invalid session** (prompting a fresh sign-in), and an **empty Jellyfin
 library** (which leaves any existing catalog untouched rather than wiping it).
 
+**Playlists & favourites sync by default.** The same Sync action — and app
+startup — also imports your Jellyfin **playlists** and adopts your **liked/
+favourite** tracks, so they appear on the Playlists and Favorites tabs without
+any extra step. Server playlists are imported as `jellyfin`-source playlists
+(name + membership mapped to your synced tracks; tracks not in your library are
+counted and shown as unavailable, never crashed), a server-side rename is picked
+up on the next sync, and a playlist deleted on the server is dropped locally.
+Liking a Jellyfin track in Linthra pushes the change to the server
+(optimistically, reconciled on the next sync); local-file favourites and
+local-only playlists always stay on-device. Sign-out clears this account's
+imported playlists and server favourites while keeping your local ones. Nothing
+here stores a token — full behaviour, limitations, troubleshooting, and security
+notes are in [docs/jellyfin-sync.md](docs/jellyfin-sync.md) and
+[docs/playlists-and-delete.md](docs/playlists-and-delete.md).
+
 **Streaming playback** routes through a `PlayableUriResolver` seam, so the
 playback controller opens whatever URI it's given rather than assuming a local
 file. A `JellyfinPlayableUriResolver` reads the live signed-in source, verifies
@@ -1398,9 +1416,11 @@ tokenized URL).
 - **Direct play only (no transcoding fallback yet).** Streaming serves the
   original file (`static=true`), which the engine decodes for the common
   containers; a server-side transcode fallback for exotic formats is deferred.
-- **No Android Auto browsing or sync-conflict handling** for Jellyfin in this
-  foundation. (Lyrics and favourites now sync from Jellyfin — see **Now Playing
-  controls** above.)
+- **No two-way conflict resolution.** For a synced playlist the server is the
+  source of truth on refresh, and playlist **rename/reorder are local-only** (not
+  pushed); favourites reconcile to the server on the next sync. Lyrics,
+  favourites, **and playlists** now sync from Jellyfin — see **Now Playing
+  controls** above and [docs/jellyfin-sync.md](docs/jellyfin-sync.md).
 
 ## Continuous integration
 

--- a/docs/jellyfin-sync.md
+++ b/docs/jellyfin-sync.md
@@ -1,0 +1,124 @@
+# Jellyfin sync: playlists & favourites
+
+Linthra mirrors your Jellyfin account so your library *and* the things you've
+organised — your **playlists** and your **liked/favourite** tracks — show up in
+the app by default. This document describes exactly what syncs, what stays
+local, the deliberate limitations, how to troubleshoot, and the security
+guarantees. For connectivity (URLs, Cloudflare, version floor) see
+[jellyfin-compatibility.md](jellyfin-compatibility.md); for the editing/delete
+model and the capability matrix see
+[playlists-and-delete.md](playlists-and-delete.md).
+
+## What syncs by default
+
+When you sign in to Jellyfin and run **Sync library** (and on each app launch),
+Linthra pulls:
+
+- **Tracks**, **albums**, and **artists** into the local catalog (the Library).
+- **Playlists** — your Jellyfin playlists are imported and listed on the
+  Playlists tab.
+- **Favourites / liked tracks** — the per-user "favourite" flag from Jellyfin is
+  adopted, so the heart is filled for the right tracks.
+
+The sync status line reports what landed, e.g. *"Synced 42 tracks, 3 playlists
+and 9 favorites from your Jellyfin library."* If only part of the account could
+be read, it stays honest — *"Synced 42 tracks from your Jellyfin library.
+Playlists could not be loaded."* — and the **tracks still sync** even when
+playlists or favourites fail.
+
+Nothing here needs a separate toggle: a sign-in + sync is enough.
+
+## Playlists
+
+- **Import / list.** Existing Jellyfin playlists appear on the Playlists tab with
+  a subtle "· Jellyfin" source label. Tapping one opens its tracks; Play /
+  Shuffle queue the available tracks.
+- **Track mapping.** A playlist stores stable Jellyfin item ids; they resolve
+  against your synced catalog. A track that isn't in your library yet is counted
+  and shown as unavailable on the detail screen — never a crash, and the rest of
+  the playlist still plays.
+- **Idempotent refresh.** Re-syncing never duplicates a playlist or its entries;
+  it updates the existing synced record in place.
+- **Rename pickup.** If you rename a playlist on the Jellyfin server, Linthra
+  adopts the new name on the next sync.
+- **Deletion pickup.** If a playlist is deleted on the server, Linthra drops its
+  local mirror on the next sync (the server is the source of truth for synced
+  playlists). Your **local-only** playlists are never touched by a refresh.
+- **Write-back (when signed in).** Creating a "Sync with Jellyfin" playlist,
+  adding Jellyfin tracks to it, removing tracks, and deleting it are pushed to
+  the server best-effort. A failed write never throws out of the edit — the local
+  change stands and the playlist's sync state flips to `syncFailed` with a
+  friendly, secret-free reason.
+
+## Favourites / likes
+
+- **Read on sync.** Jellyfin's per-user favourite set is fetched and adopted as
+  the source of truth for remote (Jellyfin) tracks; the favourited tracks show as
+  liked across the app (heart button, Favorites tab).
+- **Offline-visible.** The favourite set is stored on-device, so the right hearts
+  show even before the next sync / while offline.
+- **Toggle from Linthra.** Liking/unliking a Jellyfin track updates the UI
+  immediately (optimistic) and pushes the change to Jellyfin's user-data
+  favourite API. If the push fails (offline, expired session), the optimistic
+  local state stands and is reconciled on the next sync rather than throwing — so
+  the heart never gets stuck mid-tap. You can toggle from Now Playing and the
+  Favorites/Library track rows where a heart is shown.
+- **External changes.** If you change favourites on Jellyfin (another client, the
+  web UI), the next sync updates Linthra.
+
+## What stays local-only
+
+- **Local-file favourites.** Hearts on on-device tracks are stored on-device and
+  are **never** sent to Jellyfin. Mixed local + Jellyfin favourite lists work
+  cleanly — each side is tracked separately and merged for display.
+- **Local-only playlists.** A playlist you create without "Sync with Jellyfin"
+  lives only on the device and is never pushed or pruned by a server refresh. It
+  can still hold tracks from any source.
+
+## Sign-out
+
+Sign-out clears this account's **server-synced favourites** and **imported
+Jellyfin playlists**, plus the stale sync status, so one account's data can't
+linger or cross over to a different account on the next sign-in. Your **local**
+favourites and **local-only** playlists are kept.
+
+## Known limitations (on purpose)
+
+- **Rename / reorder of a synced playlist are local-only.** They are not pushed
+  to Jellyfin; a refresh re-adopts the server's name and order.
+- **No two-way conflict resolution.** On refresh the server wins for synced
+  playlists and the favourite set. A local change that failed to push
+  (`syncFailed`) may be reconciled to the server state on the next refresh.
+- **Missing playlist tracks** (items not in your synced library) are shown as
+  unavailable rather than fetched on the fly.
+- **Subsonic/Navidrome** playlist and favourite sync are not implemented yet;
+  their tracks can still be added to local Linthra playlists.
+
+## Troubleshooting
+
+- **Playlists not showing.** Make sure you're signed in (Settings → Jellyfin)
+  and run **Sync library**. The Playlists tab's empty state tells you whether
+  you're signed in. If the status line says "playlists could not be loaded", the
+  server was briefly unreachable or the session expired — try again, or sign in
+  again.
+- **Favourites not syncing.** Same first steps. A liked track that doesn't change
+  on the server usually means the favourite push failed silently and was kept
+  locally; the next successful sync reconciles it.
+- **Session expired.** The sync/stream errors prompt you to sign out and sign in
+  again to refresh the token.
+- **A playlist disappeared after a sync.** It was deleted on the Jellyfin server;
+  Linthra drops synced playlists that no longer exist on the server.
+
+## Security notes
+
+- **No tokens in metadata.** A playlist stores only a non-secret `remoteId`
+  (the server playlist id) and track ids; favourites store only item ids. No
+  Jellyfin token, password, or authenticated URL is ever written to playlist or
+  favourite metadata, a cache filename, a log, or a UI error.
+- **No authenticated URLs persisted.** Stream/download URLs are minted on demand
+  at play/download time from the live session and discarded; the persisted track
+  URI stays the token-free `jellyfin:<id>`.
+- **Friendly, redacted errors.** Sync/favourite/playlist failures surface as
+  friendly messages branched on a typed error kind (not signed in, expired
+  session, server unreachable, permission/API error) — never a raw error or a
+  tokenised URL. Tests assert no token reaches these sinks.

--- a/docs/playlists-and-delete.md
+++ b/docs/playlists-and-delete.md
@@ -42,8 +42,27 @@ Linthra never pretends a sync worked when the server rejected it.
 ## Jellyfin playlist sync
 
 When you're signed in to Jellyfin you can create a playlist that mirrors to your
-server (toggle "Sync with Jellyfin" in the create dialog). Linthra also imports
-your existing Jellyfin playlists on launch and on refresh.
+server (toggle "Sync with Jellyfin" in the create dialog). Linthra also **imports
+your existing Jellyfin playlists by default** — on app launch and on every
+**Sync library** — so they appear on the Playlists tab without any extra step. A
+synced playlist row shows a subtle "· Jellyfin" source label.
+
+### Reconcile on refresh (server is the source of truth)
+
+Each refresh (startup or Sync library):
+
+- **imports** new server playlists (name + membership), mapping items to your
+  synced tracks; items not in your library are counted as unavailable and shown
+  honestly on the detail screen, never crashed;
+- **updates** an already-synced playlist's name and membership — so a server-side
+  rename shows up on the next sync — and is idempotent: repeated syncs never
+  duplicate a playlist or its entries;
+- **drops** a synced playlist whose server copy is gone (it was deleted on the
+  server). Local-only playlists are never touched by a refresh.
+
+On **sign-out**, this account's imported Jellyfin playlists (and its server
+favourites) are cleared so they can't linger — or be confused with a different
+account — after disconnecting; your local-only playlists stay on-device.
 
 Supported today (best-effort, server is the source of truth for synced
 playlists):
@@ -141,6 +160,10 @@ are shown:
 | `canRemoveOfflineCopy` | — (already local) | ✅ | ✅ |
 | `canDeleteLocalFile` | ❌ (not wired up) | ❌ | ❌ |
 | `canDeleteRemoteItem` | ❌ | ❌ (not enabled) | ❌ |
+| `canFavoriteTracks` | ✅ | ✅ | ❌ |
+| `canReadFavoriteState` | ✅ | ✅ | ❌ |
+| `canSyncFavorites` | ❌ (local-only) | ✅ | ❌ |
+| `canListPlaylists` | ❌ | ✅ | ❌ |
 | `canCreatePlaylist` | ✅ | ✅ | ❌ |
 | `canEditPlaylist` | ✅ | ✅ | ❌ |
 | `canDeletePlaylist` | ✅ | ✅ | ❌ |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -9,13 +9,18 @@ Each provider declares what it can do through a small **capability model**
 (`lib/core/sources/music_provider.dart`), so the UI only ever offers actions a
 source actually supports:
 
-| Capability     | Meaning                                                        |
-| -------------- | -------------------------------------------------------------- |
-| `canStream`    | Tracks play by resolving a stream URL at play time.            |
-| `canCache`     | Tracks can be downloaded for offline use (token-free cache).   |
-| `canFavorite`  | Favorites can be toggled and reflected.                        |
-| `canLyrics`    | Lyrics can be fetched for the source's tracks.                 |
-| `canCast`      | A track's playback URL is network-reachable, so it can cast.   |
+| Capability             | Meaning                                                       |
+| ---------------------- | ------------------------------------------------------------- |
+| `canStream`            | Tracks play by resolving a stream URL at play time.           |
+| `canCache`             | Tracks can be downloaded for offline use (token-free cache).  |
+| `canFavoriteTracks`    | The heart can be toggled for this source's tracks.            |
+| `canReadFavoriteState` | The source exposes a readable liked/favourite state.          |
+| `canSyncFavorites`     | Favourites mirror two-way with this source's server.          |
+| `canListPlaylists`     | The source's (server) playlists can be imported and listed.   |
+| `canCreatePlaylist` / `canEditPlaylist` / `canDeletePlaylist` | Playlists of this kind can be created / edited / deleted. |
+| `canSyncPlaylists`     | Playlists mirror with this source's server.                   |
+| `canLyrics`            | Lyrics can be fetched for the source's tracks.                |
+| `canCast`              | A track's playback URL is network-reachable, so it can cast.  |
 
 A track carries an opaque `scheme:` URI (`subsonic:<id>`, `jellyfin:<id>`, or a
 file path) and **never** an authenticated URL — stream/download URLs are minted
@@ -24,13 +29,15 @@ persisted catalog.
 
 ## Provider matrix
 
-| Provider              | sourceId   | Stream | Cache | Favorite | Lyrics | Cast |
-| --------------------- | ---------- | :----: | :---: | :------: | :----: | :--: |
-| On this device        | `local`    |   ✅   |  —    |    ✅    |   —    |  —   |
-| Jellyfin              | `jellyfin` |   ✅   |  ✅   |    ✅    |   ✅   |  ✅  |
-| Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜    |   🔜   |  ✅  |
+| Provider              | sourceId   | Stream | Cache | Favorites | Playlists | Lyrics | Cast |
+| --------------------- | ---------- | :----: | :---: | :-------: | :-------: | :----: | :--: |
+| On this device        | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   —    |  —   |
+| Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
+| Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   🔜   |  ✅  |
 
-✅ implemented · 🔜 planned follow-up · — not applicable
+✅ implemented · 🔜 planned follow-up · — not applicable. "local" favourites/
+playlists stay on-device; "synced" ones mirror with the server (server is the
+source of truth on refresh).
 
 ## Local files
 
@@ -42,10 +49,13 @@ cannot be cast (a receiver can't reach a file on your phone).
 ## Jellyfin
 
 Connect to your own Jellyfin server, test the connection, sign in, sync your
-library, and stream — including over an HTTPS/Cloudflare-proxied domain.
-Favorites and synced lyrics work; tracks can be marked for offline use and cast
+library, and stream — including over an HTTPS/Cloudflare-proxied domain. A sync
+also imports your **playlists** and adopts your **liked/favourite** tracks by
+default, and synced lyrics work; tracks can be marked for offline use and cast
 to a Chromecast. The access token is stored encrypted on-device; the password is
-never persisted. See [jellyfin-compatibility.md](jellyfin-compatibility.md).
+never persisted. See [jellyfin-compatibility.md](jellyfin-compatibility.md) for
+connectivity, and [jellyfin-sync.md](jellyfin-sync.md) for what syncs (playlists
++ favourites), the documented limitations, and the token-free guarantees.
 
 ## Navidrome / Subsonic
 

--- a/lib/core/repositories/favorites_repository.dart
+++ b/lib/core/repositories/favorites_repository.dart
@@ -1,4 +1,5 @@
 import '../models/track.dart';
+import 'remote_sync_result.dart';
 
 /// Tracks the user's favourites and keeps them in sync with the source.
 ///
@@ -25,8 +26,11 @@ abstract interface class FavoritesRepository {
 
   /// Pulls the signed-in user's server favourites and adopts them as the remote
   /// set (server is the source of truth there), leaving local-track favourites
-  /// untouched. A no-op when not signed in. Never throws.
-  Future<void> refreshFromRemote();
+  /// untouched. Never throws: it returns a [FavoritesSyncResult] describing the
+  /// outcome (not configured / synced + count / failed) so a caller — the
+  /// "Sync library" action — can report "synced favorites" or "favorites could
+  /// not be synced" instead of guessing.
+  Future<FavoritesSyncResult> refreshFromRemote();
 
   /// Drops the server-sourced favourites (the signed-in account's), keeping
   /// on-device favourites. Called on sign-out so one account's hearts can't

--- a/lib/core/repositories/playlist_repository.dart
+++ b/lib/core/repositories/playlist_repository.dart
@@ -1,4 +1,5 @@
 import '../models/playlist.dart';
+import 'remote_sync_result.dart';
 
 /// Persistence + editing contract for user-created playlists.
 ///
@@ -55,7 +56,17 @@ abstract interface class PlaylistRepository {
   });
 
   /// Pulls playlists from the signed-in server and reconciles them into the
-  /// local set (importing new ones, adopting server membership for synced ones).
-  /// A no-op when not signed in or no server sync is configured. Never throws.
-  Future<void> refreshFromRemote();
+  /// local set: importing new ones, adopting server name/membership for synced
+  /// ones, and dropping a synced playlist whose server copy is gone (server is
+  /// the source of truth for synced playlists). Local-only playlists are never
+  /// touched. Never throws: it returns a [PlaylistSyncResult] describing the
+  /// outcome (not configured / synced + count / failed) so the "Sync library"
+  /// action can report "synced N playlists" or "playlists could not be loaded".
+  Future<PlaylistSyncResult> refreshFromRemote();
+
+  /// Drops the server-synced (remote-source) playlists, keeping local-only ones.
+  /// Called on sign-out so one account's imported playlists can't linger — or be
+  /// confused with a different account's — after disconnecting. A no-op when
+  /// there are none. Never throws.
+  Future<void> clearRemote();
 }

--- a/lib/core/repositories/remote_sync_result.dart
+++ b/lib/core/repositories/remote_sync_result.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+
+/// The outcome of pulling account-specific state (favourites or playlists) from
+/// a remote server during a sync.
+///
+/// Distinguishes "there was nothing to sync" (no client / no signed-in session —
+/// a local-only or signed-out setup) from a genuine failure, so the sync UI can
+/// stay quiet when there's no server yet report an honest "couldn't load" when a
+/// signed-in refresh fails. Carrying this — rather than a bare bool or a thrown
+/// error — keeps `refreshFromRemote` non-throwing while still letting the caller
+/// report "synced N playlists" or "favorites could not be synced".
+enum RemoteSyncOutcome {
+  /// No remote is configured (no client or no signed-in session): nothing was
+  /// attempted, so there is nothing to report.
+  notConfigured,
+
+  /// The refresh reached the server and reconciled local state successfully.
+  synced,
+
+  /// A refresh was attempted but the server (or transport) failed.
+  failed,
+}
+
+/// Result of `FavoritesRepository.refreshFromRemote`. Display-safe: it carries
+/// only an outcome and a count, never a token, id, or URL.
+@immutable
+class FavoritesSyncResult {
+  const FavoritesSyncResult(this.outcome, {this.favoriteCount = 0});
+
+  const FavoritesSyncResult.notConfigured()
+      : this(RemoteSyncOutcome.notConfigured);
+
+  const FavoritesSyncResult.failed() : this(RemoteSyncOutcome.failed);
+
+  const FavoritesSyncResult.synced(int favoriteCount)
+      : this(RemoteSyncOutcome.synced, favoriteCount: favoriteCount);
+
+  final RemoteSyncOutcome outcome;
+
+  /// How many server-synced favourites were present after a successful refresh.
+  final int favoriteCount;
+
+  bool get didSync => outcome == RemoteSyncOutcome.synced;
+  bool get didFail => outcome == RemoteSyncOutcome.failed;
+}
+
+/// Result of `PlaylistRepository.refreshFromRemote`. Display-safe: it carries
+/// only an outcome and a count, never a token, id, or URL.
+@immutable
+class PlaylistSyncResult {
+  const PlaylistSyncResult(this.outcome, {this.playlistCount = 0});
+
+  const PlaylistSyncResult.notConfigured()
+      : this(RemoteSyncOutcome.notConfigured);
+
+  const PlaylistSyncResult.failed() : this(RemoteSyncOutcome.failed);
+
+  const PlaylistSyncResult.synced(int playlistCount)
+      : this(RemoteSyncOutcome.synced, playlistCount: playlistCount);
+
+  final RemoteSyncOutcome outcome;
+
+  /// How many remote playlists the server reported on a successful refresh.
+  final int playlistCount;
+
+  bool get didSync => outcome == RemoteSyncOutcome.synced;
+  bool get didFail => outcome == RemoteSyncOutcome.failed;
+}

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -15,13 +15,16 @@ class MusicProviderCapabilities {
   const MusicProviderCapabilities({
     required this.canStream,
     required this.canCache,
-    required this.canFavorite,
+    required this.canFavoriteTracks,
+    required this.canReadFavoriteState,
+    required this.canSyncFavorites,
     required this.canLyrics,
     required this.canCast,
     required this.canRemoveFromLibrary,
     required this.canRemoveOfflineCopy,
     required this.canDeleteLocalFile,
     required this.canDeleteRemoteItem,
+    required this.canListPlaylists,
     required this.canCreatePlaylist,
     required this.canEditPlaylist,
     required this.canDeletePlaylist,
@@ -34,8 +37,20 @@ class MusicProviderCapabilities {
   /// Tracks can be downloaded for offline use safely (a token-free cache file).
   final bool canCache;
 
-  /// Favorites can be toggled and reflected for this provider.
-  final bool canFavorite;
+  /// A track's favourite/like state can be toggled for this provider (the heart
+  /// button is meaningful). For a remote provider that also implies pushing the
+  /// change to the server when [canSyncFavorites] is true.
+  final bool canFavoriteTracks;
+
+  /// This provider exposes a readable favourite/like state for its tracks, so
+  /// Linthra can show the right heart state. True for on-device tracks (stored
+  /// locally) and for servers that report a per-user favourite flag.
+  final bool canReadFavoriteState;
+
+  /// Favourites are mirrored with this provider's server (two-way): liking a
+  /// track here pushes to the server, and a server-side change is adopted on the
+  /// next sync. False for the on-device source, whose favourites stay local.
+  final bool canSyncFavorites;
 
   /// Lyrics can be fetched for this provider's tracks.
   final bool canLyrics;
@@ -65,6 +80,11 @@ class MusicProviderCapabilities {
   /// can be done safely with explicit confirmation; left `false` otherwise.
   final bool canDeleteRemoteItem;
 
+  /// This provider can enumerate its own (server-side) playlists, so Linthra can
+  /// import and list them. True for Jellyfin; false for the on-device source and
+  /// providers whose playlist listing isn't wired up yet.
+  final bool canListPlaylists;
+
   /// A playlist of this provider's kind can be created from Linthra.
   final bool canCreatePlaylist;
 
@@ -85,13 +105,16 @@ class MusicProviderCapabilities {
       (other is MusicProviderCapabilities &&
           other.canStream == canStream &&
           other.canCache == canCache &&
-          other.canFavorite == canFavorite &&
+          other.canFavoriteTracks == canFavoriteTracks &&
+          other.canReadFavoriteState == canReadFavoriteState &&
+          other.canSyncFavorites == canSyncFavorites &&
           other.canLyrics == canLyrics &&
           other.canCast == canCast &&
           other.canRemoveFromLibrary == canRemoveFromLibrary &&
           other.canRemoveOfflineCopy == canRemoveOfflineCopy &&
           other.canDeleteLocalFile == canDeleteLocalFile &&
           other.canDeleteRemoteItem == canDeleteRemoteItem &&
+          other.canListPlaylists == canListPlaylists &&
           other.canCreatePlaylist == canCreatePlaylist &&
           other.canEditPlaylist == canEditPlaylist &&
           other.canDeletePlaylist == canDeletePlaylist &&
@@ -101,13 +124,16 @@ class MusicProviderCapabilities {
   int get hashCode => Object.hash(
         canStream,
         canCache,
-        canFavorite,
+        canFavoriteTracks,
+        canReadFavoriteState,
+        canSyncFavorites,
         canLyrics,
         canCast,
         canRemoveFromLibrary,
         canRemoveOfflineCopy,
         canDeleteLocalFile,
         canDeleteRemoteItem,
+        canListPlaylists,
         canCreatePlaylist,
         canEditPlaylist,
         canDeletePlaylist,
@@ -145,7 +171,11 @@ abstract final class MusicProviders {
     capabilities: MusicProviderCapabilities(
       canStream: true,
       canCache: false,
-      canFavorite: true,
+      // On-device favourites are toggled and read locally; there is no server to
+      // sync them to.
+      canFavoriteTracks: true,
+      canReadFavoriteState: true,
+      canSyncFavorites: false,
       canLyrics: false,
       canCast: false,
       canRemoveFromLibrary: true,
@@ -155,6 +185,8 @@ abstract final class MusicProviders {
       // Deleting the real on-device file is not wired up safely yet.
       canDeleteLocalFile: false,
       canDeleteRemoteItem: false,
+      // No server playlists to enumerate; local playlists are created here.
+      canListPlaylists: false,
       canCreatePlaylist: true,
       canEditPlaylist: true,
       canDeletePlaylist: true,
@@ -169,7 +201,11 @@ abstract final class MusicProviders {
     capabilities: MusicProviderCapabilities(
       canStream: true,
       canCache: true,
-      canFavorite: true,
+      // Jellyfin tracks favourite/read/sync against the server's per-user state,
+      // so the heart follows the user across clients.
+      canFavoriteTracks: true,
+      canReadFavoriteState: true,
+      canSyncFavorites: true,
       canLyrics: true,
       canCast: true,
       canRemoveFromLibrary: true,
@@ -179,6 +215,7 @@ abstract final class MusicProviders {
       // is intentionally not enabled in this release; see
       // docs/playlists-and-delete.md.
       canDeleteRemoteItem: false,
+      canListPlaylists: true,
       canCreatePlaylist: true,
       canEditPlaylist: true,
       canDeletePlaylist: true,
@@ -196,7 +233,11 @@ abstract final class MusicProviders {
     capabilities: MusicProviderCapabilities(
       canStream: true,
       canCache: true,
-      canFavorite: false,
+      // Subsonic favourites (star/unstar) aren't wired up yet, so the heart and
+      // favourite sync stay disabled and their actions hidden.
+      canFavoriteTracks: false,
+      canReadFavoriteState: false,
+      canSyncFavorites: false,
       canLyrics: false,
       canCast: true,
       canRemoveFromLibrary: true,
@@ -205,6 +246,7 @@ abstract final class MusicProviders {
       canDeleteRemoteItem: false,
       // Subsonic/Navidrome playlists aren't synced yet; its tracks can still be
       // added to local Linthra playlists.
+      canListPlaylists: false,
       canCreatePlaylist: false,
       canEditPlaylist: false,
       canDeletePlaylist: false,

--- a/lib/data/repositories/jellyfin_synced_favorites_repository.dart
+++ b/lib/data/repositories/jellyfin_synced_favorites_repository.dart
@@ -4,6 +4,7 @@ import '../../core/models/jellyfin_session.dart';
 import '../../core/models/track.dart';
 import '../../core/repositories/favorites_repository.dart';
 import '../../core/repositories/favorites_store.dart';
+import '../../core/repositories/remote_sync_result.dart';
 import '../../core/sources/jellyfin/jellyfin_client.dart';
 import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
 
@@ -105,23 +106,28 @@ class JellyfinSyncedFavoritesRepository implements FavoritesRepository {
   }
 
   @override
-  Future<void> refreshFromRemote() async {
+  Future<FavoritesSyncResult> refreshFromRemote() async {
     await _ensureLoaded();
     final JellyfinClient? client = _client;
     final JellyfinSession? session = _session?.call();
-    if (client == null || session == null) return;
+    if (client == null || session == null) {
+      return const FavoritesSyncResult.notConfigured();
+    }
     try {
       final Set<String> serverIds = await client.fetchFavoriteIds(session);
-      // Skip the emit/save when nothing actually changed, to avoid churn.
-      if (serverIds.length == _data.remoteIds.length &&
-          serverIds.containsAll(_data.remoteIds)) {
-        return;
+      // Skip the emit/save when nothing actually changed, to avoid churn — but
+      // still report the (unchanged) count as a successful sync.
+      final bool unchanged = serverIds.length == _data.remoteIds.length &&
+          serverIds.containsAll(_data.remoteIds);
+      if (!unchanged) {
+        _data = _data.copyWith(remoteIds: serverIds);
+        _emit();
+        await _store.save(_data);
       }
-      _data = _data.copyWith(remoteIds: serverIds);
-      _emit();
-      await _store.save(_data);
+      return FavoritesSyncResult.synced(serverIds.length);
     } catch (_) {
-      // Offline or transient: keep what we have.
+      // Offline or transient: keep what we have and report a friendly failure.
+      return const FavoritesSyncResult.failed();
     }
   }
 

--- a/lib/data/repositories/synced_playlist_repository.dart
+++ b/lib/data/repositories/synced_playlist_repository.dart
@@ -4,6 +4,7 @@ import '../../core/models/jellyfin_session.dart';
 import '../../core/models/playlist.dart';
 import '../../core/repositories/playlist_repository.dart';
 import '../../core/repositories/playlist_store.dart';
+import '../../core/repositories/remote_sync_result.dart';
 import '../../core/sources/jellyfin/jellyfin_api.dart';
 import '../../core/sources/jellyfin/jellyfin_client.dart';
 import '../../core/sources/jellyfin/jellyfin_exception.dart';
@@ -260,26 +261,38 @@ class SyncedPlaylistRepository implements PlaylistRepository {
   }
 
   @override
-  Future<void> refreshFromRemote() async {
+  Future<PlaylistSyncResult> refreshFromRemote() async {
     await _ensureLoaded();
     final JellyfinClient? client = _client;
     final JellyfinSession? session = _liveSession();
-    if (client == null || session == null) return;
+    if (client == null || session == null) {
+      return const PlaylistSyncResult.notConfigured();
+    }
     final List<JellyfinPlaylistDto> remote;
     try {
       remote = await client.fetchPlaylists(session);
     } on JellyfinException catch (_) {
-      // Offline or transient: keep what we have.
-      return;
+      // Offline or transient: keep what we have and report a friendly failure.
+      return const PlaylistSyncResult.failed();
     }
 
+    final Set<String> serverIds = <String>{
+      for (final JellyfinPlaylistDto dto in remote) dto.id,
+    };
     final Map<String, Playlist> byRemoteId = <String, Playlist>{
       for (final Playlist p in _playlists)
         if (p.remoteId != null) p.remoteId!: p,
     };
 
-    final List<Playlist> next = <Playlist>[..._playlists];
-    bool changed = false;
+    // Start from the playlists we keep, dropping any synced Jellyfin playlist
+    // whose server copy is gone — it was deleted on the server, and the server
+    // is the source of truth for synced playlists. Local-only playlists and
+    // not-yet-created ones (no remoteId) are always kept.
+    final List<Playlist> next = <Playlist>[
+      for (final Playlist p in _playlists)
+        if (!_isStaleSyncedRemote(p, serverIds)) p,
+    ];
+    bool changed = next.length != _playlists.length;
     for (final JellyfinPlaylistDto dto in remote) {
       List<String> itemIds;
       try {
@@ -327,6 +340,29 @@ class SyncedPlaylistRepository implements PlaylistRepository {
       _playlists = next;
       await _persistAndEmit();
     }
+    return PlaylistSyncResult.synced(remote.length);
+  }
+
+  @override
+  Future<void> clearRemote() async {
+    await _ensureLoaded();
+    final int before = _playlists.length;
+    _playlists = <Playlist>[
+      for (final Playlist p in _playlists)
+        if (p.source != PlaylistSource.jellyfin) p,
+    ];
+    if (_playlists.length != before) {
+      await _persistAndEmit();
+    }
+  }
+
+  /// Whether [p] is a synced Jellyfin playlist (has a server [Playlist.remoteId])
+  /// that no longer exists in [serverIds] — i.e. it was deleted on the server, so
+  /// its local mirror should be dropped on the next refresh.
+  static bool _isStaleSyncedRemote(Playlist p, Set<String> serverIds) {
+    return p.source == PlaylistSource.jellyfin &&
+        p.remoteId != null &&
+        !serverIds.contains(p.remoteId);
   }
 
   // --- Internal helpers --------------------------------------------------

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -22,6 +22,9 @@ class PlaylistsScreen extends ConsumerWidget {
     final ThemeData theme = Theme.of(context);
     final Color accent = theme.colorScheme.primary;
     final AsyncValue<List<Playlist>> playlists = ref.watch(playlistsProvider);
+    final bool jellyfinConnected = ref.watch(
+      jellyfinSettingsControllerProvider.select((s) => s.isConnected),
+    );
 
     return Scaffold(
       appBar: AppBar(title: const Text('Playlists')),
@@ -48,11 +51,7 @@ class PlaylistsScreen extends ConsumerWidget {
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (_, __) => const _PlaylistsError(),
               data: (List<Playlist> items) => items.isEmpty
-                  ? const EmptyState(
-                      icon: Icons.queue_music_outlined,
-                      title: 'No playlists yet',
-                      message: 'Tap “New playlist” to create one.',
-                    )
+                  ? _PlaylistsEmpty(jellyfinConnected: jellyfinConnected)
                   : ListView.builder(
                       padding: const EdgeInsets.only(bottom: 88),
                       itemCount: items.length,
@@ -104,7 +103,7 @@ class _PlaylistTile extends ConsumerWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
-      subtitle: Text(_subtitle(theme)),
+      subtitle: Text(_subtitle()),
       trailing: PopupMenuButton<_PlaylistMenuAction>(
         icon: const Icon(Icons.more_vert),
         tooltip: 'Playlist actions',
@@ -132,11 +131,17 @@ class _PlaylistTile extends ConsumerWidget {
     );
   }
 
-  String _subtitle(ThemeData theme) {
+  /// "{n} songs", with a subtle source/status suffix: "· Sync failed" when a
+  /// sync didn't land, otherwise "· Jellyfin" for a synced playlist so its
+  /// origin is clear without cluttering the row. Local playlists show no suffix.
+  String _subtitle() {
     final String count = '${playlist.length} '
         '${playlist.length == 1 ? 'song' : 'songs'}';
     if (playlist.syncState == PlaylistSyncState.syncFailed) {
       return '$count · Sync failed';
+    }
+    if (playlist.source == PlaylistSource.jellyfin) {
+      return '$count · Jellyfin';
     }
     return count;
   }
@@ -183,6 +188,28 @@ class _PlaylistTile extends ConsumerWidget {
 }
 
 enum _PlaylistMenuAction { rename, delete }
+
+/// The empty Playlists state, worded for the situation: signed in to Jellyfin
+/// (your server playlists land here after a sync) vs not (create one, or sign in
+/// to import). A failed *load* is a separate state — see [_PlaylistsError].
+class _PlaylistsEmpty extends StatelessWidget {
+  const _PlaylistsEmpty({required this.jellyfinConnected});
+
+  final bool jellyfinConnected;
+
+  @override
+  Widget build(BuildContext context) {
+    return EmptyState(
+      icon: Icons.queue_music_outlined,
+      title: 'No playlists yet',
+      message: jellyfinConnected
+          ? 'Tap “New playlist” to create one. Your Jellyfin playlists appear '
+              'here after you sync your library.'
+          : 'Tap “New playlist” to create one, or sign in to Jellyfin in '
+              'Settings to import your server playlists.',
+    );
+  }
+}
 
 class _PlaylistsError extends StatelessWidget {
   const _PlaylistsError();

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -9,6 +9,7 @@ import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
 import '../../../core/sources/jellyfin/jellyfin_server_capabilities.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../data/repositories/jellyfin_session_store_provider.dart';
+import '../../../data/repositories/playlist_repository_provider.dart';
 import 'jellyfin_settings_providers.dart';
 import 'jellyfin_settings_state.dart';
 import 'jellyfin_sync_controller.dart';
@@ -154,7 +155,8 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
   ///
   /// Also tears down this account's *derived* state so nothing lingers — or
   /// crosses over to a different account on the next sign-in: the server-synced
-  /// favourites are dropped (on-device favourites are kept), and the now-stale
+  /// favourites and imported Jellyfin playlists are dropped (on-device
+  /// favourites and local-only playlists are kept), and the now-stale
   /// "Synced N tracks" status is reset.
   Future<void> clear() async {
     await ref.read(jellyfinSessionStoreProvider).clear();
@@ -163,6 +165,11 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
       await ref.read(favoritesRepositoryProvider).clearRemote();
     } catch (_) {
       // A storage hiccup must not block sign-out; the session is already gone.
+    }
+    try {
+      await ref.read(playlistRepositoryProvider).clearRemote();
+    } catch (_) {
+      // Same: never let a playlist-store hiccup block sign-out.
     }
     ref.invalidate(jellyfinSyncControllerProvider);
     state = const JellyfinSettingsState(

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -1,8 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/repositories/remote_sync_result.dart';
 import '../../../core/sources/jellyfin/jellyfin_exception.dart';
 import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
+import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../../data/repositories/playlist_repository_provider.dart';
 import '../../library/library_controller.dart';
 import 'jellyfin_settings_controller.dart';
 import 'jellyfin_sync_state.dart';
@@ -12,8 +15,16 @@ import 'jellyfin_sync_state.dart';
 /// Reads the signed-in [JellyfinMusicSource] (via [jellyfinMusicSourceProvider])
 /// to fetch the catalog, then hands the results to the
 /// `MusicLibraryRepository` under the stable `jellyfin` source id — the same
-/// upsert path local scanning uses. The Library screen reads from that
-/// repository, so a refresh after the upsert makes the synced tracks appear.
+/// upsert path local scanning uses. It then refreshes the user's Jellyfin
+/// playlists and favourites/liked tracks, so a single "Sync library" brings the
+/// whole account across (and picks up changes made on the server since last
+/// time). The Library/Playlists/Favorites screens read from those repositories,
+/// so a refresh after the sync makes everything appear.
+///
+/// Playlist and favourite refresh are best-effort: a failure in either is
+/// reported in the status but never fails the track sync that already landed, so
+/// a partial outcome reads honestly ("Tracks synced, but playlists could not be
+/// loaded.").
 ///
 /// Security: the source mints any authenticated streaming URL lazily at play
 /// time, so nothing persisted here carries a token. This controller never logs
@@ -24,7 +35,8 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
   JellyfinSyncState build() => const JellyfinSyncState();
 
   /// Pulls artists/albums/tracks from Jellyfin and upserts them into the local
-  /// catalog. Reflects loading/success/error through [state]; never throws.
+  /// catalog, then refreshes Jellyfin playlists and favourites. Reflects
+  /// loading/success/error through [state]; never throws.
   Future<void> sync() async {
     final JellyfinMusicSource? source = ref.read(jellyfinMusicSourceProvider);
     if (source == null) {
@@ -40,26 +52,36 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
       final albums = await source.fetchAlbums();
       final artists = await source.fetchArtists();
 
-      if (tracks.isEmpty) {
-        state = const JellyfinSyncState.success(
-          trackCount: 0,
-          message: 'Your Jellyfin library looks empty — nothing to sync yet.',
-        );
-        return;
+      // Upsert only when there's something to store, so an empty fetch can
+      // never wipe an existing catalog.
+      if (tracks.isNotEmpty) {
+        await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+              sourceId: source.id,
+              tracks: tracks,
+              albums: albums,
+              artists: artists,
+            );
+        // Reload the Library so the freshly synced tracks show up immediately.
+        await ref.read(libraryControllerProvider.notifier).refresh();
       }
 
-      await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
-            sourceId: source.id,
-            tracks: tracks,
-            albums: albums,
-            artists: artists,
-          );
-      // Reload the Library so the freshly synced tracks show up immediately.
-      await ref.read(libraryControllerProvider.notifier).refresh();
+      // Pull playlists and favourites too — this is what makes a Jellyfin sync
+      // bring across the user's playlists and liked tracks by default, and pick
+      // up server-side changes. Both are best-effort and never throw out here.
+      final PlaylistSyncResult playlists = await _refreshPlaylists();
+      final FavoritesSyncResult favorites = await _refreshFavorites();
 
       state = JellyfinSyncState.success(
         trackCount: tracks.length,
-        message: _successMessage(tracks.length),
+        playlistCount: playlists.didSync ? playlists.playlistCount : 0,
+        favoriteCount: favorites.didSync ? favorites.favoriteCount : 0,
+        playlistsFailed: playlists.didFail,
+        favoritesFailed: favorites.didFail,
+        message: _composeMessage(
+          trackCount: tracks.length,
+          playlists: playlists,
+          favorites: favorites,
+        ),
       );
     } on JellyfinException catch (error) {
       state = JellyfinSyncState.error(_friendlyMessage(error));
@@ -72,10 +94,78 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
     }
   }
 
-  String _successMessage(int trackCount) {
-    final String tracks = trackCount == 1 ? '1 track' : '$trackCount tracks';
-    return 'Synced $tracks from your Jellyfin library.';
+  /// Best-effort playlist refresh that never throws out of [sync]: a thrown
+  /// error (rather than the repository's own friendly result) is mapped to a
+  /// failed outcome so a single bad call can't abort a successful track sync.
+  Future<PlaylistSyncResult> _refreshPlaylists() async {
+    try {
+      return await ref.read(playlistRepositoryProvider).refreshFromRemote();
+    } catch (_) {
+      return const PlaylistSyncResult.failed();
+    }
   }
+
+  /// Best-effort favourites refresh, mirroring [_refreshPlaylists].
+  Future<FavoritesSyncResult> _refreshFavorites() async {
+    try {
+      return await ref.read(favoritesRepositoryProvider).refreshFromRemote();
+    } catch (_) {
+      return const FavoritesSyncResult.failed();
+    }
+  }
+
+  /// Builds the friendly success line from what actually synced: tracks,
+  /// playlists, and favourites that came across, plus an honest note for any
+  /// part that couldn't load — so a partial failure reads clearly. All values
+  /// are display-safe; no secret can reach here.
+  String _composeMessage({
+    required int trackCount,
+    required PlaylistSyncResult playlists,
+    required FavoritesSyncResult favorites,
+  }) {
+    final List<String> synced = <String>[];
+    if (trackCount > 0) {
+      synced.add(trackCount == 1 ? '1 track' : '$trackCount tracks');
+    }
+    if (playlists.didSync && playlists.playlistCount > 0) {
+      final int n = playlists.playlistCount;
+      synced.add(n == 1 ? '1 playlist' : '$n playlists');
+    }
+    if (favorites.didSync && favorites.favoriteCount > 0) {
+      final int n = favorites.favoriteCount;
+      synced.add(n == 1 ? '1 favorite' : '$n favorites');
+    }
+
+    final List<String> failures = <String>[];
+    if (playlists.didFail) failures.add('playlists could not be loaded');
+    if (favorites.didFail) failures.add('favorites could not be synced');
+
+    if (synced.isEmpty && failures.isEmpty) {
+      return 'Your Jellyfin library looks empty — nothing to sync yet.';
+    }
+
+    final StringBuffer message = StringBuffer();
+    if (synced.isNotEmpty) {
+      message.write('Synced ${_joinAnd(synced)} from your Jellyfin library.');
+    }
+    if (failures.isNotEmpty) {
+      if (message.isNotEmpty) message.write(' ');
+      message.write('${_capitalize(_joinAnd(failures))}.');
+    }
+    return message.toString();
+  }
+
+  /// Joins parts with commas and a trailing "and": `["a"]` → "a";
+  /// `["a", "b"]` → "a and b"; `["a", "b", "c"]` → "a, b and c".
+  String _joinAnd(List<String> parts) {
+    if (parts.length == 1) return parts.first;
+    if (parts.length == 2) return '${parts[0]} and ${parts[1]}';
+    final String head = parts.sublist(0, parts.length - 1).join(', ');
+    return '$head and ${parts.last}';
+  }
+
+  String _capitalize(String text) =>
+      text.isEmpty ? text : '${text[0].toUpperCase()}${text.substring(1)}';
 
   /// Turns a typed Jellyfin failure into a friendly, actionable line. Branches
   /// on [JellyfinErrorKind] rather than message text so the wording can change

--- a/lib/features/settings/jellyfin/jellyfin_sync_state.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_state.dart
@@ -4,13 +4,17 @@ enum JellyfinSyncStatus { idle, syncing, success, error }
 /// Immutable snapshot the Jellyfin settings UI renders the sync action from.
 ///
 /// Like every other state object in the app, this holds only display-safe
-/// values: a status, a friendly [message], and how many tracks landed. It never
-/// carries a token, password, or streaming URL.
+/// values: a status, a friendly [message], and how many tracks/playlists/
+/// favourites landed. It never carries a token, password, or streaming URL.
 class JellyfinSyncState {
   const JellyfinSyncState({
     this.status = JellyfinSyncStatus.idle,
     this.message,
     this.trackCount = 0,
+    this.playlistCount = 0,
+    this.favoriteCount = 0,
+    this.playlistsFailed = false,
+    this.favoritesFailed = false,
   });
 
   const JellyfinSyncState.syncing()
@@ -22,10 +26,18 @@ class JellyfinSyncState {
   const JellyfinSyncState.success({
     required int trackCount,
     required String message,
+    int playlistCount = 0,
+    int favoriteCount = 0,
+    bool playlistsFailed = false,
+    bool favoritesFailed = false,
   }) : this(
           status: JellyfinSyncStatus.success,
           trackCount: trackCount,
           message: message,
+          playlistCount: playlistCount,
+          favoriteCount: favoriteCount,
+          playlistsFailed: playlistsFailed,
+          favoritesFailed: favoritesFailed,
         );
 
   const JellyfinSyncState.error(String message)
@@ -38,6 +50,19 @@ class JellyfinSyncState {
 
   /// How many tracks the last successful sync stored.
   final int trackCount;
+
+  /// How many Jellyfin playlists the last successful sync imported/updated.
+  final int playlistCount;
+
+  /// How many server-synced favourites the last successful sync reconciled.
+  final int favoriteCount;
+
+  /// Whether the playlist part of the last sync failed (tracks may still have
+  /// synced), so the UI can be honest about the partial outcome.
+  final bool playlistsFailed;
+
+  /// Whether the favourites part of the last sync failed.
+  final bool favoritesFailed;
 
   bool get isSyncing => status == JellyfinSyncStatus.syncing;
   bool get isError => status == JellyfinSyncStatus.error;

--- a/lib/features/settings/subsonic/subsonic_settings_section.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_section.dart
@@ -240,7 +240,8 @@ class _CapabilityChips extends StatelessWidget {
       if (caps.canCache)
         (icon: Icons.download_for_offline_outlined, label: 'Offline'),
       if (caps.canCast) (icon: Icons.cast, label: 'Cast'),
-      if (caps.canFavorite) (icon: Icons.favorite_border, label: 'Favorites'),
+      if (caps.canFavoriteTracks)
+        (icon: Icons.favorite_border, label: 'Favorites'),
       if (caps.canLyrics) (icon: Icons.lyrics_outlined, label: 'Lyrics'),
     ];
     return Wrap(

--- a/test/core/services/fake_browse_repositories.dart
+++ b/test/core/services/fake_browse_repositories.dart
@@ -2,6 +2,7 @@ import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
 import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/core/repositories/remote_sync_result.dart';
 
 /// Minimal [PlaylistRepository] for browse-tree tests: serves a fixed list of
 /// playlists. Only the reads the media browser uses ([getAllPlaylists],
@@ -71,7 +72,10 @@ class FakePlaylistRepository implements PlaylistRepository {
   }
 
   @override
-  Future<void> refreshFromRemote() => throw UnimplementedError();
+  Future<PlaylistSyncResult> refreshFromRemote() => throw UnimplementedError();
+
+  @override
+  Future<void> clearRemote() => throw UnimplementedError();
 }
 
 /// Minimal local-only [FavoritesRepository] for browse-tree tests: holds a fixed
@@ -101,7 +105,8 @@ class FakeFavoritesRepository implements FavoritesRepository {
   }
 
   @override
-  Future<void> refreshFromRemote() async {}
+  Future<FavoritesSyncResult> refreshFromRemote() async =>
+      const FavoritesSyncResult.notConfigured();
 
   @override
   Future<void> clearRemote() async {}

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -6,7 +6,11 @@ void main() {
     test('local: plays and favorites on-device, but cannot cast', () {
       final caps = MusicProviders.local.capabilities;
       expect(caps.canStream, isTrue);
-      expect(caps.canFavorite, isTrue);
+      expect(caps.canFavoriteTracks, isTrue);
+      expect(caps.canReadFavoriteState, isTrue);
+      // On-device favourites stay local — there's no server to sync them to.
+      expect(caps.canSyncFavorites, isFalse);
+      expect(caps.canListPlaylists, isFalse);
       expect(caps.canCast, isFalse);
       expect(caps.canCache, isFalse);
     });
@@ -15,7 +19,10 @@ void main() {
       final caps = MusicProviders.jellyfin.capabilities;
       expect(caps.canStream, isTrue);
       expect(caps.canCache, isTrue);
-      expect(caps.canFavorite, isTrue);
+      expect(caps.canFavoriteTracks, isTrue);
+      expect(caps.canReadFavoriteState, isTrue);
+      expect(caps.canSyncFavorites, isTrue);
+      expect(caps.canListPlaylists, isTrue);
       expect(caps.canLyrics, isTrue);
       expect(caps.canCast, isTrue);
     });
@@ -27,7 +34,10 @@ void main() {
       expect(caps.canCache, isTrue);
       expect(caps.canCast, isTrue);
       // Declared unsupported so their actions stay hidden/disabled.
-      expect(caps.canFavorite, isFalse);
+      expect(caps.canFavoriteTracks, isFalse);
+      expect(caps.canReadFavoriteState, isFalse);
+      expect(caps.canSyncFavorites, isFalse);
+      expect(caps.canListPlaylists, isFalse);
       expect(caps.canLyrics, isFalse);
     });
 
@@ -72,6 +82,75 @@ void main() {
 
       // Subsonic playlists aren't synced yet.
       expect(MusicProviders.subsonic.capabilities.canSyncPlaylists, isFalse);
+    });
+
+    test('favorite capabilities reflect provider support', () {
+      // Jellyfin reads, toggles, and two-way syncs favourites against the
+      // server; local toggles/reads on-device only; Subsonic does neither yet.
+      final jelly = MusicProviders.jellyfin.capabilities;
+      expect(jelly.canReadFavoriteState, isTrue);
+      expect(jelly.canFavoriteTracks, isTrue);
+      expect(jelly.canSyncFavorites, isTrue);
+
+      final local = MusicProviders.local.capabilities;
+      expect(local.canFavoriteTracks, isTrue);
+      expect(local.canSyncFavorites, isFalse);
+
+      expect(MusicProviders.subsonic.capabilities.canFavoriteTracks, isFalse);
+    });
+
+    test('a future provider seam is data-driven via a fake provider', () {
+      // The capability matrix is a plain value, so a not-yet-shipped provider
+      // (e.g. a richer Navidrome) can declare its abilities and be tested/
+      // compared without touching any feature code.
+      const MusicProvider future = MusicProvider(
+        sourceId: 'navidrome-future',
+        displayName: 'Future Navidrome',
+        serverUrlLabel: 'Server URL',
+        capabilities: MusicProviderCapabilities(
+          canStream: true,
+          canCache: true,
+          canFavoriteTracks: true,
+          canReadFavoriteState: true,
+          canSyncFavorites: true,
+          canLyrics: false,
+          canCast: true,
+          canRemoveFromLibrary: true,
+          canRemoveOfflineCopy: true,
+          canDeleteLocalFile: false,
+          canDeleteRemoteItem: false,
+          canListPlaylists: true,
+          canCreatePlaylist: true,
+          canEditPlaylist: true,
+          canDeletePlaylist: true,
+          canSyncPlaylists: true,
+        ),
+      );
+
+      expect(future.capabilities.canListPlaylists, isTrue);
+      expect(future.capabilities.canSyncFavorites, isTrue);
+      // Value equality lets a UI compare capability sets directly.
+      expect(
+        future.capabilities,
+        const MusicProviderCapabilities(
+          canStream: true,
+          canCache: true,
+          canFavoriteTracks: true,
+          canReadFavoriteState: true,
+          canSyncFavorites: true,
+          canLyrics: false,
+          canCast: true,
+          canRemoveFromLibrary: true,
+          canRemoveOfflineCopy: true,
+          canDeleteLocalFile: false,
+          canDeleteRemoteItem: false,
+          canListPlaylists: true,
+          canCreatePlaylist: true,
+          canEditPlaylist: true,
+          canDeletePlaylist: true,
+          canSyncPlaylists: true,
+        ),
+      );
     });
   });
 

--- a/test/data/repositories/jellyfin_synced_favorites_repository_test.dart
+++ b/test/data/repositories/jellyfin_synced_favorites_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/favorites_store.dart';
+import 'package:linthra/core/repositories/remote_sync_result.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/data/repositories/in_memory_favorites_store.dart';
 import 'package:linthra/data/repositories/jellyfin_synced_favorites_repository.dart';
@@ -102,6 +103,34 @@ void main() {
 
       expect(repo.isFavorite('a'), isTrue); // local kept
       expect(repo.isFavorite('j9'), isTrue); // remote adopted
+    });
+
+    test('refreshFromRemote reports the synced favourite count', () async {
+      final repo = build(session: _session);
+      client.favoriteIds = <String>{'j1', 'j2', 'j3'};
+
+      final result = await repo.refreshFromRemote();
+
+      expect(result.didSync, isTrue);
+      expect(result.favoriteCount, 3);
+    });
+
+    test('refreshFromRemote reports not configured without a session',
+        () async {
+      final repo = build(session: null);
+
+      final result = await repo.refreshFromRemote();
+
+      expect(result.outcome, RemoteSyncOutcome.notConfigured);
+    });
+
+    test('refreshFromRemote reports a failure on a server error', () async {
+      client.favoritesError = JellyfinException.notReachable();
+      final repo = build(session: _session);
+
+      final result = await repo.refreshFromRemote();
+
+      expect(result.didFail, isTrue);
     });
 
     test('a server push failure keeps the optimistic local favourite',

--- a/test/data/repositories/synced_playlist_repository_test.dart
+++ b/test/data/repositories/synced_playlist_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/repositories/remote_sync_result.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
@@ -130,6 +131,11 @@ void main() {
       expect(created.source, PlaylistSource.local);
       expect(created.syncState, PlaylistSyncState.localOnly);
     });
+
+    test('refreshFromRemote without a client reports not configured', () async {
+      final PlaylistSyncResult result = await repository.refreshFromRemote();
+      expect(result.outcome, RemoteSyncOutcome.notConfigured);
+    });
   });
 
   group('SyncedPlaylistRepository (Jellyfin sync)', () {
@@ -248,6 +254,114 @@ void main() {
       expect(all.single.source, PlaylistSource.jellyfin);
       expect(all.single.trackIds, <String>['a', 'b']);
       expect(all.single.syncState, PlaylistSyncState.synced);
+    });
+
+    test('refreshFromRemote reports the synced playlist count', () async {
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'A'),
+        JellyfinPlaylistDto(id: 'srv-2', name: 'B'),
+      ];
+      final PlaylistSyncResult result = await repository.refreshFromRemote();
+      expect(result.didSync, isTrue);
+      expect(result.playlistCount, 2);
+    });
+
+    test('refreshFromRemote reports a failure when the server is unreachable',
+        () async {
+      client.playlistError = JellyfinException.notReachable();
+      final PlaylistSyncResult result = await repository.refreshFromRemote();
+      expect(result.didFail, isTrue);
+    });
+
+    test('repeated refresh does not duplicate the imported playlist', () async {
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'Mix'),
+      ];
+      client.playlistEntries['srv-1'] = const <JellyfinPlaylistEntry>[
+        JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+      ];
+      await repository.refreshFromRemote();
+      await repository.refreshFromRemote();
+      final List<Playlist> all = await repository.getAllPlaylists();
+      expect(all.where((Playlist p) => p.remoteId == 'srv-1'), hasLength(1));
+    });
+
+    test('a remote rename updates the local synced playlist on refresh',
+        () async {
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'Old Name'),
+      ];
+      client.playlistEntries['srv-1'] = const <JellyfinPlaylistEntry>[
+        JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+      ];
+      await repository.refreshFromRemote();
+
+      // The server renames the playlist; the next refresh adopts the new name.
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'New Name'),
+      ];
+      await repository.refreshFromRemote();
+
+      final List<Playlist> all = await repository.getAllPlaylists();
+      expect(all, hasLength(1));
+      expect(all.single.name, 'New Name');
+      expect(all.single.remoteId, 'srv-1');
+    });
+
+    test('a playlist deleted on the server is dropped on the next refresh',
+        () async {
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'Mix'),
+      ];
+      client.playlistEntries['srv-1'] = const <JellyfinPlaylistEntry>[
+        JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+      ];
+      await repository.refreshFromRemote();
+      expect(await repository.getAllPlaylists(), hasLength(1));
+
+      // The server no longer reports it — it was deleted there.
+      client.playlists = const <JellyfinPlaylistDto>[];
+      await repository.refreshFromRemote();
+      expect(await repository.getAllPlaylists(), isEmpty);
+    });
+
+    test('refresh keeps a local-only playlist while pruning a deleted remote',
+        () async {
+      final Playlist local = await repository.createPlaylist('Local Mix');
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'Server Mix'),
+      ];
+      client.playlistEntries['srv-1'] = const <JellyfinPlaylistEntry>[
+        JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+      ];
+      await repository.refreshFromRemote();
+      expect(await repository.getAllPlaylists(), hasLength(2));
+
+      // The server deletes its playlist; the local-only one must survive.
+      client.playlists = const <JellyfinPlaylistDto>[];
+      await repository.refreshFromRemote();
+      final List<Playlist> all = await repository.getAllPlaylists();
+      expect(all, hasLength(1));
+      expect(all.single.id, local.id);
+      expect(all.single.source, PlaylistSource.local);
+    });
+
+    test('clearRemote drops synced playlists but keeps local-only ones',
+        () async {
+      final Playlist local = await repository.createPlaylist('Local Mix');
+      client.createdPlaylistId = 'srv-9';
+      await repository.createPlaylist(
+        'Server Mix',
+        source: PlaylistSource.jellyfin,
+      );
+      expect(await repository.getAllPlaylists(), hasLength(2));
+
+      await repository.clearRemote();
+
+      final List<Playlist> all = await repository.getAllPlaylists();
+      expect(all, hasLength(1));
+      expect(all.single.id, local.id);
+      expect(all.single.source, PlaylistSource.local);
     });
 
     test('no token is ever stored in playlist metadata', () async {

--- a/test/features/favorites/favorites_screen_test.dart
+++ b/test/features/favorites/favorites_screen_test.dart
@@ -36,12 +36,14 @@ Future<void> _pump(
   required List<Track> tracks,
   required FavoritesData favorites,
   FakePlaybackController? playback,
+  Object? libraryError,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        musicLibraryRepositoryProvider
-            .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: tracks, error: libraryError),
+        ),
         favoritesStoreProvider
             .overrideWithValue(InMemoryFavoritesStore(favorites)),
         if (playback != null)
@@ -90,6 +92,22 @@ void main() {
 
       expect(find.text('No favorites yet'), findsOneWidget);
       expect(find.text('Alpha'), findsNothing);
+    });
+
+    testWidgets('shows a friendly error state when the catalog fails to load', (
+      tester,
+    ) async {
+      // A non-empty favourite set forces the catalog read, which then fails.
+      await _pump(
+        tester,
+        tracks: const <Track>[],
+        favorites: const FavoritesData(remoteIds: {'j1'}),
+        libraryError: Exception('boom'),
+      );
+
+      expect(find.text("Couldn't load your favorites"), findsOneWidget);
+      // The raw error is never surfaced.
+      expect(find.textContaining('boom'), findsNothing);
     });
 
     testWidgets('tapping a favourite plays it and queues the rest', (

--- a/test/features/playlists/playlists_screen_test.dart
+++ b/test/features/playlists/playlists_screen_test.dart
@@ -1,19 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
 import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
 import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/playlists/playlists_screen.dart';
 
 Future<void> _pump(
   WidgetTester tester,
-  InMemoryPlaylistStore store,
-) async {
+  InMemoryPlaylistStore store, {
+  JellyfinSession? session,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: <Override>[
         playlistStoreProvider.overrideWithValue(store),
+        // Drives the Jellyfin connection state the empty-state copy keys off; a
+        // null session keeps the screen "not signed in".
+        jellyfinSessionStoreProvider.overrideWithValue(
+          InMemoryJellyfinSessionStore(initialSession: session),
+        ),
       ],
       child: const MaterialApp(home: PlaylistsScreen()),
     ),
@@ -48,6 +57,51 @@ void main() {
       expect(find.text('Road Trip'), findsOneWidget);
       expect(find.text('2 songs'), findsOneWidget);
       expect(find.text('No playlists yet'), findsNothing);
+    });
+
+    testWidgets('shows a subtle Jellyfin source label on a synced playlist',
+        (tester) async {
+      final InMemoryPlaylistStore store = InMemoryPlaylistStore();
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+          remoteId: 'srv-1',
+          trackIds: <String>['a', 'b'],
+          syncState: PlaylistSyncState.synced,
+        ),
+      ]);
+      await _pump(tester, store);
+
+      expect(find.text('Server Mix'), findsOneWidget);
+      // The origin is shown subtly in the subtitle, not as separate chrome.
+      expect(find.text('2 songs · Jellyfin'), findsOneWidget);
+    });
+
+    testWidgets('empty state hints at signing in when not connected',
+        (tester) async {
+      await _pump(tester, InMemoryPlaylistStore());
+
+      expect(find.text('No playlists yet'), findsOneWidget);
+      expect(find.textContaining('sign in to Jellyfin'), findsOneWidget);
+    });
+
+    testWidgets('empty state mentions sync when connected to Jellyfin',
+        (tester) async {
+      await _pump(
+        tester,
+        InMemoryPlaylistStore(),
+        session: const JellyfinSession(
+          baseUrl: 'https://music.example.com',
+          userId: 'u',
+          accessToken: 'tok',
+          deviceId: 'd',
+        ),
+      );
+
+      expect(find.text('No playlists yet'), findsOneWidget);
+      expect(find.textContaining('after you sync'), findsOneWidget);
     });
 
     testWidgets('creating a playlist via the dialog adds it to the list',

--- a/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
@@ -1,13 +1,17 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
+import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/core/repositories/remote_sync_result.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/data/repositories/favorites_repository_provider.dart';
 import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
 import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_state.dart';
@@ -47,7 +51,70 @@ class _SpyFavoritesRepository implements FavoritesRepository {
   Future<void> setFavorite(Track track, bool favorite) async {}
 
   @override
-  Future<void> refreshFromRemote() async {}
+  Future<FavoritesSyncResult> refreshFromRemote() async =>
+      const FavoritesSyncResult.notConfigured();
+}
+
+/// Records [clearRemote] calls so a sign-out test can prove the controller also
+/// drops this account's imported Jellyfin playlists.
+class _SpyPlaylistRepository implements PlaylistRepository {
+  int clearRemoteCalls = 0;
+
+  @override
+  Future<void> clearRemote() async => clearRemoteCalls++;
+
+  @override
+  Stream<List<Playlist>> get playlistsStream =>
+      const Stream<List<Playlist>>.empty();
+
+  @override
+  Future<List<Playlist>> getAllPlaylists() async => const <Playlist>[];
+
+  @override
+  Future<Playlist?> getPlaylistById(String id) async => null;
+
+  @override
+  Future<PlaylistSyncResult> refreshFromRemote() async =>
+      const PlaylistSyncResult.notConfigured();
+
+  @override
+  Future<Playlist> createPlaylist(
+    String name, {
+    String? description,
+    PlaylistSource source = PlaylistSource.local,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> renamePlaylist(String id, String name, {String? description}) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> deletePlaylist(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> addTrack(String playlistId, String trackId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> addTracks(String playlistId, List<String> trackIds) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> removeTrack(String playlistId, String trackId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> reorderTracks(String playlistId, int oldIndex, int newIndex) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> markSyncState(
+    String id,
+    PlaylistSyncState state, {
+    String? error,
+  }) =>
+      throw UnimplementedError();
 }
 
 ProviderContainer _container({
@@ -261,6 +328,28 @@ void main() {
       // The account's hearts are cleared so they can't linger — or be re-pushed
       // to a different account — after signing out.
       expect(favorites.clearRemoteCalls, 1);
+    });
+
+    test("sign-out drops this account's imported Jellyfin playlists", () async {
+      final playlists = _SpyPlaylistRepository();
+      final container = ProviderContainer(overrides: <Override>[
+        jellyfinAuthenticatorProvider
+            .overrideWithValue(FakeJellyfinAuthenticator()),
+        jellyfinSessionStoreProvider.overrideWithValue(
+          InMemoryJellyfinSessionStore(initialSession: _session),
+        ),
+        jellyfinClientProvider.overrideWithValue(FakeJellyfinClient()),
+        playlistRepositoryProvider.overrideWithValue(playlists),
+      ]);
+      addTearDown(container.dispose);
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      await container.read(jellyfinSettingsControllerProvider.notifier).clear();
+
+      // The account's imported Jellyfin playlists are dropped so they can't
+      // linger after signing out; local-only playlists are kept (repository).
+      expect(playlists.clearRemoteCalls, 1);
     });
 
     test('sign-out resets the (now stale) sync status', () async {

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -4,11 +4,19 @@ import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/favorites_repository.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/repositories/playlist_repository.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_music_source.dart';
+import 'package:linthra/data/repositories/favorites_repository_provider.dart';
+import 'package:linthra/data/repositories/in_memory_favorites_store.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/jellyfin_synced_favorites_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/data/repositories/synced_playlist_repository.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
@@ -93,16 +101,26 @@ JellyfinMusicSource _source({
 ProviderContainer _container({
   required MusicLibraryRepository repository,
   JellyfinMusicSource? source,
+  PlaylistRepository? playlists,
+  FavoritesRepository? favorites,
 }) {
   final container = ProviderContainer(
     overrides: <Override>[
       musicLibraryRepositoryProvider.overrideWithValue(repository),
       jellyfinMusicSourceProvider.overrideWithValue(source),
+      if (playlists != null)
+        playlistRepositoryProvider.overrideWithValue(playlists),
+      if (favorites != null)
+        favoritesRepositoryProvider.overrideWithValue(favorites),
     ],
   );
   addTearDown(container.dispose);
   return container;
 }
+
+/// A [JellyfinMusicSource] over [client] for the playlist/favourite sync tests.
+JellyfinMusicSource _sourceOver(FakeJellyfinClient client) =>
+    JellyfinMusicSource(session: _session, client: client);
 
 void main() {
   group('JellyfinSyncController', () {
@@ -243,6 +261,162 @@ void main() {
       // The raw error is not surfaced to the user.
       expect(state.message, isNot(contains('disk full')));
       expect(state.message, contains('Please try again'));
+    });
+  });
+
+  group('JellyfinSyncController playlists + favourites', () {
+    SyncedPlaylistRepository playlistRepo(FakeJellyfinClient client) {
+      final repo = SyncedPlaylistRepository(
+        store: InMemoryPlaylistStore(),
+        client: client,
+        session: () => _session,
+      );
+      addTearDown(repo.dispose);
+      return repo;
+    }
+
+    JellyfinSyncedFavoritesRepository favoritesRepo(FakeJellyfinClient client) {
+      final repo = JellyfinSyncedFavoritesRepository(
+        store: InMemoryFavoritesStore(),
+        client: client,
+        session: () => _session,
+      );
+      addTearDown(repo.dispose);
+      return repo;
+    }
+
+    test('a library sync imports Jellyfin playlists and reports the count',
+        () async {
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a'), _audio('b')],
+        },
+      );
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv-1', name: 'Road Trip'),
+      ];
+      client.playlistEntries['srv-1'] = const <JellyfinPlaylistEntry>[
+        JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+      ];
+      final playlists = playlistRepo(client);
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _sourceOver(client),
+        playlists: playlists,
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.success);
+      expect(state.playlistCount, 1);
+      expect(state.message, contains('1 playlist'));
+      // The imported playlist now lives in the repository as a synced record.
+      final imported = (await playlists.getAllPlaylists())
+          .where((p) => p.remoteId == 'srv-1');
+      expect(imported, hasLength(1));
+      expect(imported.single.name, 'Road Trip');
+      expect(imported.single.trackIds, <String>['a']);
+    });
+
+    test('a library sync adopts Jellyfin favourites and reports them',
+        () async {
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+        },
+      );
+      client.favoriteIds = <String>{'fav-1', 'fav-2'};
+      final favorites = favoritesRepo(client);
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _sourceOver(client),
+        favorites: favorites,
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.favoriteCount, 2);
+      expect(state.message, contains('2 favorites'));
+      expect(favorites.isFavorite('fav-1'), isTrue);
+      expect(favorites.isFavorite('fav-2'), isTrue);
+    });
+
+    test('a playlist sync failure is reported without failing the track sync',
+        () async {
+      final repository = _RecordingRepository();
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a'), _audio('b')],
+        },
+      );
+      client.playlistError = JellyfinException.notReachable();
+      final container = _container(
+        repository: repository,
+        source: _sourceOver(client),
+        playlists: playlistRepo(client),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      // Tracks still synced…
+      expect(state.status, JellyfinSyncStatus.success);
+      expect(state.trackCount, 2);
+      expect(repository.upsertedTracks, hasLength(2));
+      // …but the playlist failure is surfaced honestly.
+      expect(state.playlistsFailed, isTrue);
+      expect(state.message, contains('2 tracks'));
+      expect(state.message, contains('could not be loaded'));
+    });
+
+    test('a favourites sync failure is reported without failing the track sync',
+        () async {
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+        },
+      );
+      client.favoritesError = JellyfinException.notReachable();
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _sourceOver(client),
+        favorites: favoritesRepo(client),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.success);
+      expect(state.favoritesFailed, isTrue);
+      expect(state.message, contains('could not be synced'));
+    });
+
+    test('no token leaks into the combined sync message', () async {
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+        },
+      );
+      client.playlists = const <JellyfinPlaylistDto>[
+        JellyfinPlaylistDto(id: 'srv', name: 'Mix'),
+      ];
+      client.playlistEntries['srv'] = const <JellyfinPlaylistEntry>[
+        JellyfinPlaylistEntry(itemId: 'a', playlistItemId: 'e-a'),
+      ];
+      client.favoriteIds = <String>{'a'};
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _sourceOver(client),
+        playlists: playlistRepo(client),
+        favorites: favoritesRepo(client),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.message, isNot(contains('secret-token')));
     });
   });
 }


### PR DESCRIPTION
## Summary

Makes a Jellyfin **Sync library** bring across the *whole* account by default: your **playlists** and your **liked/favourite** tracks, not just artists/albums/tracks. The repository + client plumbing already existed and refreshed at app launch; this PR wires it into the manual sync so server-side changes are picked up on the next sync (the user's expectation), reports what landed, fails gracefully, and tidies up on sign-out.

## Jellyfin playlist sync

- Imported by default on app launch **and on every Sync library**; they appear on the Playlists tab with a subtle "· Jellyfin" source label.
- Items map to your synced tracks; tracks not in your library are counted and shown as unavailable on the detail screen (never a crash). Tapping plays the available tracks.
- Reconcile-on-refresh (server is the source of truth): **imports** new playlists, **updates** name + membership (server rename shows up next sync), is **idempotent** (no duplicate playlists/entries), and **drops** a synced playlist deleted on the server. Local-only playlists are never touched.
- Write-back (create / add / remove / delete) was already supported best-effort; a failed write flips `syncState` to `syncFailed` rather than throwing.

## Jellyfin favourites / likes sync

- The per-user favourite set is fetched on sync and adopted as the source of truth for Jellyfin tracks; stored locally so the right hearts show offline.
- Toggling a Jellyfin track is optimistic and pushes to Jellyfin's favourite API; a failed push keeps the local intent and reconciles on the next sync (documented choice — never throws/sticks mid-tap).
- Local-file favourites stay on-device and are never sent to Jellyfin; mixed local/Jellyfin lists work cleanly.

## Default sync behaviour

`JellyfinSyncController.sync()` now upserts tracks, then refreshes playlists + favourites (best-effort). The status reports counts and honest partial failures, e.g. *"Synced 42 tracks, 3 playlists and 9 favorites from your Jellyfin library."* or *"Synced 42 tracks from your Jellyfin library. Playlists could not be loaded."* A playlist/favourite failure never fails the track sync. `refreshFromRemote` now returns a `FavoritesSyncResult` / `PlaylistSyncResult` (not configured / synced + count / failed).

## UI changes

- Playlists tab: subtle "· Jellyfin" source label on synced rows; empty state distinguishes signed-in ("…appear here after you sync") vs not ("…sign in to Jellyfin in Settings"); load failures keep the separate error state.
- Favourites: existing list/empty states kept; added a friendly catalog-load error state.

## Provider capability changes

Refined the capability model so the UI only offers supported actions and future providers can reuse the seam:

- Added `canListPlaylists`, `canSyncFavorites`, `canReadFavoriteState`; renamed `canFavorite` → `canFavoriteTracks`.
- Jellyfin exposes full playlist + favourite support; local is local-only favourites/playlists; Subsonic stays unsupported (actions hidden) pending its follow-up.

## Sign-out

Clears this account's imported Jellyfin playlists (new `PlaylistRepository.clearRemote`) **and** its server favourites, plus the stale sync status — local favourites and local-only playlists are kept.

## Security / token notes

- No token or authenticated URL is ever written to playlist/favourite metadata, a cache filename, a log, or a UI error. Persisted track URIs stay the token-free `jellyfin:<id>`; stream/download URLs are minted on demand.
- The new sync status line is counts-only (no ids/URLs); a test asserts no token reaches it. Errors are friendly and branched on a typed error kind.

## Tests added

- **Sync controller:** imports playlists + reports count; adopts favourites + reports count; playlist failure and favourite failure each reported without failing the track sync; no token in the combined message.
- **Playlist repo:** synced-count result; failure result; idempotent refresh; remote rename updates locally; deleted remote pruned; local-only kept while remote pruned; `clearRemote` drops synced but keeps local.
- **Favourites repo:** synced-count result; not-configured without session; failure result.
- **Capabilities:** updated for the new/renamed fields; favourite-capability matrix; data-driven fake-provider seam.
- **UI:** Playlists "· Jellyfin" label; signed-in vs signed-out empty states; favourites error state.
- **Settings controller:** sign-out drops imported Jellyfin playlists.

## Known limitations (documented on purpose)

- Rename / reorder of a *synced* playlist are local-only (not pushed); a refresh re-adopts the server's name/order.
- No two-way conflict resolution — server wins on refresh; favourites reconcile to the server on the next sync.
- Missing playlist tracks are shown as unavailable rather than fetched on the fly.
- Subsonic/Navidrome playlist & favourite sync remain follow-ups.

## Docs

`docs/jellyfin-sync.md` (new, comprehensive), plus updates to `docs/playlists-and-delete.md`, `docs/providers.md`, and the README Jellyfin section.

## Verification

⚠️ No Flutter/Dart SDK is available in this environment, so `flutter pub get` / `dart format` / `flutter analyze` / `flutter test` / `flutter build apk --debug` were **not** run locally — they need to pass in CI. Code was written to match the repo's conventions and lints (`directives_ordering`, `prefer_const_constructors`, `prefer_final_locals`, etc.).

## Manual Android checklist

1. On Jellyfin, create a playlist with several tracks.
2. Favourite/like several tracks in Jellyfin.
3. Open Linthra and sign in to Jellyfin.
4. Run Sync library.
5. Confirm Jellyfin playlists appear in Linthra (with a "· Jellyfin" label).
6. Open a Jellyfin playlist and play it.
7. Confirm Jellyfin liked tracks show as favourited in Linthra.
8. Favourite a Jellyfin track in Linthra → confirm it appears favourited in Jellyfin.
9. Unfavourite a Jellyfin track in Linthra → confirm it updates in Jellyfin.
10. Change favourite state / rename / delete a playlist in Jellyfin, run sync again → confirm Linthra updates (rename adopted, deleted playlist dropped).
11. Sign out → confirm account-specific Jellyfin favourites/playlists are cleared, local ones kept.
12. Confirm no tokens or sensitive URLs appear in UI/errors/logs.

https://claude.ai/code/session_011yLoWhsS2EbwXbJmnR7Yvw

---
_Generated by [Claude Code](https://claude.ai/code/session_011yLoWhsS2EbwXbJmnR7Yvw)_