### PR TITLE
Chromecast metadata polish (duration + branding honesty) & cast reload hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ gradient, generated from one source design (not mockups).
 - **Smart offline cache** — tap to download the tracks you want offline; Wi-Fi
   only by default, with a size limit and "Keep offline" pinning.
 - **Cast / Chromecast** — hand a stream off to a speaker or TV, with device
-  volume control. Pure-Dart Cast, no Google Play Services.
+  volume control and track metadata (title/artist/album/artwork) on the receiver.
+  Pure-Dart Cast, no Google Play Services. (App-name/logo branding on the receiver
+  needs a custom receiver app — see [docs/cast.md](./docs/cast.md).)
 - **Android Auto** — browse your Library, Queue, Playlists, and Favorites from
   the car screen and tap to play.
 - **Playlists & favourites** — create/edit/reorder/delete playlists; favourite

--- a/docs/cast.md
+++ b/docs/cast.md
@@ -29,6 +29,63 @@ or F-Droid-style build.
   failed volume command surfaces a calm notice **without ever interrupting
   playback**.
 
+## What the receiver shows (metadata)
+
+When Linthra hands a track to the **default media receiver**, it sends the track's
+metadata so the TV/speaker/display shows what's playing rather than a bare URL:
+
+| Field | Sent? | Source |
+| --- | --- | --- |
+| **Title** | ✅ | the track title |
+| **Artist** | ✅ when known | the track artist |
+| **Album** | ✅ when known | the track album |
+| **Duration** | ✅ when known | the track's catalog duration (so the seek bar has a length immediately) |
+| **Artwork** | ✅ Jellyfin · ❌ Subsonic | see below |
+
+This metadata is built in one tested place — `CastLoadMessage` (in
+`lib/core/services/cast/`) — from a `CastMedia` produced by the source's
+`CastMediaResolver`. `ChromecastCastTransport` only serialises that message onto
+the wire, so metadata formatting never scatters across the app or into a widget.
+When the current track changes, the new track's metadata is sent automatically; a
+re-emission of the *same* track is a no-op, so steady playback never reloads the
+stream just to refresh metadata.
+
+### Artwork
+
+- **Jellyfin** cover art (`/Items/<id>/Images/Primary`) needs no auth, so it is a
+  safe, token-free URL the receiver can fetch directly — Linthra sends it.
+- **Subsonic/Navidrome** cover art (`getCoverArt`) requires the salt+token in its
+  query, so sending it would leak the credential to the receiver. Linthra
+  **omits** Subsonic artwork rather than leak a token. (A token-free cover proxy
+  is a possible follow-up.)
+
+Artwork is only ever sent when it is a URL the receiver can actually reach without
+a credential; otherwise it is omitted.
+
+## Receiver app name / logo (branding)
+
+**The receiver shows "Default Media Receiver" (and your Cast device's name), not a
+Linthra name or logo.** This is a limitation of the *default* Cast media receiver,
+not something Linthra can fix from the sender:
+
+- The app name and logo shown on a Cast device are fixed by the **receiver
+  application** that's running on the device, not by the sender or by any media
+  metadata field. There is no Cast field that lets a sender set the receiver's
+  displayed app name or logo.
+- Linthra uses Google's published **default media receiver** (app id `CC1AD845`)
+  so casting needs **no Google Play Services and no proprietary Cast SDK**, which
+  is what keeps it F-Droid/open-source friendly. That receiver renders the media
+  metadata above, but always under its own generic branding.
+- Showing **"Linthra" + the Linthra logo** on the receiver would require shipping a
+  **custom Cast receiver application** — a small hosted HTML/JS app registered in
+  Google's Cast Developer Console under a Linthra-owned app id. That is a hosting +
+  registration commitment (and arguably a Play-Services-adjacent dependency), so
+  it is **out of scope** for now and tracked as a follow-up.
+
+Linthra deliberately **does not fake** app branding it can't deliver: it improves
+exactly what the default receiver *can* show (title / artist / album / duration /
+artwork) and is honest about the rest.
+
 ## How it works (architecture)
 
 The UI renders a `CastState` and drives discovery/connection through the
@@ -67,6 +124,16 @@ and it is **never logged or persisted**. A track's stored reference stays the
 token-free `jellyfin:<id>` / `subsonic:<id>`; the receiver is told to fetch a
 freshly minted URL that never lands in `Track`, the catalog, a log, or app state.
 
+- The token rides on exactly **one** field — the `contentId` (the stream URL the
+  receiver fetches). It must be there; the receiver pulls the bytes itself.
+- **Nothing else carries it.** The displayed metadata (title / artist / album /
+  artwork) never embeds the token; `CastMedia.toString()` redacts the stream URL
+  down to scheme/host/path; and the only diagnostics line emitted at cast time
+  has no field for a token or full URL.
+- **Artwork follows the same rule**: a tokenised cover-art URL is never sent.
+  Jellyfin's cover art is token-free (sent); Subsonic's needs the credential
+  (omitted).
+
 ## Resilience while casting
 
 - A dropped receiver returns playback to the device **paused** at the last
@@ -77,7 +144,14 @@ freshly minted URL that never lands in `Track`, the catalog, a log, or app state
 
 ## Known limitations
 
+- **No Linthra app name/logo on the receiver** with the default media receiver —
+  it shows "Default Media Receiver". True branding needs a custom receiver app
+  (see [above](#receiver-app-name--logo-branding)). Tracked as a follow-up.
+- **Subsonic/Navidrome artwork is not shown** on the receiver, because its
+  cover-art URL would leak the credential. Jellyfin artwork is shown.
 - **On-device files can't be cast** (no receiver-reachable URL).
 - Receiver transport controls (volume aside) and local-file casting are
   follow-ups.
+- Per-track content type is a best-effort `audio/mpeg` hint; an exact MIME /
+  transcoded cast profile for exotic codecs is a follow-up.
 - mDNS discovery depends on a LAN that allows it.

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -68,19 +68,53 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
 
 ## 4. Cast / Chromecast
 
-- ☑ Cast button discovers and connects to a real Chromecast.
-- ☑ Disconnect returns to the phone **paused** (never surprise-starts audio).
-- ☑ Play / pause / seek route to the receiver while connected.
-- ☐ Next / Previous change the receiver's track.
-- ☐ Background/foreground the app while casting — position stays in sync, no
-  duplicate local audio.
-- ☑ No duplicate local playback while Cast is active.
+Run the end-to-end pass in this order (a streamed track is required — local
+files can't cast):
+
+1. ☐ Start a **Jellyfin** (or Subsonic) track playing on the phone.
+2. ☐ Open the cast sheet, discover, and **connect** to a real Chromecast.
+3. ☐ Audio plays **on the receiver**.
+4. ☐ Phone audio does **not** duplicate (no double sound).
+5. ☐ The receiver (TV/display) shows **title, artist, and album** where the
+   receiver renders them; the seek bar reflects the track **duration**.
+6. ☐ **Artwork** appears for Jellyfin tracks (its cover art is a token-free URL);
+   Subsonic tracks show no artwork by design (see the cast doc) — neither leaks a
+   token.
+7. ☐ Receiver **app branding**: with the *default* media receiver the device
+   shows "Default Media Receiver" / the cast device name, **not** a Linthra
+   name/logo. This is expected — true app branding needs a custom receiver app
+   (see [cast.md](cast.md#receiver-app-name--logo-branding)). Do **not** fail the
+   pass on this.
+8. ☐ **Skip to next** track.
+9. ☐ The receiver's metadata (title/artist/album/artwork/duration) **updates** to
+   the new track, and position resets to 0 (no flash of the old track's
+   progress).
+10. ☐ **Background the app for ~5 minutes** while casting.
+11. ☐ Cast **keeps playing** on the receiver throughout.
+12. ☐ **Reopen** the app.
+13. ☐ Now Playing/mini-player are **still in sync** with the receiver (position,
+    track, casting indicator); no second local stream started.
+14. ☐ Adjust the **Cast volume** slider / mute — it drives the *device* volume and
+    follows the receiver's reported level; a fixed-volume device shows an honest
+    disabled state.
+15. ☐ **Disconnect** cast.
+16. ☐ Local playback returns **paused** at the receiver's last position (never
+    surprise-starts audio).
+17. ☐ Throughout, **no token / authenticated URL** appears in the UI, in
+    `adb logcat | grep -iE "api_key|AccessToken|Bearer"`, or in a saved
+    diagnostics snapshot.
+
+Additional cast checks:
+
+- ☐ Play / pause / seek route to the receiver while connected.
 - ☑ Cast icon/status is consistent between mini-player, Now Playing, and sheet.
-- ☐ Cast device volume slider/mute work when the receiver supports it; an
-  honest disabled note shows when it doesn't.
 - ☐ Casting a **local** file shows the friendly "streamed tracks only"
   limitation, leaving local playback untouched.
 - ☐ Cast failure (Wi-Fi off, receiver gone) shows a friendly, token-free error.
+- ☐ A dropped receiver (power it off mid-stream) returns the phone to a clear,
+  **paused** state — it never restarts unexpectedly.
+- ☐ Reconnecting after a disconnect re-casts the current track once (no duplicate
+  local + cast audio).
 
 ## 5. Android Auto
 

--- a/lib/core/models/cast_media.dart
+++ b/lib/core/models/cast_media.dart
@@ -16,6 +16,7 @@ class CastMedia {
     this.title,
     this.artist,
     this.album,
+    this.duration,
     this.artworkUrl,
   });
 
@@ -31,8 +32,15 @@ class CastMedia {
   final String? artist;
   final String? album;
 
+  /// The track's known duration, sent so the receiver can show the seek-bar
+  /// length immediately instead of waiting to probe the stream. Null (or zero)
+  /// when unknown, in which case the receiver derives it from the stream.
+  final Duration? duration;
+
   /// A token-free artwork URL for the receiver to show while playing, or null.
   /// Jellyfin's primary-image URL needs no auth, so it is safe to send as-is.
+  /// Subsonic cover art requires the credential in its query, so it is omitted
+  /// (null) rather than leak a token to the receiver.
   final Uri? artworkUrl;
 
   /// Redacts the secret-bearing [url] down to scheme/host/path so the media can

--- a/lib/core/services/cast/cast_load_message.dart
+++ b/lib/core/services/cast/cast_load_message.dart
@@ -1,0 +1,81 @@
+import '../../models/cast_media.dart';
+
+/// Builds the Google Cast v2 `LOAD` message (and the `MediaInformation` /
+/// metadata blocks inside it) for a [CastMedia], in one tested place.
+///
+/// Keeping this here — rather than inline in [ChromecastCastTransport] — means
+/// the transport stays a thin socket adapter, metadata formatting never scatters
+/// across the app or into a widget, and the exact wire shape the receiver sees
+/// is unit-testable (the transport itself can't be, since it opens a real
+/// socket).
+///
+/// What the receiver shows: the **default media receiver** renders this
+/// metadata — track title, artist, album, artwork — and uses [CastMedia.duration]
+/// for the seek-bar length. That metadata is the *only* Linthra-specific content
+/// the default receiver can display; the receiver's own app name and logo are
+/// fixed by the receiver application and **cannot** be set from a sender, so true
+/// "Linthra" branding on the device would require shipping a custom Cast receiver
+/// app (out of scope). See docs/cast.md.
+///
+/// Security: `contentId` is the one field that legitimately carries the
+/// authenticated stream URL — the receiver fetches the bytes itself, so the
+/// token must be in it. Nothing else does: the metadata block holds only display
+/// text and a token-free artwork URL (Jellyfin's public image; Subsonic omits
+/// artwork rather than embed its credential). This message is handed straight to
+/// the cast session and is never logged or persisted.
+abstract final class CastLoadMessage {
+  /// The Cast `MusicTrackMediaMetadata` discriminator (per the Cast media
+  /// metadata types), so the receiver renders title/artist/album as a track.
+  static const int musicTrackMetadataType = 3;
+
+  /// The default media receiver streams a fully-buffered remote URL (as opposed
+  /// to a `LIVE` stream).
+  static const String bufferedStreamType = 'BUFFERED';
+
+  /// The complete `LOAD` payload for [media], tagged with [requestId]. Autoplays
+  /// from the start; the receiver replies with a `MEDIA_STATUS` carrying the new
+  /// media session id.
+  static Map<String, dynamic> build(
+    CastMedia media, {
+    required int requestId,
+  }) {
+    return <String, dynamic>{
+      'type': 'LOAD',
+      'requestId': requestId,
+      'autoplay': true,
+      'currentTime': 0,
+      'media': mediaInfo(media),
+    };
+  }
+
+  /// The Cast `MediaInformation` object for [media]: what to fetch, how to
+  /// decode it, its duration (when known), and the metadata the receiver
+  /// displays.
+  static Map<String, dynamic> mediaInfo(CastMedia media) {
+    final Duration? duration = media.duration;
+    return <String, dynamic>{
+      'contentId': media.url.toString(),
+      'contentType': media.contentType,
+      'streamType': bufferedStreamType,
+      if (duration != null && duration > Duration.zero)
+        'duration': duration.inMilliseconds / 1000.0,
+      'metadata': metadata(media),
+    };
+  }
+
+  /// The Cast `MusicTrackMediaMetadata` the receiver renders. Carries only
+  /// display fields and a token-free artwork URL — never the stream token.
+  static Map<String, dynamic> metadata(CastMedia media) {
+    final Uri? artworkUrl = media.artworkUrl;
+    return <String, dynamic>{
+      'metadataType': musicTrackMetadataType,
+      if (media.title != null) 'title': media.title,
+      if (media.artist != null) 'artist': media.artist,
+      if (media.album != null) 'albumName': media.album,
+      if (artworkUrl != null)
+        'images': <Map<String, dynamic>>[
+          <String, dynamic>{'url': artworkUrl.toString()},
+        ],
+    };
+  }
+}

--- a/lib/core/services/cast/chromecast_cast_transport.dart
+++ b/lib/core/services/cast/chromecast_cast_transport.dart
@@ -7,6 +7,7 @@ import '../../models/cast_playback_status.dart';
 import '../../models/cast_state.dart';
 import '../../models/cast_volume.dart';
 import '../../models/playback_state.dart';
+import 'cast_load_message.dart';
 import 'cast_transport.dart';
 
 /// The one place the `cast` package is touched. It implements [CastTransport]
@@ -133,27 +134,13 @@ class _ChromecastSessionHandle implements CastSessionHandle {
     // skip on track change while casting.
     _mediaSessionId = null;
     _lastDuration = Duration.zero;
-    _session.sendMessage(cast.CastSession.kNamespaceMedia, <String, dynamic>{
-      'type': 'LOAD',
-      'requestId': _requestId++,
-      'autoplay': true,
-      'currentTime': 0,
-      'media': <String, dynamic>{
-        'contentId': media.url.toString(),
-        'contentType': media.contentType,
-        'streamType': 'BUFFERED',
-        'metadata': <String, dynamic>{
-          'metadataType': 3, // MusicTrackMediaMetadata
-          if (media.title != null) 'title': media.title,
-          if (media.artist != null) 'artist': media.artist,
-          if (media.album != null) 'albumName': media.album,
-          if (media.artworkUrl != null)
-            'images': <Map<String, dynamic>>[
-              <String, dynamic>{'url': media.artworkUrl.toString()},
-            ],
-        },
-      },
-    });
+    // The message (including the title/artist/album/artwork/duration metadata
+    // the receiver displays) is built by the tested CastLoadMessage so this
+    // adapter stays pure transport.
+    _session.sendMessage(
+      cast.CastSession.kNamespaceMedia,
+      CastLoadMessage.build(media, requestId: _requestId++),
+    );
     // Keep position fresh between the receiver's spontaneous status pushes by
     // polling its media status once a second.
     _startPolling();

--- a/lib/core/services/cast/default_cast_service.dart
+++ b/lib/core/services/cast/default_cast_service.dart
@@ -93,6 +93,13 @@ class DefaultCastService implements CastService {
   /// changes within a session). Null until the receiver reports one.
   CastVolume? _volume;
 
+  /// The id of the track currently loaded on the receiver, so a re-emission of
+  /// the *same* track (a duplicate stream event, a metadata refresh) is a no-op
+  /// instead of a needless re-resolve + reload — which would restart playback on
+  /// the receiver and re-mint a stream URL. Cleared whenever the session ends or
+  /// nothing castable is loaded. Distinct track changes still reload.
+  String? _castingTrackId;
+
   @override
   CastState get state => _state;
 
@@ -246,12 +253,19 @@ class DefaultCastService implements CastService {
     if (handle == null) return; // disconnected mid-flight
 
     if (track == null) {
+      _castingTrackId = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device));
       return;
     }
 
+    // Already streaming this exact track on the receiver: a duplicate emission
+    // (or a metadata-only change carrying the same track) must not reload — that
+    // would restart receiver playback and re-resolve the stream URL for nothing.
+    if (_state.isCasting && _castingTrackId == track.id) return;
+
     if (!_mediaResolver.canCast(track)) {
+      _castingTrackId = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device, message: localFileLimitation));
       return;
@@ -261,10 +275,12 @@ class DefaultCastService implements CastService {
     try {
       media = await _mediaResolver.resolve(track);
     } on CastMediaException catch (error) {
+      _castingTrackId = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device, message: error.message));
       return;
     } catch (_) {
+      _castingTrackId = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device, message: "Couldn't cast this track."));
       return;
@@ -276,11 +292,15 @@ class DefaultCastService implements CastService {
     try {
       await handle.loadMedia(media);
     } catch (_) {
+      _castingTrackId = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device,
           message: "Couldn't start playback on ${device.name}."));
       return;
     }
+    // Remember what is now loaded so a duplicate emission of the same track is a
+    // no-op (see the guard above).
+    _castingTrackId = track.id;
 
     // Playing on the receiver now. Marking isCasting true is the signal the
     // ActivePlaybackController uses to silence the local engine. Report a fresh
@@ -408,6 +428,9 @@ class DefaultCastService implements CastService {
     // The device volume belongs to the session; forget it so the next connect
     // starts from "unknown" rather than a stale level.
     _volume = null;
+    // Forget what was loaded so a reconnect re-casts the current track from
+    // scratch rather than treating it as a duplicate of the last session.
+    _castingTrackId = null;
     final CastSessionHandle? handle = _handle;
     _handle = null;
     if (handle != null) await _safeClose(handle);

--- a/lib/core/sources/jellyfin/jellyfin_cast_media_resolver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_cast_media_resolver.dart
@@ -74,6 +74,7 @@ class JellyfinCastMediaResolver implements CastMediaResolver {
       title: track.title,
       artist: track.artistName,
       album: track.albumName,
+      duration: track.duration > Duration.zero ? track.duration : null,
       // Token-free per JellyfinEndpoints.primaryImage, so safe to send as-is.
       artworkUrl: track.artworkUri,
     );

--- a/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
@@ -71,6 +71,9 @@ class SubsonicCastMediaResolver implements CastMediaResolver {
       title: track.title,
       artist: track.artistName,
       album: track.albumName,
+      duration: track.duration > Duration.zero ? track.duration : null,
+      // Artwork is intentionally omitted: Subsonic's getCoverArt URL embeds the
+      // salt+token, so sending it would leak the credential to the receiver.
     );
   }
 

--- a/test/core/models/cast_media_test.dart
+++ b/test/core/models/cast_media_test.dart
@@ -47,5 +47,28 @@ void main() {
       expect(text, isNot(contains('mypass')));
       expect(text, isNot(contains('ZZZTOKEN')));
     });
+
+    test('carries the optional duration and artwork when given', () {
+      final media = CastMedia(
+        url: Uri.parse('https://music.example.com/Audio/t1/stream'),
+        contentType: 'audio/mpeg',
+        title: 'Song',
+        duration: const Duration(minutes: 4),
+        artworkUrl:
+            Uri.parse('https://music.example.com/Items/t1/Images/Primary'),
+      );
+      expect(media.duration, const Duration(minutes: 4));
+      expect(media.artworkUrl,
+          Uri.parse('https://music.example.com/Items/t1/Images/Primary'));
+    });
+
+    test('duration and artwork are null when omitted', () {
+      final media = CastMedia(
+        url: Uri.parse('https://music.example.com/Audio/t1/stream'),
+        contentType: 'audio/mpeg',
+      );
+      expect(media.duration, isNull);
+      expect(media.artworkUrl, isNull);
+    });
   });
 }

--- a/test/core/services/cast/cast_load_message_test.dart
+++ b/test/core/services/cast/cast_load_message_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cast_media.dart';
+import 'package:linthra/core/services/cast/cast_load_message.dart';
+
+/// A token-bearing stream URL like the resolvers mint at cast time.
+final _streamUrl = Uri.parse(
+  'https://music.example.com/Audio/t1/stream?static=true&api_key=SECRET-TOKEN',
+);
+
+CastMedia _media({
+  String? title = 'Midnight',
+  String? artist = 'Kavinsky',
+  String? album = 'OutRun',
+  Duration? duration = const Duration(minutes: 3, seconds: 30),
+  Uri? artworkUrl,
+}) =>
+    CastMedia(
+      url: _streamUrl,
+      contentType: 'audio/mpeg',
+      title: title,
+      artist: artist,
+      album: album,
+      duration: duration,
+      artworkUrl: artworkUrl,
+    );
+
+void main() {
+  group('CastLoadMessage envelope', () {
+    test('is a LOAD that autoplays from the start, tagged with the requestId',
+        () {
+      final msg = CastLoadMessage.build(_media(), requestId: 7);
+      expect(msg['type'], 'LOAD');
+      expect(msg['requestId'], 7);
+      expect(msg['autoplay'], isTrue);
+      expect(msg['currentTime'], 0);
+      expect(msg['media'], isA<Map<String, dynamic>>());
+    });
+
+    test('the contentId is the reachable stream URL the receiver fetches', () {
+      final info = CastLoadMessage.mediaInfo(_media());
+      expect(info['contentId'], _streamUrl.toString());
+      expect(info['contentType'], 'audio/mpeg');
+      expect(info['streamType'], CastLoadMessage.bufferedStreamType);
+    });
+  });
+
+  group('metadata', () {
+    test('is tagged as a music track and includes the title', () {
+      final meta = CastLoadMessage.metadata(_media(title: 'Midnight'));
+      expect(meta['metadataType'], CastLoadMessage.musicTrackMetadataType);
+      expect(meta['title'], 'Midnight');
+    });
+
+    test('includes artist and album when available', () {
+      final meta =
+          CastLoadMessage.metadata(_media(artist: 'Kavinsky', album: 'OutRun'));
+      expect(meta['artist'], 'Kavinsky');
+      expect(meta['albumName'], 'OutRun');
+    });
+
+    test('omits artist/album keys entirely when null', () {
+      final meta = CastLoadMessage.metadata(_media(artist: null, album: null));
+      expect(meta.containsKey('artist'), isFalse);
+      expect(meta.containsKey('albumName'), isFalse);
+    });
+
+    test('includes artwork as an images list only when an URL is present', () {
+      final withArt = CastLoadMessage.metadata(_media(
+        artworkUrl:
+            Uri.parse('https://music.example.com/Items/t1/Images/Primary'),
+      ));
+      expect(withArt['images'], <Map<String, dynamic>>[
+        <String, dynamic>{
+          'url': 'https://music.example.com/Items/t1/Images/Primary',
+        },
+      ]);
+    });
+
+    test(
+        'omits the images key entirely when there is no artwork (e.g. Subsonic)',
+        () {
+      final meta = CastLoadMessage.metadata(_media(artworkUrl: null));
+      expect(meta.containsKey('images'), isFalse);
+    });
+  });
+
+  group('duration', () {
+    test('is sent in seconds when known', () {
+      final info = CastLoadMessage.mediaInfo(
+        _media(duration: const Duration(minutes: 3, seconds: 30)),
+      );
+      expect(info['duration'], 210.0);
+    });
+
+    test('is omitted when unknown (null)', () {
+      final info = CastLoadMessage.mediaInfo(_media(duration: null));
+      expect(info.containsKey('duration'), isFalse);
+    });
+
+    test('is omitted when zero', () {
+      final info = CastLoadMessage.mediaInfo(_media(duration: Duration.zero));
+      expect(info.containsKey('duration'), isFalse);
+    });
+  });
+
+  group('security: the token rides only on the contentId, never the metadata',
+      () {
+    test('the displayed metadata block never carries the stream token', () {
+      final meta = CastLoadMessage.metadata(_media(
+        // Even an (incorrectly) token-bearing artwork URL would be the only
+        // other place a token could appear — assert the safe path stays clean.
+        artworkUrl:
+            Uri.parse('https://music.example.com/Items/t1/Images/Primary'),
+      ));
+      expect(meta.toString(), isNot(contains('SECRET-TOKEN')));
+      expect(meta.toString(), isNot(contains('api_key')));
+    });
+
+    test('only the contentId field contains the authenticated URL', () {
+      final info = CastLoadMessage.mediaInfo(_media());
+      // The contentId must carry the token (the receiver fetches it itself)...
+      expect(info['contentId'], contains('api_key=SECRET-TOKEN'));
+      // ...but nothing in the metadata does.
+      expect(info['metadata'].toString(), isNot(contains('SECRET-TOKEN')));
+    });
+  });
+}

--- a/test/core/services/cast/default_cast_service_test.dart
+++ b/test/core/services/cast/default_cast_service_test.dart
@@ -319,6 +319,52 @@ void main() {
       expect(service.state.isCasting, isTrue);
     });
 
+    test('a duplicate emission of the same track does not reload the receiver',
+        () async {
+      current = _jellyfinTrack;
+      final handle = _FakeHandle();
+      transport.handle = handle;
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+      expect(handle.loaded, hasLength(1));
+      final int resolvesAfterConnect = resolver.resolved.length;
+
+      // The same track is emitted again (a duplicate stream event / metadata
+      // refresh). It must not re-resolve or re-LOAD — that would restart the
+      // receiver and re-mint the stream URL for nothing.
+      trackChanges.add(_jellyfinTrack);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(handle.loaded, hasLength(1));
+      expect(resolver.resolved.length, resolvesAfterConnect);
+      expect(service.state.isCasting, isTrue);
+    });
+
+    test('reconnecting re-casts the current track (no stale dedupe)', () async {
+      current = _jellyfinTrack;
+      final firstHandle = _FakeHandle();
+      transport.handle = firstHandle;
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+      expect(firstHandle.loaded, hasLength(1));
+
+      await service.disconnect();
+
+      // A brand-new session for the (unchanged) current track must load it
+      // again — the previous session's loaded-track memory is cleared on
+      // teardown, so a reconnect is never mistaken for a duplicate.
+      final secondHandle = _FakeHandle();
+      transport.handle = secondHandle;
+      await service.connect(_d1);
+
+      expect(secondHandle.loaded, hasLength(1));
+      expect(service.state.isCasting, isTrue);
+    });
+
     test('a track change resets the reported position and duration', () async {
       current = _jellyfinTrack;
       final handle = _FakeHandle();

--- a/test/core/sources/jellyfin/jellyfin_cast_media_resolver_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_cast_media_resolver_test.dart
@@ -36,6 +36,7 @@ final _jellyfinTrack = Track(
   uri: 'jellyfin:t1',
   artistName: 'Artist',
   albumName: 'Album',
+  duration: const Duration(minutes: 3, seconds: 12),
   artworkUri: Uri.parse('https://music.example.com/Items/t1/Images/Primary'),
 );
 
@@ -67,6 +68,7 @@ void main() {
       expect(media.title, 'One');
       expect(media.artist, 'Artist');
       expect(media.album, 'Album');
+      expect(media.duration, const Duration(minutes: 3, seconds: 12));
       expect(media.artworkUrl, _jellyfinTrack.artworkUri);
       // The session is verified before a URL is minted.
       expect(source.verifyCount, 1);

--- a/test/core/sources/subsonic/subsonic_cast_media_resolver_test.dart
+++ b/test/core/sources/subsonic/subsonic_cast_media_resolver_test.dart
@@ -29,6 +29,7 @@ const _track = Track(
   uri: 'subsonic:s1',
   artistName: 'Kavinsky',
   albumName: 'Drive',
+  duration: Duration(minutes: 4, seconds: 5),
 );
 
 void main() {
@@ -54,7 +55,23 @@ void main() {
     expect(media.title, 'One');
     expect(media.artist, 'Kavinsky');
     expect(media.album, 'Drive');
+    expect(media.duration, const Duration(minutes: 4, seconds: 5));
     expect(media.contentType, 'audio/mpeg');
+  });
+
+  test('omits artwork: Subsonic cover art needs auth, so a token never leaks',
+      () async {
+    final source = _FakeStreamSource(
+      uri: Uri.parse(
+          'https://music.example.com/rest/stream.view?id=s1&t=tok&s=salt'),
+    );
+    final resolver = SubsonicCastMediaResolver(() => source);
+
+    final media = await resolver.resolve(_track);
+
+    // The cover-art endpoint would embed the salt+token, so it is deliberately
+    // never sent to the receiver — only the stream URL carries the credential.
+    expect(media.artworkUrl, isNull);
   });
 
   test('throws notSignedIn when no source is connected', () async {


### PR DESCRIPTION
## Summary

A focused Chromecast polish + stability pass. The big visible win: the receiver
now shows **track duration** (so its seek bar has a length immediately) on top of
the title/artist/album/artwork it already showed, and the metadata is built in one
**tested** place. The honest part: with the default Cast media receiver we **can't**
put Linthra's app name/logo on the device — that's documented clearly rather than
faked. Plus a defensive guard so a metadata/track re-emission can never reload the
stream.

No UI/logo redesign, no new provider, no publishing — as scoped.

## Stability hardening (Part A)

I audited `PlaybackController` / `JustAudioPlaybackController` / `LinthraAudioHandler`,
the cast service + transport, the URI/stream resolvers, `SmartPrecacheService`,
`CacheDownloadRepository`, app lifecycle, and diagnostics against the 10 listed
risks. **They were already well-covered** by prior PRs (bounded 1-retry, suspend
silences the local engine while casting, resume is `play:false`, timers/subs all
cancelled, `trackChanges` is `.distinct()`, secret-free diagnostics, background
`playing:true` during buffering/loading is intact). Rather than over-expand, I made
**one** safe, clearly-beneficial fix:

- **No reload on same-track re-emission** — `DefaultCastService` now tracks the
  loaded track id and treats a duplicate emission of the *current* track as a no-op
  (no re-resolve, no `LOAD`, no receiver restart). Distinct track changes still
  reload; teardown clears it so a reconnect re-casts cleanly. This makes the service
  self-protecting even if the upstream `.distinct()` wiring ever changes.

## Cast metadata & branding (Part B)

- **Duration** added to `CastMedia` and sent in the `LOAD` (seconds), so the
  receiver's seek bar is correct from the first frame.
- **Centralized, testable metadata** — new `CastLoadMessage` builds the Cast v2
  `LOAD` payload (contentId / contentType / streamType / duration / music-track
  metadata). `ChromecastCastTransport` now only serialises it onto the socket, so
  metadata formatting no longer lives in the untestable transport or any widget.
- **Metadata stays in sync** on track change (existing re-handoff) and updates the
  receiver's title/artist/album/artwork/duration.

### What the default Chromecast receiver can / can't show

| | Shown on the default receiver? |
| --- | --- |
| Title / artist / album | ✅ |
| Duration (seek bar length) | ✅ |
| Artwork | ✅ Jellyfin · ❌ Subsonic (see security) |
| **Linthra app name / logo** | ❌ **not possible with the default receiver** |

**A custom receiver app is required for true app/logo branding.** The app name and
logo on a Cast device are fixed by the *receiver application*, not by the sender or
any metadata field. Linthra uses Google's published default media receiver
(`CC1AD845`) precisely so casting needs **no Google Play Services / proprietary Cast
SDK** (F-Droid-friendly). Shipping "Linthra + logo" on the receiver would mean
registering and hosting a custom Cast receiver app — out of scope, tracked as a
follow-up (see below). We **don't fake** branding we can't deliver.

## Cast stability (Part C)

Connection-state accuracy, disconnect-returns-paused (never surprise-starts local),
background/foreground keeps the active output as cast, stable device volume, and
secret-free errors were already in place and tested. This PR adds the
**metadata-update-doesn't-reload** guarantee above and a reconnect test.

## Security / token notes

- The token rides on exactly **one** field: the `contentId` stream URL the receiver
  fetches. **Nothing in the displayed metadata** (title/artist/album/artwork) carries
  it; `CastMedia.toString()` still redacts the URL; diagnostics have no token field.
- **Artwork follows the same rule**: Jellyfin cover art is token-free → sent;
  Subsonic `getCoverArt` needs the salt+token → **omitted** rather than leak it.

## Tests added (Part E)

- `cast_load_message_test.dart` (new): title present; artist/album present-or-omitted;
  duration in seconds / omitted when zero/null; artwork only when present; **token
  rides only on contentId, never the metadata block**.
- `default_cast_service_test.dart`: duplicate same-track emission doesn't reload;
  reconnect re-casts (no stale dedupe).
- `cast_media_test.dart`: duration/artwork round-trip.
- Jellyfin/Subsonic resolver tests: duration carried; Subsonic artwork omitted.

Already-covered behaviours I relied on (no duplication added): background buffering
stays `playing`, foreground-while-casting keeps cast output, Android-Auto-with-cast
starts no local audio, disconnect/secret-free.

## Issue triage (Part D)

- Searched open/closed issues for Chromecast logo / app name / cast metadata /
  artwork / stability / disconnect / background / duplicate playback / media metadata.
- **No existing bug report is fixed by this PR**, so nothing is closed.
- **#81 (Test Chromecast / Cast devices for compatibility)** is a broad help-wanted
  testing roadmap issue — left open (acceptance is community device reports, not
  satisfied here); added one brief note so testers know the metadata is new and the
  app-name/logo limitation is expected.
- **Follow-up filed**: a focused issue for shipping a custom Cast receiver app to get
  true Linthra branding on the device.

## Verification

- `flutter pub get` ✅
- `dart format --set-exit-if-changed` ✅ (0 changed)
- `flutter analyze` ✅ (No issues found)
- `flutter test` ✅ (**1024 passing**)
- `flutter build apk --debug` — skipped: no Android SDK in this environment, and the
  change is pure Dart + docs (no Android/Gradle/native changes), so analyze + tests
  cover it. CI builds the APK on its Flutter 3.27.4 runner.

## Manual Android / Chromecast checklist

Added to [`docs/manual-test-checklist.md`](docs/manual-test-checklist.md) §4 as an
ordered end-to-end pass:

1. Start a Jellyfin track → 2. Connect Chromecast → 3. Audio on receiver →
4. No phone duplicate → 5. Receiver shows title/artist/album + duration →
6. Artwork (Jellyfin yes / Subsonic no, no token) → 7. Branding limitation is
expected (don't fail) → 8. Skip next → 9. Metadata updates → 10–11. Background 5 min,
keeps playing → 12–13. Reopen, still synced → 14. Cast volume → 15. Disconnect →
16. Local returns paused → 17. No token in UI/logs/diagnostics.

## Known limitations

- No Linthra app name/logo on the default receiver (custom receiver app needed).
- Subsonic/Navidrome artwork not shown on the receiver (would leak the credential).
- On-device files can't be cast; content type is a best-effort `audio/mpeg` hint.

https://claude.ai/code/session_01Si64ttHX5Z1jh4rUjtsUNW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Si64ttHX5Z1jh4rUjtsUNW)_