### PR TITLE
Simplify README into a landing page + improve streaming resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1604 +1,184 @@
 # Linthra
 
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](./LICENSE)
-[![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
+[![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#-try-it)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#project-status)
+[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#-status)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 
 ![Linthra](fastlane/metadata/android/en-US/images/featureGraphic.png)
 
+### Your music. Your server. Your rules.
+
 **Linthra is an open-source Android music player for people who own their
-music** — with Jellyfin streaming, a smart offline cache, Android Auto, a
-Chromecast foundation, synced lyrics, and **no surprise downloads**. Your
-library lives on your device, the app reads from a local catalog, and anything
-that touches the network is something you asked for.
+music** — with Jellyfin/Navidrome streaming, a smart offline cache, Cast,
+Android Auto, and **no surprise downloads**.
 
-> **Your music, beautifully yours.**
+---
 
-Linthra is **early-stage alpha software**. The sections below honestly separate
-what works today from what is still planned — nothing here overpromises, and
-Linthra is **not on F-Droid** and **not production-stable** yet.
+## 🎧 Why Linthra?
 
-- [Screenshots](#screenshots)
-- [What works today](#what-works-today)
-- [Known limitations](#known-limitations)
-- [Install](#install)
-- [Connect your Jellyfin server](#connect-your-jellyfin-server)
-- [Cast to a speaker or TV](#cast-to-a-speaker-or-tv)
-- [Offline cache, in short](#offline-cache-in-short)
-- [Reporting bugs &amp; feedback](#reporting-bugs--feedback)
-- [Privacy &amp; security](#privacy--security)
-- [Roadmap](#roadmap)
-- [Project status](#project-status)
-- [Contributing &amp; deeper docs](#contributing--deeper-docs)
+You ripped the CDs. You pay for the server. You shouldn't have to rent your own
+music back from someone else's app.
 
-## Screenshots
+Most "music apps" are storefronts that happen to play audio — they nudge you
+toward a catalog, sync things you didn't ask for, and treat your library as a
+guest. Linthra flips that around:
 
-Linthra ships with real branding — an equalizer mark carrying the brand's
-violet→orange gradient — generated from a single source design (not mockups):
+- Point it at **your** Jellyfin / Navidrome / Subsonic server, or a folder of
+  local files.
+- **Streaming is the default.** Nothing downloads unless you tap download.
+- Your whole library is browsable instantly because the app reads from a local
+  catalog, not the network.
+- No telemetry, no ads, no account, no phoning home.
+
+If you self-host your music and want a clean Android player that respects that,
+Linthra is for you.
+
+## 🌱 Status
+
+**Linthra is early alpha — but already usable for testing today.** You can
+connect a real server, sync your library, stream, cache, cast, and drive it from
+Android Auto on a real phone. It's not production-stable, it's **not on Google
+Play or F-Droid**, and it has honest, documented rough edges (see
+[Roadmap](#-roadmap) and the per-feature docs). That's exactly why it's a great
+time to jump in — small contributions land fast and shape where it goes.
+
+## 📸 Screenshots
+
+Linthra ships with real branding — an equalizer mark carrying a violet→orange
+gradient, generated from one source design (not mockups).
 
 | App icon | Feature graphic |
 | --- | --- |
 | ![Linthra icon](fastlane/metadata/android/en-US/images/icon.png) | ![Linthra feature graphic](fastlane/metadata/android/en-US/images/featureGraphic.png) |
 
-> **In-app screenshots are not committed yet.** Rather than ship placeholder or
-> mock images, no screenshots from a running build are included until real ones
-> are captured. The capture checklist and exact sizes live in
-> [docs/listing-assets.md](./docs/listing-assets.md).
+> **In-app screenshots aren't committed yet.** Rather than ship mock images, no
+> screenshots from a running build are included until real ones are captured —
+> [a great first contribution](#-ways-to-help)! The capture checklist and sizes
+> are in [docs/listing-assets.md](./docs/listing-assets.md).
 
-## What works today
+## ✨ What works today
 
-Everything below works end to end on a real Android device in the current alpha
-(`0.1.0-alpha.15`):
+- **Local library** — pick a folder (Storage Access Framework), scan it, browse
+  **Songs / Albums / Artists** with search. No broad storage permission.
+- **Self-hosted streaming** — connect your own **Jellyfin** or
+  **Navidrome / Subsonic** server: test, sign in, sync, and stream. Works over
+  HTTPS / Cloudflare-proxied domains.
+- **Smart offline cache** — tap to download the tracks you want offline; Wi-Fi
+  only by default, with a size limit and "Keep offline" pinning.
+- **Cast / Chromecast** — hand a stream off to a speaker or TV, with device
+  volume control. Pure-Dart Cast, no Google Play Services.
+- **Android Auto** — browse your Library, Queue, Playlists, and Favorites from
+  the car screen and tap to play.
+- **Playlists & favourites** — create/edit/reorder/delete playlists; favourite
+  tracks. Both sync with Jellyfin where supported.
+- **Background playback** — media notification with lock-screen, Bluetooth, and
+  wired-headset controls, plus shuffle / repeat and synced lyrics.
 
-- **Local library** — pick a folder with the native Android picker (Storage
-  Access Framework), scan it, and list your tracks. The chosen folder and the
-  scanned catalog survive a restart. No broad storage permission is requested.
-- **Library browsing & search** — browse across **Songs**, **Albums**, and
-  **Artists** tabs, with a search box that filters the active tab (by title,
-  artist, or album) — case- and accent-insensitive. Open an album or artist to
-  play or shuffle it. See [docs/library.md](docs/library.md).
-- **Playback** — play local tracks with an up-next queue, plus working
-  **shuffle** and **repeat** (off / all / one).
-- **Playlists** — create, rename, reorder, and delete playlists; add and remove
-  tracks (including multi-select bulk actions); play or shuffle a playlist.
-  Playlists persist locally and **sync with Jellyfin** where supported. See
-  [docs/playlists-and-delete.md](docs/playlists-and-delete.md).
-- **Safe song removal** — clearly-separated, always-confirmed actions. "Remove
-  from Linthra" (index only) and "Remove offline copy" (app-managed cache only)
-  never touch your real files or server items.
-- **Background playback** — a media notification with lock-screen, Bluetooth,
-  and wired-headset transport controls.
-- **Android Auto** — browse your Library and Queue from the car screen and
-  tap to play.
-- **Jellyfin (self-hosted)** — connect to your own server, test the connection,
-  sign in, sync your library, and **stream** tracks. Works with HTTPS /
-  Cloudflare-proxied domains.
-- **Navidrome / Subsonic (self-hosted)** — connect to your own
-  Subsonic-compatible server, test the connection, sign in, **sync** your
-  library, and **stream / cache / cast** tracks. Auth uses the Subsonic
-  token+salt scheme, so your password is never stored — only a derived token is
-  kept (encrypted). Favorites and lyrics are follow-ups; see
-  [docs/providers.md](docs/providers.md).
-- **Smart offline cache** — mark individual Jellyfin tracks for offline use
-  (Plexamp-style explicit downloads), Wi-Fi-only by default with an opt-in
-  **"Allow mobile data"** toggle, a configurable cache size limit, "Keep
-  offline" pinning, and optional smart pre-caching of upcoming tracks. Cached
-  tracks play fully offline. See [docs/offline-cache.md](docs/offline-cache.md).
-- **Synced lyrics** — fetch a Jellyfin track's lyrics into a sheet; favorites
-  also sync with your Jellyfin server.
-- **Chromecast** — discover Cast devices, connect, and hand off the current
-  Jellyfin/Subsonic stream to the receiver, using a pure-Dart Cast protocol (no
-  Google Play Services). When connected, the Cast sheet shows a **Cast volume**
-  control (slider + mute) that drives the *device's* volume.
+Each feature has a deep-dive in [the docs](#-documentation).
 
-## Known limitations
+## 📦 Try it
 
-This is an alpha — expect rough edges. The honest gaps today:
+> Linthra is **not on Google Play or F-Droid**. It's distributed as a
+> sideloadable APK from **[GitHub Releases](https://github.com/thezupzup/linthra/releases)**.
+> Alpha releases are GitHub **pre-releases**.
 
-- **No local tag/metadata parsing yet** — local files show their file name, and
-  there is no album artwork for them. Because album/artist tags aren't read,
-  local tracks group under **Unknown Album** / **Unknown Artist** in the Albums
-  and Artists tabs. Jellyfin/Subsonic tracks carry real album/artist names and
-  artwork, so they group properly. See [docs/library.md](docs/library.md).
-- **Playlist sync is partial** — local playlists are full-featured (create,
-  edit, reorder, delete, bulk actions); Jellyfin create / add / remove / delete
-  sync, but **rename and reorder of a synced playlist stay local for now**, and
-  Subsonic/Navidrome playlist sync isn't implemented. See
-  [docs/playlists-and-delete.md](docs/playlists-and-delete.md).
-- **File/server deletion is intentionally disabled** — only the safe "Remove
-  from Linthra" and "Remove offline copy" actions ship today; deleting the real
-  device file or the Jellyfin server item is modelled but not enabled until it's
-  robust.
-- **Downloads are track-level only** — no album/playlist "download all" and no
-  background download manager (downloads run inline; no resume).
-- **Single Jellyfin server** — one session at a time; no multi-server support.
-- **Subsonic favorites & lyrics** — Navidrome/Subsonic streaming, offline cache,
-  and casting work, but favorites, lyrics, and cover art are documented
-  follow-ups (see [docs/providers.md](docs/providers.md)).
-- **Direct play only** — no server-side transcoding fallback for exotic
-  formats; Cloudflare Access / Zero Trust in front of Jellyfin is not supported.
-- **On-device files can't be cast** — a Cast receiver can't reach a local file,
-  so only Jellyfin streams hand off.
-- **Connectivity is optimistic** — the Wi-Fi / mobile-data gate relies on a
-  placeholder detector for now (it reports Wi-Fi until real detection lands).
-- **Android only today** — Linux desktop is planned later from the same codebase.
-- **Release signing not yet provisioned** — alpha APKs may be debug-signed (see
-  [Install](#install)).
+**Obtainium (recommended)** — [Obtainium](https://github.com/ImranR98/Obtainium)
+installs straight from GitHub Releases and keeps you updated. Add app, paste
+`https://github.com/thezupzup/linthra`, enable **"Include prereleases"**, install.
 
-## Install
+**Manual APK** — download the `.apk` from the
+[latest release](https://github.com/thezupzup/linthra/releases), open it on your
+phone, and allow "install from unknown sources" if prompted.
 
-> Linthra is **not on Google Play or F-Droid**. It is distributed as a
-> sideloadable APK from **GitHub Releases**. Alpha releases are GitHub
-> **pre-releases**.
+**Build it yourself** — `flutter pub get && flutter build apk --debug`. Full
+setup, CI builds, and release details are in
+[docs/development.md](./docs/development.md).
 
-### Obtainium (recommended)
-
-[Obtainium](https://github.com/ImranR98/Obtainium) installs apps straight from
-GitHub Releases and keeps them updated — a great fit for alpha sideloading.
-
-1. Install Obtainium (from its
-   [GitHub Releases](https://github.com/ImranR98/Obtainium/releases) or F-Droid).
-2. Tap **Add App** and paste the repository URL:
-   `https://github.com/thezupzup/linthra`
-3. Because alphas are **pre-releases**, open the app's settings in Obtainium and
-   enable **"Include prereleases"** so it picks up the latest alpha APK.
-4. Tap **Add**, then **Install**. Obtainium will notify you when a newer alpha
-   is published.
-
+> **Using Android Auto?** Sideloaded media apps only appear after you enable
+> Android Auto's developer **"Unknown sources"** toggle — a one-time step,
+> detailed in [docs/android-auto.md](./docs/android-auto.md).
+>
 > **Heads up:** until release signing is provisioned, some alpha APKs may be
-> **debug-signed**. If a signature changes between builds, Obtainium may ask you
-> to uninstall and reinstall before updating.
+> **debug-signed**; if a signature changes, you may need to reinstall.
 
-### Manual APK sideload
+## 🙌 Ways to help
 
-1. Open the [Releases page](https://github.com/thezupzup/linthra/releases) and
-   download the `app-release.apk` (or `.apk`) attached to the latest alpha.
-2. On your device, open the APK and allow **"install from unknown sources"** if
-   prompted. Or, with the phone connected over ADB:
-   ```bash
-   adb install -r app-release.apk
-   ```
-3. On first launch (Android 13+), tap **Allow** on the notification prompt so
-   the media notification and its controls can appear.
+Linthra is small and friendly — good first contributions are very welcome, and
+many don't need a single line of code:
 
-> **Using Android Auto?** Android Auto only lists media apps installed from the
-> Play Store unless you enable sideloaded ones: in the Android Auto settings, tap
-> the version number to unlock **Developer settings**, then turn on **Unknown
-> sources**. Without this, Linthra works on the phone but won't appear on the car
-> screen. Full steps are in [docs/android-auto.md](docs/android-auto.md).
+- 🧪 **Test with your server** — does it work with your **Jellyfin**? Your
+  **Navidrome / Subsonic**? Tell us what broke.
+- 📺 **Try Cast** — connect a Chromecast/speaker/TV and report device
+  compatibility.
+- 🚗 **Test Android Auto** — on a head unit or the Desktop Head Unit.
+- 📸 **Capture screenshots** for the README and store listing.
+- 📝 **Improve docs** — fix a confusing step, add a setup gotcha.
+- 🐞 **Report bugs with diagnostics** — **Settings → Diagnostics** exports a
+  **secret-free** report (no tokens, no passwords) you can paste into an issue.
+- 🎨 **Polish UI/UX** — small refinements add up.
+- 🔌 **Help future providers** — WebDAV/NAS support behind the same interface.
 
-### Build it yourself
+Found Linthra useful? A **GitHub star** helps others discover it. Start at the
+[issue tracker](https://github.com/thezupzup/linthra/issues).
 
-Linthra is a standard Flutter app (the committed `android/` scaffold means no
-`flutter create` step is needed):
+## 🗄️ Self-hosted sources
 
-```bash
-flutter pub get
-flutter build apk --debug   # → build/app/outputs/flutter-apk/app-debug.apk
-# or run on a connected device / emulator
-flutter run
-```
+Sources sit behind one interface, so the app treats them uniformly:
 
-Full build, CI, and release details — including the GitHub **Android Debug APK**
-workflow you can use without a local toolchain — are in
-[Getting started](#getting-started) and
-[Building release artifacts](#building-release-artifacts-android) below.
+| Source | Status |
+| --- | --- |
+| **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) |
+| **Jellyfin** | ✅ Stream, cache, cast, playlists & favourites — [docs](./docs/jellyfin.md) |
+| **Navidrome / Subsonic** | ✅ Stream, cache, cast (favourites & lyrics are follow-ups) — [docs](./docs/providers.md) |
+| **WebDAV / NAS** | 🔜 Planned — same `MusicSource` seam |
 
-## Connect your Jellyfin server
-
-Linthra can connect to your own [Jellyfin](https://jellyfin.org) server,
-including one published over HTTPS through a Cloudflare domain or tunnel.
-
-1. **Settings → Jellyfin → Server URL** — enter your address, e.g.
-   `https://music.example.com` (a bare host gets `https://`; a LAN
-   `http://host:8096` and reverse-proxy subpaths also work).
-2. **Test connection** — confirms the address is reachable and really is a
-   Jellyfin server, and shows its name/version.
-3. **Username + password → Sign in** — authenticates and stores the resulting
-   session encrypted on-device. Your **password is never saved**.
-4. **Sync library** — pulls your artists/albums/tracks into the local catalog so
-   they appear in the Library.
-5. Tap a synced track to **stream** it, or use the download control to keep it
-   **offline**.
-
-Cloudflare-proxied domains and tunnels work out of the box. **Cloudflare Access
-/ Zero Trust** (an extra auth layer in front of Jellyfin) is not supported yet.
-Full setup notes, supported endpoints, compatibility, and troubleshooting are in
-[Jellyfin (self-hosted music) — setup &amp; known limitations](#jellyfin-self-hosted-music--setup--known-limitations)
-and [docs/jellyfin-compatibility.md](docs/jellyfin-compatibility.md).
-
-## Cast to a speaker or TV
-
-Linthra can hand a Jellyfin or Navidrome/Subsonic stream off to a **Chromecast**
-device (a Cast-enabled speaker, TV, or display) on your network. It uses a
-pure-Dart implementation of the Google Cast v2 protocol — **no Google Play
-Services and no proprietary Cast SDK** — so casting works the same on a
-sideloaded or F-Droid-style build.
-
-1. Be on the **same Wi-Fi network** as the Cast device.
-2. Start playing a **streamed** track (Jellyfin or Subsonic).
-3. Tap the **cast icon** in the Now Playing header to open the device sheet.
-4. Pick a device. Linthra resolves the stream at cast time, plays it on the
-   receiver, and pauses local audio so you don't hear it twice.
-5. While connected, the sheet shows a **Cast volume** slider and mute that drive
-   the *device's* own volume. Disconnecting (or the receiver dropping) resumes
-   local playback, paused.
-
-**Good to know:**
-
-- **On-device (local) files can't be cast** — a receiver can't reach a file on
-  your phone, so only network streams hand off. The sheet says so plainly rather
-  than failing silently.
-- Discovery uses mDNS, so a device only appears if it's reachable on your LAN
-  (some guest/isolated networks block this).
-
-Architecture and token-handling details are in
-[Now Playing controls — casting](#now-playing-controls--shuffle-repeat-favorite-lyrics--casting).
-
-## Offline cache, in short
-
-Linthra's offline model is **explicit and user-controlled** — Plexamp-style, but
-open-source, with no surprise downloads:
-
-- Your **whole synced library stays visible**; nothing is hidden behind a
-  download.
-- **Streaming is the default.** You tap the download icon on the tracks you want
-  available offline; only those are fetched.
-- **Cached tracks play with no network** — airplane mode, dead tunnel, anywhere.
-- **Wi-Fi only by default.** Downloads and pre-caching run on Wi-Fi; on mobile
-  data they wait until you turn on **"Allow mobile data for downloads"** in
-  Settings (with a confirmation first, since it can use a lot of data).
-- A **size limit** (4 GB by default; presets up to 16 GB or a custom value) keeps
-  the cache from filling your phone. When it's full, Linthra evicts pre-cached
-  and least-recently-played, unpinned tracks first — never something you
-  **pinned** with "Keep offline".
-- Optional **smart pre-cache** warms the next few queued tracks so they start
-  instantly; it follows the same mobile-data setting and size limit.
-
-The full mechanics, eviction policy, and token handling are in
-[Offline downloads &amp; known limitations](#offline-downloads--known-limitations).
-
-## Reporting bugs &amp; feedback
-
-This is an alpha, and **focused bug reports are the most useful thing a tester
-can send.** Please file issues on the
-[GitHub issue tracker](https://github.com/thezupzup/linthra/issues).
-
-**Attach diagnostics.** Linthra has a built-in, **secret-free** diagnostics
-export — open **Settings → Diagnostics** and tap **Copy diagnostics** (or **Save
-diagnostics** to write `linthra-diagnostics.txt`), then paste it into the report.
-The snapshot includes the app version, Android version, Jellyfin/Subsonic
-connection state and **server host only**, library track count, cache used/limit,
-current playback output, the last error kind, and which features are
-available/enabled. By construction it contains **no password, token,
-`Authorization` header, or full server URL** — so it's safe to share publicly.
-
-A good report includes:
-
-1. **What you did** — the steps to reproduce, ideally numbered.
-2. **What you expected** vs. **what happened**.
-3. **The diagnostics block** from Settings → Diagnostics (above).
-4. **Install source** — GitHub Releases APK, Obtainium, or a self-built APK — and
-   whether it was debug- or release-signed (shown on the Release asset name).
-5. **Your setup** — local files, Jellyfin, and/or Navidrome/Subsonic; and whether
-   Android Auto or Cast was involved.
-
-**Advanced (optional) logs.** For playback or Android Auto issues, a logcat
-capture from a USB-connected device often pinpoints the cause. Linthra's own log
-lines are tagged and **secret-free by design** (tokens and URLs are never
-logged):
-
-```bash
-adb logcat | grep -i linthra
-```
-
-There is **no telemetry or crash reporting** — nothing is collected unless you
-choose to send it.
-
-## Privacy &amp; security
+## 🔒 Privacy
 
 Linthra is built to respect the people who use it:
 
-- **No telemetry, no analytics, no phoning home.** The app never uploads your
-  library or reports usage.
-- **No forced sync and no surprise downloads.** Offline downloads are always
-  user-initiated; there is no automatic full-library sync, and the default is
-  Wi-Fi only — mobile data is used for downloads/cache only after you opt in.
-- **Minimal Android permissions.** Just foreground-service + notification (for
-  background playback) and internet (to reach your Jellyfin server). **No broad
-  storage permission** — folder access uses the Storage Access Framework grant
-  you pick.
-- **Your Jellyfin secrets stay safe.** The password is used once to obtain a
-  token and then discarded — it is **never stored**. The session token is
-  encrypted at rest (`flutter_secure_storage`, Android Keystore-backed), is
-  **never logged** or shown in the UI, and authenticated stream/download URLs are
-  minted only on demand. The **Settings → Diagnostics** export (see
-  [Reporting bugs &amp; feedback](#reporting-bugs--feedback)) is secret-free by
-  construction — it can carry a host name and counts, never a token or password.
+- **No telemetry, no analytics, no phoning home** — nothing is collected unless
+  you choose to send a diagnostics report.
+- **No surprise downloads** — streaming is the default; downloads are always
+  user-initiated, Wi-Fi only unless you opt in to mobile data.
+- **Minimal permissions** — foreground-service + notification (playback) and
+  internet (your server). **No broad storage permission.**
+- **Your secrets stay safe** — the server password is used once to get a token,
+  then discarded; the token is encrypted at rest, never logged, and stream URLs
+  are minted only on demand. Token-handling details are in each provider's doc.
 
-More detail lives in the
-[Jellyfin security notes](#jellyfin-self-hosted-music--setup--known-limitations)
-and the offline-downloads section below.
+## 🧭 Roadmap
 
-## Roadmap
-
-**Working now:** local scanning + playback, background playback & media session,
-Android Auto browsing, shuffle/repeat, playlists (create/edit/reorder/delete,
-with partial Jellyfin sync), safe song removal, Jellyfin and Navidrome/Subsonic
-connect/sync/stream, explicit offline downloads with a smart cache, synced
-favorites & lyrics (Jellyfin), Chromecast with device-volume control, and a
-secret-free diagnostics export.
-
-**Next up (roughly in order):**
-
-1. Tag/metadata parsing and album artwork.
-2. Browse by artist/album, and search.
-3. Subsonic favorites, lyrics, and cover art.
-4. Full playlist sync (rename/reorder of synced playlists; Subsonic playlists).
-5. Album/playlist "download all" and a background download manager.
-6. Real connectivity detection for the Wi-Fi / mobile-data gate.
-7. More sources behind the same interface — WebDAV, NAS.
+**Next up:** local tag/metadata parsing + album artwork · Subsonic favourites,
+lyrics & cover art · full playlist sync · album/playlist "download all" +
+background download manager · real connectivity detection for the Wi-Fi gate ·
+WebDAV / NAS sources.
 
 **Later:** local-file lyrics (`.lrc`/tags), ReplayGain, MPRIS, smart playlists,
-Linux desktop, and richer Android Auto (album/artist grouping, search) and
-casting (local-file casting, receiver transport controls).
-
-See [Roadmap (MVP)](#roadmap-mvp) below for the full breakdown.
-
-## Project status
-
-**Current alpha: `0.1.0-alpha.15`.** Linthra is a manually testable Android build
-with several rounds of features and fixes since the first alpha. It is still
-early software with honest, documented limitations — see
-[Known limitations](#known-limitations) and the
-[release notes](./docs/release-notes/v0.1.0-alpha.9.md). It is **not** on
-F-Droid, **not** on Google Play, and nothing is published automatically. Release
-signing is wired up but not yet provisioned, so some alpha APKs may be
-debug-signed (and clearly labeled as such).
-
-### Real-device QA
-
-The automated suite (`flutter test`) covers the logic seams; the device-only
-surfaces are verified by hand against the
-[manual QA checklist](./docs/manual-test-checklist.md). Confirmed on real
-hardware for this alpha:
-
-- Jellyfin **direct streaming** plays on the first tap after launch.
-- **Chromecast** connect / disconnect / transport, with no duplicate local
-  audio while casting and a paused (never surprise-starting) hand-back.
-- **Android Auto** appears and browses (after enabling Android Auto "unknown
-  sources"); media ids/extras/logs carry no token.
-- **Offline cache** with a user-configurable size limit; local source files are
-  never deleted by cache cleanup.
-- **Shuffle / repeat** and a polished Now Playing screen.
-
-Re-run the [checklist](./docs/manual-test-checklist.md) before each release; it
-also tracks the current known limitations and follow-ups.
-
-## Contributing &amp; deeper docs
-
-Linthra aims to be contributor-friendly: small focused files, explicit naming,
-and clean layers (features depend on interfaces in `core/`, never on concrete
-services or storage). If you find Linthra useful, a **GitHub star** helps others
-discover it.
-
-- **Architecture & extension points:** [Architecture](#architecture)
-- **Run it / build it:** [Getting started](#getting-started)
-- **Feature deep-dives:** background playback & Android Auto, Now Playing
-  controls, folder selection, offline downloads, and Jellyfin — all detailed in
-  the sections below.
-- **Release, F-Droid & Google Play planning:** [docs/](./docs) (release process,
-  signing, F-Droid readiness, dependency/license audit, Jellyfin compatibility,
-  and [Google Play closed-testing readiness](#google-play-closed-testing-work-in-progress)).
-
-## Philosophy
-
-- **Local-first & offline-first** — the UI always reads from a local cache.
-- **Privacy-focused** — no telemetry, no forced sync.
-- **User-controlled downloads** — never automatic; Wi-Fi only by default, with
-  an explicit "Allow mobile data" opt-in.
-- **No vendor lock-in** — sources (local, Jellyfin, WebDAV, NAS) sit behind a
-  single interface.
-- **Contributor-friendly** — small focused files, explicit naming, clean layers.
-
-## Target platforms
-
-Android first, Linux desktop later, and possibly Windows — all from one Flutter
-codebase.
-
-## Tech stack
-
-| Concern          | Choice                                            |
-| ---------------- | ------------------------------------------------- |
-| Framework        | Flutter                                           |
-| State management | Riverpod                                          |
-| Navigation       | go_router (`StatefulShellRoute` for bottom nav)   |
-| Local metadata   | SQLite via `drift`                                |
-| Playback         | `just_audio` + `audio_service` (behind interface) |
-| Remote sources   | `http` (behind `JellyfinClient`)                  |
-| Secrets at rest  | `flutter_secure_storage` (Jellyfin session token) |
-
-Dependencies are added when a feature needs them rather than up front, so
-`pubspec.yaml` stays honest about what the code actually uses. Today that's
-`flutter_riverpod`, `go_router`, `path` (for the local file scanner),
-`drift` + `sqlite3_flutter_libs` + `path_provider` for SQLite persistence,
-`just_audio` for playback, `audio_service` for the background media session
-(notification / lock screen / Android Auto), `file_picker` for the native
-folder chooser, `shared_preferences` for remembering the selected folder,
-`http` for talking to a Jellyfin server (behind `JellyfinClient`), and
-`flutter_secure_storage` for keeping the Jellyfin session token encrypted at
-rest (`drift_dev` + `build_runner` are dev-only, for code generation).
-
-## Architecture
-
-Layered and feature-first. The golden rule: **features depend on interfaces in
-`core/`, never on concrete services or storage.** That seam is what makes the
-Jellyfin/WebDAV roadmap possible without rewriting the UI.
-
-```
-lib/
-  main.dart                 entry point; hosts the Riverpod ProviderScope
-  app/                      app-level wiring
-    linthra_app.dart         root MaterialApp.router widget
-    router.dart             go_router config (Riverpod provider)
-    routes.dart             route path constants
-    theme.dart              dark-first ThemeData (violet brand + orange accent)
-    colors.dart / dimens.dart  design tokens (palette, spacing, radii)
-  core/                     framework-free domain layer
-    app_info.dart           static app metadata
-    models/                 immutable entities: Track, Album, Artist,
-                            Playlist, PlaybackState
-    repositories/           persistence contracts: MusicLibraryRepository,
-                            PlaylistRepository, DownloadRepository,
-                            JellyfinSessionStore
-    services/               device-facing contracts: PlaybackController,
-                            MusicSource, ConnectivityService
-    sources/                concrete MusicSource implementations:
-                            local/ (LocalMusicSource + file scanning),
-                            jellyfin/ (JellyfinClient + auth + source + mapper)
-  data/                     concrete repository implementations + storage
-    database/               LinthraDatabase (Drift) + tables/ (tracks_table.dart)
-    mappers/                domain <-> Drift row conversion (track_mapper.dart)
-    repositories/           drift_music_library_repository.dart (persistent),
-                            in_memory_music_library_repository.dart (dev/tests),
-                            secure_jellyfin_session_store.dart (encrypted token)
-  features/                 one folder per screen/feature
-    library/  player/  playlists/  downloads/  settings/ (+ jellyfin/)  shell/
-  shared/
-    widgets/                reusable UI (e.g. EmptyState)
-```
-
-### Key extension points
-
-- **`MusicSource`** (`core/services/music_source.dart`) — a media backend.
-  `LocalMusicSource` shipped first; `JellyfinMusicSource`
-  (`core/sources/jellyfin/`) and `SubsonicMusicSource` (`core/sources/subsonic/`,
-  for Navidrome and other Subsonic-compatible servers) now implement the same
-  contract over their own HTTP clients, each with a separate authenticator,
-  encrypted session store, and library fetcher — authentication, persistence,
-  and library fetching kept apart. A small **capability model**
-  (`core/sources/music_provider.dart`) declares what each provider supports
-  (`canStream`/`canCache`/`canFavorite`/`canLyrics`/`canCast`) so the UI offers
-  only the actions that work. `WebDavMusicSource` slots in the same way later;
-  see [docs/providers.md](docs/providers.md).
-- **`MusicLibraryRepository`** (`core/repositories/`) — the local SQLite cache
-  the UI reads from. Sources *sync into* it; the UI never talks to a source
-  directly. This is what keeps the app fast and fully offline.
-- **`PlaybackController`** (`core/services/playback_controller.dart`) — playback
-  *and* the up-next queue, fully decoupled from `just_audio`. It owns a pure
-  [`PlaybackQueue`](lib/core/models/playback_queue.dart) model (current track +
-  upcoming tracks) and exposes `playTracks`, `playNext`, `skipToNext`,
-  `clearQueue`, and the **shuffle/repeat modes** (`setShuffleEnabled`,
-  `setRepeatMode`); shuffle reorders the queue in place (keeping the current
-  track playing) and repeat (off / all / one) is consulted when a track
-  finishes. The UI reads the queue, `shuffleEnabled`, and `repeatMode` from
-  `PlaybackState` and never edits them directly. `LinthraAudioHandler` wraps it
-  for background audio / the platform media session (notification, lock screen,
-  Android Auto), mirroring shuffle/repeat into the session, without touching
-  feature code; MPRIS can attach the same way later.
-- **`CastService`** (`core/services/cast/cast_service.dart`) — the seam for
-  remote playback handoff (Chromecast). The UI renders a `CastState` and drives
-  discovery/connection through this interface, never a cast SDK directly —
-  mirroring how the audio engine is hidden behind `PlaybackController`. Android
-  and iOS get the real `DefaultCastService`, which owns cast state and the
-  playback handoff (resolve the current track's stream URL **at cast time**,
-  load it on the receiver, pause local audio; resume on disconnect) while
-  delegating the wire protocol to a thin `ChromecastCastTransport` over the
-  pure-Dart `cast` package (no Google Play Services / Cast SDK). Other platforms
-  keep `UnavailableCastService`, so the button stays honest. The
-  network-touching transport is isolated so all of casting's decision-making is
-  unit-tested with a fake; the resolved URL (with any token) is never logged or
-  persisted. When connected, `CastService` also exposes the receiver's **device
-  volume** (`setVolume`/`volumeUp`/`volumeDown`/`setMuted`, surfaced in
-  `CastState` as `volume`/`muted`/`supportsVolumeControl`); the Cast sheet shows
-  a "Cast volume" slider, and a failed volume command never interrupts playback.
-- **`DownloadRepository`** (`core/repositories/`) — enforces the
-  user-initiated, mobile-data-respecting download policy in one place.
-  `CacheDownloadRepository` implements it today over a `DownloadStore`
-  (durable cached-ID set), a `DownloadPreferences` ("Allow mobile data" switch),
-  and a `ConnectivityService` (Wi-Fi / mobile data / offline / unknown). Remote
-  (Jellyfin/WebDAV) downloads add a real byte-fetch without touching the policy
-  or the UI.
-
-## Getting started
-
-This repository contains the Dart/Flutter source plus the committed **Android**
-platform scaffold (`android/`). Other native platform folders (`linux/`, …)
-are **not committed** — generate them locally when you need them so the repo
-stays focused on the cross-platform Dart code.
-
-```bash
-# 1. Fetch dependencies
-flutter pub get
-
-# 2. Run on a connected Android device or emulator
-flutter run
-
-# (Optional) generate scaffolding for another platform, e.g. Linux desktop:
-flutter create --platforms=linux .
-```
-
-> Note: `flutter create` may regenerate template files such as `main.dart`.
-> If prompted, keep the existing versions in this repo.
-
-### Building a debug APK (Android)
-
-The `android/` scaffold is committed, so no `flutter create` step is needed.
-You do need a working Android SDK (`ANDROID_HOME`/`ANDROID_SDK_ROOT` set) and a
-JDK that matches the bundled Gradle wrapper — **JDK 17** is the safe choice
-for the Gradle 8.3 / Android Gradle Plugin 8.1 the scaffold ships with. Run
-`flutter doctor` to confirm your toolchain.
-
-To install and test Linthra on an Android phone:
-
-```bash
-flutter pub get
-
-# Build an unsigned debug APK
-flutter build apk --debug
-# → build/app/outputs/flutter-apk/app-debug.apk
-
-# Or build and install straight onto a connected device
-flutter run --debug          # hot-reloadable dev session
-flutter install              # installs the last debug build
-```
-
-The debug APK is unsigned and meant for local testing only. Release builds and
-optional release signing are handled separately by the **Android Release
-Build** workflow — manual for test builds, automatic on `v*` tags (see
-[Building release artifacts](#building-release-artifacts-android) and
-[docs/release-signing.md](./docs/release-signing.md)); nothing is published to a
-store or F-Droid. Alpha/beta/rc tags may auto-create a GitHub **pre-release** and
-attach artifacts to it, but production release notes are never written for you.
-
-#### Downloading a debug APK from CI
-
-If you don't have a local Flutter/Android toolchain, the
-**Android Debug APK** workflow (`.github/workflows/android-debug-apk.yml`)
-builds the same `flutter build apk --debug` output on GitHub and attaches it as
-a downloadable artifact.
-
-- **How to run it:** open the repo's **Actions** tab → **Android Debug APK** →
-  **Run workflow** (the `workflow_dispatch` trigger). It also runs
-  automatically on pull requests.
-- **Artifact:** `linthra-debug-apk`, containing
-  `app-debug.apk` (built from `build/app/outputs/flutter-apk/app-debug.apk`).
-- **Download:** open the completed workflow run and grab `linthra-debug-apk`
-  from the run's **Artifacts** section. GitHub serves it as a `.zip`; unzip it
-  to get `app-debug.apk`.
-- **Install manually:** copy the APK to an Android device and open it (you may
-  need to allow "install from unknown sources"), or with the device connected
-  over ADB run:
-
-  ```bash
-  adb install -r app-debug.apk
-  ```
-
-This artifact is an **unsigned debug build for testing only** — it is not
-signed for release, not published to any store or F-Droid, and no GitHub
-release is created.
-
-#### Manual smoke test on a real Android phone
-
-After installing the debug APK on a physical device (most useful on **Android
-13+**, where the runtime notification permission applies), walk this checklist —
-it covers the paths that only behave correctly on real hardware:
-
-1. **First launch & notification prompt.** Cold-start the app. On Android 13+ a
-   **"Allow notifications?"** system prompt should appear shortly after the UI
-   loads. Tap **Allow** (the media notification depends on it). If you tap
-   **Don't allow**, playback still works but no notification appears — re-enable
-   it later under *Settings → Apps → Linthra → Notifications*.
-2. **Pick a folder & scan.** Library tab → folder icon → choose a folder with a
-   few audio files (e.g. `Music`). It should list the tracks. Pick a folder a
-   provider can't traverse (or an empty one) and confirm you get a **clear,
-   friendly message or "No music found"**, never a raw error or an indefinite
-   spinner.
-3. **Play a local track.** Tap a track. It should start, and the **Now Playing**
-   screen should show title/artist and working play/pause/next/stop.
-4. **Background playback & notification.** Background the app (Home button). Audio
-   should keep playing and a **media notification** should show the track with
-   working transport controls. Lock the phone and confirm lock-screen controls
-   work. Headset/Bluetooth play-pause buttons should work too.
-5. **Jellyfin (optional).** Settings → Jellyfin → enter your server URL → **Test
-   connection** → sign in → **Sync library** → play a synced track. Confirm
-   streaming works over the network. Try a wrong URL / offline server and
-   confirm you get a **friendly error** (unreachable / not-a-Jellyfin-server /
-   expired session), not a raw failure.
-6. **Friendly playback errors.** With Jellyfin signed out, try to play a synced
-   Jellyfin track and confirm the Now Playing status line shows a precise,
-   friendly message (e.g. "not signed in"), not an opaque engine error.
-7. **Download a Jellyfin track for offline.** Signed in and online, tap the
-   download icon on a synced Jellyfin track in the Library. It should show a
-   spinner, then a filled "downloaded" icon. The track should also appear on the
-   **Downloads** tab.
-8. **Play a cached track fully offline.** Enable **airplane mode** (or stop the
-   server). Play the downloaded track — it should play from the **local cached
-   file** with no network error. Then try an *un-downloaded* Jellyfin track and
-   confirm you get the friendly "couldn't reach your server" message, never a
-   raw failure or a silent hang.
-9. **Remove a download.** Back online or off, remove the download (Downloads tab
-   trash icon, or the Library row's "remove" action). It should **disappear from
-   the Downloads tab immediately** and the Library row should revert to the
-   "download" action.
-10. **Retry a failed download.** Start a Jellyfin download, then kill the server
-    or connection mid-fetch so it fails. The Library row should show an **error
-    icon with a "Retry download" tooltip**; tapping it re-attempts the download
-    (it succeeds once the server is reachable again).
-11. **Mobile-data gate.** With **Allow mobile data** off (the default), switch to
-    mobile data (or a future real detector) and start a download — it should be
-    **queued** with a friendly "Downloads are limited to Wi-Fi" message rather
-    than run over mobile data. Turn **Allow mobile data** on (confirm the
-    dialog) and retry — it should download over mobile data. (See the
-    connectivity note in *Offline downloads & known limitations*.)
-12. **No secrets on screen.** Throughout, confirm no error, status line, or
-    track subtitle ever shows a Jellyfin token, `api_key`, password, or raw URL.
-
-See *Testing scanning on Android* below for the SAF-specific detail, and the
-*Limitations still remaining* list at the end of this section.
-
-**Android identity & permissions.** The app ships with a stable application ID
-**`io.github.thezupzup.linthra`** (also the Kotlin/Gradle `namespace`) and the
-display name **Linthra** — both chosen for future F-Droid / GitHub Releases
-distribution. Permissions are kept deliberately minimal. The production manifest
-declares only:
-
-- **`FOREGROUND_SERVICE`** / **`FOREGROUND_SERVICE_MEDIA_PLAYBACK`** — so
-  `audio_service` can keep playing while backgrounded (Android 14+ requires the
-  typed `mediaPlayback` grant).
-- **`POST_NOTIFICATIONS`** — required on Android 13+ for the media notification
-  (and its transport controls) to appear; it is a *runtime* permission the app
-  asks for once on first launch (see *Background playback* below).
-- **`INTERNET`** — needed to reach a self-hosted Jellyfin server (connection
-  test, sign-in, library sync, and streaming). The `debug`/`profile` manifests
-  also add it for Flutter's tooling; the manifest merger de-duplicates.
-
-**No storage permission is requested** — folder access uses the Storage Access
-Framework grant the user picks. See *Android folder selection & known
-limitations* for why a narrow `READ_MEDIA_AUDIO` flow is a deliberate later step
-rather than a broad "all files" grant.
-
-> The `audio_service` native wiring (foreground-service permissions, the
-> playback `<service>`/`<receiver>`, the Android Auto media-app declaration, and
-> `MainActivity` extending `AudioServiceActivity`) documented under *Background
-> playback & Android Auto* is now **applied** to the committed scaffold.
-> `connectMediaSession` still falls back gracefully if the session can't
-> initialise (e.g. an unsupported platform or a test environment), so basic
-> playback never depends on it.
-
-### Building release artifacts (Android)
-
-The **Android Release Build** workflow
-(`.github/workflows/android-release-build.yml`) builds the Android **release**
-artifacts. It runs **manually** for test builds and **automatically on version
-tags** so a tagged release builds its APK/AAB without anyone clicking *Run
-workflow*. It still never publishes to a store or F-Droid and never writes
-production release notes.
-
-- **Manual test builds:** open the repo's **Actions** tab → **Android Release
-  Build** → **Run workflow** (`workflow_dispatch`). A `signed` input controls
-  whether the build is release-signed (see
-  [Signing status](#signing-status-important) below). Manual runs never touch
-  any GitHub Release.
-- **Automatic tag builds:** pushing a tag matching `v*` (e.g. `v0.1.0-alpha.1`)
-  triggers the workflow automatically:
-
-  ```bash
-  git tag -a v0.1.0-alpha.1 -m "Linthra 0.1.0-alpha.1"
-  git push origin v0.1.0-alpha.1
-  ```
-
-  Creating a Release in the GitHub UI on a *new* tag also creates+pushes that
-  tag, which starts the same build — so you can write the Release notes first
-  and let the build attach to it (see below). The workflow listens only to the
-  tag push (not to `release: published`) so a tag never builds twice.
-- **What it builds:** `flutter build apk --release` and
-  `flutter build appbundle --release`.
-- **Artifacts** are named with both the version (tag) and the signing label, so
-  a debug-signed preview can never be mistaken for a production release:
-  - Tag builds: `linthra-<tag>-<signing>.apk` / `.aab`, e.g.
-    `linthra-v0.1.0-alpha.1-debug-signed.apk` or
-    `linthra-v0.1.0-alpha.1-release-signed.aab`.
-  - Manual builds (no tag): `linthra-<signing>.apk` / `.aab`.
-  - The build job uploads each as a workflow artifact
-    (`linthra-<signing>-apk` / `linthra-<signing>-aab`) from
-    `build/app/outputs/flutter-apk/app-release.apk` and
-    `build/app/outputs/bundle/release/app-release.aab`.
-- **Release attachment (tag builds only):**
-  - **Pre-release tags** — any tag containing `alpha`, `beta`, or `rc` — attach
-    their APK/AAB to a GitHub **pre-release**. If no Release exists for the tag,
-    one is **created as a pre-release** automatically. These tags may attach
-    release-signed *or* clearly-labeled **debug-signed** artifacts; debug-signed
-    builds are for **testing only** and are named and described as such.
-  - **Stable tags** — e.g. `v1.0.0` — **require release signing**. If the
-    `LINTHRA_*` secrets are missing the run **fails fast** rather than attaching
-    a debug-signed build. Stable assets are only uploaded to a Release that
-    **already exists** (notes stay manual); stable Releases are never
-    auto-created.
-  - When a Release already exists, assets are uploaded/replaced (`--clobber`).
-- **Download:** open the completed run and grab the artifacts from the run's
-  **Artifacts** section (GitHub serves each as a `.zip`; unzip to get the
-  APK/AAB). For a published Release, download the attached APK/AAB directly from
-  the Release page.
-
-Build the same artifacts locally with:
-
-```bash
-flutter pub get
-flutter build apk --release        # → build/app/outputs/flutter-apk/app-release.apk
-flutter build appbundle --release  # → build/app/outputs/bundle/release/app-release.aab
-```
-
-#### Signing status (important)
-
-Release signing is **wired up but not yet provisioned**. `android/app/build.gradle`
-resolves a release signing config from environment variables (used by CI) or a
-git-ignored `android/key.properties` (local). **Only if** complete signing
-material is present does it sign with the release key; otherwise it falls back to
-the **debug** key so `flutter run --release` still works. **No signing keys or
-secrets are committed** to the repo.
-
-- Manual run with **`signed = false`** (default) → **debug-key signed**
-  artifacts, labeled `…-debug-signed-…`. Fine for previewing a release build,
-  **not** suitable for store or F-Droid distribution.
-- Manual run with **`signed = true`** → the workflow decodes a keystore from the
-  `LINTHRA_*` repository secrets and produces **release-signed** artifacts
-  (labeled `…-release-signed-…`). If a required secret is missing, the run
-  **fails fast** rather than silently producing a debug-signed build.
-- **Tag build** (`v*` push) → attempts release signing automatically:
-  - If the `LINTHRA_*` secrets are present → **release-signed** artifacts,
-    eligible for Release attachment.
-  - If the secrets are missing on a **pre-release** tag (`alpha`/`beta`/`rc`) →
-    the run does **not** pretend to be a production release: it emits a loud
-    warning and builds **debug-key signed** artifacts labeled `…-debug-signed`,
-    which are attached to a GitHub **pre-release** clearly marked as
-    testing-only.
-  - If the secrets are missing on a **stable** tag (e.g. `v1.0.0`) → the run
-    **fails fast**. Stable releases must be release-signed; debug-signed
-    artifacts are never attached to a stable Release.
-
-The keystore secrets are not configured in this repository yet, so until they
-are, **pre-release** tag builds fall back to clearly-labeled debug-signed
-artifacts (attached to a pre-release for testing), and **stable** tag builds
-fail until signing is provisioned. Configure the secrets (see
-[docs/release-signing.md](./docs/release-signing.md)) to get release-signed tag
-builds. Full details — required
-secrets, how to generate/rotate a keystore, and how this relates to F-Droid (which
-signs its own builds) — are in [docs/release-signing.md](./docs/release-signing.md).
-
-#### Limitations & next steps
-
-- The workflow **does not** upload anything to a store or submit to F-Droid, and
-  it does **not** write production release notes. For **pre-release** tags it can
-  create a GitHub pre-release and attach (debug- or release-signed) artifacts to
-  it, with auto-generated placeholder notes you should edit. For **stable** tags
-  it only attaches release-signed artifacts to a Release you created manually.
-- Release signing **secrets are not yet provisioned**, so until they are,
-  pre-release tag builds fall back to clearly-labeled debug-signed artifacts
-  (for testing only) and stable tag builds fail until signing is configured.
-- **Next steps:** provision the `LINTHRA_*` keystore secrets
-  ([docs/release-signing.md](./docs/release-signing.md)), then follow the manual
-  release/tagging and GitHub-Release flow in
-  [docs/release-process.md](./docs/release-process.md). F-Droid readiness is
-  tracked separately in [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
-
-> **First alpha (`v0.1.0-alpha.1`).** The draft GitHub-Release body — what
-> works, known limitations, sideload instructions, and the manual release
-> steps — lives in
-> [docs/release-notes/v0.1.0-alpha.1.md](./docs/release-notes/v0.1.0-alpha.1.md).
-> It is a draft only; cutting the tag and publishing the Release stay manual.
-
-### Background playback & Android Auto
-
-Linthra registers a platform **media session** through `audio_service` so
-playback survives backgrounding and shows up where the OS expects it:
-
-- **Notification & lock screen.** A media notification mirrors the current
-  track (title / artist / album) and exposes **play/pause**, **stop**, and
-  **skip-next** (the skip control only appears when the up-next queue has a
-  track). Position updates flow through so scrubbing/seek work from the system
-  UI.
-- **Skip controls.** Transport exposes **skip-previous** and **skip-next**
-  alongside play/pause/stop. Each skip button only appears when the queue has a
-  track in that direction (`hasPrevious` / `hasNext`), so the controls match what
-  the queue can actually do.
-- **Android Auto — browsable.** The same session is what Android Auto and other
-  media browsers attach to, so the now-playing card and transport controls are
-  reachable from the car head unit. On top of that, Linthra now serves a
-  **browsable media library** so you can pick what to play from the car screen
-  (see the tree below). Selecting a track starts it and queues the rest behind
-  it, exactly like tapping a track in the in-app library.
-
-**Media tree.** The browsable hierarchy served to Android Auto is intentionally
-shallow:
-
-```
-root
-├── Library    → every catalog track (tap to play; the rest of the library
-│                becomes up-next)
-├── Queue      → the current track followed by the up-next list (tap to jump)
-├── Playlists  → your playlists (shown only when you have some); open one to
-│                play a track and queue the rest of that playlist
-└── Favorites  → your favourited tracks (shown only when you have some)
-```
-
-Nodes are addressed by stable IDs: the `Library`, `Queue`, `Playlists` and
-`Favorites` categories, and leaf IDs `library/<trackId>`, `queue/<index>`,
-`playlist/<playlistId>/<index>` and `favorite/<index>` that a selection is
-resolved back through. `Playlists` and `Favorites` appear only when you have
-some, so the car never shows an empty dead-end category. Every ID is built only
-from opaque catalog/track/playlist ids — never a Jellyfin token or an
-authenticated stream URL (those are minted lazily at play time, never stored on
-a track or exposed to the browser). See **[docs/android-auto.md](docs/android-auto.md)**
-for the current status, how to test on a real head unit or the Desktop Head
-Unit, troubleshooting, and the manual checklist.
-
-**Architecture.** `audio_service` is a pure infrastructure layer.
-`LinthraAudioHandler` (`lib/core/services/linthra_audio_handler.dart`) is the
-only file that imports it: it forwards session commands
-(play/pause/stop/skip/seek) to the `PlaybackController` and mirrors the
-controller's `PlaybackState` back out as the session's playback state + media
-item. The browse tree itself is **pure Dart** — `MediaBrowserTree`
-(`lib/core/services/media_browser_tree.dart`) builds neutral `MediaNode`s from
-the `MusicLibraryRepository` (catalog), a `PlaybackState` snapshot (the live
-queue), and — when wired — the `PlaylistRepository` and `FavoritesRepository`,
-and the handler maps those onto `audio_service` media items. It reads only those
-repository seams (no widget), so Android Auto can load the tree the moment the
-media service starts, before any phone screen is opened. So library data still
-flows only through `MusicLibraryRepository`, playback still flows only through
-`PlaybackController`, and **the UI continues to depend only on
-`PlaybackController`** — never on `audio_service`. Attaching the session in
-`main.dart` is best-effort: it logs a secret-free line under the
-`Linthra.AndroidAuto` tag on success/failure (visible via `adb logcat`), and if
-it fails to initialise (e.g. an unsupported platform) basic playback still
-works.
-
-**Native setup (applied).** The required Android wiring lives in the committed
-scaffold so the media session can run as a foreground service and be visible to
-Android Auto:
-
-- `android/app/src/main/AndroidManifest.xml` declares the playback permissions —
-  `FOREGROUND_SERVICE` (run the playback service in the foreground so audio
-  continues while backgrounded) and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` (the
-  typed-foreground grant Android 14+/API 34 requires for a `mediaPlayback`
-  service) — plus `POST_NOTIFICATIONS` (Android 13+ runtime permission, without
-  which the notification is silently suppressed). `INTERNET` is also declared
-  for Jellyfin; no storage permission is added.
-- **Notification permission prompt.** On Android 13+ the media notification only
-  shows once the user grants `POST_NOTIFICATIONS`. `LinthraApp` asks for it once
-  on first launch (after the first frame, via the `NotificationPermission` seam
-  → `permission_handler`). The request is best-effort: if it's denied, playback
-  still works but the notification / lock-screen controls won't appear until the
-  permission is enabled in system settings.
-- the same manifest declares the audio_service playback `<service>`
-  (`com.ryanheise.audioservice.AudioService`, `foregroundServiceType`
-  `mediaPlayback`, exposing the `MediaBrowserService` action Android Auto binds
-  to) and the `<receiver>` (`com.ryanheise.audioservice.MediaButtonReceiver`)
-  that handles hardware/Bluetooth/Android Auto media-button intents.
-- the manifest also declares the `com.google.android.gms.car.application`
-  meta-data pointing at `res/xml/automotive_app_desc.xml` (`<uses name="media"/>`),
-  which is what lets Android Auto list Linthra as a media app and bind to the
-  browser service to load the tree. Without it the session works but the app
-  never appears in the car's browse UI.
-- `android/app/.../MainActivity.kt` extends `AudioServiceActivity` (instead of
-  the default `FlutterActivity`) so the Flutter activity binds to the session.
-
-For reference, the manifest additions are:
-
-```xml
-<manifest ...>
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-  <uses-permission
-      android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
-  <!-- Android 13+ runtime permission for the media notification. -->
-  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-  <!-- Reaching a self-hosted Jellyfin server. -->
-  <uses-permission android:name="android.permission.INTERNET" />
-
-  <application ...>
-    <!-- audio_service playback service -->
-    <service
-        android:name="com.ryanheise.audioservice.AudioService"
-        android:foregroundServiceType="mediaPlayback"
-        android:exported="true">
-      <intent-filter>
-        <action android:name="android.media.browse.MediaBrowserService" />
-      </intent-filter>
-    </service>
-
-    <!-- Media button + Android Auto receiver -->
-    <receiver
-        android:name="com.ryanheise.audioservice.MediaButtonReceiver"
-        android:exported="true">
-      <intent-filter>
-        <action android:name="android.intent.action.MEDIA_BUTTON" />
-      </intent-filter>
-    </receiver>
-
-    <!-- Marks Linthra as an Android Auto media app -->
-    <meta-data
-        android:name="com.google.android.gms.car.application"
-        android:resource="@xml/automotive_app_desc" />
-  </application>
-</manifest>
-```
-
-The notification channel id/name are configured in `connectMediaSession`
-(`com.linthra.audio` / "Linthra playback").
-
-**Limitations (this PR).**
-
-- **Sideloaded builds need "unknown sources".** Android Auto only lists media
-  apps installed from the Play Store unless you enable Developer mode → *Add
-  unknown sources* in the Android Auto settings. Linthra ships via F-Droid /
-  GitHub Releases, so this toggle is required for a sideloaded build to appear —
-  it is the most common reason Linthra "doesn't show up in Android Auto". Full
-  steps and troubleshooting are in **[docs/android-auto.md](docs/android-auto.md)**.
-- The browse tree is **flat**: `Library`, `Playlists` and `Favorites` are flat
-  track lists (no album/artist/folder grouping) and there is no search-from-Auto.
-  Large libraries are not paged. A favourite or playlist track that isn't in the
-  on-device catalog yet is skipped (it can't be played until synced).
-- Queue browsing is **read + jump only**: you can play from a queue position,
-  but reordering/removing queue items from the car isn't supported.
-- The car experience is **basic browsing**, not a polished/custom car UI
-  (no tabs, content style hints, or now-playing artwork tuning).
-- No MPRIS (Linux desktop media keys) yet.
-- Lock-screen / car artwork depends on `Track.artworkUri`, which local scanning
-  does not populate yet.
-
-### Now Playing controls — shuffle, repeat, favorite, lyrics & casting
-
-The Now Playing screen drives every transport action through
-`PlaybackController`/`PlaybackState`; the widgets hold no playback logic of their
-own.
-
-- **Shuffle (working).** The shuffle button toggles a playback *mode* on the
-  controller. Turning it on reorders the current queue with the playing track
-  kept at the front (so the music never skips), and remembers the original order;
-  turning it off restores that order with the current track still current. The
-  mode persists, so a queue loaded while shuffle is on starts shuffled. State
-  lives in `PlaybackState.shuffleEnabled`, and the button shows its on/off state
-  with the accent colour + selected styling. The reordering itself is a pure
-  `PlaybackQueue.shuffled()`/`unshuffled()` transform, unit-tested without an
-  audio engine.
-- **Repeat / loop (working).** The repeat button cycles **off → repeat all →
-  repeat one → off**. When a track finishes the controller consults
-  `PlaybackState.repeatMode`: *off* plays to the end and stops, *all* wraps from
-  the last track back to the first, and *one* replays the current track (from the
-  start, without re-resolving its URL — so a stream isn't re-fetched each loop).
-  Next/previous keep working normally in every mode. The glyph switches to
-  `repeat_one` for repeat-one and is tinted/selected whenever repeat is active.
-- **Favorite (working).** The heart toggles a favourite through a
-  `FavoritesRepository`. For a **Jellyfin** track the change is synced to the
-  server (`POST`/`DELETE …/FavoriteItems/<id>`), so it follows the user across
-  clients; for a **local** track it's stored on-device. Either way the UI updates
-  optimistically from a single favourite-id set, and a failed server push keeps
-  the local intent and reconciles on the next refresh (the signed-in user's
-  server favourites are pulled at startup). Only non-secret ids are stored or
-  sent — never a token.
-- **Lyrics (working for Jellyfin).** The lyrics button fetches the track's
-  lyrics from the signed-in Jellyfin server (`GET /Audio/<id>/Lyrics`) behind a
-  `LyricsService` seam and shows the lines in a sheet. A track with no lyrics, a
-  local track, or being signed out shows a calm "No lyrics available" placeholder
-  (and a fetch failure a friendly "couldn't load" line) — never a blank sheet. A
-  local `.lrc`/tag reader can slot in behind the same seam later.
-- **Cast / Chromecast (working on Android/iOS).** The cast control in the Now
-  Playing header opens a device sheet that drives **real Chromecast**: mDNS
-  discovery of devices on the network, connect/disconnect, and handing the
-  current track off to the receiver. It's built on the pure-Dart `cast` package
-  (Google Cast **v2 protocol** over a TLS socket, `bonsoir` for discovery) — **no
-  Google Play Services or proprietary Cast SDK**, so the F-Droid build keeps
-  casting (see [docs](docs/dependency-license-audit.md#casting-chromecast--real-cast-without-google-play-services)).
-  The handoff resolves the current track's stream URL **only at cast time**
-  (Jellyfin's or Subsonic's authenticated URL, the credential woven in on demand
-  and **never logged or persisted**), tells the receiver to fetch it, and pauses
-  local audio so it isn't heard twice; disconnecting (or the receiver dropping)
-  resumes local playback. **On-device files can't be cast** — a receiver can't
-  reach a `file://` path — so those surface a clear limitation in the sheet
-  rather than failing silently. The sheet shows every state honestly: searching,
-  available devices, connecting, connected, the local-file notice, and
-  error/no-devices.
-- **Cast volume.** While connected, the Cast sheet shows a clearly labelled
-  **Cast volume** slider plus mute, driving the *device's* own volume (not the
-  phone's media volume) and following the receiver's reported level live. It's
-  all behind `CastService` (`setVolume`/`volumeUp`/`volumeDown`/`setMuted`), with
-  `CastState` exposing `volume`/`muted`/`supportsVolumeControl`; a device that
-  reports a fixed volume shows an honest disabled state, and a failed volume
-  command surfaces a calm notice **without ever interrupting playback**.
-  Architecturally the UI still only touches `CastService`/`CastState`; the real
-  `DefaultCastService` owns state + handoff and is fully unit-tested behind a
-  faked `CastTransport`, while the thin `ChromecastCastTransport` (the only code
-  that opens a socket) is verified by analysis and on-device testing. Platforms
-  without a cast stack keep the honest `UnavailableCastService`.
-
-Both shuffle and repeat are also mirrored into the `audio_service` media session
-(`shuffleMode`/`repeatMode`), and the session forwards the system's
-shuffle/repeat actions back to the controller, so the modes stay coherent
-between the in-app screen, the notification, and Android Auto.
-
-### Android folder selection & known limitations
-
-**How scanning works now.** Tap the folder icon in the Library app bar → the
-native folder chooser opens → the chosen folder is persisted and immediately
-scanned. The selection survives restarts, and the empty state adapts: when no
-folder is chosen it invites you to pick one; when a folder is chosen but nothing
-playable is found it shows that folder and offers **Rescan folder** / **Change
-folder**. On Linux/desktop the same flow uses the GTK/Win32 directory dialog and
-returns a real filesystem path, which `LocalMusicSource` scans directly.
-
-**How content:// folders are scanned.** On modern Android the folder chooser
-hands back a `content://…/tree/…` URI under the Storage Access Framework (SAF)
-rather than a filesystem path. `LocalMusicSource` handles such a selection in
-two ways, in order:
-
-1. **Content-resolver traversal (preferred).** A `SafDocumentLister` walks the
-   picked tree through Android's content resolver (`DocumentsContract`) in
-   native code (`MethodChannelSafDocumentLister` → `SafDocumentScanner.kt`) and
-   returns the `content://` document URIs of the audio files it finds. This is
-   the scoped-storage-correct path: it uses only the access the system granted
-   when the user picked the folder, needs **no** storage permission, and never
-   touches `MANAGE_EXTERNAL_STORAGE`. Tracks found this way are stored as their
-   `content://` document URIs (titled from the SAF display name) and play back
-   directly through that URI.
-2. **Filesystem-path fallback.** When native SAF traversal isn't available on
-   the build (desktop, or the channel isn't registered), the scan falls back to
-   the earlier behaviour: `ContentUriAudioFileScanner` maps an external-storage
-   tree URI to a real path via `SafTreeUriResolver` (`primary:Music` →
-   `/storage/emulated/0/Music`, named SD-card volumes → `/storage/<volume>/…`,
-   `raw:` absolute ids), probes it for readability (`DirectoryReadability`), and
-   either walks it or raises a clear `FolderScanException` when scoped storage
-   blocks the read.
-
-Desktop/Linux selections are real filesystem paths and always take the
-`IoAudioFileScanner` `dart:io` walk, unchanged. How a selection is addressed
-(path vs `content://`) is decided once by `FolderLocation`; nothing downstream
-re-parses the string, SAF traversal stays behind the `SafDocumentLister` seam,
-and the UI never sees a platform channel.
-
-> **Native verification note.** The Dart side of SAF traversal — the lister
-> seam, routing, content-URI track mapping, and playback — is fully unit-tested
-> with fakes. The native `DocumentsContract` walk compiles in the debug-APK
-> workflow but is runtime-verifiable only on a real device/emulator (see the
-> manual checklist below). The folder grant is taken best-effort
-> (`takePersistableUriPermission`), so a folder picked once can be re-scanned
-> after a restart when the picker granted persistable access.
-
-Deliberate gaps the next PRs will close:
-
-- **Content-resolver SAF scanning — landed.** The native `DocumentsContract`
-  traversal above reads a picked folder the scoped-storage-correct way, so
-  external-storage *and* other document-provider trees can be scanned without a
-  filesystem path or a broad permission. The filesystem-path fallback (with its
-  `DirectoryReadability` probe and friendly error) remains for builds without
-  the native channel. Cross-restart access depends on the picker having granted
-  a *persistable* URI permission; if it didn't, re-pick the folder.
-- **No runtime storage permissions yet.** No `READ_MEDIA_AUDIO` request flow is
-  wired up, and **`MANAGE_EXTERNAL_STORAGE` is intentionally *not* requested** —
-  it is an "all files access" permission Google restricts on the Play Store and
-  it is the opposite of the scoped-storage approach this project prefers. On
-  Android 11+ a resolved path can still be unreadable without a media
-  permission; granting `READ_MEDIA_AUDIO` (a narrow, audio-only permission) is
-  the natural next step. Until then, point the scan at a folder the app can
-  already read, or use the content-resolver follow-up above.
-- **No tag/metadata parsing.** Tracks show their title (derived from the file
-  name) and fall back to the file path when artist/album tags are absent.
-- **Up-next queue with shuffle & repeat, no playlists.** Tapping a track in the
-  Library plays it and queues the rest of the visible list behind it; the Now
-  Playing screen shows the current track, an **Up next** list, a **Next** button,
-  **Clear** (which empties up next but keeps the current track), and working
-  **shuffle** and **repeat** controls. When a track finishes, playback follows
-  the repeat mode (roll into the next track, wrap the queue, or replay the
-  current one). Manual reordering and saved playlists are not part of this
-  foundation yet.
-- **Jellyfin streaming works; WebDAV pending.** A signed-in user can sync their
-  Jellyfin catalog into the Library and stream it (see the Jellyfin section
-  below). Other remote sources (WebDAV/NAS) are still pending.
-
-### Testing scanning on Android
-
-1. Build and install a debug APK (see *Building a debug APK* above) on a device
-   or emulator.
-2. Put a few audio files under a folder on shared storage, e.g.
-   `/storage/emulated/0/Music`.
-3. In **Library**, tap the folder icon and pick that folder. The chooser
-   returns a `content://…/tree/primary:Music` URI; Linthra walks that tree
-   through the content resolver and lists the audio files it finds — no path
-   resolution or storage permission needed.
-4. Tapping a scanned track plays it directly from its `content://` document URI.
-5. Picking a folder a document provider can enumerate (including cloud/document
-   providers that expose their tree) is scanned the same way. If a provider
-   can't be traversed at all, or the build has no native SAF channel and the
-   filesystem fallback can't read the resolved path under scoped storage, the
-   Library shows a clear, secret-free error instead of a silent empty list.
-
-This SAF traversal is the native step the earlier `content://` routing work set
-up. A narrow `READ_MEDIA_AUDIO` permission flow (only relevant to the
-filesystem fallback) and a playlist-editor foundation remain natural follow-ups.
-
-### Offline downloads & known limitations
-
-Linthra's offline model is **Plexamp/Plex Pass-style, but open-source and fully
-user-controlled**:
-
-- **The full library stays visible.** Syncing Jellyfin shows your whole catalog;
-  nothing is hidden behind a download.
-- **Downloads are explicit.** You mark the tracks you want offline. There is **no
-  automatic full-library sync** and no surprise downloads.
-- **Streaming is the default.** An un-downloaded Jellyfin track streams normally
-  when you're online and signed in.
-- **Cached items are playable offline.** Once a track is downloaded, playback
-  **prefers the local cached file**; if it isn't cached and you're offline, the
-  player shows a friendly "couldn't reach your server" message rather than
-  failing opaquely.
-- **The cache stays under a size limit.** You set a maximum (presets of 1, 2, 4,
-  8, 16 GB or a custom value; **4 GB by default**), so Linthra never fills your
-  phone unexpectedly. Both your downloads **and** any smart-pre-cached upcoming
-  tracks (see below) count toward this one limit. When a new download would
-  exceed it, space is freed by removing **pre-cached tracks first**, then the
-  **least-recently-played, unpinned, not-currently-playing** downloads. Pin a
-  track ("Keep offline") to protect it. If nothing safe can be freed, the
-  download is refused with a friendly "not enough cache space" message instead of
-  deleting something you wanted.
-
-**How it works now.** Each Library row shows an offline-download control:
-download an absent track, see a spinner while it's in flight, remove a cached
-one, or retry a failed one. The **Downloads** tab lists everything currently
-cached — with each track's **size** and a **Keep offline** pin — shows how much
-of the limit is in use, and hosts the **Allow mobile data** toggle (also under
-**Settings → Downloads & network**). **Settings → Smart pre-cache** turns
-automatic pre-caching on/off and sets how many upcoming tracks to warm (1, 3, 5,
-or 10); **Settings → Offline cache** shows used / max / free space and the
-**Change limit** and **Clear cache** (clear unpinned, or clear all) actions. The download lifecycle flows through `DownloadRepository`, which
-centralizes three guarantees:
-
-- **Downloads are user-initiated.** A track's *download status* only ever changes
-  in response to an explicit download/remove action. (Smart pre-cache, below,
-  also caches bytes automatically — but a pre-cached track never takes on a
-  download status, never shows as a download, and is evicted before any
-  download.)
-- **Source-aware.** A **Jellyfin** track has its bytes fetched (via
-  `RemoteTrackDownloader` → `JellyfinTrackDownloader`) and written to an
-  app-private offline directory (`OfflineFileStore`); an **on-device** track is
-  already local, so it's recorded as available offline with no network fetch and
-  no managed file.
-- **The mobile-data policy is respected.** Remote downloads run on Wi-Fi always,
-  on mobile data only when **Allow mobile data** is on, and never while offline.
-  When the connection isn't allowed the request is *queued* instead of run, and
-  the UI shows a friendly reason ("limited to Wi-Fi", or "you're offline").
-  (Local tracks are never queued — there are no bytes to fetch.)
-
-**Smart pre-cache.** As playback moves, Linthra warms a small number of upcoming
-queued tracks into the same cache ahead of time — the Plex/Plexamp-style "the
-next track is already here" feel — so upcoming songs start instantly (and play
-offline) instead of buffering a fresh stream at each track change, kept
-deliberately modest so it never fills your phone or downloads the whole library.
-A `SmartPrecacheService` watches the unified `PlaybackState` and, whenever the
-inputs that decide *what to cache* change (the playing track, the up-next list,
-shuffle, or repeat), asks a `TrackPrefetcher` (the `CacheDownloadRepository`
-again) to warm the next **N** `upNext` entries — which is the **queue order** in
-normal playback and the **shuffled order** when shuffle is on, since the
-controller keeps `upNext` in effective play order. The same applies while
-**casting**: the queue is always owned locally, so it pre-caches the active
-queue either way. It is deliberately well-behaved: only remote, not-yet-cached
-tracks are fetched, one at a time; it **follows the same mobile-data policy**
-(skipping rather than queueing when the connection isn't allowed); it respects
-the cache limit *before* spending data
-(and **evicts pre-cached entries before any download**); a pre-cache that won't
-fit or fails is silently skipped (the track still streams when reached); and it
-never blocks or interrupts what's playing. Under **repeat-one** it stays calm —
-the current track loops, so the up-next won't play soon and isn't pre-cached.
-Pre-cached tracks count toward cache usage but never appear as downloads, and are
-the first to be evicted. Configure it in **Settings → Smart pre-cache**: an
-on/off switch (on by default) and the number of upcoming tracks to warm (1, 3,
-5, or 10; **3 by default**). Smart pre-cache is automatic and *evictable*; to
-keep a song for good, pin it with **Keep offline**, which is protected and never
-auto-evicted.
-
-**Storage & playback.** Downloaded bytes live in an app-controlled directory
-(`path_provider`'s application-support location, not the OS cache that can be
-reclaimed). The durable metadata is a small `CachedTrack` set behind
-`DownloadStore`, persisted via `shared_preferences`; each record carries the
-non-secret track id, the id-derived cache file name, the source's URI scheme,
-the byte size, `cachedAt`/`lastAccessedAt` timestamps, and a `pinned` flag — the
-signals the cache manager cleans up by. Playback goes through an
-`OfflineFirstPlayableUriResolver`: it asks a `CachedTrackLocator` for a local
-copy first and, on a miss, falls back to the source router (Jellyfin streaming,
-or the on-device file); a cache **hit refreshes `lastAccessedAt`** so eviction
-keeps what you actually listen to. `downloaded` is the only durable state;
-`queued`/`downloading`/`failed` are in-memory and reset on restart.
-
-**Smart cache management.** The limit and eviction live in one place. The
-`CacheDownloadRepository` also implements an `OfflineCacheManager` (usage stream,
-pin, note-played, clear), and delegates the *what to evict* decision to a pure,
-exhaustively tested `CacheEvictionPolicy` — never the UI, which only calls the
-manager. What can and can't be deleted is a hard line: only **app-managed cache
-files** in the offline directory are ever removed (by id-derived file name);
-the user's **local source files** in their music folder are never passed to the
-file store, so they can't be touched. The **currently playing** track and
-**pinned** tracks are never auto-evicted. A managed file the OS reclaimed is
-detected on load — its stale metadata is pruned and playback falls back to
-streaming rather than opening a missing file. "Clear all" removes everything
-(pinned included); "Clear unpinned" keeps what you pinned. The maximum size is a
-`DownloadPreferences` value (also `shared_preferences`), clamped to a sane range.
-
-**Security (token handling).** The Jellyfin access token is **never** stored on
-`Track.uri`, in the `DownloadStore` metadata, in a cache file name, in a log, or
-in a user-facing error. A track's stored URI stays the token-free `jellyfin:<id>`;
-the authenticated **download** URL is minted only at fetch time inside
-`JellyfinTrackDownloader` (mirroring how the **stream** URL is minted at play
-time), and a transport failure is re-raised as a generic message so a
-`ClientException` carrying the tokenized URL can't escape. Cache file names are
-derived only from the non-secret track id, sanitized to filename-safe characters.
-The richer metadata the cache manager adds is likewise non-secret: the stored
-**source type is the bare URI scheme** (`jellyfin` / `file`), never the full URL,
-and the "not enough cache space" error carries no path, URL, or token.
-
-Deliberate gaps the next PRs will close:
-
-- **Track-level only.** Album- and playlist-level "download all" is intentionally
-  out of scope for this PR. The seam is ready — `requestDownload(Track)` plus the
-  `RemoteTrackDownloader` compose per-track — so a batch action is additive UI
-  over the existing policy, with no architectural change.
-- **No background download manager.** Downloads (and smart pre-cache) run inline;
-  there is no worker, no Android download/notification service, no resume of a
-  partial transfer, and no auto-flush of the queue when Wi-Fi returns (re-tap a
-  queued track to retry). Smart pre-cache runs as a foreground side effect of
-  playback, not a scheduled background job.
-- **Eviction is inline, not a background sweeper.** Space is freed only when a
-  new download needs it (and stale metadata only on load); there is no periodic
-  reconciliation against the directory's actual on-disk size, and a remote track
-  larger than the whole limit can't be cached at all.
-- **Connectivity is optimistic.** `OptimisticConnectivityService` always reports
-  Wi-Fi until `connectivity_plus` is wired in, so the mobile-data gate currently
-  blocks only when a test (or a future real detector) reports mobile/offline/
-  unknown — the seam and its tests are in place for when it does.
-- **No Drift table for downloads.** Persisting a small `CachedTrack` set is a
-  key/value job; a `downloads` table (with byte progress) graduates from the
-  `DownloadStore` seam when background/resumable downloads need it.
-
-### Jellyfin (self-hosted music) — setup & known limitations
-
-Linthra can connect to your own [Jellyfin](https://jellyfin.org) server,
-including one published over HTTPS through a **Cloudflare** domain or tunnel.
-
-> **Compatibility reference.** Supported use cases, exact endpoints, the tested
-> version floor, Cloudflare Tunnel vs. Zero Trust, troubleshooting, and how to
-> report an issue without leaking secrets are documented in
-> [docs/jellyfin-compatibility.md](docs/jellyfin-compatibility.md).
-
-**Setup.** Open **Settings → Jellyfin** and:
-
-1. **Server URL** — enter your server address, e.g. `https://music.example.com`.
-   A bare host gets `https://` automatically (the Cloudflare-proxied default);
-   a `http://host:8096` on your LAN works too, and a reverse-proxy subpath like
-   `https://example.com/jellyfin` is preserved.
-2. **Test connection** — checks the address is reachable and is really a
-   Jellyfin server (it reads the public `/System/Info/Public` endpoint, no
-   credentials needed) and shows the server name/version. The server version is
-   also classified for compatibility, and an older-than-tested server shows a
-   gentle "untested" note (it is never blocked).
-3. **Username + password → Sign in** — authenticates and stores the resulting
-   session. The password field has a show/hide toggle. Sign-in also records the
-   server name/version/product (reading `/System/Info/Public` if you didn't tap
-   Test first) so diagnostics show them after a restart.
-4. **Sync library** — once signed in, pulls your Jellyfin artists/albums/tracks
-   **and your playlists and liked/favourite tracks** into the local catalog so
-   they show up in Library, Playlists, and Favorites. Shows a spinner while it
-   runs and a friendly result line ("Synced 42 tracks, 3 playlists and 9
-   favorites from your Jellyfin library.") — with honest partial-failure notes
-   when only playlists or favourites couldn't load.
-5. **Copy Jellyfin diagnostics** — copies a short, **secret-free** report (app
-   version, connection state, server name/version/host-only, last error kind) to
-   the clipboard for bug reports. It never includes your password, token,
-   `Authorization` header, or any full authenticated URL.
-6. **Sign out & clear** — forgets the saved session and clears the settings.
-
-**Cloudflare notes.** A Cloudflare-proxied or Cloudflare Tunnel (`cloudflared`)
-Jellyfin is just a normal HTTPS endpoint, so it works without any special
-configuration — point the URL at your public domain. Two things to know:
-
-- If the domain returns a Cloudflare **error page** (HTML / a 5xx like 521/522)
-  or a challenge, Linthra reports a friendly "doesn't look like a Jellyfin
-  server" / "couldn't reach the server" message rather than a raw failure —
-  usually it means the tunnel is down or the domain isn't pointed at Jellyfin.
-- **Cloudflare Access / Zero Trust** (an extra auth layer *in front of*
-  Jellyfin) is **not** supported yet; Linthra speaks only to Jellyfin's own
-  auth. Use a hostname that reaches Jellyfin directly.
-
-**Security.** This integration is built so secrets don't leak:
-
-- **Passwords are never persisted.** The password is sent once to obtain a
-  token and then discarded; it's cleared from the form as soon as sign-in
-  succeeds and never enters app state.
-- **The token is encrypted at rest.** It's stored via `flutter_secure_storage`
-  (Android Keystore-backed), not in plaintext `shared_preferences`.
-- **Nothing logs the token or password.** `JellyfinSession.toString()` redacts
-  the token, and a track's cached URI is a token-free `jellyfin:<id>` — both the
-  authenticated streaming URL (at play time) and the download URL (at fetch time)
-  are minted only on demand, never stored.
-- **Offline downloads inherit the same handling.** A downloaded track's cache
-  file name is derived only from the non-secret track id; the token never lands
-  in the file name, the `DownloadStore` metadata, a log, or a download error.
-- **Diagnostics are secret-free by construction.** The "Copy Jellyfin
-  diagnostics" report (and the debug `PlaybackDiagnostics` log) have no field for
-  a password, token, `Authorization` header, or full authenticated URL; the
-  server address is reduced to its **host only**, and the persisted server
-  version/product are non-secret display values. Tests assert no token reaches
-  either sink.
-
-**What works now.** Configuring a server, testing the connection, signing in
-with friendly URL/connection/auth errors, persisting the session across
-restarts, **syncing the library**, and **streaming playback**. The **Sync
-library** action drives `JellyfinSyncController`, which reads the signed-in
-`JellyfinMusicSource` (via `jellyfinMusicSourceProvider`), fetches
-artists/albums/tracks, and upserts them into `MusicLibraryRepository` under the
-stable `jellyfin` source id — the same upsert path local scanning uses. The
-Library reloads automatically afterward, so synced tracks appear alongside local
-ones. The sync surfaces loading / success / error states and friendly messages
-for being **not signed in**, a **server it couldn't reach**, an
-**expired/invalid session** (prompting a fresh sign-in), and an **empty Jellyfin
-library** (which leaves any existing catalog untouched rather than wiping it).
-
-**Playlists & favourites sync by default.** The same Sync action — and app
-startup — also imports your Jellyfin **playlists** and adopts your **liked/
-favourite** tracks, so they appear on the Playlists and Favorites tabs without
-any extra step. Server playlists are imported as `jellyfin`-source playlists
-(name + membership mapped to your synced tracks; tracks not in your library are
-counted and shown as unavailable, never crashed), a server-side rename is picked
-up on the next sync, and a playlist deleted on the server is dropped locally.
-Liking a Jellyfin track in Linthra pushes the change to the server
-(optimistically, reconciled on the next sync); local-file favourites and
-local-only playlists always stay on-device. Sign-out clears this account's
-imported playlists and server favourites while keeping your local ones. Nothing
-here stores a token — full behaviour, limitations, troubleshooting, and security
-notes are in [docs/jellyfin-sync.md](docs/jellyfin-sync.md) and
-[docs/playlists-and-delete.md](docs/playlists-and-delete.md).
-
-**Streaming playback** routes through a `PlayableUriResolver` seam, so the
-playback controller opens whatever URI it's given rather than assuming a local
-file. A `JellyfinPlayableUriResolver` reads the live signed-in source, verifies
-the session (a tiny `GET /Users/Me` check), then asks the source to mint the
-authenticated **direct-play** stream URL — `/Audio/<id>/stream?static=true` —
-**at play time**. `static=true` serves the original file bytes (the reliable
-"direct streaming" path the engine can open), rather than a negotiated
-transcode/HLS variant ExoPlayer may reject; auth rides in the `api_key` **query**
-(not a header), because that is what the engine itself fetches with and query
-auth survives the redirects a stripped header would not. Before the URL reaches
-the engine the source **probes** it (a one-byte ranged GET, following any
-Cloudflare/Jellyfin redirects) and checks the status + content type, so a
-Cloudflare page, an expired token, or a non-audio response becomes a precise
-message instead of the engine's opaque "couldn't play". The player surfaces
-friendly errors — **not signed in**, **expired session**, **server
-unreachable**, **a web page instead of audio (Cloudflare/Jellyfin access)**,
-**not an audio stream**, a **track that isn't available** (a 404 from the stream
-endpoint), an **unsupported server response** (an unexpected status or shape),
-and a generic **couldn't stream** — branched on a typed error kind, not message
-text (the full mapping is tabulated in the compatibility doc). All Jellyfin URLs
-are built in one place (`JellyfinEndpoints`), so the stream, download, and probe
-paths can't drift apart. Local and `content://` file playback are untouched
-(they never enter the Jellyfin resolver), and a downloaded track still plays from
-its cached copy; a cache miss falls straight through to streaming. Debug builds
-emit a secret-free `PlaybackDiagnostics` line (source, resolver, HTTP status,
-content type, hashed item id) to make field failures diagnosable — never the
-token, password, full URL, or `Authorization` header.
-
-**Offline downloads** let a signed-in user mark individual Jellyfin tracks for
-offline use; the bytes are fetched from Jellyfin's `/Items/<id>/Download`
-endpoint and cached on disk, and playback then prefers the local copy. The full
-flow, storage, and token handling are covered in **Offline downloads & known
-limitations** above.
-
-**Token safety holds end to end.** A track's stored URI stays the token-free
-`jellyfin:<id>`; the authenticated stream/download URLs are built only on demand
-and are never stored on the track, written to the catalog, logged, shown in the
-UI, or placed in player state. `JellyfinSession.toString()` redacts the token,
-and both the playback error messages and the download path are asserted in tests
-to contain no token (including when a transport error would otherwise echo the
-tokenized URL).
-
-**Deliberate gaps the next PRs will close:**
-
-- **Track-level downloads only.** Album/playlist "download all" is deferred; the
-  per-track seam already composes for it (see offline-downloads section above).
-- **Single server only.** One session is stored; multi-server support comes
-  later.
-- **Direct play only (no transcoding fallback yet).** Streaming serves the
-  original file (`static=true`), which the engine decodes for the common
-  containers; a server-side transcode fallback for exotic formats is deferred.
-- **No two-way conflict resolution.** For a synced playlist the server is the
-  source of truth on refresh, and playlist **rename/reorder are local-only** (not
-  pushed); favourites reconcile to the server on the next sync. Lyrics,
-  favourites, **and playlists** now sync from Jellyfin — see **Now Playing
-  controls** above and [docs/jellyfin-sync.md](docs/jellyfin-sync.md).
-
-## Continuous integration
-
-Every pull request and every push to `main` runs a small Flutter workflow
-(`.github/workflows/ci.yml`). It needs to be green before a change merges.
-
-CI runs the checks below, and you can run the exact same ones locally before
-opening a PR:
-
-```bash
-flutter pub get                      # resolve dependencies
-dart format --set-exit-if-changed .  # code must already match `dart format`
-flutter analyze                      # static analysis + lints
-flutter test                         # widget/unit tests
-```
-
-CI pins **Flutter 3.27.x (stable)** for reproducible results; using a matching
-SDK locally avoids spurious `dart format` diffs from formatter changes in newer
-Dart releases. The automatic `ci.yml` workflow is **code-quality only**. Native
-builds and optional release signing live in **separate** workflows (**Android
-Debug APK**, and **Android Release Build** — manual for test builds, automatic
-on `v*` tags); nothing publishes to a store or F-Droid. See
-[Building release artifacts](#building-release-artifacts-android) and
-[docs/release-process.md](./docs/release-process.md).
-
-### Generating Drift files in CI
-
-Drift/SQLite persistence relies on `build_runner` code generation, which can be
-unreliable to run locally. The **Generate Drift files** workflow
-(`.github/workflows/generate-drift.yml`) runs that generation in CI and commits
-the result back to the chosen branch. It is **manual only** (`workflow_dispatch`)
-— it never runs on a normal push or PR, and it neither builds nor publishes
-anything. It uses the same Flutter version as the main CI workflow, runs
-`flutter pub get`, `dart run build_runner build --delete-conflicting-outputs`,
-and `dart format .`, then commits **only if** something actually changed.
-
-To regenerate Drift files on a PR:
-
-1. Open the Drift PR.
-2. Go to the **Actions** tab.
-3. Select the **Generate Drift files** workflow.
-4. Click **Run workflow** and choose the PR branch.
-5. Wait for the bot to push the generated commit (`Generate Drift files`).
-6. Let normal CI run against the updated branch.
-
-The workflow pushes to whichever branch you launch it on, so run it on the PR
-branch rather than `main`.
-
-## Roadmap (MVP)
-
-1. Local music library scanning
-2. Artist / album / track views
-3. Playlist creation & editing
-4. Audio playback
-5. Queue management
-6. Search
-7. Album artwork
-8. Explicit offline downloads
-9. "Allow mobile data for downloads" option (Wi-Fi only by default)
-10. Settings
-
-Later: Jellyfin (landed — settings, auth, encrypted session, a library source,
-Library sync, streaming playback, explicit per-track offline downloads,
-smart pre-cache of upcoming tracks, server-synced favourites, and lyrics;
-album/playlist "download all" and a background download manager next), Android
-Auto (foundation landed — browsable Library/Queue; album/artist grouping and
-search next), Chromecast/casting (real device discovery + connect/disconnect +
-Jellyfin-stream handoff landed on Android/iOS via a pure-Dart Cast protocol;
-local-file casting and receiver transport controls next), WebDAV, NAS, local-file lyrics
-(`.lrc`/tags), ReplayGain, MPRIS, smart playlists, and more.
-
-## F-Droid metadata (work in progress)
-
-Linthra is **not** on F-Droid yet, and no submission has been made. As
-groundwork for a possible future submission, the repository now carries
-F-Droid / Fastlane-style store metadata under
-`fastlane/metadata/android/en-US/`:
-
-- `title.txt` — app name.
-- `short_description.txt` — one-line summary (kept under F-Droid's 80-char
-  limit).
-- `full_description.txt` — long description that deliberately separates what
-  works today from what is still planned.
-- `changelogs/1.txt` — release notes for `versionCode` 1 (the current
-  `0.1.0-alpha.1+1`), shown by F-Droid if/when the app is listed.
-
-**Branding (real, committed).** Linthra has a genuine app icon — a small
-equalizer of four rounded bars carrying a single violet→orange gradient (the
-brand's two colours) on a dark, premium squircle — generated deterministically
-from one source design (`tool/branding/linthra_icon.svg` via
-`tool/branding/generate_icons.py`, standard library only). That same mark backs:
-
-- the Android launcher icons: regenerated legacy `mipmap-*/ic_launcher.png` plus
-  an **adaptive icon** (`mipmap-anydpi-v26/ic_launcher.xml`) with the gradient
-  equalizer foreground over a dark vector-gradient background — no longer the
-  default Flutter icon;
-- the listing graphics: real `images/icon.png` (512×512) and
-  `images/featureGraphic.png` (1024×500);
-- an in-app `LinthraLogoMark` (`lib/shared/widgets/`), the Dart twin of the same
-  mark, shown in the Settings about footer so the identity reads from the home
-  screen into the app.
-
-The palette is centralized in `lib/app/colors.dart`: a vivid **violet** carries
-the brand (logo, primary actions, structure) and a warm **orange** accent is
-held in reserve for *live* states — the play button, active/selected controls,
-and playback progress — over a dark, premium surface ramp.
-
-**Still missing: screenshots.** No real screenshots have been captured from a
-running build, so none are committed — `images/` carries them as a documented
-gap only (`NEEDED-ASSETS.txt`). Placeholder/mock screenshots are intentionally
-avoided so the listing never misrepresents the app. The full asset checklist,
-exact sizes, and screenshot-capture steps are in
-[docs/listing-assets.md](./docs/listing-assets.md).
-
-The wording describes only shipped behaviour (folder selection, scanning, local
-and Jellyfin playback, background playback, Android Auto browsing, and explicit
-offline downloads) as done; tag parsing, artwork, playlists, and batch
-downloads are described as planned. There are no claims of F-Droid availability
-and no marketing language that overpromises.
-
-### Release & F-Droid documentation
-
-Planning/readiness docs (none of these publish or submit anything):
-
-- [docs/fdroid-readiness.md](./docs/fdroid-readiness.md) — full F-Droid
-  submission checklist: app identity, build requirements, dependency &
-  anti-feature review, release/tagging plan, and remaining blockers.
-- [docs/fdroid-build-recipe.md](./docs/fdroid-build-recipe.md) — F-Droid build
-  recipe planning: expected metadata fields, build-source/toolchain
-  expectations, reproducible-build notes, and a draft recipe snippet.
-- [docs/dependency-license-audit.md](./docs/dependency-license-audit.md) —
-  per-dependency licenses, native/bundled-component review, and the
-  network/anti-feature assessment.
-- [docs/release-process.md](./docs/release-process.md) — canonical versioning,
-  tagging, and (manual) GitHub-Release process.
-- [docs/release-signing.md](./docs/release-signing.md) — how release builds are
-  signed, required CI secrets, and keystore generation/rotation.
-- [docs/listing-assets.md](./docs/listing-assets.md) — store icon, feature
-  graphic, and screenshot checklist with capture instructions.
-
-> **Status:** Linthra is **not** on F-Droid and no submission has been made. The
-> remaining blockers before a submission would be possible are listed in
-> [docs/fdroid-readiness.md §8](./docs/fdroid-readiness.md#8-remaining-blockers-before-submission).
-
-## Google Play closed testing (work in progress)
-
-Linthra is **not** on Google Play, and no submission has been made. As
-groundwork for a first **internal / closed testing** (alpha) submission — **not**
-a production launch — the repository carries Play-oriented planning docs. None of
-them publish or submit anything.
-
-- [docs/play-store-readiness.md](./docs/play-store-readiness.md) — Play
-  readiness checklist: identity, AAB vs APK, Play App Signing, testing tracks,
-  required assets, blockers, the recommended submission path, versioning, and a
-  permissions review.
-- [docs/privacy-policy.md](./docs/privacy-policy.md) — privacy policy **draft**
-  (needs review and a public URL before submission).
-- [docs/google-play-listing.md](./docs/google-play-listing.md) — store listing
-  **draft**: short/full description, features, what-works-today, alpha
-  limitations, keywords, and a screenshot checklist.
-- [docs/google-play-data-safety.md](./docs/google-play-data-safety.md) — Data
-  Safety form prep (no ads, no analytics, no data sold; on-device storage and
-  the user's own Jellyfin server).
-
-> **Status:** alpha only. The blockers before closed testing — and the much
-> longer list before production — are in
-> [docs/play-store-readiness.md §9](./docs/play-store-readiness.md#9-known-blockers-before-production).
+Linux desktop, richer Android Auto and Cast.
+
+Honest gaps (no local tag parsing yet, single Jellyfin server, direct-play only,
+partial playlist sync, optimistic connectivity) are documented per feature.
+
+## 📚 Documentation
+
+| Topic | Doc |
+| --- | --- |
+| Architecture & extension points | [docs/architecture.md](./docs/architecture.md) |
+| Development, build & CI | [docs/development.md](./docs/development.md) |
+| Library browsing & search | [docs/library.md](./docs/library.md) |
+| Music providers (overview) | [docs/providers.md](./docs/providers.md) |
+| Jellyfin setup | [docs/jellyfin.md](./docs/jellyfin.md) · [compatibility](./docs/jellyfin-compatibility.md) · [sync](./docs/jellyfin-sync.md) |
+| Streaming, buffering & recovery | [docs/streaming.md](./docs/streaming.md) |
+| Offline cache & downloads | [docs/offline-cache.md](./docs/offline-cache.md) |
+| Cast / Chromecast | [docs/cast.md](./docs/cast.md) |
+| Android Auto | [docs/android-auto.md](./docs/android-auto.md) |
+| Playlists & safe removal | [docs/playlists-and-delete.md](./docs/playlists-and-delete.md) |
+| Manual QA checklist | [docs/manual-test-checklist.md](./docs/manual-test-checklist.md) |
+| Release process & signing | [docs/release-process.md](./docs/release-process.md) · [signing](./docs/release-signing.md) |
+| F-Droid readiness | [docs/fdroid-readiness.md](./docs/fdroid-readiness.md) |
+| Google Play readiness | [docs/play-store-readiness.md](./docs/play-store-readiness.md) |
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,156 @@
+# Architecture
+
+Linthra is a Flutter app, layered and feature-first. The golden rule:
+**features depend on interfaces in `core/`, never on concrete services or
+storage.** That seam is what makes the Jellyfin / Subsonic / WebDAV roadmap
+possible without rewriting the UI.
+
+## Philosophy
+
+- **Local-first & offline-first** — the UI always reads from a local cache.
+- **Privacy-focused** — no telemetry, no forced sync.
+- **User-controlled downloads** — never automatic; Wi-Fi only by default, with
+  an explicit "Allow mobile data" opt-in.
+- **No vendor lock-in** — sources (local, Jellyfin, Subsonic, WebDAV, NAS) sit
+  behind a single interface.
+- **Contributor-friendly** — small focused files, explicit naming, clean layers.
+
+## Target platforms
+
+Android first, Linux desktop later, and possibly Windows — all from one Flutter
+codebase.
+
+## Tech stack
+
+| Concern          | Choice                                            |
+| ---------------- | ------------------------------------------------- |
+| Framework        | Flutter                                           |
+| State management | Riverpod                                          |
+| Navigation       | go_router (`StatefulShellRoute` for bottom nav)   |
+| Local metadata   | SQLite via `drift`                                |
+| Playback         | `just_audio` + `audio_service` (behind interface) |
+| Remote sources   | `http` (behind `JellyfinClient` / Subsonic client)|
+| Secrets at rest  | `flutter_secure_storage` (session tokens)         |
+
+Dependencies are added when a feature needs them rather than up front, so
+`pubspec.yaml` stays honest about what the code actually uses.
+
+## Layout
+
+```
+lib/
+  main.dart                 entry point; hosts the Riverpod ProviderScope
+  app/                      app-level wiring (router, theme, design tokens)
+  core/                     framework-free domain layer
+    models/                 immutable entities: Track, Album, Artist,
+                            Playlist, PlaybackState, …
+    repositories/           persistence contracts: MusicLibraryRepository,
+                            PlaylistRepository, DownloadRepository, …
+    services/               device-facing contracts: PlaybackController,
+                            MusicSource, ConnectivityService, CastService, …
+    sources/                concrete MusicSource implementations:
+                            local/, jellyfin/, subsonic/
+  data/                     concrete repository implementations + storage
+    database/               LinthraDatabase (Drift) + tables/
+    mappers/                domain <-> Drift row conversion
+    repositories/           persistent + in-memory implementations
+  features/                 one folder per screen/feature
+    library/ player/ playlists/ downloads/ settings/ favorites/ shell/
+  shared/
+    widgets/                reusable UI (e.g. EmptyState, LinthraLogoMark)
+```
+
+## Key extension points
+
+- **`MusicSource`** (`core/services/music_source.dart`) — a media backend.
+  `LocalMusicSource` shipped first; `JellyfinMusicSource` and
+  `SubsonicMusicSource` (Navidrome and other Subsonic-compatible servers) now
+  implement the same contract over their own HTTP clients, each with a separate
+  authenticator, encrypted session store, and library fetcher. A small
+  **capability model** (`core/sources/music_provider.dart`) declares what each
+  provider supports (`canStream` / `canCache` / `canFavorite` / `canLyrics` /
+  `canCast`) so the UI offers only the actions that work. `WebDavMusicSource`
+  slots in the same way later; see [providers.md](providers.md).
+- **`MusicLibraryRepository`** (`core/repositories/`) — the local SQLite cache
+  the UI reads from. Sources *sync into* it; the UI never talks to a source
+  directly. This is what keeps the app fast and fully offline.
+- **`PlaybackController`** (`core/services/playback_controller.dart`) — playback
+  *and* the up-next queue, fully decoupled from `just_audio`. It owns a pure
+  `PlaybackQueue` model (current track + upcoming tracks) and exposes
+  `playTracks`, `playNext`, `skipToNext`, `clearQueue`, and the shuffle/repeat
+  modes. `LinthraAudioHandler` wraps it for background audio / the platform
+  media session (notification, lock screen, Android Auto); MPRIS can attach the
+  same way later. The UI depends only on this interface, never on the engine.
+- **`PlayableUriResolver`** (`core/services/playable_uri_resolver.dart`) — turns
+  a `Track` into a URI the engine can open. A routing resolver composes
+  per-source resolvers (Jellyfin / Subsonic / local) behind an offline-first
+  wrapper that prefers a downloaded copy. Remote URL minting — and the secrets it
+  weaves in — lives here, never in the audio layer. See
+  [streaming.md](streaming.md).
+- **`CastService`** (`core/services/cast/cast_service.dart`) — the seam for
+  remote playback handoff (Chromecast). The UI renders a `CastState` and drives
+  discovery/connection through this interface, never a cast SDK directly. See
+  [cast.md](cast.md).
+- **`DownloadRepository`** (`core/repositories/`) — enforces the user-initiated,
+  mobile-data-respecting download policy in one place. See
+  [offline-cache.md](offline-cache.md).
+
+## The single playback seam (local + cast)
+
+The now-playing screen, mini-player, and lyrics read from **one**
+`ActivePlaybackController`, which presents a single unified `PlaybackState`:
+
+- The queue (current track, up-next, shuffle, repeat) is always owned by the
+  on-device `LocalPlaybackController` (`JustAudioPlaybackController`), regardless
+  of which output is making sound.
+- While casting, the receiver's position / play-state / duration are folded onto
+  that queue, so the UI follows the *device* rather than the silenced engine.
+- Transport commands (play/pause/seek) route to whichever output is active;
+  queue commands (skip/playTracks) always go to the local controller, whose track
+  changes the cast service mirrors onto the receiver.
+
+This is the seam that prevents Cast desync, and it is the reason the engine can
+be swapped or wrapped (background playback, MPRIS) without touching feature code.
+
+## Now Playing controls
+
+Every transport action is driven through `PlaybackController` / `PlaybackState`;
+the widgets hold no playback logic of their own.
+
+- **Shuffle** is a playback *mode*: turning it on reorders the queue with the
+  playing track kept at the front and remembers the original order. The reorder
+  is a pure `PlaybackQueue.shuffled()` / `unshuffled()` transform.
+- **Repeat** cycles off → all → one. When a track finishes the controller
+  consults `repeatMode`: *off* stops at the end, *all* wraps, and *one* replays
+  the current track without re-resolving its URL.
+- **Favorite** toggles through a `FavoritesRepository` (synced to Jellyfin for
+  remote tracks, on-device for local ones), optimistically and token-free.
+- **Lyrics** are fetched behind a `LyricsService` seam (Jellyfin today; a local
+  `.lrc`/tag reader can slot in later).
+- **Cast** drives real Chromecast through `CastService`; see [cast.md](cast.md).
+
+## Android folder selection (SAF)
+
+On modern Android the folder chooser returns a `content://…/tree/…` URI under the
+Storage Access Framework (SAF) rather than a filesystem path. `LocalMusicSource`
+handles a selection in two ways, in order:
+
+1. **Content-resolver traversal (preferred).** A `SafDocumentLister` walks the
+   picked tree through Android's content resolver (`DocumentsContract`) in native
+   code and returns the `content://` document URIs of the audio files it finds.
+   This is the scoped-storage-correct path: it uses only the access the system
+   granted, needs **no** storage permission, and never touches
+   `MANAGE_EXTERNAL_STORAGE`.
+2. **Filesystem-path fallback.** When native SAF traversal isn't available
+   (desktop, or the channel isn't registered), the scan maps an external-storage
+   tree URI to a real path, probes it for readability, and either walks it or
+   raises a clear `FolderScanException` when scoped storage blocks the read.
+
+How a selection is addressed (path vs `content://`) is decided once by
+`FolderLocation`; nothing downstream re-parses the string, SAF traversal stays
+behind the `SafDocumentLister` seam, and the UI never sees a platform channel.
+
+> **No broad storage permission is requested.** `MANAGE_EXTERNAL_STORAGE` ("all
+> files access") is intentionally *not* used — it is the opposite of the
+> scoped-storage approach this project prefers. A narrow `READ_MEDIA_AUDIO` flow
+> (only relevant to the filesystem fallback) is a deliberate later step.

--- a/docs/cast.md
+++ b/docs/cast.md
@@ -1,0 +1,83 @@
+# Cast / Chromecast
+
+Linthra can hand a Jellyfin or Navidrome/Subsonic stream off to a **Chromecast**
+device (a Cast-enabled speaker, TV, or display) on your network. It uses a
+pure-Dart implementation of the Google Cast v2 protocol — **no Google Play
+Services and no proprietary Cast SDK** — so casting works the same on a sideloaded
+or F-Droid-style build.
+
+## Using it
+
+1. Be on the **same Wi-Fi network** as the Cast device.
+2. Start playing a **streamed** track (Jellyfin or Subsonic).
+3. Tap the **cast icon** in the Now Playing header to open the device sheet.
+4. Pick a device. Linthra resolves the stream at cast time, plays it on the
+   receiver, and pauses local audio so you don't hear it twice.
+5. While connected, the sheet shows a **Cast volume** slider and mute that drive
+   the *device's* own volume. Disconnecting (or the receiver dropping) resumes
+   local playback, **paused**, at the receiver's last position — so it never
+   surprise-starts the phone.
+
+## Good to know
+
+- **On-device (local) files can't be cast** — a receiver can't reach a `file://`
+  path on your phone, so only network streams hand off. The sheet says so plainly
+  rather than failing silently.
+- Discovery uses mDNS, so a device only appears if it's reachable on your LAN
+  (some guest/isolated networks block this).
+- A device that reports a fixed volume shows an honest disabled state, and a
+  failed volume command surfaces a calm notice **without ever interrupting
+  playback**.
+
+## How it works (architecture)
+
+The UI renders a `CastState` and drives discovery/connection through the
+`CastService` interface, never a cast SDK directly — mirroring how the audio
+engine is hidden behind `PlaybackController`.
+
+- Android and iOS get the real `DefaultCastService`, which owns cast state and
+  the playback handoff: it resolves the current track's stream URL **at cast
+  time**, loads it on the receiver, pauses local audio, and resumes on
+  disconnect. It delegates the wire protocol to a thin `ChromecastCastTransport`
+  over the pure-Dart `cast` package (Cast v2 over a TLS socket; `bonsoir` for
+  discovery). Other platforms keep `UnavailableCastService`, so the button stays
+  honest.
+- The network-touching transport is isolated, so all of casting's decision-making
+  is unit-tested behind a fake `CastTransport`; the only code that opens a socket
+  is verified by analysis and on-device testing.
+- The single `ActivePlaybackController` keeps one source of truth: while casting,
+  the now-playing screen / mini-player / lyrics follow the receiver's
+  position/play-state, while the queue stays owned locally and track changes are
+  mirrored onto the receiver. This is what fixes Cast desync. See
+  [architecture.md](architecture.md#the-single-playback-seam-local--cast).
+
+## Cast volume
+
+While connected, the Cast sheet shows a clearly labelled **Cast volume** slider
+plus mute, driving the *device's* own volume (not the phone's media volume) and
+following the receiver's reported level live. It is all behind `CastService`
+(`setVolume` / `volumeUp` / `volumeDown` / `setMuted`), with `CastState` exposing
+`volume` / `muted` / `supportsVolumeControl`.
+
+## Security / token notes
+
+The handoff resolves the current track's stream URL **only at cast time**
+(Jellyfin's or Subsonic's authenticated URL, the credential woven in on demand)
+and it is **never logged or persisted**. A track's stored reference stays the
+token-free `jellyfin:<id>` / `subsonic:<id>`; the receiver is told to fetch a
+freshly minted URL that never lands in `Track`, the catalog, a log, or app state.
+
+## Resilience while casting
+
+- A dropped receiver returns playback to the device **paused** at the last
+  position, with a friendly Cast/session notice — it never restarts unexpectedly.
+- Local engine errors are ignored while casting (the engine is suspended), so a
+  cast session never falls back to duplicate local playback. See
+  [streaming.md](streaming.md#cast).
+
+## Known limitations
+
+- **On-device files can't be cast** (no receiver-reachable URL).
+- Receiver transport controls (volume aside) and local-file casting are
+  follow-ups.
+- mDNS discovery depends on a LAN that allows it.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,159 @@
+# Development
+
+Linthra is a standard Flutter app. The **Android** platform scaffold (`android/`)
+is committed, so no `flutter create` step is needed. Other native platform
+folders (`linux/`, …) are generated locally when you need them, so the repo stays
+focused on the cross-platform Dart code.
+
+## Getting started
+
+```bash
+# 1. Fetch dependencies
+flutter pub get
+
+# 2. Run on a connected Android device or emulator
+flutter run
+
+# (Optional) generate scaffolding for another platform, e.g. Linux desktop:
+flutter create --platforms=linux .
+```
+
+> `flutter create` may regenerate template files such as `main.dart`. If
+> prompted, keep the existing versions in this repo.
+
+## Building a debug APK (Android)
+
+You need a working Android SDK (`ANDROID_HOME` / `ANDROID_SDK_ROOT` set) and a
+JDK that matches the bundled Gradle wrapper — **JDK 17** is the safe choice for
+the Gradle 8.3 / Android Gradle Plugin 8.1 the scaffold ships with. Run
+`flutter doctor` to confirm your toolchain.
+
+```bash
+flutter pub get
+
+# Build an unsigned debug APK
+flutter build apk --debug
+# → build/app/outputs/flutter-apk/app-debug.apk
+
+# Or build and install straight onto a connected device
+flutter run --debug          # hot-reloadable dev session
+flutter install              # installs the last debug build
+```
+
+The debug APK is unsigned and meant for local testing only.
+
+### Downloading a debug APK from CI
+
+If you don't have a local Flutter/Android toolchain, the **Android Debug APK**
+workflow (`.github/workflows/android-debug-apk.yml`) builds the same
+`flutter build apk --debug` output on GitHub and attaches it as a downloadable
+artifact (`linthra-debug-apk`, containing `app-debug.apk`).
+
+- **Run it:** repo **Actions** tab → **Android Debug APK** → **Run workflow**
+  (`workflow_dispatch`). It also runs automatically on pull requests.
+- **Install:** download the artifact (GitHub serves it as a `.zip`; unzip to get
+  `app-debug.apk`), then copy it to a device and open it (allow "install from
+  unknown sources"), or `adb install -r app-debug.apk`.
+
+This artifact is an **unsigned debug build for testing only** — not signed for
+release, not published to any store or F-Droid.
+
+## Building release artifacts (Android)
+
+The **Android Release Build** workflow
+(`.github/workflows/android-release-build.yml`) builds the Android **release**
+artifacts. It runs **manually** for test builds and **automatically on version
+tags** (`v*`). It never publishes to a store or F-Droid and never writes
+production release notes.
+
+```bash
+flutter pub get
+flutter build apk --release        # → build/app/outputs/flutter-apk/app-release.apk
+flutter build appbundle --release  # → build/app/outputs/bundle/release/app-release.aab
+```
+
+Artifacts are named with both the version (tag) and the signing label, so a
+debug-signed preview can never be mistaken for a production release
+(e.g. `linthra-v0.1.0-alpha.1-debug-signed.apk`). Pre-release tags
+(`alpha`/`beta`/`rc`) attach to a GitHub **pre-release** (created if absent);
+stable tags **require release signing** and only attach to a Release you created
+manually. Full versioning/tagging flow is in
+[release-process.md](release-process.md).
+
+### Signing status
+
+Release signing is **wired up but not yet provisioned**. `android/app/build.gradle`
+resolves a release signing config from environment variables (CI) or a
+git-ignored `android/key.properties` (local). Only if complete signing material
+is present does it sign with the release key; otherwise it falls back to the
+**debug** key so `flutter run --release` still works. **No signing keys or
+secrets are committed.** Required secrets, keystore generation/rotation, and how
+this relates to F-Droid (which signs its own builds) are in
+[release-signing.md](release-signing.md).
+
+## Continuous integration
+
+Every pull request and every push to `main` runs a small Flutter workflow
+(`.github/workflows/ci.yml`). Run the exact same checks locally before opening a
+PR:
+
+```bash
+flutter pub get                      # resolve dependencies
+dart format --set-exit-if-changed .  # code must already match `dart format`
+flutter analyze                      # static analysis + lints
+flutter test                         # widget/unit tests
+```
+
+CI pins **Flutter 3.27.x (stable)** for reproducible results; using a matching
+SDK locally avoids spurious `dart format` diffs from formatter changes in newer
+Dart releases. The automatic `ci.yml` workflow is **code-quality only**; native
+builds and optional release signing live in separate workflows.
+
+### Generating Drift files in CI
+
+Drift/SQLite persistence relies on `build_runner` code generation, which can be
+unreliable to run locally. The **Generate Drift files** workflow
+(`.github/workflows/generate-drift.yml`) runs that generation in CI and commits
+the result back to the chosen branch. It is **manual only**
+(`workflow_dispatch`). Run it on your **PR branch** (not `main`): Actions →
+**Generate Drift files** → **Run workflow** → choose the branch, then let the bot
+push the generated commit before normal CI runs.
+
+## Android identity & permissions
+
+The app ships with a stable application ID **`io.github.thezupzup.linthra`** (also
+the Kotlin/Gradle `namespace`) and the display name **Linthra**. The production
+manifest declares only:
+
+- **`FOREGROUND_SERVICE`** / **`FOREGROUND_SERVICE_MEDIA_PLAYBACK`** — so
+  `audio_service` can keep playing while backgrounded (Android 14+ requires the
+  typed `mediaPlayback` grant).
+- **`POST_NOTIFICATIONS`** — required on Android 13+ for the media notification;
+  a *runtime* permission requested once on first launch.
+- **`INTERNET`** — to reach a self-hosted Jellyfin / Subsonic server.
+
+**No storage permission is requested** — folder access uses the Storage Access
+Framework grant the user picks (see [architecture.md](architecture.md#android-folder-selection-saf)).
+
+### Native media-session setup (applied)
+
+The committed scaffold wires `audio_service` so the media session runs as a
+foreground service and is visible to Android Auto: the manifest declares the
+`com.ryanheise.audioservice.AudioService` playback service (with the
+`MediaBrowserService` action and `mediaPlayback` foreground type), the
+`MediaButtonReceiver`, and the `com.google.android.gms.car.application` Android
+Auto media-app meta-data; `MainActivity` extends `AudioServiceActivity`. The
+notification channel id/name are set in `connectMediaSession` (`com.linthra.audio`
+/ "Linthra playback"). See [android-auto.md](android-auto.md) for the browse tree
+and testing.
+
+## Manual smoke test on a real Android phone
+
+After installing the debug APK on a physical device (most useful on **Android
+13+**, where the runtime notification permission applies), walk the
+[manual QA checklist](manual-test-checklist.md). It covers the paths that only
+behave correctly on real hardware: first-launch notification prompt, folder
+pick & scan, local playback, background playback & lock-screen controls, Jellyfin
+connect/sync/stream, friendly playback errors, offline downloads, the mobile-data
+gate, Cast, and Android Auto — plus a security spot-check that no token ever
+appears on screen.

--- a/docs/jellyfin.md
+++ b/docs/jellyfin.md
@@ -1,0 +1,93 @@
+# Jellyfin (self-hosted music)
+
+Linthra can connect to your own [Jellyfin](https://jellyfin.org) server,
+including one published over HTTPS through a **Cloudflare** domain or tunnel. This
+page is the setup overview; deeper references live in
+[jellyfin-compatibility.md](jellyfin-compatibility.md) (endpoints, version floor,
+Cloudflare, troubleshooting) and [jellyfin-sync.md](jellyfin-sync.md) (playlists
+& favourites sync).
+
+## Setup
+
+Open **Settings → Jellyfin** and:
+
+1. **Server URL** — enter your address, e.g. `https://music.example.com`. A bare
+   host gets `https://` automatically; a LAN `http://host:8096` and a
+   reverse-proxy subpath like `https://example.com/jellyfin` also work.
+2. **Test connection** — confirms the address is reachable and really is a
+   Jellyfin server (reads the public `/System/Info/Public` endpoint, no
+   credentials) and shows its name/version. An older-than-tested server shows a
+   gentle "untested" note; it is never blocked.
+3. **Username + password → Sign in** — authenticates and stores the resulting
+   session encrypted on-device. Your **password is never saved**.
+4. **Sync library** — pulls your artists/albums/tracks **and your playlists and
+   liked/favourite tracks** into the local catalog so they appear in Library,
+   Playlists, and Favorites.
+5. Tap a synced track to **stream** it, or use the download control to keep it
+   **offline** (see [offline-cache.md](offline-cache.md)).
+6. **Copy Jellyfin diagnostics** — a short, **secret-free** report for bug
+   reports (app version, connection state, server name/version/host-only, last
+   error kind). It never includes a password, token, `Authorization` header, or
+   full authenticated URL.
+7. **Sign out & clear** — forgets the saved session and clears the settings.
+
+## Cloudflare
+
+A Cloudflare-proxied or Cloudflare Tunnel (`cloudflared`) Jellyfin is just a
+normal HTTPS endpoint — point the URL at your public domain. Two things to know:
+
+- If the domain returns a Cloudflare **error page** (HTML / a 5xx like 521/522)
+  or a challenge, Linthra reports a friendly "doesn't look like a Jellyfin
+  server" / "couldn't reach the server" message rather than a raw failure.
+- **Cloudflare Access / Zero Trust** (an extra auth layer *in front of* Jellyfin)
+  is **not** supported yet; Linthra speaks only to Jellyfin's own auth. Use a
+  hostname that reaches Jellyfin directly.
+
+## Streaming playback
+
+Streaming routes through a `PlayableUriResolver` seam, so the controller opens
+whatever URI it's given rather than assuming a local file. A
+`JellyfinPlayableUriResolver` reads the live signed-in source, verifies the
+session (a tiny `GET /Users/Me` check), then asks the source to mint the
+authenticated **direct-play** stream URL — `/Audio/<id>/stream?static=true` — **at
+play time**. `static=true` serves the original file bytes (the reliable "direct
+streaming" path the engine can open) rather than a negotiated transcode/HLS
+variant; auth rides in the `api_key` **query** (not a header), because that is
+what the engine itself fetches with and query auth survives redirects.
+
+Before the URL reaches the engine the source **probes** it (a one-byte ranged GET,
+following any Cloudflare/Jellyfin redirects) and checks the status + content type,
+so a Cloudflare page, an expired token, or a non-audio response becomes a precise
+message instead of the engine's opaque "couldn't play". The player surfaces
+friendly errors — **not signed in**, **expired session**, **server unreachable**,
+**a web page instead of audio**, **not an audio stream**, **track not available**,
+**unsupported response**, and a generic **couldn't stream** — branched on a typed
+error kind, not message text. Buffering, preload, and interruption recovery are in
+[streaming.md](streaming.md).
+
+## Security (token handling)
+
+This integration is built so secrets don't leak:
+
+- **Passwords are never persisted.** The password is sent once to obtain a token,
+  then discarded; it never enters app state.
+- **The token is encrypted at rest** via `flutter_secure_storage` (Android
+  Keystore-backed), not plaintext `shared_preferences`.
+- **Nothing logs the token or password.** `JellyfinSession.toString()` redacts
+  the token; a track's stored URI is a token-free `jellyfin:<id>`. The
+  authenticated stream URL (play time) and download URL (fetch time) are minted
+  only on demand, never stored, never logged, never shown in the UI.
+- **Offline downloads inherit the same handling** — a cache file name is derived
+  only from the non-secret track id; the token never lands in the file name, the
+  download-store metadata, a log, or an error.
+- **Diagnostics are secret-free by construction** — the server address is reduced
+  to its **host only**, and tests assert no token reaches either sink.
+
+## Known limitations
+
+- **Track-level downloads only** — album/playlist "download all" is deferred.
+- **Single server only** — one session at a time; no multi-server support.
+- **Direct play only** — no server-side transcoding fallback for exotic formats.
+- **No two-way conflict resolution** — for a synced playlist the server is the
+  source of truth on refresh; playlist rename/reorder are local-only. See
+  [jellyfin-sync.md](jellyfin-sync.md).

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -41,6 +41,89 @@ engine's opaque "couldn't play". The player distinguishes:
 
 These are branched on a typed error *kind*, not message text.
 
+## Buffering & resilience
+
+The engine is configured to buffer generously for remote streams so a brief
+network hiccup is absorbed instead of stalling playback:
+
+- a **larger look-ahead buffer** (up to ~2 minutes) so playback keeps going
+  through a short drop;
+- a healthy **minimum to resume on** after a stall (so it doesn't re-stall
+  immediately);
+- a **quick initial start** so the first frame isn't delayed.
+
+> **Limitation (documented honestly):** `just_audio` exposes ExoPlayer's
+> high-level `LoadControl` (buffer *durations*), not a lower-level per-request
+> byte-size knob. So beyond tuning those durations, resilience also comes from
+> the **retry/recovery** and **preload** paths below.
+
+## Preloading the next track
+
+While a remote track plays, Linthra warms the **immediate next** remote track's
+stream URL ahead of time, so a skip — or the natural roll into the next track —
+starts faster instead of re-running the session check + URL probe at the change.
+
+- With shuffle **off** it warms the next track in queue order; with shuffle
+  **on**, the next track in the shuffled order (the queue is kept in effective
+  play order, so this needs no special-casing).
+- Under **repeat-one** it warms nothing — the current track loops, so an
+  upcoming track won't play soon.
+- It is **best-effort and never blocks** the current track; a failed warm just
+  means that track resolves normally when reached.
+
+**This is not the offline cache.** Preloading only holds a **short-lived,
+in-memory** resolved URL that is **consumed on first use**. It never writes bytes
+to disk, never marks a track as downloaded, and never fills the offline cache —
+that is the separate, explicit job of downloads and smart pre-cache (see
+[offline-cache.md](offline-cache.md)). Because the warmed URL is consumed on use,
+a retry after a failed load always re-resolves a **fresh** URL rather than
+replaying a possibly-stale one.
+
+## Recovering from interruptions
+
+If a stream fails **mid-playback**, Linthra recovers rather than dying silently:
+
+- A **transient network drop** gets **one** bounded retry that re-resolves and
+  reloads at the **preserved position** (no jump to the start, no duplicate
+  playback). The re-resolution re-checks the session/server, so a real outage or
+  expiry then surfaces a precise message instead of looping.
+- An **expired session** shows a friendly "sign in again" message and is **not**
+  retried (no infinite loop).
+- A **server-unreachable** failure shows a friendly "couldn't reach your server"
+  message.
+- An **unsupported format** is reported plainly rather than retried.
+- Reaching `playing` again resets the budget, so a *later* independent drop gets
+  its own single retry.
+
+The engine's raw error can carry the tokenized stream URL; it is **only
+classified, never echoed, logged, or surfaced** — the message shown is always a
+fixed, secret-free string.
+
+## Streaming over mobile data (LTE)
+
+- **Streaming works over LTE by default** when you've chosen to stream — normal
+  playback is never treated as a forbidden download/cache action.
+- The **Wi-Fi-only gate controls downloads and the offline cache**, not
+  streaming playback (see [offline-cache.md](offline-cache.md)).
+- **Preloading is conservative on data**: it only warms a single upcoming URL
+  (a tiny request, the same one-byte probe play would do anyway) — it never
+  downloads track bytes ahead of time.
+
+## Playback states
+
+The player exposes distinct states so the UI is honest and never looks frozen:
+
+| State | Meaning | UI |
+| --- | --- | --- |
+| `loading` | preparing (resolving + opening) | spinner |
+| `buffering` | mid-stream re-buffer (waiting on data) | calm "Buffering…" hint; mini-player spinner; transport stays usable |
+| `playing` / `paused` | steady playback | play/pause |
+| `error` | a specific, friendly failure | the friendly message |
+
+`loading` and `buffering` are deliberately separate: a fresh load shows a
+spinner, while a mid-stream stall shows a subtle "Buffering…" — so the
+mini-player keeps signalling activity and the screen never reads as frozen.
+
 ## Security
 
 - A track's stored URI stays the token-free `jellyfin:<id>` / `subsonic:<id>`.
@@ -60,8 +143,28 @@ behaviour is in [cast.md](cast.md).
 
 ## Known limitations
 
+- **No low-level buffer-size knob.** `just_audio` exposes ExoPlayer's
+  buffer *durations*, not a per-request byte budget; tuning is at that level.
+- **One retry per drop.** Mid-stream recovery attempts a single retry by design
+  (never an endless loop); a persistent outage surfaces a friendly error.
+- **Preload warms one track ahead.** Only the immediate next remote track's URL
+  is warmed in memory; warming further ahead to *disk* is smart pre-cache's job.
 - **Direct play only** — no server-side transcoding fallback for exotic formats.
 - **On-device files can't be cast** — a receiver can't reach a `file://` path.
 - **Connectivity is optimistic** — the Wi-Fi / mobile-data gate (for downloads)
   relies on a placeholder detector until real detection lands; it does **not**
   block normal streaming playback.
+
+## Manual Android checklist
+
+1. Stream a Jellyfin track over **Wi-Fi**.
+2. Stream a Jellyfin track over **LTE / mobile data** (streaming should work by
+   default; downloads still respect the Wi-Fi gate).
+3. **Skip to next** and confirm it starts faster (the next URL was preloaded).
+4. Enable **shuffle** and confirm upcoming tracks still start smoothly.
+5. Simulate a **weak network** (briefly toggle airplane mode mid-song).
+6. Confirm a **"Buffering…"** state appears instead of an instant failure.
+7. Confirm playback **does not restart from the beginning** after recovery.
+8. **Cast** a stream and confirm Cast does not desync or fall back to local.
+9. Confirm offline cache/download behaviour is **unchanged**.
+10. Confirm **no tokenized URLs** appear in the UI, errors, or `adb logcat`.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -1,0 +1,67 @@
+# Streaming & playback
+
+Linthra is designed for **direct streaming** from your self-hosted server, with
+an explicit **smart offline cache** for the tracks you choose to keep (see
+[offline-cache.md](offline-cache.md)). This page covers how a remote stream is
+resolved and played, and how Linthra keeps playback smooth and recovers from
+network hiccups.
+
+> **Streaming is not the offline cache.** Stream buffering keeps *live* playback
+> smooth; it does **not** write to the offline cache or mark tracks as
+> downloaded. Only the explicit download / "Keep offline" / smart pre-cache
+> actions populate the on-disk cache.
+
+## How a remote track is resolved
+
+Playback opens whatever URI a `PlayableUriResolver` returns, so local files,
+Android SAF `content://` documents, and remote streams all share one path:
+
+1. **Offline first.** If the track has a downloaded copy, it plays from the local
+   `file://` cache — no network.
+2. **Stream on a miss.** For a Jellyfin/Subsonic track the source verifies the
+   session (a tiny reachability check), then mints the **authenticated stream
+   URL at play time** and **probes** it (a one-byte ranged GET, following
+   redirects) to confirm it's really audio.
+3. The minted URL is handed to the engine and **never stored on the track,
+   logged, or shown** — see [Security](#security).
+
+`static=true` (Jellyfin) requests the original file bytes — the reliable
+"direct play" path — rather than a negotiated transcode/HLS variant.
+
+## Friendly errors
+
+The probe turns server problems into precise, secret-free messages instead of the
+engine's opaque "couldn't play". The player distinguishes:
+
+- **not signed in** / **expired session** → prompts a fresh sign-in
+- **server unreachable** → "couldn't reach your server"
+- **a web page instead of audio** → Cloudflare/Jellyfin access misconfiguration
+- **not an audio stream** / **unsupported response** → server/format issue
+- **track not available** (404) and a generic **couldn't stream**
+
+These are branched on a typed error *kind*, not message text.
+
+## Security
+
+- A track's stored URI stays the token-free `jellyfin:<id>` / `subsonic:<id>`.
+- The authenticated stream/download URL is built **only on demand** and is never
+  written to the catalog, logged, shown in the UI, or placed in player state.
+- Playback error messages are asserted in tests to contain **no token** — even
+  when a transport error would otherwise echo the tokenized URL.
+- Diagnostics are secret-free by construction (host only, no token/URL).
+
+## Cast
+
+While casting, the receiver fetches a freshly minted stream URL and the local
+engine is suspended, so the phone never plays the same audio twice and a local
+playback error can't pull output back from the receiver. A dropped receiver
+returns playback to the device **paused** at the last position. Full Cast
+behaviour is in [cast.md](cast.md).
+
+## Known limitations
+
+- **Direct play only** — no server-side transcoding fallback for exotic formats.
+- **On-device files can't be cast** — a receiver can't reach a `file://` path.
+- **Connectivity is optimistic** — the Wi-Fi / mobile-data gate (for downloads)
+  relies on a placeholder detector until real detection lands; it does **not**
+  block normal streaming playback.

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -5,7 +5,21 @@ import 'repeat_mode.dart';
 import 'track.dart';
 
 /// High-level playback status, deliberately decoupled from any audio package.
-enum PlaybackStatus { idle, loading, playing, paused, completed, error }
+///
+/// [loading] is the initial *preparing* state (resolving + opening a source);
+/// [buffering] is a distinct mid-playback re-buffer (the engine wants to play but
+/// is waiting for more data over the network). Keeping them apart lets the UI
+/// show a calm "Buffering…" hint instead of a fresh-load spinner, and keeps the
+/// mini-player from looking frozen during a brief network stall.
+enum PlaybackStatus {
+  idle,
+  loading,
+  buffering,
+  playing,
+  paused,
+  completed,
+  error,
+}
 
 /// An immutable snapshot of what the player is doing. The UI renders from this
 /// instead of reaching into the audio backend, which keeps playback internals
@@ -66,6 +80,15 @@ class PlaybackState {
   bool get isPlaying => status == PlaybackStatus.playing;
   bool get hasTrack => currentTrack != null;
   bool get hasNext => upNext.isNotEmpty;
+
+  /// Whether a mid-playback re-buffer is in progress (engine waiting on data).
+  bool get isBuffering => status == PlaybackStatus.buffering;
+
+  /// Whether the player is preparing or re-buffering — i.e. working, not idle and
+  /// not steadily playing. The mini-player shows a spinner for this so it never
+  /// looks frozen during a network stall.
+  bool get isBusy =>
+      status == PlaybackStatus.loading || status == PlaybackStatus.buffering;
 
   PlaybackState copyWith({
     PlaybackStatus? status,

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 
 import '../models/playback_queue.dart';
@@ -12,6 +13,7 @@ import 'local_playable_uri_resolver.dart';
 import 'local_playback_controller.dart';
 import 'playable_uri_resolver.dart';
 import 'playback_controller.dart';
+import 'stream_interruption.dart';
 
 /// [PlaybackController] backed by `just_audio`.
 ///
@@ -31,11 +33,41 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     AudioPlayer? player,
     PlayableUriResolver resolver = const LocalPlayableUriResolver(),
     Random? random,
-  })  : _player = player ?? AudioPlayer(),
+  })  : _player = player ?? _defaultPlayer(),
         _resolver = resolver,
         _random = random ?? Random() {
     _wire();
   }
+
+  /// The default engine, tuned for resilient remote streaming. An injected
+  /// [player] (tests, or a future custom engine) bypasses this.
+  static AudioPlayer _defaultPlayer() =>
+      AudioPlayer(audioLoadConfiguration: _streamBuffering);
+
+  /// Buffering tuned for remote streams so a brief network hiccup is absorbed
+  /// instead of stalling playback: a generous look-ahead (up to ~2 minutes), a
+  /// healthy minimum to resume on after a stall, and a quick initial start.
+  /// Applied to the default engine only — an injected player (tests, or a future
+  /// custom engine) is left untouched. just_audio exposes ExoPlayer's
+  /// `LoadControl` here; there is no lower-level per-request buffer-size knob, so
+  /// resilience also comes from the retry/recovery and preload paths.
+  static const AudioLoadConfiguration _streamBuffering = AudioLoadConfiguration(
+    androidLoadControl: AndroidLoadControl(
+      minBufferDuration: Duration(seconds: 30),
+      maxBufferDuration: Duration(minutes: 2),
+      bufferForPlaybackDuration: Duration(seconds: 2),
+      bufferForPlaybackAfterRebufferDuration: Duration(seconds: 5),
+      prioritizeTimeOverSizeThresholds: true,
+    ),
+    darwinLoadControl: DarwinLoadControl(
+      automaticallyWaitsToMinimizeStalling: true,
+      preferredForwardBufferDuration: Duration(minutes: 1),
+    ),
+  );
+
+  /// One bounded retry per track for a mid-stream failure, so a transient drop
+  /// recovers without ever looping forever on a real outage/expiry.
+  static const int _maxStreamRetries = 1;
 
   final AudioPlayer _player;
   final PlayableUriResolver _resolver;
@@ -59,6 +91,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   bool _shuffleEnabled = false;
   RepeatMode _repeatMode = RepeatMode.off;
 
+  // How many times the current track has been retried after a mid-stream
+  // failure. Reset when a fresh track loads and when playback reaches `playing`,
+  // so each track (and each successful stretch) gets its own one-retry budget.
+  int _retriesForCurrent = 0;
+
   @override
   PlaybackState get state => _state;
 
@@ -72,12 +109,18 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       // status underneath the cast session.
       if (_suspended) return;
       final status = _statusFor(playerState);
+      // Playback is healthy again: give a later, independent drop a fresh retry.
+      if (status == PlaybackStatus.playing) _retriesForCurrent = 0;
       // When a track finishes, what happens next depends on the repeat mode.
       if (status == PlaybackStatus.completed) {
         _onCompleted();
         return;
       }
       _emit(_state.copyWith(status: status));
+    }, onError: (Object _, StackTrace __) {
+      // Engine errors are recovered via [playbackEventStream] below; swallow any
+      // duplicate that the player-state stream may forward so it never becomes
+      // an unhandled async error (and so we never act on it twice).
     }));
     _subscriptions.add(_player.positionStream.listen((position) {
       if (_suspended) return;
@@ -87,15 +130,66 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       if (_suspended) return;
       if (duration != null) _emit(_state.copyWith(duration: duration));
     }));
+    // A mid-stream failure (network drop, expired token, server gone) surfaces
+    // here as a stream error. Recover gracefully rather than dying silently.
+    _subscriptions.add(
+      _player.playbackEventStream.listen((_) {}, onError: _onEngineError),
+    );
   }
+
+  /// Recovers from an engine error that happens **while streaming**. A transient
+  /// drop gets one bounded retry that re-resolves and reloads at the preserved
+  /// position; an auth/format failure (or an exhausted retry) shows a friendly,
+  /// secret-free message. The raw [error] (which can carry a tokenized URL) is
+  /// never logged or surfaced — only its classification is used.
+  void _onEngineError(Object error, StackTrace _) {
+    // A cast receiver owns the audio while suspended: never touch local
+    // playback, so a local engine glitch can't pull output back from the
+    // receiver or start duplicate audio.
+    if (_suspended) return;
+    // Only recover from a failure that happens once we're actually streaming; an
+    // initial-load failure is handled where setUrl is awaited (with its own
+    // friendly message), so we don't fight it here.
+    if (_state.status != PlaybackStatus.playing &&
+        _state.status != PlaybackStatus.buffering) {
+      return;
+    }
+    final Track? track = _queue.current;
+    if (track == null) return;
+
+    final StreamInterruption interruption = classifyEngineError(error);
+    if (interruption.retryable && _retriesForCurrent < _maxStreamRetries) {
+      _retriesForCurrent++;
+      // Re-resolve and reload at the preserved position. The resolver re-checks
+      // the session/server, so a real expiry/outage surfaces a precise friendly
+      // error while a transient blip simply recovers. setUrl replaces the
+      // source, so there is no duplicate playback and no jump to the start.
+      unawaited(_playCurrent(startAt: _state.position, isRetry: true));
+      return;
+    }
+    _emitError(track, interruption.message);
+  }
+
+  /// Maps the engine's (playing, processingState) pair to a [PlaybackStatus].
+  ///
+  /// The key distinction: `buffering` *while the engine wants to play* is a
+  /// mid-stream re-buffer ([PlaybackStatus.buffering] — a calm "Buffering…"
+  /// hint, not a frozen player), whereas `loading`, or buffering *before* the
+  /// first play, is still the initial preparing state ([PlaybackStatus.loading]).
+  @visibleForTesting
+  static PlaybackStatus statusFor(PlayerState playerState) =>
+      _statusFor(playerState);
 
   static PlaybackStatus _statusFor(PlayerState playerState) {
     switch (playerState.processingState) {
       case ProcessingState.idle:
         return PlaybackStatus.idle;
       case ProcessingState.loading:
-      case ProcessingState.buffering:
         return PlaybackStatus.loading;
+      case ProcessingState.buffering:
+        return playerState.playing
+            ? PlaybackStatus.buffering
+            : PlaybackStatus.loading;
       case ProcessingState.ready:
         return playerState.playing
             ? PlaybackStatus.playing
@@ -212,9 +306,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   Future<void> _playCurrent({
     Duration startAt = Duration.zero,
     bool autoplay = true,
+    bool isRetry = false,
   }) async {
     final track = _queue.current;
     if (track == null) return;
+
+    // A fresh (non-retry) load starts a new track or a deliberate (re)play, so
+    // reset the mid-stream recovery budget. A retry must keep its counter.
+    if (!isRetry) _retriesForCurrent = 0;
 
     if (_suspended) {
       // A cast receiver owns the audio. Reflect only the queue/track so the UI
@@ -233,17 +332,23 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       return;
     }
 
-    // Reset position/duration up front so the UI doesn't show the previous
-    // track's progress while the new one loads.
-    final loading = PlaybackState(
-      status: PlaybackStatus.loading,
-      currentTrack: track,
-      upNext: _queue.upNext,
-      hasPrevious: _queue.hasPrevious,
-      shuffleEnabled: _shuffleEnabled,
-      repeatMode: _repeatMode,
-    );
-    _emit(loading);
+    if (isRetry) {
+      // Recovering from a mid-stream drop: keep the current track and position
+      // visible and show a calm buffering state, rather than blanking to a fresh
+      // load (which would look like the track jumped back to the start).
+      _emit(_state.copyWith(status: PlaybackStatus.buffering));
+    } else {
+      // Reset position/duration up front so the UI doesn't show the previous
+      // track's progress while the new one loads.
+      _emit(PlaybackState(
+        status: PlaybackStatus.loading,
+        currentTrack: track,
+        upNext: _queue.upNext,
+        hasPrevious: _queue.hasPrevious,
+        shuffleEnabled: _shuffleEnabled,
+        repeatMode: _repeatMode,
+      ));
+    }
 
     final ResolvedPlayable resolved;
     try {

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -234,6 +234,8 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         return audio.AudioProcessingState.idle;
       case PlaybackStatus.loading:
         return audio.AudioProcessingState.loading;
+      case PlaybackStatus.buffering:
+        return audio.AudioProcessingState.buffering;
       case PlaybackStatus.playing:
       case PlaybackStatus.paused:
         return audio.AudioProcessingState.ready;

--- a/lib/core/services/stream_interruption.dart
+++ b/lib/core/services/stream_interruption.dart
@@ -1,0 +1,107 @@
+/// Why a remote stream stopped mid-playback, classified from the audio engine's
+/// raw error so the player can recover (a bounded retry) or show a precise,
+/// friendly message.
+enum StreamInterruptionKind {
+  /// A transient connection glitch — usually recoverable with one retry.
+  networkDropped,
+
+  /// The server could not be reached (DNS, refused, unreachable).
+  serverUnreachable,
+
+  /// The server rejected the request — the session/token is no longer valid.
+  sessionExpired,
+
+  /// The engine can't decode this stream (unsupported container/codec).
+  formatUnsupported,
+
+  /// Anything else; treated as a transient glitch worth a single retry.
+  unknown,
+}
+
+/// A classified stream interruption: a [kind], a friendly, **secret-free**
+/// [message] safe to show in the UI, and whether a retry is worth attempting.
+class StreamInterruption {
+  const StreamInterruption(
+    this.kind,
+    this.message, {
+    required this.retryable,
+  });
+
+  final StreamInterruptionKind kind;
+  final String message;
+  final bool retryable;
+}
+
+/// Classifies an audio-engine error into a [StreamInterruption].
+///
+/// Security invariant: the engine's raw error can carry the tokenized stream URL
+/// (e.g. a `ClientException` echoing the request URI). This NEVER echoes, logs,
+/// or interpolates the error text — it only *reads* it to pick a branch and
+/// returns a fixed, safe message. So a token can't leak through a playback error.
+StreamInterruption classifyEngineError(Object error) {
+  final String text = error.toString().toLowerCase();
+
+  bool mentions(List<String> needles) =>
+      needles.any((String needle) => text.contains(needle));
+
+  // Auth first: a rejected session is not worth retrying — prompt a sign-in.
+  if (mentions(<String>['401', '403', 'unauthor', 'forbidden'])) {
+    return const StreamInterruption(
+      StreamInterruptionKind.sessionExpired,
+      'Your session expired. Sign in again to keep streaming.',
+      retryable: false,
+    );
+  }
+  // A decode failure won't fix itself by retrying the same bytes.
+  if (mentions(<String>[
+    'unsupported',
+    'decoder',
+    'codec',
+    'unable to instantiate',
+    'parse',
+  ])) {
+    return const StreamInterruption(
+      StreamInterruptionKind.formatUnsupported,
+      "This track's format isn't supported on this device.",
+      retryable: false,
+    );
+  }
+  // The server isn't answering at all — worth one retry, then a friendly notice.
+  if (mentions(<String>[
+    'unreachable',
+    'refused',
+    'failed host lookup',
+    'no address',
+    'name resolution',
+  ])) {
+    return const StreamInterruption(
+      StreamInterruptionKind.serverUnreachable,
+      "Couldn't reach your music server. Check your connection and try again.",
+      retryable: true,
+    );
+  }
+  // A transient network drop mid-stream — the common case to recover from.
+  if (mentions(<String>[
+    'timeout',
+    'timed out',
+    'network',
+    'connection',
+    'reset',
+    'source error',
+    'socket',
+    'broken pipe',
+    'eof',
+  ])) {
+    return const StreamInterruption(
+      StreamInterruptionKind.networkDropped,
+      'The connection dropped while streaming. Reconnecting…',
+      retryable: true,
+    );
+  }
+  // Unknown: assume a transient glitch and allow a single retry.
+  return const StreamInterruption(
+    StreamInterruptionKind.unknown,
+    'Playback was interrupted. Trying again…',
+    retryable: true,
+  );
+}

--- a/lib/core/services/stream_preload_service.dart
+++ b/lib/core/services/stream_preload_service.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import '../models/repeat_mode.dart';
+import '../models/track.dart';
+import 'stream_preloader.dart';
+
+/// Warms the **immediate next** remote track's stream URL as playback moves, so
+/// a skip — or the natural roll into the next track — starts faster instead of
+/// re-running the session check + URL probe at the track change.
+///
+/// It listens to the unified [PlaybackState] and, whenever what-plays-next
+/// changes, asks a [StreamPreloader] to warm `upNext.first`. Because the
+/// controller keeps `upNext` in effective play order, this preloads the
+/// queue-order next track normally and the shuffled-order next track when
+/// shuffle is on, with no special-casing.
+///
+/// What it deliberately does NOT do:
+///  - **Repeat-one stays calm.** The current track loops, so the up-next won't
+///    play soon — nothing is preloaded.
+///  - **No disk, no downloads.** Preloading only warms an in-memory URL via the
+///    [StreamPreloader]; it never writes the offline cache or marks a track as
+///    downloaded. A local/non-remote next track is a no-op in the preloader.
+///  - **Best-effort, never blocking.** Warms run off the playback path, one at a
+///    time, and a failure is swallowed — so a slow or failing warm never stalls
+///    or restarts the current track.
+class StreamPreloadService {
+  StreamPreloadService({
+    required Stream<PlaybackState> playbackStates,
+    required StreamPreloader preloader,
+  }) : _preloader = preloader {
+    _subscription = playbackStates.listen(_onState);
+  }
+
+  final StreamPreloader _preloader;
+  late final StreamSubscription<PlaybackState> _subscription;
+
+  /// The last set of inputs we preloaded against, so pure position/status ticks
+  /// don't re-trigger a warm.
+  String? _lastKey;
+  Track? _pending;
+  bool _running = false;
+
+  void _onState(PlaybackState state) {
+    final String key = _keyFor(state);
+    // Only react when something that affects *what plays next* changed — not on
+    // every position tick (which re-emits the same key).
+    if (key == _lastKey) return;
+    _lastKey = key;
+    if (state.currentTrack == null) return;
+    // Repeat-one replays the current track, so the up-next won't play soon:
+    // don't preload unrelated tracks.
+    if (state.repeatMode == RepeatMode.one) return;
+    if (state.upNext.isEmpty) return;
+    // Warm the immediate next track only — the highest-value, lowest-cost win.
+    // (Further-ahead warming to *disk* is the smart pre-cache's job.)
+    _pending = state.upNext.first;
+    unawaited(_drain());
+  }
+
+  /// A fingerprint of the inputs that decide the next track: the playing track,
+  /// shuffle, repeat, and the head of up-next. Excludes position/duration/status
+  /// so listening doesn't thrash on playback ticks.
+  static String _keyFor(PlaybackState state) {
+    final String current = state.currentTrack?.id ?? '-';
+    final String next = state.upNext.isEmpty ? '-' : state.upNext.first.id;
+    return '$current|${state.shuffleEnabled}|${state.repeatMode.name}|$next';
+  }
+
+  Future<void> _drain() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (_pending != null) {
+        final Track track = _pending!;
+        _pending = null;
+        // Sequential on purpose: one warm at a time keeps it off the playback
+        // path and lets a newer queue (set while a warm is in flight) win.
+        await _preloader.preload(track);
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> dispose() => _subscription.cancel();
+}

--- a/lib/core/services/stream_preloader.dart
+++ b/lib/core/services/stream_preloader.dart
@@ -1,0 +1,21 @@
+import '../models/track.dart';
+
+/// Warms an upcoming **remote** track's stream URL into memory so a skip to it
+/// starts faster — it skips the play-time session check + URL probe round-trips
+/// that otherwise run at each track change.
+///
+/// This is **not** the offline cache. Preloading:
+///  - never writes bytes to disk and never marks a track as downloaded,
+///  - holds only a short-lived, in-memory resolution that is consumed on first
+///    use,
+///  - is best-effort and must never throw or interrupt the current track,
+///  - never logs or surfaces the token-bearing URL it resolves.
+///
+/// `StreamPreloadingResolver` implements it alongside `PlayableUriResolver`, so
+/// the same in-memory cache it warms is the one the playback controller reads at
+/// play time.
+abstract interface class StreamPreloader {
+  /// Best-effort: resolve [track]'s stream URL ahead of time and hold it briefly
+  /// in memory. A no-op for non-remote tracks and on any failure. Never throws.
+  Future<void> preload(Track track);
+}

--- a/lib/core/services/stream_preloading_resolver.dart
+++ b/lib/core/services/stream_preloading_resolver.dart
@@ -1,0 +1,88 @@
+import '../models/playback_source.dart';
+import '../models/track.dart';
+import 'playable_uri_resolver.dart';
+import 'stream_preloader.dart';
+
+/// A [PlayableUriResolver] decorator that pre-resolves upcoming remote stream
+/// URLs and serves them on the next play, so a track change doesn't pay the
+/// session-check + probe latency again.
+///
+/// How it behaves:
+///  - [preload] resolves a remote track through the wrapped resolver and stores
+///    the result in an in-memory map keyed by track id, with a short TTL.
+///  - [resolve] returns a *fresh, unexpired* preloaded entry **once**
+///    (consume-on-read) and otherwise delegates to the wrapped resolver. So a
+///    retry after a failed load re-resolves a fresh URL rather than replaying a
+///    possibly-stale one, and a repeat/replay later also re-resolves fresh.
+///
+/// What it deliberately does **not** do: it never touches the offline cache,
+/// never marks a track as downloaded, persists nothing, and logs nothing. It
+/// only ever holds short-lived remote stream URLs in memory, and swallows any
+/// resolution error during a warm — so a token-bearing URL can't leak through a
+/// preload path, and a failed warm just means the track resolves normally when
+/// it is actually reached.
+class StreamPreloadingResolver implements PlayableUriResolver, StreamPreloader {
+  StreamPreloadingResolver(
+    this._inner, {
+    Duration ttl = const Duration(minutes: 2),
+    DateTime Function()? clock,
+  })  : _ttl = ttl,
+        _now = clock ?? DateTime.now;
+
+  final PlayableUriResolver _inner;
+  final Duration _ttl;
+  final DateTime Function() _now;
+
+  final Map<String, _PreloadedResolution> _cache =
+      <String, _PreloadedResolution>{};
+
+  /// Remote stream schemes worth preloading; local files and `content://`
+  /// documents open instantly and need no warming.
+  static const Set<String> _remoteSchemes = <String>{'jellyfin', 'subsonic'};
+
+  @override
+  bool handles(Track track) => _inner.handles(track);
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    // Consume-on-read: a warmed URL is a one-shot. Removing it means a later
+    // retry/replay of the same track re-resolves fresh instead of reusing a
+    // possibly-expired URL.
+    final _PreloadedResolution? cached = _cache.remove(track.id);
+    if (cached != null && cached.expiresAt.isAfter(_now())) {
+      return cached.resolved;
+    }
+    return _inner.resolve(track);
+  }
+
+  @override
+  Future<void> preload(Track track) async {
+    if (!_isRemoteStream(track) || !_inner.handles(track)) return;
+    // Already warm and unexpired: don't re-resolve (and don't spend a request).
+    final _PreloadedResolution? existing = _cache[track.id];
+    if (existing != null && existing.expiresAt.isAfter(_now())) return;
+    try {
+      final ResolvedPlayable resolved = await _inner.resolve(track);
+      // Only hold short-lived remote stream URLs in memory; never cache a local
+      // path or a cache-hit (those carry no benefit and shouldn't be retained).
+      if (resolved.source == PlaybackSource.streamingDirect) {
+        _cache[track.id] = _PreloadedResolution(resolved, _now().add(_ttl));
+      }
+    } catch (_) {
+      // Best-effort: a failed warm just means the track resolves normally when
+      // it is reached. Never rethrow, never log (no URL/token must leak).
+    }
+  }
+
+  static bool _isRemoteStream(Track track) {
+    final String scheme = Uri.tryParse(track.uri)?.scheme.toLowerCase() ?? '';
+    return _remoteSchemes.contains(scheme);
+  }
+}
+
+class _PreloadedResolution {
+  const _PreloadedResolution(this.resolved, this.expiresAt);
+
+  final ResolvedPlayable resolved;
+  final DateTime expiresAt;
+}

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -166,7 +166,9 @@ class _PlayPauseButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (state.status == PlaybackStatus.loading) {
+    // A spinner for both preparing and mid-stream buffering, so the mini-player
+    // shows activity (never looks frozen) while the stream catches up.
+    if (state.isBusy) {
       return const SizedBox.square(
         dimension: 24,
         child: Padding(

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -12,6 +12,8 @@ import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/services/smart_precache_service.dart';
+import '../../core/services/stream_preload_service.dart';
+import '../../core/services/stream_preloading_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
@@ -19,24 +21,39 @@ import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'cast/cast_providers.dart';
 
+/// The source router wrapped in the stream-preloading decorator.
+///
+/// Pinned as its own provider so the controller's resolver **and** the
+/// [streamPreloadServiceProvider] share the *same* in-memory preload cache: the
+/// service warms the next remote track's stream URL here, and the controller
+/// consumes it on the next play. It only ever holds short-lived remote URLs in
+/// memory — never the offline cache. Depends only on lazily-read source getters,
+/// so signing in/out is picked up without rebuilding (keeping the instance, and
+/// its cache, stable for the session).
+final streamPreloadingResolverProvider =
+    Provider<StreamPreloadingResolver>((ref) {
+  return StreamPreloadingResolver(
+    RoutingPlayableUriResolver(<PlayableUriResolver>[
+      JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
+      SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
+      const LocalPlayableUriResolver(),
+    ]),
+  );
+});
+
 /// Composes the [PlayableUriResolver] the controller resolves tracks through.
 ///
 /// Offline first: a downloaded track resolves to its cached `file://` copy
-/// before anything else. On a cache miss it falls through to the source router,
-/// which mints an authenticated Jellyfin stream URL at play time (reading the
-/// live signed-in source, so sign-in/out is picked up without a rebuild) and
-/// sends everything else to the on-device resolver. The UI and controller
-/// depend only on the [PlayableUriResolver] interface, never on Jellyfin, the
-/// cache, or HTTP.
+/// before anything else. On a cache miss it falls through to the
+/// stream-preloading source router, which serves a pre-warmed URL when one is
+/// ready or mints a fresh authenticated stream URL at play time (reading the
+/// live signed-in source, so sign-in/out is picked up without a rebuild). The UI
+/// and controller depend only on the [PlayableUriResolver] interface, never on
+/// Jellyfin, the cache, or HTTP.
 final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
-  final fallback = RoutingPlayableUriResolver(<PlayableUriResolver>[
-    JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
-    SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
-    const LocalPlayableUriResolver(),
-  ]);
   return OfflineFirstPlayableUriResolver(
     locator: ref.watch(cachedTrackLocatorProvider),
-    fallback: fallback,
+    fallback: ref.watch(streamPreloadingResolverProvider),
     // On a cache hit, refresh the track's least-recently-used position so
     // eviction keeps what's actually listened to. Read lazily (no build-time
     // dependency on the cache manager) and never awaited — a metadata write
@@ -109,6 +126,25 @@ final smartPrecacheServiceProvider = Provider<SmartPrecacheService>((ref) {
     playbackStates: ref.read(playbackControllerProvider).stateStream,
     prefetcher: ref.read(trackPrefetcherProvider),
     preferences: ref.read(downloadPreferencesProvider),
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// Stream preload: as playback advances, warms the **immediate next** remote
+/// track's stream URL into the shared in-memory cache so a skip starts faster.
+///
+/// This is **not** the offline cache — it never writes bytes to disk, never
+/// marks a track as downloaded, and never blocks the current track (best-effort,
+/// one warm at a time, calm under repeat-one). It complements smart pre-cache
+/// (which warms upcoming tracks to *disk*). Pinned for the session like the
+/// controller; reads its seams once with [Ref.read]. It does its work as a side
+/// effect of listening, so `main` instantiates it once after startup; nothing in
+/// the UI reads its value.
+final streamPreloadServiceProvider = Provider<StreamPreloadService>((ref) {
+  final service = StreamPreloadService(
+    playbackStates: ref.read(playbackControllerProvider).stateStream,
+    preloader: ref.read(streamPreloadingResolverProvider),
   );
   ref.onDispose(service.dispose);
   return service;

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -202,11 +202,48 @@ class _SourceOrError extends ConsumerWidget {
         textAlign: TextAlign.center,
       );
     }
+    // A mid-stream re-buffer: a calm "Buffering…" hint rather than the source
+    // badge, so it's clear the stream is catching up (not stalled).
+    if (state.status == PlaybackStatus.buffering) {
+      return const _BufferingIndicator();
+    }
     final source = state.source;
     if (source == null) {
       return const SizedBox(height: 28);
     }
     return PlaybackSourceChip(source: source);
+  }
+}
+
+/// A small, calm "Buffering…" hint shown on Now Playing during a mid-stream
+/// re-buffer, so the screen reads as catching-up rather than frozen.
+class _BufferingIndicator extends StatelessWidget {
+  const _BufferingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox.square(
+          dimension: 14,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        Text(
+          'Buffering…',
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            letterSpacing: 0.3,
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/features/player/widgets/playback_controls.dart
+++ b/lib/features/player/widgets/playback_controls.dart
@@ -125,8 +125,11 @@ class _PlayPauseButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Only the initial prepare shows the spinner-and-disabled state. A mid-stream
+    // re-buffer keeps the (active) pause button so the user stays in control —
+    // the calm "Buffering…" hint on Now Playing signals the wait instead.
     final bool loading = state.status == PlaybackStatus.loading;
-    final bool playing = state.isPlaying;
+    final bool playing = state.isPlaying || state.isBuffering;
     final VoidCallback? onTap =
         loading ? null : (playing ? controller.pause : controller.play);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,6 +76,11 @@ Future<void> main() async {
   // Instantiating it wires the listener; it has no value the UI reads.
   container.read(smartPrecacheServiceProvider);
 
+  // Start stream preload: as playback advances it warms the next remote track's
+  // stream URL in memory so a skip starts faster — without touching the offline
+  // cache or marking anything downloaded. Side-effect-only, like smart pre-cache.
+  container.read(streamPreloadServiceProvider);
+
   // Warm the persisted Jellyfin session before the first frame so a synced
   // remote track can stream on the first tap — without it, playback would race
   // the background session load and could fail with "not signed in", making

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -159,6 +159,38 @@ void main() {
       expect(state.currentTrack, _trackA);
     });
 
+    test('a local engine error while casting never pulls output back to local',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      cast.emitPlayback(const CastPlaybackStatus(
+        status: PlaybackStatus.playing,
+        position: Duration(seconds: 12),
+        duration: Duration(minutes: 3),
+      ));
+      await _waitFor(controller, (s) => s.status == PlaybackStatus.playing);
+
+      // The silenced local engine reports an error (e.g. a stale stream URL it
+      // was never actually playing). It must not change the active output, and
+      // the merged state must keep following the receiver — no fall-back to
+      // duplicate local playback, no error surfaced over a healthy cast.
+      local.emit(const PlaybackState(
+        status: PlaybackStatus.error,
+        currentTrack: _trackA,
+        errorMessage: "Couldn't stream this track.",
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(controller.activeOutput, ActivePlaybackOutput.cast);
+      expect(controller.state.status, PlaybackStatus.playing);
+      expect(controller.state.errorMessage, isNull);
+      expect(local.playCount, 0);
+    });
+
     test(
         'skip advances the local queue without local audio; cast re-casts via '
         'the track change', () async {

--- a/test/core/services/just_audio_playback_controller_test.dart
+++ b/test/core/services/just_audio_playback_controller_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/services/just_audio_playback_controller.dart';
 
@@ -72,6 +74,41 @@ void main() {
         containsAllInOrder(<RepeatMode>[RepeatMode.all, RepeatMode.one]),
       );
       await sub.cancel();
+    });
+  });
+
+  group('JustAudioPlaybackController.statusFor', () {
+    // Pure mapping from the engine's (playing, processingState) pair to the
+    // app's PlaybackStatus — no platform channel, no playback.
+    PlaybackStatus map(bool playing, ProcessingState state) =>
+        JustAudioPlaybackController.statusFor(PlayerState(playing, state));
+
+    test('an idle engine is idle', () {
+      expect(map(false, ProcessingState.idle), PlaybackStatus.idle);
+    });
+
+    test('loading is the preparing state', () {
+      expect(map(false, ProcessingState.loading), PlaybackStatus.loading);
+      expect(map(true, ProcessingState.loading), PlaybackStatus.loading);
+    });
+
+    test('buffering while playing is the mid-stream buffering state', () {
+      // The engine wants to play but is waiting for data: a calm "Buffering…",
+      // not a frozen player.
+      expect(map(true, ProcessingState.buffering), PlaybackStatus.buffering);
+    });
+
+    test('buffering before the first play is still preparing (loading)', () {
+      expect(map(false, ProcessingState.buffering), PlaybackStatus.loading);
+    });
+
+    test('ready maps to playing or paused by the play flag', () {
+      expect(map(true, ProcessingState.ready), PlaybackStatus.playing);
+      expect(map(false, ProcessingState.ready), PlaybackStatus.paused);
+    });
+
+    test('completed maps to completed', () {
+      expect(map(false, ProcessingState.completed), PlaybackStatus.completed);
     });
   });
 }

--- a/test/core/services/stream_interruption_test.dart
+++ b/test/core/services/stream_interruption_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/stream_interruption.dart';
+
+/// A stand-in for the audio engine's raw error whose [toString] carries text the
+/// classifier branches on — including, deliberately, a tokenized URL, so we can
+/// prove the friendly message never echoes it.
+class _EngineError {
+  _EngineError(this._text);
+  final String _text;
+  @override
+  String toString() => _text;
+}
+
+void main() {
+  group('classifyEngineError', () {
+    test('a transient network drop is recoverable (retryable)', () {
+      for (final String raw in <String>[
+        'SocketException: Connection reset by peer',
+        'Source error: connection closed',
+        'java.net.SocketTimeoutException: timeout',
+        'Network is unreachable while reading',
+      ]) {
+        final result = classifyEngineError(_EngineError(raw));
+        expect(
+          result.retryable,
+          isTrue,
+          reason: 'expected "$raw" to be retryable',
+        );
+        expect(
+          result.kind,
+          anyOf(
+            StreamInterruptionKind.networkDropped,
+            StreamInterruptionKind.serverUnreachable,
+          ),
+        );
+      }
+    });
+
+    test('an expired session maps to a sign-in error and is not retried', () {
+      final StreamInterruption result = classifyEngineError(
+        _EngineError('PlayerException(0, Response 401 Unauthorized)'),
+      );
+
+      expect(result.kind, StreamInterruptionKind.sessionExpired);
+      expect(result.retryable, isFalse);
+      expect(result.message.toLowerCase(), contains('sign in'));
+    });
+
+    test('an unreachable server maps to a friendly, retryable error', () {
+      final StreamInterruption result = classifyEngineError(
+        _EngineError('Failed host lookup: music.example.com'),
+      );
+
+      expect(result.kind, StreamInterruptionKind.serverUnreachable);
+      expect(result.retryable, isTrue);
+      expect(result.message, contains("Couldn't reach your music server"));
+    });
+
+    test('an unsupported format is not retried', () {
+      final result = classifyEngineError(
+        _EngineError('PlayerException: unsupported codec'),
+      );
+
+      expect(result.kind, StreamInterruptionKind.formatUnsupported);
+      expect(result.retryable, isFalse);
+    });
+
+    test('an unknown error defaults to a single retry', () {
+      final StreamInterruption result =
+          classifyEngineError(_EngineError('something inexplicable happened'));
+
+      expect(result.kind, StreamInterruptionKind.unknown);
+      expect(result.retryable, isTrue);
+    });
+
+    test('the friendly message never echoes the raw error (no token leak)', () {
+      // A real ExoPlayer/HTTP error often echoes the failing request URL, which
+      // for a stream carries the access token. The classifier must branch on it
+      // without ever surfacing it.
+      const String tokenized =
+          'ClientException: Connection reset, uri=https://music.example.com/'
+          'Audio/abc/stream?static=true&api_key=SUPERSECRETTOKEN';
+      final StreamInterruption result =
+          classifyEngineError(_EngineError(tokenized));
+
+      expect(result.message, isNot(contains('api_key')));
+      expect(result.message, isNot(contains('SUPERSECRETTOKEN')));
+      expect(result.message, isNot(contains('music.example.com')));
+      // It is still classified as a recoverable network drop.
+      expect(result.retryable, isTrue);
+    });
+  });
+}

--- a/test/core/services/stream_preload_service_test.dart
+++ b/test/core/services/stream_preload_service_test.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/stream_preload_service.dart';
+import 'package:linthra/core/services/stream_preloader.dart';
+
+/// Records the track ids it was asked to warm, in order. Returning without
+/// "caching" anything is — from the service's vantage point — indistinguishable
+/// from a best-effort warm that resolved nothing, exactly like the real one.
+class _RecordingPreloader implements StreamPreloader {
+  final List<String> preloaded = <String>[];
+
+  @override
+  Future<void> preload(Track track) async {
+    preloaded.add(track.id);
+  }
+}
+
+/// A preloader whose calls block on [gate] until a test opens it, to prove a
+/// slow warm runs off the playback path and never blocks new states.
+class _GatedPreloader implements StreamPreloader {
+  final List<String> started = <String>[];
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<void> preload(Track track) async {
+    started.add(track.id);
+    await gate.future;
+  }
+}
+
+Track _t(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+
+PlaybackState _playing(
+  Track current,
+  List<Track> upNext, {
+  bool shuffle = false,
+  RepeatMode repeat = RepeatMode.off,
+}) =>
+    PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: current,
+      upNext: upNext,
+      shuffleEnabled: shuffle,
+      repeatMode: repeat,
+    );
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('StreamPreloadService', () {
+    late StreamController<PlaybackState> states;
+    late _RecordingPreloader preloader;
+
+    setUp(() {
+      states = StreamController<PlaybackState>.broadcast();
+      preloader = _RecordingPreloader();
+    });
+
+    StreamPreloadService build() => StreamPreloadService(
+          playbackStates: states.stream,
+          preloader: preloader,
+        );
+
+    test('preloads the immediate next track in queue order (shuffle off)',
+        () async {
+      final service = build();
+
+      states.add(_playing(_t('a'), <Track>[_t('b'), _t('c'), _t('d')]));
+      await _settle();
+
+      // Only the immediate next — never the current track, never the whole queue.
+      expect(preloader.preloaded, <String>['b']);
+      await service.dispose();
+    });
+
+    test('preloads the shuffled-next track when shuffle is on', () async {
+      final service = build();
+
+      // upNext is already the effective (shuffled) play order, so its head is
+      // the shuffled-next song.
+      states.add(
+        _playing(_t('a'), <Track>[_t('d'), _t('b'), _t('c')], shuffle: true),
+      );
+      await _settle();
+
+      expect(preloader.preloaded, <String>['d']);
+      await service.dispose();
+    });
+
+    test('repeat-one preloads nothing (no unrelated tracks)', () async {
+      final service = build();
+
+      states.add(
+        _playing(_t('a'), <Track>[_t('b'), _t('c')], repeat: RepeatMode.one),
+      );
+      await _settle();
+
+      expect(preloader.preloaded, isEmpty);
+      await service.dispose();
+    });
+
+    test('starts preloading once repeat-one is turned off', () async {
+      final service = build();
+
+      states.add(_playing(_t('a'), <Track>[_t('b')], repeat: RepeatMode.one));
+      await _settle();
+      expect(preloader.preloaded, isEmpty);
+
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+      expect(preloader.preloaded, <String>['b']);
+
+      await service.dispose();
+    });
+
+    test('reacts to a next-track change, not to every state update', () async {
+      final service = build();
+
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+      // A position-only update keeps the same current track and next track.
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+
+      expect(preloader.preloaded, <String>['b']);
+      await service.dispose();
+    });
+
+    test('re-preloads against the new next track after advancing', () async {
+      final service = build();
+
+      states.add(_playing(_t('a'), <Track>[_t('b'), _t('c')]));
+      await _settle();
+      states.add(_playing(_t('b'), <Track>[_t('c'), _t('d')]));
+      await _settle();
+
+      expect(preloader.preloaded, <String>['b', 'c']);
+      await service.dispose();
+    });
+
+    test('re-preloads the new head when shuffle reorders up-next', () async {
+      final service = build();
+
+      states.add(_playing(_t('a'), <Track>[_t('b'), _t('c'), _t('d')]));
+      await _settle();
+      states.add(
+        _playing(_t('a'), <Track>[_t('d'), _t('c'), _t('b')], shuffle: true),
+      );
+      await _settle();
+
+      expect(preloader.preloaded, <String>['b', 'd']);
+      await service.dispose();
+    });
+
+    test('does nothing with an empty up-next list', () async {
+      final service = build();
+
+      states.add(_playing(_t('a'), const <Track>[]));
+      await _settle();
+
+      expect(preloader.preloaded, isEmpty);
+      await service.dispose();
+    });
+
+    test('a slow preload never blocks new states arriving', () async {
+      final gated = _GatedPreloader();
+      final service = StreamPreloadService(
+        playbackStates: states.stream,
+        preloader: gated,
+      );
+
+      states.add(_playing(_t('a'), <Track>[_t('b')]));
+      await _settle();
+      expect(gated.started, <String>['b']);
+
+      // Advance while 'b''s warm is still in flight — must not deadlock.
+      states.add(_playing(_t('b'), <Track>[_t('c')]));
+      await _settle();
+      expect(gated.started, <String>['b']); // still one at a time, nothing hung
+
+      gated.gate.complete();
+      await _settle();
+      expect(gated.started, <String>['b', 'c']); // catches up to the latest
+
+      await service.dispose();
+    });
+  });
+}

--- a/test/core/services/stream_preloading_resolver_test.dart
+++ b/test/core/services/stream_preloading_resolver_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/stream_preloading_resolver.dart';
+
+/// A configurable inner resolver that records every `resolve` call, so a test
+/// can prove when the decorator served a *cached* URL (no inner call) vs.
+/// resolved fresh. By default it mints a fresh https stream URL per call; it can
+/// be told to fail, or to report a non-stream (local) source.
+class _FakeInnerResolver implements PlayableUriResolver {
+  _FakeInnerResolver({
+    this.source = PlaybackSource.streamingDirect,
+    this.fail = false,
+  });
+
+  PlaybackSource source;
+  bool fail;
+  final List<String> resolved = <String>[];
+  int _counter = 0;
+
+  @override
+  bool handles(Track track) =>
+      track.uri.startsWith('jellyfin:') || track.uri.startsWith('subsonic:');
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    resolved.add(track.id);
+    if (fail) {
+      throw const PlaybackResolutionException(
+        "Couldn't reach your server.",
+        kind: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+    }
+    // A fresh, unique URL each time so a served-from-cache result is provably
+    // the *preloaded* one, not a re-resolve.
+    _counter++;
+    return ResolvedPlayable(
+      Uri.parse('https://x/${track.id}?n=$_counter'),
+      source,
+    );
+  }
+}
+
+Track _remote(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+Track _local(String id) => Track(id: id, title: id, uri: '/music/$id.mp3');
+
+void main() {
+  group('StreamPreloadingResolver', () {
+    test('preload warms a remote URL that resolve then serves once', () async {
+      final inner = _FakeInnerResolver();
+      final resolver = StreamPreloadingResolver(inner);
+      final track = _remote('a');
+
+      await resolver.preload(track);
+      expect(inner.resolved, <String>['a']); // warmed once
+
+      final resolved = await resolver.resolve(track);
+      // Served from the warm cache — the inner resolver was NOT called again.
+      expect(inner.resolved, <String>['a']);
+      expect(resolved.uri.toString(), contains('n=1'));
+      expect(resolved.source, PlaybackSource.streamingDirect);
+    });
+
+    test('a second resolve re-resolves fresh (consume-on-read)', () async {
+      // This is what lets a retry after a failed load get a *fresh* URL rather
+      // than replaying a possibly-expired preloaded one.
+      final inner = _FakeInnerResolver();
+      final resolver = StreamPreloadingResolver(inner);
+      final track = _remote('a');
+
+      await resolver.preload(track);
+      await resolver.resolve(track); // consumes the warm entry (n=1)
+      final second = await resolver.resolve(track); // re-resolves (n=2)
+
+      expect(inner.resolved, <String>['a', 'a']);
+      expect(second.uri.toString(), contains('n=2'));
+    });
+
+    test('preload is a no-op for a local track', () async {
+      final inner = _FakeInnerResolver();
+      final resolver = StreamPreloadingResolver(inner);
+
+      await resolver.preload(_local('a'));
+
+      expect(inner.resolved, isEmpty); // local files need no warming
+    });
+
+    test('a non-stream resolution is never cached', () async {
+      // If the inner ever reports a local/cache source for a "remote" track, the
+      // decorator must not retain it — only short-lived stream URLs are held.
+      final inner = _FakeInnerResolver(source: PlaybackSource.localFile);
+      final resolver = StreamPreloadingResolver(inner);
+      final track = _remote('a');
+
+      // Preload resolves but won't cache (source != streamingDirect), so the
+      // resolve must go back to the inner rather than serve a cached entry.
+      await resolver.preload(track);
+      await resolver.resolve(track);
+
+      expect(inner.resolved, <String>['a', 'a']);
+    });
+
+    test('an expired warm entry is ignored (short-lived, in-memory only)',
+        () async {
+      var now = DateTime(2026, 1, 1, 12, 0, 0);
+      final inner = _FakeInnerResolver();
+      final resolver = StreamPreloadingResolver(
+        inner,
+        ttl: const Duration(minutes: 2),
+        clock: () => now,
+      );
+      final track = _remote('a');
+
+      await resolver.preload(track); // warmed at 12:00, expires 12:02
+      now = DateTime(2026, 1, 1, 12, 5, 0); // 5 minutes later: expired
+
+      final resolved = await resolver.resolve(track);
+      // Stale entry dropped; resolved fresh from the inner resolver.
+      expect(inner.resolved, <String>['a', 'a']);
+      expect(resolved.uri.toString(), contains('n=2'));
+    });
+
+    test('preload swallows inner errors and caches nothing', () async {
+      final inner = _FakeInnerResolver(fail: true);
+      final resolver = StreamPreloadingResolver(inner);
+      final track = _remote('a');
+
+      // Must not throw despite the inner failing.
+      await resolver.preload(track);
+      expect(inner.resolved, <String>['a']);
+
+      // Nothing was cached, so a later resolve goes back to the inner (which now
+      // succeeds once we stop failing) rather than serving a poisoned entry.
+      inner.fail = false;
+      final resolved = await resolver.resolve(track);
+      expect(inner.resolved, <String>['a', 'a']);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+    });
+
+    test('preload does not re-resolve when a fresh entry already exists',
+        () async {
+      // Idempotent: rapid duplicate preload requests for the same track spend
+      // only one resolve (and on LTE, only one tiny request).
+      final inner = _FakeInnerResolver();
+      final resolver = StreamPreloadingResolver(inner);
+      final track = _remote('a');
+
+      await resolver.preload(track);
+      await resolver.preload(track);
+      await resolver.preload(track);
+
+      expect(inner.resolved, <String>['a']);
+    });
+
+    test('resolve without a preload delegates straight to the inner', () async {
+      final inner = _FakeInnerResolver();
+      final resolver = StreamPreloadingResolver(inner);
+
+      final resolved = await resolver.resolve(_remote('a'));
+
+      expect(inner.resolved, <String>['a']);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+    });
+  });
+}


### PR DESCRIPTION
Two focused improvements for a stronger public alpha, kept in separate commits.

## 1) README → a short, fun, contributor-friendly landing page

**Summary.** `README.md` went from ~1,600 lines of full documentation to **185
lines**: title + badges + feature graphic, the tagline *"Your music. Your
server. Your rules."*, one clear description, a **Why Linthra?** section, a
**positive** alpha-status note, screenshots placeholder, **What works today**,
**Try it** (Releases / Obtainium / build-from-source link), **Ways to help**,
**Self-hosted sources**, **Privacy**, a short **Roadmap**, a **Documentation**
index, and the license.

**Tone / contribution improvements.** Friendly, confident, identity-first; leads
with *why it's exciting* and mentions limitations honestly afterward. Adds a
concrete **Ways to help** list (test with your Jellyfin / Navidrome / Subsonic
server, try Cast, test Android Auto, capture screenshots, improve docs, report
bugs with Settings → Diagnostics, polish UI/UX, help future providers).

**Docs created.**
- `docs/architecture.md` — layers, extension points, the single local+cast
  playback seam, Now Playing controls, SAF folder selection.
- `docs/development.md` — getting started, debug/release APK, CI, Drift
  generation, signing status, native media-session setup, smoke test.
- `docs/cast.md` — Chromecast usage, architecture, token notes, resilience.
- `docs/jellyfin.md` — setup, streaming, security (links to compatibility/sync).
- `docs/streaming.md` — streaming & playback (expanded in commit 2).

**What moved.** All the long README sections (architecture, tech stack, build /
CI / release artifacts / signing, Android Auto native setup, cast controls,
Jellyfin setup & streaming, SAF internals) moved into the docs above. Topics
that already had authoritative docs (`offline-cache.md`, `library.md`,
`providers.md`, `android-auto.md`, `playlists-and-delete.md`, release/F-Droid/
Play docs) are **linked**, not duplicated. Safety/security and token/privacy
notes were preserved in the relevant docs. "Not on F-Droid / not on Google Play
yet", the Android Auto "Unknown sources" note, and accurate install steps are
all kept (short in README, detailed in docs).

All Markdown links and intra-doc anchors were checked.

## 2) Streaming buffering / playback resilience

This is **not** the offline cache — stream pre-buffering keeps *live* playback
smooth, never writes to disk, and never marks tracks as downloaded.

**Buffering.** The engine is tuned for remote streams (larger look-ahead buffer
~2 min, a healthy resume-after-stall minimum, a quick initial start) so a brief
hiccup is absorbed. *Limitation:* `just_audio` exposes ExoPlayer's `LoadControl`
durations, not a per-request byte budget — documented, with resilience also
coming from preload + recovery.

**Preload (next stream).** While a remote track plays, a new `StreamPreloadService`
warms the **immediate next** remote track's stream URL via an in-memory
`StreamPreloadingResolver`: queue order with shuffle off, shuffled order with
shuffle on, **nothing** under repeat-one. It's best-effort, **consumed on first
use**, short-lived (TTL), and never blocks/restarts the current track. It does
**not** write the offline cache or mark tracks downloaded; local/non-remote next
tracks are a no-op. It sits *inside* offline-first, so it never triggers the
LRU "played" side effect and never downloads the whole queue.

**Retry / recovery.** A mid-stream failure gets **one** bounded retry that
re-resolves and reloads at the **preserved position** (no restart, no duplicate);
the re-resolution re-checks the session/server, so a real expiry/outage surfaces
a precise message instead of looping. Expired session → friendly "sign in again"
(not retried). Server unreachable / unsupported format → friendly messages. A
new `classifyEngineError` maps the raw error to a kind + safe message + retryable
flag.

**LTE.** Streaming works over mobile data by default; the Wi-Fi-only gate still
governs **downloads/cache**, not normal playback. Preload only warms one URL (a
tiny request), never track bytes.

**Cast.** While casting, the suspended local engine ignores its own errors, so a
cast session never falls back to duplicate local playback; a dropped receiver
still resumes locally **paused** at the last position.

**Playback states.** Added a distinct `buffering` state (vs initial `loading`):
a calm "Buffering…" hint on Now Playing and a mini-player spinner so it never
looks frozen; the transport stays usable; playback doesn't jump to the start.

**Security / tokens.** Tokens never enter `Track.uri`; authenticated URLs are
minted on demand, never persisted/logged; preloaded URLs are in-memory and
short-lived; the raw engine error (which can carry a tokenized URL) is only
classified, never echoed/logged/surfaced; diagnostics stay secret-free.

### Tests added
- interruption classifier: transient/network → recoverable; 401 → session
  (no retry); unreachable → friendly; unsupported → no retry; unknown →
  one retry; **no message echoes the raw error (no token leak)**.
- preloading resolver: warm-then-serve-once (consume-on-read), re-resolve fresh
  after consume, no-op for local, non-stream never cached, TTL expiry, swallows
  errors, idempotent, transparent passthrough.
- preload service: queue order (shuffle off), shuffled order (shuffle on),
  repeat-one preloads nothing, reacts to next-track change only, re-preloads
  after advancing, empty up-next, slow warm never blocks.
- buffering vs loading/preparing state mapping.
- cast-active never falls back to duplicate local playback.

### Known limitations
No low-level buffer-size knob (LoadControl durations only); one retry per drop
by design; preload warms one track ahead (further-ahead-to-disk is smart
pre-cache's job); direct play only; on-device files can't be cast; connectivity
is optimistic (gates downloads, not streaming).

### Manual Android checklist
Stream Jellyfin over Wi-Fi and LTE · skip-next starts faster · shuffle upcoming
still smooth · simulate a weak network · buffering state appears (not instant
failure) · no restart-from-start after recovery · Cast doesn't desync/fall back ·
offline cache/download unchanged · no tokenized URLs in UI/logs.

---

> **Verification note:** Flutter/Dart isn't installed in this environment, so I
> could **not** run `flutter pub get` / `dart format` / `flutter analyze` /
> `flutter test` / `flutter build apk`. Code was written to match the existing
> patterns, lint rules (`directives_ordering`, `prefer_const_*`,
> `unawaited_futures`, etc.), the just_audio 0.9.x API, and an 80-col budget for
> code lines. Please run CI / the manual checklist before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FcFknA26v6kQoo48nuEr2w)_