### PR TITLE
Add smart mixes (automatic playlists) built from on-device signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ gradient, generated from one source design (not mockups).
   queue as a playlist — without building a playlist first ([docs](./docs/queue.md)).
 - **Playlists & favourites** — create/edit/reorder/delete playlists; favourite
   tracks. Both sync with Jellyfin where supported.
+- **Smart mixes** — automatic, Made-by-Linthra collections (Recently added /
+  played, Most played, Favorites, Downloaded, Random, Never played) built from
+  on-device signals that stay on the device ([docs](./docs/smart-mixes.md)).
 - **Background playback** — media notification with lock-screen, Bluetooth, and
   wired-headset controls, plus shuffle / repeat and synced lyrics.
 
@@ -168,8 +171,8 @@ lyrics & cover art · full playlist sync · album/playlist "download all" +
 background download manager · real connectivity detection for the Wi-Fi gate ·
 WebDAV / NAS sources.
 
-**Later:** local-file lyrics (`.lrc`/tags), ReplayGain, MPRIS, smart playlists,
-Linux desktop, richer Android Auto and Cast.
+**Later:** local-file lyrics (`.lrc`/tags), ReplayGain, MPRIS, Linux desktop,
+richer Android Auto and Cast.
 
 Honest gaps (no local tag parsing yet, single Jellyfin server, direct-play only,
 partial playlist sync, optimistic connectivity) are documented per feature.
@@ -190,6 +193,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Android Auto | [docs/android-auto.md](./docs/android-auto.md) |
 | Reporting a bug | [docs/reporting-bugs.md](./docs/reporting-bugs.md) |
 | Playlists & safe removal | [docs/playlists-and-delete.md](./docs/playlists-and-delete.md) |
+| Smart mixes (automatic playlists) | [docs/smart-mixes.md](./docs/smart-mixes.md) |
 | Manual QA checklist | [docs/manual-test-checklist.md](./docs/manual-test-checklist.md) |
 | Release process & signing | [docs/release-process.md](./docs/release-process.md) · [signing](./docs/release-signing.md) |
 | F-Droid readiness | [docs/fdroid-readiness.md](./docs/fdroid-readiness.md) |

--- a/docs/smart-mixes.md
+++ b/docs/smart-mixes.md
@@ -1,0 +1,71 @@
+# Smart mixes (automatic playlists)
+
+Linthra builds a handful of **smart mixes** — automatic, "Made by Linthra"
+collections that need no manual curation. They live under **Playlists → Smart
+mixes** and each one opens to a track list with **Play** and **Shuffle**, just
+like a regular playlist or album.
+
+## The mixes
+
+| Mix | What it contains | Signal it's built from |
+| --- | --- | --- |
+| **Recently added** | Newest tracks in your library, newest first | First-seen timestamp recorded on each scan/sync |
+| **Recently played** | Tracks you've finished, most recent first | On-device play history (`lastPlayedAt`) |
+| **Most played** | The songs you reach for most | On-device play history (`playCount`) |
+| **Favorites** | Everything you've liked | The existing favourites repository |
+| **Downloaded** | Tracks available offline | The offline download/cache state |
+| **Random mix** | A bounded shuffle of your library | The catalog (a fresh shuffle each visit) |
+| **Never played** | Tracks you haven't heard yet | Tracks absent from play history |
+
+Every mix works across **local**, **Jellyfin**, and **Navidrome/Subsonic**
+tracks wherever the underlying data exists — the mixes are derived from the
+unified catalog plus on-device signals, never from a single source.
+
+Mixes are always shown (even when empty) so the section is stable and
+discoverable; an empty mix opens to a friendly explanation of how to fill it.
+The open-ended mixes (recently added/played, most played, random, never played)
+are capped (100 tracks) so a mix stays a digestible set — and so the random mix
+is always bounded. Favourites and Downloaded are user-curated, so they show
+everything.
+
+## Play history
+
+Two new on-device signals back the play-history mixes:
+
+- **`playCount`** — incremented when a track reaches its natural end.
+- **`lastPlayedAt`** — set to "now" on that same completion.
+- **Recently played** is the play history ordered by `lastPlayedAt`.
+
+A play is counted on **completion**, not on start or skip: skipping a track
+forward does **not** count as a play, while each full loop under repeat-one
+does. Completion is observed at the one place that can tell a genuine end from a
+skip — the playback engine's completion handler — and recorded through
+`PlayHistoryRepository`.
+
+## Privacy
+
+Play history and library-added timestamps are **on-device only**:
+
+- They store **only non-secret track ids**, play counts, and timestamps —
+  never a track `uri`, a token, or an authenticated stream URL.
+- Nothing is uploaded: **no telemetry, no server sync.** (A provider that
+  explicitly supports play counts could sync them in the future; until then it
+  stays local.)
+- Catalog track `uri`s themselves are opaque ids (`jellyfin:<id>`,
+  `subsonic:<id>`, or a local `file://`/content path) — the authenticated
+  stream URL is minted only at play time and never stored — so a resolved mix
+  carries no secret either.
+
+## Where it lives
+
+- **Model** — `lib/core/models/smart_playlist.dart` (the mix kinds + copy) and
+  `lib/core/models/play_history.dart` (counts + last-played).
+- **Resolver** — `lib/core/services/smart_playlist_resolver.dart` turns the
+  signals into an ordered track list per mix (pure and unit-tested).
+- **Persistence** — `PlayHistoryStore` / `LibraryAddedStore` (in-memory for
+  tests, `shared_preferences` in the app), mirroring the favourites store.
+- **Recording** — `RecordingMusicLibraryRepository` stamps newly-seen tracks on
+  sync; `JustAudioPlaybackController` records completions into
+  `PlayHistoryRepository`.
+- **UI** — `lib/features/smart_mixes/` (the list and detail screens, reached
+  from the Playlists tab).

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -12,6 +12,8 @@ import '../features/playlists/playlists_screen.dart';
 import '../features/settings/bug_report/bug_report_screen.dart';
 import '../features/settings/settings_screen.dart';
 import '../features/shell/home_shell.dart';
+import '../features/smart_mixes/smart_mix_detail_screen.dart';
+import '../features/smart_mixes/smart_mixes_screen.dart';
 import 'routes.dart';
 
 /// Single source of truth for navigation. Exposed through Riverpod so future
@@ -63,6 +65,18 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                     builder: (context, state) => PlaylistDetailScreen(
                       playlistId: state.pathParameters['id']!,
                     ),
+                  ),
+                  GoRoute(
+                    path: 'smart',
+                    builder: (context, state) => const SmartMixesScreen(),
+                    routes: [
+                      GoRoute(
+                        path: ':kind',
+                        builder: (context, state) => SmartMixDetailScreen(
+                          kindId: state.pathParameters['kind']!,
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ),

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -33,6 +33,15 @@ abstract final class AppRoutes {
   /// Builds the [playlistDetail] location for a given playlist [id].
   static String playlistDetailPath(String id) => '$playlistDetail/$id';
 
+  /// The "Smart mixes" section (automatic, Made-by-Linthra collections), reached
+  /// from the Playlists tab. A child of [playlists] so it keeps the bottom nav
+  /// and pops back into that tab.
+  static const String smartMixes = '/playlists/smart';
+
+  /// Builds the location for a single smart mix, identified by its kind [id]
+  /// (`SmartPlaylistKind.id`), which rides as a path segment.
+  static String smartMixPath(String id) => '$smartMixes/$id';
+
   static const String downloads = '/downloads';
   static const String settings = '/settings';
 

--- a/lib/core/models/play_history.dart
+++ b/lib/core/models/play_history.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart';
+
+/// How often a single track has been played, and when it last finished.
+///
+/// Deliberately tiny and id-free: the owning [PlayHistory] keys these by track
+/// id, so this carries no track identity, no uri, and never a token or stream
+/// URL. Play history is on-device only.
+@immutable
+class TrackPlayStats {
+  const TrackPlayStats({required this.playCount, required this.lastPlayedAt});
+
+  /// Number of completed plays (a play is counted when a track reaches its end).
+  final int playCount;
+
+  /// When the track most recently finished playing.
+  final DateTime lastPlayedAt;
+
+  /// Returns these stats with one more completed play recorded at [at].
+  TrackPlayStats bumped(DateTime at) =>
+      TrackPlayStats(playCount: playCount + 1, lastPlayedAt: at);
+}
+
+/// On-device playback history: per-track play counts and last-played times.
+///
+/// The data behind "Recently played", "Most played", and "Never played" smart
+/// mixes. Stores only non-secret track ids mapped to [TrackPlayStats] — never a
+/// uri, token, or authenticated URL — and stays on the device (no telemetry, no
+/// server upload).
+@immutable
+class PlayHistory {
+  const PlayHistory({this.stats = const <String, TrackPlayStats>{}});
+
+  static const PlayHistory empty = PlayHistory();
+
+  /// Per-track stats keyed by stable Linthra track id.
+  final Map<String, TrackPlayStats> stats;
+
+  bool hasPlayed(String trackId) => stats.containsKey(trackId);
+
+  int playCountFor(String trackId) => stats[trackId]?.playCount ?? 0;
+
+  DateTime? lastPlayedFor(String trackId) => stats[trackId]?.lastPlayedAt;
+
+  /// Track ids that have been played, ordered most-recently-played first.
+  List<String> get recentlyPlayedIds {
+    final List<String> ids = stats.keys.toList();
+    ids.sort((String a, String b) =>
+        stats[b]!.lastPlayedAt.compareTo(stats[a]!.lastPlayedAt));
+    return ids;
+  }
+
+  /// Track ids that have been played, ordered most-played first; ties are
+  /// broken by most-recently-played so the order is stable and meaningful.
+  List<String> get mostPlayedIds {
+    final List<String> ids = stats.keys.toList();
+    ids.sort((String a, String b) {
+      final int byCount = stats[b]!.playCount.compareTo(stats[a]!.playCount);
+      if (byCount != 0) return byCount;
+      return stats[b]!.lastPlayedAt.compareTo(stats[a]!.lastPlayedAt);
+    });
+    return ids;
+  }
+
+  /// Returns a copy with one more completed play for [trackId] recorded at [at].
+  PlayHistory recordPlay(String trackId, DateTime at) {
+    final Map<String, TrackPlayStats> next =
+        Map<String, TrackPlayStats>.of(stats);
+    final TrackPlayStats? existing = next[trackId];
+    next[trackId] = existing == null
+        ? TrackPlayStats(playCount: 1, lastPlayedAt: at)
+        : existing.bumped(at);
+    return PlayHistory(stats: next);
+  }
+}

--- a/lib/core/models/smart_playlist.dart
+++ b/lib/core/models/smart_playlist.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/foundation.dart';
+
+/// The kinds of automatic "smart mix" Linthra builds from on-device signals.
+///
+/// Each kind is derived from data the app already has — library timestamps,
+/// playback history, favourites, the offline cache, or just the catalog — so a
+/// mix needs no manual curation and works across local, Jellyfin, and
+/// Navidrome/Subsonic tracks wherever that data exists.
+enum SmartPlaylistKind {
+  recentlyAdded,
+  recentlyPlayed,
+  mostPlayed,
+  favorites,
+  downloaded,
+  random,
+  neverPlayed;
+
+  /// The stable id used in routing (`kind.name`).
+  String get id => name;
+
+  /// Parses a routing [id] back to a kind, or `null` for an unknown value so a
+  /// stale/forward link can show a friendly "not found" rather than crash.
+  static SmartPlaylistKind? fromId(String? id) {
+    for (final SmartPlaylistKind kind in SmartPlaylistKind.values) {
+      if (kind.id == id) return kind;
+    }
+    return null;
+  }
+}
+
+/// A single automatic mix: its [kind] plus the title/description the UI shows.
+///
+/// Carries no tracks — those are resolved on demand by `SmartPlaylistResolver`
+/// from the live catalog and on-device signals, so a mix is always current and
+/// never persists track ids or any secret.
+@immutable
+class SmartPlaylist {
+  const SmartPlaylist({
+    required this.kind,
+    required this.title,
+    required this.description,
+  });
+
+  final SmartPlaylistKind kind;
+  final String title;
+  final String description;
+
+  String get id => kind.id;
+
+  /// The canonical mix for [kind], with its app-facing copy.
+  factory SmartPlaylist.forKind(SmartPlaylistKind kind) {
+    switch (kind) {
+      case SmartPlaylistKind.recentlyAdded:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.recentlyAdded,
+          title: 'Recently added',
+          description: 'New in your library',
+        );
+      case SmartPlaylistKind.recentlyPlayed:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.recentlyPlayed,
+          title: 'Recently played',
+          description: 'Jump back in',
+        );
+      case SmartPlaylistKind.mostPlayed:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.mostPlayed,
+          title: 'Most played',
+          description: 'The songs you reach for',
+        );
+      case SmartPlaylistKind.favorites:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.favorites,
+          title: 'Favorites',
+          description: 'Tracks you’ve liked',
+        );
+      case SmartPlaylistKind.downloaded:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.downloaded,
+          title: 'Downloaded',
+          description: 'Available offline',
+        );
+      case SmartPlaylistKind.random:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.random,
+          title: 'Random mix',
+          description: 'A fresh shuffle every time',
+        );
+      case SmartPlaylistKind.neverPlayed:
+        return const SmartPlaylist(
+          kind: SmartPlaylistKind.neverPlayed,
+          title: 'Never played',
+          description: 'Hidden gems you haven’t heard yet',
+        );
+    }
+  }
+
+  /// Every mix, in the order shown in the "Smart mixes" section.
+  static List<SmartPlaylist> get all => <SmartPlaylist>[
+        for (final SmartPlaylistKind kind in SmartPlaylistKind.values)
+          SmartPlaylist.forKind(kind),
+      ];
+}

--- a/lib/core/repositories/library_added_store.dart
+++ b/lib/core/repositories/library_added_store.dart
@@ -1,0 +1,15 @@
+/// Durable storage for when each catalog track was first added to the library.
+///
+/// Records a `trackId -> firstSeen` map that powers the "Recently added" smart
+/// mix. It's written by [RecordingMusicLibraryRepository] as a side effect of a
+/// scan/sync (stamping newly-seen track ids with the time they first appeared),
+/// and read by the smart-mix layer. Kept as a separate seam so the backing
+/// store swaps freely (in-memory for tests, key/value in the app), mirroring
+/// [FavoritesStore].
+///
+/// Privacy: only non-secret track ids and timestamps are stored here — never a
+/// uri, token, or authenticated URL. It never leaves the device.
+abstract interface class LibraryAddedStore {
+  Future<Map<String, DateTime>> load();
+  Future<void> save(Map<String, DateTime> addedAt);
+}

--- a/lib/core/repositories/play_history_repository.dart
+++ b/lib/core/repositories/play_history_repository.dart
@@ -1,0 +1,25 @@
+import '../models/play_history.dart';
+import '../models/track.dart';
+
+/// Records and exposes the user's on-device playback history.
+///
+/// The player records a completed play through [recordCompletion] (called when
+/// a track reaches its end); the UI reads [historyStream] to power the
+/// "Recently played", "Most played", and "Never played" smart mixes — never
+/// touching the backing store directly, mirroring how the player reads a
+/// `PlaybackState` and never the audio engine.
+///
+/// Privacy invariant: only the track *id* is recorded — never its uri, a token,
+/// or an authenticated URL — and the history stays on the device (no telemetry,
+/// no server upload).
+abstract interface class PlayHistoryRepository {
+  /// Emits the current history immediately, then on every recorded play.
+  Stream<PlayHistory> get historyStream;
+
+  /// The latest known history, for synchronous reads on first build.
+  PlayHistory get current;
+
+  /// Records that [track] finished playing: increments its play count and sets
+  /// its last-played time to now. Only [Track.id] is read. Never throws.
+  Future<void> recordCompletion(Track track);
+}

--- a/lib/core/repositories/play_history_store.dart
+++ b/lib/core/repositories/play_history_store.dart
@@ -1,0 +1,16 @@
+import '../models/play_history.dart';
+
+/// Durable storage for the user's on-device [PlayHistory].
+///
+/// The persistence seam under [PlayHistoryRepository]: it knows nothing about
+/// playback — only how to load and save the play-count/last-played map.
+/// Splitting it out lets the backing store swap freely (in-memory for tests,
+/// key/value in the app), mirroring [FavoritesStore].
+///
+/// Privacy: only non-secret track ids, play counts, and timestamps are stored
+/// here — never a uri, token, or authenticated URL. Play history never leaves
+/// the device.
+abstract interface class PlayHistoryStore {
+  Future<PlayHistory> load();
+  Future<void> save(PlayHistory history);
+}

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -16,6 +16,11 @@ import 'playback_controller.dart';
 import 'stability_diagnostics.dart';
 import 'stream_interruption.dart';
 
+/// Notified when a track finishes playing (reaches its natural end), so play
+/// history can be recorded. Carries only the catalog [Track] — never a resolved
+/// or authenticated stream URL.
+typedef TrackCompletionCallback = void Function(Track track);
+
 /// [PlaybackController] backed by `just_audio`.
 ///
 /// This is the only file in the app that knows `just_audio` exists. It adapts
@@ -34,9 +39,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     AudioPlayer? player,
     PlayableUriResolver resolver = const LocalPlayableUriResolver(),
     Random? random,
+    TrackCompletionCallback? onTrackCompleted,
   })  : _player = player ?? _defaultPlayer(),
         _resolver = resolver,
-        _random = random ?? Random() {
+        _random = random ?? Random(),
+        _onTrackCompleted = onTrackCompleted {
     _wire();
   }
 
@@ -73,6 +80,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   final AudioPlayer _player;
   final PlayableUriResolver _resolver;
   final Random _random;
+
+  /// Invoked once each time a track reaches its natural end, before the repeat
+  /// mode decides what plays next. Null when no listener is wired (tests, or the
+  /// default engine). Used to record play history.
+  final TrackCompletionCallback? _onTrackCompleted;
   final StreamController<PlaybackState> _states =
       StreamController<PlaybackState>.broadcast();
   final List<StreamSubscription<void>> _subscriptions =
@@ -375,6 +387,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// end), and off advances until the queue runs out and then settles on
   /// [PlaybackStatus.completed].
   void _onCompleted() {
+    // The track that just finished is still current here, before any advance.
+    // Record the completed play once, regardless of what plays next.
+    final Track? finished = _queue.current;
+    if (finished != null) _onTrackCompleted?.call(finished);
     switch (_repeatMode) {
       case RepeatMode.one:
         unawaited(_replayCurrent());

--- a/lib/core/services/smart_playlist_resolver.dart
+++ b/lib/core/services/smart_playlist_resolver.dart
@@ -1,0 +1,109 @@
+import 'dart:math';
+
+import '../models/play_history.dart';
+import '../models/smart_playlist.dart';
+import '../models/track.dart';
+
+/// Turns a [SmartPlaylistKind] plus the on-device signals into an ordered track
+/// list. Pure and synchronous: it takes everything it needs as arguments and
+/// performs no IO, so each mix is trivially unit-testable in isolation.
+///
+/// All inputs are catalog [Track]s and non-secret track ids — the resolver
+/// never sees (or produces) a token or authenticated URL, so the resulting mix
+/// is safe to render and queue as-is.
+class SmartPlaylistResolver {
+  const SmartPlaylistResolver({this.maxTracks = 100});
+
+  /// Upper bound on the size of an open-ended, signal-ranked mix (recently
+  /// added/played, most played, random, never played). Keeps a mix a digestible
+  /// set — and keeps the random mix bounded — rather than the whole library.
+  /// User-curated mixes (favourites, downloaded) are not capped: they're only as
+  /// large as the user made them.
+  final int maxTracks;
+
+  /// Resolves the tracks for [kind]. Missing data degrades gracefully: an empty
+  /// catalog (or empty signal) yields an empty list rather than throwing.
+  ///
+  /// [random] seeds the shuffle for [SmartPlaylistKind.random]; pass a seeded
+  /// [Random] for deterministic tests. It's ignored by every other kind.
+  List<Track> resolve(
+    SmartPlaylistKind kind, {
+    required List<Track> allTracks,
+    required PlayHistory history,
+    required Map<String, DateTime> addedAt,
+    required Set<String> favoriteIds,
+    required Set<String> downloadedIds,
+    Random? random,
+  }) {
+    switch (kind) {
+      case SmartPlaylistKind.recentlyAdded:
+        return _recentlyAdded(allTracks, addedAt);
+      case SmartPlaylistKind.recentlyPlayed:
+        return _byIdOrder(allTracks, history.recentlyPlayedIds);
+      case SmartPlaylistKind.mostPlayed:
+        return _byIdOrder(allTracks, history.mostPlayedIds);
+      case SmartPlaylistKind.favorites:
+        return _filter(allTracks, favoriteIds);
+      case SmartPlaylistKind.downloaded:
+        return _filter(allTracks, downloadedIds);
+      case SmartPlaylistKind.random:
+        return _random(allTracks, random);
+      case SmartPlaylistKind.neverPlayed:
+        return _bounded(
+          <Track>[
+            for (final Track track in allTracks)
+              if (!history.hasPlayed(track.id)) track,
+          ],
+        );
+    }
+  }
+
+  /// Tracks newest-first by first-seen time. Tracks with no recorded timestamp
+  /// (e.g. before timestamping was wired) sort oldest, so they still appear but
+  /// never crowd out genuinely new additions.
+  List<Track> _recentlyAdded(
+    List<Track> allTracks,
+    Map<String, DateTime> addedAt,
+  ) {
+    final List<Track> sorted = List<Track>.of(allTracks)
+      ..sort((a, b) {
+        final DateTime ta = addedAt[a.id] ?? _epoch;
+        final DateTime tb = addedAt[b.id] ?? _epoch;
+        return tb.compareTo(ta);
+      });
+    return _bounded(sorted);
+  }
+
+  /// Resolves [orderedIds] against the catalog, preserving the given order and
+  /// dropping ids the catalog no longer has.
+  List<Track> _byIdOrder(List<Track> allTracks, List<String> orderedIds) {
+    final Map<String, Track> byId = <String, Track>{
+      for (final Track track in allTracks) track.id: track,
+    };
+    return _bounded(<Track>[
+      for (final String id in orderedIds)
+        if (byId[id] != null) byId[id]!,
+    ]);
+  }
+
+  /// Catalog-ordered subset whose ids are in [ids]. Not bounded: favourites and
+  /// downloads are user-curated, so the mix shows all of them.
+  List<Track> _filter(List<Track> allTracks, Set<String> ids) {
+    return <Track>[
+      for (final Track track in allTracks)
+        if (ids.contains(track.id)) track,
+    ];
+  }
+
+  /// A bounded shuffle of the catalog. Shuffles a *copy* so the input is never
+  /// mutated, and is safe on an empty catalog (returns an empty list).
+  List<Track> _random(List<Track> allTracks, Random? random) {
+    final List<Track> shuffled = List<Track>.of(allTracks)..shuffle(random);
+    return _bounded(shuffled);
+  }
+
+  List<Track> _bounded(List<Track> tracks) =>
+      tracks.length <= maxTracks ? tracks : tracks.sublist(0, maxTracks);
+
+  static final DateTime _epoch = DateTime.fromMillisecondsSinceEpoch(0);
+}

--- a/lib/data/repositories/default_play_history_repository.dart
+++ b/lib/data/repositories/default_play_history_repository.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import '../../core/models/play_history.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/play_history_repository.dart';
+import '../../core/repositories/play_history_store.dart';
+
+/// The app's [PlayHistoryRepository]: an in-memory mirror persisted through a
+/// [PlayHistoryStore].
+///
+/// Loads the stored history lazily on first read, records a completed play by
+/// bumping that track's count and last-played time, then emits and persists.
+/// Mirrors `JellyfinSyncedFavoritesRepository`'s shape (load-once, emit,
+/// persist) minus any server sync — play history is on-device only.
+///
+/// Privacy: [recordCompletion] reads only [Track.id]; no uri, token, or
+/// authenticated URL is ever recorded, and nothing is sent off the device.
+class DefaultPlayHistoryRepository implements PlayHistoryRepository {
+  DefaultPlayHistoryRepository({
+    required PlayHistoryStore store,
+    DateTime Function()? now,
+  })  : _store = store,
+        _now = now ?? DateTime.now;
+
+  final PlayHistoryStore _store;
+  final DateTime Function() _now;
+
+  final StreamController<PlayHistory> _changes =
+      StreamController<PlayHistory>.broadcast();
+
+  PlayHistory _history = PlayHistory.empty;
+  bool _loaded = false;
+
+  // Serialises writes so two quick completions can't race on load-then-save and
+  // lose a count: each recorded play runs only after the previous one persists.
+  Future<void> _writes = Future<void>.value();
+
+  Future<void> _ensureLoaded() async {
+    if (_loaded) return;
+    _history = await _store.load();
+    _loaded = true;
+  }
+
+  @override
+  PlayHistory get current => _history;
+
+  @override
+  Stream<PlayHistory> get historyStream async* {
+    await _ensureLoaded();
+    yield _history;
+    yield* _changes.stream;
+  }
+
+  @override
+  Future<void> recordCompletion(Track track) {
+    // Capture only the id (never the uri) and chain onto the write queue.
+    final String trackId = track.id;
+    _writes = _writes.then((_) async {
+      try {
+        await _ensureLoaded();
+        _history = _history.recordPlay(trackId, _now());
+        if (!_changes.isClosed) _changes.add(_history);
+        await _store.save(_history);
+      } catch (_) {
+        // Never throw out of recordCompletion: a failed persist keeps the
+        // in-memory count and the next write retries the save.
+      }
+    });
+    return _writes;
+  }
+
+  Future<void> dispose() => _changes.close();
+}

--- a/lib/data/repositories/in_memory_library_added_store.dart
+++ b/lib/data/repositories/in_memory_library_added_store.dart
@@ -1,0 +1,20 @@
+import '../../core/repositories/library_added_store.dart';
+
+/// A non-persistent [LibraryAddedStore] for development and tests.
+class InMemoryLibraryAddedStore implements LibraryAddedStore {
+  InMemoryLibraryAddedStore([Map<String, DateTime>? initial])
+      : _addedAt = <String, DateTime>{...?initial};
+
+  final Map<String, DateTime> _addedAt;
+
+  @override
+  Future<Map<String, DateTime>> load() async =>
+      Map<String, DateTime>.of(_addedAt);
+
+  @override
+  Future<void> save(Map<String, DateTime> addedAt) async {
+    _addedAt
+      ..clear()
+      ..addAll(addedAt);
+  }
+}

--- a/lib/data/repositories/in_memory_play_history_store.dart
+++ b/lib/data/repositories/in_memory_play_history_store.dart
@@ -1,0 +1,18 @@
+import '../../core/models/play_history.dart';
+import '../../core/repositories/play_history_store.dart';
+
+/// A non-persistent [PlayHistoryStore] for development and tests.
+class InMemoryPlayHistoryStore implements PlayHistoryStore {
+  InMemoryPlayHistoryStore([PlayHistory initial = PlayHistory.empty])
+      : _history = initial;
+
+  PlayHistory _history;
+
+  @override
+  Future<PlayHistory> load() async => _history;
+
+  @override
+  Future<void> save(PlayHistory history) async {
+    _history = history;
+  }
+}

--- a/lib/data/repositories/library_added_store_provider.dart
+++ b/lib/data/repositories/library_added_store_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/library_added_store.dart';
+import 'in_memory_library_added_store.dart';
+import 'shared_preferences_library_added_store.dart';
+
+/// Durable store of when each track first entered the library (the signal
+/// behind the "Recently added" smart mix). Defaults to in-memory so tests and
+/// dev runs need no plugins; the app overrides it with the `shared_preferences`
+/// binding below so timestamps survive a restart.
+final libraryAddedStoreProvider = Provider<LibraryAddedStore>((ref) {
+  return InMemoryLibraryAddedStore();
+});
+
+/// Production binding: persist library-added timestamps via `shared_preferences`
+/// so "Recently added" stays meaningful across restarts. Applied in `main`;
+/// tests keep the in-memory default.
+final sharedPreferencesLibraryAddedStoreOverride =
+    libraryAddedStoreProvider.overrideWithValue(
+  const SharedPreferencesLibraryAddedStore(),
+);

--- a/lib/data/repositories/music_library_repository_provider.dart
+++ b/lib/data/repositories/music_library_repository_provider.dart
@@ -4,6 +4,8 @@ import '../../core/repositories/music_library_repository.dart';
 import '../database/linthra_database_provider.dart';
 import 'drift_music_library_repository.dart';
 import 'in_memory_music_library_repository.dart';
+import 'library_added_store_provider.dart';
+import 'recording_music_library_repository.dart';
 
 /// The single [MusicLibraryRepository] the app reads its catalog from.
 ///
@@ -21,4 +23,18 @@ final musicLibraryRepositoryProvider = Provider<MusicLibraryRepository>((ref) {
 final driftMusicLibraryRepositoryOverride =
     musicLibraryRepositoryProvider.overrideWith(
   (ref) => DriftMusicLibraryRepository(ref.watch(linthraDatabaseProvider)),
+);
+
+/// Production binding used by `main`: the Drift repository wrapped so each
+/// scan/sync stamps newly-seen tracks with a first-seen time (the signal behind
+/// the "Recently added" smart mix). Reads pass straight through to Drift; only
+/// [MusicLibraryRepository.upsertCatalog]/[MusicLibraryRepository.removeTracks]
+/// also touch the timestamp store. Replaces [driftMusicLibraryRepositoryOverride]
+/// in the app's override list.
+final recordingDriftMusicLibraryRepositoryOverride =
+    musicLibraryRepositoryProvider.overrideWith(
+  (ref) => RecordingMusicLibraryRepository(
+    delegate: DriftMusicLibraryRepository(ref.watch(linthraDatabaseProvider)),
+    addedStore: ref.watch(libraryAddedStoreProvider),
+  ),
 );

--- a/lib/data/repositories/play_history_repository_provider.dart
+++ b/lib/data/repositories/play_history_repository_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/play_history_repository.dart';
+import '../../core/repositories/play_history_store.dart';
+import 'default_play_history_repository.dart';
+import 'in_memory_play_history_store.dart';
+import 'shared_preferences_play_history_store.dart';
+
+/// Durable store of the user's play history. Defaults to in-memory so tests and
+/// dev runs need no plugins; the app overrides it with the `shared_preferences`
+/// binding below so counts and last-played times survive a restart.
+final playHistoryStoreProvider = Provider<PlayHistoryStore>((ref) {
+  return InMemoryPlayHistoryStore();
+});
+
+/// The app's [PlayHistoryRepository]. Pinned for the session (the player records
+/// completions into it and the smart-mix UI reads its stream) and disposed with
+/// the scope.
+final playHistoryRepositoryProvider = Provider<PlayHistoryRepository>((ref) {
+  final DefaultPlayHistoryRepository repository =
+      DefaultPlayHistoryRepository(store: ref.watch(playHistoryStoreProvider));
+  ref.onDispose(repository.dispose);
+  return repository;
+});
+
+/// Production binding: persist play history via `shared_preferences` so it
+/// survives a restart. Applied in `main`; tests keep the in-memory default.
+final sharedPreferencesPlayHistoryStoreOverride =
+    playHistoryStoreProvider.overrideWithValue(
+  const SharedPreferencesPlayHistoryStore(),
+);

--- a/lib/data/repositories/recording_music_library_repository.dart
+++ b/lib/data/repositories/recording_music_library_repository.dart
@@ -1,0 +1,82 @@
+import '../../core/models/album.dart';
+import '../../core/models/artist.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/library_added_store.dart';
+import '../../core/repositories/music_library_repository.dart';
+
+/// A [MusicLibraryRepository] decorator that stamps each track with the time it
+/// first entered the library, so the "Recently added" smart mix has a signal to
+/// rank by.
+///
+/// It wraps the real repository and, on every [upsertCatalog] (the single point
+/// every source — local, Jellyfin, Subsonic — funnels a scan/sync through),
+/// records `now` for any track id not seen before, preserving the original
+/// timestamp for ids that already had one. That means a routine re-sync never
+/// resets "recently added": only genuinely new tracks bubble to the top.
+/// [removeTracks] forgets the timestamps for ids it removes, so a track that's
+/// removed and later re-added is correctly treated as new again.
+///
+/// Reads (`getAllTracks`, etc.) pass straight through. The stored map holds only
+/// non-secret track ids and timestamps; it never carries a uri or token.
+class RecordingMusicLibraryRepository implements MusicLibraryRepository {
+  RecordingMusicLibraryRepository({
+    required MusicLibraryRepository delegate,
+    required LibraryAddedStore addedStore,
+    DateTime Function()? now,
+  })  : _delegate = delegate,
+        _addedStore = addedStore,
+        _now = now ?? DateTime.now;
+
+  final MusicLibraryRepository _delegate;
+  final LibraryAddedStore _addedStore;
+  final DateTime Function() _now;
+
+  @override
+  Future<List<Track>> getAllTracks() => _delegate.getAllTracks();
+
+  @override
+  Future<List<Album>> getAllAlbums() => _delegate.getAllAlbums();
+
+  @override
+  Future<List<Artist>> getAllArtists() => _delegate.getAllArtists();
+
+  @override
+  Future<Track?> getTrackById(String id) => _delegate.getTrackById(id);
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    await _delegate.upsertCatalog(
+      sourceId: sourceId,
+      tracks: tracks,
+      albums: albums,
+      artists: artists,
+    );
+    final Map<String, DateTime> addedAt = await _addedStore.load();
+    final DateTime now = _now();
+    bool changed = false;
+    for (final Track track in tracks) {
+      if (!addedAt.containsKey(track.id)) {
+        addedAt[track.id] = now;
+        changed = true;
+      }
+    }
+    if (changed) await _addedStore.save(addedAt);
+  }
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {
+    await _delegate.removeTracks(trackIds);
+    if (trackIds.isEmpty) return;
+    final Map<String, DateTime> addedAt = await _addedStore.load();
+    bool changed = false;
+    for (final String id in trackIds) {
+      if (addedAt.remove(id) != null) changed = true;
+    }
+    if (changed) await _addedStore.save(addedAt);
+  }
+}

--- a/lib/data/repositories/shared_preferences_library_added_store.dart
+++ b/lib/data/repositories/shared_preferences_library_added_store.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/library_added_store.dart';
+
+/// A [LibraryAddedStore] backed by `shared_preferences`.
+///
+/// A small map of non-secret track ids to a first-seen epoch-millis timestamp,
+/// stored as `{ "<trackId>": <epochMs>, ... }`. The same key/value weight
+/// favourites and the offline-download set use.
+///
+/// Privacy: only ids and timestamps are written — never a uri, token, or
+/// authenticated URL — and it stays on the device.
+class SharedPreferencesLibraryAddedStore implements LibraryAddedStore {
+  const SharedPreferencesLibraryAddedStore();
+
+  static const String _key = 'library_added_v1';
+
+  @override
+  Future<Map<String, DateTime>> load() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return <String, DateTime>{};
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      // A corrupt record reads as "nothing recorded" rather than crashing.
+      return <String, DateTime>{};
+    }
+    if (decoded is! Map<String, dynamic>) return <String, DateTime>{};
+    final Map<String, DateTime> addedAt = <String, DateTime>{};
+    decoded.forEach((String id, Object? value) {
+      if (id.isEmpty || value is! int) return;
+      addedAt[id] = DateTime.fromMillisecondsSinceEpoch(value);
+    });
+    return addedAt;
+  }
+
+  @override
+  Future<void> save(Map<String, DateTime> addedAt) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final Map<String, dynamic> document = <String, dynamic>{
+      for (final MapEntry<String, DateTime> entry in addedAt.entries)
+        entry.key: entry.value.millisecondsSinceEpoch,
+    };
+    await prefs.setString(_key, jsonEncode(document));
+  }
+}

--- a/lib/data/repositories/shared_preferences_play_history_store.dart
+++ b/lib/data/repositories/shared_preferences_play_history_store.dart
@@ -1,0 +1,63 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/play_history.dart';
+import '../../core/repositories/play_history_store.dart';
+
+/// A [PlayHistoryStore] backed by `shared_preferences`.
+///
+/// Play history is a small map of non-secret track ids to a play count and a
+/// last-played timestamp, so a key/value document is the right weight (the same
+/// reasoning favourites and the offline-download set follow). Stored as
+/// `{ "<trackId>": { "c": <count>, "t": <epochMs> }, ... }`.
+///
+/// Privacy: only ids, counts, and timestamps are written — never a uri, token,
+/// or authenticated URL — so the document can never carry a secret, and it
+/// stays on the device.
+class SharedPreferencesPlayHistoryStore implements PlayHistoryStore {
+  const SharedPreferencesPlayHistoryStore();
+
+  static const String _key = 'play_history_v1';
+
+  @override
+  Future<PlayHistory> load() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return PlayHistory.empty;
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      // A corrupt record reads as "no history" rather than crashing.
+      return PlayHistory.empty;
+    }
+    if (decoded is! Map<String, dynamic>) return PlayHistory.empty;
+    final Map<String, TrackPlayStats> stats = <String, TrackPlayStats>{};
+    decoded.forEach((String id, Object? value) {
+      if (id.isEmpty || value is! Map<String, dynamic>) return;
+      final Object? count = value['c'];
+      final Object? millis = value['t'];
+      if (count is! int || count <= 0 || millis is! int) return;
+      stats[id] = TrackPlayStats(
+        playCount: count,
+        lastPlayedAt: DateTime.fromMillisecondsSinceEpoch(millis),
+      );
+    });
+    return PlayHistory(stats: stats);
+  }
+
+  @override
+  Future<void> save(PlayHistory history) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final Map<String, dynamic> document = <String, dynamic>{
+      for (final MapEntry<String, TrackPlayStats> entry
+          in history.stats.entries)
+        entry.key: <String, dynamic>{
+          'c': entry.value.playCount,
+          't': entry.value.lastPlayedAt.millisecondsSinceEpoch,
+        },
+    };
+    await prefs.setString(_key, jsonEncode(document));
+  }
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -17,6 +17,7 @@ import '../../core/services/stream_preloading_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
+import '../../data/repositories/play_history_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'cast/cast_providers.dart';
@@ -77,6 +78,12 @@ final localPlaybackControllerProvider =
     Provider<LocalPlaybackController>((ref) {
   final controller = JustAudioPlaybackController(
     resolver: ref.read(playableUriResolverProvider),
+    // Record a completed play when a track reaches its end. Read lazily at
+    // completion time (not watched), so the play-history repository never ties
+    // into the engine's lifecycle. Only the track id is recorded; it stays
+    // on-device. Casting suspends the engine, so cast plays aren't counted.
+    onTrackCompleted: (track) => unawaited(
+        ref.read(playHistoryRepositoryProvider).recordCompletion(track)),
   );
   ref.onDispose(controller.dispose);
   return controller;

--- a/lib/features/playlists/playlists_screen.dart
+++ b/lib/features/playlists/playlists_screen.dart
@@ -46,6 +46,17 @@ class PlaylistsScreen extends ConsumerWidget {
             onTap: () => context.push(AppRoutes.favorites),
           ),
           const Divider(height: 0),
+          ListTile(
+            leading: CircleAvatar(
+              backgroundColor: accent.withValues(alpha: 0.12),
+              child: Icon(Icons.auto_awesome, color: accent),
+            ),
+            title: const Text('Smart mixes'),
+            subtitle: const Text('Made by Linthra'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push(AppRoutes.smartMixes),
+          ),
+          const Divider(height: 0),
           Expanded(
             child: playlists.when(
               loading: () => const Center(child: CircularProgressIndicator()),

--- a/lib/features/smart_mixes/smart_mix_detail_screen.dart
+++ b/lib/features/smart_mixes/smart_mix_detail_screen.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/smart_playlist.dart';
+import '../../core/models/track.dart';
+import '../../shared/widgets/empty_state.dart';
+import '../library/widgets/track_tile.dart';
+import '../player/player_providers.dart';
+import 'smart_mix_providers.dart';
+
+/// One smart mix's tracks, with Play / Shuffle and tap-to-play.
+///
+/// Read-only by design: a smart mix is derived from on-device signals, not a
+/// hand-curated list, so there's no reorder/rename/delete — reopening it simply
+/// reflects the latest data. Reuses [TrackTile], so per-track actions and
+/// download state look identical to the rest of the library.
+class SmartMixDetailScreen extends ConsumerWidget {
+  const SmartMixDetailScreen({required this.kindId, super.key});
+
+  /// The routing id of the mix (`SmartPlaylistKind.id`).
+  final String kindId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final SmartPlaylistKind? kind = SmartPlaylistKind.fromId(kindId);
+    if (kind == null) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const EmptyState(
+          icon: Icons.auto_awesome_outlined,
+          title: 'Mix not found',
+          message: 'This smart mix is no longer available.',
+        ),
+      );
+    }
+
+    final SmartPlaylist mix = SmartPlaylist.forKind(kind);
+    final AsyncValue<List<Track>> tracksAsync =
+        ref.watch(smartPlaylistTracksProvider(kind));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(mix.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      ),
+      body: tracksAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const EmptyState(
+          icon: Icons.error_outline,
+          title: "Couldn't build this mix",
+          message: 'Try again in a moment.',
+        ),
+        data: (List<Track> tracks) => _content(context, ref, mix, tracks),
+      ),
+    );
+  }
+
+  Widget _content(
+    BuildContext context,
+    WidgetRef ref,
+    SmartPlaylist mix,
+    List<Track> tracks,
+  ) {
+    if (tracks.isEmpty) {
+      return EmptyState(
+        icon: Icons.auto_awesome_outlined,
+        title: 'Nothing here yet',
+        message: _emptyMessage(mix.kind),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        _Header(
+          onPlay: () => _play(context, ref, tracks),
+          onShuffle: () => _shuffle(context, ref, tracks),
+        ),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.only(bottom: 88),
+            itemCount: tracks.length,
+            itemBuilder: (context, index) =>
+                TrackTile(tracks: tracks, index: index),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _play(BuildContext context, WidgetRef ref, List<Track> tracks) {
+    if (tracks.isEmpty) return;
+    ref.read(playbackControllerProvider).playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  void _shuffle(BuildContext context, WidgetRef ref, List<Track> tracks) {
+    if (tracks.isEmpty) return;
+    final controller = ref.read(playbackControllerProvider);
+    controller.setShuffleEnabled(true);
+    controller.playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  /// A friendly, mix-specific hint for an empty mix, so the screen explains
+  /// *why* it's empty rather than just looking broken.
+  static String _emptyMessage(SmartPlaylistKind kind) {
+    switch (kind) {
+      case SmartPlaylistKind.recentlyAdded:
+        return 'Add a music folder or sync a server to fill your library.';
+      case SmartPlaylistKind.recentlyPlayed:
+        return 'Play some music and it’ll show up here.';
+      case SmartPlaylistKind.mostPlayed:
+        return 'Your most-played tracks appear here as you listen.';
+      case SmartPlaylistKind.favorites:
+        return 'Tap the heart on a track to add it here.';
+      case SmartPlaylistKind.downloaded:
+        return 'Download tracks for offline and they’ll appear here.';
+      case SmartPlaylistKind.random:
+        return 'Add some music and Linthra will shuffle up a mix.';
+      case SmartPlaylistKind.neverPlayed:
+        return 'Once you’ve heard everything, this mix will be empty.';
+    }
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.onPlay, required this.onShuffle});
+
+  final VoidCallback onPlay;
+  final VoidCallback onShuffle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: FilledButton.icon(
+              onPressed: onPlay,
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('Play'),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: FilledButton.tonalIcon(
+              onPressed: onShuffle,
+              icon: const Icon(Icons.shuffle),
+              label: const Text('Shuffle'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/smart_mixes/smart_mix_providers.dart
+++ b/lib/features/smart_mixes/smart_mix_providers.dart
@@ -1,0 +1,125 @@
+import 'dart:math';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/play_history.dart';
+import '../../core/models/smart_playlist.dart';
+import '../../core/models/track.dart';
+import '../../core/repositories/download_repository.dart';
+import '../../core/services/smart_playlist_resolver.dart';
+import '../../data/repositories/download_repository_provider.dart';
+import '../../data/repositories/library_added_store_provider.dart';
+import '../../data/repositories/music_library_repository_provider.dart';
+import '../../data/repositories/play_history_repository_provider.dart';
+import '../player/favorites_providers.dart';
+
+/// The shared resolver. Stateless and const, so every mix is computed the same
+/// way; the random seed is supplied per call by the providers below.
+const SmartPlaylistResolver _resolver = SmartPlaylistResolver();
+
+/// Streams the on-device play history for the UI; emits on every recorded play
+/// so "Recently played" / "Most played" / "Never played" stay live.
+final playHistoryProvider = StreamProvider<PlayHistory>((ref) {
+  return ref.watch(playHistoryRepositoryProvider).historyStream;
+});
+
+/// The set of fully-downloaded (offline) track ids, recomputed whenever the
+/// download status map changes, so the "Downloaded" mix tracks the cache.
+final _downloadedTrackIdsProvider = StreamProvider<Set<String>>((ref) {
+  final DownloadRepository repository = ref.watch(downloadRepositoryProvider);
+  return repository.statusStream.map((Map<String, DownloadStatus> statuses) {
+    return <String>{
+      for (final MapEntry<String, DownloadStatus> entry in statuses.entries)
+        if (entry.value == DownloadStatus.downloaded) entry.key,
+    };
+  });
+});
+
+/// The signals every (non-random) mix is derived from, gathered once. Re-runs
+/// when favourites, play history, or the downloaded set change so the mixes and
+/// their counts stay live; the catalog and added-timestamps are read on demand.
+typedef SmartPlaylistInputs = ({
+  List<Track> allTracks,
+  PlayHistory history,
+  Map<String, DateTime> addedAt,
+  Set<String> favoriteIds,
+  Set<String> downloadedIds,
+});
+
+final smartPlaylistInputsProvider =
+    FutureProvider<SmartPlaylistInputs>((ref) async {
+  // Establish every dependency synchronously, before any await, so the provider
+  // reacts to all of them (Riverpod tracks watches made during the sync phase).
+  final library = ref.watch(musicLibraryRepositoryProvider);
+  final addedStore = ref.watch(libraryAddedStoreProvider);
+  final PlayHistory history =
+      ref.watch(playHistoryProvider).valueOrNull ?? PlayHistory.empty;
+  final Set<String> favoriteIds =
+      ref.watch(favoriteIdsProvider).valueOrNull ?? const <String>{};
+  final Set<String> downloadedIds =
+      ref.watch(_downloadedTrackIdsProvider).valueOrNull ?? const <String>{};
+
+  final List<Track> allTracks = await library.getAllTracks();
+  final Map<String, DateTime> addedAt = await addedStore.load();
+
+  return (
+    allTracks: allTracks,
+    history: history,
+    addedAt: addedAt,
+    favoriteIds: favoriteIds,
+    downloadedIds: downloadedIds,
+  );
+});
+
+/// A mix paired with how many tracks it currently holds, for the list screen.
+typedef SmartMixSummary = ({SmartPlaylist mix, int trackCount});
+
+/// Every smart mix with its live track count, in display order. Shows all mixes
+/// (even empty ones) so the section is stable and discoverable; an empty mix
+/// presents a friendly empty state when opened.
+final smartMixesProvider = FutureProvider<List<SmartMixSummary>>((ref) async {
+  final SmartPlaylistInputs inputs =
+      await ref.watch(smartPlaylistInputsProvider.future);
+  return <SmartMixSummary>[
+    for (final SmartPlaylist mix in SmartPlaylist.all)
+      (mix: mix, trackCount: _resolve(mix.kind, inputs).length),
+  ];
+});
+
+/// The resolved tracks for one mix. Auto-disposed so each visit recomputes —
+/// which gives the random mix a fresh shuffle every time it's opened while
+/// keeping it stable for the duration of that visit.
+final smartPlaylistTracksProvider = FutureProvider.autoDispose
+    .family<List<Track>, SmartPlaylistKind>(
+        (ref, SmartPlaylistKind kind) async {
+  // The random mix needs only the catalog; not watching the other signals
+  // keeps it from reshuffling when an unrelated favourite or play is recorded.
+  if (kind == SmartPlaylistKind.random) {
+    final library = ref.watch(musicLibraryRepositoryProvider);
+    final List<Track> allTracks = await library.getAllTracks();
+    return _resolver.resolve(
+      kind,
+      allTracks: allTracks,
+      history: PlayHistory.empty,
+      addedAt: const <String, DateTime>{},
+      favoriteIds: const <String>{},
+      downloadedIds: const <String>{},
+      random: Random(),
+    );
+  }
+  final SmartPlaylistInputs inputs =
+      await ref.watch(smartPlaylistInputsProvider.future);
+  return _resolve(kind, inputs);
+});
+
+List<Track> _resolve(SmartPlaylistKind kind, SmartPlaylistInputs inputs) {
+  return _resolver.resolve(
+    kind,
+    allTracks: inputs.allTracks,
+    history: inputs.history,
+    addedAt: inputs.addedAt,
+    favoriteIds: inputs.favoriteIds,
+    downloadedIds: inputs.downloadedIds,
+    random: Random(),
+  );
+}

--- a/lib/features/smart_mixes/smart_mixes_screen.dart
+++ b/lib/features/smart_mixes/smart_mixes_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/routes.dart';
+import '../../core/models/smart_playlist.dart';
+import '../../shared/widgets/empty_state.dart';
+import 'smart_mix_providers.dart';
+
+/// The "Smart mixes" section: automatic, Made-by-Linthra collections built from
+/// on-device signals (library timestamps, play history, favourites, the offline
+/// cache, the catalog). Each row opens the mix's tracks with Play / Shuffle.
+class SmartMixesScreen extends ConsumerWidget {
+  const SmartMixesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<List<SmartMixSummary>> mixes =
+        ref.watch(smartMixesProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Smart mixes')),
+      body: mixes.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => const EmptyState(
+          icon: Icons.error_outline,
+          title: "Couldn't build your mixes",
+          message: 'Try again in a moment.',
+        ),
+        data: (List<SmartMixSummary> items) => ListView.builder(
+          padding: const EdgeInsets.only(bottom: 88),
+          itemCount: items.length,
+          itemBuilder: (context, index) => _SmartMixTile(summary: items[index]),
+        ),
+      ),
+    );
+  }
+}
+
+class _SmartMixTile extends StatelessWidget {
+  const _SmartMixTile({required this.summary});
+
+  final SmartMixSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color accent = theme.colorScheme.primary;
+    final int count = summary.trackCount;
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: accent.withValues(alpha: 0.12),
+        child: Icon(iconFor(summary.mix.kind), color: accent),
+      ),
+      title: Text(
+        summary.mix.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        '${summary.mix.description} · '
+        '$count ${count == 1 ? 'song' : 'songs'}',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => context.push(AppRoutes.smartMixPath(summary.mix.id)),
+    );
+  }
+
+  /// The glyph for each mix. Kept with the UI (not the model) so the domain
+  /// stays free of widget concerns.
+  static IconData iconFor(SmartPlaylistKind kind) {
+    switch (kind) {
+      case SmartPlaylistKind.recentlyAdded:
+        return Icons.library_add_outlined;
+      case SmartPlaylistKind.recentlyPlayed:
+        return Icons.history;
+      case SmartPlaylistKind.mostPlayed:
+        return Icons.trending_up;
+      case SmartPlaylistKind.favorites:
+        return Icons.favorite;
+      case SmartPlaylistKind.downloaded:
+        return Icons.download_done;
+      case SmartPlaylistKind.random:
+        return Icons.shuffle;
+      case SmartPlaylistKind.neverPlayed:
+        return Icons.auto_awesome;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,9 @@ import 'core/services/linthra_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/favorites_repository_provider.dart';
 import 'data/repositories/jellyfin_session_store_provider.dart';
+import 'data/repositories/library_added_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
+import 'data/repositories/play_history_repository_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
@@ -36,7 +38,10 @@ Future<void> main() async {
   // in-memory defaults unless they opt into these bindings.
   final container = ProviderContainer(
     overrides: [
-      driftMusicLibraryRepositoryOverride,
+      // The Drift catalog, wrapped so each scan/sync stamps newly-seen tracks
+      // with a first-seen time for the "Recently added" smart mix.
+      recordingDriftMusicLibraryRepositoryOverride,
+      sharedPreferencesLibraryAddedStoreOverride,
       sharedPreferencesSelectedMusicFolderRepositoryOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
@@ -49,6 +54,9 @@ Future<void> main() async {
       jellyfinFavoritesOverride,
       sharedPreferencesPlaylistStoreOverride,
       jellyfinPlaylistSyncOverride,
+      // Persist on-device play history (counts + last-played) for the
+      // "Recently played" / "Most played" / "Never played" smart mixes.
+      sharedPreferencesPlayHistoryStoreOverride,
       jellyfinLyricsOverride,
       // Real Chromecast backend (Android/iOS only); see cast_providers.dart.
       chromecastCastServiceOverride,

--- a/test/core/services/smart_playlist_resolver_test.dart
+++ b/test/core/services/smart_playlist_resolver_test.dart
@@ -1,0 +1,128 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/play_history.dart';
+import 'package:linthra/core/models/smart_playlist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/smart_playlist_resolver.dart';
+
+Track _t(String id) => Track(id: id, title: 'Title $id', uri: 'jellyfin:$id');
+
+List<String> _ids(List<Track> tracks) =>
+    <String>[for (final Track t in tracks) t.id];
+
+void main() {
+  // A small catalog plus the on-device signals each mix is built from.
+  final List<Track> catalog = <Track>[_t('a'), _t('b'), _t('c'), _t('d')];
+
+  final PlayHistory history = PlayHistory(
+    stats: <String, TrackPlayStats>{
+      'a': TrackPlayStats(playCount: 5, lastPlayedAt: DateTime(2024, 1, 1)),
+      'b': TrackPlayStats(playCount: 1, lastPlayedAt: DateTime(2024, 1, 3)),
+      'c': TrackPlayStats(playCount: 3, lastPlayedAt: DateTime(2024, 1, 2)),
+    },
+  );
+
+  final Map<String, DateTime> addedAt = <String, DateTime>{
+    'a': DateTime(2024, 1, 1),
+    'b': DateTime(2024, 1, 3),
+    'c': DateTime(2024, 1, 2),
+    'd': DateTime(2024, 1, 4),
+  };
+
+  List<Track> resolve(
+    SmartPlaylistKind kind, {
+    List<Track>? tracks,
+    Set<String> favoriteIds = const <String>{},
+    Set<String> downloadedIds = const <String>{},
+    int maxTracks = 100,
+    Random? random,
+  }) {
+    return SmartPlaylistResolver(maxTracks: maxTracks).resolve(
+      kind,
+      allTracks: tracks ?? catalog,
+      history: history,
+      addedAt: addedAt,
+      favoriteIds: favoriteIds,
+      downloadedIds: downloadedIds,
+      random: random,
+    );
+  }
+
+  group('SmartPlaylistResolver', () {
+    test('recently added is newest-first by first-seen time', () {
+      expect(_ids(resolve(SmartPlaylistKind.recentlyAdded)),
+          <String>['d', 'b', 'c', 'a']);
+    });
+
+    test('recently played is most-recently-played first, played-only', () {
+      // a@Jan1, b@Jan3, c@Jan2 → b, c, a; d was never played so it's excluded.
+      expect(_ids(resolve(SmartPlaylistKind.recentlyPlayed)),
+          <String>['b', 'c', 'a']);
+    });
+
+    test('most played is highest-count first', () {
+      // counts a:5, c:3, b:1 → a, c, b; d excluded.
+      expect(
+          _ids(resolve(SmartPlaylistKind.mostPlayed)), <String>['a', 'c', 'b']);
+    });
+
+    test('favorites mix uses the favorite id set', () {
+      final List<Track> result = resolve(
+        SmartPlaylistKind.favorites,
+        // 'z' isn't in the catalog and must be ignored gracefully.
+        favoriteIds: <String>{'b', 'd', 'z'},
+      );
+      expect(_ids(result), <String>['b', 'd']);
+    });
+
+    test('downloaded mix uses the cached (downloaded) id set', () {
+      final List<Track> result = resolve(
+        SmartPlaylistKind.downloaded,
+        downloadedIds: <String>{'a', 'c'},
+      );
+      expect(_ids(result), <String>['a', 'c']);
+    });
+
+    test('never played excludes anything in the play history', () {
+      // a, b, c have history; only d is never played.
+      expect(_ids(resolve(SmartPlaylistKind.neverPlayed)), <String>['d']);
+    });
+
+    test('random mix is bounded by maxTracks', () {
+      final List<Track> result =
+          resolve(SmartPlaylistKind.random, maxTracks: 2, random: Random(7));
+      expect(result, hasLength(2));
+    });
+
+    test('random mix is a permutation that does not mutate the input', () {
+      final List<Track> input = <Track>[_t('a'), _t('b'), _t('c'), _t('d')];
+      final List<String> before = _ids(input);
+      final List<Track> result = resolve(
+        SmartPlaylistKind.random,
+        tracks: input,
+        random: Random(1),
+      );
+      // Same members, input untouched.
+      expect(_ids(result).toSet(), before.toSet());
+      expect(_ids(input), before);
+    });
+
+    test('random mix is safe on an empty catalog', () {
+      expect(
+        resolve(SmartPlaylistKind.random, tracks: const <Track>[]),
+        isEmpty,
+      );
+    });
+
+    test('an empty catalog yields an empty mix for every kind', () {
+      for (final SmartPlaylistKind kind in SmartPlaylistKind.values) {
+        expect(
+          resolve(kind, tracks: const <Track>[], favoriteIds: <String>{'a'}),
+          isEmpty,
+          reason: 'kind $kind should be empty for an empty catalog',
+        );
+      }
+    });
+  });
+}

--- a/test/data/repositories/default_play_history_repository_test.dart
+++ b/test/data/repositories/default_play_history_repository_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/play_history.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/default_play_history_repository.dart';
+import 'package:linthra/data/repositories/in_memory_play_history_store.dart';
+
+Track _t(String id) => Track(id: id, title: 'Title $id', uri: 'jellyfin:$id');
+
+void main() {
+  group('DefaultPlayHistoryRepository', () {
+    late InMemoryPlayHistoryStore store;
+
+    setUp(() {
+      store = InMemoryPlayHistoryStore();
+    });
+
+    DefaultPlayHistoryRepository build({DateTime Function()? now}) {
+      final DefaultPlayHistoryRepository repository =
+          DefaultPlayHistoryRepository(store: store, now: now);
+      addTearDown(repository.dispose);
+      return repository;
+    }
+
+    test('records a completed play, incrementing the count', () async {
+      final DefaultPlayHistoryRepository repository = build();
+
+      await repository.recordCompletion(_t('a'));
+      expect(repository.current.playCountFor('a'), 1);
+
+      await repository.recordCompletion(_t('a'));
+      expect(repository.current.playCountFor('a'), 2);
+    });
+
+    test('updates last-played time on completion', () async {
+      DateTime clock = DateTime(2024, 1, 1, 9);
+      final DefaultPlayHistoryRepository repository = build(now: () => clock);
+
+      await repository.recordCompletion(_t('a'));
+      expect(repository.current.lastPlayedFor('a'), DateTime(2024, 1, 1, 9));
+
+      clock = DateTime(2024, 1, 1, 10);
+      await repository.recordCompletion(_t('a'));
+      expect(repository.current.lastPlayedFor('a'), DateTime(2024, 1, 1, 10));
+    });
+
+    test('recently played reflects completion order, most-recent first',
+        () async {
+      DateTime clock = DateTime(2024, 1, 1, 0);
+      DateTime tick() {
+        clock = clock.add(const Duration(minutes: 1));
+        return clock;
+      }
+
+      final DefaultPlayHistoryRepository repository = build(now: tick);
+
+      await repository.recordCompletion(_t('a'));
+      await repository.recordCompletion(_t('b'));
+      await repository.recordCompletion(_t('c'));
+      expect(repository.current.recentlyPlayedIds, <String>['c', 'b', 'a']);
+
+      // Replaying 'a' moves it back to the front.
+      await repository.recordCompletion(_t('a'));
+      expect(repository.current.recentlyPlayedIds, <String>['a', 'c', 'b']);
+    });
+
+    test('most played orders by count', () async {
+      final DefaultPlayHistoryRepository repository = build();
+      await repository.recordCompletion(_t('a'));
+      await repository.recordCompletion(_t('b'));
+      await repository.recordCompletion(_t('b'));
+      await repository.recordCompletion(_t('b'));
+      await repository.recordCompletion(_t('c'));
+      await repository.recordCompletion(_t('c'));
+      expect(repository.current.mostPlayedIds, <String>['b', 'c', 'a']);
+    });
+
+    test('historyStream emits the initial history then every change', () async {
+      final DefaultPlayHistoryRepository repository = build();
+      final List<int> counts = <int>[];
+      final sub = repository.historyStream
+          .listen((PlayHistory h) => counts.add(h.playCountFor('a')));
+
+      await Future<void>.delayed(Duration.zero); // initial (empty) emission
+      await repository.recordCompletion(_t('a'));
+      await repository.recordCompletion(_t('a'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(counts, containsAllInOrder(<int>[0, 1, 2]));
+      await sub.cancel();
+    });
+
+    test('persists through the store across instances', () async {
+      final DefaultPlayHistoryRepository first = build();
+      await first.recordCompletion(_t('a'));
+      await first.recordCompletion(_t('a'));
+
+      // A fresh repository over the same store sees the persisted count.
+      final DefaultPlayHistoryRepository second = build();
+      // Touch the stream to force a load.
+      await second.historyStream.first;
+      expect(second.current.playCountFor('a'), 2);
+    });
+
+    test('only the track id is recorded — never its uri', () async {
+      const String token = 'secret-token-abc123';
+      final DefaultPlayHistoryRepository repository = build();
+      const Track tokenized =
+          Track(id: 'a', title: 'A', uri: 'https://x/?t=$token');
+      await repository.recordCompletion(tokenized);
+
+      expect(repository.current.stats.containsKey('a'), isTrue);
+      // The stats carry only count + time, never the uri/token.
+      final TrackPlayStats stats = repository.current.stats['a']!;
+      expect(stats.playCount, 1);
+      expect(stats.toString(), isNot(contains(token)));
+    });
+  });
+}

--- a/test/data/repositories/recording_music_library_repository_test.dart
+++ b/test/data/repositories/recording_music_library_repository_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_library_added_store.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/recording_music_library_repository.dart';
+
+Track _t(String id) => Track(id: id, title: 'Title $id', uri: 'jellyfin:$id');
+
+void main() {
+  group('RecordingMusicLibraryRepository', () {
+    late InMemoryMusicLibraryRepository delegate;
+    late InMemoryLibraryAddedStore addedStore;
+
+    setUp(() {
+      delegate = InMemoryMusicLibraryRepository();
+      addedStore = InMemoryLibraryAddedStore();
+    });
+
+    RecordingMusicLibraryRepository build({DateTime Function()? now}) {
+      return RecordingMusicLibraryRepository(
+        delegate: delegate,
+        addedStore: addedStore,
+        now: now,
+      );
+    }
+
+    Future<void> sync(
+      RecordingMusicLibraryRepository repo,
+      List<Track> tracks, {
+      String sourceId = 'jellyfin',
+    }) {
+      return repo.upsertCatalog(
+        sourceId: sourceId,
+        tracks: tracks,
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+    }
+
+    test('stamps newly-seen tracks with the current time on sync', () async {
+      final DateTime now = DateTime(2024, 6, 1, 12);
+      final RecordingMusicLibraryRepository repo = build(now: () => now);
+
+      await sync(repo, <Track>[_t('a'), _t('b')]);
+
+      final Map<String, DateTime> added = await addedStore.load();
+      expect(added['a'], now);
+      expect(added['b'], now);
+      // The catalog write itself still went through to the delegate.
+      expect((await repo.getAllTracks()).map((Track t) => t.id),
+          containsAll(<String>['a', 'b']));
+    });
+
+    test('preserves the original time for tracks seen in a previous sync',
+        () async {
+      DateTime clock = DateTime(2024, 6, 1);
+      final RecordingMusicLibraryRepository repo = build(now: () => clock);
+
+      await sync(repo, <Track>[_t('a')]);
+      final DateTime firstSeenA = (await addedStore.load())['a']!;
+
+      // A later re-sync that still includes 'a' and adds 'b'.
+      clock = DateTime(2024, 6, 10);
+      await sync(repo, <Track>[_t('a'), _t('b')]);
+
+      final Map<String, DateTime> added = await addedStore.load();
+      // 'a' keeps its original first-seen time; only 'b' gets the new time.
+      expect(added['a'], firstSeenA);
+      expect(added['b'], DateTime(2024, 6, 10));
+    });
+
+    test('forgets the timestamp when a track is removed', () async {
+      final RecordingMusicLibraryRepository repo =
+          build(now: () => DateTime(2024, 6, 1));
+      await sync(repo, <Track>[_t('a'), _t('b')]);
+
+      await repo.removeTracks(<String>['a']);
+
+      final Map<String, DateTime> added = await addedStore.load();
+      expect(added.containsKey('a'), isFalse);
+      expect(added.containsKey('b'), isTrue);
+    });
+
+    test('the timestamp store never holds a track uri', () async {
+      final RecordingMusicLibraryRepository repo = build();
+      await sync(repo, const <Track>[
+        Track(id: 'a', title: 'A', uri: 'https://server/stream?token=secret'),
+      ]);
+      final Map<String, DateTime> added = await addedStore.load();
+      expect(added.keys, <String>['a']);
+      expect(added.toString(), isNot(contains('secret')));
+    });
+  });
+}

--- a/test/data/repositories/shared_preferences_library_added_store_test.dart
+++ b/test/data/repositories/shared_preferences_library_added_store_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/shared_preferences_library_added_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SharedPreferencesLibraryAddedStore', () {
+    test('round-trips first-seen timestamps', () async {
+      const SharedPreferencesLibraryAddedStore store =
+          SharedPreferencesLibraryAddedStore();
+      final Map<String, DateTime> addedAt = <String, DateTime>{
+        'a': DateTime(2024, 3, 1),
+        'b': DateTime(2024, 3, 2),
+      };
+
+      await store.save(addedAt);
+      final Map<String, DateTime> loaded = await store.load();
+
+      expect(loaded['a'], DateTime(2024, 3, 1));
+      expect(loaded['b'], DateTime(2024, 3, 2));
+    });
+
+    test('returns empty for no stored value', () async {
+      const SharedPreferencesLibraryAddedStore store =
+          SharedPreferencesLibraryAddedStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('a corrupt record reads as nothing recorded', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'library_added_v1': 'not json {',
+      });
+      const SharedPreferencesLibraryAddedStore store =
+          SharedPreferencesLibraryAddedStore();
+      expect(await store.load(), isEmpty);
+    });
+
+    test('stores only ids and timestamps — never a track uri', () async {
+      const SharedPreferencesLibraryAddedStore store =
+          SharedPreferencesLibraryAddedStore();
+      await store.save(<String, DateTime>{'track-1': DateTime(2024, 1, 1)});
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final String raw = prefs.getString('library_added_v1') ?? '';
+      expect(raw, contains('track-1'));
+      expect(raw, isNot(contains('http')));
+      expect(raw, isNot(contains('jellyfin:')));
+    });
+  });
+}

--- a/test/data/repositories/shared_preferences_play_history_store_test.dart
+++ b/test/data/repositories/shared_preferences_play_history_store_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/play_history.dart';
+import 'package:linthra/data/repositories/shared_preferences_play_history_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SharedPreferencesPlayHistoryStore', () {
+    test('round-trips counts and last-played times', () async {
+      const SharedPreferencesPlayHistoryStore store =
+          SharedPreferencesPlayHistoryStore();
+      final PlayHistory history = PlayHistory(
+        stats: <String, TrackPlayStats>{
+          'a': TrackPlayStats(playCount: 3, lastPlayedAt: DateTime(2024, 5, 1)),
+          'b': TrackPlayStats(playCount: 1, lastPlayedAt: DateTime(2024, 5, 2)),
+        },
+      );
+
+      await store.save(history);
+      final PlayHistory loaded = await store.load();
+
+      expect(loaded.playCountFor('a'), 3);
+      expect(loaded.lastPlayedFor('a'), DateTime(2024, 5, 1));
+      expect(loaded.playCountFor('b'), 1);
+      expect(loaded.lastPlayedFor('b'), DateTime(2024, 5, 2));
+    });
+
+    test('returns empty for no stored value', () async {
+      const SharedPreferencesPlayHistoryStore store =
+          SharedPreferencesPlayHistoryStore();
+      expect((await store.load()).stats, isEmpty);
+    });
+
+    test('a corrupt record reads as no history', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'play_history_v1': 'not json {',
+      });
+      const SharedPreferencesPlayHistoryStore store =
+          SharedPreferencesPlayHistoryStore();
+      expect((await store.load()).stats, isEmpty);
+    });
+
+    test('drops malformed entries (bad/zero count) without crashing', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'play_history_v1':
+            '{"a":{"c":2,"t":1700000000000},"b":{"c":0,"t":1},"c":"nope"}',
+      });
+      const SharedPreferencesPlayHistoryStore store =
+          SharedPreferencesPlayHistoryStore();
+      final PlayHistory loaded = await store.load();
+      expect(loaded.stats.keys, <String>['a']);
+      expect(loaded.playCountFor('a'), 2);
+    });
+
+    test('the persisted document holds only ids/counts/times — no token',
+        () async {
+      // Even if a track carried a tokenized uri, play history stores only the
+      // id, so the persisted JSON can never leak it.
+      const String token = 'super-secret-token-1234567890';
+      const SharedPreferencesPlayHistoryStore store =
+          SharedPreferencesPlayHistoryStore();
+      // The id is the only track field play history ever sees.
+      await store.save(PlayHistory(
+        stats: <String, TrackPlayStats>{
+          'track-1': TrackPlayStats(
+            playCount: 1,
+            lastPlayedAt: DateTime(2024, 1, 1),
+          ),
+        },
+      ));
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final String raw = prefs.getString('play_history_v1') ?? '';
+      expect(raw, contains('track-1'));
+      expect(raw, isNot(contains(token)));
+      expect(raw, isNot(contains('http')));
+    });
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -16,8 +16,15 @@ import 'package:linthra/core/services/local_playback_controller.dart';
 /// [ActivePlaybackController] in cast-routing tests: while suspended, queue
 /// changes update the current track without "playing" locally.
 class FakePlaybackController implements LocalPlaybackController {
-  FakePlaybackController({PlaybackState initial = PlaybackState.idle})
-      : _state = initial;
+  FakePlaybackController({
+    PlaybackState initial = PlaybackState.idle,
+    this.onTrackCompleted,
+  }) : _state = initial;
+
+  /// Mirrors the production controller's completion callback: invoked with the
+  /// finished track when [completeCurrent] runs, so play-history wiring can be
+  /// exercised without `just_audio`.
+  final void Function(Track track)? onTrackCompleted;
 
   final StreamController<PlaybackState> _states =
       StreamController<PlaybackState>.broadcast();
@@ -171,6 +178,10 @@ class FakePlaybackController implements LocalPlaybackController {
   /// Test seam mirroring the production controller's completion handling: drives
   /// what plays when the current track finishes, honouring the repeat mode.
   void completeCurrent() {
+    // The finished track is still current here, before any advance — matching
+    // JustAudioPlaybackController._onCompleted.
+    final Track? finished = _queue.current;
+    if (finished != null) onTrackCompleted?.call(finished);
     switch (_repeatMode) {
       case RepeatMode.one:
         _playCurrent();

--- a/test/features/player/play_history_recording_test.dart
+++ b/test/features/player/play_history_recording_test.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/default_play_history_repository.dart';
+import 'package:linthra/data/repositories/in_memory_play_history_store.dart';
+
+import 'fake_playback_controller.dart';
+
+Track _t(String id) => Track(id: id, title: 'Title $id', uri: 'jellyfin:$id');
+
+/// Wires the controller's completion callback to play history exactly as
+/// `localPlaybackControllerProvider` does in the app, then drives completions
+/// through the fake controller's `completeCurrent` test seam (which mirrors
+/// `JustAudioPlaybackController._onCompleted`).
+void main() {
+  group('play history recording on completion', () {
+    late InMemoryPlayHistoryStore store;
+    late DefaultPlayHistoryRepository history;
+    late FakePlaybackController controller;
+
+    setUp(() {
+      store = InMemoryPlayHistoryStore();
+      history = DefaultPlayHistoryRepository(store: store);
+      controller = FakePlaybackController(
+        onTrackCompleted: (Track track) =>
+            unawaited(history.recordCompletion(track)),
+      );
+      addTearDown(history.dispose);
+      addTearDown(controller.dispose);
+    });
+
+    test('completing a track increments its play count', () async {
+      await controller.playTracks(<Track>[_t('a'), _t('b')]);
+
+      controller.completeCurrent(); // 'a' finishes, 'b' starts
+      await Future<void>.delayed(Duration.zero);
+      expect(history.current.playCountFor('a'), 1);
+      expect(history.current.playCountFor('b'), 0);
+
+      controller.completeCurrent(); // 'b' finishes (queue ends)
+      await Future<void>.delayed(Duration.zero);
+      expect(history.current.playCountFor('b'), 1);
+    });
+
+    test('repeat-one counts each completed loop as a play', () async {
+      await controller.playTracks(<Track>[_t('a')]);
+      controller.setRepeatMode(RepeatMode.one);
+
+      controller.completeCurrent();
+      controller.completeCurrent();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(history.current.playCountFor('a'), 2);
+    });
+
+    test('skipping a track does NOT count as a play', () async {
+      await controller.playTracks(<Track>[_t('a'), _t('b')]);
+
+      await controller.skipToNext(); // user skip, not a completion
+      await Future<void>.delayed(Duration.zero);
+
+      expect(history.current.hasPlayed('a'), isFalse);
+      expect(history.current.hasPlayed('b'), isFalse);
+    });
+  });
+}

--- a/test/features/playlists/playlists_screen_test.dart
+++ b/test/features/playlists/playlists_screen_test.dart
@@ -43,6 +43,12 @@ void main() {
           findsOneWidget);
     });
 
+    testWidgets('pins the Smart mixes section', (tester) async {
+      await _pump(tester, InMemoryPlaylistStore());
+      expect(find.text('Smart mixes'), findsOneWidget);
+      expect(find.text('Made by Linthra'), findsOneWidget);
+    });
+
     testWidgets('lists existing playlists with a song count', (tester) async {
       final InMemoryPlaylistStore store = InMemoryPlaylistStore();
       await store.save(<Playlist>[

--- a/test/features/smart_mixes/smart_mix_detail_screen_test.dart
+++ b/test/features/smart_mixes/smart_mix_detail_screen_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/smart_mixes/smart_mix_detail_screen.dart';
+
+import '../library/fake_music_library_repository.dart';
+import '../player/fake_playback_controller.dart';
+
+const List<Track> _tracks = <Track>[
+  Track(id: 'a', title: 'Song A', uri: 'jellyfin:a', artistName: 'Artist A'),
+  Track(id: 'b', title: 'Song B', uri: 'jellyfin:b', artistName: 'Artist B'),
+  Track(id: 'c', title: 'Song C', uri: 'jellyfin:c', artistName: 'Artist C'),
+];
+
+GoRouter _router(String kindId) {
+  return GoRouter(
+    initialLocation: '/',
+    routes: <RouteBase>[
+      GoRoute(
+        path: '/',
+        builder: (_, __) => SmartMixDetailScreen(kindId: kindId),
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (_, __) => const Scaffold(body: Text('player-screen')),
+      ),
+    ],
+  );
+}
+
+Future<FakePlaybackController> _pump(
+  WidgetTester tester, {
+  required String kindId,
+  List<Track> tracks = _tracks,
+}) async {
+  final FakePlaybackController controller = FakePlaybackController();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: MaterialApp.router(routerConfig: _router(kindId)),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+void main() {
+  group('SmartMixDetailScreen', () {
+    testWidgets('shows the mix title and its tracks', (tester) async {
+      await _pump(tester, kindId: 'recentlyAdded');
+
+      expect(find.text('Recently added'), findsOneWidget);
+      expect(find.text('Song A'), findsOneWidget);
+      expect(find.text('Song B'), findsOneWidget);
+      expect(find.text('Song C'), findsOneWidget);
+    });
+
+    testWidgets('Play queues the mix and opens the player', (tester) async {
+      final FakePlaybackController controller =
+          await _pump(tester, kindId: 'recentlyAdded');
+
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack, isNotNull);
+      expect(controller.playedTracks, isNotEmpty);
+      expect(find.text('player-screen'), findsOneWidget);
+    });
+
+    testWidgets('Shuffle turns shuffle on and starts playback', (tester) async {
+      final FakePlaybackController controller =
+          await _pump(tester, kindId: 'recentlyAdded');
+
+      await tester.tap(find.text('Shuffle'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.shuffleEnabled, isTrue);
+      expect(controller.state.currentTrack, isNotNull);
+      expect(find.text('player-screen'), findsOneWidget);
+    });
+
+    testWidgets('tapping a track plays from there', (tester) async {
+      final FakePlaybackController controller =
+          await _pump(tester, kindId: 'recentlyAdded');
+
+      await tester.tap(find.text('Song B'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack?.id, 'b');
+      expect(find.text('player-screen'), findsOneWidget);
+    });
+
+    testWidgets('an empty mix shows a friendly empty state', (tester) async {
+      // Nothing has been played, so "Recently played" is empty.
+      await _pump(tester, kindId: 'recentlyPlayed');
+
+      expect(find.text('Nothing here yet'), findsOneWidget);
+      expect(find.text('Play'), findsNothing);
+    });
+
+    testWidgets('an unknown mix id shows "Mix not found"', (tester) async {
+      await _pump(tester, kindId: 'bogus');
+
+      expect(find.text('Mix not found'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/smart_mixes/smart_mixes_screen_test.dart
+++ b/test/features/smart_mixes/smart_mixes_screen_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/smart_mixes/smart_mix_detail_screen.dart';
+import 'package:linthra/features/smart_mixes/smart_mixes_screen.dart';
+
+import '../library/fake_music_library_repository.dart';
+import '../player/fake_playback_controller.dart';
+
+const List<Track> _tracks = <Track>[
+  Track(id: 'a', title: 'Song A', uri: 'jellyfin:a'),
+  Track(id: 'b', title: 'Song B', uri: 'jellyfin:b'),
+  Track(id: 'c', title: 'Song C', uri: 'jellyfin:c'),
+];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.smartMixes,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.smartMixes,
+        builder: (_, __) => const SmartMixesScreen(),
+        routes: <RouteBase>[
+          GoRoute(
+            path: ':kind',
+            builder: (_, GoRouterState s) =>
+                SmartMixDetailScreen(kindId: s.pathParameters['kind']!),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: AppRoutes.player,
+        builder: (_, __) => const Scaffold(body: Text('player-screen')),
+      ),
+    ],
+  );
+}
+
+Future<void> _pump(WidgetTester tester, {List<Track> tracks = _tracks}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SmartMixesScreen', () {
+    testWidgets('lists every smart mix', (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Recently added'), findsOneWidget);
+      expect(find.text('Recently played'), findsOneWidget);
+      expect(find.text('Most played'), findsOneWidget);
+      expect(find.text('Favorites'), findsOneWidget);
+      expect(find.text('Downloaded'), findsOneWidget);
+      expect(find.text('Random mix'), findsOneWidget);
+      expect(find.text('Never played'), findsOneWidget);
+    });
+
+    testWidgets('shows a live track count per mix', (tester) async {
+      await _pump(tester);
+
+      // Catalog-wide mixes count all 3 tracks; signal-based mixes are empty
+      // until the user plays / likes / downloads something.
+      expect(find.text('New in your library · 3 songs'), findsOneWidget);
+      expect(find.text('A fresh shuffle every time · 3 songs'), findsOneWidget);
+      expect(find.text('Jump back in · 0 songs'), findsOneWidget);
+    });
+
+    testWidgets('tapping a mix opens its tracks', (tester) async {
+      await _pump(tester);
+
+      await tester.tap(find.text('Recently added'));
+      await tester.pumpAndSettle();
+
+      // The detail screen's Play action plus the tracks confirm we navigated.
+      expect(find.text('Play'), findsOneWidget);
+      expect(find.text('Shuffle'), findsOneWidget);
+      expect(find.text('Song A'), findsOneWidget);
+      expect(find.text('Song B'), findsOneWidget);
+      expect(find.text('Song C'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **"Smart mixes"** (Made-by-Linthra) section under the Playlists tab — automatic playlists that need no manual curation, built from data the app already has. Each mix opens to a track list with **Play / Shuffle** and tap-to-play, and works across **local, Jellyfin, and Navidrome/Subsonic** tracks wherever the underlying data exists.

Seven mixes:

| Mix | Signal |
| --- | --- |
| Recently added | First-seen timestamp stamped on each scan/sync |
| Recently played | On-device play history (`lastPlayedAt`) |
| Most played | On-device play history (`playCount`) |
| Favorites | Existing favourites repository |
| Downloaded | Offline download/cache state |
| Random mix | Bounded shuffle of the catalog (fresh each visit) |
| Never played | Tracks absent from play history |

### Play history (new)
- Records `playCount` + `lastPlayedAt` on **track completion** — hooked at the engine's completion handler, the one place that can tell a genuine end from a skip. Skips don't count; each repeat-one loop does.
- Exposed via `PlayHistoryRepository` (stream + `recordCompletion`), persisted with `shared_preferences`.
- Writes are serialised so two quick completions can't lose a count.

### "Recently added"
- A thin `RecordingMusicLibraryRepository` decorator stamps newly-seen track ids with a first-seen time on every `upsertCatalog` (so a routine re-sync never resets the order), preserving existing timestamps and forgetting removed ones.

### Architecture
- Pure `SmartPlaylistResolver` turns the signals into each mix's ordered list (fully unit-tested).
- Riverpod providers gather the signals; the random mix is `autoDispose` so it reshuffles per visit but stays stable while open.
- New screens under `lib/features/smart_mixes/`; reuses the existing `TrackTile` and Play/Shuffle header.

### Privacy
- Play history and added-timestamps **stay on the device** (no telemetry, no server upload) and store **only non-secret track ids/counts/times** — never a `uri`, token, or authenticated URL.
- Resolved mixes use catalog `uri`s, which are opaque ids (`jellyfin:<id>` / `subsonic:<id>` / local path) — the authenticated stream URL is minted only at play time and never stored.

### Out of scope (unchanged)
No provider expansion, no Cast changes (cast suspends the engine, so cast plays simply aren't counted), no release-workflow changes, no Drift schema change.

## Test plan
- [x] `flutter pub get`
- [x] `dart format --set-exit-if-changed .` (clean)
- [x] `flutter analyze` (no issues)
- [x] `flutter test` (1100 passed)

New tests:
- [x] Each smart mix returns the expected tracks (`smart_playlist_resolver_test.dart`)
- [x] Play count updates after completion; recently-played order updates (`default_play_history_repository_test.dart`, `play_history_recording_test.dart`)
- [x] A skip does **not** count; repeat-one counts each loop
- [x] Downloaded mix uses cached ids; favorites mix uses favourite state
- [x] Random mix is bounded, safe on empty, and doesn't mutate its input
- [x] No tokens/authenticated URLs in persisted play-history / added state
- [x] Smart mixes list + detail screens render, navigate, Play/Shuffle work

## Docs
- `docs/smart-mixes.md`; README feature bullet + docs link (removed "smart playlists" from the Later roadmap).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGDWPeM9oBzHPWTJJDE2DM)_