### PR TITLE
Add a safe, on-device "Report a bug" flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,10 +8,12 @@ body:
         Thanks for testing Linthra! This is alpha software, so rough edges are
         expected — clear reports help a lot.
 
-        **Tip:** open **Settings → Diagnostics → Copy diagnostics** in the app
-        and paste the result below. It's secret-free by construction (no
-        password, token, or full server URL — just versions, connection state,
-        server host, counts, and feature flags).
+        **Tip:** in the app, open **Settings → Report a bug** to build a
+        secret-free report, review it, then tap **Open GitHub issue** to land
+        here with everything prefilled. (Or **Settings → Diagnostics → Copy
+        diagnostics** and paste it into the Diagnostics field below.) Reports are
+        secret-free by construction — no password, token, or full server URL,
+        just versions, connection state, server host, counts, and feature flags.
   - type: textarea
     id: what-happened
     attributes:

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ many don't need a single line of code:
 - 🚗 **Test Android Auto** — on a head unit or the Desktop Head Unit.
 - 📸 **Capture screenshots** for the README and store listing.
 - 📝 **Improve docs** — fix a confusing step, add a setup gotcha.
-- 🐞 **Report bugs with diagnostics** — **Settings → Diagnostics** exports a
-  **secret-free** report (no tokens, no passwords) you can paste into an issue.
+- 🐞 **Report bugs in one tap** — **Settings → Report a bug** builds a
+  **secret-free** report on your device (no tokens, no passwords); review it,
+  then copy it or open a prefilled GitHub issue.
+  ([how it works](./docs/reporting-bugs.md))
 - 🎨 **Polish UI/UX** — small refinements add up.
 - 🔌 **Help future providers** — WebDAV/NAS support behind the same interface.
 
@@ -138,8 +140,9 @@ Sources sit behind one interface, so the app treats them uniformly:
 
 Linthra is built to respect the people who use it:
 
-- **No telemetry, no analytics, no phoning home** — nothing is collected unless
-  you choose to send a diagnostics report.
+- **No telemetry, no analytics, no phoning home** — nothing leaves your device
+  unless **you** choose to. Bug reports are built locally and never auto-sent;
+  "Open GitHub issue" only opens your browser to a prefilled, unsubmitted issue.
 - **No surprise downloads** — streaming is the default; downloads are always
   user-initiated, Wi-Fi only unless you opt in to mobile data.
 - **Minimal permissions** — foreground-service + notification (playback) and
@@ -174,6 +177,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Offline cache & downloads | [docs/offline-cache.md](./docs/offline-cache.md) |
 | Cast / Chromecast | [docs/cast.md](./docs/cast.md) |
 | Android Auto | [docs/android-auto.md](./docs/android-auto.md) |
+| Reporting a bug | [docs/reporting-bugs.md](./docs/reporting-bugs.md) |
 | Playlists & safe removal | [docs/playlists-and-delete.md](./docs/playlists-and-delete.md) |
 | Manual QA checklist | [docs/manual-test-checklist.md](./docs/manual-test-checklist.md) |
 | Release process & signing | [docs/release-process.md](./docs/release-process.md) · [signing](./docs/release-signing.md) |

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -116,5 +116,14 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Lets url_launcher resolve a browser for the "Report a bug" →
+             "Open GitHub issue" action on Android 11+ (package visibility).
+             Without it, launching the prefilled https issue URL can fail to
+             find a handler. This only declares intent visibility — it grants no
+             new permission and opens nothing on its own. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
     </queries>
 </manifest>

--- a/docs/dependency-license-audit.md
+++ b/docs/dependency-license-audit.md
@@ -70,13 +70,19 @@ compatible with MPL-2.0 and acceptable to F-Droid.
 | `flutter_secure_storage` | `^9.2.2`     | (juliansteenbakker) | BSD-3-Clause   | Encrypted store for the Jellyfin session token (§7). |
 | `cast`                   | `^2.1.0`     | (johnvuko)          | MIT            | Pure-Dart Google Cast v2 protocol for real Chromecast — **no** Google Play Services / proprietary Cast SDK. See §5 (Casting). |
 | `bonsoir`                | `^5.1.11`    | (Skyost)            | MIT            | mDNS/Bonjour service discovery used by `cast`; Android side is AOSP `NsdManager`, not GMS. Pinned to 5.x for Dart 3.6 (6.x+ needs Dart ≥3.8). See §5 (Casting). |
+| `url_launcher`           | `^6.3.0`     | flutter.dev         | BSD-3-Clause   | Opens the browser for the "Report a bug" → "Open GitHub issue" action (a prefilled, **unsubmitted** issue the user reviews). AOSP `ACTION_VIEW` intent; **no** GMS. See note below and §7 (Reporting a bug). |
 
 > The `http` and `flutter_secure_storage` entries were added with the Jellyfin
 > source foundation; `cast` and `bonsoir` were added with real Chromecast
 > support (§5, Casting). All four are permissive (MIT / BSD-3-Clause) Dart/Flutter-
 > ecosystem packages. `cast` pulls in one transitive runtime package, `protobuf`
 > (`^3.1.0`, dart.dev, **BSD-3-Clause**), used only to frame cast-channel
-> messages — also free software, no GMS.
+> messages — also free software, no GMS. `url_launcher` was added with the
+> "Report a bug" flow; it is the official Flutter-team plugin (**BSD-3-Clause**),
+> and on Android it fires a standard AOSP `ACTION_VIEW` intent (no Google Play
+> Services). It is wrapped behind the `ExternalLinkLauncher` interface and is
+> invoked only on an explicit user tap — the app never opens a link on its own.
+> See §7.
 
 ## 4. Dev / build-only dependencies (NOT shipped in the APK)
 
@@ -184,6 +190,30 @@ encrypted session token, a library source behind an interface). It is the reason
   manifest will need an `INTERNET` permission; that is a normal, expected
   permission for a user-opted-in remote source and is not an anti-feature by
   itself.
+
+### Reporting a bug (browser hand-off, no auto-send)
+
+The in-app "Report a bug" flow (Settings → Report a bug) is the reason
+`url_launcher` is a dependency. Its network/privacy posture:
+
+- **Nothing is sent automatically.** The report is assembled **on device** from
+  the existing secret-free diagnostics and a bounded in-memory ring of
+  structural breadcrumbs. The user reviews it in a preview, then chooses to copy,
+  save, or open a GitHub issue. There is **no backend**, no Linthra server, and
+  **no upload to Claude/OpenAI/Anthropic or any third-party/AI service**.
+- **"Open GitHub issue" is a browser hand-off.** It builds a
+  `github.com/.../issues/new?...` URL with the report prefilled and opens it via
+  `url_launcher` (AOSP `ACTION_VIEW`). The issue is **unsubmitted**: the user
+  reviews and submits it themselves in their browser. **No GitHub token** is used
+  and the app posts nothing on the user's behalf.
+- **No new data collection.** The recent-events buffer holds only the same
+  secret-free labels `StabilityDiagnostics` already emits (an output name, a
+  lifecycle state, an error *kind*); it is memory-only, capped, never persisted,
+  and surfaced solely when the user opts in while building a report.
+- **Anti-feature judgement:** opening a user-chosen link in the browser is not an
+  anti-feature and introduces no tracking. `url_launcher` is the official
+  Flutter-team plugin and pulls in only its own federated platform packages — no
+  GMS (to be confirmed by the mechanical transitive walk in §9).
 
 ## 8. Summary
 

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -72,6 +72,7 @@ accepted on F-Droid:
 | `flutter_secure_storage` | Encrypted Jellyfin session-token store   | BSD-3-Clause | OK (Android Keystore; AOSP, not GMS) |
 | `cast`                   | Real Chromecast (pure-Dart Cast v2 protocol) | MIT | OK — **no** GMS / Google Cast SDK; see [audit §5 (Casting)](./dependency-license-audit.md#casting-chromecast--real-cast-without-google-play-services) |
 | `bonsoir`                | mDNS discovery used by `cast`            | MIT | OK — Android side is AOSP `NsdManager`, not GMS; pinned to 5.x for Dart 3.6 |
+| `url_launcher`           | Opens the browser for "Report a bug" → "Open GitHub issue" | BSD-3-Clause | OK — official Flutter plugin; AOSP `ACTION_VIEW` intent, no GMS; fired only on an explicit user tap. See [audit §7 (Reporting a bug)](./dependency-license-audit.md#reporting-a-bug-browser-hand-off-no-auto-send) |
 
 Dev-only dependencies (`flutter_lints`, `flutter_test`, `drift_dev`,
 `build_runner`) are not shipped in the APK.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -94,6 +94,27 @@ control:
 Linthra does **not** phone home, upload your library, or send usage data
 anywhere.
 
+## Diagnostics and bug reports
+
+Linthra can generate a diagnostic / bug report to help fix problems
+(**Settings → Report a bug**, or **Settings → Diagnostics**). This is always on
+your terms:
+
+- The report is **generated on your device** and shown to you to review first.
+- It is **secret-free by construction**: it never includes your password, a
+  session token, or a full server URL — only app/OS versions, connection state,
+  the server **host**, counts, feature flags, and (if you opt in) a few
+  structural app events such as lifecycle transitions and playback-error kinds.
+- **Nothing is sent automatically.** There is no backend and no upload to any
+  third party or AI service (including Claude/OpenAI/Anthropic). You choose
+  whether to copy it, save it, or open a prefilled GitHub issue.
+- **"Open GitHub issue"** simply opens your browser at a prefilled — but
+  **unsubmitted** — issue on the project's GitHub. Linthra uses **no GitHub
+  token** and posts nothing on your behalf; you review and submit it yourself.
+
+Please still review a report before sharing, and don't paste secrets into the
+free-text fields.
+
 ## Permissions
 
 Linthra requests a minimal set of Android permissions, each tied to a feature:

--- a/docs/reporting-bugs.md
+++ b/docs/reporting-bugs.md
@@ -1,0 +1,118 @@
+# Reporting a bug
+
+Linthra can build a high-quality, **secret-free** bug report entirely on your
+device, so a problem can be described precisely without leaking anything
+sensitive. This page explains the flow, what the report contains, and the
+privacy guarantees behind it.
+
+> **Nothing is sent automatically.** The report is generated locally and shown
+> to you for review. Linthra has **no backend**, uses **no GitHub token**, and
+> **never** uploads your data to Claude/OpenAI/Anthropic or any third‑party or
+> AI service. Every share action is an explicit tap you take.
+
+## How to use it
+
+1. Open **Settings → Report a bug**.
+2. Fill in the short fields (summary, what happened, steps, expected) — all
+   optional; blanks become neutral placeholders.
+3. Choose what to include with the toggles (see [below](#what-you-can-toggle)).
+4. **Review the live preview.** It is exactly what will be copied, saved, or
+   prefilled.
+5. Pick an action:
+   - **Copy bug report** — puts the Markdown on your clipboard.
+   - **Share bug report** — copies it so you can paste it into email, chat, or an
+     issue. _(A native share sheet may be added later; today this copies.)_
+   - **Open GitHub issue** — opens your browser at a **prefilled but
+     unsubmitted** [new issue](https://github.com/thezupzup/linthra/issues/new).
+     You review and submit it yourself.
+   - **Save report file** — writes `linthra-bug-report.md` into the app's private
+     documents directory.
+
+## Report format
+
+The report is Markdown so it pastes cleanly into a GitHub issue:
+
+```markdown
+# Linthra bug report
+
+## Summary
+…
+
+## What happened
+…
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behavior
+…
+
+## Diagnostics
+```text
+Linthra diagnostics
+App version: …
+Jellyfin: connected
+Jellyfin host: music.example.com
+…
+```
+
+## Recent app events   ← only when you opt in
+```text
+lifecycle: resumed
+output: cast
+error: load
+```
+```
+
+## What you can toggle
+
+- **Include playback state** — the current output, status, and a non‑reversible
+  hashed tag of the playing track's id (never the id, title, or URL).
+- **Include cache state** — how much offline cache is used of your limit.
+- **Include recent app events** — the last few structural breadcrumbs the app
+  records in memory (lifecycle transitions, playback‑output handoffs, pre‑cache
+  decisions, and error *kinds*). Useful for diagnosing freezes/ANRs.
+
+## Why it is secret‑free
+
+The diagnostics block reuses the same builder as **Settings → Diagnostics**
+([`AppDiagnostics`](../lib/core/diagnostics/app_diagnostics.dart)), which is
+secret‑free *by construction*:
+
+- Server addresses are always reduced to **host[:port]** (`hostOnly`), so a full
+  authenticated URL can never carry a token, an `api_key` query, or a
+  `user:pass@` prefix into the report.
+- The "last error" is a stable **enum name**, never a raw error string (which
+  could contain a tokenized URL or a path).
+- The current track is a **hash tag** (e.g. `id#1a2b3c`), never the id/title/URL.
+- File paths shown after **Save** are reduced to a basename behind a `…/` marker.
+
+The **recent app events** come from
+[`SafeEventLog`](../lib/core/diagnostics/safe_event_log.dart), a bounded,
+in‑memory ring buffer fed by
+[`StabilityDiagnostics`](../lib/core/services/stability_diagnostics.dart). Each
+entry is only a fixed label (an output name, a lifecycle state, an error kind) —
+there is no field for a token, password, URL, track title, or path. The buffer
+is never written to disk and is cleared when the process ends.
+
+Even so: **review the preview before sharing.** Anything *you* type into the
+free‑text fields is your responsibility — don't paste secrets there.
+
+## The "fix it with an agent" idea (you drive it)
+
+A natural next step is to paste a report into Claude or another coding agent to
+get a fix faster. That is a great workflow — **and it stays entirely in your
+hands.** Linthra will never do this for you or in the background: it does not
+contact any AI service, and it has no automatic upload of any kind. If you want
+an agent to look at a bug, *you* copy the report and *you* paste it where you
+choose.
+
+## See also
+
+- [docs/dependency-license-audit.md §7 (Reporting a bug)](./dependency-license-audit.md#reporting-a-bug-browser-hand-off-no-auto-send)
+  — why `url_launcher` is the only added dependency and how it stays F‑Droid‑clean.
+- [docs/privacy-policy.md](./privacy-policy.md) — the overall privacy posture.
+- The GitHub issue forms under [`.github/ISSUE_TEMPLATE`](../.github/ISSUE_TEMPLATE)
+  — used when you open an issue directly on the website.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -9,6 +9,7 @@ import '../features/library/library_screen.dart';
 import '../features/player/player_screen.dart';
 import '../features/playlists/playlist_detail_screen.dart';
 import '../features/playlists/playlists_screen.dart';
+import '../features/settings/bug_report/bug_report_screen.dart';
 import '../features/settings/settings_screen.dart';
 import '../features/shell/home_shell.dart';
 import 'routes.dart';
@@ -80,6 +81,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: AppRoutes.settings,
                 builder: (context, state) => const SettingsScreen(),
+                routes: [
+                  GoRoute(
+                    path: 'report-bug',
+                    builder: (context, state) => const BugReportScreen(),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -36,6 +36,10 @@ abstract final class AppRoutes {
   static const String downloads = '/downloads';
   static const String settings = '/settings';
 
+  /// The "Report a bug" builder, reached from Settings. A child of [settings]
+  /// so it keeps the bottom nav and pops back into that tab.
+  static const String reportBug = '/settings/report-bug';
+
   /// Full-screen now-playing view, pushed above the shell.
   static const String player = '/player';
 }

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -109,10 +109,19 @@ abstract final class AppDiagnostics {
   /// Assembles the multi-line report. Only [AppDiagnosticsData.appVersion] is
   /// guaranteed present; every other line is emitted only when its value is
   /// known, so the report is useful even before a connection or a library sync.
-  static String report(AppDiagnosticsData data) {
+  ///
+  /// [includePlayback] and [includeCache] let the "Report a bug" flow drop the
+  /// playback (output/state/current-track) and cache lines when the user turns
+  /// those toggles off. Both default to true, so the plain Diagnostics export is
+  /// unchanged.
+  static String report(
+    AppDiagnosticsData data, {
+    bool includePlayback = true,
+    bool includeCache = true,
+  }) {
     final String? jellyfinHost = hostOnly(data.jellyfinHost);
     final String? subsonicHost = hostOnly(data.subsonicHost);
-    final String? cache = _cacheLine(data);
+    final String? cache = includeCache ? _cacheLine(data) : null;
     final List<String> lines = <String>[
       'Linthra diagnostics',
       'App version: ${data.appVersion}',
@@ -125,10 +134,11 @@ abstract final class AppDiagnostics {
       if (data.libraryTrackCount != null)
         'Library tracks: ${data.libraryTrackCount}',
       if (cache != null) cache,
-      if (data.playbackOutput != null)
+      if (includePlayback && data.playbackOutput != null)
         'Playback output: ${data.playbackOutput}',
-      if (data.playbackStatus != null) 'Playback state: ${data.playbackStatus}',
-      if (data.currentTrackIdHash != null)
+      if (includePlayback && data.playbackStatus != null)
+        'Playback state: ${data.playbackStatus}',
+      if (includePlayback && data.currentTrackIdHash != null)
         'Current track: ${data.currentTrackIdHash}',
       'Last error: ${data.lastErrorKind ?? 'none'}',
       'Cast available: ${_yesNo(data.castAvailable)}',

--- a/lib/core/diagnostics/bug_report.dart
+++ b/lib/core/diagnostics/bug_report.dart
@@ -1,0 +1,103 @@
+/// Builds the Markdown "Report a bug" document and the GitHub "new issue" URL
+/// that prefills it.
+///
+/// Pure and free of any I/O or plugin: the screen feeds in the user's text, the
+/// secret-free diagnostics block (already rendered by `AppDiagnostics.report`),
+/// and the optional recent-events block, and gets back a single Markdown string
+/// to copy, save, or hand to the browser as a prefilled issue. Nothing here
+/// sends, uploads, or logs anything — assembling text and a URL is all it does.
+abstract final class BugReport {
+  /// The public repository the "Open GitHub issue" action targets. The report
+  /// carries no token; the prefilled issue opens in the user's own browser,
+  /// where they review and submit it themselves.
+  static const String repositoryUrl = 'https://github.com/thezupzup/linthra';
+
+  /// Shown in place of a free-text field the user left blank, so the report's
+  /// structure is always present for whoever reads it.
+  static const String fieldPlaceholder = '_(add details here)_';
+
+  /// The scaffold offered for "Steps to reproduce" when left blank.
+  static const String stepsScaffold = '1. \n2. \n3. ';
+
+  /// Assembles the Markdown bug report.
+  ///
+  /// [diagnostics] is the secret-free block from `AppDiagnostics.report`.
+  /// [recentEvents], when non-null and non-blank, is appended as its own fenced
+  /// "Recent app events" section. The four free-text fields fall back to a
+  /// neutral placeholder (and steps to a numbered scaffold) when blank.
+  static String markdown({
+    String summary = '',
+    String whatHappened = '',
+    String steps = '',
+    String expected = '',
+    required String diagnostics,
+    String? recentEvents,
+  }) {
+    final StringBuffer buffer = StringBuffer()
+      ..writeln('# Linthra bug report')
+      ..writeln()
+      ..writeln('## Summary')
+      ..writeln(_fieldOr(summary, fieldPlaceholder))
+      ..writeln()
+      ..writeln('## What happened')
+      ..writeln(_fieldOr(whatHappened, fieldPlaceholder))
+      ..writeln()
+      ..writeln('## Steps to reproduce')
+      ..writeln(_fieldOr(steps, stepsScaffold))
+      ..writeln()
+      ..writeln('## Expected behavior')
+      ..writeln(_fieldOr(expected, fieldPlaceholder))
+      ..writeln()
+      ..writeln('## Diagnostics')
+      ..writeln('```text')
+      ..writeln(diagnostics.trim())
+      ..writeln('```');
+
+    final String? events = _nullIfBlank(recentEvents);
+    if (events != null) {
+      buffer
+        ..writeln()
+        ..writeln('## Recent app events')
+        ..writeln('```text')
+        ..writeln(events)
+        ..writeln('```');
+    }
+
+    return '${buffer.toString().trimRight()}\n';
+  }
+
+  /// Builds the GitHub "new issue" URL that prefills [body] (and an optional
+  /// [title]) and tags it `bug`. It is opened in the user's browser; they
+  /// review and submit. No GitHub token is involved and nothing is posted by the
+  /// app.
+  static Uri newIssueUrl({required String body, String title = ''}) {
+    final String trimmedTitle = title.trim();
+    return Uri.parse('$repositoryUrl/issues/new').replace(
+      queryParameters: <String, String>{
+        'labels': 'bug',
+        if (trimmedTitle.isNotEmpty) 'title': trimmedTitle,
+        'body': body,
+      },
+    );
+  }
+
+  /// A concise issue title derived from the user's [summary], or a sensible
+  /// default when it is blank. Truncated so the URL stays reasonable.
+  static String issueTitle(String summary) {
+    final String trimmed = summary.trim();
+    if (trimmed.isEmpty) return 'Bug report';
+    if (trimmed.length <= 72) return trimmed;
+    return '${trimmed.substring(0, 69)}...';
+  }
+
+  static String _fieldOr(String value, String fallback) {
+    final String trimmed = value.trim();
+    return trimmed.isEmpty ? fallback : trimmed;
+  }
+
+  static String? _nullIfBlank(String? value) {
+    if (value == null) return null;
+    final String trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}

--- a/lib/core/diagnostics/safe_event_log.dart
+++ b/lib/core/diagnostics/safe_event_log.dart
@@ -1,0 +1,71 @@
+import 'dart:collection';
+
+/// A small, in-memory ring buffer of the secret-free breadcrumbs
+/// [StabilityDiagnostics] emits (lifecycle transitions, playback-output
+/// handoffs, pre-cache decisions, and playback-error kinds).
+///
+/// It exists so the "Report a bug" flow can optionally include the last few app
+/// events even in a release build, where [StabilityDiagnostics]'s
+/// `developer.log` output is silent. Nothing here is ever sent anywhere on its
+/// own: events are held only in memory, capped at [capacity], cleared when the
+/// process ends, and surfaced solely when the user explicitly builds a bug
+/// report and leaves the "recent app events" toggle on.
+///
+/// Secret-free by construction: an event carries only a fixed
+/// [SafeEvent.category] and a structural [SafeEvent.detail] (an enum name or a
+/// fixed label like `skip:disabled`) handed in by [StabilityDiagnostics]. There
+/// is no field for a token, password, authenticated URL, track title, or local
+/// path, so nothing sensitive can be recorded here in the first place.
+class SafeEventLog {
+  SafeEventLog({this.capacity = 50}) : assert(capacity > 0);
+
+  /// The most events retained. Older events roll off once this is exceeded, so
+  /// the buffer stays bounded over a long session.
+  final int capacity;
+
+  final ListQueue<SafeEvent> _events = ListQueue<SafeEvent>();
+
+  /// Records one breadcrumb, dropping the oldest entry once [capacity] is
+  /// exceeded.
+  void record(String category, String detail) {
+    _events.addLast(SafeEvent(category, detail));
+    while (_events.length > capacity) {
+      _events.removeFirst();
+    }
+  }
+
+  /// The retained events, oldest first.
+  List<SafeEvent> get events => List<SafeEvent>.unmodifiable(_events);
+
+  /// The retained events rendered one per line (`category: detail`), oldest
+  /// first — the form the bug report embeds.
+  List<String> get lines =>
+      _events.map((SafeEvent event) => event.line).toList(growable: false);
+
+  bool get isEmpty => _events.isEmpty;
+
+  bool get isNotEmpty => _events.isNotEmpty;
+
+  /// Clears all retained events.
+  void clear() => _events.clear();
+
+  /// The process-wide log [StabilityDiagnostics] writes to and the bug report
+  /// reads from. A single shared instance mirrors the static, plugin-free style
+  /// of the diagnostics utilities that feed it.
+  static final SafeEventLog instance = SafeEventLog();
+}
+
+/// One secret-free breadcrumb: a fixed [category] and a structural [detail].
+class SafeEvent {
+  const SafeEvent(this.category, this.detail);
+
+  /// The kind of event — e.g. `lifecycle`, `output`, `precache`, `error`.
+  final String category;
+
+  /// The structural detail: an enum name or fixed label (e.g. `resumed`,
+  /// `cast`, `skip:disabled`, `load`). Never free text or a secret.
+  final String detail;
+
+  /// The one-line form embedded in a report: `category: detail`.
+  String get line => '$category: $detail';
+}

--- a/lib/core/services/external_link_launcher.dart
+++ b/lib/core/services/external_link_launcher.dart
@@ -1,0 +1,38 @@
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
+
+/// Opens an external link — typically the user's browser — for the app.
+///
+/// The single seam between the app and `url_launcher`, so feature code depends
+/// only on this interface and never imports the plugin directly. That keeps
+/// widget tests plugin-free (they inject a fake) and matches how the rest of the
+/// app wraps its platform plugins. The only caller today is the "Report a bug"
+/// flow's "Open GitHub issue" action, which hands the browser a prefilled — but
+/// unsubmitted — issue. Every launch is an explicit user tap; nothing opens on
+/// its own.
+abstract interface class ExternalLinkLauncher {
+  /// Opens [url] in an external application (the browser). Returns true when the
+  /// platform accepted the request, false otherwise. Never throws for an
+  /// unlaunchable URL — the caller falls back (e.g. copies the link instead).
+  Future<bool> open(Uri url);
+}
+
+/// The production [ExternalLinkLauncher], backed by `url_launcher`.
+///
+/// Launches in an external application so a prefilled GitHub issue opens in the
+/// real browser, not an in-app webview. Any plugin failure is swallowed and
+/// reported as `false` so the caller can fall back gracefully.
+class UrlLauncherExternalLinkLauncher implements ExternalLinkLauncher {
+  const UrlLauncherExternalLinkLauncher();
+
+  @override
+  Future<bool> open(Uri url) async {
+    try {
+      return await url_launcher.launchUrl(
+        url,
+        mode: url_launcher.LaunchMode.externalApplication,
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/core/services/stability_diagnostics.dart
+++ b/lib/core/services/stability_diagnostics.dart
@@ -2,12 +2,19 @@ import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
 
+import '../diagnostics/safe_event_log.dart';
+
 /// Secret-free breadcrumb logs for diagnosing the field freezes/ANRs this
 /// stabilization pass targets, and the playback-output handoffs that surround
 /// them. Filter device logs with `adb logcat | grep linthra.stability`.
 ///
-/// Debug-only (silent in release builds; active under `flutter test`) and
-/// secret-free *by construction*: every method takes only a fixed, structural
+/// Each breadcrumb is also recorded into [SafeEventLog.instance] — a bounded,
+/// in-memory ring buffer — so the "Report a bug" flow can include the last few
+/// app events even in a release build, where the `developer.log` output below
+/// is silent. The recorder runs in every build (it is just memory, no I/O) but
+/// is surfaced only when the user explicitly opts in while building a report.
+///
+/// Secret-free *by construction*: every method takes only a fixed, structural
 /// label — an output name, a lifecycle state, a pre-cache outcome, an error
 /// *kind* (an enum name) — and there is no parameter for a token, password,
 /// authenticated URL, track title, or local path. The `describe*` helpers are
@@ -23,27 +30,39 @@ abstract final class StabilityDiagnostics {
 
   /// An app lifecycle transition (`resumed`, `paused`, `inactive`, …) — the
   /// boundary most freezes/ANRs cluster around (background/foreground).
-  static void lifecycle(String state) => _log(describeLifecycle(state));
+  static void lifecycle(String state) {
+    SafeEventLog.instance.record('lifecycle', state);
+    _log(describeLifecycle(state));
+  }
 
   static String describeLifecycle(String state) => 'lifecycle: $state';
 
   /// The active playback output changed (`local` / `cast`), so a handoff can be
   /// correlated with a freeze without logging anything about the track.
-  static void output(String output) => _log(describeOutput(output));
+  static void output(String output) {
+    SafeEventLog.instance.record('output', output);
+    _log(describeOutput(output));
+  }
 
   static String describeOutput(String output) => 'output -> $output';
 
   /// A smart pre-cache decision, by safe outcome: `start:<count>`,
   /// `skip:<reason>` (e.g. `skip:disabled`, `skip:repeat-one`). No track id,
   /// title, or URL is ever included.
-  static void precache(String outcome) => _log(describePrecache(outcome));
+  static void precache(String outcome) {
+    SafeEventLog.instance.record('precache', outcome);
+    _log(describePrecache(outcome));
+  }
 
   static String describePrecache(String outcome) => 'precache: $outcome';
 
   /// A playback / stream-resolution failure, by its safe [kind] (a
   /// [StreamInterruptionKind] name or a fixed label like `resolution`/`load`) —
   /// never the raw error, which can carry a tokenized URL.
-  static void playbackError(String kind) => _log(describePlaybackError(kind));
+  static void playbackError(String kind) {
+    SafeEventLog.instance.record('error', kind);
+    _log(describePlaybackError(kind));
+  }
 
   static String describePlaybackError(String kind) => 'playback error: $kind';
 }

--- a/lib/features/settings/bug_report/bug_report_providers.dart
+++ b/lib/features/settings/bug_report/bug_report_providers.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/diagnostics/app_diagnostics.dart';
+import '../../../core/diagnostics/safe_event_log.dart';
+import '../../../core/services/external_link_launcher.dart';
+import '../diagnostics/diagnostics_collector.dart';
+
+/// The secret-free inputs the bug-report screen renders from: the diagnostics
+/// snapshot and the recent safe app events.
+///
+/// Collected once when the screen opens, then composed locally as the user
+/// edits text and flips toggles — so the live preview never re-runs async work
+/// on a keystroke.
+class BugReportDiagnostics {
+  const BugReportDiagnostics({
+    required this.data,
+    required this.recentEventLines,
+  });
+
+  /// The display-safe app snapshot (host-only addresses, counts, flags).
+  final AppDiagnosticsData data;
+
+  /// Recent secret-free breadcrumbs, oldest first, each `category: detail`.
+  final List<String> recentEventLines;
+
+  bool get hasRecentEvents => recentEventLines.isNotEmpty;
+}
+
+/// Collects the diagnostics snapshot and recent safe events for the bug report.
+///
+/// Overridden in tests with a fixed bundle so the screen can be exercised
+/// without the playback/cast plugins behind the collector.
+final bugReportDiagnosticsProvider =
+    FutureProvider<BugReportDiagnostics>((ref) async {
+  final AppDiagnosticsData data = await DiagnosticsCollector(ref).collect();
+  return BugReportDiagnostics(
+    data: data,
+    recentEventLines: SafeEventLog.instance.lines,
+  );
+});
+
+/// The browser seam the "Open GitHub issue" action launches through. Production
+/// wires the `url_launcher`-backed launcher; tests override it with a fake so
+/// no real browser is opened.
+final externalLinkLauncherProvider = Provider<ExternalLinkLauncher>(
+  (ref) => const UrlLauncherExternalLinkLauncher(),
+);

--- a/lib/features/settings/bug_report/bug_report_screen.dart
+++ b/lib/features/settings/bug_report/bug_report_screen.dart
@@ -1,0 +1,407 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/diagnostics/app_diagnostics.dart';
+import '../../../core/diagnostics/bug_report.dart';
+import 'bug_report_providers.dart';
+
+/// The "Report a bug" screen.
+///
+/// Generates a high-quality, secret-free Markdown bug report entirely on the
+/// device. The user fills in a short summary / steps, reviews the live preview,
+/// then chooses to copy it, save it, or open a prefilled GitHub issue in their
+/// browser. Nothing is sent anywhere automatically: there is no backend, no
+/// GitHub token, and no upload to Claude/OpenAI/Anthropic or any third party.
+class BugReportScreen extends ConsumerStatefulWidget {
+  const BugReportScreen({super.key});
+
+  @override
+  ConsumerState<BugReportScreen> createState() => _BugReportScreenState();
+}
+
+class _BugReportScreenState extends ConsumerState<BugReportScreen> {
+  final TextEditingController _summary = TextEditingController();
+  final TextEditingController _whatHappened = TextEditingController();
+  final TextEditingController _steps =
+      TextEditingController(text: BugReport.stepsScaffold);
+  final TextEditingController _expected = TextEditingController();
+
+  bool _includeRecentEvents = true;
+  bool _includePlayback = true;
+  bool _includeCache = true;
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _summary.dispose();
+    _whatHappened.dispose();
+    _steps.dispose();
+    _expected.dispose();
+    super.dispose();
+  }
+
+  /// Builds the current Markdown report from the collected [bundle] and the live
+  /// field/toggle state. Pure and synchronous, so the preview updates instantly.
+  String _composeReport(BugReportDiagnostics bundle) {
+    final String diagnostics = AppDiagnostics.report(
+      bundle.data,
+      includePlayback: _includePlayback,
+      includeCache: _includeCache,
+    );
+    final bool withEvents = _includeRecentEvents && bundle.hasRecentEvents;
+    return BugReport.markdown(
+      summary: _summary.text,
+      whatHappened: _whatHappened.text,
+      steps: _steps.text,
+      expected: _expected.text,
+      diagnostics: diagnostics,
+      recentEvents: withEvents ? bundle.recentEventLines.join('\n') : null,
+    );
+  }
+
+  Future<void> _copy(BugReportDiagnostics bundle) async {
+    await Clipboard.setData(ClipboardData(text: _composeReport(bundle)));
+    _showSnack('Bug report copied. Review it before sharing.');
+  }
+
+  Future<void> _share(BugReportDiagnostics bundle) async {
+    // No share-sheet plugin is bundled, so "Share" copies the report and tells
+    // the user they can paste it wherever they like. Nothing is sent for them.
+    await Clipboard.setData(ClipboardData(text: _composeReport(bundle)));
+    _showSnack('Bug report copied — paste it into an email, chat, or issue.');
+  }
+
+  Future<void> _openIssue(BugReportDiagnostics bundle) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final Uri url = BugReport.newIssueUrl(
+        body: _composeReport(bundle),
+        title: BugReport.issueTitle(_summary.text),
+      );
+      final bool opened =
+          await ref.read(externalLinkLauncherProvider).open(url);
+      if (opened) {
+        _showSnack(
+            'Opening a prefilled issue — review and submit it yourself.');
+      } else {
+        await Clipboard.setData(ClipboardData(text: url.toString()));
+        _showSnack("Couldn't open the browser — issue link copied instead.");
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _save(BugReportDiagnostics bundle) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final String report = _composeReport(bundle);
+      final Directory dir = await getApplicationDocumentsDirectory();
+      final File file = File('${dir.path}/linthra-bug-report.md');
+      await file.writeAsString(report, flush: true);
+      // Show only the redacted basename — never the private app directory path.
+      _showSnack('Saved to ${AppDiagnostics.redactPath(file.path)}.');
+    } catch (_) {
+      _showSnack("Couldn't save the report. Try Copy instead.");
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _showSnack(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<BugReportDiagnostics> snapshot =
+        ref.watch(bugReportDiagnosticsProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Report a bug')),
+      body: snapshot.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (Object error, StackTrace _) => const Center(
+          child: Padding(
+            padding: EdgeInsets.all(AppSpacing.lg),
+            child: Text(
+              "Couldn't gather diagnostics right now. You can still open an "
+              'issue from the project README.',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        data: (BugReportDiagnostics bundle) => _form(context, bundle),
+      ),
+    );
+  }
+
+  Widget _form(BuildContext context, BugReportDiagnostics bundle) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final String report = _composeReport(bundle);
+
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      children: [
+        Text(
+          'Linthra can generate a safe diagnostic report to help fix bugs.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        _PrivacyNote(muted: muted),
+        const SizedBox(height: AppSpacing.md),
+        _field(
+          controller: _summary,
+          label: 'Summary',
+          hint: 'A one-line summary of the problem',
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _field(
+          controller: _whatHappened,
+          label: 'What happened',
+          hint: 'What did you do, and what went wrong?',
+          maxLines: 3,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _field(
+          controller: _steps,
+          label: 'Steps to reproduce',
+          hint: '1. …\n2. …\n3. …',
+          maxLines: 4,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _field(
+          controller: _expected,
+          label: 'Expected behavior',
+          hint: 'What did you expect to happen?',
+          maxLines: 2,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _IncludeOptions(
+          includePlayback: _includePlayback,
+          includeCache: _includeCache,
+          includeRecentEvents: _includeRecentEvents,
+          hasRecentEvents: bundle.hasRecentEvents,
+          onPlaybackChanged: (bool v) => setState(() => _includePlayback = v),
+          onCacheChanged: (bool v) => setState(() => _includeCache = v),
+          onRecentEventsChanged: (bool v) =>
+              setState(() => _includeRecentEvents = v),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _PreviewCard(report: report),
+        const SizedBox(height: AppSpacing.md),
+        _actions(bundle),
+      ],
+    );
+  }
+
+  Widget _field({
+    required TextEditingController controller,
+    required String label,
+    required String hint,
+    int maxLines = 1,
+  }) {
+    return TextField(
+      controller: controller,
+      maxLines: maxLines,
+      textInputAction: maxLines > 1 ? TextInputAction.newline : null,
+      onChanged: (_) => setState(() {}),
+      decoration: InputDecoration(
+        labelText: label,
+        hintText: hint,
+        border: const OutlineInputBorder(),
+        alignLabelWithHint: maxLines > 1,
+      ),
+    );
+  }
+
+  Widget _actions(BugReportDiagnostics bundle) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.icon(
+          onPressed: _busy ? null : () => _openIssue(bundle),
+          icon: const Icon(Icons.open_in_new),
+          label: const Text('Open GitHub issue'),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton.tonalIcon(
+                onPressed: _busy ? null : () => _copy(bundle),
+                icon: const Icon(Icons.copy_outlined),
+                label: const Text('Copy bug report'),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: _busy ? null : () => _share(bundle),
+                icon: const Icon(Icons.ios_share),
+                label: const Text('Share bug report'),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        OutlinedButton.icon(
+          onPressed: _busy ? null : () => _save(bundle),
+          icon: const Icon(Icons.save_alt_outlined),
+          label: const Text('Save report file'),
+        ),
+      ],
+    );
+  }
+}
+
+/// The on-device privacy reassurance shown above the form.
+class _PrivacyNote extends StatelessWidget {
+  const _PrivacyNote({required this.muted});
+
+  final Color muted;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(Icons.lock_outline, size: 18, color: muted),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            'The report is generated on your device. Review it before sharing — '
+            'nothing is sent anywhere automatically.',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The three "Include in the report" toggles.
+class _IncludeOptions extends StatelessWidget {
+  const _IncludeOptions({
+    required this.includePlayback,
+    required this.includeCache,
+    required this.includeRecentEvents,
+    required this.hasRecentEvents,
+    required this.onPlaybackChanged,
+    required this.onCacheChanged,
+    required this.onRecentEventsChanged,
+  });
+
+  final bool includePlayback;
+  final bool includeCache;
+  final bool includeRecentEvents;
+  final bool hasRecentEvents;
+  final ValueChanged<bool> onPlaybackChanged;
+  final ValueChanged<bool> onCacheChanged;
+  final ValueChanged<bool> onRecentEventsChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+        child: Column(
+          children: [
+            SwitchListTile(
+              value: includePlayback,
+              onChanged: onPlaybackChanged,
+              title: const Text('Include playback state'),
+              subtitle: const Text('Output, status, and a hashed track tag.'),
+            ),
+            SwitchListTile(
+              value: includeCache,
+              onChanged: onCacheChanged,
+              title: const Text('Include cache state'),
+              subtitle:
+                  const Text('How much offline cache is used of the limit.'),
+            ),
+            SwitchListTile(
+              value: includeRecentEvents,
+              onChanged: onRecentEventsChanged,
+              title: const Text('Include recent app events'),
+              subtitle: Text(
+                hasRecentEvents
+                    ? 'The last few secret-free app events (lifecycle, '
+                        'playback).'
+                    : 'No recent events recorded yet.',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A read-only preview of exactly what will be copied, saved, or prefilled.
+class _PreviewCard extends StatelessWidget {
+  const _PreviewCard({required this.report});
+
+  final String report;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.description_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Preview', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'This is exactly what will be copied, saved, or prefilled.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Container(
+              width: double.infinity,
+              constraints: const BoxConstraints(maxHeight: 320),
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest
+                    .withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(AppRadii.sm),
+              ),
+              child: SingleChildScrollView(
+                child: SelectableText(
+                  report,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
+                    height: 1.4,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/bug_report/report_bug_settings_section.dart
+++ b/lib/features/settings/bug_report/report_bug_settings_section.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../app/dimens.dart';
+import '../../../app/routes.dart';
+
+/// The "Report a bug" card on the Settings screen — the entry point into the
+/// [BugReportScreen] flow.
+///
+/// It only opens the report builder; nothing is generated or sent from here, so
+/// tapping it is always safe.
+class ReportBugSettingsSection extends StatelessWidget {
+  const ReportBugSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.bug_report_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Report a bug', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Linthra can build a safe diagnostic report to help fix bugs. It '
+              'is generated on your device — review it before sharing, then '
+              'copy it or open a prefilled GitHub issue.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            FilledButton.icon(
+              onPressed: () => context.push(AppRoutes.reportBug),
+              icon: const Icon(Icons.bug_report_outlined),
+              label: const Text('Report a bug'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -35,10 +35,12 @@ class DiagnosticsCollector {
   /// library track count asynchronously; everything else is read synchronously
   /// from the current provider state.
   Future<String> buildReport() async {
-    return AppDiagnostics.report(await _collect());
+    return AppDiagnostics.report(await collect());
   }
 
-  Future<AppDiagnosticsData> _collect() async {
+  /// Gathers the live, display-safe snapshot. Public so the "Report a bug" flow
+  /// can render it with its own toggles via [AppDiagnostics.report].
+  Future<AppDiagnosticsData> collect() async {
     final JellyfinSettingsState jellyfin =
         _ref.read(jellyfinSettingsControllerProvider);
     final SubsonicSettingsState subsonic =

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../app/dimens.dart';
 import '../../core/app_info.dart';
 import '../../shared/widgets/linthra_logo_mark.dart';
+import 'bug_report/report_bug_settings_section.dart';
 import 'cache/cache_settings_section.dart';
 import 'diagnostics/diagnostics_settings_section.dart';
 import 'jellyfin/jellyfin_settings_section.dart';
@@ -31,6 +32,8 @@ class SettingsScreen extends StatelessWidget {
           NetworkSettingsSection(),
           SizedBox(height: AppSpacing.md),
           PrecacheSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          ReportBugSettingsSection(),
           SizedBox(height: AppSpacing.md),
           DiagnosticsSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,15 @@ dependencies:
   # docs/dependency-license-audit.md §"Cast" and docs/fdroid-readiness.md.
   cast: ^2.1.0
   bonsoir: ^5.1.11
+  # Opens an external URL (the user's browser) for the "Report a bug" flow's
+  # "Open GitHub issue" action, which hands the browser a prefilled — but
+  # unsubmitted — issue the user reviews and submits themselves. Used ONLY by
+  # UrlLauncherExternalLinkLauncher behind the ExternalLinkLauncher interface;
+  # the UI never calls url_launcher directly. The official Flutter-team plugin
+  # (BSD-3-Clause); on Android it fires a standard AOSP VIEW intent — no Google
+  # Play Services. The app never auto-opens anything; every launch is an
+  # explicit user tap. See docs/dependency-license-audit.md §"Reporting a bug".
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -134,6 +134,35 @@ void main() {
       expect(report, isNot(contains('Current track:')));
     });
 
+    test('includePlayback: false drops every playback line', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          playbackOutput: 'local',
+          playbackStatus: 'playing',
+          currentTrackIdHash: 'id#1a2b3c',
+        ),
+        includePlayback: false,
+      );
+
+      expect(report, isNot(contains('Playback output:')));
+      expect(report, isNot(contains('Playback state:')));
+      expect(report, isNot(contains('Current track:')));
+    });
+
+    test('includeCache: false drops the cache line', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          cacheUsedBytes: 2 * CacheSize.bytesPerGb,
+          cacheLimitBytes: 4 * CacheSize.bytesPerGb,
+        ),
+        includeCache: false,
+      );
+
+      expect(report, isNot(contains('Cache:')));
+    });
+
     test('omits absent optional fields but always reports app version', () {
       final String report =
           AppDiagnostics.report(const AppDiagnosticsData(appVersion: '0.1.0'));

--- a/test/core/diagnostics/bug_report_test.dart
+++ b/test/core/diagnostics/bug_report_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/bug_report.dart';
+
+void main() {
+  const String diagnostics = 'Linthra diagnostics\n'
+      'App version: 0.1.0-test\n'
+      'Jellyfin host: music.example.com\n'
+      'Last error: none';
+
+  group('BugReport.markdown', () {
+    test('lays out all sections with a fenced diagnostics block', () {
+      final String report = BugReport.markdown(diagnostics: diagnostics);
+
+      expect(report, contains('# Linthra bug report'));
+      expect(report, contains('## Summary'));
+      expect(report, contains('## What happened'));
+      expect(report, contains('## Steps to reproduce'));
+      expect(report, contains('## Expected behavior'));
+      expect(report, contains('## Diagnostics'));
+      expect(report, contains('```text\n$diagnostics\n```'));
+    });
+
+    test('fills blank fields with a placeholder and a steps scaffold', () {
+      final String report = BugReport.markdown(diagnostics: diagnostics);
+
+      expect(report, contains(BugReport.fieldPlaceholder));
+      expect(report, contains(BugReport.stepsScaffold));
+    });
+
+    test('uses the provided field values when present', () {
+      final String report = BugReport.markdown(
+        summary: 'Crash on play',
+        whatHappened: 'It crashed',
+        steps: '1. open\n2. play',
+        expected: 'It plays',
+        diagnostics: diagnostics,
+      );
+
+      expect(report, contains('## Summary\nCrash on play'));
+      expect(report, contains('## What happened\nIt crashed'));
+      expect(report, contains('## Steps to reproduce\n1. open\n2. play'));
+      expect(report, contains('## Expected behavior\nIt plays'));
+      expect(report, isNot(contains(BugReport.fieldPlaceholder)));
+    });
+
+    test('appends a Recent app events section only when provided', () {
+      final String without = BugReport.markdown(diagnostics: diagnostics);
+      expect(without, isNot(contains('## Recent app events')));
+
+      final String withEvents = BugReport.markdown(
+        diagnostics: diagnostics,
+        recentEvents: 'lifecycle: resumed\noutput: cast',
+      );
+      expect(withEvents, contains('## Recent app events'));
+      expect(
+        withEvents,
+        contains('```text\nlifecycle: resumed\noutput: cast\n```'),
+      );
+    });
+
+    test('treats blank recent events as absent', () {
+      final String report = BugReport.markdown(
+        diagnostics: diagnostics,
+        recentEvents: '   ',
+      );
+      expect(report, isNot(contains('## Recent app events')));
+    });
+
+    test('embeds the diagnostics verbatim and adds nothing secret', () {
+      final String report = BugReport.markdown(diagnostics: diagnostics);
+      expect(report, isNot(contains('api_key')));
+      expect(report.toLowerCase(), isNot(contains('password')));
+    });
+  });
+
+  group('BugReport.newIssueUrl', () {
+    test('targets the repo issues/new with a bug label and prefilled body', () {
+      final Uri url = BugReport.newIssueUrl(
+        body: 'Hello world\nLine two',
+        title: 'My bug',
+      );
+
+      expect(url.scheme, 'https');
+      expect(url.host, 'github.com');
+      expect(url.path, '/thezupzup/linthra/issues/new');
+      expect(url.queryParameters['labels'], 'bug');
+      expect(url.queryParameters['title'], 'My bug');
+      // The body round-trips through URL decoding intact.
+      expect(url.queryParameters['body'], 'Hello world\nLine two');
+    });
+
+    test('omits the title when blank', () {
+      final Uri url = BugReport.newIssueUrl(body: 'x');
+      expect(url.queryParameters.containsKey('title'), isFalse);
+    });
+  });
+
+  group('BugReport.issueTitle', () {
+    test('uses the trimmed summary, or a default when blank', () {
+      expect(BugReport.issueTitle('  Crash on play  '), 'Crash on play');
+      expect(BugReport.issueTitle(''), 'Bug report');
+      expect(BugReport.issueTitle('   '), 'Bug report');
+    });
+
+    test('truncates a very long summary', () {
+      final String title = BugReport.issueTitle('x' * 100);
+      expect(title.length, lessThanOrEqualTo(72));
+      expect(title, endsWith('...'));
+    });
+  });
+}

--- a/test/core/diagnostics/safe_event_log_test.dart
+++ b/test/core/diagnostics/safe_event_log_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/safe_event_log.dart';
+
+void main() {
+  group('SafeEventLog', () {
+    test('records events oldest-first and renders "category: detail" lines',
+        () {
+      final SafeEventLog log = SafeEventLog();
+      log.record('lifecycle', 'resumed');
+      log.record('output', 'cast');
+
+      expect(log.lines, <String>['lifecycle: resumed', 'output: cast']);
+      expect(log.events.first.category, 'lifecycle');
+      expect(log.events.first.detail, 'resumed');
+      expect(log.isNotEmpty, isTrue);
+    });
+
+    test('caps at capacity, dropping the oldest events', () {
+      final SafeEventLog log = SafeEventLog(capacity: 3);
+      for (int i = 0; i < 5; i++) {
+        log.record('n', '$i');
+      }
+
+      expect(log.lines, <String>['n: 2', 'n: 3', 'n: 4']);
+    });
+
+    test('clear empties the log', () {
+      final SafeEventLog log = SafeEventLog()..record('a', 'b');
+      expect(log.isEmpty, isFalse);
+
+      log.clear();
+
+      expect(log.isEmpty, isTrue);
+      expect(log.lines, isEmpty);
+    });
+
+    test('the exposed events list is unmodifiable', () {
+      final SafeEventLog log = SafeEventLog()..record('a', 'b');
+      expect(
+        () => log.events.add(const SafeEvent('x', 'y')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('the recorded structural lines carry no secret', () {
+      final SafeEventLog log = SafeEventLog()
+        ..record('lifecycle', 'paused')
+        ..record('output', 'local')
+        ..record('error', 'networkDropped');
+
+      for (final String line in log.lines) {
+        expect(line, isNot(contains('://')));
+        expect(line.toLowerCase(), isNot(contains('token')));
+        expect(line.toLowerCase(), isNot(contains('password')));
+      }
+    });
+  });
+}

--- a/test/core/services/stability_diagnostics_test.dart
+++ b/test/core/services/stability_diagnostics_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/safe_event_log.dart';
 import 'package:linthra/core/services/stability_diagnostics.dart';
 
 void main() {
@@ -48,6 +49,36 @@ void main() {
         },
         returnsNormally,
       );
+    });
+  });
+
+  group('StabilityDiagnostics recent-event recording', () {
+    setUp(SafeEventLog.instance.clear);
+    tearDown(SafeEventLog.instance.clear);
+
+    test('records each breadcrumb into the shared SafeEventLog', () {
+      StabilityDiagnostics.lifecycle('resumed');
+      StabilityDiagnostics.output('cast');
+      StabilityDiagnostics.precache('start:3');
+      StabilityDiagnostics.playbackError('load');
+
+      expect(SafeEventLog.instance.lines, <String>[
+        'lifecycle: resumed',
+        'output: cast',
+        'precache: start:3',
+        'error: load',
+      ]);
+    });
+
+    test('the recorded lines carry no secret', () {
+      StabilityDiagnostics.lifecycle('paused');
+      StabilityDiagnostics.playbackError('networkDropped');
+
+      for (final String line in SafeEventLog.instance.lines) {
+        expect(line, isNot(contains('://')));
+        expect(line.toLowerCase(), isNot(contains('token')));
+        expect(line.toLowerCase(), isNot(contains('password')));
+      }
     });
   });
 }

--- a/test/features/settings/bug_report/bug_report_screen_test.dart
+++ b/test/features/settings/bug_report/bug_report_screen_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/app_diagnostics.dart';
+import 'package:linthra/core/models/cache_size.dart';
+import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/settings/bug_report/bug_report_providers.dart';
+import 'package:linthra/features/settings/bug_report/bug_report_screen.dart';
+
+/// A fixed, secret-free snapshot the screen renders from. The Jellyfin host is
+/// deliberately a full authenticated URL to prove `hostOnly` still reduces it.
+const BugReportDiagnostics _bundle = BugReportDiagnostics(
+  data: AppDiagnosticsData(
+    appVersion: '0.1.0-test',
+    jellyfinState: 'connected',
+    jellyfinHost: 'https://user:pass@music.example.com/jellyfin?api_key=secret',
+    cacheUsedBytes: 2 * CacheSize.bytesPerGb,
+    cacheLimitBytes: 4 * CacheSize.bytesPerGb,
+    playbackOutput: 'local',
+    playbackStatus: 'playing',
+    currentTrackIdHash: 'id#1a2b3c',
+  ),
+  recentEventLines: <String>[
+    'lifecycle: resumed',
+    'output: local',
+    'error: load',
+  ],
+);
+
+class _FakeLinkLauncher implements ExternalLinkLauncher {
+  _FakeLinkLauncher({this.result = true});
+
+  final bool result;
+  Uri? opened;
+
+  @override
+  Future<bool> open(Uri url) async {
+    opened = url;
+    return result;
+  }
+}
+
+Future<_FakeLinkLauncher> _pumpScreen(
+  WidgetTester tester, {
+  bool launchResult = true,
+}) async {
+  // A tall surface so the whole scrolling form is laid out and every action is
+  // hittable without scrolling.
+  tester.view.physicalSize = const Size(1080, 4000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final _FakeLinkLauncher launcher = _FakeLinkLauncher(result: launchResult);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        bugReportDiagnosticsProvider.overrideWith((ref) async => _bundle),
+        externalLinkLauncherProvider.overrideWithValue(launcher),
+      ],
+      child: const MaterialApp(home: BugReportScreen()),
+    ),
+  );
+  // Resolve the (overridden) diagnostics future so the form replaces the
+  // loading spinner.
+  await tester.pump();
+  await tester.pump();
+  return launcher;
+}
+
+void _mockClipboard(WidgetTester tester, List<MethodCall> sink) {
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    SystemChannels.platform,
+    (MethodCall call) async {
+      if (call.method == 'Clipboard.setData') sink.add(call);
+      return null;
+    },
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null),
+  );
+}
+
+void main() {
+  group('BugReportScreen', () {
+    testWidgets('shows the explanation, privacy note, actions, and preview',
+        (tester) async {
+      await _pumpScreen(tester);
+
+      expect(
+        find.textContaining('safe diagnostic report to help fix bugs'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('generated on your device'),
+        findsOneWidget,
+      );
+      expect(find.text('Open GitHub issue'), findsOneWidget);
+      expect(find.text('Copy bug report'), findsOneWidget);
+      expect(find.text('Share bug report'), findsOneWidget);
+      expect(find.text('Save report file'), findsOneWidget);
+
+      // The live preview shows the assembled, host-only report.
+      expect(find.textContaining('# Linthra bug report'), findsOneWidget);
+      expect(find.textContaining('App version: 0.1.0-test'), findsOneWidget);
+      expect(find.textContaining('Jellyfin host: music.example.com'),
+          findsOneWidget);
+    });
+
+    testWidgets('Copy puts the secret-free markdown report on the clipboard',
+        (tester) async {
+      final List<MethodCall> calls = <MethodCall>[];
+      _mockClipboard(tester, calls);
+
+      await _pumpScreen(tester);
+      await tester.tap(find.text('Copy bug report'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(calls, hasLength(1));
+      final Map<dynamic, dynamic> args =
+          calls.single.arguments as Map<dynamic, dynamic>;
+      final String copied = args['text'] as String;
+      expect(copied, contains('# Linthra bug report'));
+      expect(copied, contains('## Diagnostics'));
+      expect(copied, contains('Jellyfin host: music.example.com'));
+      // Nothing sensitive from the full authenticated URL survives.
+      expect(copied, isNot(contains('api_key')));
+      expect(copied, isNot(contains('secret')));
+      expect(copied, isNot(contains('pass@')));
+
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('Open GitHub issue launches a prefilled issues/new URL',
+        (tester) async {
+      final _FakeLinkLauncher launcher = await _pumpScreen(tester);
+
+      await tester.tap(find.text('Open GitHub issue'));
+      await tester.pump();
+      await tester.pump();
+
+      final Uri? opened = launcher.opened;
+      expect(opened, isNotNull);
+      expect(opened!.host, 'github.com');
+      expect(opened.path, '/thezupzup/linthra/issues/new');
+      expect(opened.queryParameters['labels'], 'bug');
+      final String body = opened.queryParameters['body']!;
+      expect(body, contains('# Linthra bug report'));
+      expect(body, isNot(contains('api_key')));
+
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('falls back to copying the link when the browser won\'t open',
+        (tester) async {
+      final List<MethodCall> calls = <MethodCall>[];
+      _mockClipboard(tester, calls);
+
+      await _pumpScreen(tester, launchResult: false);
+      await tester.tap(find.text('Open GitHub issue'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(calls, hasLength(1));
+      final Map<dynamic, dynamic> args =
+          calls.single.arguments as Map<dynamic, dynamic>;
+      expect(args['text'] as String, contains('github.com'));
+
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('turning off "Include cache state" drops the cache line',
+        (tester) async {
+      await _pumpScreen(tester);
+      expect(find.textContaining('Cache: 2 GB of 4 GB'), findsOneWidget);
+
+      await tester.tap(find.text('Include cache state'));
+      await tester.pump();
+
+      expect(find.textContaining('Cache: 2 GB of 4 GB'), findsNothing);
+    });
+
+    testWidgets('recent events appear and can be excluded', (tester) async {
+      await _pumpScreen(tester);
+      expect(find.textContaining('## Recent app events'), findsOneWidget);
+      expect(find.textContaining('lifecycle: resumed'), findsOneWidget);
+
+      await tester.tap(find.text('Include recent app events'));
+      await tester.pump();
+
+      expect(find.textContaining('## Recent app events'), findsNothing);
+    });
+  });
+}

--- a/test/features/settings/bug_report/report_bug_settings_section_test.dart
+++ b/test/features/settings/bug_report/report_bug_settings_section_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/bug_report/report_bug_settings_section.dart';
+
+void main() {
+  group('ReportBugSettingsSection', () {
+    testWidgets('shows the title, explanation, and entry button',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: ReportBugSettingsSection()),
+        ),
+      );
+
+      // The card title and the button both read "Report a bug".
+      expect(find.text('Report a bug'), findsNWidgets(2));
+      expect(
+        find.textContaining('generated on your device'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.bug_report_outlined), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds **Settings → Report a bug**: a flow that builds a high-quality,
**secret-free** Markdown bug report **entirely on the device**. The user fills
in a short summary/steps, reviews a **live preview**, then chooses to **Copy**,
**Share** (copies, with a hint), **Save report file**, or **Open GitHub issue**
(opens the browser at a prefilled — but **unsubmitted** — issue they review and
submit themselves).

It builds on the existing secret-free diagnostics (#69) rather than introducing
any new data collection.

> **Privacy, by design:** no backend, **no GitHub token**, no automatic send,
> and **no upload to Claude/OpenAI/Anthropic or any third party**. Every share
> action is an explicit tap, and the report is shown for review first.

## What's included

- **Report screen** (`BugReportScreen`) reached from a new "Report a bug" card
  in Settings. Short explanation, an on-device privacy note, the four actions,
  and three opt-in toggles: **playback state**, **cache state**, and **recent
  app events**.
- **Markdown report** (`BugReport`): `# Linthra bug report` with
  Summary / What happened / Steps to reproduce / Expected behavior / fenced
  Diagnostics (and an optional Recent app events block). Also builds the
  `github.com/.../issues/new?labels=bug&title=…&body=…` URL.
- **Diagnostics reuse**: `AppDiagnostics.report` gains `includePlayback` /
  `includeCache` (default `true`, so the plain Diagnostics export is unchanged).
  Server addresses stay host-only, the track id stays hashed, errors stay enum
  names.
- **Recent safe events**: `SafeEventLog`, a bounded in-memory ring buffer fed by
  `StabilityDiagnostics`, so a **release** build can include the last few
  structural breadcrumbs (lifecycle / output / error kind). Memory-only, capped,
  never persisted, surfaced only on opt-in.
- **Browser hand-off**: `url_launcher` wrapped behind the `ExternalLinkLauncher`
  interface (UI never touches the plugin directly). Falls back to copying the
  link if no browser opens. Manifest declares the `https` `VIEW` query so it
  resolves on Android 11+.
- **Docs**: new `docs/reporting-bugs.md`; updates to the README, privacy policy,
  the license/F-Droid audit (the one new dependency, `url_launcher`,
  BSD-3-Clause, no GMS), and the issue-template tip.

## Out of scope (by request)

No backend, no automatic upload, no GitHub token, no new telemetry, no hidden
collection, no unrelated UI redesign. The "paste a report into an agent" idea is
documented as an explicitly **user-driven** future workflow — never automatic.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `flutter test` — full suite green (989), incl. new tests:
  - `safe_event_log_test` (ring buffer, ordering, cap, secret-free)
  - `bug_report_test` (Markdown structure/placeholders, issue URL round-trip)
  - `app_diagnostics_test` (the new include toggles)
  - `stability_diagnostics_test` (recording into the shared buffer)
  - `bug_report_screen_test` (copy is secret-free, open-issue URL, toggles, browser-fail fallback)
- [ ] Manual on-device check of the four actions (couldn't run an Android build in this environment)

https://claude.ai/code/session_01GCiLD2ghs4W6x1XoSwZUmo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCiLD2ghs4W6x1XoSwZUmo)_