### PR TITLE
Add advanced Queue / Up Next manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ gradient, generated from one source design (not mockups).
   needs a custom receiver app — see [docs/cast.md](./docs/cast.md).)
 - **Android Auto** — browse your Library, Queue, Playlists, and Favorites from
   the car screen and tap to play.
+- **Queue / Up Next** — play next, add to queue, reorder, remove, and save the
+  queue as a playlist — without building a playlist first ([docs](./docs/queue.md)).
 - **Playlists & favourites** — create/edit/reorder/delete playlists; favourite
   tracks. Both sync with Jellyfin where supported.
 - **Background playback** — media notification with lock-screen, Bluetooth, and
@@ -182,6 +184,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Music providers (overview) | [docs/providers.md](./docs/providers.md) |
 | Jellyfin setup | [docs/jellyfin.md](./docs/jellyfin.md) · [compatibility](./docs/jellyfin-compatibility.md) · [sync](./docs/jellyfin-sync.md) |
 | Streaming, buffering & recovery | [docs/streaming.md](./docs/streaming.md) |
+| Queue / Up Next | [docs/queue.md](./docs/queue.md) |
 | Offline cache & downloads | [docs/offline-cache.md](./docs/offline-cache.md) |
 | Cast / Chromecast | [docs/cast.md](./docs/cast.md) |
 | Android Auto | [docs/android-auto.md](./docs/android-auto.md) |

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -57,7 +57,14 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
 - ☑ Next / Previous (Previous restarts/steps back correctly).
 - ☑ Shuffle on/off (current track keeps playing; up-next reorders).
 - ☑ Repeat off → all → one (one loops without re-minting a stream each loop).
-- ☐ Queue sheet shows the live up-next; Clear empties it.
+- ☐ Queue sheet (Now Playing → Queue) shows history, current, and live up-next;
+  Clear empties up-next + history but keeps the current track playing.
+- ☐ Play next / Add to queue (song ⋮ menu in Songs, Album, Artist, Playlist,
+  Search) land in the right place and never restart the current track.
+- ☐ Reorder an up-next track by its handle; remove one with ✕ (library + offline
+  copy stay intact); tap an up-next/history row to jump there.
+- ☐ Save queue as playlist creates a local playlist with the queue's songs.
+- ☐ While casting, queue edits and "play now" never start audio on the phone.
 - ☑ Mini-player shows on every tab, collapses when nothing is loaded, opens Now
   Playing on tap.
 - ☑ Now Playing: artwork, metadata, source badge / casting indicator, controls.

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -1,0 +1,140 @@
+# Queue / Up Next
+
+Linthra has a proper **Up Next manager** so you can control what plays without
+building a playlist every time. This page covers the queue model, the actions,
+how it behaves with shuffle/repeat/Cast/Android Auto, and the known limits.
+
+The queue is owned by a single `PlaybackController` (see
+[docs/architecture.md](./architecture.md) and
+[docs/background-playback.md](./background-playback.md)). Every surface —
+mini-player, Now Playing, the Queue sheet, Cast, and the Android Auto media
+session — reads from and edits the **same** queue. There is never a second copy.
+
+## Opening the Queue
+
+From **Now Playing**, tap the **Queue** button (the up-next icon in the bottom
+action row). The queue opens as a bottom sheet that floats over Now Playing, so
+**opening or browsing the queue never touches playback** — the current track
+keeps playing while you reorder, remove, or look around.
+
+The sheet shows, top to bottom:
+
+- **Previously played** — the tracks already played (history), when any. Tap one
+  to jump back to it.
+- **Now playing** — the current track, highlighted in the warm "live" accent. It
+  has no remove/drag controls on purpose (see *Removing* below).
+- **Up next** — the upcoming tracks. Each row can be played now (tap), removed
+  (the ✕), or dragged to a new position (the drag handle).
+
+Header actions: **Save queue as playlist** and **Clear**.
+
+## Play next vs. Add to queue
+
+Both are available from a track's overflow (⋮) menu in the **Songs** list,
+**Album**, **Artist**, **Playlist**, and **Search** results:
+
+| Action | Behaviour |
+| --- | --- |
+| **Play next** | Inserts the track **immediately after** the current one, so it plays next without interrupting what's playing. |
+| **Add to queue** | **Appends** the track to the **end** of the queue. |
+
+**When nothing is playing**, both actions simply **start** the track (there's
+nothing to play "after", so this is the cleanest behaviour — the action is never
+a silent no-op).
+
+## Reordering
+
+Drag an **upcoming** track by its handle to a new position. The current track is
+untouched and keeps playing — reordering only changes the order of what follows.
+History and the current track are not draggable.
+
+- **Shuffle stays coherent.** While shuffle is on, you reorder the *shuffled*
+  (effective) order. Turning shuffle **off** restores the original
+  pre-shuffle order, which drops a manual reorder — that's the defined meaning of
+  un-shuffling, not a bug.
+- **Repeat stays coherent.** Repeat-all still wraps to the start of the
+  (reordered) queue; repeat-one still replays the current track.
+
+## Removing
+
+The ✕ on an upcoming row removes **only that queue entry**. It does **not**:
+
+- delete the track from your library, or
+- remove its offline (downloaded) copy.
+
+The **currently playing** track cannot be removed from the Queue sheet — the
+manager never yanks the playing track out from under playback. To stop the
+current track, use the transport controls (pause/stop) or skip.
+
+If the queue becomes empty (everything up next removed, or **Clear**), the
+**current track keeps playing**.
+
+## Clear queue
+
+**Clear** drops the up-next list **and** the history, keeping only the track
+playing now. Playback is not interrupted.
+
+## Save queue as playlist
+
+**Save queue as playlist** creates a **local** playlist from the whole queue
+(history + current + up next, in order) and prompts for a name.
+
+- It is **local-only** and **never auto-syncs to Jellyfin**. This is deliberate:
+  a queue can mix local and remote tracks, and the Jellyfin playlist rules only
+  accept Jellyfin tracks — so auto-syncing could silently drop the local ones or
+  push to a server unexpectedly. Saving locally avoids both. You can still sync
+  it later from the playlist screen if it holds only Jellyfin tracks.
+- Duplicate track ids collapse to one entry (a playlist holds each track once).
+
+## Cast & Android Auto
+
+The queue is **output-agnostic** because it lives in one controller and the
+output (local engine vs. a Cast receiver) is routed underneath it:
+
+- **Editing the queue while casting is safe.** Add / remove / reorder only
+  reshape the up-next list; the receiver keeps playing the current track. They
+  **never start a second, duplicate stream** on the phone (the local engine is
+  suspended while casting). "Play this now" changes the current track, which the
+  Cast service mirrors onto the receiver via the normal track-change path — again
+  with no local audio.
+- **Android Auto** drives the same controller. Its media session reflects the
+  current track and whether a next/previous exists; editing the queue in the app
+  is reflected there without starting duplicate playback.
+
+See [docs/cast.md](./cast.md) and [docs/android-auto.md](./android-auto.md) for
+the routing details.
+
+## Security
+
+The queue state and UI carry **only catalog metadata** — track id, title,
+artist, album, artwork reference. They never hold a resolved/authenticated
+stream URL or a token. Authenticated URLs are minted at play time by the resolver
+and live only transiently in the audio engine / Cast load message; they are
+never stored in the queue, never shown in the Queue sheet, and never persisted
+when you save the queue as a playlist (only stable track ids are saved).
+
+## Known limitations / follow-ups
+
+- **Save queue as playlist is local-only.** Syncing a saved queue to Jellyfin in
+  one step is a possible follow-up (today: save locally, then sync from the
+  playlist screen if all tracks are Jellyfin).
+- **Un-shuffling drops a manual reorder** of the up-next list (it restores the
+  true pre-shuffle order). This is intentional and documented above.
+- **Duplicate tracks** in a queue share a track id; reorder/remove act on the
+  first matching entry. Queues rarely contain exact duplicates.
+
+## Manual Android checklist
+
+- [ ] Play an album, open **Queue** from Now Playing — current + up next render.
+- [ ] **Play next** / **Add to queue** from a song's ⋮ menu (Songs, Album,
+      Artist, Playlist, Search) land in the right spot; current track keeps
+      playing (no restart).
+- [ ] With nothing playing, **Play next** / **Add to queue** start the track.
+- [ ] Drag an up-next track to reorder; current track keeps playing.
+- [ ] Remove an up-next track (✕) — it leaves the library and offline copy intact.
+- [ ] **Clear** keeps the current track playing.
+- [ ] Tap an up-next track to play it now; tap a history track to step back.
+- [ ] **Save queue as playlist** creates a local playlist with the queue's songs.
+- [ ] While **casting**: add/remove/reorder and "play now" never start audio on
+      the phone; the receiver follows the current track.
+- [ ] **Android Auto**: queue edits in the app don't start duplicate playback.

--- a/lib/core/models/playback_queue.dart
+++ b/lib/core/models/playback_queue.dart
@@ -66,6 +66,18 @@ class PlaybackQueue {
     return tracks.sublist(currentIndex + 1);
   }
 
+  /// The tracks played before the current one, in play order — the queue's
+  /// history. Empty when the current track is the first (or the queue is
+  /// empty). Lets the queue UI show where you've been without the controller
+  /// carrying a separate history list. Named [history] (not `previous`) to
+  /// avoid clashing with the [previous] step-back method.
+  List<Track> get history {
+    if (currentIndex <= 0 || currentIndex > tracks.length) {
+      return const <Track>[];
+    }
+    return tracks.sublist(0, currentIndex);
+  }
+
   /// Whether there is at least one track after the current one.
   bool get hasNext => currentIndex >= 0 && currentIndex < tracks.length - 1;
 
@@ -120,6 +132,91 @@ class PlaybackQueue {
       tracks: updated,
       currentIndex: currentIndex,
       originalOrder: updatedOriginal,
+    );
+  }
+
+  /// Appends [track] to the end of the queue ("add to queue"). With an empty
+  /// queue it becomes the current track. When shuffled, the track is also
+  /// appended to [originalOrder] so it survives a later unshuffle (mirroring
+  /// [enqueueNext]).
+  PlaybackQueue appended(Track track) {
+    if (current == null) return PlaybackQueue.single(track);
+    final updated = List<Track>.of(tracks)..add(track);
+    final updatedOriginal = originalOrder == null
+        ? null
+        : (List<Track>.of(originalOrder!)..add(track));
+    return PlaybackQueue(
+      tracks: updated,
+      currentIndex: currentIndex,
+      originalOrder: updatedOriginal,
+    );
+  }
+
+  /// Removes the upcoming track at [upNextIndex] (0-based into [upNext]),
+  /// leaving the current track and everything before it untouched so playback
+  /// continues uninterrupted. An out-of-range index is a no-op (returns this).
+  /// When shuffled, the same track is dropped from [originalOrder] so a later
+  /// unshuffle can't resurrect it.
+  PlaybackQueue removeUpNextAt(int upNextIndex) {
+    if (upNextIndex < 0 || upNextIndex >= upNext.length) return this;
+    final absolute = currentIndex + 1 + upNextIndex;
+    final removed = tracks[absolute];
+    final updated = List<Track>.of(tracks)..removeAt(absolute);
+    final updatedOriginal = originalOrder == null
+        ? null
+        : (List<Track>.of(originalOrder!)..remove(removed));
+    return PlaybackQueue(
+      tracks: updated,
+      currentIndex: currentIndex,
+      originalOrder: updatedOriginal,
+    );
+  }
+
+  /// Moves the upcoming track from [oldUpNextIndex] to [newUpNextIndex] (both
+  /// 0-based into [upNext]; [newUpNextIndex] is the destination *after* removal,
+  /// the index a normalised `ReorderableList` reports). The current track is
+  /// untouched, so it keeps playing. A no-op for out-of-range or equal indices.
+  ///
+  /// While shuffled this reorders only the *effective* (shuffled) order;
+  /// [originalOrder] is left intact, so a later [unshuffled] restores the
+  /// pre-shuffle order and drops the manual move — keeping shuffle coherent.
+  PlaybackQueue reorderUpNext(int oldUpNextIndex, int newUpNextIndex) {
+    final int count = upNext.length;
+    if (oldUpNextIndex < 0 || oldUpNextIndex >= count) return this;
+    if (newUpNextIndex < 0 || newUpNextIndex >= count) return this;
+    if (oldUpNextIndex == newUpNextIndex) return this;
+    final int base = currentIndex + 1;
+    final updated = List<Track>.of(tracks);
+    final moved = updated.removeAt(base + oldUpNextIndex);
+    updated.insert(base + newUpNextIndex, moved);
+    return PlaybackQueue(
+      tracks: updated,
+      currentIndex: currentIndex,
+      originalOrder: originalOrder,
+    );
+  }
+
+  /// Makes the upcoming track at [upNextIndex] (0-based into [upNext]) the
+  /// current one — "play this now". The tracks between the old current and it
+  /// fall into [previous] (history). A no-op for an out-of-range index.
+  PlaybackQueue jumpToUpNext(int upNextIndex) {
+    if (upNextIndex < 0 || upNextIndex >= upNext.length) return this;
+    return PlaybackQueue(
+      tracks: tracks,
+      currentIndex: currentIndex + 1 + upNextIndex,
+      originalOrder: originalOrder,
+    );
+  }
+
+  /// Steps back to the previously-played track at [historyIndex] (0-based into
+  /// [history]), making it current. The tracks after it — including the old
+  /// current — become [upNext] again. A no-op for an out-of-range index.
+  PlaybackQueue jumpToHistory(int historyIndex) {
+    if (historyIndex < 0 || historyIndex >= history.length) return this;
+    return PlaybackQueue(
+      tracks: tracks,
+      currentIndex: historyIndex,
+      originalOrder: originalOrder,
     );
   }
 

--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -29,6 +29,7 @@ class PlaybackState {
     this.status = PlaybackStatus.idle,
     this.currentTrack,
     this.upNext = const <Track>[],
+    this.previous = const <Track>[],
     this.hasPrevious = false,
     this.position = Duration.zero,
     this.duration = Duration.zero,
@@ -53,9 +54,15 @@ class PlaybackState {
   /// queue holds only the current track.
   final List<Track> upNext;
 
-  /// Whether a previous track exists to step back to. Stored as a flag (unlike
-  /// [hasNext], which reads off [upNext]) because the state carries no played
-  /// history — the controller derives it from the queue's current position.
+  /// Tracks played before [currentTrack], in play order — the queue's history,
+  /// shown in the Queue screen so the listener can step back to one. Empty when
+  /// the current track is the first. Carries only catalog [Track]s (id, title,
+  /// artist, album, artwork) — never a resolved/authenticated stream URL.
+  final List<Track> previous;
+
+  /// Whether a previous track exists to step back to. Kept as a flag the
+  /// transport controls read directly; it mirrors `previous.isNotEmpty` (both
+  /// are set together by the controller from the queue's current position).
   final bool hasPrevious;
 
   final Duration position;
@@ -94,6 +101,7 @@ class PlaybackState {
     PlaybackStatus? status,
     Track? currentTrack,
     List<Track>? upNext,
+    List<Track>? previous,
     bool? hasPrevious,
     Duration? position,
     Duration? duration,
@@ -105,6 +113,7 @@ class PlaybackState {
       status: status ?? this.status,
       currentTrack: currentTrack ?? this.currentTrack,
       upNext: upNext ?? this.upNext,
+      previous: previous ?? this.previous,
       hasPrevious: hasPrevious ?? this.hasPrevious,
       position: position ?? this.position,
       duration: duration ?? this.duration,
@@ -121,6 +130,7 @@ class PlaybackState {
           other.status == status &&
           other.currentTrack == currentTrack &&
           listEquals(other.upNext, upNext) &&
+          listEquals(other.previous, previous) &&
           other.hasPrevious == hasPrevious &&
           other.position == position &&
           other.duration == duration &&
@@ -135,6 +145,7 @@ class PlaybackState {
       status,
       currentTrack,
       Object.hashAll(upNext),
+      Object.hashAll(previous),
       hasPrevious,
       position,
       duration,

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -227,6 +227,24 @@ class ActivePlaybackController implements PlaybackController {
   void playNext(Track track) => _local.playNext(track);
 
   @override
+  void addToQueue(Track track) => _local.addToQueue(track);
+
+  @override
+  void removeFromQueue(int upNextIndex) => _local.removeFromQueue(upNextIndex);
+
+  @override
+  void reorderQueue(int oldIndex, int newIndex) =>
+      _local.reorderQueue(oldIndex, newIndex);
+
+  @override
+  Future<void> playFromQueue(int upNextIndex) =>
+      _local.playFromQueue(upNextIndex);
+
+  @override
+  Future<void> playFromHistory(int previousIndex) =>
+      _local.playFromHistory(previousIndex);
+
+  @override
   Future<void> skipToNext() => _local.skipToNext();
 
   @override

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -262,9 +262,64 @@ class JustAudioPlaybackController implements LocalPlaybackController {
 
   @override
   void playNext(Track track) {
+    final bool wasEmpty = _queue.current == null;
     _queue = _queue.enqueueNext(track);
+    if (wasEmpty) {
+      // Nothing was playing: "play next" has nothing to play after, so start
+      // the track now rather than silently leaving it queued.
+      unawaited(_playCurrent());
+      return;
+    }
     // The current track keeps playing; only the up-next list changes.
     _emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  void addToQueue(Track track) {
+    final bool wasEmpty = _queue.current == null;
+    _queue = _queue.appended(track);
+    if (wasEmpty) {
+      // An empty queue has nothing playing to append behind: start the track.
+      unawaited(_playCurrent());
+      return;
+    }
+    // The current track keeps playing; only the up-next list grows.
+    _emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  void removeFromQueue(int upNextIndex) {
+    final updated = _queue.removeUpNextAt(upNextIndex);
+    if (identical(updated, _queue)) return; // out of range: nothing to do
+    _queue = updated;
+    // Only the up-next list shrank; the current track and its audio are
+    // untouched — no reload, no restart.
+    _emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  void reorderQueue(int oldIndex, int newIndex) {
+    final updated = _queue.reorderUpNext(oldIndex, newIndex);
+    if (identical(updated, _queue)) return;
+    _queue = updated;
+    // The current track keeps playing; only the order of what follows changes.
+    _emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  Future<void> playFromQueue(int upNextIndex) async {
+    final jumped = _queue.jumpToUpNext(upNextIndex);
+    if (identical(jumped, _queue)) return;
+    _queue = jumped;
+    await _playCurrent();
+  }
+
+  @override
+  Future<void> playFromHistory(int previousIndex) async {
+    final jumped = _queue.jumpToHistory(previousIndex);
+    if (identical(jumped, _queue)) return;
+    _queue = jumped;
+    await _playCurrent();
   }
 
   @override
@@ -284,7 +339,13 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   @override
   void clearQueue() {
     _queue = _queue.cleared();
-    _emit(_state.copyWith(upNext: _queue.upNext, hasPrevious: false));
+    // Clearing keeps only the current track, so both the up-next list and the
+    // history collapse to empty; the current track's audio is untouched.
+    _emit(_state.copyWith(
+      upNext: _queue.upNext,
+      previous: _queue.history,
+      hasPrevious: false,
+    ));
   }
 
   @override
@@ -296,6 +357,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _queue = enabled ? _queue.shuffled(_random) : _queue.unshuffled();
     _emit(_state.copyWith(
       upNext: _queue.upNext,
+      previous: _queue.history,
       hasPrevious: _queue.hasPrevious,
       shuffleEnabled: _shuffleEnabled,
     ));
@@ -371,6 +433,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         status: PlaybackStatus.paused,
         currentTrack: track,
         upNext: _queue.upNext,
+        previous: _queue.history,
         hasPrevious: _queue.hasPrevious,
         shuffleEnabled: _shuffleEnabled,
         repeatMode: _repeatMode,
@@ -390,6 +453,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         status: PlaybackStatus.loading,
         currentTrack: track,
         upNext: _queue.upNext,
+        previous: _queue.history,
         hasPrevious: _queue.hasPrevious,
         shuffleEnabled: _shuffleEnabled,
         repeatMode: _repeatMode,
@@ -451,6 +515,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       status: PlaybackStatus.error,
       currentTrack: track,
       upNext: _queue.upNext,
+      previous: _queue.history,
       hasPrevious: _queue.hasPrevious,
       shuffleEnabled: _shuffleEnabled,
       repeatMode: _repeatMode,
@@ -506,6 +571,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     final stopped = PlaybackState(
       currentTrack: _state.currentTrack,
       upNext: _queue.upNext,
+      previous: _queue.history,
       hasPrevious: _queue.hasPrevious,
       shuffleEnabled: _shuffleEnabled,
       repeatMode: _repeatMode,

--- a/lib/core/services/playback_controller.dart
+++ b/lib/core/services/playback_controller.dart
@@ -25,8 +25,33 @@ abstract interface class PlaybackController {
   Future<void> playTracks(List<Track> tracks, {int startIndex = 0});
 
   /// Inserts [track] so it plays immediately after the current one
-  /// ("play next") without interrupting what is playing now.
+  /// ("play next") without interrupting what is playing now. When nothing is
+  /// playing it starts [track] (so the action is never a silent no-op).
   void playNext(Track track);
+
+  /// Appends [track] to the end of the queue ("add to queue") without
+  /// interrupting playback. When nothing is playing it starts [track].
+  void addToQueue(Track track);
+
+  /// Removes the upcoming track at [upNextIndex] (0-based into
+  /// [PlaybackState.upNext]). The current track keeps playing; the track is
+  /// only dropped from the queue — never deleted from the library or its
+  /// offline copy. Out-of-range indices are a no-op.
+  void removeFromQueue(int upNextIndex);
+
+  /// Moves an upcoming track within the queue, from [oldIndex] to [newIndex]
+  /// (both 0-based into [PlaybackState.upNext]). The current track is untouched,
+  /// so it keeps playing. A no-op for out-of-range or equal indices.
+  void reorderQueue(int oldIndex, int newIndex);
+
+  /// Jumps to the upcoming track at [upNextIndex] (0-based into
+  /// [PlaybackState.upNext]) and plays it now. The skipped tracks become
+  /// history ([PlaybackState.previous]). A no-op for an out-of-range index.
+  Future<void> playFromQueue(int upNextIndex);
+
+  /// Steps back to the previously-played track at [previousIndex] (0-based into
+  /// [PlaybackState.previous]) and plays it. A no-op for an out-of-range index.
+  Future<void> playFromHistory(int previousIndex);
 
   /// Advances to the next track in the queue, if any. A no-op when the queue
   /// has no upcoming tracks.

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -18,6 +18,7 @@ import '../song_actions.dart';
 /// its current [DownloadStatus] (see `_OverflowMenu._menuItems`).
 enum _TrackAction {
   playNext,
+  addToQueue,
   addToPlaylist,
   download,
   removeOffline,
@@ -248,6 +249,7 @@ class _OverflowMenu extends ConsumerWidget {
   List<PopupMenuEntry<_TrackAction>> _menuItems() {
     final items = <PopupMenuEntry<_TrackAction>>[
       _item(_TrackAction.playNext, Icons.queue_music, 'Play next'),
+      _item(_TrackAction.addToQueue, Icons.add_to_queue, 'Add to queue'),
       _item(_TrackAction.addToPlaylist, Icons.playlist_add, 'Add to playlist'),
     ];
     if (isRemote) {
@@ -295,6 +297,8 @@ class _OverflowMenu extends ConsumerWidget {
     switch (action) {
       case _TrackAction.playNext:
         ref.read(playbackControllerProvider).playNext(track);
+      case _TrackAction.addToQueue:
+        ref.read(playbackControllerProvider).addToQueue(track);
       case _TrackAction.addToPlaylist:
         await showAddToPlaylistSheet(context, <Track>[track]);
       case _TrackAction.download:

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -4,11 +4,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import '../../../core/models/track.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
-import '../../../shared/widgets/empty_state.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../favorites_providers.dart';
-import '../player_providers.dart';
 import 'lyrics_view.dart';
+import 'queue_sheet.dart';
 
 /// Bottom action row on the now-playing screen: favorite · queue · lyrics.
 ///
@@ -59,12 +58,7 @@ class NowPlayingActions extends ConsumerWidget {
   }
 
   void _openQueue(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      isScrollControlled: true,
-      builder: (_) => const _QueueSheet(),
-    );
+    showQueueSheet(context);
   }
 
   void _openLyrics(BuildContext context) {
@@ -115,90 +109,6 @@ class _LyricsSheet extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-/// The queue sheet: the playing track followed by the live up-next list, with a
-/// Clear action. Watches playback state so it stays current while open.
-class _QueueSheet extends ConsumerWidget {
-  const _QueueSheet();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final controller = ref.watch(playbackControllerProvider);
-    final state =
-        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
-    final upNext = state.upNext;
-
-    return SafeArea(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.sizeOf(context).height * 0.6,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(
-                AppSpacing.lg,
-                0,
-                AppSpacing.sm,
-                AppSpacing.sm,
-              ),
-              child: Row(
-                children: [
-                  Text('Up next', style: theme.textTheme.titleMedium),
-                  const Spacer(),
-                  if (upNext.isNotEmpty)
-                    TextButton(
-                      onPressed: controller.clearQueue,
-                      child: const Text('Clear'),
-                    ),
-                ],
-              ),
-            ),
-            Flexible(
-              child: upNext.isEmpty
-                  ? const Padding(
-                      padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
-                      child: EmptyState(
-                        icon: Icons.queue_music_outlined,
-                        title: 'Nothing up next',
-                        message: 'Tracks you queue will appear here.',
-                      ),
-                    )
-                  : ListView.builder(
-                      shrinkWrap: true,
-                      itemCount: upNext.length,
-                      itemBuilder: (context, index) =>
-                          _QueueTile(track: upNext[index]),
-                    ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _QueueTile extends StatelessWidget {
-  const _QueueTile({required this.track});
-
-  final Track track;
-
-  @override
-  Widget build(BuildContext context) {
-    final artist = track.artistName;
-    return ListTile(
-      dense: true,
-      leading: const Icon(Icons.queue_music_outlined),
-      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
-      subtitle: artist == null || artist.isEmpty
-          ? null
-          : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
     );
   }
 }

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -1,0 +1,419 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/colors.dart';
+import '../../../app/dimens.dart';
+import '../../../core/models/playback_state.dart';
+import '../../../core/models/playlist.dart';
+import '../../../core/models/track.dart';
+import '../../../data/repositories/playlist_repository_provider.dart';
+import '../../playlists/widgets/create_playlist_dialog.dart';
+import '../player_providers.dart';
+import 'album_artwork.dart';
+
+/// Opens the advanced Queue / Up Next manager as a tall bottom sheet.
+///
+/// It's a sheet (not a route) so it floats over Now Playing without leaving it —
+/// browsing the queue never touches playback. The current track keeps playing
+/// while the listener reorders, removes, or jumps around the queue.
+Future<void> showQueueSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (_) => const QueueSheet(),
+  );
+}
+
+/// The Queue / Up Next manager.
+///
+/// Reads the live [PlaybackState] (so it stays current while open) and shows,
+/// top to bottom: a header with Save/Clear actions, the played history, the
+/// current track, and the reorderable up-next list. Every edit goes through the
+/// [PlaybackController] — the same single source of truth the mini-player, Now
+/// Playing, Cast, and the media session use — so editing the queue here can
+/// never start a second, duplicate playback (local or cast). It only ever holds
+/// catalog [Track]s, never a resolved/authenticated stream URL.
+class QueueSheet extends ConsumerWidget {
+  const QueueSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final controller = ref.watch(playbackControllerProvider);
+    final PlaybackState state =
+        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+
+    final Track? current = state.currentTrack;
+    final List<Track> upNext = state.upNext;
+    final List<Track> history = state.previous;
+    final bool canClear = upNext.isNotEmpty || history.isNotEmpty;
+    final bool canSave = current != null;
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                0,
+                AppSpacing.sm,
+                AppSpacing.sm,
+              ),
+              child: Row(
+                children: <Widget>[
+                  Icon(Icons.queue_music, color: theme.colorScheme.primary),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text('Queue', style: theme.textTheme.titleMedium),
+                  const Spacer(),
+                  IconButton(
+                    onPressed: canSave
+                        ? () => _saveAsPlaylist(context, ref, state)
+                        : null,
+                    icon: const Icon(Icons.playlist_add),
+                    tooltip: 'Save queue as playlist',
+                  ),
+                  TextButton(
+                    onPressed: canClear ? controller.clearQueue : null,
+                    child: const Text('Clear'),
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: current == null
+                  ? const _EmptyQueue()
+                  : CustomScrollView(
+                      slivers: <Widget>[
+                        if (history.isNotEmpty) ...<Widget>[
+                          const _SectionLabel(label: 'Previously played'),
+                          SliverList.builder(
+                            itemCount: history.length,
+                            itemBuilder: (context, index) => _HistoryTile(
+                              track: history[index],
+                              onTap: () => ref
+                                  .read(playbackControllerProvider)
+                                  .playFromHistory(index),
+                            ),
+                          ),
+                        ],
+                        const _SectionLabel(label: 'Now playing'),
+                        SliverToBoxAdapter(
+                          child: _CurrentTile(track: current),
+                        ),
+                        const _SectionLabel(label: 'Up next'),
+                        if (upNext.isEmpty)
+                          const SliverToBoxAdapter(child: _NothingUpNext())
+                        else
+                          SliverReorderableList(
+                            itemCount: upNext.length,
+                            onReorder: (int oldIndex, int newIndex) {
+                              // SliverReorderableList reports newIndex as an
+                              // insertion point in the pre-removal list; convert
+                              // to the destination index the queue model expects.
+                              if (oldIndex < newIndex) newIndex -= 1;
+                              ref
+                                  .read(playbackControllerProvider)
+                                  .reorderQueue(oldIndex, newIndex);
+                            },
+                            itemBuilder: (context, index) => _UpNextTile(
+                              // Index-qualified so the same track queued twice
+                              // never produces a duplicate key (which would crash
+                              // the reorderable list).
+                              key: ValueKey<String>(
+                                'queue-$index-${upNext[index].id}',
+                              ),
+                              track: upNext[index],
+                              index: index,
+                              onPlay: () => ref
+                                  .read(playbackControllerProvider)
+                                  .playFromQueue(index),
+                              onRemove: () => ref
+                                  .read(playbackControllerProvider)
+                                  .removeFromQueue(index),
+                            ),
+                          ),
+                        const SliverToBoxAdapter(
+                          child: SizedBox(height: AppSpacing.md),
+                        ),
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Saves the whole queue (history + current + up-next) as a new **local**
+  /// playlist. Deliberately local-only: it never auto-syncs to Jellyfin, so a
+  /// queue mixing local and remote tracks can't silently drop the local ones or
+  /// push anything to a server (see docs/queue.md). Reuses the shared create
+  /// dialog (with sync hidden) so the name prompt matches the rest of the app.
+  Future<void> _saveAsPlaylist(
+    BuildContext context,
+    WidgetRef ref,
+    PlaybackState state,
+  ) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final List<Track> tracks = <Track>[
+      ...state.previous,
+      if (state.currentTrack != null) state.currentTrack!,
+      ...state.upNext,
+    ];
+    if (tracks.isEmpty) return;
+
+    final PlaylistEdit? edit = await showCreatePlaylistDialog(context);
+    if (edit == null) return;
+
+    final repository = ref.read(playlistRepositoryProvider);
+    final Playlist created = await repository.createPlaylist(
+      edit.name,
+      description: edit.description,
+      source: PlaylistSource.local,
+    );
+    await repository.addTracks(
+      created.id,
+      <String>[for (final Track track in tracks) track.id],
+    );
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          tracks.length == 1
+              ? 'Saved 1 song to “${edit.name}”.'
+              : 'Saved ${tracks.length} songs to “${edit.name}”.',
+        ),
+      ),
+    );
+  }
+}
+
+/// A small, calm section label (Previously played / Now playing / Up next).
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.sm,
+          AppSpacing.lg,
+          AppSpacing.xs,
+        ),
+        child: Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.primary,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.4,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The current track row, highlighted with the warm "live" accent so it reads
+/// as the one playing now. Non-draggable and non-removable on purpose: the
+/// queue manager never yanks the playing track out from under playback.
+class _CurrentTile extends StatelessWidget {
+  const _CurrentTile({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final String? artist = track.artistName;
+    return ListTile(
+      leading: SizedBox.square(
+        dimension: 44,
+        child: AlbumArtwork(
+          artworkUri: track.artworkUri,
+          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+        ),
+      ),
+      title: Text(
+        track.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.titleMedium?.copyWith(
+          color: AppColors.accent,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+      subtitle: artist == null || artist.isEmpty
+          ? null
+          : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
+      trailing: const Icon(
+        Icons.graphic_eq,
+        color: AppColors.accent,
+        semanticLabel: 'Now playing',
+      ),
+    );
+  }
+}
+
+/// An already-played track. Tapping it steps back to that point in the queue.
+class _HistoryTile extends StatelessWidget {
+  const _HistoryTile({required this.track, required this.onTap});
+
+  final Track track;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final String? artist = track.artistName;
+    return ListTile(
+      dense: true,
+      onTap: onTap,
+      leading: SizedBox.square(
+        dimension: 40,
+        child: Opacity(
+          opacity: 0.6,
+          child: AlbumArtwork(
+            artworkUri: track.artworkUri,
+            borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+          ),
+        ),
+      ),
+      title: Text(
+        track.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyLarge?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+        ),
+      ),
+      subtitle: artist == null || artist.isEmpty
+          ? null
+          : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
+  }
+}
+
+/// An upcoming track: tap to play now, an X to remove it from the queue, and a
+/// drag handle to reorder. Removing only drops the queue entry — it never
+/// deletes the track from the library or its offline copy.
+class _UpNextTile extends StatelessWidget {
+  const _UpNextTile({
+    required this.track,
+    required this.index,
+    required this.onPlay,
+    required this.onRemove,
+    super.key,
+  });
+
+  final Track track;
+  final int index;
+  final VoidCallback onPlay;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final String? artist = track.artistName;
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        onTap: onPlay,
+        leading: SizedBox.square(
+          dimension: 44,
+          child: AlbumArtwork(
+            artworkUri: track.artworkUri,
+            borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
+          ),
+        ),
+        title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        subtitle: artist == null || artist.isEmpty
+            ? null
+            : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.close),
+              tooltip: 'Remove from queue',
+              onPressed: onRemove,
+            ),
+            ReorderableDragStartListener(
+              index: index,
+              child: const Padding(
+                padding: EdgeInsets.only(left: AppSpacing.xs),
+                child: Icon(Icons.drag_handle),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shown under "Up next" when the queue holds only the current track.
+class _NothingUpNext extends StatelessWidget {
+  const _NothingUpNext();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.xs,
+        AppSpacing.lg,
+        AppSpacing.md,
+      ),
+      child: Text(
+        'Nothing up next. Use “Play next” or “Add to queue” from any song.',
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+      ),
+    );
+  }
+}
+
+/// The whole-sheet empty state: nothing is playing at all.
+class _EmptyQueue extends StatelessWidget {
+  const _EmptyQueue();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(
+            Icons.queue_music_outlined,
+            size: 40,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Text('Nothing playing', style: theme.textTheme.titleMedium),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'Pick a track to start a queue.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -259,6 +259,14 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                 ),
               ),
               PopupMenuItem<_RowAction>(
+                value: _RowAction.addToQueue,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(Icons.add_to_queue),
+                  title: Text('Add to queue'),
+                ),
+              ),
+              PopupMenuItem<_RowAction>(
                 value: _RowAction.addToPlaylist,
                 child: ListTile(
                   contentPadding: EdgeInsets.zero,
@@ -399,6 +407,8 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     switch (action) {
       case _RowAction.playNext:
         ref.read(playbackControllerProvider).playNext(track);
+      case _RowAction.addToQueue:
+        ref.read(playbackControllerProvider).addToQueue(track);
       case _RowAction.addToPlaylist:
         await showAddToPlaylistSheet(context, <Track>[track]);
       case _RowAction.removeFromPlaylist:
@@ -515,7 +525,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
 
 enum _DetailMenuAction { rename, delete }
 
-enum _RowAction { playNext, addToPlaylist, removeFromPlaylist }
+enum _RowAction { playNext, addToQueue, addToPlaylist, removeFromPlaylist }
 
 class _Header extends StatelessWidget {
   const _Header({required this.onPlay, required this.onShuffle});

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -131,6 +131,152 @@ void main() {
     });
   });
 
+  group('PlaybackQueue advanced editing', () {
+    test('history exposes the tracks played before the current one', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+        startIndex: 2,
+      );
+
+      expect(queue.history, [_track('a'), _track('b')]);
+    });
+
+    test('history is empty at the start of the queue', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')]);
+
+      expect(queue.history, isEmpty);
+    });
+
+    test('appended() adds a track to the end, keeping the current one', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')]);
+
+      final updated = queue.appended(_track('c'));
+
+      expect(updated.current, _track('a'));
+      expect(updated.upNext, [_track('b'), _track('c')]);
+    });
+
+    test('appended() on an empty queue makes the track current', () {
+      final updated = PlaybackQueue.empty.appended(_track('a'));
+
+      expect(updated.current, _track('a'));
+      expect(updated.hasNext, isFalse);
+    });
+
+    test('appended() while shuffled survives a later unshuffle', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')])
+          .shuffled(Random(2))
+          .appended(_track('z'));
+
+      expect(queue.unshuffled().tracks, contains(_track('z')));
+    });
+
+    test('removeUpNextAt() drops only that upcoming entry', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c'), _track('d')],
+      );
+
+      // up next is [b, c, d]; remove index 1 (c).
+      final updated = queue.removeUpNextAt(1);
+
+      expect(updated.current, _track('a'));
+      expect(updated.upNext, [_track('b'), _track('d')]);
+    });
+
+    test('removeUpNextAt() leaves the current track and history untouched', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+        startIndex: 1,
+      );
+
+      // current is b, history [a], up next [c]; remove the only up-next entry.
+      final updated = queue.removeUpNextAt(0);
+
+      expect(updated.current, _track('b'));
+      expect(updated.history, [_track('a')]);
+      expect(updated.upNext, isEmpty);
+    });
+
+    test('removeUpNextAt() out of range is a no-op', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')]);
+
+      expect(queue.removeUpNextAt(5), same(queue));
+      expect(queue.removeUpNextAt(-1), same(queue));
+    });
+
+    test('removeUpNextAt() drops the track from the shuffle original too', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b'), _track('c')])
+          .shuffled(Random(4));
+      // Remove the first up-next track in the shuffled order.
+      final removed = queue.upNext.first;
+
+      final updated = queue.removeUpNextAt(0).unshuffled();
+
+      // Unshuffling must not resurrect the removed track.
+      expect(updated.tracks, isNot(contains(removed)));
+    });
+
+    test('reorderUpNext() moves an upcoming track, keeping current playing',
+        () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c'), _track('d')],
+      );
+
+      // up next is [b, c, d]; move b (0) to the end (2).
+      final updated = queue.reorderUpNext(0, 2);
+
+      expect(updated.current, _track('a'));
+      expect(updated.upNext, [_track('c'), _track('d'), _track('b')]);
+    });
+
+    test('reorderUpNext() is a no-op for equal or out-of-range indices', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b'), _track('c')]);
+
+      expect(queue.reorderUpNext(0, 0), same(queue));
+      expect(queue.reorderUpNext(0, 9), same(queue));
+      expect(queue.reorderUpNext(-1, 0), same(queue));
+    });
+
+    test('jumpToUpNext() makes an upcoming track current', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c'), _track('d')],
+      );
+
+      // up next is [b, c, d]; jump to c (index 1).
+      final updated = queue.jumpToUpNext(1);
+
+      expect(updated.current, _track('c'));
+      expect(updated.history, [_track('a'), _track('b')]);
+      expect(updated.upNext, [_track('d')]);
+    });
+
+    test('jumpToUpNext() out of range is a no-op', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')]);
+
+      expect(queue.jumpToUpNext(5), same(queue));
+    });
+
+    test('jumpToHistory() steps back to a played track', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+        startIndex: 2,
+      );
+
+      // history is [a, b]; jump back to a (index 0).
+      final updated = queue.jumpToHistory(0);
+
+      expect(updated.current, _track('a'));
+      expect(updated.upNext, [_track('b'), _track('c')]);
+      expect(updated.history, isEmpty);
+    });
+
+    test('jumpToHistory() out of range is a no-op', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b')], startIndex: 1);
+
+      expect(queue.jumpToHistory(5), same(queue));
+    });
+  });
+
   group('PlaybackQueue shuffle', () {
     test('shuffled() keeps the current track current and shuffles the rest',
         () {

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -236,6 +236,58 @@ void main() {
     });
   });
 
+  group('queue editing while casting never starts duplicate local playback',
+      () {
+    test('add/remove/reorder update up-next without local audio', () async {
+      local = FakePlaybackController();
+      await local.playTracks(const <Track>[_trackA, _trackB]);
+      cast = FakeCastService();
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      final int playedBefore = local.playedTracks.length;
+
+      const trackC = Track(id: 'c', title: 'Song C', uri: 'jellyfin:c');
+      controller.addToQueue(trackC); // up next: [B, C]
+      controller.reorderQueue(0, 1); // up next: [C, B]
+      controller.removeFromQueue(0); // up next: [B]
+
+      // The local engine is suspended: every edit just reshapes the up-next
+      // list. None of them ever started local playback (no duplicate audio).
+      expect(local.playedTracks.length, playedBefore);
+      expect(controller.activeOutput, ActivePlaybackOutput.cast);
+      expect(controller.state.currentTrack, _trackA);
+      expect(controller.state.upNext, const <Track>[_trackB]);
+    });
+
+    test('playFromQueue changes the current track without local audio',
+        () async {
+      local = FakePlaybackController();
+      await local.playTracks(const <Track>[_trackA, _trackB]);
+      cast = FakeCastService();
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+      final int playedBefore = local.playedTracks.length;
+
+      // up next is [B]; play it now while casting.
+      await controller.playFromQueue(0);
+
+      // The current track advances (the cast service mirrors it onto the
+      // receiver via the track-change stream), but the suspended local engine
+      // produced no audio of its own.
+      expect(controller.state.currentTrack, _trackB);
+      expect(local.playedTracks.length, playedBefore);
+      expect(controller.activeOutput, ActivePlaybackOutput.cast);
+    });
+  });
+
   group('ending a cast session never surprise-starts local playback', () {
     test('disconnect resumes the local engine paused at the cast position',
         () async {

--- a/test/features/library/track_tile_test.dart
+++ b/test/features/library/track_tile_test.dart
@@ -81,6 +81,18 @@ void main() {
       expect(find.text('Add to playlist'), findsOneWidget);
       expect(find.text('Remove from Linthra'), findsOneWidget);
     });
+
+    testWidgets('overflow menu offers queue actions', (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+      ]);
+
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Play next'), findsOneWidget);
+      expect(find.text('Add to queue'), findsOneWidget);
+    });
   });
 
   group('TrackTile selection', () {

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -70,8 +70,56 @@ class FakePlaybackController implements LocalPlaybackController {
 
   @override
   void playNext(Track track) {
+    final bool wasEmpty = _queue.current == null;
     _queue = _queue.enqueueNext(track);
+    if (wasEmpty) {
+      _playCurrent();
+      return;
+    }
     emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  void addToQueue(Track track) {
+    final bool wasEmpty = _queue.current == null;
+    _queue = _queue.appended(track);
+    if (wasEmpty) {
+      _playCurrent();
+      return;
+    }
+    emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  void removeFromQueue(int upNextIndex) {
+    final updated = _queue.removeUpNextAt(upNextIndex);
+    if (identical(updated, _queue)) return;
+    _queue = updated;
+    emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  void reorderQueue(int oldIndex, int newIndex) {
+    final updated = _queue.reorderUpNext(oldIndex, newIndex);
+    if (identical(updated, _queue)) return;
+    _queue = updated;
+    emit(_state.copyWith(upNext: _queue.upNext));
+  }
+
+  @override
+  Future<void> playFromQueue(int upNextIndex) async {
+    final jumped = _queue.jumpToUpNext(upNextIndex);
+    if (identical(jumped, _queue)) return;
+    _queue = jumped;
+    _playCurrent();
+  }
+
+  @override
+  Future<void> playFromHistory(int previousIndex) async {
+    final jumped = _queue.jumpToHistory(previousIndex);
+    if (identical(jumped, _queue)) return;
+    _queue = jumped;
+    _playCurrent();
   }
 
   @override
@@ -94,7 +142,11 @@ class FakePlaybackController implements LocalPlaybackController {
   void clearQueue() {
     clearCount++;
     _queue = _queue.cleared();
-    emit(_state.copyWith(upNext: _queue.upNext, hasPrevious: false));
+    emit(_state.copyWith(
+      upNext: _queue.upNext,
+      previous: _queue.history,
+      hasPrevious: false,
+    ));
   }
 
   @override
@@ -145,6 +197,7 @@ class FakePlaybackController implements LocalPlaybackController {
         status: PlaybackStatus.paused,
         currentTrack: track,
         upNext: _queue.upNext,
+        previous: _queue.history,
         hasPrevious: _queue.hasPrevious,
         shuffleEnabled: _shuffleEnabled,
         repeatMode: _repeatMode,
@@ -156,6 +209,7 @@ class FakePlaybackController implements LocalPlaybackController {
       status: PlaybackStatus.playing,
       currentTrack: track,
       upNext: _queue.upNext,
+      previous: _queue.history,
       hasPrevious: _queue.hasPrevious,
       shuffleEnabled: _shuffleEnabled,
       repeatMode: _repeatMode,

--- a/test/features/player/queue_behavior_test.dart
+++ b/test/features/player/queue_behavior_test.dart
@@ -85,5 +85,81 @@ void main() {
       expect(controller.state.upNext, isEmpty);
       expect(controller.state.hasNext, isFalse);
     });
+
+    test('addToQueue appends a track to the end', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b')]);
+
+      controller.addToQueue(_track('c'));
+
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.state.upNext, [_track('b'), _track('c')]);
+    });
+
+    test('addToQueue on an empty queue starts playback', () async {
+      final controller = FakePlaybackController();
+
+      controller.addToQueue(_track('a'));
+
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.playedTracks, [_track('a')]);
+    });
+
+    test('playNext on an empty queue starts playback', () async {
+      final controller = FakePlaybackController();
+
+      controller.playNext(_track('a'));
+
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.playedTracks, [_track('a')]);
+    });
+
+    test('removeFromQueue drops only that up-next entry', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+
+      // up next is [b, c]; remove index 0 (b).
+      controller.removeFromQueue(0);
+
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.state.upNext, [_track('c')]);
+    });
+
+    test('reorderQueue moves an up-next track', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks(
+        [_track('a'), _track('b'), _track('c'), _track('d')],
+      );
+
+      // up next is [b, c, d]; move b (0) to the end (2).
+      controller.reorderQueue(0, 2);
+
+      expect(controller.state.upNext, [_track('c'), _track('d'), _track('b')]);
+    });
+
+    test('playFromQueue jumps to and plays the chosen up-next track', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+
+      // up next is [b, c]; play c (index 1).
+      await controller.playFromQueue(1);
+
+      expect(controller.state.currentTrack, _track('c'));
+      expect(controller.playedTracks, [_track('a'), _track('c')]);
+    });
+
+    test('queue edits do not restart the current track', () async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('a'), _track('b'), _track('c')]);
+      final int playedBefore = controller.playedTracks.length;
+
+      controller.addToQueue(_track('d'));
+      controller.removeFromQueue(0); // removes b
+      controller.reorderQueue(0, 1); // reorders the remaining up-next
+
+      // The current track is still 'a' and was never re-played by any edit.
+      expect(controller.state.currentTrack, _track('a'));
+      expect(controller.playedTracks.length, playedBefore);
+    });
   });
 }

--- a/test/features/player/queue_sheet_test.dart
+++ b/test/features/player/queue_sheet_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/widgets/queue_sheet.dart';
+
+import 'fake_playback_controller.dart';
+
+Track _track(String id) =>
+    Track(id: id, title: 'Song $id', uri: '/$id.mp3', artistName: 'Artist $id');
+
+/// Pumps a host with a button that opens the Queue sheet over the given
+/// [controller], faithfully exercising it as the modal bottom sheet it is.
+Future<void> _open(
+  WidgetTester tester,
+  FakePlaybackController controller, {
+  InMemoryPlaylistStore? store,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+        if (store != null) playlistStoreProvider.overrideWithValue(store),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => showQueueSheet(context),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('QueueSheet', () {
+    testWidgets('renders the current track and the up-next tracks',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+
+      expect(find.text('Now playing'), findsOneWidget);
+      expect(find.text('Up next'), findsOneWidget);
+      // Current track + both up-next tracks are listed.
+      expect(find.text('Song A'), findsOneWidget);
+      expect(find.text('Song B'), findsOneWidget);
+      expect(find.text('Song C'), findsOneWidget);
+    });
+
+    testWidgets('removing an up-next entry keeps the current track playing',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+      // Remove the first up-next track (Song B).
+      await tester.tap(find.byTooltip('Remove from queue').first);
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack, _track('A'));
+      expect(controller.state.upNext, [_track('C')]);
+      expect(find.text('Song B'), findsNothing);
+    });
+
+    testWidgets('Clear empties up next but keeps the current track',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+      await tester.tap(find.text('Clear'));
+      await tester.pumpAndSettle();
+
+      expect(controller.clearCount, 1);
+      expect(controller.state.currentTrack, _track('A'));
+      expect(controller.state.upNext, isEmpty);
+      expect(find.text('Song B'), findsNothing);
+    });
+
+    testWidgets('tapping an up-next track plays it now', (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+      await tester.tap(find.text('Song C'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack, _track('C'));
+    });
+
+    testWidgets('shows a drag handle for each upcoming track', (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller);
+
+      // One handle per up-next track (B and C), not the current one.
+      expect(find.byIcon(Icons.drag_handle), findsNWidgets(2));
+      expect(find.byType(ReorderableDragStartListener), findsNWidgets(2));
+    });
+
+    testWidgets('history is shown and tapping it steps back', (tester) async {
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+      await controller.skipToNext(); // current B, history [A], up next [C]
+
+      await _open(tester, controller);
+
+      expect(find.text('Previously played'), findsOneWidget);
+      expect(find.text('Song A'), findsOneWidget);
+
+      await tester.tap(find.text('Song A'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack, _track('A'));
+    });
+
+    testWidgets('save queue as playlist creates a local playlist',
+        (tester) async {
+      final store = InMemoryPlaylistStore();
+      final controller = FakePlaybackController();
+      await controller.playTracks([_track('A'), _track('B'), _track('C')]);
+
+      await _open(tester, controller, store: store);
+      await tester.tap(find.byTooltip('Save queue as playlist'));
+      await tester.pumpAndSettle();
+
+      // The shared create-playlist dialog: enter a name, then Create.
+      await tester.enterText(find.byType(TextField).first, 'My Queue');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      final List<Playlist> saved = await store.load();
+      expect(saved, hasLength(1));
+      expect(saved.single.name, 'My Queue');
+      // Order is history + current + up-next: [A, B, C].
+      expect(saved.single.trackIds, <String>['A', 'B', 'C']);
+      expect(saved.single.source, PlaylistSource.local);
+      expect(find.textContaining('Saved 3 songs to'), findsOneWidget);
+    });
+
+    testWidgets('never renders a track uri / authenticated source string',
+        (tester) async {
+      final controller = FakePlaybackController();
+      // A remote track whose source reference would carry a token if leaked.
+      await controller.playTracks(const <Track>[
+        Track(
+          id: 'r1',
+          title: 'Remote One',
+          uri: 'https://host/stream?api_key=SECRETTOKEN123',
+          artistName: 'Artist R',
+        ),
+        Track(
+          id: 'r2',
+          title: 'Remote Two',
+          uri: 'jellyfin:r2',
+          artistName: 'Artist R',
+        ),
+      ]);
+
+      await _open(tester, controller);
+
+      // Titles/artists render; the raw uri and any token never do.
+      expect(find.text('Remote One'), findsOneWidget);
+      expect(find.text('Remote Two'), findsOneWidget);
+      expect(find.textContaining('SECRETTOKEN'), findsNothing);
+      expect(find.textContaining('api_key'), findsNothing);
+      expect(find.textContaining('https://'), findsNothing);
+      expect(find.textContaining('jellyfin:'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a proper **Queue / Up Next manager** so listeners can control what plays next without building a playlist every time. Everything routes through the single `PlaybackController`, so the mini-player, Now Playing, Cast, and the Android Auto media session all read and edit the **same** queue — there is never a second copy.

Docs: [`docs/queue.md`](./docs/queue.md).

## Queue UI behavior

A bottom sheet opened from **Now Playing → Queue** (floats over Now Playing, so opening/browsing it **never touches playback**). Top to bottom:

- **Previously played** — history; tap a row to step back to it.
- **Now playing** — current track, highlighted in the warm accent. No remove/drag controls (the manager never yanks the playing track out from under playback).
- **Up next** — reorderable rows, each with tap-to-play-now, an ✕ to remove, and a drag handle.
- Header actions: **Save queue as playlist** and **Clear**.

Uses the dark-purple/orange theme (primary section labels, accent "now playing"). State-driven, so it stays live while open.

## Queue editing behavior

- **Reorder**: drag an upcoming track; the current track keeps playing. Shuffle/repeat stay coherent (you reorder the *effective* order; un-shuffling restores the pre-shuffle order, which is its defined meaning).
- **Remove**: drops **only** that queue entry — never deletes the track from the library or its offline copy. Empty queue → the current track keeps playing.
- **Clear**: drops up-next **and** history, keeping the current track playing.
- **Play now / step back**: tapping an up-next row plays it now; tapping a history row steps back.
- **No restart**: every edit leaves the current track's audio untouched (no reload/restart).

## Play next / Add to queue

Added to track overflow (⋮) menus in **Songs, Album, Artist, Playlist, and Search**:

- **Play next** — inserts directly after the current track.
- **Add to queue** — appends to the end.
- **When nothing is playing**, both simply **start** the track (cleanest behavior, never a silent no-op). Documented in `docs/queue.md`.

## Save queue as playlist

**Implemented.** Saves the whole queue (history + current + up-next, in order) as a **local** playlist, prompting for a name via the shared create-playlist dialog.

- **Local-only / never auto-syncs to Jellyfin** — a queue can mix local and remote tracks, and the Jellyfin playlist rules only accept Jellyfin tracks, so auto-syncing could silently drop local tracks or push to a server. Saving locally avoids both; the user can still sync later from the playlist screen. One-step Jellyfin sync is noted as a follow-up.

## Cast / Android Auto safety

- Editing the queue while **casting** only reshapes up-next; the receiver keeps playing the current track. Edits **never start duplicate local audio** (the local engine is suspended while casting). "Play now" changes the current track, which the Cast service mirrors onto the receiver via the normal track-change path — still no local audio. Covered by tests.
- **Android Auto** drives the same controller; queue edits are reflected without starting duplicate playback. The media-session handler is unchanged.
- The queue state/UI carry **only catalog metadata** (id/title/artist/album/artwork) — never a resolved/authenticated URL or token. Authenticated URLs are minted at play time and live only transiently in the engine/Cast load message.

## Tests added

- **Model** (`playback_queue_test.dart`): `history`, `appended`, `removeUpNextAt`, `reorderUpNext`, `jumpToUpNext`, `jumpToHistory` (incl. shuffle coherence & no-op bounds).
- **Controller** (`queue_behavior_test.dart`): add to queue appends, remove drops one entry, reorder, play-from-queue, play-next/add-to-queue on an empty queue start playback, and **queue edits do not restart the current track**.
- **Cast** (`active_playback_controller_test.dart`): add/remove/reorder and play-now **while casting** never start local audio.
- **Overflow menu** (`track_tile_test.dart`): Play next + Add to queue present.
- **Queue sheet** (`queue_sheet_test.dart`): renders current + up-next, remove keeps current, Clear keeps current, tap-to-play, drag handles present, history step-back, save-as-playlist, and **no token/uri rendered**.

Full suite green: `flutter pub get`, `dart format --set-exit-if-changed .`, `flutter analyze`, `flutter test` (**1057 passing**).

> `flutter build apk --debug` was **not** run here — the cloud environment has no Android SDK. CI's Android workflow builds the debug APK.

## Known limitations

- Save queue as playlist is **local-only** (one-step Jellyfin sync is a follow-up).
- **Un-shuffling drops a manual reorder** of up-next (it restores the true pre-shuffle order) — intentional.
- Duplicate tracks in a queue share a track id; reorder/remove act on the first matching entry (queue tile keys are index-qualified so duplicates can't crash the reorderable list).

## Manual Android checklist

- [ ] Open **Queue** from Now Playing — history + current + up-next render.
- [ ] **Play next** / **Add to queue** from a ⋮ menu (Songs/Album/Artist/Playlist/Search) land in the right spot; current track does not restart.
- [ ] With nothing playing, Play next / Add to queue start the track.
- [ ] Drag an up-next track to reorder; current keeps playing.
- [ ] Remove an up-next track (✕) — library and offline copy stay intact.
- [ ] **Clear** keeps the current track playing.
- [ ] Tap an up-next track to play now; tap a history track to step back.
- [ ] **Save queue as playlist** creates a local playlist with the queue's songs.
- [ ] While **casting**: add/remove/reorder and "play now" never start audio on the phone; the receiver follows the current track.
- [ ] **Android Auto**: queue edits in the app don't start duplicate playback.

https://claude.ai/code/session_01BiuuqDmYTMNrRTbbGj477U

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiuuqDmYTMNrRTbbGj477U)_