### PR TITLE
Fix background playback stopping when the screen is off/locked

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,15 @@
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
+    <!-- WAKE_LOCK: keeps the CPU (and, paired with the foreground media service,
+         the Wi-Fi radio) awake while audio is playing so playback and streaming
+         survive the screen being off. audio_service's foreground service holds
+         this lock only while it reports `playing`; the manifest merger already
+         pulls this permission in from the audio_service plugin, but it is
+         declared here too so the background-playback permission set stays
+         auditable in one place. It grants no network or storage access. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <!-- POST_NOTIFICATIONS: required on Android 13+ (API 33) for the
          audio_service media notification (and its transport controls) to appear
          at all. It is a runtime permission the user must grant; the app asks

--- a/docs/background-playback.md
+++ b/docs/background-playback.md
@@ -1,0 +1,116 @@
+# Background & lock-screen playback
+
+Linthra keeps music playing while the screen is off, the phone is locked, or the
+app is in the background, using a **foreground media service** (via
+`audio_service`) wrapped around the `just_audio` engine. This document explains
+how it stays alive, the one field bug that used to break it, and the
+device-level settings that can still get in its way.
+
+## How it stays alive
+
+- The single `PlaybackController` owns the `just_audio` engine and is **pinned
+  for the whole app session** (never `autoDispose`), so navigating between
+  screens, changing settings, or backgrounding the app can never tear it down.
+- `LinthraAudioHandler` mirrors the controller's state onto the platform media
+  session. While the session reports `playing`, `audio_service` runs a
+  **foreground service of type `mediaPlayback`** and holds the CPU + Wi-Fi wake
+  locks that keep audio (and streaming) alive with the screen off.
+- The app's lifecycle observer **never pauses, stops, or disposes** playback on a
+  background transition. It only snapshots the playback state for diagnostics and
+  — while casting — re-syncs from the receiver on resume.
+
+### The screen-off bug this fixed
+
+`audio_service` keeps the foreground service (and its wake locks) alive only
+while the session reports `playing: true`. It was previously reported as `true`
+**only** for the steady `playing` state — so during a mid-stream **re-buffer**
+(common when Wi-Fi enters power-save with the screen off) or a **track
+transition** the session briefly reported `playing: false`. That demoted the
+foreground service, the OS could then freeze the backgrounded process, and audio
+went silent until the app was reopened (which un-froze the process and let
+playback continue).
+
+The fix: the media session is treated as **playing whenever the engine is
+working toward sound** — steadily playing, re-buffering, or loading the next
+track — and reports `playing: false` only on a real user pause, stop, idle,
+completion, or error. The buffering/loading state still drives the notification
+spinner; the foreground service stays up.
+
+## Notification permission (Android 13+)
+
+On Android 13+ the media notification and its lock-screen / Bluetooth transport
+controls require the `POST_NOTIFICATIONS` runtime permission. Linthra asks for it
+once on first launch.
+
+- If you **grant** it: full media notification + lock-screen controls.
+- If you **deny** it: audio still plays in the background, but the notification
+  and its transport controls are suppressed by the OS. You can re-enable it later
+  in **Android Settings ▸ Apps ▸ Linthra ▸ Notifications**.
+
+Settings ▸ Diagnostics reports the current notification-permission state
+(`granted` / `denied` / `unknown`) so a "lock-screen controls don't work" report
+is self-explaining.
+
+## Battery optimization (device-specific)
+
+Even with everything above correct, some Android OEMs aggressively kill or freeze
+background apps for battery. If music **still** stops when the screen is off after
+a few minutes, exempt Linthra from battery optimization. This is a
+troubleshooting step, not the primary fix — Linthra relies on the foreground
+media service first.
+
+- **Stock Android / Pixel:** Settings ▸ Apps ▸ Linthra ▸ App battery usage →
+  **Unrestricted**.
+- **Samsung (One UI):** Settings ▸ Battery ▸ Background usage limits → remove
+  Linthra from "Sleeping apps" / "Deep sleeping apps"; set App battery usage to
+  **Unrestricted**.
+- **Xiaomi / MIUI:** Settings ▸ Apps ▸ Manage apps ▸ Linthra ▸ Battery saver →
+  **No restrictions**; also enable **Autostart**.
+- **OPPO / realme / OnePlus (ColorOS / OxygenOS):** Settings ▸ Battery ▸ App
+  battery management ▸ Linthra → allow background activity, disable "Sleep
+  standby optimization".
+- **Huawei (EMUI):** Settings ▸ Battery ▸ App launch ▸ Linthra → **Manage
+  manually**, enable Auto-launch, Secondary launch, and Run in background.
+
+(See <https://dontkillmyapp.com> for an up-to-date, per-vendor guide.)
+
+## Diagnostics
+
+Settings ▸ Diagnostics and the on-device "Report a bug" flow include
+**secret-free** background-playback fields to make a "stopped when locked" report
+actionable — never a token, authenticated URL, track title, or path:
+
+- **Notification permission:** `granted` / `denied` / `unknown`.
+- **Audio output:** `local` / `cast`.
+- **Last lifecycle:** the most recent app lifecycle state.
+- **Playback at last background:** the playback status when the app was last
+  backgrounded.
+- **Playback state:** the current playback status.
+- **Last interruption:** the last safe playback/stream interruption *kind*.
+
+Foreground-service-active and battery-optimization status are **not** reported:
+both would require additional native platform code, and the foreground service is
+managed entirely by `audio_service`. The battery-optimization guidance above is
+the practical substitute.
+
+## Manual Android checklist (screen-off / lock-screen)
+
+Run on a physical device against a real server where possible:
+
+1. Start **local** playback.
+2. Turn the screen off for 5 minutes. → Music continues.
+3. Wake the phone. → Playback state is correct (not restarted).
+4. Start **Jellyfin** streaming.
+5. Turn the screen off for 5 minutes. → Stream continues (no silence on
+   re-buffer).
+6. Test **cached/offline** playback with the screen off. → Continues.
+7. Test **Cast** playback with the screen off. → Continues; the phone stays a
+   remote, no second local stream.
+8. Test **Bluetooth/headset** transport controls while locked.
+9. Test **lock-screen** notification controls (play/pause/next/prev/seek).
+10. Deny the notification permission (if practical) → background audio still
+    plays; controls are suppressed; Diagnostics shows `denied`.
+11. Compare **optimized** vs **unrestricted** battery modes; document any device
+    that needs the exemption.
+12. Confirm reopening Linthra does **not** restart or duplicate playback.
+13. Confirm no token or sensitive URL appears in logs or diagnostics.

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -31,6 +31,9 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
   "Known limitations".)*
 - ☐ Returning to the foreground while casting re-syncs the shown position and
   never starts a second local stream.
+- ☐ Screen-off / lock-screen playback survives a 5-minute screen-off for local,
+  streaming, cached, and cast playback. See the dedicated checklist and battery
+  troubleshooting in [background-playback.md](background-playback.md).
 
 ## 2. Library
 

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -55,6 +55,16 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
     // A secret-free breadcrumb (debug only): freezes/ANRs cluster around
     // background/foreground, so logging the transition makes them correlatable.
     StabilityDiagnostics.lifecycle(state.name);
+    // On a background transition (screen off / app hidden), snapshot the
+    // playback status so a "music stopped when I locked the phone" report can
+    // show what state playback was in at that exact boundary. This only reads
+    // the controller's status — it never pauses, stops, or disposes playback.
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.inactive) {
+      final status = ref.read(playbackControllerProvider).state.status;
+      StabilityDiagnostics.backgroundPlaybackState(status.name);
+    }
     // Returning from the background while casting: re-sync from the receiver so
     // the position the UI shows is fresh. This never starts local playback —
     // backgrounding/foregrounding the app must not recreate or resume the local

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -28,6 +28,10 @@ class AppDiagnosticsData {
     this.playbackStatus,
     this.currentTrackIdHash,
     this.lastErrorKind,
+    this.notificationPermission,
+    this.lastLifecycleState,
+    this.playbackStateAtBackground,
+    this.lastInterruptionKind,
     this.castAvailable = false,
     this.castConnected = false,
     this.androidAutoSupported = false,
@@ -85,6 +89,25 @@ class AppDiagnosticsData {
   /// occurred. Never a raw error message.
   final String? lastErrorKind;
 
+  /// Whether the notification permission is `granted`/`denied`/`unknown`, so a
+  /// "lock-screen controls don't work" report can show whether the Android 13+
+  /// `POST_NOTIFICATIONS` grant — required for the media notification and its
+  /// transport controls — is in place. Null when not collected.
+  final String? notificationPermission;
+
+  /// The most recent app lifecycle state (`resumed`/`paused`/…), when known —
+  /// the background/foreground boundary screen-off playback bugs cluster around.
+  final String? lastLifecycleState;
+
+  /// The playback status captured the last time the app was backgrounded
+  /// (`playing`/`buffering`/`paused`/…), when known — so a "music stopped when I
+  /// locked the phone" report shows what state playback was in at that boundary.
+  final String? playbackStateAtBackground;
+
+  /// The last safe playback/stream interruption kind (an enum name or fixed
+  /// label like `load`), when one occurred. Never a raw error.
+  final String? lastInterruptionKind;
+
   final bool castAvailable;
   final bool castConnected;
   final bool androidAutoSupported;
@@ -140,7 +163,15 @@ abstract final class AppDiagnostics {
         'Playback state: ${data.playbackStatus}',
       if (includePlayback && data.currentTrackIdHash != null)
         'Current track: ${data.currentTrackIdHash}',
+      if (includePlayback && data.playbackStateAtBackground != null)
+        'Playback at last background: ${data.playbackStateAtBackground}',
+      if (_has(data.lastLifecycleState))
+        'Last lifecycle: ${data.lastLifecycleState}',
+      if (_has(data.notificationPermission))
+        'Notification permission: ${data.notificationPermission}',
       'Last error: ${data.lastErrorKind ?? 'none'}',
+      if (includePlayback && _has(data.lastInterruptionKind))
+        'Last interruption: ${data.lastInterruptionKind}',
       'Cast available: ${_yesNo(data.castAvailable)}',
       'Cast connected: ${_yesNo(data.castConnected)}',
       'Android Auto supported: ${_yesNo(data.androidAutoSupported)}',

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -261,13 +261,43 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
         audio.MediaAction.setRepeatMode,
       },
       processingState: _processingStateFor(state.status),
-      playing: state.isPlaying,
+      playing: _isSessionPlaying(state.status),
       updatePosition: state.position,
       shuffleMode: state.shuffleEnabled
           ? audio.AudioServiceShuffleMode.all
           : audio.AudioServiceShuffleMode.none,
       repeatMode: _repeatModeTo(state.repeatMode),
     );
+  }
+
+  /// Whether the platform session should be reported as `playing`.
+  ///
+  /// This is the value that keeps the foreground media service (and the CPU +
+  /// Wi-Fi wake locks `audio_service` holds with it) alive: `audio_service`
+  /// promotes the service to the foreground while `playing` is `true` and, with
+  /// the default `androidStopForegroundOnPause`, demotes it the moment it goes
+  /// `false`. If a mid-stream re-buffer or a track transition reported
+  /// `playing: false`, the OS could freeze the backgrounded process with the
+  /// screen off — so streaming would go silent and only resume when the app is
+  /// reopened (the exact field bug this guards against).
+  ///
+  /// So the session is "playing" whenever the engine is actively working toward
+  /// sound — steadily playing, re-buffering mid-stream, or loading the next
+  /// track — and only reports `false` on a real user pause, stop, idle, normal
+  /// completion, or error. The distinct buffering/loading `processingState`
+  /// still drives the notification's spinner; the foreground service stays up.
+  static bool _isSessionPlaying(PlaybackStatus status) {
+    switch (status) {
+      case PlaybackStatus.playing:
+      case PlaybackStatus.buffering:
+      case PlaybackStatus.loading:
+        return true;
+      case PlaybackStatus.idle:
+      case PlaybackStatus.paused:
+      case PlaybackStatus.completed:
+      case PlaybackStatus.error:
+        return false;
+    }
   }
 
   static RepeatMode _repeatModeFrom(audio.AudioServiceRepeatMode mode) {
@@ -294,9 +324,15 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   }
 
   List<audio.MediaControl> _controlsFor(PlaybackState state) {
+    // Show the pause control whenever the session is treated as playing
+    // (including while buffering/loading), so the notification/lock-screen
+    // toggle matches the reported `playing` flag rather than flipping to a play
+    // icon during a mid-stream re-buffer.
     return <audio.MediaControl>[
       if (state.hasPrevious) audio.MediaControl.skipToPrevious,
-      state.isPlaying ? audio.MediaControl.pause : audio.MediaControl.play,
+      _isSessionPlaying(state.status)
+          ? audio.MediaControl.pause
+          : audio.MediaControl.play,
       audio.MediaControl.stop,
       if (state.hasNext) audio.MediaControl.skipToNext,
     ];
@@ -355,7 +391,15 @@ Future<LinthraAudioHandler?> connectMediaSession(
       config: const audio.AudioServiceConfig(
         androidNotificationChannelId: 'com.linthra.audio',
         androidNotificationChannelName: 'Linthra playback',
+        // Keep the notification ongoing (un-swipeable) while the session reports
+        // `playing`, so the foreground media service — and the CPU/Wi-Fi wake
+        // locks it holds — stay alive with the screen off. `audio_service`
+        // requires `androidStopForegroundOnPause: true` (the default, set
+        // explicitly here) whenever the notification is ongoing: the service is
+        // foregrounded only while playing and demoted on a real pause, never on
+        // a mid-stream re-buffer (see [_isSessionPlaying]).
         androidNotificationOngoing: true,
+        androidStopForegroundOnPause: true,
       ),
     );
     _log('media session attached (Android Auto browser ready)');

--- a/lib/core/services/notification_permission.dart
+++ b/lib/core/services/notification_permission.dart
@@ -18,6 +18,39 @@ abstract interface class NotificationPermission {
   /// Never throws — a platform that can't service the request is treated as
   /// "nothing to do" so startup is never blocked by it.
   Future<void> ensureGranted();
+
+  /// The current notification-permission state, for diagnostics.
+  ///
+  /// Never throws and never prompts: it only *reads* the status so a bug report
+  /// can say whether the media notification / lock-screen controls can appear at
+  /// all. Returns [NotificationPermissionStatus.unknown] off Android (where
+  /// there is no `POST_NOTIFICATIONS` gate) and whenever the platform can't
+  /// answer.
+  Future<NotificationPermissionStatus> status();
+}
+
+/// The display-safe notification-permission state surfaced in diagnostics.
+///
+/// On Android 13+ the media notification (and its transport controls) only
+/// appears when [granted]; when [denied] the foreground service still runs but
+/// the controls are suppressed, which is worth surfacing in a bug report.
+/// [unknown] covers platforms with no runtime gate and any read that fails.
+enum NotificationPermissionStatus {
+  granted,
+  denied,
+  unknown;
+
+  /// A stable, secret-free label for the diagnostics report.
+  String get label {
+    switch (this) {
+      case NotificationPermissionStatus.granted:
+        return 'granted';
+      case NotificationPermissionStatus.denied:
+        return 'denied';
+      case NotificationPermissionStatus.unknown:
+        return 'unknown';
+    }
+  }
 }
 
 /// The production [NotificationPermission], backed by `permission_handler`.
@@ -48,6 +81,22 @@ class PermissionHandlerNotificationPermission
       // runs without the notification rather than failing to start.
     }
   }
+
+  @override
+  Future<NotificationPermissionStatus> status() async {
+    if (!Platform.isAndroid) {
+      return NotificationPermissionStatus.unknown;
+    }
+    try {
+      final PermissionStatus status = await Permission.notification.status;
+      return status.isGranted
+          ? NotificationPermissionStatus.granted
+          : NotificationPermissionStatus.denied;
+    } catch (_) {
+      // A read that the platform can't service must never crash diagnostics.
+      return NotificationPermissionStatus.unknown;
+    }
+  }
 }
 
 /// A [NotificationPermission] that does nothing.
@@ -58,4 +107,8 @@ class NoopNotificationPermission implements NotificationPermission {
 
   @override
   Future<void> ensureGranted() async {}
+
+  @override
+  Future<NotificationPermissionStatus> status() async =>
+      NotificationPermissionStatus.unknown;
 }

--- a/lib/core/services/stability_diagnostics.dart
+++ b/lib/core/services/stability_diagnostics.dart
@@ -28,14 +28,44 @@ abstract final class StabilityDiagnostics {
     developer.log(message, name: name);
   }
 
+  /// The most recent app lifecycle state seen (`resumed`, `paused`, …), retained
+  /// for diagnostics so a bug report can show what transition the app was in.
+  /// Null until the first transition. A fixed enum-name label — never a secret.
+  static String? lastLifecycleState;
+
+  /// The playback status (`playing`, `buffering`, `paused`, …) captured the last
+  /// time the app was backgrounded, retained for diagnostics so a "music stopped
+  /// when I locked the phone" report can show what state playback was in at that
+  /// boundary. Null until the app has been backgrounded at least once.
+  static String? playbackStateAtBackground;
+
+  /// The last safe playback/stream interruption *kind* seen (an enum name or a
+  /// fixed label like `load`/`resolution`), retained for diagnostics. Null until
+  /// one occurs. Never the raw error (which can carry a tokenized URL).
+  static String? lastInterruptionKind;
+
   /// An app lifecycle transition (`resumed`, `paused`, `inactive`, …) — the
   /// boundary most freezes/ANRs cluster around (background/foreground).
   static void lifecycle(String state) {
+    lastLifecycleState = state;
     SafeEventLog.instance.record('lifecycle', state);
     _log(describeLifecycle(state));
   }
 
   static String describeLifecycle(String state) => 'lifecycle: $state';
+
+  /// The playback status at the moment the app was backgrounded (screen off /
+  /// app hidden). Retained in [playbackStateAtBackground] and recorded as a
+  /// breadcrumb so a screen-off "playback stopped" report is correlatable.
+  /// [status] is a stable [PlaybackStatus] name — never a track, URL, or token.
+  static void backgroundPlaybackState(String status) {
+    playbackStateAtBackground = status;
+    SafeEventLog.instance.record('bg-playback', status);
+    _log(describeBackgroundPlaybackState(status));
+  }
+
+  static String describeBackgroundPlaybackState(String status) =>
+      'background playback: $status';
 
   /// The active playback output changed (`local` / `cast`), so a handoff can be
   /// correlated with a freeze without logging anything about the track.
@@ -60,6 +90,7 @@ abstract final class StabilityDiagnostics {
   /// [StreamInterruptionKind] name or a fixed label like `resolution`/`load`) —
   /// never the raw error, which can carry a tokenized URL.
   static void playbackError(String kind) {
+    lastInterruptionKind = kind;
     SafeEventLog.instance.record('error', kind);
     _log(describePlaybackError(kind));
   }

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -8,7 +8,9 @@ import '../../../core/models/active_playback_output.dart';
 import '../../../core/models/cast_state.dart';
 import '../../../core/models/playback_state.dart';
 import '../../../core/services/active_playback_controller.dart';
+import '../../../core/services/notification_permission.dart';
 import '../../../core/services/playback_diagnostics.dart';
+import '../../../core/services/stability_diagnostics.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../downloads/download_providers.dart';
 import '../../player/cast/cast_providers.dart';
@@ -64,6 +66,10 @@ class DiagnosticsCollector {
       playbackStatus: _playbackStatus(),
       currentTrackIdHash: _currentTrackIdHash(),
       lastErrorKind: jellyfin.errorKind?.name ?? subsonic.errorKind?.name,
+      notificationPermission: (await _notificationPermission()).label,
+      lastLifecycleState: StabilityDiagnostics.lastLifecycleState,
+      playbackStateAtBackground: StabilityDiagnostics.playbackStateAtBackground,
+      lastInterruptionKind: StabilityDiagnostics.lastInterruptionKind,
       castAvailable: cast.isAvailable,
       castConnected: cast.isConnected,
       androidAutoSupported: _androidAutoSupported(),
@@ -73,6 +79,12 @@ class DiagnosticsCollector {
       smartPrecacheEnabled: _ref.read(smartPrecacheEnabledProvider).valueOrNull,
     );
   }
+
+  /// Reads (never prompts for) the notification permission state, so the report
+  /// can show whether the media notification / lock-screen controls can appear.
+  /// Best-effort: the seam returns `unknown` off Android and on any read error.
+  Future<NotificationPermissionStatus> _notificationPermission() =>
+      const PermissionHandlerNotificationPermission().status();
 
   String? _androidVersion() =>
       Platform.isAndroid ? Platform.operatingSystemVersion : null;

--- a/test/app/notification_permission_request_test.dart
+++ b/test/app/notification_permission_request_test.dart
@@ -16,6 +16,10 @@ class _RecordingNotificationPermission implements NotificationPermission {
   Future<void> ensureGranted() async {
     calls += 1;
   }
+
+  @override
+  Future<NotificationPermissionStatus> status() async =>
+      NotificationPermissionStatus.unknown;
 }
 
 void main() {

--- a/test/app/playback_lifecycle_test.dart
+++ b/test/app/playback_lifecycle_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/linthra_app.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/notification_permission.dart';
+import 'package:linthra/core/services/stability_diagnostics.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../features/player/fake_playback_controller.dart';
+
+/// Notification-permission seam that never prompts, so pumping the app can't
+/// trigger a real OS dialog.
+class _SilentNotificationPermission implements NotificationPermission {
+  @override
+  Future<void> ensureGranted() async {}
+
+  @override
+  Future<NotificationPermissionStatus> status() async =>
+      NotificationPermissionStatus.unknown;
+}
+
+const _playingTrack = Track(id: 'a', title: 'Song A', uri: '/a.mp3');
+
+/// Drives the app from `resumed` down to `paused` through the legal lifecycle
+/// chain Flutter's binding enforces (resumed → inactive → hidden → paused).
+Future<void> _background(WidgetTester tester) async {
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+  await tester.pump();
+}
+
+/// Drives the app back up to `resumed` (paused → hidden → inactive → resumed).
+Future<void> _foreground(WidgetTester tester) async {
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+  tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+  await tester.pump();
+}
+
+Future<FakePlaybackController> _pumpApp(WidgetTester tester) async {
+  final controller = FakePlaybackController(
+    initial: const PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _playingTrack,
+    ),
+  );
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        notificationPermissionProvider
+            .overrideWithValue(_SilentNotificationPermission()),
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: const LinthraApp(),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+void main() {
+  testWidgets('backgrounding the app never pauses or stops active playback',
+      (tester) async {
+    final controller = await _pumpApp(tester);
+
+    await _background(tester);
+
+    // The screen-off bug guard: a background transition must not touch
+    // transport at all — the foreground service keeps audio alive instead.
+    expect(controller.pauseCount, 0);
+    expect(controller.stopCount, 0);
+    expect(controller.playedTracks, isEmpty);
+  });
+
+  testWidgets('returning to the foreground does not restart playback',
+      (tester) async {
+    final controller = await _pumpApp(tester);
+
+    await _background(tester);
+    await _foreground(tester);
+
+    // No re-load (playTracks) and no extra play(): the engine is left running.
+    expect(controller.playedTracks, isEmpty);
+    expect(controller.playCount, 0);
+    expect(controller.pauseCount, 0);
+    expect(controller.stopCount, 0);
+  });
+
+  testWidgets('a background transition records the playback state for reports',
+      (tester) async {
+    StabilityDiagnostics.playbackStateAtBackground = null;
+    await _pumpApp(tester);
+
+    await _background(tester);
+
+    // The "music stopped when I locked the phone" breadcrumb: the status at the
+    // background boundary is captured (here, playing) for the bug report.
+    expect(StabilityDiagnostics.playbackStateAtBackground, 'playing');
+    expect(StabilityDiagnostics.lastLifecycleState, 'paused');
+  });
+}

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -150,6 +150,76 @@ void main() {
       expect(report, isNot(contains('Current track:')));
     });
 
+    test('includes the background-playback diagnostic fields', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          notificationPermission: 'denied',
+          lastLifecycleState: 'paused',
+          playbackStateAtBackground: 'playing',
+          lastInterruptionKind: 'connectionLost',
+        ),
+      );
+
+      expect(report, contains('Notification permission: denied'));
+      expect(report, contains('Last lifecycle: paused'));
+      expect(report, contains('Playback at last background: playing'));
+      expect(report, contains('Last interruption: connectionLost'));
+    });
+
+    test('includePlayback: false drops the background-playback playback lines',
+        () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          notificationPermission: 'granted',
+          lastLifecycleState: 'resumed',
+          playbackStateAtBackground: 'buffering',
+          lastInterruptionKind: 'connectionLost',
+        ),
+        includePlayback: false,
+      );
+
+      // Notification permission and lifecycle carry no track info, so they stay.
+      expect(report, contains('Notification permission: granted'));
+      expect(report, contains('Last lifecycle: resumed'));
+      // The playback-describing lines are dropped with the rest of playback.
+      expect(report, isNot(contains('Playback at last background:')));
+      expect(report, isNot(contains('Last interruption:')));
+    });
+
+    test('the background-playback diagnostics never carry a secret', () {
+      // Every field here is a fixed enum-name/label, so a report built from a
+      // backgrounded streaming session leaks no token, URL, or track identity.
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          playbackOutput: 'local',
+          playbackStatus: 'buffering',
+          notificationPermission: 'granted',
+          lastLifecycleState: 'paused',
+          playbackStateAtBackground: 'buffering',
+          lastInterruptionKind: 'connectionLost',
+        ),
+      );
+
+      expect(report.toLowerCase(), isNot(contains('http')));
+      expect(report.toLowerCase(), isNot(contains('token')));
+      expect(report, isNot(contains('api_key')));
+      expect(report.toLowerCase(), isNot(contains('authorization')));
+      expect(report.toLowerCase(), isNot(contains('bearer')));
+    });
+
+    test('omits the background-playback fields when absent', () {
+      final String report =
+          AppDiagnostics.report(const AppDiagnosticsData(appVersion: '0.1.0'));
+
+      expect(report, isNot(contains('Notification permission:')));
+      expect(report, isNot(contains('Last lifecycle:')));
+      expect(report, isNot(contains('Playback at last background:')));
+      expect(report, isNot(contains('Last interruption:')));
+    });
+
     test('includeCache: false drops the cache line', () {
       final String report = AppDiagnostics.report(
         const AppDiagnosticsData(

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -302,6 +302,27 @@ void main() {
       expect(local.playCount, localPlaysBefore);
     });
 
+    test('the active output stays cast across a background/foreground cycle',
+        () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      final int suspendsBefore = local.suspendCount;
+      final int resumesBefore = local.resumeCount;
+
+      // Simulate leaving and returning to the app while casting.
+      controller.onAppResumed();
+
+      // Output is unchanged and the local engine was neither re-suspended nor
+      // resumed — backgrounding must not reset the active output.
+      expect(controller.activeOutput, ActivePlaybackOutput.cast);
+      expect(local.suspendCount, suspendsBefore);
+      expect(local.resumeCount, resumesBefore);
+    });
+
     test('onAppResumed is a no-op when not casting', () async {
       final controller = build();
       addTearDown(controller.dispose);

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -210,6 +210,82 @@ void main() {
       });
     });
 
+    group('foreground service stays alive across buffering & transitions', () {
+      // The screen-off bug: if the session reported `playing: false` during a
+      // mid-stream re-buffer or a track transition, audio_service would demote
+      // the foreground service and the OS could freeze the backgrounded process,
+      // silencing playback until the app is reopened. So the session must stay
+      // `playing` whenever the engine is working toward sound.
+
+      test('a mid-stream re-buffer stays playing (service not demoted)',
+          () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        controller.emit(
+          controller.state.copyWith(status: PlaybackStatus.buffering),
+        );
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.playing, isTrue);
+        expect(state.processingState, audio.AudioProcessingState.buffering);
+        // The toggle still offers pause (not play) while buffering.
+        expect(state.controls, contains(audio.MediaControl.pause));
+        expect(state.controls, isNot(contains(audio.MediaControl.play)));
+      });
+
+      test('a loading track transition stays playing', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        controller.emit(
+          controller.state.copyWith(status: PlaybackStatus.loading),
+        );
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.playing, isTrue);
+        expect(state.processingState, audio.AudioProcessingState.loading);
+      });
+
+      test('a real user pause reports not-playing', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        controller.emit(
+          controller.state.copyWith(status: PlaybackStatus.paused),
+        );
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.playing, isFalse);
+        expect(state.controls, contains(audio.MediaControl.play));
+        expect(state.controls, isNot(contains(audio.MediaControl.pause)));
+      });
+
+      test('completion and error report not-playing', () async {
+        await controller.playTracks(<Track>[_track('a')]);
+        await _settle();
+
+        controller.emit(
+          controller.state.copyWith(status: PlaybackStatus.completed),
+        );
+        await _settle();
+        expect(handler.playbackState.value.playing, isFalse);
+        expect(
+          handler.playbackState.value.processingState,
+          audio.AudioProcessingState.completed,
+        );
+
+        controller.emit(
+          controller.state.copyWith(status: PlaybackStatus.error),
+        );
+        await _settle();
+        expect(handler.playbackState.value.playing, isFalse);
+      });
+    });
+
     group('media browser', () {
       test('root lists Library and Queue as browsable categories', () async {
         final children = await handler.getChildren(MediaId.root);

--- a/test/core/services/notification_permission_test.dart
+++ b/test/core/services/notification_permission_test.dart
@@ -10,12 +10,38 @@ void main() {
       const permission = PermissionHandlerNotificationPermission();
       await expectLater(permission.ensureGranted(), completes);
     });
+
+    test('status reads as unknown off Android (no runtime gate)', () async {
+      // Off Android there is no POST_NOTIFICATIONS gate, so the status read
+      // short-circuits to `unknown` without touching the plugin channel.
+      const permission = PermissionHandlerNotificationPermission();
+      await expectLater(
+        permission.status(),
+        completion(NotificationPermissionStatus.unknown),
+      );
+    });
   });
 
   group('NoopNotificationPermission', () {
     test('does nothing and completes', () async {
       const permission = NoopNotificationPermission();
       await expectLater(permission.ensureGranted(), completes);
+    });
+
+    test('reports an unknown status', () async {
+      const permission = NoopNotificationPermission();
+      await expectLater(
+        permission.status(),
+        completion(NotificationPermissionStatus.unknown),
+      );
+    });
+  });
+
+  group('NotificationPermissionStatus.label', () {
+    test('maps each state to a stable, secret-free label', () {
+      expect(NotificationPermissionStatus.granted.label, 'granted');
+      expect(NotificationPermissionStatus.denied.label, 'denied');
+      expect(NotificationPermissionStatus.unknown.label, 'unknown');
     });
   });
 }

--- a/test/core/services/stability_diagnostics_test.dart
+++ b/test/core/services/stability_diagnostics_test.dart
@@ -81,4 +81,30 @@ void main() {
       }
     });
   });
+
+  group('StabilityDiagnostics retained fields for diagnostics', () {
+    setUp(SafeEventLog.instance.clear);
+    tearDown(SafeEventLog.instance.clear);
+
+    test('lifecycle retains the last state seen', () {
+      StabilityDiagnostics.lifecycle('inactive');
+      StabilityDiagnostics.lifecycle('paused');
+      expect(StabilityDiagnostics.lastLifecycleState, 'paused');
+    });
+
+    test('backgroundPlaybackState retains and records the status', () {
+      StabilityDiagnostics.backgroundPlaybackState('buffering');
+      expect(StabilityDiagnostics.playbackStateAtBackground, 'buffering');
+      expect(SafeEventLog.instance.lines, contains('bg-playback: buffering'));
+      expect(
+        StabilityDiagnostics.describeBackgroundPlaybackState('playing'),
+        'background playback: playing',
+      );
+    });
+
+    test('playbackError retains the last interruption kind', () {
+      StabilityDiagnostics.playbackError('connectionLost');
+      expect(StabilityDiagnostics.lastInterruptionKind, 'connectionLost');
+    });
+  });
 }


### PR DESCRIPTION
## Root cause

`audio_service` keeps its **foreground media service** — and the CPU + Wi-Fi wake
locks it holds — alive only while the media session reports `playing: true`, and
(with the default `androidStopForegroundOnPause`) demotes it the moment the
session reports `playing: false`.

`LinthraAudioHandler` mapped the session's `playing` flag to
`PlaybackState.isPlaying`, which is `true` **only** for the steady
`PlaybackStatus.playing`. So during a mid-stream **re-buffer** (very common when
Wi-Fi enters power-save with the screen off — i.e. Jellyfin streaming) or a
**track transition** (`loading`), the session briefly reported `playing: false`.
That demoted the foreground service, Android then froze the backgrounded process,
and audio went silent until the app was reopened (which un-froze the process and
let playback "continue again") — exactly the reported symptom.

## Lifecycle review (no bug found, verified safe)

- The single `PlaybackController` is pinned for the session (read-once, not
  `autoDispose`); navigation/settings churn can't tear it down (already covered
  by `playback_controller_lifecycle_test.dart`).
- The lifecycle observer never pauses/stops/disposes playback on background; it
  only re-syncs from the receiver on resume **while casting**. Left intact and
  now covered by tests.

## Fixes

- **Media session `playing` flag (the fix):** treat the session as playing
  whenever the engine is working toward sound — `playing`, `buffering`, or
  `loading` — and report `playing: false` only on a real user pause, stop, idle,
  completion, or error. The distinct `buffering`/`loading` `processingState`
  still drives the notification spinner; the foreground service stays up across
  re-buffers and track changes. (`lib/core/services/linthra_audio_handler.dart`)
- **Transport controls** show pause whenever the session is treated as playing,
  so the notification toggle doesn't flip to "play" during a re-buffer.
- **Foreground-service config** documented and made explicit
  (`androidNotificationOngoing: true` + `androidStopForegroundOnPause: true`).
- **`WAKE_LOCK`** declared explicitly in the manifest for auditability (it was
  already merged from the `audio_service` plugin).

## Notification / media-session behavior

- On Android 13+ the media notification + lock-screen/Bluetooth controls need
  `POST_NOTIFICATIONS` (asked once on launch). If denied, background audio still
  plays; the controls are suppressed by the OS. The notification-permission
  state is now surfaced in Diagnostics (`granted`/`denied`/`unknown`) instead of
  failing silently.

## Audio focus behavior

`just_audio` handles audio focus internally (transient → duck/pause, permanent →
pause). There is **no** volume manipulation anywhere in the app, so nothing
mutes on a lifecycle change; screen-off is not an audio-focus event. No change
needed here, verified by inspection.

## Battery optimization notes

Some OEMs still freeze background apps regardless of a correct foreground
service. Added per-vendor "set Linthra to Unrestricted / not optimized"
troubleshooting in `docs/background-playback.md` (as troubleshooting, not the
primary fix).

## Diagnostics added (secret-free)

`notification permission` · `audio output (local/cast)` · `last lifecycle` ·
`playback state at last background` · `playback state` · `last interruption
kind`. Foreground-service-active and battery-optimization status are **not**
reported (would need extra native code; documented instead). No token,
authenticated URL, `Authorization` header, password, track title, or path can
reach any of these by construction.

## Tests added/updated

- `linthra_audio_handler_test.dart`: re-buffer and `loading` transition stay
  `playing` (service not demoted); a real pause / completion / error report
  not-playing; controls show pause while buffering.
- `playback_lifecycle_test.dart` (new): backgrounding never pauses/stops/restarts
  playback; resume doesn't restart; the background-transition breadcrumb is
  recorded.
- `active_playback_controller_test.dart`: active output stays `cast` across a
  background/foreground cycle (no re-suspend/resume).
- `notification_permission_test.dart`: status maps to `granted`/`denied`/
  `unknown`; off-Android reads `unknown`.
- `stability_diagnostics_test.dart`: retained last-lifecycle / background-playback
  / last-interruption fields.
- `app_diagnostics_test.dart`: new diagnostic lines render, respect
  `includePlayback`, and carry no secret.

## Verification

⚠️ Flutter/Dart are **not available** in this remote environment, so I could not
run `flutter pub get` / `dart format` / `flutter analyze` / `flutter test` /
`flutter build apk --debug`. Changes were written to match the existing style and
analyzer expectations; please run the suite locally/CI:

- [ ] `flutter pub get`
- [ ] `dart format --set-exit-if-changed .`
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] `flutter build apk --debug`

## Manual Android checklist

1. Start local playback.
2. Turn screen off for 5 minutes → music continues.
3. Wake phone → playback state correct (not restarted).
4. Start Jellyfin streaming.
5. Turn screen off for 5 minutes → stream continues (no silence on re-buffer).
6. Cached/offline playback with screen off → continues.
7. Local file playback with screen off → continues.
8. Cast playback with screen off → continues; phone stays a remote, no second
   local stream.
9. Bluetooth/headset controls while locked.
10. Lock-screen notification controls (play/pause/next/prev/seek).
11. Deny notification permission → background audio still plays; controls
    suppressed; Diagnostics shows `denied`.
12. Compare optimized vs unrestricted battery modes; note any device needing the
    exemption.
13. Reopening Linthra does not restart or duplicate playback.
14. No token/sensitive URL in logs or diagnostics.

## Known remaining limitations

- Aggressive OEM battery managers can still kill the process; mitigated only by
  the documented per-vendor exemption, not by app code.
- Foreground-service-active and battery-optimization status are not surfaced in
  diagnostics (would require additional native platform channels).
- The play queue/position is still not restored across a full process kill
  (pre-existing, out of scope).

https://claude.ai/code/session_01AzRUCmisVKwnSjpd4aeHRQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzRUCmisVKwnSjpd4aeHRQ)_