### PR TITLE
Allow mobile data for downloads & smart pre-cache (opt-in, Wi-Fi only by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ Everything below works end to end on a real Android device in the current alpha
   kept (encrypted). Favorites and lyrics are follow-ups; see
   [docs/providers.md](docs/providers.md).
 - **Smart offline cache** — mark individual Jellyfin tracks for offline use
-  (Plexamp-style explicit downloads), with a **"Wi-Fi only"** option, a
-  configurable cache size limit, "Keep offline" pinning, and optional smart
-  pre-caching of upcoming tracks. Cached tracks play fully offline.
+  (Plexamp-style explicit downloads), Wi-Fi-only by default with an opt-in
+  **"Allow mobile data"** toggle, a configurable cache size limit, "Keep
+  offline" pinning, and optional smart pre-caching of upcoming tracks. Cached
+  tracks play fully offline. See [docs/offline-cache.md](docs/offline-cache.md).
 - **Synced lyrics** — fetch a Jellyfin track's lyrics into a sheet; favorites
   also sync with your Jellyfin server.
 - **Chromecast** — discover Cast devices, connect, and hand off the current
@@ -120,8 +121,8 @@ This is an alpha — expect rough edges. The honest gaps today:
   formats; Cloudflare Access / Zero Trust in front of Jellyfin is not supported.
 - **On-device files can't be cast** — a Cast receiver can't reach a local file,
   so only Jellyfin streams hand off.
-- **Connectivity is optimistic** — the "Wi-Fi only" gate relies on a placeholder
-  detector for now.
+- **Connectivity is optimistic** — the Wi-Fi / mobile-data gate relies on a
+  placeholder detector for now (it reports Wi-Fi until real detection lands).
 - **Android only today** — Linux desktop is planned later from the same codebase.
 - **Release signing not yet provisioned** — alpha APKs may be debug-signed (see
   [Install](#install)).
@@ -246,12 +247,15 @@ open-source, with no surprise downloads:
 - **Streaming is the default.** You tap the download icon on the tracks you want
   available offline; only those are fetched.
 - **Cached tracks play with no network** — airplane mode, dead tunnel, anywhere.
+- **Wi-Fi only by default.** Downloads and pre-caching run on Wi-Fi; on mobile
+  data they wait until you turn on **"Allow mobile data for downloads"** in
+  Settings (with a confirmation first, since it can use a lot of data).
 - A **size limit** (4 GB by default; presets up to 16 GB or a custom value) keeps
   the cache from filling your phone. When it's full, Linthra evicts pre-cached
   and least-recently-played, unpinned tracks first — never something you
   **pinned** with "Keep offline".
 - Optional **smart pre-cache** warms the next few queued tracks so they start
-  instantly; it honours the "Wi-Fi only" toggle and the same size limit.
+  instantly; it follows the same mobile-data setting and size limit.
 
 The full mechanics, eviction policy, and token handling are in
 [Offline downloads &amp; known limitations](#offline-downloads--known-limitations).
@@ -300,8 +304,8 @@ Linthra is built to respect the people who use it:
 - **No telemetry, no analytics, no phoning home.** The app never uploads your
   library or reports usage.
 - **No forced sync and no surprise downloads.** Offline downloads are always
-  user-initiated; there is no automatic full-library sync, and a "Wi-Fi only"
-  option is respected for remote downloads.
+  user-initiated; there is no automatic full-library sync, and the default is
+  Wi-Fi only — mobile data is used for downloads/cache only after you opt in.
 - **Minimal Android permissions.** Just foreground-service + notification (for
   background playback) and internet (to reach your Jellyfin server). **No broad
   storage permission** — folder access uses the Storage Access Framework grant
@@ -334,7 +338,7 @@ secret-free diagnostics export.
 3. Subsonic favorites, lyrics, and cover art.
 4. Full playlist sync (rename/reorder of synced playlists; Subsonic playlists).
 5. Album/playlist "download all" and a background download manager.
-6. Real connectivity detection for the "Wi-Fi only" gate.
+6. Real connectivity detection for the Wi-Fi / mobile-data gate.
 7. More sources behind the same interface — WebDAV, NAS.
 
 **Later:** local-file lyrics (`.lrc`/tags), ReplayGain, MPRIS, smart playlists,
@@ -393,7 +397,8 @@ discover it.
 
 - **Local-first & offline-first** — the UI always reads from a local cache.
 - **Privacy-focused** — no telemetry, no forced sync.
-- **User-controlled downloads** — never automatic; "Wi-Fi only" is respected.
+- **User-controlled downloads** — never automatic; Wi-Fi only by default, with
+  an explicit "Allow mobile data" opt-in.
 - **No vendor lock-in** — sources (local, Jellyfin, WebDAV, NAS) sit behind a
   single interface.
 - **Contributor-friendly** — small focused files, explicit naming, clean layers.
@@ -510,11 +515,12 @@ lib/
   `CastState` as `volume`/`muted`/`supportsVolumeControl`); the Cast sheet shows
   a "Cast volume" slider, and a failed volume command never interrupts playback.
 - **`DownloadRepository`** (`core/repositories/`) — enforces the
-  user-initiated, "Wi-Fi only"-respecting download policy in one place.
+  user-initiated, mobile-data-respecting download policy in one place.
   `CacheDownloadRepository` implements it today over a `DownloadStore`
-  (durable cached-ID set), a `DownloadPreferences` ("Wi-Fi only" switch), and a
-  `ConnectivityService`. Remote (Jellyfin/WebDAV) downloads add a real
-  byte-fetch in `_obtainOfflineCopy` without touching the policy or the UI.
+  (durable cached-ID set), a `DownloadPreferences` ("Allow mobile data" switch),
+  and a `ConnectivityService` (Wi-Fi / mobile data / offline / unknown). Remote
+  (Jellyfin/WebDAV) downloads add a real byte-fetch without touching the policy
+  or the UI.
 
 ## Getting started
 
@@ -641,10 +647,12 @@ it covers the paths that only behave correctly on real hardware:
     or connection mid-fetch so it fails. The Library row should show an **error
     icon with a "Retry download" tooltip**; tapping it re-attempts the download
     (it succeeds once the server is reachable again).
-11. **Wi-Fi-only gate.** On the Downloads tab, turn on **Wi-Fi only**, switch to
-    mobile data (or a future real detector), and start a download — it should be
-    **queued** rather than run over mobile data. (See the connectivity note in
-    *Offline downloads & known limitations*.)
+11. **Mobile-data gate.** With **Allow mobile data** off (the default), switch to
+    mobile data (or a future real detector) and start a download — it should be
+    **queued** with a friendly "Downloads are limited to Wi-Fi" message rather
+    than run over mobile data. Turn **Allow mobile data** on (confirm the
+    dialog) and retry — it should download over mobile data. (See the
+    connectivity note in *Offline downloads & known limitations*.)
 12. **No secrets on screen.** Throughout, confirm no error, status line, or
     track subtitle ever shows a Jellyfin token, `api_key`, password, or raw URL.
 
@@ -1158,11 +1166,11 @@ user-controlled**:
 download an absent track, see a spinner while it's in flight, remove a cached
 one, or retry a failed one. The **Downloads** tab lists everything currently
 cached — with each track's **size** and a **Keep offline** pin — shows how much
-of the limit is in use, and hosts the **Wi-Fi only** toggle. **Settings → Smart
-pre-cache** turns automatic pre-caching on/off and sets how many upcoming tracks
-to warm (1, 3, 5, or 10); **Settings → Offline cache** shows used / max / free
-space and the **Change limit** and **Clear cache** (clear unpinned, or clear
-all) actions. The download lifecycle flows through `DownloadRepository`, which
+of the limit is in use, and hosts the **Allow mobile data** toggle (also under
+**Settings → Downloads & network**). **Settings → Smart pre-cache** turns
+automatic pre-caching on/off and sets how many upcoming tracks to warm (1, 3, 5,
+or 10); **Settings → Offline cache** shows used / max / free space and the
+**Change limit** and **Clear cache** (clear unpinned, or clear all) actions. The download lifecycle flows through `DownloadRepository`, which
 centralizes three guarantees:
 
 - **Downloads are user-initiated.** A track's *download status* only ever changes
@@ -1175,9 +1183,11 @@ centralizes three guarantees:
   app-private offline directory (`OfflineFileStore`); an **on-device** track is
   already local, so it's recorded as available offline with no network fetch and
   no managed file.
-- **Wi-Fi only is respected.** For remote downloads, with the toggle on a request
-  made off Wi-Fi is *queued* instead of run; with it off, downloads proceed on
-  any connection. (Local tracks are never queued — there are no bytes to fetch.)
+- **The mobile-data policy is respected.** Remote downloads run on Wi-Fi always,
+  on mobile data only when **Allow mobile data** is on, and never while offline.
+  When the connection isn't allowed the request is *queued* instead of run, and
+  the UI shows a friendly reason ("limited to Wi-Fi", or "you're offline").
+  (Local tracks are never queued — there are no bytes to fetch.)
 
 **Smart pre-cache.** As playback moves, Linthra warms a small number of upcoming
 queued tracks into the same cache ahead of time — the Plex/Plexamp-style "the
@@ -1192,8 +1202,9 @@ normal playback and the **shuffled order** when shuffle is on, since the
 controller keeps `upNext` in effective play order. The same applies while
 **casting**: the queue is always owned locally, so it pre-caches the active
 queue either way. It is deliberately well-behaved: only remote, not-yet-cached
-tracks are fetched, one at a time; it **honours "Wi-Fi only"** (skipping rather
-than queueing off Wi-Fi); it respects the cache limit *before* spending data
+tracks are fetched, one at a time; it **follows the same mobile-data policy**
+(skipping rather than queueing when the connection isn't allowed); it respects
+the cache limit *before* spending data
 (and **evicts pre-cached entries before any download**); a pre-cache that won't
 fit or fails is silently skipped (the track still streams when reached); and it
 never blocks or interrupts what's playing. Under **repeat-one** it stays calm —
@@ -1260,9 +1271,9 @@ Deliberate gaps the next PRs will close:
   reconciliation against the directory's actual on-disk size, and a remote track
   larger than the whole limit can't be cached at all.
 - **Connectivity is optimistic.** `OptimisticConnectivityService` always reports
-  Wi-Fi until `connectivity_plus` is wired in, so the "Wi-Fi only" gate currently
-  blocks only when a test (or a future real detector) reports mobile/offline —
-  the seam and its tests are in place for when it does.
+  Wi-Fi until `connectivity_plus` is wired in, so the mobile-data gate currently
+  blocks only when a test (or a future real detector) reports mobile/offline/
+  unknown — the seam and its tests are in place for when it does.
 - **No Drift table for downloads.** Persisting a small `CachedTrack` set is a
   key/value job; a `downloads` table (with byte progress) graduates from the
   `DownloadStore` seam when background/resumable downloads need it.
@@ -1479,7 +1490,7 @@ branch rather than `main`.
 6. Search
 7. Album artwork
 8. Explicit offline downloads
-9. "Wi-Fi only downloads" option
+9. "Allow mobile data for downloads" option (Wi-Fi only by default)
 10. Settings
 
 Later: Jellyfin (landed — settings, auth, encrypted session, a library source,

--- a/docs/google-play-listing.md
+++ b/docs/google-play-listing.md
@@ -55,7 +55,8 @@ WORKS TODAY
 • Connect to your own Jellyfin server, sign in, sync your library, and stream.
   The session token is stored encrypted and your password is never saved.
 • Explicit, user-initiated offline downloads with a smart cache and a size
-  limit you set, plus a "Wi-Fi only" option — never automatic.
+  limit you set — Wi-Fi only by default, with an optional "Allow mobile data"
+  toggle. Never automatic.
 • Cast to Chromecast-compatible devices on your local network.
 
 PLANNED (NOT FINISHED YET)
@@ -73,7 +74,7 @@ bundles no server and runs no cloud service of its own.
 NO SURPRISES
 No ads. No account. No forced sync. No surprise downloads — Linthra never
 downloads your library in the background; downloads happen only when you ask,
-and a "Wi-Fi only" option is respected.
+and they use Wi-Fi only by default unless you allow mobile data.
 
 Linthra is alpha software with honest, documented limitations. Expect rough
 edges, and please share feedback.
@@ -118,7 +119,7 @@ Be upfront in the listing and/or release notes:
 - No browse-by-artist/album and **no search** yet.
 - **No playlist** creation/editing yet; queue reordering is limited.
 - No album/playlist "download all" or background download manager yet.
-- The "Wi-Fi only" gate relies on basic connectivity handling; robust
+- The Wi-Fi / mobile-data gate relies on basic connectivity handling; robust
   connectivity detection is still planned.
 - Some Android 11+ scoped-storage folders may be unreadable; the app surfaces a
   clear error rather than a silent empty library.
@@ -160,8 +161,8 @@ emulator.
 A core promise worth stating plainly in the listing and release notes:
 
 > Linthra never downloads your library in the background. Offline downloads are
-> always something **you** start, with a size limit you set and an optional
-> "Wi-Fi only" restriction. There is no forced full-library sync.
+> always something **you** start, with a size limit you set and Wi-Fi-only by
+> default (mobile data is opt-in). There is no forced full-library sync.
 
 ## 9. Jellyfin / NAS / self-hosted positioning
 

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -108,6 +108,13 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
   *(Regression-fixed this release.)*
 - ☐ **Local source files are never deleted** by any cache action.
 - ☐ Tokens / authenticated URLs never appear in the downloads UI or progress.
+- ☐ **Wi-Fi only by default**: with **Allow mobile data** off, a download on
+  mobile data is queued with a friendly "limited to Wi-Fi" message.
+- ☐ Enabling **Allow mobile data** shows the confirmation dialog; allowing it
+  lets the same download run over mobile data; cancelling leaves it off.
+- ☐ The toggle persists across restart and stays in sync between the Downloads
+  tab and **Settings → Downloads & network**.
+- ☐ With mobile data allowed, the **cache size limit still applies** over LTE.
 
 ## 7. Smart pre-cache
 
@@ -115,7 +122,7 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
 - ☐ Enabled: only the next small window (1/3/5/10) is warmed; not the whole
   library.
 - ☐ Respects shuffle order and stays quiet under repeat-one.
-- ☐ Respects the cache limit and "Wi-Fi only".
+- ☐ Respects the cache limit and the "Allow mobile data" setting.
 - ☐ Never blocks or stutters what's playing.
 
 ## 8. Favorites

--- a/docs/offline-cache.md
+++ b/docs/offline-cache.md
@@ -1,0 +1,109 @@
+# Offline cache & downloads
+
+Linthra's offline model is **explicit and user-controlled** — Plexamp-style,
+open-source, with no surprise downloads. This page covers the network policy
+(Wi-Fi vs. mobile data), the cache size limit, and smart pre-cache.
+
+## Wi-Fi only by default
+
+Out of the box Linthra downloads and pre-caches **only on Wi-Fi**. If you start
+a download (or smart pre-cache wants to warm a track) while on mobile data, it
+**waits** instead of spending your data — the track is queued, and the UI shows
+a friendly reason rather than failing silently:
+
+> Downloads are limited to Wi-Fi. Turn on "Allow mobile data" in Settings to
+> download over mobile data.
+
+When you're fully offline, a requested download is queued until a connection
+returns:
+
+> You're offline. This download will start automatically when you're back
+> online.
+
+Local (on-device) tracks are never affected by the network policy — they're
+already on disk, so "Keep offline" records them immediately.
+
+## Allowing mobile data
+
+To let downloads and smart pre-cache run over mobile data/LTE:
+
+1. Open **Settings → Downloads & network** (the same toggle is also on the
+   **Downloads** tab).
+2. Turn on **Allow mobile data for downloads**.
+3. Confirm the prompt:
+
+   > **Use mobile data for downloads?**
+   > Caching music over mobile data may use a lot of data depending on your
+   > library and cache settings.
+
+   Choose **Allow mobile data** to opt in, or **Cancel** to stay Wi-Fi-only.
+
+The setting is persisted across restarts. Turning it back off applies
+immediately (no confirmation needed); in-flight downloads on mobile data stop
+queueing for Wi-Fi again.
+
+> ⚠️ **Mobile data can be expensive.** With this on, manual downloads and smart
+> pre-cache may use a lot of cellular data depending on your library size and
+> cache limit. The cache **size limit still applies**, and Linthra never
+> downloads your whole library automatically.
+
+### Network policy at a glance
+
+| Connection | Allow mobile data **off** (default) | Allow mobile data **on** |
+| ---------- | ----------------------------------- | ------------------------ |
+| Wi-Fi      | Download                            | Download                 |
+| Mobile     | Queue (wait for Wi-Fi)              | Download                 |
+| Offline    | Queue (wait for a connection)       | Queue (wait)             |
+| Unknown    | Queue (treated conservatively)      | Download                 |
+
+An **unknown** connection type is treated like mobile data: it downloads only
+when you've allowed mobile data, so an undetermined link is never assumed to be
+unmetered.
+
+## Cache size limit always applies
+
+A configurable **size limit** (4 GB by default; presets up to 16 GB, or a
+custom value) keeps the cache from filling your phone. Allowing mobile data
+**never** raises or bypasses this limit. When the cache is full, Linthra evicts,
+in order:
+
+1. **Smart pre-cached** tracks (automatic, evictable) first.
+2. Then **least-recently-played, unpinned** downloads.
+
+It never evicts a track you **pinned** with "Keep offline", and never the track
+playing right now. If a new download still won't fit, it's refused with a
+friendly "not enough cache space" message instead of deleting something you
+wanted.
+
+## Smart pre-cache follows the same policy
+
+Smart pre-cache warms a small, fixed number of **upcoming** queued tracks (1, 3,
+5, or 10 — configurable in **Settings → Smart pre-cache**) so the next songs
+start instantly and play offline. It is deliberately modest and **never
+downloads the whole library**. It follows the **same mobile-data policy** as
+manual downloads: on Wi-Fi always, on mobile data only when you've allowed it,
+and never offline. Pre-cache is best-effort — when the connection isn't allowed
+it simply skips (it doesn't queue), and pre-cached tracks are the first to be
+evicted under the cache limit.
+
+## Security & privacy
+
+- Track URIs and cache metadata carry only a non-secret track id, an id-derived
+  file name, the source's URI scheme, a byte size, timestamps, and the pinned
+  flag — **never a Jellyfin token or an authenticated URL**.
+- The credential-bearing download URL is minted only at fetch time inside the
+  source's downloader; the repository never sees, stores, or logs it.
+- Network-policy and "cache full" messages are friendly and **secret-free** —
+  they never include a URL, token, or file path, so the UI shows them verbatim.
+
+## Manual Android checklist
+
+1. Disable Wi-Fi and use LTE/mobile data.
+2. With **Allow mobile data** off, try downloading a Jellyfin track.
+3. Confirm the friendly "limited to Wi-Fi" message and a **queued** state.
+4. Enable **Allow mobile data** in Settings and confirm the dialog.
+5. Try downloading again.
+6. Confirm the download/cache works over LTE.
+7. Enable smart pre-cache and confirm it follows the same setting.
+8. Confirm the cache size limit still applies (downloads evict, never overflow).
+9. Turn **Allow mobile data** back off and confirm LTE downloads queue again.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -64,8 +64,9 @@ data stays on the device.
 Tracks you explicitly download, and tracks the app pre-caches to play smoothly,
 are stored as files in Linthra's **local storage on your device**, within a
 size limit you control. Downloads are always **user-initiated** — Linthra does
-not silently download your library. A "Wi-Fi only" option is available for
-remote downloads.
+not silently download your library. Downloads and pre-caching use **Wi-Fi only
+by default**; an optional "Allow mobile data" setting lets them use mobile data
+once you opt in.
 
 ### App settings
 

--- a/lib/core/repositories/download_preferences.dart
+++ b/lib/core/repositories/download_preferences.dart
@@ -20,16 +20,19 @@ int sanitizePrecacheCount(int value) =>
 /// These are kept behind an interface so the [DownloadRepository] and cache
 /// manager can consult them without binding to a storage plugin. The policy
 /// lives in the repository; this only remembers the choices:
-///  - "Wi-Fi only": downloads that would run over mobile data are queued.
+///  - "Allow mobile data": when off (the safe default), downloads and smart
+///    pre-cache run only on Wi-Fi and are queued on mobile data; when on, they
+///    may also run over a metered/cellular connection.
 ///  - "Max cache size": the byte ceiling the offline cache is kept under, with
 ///    least-recently-used eviction once a new download would exceed it.
 ///  - Smart pre-cache "on/off" and "how many upcoming tracks": whether, and how
 ///    far ahead, playback warms the next queued tracks into the cache.
 abstract interface class DownloadPreferences {
-  /// Whether downloads should only run on Wi-Fi. Defaults to `false`.
-  Future<bool> wifiOnly();
+  /// Whether downloads and smart pre-cache may use mobile data. Defaults to
+  /// `false`, so the safe behaviour out of the box is Wi-Fi only.
+  Future<bool> allowMobileData();
 
-  Future<void> setWifiOnly(bool value);
+  Future<void> setAllowMobileData(bool value);
 
   /// The maximum total size of the offline cache in bytes. Defaults to
   /// [CacheSize.defaultLimit] when the user hasn't chosen one.
@@ -39,8 +42,8 @@ abstract interface class DownloadPreferences {
 
   /// Whether smart pre-cache is on: upcoming queued tracks are warmed into the
   /// cache ahead of play. Defaults to `true`. Pre-cached bytes are bounded by
-  /// [maxCacheBytes], skipped (not queued) when "Wi-Fi only" is on and the
-  /// connection isn't Wi-Fi, and evicted before any user download.
+  /// [maxCacheBytes], skipped (not queued) when the connection isn't allowed by
+  /// the mobile-data policy, and evicted before any user download.
   Future<bool> preloadEnabled();
 
   Future<void> setPreloadEnabled(bool value);

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -4,6 +4,41 @@ import '../models/track.dart';
 /// Where a track stands in the offline-download lifecycle.
 enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
 
+/// The result of a [DownloadRepository.requestDownload] call, so the UI can tell
+/// the user *why* a download didn't start instead of failing silently.
+enum DownloadRequestOutcome {
+  /// The download started, was already in progress/finished, or (for an
+  /// on-device track) was recorded immediately.
+  started,
+
+  /// Held back by the network policy: the device is on mobile data and the user
+  /// hasn't allowed it (or the connection type is unknown). The track is queued
+  /// and starts on Wi-Fi, or once the user allows mobile data.
+  waitingForWifi,
+
+  /// Held back because the device is offline. The track is queued and starts
+  /// when a connection returns.
+  waitingForConnection,
+}
+
+/// A friendly, secret-free line for an outcome that didn't start, or `null` when
+/// the download started (so callers stay quiet on success). Never carries a URL,
+/// token, or path, so the UI can show it verbatim.
+extension DownloadRequestOutcomeMessage on DownloadRequestOutcome {
+  String? get blockedMessage {
+    switch (this) {
+      case DownloadRequestOutcome.started:
+        return null;
+      case DownloadRequestOutcome.waitingForWifi:
+        return 'Downloads are limited to Wi-Fi. Turn on "Allow mobile data" in '
+            'Settings to download over mobile data.';
+      case DownloadRequestOutcome.waitingForConnection:
+        return "You're offline. This download will start automatically when "
+            "you're back online.";
+    }
+  }
+}
+
 /// Thrown by [DownloadRepository.requestDownload] when a download can't be
 /// cached because the cache is at its limit and nothing safe is left to evict
 /// (everything remaining is pinned or currently playing, or the track is larger
@@ -27,9 +62,10 @@ class CacheStorageException implements Exception {
 /// Tracks which library items are available offline.
 ///
 /// Downloads in Linthra are always *explicit and user-initiated* — never
-/// automatic. Implementations must also honor the user's "Wi-Fi only" pref
-/// (queueing rather than downloading over mobile data when set), so that
-/// promise is enforced in one place rather than scattered through the UI.
+/// automatic. Implementations must also honor the user's mobile-data preference
+/// (queueing rather than downloading over mobile data unless the user allowed
+/// it), so that promise is enforced in one place rather than scattered through
+/// the UI.
 ///
 /// [requestDownload] takes the whole [Track], not just an id, so the repository
 /// can be *source-aware*: a remote (Jellyfin) track has its bytes fetched and
@@ -56,7 +92,11 @@ abstract interface class DownloadRepository {
   /// To stay under the user's cache limit, a remote download may first evict
   /// least-recently-used, unpinned, not-currently-playing tracks. If even then
   /// there isn't room, it throws [CacheStorageException] and caches nothing.
-  Future<void> requestDownload(Track track);
+  ///
+  /// Returns a [DownloadRequestOutcome] so the caller can tell the user when a
+  /// download was queued by the network policy (mobile data not allowed, or
+  /// offline) rather than started.
+  Future<DownloadRequestOutcome> requestDownload(Track track);
 
   /// Removes the offline copy of [trackId], deleting any cached file and
   /// freeing storage.

--- a/lib/core/services/connectivity_service.dart
+++ b/lib/core/services/connectivity_service.dart
@@ -1,6 +1,14 @@
 /// Network reachability, abstracted so the downloads feature can enforce the
-/// user's "Wi-Fi only downloads" preference without binding to a plugin.
-enum NetworkStatus { offline, wifi, mobile }
+/// user's mobile-data download preference without binding to a plugin.
+///
+///  - [offline]: no usable connection — downloads wait.
+///  - [wifi]: an unmetered connection — downloads always allowed.
+///  - [mobile]: a metered/cellular connection — downloads allowed only when the
+///    user has turned on "Allow mobile data".
+///  - [unknown]: the connection type couldn't be determined. Treated
+///    conservatively (like [mobile]): downloads run only when the user has
+///    allowed mobile data, so an unknown connection is never assumed unmetered.
+enum NetworkStatus { offline, wifi, mobile, unknown }
 
 abstract interface class ConnectivityService {
   /// Emits whenever connectivity changes.

--- a/lib/core/services/optimistic_connectivity_service.dart
+++ b/lib/core/services/optimistic_connectivity_service.dart
@@ -5,10 +5,10 @@ import 'connectivity_service.dart';
 /// There is no network detection plugin yet (and nothing downloads over the
 /// network — the offline cache foundation only marks already-local tracks). The
 /// real implementation, backed by `connectivity_plus`, lands alongside remote
-/// (Jellyfin/WebDAV) downloads, where the "Wi-Fi only" gate actually has data
+/// (Jellyfin/WebDAV) downloads, where the mobile-data gate actually has data
 /// to guard. Until then this keeps the seam wired and the default app behaving
-/// as "connected", while tests inject a fake to exercise the mobile/offline
-/// branches of the download policy.
+/// as "connected", while tests inject a fake to exercise the mobile/offline/
+/// unknown branches of the download policy.
 class OptimisticConnectivityService implements ConnectivityService {
   const OptimisticConnectivityService();
 

--- a/lib/core/services/smart_precache_service.dart
+++ b/lib/core/services/smart_precache_service.dart
@@ -27,8 +27,9 @@ import 'track_prefetcher.dart';
 ///    service caches nothing extra and lets those tracks stream if reached.
 ///  - **It only decides what/when.** Everything that *bounds* a pre-cache lives
 ///    downstream in the [TrackPrefetcher]: it pre-caches only remote tracks
-///    (skipping local files, already on disk), avoids duplicates, honours
-///    "Wi-Fi only", stays under the cache limit (evicting pre-cached entries
+///    (skipping local files, already on disk), avoids duplicates, honours the
+///    mobile-data policy (Wi-Fi always; mobile data only when the user allowed
+///    it; never offline), stays under the cache limit (evicting pre-cached entries
 ///    before any user download), and never throws. A pre-cache never blocks or
 ///    interrupts what's playing.
 ///  - **One at a time.** Pre-caches run sequentially (effective concurrency 1),

--- a/lib/core/services/track_prefetcher.dart
+++ b/lib/core/services/track_prefetcher.dart
@@ -10,7 +10,7 @@ import '../models/track.dart';
 ///
 /// A pre-cache is *best-effort and never user-visible as a download*: it caches
 /// a remote track's bytes (skipping local tracks, which are already on disk),
-/// honours the user's "Wi-Fi only" and smart-pre-cache preferences, stays under
+/// honours the user's mobile-data and smart-pre-cache preferences, stays under
 /// the cache limit (evicting other pre-cached entries first), and silently does
 /// nothing on any failure — the track still streams normally when it's reached.
 abstract interface class TrackPrefetcher {

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -35,8 +35,11 @@ import '../../core/services/track_prefetcher.dart';
 ///  - **Source-aware.** A remote (Jellyfin) track has its bytes fetched and
 ///    written to the offline directory; an on-device track is already local, so
 ///    it's recorded as available offline with no fetch and no managed file.
-///  - **Wi-Fi only is respected.** A *remote* request is queued (not run) when
-///    the user set "Wi-Fi only" and the connection isn't Wi-Fi.
+///  - **The mobile-data policy is respected.** A *remote* request runs on Wi-Fi
+///    always, on mobile data only when the user turned on "Allow mobile data",
+///    and never while offline. When the connection isn't allowed the request is
+///    queued (not run) and [requestDownload] reports why, so the UI can prompt
+///    the user instead of failing silently.
 ///  - **Stays under the cache limit.** Before writing a remote download, the
 ///    policy evicts least-recently-used, unpinned, not-currently-playing tracks
 ///    to make room; if it still won't fit, the download is refused with a
@@ -193,12 +196,12 @@ class CacheDownloadRepository
   }
 
   @override
-  Future<void> requestDownload(Track track) async {
+  Future<DownloadRequestOutcome> requestDownload(Track track) async {
     if (!_downloader.isRemote(track)) {
       // On-device track: no bytes to fetch and no network gate, so record it as
       // available offline directly.
       await _requestOnDeviceDownload(track);
-      return;
+      return DownloadRequestOutcome.started;
     }
 
     // A fresh, explicit request supersedes any pending cancellation for this id
@@ -207,9 +210,9 @@ class CacheDownloadRepository
     // Reserve the in-flight slot synchronously, before any `await`, so a second
     // request for the same track (a double tap, or a second caller) bails out
     // here instead of starting a duplicate fetch.
-    if (!_inFlight.add(track.id)) return;
+    if (!_inFlight.add(track.id)) return DownloadRequestOutcome.started;
     try {
-      await _runRemoteRequest(track);
+      return await _runRemoteRequest(track);
     } on CacheStorageException {
       // The cache is full with nothing safe to evict; surface the friendly,
       // secret-free error so the UI can prompt to free space or raise the
@@ -222,6 +225,7 @@ class CacheDownloadRepository
       if (!_canceled.contains(track.id)) {
         _set(track.id, DownloadStatus.failed);
       }
+      return DownloadRequestOutcome.started;
     } finally {
       _canceled.remove(track.id);
       _inFlight.remove(track.id);
@@ -230,7 +234,7 @@ class CacheDownloadRepository
   }
 
   /// Records an on-device track as available offline: its bytes are already
-  /// local, so there is no fetch, no managed file, and no Wi-Fi gate.
+  /// local, so there is no fetch, no managed file, and no network gate.
   Future<void> _requestOnDeviceDownload(Track track) async {
     await _ensureLoaded();
     if (_statuses[track.id] == DownloadStatus.downloaded) return;
@@ -246,13 +250,15 @@ class CacheDownloadRepository
   }
 
   /// Drives one remote download: skip if already cached, promote a preloaded
-  /// copy in place, honor "Wi-Fi only", then wait for a concurrency slot before
-  /// fetching the bytes and committing them under the cache limit.
-  Future<void> _runRemoteRequest(Track track) async {
+  /// copy in place, apply the mobile-data policy, then wait for a concurrency
+  /// slot before fetching the bytes and committing them under the cache limit.
+  Future<DownloadRequestOutcome> _runRemoteRequest(Track track) async {
     await _ensureLoaded();
     // Already cached — nothing to do. (A track that is downloading or queued is
     // already in [_inFlight], so it never reaches here a second time.)
-    if (_statuses[track.id] == DownloadStatus.downloaded) return;
+    if (_statuses[track.id] == DownloadStatus.downloaded) {
+      return DownloadRequestOutcome.started;
+    }
 
     // A track preloaded ahead of play is already cached: promote it to a user
     // download in place, without re-fetching its bytes.
@@ -265,15 +271,19 @@ class CacheDownloadRepository
       _statuses[track.id] = DownloadStatus.downloaded;
       _emitStatus();
       _emitCache();
-      return;
+      return DownloadRequestOutcome.started;
     }
 
-    // The Wi-Fi gate only matters here, where there are bytes to pull over the
+    // The network gate only matters here, where there are bytes to pull over the
     // network. When it blocks, the track waits as "queued" for an explicit
-    // retry once on Wi-Fi (the in-flight reservation is released by the caller).
-    if (!await _allowedToDownloadNow()) {
+    // retry once allowed (the in-flight reservation is released by the caller),
+    // and the outcome tells the UI why so it can prompt instead of failing.
+    final _NetworkDecision decision = await _networkDecision();
+    if (decision != _NetworkDecision.allowed) {
       _set(track.id, DownloadStatus.queued);
-      return;
+      return decision == _NetworkDecision.offline
+          ? DownloadRequestOutcome.waitingForConnection
+          : DownloadRequestOutcome.waitingForWifi;
     }
 
     // Accepted: show "queued" until a concurrency slot frees up, then fetch.
@@ -289,6 +299,7 @@ class CacheDownloadRepository
       // limit; the (slow) byte fetch above already ran in parallel.
       await _commit(() => _cacheRemote(track, data));
     });
+    return DownloadRequestOutcome.started;
   }
 
   /// Writes a freshly fetched remote track's bytes, evicting first to stay under
@@ -381,8 +392,8 @@ class CacheDownloadRepository
     // of the same track bails here instead of fetching the same bytes twice.
     if (!_preloading.add(track.id)) return;
     try {
-      // Preload is best-effort and network-heavy, so it honours "Wi-Fi only"
-      // and simply skips (rather than queueing) when it can't run right now.
+      // Preload is best-effort and network-heavy, so it honours the mobile-data
+      // policy and simply skips (rather than queueing) when it can't run now.
       if (!await _allowedToDownloadNow()) return;
       // Respect the cache limit *before* spending data: if the cache is already
       // full and nothing is safe to evict (every entry pinned or playing), a
@@ -521,11 +532,32 @@ class CacheDownloadRepository
     return used < maxBytes || hasEvictable;
   }
 
-  /// The connectivity gate. With "Wi-Fi only" off, anything goes; with it on,
-  /// only a Wi-Fi connection clears a download to start now.
-  Future<bool> _allowedToDownloadNow() async {
-    if (!await _preferences.wifiOnly()) return true;
-    return await _connectivity.currentStatus() == NetworkStatus.wifi;
+  /// The connectivity gate as a simple yes/no, for the best-effort pre-cache
+  /// path that just skips when it can't run.
+  Future<bool> _allowedToDownloadNow() async =>
+      await _networkDecision() == _NetworkDecision.allowed;
+
+  /// Decides whether a download may run right now, and (when it can't) why:
+  ///  - Wi-Fi: always allowed.
+  ///  - Mobile data: allowed only when the user turned on "Allow mobile data";
+  ///    otherwise held for Wi-Fi.
+  ///  - Unknown: treated conservatively, like mobile data — allowed only when
+  ///    the user allowed mobile data, so an undetermined link is never assumed
+  ///    unmetered.
+  ///  - Offline: never allowed; the request waits for a connection.
+  Future<_NetworkDecision> _networkDecision() async {
+    final NetworkStatus status = await _connectivity.currentStatus();
+    switch (status) {
+      case NetworkStatus.wifi:
+        return _NetworkDecision.allowed;
+      case NetworkStatus.mobile:
+      case NetworkStatus.unknown:
+        return await _preferences.allowMobileData()
+            ? _NetworkDecision.allowed
+            : _NetworkDecision.needsWifi;
+      case NetworkStatus.offline:
+        return _NetworkDecision.offline;
+    }
   }
 
   /// Deletes the app-managed cache file behind [entry], if any. A `null` entry
@@ -611,3 +643,8 @@ class CacheDownloadRepository
     return scheme.isEmpty ? null : scheme;
   }
 }
+
+/// Whether the network policy lets a download run now, and why not when it
+/// doesn't: held for Wi-Fi (mobile data not allowed) or waiting for a
+/// connection (offline).
+enum _NetworkDecision { allowed, needsWifi, offline }

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -43,15 +43,15 @@ final remoteTrackDownloaderProvider = Provider<RemoteTrackDownloader>((ref) {
   return const _UnsupportedRemoteTrackDownloader();
 });
 
-/// The user's "Wi-Fi only" download preference. In-memory by default; the app
-/// persists it via `shared_preferences`.
+/// The user's download/offline preferences (including "Allow mobile data").
+/// In-memory by default; the app persists them via `shared_preferences`.
 final downloadPreferencesProvider = Provider<DownloadPreferences>((ref) {
   return InMemoryDownloadPreferences();
 });
 
-/// Network reachability used to honor the "Wi-Fi only" preference. The default
-/// optimistically reports Wi-Fi until real detection lands; tests inject a fake
-/// to drive the policy's mobile/offline paths.
+/// Network reachability used to honor the mobile-data download preference. The
+/// default optimistically reports Wi-Fi until real detection lands; tests inject
+/// a fake to drive the policy's mobile/offline/unknown paths.
 final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
   return const OptimisticConnectivityService();
 });
@@ -112,7 +112,8 @@ final cachedTrackLocatorProvider = Provider<CachedTrackLocator>((ref) {
   );
 });
 
-/// Production bindings: persist the cached-track set and the Wi-Fi-only switch
+/// Production bindings: persist the cached-track set and the download/offline
+/// preferences (including "Allow mobile data")
 /// via `shared_preferences`, and store downloaded bytes on the device
 /// filesystem, so all three survive a restart. Applied in `main`; tests keep
 /// the in-memory defaults.

--- a/lib/data/repositories/in_memory_download_preferences.dart
+++ b/lib/data/repositories/in_memory_download_preferences.dart
@@ -4,26 +4,26 @@ import '../../core/repositories/download_preferences.dart';
 /// A non-persistent [DownloadPreferences] for development and tests.
 class InMemoryDownloadPreferences implements DownloadPreferences {
   InMemoryDownloadPreferences({
-    bool wifiOnly = false,
+    bool allowMobileData = false,
     int maxCacheBytes = CacheSize.defaultLimit,
     bool preloadEnabled = true,
     int precacheCount = kDefaultPrecacheCount,
-  })  : _wifiOnly = wifiOnly,
+  })  : _allowMobileData = allowMobileData,
         _maxCacheBytes = maxCacheBytes,
         _preloadEnabled = preloadEnabled,
         _precacheCount = sanitizePrecacheCount(precacheCount);
 
-  bool _wifiOnly;
+  bool _allowMobileData;
   int _maxCacheBytes;
   bool _preloadEnabled;
   int _precacheCount;
 
   @override
-  Future<bool> wifiOnly() async => _wifiOnly;
+  Future<bool> allowMobileData() async => _allowMobileData;
 
   @override
-  Future<void> setWifiOnly(bool value) async {
-    _wifiOnly = value;
+  Future<void> setAllowMobileData(bool value) async {
+    _allowMobileData = value;
   }
 
   @override

--- a/lib/data/repositories/shared_preferences_download_preferences.dart
+++ b/lib/data/repositories/shared_preferences_download_preferences.dart
@@ -9,21 +9,22 @@ import '../../core/repositories/download_preferences.dart';
 class SharedPreferencesDownloadPreferences implements DownloadPreferences {
   const SharedPreferencesDownloadPreferences();
 
-  static const String _wifiOnlyKey = 'downloads_wifi_only';
+  static const String _allowMobileDataKey = 'downloads_allow_mobile_data';
   static const String _maxCacheBytesKey = 'downloads_max_cache_bytes';
   static const String _preloadEnabledKey = 'downloads_preload_enabled';
   static const String _precacheCountKey = 'downloads_precache_count';
 
   @override
-  Future<bool> wifiOnly() async {
+  Future<bool> allowMobileData() async {
     final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_wifiOnlyKey) ?? false;
+    // Default false: Wi-Fi only is the safe out-of-the-box behaviour.
+    return prefs.getBool(_allowMobileDataKey) ?? false;
   }
 
   @override
-  Future<void> setWifiOnly(bool value) async {
+  Future<void> setAllowMobileData(bool value) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_wifiOnlyKey, value);
+    await prefs.setBool(_allowMobileDataKey, value);
   }
 
   @override

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -145,22 +145,25 @@ final maxCacheBytesControllerProvider =
   MaxCacheBytesController.new,
 );
 
-/// Owns the "Wi-Fi only downloads" switch: loads the persisted value and writes
-/// changes back through [DownloadPreferences].
-class WifiOnlyController extends AsyncNotifier<bool> {
+/// Owns the "Allow mobile data" switch: loads the persisted value and writes
+/// changes back through [DownloadPreferences]. When off (the safe default),
+/// downloads and smart pre-cache run only on Wi-Fi.
+class AllowMobileDataController extends AsyncNotifier<bool> {
   @override
   Future<bool> build() {
-    return ref.read(downloadPreferencesProvider).wifiOnly();
+    return ref.read(downloadPreferencesProvider).allowMobileData();
   }
 
-  Future<void> setWifiOnly(bool value) async {
-    await ref.read(downloadPreferencesProvider).setWifiOnly(value);
+  Future<void> setAllowMobileData(bool value) async {
+    await ref.read(downloadPreferencesProvider).setAllowMobileData(value);
     state = AsyncData<bool>(value);
   }
 }
 
-final wifiOnlyControllerProvider =
-    AsyncNotifierProvider<WifiOnlyController, bool>(WifiOnlyController.new);
+final allowMobileDataControllerProvider =
+    AsyncNotifierProvider<AllowMobileDataController, bool>(
+  AllowMobileDataController.new,
+);
 
 /// Owns the "Smart pre-cache" on/off switch: loads the persisted value and
 /// writes changes back through [DownloadPreferences]. When on, the player warms

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -11,13 +11,14 @@ import '../../core/services/offline_cache_manager.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/widgets/album_artwork.dart';
+import '../settings/network/network_settings_section.dart';
 import 'download_providers.dart';
 
 /// Manage explicit, user-controlled downloads. Lists the tracks the user has
 /// marked for offline use — both the ones still in flight (queued / downloading
 /// with live progress / failed) and the finished ones — with their cache size
 /// and a "Keep offline" pin, shows how much cache is in use, and exposes the
-/// "Wi-Fi only" preference. Downloads are always user-initiated — never
+/// "Allow mobile data" preference. Downloads are always user-initiated — never
 /// automatic.
 class DownloadsScreen extends ConsumerWidget {
   const DownloadsScreen({super.key});
@@ -29,7 +30,7 @@ class DownloadsScreen extends ConsumerWidget {
       body: const Column(
         children: [
           _CacheUsageHeader(),
-          _WifiOnlyToggle(),
+          MobileDataDownloadsTile(),
           Divider(height: 1),
           Expanded(child: _DownloadsBody()),
         ],
@@ -83,26 +84,6 @@ class _CacheUsageHeader extends ConsumerWidget {
         ],
       ),
     );
-  }
-}
-
-class _WifiOnlyToggle extends ConsumerWidget {
-  const _WifiOnlyToggle();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final wifiOnly = ref.watch(wifiOnlyControllerProvider);
-    return SwitchListTile(
-      secondary: const Icon(Icons.wifi_outlined),
-      title: const Text('Wi-Fi only'),
-      subtitle: const Text('Queue downloads until Wi-Fi is available'),
-      value: wifiOnly.valueOrNull ?? false,
-      onChanged: wifiOnly.isLoading ? null : (value) => _set(ref, value),
-    );
-  }
-
-  void _set(WidgetRef ref, bool value) {
-    ref.read(wifiOnlyControllerProvider.notifier).setWifiOnly(value);
   }
 }
 
@@ -253,13 +234,19 @@ class _ActiveDownloadTile extends ConsumerWidget {
     );
   }
 
-  /// Re-requests the download. Surfaces only the friendly, secret-free "cache
-  /// full" message; any other failure simply lands back in the row's failed
-  /// state (which keeps offering Retry).
+  /// Re-requests the download. Surfaces the friendly, secret-free reasons it
+  /// might not start — a full cache, or the network policy queueing it — while
+  /// any other failure simply lands back in the row's failed state (which keeps
+  /// offering Retry).
   Future<void> _retry(BuildContext context, WidgetRef ref) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     try {
-      await ref.read(downloadRepositoryProvider).requestDownload(track);
+      final DownloadRequestOutcome outcome =
+          await ref.read(downloadRepositoryProvider).requestDownload(track);
+      final String? message = outcome.blockedMessage;
+      if (message != null) {
+        messenger.showSnackBar(SnackBar(content: Text(message)));
+      }
     } on CacheStorageException catch (error) {
       messenger.showSnackBar(SnackBar(content: Text(error.message)));
     }

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -311,14 +311,19 @@ class _OverflowMenu extends ConsumerWidget {
     }
   }
 
-  /// Starts the download, surfacing the one user-facing failure that isn't a
-  /// transient "failed" status: a full cache with nothing safe to evict. The
-  /// message is friendly and secret-free; other errors fall through to the
-  /// row's "failed" indicator (with a retry action).
+  /// Starts the download, surfacing the friendly, secret-free reasons it might
+  /// not start: a full cache with nothing safe to evict, or the network policy
+  /// queueing it (mobile data not allowed, or offline). Other errors fall
+  /// through to the row's "failed" indicator (with a retry action).
   Future<void> _download(BuildContext context, WidgetRef ref) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     try {
-      await ref.read(downloadRepositoryProvider).requestDownload(track);
+      final DownloadRequestOutcome outcome =
+          await ref.read(downloadRepositoryProvider).requestDownload(track);
+      final String? message = outcome.blockedMessage;
+      if (message != null) {
+        messenger.showSnackBar(SnackBar(content: Text(message)));
+      }
     } on CacheStorageException catch (error) {
       messenger.showSnackBar(SnackBar(content: Text(error.message)));
     }

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -96,8 +96,8 @@ final playbackStateProvider = StreamProvider<PlaybackState>((ref) {
 
 /// Smart pre-cache: warms the next few queued tracks into the offline cache as
 /// playback moves, so upcoming songs play instantly and offline (bounded by the
-/// cache limit, honouring "Wi-Fi only" and the user's smart-pre-cache on/off and
-/// count; calm under repeat-one).
+/// cache limit, honouring "Allow mobile data" and the user's smart-pre-cache
+/// on/off and count; calm under repeat-one).
 ///
 /// Pinned for the session like the controller: it reads the controller's state
 /// stream and the cache/prefs seams once with [Ref.read], so a rebuild of the

--- a/lib/features/settings/network/network_settings_section.dart
+++ b/lib/features/settings/network/network_settings_section.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../downloads/download_providers.dart';
+
+/// The "Downloads & network" card on the Settings screen.
+///
+/// Hosts the single mobile-data choice that the whole download/cache stack
+/// keys off: with it off (the safe default) downloads and smart pre-cache run
+/// only on Wi-Fi; with it on they may also use mobile data. The widget never
+/// downloads or caches anything itself — it only writes the user's choice back
+/// through the preference controller; the repository and smart pre-cache enforce
+/// it (and always keep the cache under its size limit).
+class NetworkSettingsSection extends StatelessWidget {
+  const NetworkSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.network_cell_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Downloads & network', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'By default Linthra downloads and pre-caches only on Wi-Fi. Allow '
+              'mobile data to let downloads and smart pre-cache run on mobile '
+              'data too. The cache size limit always applies.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            const MobileDataDownloadsTile(contentPadding: EdgeInsets.zero),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The "Allow mobile data" switch, shared by the Settings card and the Downloads
+/// screen so both stay in sync through [allowMobileDataControllerProvider].
+///
+/// Turning it on first asks for confirmation (mobile data can be expensive);
+/// turning it off applies immediately. The widget only writes the preference —
+/// the download/pre-cache policy lives in the repository.
+class MobileDataDownloadsTile extends ConsumerWidget {
+  const MobileDataDownloadsTile({super.key, this.contentPadding});
+
+  /// Lets the Downloads screen use the default list padding while the Settings
+  /// card sits flush inside its own padding.
+  final EdgeInsetsGeometry? contentPadding;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<bool> allow = ref.watch(allowMobileDataControllerProvider);
+    final bool isOn = allow.valueOrNull ?? false;
+    return SwitchListTile(
+      contentPadding: contentPadding,
+      secondary: const Icon(Icons.signal_cellular_alt_outlined),
+      title: const Text('Allow mobile data for downloads'),
+      subtitle: const Text(
+        'When enabled, Linthra can download/cache music using mobile data. '
+        'This may use a lot of data.',
+      ),
+      value: isOn,
+      onChanged:
+          allow.isLoading ? null : (value) => _toggle(context, ref, value),
+    );
+  }
+
+  Future<void> _toggle(BuildContext context, WidgetRef ref, bool value) async {
+    // Turning the switch off is always safe and immediate.
+    if (!value) {
+      await ref
+          .read(allowMobileDataControllerProvider.notifier)
+          .setAllowMobileData(false);
+      return;
+    }
+    // Turning it on opts into metered data, so confirm first.
+    final bool confirmed = await showDialog<bool>(
+          context: context,
+          builder: (_) => const _MobileDataConfirmDialog(),
+        ) ??
+        false;
+    if (!confirmed) return;
+    await ref
+        .read(allowMobileDataControllerProvider.notifier)
+        .setAllowMobileData(true);
+  }
+}
+
+/// Confirms the opt-in to downloading over mobile data.
+class _MobileDataConfirmDialog extends StatelessWidget {
+  const _MobileDataConfirmDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Use mobile data for downloads?'),
+      content: const Text(
+        'Caching music over mobile data may use a lot of data depending on '
+        'your library and cache settings.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Allow mobile data'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/precache/precache_settings_section.dart
+++ b/lib/features/settings/precache/precache_settings_section.dart
@@ -14,7 +14,7 @@ import '../../downloads/download_providers.dart';
 /// **protected** and never removed automatically. The widget never caches or
 /// evicts anything itself — it only writes the user's choices back through the
 /// preference controllers; the `SmartPrecacheService` and cache policy do the
-/// rest, honouring the cache limit and the "Wi-Fi only" setting.
+/// rest, honouring the cache limit and the "Allow mobile data" setting.
 class PrecacheSettingsSection extends ConsumerWidget {
   const PrecacheSettingsSection({super.key});
 
@@ -65,8 +65,8 @@ class PrecacheSettingsSection extends ConsumerWidget {
               contentPadding: EdgeInsets.zero,
               secondary: const Icon(Icons.bolt_outlined),
               title: const Text('Pre-cache upcoming tracks'),
-              subtitle:
-                  const Text('Follows your Wi-Fi-only setting and cache limit'),
+              subtitle: const Text(
+                  'Follows your mobile-data setting and cache limit'),
               value: isOn,
               onChanged: enabled.isLoading
                   ? null

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import '../../shared/widgets/linthra_logo_mark.dart';
 import 'cache/cache_settings_section.dart';
 import 'diagnostics/diagnostics_settings_section.dart';
 import 'jellyfin/jellyfin_settings_section.dart';
+import 'network/network_settings_section.dart';
 import 'precache/precache_settings_section.dart';
 import 'subsonic/subsonic_settings_section.dart';
 
@@ -26,6 +27,8 @@ class SettingsScreen extends StatelessWidget {
           SubsonicSettingsSection(),
           SizedBox(height: AppSpacing.md),
           CacheSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          NetworkSettingsSection(),
           SizedBox(height: AppSpacing.md),
           PrecacheSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ Future<void> main() async {
   // the platform media session: Android Auto browses the real catalog and the
   // notification / lock screen reflect the real controller. The running app
   // persists its catalog to SQLite (Drift override) and its chosen folder,
-  // offline-download set, and Wi-Fi-only preference via shared_preferences;
+  // offline-download set, and mobile-data preference via shared_preferences;
   // downloaded audio is written to an app-private directory on disk; and the
   // Jellyfin and Subsonic/Navidrome session credentials are each persisted in
   // encrypted on-device storage. The remote downloader override makes both
@@ -70,8 +70,9 @@ Future<void> main() async {
   );
 
   // Start smart pre-cache: as playback advances it warms the next queued tracks
-  // into the offline cache (under the same limit, honouring "Wi-Fi only" and the
-  // user's smart-pre-cache on/off + count, and staying calm under repeat-one).
+  // into the offline cache (under the same limit, honouring "Allow mobile data"
+  // and the user's smart-pre-cache on/off + count, and staying calm under
+  // repeat-one).
   // Instantiating it wires the listener; it has no value the UI reads.
   container.read(smartPrecacheServiceProvider);
 

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -288,53 +288,94 @@ void main() {
       expect(downloader.fetchCount, 1);
     });
 
-    group('Wi-Fi only policy (remote downloads)', () {
-      test('queues instead of downloading when on mobile', () async {
-        await preferences.setWifiOnly(true);
+    group('mobile-data policy (remote downloads)', () {
+      test('Wi-Fi only by default: queues on mobile and reports why', () async {
+        // Default preference: mobile data is not allowed.
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
 
-        await repository.requestDownload(_jellyfin('j1'));
+        final DownloadRequestOutcome outcome =
+            await repository.requestDownload(_jellyfin('j1'));
 
+        expect(outcome, DownloadRequestOutcome.waitingForWifi);
         expect(await repository.statusFor('j1'), DownloadStatus.queued);
         expect(downloader.fetchCount, 0);
         expect(await store.loadDownloads(), isEmpty);
       });
 
-      test('downloads when on Wi-Fi', () async {
-        await preferences.setWifiOnly(true);
+      test('downloads when on Wi-Fi even with mobile data not allowed',
+          () async {
         connectivity.status = NetworkStatus.wifi;
         final repository = build();
 
-        await repository.requestDownload(_jellyfin('j1'));
+        final DownloadRequestOutcome outcome =
+            await repository.requestDownload(_jellyfin('j1'));
 
+        expect(outcome, DownloadRequestOutcome.started);
         expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
       });
 
-      test('downloads over mobile when the preference is off', () async {
-        await preferences.setWifiOnly(false);
+      test('downloads over mobile when the user allows mobile data', () async {
+        await preferences.setAllowMobileData(true);
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
 
-        await repository.requestDownload(_jellyfin('j1'));
+        final DownloadRequestOutcome outcome =
+            await repository.requestDownload(_jellyfin('j1'));
 
+        expect(outcome, DownloadRequestOutcome.started);
         expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
       });
 
-      test('a local track is never queued, even off Wi-Fi', () async {
-        await preferences.setWifiOnly(true);
+      test('queues with a connection-waiting reason when offline', () async {
+        // Even with mobile data allowed, offline means there is no link to use.
+        await preferences.setAllowMobileData(true);
+        connectivity.status = NetworkStatus.offline;
+        final repository = build();
+
+        final DownloadRequestOutcome outcome =
+            await repository.requestDownload(_jellyfin('j1'));
+
+        expect(outcome, DownloadRequestOutcome.waitingForConnection);
+        expect(await repository.statusFor('j1'), DownloadStatus.queued);
+        expect(downloader.fetchCount, 0);
+      });
+
+      test('treats an unknown connection conservatively, like mobile data',
+          () async {
+        connectivity.status = NetworkStatus.unknown;
+        final repository = build();
+
+        // Mobile data not allowed: an unknown link is held for Wi-Fi…
+        expect(
+          await repository.requestDownload(_jellyfin('j1')),
+          DownloadRequestOutcome.waitingForWifi,
+        );
+        expect(await repository.statusFor('j1'), DownloadStatus.queued);
+
+        // …and allowed once the user opts into mobile data.
+        await preferences.setAllowMobileData(true);
+        expect(
+          await repository.requestDownload(_jellyfin('j1')),
+          DownloadRequestOutcome.started,
+        );
+        expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+      });
+
+      test('a local track is never queued, even on mobile data', () async {
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
 
-        await repository.requestDownload(_local('a'));
+        final DownloadRequestOutcome outcome =
+            await repository.requestDownload(_local('a'));
 
-        // Already local: the Wi-Fi gate doesn't apply (no bytes to fetch).
+        // Already local: the network gate doesn't apply (no bytes to fetch).
+        expect(outcome, DownloadRequestOutcome.started);
         expect(await repository.statusFor('a'), DownloadStatus.downloaded);
       });
 
       test('a queued track downloads on an explicit retry once on Wi-Fi',
           () async {
-        await preferences.setWifiOnly(true);
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
         await repository.requestDownload(_jellyfin('j1'));
@@ -344,6 +385,28 @@ void main() {
         await repository.requestDownload(_jellyfin('j1'));
 
         expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
+      });
+
+      test('blocked-download messages are friendly and secret-free', () async {
+        // No URL, token, scheme, or path leaks into what the user would see.
+        const String wifi =
+            'Downloads are limited to Wi-Fi. Turn on "Allow mobile data" in '
+            'Settings to download over mobile data.';
+        const String offline =
+            "You're offline. This download will start automatically when "
+            "you're back online.";
+        expect(DownloadRequestOutcome.waitingForWifi.blockedMessage, wifi);
+        expect(
+          DownloadRequestOutcome.waitingForConnection.blockedMessage,
+          offline,
+        );
+        expect(DownloadRequestOutcome.started.blockedMessage, isNull);
+        for (final String message in <String>[wifi, offline]) {
+          expect(message, isNot(contains('jellyfin:')));
+          expect(message, isNot(contains('http')));
+          expect(message, isNot(contains('token')));
+          expect(message, isNot(contains('/')));
+        }
       });
     });
 
@@ -463,6 +526,24 @@ void main() {
         expect(await repository.statusFor('j3'), DownloadStatus.downloaded);
         // The evicted file's bytes are gone from disk.
         expect(files.bytesFor('j1.mp3'), isNull);
+      });
+
+      test('the cache limit is still enforced when downloading over mobile data',
+          () async {
+        final repository = buildLimited(maxBytes: 10, now: incrementingClock());
+        await preferences.setAllowMobileData(true);
+        connectivity.status = NetworkStatus.mobile;
+
+        await repository.requestDownload(_jellyfin('j1')); // oldest
+        await repository.requestDownload(_jellyfin('j2'));
+        await repository.requestDownload(_jellyfin('j3')); // forces eviction
+
+        // Allowing mobile data never lets the cache exceed its limit.
+        expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect(
+          (await repository.cacheSnapshot()).usedBytes,
+          lessThanOrEqualTo(10),
+        );
       });
 
       test('playing a track refreshes it so a stale one is evicted instead',
@@ -731,9 +812,9 @@ void main() {
         expect(await store.loadDownloads(), isEmpty);
       });
 
-      test('respects "Wi-Fi only" and skips (without queueing) on mobile',
+      test('skips (without queueing) on mobile when mobile data not allowed',
           () async {
-        await preferences.setWifiOnly(true);
+        // Default: mobile data is not allowed, so pre-cache stays Wi-Fi-only.
         connectivity.status = NetworkStatus.mobile;
         final repository = build();
 
@@ -741,6 +822,30 @@ void main() {
 
         expect(downloader.fetchCount, 0);
         expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect(await store.loadDownloads(), isEmpty);
+      });
+
+      test('runs on mobile when the user allows mobile data', () async {
+        await preferences.setAllowMobileData(true);
+        connectivity.status = NetworkStatus.mobile;
+        final repository = build();
+
+        await repository.prefetch(_jellyfin('j1'));
+
+        // Pre-cached over mobile, but it stays invisible as a download.
+        expect(downloader.fetchCount, 1);
+        expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
+        expect((await store.loadDownloads()).single.preloaded, isTrue);
+      });
+
+      test('skips when offline, even with mobile data allowed', () async {
+        await preferences.setAllowMobileData(true);
+        connectivity.status = NetworkStatus.offline;
+        final repository = build();
+
+        await repository.prefetch(_jellyfin('j1'));
+
+        expect(downloader.fetchCount, 0);
         expect(await store.loadDownloads(), isEmpty);
       });
 

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -528,7 +528,8 @@ void main() {
         expect(files.bytesFor('j1.mp3'), isNull);
       });
 
-      test('the cache limit is still enforced when downloading over mobile data',
+      test(
+          'the cache limit is still enforced when downloading over mobile data',
           () async {
         final repository = buildLimited(maxBytes: 10, now: incrementingClock());
         await preferences.setAllowMobileData(true);

--- a/test/features/downloads/downloads_screen_test.dart
+++ b/test/features/downloads/downloads_screen_test.dart
@@ -84,7 +84,7 @@ void main() {
     Future<ProviderContainer> pump(
       WidgetTester tester, {
       required RemoteTrackDownloader downloader,
-      bool wifiOnly = false,
+      bool allowMobileData = false,
       NetworkStatus connectivity = NetworkStatus.wifi,
     }) async {
       await tester.pumpWidget(
@@ -95,7 +95,7 @@ void main() {
             ),
             remoteTrackDownloaderProvider.overrideWithValue(downloader),
             downloadPreferencesProvider.overrideWithValue(
-              InMemoryDownloadPreferences(wifiOnly: wifiOnly),
+              InMemoryDownloadPreferences(allowMobileData: allowMobileData),
             ),
             connectivityServiceProvider
                 .overrideWithValue(_FakeConnectivity(connectivity)),
@@ -162,13 +162,13 @@ void main() {
       expect(find.byTooltip('Remove download'), findsOneWidget);
     });
 
-    testWidgets('shows a queued track when Wi-Fi-only blocks it on mobile', (
+    testWidgets('shows a queued track when mobile data is not allowed', (
       tester,
     ) async {
       final container = await pump(
         tester,
         downloader: _FakeRemoteDownloader(),
-        wifiOnly: true,
+        // Default: mobile data not allowed, so on mobile the download queues.
         connectivity: NetworkStatus.mobile,
       );
 
@@ -182,8 +182,8 @@ void main() {
   });
 }
 
-/// A connectivity stand-in reporting a fixed status, so the Wi-Fi-only gate can
-/// be driven without a plugin.
+/// A connectivity stand-in reporting a fixed status, so the mobile-data gate
+/// can be driven without a plugin.
 class _FakeConnectivity implements ConnectivityService {
   _FakeConnectivity(this._status);
 

--- a/test/features/settings/network/network_settings_section_test.dart
+++ b/test/features/settings/network/network_settings_section_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
+import 'package:linthra/features/settings/network/network_settings_section.dart';
+
+void main() {
+  group('NetworkSettingsSection', () {
+    late InMemoryDownloadPreferences preferences;
+
+    Future<ProviderContainer> pump(WidgetTester tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          downloadPreferencesProvider.overrideWithValue(preferences),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: NetworkSettingsSection()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    setUp(() => preferences = InMemoryDownloadPreferences());
+
+    testWidgets('shows the toggle off by default with helper text',
+        (tester) async {
+      await pump(tester);
+
+      expect(find.text('Downloads & network'), findsOneWidget);
+      expect(
+        find.text('Allow mobile data for downloads'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('may use a lot of data'), findsOneWidget);
+      final SwitchListTile tile =
+          tester.widget(find.byType(SwitchListTile));
+      expect(tile.value, isFalse);
+    });
+
+    testWidgets('enabling asks for confirmation and persists when allowed',
+        (tester) async {
+      await pump(tester);
+
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+
+      // The confirmation dialog appears before anything is persisted.
+      expect(find.text('Use mobile data for downloads?'), findsOneWidget);
+      expect(await preferences.allowMobileData(), isFalse);
+
+      await tester.tap(find.text('Allow mobile data'));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.allowMobileData(), isTrue);
+      final SwitchListTile tile =
+          tester.widget(find.byType(SwitchListTile));
+      expect(tile.value, isTrue);
+    });
+
+    testWidgets('cancelling the confirmation leaves the toggle off',
+        (tester) async {
+      await pump(tester);
+
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.allowMobileData(), isFalse);
+      final SwitchListTile tile =
+          tester.widget(find.byType(SwitchListTile));
+      expect(tile.value, isFalse);
+    });
+
+    testWidgets('turning it off applies immediately without a dialog',
+        (tester) async {
+      preferences = InMemoryDownloadPreferences(allowMobileData: true);
+      await pump(tester);
+
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+
+      // No confirmation when turning the switch off.
+      expect(find.text('Use mobile data for downloads?'), findsNothing);
+      expect(await preferences.allowMobileData(), isFalse);
+    });
+  });
+}

--- a/test/features/settings/network/network_settings_section_test.dart
+++ b/test/features/settings/network/network_settings_section_test.dart
@@ -40,8 +40,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('may use a lot of data'), findsOneWidget);
-      final SwitchListTile tile =
-          tester.widget(find.byType(SwitchListTile));
+      final SwitchListTile tile = tester.widget(find.byType(SwitchListTile));
       expect(tile.value, isFalse);
     });
 
@@ -60,8 +59,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(await preferences.allowMobileData(), isTrue);
-      final SwitchListTile tile =
-          tester.widget(find.byType(SwitchListTile));
+      final SwitchListTile tile = tester.widget(find.byType(SwitchListTile));
       expect(tile.value, isTrue);
     });
 
@@ -75,8 +73,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(await preferences.allowMobileData(), isFalse);
-      final SwitchListTile tile =
-          tester.widget(find.byType(SwitchListTile));
+      final SwitchListTile tile = tester.widget(find.byType(SwitchListTile));
       expect(tile.value, isFalse);
     });
 


### PR DESCRIPTION
## Summary

Linthra's offline cache/downloads were Wi-Fi-focused. This adds a clear,
user-controlled setting that lets manual downloads **and** smart pre-cache run
over mobile data/LTE when the user explicitly allows it, while keeping the safe
default (Wi-Fi only) and every existing guarantee intact.

## Mobile-data cache/download behavior

- **Default policy: Wi-Fi only.** A new persisted preference `allowMobileData`
  (key `downloads_allow_mobile_data`, default `false`) replaces the old
  inverse `wifiOnly`. With the placeholder connectivity service (always reports
  Wi-Fi) there is no behavior change today; the safe default only takes effect
  once a real detector reports mobile/offline.
- Network policy, centralized in `CacheDownloadRepository._networkDecision()`:
  | Connection | mobile data off (default) | mobile data on |
  | --- | --- | --- |
  | Wi-Fi | download | download |
  | Mobile | queue (wait for Wi-Fi) | download |
  | Offline | queue (wait) | queue (wait) |
  | Unknown | queue (conservative) | download |
- `NetworkStatus` gains an `unknown` value, treated conservatively (like mobile).
- `requestDownload` now returns a `DownloadRequestOutcome`
  (`started` / `waitingForWifi` / `waitingForConnection`) with a friendly,
  secret-free `blockedMessage`, so a blocked download shows a message instead of
  failing silently (e.g. *"Downloads are limited to Wi-Fi. Turn on Allow mobile
  data in Settings…"*). The existing queued status/indicator is unchanged.

## Settings UI changes

- New **Settings → Downloads & network** card with the **Allow mobile data for
  downloads** toggle, helper text (*"…This may use a lot of data."*), and a
  confirmation dialog when enabling (*"Use mobile data for downloads?"* →
  Cancel / Allow mobile data). Turning it off applies immediately.
- The same toggle (shared `MobileDataDownloadsTile`) also lives on the Downloads
  tab, so both stay in sync. Settings still shows cache size limit and smart
  pre-cache.

## Smart pre-cache behavior

- Follows the **same** network policy via the shared gate: Wi-Fi always, mobile
  data only when allowed, never offline. Still best-effort, still limited to the
  small upcoming window (1/3/5/10), still evicted before any user download, and
  still bounded by the cache size limit. No whole-library download.

## Cache/eviction guarantees (unchanged)

- Cache size limit always respected, including over LTE.
- Pinned/"Keep offline" downloads and the currently-playing track are never
  evicted; local source files are never deleted.

## Tests added/updated

- Repository: Wi-Fi-only default queues on mobile (+ reason); downloads on
  Wi-Fi; downloads on mobile when allowed; offline queues; unknown is
  conservative; local tracks never queued; retry on Wi-Fi; cache limit enforced
  over mobile data; blocked messages are friendly & secret-free.
- Smart pre-cache: skips on mobile when not allowed; runs on mobile when
  allowed; skips when offline.
- New widget test for the settings toggle: default off + helper text;
  confirmation dialog on enable; persists when allowed; cancel leaves it off;
  off applies without a dialog.
- Updated downloads-screen test (queued when mobile data not allowed).

## Security / token notes

- No Jellyfin tokens in `Track.uri`; no authenticated URLs in cache metadata
  (persists only non-secret id, id-derived file name, scheme, size, timestamps,
  pinned flag).
- Network-policy and "cache full" messages are secret-free (no URL/token/path),
  verified by a test.

## Docs

- New `docs/offline-cache.md` (default policy, how to allow mobile data, data
  warning, pre-cache follows the same policy, cache limit always applies).
- README, manual checklist, privacy policy, and Play listing updated.

## Verification

⚠️ Flutter/Dart SDK is **not available in this remote environment**, so
`flutter pub get` / `dart format` / `flutter analyze` / `flutter test` /
`flutter build apk` could **not** be run here. Changes were made to match the
repo's existing style and 80-col formatting; please run the standard checks in
CI/locally before merging.

## Manual Android checklist

1. Disable Wi-Fi, use LTE.
2. With **Allow mobile data** off, download a Jellyfin track.
3. Confirm friendly blocked/queued message.
4. Enable **Allow mobile data** (confirm dialog).
5. Download again.
6. Confirm download/cache works over LTE.
7. Enable smart pre-cache; confirm it follows the same setting.
8. Confirm cache size limit still applies.
9. Turn **Allow mobile data** back off; confirm LTE downloads queue again.

https://claude.ai/code/session_018eNfaRAD4WT6S4P7FZRUMi

---
_Generated by [Claude Code](https://claude.ai/code/session_018eNfaRAD4WT6S4P7FZRUMi)_