### PR TITLE
Add ReplayGain volume normalization

### DIFF
--- a/docs/volume-normalization.md
+++ b/docs/volume-normalization.md
@@ -1,0 +1,83 @@
+# Volume normalization (ReplayGain)
+
+Linthra can even out the loudness of tracks during playback so a quiet ballad
+and a loud single sit closer together, instead of you reaching for the volume
+between songs. It does this with **ReplayGain** metadata and is **off by
+default** — audio is never altered unless you turn it on in
+**Settings → Playback → Normalize volume**.
+
+## What it does
+
+- Reads a track's ReplayGain loudness metadata (gain in dB, plus an optional
+  peak) into the `ReplayGain` model (`lib/core/models/replay_gain.dart`).
+- At play time the engine applies a **safe linear volume multiplier** derived
+  from that gain (`ReplayGain.linearVolume`).
+- It is applied **per track** as each track loads, and re-applied immediately
+  when you flip the setting — no track change needed.
+
+## Safety guarantees
+
+These are enforced in `ReplayGain.linearVolume` and covered by tests
+(`test/core/models/replay_gain_test.dart`):
+
+1. **Files are never modified.** Normalization only sets the player's runtime
+   volume. Nothing is re-encoded, no tags are written, and nothing is uploaded.
+2. **No clipping.** When a peak is known, the gain is capped so the loudest
+   sample can't exceed full scale. And because the engine can only attenuate
+   (see the limitation below), applying a gain can never push audio into
+   clipping.
+3. **Safe default.** When a track carries no ReplayGain data, or the setting is
+   off, playback uses full volume (`1.0`) — i.e. the original, untouched audio.
+
+## just_audio limitation: attenuation only
+
+The playback engine is [`just_audio`], whose `setVolume` accepts a value in the
+range **`0.0`–`1.0`**. It can turn a track **down** but **cannot amplify above
+the source level**.
+
+ReplayGain gains are usually **negative** (most masters are louder than the
+reference level), so the common case — turning loud tracks **down** to match —
+works as intended. But a **positive** gain (a quiet track that ReplayGain wants
+to turn **up**) cannot be fully applied: it is clamped to full volume and plays
+at its original level rather than being boosted.
+
+In practice this means tracks converge **down toward the quieter ones**, not up.
+This is a deliberate, clip-safe trade-off, not a bug. A future engine with
+pre-amp/gain headroom (or an explicit pre-amp setting) could lift the ceiling;
+until then the ceiling is `1.0`.
+
+There is intentionally **no equalizer** and no album/track mode switch in the
+UI yet — the model supports both `ReplayGainMode.track` and `.album` (album
+mode falls back to track gain and vice-versa), but the playback path uses track
+mode.
+
+## Supported sources and formats
+
+Normalization applies to whatever loudness metadata a `Track` carries in its
+`replayGain` field. Population of that field depends on the source:
+
+| Source                | ReplayGain populated? | Notes |
+| --------------------- | --------------------- | ----- |
+| On this device (local) | Not yet               | Local tag parsing (ID3 `TXXX:REPLAYGAIN_*`, Vorbis `REPLAYGAIN_*`/`R128_*`) has not landed yet (see `lib/core/sources/local/local_track_mapper.dart`). When it does, the gain/peak read from tags flows straight into `Track.replayGain`. |
+| Jellyfin              | Not yet               | The current item DTO doesn't carry a normalization-gain field; reading one is a follow-up and is out of scope here ("no provider expansion"). |
+| Navidrome / Subsonic  | Not yet               | Same as above. |
+
+Because the plumbing is source-agnostic, **enabling tag/metadata reading in any
+one source is all that's needed** for normalization to take effect there — no
+change to the settings, the engine, or the gain math. Until then the toggle is
+present and safe, and simply has nothing to act on (every track normalizes to
+full volume).
+
+Formats are not restricted by Linthra: any container/codec `just_audio` can play
+is eligible; what matters is whether ReplayGain metadata is available for the
+track.
+
+## Local vs. remote playback
+
+The gain is applied the same way regardless of where audio comes from — local
+files, Android SAF documents, the offline cache, or a remote stream — because it
+acts on the single engine volume after the source URI is resolved. Casting is
+unaffected: while a cast receiver owns playback the local engine is suspended,
+so Linthra does not touch the receiver's volume.
+
+[`just_audio`]: https://pub.dev/packages/just_audio

--- a/lib/core/models/replay_gain.dart
+++ b/lib/core/models/replay_gain.dart
@@ -1,0 +1,124 @@
+import 'dart:math' as math;
+
+/// Which ReplayGain reference to normalize against.
+///
+///  - [track]: each track is leveled independently. Best for shuffle/mixed
+///    playback so every song lands near the same loudness.
+///  - [album]: the album's single gain is applied to every track, preserving the
+///    intended loudness *relationship* between tracks on the album.
+enum ReplayGainMode { track, album }
+
+/// ReplayGain loudness metadata for a track, as written by taggers/servers.
+///
+/// Gains are in **decibels** relative to the ReplayGain reference loudness
+/// (positive means "turn up", negative means "turn down"). Peaks are the
+/// track/album's maximum sample amplitude as a **linear** value where `1.0` is
+/// full scale; a peak above `1.0` means the master already clips.
+///
+/// This is a pure value type — it carries the numbers but does not itself touch
+/// the audio engine. [linearVolume] turns it into the safe multiplier the
+/// playback layer applies. Everything is nullable because real-world files often
+/// carry only some of the four fields (e.g. track gain but no peak).
+class ReplayGain {
+  const ReplayGain({
+    this.trackGainDb,
+    this.trackPeak,
+    this.albumGainDb,
+    this.albumPeak,
+  });
+
+  /// No ReplayGain data — the safe default for a track whose source didn't
+  /// provide any. [linearVolume] returns `1.0` (no change) for this.
+  static const ReplayGain none = ReplayGain();
+
+  /// Per-track gain in dB, or null when the source didn't provide it.
+  final double? trackGainDb;
+
+  /// Per-track peak amplitude (linear, `1.0` == full scale), or null.
+  final double? trackPeak;
+
+  /// Per-album gain in dB, or null when the source didn't provide it.
+  final double? albumGainDb;
+
+  /// Per-album peak amplitude (linear, `1.0` == full scale), or null.
+  final double? albumPeak;
+
+  /// Whether this carries no usable gain at all (so normalization is a no-op).
+  bool get isEmpty => trackGainDb == null && albumGainDb == null;
+
+  /// The gain in dB to apply for [mode], falling back to the other reference
+  /// when the preferred one is missing (album mode uses track gain when the file
+  /// has no album gain, and vice versa), so a half-tagged file still levels.
+  double? gainDbFor(ReplayGainMode mode) {
+    switch (mode) {
+      case ReplayGainMode.track:
+        return trackGainDb ?? albumGainDb;
+      case ReplayGainMode.album:
+        return albumGainDb ?? trackGainDb;
+    }
+  }
+
+  /// The peak to use alongside [gainDbFor], following the same fallback so the
+  /// clipping guard always pairs with the gain it's guarding.
+  double? peakFor(ReplayGainMode mode) {
+    switch (mode) {
+      case ReplayGainMode.track:
+        return trackPeak ?? albumPeak;
+      case ReplayGainMode.album:
+        return albumPeak ?? trackPeak;
+    }
+  }
+
+  /// The safe linear volume multiplier (in `0.0..maxVolume`) to apply for this
+  /// track's ReplayGain.
+  ///
+  /// Three rules keep it safe:
+  ///  1. **No data → no change.** Missing gain returns [maxVolume] (`1.0`), so a
+  ///     track without ReplayGain plays untouched rather than guessed-at.
+  ///  2. **Never clip.** When a peak is known, the gain is capped so the loudest
+  ///     sample can't exceed full scale (`gain ≤ 1 / peak`).
+  ///  3. **Attenuate only.** The result is clamped to `maxVolume` (default
+  ///     `1.0`). `just_audio` exposes volume as `0.0..1.0` and cannot amplify
+  ///     past the source level, so a *positive* gain (quiet track) can't be
+  ///     fully applied — it simply plays at its original level. Loud tracks
+  ///     (negative gain) are turned down as intended. This is the documented
+  ///     trade-off, not a bug; see docs/volume-normalization.md.
+  double linearVolume({
+    ReplayGainMode mode = ReplayGainMode.track,
+    double maxVolume = 1.0,
+  }) {
+    final double ceiling = maxVolume.clamp(0.0, 1.0).toDouble();
+    final double? gainDb = gainDbFor(mode);
+    if (gainDb == null) return ceiling;
+
+    double linear = math.pow(10, gainDb / 20).toDouble();
+
+    final double? peak = peakFor(mode);
+    if (peak != null && peak > 0) {
+      // Peak limiting: keep peak * gain ≤ full scale so applying the gain can
+      // never push a sample into clipping.
+      linear = math.min(linear, 1.0 / peak);
+    }
+
+    return linear.clamp(0.0, ceiling).toDouble();
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ReplayGain &&
+          other.trackGainDb == trackGainDb &&
+          other.trackPeak == trackPeak &&
+          other.albumGainDb == albumGainDb &&
+          other.albumPeak == albumPeak);
+
+  @override
+  int get hashCode =>
+      Object.hash(trackGainDb, trackPeak, albumGainDb, albumPeak);
+
+  @override
+  String toString() => isEmpty
+      ? 'ReplayGain.none'
+      : 'ReplayGain(trackGainDb: $trackGainDb, trackPeak: $trackPeak, '
+          'albumGainDb: $albumGainDb, albumPeak: $albumPeak)';
+}

--- a/lib/core/models/track.dart
+++ b/lib/core/models/track.dart
@@ -1,3 +1,5 @@
+import 'replay_gain.dart';
+
 /// A single playable track, independent of where it came from.
 ///
 /// [uri] may point to a local file path or a remote resource. Keeping it
@@ -13,6 +15,7 @@ class Track {
     this.duration = Duration.zero,
     this.trackNumber,
     this.artworkUri,
+    this.replayGain = ReplayGain.none,
   });
 
   final String id;
@@ -24,6 +27,10 @@ class Track {
   final int? trackNumber;
   final Uri? artworkUri;
 
+  /// Loudness metadata used for volume normalization. Defaults to
+  /// [ReplayGain.none]; sources that read it populate this when available.
+  final ReplayGain replayGain;
+
   Track copyWith({
     String? id,
     String? title,
@@ -33,6 +40,7 @@ class Track {
     Duration? duration,
     int? trackNumber,
     Uri? artworkUri,
+    ReplayGain? replayGain,
   }) {
     return Track(
       id: id ?? this.id,
@@ -43,6 +51,7 @@ class Track {
       duration: duration ?? this.duration,
       trackNumber: trackNumber ?? this.trackNumber,
       artworkUri: artworkUri ?? this.artworkUri,
+      replayGain: replayGain ?? this.replayGain,
     );
   }
 

--- a/lib/core/repositories/playback_preferences.dart
+++ b/lib/core/repositories/playback_preferences.dart
@@ -1,0 +1,15 @@
+/// The user's playback preferences.
+///
+/// Kept behind an interface (like [DownloadPreferences]) so the playback layer
+/// can consult the user's choices without binding to a storage plugin.
+///
+///  - "Normalize volume": when on, playback applies a track's ReplayGain so
+///    songs play at a more even loudness. Off by default — the safe choice, so
+///    audio is never altered unless the listener opts in.
+abstract interface class PlaybackPreferences {
+  /// Whether volume normalization (ReplayGain) is applied during playback.
+  /// Defaults to `false`, so audio plays untouched out of the box.
+  Future<bool> normalizeVolume();
+
+  Future<void> setNormalizeVolume(bool value);
+}

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -8,6 +8,7 @@ import '../models/playback_queue.dart';
 import '../models/playback_source.dart';
 import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
+import '../models/replay_gain.dart';
 import '../models/track.dart';
 import 'local_playable_uri_resolver.dart';
 import 'local_playback_controller.dart';
@@ -103,6 +104,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   // across track changes and are mirrored onto every emitted state.
   bool _shuffleEnabled = false;
   RepeatMode _repeatMode = RepeatMode.off;
+
+  // Whether ReplayGain volume normalization is applied. Off by default so audio
+  // is never altered until the listener opts in. Mirrored onto the engine's
+  // volume whenever a track loads (and immediately when toggled).
+  bool _normalizeVolume = false;
 
   // How many times the current track has been retried after a mid-stream
   // failure. Reset when a fresh track loads and when playback reaches `playing`,
@@ -382,6 +388,39 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _emit(_state.copyWith(repeatMode: _repeatMode));
   }
 
+  @override
+  void setVolumeNormalizationEnabled(bool enabled) {
+    if (enabled == _normalizeVolume) return;
+    _normalizeVolume = enabled;
+    // Re-level whatever is loaded so toggling takes effect now, not only on the
+    // next track. Best-effort and silent: a volume tweak must never surface as a
+    // playback error or interrupt audio.
+    unawaited(_applyVolume());
+  }
+
+  /// The engine volume (0.0–1.0) to use for [track] given whether normalization
+  /// is on. With it off, or no track loaded, returns 1.0 (full, untouched).
+  /// With it on, returns the track's safe ReplayGain multiplier — attenuation
+  /// only and clip-safe (see [ReplayGain.linearVolume]).
+  @visibleForTesting
+  static double volumeFor(Track? track, {required bool normalizeVolume}) {
+    if (!normalizeVolume || track == null) return 1.0;
+    return track.replayGain.linearVolume();
+  }
+
+  /// Pushes the target volume for the current track onto the engine. A cast
+  /// receiver owns its own volume while suspended, so this is a no-op then.
+  Future<void> _applyVolume() async {
+    if (_suspended) return;
+    final double volume =
+        volumeFor(_queue.current, normalizeVolume: _normalizeVolume);
+    try {
+      await _player.setVolume(volume);
+    } catch (_) {
+      // A volume failure must never break playback; leave the prior volume.
+    }
+  }
+
   /// Decides what to play when the current track finishes, per [_repeatMode]:
   /// repeat-one replays the same track, repeat-all advances (wrapping past the
   /// end), and off advances until the queue runs out and then settles on
@@ -503,6 +542,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       // is turned into an authenticated stream URL (or a friendly error) before
       // it ever reaches here.
       await _player.setUrl(resolved.uri.toString());
+      // Level this track before it's heard: apply its ReplayGain (or full
+      // volume when normalization is off), so the very first moment of audio is
+      // already at the right loudness rather than jumping after a beat.
+      await _applyVolume();
       // Resuming on this device after casting picks up where the receiver left
       // off, paused unless asked to play.
       if (startAt > Duration.zero) await _player.seek(startAt);

--- a/lib/core/services/local_playback_controller.dart
+++ b/lib/core/services/local_playback_controller.dart
@@ -25,4 +25,10 @@ abstract interface class LocalPlaybackController implements PlaybackController {
   /// Wraps the queue back to its first track and (re)loads it. Used to honour
   /// repeat-all when a cast track finishes at the end of the queue.
   Future<void> restartQueue();
+
+  /// Turns ReplayGain volume normalization on or off. When on, the engine
+  /// attenuates each loaded track by its ReplayGain so songs play at a more
+  /// even loudness; when off, audio plays untouched. Applies to the currently
+  /// loaded track immediately, so toggling takes effect without a track change.
+  void setVolumeNormalizationEnabled(bool enabled);
 }

--- a/lib/data/repositories/in_memory_playback_preferences.dart
+++ b/lib/data/repositories/in_memory_playback_preferences.dart
@@ -1,0 +1,17 @@
+import '../../core/repositories/playback_preferences.dart';
+
+/// A non-persistent [PlaybackPreferences] for development and tests.
+class InMemoryPlaybackPreferences implements PlaybackPreferences {
+  InMemoryPlaybackPreferences({bool normalizeVolume = false})
+      : _normalizeVolume = normalizeVolume;
+
+  bool _normalizeVolume;
+
+  @override
+  Future<bool> normalizeVolume() async => _normalizeVolume;
+
+  @override
+  Future<void> setNormalizeVolume(bool value) async {
+    _normalizeVolume = value;
+  }
+}

--- a/lib/data/repositories/playback_preferences_provider.dart
+++ b/lib/data/repositories/playback_preferences_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/playback_preferences.dart';
+import 'in_memory_playback_preferences.dart';
+import 'shared_preferences_playback_preferences.dart';
+
+/// The user's playback preferences (currently "Normalize volume"). In-memory by
+/// default so tests and dev runs need no plugins; the app persists them via
+/// `shared_preferences` through [sharedPreferencesPlaybackPreferencesOverride].
+final playbackPreferencesProvider = Provider<PlaybackPreferences>((ref) {
+  return InMemoryPlaybackPreferences();
+});
+
+final sharedPreferencesPlaybackPreferencesOverride =
+    playbackPreferencesProvider.overrideWithValue(
+  const SharedPreferencesPlaybackPreferences(),
+);

--- a/lib/data/repositories/shared_preferences_playback_preferences.dart
+++ b/lib/data/repositories/shared_preferences_playback_preferences.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/playback_preferences.dart';
+
+/// A [PlaybackPreferences] backed by `shared_preferences`. The single choice is
+/// a small bool, so it lives next to the other small user choices in the
+/// key/value store rather than in the SQLite catalog.
+class SharedPreferencesPlaybackPreferences implements PlaybackPreferences {
+  const SharedPreferencesPlaybackPreferences();
+
+  static const String _normalizeVolumeKey = 'playback_normalize_volume';
+
+  @override
+  Future<bool> normalizeVolume() async {
+    final prefs = await SharedPreferences.getInstance();
+    // Default false: never alter audio unless the listener opts in.
+    return prefs.getBool(_normalizeVolumeKey) ?? false;
+  }
+
+  @override
+  Future<void> setNormalizeVolume(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_normalizeVolumeKey, value);
+  }
+}

--- a/lib/features/settings/playback/normalize_volume_controller.dart
+++ b/lib/features/settings/playback/normalize_volume_controller.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../data/repositories/playback_preferences_provider.dart';
+
+/// Owns the "Normalize volume" switch: loads the persisted value and writes
+/// changes back through [PlaybackPreferences]. When on, playback applies each
+/// track's ReplayGain so songs play at a more even loudness; off (the default)
+/// leaves audio untouched.
+class NormalizeVolumeController extends AsyncNotifier<bool> {
+  @override
+  Future<bool> build() {
+    return ref.read(playbackPreferencesProvider).normalizeVolume();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    await ref.read(playbackPreferencesProvider).setNormalizeVolume(value);
+    state = AsyncData<bool>(value);
+  }
+}
+
+final normalizeVolumeControllerProvider =
+    AsyncNotifierProvider<NormalizeVolumeController, bool>(
+  NormalizeVolumeController.new,
+);

--- a/lib/features/settings/playback/playback_settings_section.dart
+++ b/lib/features/settings/playback/playback_settings_section.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import 'normalize_volume_controller.dart';
+
+/// The "Playback" card on the Settings screen.
+///
+/// Hosts the "Normalize volume" choice. With it off (the default) audio plays
+/// untouched; with it on, playback applies each track's ReplayGain so songs sit
+/// at a more even loudness. The widget never touches the audio engine itself —
+/// it only writes the user's choice back through the preference controller; the
+/// playback layer reads it and applies the (clip-safe, attenuation-only) gain.
+class PlaybackSettingsSection extends StatelessWidget {
+  const PlaybackSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.graphic_eq, color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Playback', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Normalize volume evens out loudness between tracks using '
+              'ReplayGain tags when a track has them. It only turns loud tracks '
+              'down (never up) and never changes the files themselves.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            const NormalizeVolumeTile(contentPadding: EdgeInsets.zero),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The "Normalize volume" switch. Writes the preference through
+/// [normalizeVolumeControllerProvider]; the playback engine reads it and applies
+/// the gain. Disabled while the stored value is still loading.
+class NormalizeVolumeTile extends ConsumerWidget {
+  const NormalizeVolumeTile({super.key, this.contentPadding});
+
+  final EdgeInsetsGeometry? contentPadding;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<bool> normalize =
+        ref.watch(normalizeVolumeControllerProvider);
+    final bool isOn = normalize.valueOrNull ?? false;
+    return SwitchListTile(
+      contentPadding: contentPadding,
+      secondary: const Icon(Icons.volume_up_outlined),
+      title: const Text('Normalize volume'),
+      subtitle: const Text(
+        'Play tracks at a more even loudness using their ReplayGain tags. '
+        'Off by default.',
+      ),
+      value: isOn,
+      onChanged: normalize.isLoading
+          ? null
+          : (value) => ref
+              .read(normalizeVolumeControllerProvider.notifier)
+              .setEnabled(value),
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -8,6 +8,7 @@ import 'cache/cache_settings_section.dart';
 import 'diagnostics/diagnostics_settings_section.dart';
 import 'jellyfin/jellyfin_settings_section.dart';
 import 'network/network_settings_section.dart';
+import 'playback/playback_settings_section.dart';
 import 'precache/precache_settings_section.dart';
 import 'subsonic/subsonic_settings_section.dart';
 
@@ -28,6 +29,8 @@ class SettingsScreen extends StatelessWidget {
           SubsonicSettingsSection(),
           SizedBox(height: AppSpacing.md),
           CacheSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          PlaybackSettingsSection(),
           SizedBox(height: AppSpacing.md),
           NetworkSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'data/repositories/jellyfin_session_store_provider.dart';
 import 'data/repositories/library_added_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/play_history_repository_provider.dart';
+import 'data/repositories/playback_preferences_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
@@ -20,6 +21,7 @@ import 'features/player/favorites_providers.dart';
 import 'features/player/lyrics_providers.dart';
 import 'features/player/player_providers.dart';
 import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
+import 'features/settings/playback/normalize_volume_controller.dart';
 import 'features/settings/subsonic/subsonic_settings_controller.dart';
 
 Future<void> main() async {
@@ -45,6 +47,7 @@ Future<void> main() async {
       sharedPreferencesSelectedMusicFolderRepositoryOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
+      sharedPreferencesPlaybackPreferencesOverride,
       fileSystemOfflineFileStoreOverride,
       remoteTrackDownloaderOverride,
       currentlyPlayingTrackIdOverride,
@@ -88,6 +91,20 @@ Future<void> main() async {
   // stream URL in memory so a skip starts faster — without touching the offline
   // cache or marking anything downloaded. Side-effect-only, like smart pre-cache.
   container.read(streamPreloadServiceProvider);
+
+  // Mirror the user's "Normalize volume" choice onto the local audio engine,
+  // seeding the persisted value now and pushing every later toggle. The engine
+  // applies the clip-safe ReplayGain attenuation; with the choice off (the
+  // default) audio plays untouched.
+  container.listen<AsyncValue<bool>>(
+    normalizeVolumeControllerProvider,
+    (_, next) {
+      container
+          .read(localPlaybackControllerProvider)
+          .setVolumeNormalizationEnabled(next.valueOrNull ?? false);
+    },
+    fireImmediately: true,
+  );
 
   // Warm the persisted Jellyfin session before the first frame so a synced
   // remote track can stream on the first tap — without it, playback would race

--- a/test/core/models/replay_gain_test.dart
+++ b/test/core/models/replay_gain_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/replay_gain.dart';
+
+void main() {
+  group('ReplayGain.linearVolume', () {
+    test('no data plays at full volume (untouched)', () {
+      expect(ReplayGain.none.linearVolume(), 1.0);
+      expect(const ReplayGain(trackPeak: 0.9).linearVolume(), 1.0);
+    });
+
+    test('a negative gain attenuates', () {
+      // -6 dB ≈ half amplitude.
+      final double v = const ReplayGain(trackGainDb: -6.0).linearVolume();
+      expect(v, closeTo(0.501, 0.01));
+      expect(v, lessThan(1.0));
+    });
+
+    test('a positive gain cannot amplify past full (attenuation only)', () {
+      // +6 dB would be ~2.0 linear, but just_audio can't amplify, so it's
+      // clamped to 1.0 — a quiet track plays at its original level.
+      expect(const ReplayGain(trackGainDb: 6.0).linearVolume(), 1.0);
+    });
+
+    test('peak limiting keeps a positive gain from clipping', () {
+      // A modest positive gain that, with this peak, would push past full
+      // scale: the result is capped at 1/peak (still ≤ 1.0 here anyway).
+      final double v =
+          const ReplayGain(trackGainDb: 3.0, trackPeak: 0.8).linearVolume();
+      // 1/0.8 = 1.25, but the global ≤1.0 clamp wins.
+      expect(v, 1.0);
+    });
+
+    test('peak below the gain bounds the result when attenuating', () {
+      // Negative gain (0.5 linear) with a loud peak: peak limit 1/0.95 ≈ 1.05
+      // doesn't bind, so the gain itself applies.
+      final double v =
+          const ReplayGain(trackGainDb: -6.0, trackPeak: 0.95).linearVolume();
+      expect(v, closeTo(0.501, 0.01));
+    });
+
+    test('result never leaves 0.0..1.0', () {
+      final double loud = const ReplayGain(trackGainDb: 60.0).linearVolume();
+      final double quiet = const ReplayGain(trackGainDb: -120.0).linearVolume();
+      expect(loud, inInclusiveRange(0.0, 1.0));
+      expect(quiet, inInclusiveRange(0.0, 1.0));
+    });
+  });
+
+  group('ReplayGain mode selection', () {
+    const both = ReplayGain(
+      trackGainDb: -8.0,
+      trackPeak: 0.99,
+      albumGainDb: -5.0,
+      albumPeak: 0.95,
+    );
+
+    test('track mode prefers track gain', () {
+      expect(both.gainDbFor(ReplayGainMode.track), -8.0);
+      expect(both.peakFor(ReplayGainMode.track), 0.99);
+    });
+
+    test('album mode prefers album gain', () {
+      expect(both.gainDbFor(ReplayGainMode.album), -5.0);
+      expect(both.peakFor(ReplayGainMode.album), 0.95);
+    });
+
+    test('album mode falls back to track gain when album gain is missing', () {
+      const trackOnly = ReplayGain(trackGainDb: -7.0, trackPeak: 0.9);
+      expect(trackOnly.gainDbFor(ReplayGainMode.album), -7.0);
+      expect(trackOnly.peakFor(ReplayGainMode.album), 0.9);
+    });
+
+    test('track mode falls back to album gain when track gain is missing', () {
+      const albumOnly = ReplayGain(albumGainDb: -4.0, albumPeak: 0.92);
+      expect(albumOnly.gainDbFor(ReplayGainMode.track), -4.0);
+      expect(albumOnly.peakFor(ReplayGainMode.track), 0.92);
+    });
+  });
+
+  group('ReplayGain value semantics', () {
+    test('isEmpty reflects absence of any gain', () {
+      expect(ReplayGain.none.isEmpty, isTrue);
+      expect(const ReplayGain(trackPeak: 0.9).isEmpty, isTrue);
+      expect(const ReplayGain(trackGainDb: -3.0).isEmpty, isFalse);
+      expect(const ReplayGain(albumGainDb: -3.0).isEmpty, isFalse);
+    });
+
+    test('equality and hashCode are value-based', () {
+      const a = ReplayGain(trackGainDb: -6.0, trackPeak: 0.9);
+      const b = ReplayGain(trackGainDb: -6.0, trackPeak: 0.9);
+      const c = ReplayGain(trackGainDb: -7.0, trackPeak: 0.9);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+    });
+  });
+}

--- a/test/core/services/playback_controller_volume_test.dart
+++ b/test/core/services/playback_controller_volume_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/replay_gain.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+
+void main() {
+  Track track({ReplayGain gain = ReplayGain.none}) =>
+      Track(id: 't', title: 'T', uri: 'file:///t.flac', replayGain: gain);
+
+  group('JustAudioPlaybackController.volumeFor', () {
+    test('full volume when normalization is off, whatever the gain', () {
+      final loud = track(gain: const ReplayGain(trackGainDb: -12.0));
+      expect(
+        JustAudioPlaybackController.volumeFor(loud, normalizeVolume: false),
+        1.0,
+      );
+    });
+
+    test('full volume when there is no track', () {
+      expect(
+        JustAudioPlaybackController.volumeFor(null, normalizeVolume: true),
+        1.0,
+      );
+    });
+
+    test('full volume for a track with no ReplayGain even when on', () {
+      expect(
+        JustAudioPlaybackController.volumeFor(track(), normalizeVolume: true),
+        1.0,
+      );
+    });
+
+    test('attenuates a loud track when normalization is on', () {
+      final loud = track(gain: const ReplayGain(trackGainDb: -6.0));
+      final v =
+          JustAudioPlaybackController.volumeFor(loud, normalizeVolume: true);
+      expect(v, lessThan(1.0));
+      expect(v, closeTo(0.501, 0.01));
+    });
+
+    test('never amplifies a quiet track (clamped to full)', () {
+      final quiet = track(gain: const ReplayGain(trackGainDb: 6.0));
+      expect(
+        JustAudioPlaybackController.volumeFor(quiet, normalizeVolume: true),
+        1.0,
+      );
+    });
+  });
+}

--- a/test/data/repositories/playback_preferences_test.dart
+++ b/test/data/repositories/playback_preferences_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_playback_preferences.dart';
+import 'package:linthra/data/repositories/shared_preferences_playback_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('normalizeVolume preference', () {
+    test('in-memory defaults to off and round-trips', () async {
+      final prefs = InMemoryPlaybackPreferences();
+      expect(await prefs.normalizeVolume(), isFalse);
+
+      await prefs.setNormalizeVolume(true);
+      expect(await prefs.normalizeVolume(), isTrue);
+
+      await prefs.setNormalizeVolume(false);
+      expect(await prefs.normalizeVolume(), isFalse);
+    });
+
+    test('in-memory honours an initial value', () async {
+      final prefs = InMemoryPlaybackPreferences(normalizeVolume: true);
+      expect(await prefs.normalizeVolume(), isTrue);
+    });
+
+    group('shared_preferences', () {
+      setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+      test('defaults to off when never set', () async {
+        const prefs = SharedPreferencesPlaybackPreferences();
+        expect(await prefs.normalizeVolume(), isFalse);
+      });
+
+      test('persists the choice across instances', () async {
+        const prefs = SharedPreferencesPlaybackPreferences();
+        await prefs.setNormalizeVolume(true);
+
+        const reopened = SharedPreferencesPlaybackPreferences();
+        expect(await reopened.normalizeVolume(), isTrue);
+      });
+    });
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -175,6 +175,15 @@ class FakePlaybackController implements LocalPlaybackController {
     emit(_state.copyWith(repeatMode: _repeatMode));
   }
 
+  /// The last value passed to [setVolumeNormalizationEnabled], so wiring tests
+  /// can assert the preference reaches the engine. Null until first set.
+  bool? normalizeVolumeEnabled;
+
+  @override
+  void setVolumeNormalizationEnabled(bool enabled) {
+    normalizeVolumeEnabled = enabled;
+  }
+
   /// Test seam mirroring the production controller's completion handling: drives
   /// what plays when the current track finishes, honouring the repeat mode.
   void completeCurrent() {

--- a/test/features/settings/playback/playback_settings_section_test.dart
+++ b/test/features/settings/playback/playback_settings_section_test.dart
@@ -45,8 +45,7 @@ void main() {
 
     testWidgets('defaults off', (tester) async {
       await pump(tester);
-      final SwitchListTile tile =
-          tester.widget(find.byType(SwitchListTile));
+      final SwitchListTile tile = tester.widget(find.byType(SwitchListTile));
       expect(tile.value, isFalse);
     });
 

--- a/test/features/settings/playback/playback_settings_section_test.dart
+++ b/test/features/settings/playback/playback_settings_section_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_playback_preferences.dart';
+import 'package:linthra/data/repositories/playback_preferences_provider.dart';
+import 'package:linthra/features/settings/playback/normalize_volume_controller.dart';
+import 'package:linthra/features/settings/playback/playback_settings_section.dart';
+
+void main() {
+  group('PlaybackSettingsSection', () {
+    late InMemoryPlaybackPreferences preferences;
+
+    Future<ProviderContainer> pump(
+      WidgetTester tester, {
+      bool normalizeVolume = false,
+    }) async {
+      preferences =
+          InMemoryPlaybackPreferences(normalizeVolume: normalizeVolume);
+      final container = ProviderContainer(
+        overrides: [
+          playbackPreferencesProvider.overrideWithValue(preferences),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: PlaybackSettingsSection()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets('shows the playback copy and the normalize switch',
+        (tester) async {
+      await pump(tester);
+
+      expect(find.text('Playback'), findsOneWidget);
+      expect(find.text('Normalize volume'), findsOneWidget);
+      expect(find.textContaining('ReplayGain'), findsWidgets);
+    });
+
+    testWidgets('defaults off', (tester) async {
+      await pump(tester);
+      final SwitchListTile tile =
+          tester.widget(find.byType(SwitchListTile));
+      expect(tile.value, isFalse);
+    });
+
+    testWidgets('toggling on persists the choice', (tester) async {
+      final container = await pump(tester);
+      expect(await preferences.normalizeVolume(), isFalse);
+
+      await tester.tap(find.text('Normalize volume'));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.normalizeVolume(), isTrue);
+      expect(
+        container.read(normalizeVolumeControllerProvider).valueOrNull,
+        isTrue,
+      );
+    });
+
+    testWidgets('toggling off persists the choice', (tester) async {
+      final container = await pump(tester, normalizeVolume: true);
+      expect(await preferences.normalizeVolume(), isTrue);
+
+      await tester.tap(find.text('Normalize volume'));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.normalizeVolume(), isFalse);
+      expect(
+        container.read(normalizeVolumeControllerProvider).valueOrNull,
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **"Normalize volume"** playback setting that applies a track's **ReplayGain** during playback, evening out loudness between songs.

- **Off by default** — audio is never altered unless the listener turns it on (Settings → Playback → Normalize volume).
- **Clip-safe and attenuation-only.** `ReplayGain.linearVolume()` converts gain (dB) to a linear multiplier, caps it by the known peak, and clamps to `1.0`. Because `just_audio`'s `setVolume` can't amplify above the source, loud tracks are turned **down** but quiet tracks are never boosted — a documented, clip-proof trade-off.
- **Files are never modified and no metadata is uploaded.** Normalization only sets the engine's runtime volume.
- Applies to local, cached, and remote playback alike; cast sessions are left untouched (the receiver owns its own volume).

## What's included (per scope)

- **ReplayGain metadata model** — `lib/core/models/replay_gain.dart` (track/album gain + peaks, mode fallback, safe `linearVolume`), plus a `Track.replayGain` field.
- **Playback gain application** — `setVolumeNormalizationEnabled` on `LocalPlaybackController`; the engine levels each track on load and re-levels immediately on toggle. Best-effort/silent so a volume tweak never interrupts playback.
- **Settings toggle** — `PlaybackPreferences` (shared_preferences + in-memory), `NormalizeVolumeController`, a "Playback" settings card, wired through `main.dart`.
- **Tests** — model math/fallbacks/equality, preference round-trip, controller `volumeFor`, and the settings widget.
- **Docs** — `docs/volume-normalization.md` (safety guarantees, the just_audio limitation, supported sources/formats).
- **No equalizer**, **no provider expansion.**

### Note on "read when available"

The plumbing is source-agnostic and ready, but **no source populates `Track.replayGain` yet**: local tag parsing hasn't landed, and the Jellyfin/Subsonic DTOs don't carry a normalization-gain field. Enabling metadata reading in any one source is all that's needed for normalization to take effect there — no further changes to the setting, engine, or gain math. This is documented in `docs/volume-normalization.md`. Until then the toggle is present and safe and simply normalizes every track to full volume.

## Test plan

- [x] `flutter analyze` clean on changed files
- [x] Full suite green (1125 tests)
- [ ] Manual: toggle in Settings persists across restart; verify a track tagged with negative ReplayGain plays attenuated (requires a source that populates `replayGain`)

https://claude.ai/code/session_01NMmCqgRcMKAcTmc4YiFCHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMmCqgRcMKAcTmc4YiFCHp)_