### PR TITLE
Fix ANR/freeze root causes (media-session flood, blur rebuild, hot-path decode)

### DIFF
--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/app_info.dart';
 import '../core/services/active_playback_controller.dart';
 import '../core/services/notification_permission.dart';
+import '../core/services/stability_diagnostics.dart';
 import '../features/player/player_providers.dart';
 import 'router.dart';
 import 'theme.dart';
@@ -51,6 +52,9 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
+    // A secret-free breadcrumb (debug only): freezes/ANRs cluster around
+    // background/foreground, so logging the transition makes them correlatable.
+    StabilityDiagnostics.lifecycle(state.name);
     // Returning from the background while casting: re-sync from the receiver so
     // the position the UI shows is fresh. This never starts local playback —
     // backgrounding/foregrounding the app must not recreate or resume the local

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -127,8 +127,7 @@ abstract final class AppDiagnostics {
       if (cache != null) cache,
       if (data.playbackOutput != null)
         'Playback output: ${data.playbackOutput}',
-      if (data.playbackStatus != null)
-        'Playback state: ${data.playbackStatus}',
+      if (data.playbackStatus != null) 'Playback state: ${data.playbackStatus}',
       if (data.currentTrackIdHash != null)
         'Current track: ${data.currentTrackIdHash}',
       'Last error: ${data.lastErrorKind ?? 'none'}',

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -25,6 +25,8 @@ class AppDiagnosticsData {
     this.cacheUsedBytes,
     this.cacheLimitBytes,
     this.playbackOutput,
+    this.playbackStatus,
+    this.currentTrackIdHash,
     this.lastErrorKind,
     this.castAvailable = false,
     this.castConnected = false,
@@ -69,6 +71,15 @@ class AppDiagnosticsData {
   /// Which output is producing sound now: `local`, `cast`, or `android auto`.
   /// Null when nothing is playing / not known.
   final String? playbackOutput;
+
+  /// The current playback status (a stable enum name like `playing`/`buffering`/
+  /// `error`), when a controller is available. Null otherwise.
+  final String? playbackStatus;
+
+  /// A non-reversible hash tag of the currently playing track's id (e.g.
+  /// `id#1a2b3c`) — never the raw id, title, or URI — so a report can correlate
+  /// "which track was playing when it froze" without revealing anything.
+  final String? currentTrackIdHash;
 
   /// The stable name of the last safe error kind (an enum name), when one
   /// occurred. Never a raw error message.
@@ -116,6 +127,10 @@ abstract final class AppDiagnostics {
       if (cache != null) cache,
       if (data.playbackOutput != null)
         'Playback output: ${data.playbackOutput}',
+      if (data.playbackStatus != null)
+        'Playback state: ${data.playbackStatus}',
+      if (data.currentTrackIdHash != null)
+        'Current track: ${data.currentTrackIdHash}',
       'Last error: ${data.lastErrorKind ?? 'none'}',
       'Cast available: ${_yesNo(data.castAvailable)}',
       'Cast connected: ${_yesNo(data.castConnected)}',

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -9,6 +9,7 @@ import '../models/track.dart';
 import 'cast/cast_service.dart';
 import 'local_playback_controller.dart';
 import 'playback_controller.dart';
+import 'stability_diagnostics.dart';
 
 /// The single [PlaybackController] the UI talks to, routing between the
 /// on-device engine and a cast receiver and presenting *one* unified
@@ -124,6 +125,7 @@ class ActivePlaybackController implements PlaybackController {
       // A handoff began: the receiver is the active output. Silence the engine
       // so audio isn't heard twice; the queue stays owned locally.
       _output = ActivePlaybackOutput.cast;
+      StabilityDiagnostics.output('cast');
       unawaited(_local.suspend());
     } else if (!shouldCast && _output == ActivePlaybackOutput.cast) {
       // The session ended (user disconnect or a dropped receiver). Return to the
@@ -131,6 +133,7 @@ class ActivePlaybackController implements PlaybackController {
       // surprise-starts; the user can press play to continue here.
       final Duration resumeAt = _interpolatedCastPosition();
       _output = ActivePlaybackOutput.local;
+      StabilityDiagnostics.output('local');
       _castStatus = CastPlaybackStatus.idle;
       _castAnchoredAt = null;
       _castWasCompleted = false;

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -13,6 +13,7 @@ import 'local_playable_uri_resolver.dart';
 import 'local_playback_controller.dart';
 import 'playable_uri_resolver.dart';
 import 'playback_controller.dart';
+import 'stability_diagnostics.dart';
 import 'stream_interruption.dart';
 
 /// [PlaybackController] backed by `just_audio`.
@@ -96,6 +97,16 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   // so each track (and each successful stretch) gets its own one-retry budget.
   int _retriesForCurrent = 0;
 
+  // The latest engine position awaiting a coalesced flush, and the timer that
+  // flushes it. The engine's positionStream can fire several times a second
+  // (more in bursts during seeking/buffering); emitting a new state for every
+  // raw tick floods the unified stream — and the UI, media session, and
+  // pre-cache services hanging off it. These coalesce position onto a steady
+  // cadence; status/duration/track changes still emit immediately.
+  Duration? _pendingPosition;
+  Timer? _positionFlush;
+  static const Duration _positionFlushInterval = Duration(milliseconds: 250);
+
   @override
   PlaybackState get state => _state;
 
@@ -124,7 +135,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     }));
     _subscriptions.add(_player.positionStream.listen((position) {
       if (_suspended) return;
-      _emit(_state.copyWith(position: position));
+      // Coalesce raw position ticks onto a steady ~4 Hz flush so a high (or
+      // bursty) engine tick rate can never flood the state stream with rebuilds.
+      _pendingPosition = position;
+      _positionFlush ??=
+          Timer.periodic(_positionFlushInterval, (_) => _flushPosition());
     }));
     _subscriptions.add(_player.durationStream.listen((duration) {
       if (_suspended) return;
@@ -158,6 +173,9 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     if (track == null) return;
 
     final StreamInterruption interruption = classifyEngineError(error);
+    // Secret-free breadcrumb: only the classified *kind*, never the raw error
+    // (which can echo a tokenized stream URL).
+    StabilityDiagnostics.playbackError(interruption.kind.name);
     if (interruption.retryable && _retriesForCurrent < _maxStreamRetries) {
       _retriesForCurrent++;
       // Re-resolve and reload at the preserved position. The resolver re-checks
@@ -203,6 +221,30 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     if (next == _state) return;
     _state = next;
     if (!_states.isClosed) _states.add(next);
+  }
+
+  /// Emits the latest coalesced position. When nothing new has arrived since the
+  /// last flush (paused/stopped), it stops the timer so it never ticks idly; the
+  /// next position event restarts it.
+  void _flushPosition() {
+    final Duration? position = _pendingPosition;
+    _pendingPosition = null;
+    if (position == null) {
+      _positionFlush?.cancel();
+      _positionFlush = null;
+      return;
+    }
+    if (_suspended) return;
+    _emit(_state.copyWith(position: position));
+  }
+
+  /// Drops any pending position and stops the flush timer, so a stale tick from
+  /// the previous source can't flush onto a freshly established state (a new
+  /// track loading, stop, or a cast handoff).
+  void _resetPositionFlush() {
+    _pendingPosition = null;
+    _positionFlush?.cancel();
+    _positionFlush = null;
   }
 
   @override
@@ -311,6 +353,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     final track = _queue.current;
     if (track == null) return;
 
+    // A fresh load (or retry) establishes a new position baseline; drop any
+    // coalesced tick from the previous source so it can't flush onto it.
+    _resetPositionFlush();
+
     // A fresh (non-retry) load starts a new track or a deliberate (re)play, so
     // reset the mid-stream recovery budget. A retry must keep its counter.
     if (!isRetry) _retriesForCurrent = 0;
@@ -355,10 +401,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       resolved = await _resolver.resolve(track);
     } on PlaybackResolutionException catch (error) {
       // A resolver failure carries its own friendly, secret-free message.
+      StabilityDiagnostics.playbackError('resolution');
       _emitError(track, error.message);
       return;
     } catch (_) {
       // An unexpected error before we even know the source: stay generic.
+      StabilityDiagnostics.playbackError('resolution-unknown');
       _emitError(track, "Couldn't play this track.");
       return;
     }
@@ -383,6 +431,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     } catch (_) {
       // The URL resolved and (for streams) probed OK, so a failure here is the
       // engine itself. Word it for the source the listener can see on the badge.
+      StabilityDiagnostics.playbackError('load');
       _emitError(track, _loadErrorFor(resolved.source));
     }
   }
@@ -416,6 +465,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   Future<void> suspend() async {
     if (_suspended) return;
     _suspended = true;
+    // A cast receiver now owns position; stop flushing local ticks underneath it.
+    _resetPositionFlush();
     // Silence the engine but keep the loaded source and queue intact, so a
     // later resume can pick up the same track instantly when nothing changed.
     await _player.pause();
@@ -450,6 +501,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
 
   @override
   Future<void> stop() async {
+    _resetPositionFlush();
     await _player.stop();
     final stopped = PlaybackState(
       currentTrack: _state.currentTrack,
@@ -469,6 +521,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
 
   @override
   Future<void> dispose() async {
+    _resetPositionFlush();
     for (final subscription in _subscriptions) {
       await subscription.cancel();
     }

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -65,6 +65,24 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   final MediaBrowserTree _tree;
   late final StreamSubscription<PlaybackState> _subscription;
 
+  // The last media item / playback state actually pushed to the platform
+  // session. Position ticks arrive several times a second; re-pushing identical
+  // metadata on every one of them thrashes the Android MediaSession and rebuilds
+  // the notification needlessly (a real source of jank/ANR during long
+  // playback), so [_broadcast] pushes only when something the session shows
+  // actually changes. `audio_service` already interpolates the displayed
+  // position from `updatePosition` + the wall clock, so it does not need a push
+  // per tick — only when the position is discontinuous (a seek/track change) or
+  // has drifted enough to re-sync.
+  audio.MediaItem? _lastItem;
+  audio.PlaybackState? _lastPlaybackState;
+  bool _seeded = false;
+
+  /// How far the reported position may drift before a fresh playback-state push
+  /// re-syncs the session — so steady playback produces only this ~1 Hz
+  /// correction rather than ~5 platform pushes a second.
+  static const Duration _positionResyncThreshold = Duration(seconds: 1);
+
   @override
   Future<void> play() => _controller.play();
 
@@ -136,13 +154,69 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   // ------------------------------------------------------------------------
 
   void _broadcast(PlaybackState state) {
-    final track = state.currentTrack;
-    mediaItem.add(
-      track == null
-          ? null
-          : _trackMediaItem(track, id: track.id, live: state.duration),
-    );
-    playbackState.add(_playbackStateFor(state));
+    final Track? track = state.currentTrack;
+    final audio.MediaItem? item = track == null
+        ? null
+        : _trackMediaItem(track, id: track.id, live: state.duration);
+    // Re-push the media item only when its identity/metadata changes (a track
+    // change, or its duration becoming known) — not on every position tick.
+    if (!_seeded || !_sameItem(item, _lastItem)) {
+      _lastItem = item;
+      mediaItem.add(item);
+    }
+    final audio.PlaybackState next = _playbackStateFor(state);
+    if (!_seeded || _shouldPushPlayback(next, _lastPlaybackState)) {
+      _lastPlaybackState = next;
+      playbackState.add(next);
+    }
+    _seeded = true;
+  }
+
+  /// Whether two media items would show the same thing in the session, so a
+  /// re-push can be skipped. Compares the fields the platform renders; all of
+  /// them derive from the track (identified by [audio.MediaItem.id]) plus the
+  /// live duration, so this never drops a real metadata change.
+  static bool _sameItem(audio.MediaItem? a, audio.MediaItem? b) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null) return false;
+    return a.id == b.id &&
+        a.title == b.title &&
+        a.artist == b.artist &&
+        a.album == b.album &&
+        a.duration == b.duration &&
+        a.artUri == b.artUri;
+  }
+
+  /// Whether a playback state must be pushed to the platform session: when any
+  /// field the session renders as a *control/mode* changes, or when the position
+  /// is discontinuous relative to the last push (a seek, a track reset) or has
+  /// drifted past [_positionResyncThreshold]. Steady position ticks within the
+  /// threshold are skipped — `audio_service` interpolates them.
+  static bool _shouldPushPlayback(
+    audio.PlaybackState next,
+    audio.PlaybackState? last,
+  ) {
+    if (last == null) return true;
+    if (next.playing != last.playing ||
+        next.processingState != last.processingState ||
+        next.shuffleMode != last.shuffleMode ||
+        next.repeatMode != last.repeatMode ||
+        !_sameControls(next.controls, last.controls)) {
+      return true;
+    }
+    return (next.updatePosition - last.updatePosition).abs() >=
+        _positionResyncThreshold;
+  }
+
+  static bool _sameControls(
+    List<audio.MediaControl> a,
+    List<audio.MediaControl> b,
+  ) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   audio.MediaItem _mediaItemForNode(MediaNode node) {

--- a/lib/core/services/smart_precache_service.dart
+++ b/lib/core/services/smart_precache_service.dart
@@ -4,6 +4,7 @@ import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
 import '../models/track.dart';
 import '../repositories/download_preferences.dart';
+import 'stability_diagnostics.dart';
 import 'track_prefetcher.dart';
 
 /// Smart pre-cache: warms a small number of upcoming Jellyfin tracks into the
@@ -108,15 +109,24 @@ class SmartPrecacheService {
   Future<void> _precacheUpcoming(PlaybackState state) async {
     final List<Track> upNext = state.upNext;
     if (upNext.isEmpty) return;
-    if (!await _preferences.preloadEnabled()) return;
+    if (!await _preferences.preloadEnabled()) {
+      StabilityDiagnostics.precache('skip:disabled');
+      return;
+    }
     // Repeat-one replays the current track indefinitely, so the up-next won't
     // play soon. Don't aggressively pre-cache unrelated tracks — stay quiet.
-    if (state.repeatMode == RepeatMode.one) return;
+    if (state.repeatMode == RepeatMode.one) {
+      StabilityDiagnostics.precache('skip:repeat-one');
+      return;
+    }
     final int aheadCount = sanitizePrecacheCount(
       await _preferences.precacheCount(),
     );
     if (aheadCount <= 0) return;
     final int count = upNext.length < aheadCount ? upNext.length : aheadCount;
+    // Secret-free count only — never which tracks. A real pre-cache pass per
+    // queue change (not per position tick — see [_onState]) reads as one log.
+    StabilityDiagnostics.precache('start:$count');
     for (int i = 0; i < count; i++) {
       // Sequential on purpose: one warm fetch at a time keeps pre-cache off the
       // critical path and lets the cache limit settle between writes.

--- a/lib/core/services/stability_diagnostics.dart
+++ b/lib/core/services/stability_diagnostics.dart
@@ -1,0 +1,49 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+/// Secret-free breadcrumb logs for diagnosing the field freezes/ANRs this
+/// stabilization pass targets, and the playback-output handoffs that surround
+/// them. Filter device logs with `adb logcat | grep linthra.stability`.
+///
+/// Debug-only (silent in release builds; active under `flutter test`) and
+/// secret-free *by construction*: every method takes only a fixed, structural
+/// label — an output name, a lifecycle state, a pre-cache outcome, an error
+/// *kind* (an enum name) — and there is no parameter for a token, password,
+/// authenticated URL, track title, or local path. The `describe*` helpers are
+/// pure and public so a test can assert the emitted line carries no secret.
+abstract final class StabilityDiagnostics {
+  /// The developer-log channel these breadcrumbs go to.
+  static const String name = 'linthra.stability';
+
+  static void _log(String message) {
+    if (!kDebugMode) return;
+    developer.log(message, name: name);
+  }
+
+  /// An app lifecycle transition (`resumed`, `paused`, `inactive`, …) — the
+  /// boundary most freezes/ANRs cluster around (background/foreground).
+  static void lifecycle(String state) => _log(describeLifecycle(state));
+
+  static String describeLifecycle(String state) => 'lifecycle: $state';
+
+  /// The active playback output changed (`local` / `cast`), so a handoff can be
+  /// correlated with a freeze without logging anything about the track.
+  static void output(String output) => _log(describeOutput(output));
+
+  static String describeOutput(String output) => 'output -> $output';
+
+  /// A smart pre-cache decision, by safe outcome: `start:<count>`,
+  /// `skip:<reason>` (e.g. `skip:disabled`, `skip:repeat-one`). No track id,
+  /// title, or URL is ever included.
+  static void precache(String outcome) => _log(describePrecache(outcome));
+
+  static String describePrecache(String outcome) => 'precache: $outcome';
+
+  /// A playback / stream-resolution failure, by its safe [kind] (a
+  /// [StreamInterruptionKind] name or a fixed label like `resolution`/`load`) —
+  /// never the raw error, which can carry a tokenized URL.
+  static void playbackError(String kind) => _log(describePlaybackError(kind));
+
+  static String describePlaybackError(String kind) => 'playback error: $kind';
+}

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -119,7 +119,7 @@ final cachedTrackLocatorProvider = Provider<CachedTrackLocator>((ref) {
 /// the in-memory defaults.
 final sharedPreferencesDownloadStoreOverride =
     downloadStoreProvider.overrideWithValue(
-  const SharedPreferencesDownloadStore(),
+  SharedPreferencesDownloadStore(),
 );
 
 final sharedPreferencesDownloadPreferencesOverride =

--- a/lib/data/repositories/shared_preferences_download_store.dart
+++ b/lib/data/repositories/shared_preferences_download_store.dart
@@ -16,23 +16,61 @@ import '../../core/repositories/download_store.dart';
 /// Security: only the non-secret track id and a track-id-derived file name are
 /// persisted — never a token or an authenticated URL.
 class SharedPreferencesDownloadStore implements DownloadStore {
-  const SharedPreferencesDownloadStore();
+  SharedPreferencesDownloadStore();
 
   // A JSON document under a v2 key. The pre-1.0 IDs-only key is intentionally
   // not migrated (there were no remote downloads to preserve).
   static const String _key = 'offline_downloads_v2';
 
+  // The decoded set memoized against the exact persisted JSON string. The
+  // playback read-path (`CachedTrackLocator`) calls [loadDownloads] on *every*
+  // resolve — each play, skip, pre-cache and stream-preload — and re-running
+  // `jsonDecode` + rebuilding every `CachedTrack` on the UI isolate each time
+  // adds up to real jank during rapid skips and pre-cache passes. Keying the
+  // cache on the raw string makes a repeat read a cheap string compare + a
+  // shallow list copy, and a write (which changes the string) is picked up
+  // automatically, so a stale set can never be returned.
+  String? _cachedRaw;
+  List<CachedTrack> _cachedDownloads = const <CachedTrack>[];
+
   @override
   Future<List<CachedTrack>> loadDownloads() async {
     final prefs = await SharedPreferences.getInstance();
     final String? raw = prefs.getString(_key);
-    if (raw == null || raw.isEmpty) return const <CachedTrack>[];
+    if (raw == null || raw.isEmpty) {
+      _cachedRaw = raw;
+      _cachedDownloads = const <CachedTrack>[];
+      return <CachedTrack>[];
+    }
+    if (raw != _cachedRaw) {
+      _cachedRaw = raw;
+      _cachedDownloads = _decode(raw);
+    }
+    // Hand back a fresh, caller-owned copy so a caller mutating the list can
+    // never corrupt the shared cache (the heavy decode is what was skipped).
+    return List<CachedTrack>.of(_cachedDownloads);
+  }
 
+  @override
+  Future<void> saveDownloads(List<CachedTrack> downloads) async {
+    final prefs = await SharedPreferences.getInstance();
+    final String raw = jsonEncode(
+      <Map<String, dynamic>>[for (final c in downloads) c.toJson()],
+    );
+    await prefs.setString(_key, raw);
+    // Keep the memo consistent with what was just persisted, so the very next
+    // read (common right after a download completes) skips the decode too.
+    _cachedRaw = raw;
+    _cachedDownloads = List<CachedTrack>.of(downloads);
+  }
+
+  /// Decodes the persisted JSON document into records. A corrupt document reads
+  /// as "nothing downloaded" rather than crashing.
+  static List<CachedTrack> _decode(String raw) {
     Object? decoded;
     try {
       decoded = jsonDecode(raw);
     } on FormatException {
-      // A corrupt record reads as "nothing downloaded" rather than crashing.
       return const <CachedTrack>[];
     }
     if (decoded is! List) return const <CachedTrack>[];
@@ -45,14 +83,5 @@ class SharedPreferencesDownloadStore implements DownloadStore {
       }
     }
     return downloads;
-  }
-
-  @override
-  Future<void> saveDownloads(List<CachedTrack> downloads) async {
-    final prefs = await SharedPreferences.getInstance();
-    final String raw = jsonEncode(
-      <Map<String, dynamic>>[for (final c in downloads) c.toJson()],
-    );
-    await prefs.setString(_key, raw);
   }
 }

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
+import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_grouping.dart';
 import 'library_state.dart';
@@ -36,7 +37,18 @@ class AlbumDetailScreen extends ConsumerWidget {
       );
     }
 
-    final Album? album = albumById(state.tracks, albumId);
+    // Reuse the album grouping the Albums tab already memoized, instead of
+    // re-grouping the entire catalog on every build — that O(N) pass (base64
+    // key + sort per track) blocked the UI thread for seconds on large
+    // libraries when opening a detail page. Only the per-album track list, a
+    // single bounded filter, is derived here.
+    Album? album;
+    for (final Album candidate in ref.watch(libraryAlbumsProvider)) {
+      if (candidate.id == albumId) {
+        album = candidate;
+        break;
+      }
+    }
     final List<Track> tracks = tracksForAlbum(state.tracks, albumId);
     if (album == null || tracks.isEmpty) {
       return Scaffold(

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
+import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_grouping.dart';
 import 'library_state.dart';
@@ -38,7 +39,17 @@ class ArtistDetailScreen extends ConsumerWidget {
       );
     }
 
-    final Artist? artist = artistById(state.tracks, artistId);
+    // Reuse the artist grouping the Artists tab already memoized, rather than
+    // re-grouping the whole catalog on every build (the freeze on large
+    // libraries). The per-artist track and album lists below are bounded
+    // filters over the catalog, not another full grouping of it.
+    Artist? artist;
+    for (final Artist candidate in ref.watch(libraryArtistsProvider)) {
+      if (candidate.id == artistId) {
+        artist = candidate;
+        break;
+      }
+    }
     final List<Track> tracks = tracksForArtist(state.tracks, artistId);
     if (artist == null || tracks.isEmpty) {
       return Scaffold(

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -5,8 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../app/colors.dart';
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
-import '../../core/models/playback_state.dart';
-import '../../core/services/playback_controller.dart';
+import '../../core/models/track.dart';
 import 'cast/cast_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
@@ -26,22 +25,27 @@ class MiniPlayer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final controller = ref.watch(playbackControllerProvider);
-    final state =
-        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+    // Watch only the current track (id-distinct), so the ~5 Hz position ticks
+    // rebuild just the thin progress line and the play/pause button below — not
+    // the whole bar (artwork, text) on every screen, every tick. Falls back to
+    // the controller's latest state until the first stream event arrives.
+    final Track? streamed = ref.watch(
+      playbackStateProvider.select((s) => s.valueOrNull?.currentTrack),
+    );
+    final Track? track =
+        streamed ?? ref.read(playbackControllerProvider).state.currentTrack;
 
     // Collapse entirely when there is nothing to show, so screens without a
     // loaded track look exactly as they did before.
-    if (!state.hasTrack) {
+    if (track == null) {
       return const SizedBox.shrink();
     }
 
     final theme = Theme.of(context);
-    final track = state.currentTrack!;
     final bool isCasting = ref.watch(
       castStateProvider.select((s) => s.valueOrNull?.isConnected ?? false),
     );
-    final subtitle = _subtitle(state);
+    final subtitle = _subtitle(track);
 
     return Material(
       color: theme.colorScheme.surfaceContainerHigh,
@@ -51,10 +55,7 @@ class MiniPlayer extends ConsumerWidget {
           height: 64,
           child: Column(
             children: [
-              _MiniProgressBar(
-                position: state.position,
-                duration: state.duration,
-              ),
+              const _MiniProgressBar(),
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
@@ -105,7 +106,7 @@ class MiniPlayer extends ConsumerWidget {
                         const SizedBox(width: AppSpacing.sm),
                       ],
                       const SizedBox(width: AppSpacing.sm),
-                      _PlayPauseButton(state: state, controller: controller),
+                      const _PlayPauseButton(),
                     ],
                   ),
                 ),
@@ -119,8 +120,7 @@ class MiniPlayer extends ConsumerWidget {
 
   /// Artist • album when present; falls back to artist or album alone, and to
   /// nothing when the track carries no metadata.
-  static String? _subtitle(PlaybackState state) {
-    final track = state.currentTrack!;
+  static String? _subtitle(Track track) {
     final parts = <String>[
       if (track.artistName != null && track.artistName!.isNotEmpty)
         track.artistName!,
@@ -134,18 +134,22 @@ class MiniPlayer extends ConsumerWidget {
 /// A 2.5dp accent line tracking playback progress across the mini-player's top
 /// edge. Sits at 0 (an empty track) when the duration is still unknown, so it
 /// never animates indeterminately or jumps.
-class _MiniProgressBar extends StatelessWidget {
-  const _MiniProgressBar({required this.position, required this.duration});
-
-  final Duration position;
-  final Duration duration;
+///
+/// It watches the position/duration itself, so a position tick rebuilds only
+/// this thin line — not the artwork and text above it.
+class _MiniProgressBar extends ConsumerWidget {
+  const _MiniProgressBar();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(playbackControllerProvider);
+    final state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
     final theme = Theme.of(context);
-    final int total = duration.inMilliseconds;
-    final double value =
-        total > 0 ? (position.inMilliseconds / total).clamp(0.0, 1.0) : 0.0;
+    final int total = state.duration.inMilliseconds;
+    final double value = total > 0
+        ? (state.position.inMilliseconds / total).clamp(0.0, 1.0)
+        : 0.0;
     return LinearProgressIndicator(
       value: value,
       minHeight: 2.5,
@@ -157,15 +161,16 @@ class _MiniProgressBar extends StatelessWidget {
 
 /// The mini-player's transport control: a spinner while a track loads, then a
 /// play/pause toggle (tinted with the warm accent) that forwards to the
-/// controller.
-class _PlayPauseButton extends StatelessWidget {
-  const _PlayPauseButton({required this.state, required this.controller});
-
-  final PlaybackState state;
-  final PlaybackController controller;
+/// controller. Watches the playback status itself so it stays live even though
+/// the bar around it only rebuilds when the track changes.
+class _PlayPauseButton extends ConsumerWidget {
+  const _PlayPauseButton();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(playbackControllerProvider);
+    final state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
     // A spinner for both preparing and mid-stream buffering, so the mini-player
     // shows activity (never looks frozen) while the stream catches up.
     if (state.isBusy) {

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -25,10 +25,16 @@ class PlayerScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final controller = ref.watch(playbackControllerProvider);
-    final state =
-        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
-    final Track? track = state.currentTrack;
+    // Watch only the current track (id-distinct), so the ~5 Hz position ticks
+    // never rebuild this whole screen — above all the full-screen *blurred*
+    // artwork background, which is expensive to re-paint and was rebuilding on
+    // every tick. The position/status pieces watch their own slice in
+    // [_LiveControls], so they stay live without dragging the heavy widgets.
+    final Track? streamed = ref.watch(
+      playbackStateProvider.select((s) => s.valueOrNull?.currentTrack),
+    );
+    final Track? track =
+        streamed ?? ref.read(playbackControllerProvider).state.currentTrack;
 
     return Scaffold(
       body: Stack(
@@ -43,7 +49,7 @@ class PlayerScreen extends ConsumerWidget {
                 Expanded(
                   child: track == null
                       ? const _EmptyNowPlaying()
-                      : _NowPlaying(state: state, track: track),
+                      : _NowPlaying(track: track),
                 ),
               ],
             ),
@@ -103,14 +109,13 @@ class _EmptyNowPlaying extends StatelessWidget {
   }
 }
 
-class _NowPlaying extends ConsumerWidget {
-  const _NowPlaying({required this.state, required this.track});
+class _NowPlaying extends StatelessWidget {
+  const _NowPlaying({required this.track});
 
-  final PlaybackState state;
   final Track track;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppSpacing.lg,
@@ -151,20 +156,43 @@ class _NowPlaying extends ConsumerWidget {
             albumName: track.albumName,
           ),
           const SizedBox(height: AppSpacing.md),
-          _SourceOrError(state: state),
-          const SizedBox(height: AppSpacing.sm),
-          PlaybackProgressBar(
-            position: state.position,
-            duration: state.duration,
-            onSeek: (position) =>
-                ref.read(playbackControllerProvider).seek(position),
-          ),
-          const SizedBox(height: AppSpacing.xs),
-          PlaybackControls(state: state),
+          // The only part of the screen that follows the live, high-frequency
+          // playback state — kept separate so the artwork, metadata, and the
+          // blurred background above never rebuild on a position tick.
+          const _LiveControls(),
           const SizedBox(height: AppSpacing.sm),
           NowPlayingActions(track: track),
         ],
       ),
+    );
+  }
+}
+
+/// The source/error line, seekable progress bar, and transport controls —
+/// everything that must follow position/status. Isolated into its own consumer
+/// so a position tick rebuilds only this slim column, not the screen.
+class _LiveControls extends ConsumerWidget {
+  const _LiveControls();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(playbackControllerProvider);
+    final PlaybackState state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _SourceOrError(state: state),
+        const SizedBox(height: AppSpacing.sm),
+        PlaybackProgressBar(
+          position: state.position,
+          duration: state.duration,
+          onSeek: (position) =>
+              ref.read(playbackControllerProvider).seek(position),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        PlaybackControls(state: state),
+      ],
     );
   }
 }

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -6,7 +6,9 @@ import '../../../core/app_info.dart';
 import '../../../core/diagnostics/app_diagnostics.dart';
 import '../../../core/models/active_playback_output.dart';
 import '../../../core/models/cast_state.dart';
+import '../../../core/models/playback_state.dart';
 import '../../../core/services/active_playback_controller.dart';
+import '../../../core/services/playback_diagnostics.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../downloads/download_providers.dart';
 import '../../player/cast/cast_providers.dart';
@@ -57,6 +59,8 @@ class DiagnosticsCollector {
       cacheUsedBytes: _cacheUsedBytes(),
       cacheLimitBytes: _cacheLimitBytes(),
       playbackOutput: _playbackOutput(),
+      playbackStatus: _playbackStatus(),
+      currentTrackIdHash: _currentTrackIdHash(),
       lastErrorKind: jellyfin.errorKind?.name ?? subsonic.errorKind?.name,
       castAvailable: cast.isAvailable,
       castConnected: cast.isConnected,
@@ -134,6 +138,25 @@ class DiagnosticsCollector {
       case ActivePlaybackOutput.cast:
         return 'cast';
     }
+  }
+
+  /// The current playback status as a stable enum name, or null when nothing is
+  /// loaded (so a quiet, never-played session reports no line).
+  String? _playbackStatus() {
+    final PlaybackState state = _ref.read(playbackControllerProvider).state;
+    if (state.currentTrack == null && state.status == PlaybackStatus.idle) {
+      return null;
+    }
+    return state.status.name;
+  }
+
+  /// A non-reversible hash of the currently playing track's id (never the id,
+  /// title, or URI), or null when nothing is playing.
+  String? _currentTrackIdHash() {
+    final String? id =
+        _ref.read(playbackControllerProvider).state.currentTrack?.id;
+    if (id == null || id.isEmpty) return null;
+    return PlaybackDiagnostics.redactId(id);
   }
 }
 

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -110,6 +110,30 @@ void main() {
       expect(report, contains('Smart pre-cache: disabled'));
     });
 
+    test('includes the playback state and a hashed current-track id', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          playbackOutput: 'local',
+          playbackStatus: 'playing',
+          currentTrackIdHash: 'id#1a2b3c',
+        ),
+      );
+
+      expect(report, contains('Playback output: local'));
+      expect(report, contains('Playback state: playing'));
+      // A hash tag — never a raw id, title, or URI.
+      expect(report, contains('Current track: id#1a2b3c'));
+    });
+
+    test('omits the playback state / current track lines when absent', () {
+      final String report =
+          AppDiagnostics.report(const AppDiagnosticsData(appVersion: '0.1.0'));
+
+      expect(report, isNot(contains('Playback state:')));
+      expect(report, isNot(contains('Current track:')));
+    });
+
     test('omits absent optional fields but always reports app version', () {
       final String report =
           AppDiagnostics.report(const AppDiagnosticsData(appVersion: '0.1.0'));

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -96,6 +96,29 @@ void main() {
       );
       expect(state.position, const Duration(seconds: 42));
     });
+
+    test('passive position updates never re-issue play or load', () async {
+      local = FakePlaybackController();
+      await local.playTracks(const <Track>[_trackA, _trackB]);
+      cast = FakeCastService();
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      final int playsBefore = local.playCount;
+      final int playedBefore = local.playedTracks.length;
+
+      // The engine's position stream pushes a series of position-only updates;
+      // the merged controller must only mirror them out, never command playback.
+      for (int s = 1; s <= 5; s++) {
+        local.emit(local.state.copyWith(position: Duration(seconds: s)));
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(local.playCount, playsBefore);
+      expect(local.playedTracks.length, playedBefore);
+      expect(cast.playCount, 0);
+      expect(cast.seeks, isEmpty);
+    });
   });
 
   group('handoff to cast', () {

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -121,6 +121,95 @@ void main() {
       );
     });
 
+    group('session updates are not flooded by position ticks', () {
+      test('the media item is pushed once per track, not per position tick',
+          () async {
+        final List<audio.MediaItem?> items = <audio.MediaItem?>[];
+        final sub = handler.mediaItem.listen(items.add);
+        addTearDown(sub.cancel);
+
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+        // Four position-only updates for the same track, each well under a
+        // second apart — exactly what the engine's position stream produces.
+        for (int ms = 200; ms <= 800; ms += 200) {
+          controller.emit(
+            controller.state.copyWith(position: Duration(milliseconds: ms)),
+          );
+          await _settle();
+        }
+
+        // Only one real item (track 'a') reached the session despite the ticks.
+        final List<audio.MediaItem> nonNull =
+            items.whereType<audio.MediaItem>().toList();
+        expect(nonNull, hasLength(1));
+        expect(nonNull.single.id, 'a');
+      });
+
+      test('playback state is not re-pushed on sub-second position ticks',
+          () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        final List<audio.PlaybackState> pushed = <audio.PlaybackState>[];
+        final sub = handler.playbackState.listen(pushed.add);
+        addTearDown(sub.cancel);
+        await _settle();
+        // Listening replays the current value; count only pushes after that.
+        final int baseline = pushed.length;
+
+        for (int ms = 100; ms <= 900; ms += 200) {
+          controller.emit(
+            controller.state.copyWith(position: Duration(milliseconds: ms)),
+          );
+          await _settle();
+        }
+
+        // Same shape, drift under the 1s threshold: nothing new was pushed —
+        // audio_service interpolates the displayed position between pushes.
+        expect(pushed.length, baseline);
+      });
+
+      test('a position jump (a seek) is pushed immediately', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        final List<audio.PlaybackState> pushed = <audio.PlaybackState>[];
+        final sub = handler.playbackState.listen(pushed.add);
+        addTearDown(sub.cancel);
+        await _settle();
+        final int baseline = pushed.length;
+
+        // A discontinuity (>1s) is a seek/track reset and must re-sync.
+        controller.emit(
+          controller.state.copyWith(position: const Duration(seconds: 30)),
+        );
+        await _settle();
+
+        expect(pushed.length, greaterThan(baseline));
+      });
+
+      test('a pause is pushed even when the position is steady', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        final List<audio.PlaybackState> pushed = <audio.PlaybackState>[];
+        final sub = handler.playbackState.listen(pushed.add);
+        addTearDown(sub.cancel);
+        await _settle();
+        final int baseline = pushed.length;
+
+        // Same position, different shape (paused): a control change always pushes.
+        controller.emit(
+          controller.state.copyWith(status: PlaybackStatus.paused),
+        );
+        await _settle();
+
+        expect(pushed.length, greaterThan(baseline));
+        expect(pushed.last.playing, isFalse);
+      });
+    });
+
     group('media browser', () {
       test('root lists Library and Queue as browsable categories', () async {
         final children = await handler.getChildren(MediaId.root);

--- a/test/core/services/stability_diagnostics_test.dart
+++ b/test/core/services/stability_diagnostics_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/stability_diagnostics.dart';
+
+void main() {
+  group('StabilityDiagnostics breadcrumbs (secret-free)', () {
+    test('describe* render the fixed, structural label', () {
+      expect(
+        StabilityDiagnostics.describeLifecycle('resumed'),
+        'lifecycle: resumed',
+      );
+      expect(StabilityDiagnostics.describeOutput('cast'), 'output -> cast');
+      expect(
+        StabilityDiagnostics.describePrecache('start:3'),
+        'precache: start:3',
+      );
+      expect(
+        StabilityDiagnostics.describePlaybackError('sessionExpired'),
+        'playback error: sessionExpired',
+      );
+    });
+
+    test('a breadcrumb carries only its label — no room to leak a secret', () {
+      // The call sites pass enum names / fixed labels by construction; these
+      // assert the rendered line is exactly that label with a fixed prefix, so
+      // a token, authenticated URL, or path can never ride along.
+      final List<String> lines = <String>[
+        StabilityDiagnostics.describeLifecycle('paused'),
+        StabilityDiagnostics.describeOutput('local'),
+        StabilityDiagnostics.describePrecache('skip:repeat-one'),
+        StabilityDiagnostics.describePlaybackError('networkDropped'),
+      ];
+      for (final String line in lines) {
+        expect(line, isNot(contains('://')));
+        expect(line, isNot(contains('api_key')));
+        expect(line.toLowerCase(), isNot(contains('token')));
+        expect(line.toLowerCase(), isNot(contains('authorization')));
+        expect(line.toLowerCase(), isNot(contains('password')));
+      }
+    });
+
+    test('the logging entry points never throw', () {
+      expect(
+        () {
+          StabilityDiagnostics.lifecycle('resumed');
+          StabilityDiagnostics.output('cast');
+          StabilityDiagnostics.precache('start:1');
+          StabilityDiagnostics.playbackError('unknown');
+        },
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/test/data/repositories/shared_preferences_download_store_test.dart
+++ b/test/data/repositories/shared_preferences_download_store_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/download_store.dart';
+import 'package:linthra/data/repositories/shared_preferences_download_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Covers the persistence contract *and* the in-memory memoization added to keep
+/// the hot playback read-path (the cached-track locator calls [loadDownloads] on
+/// every resolve/skip/pre-cache) from re-decoding the whole JSON document each
+/// time. The memo must never hand back a stale or shared-mutable set.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SharedPreferencesDownloadStore', () {
+    test('round-trips the cached set across separate instances', () async {
+      await SharedPreferencesDownloadStore().saveDownloads(<CachedTrack>[
+        const CachedTrack(trackId: 'a', fileName: 'a.mp3', sizeBytes: 10),
+        const CachedTrack(trackId: 'b'),
+      ]);
+
+      // A fresh instance (no shared in-memory state) reads the persisted set
+      // through the decode path.
+      final List<CachedTrack> loaded =
+          await SharedPreferencesDownloadStore().loadDownloads();
+
+      expect(loaded.map((CachedTrack c) => c.trackId), <String>['a', 'b']);
+      expect(
+        loaded.firstWhere((CachedTrack c) => c.trackId == 'a').fileName,
+        'a.mp3',
+      );
+    });
+
+    test('repeated loads return equal but independent, caller-owned lists',
+        () async {
+      final SharedPreferencesDownloadStore store =
+          SharedPreferencesDownloadStore();
+      await store.saveDownloads(<CachedTrack>[
+        const CachedTrack(trackId: 'a', fileName: 'a.mp3'),
+      ]);
+
+      final List<CachedTrack> first = await store.loadDownloads();
+      final List<CachedTrack> second = await store.loadDownloads();
+      expect(first, equals(second));
+      // Not the same instance — a caller can't reach into the memo.
+      expect(identical(first, second), isFalse);
+
+      // Mutating a returned list must not corrupt the memoized set.
+      first.clear();
+      final List<CachedTrack> third = await store.loadDownloads();
+      expect(third.map((CachedTrack c) => c.trackId), <String>['a']);
+    });
+
+    test('a save is reflected by the very next load (no stale memo)', () async {
+      final SharedPreferencesDownloadStore store =
+          SharedPreferencesDownloadStore();
+      await store.saveDownloads(
+        <CachedTrack>[const CachedTrack(trackId: 'a', fileName: 'a.mp3')],
+      );
+      expect(
+        (await store.loadDownloads()).map((CachedTrack c) => c.trackId),
+        <String>['a'],
+      );
+
+      // A different set writes a different JSON string, so the change is picked
+      // up rather than the memo returning the old set.
+      await store.saveDownloads(
+        <CachedTrack>[const CachedTrack(trackId: 'b', fileName: 'b.mp3')],
+      );
+      expect(
+        (await store.loadDownloads()).map((CachedTrack c) => c.trackId),
+        <String>['b'],
+      );
+    });
+
+    test('an empty store loads as nothing downloaded', () async {
+      expect(await SharedPreferencesDownloadStore().loadDownloads(), isEmpty);
+    });
+
+    test('a corrupt record reads as nothing downloaded', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'offline_downloads_v2': 'not json at all',
+      });
+      expect(await SharedPreferencesDownloadStore().loadDownloads(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Critical stabilization PR — ANR / freeze / crash

After real-device testing, Android showed **"Linthra ne répond pas / Linthra isn't responding"** during normal use, sometimes followed by a crash — **even when Lyrics was not open**. This PR finds and fixes the global root causes. No new features, no UI redesign, no theme/logo/provider/release changes.

> ⚠️ **Verification note:** this environment has **no Flutter/Dart SDK**, so I could **not** run `flutter pub get / analyze / test / dart format / build apk` locally. Changes were made by careful review against existing conventions and the test suite. **CI must run the gates** (commands listed at the bottom). Any `dart format` nit is non-functional and trivially fixable.

### Suspected root cause (going in)
The screenshot pointed at Lyrics, but the report said it happens without Lyrics too — so the likely cause is global: the playback **position stream** (~5/s) fanning out to too many consumers.

### Actual root cause (found) — two classes

**A. Synchronous heavy work on the UI isolate (hard, multi-second freezes):**
1. `StoreCachedTrackLocator.cachedFilePath` calls `DownloadStore.loadDownloads()` on **every** resolve (each play / skip / pre-cache / stream-preload). `SharedPreferencesDownloadStore.loadDownloads` re-ran `jsonDecode` + rebuilt every `CachedTrack` each call, on the UI isolate — janks badly during rapid skips and pre-cache passes.
2. Album/Artist **detail screens re-grouped the entire catalog 3–4× per build** (`albumById`/`artistById` + `tracksFor*` + `albumsForArtist`, each an O(N) base64-key + sort pass) instead of reusing the already-memoized `libraryAlbums/ArtistsProvider`. On a large synced library this blocked the main thread for seconds when opening a detail page.

**B. Position-stream over-emission (sustained pressure during playback — the part Lyrics made easy to notice):**
3. `LinthraAudioHandler` pushed a **fresh `MediaItem` + `PlaybackState` to the Android media session on every position tick (~5/s)** — re-setting `MediaMetadata`/rebuilding the notification needlessly.
4. `PlayerScreen` rebuilt its **whole tree, including the full-screen 40px-blur artwork background**, and `MiniPlayer` (on every screen) rebuilt fully incl. artwork, on every position tick — because both watched the full state at the top.

The cast layer, download scheduler, connectivity, and subscription/timer/controller lifecycles were audited and found **clean** (no leaks, no retry storms, no unthrottled cast polling).

### Fixes

**Main-thread / hot-path (class A)**
- `SharedPreferencesDownloadStore`: memoize the decode keyed by the persisted JSON string. A repeat read becomes a string compare + shallow copy; a `saveDownloads` updates the memo so a stale set can never be returned. Returns a caller-owned copy (callers only iterate). Benefits the locator (hot path) and the repository.
- `AlbumDetailScreen` / `ArtistDetailScreen`: reuse `libraryAlbumsProvider` / `libraryArtistsProvider` (computed once per library change, shared with the tabs); derive only the bounded per-entity lists. Eliminates the per-build full re-grouping.

**Position throttling & rebuild scoping (class B / section C)**
- `LinthraAudioHandler._broadcast`: push the **media item only on identity/metadata change**, and the **playback state only on a control-shape change or a position discontinuity** (seek / track reset / ≥1s drift). `audio_service` interpolates the displayed position between pushes, so steady-playback pushes drop from ~5/s to ~1/s, and media-item pushes drop to ~once/track.
- `PlayerScreen` & `MiniPlayer`: watch only the current **track** (id-distinct) at the top; isolate position/status into small self-watching consumers (`_LiveControls`, `_MiniProgressBar`, `_PlayPauseButton`). The blurred background, artwork, and metadata now rebuild **only on track change**; only the slim progress/controls rebuild on a tick. Pixel-identical.
- `JustAudioPlaybackController`: **coalesce raw position ticks onto a steady ~4 Hz flush** so a high/bursty engine tick rate can't flood the unified stream (and everything hanging off it). Status/duration/track changes still emit immediately. The flush timer self-cancels when idle and is reset on load/stop/suspend/dispose (no stale flush, no use-after-dispose).

### Stream / listener / timer cleanup
- The new position-flush `Timer.periodic` is cancelled on load (new track), `stop`, `suspend`, and `dispose`, and idles itself when no new position arrives. No new leaks introduced; the existing subscription/timer/controller disposal (audited) is unchanged.

### Playback / cast / cache stability
- Local & cast outputs unchanged in behaviour (cast still throttled to 250 ms while playing; no auto-restart; no retry storm — verified).
- Passive position updates **never** re-issue play/load (verified + test).
- Pre-cache/cache cleanup still keys off structural changes only (not per-tick); a failed pre-cache still isn't retried in a loop (existing tests).

### Diagnostics added (secret-free, debug-only)
- New `StabilityDiagnostics` breadcrumbs (`adb logcat | grep linthra.stability`): app lifecycle transitions, playback **output handoffs** (local/cast), smart pre-cache **start/skip** (count + reason only), and playback/stream-resolution **error kind** (the classified `StreamInterruptionKind` name — never the raw error, which can carry a tokenized URL). Android Auto browse/play already logs under `Linthra.AndroidAuto`.
- In-app diagnostics snapshot (Settings ▸ Diagnostics) gains **playback state** and a **hashed current-track id** (`id#…`, never the raw id/title/URI), alongside the existing active output, cast-connected, smart-pre-cache, last-error-kind, and app version. No tokens, auth headers, authenticated URLs, passwords, or private paths can appear (enforced by construction + tests).

### Tests added / updated
- `linthra_audio_handler_test`: media item pushed once per track (not per tick); playback state not re-pushed on sub-second ticks; a seek (discontinuity) and a pause still push immediately.
- `active_playback_controller_test`: passive position updates never re-issue play/load (no duplicate commands).
- `shared_preferences_download_store_test` (new): round-trip across instances, repeated loads return equal-but-independent lists, save reflected immediately (no stale memo), empty/corrupt handling.
- `stability_diagnostics_test` (new): breadcrumbs render as fixed labels and carry no secret; loggers never throw.
- `app_diagnostics_test`: new snapshot fields render; omitted when absent.
- Existing coverage already exercises: cast-active prevents local duplicate playback, cast disconnect cancels polling/listeners, pre-cache failure no tight loop, opening/closing Now Playing & Lyrics no duplicate subscriptions, cleanup not per-tick.

### Manual Android checklist (please run on a real device)
1. Start Linthra cold.
2. Play a Jellyfin track for 10 minutes.
3. Leave Now Playing open.
4. Switch between Library, Settings, Downloads, Now Playing (incl. opening an album/artist detail on a large library).
5. Background the app for 5 minutes.
6. Foreground the app.
7. Cast to Chromecast for 10 minutes.
8. Disconnect Cast.
9. Use Android Auto if available.
10. Open and close Lyrics several times.
11. Enable smart pre-cache and play several tracks.
12. Disable smart pre-cache and repeat.
13. Test over LTE and Wi-Fi.
14. Confirm **no** "app isn't responding" dialog appears.
15. Confirm **no** crash after long playback.
16. If a freeze/crash happens, capture logcat (below).

### If a freeze/crash still happens — capture logs
```
adb logcat -v time | grep -iE "linthra|flutter|AndroidRuntime|ANR|audio_service|just_audio"
```
The new breadcrumbs (`linthra.stability`) and the existing `Linthra.AndroidAuto` / `playback` channels are all secret-free, so logs are safe to attach to a bug report. The Settings ▸ Diagnostics "Copy" export is also safe to paste.

### Known remaining risks
- **No local Flutter SDK** here, so `flutter analyze` / `flutter test` / `dart format` were not run locally — CI is the source of truth.
- **Library search** still folds the whole catalog per keystroke (no debounce) — a real but secondary freeze on very large libraries while typing. Left out to avoid destabilizing the search widget tests; recommended follow-up: debounce the query.
- Catalog **grouping** itself still runs on the UI isolate (now memoized + shared, not per-build). For very large libraries, moving `groupAlbums`/`groupArtists` to a background isolate is a possible follow-up.
- Position coalescing in the engine controller is verified by review (it needs the real `just_audio` player, so it isn't unit-tested) — the manual checklist + CI cover it.

### Verification (CI)
- `flutter pub get`
- `dart format --set-exit-if-changed .`
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug` (if practical)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoQL9K4n2eVyjgn6hXaoXh)_