### PR TITLE
Derive release version from the git tag

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -50,6 +50,21 @@ name: Android Release Build
 #   linthra-v0.1.0-alpha.1-debug-signed.apk / .aab
 #   linthra-v0.1.0-alpha.1-release-signed.apk / .aab
 #
+# Version derivation (tag builds):
+#
+#   * The tag is the single source of truth for the release version. A "Derive
+#     version from tag" step runs `tool/version_from_tag.dart` on GITHUB_REF_NAME
+#     to produce LINTHRA_VERSION_NAME (e.g. 0.1.0-alpha.16) and a strictly
+#     monotonic LINTHRA_VERSION_CODE (e.g. 100016). A malformed tag fails the run
+#     there, before any build, so a release never ships stale/guessed metadata.
+#   * The build bakes those in: `--build-name`/`--build-number` set Android's
+#     versionName/versionCode, and `--dart-define=LINTHRA_VERSION_NAME=...` sets
+#     the in-app version (AppInfo.version) to the same value. A verification step
+#     then confirms the built APK actually carries the derived version.
+#   * Manual `workflow_dispatch` runs pass none of these, so they build the
+#     pubspec.yaml version and are named without a tag (never passed off as a
+#     tagged release). See docs/release-process.md §1 for the full strategy.
+#
 # See docs/release-signing.md for the required secrets and keystore handling,
 # and docs/release-process.md for the overall release flow.
 on:
@@ -86,6 +101,8 @@ jobs:
       trigger: ${{ steps.mode.outputs.trigger }}
       prerelease: ${{ steps.mode.outputs.prerelease }}
       asset_base: ${{ steps.mode.outputs.asset_base }}
+      version_name: ${{ steps.version.outputs.LINTHRA_VERSION_NAME }}
+      version_code: ${{ steps.version.outputs.LINTHRA_VERSION_CODE }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -182,11 +199,80 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      # Tag is the single source of truth for the release version. Parse it once
+      # (tool/version_from_tag.dart), export the result for the build steps, and
+      # fail fast here on a malformed tag — before any expensive build. The grep
+      # guarantees only the two expected KEY=VALUE lines ever reach the env file.
+      - name: Derive version from tag
+        if: ${{ steps.mode.outputs.trigger == 'tag' }}
+        id: version
+        run: |
+          set -euo pipefail
+          if ! out="$(dart run tool/version_from_tag.dart "$GITHUB_REF_NAME")"; then
+            echo "::error::Could not derive a version from tag '$GITHUB_REF_NAME' (see the error above). Use a tag like v0.1.0-alpha.16, v0.1.0-rc.1, or v1.2.3."
+            exit 1
+          fi
+          echo "Derived from tag '$GITHUB_REF_NAME':"
+          echo "$out"
+          printf '%s\n' "$out" | grep -E '^LINTHRA_VERSION_(NAME|CODE)=' >> "$GITHUB_ENV"
+          printf '%s\n' "$out" | grep -E '^LINTHRA_VERSION_(NAME|CODE)=' >> "$GITHUB_OUTPUT"
+
+      # On a tag build, bake the tag-derived version into both the Android build
+      # metadata (--build-name/--build-number) and the in-app version
+      # (--dart-define), so the APK/AAB and Settings/About all agree. A manual
+      # run passes neither, building the pubspec.yaml version instead.
       - name: Build release APK
-        run: flutter build apk --release
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
+            flutter build apk --release \
+              --build-name="$LINTHRA_VERSION_NAME" \
+              --build-number="$LINTHRA_VERSION_CODE" \
+              --dart-define=LINTHRA_VERSION_NAME="$LINTHRA_VERSION_NAME"
+          else
+            flutter build apk --release
+          fi
 
       - name: Build release AAB
-        run: flutter build appbundle --release
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
+            flutter build appbundle --release \
+              --build-name="$LINTHRA_VERSION_NAME" \
+              --build-number="$LINTHRA_VERSION_CODE" \
+              --dart-define=LINTHRA_VERSION_NAME="$LINTHRA_VERSION_NAME"
+          else
+            flutter build appbundle --release
+          fi
+
+      # Confirm the built APK actually carries the tag-derived version, so a
+      # release can never ship stale metadata. Uses aapt from the Android SDK the
+      # build just used; if it cannot be located the check warns rather than
+      # blocks (a missing tool is not a version mismatch).
+      - name: Verify APK version matches the tag
+        if: ${{ steps.mode.outputs.trigger == 'tag' }}
+        run: |
+          set -euo pipefail
+          apk="build/app/outputs/flutter-apk/app-release.apk"
+          sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+          aapt=""
+          if [ -n "$sdk" ]; then
+            aapt="$(find "$sdk"/build-tools -name aapt -type f 2>/dev/null | sort -V | tail -n1 || true)"
+          fi
+          if [ -z "$aapt" ]; then
+            echo "::warning::aapt not found (ANDROID_HOME/ANDROID_SDK_ROOT); skipping APK version verification."
+            exit 0
+          fi
+          badging="$("$aapt" dump badging "$apk")"
+          got_name="$(printf '%s\n' "$badging" | sed -n "s/.*versionName='\([^']*\)'.*/\1/p")"
+          got_code="$(printf '%s\n' "$badging" | sed -n "s/.*versionCode='\([^']*\)'.*/\1/p")"
+          echo "APK reports versionName=$got_name versionCode=$got_code"
+          echo "Tag derived  versionName=$LINTHRA_VERSION_NAME versionCode=$LINTHRA_VERSION_CODE"
+          if [ "$got_name" != "$LINTHRA_VERSION_NAME" ] || [ "$got_code" != "$LINTHRA_VERSION_CODE" ]; then
+            echo "::error::Built APK version ($got_name/$got_code) does not match the tag-derived version ($LINTHRA_VERSION_NAME/$LINTHRA_VERSION_CODE)."
+            exit 1
+          fi
+          echo "Verified: APK version matches the tag-derived version."
 
       # Give the outputs descriptive, self-documenting names that carry the
       # version (tag) and the signing label, so a debug-signed build can never
@@ -220,6 +306,13 @@ jobs:
             echo ""
             echo "**Trigger:** ${{ steps.mode.outputs.trigger }}${{ github.event_name == 'push' && format(' (tag {0})', github.ref_name) || '' }}"
             echo ""
+            if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
+              echo "**Version:** \`${LINTHRA_VERSION_NAME}\` (versionName) / \`${LINTHRA_VERSION_CODE}\` (versionCode), derived from the tag. The APK/AAB metadata and the in-app Settings/About version all use this value."
+              echo ""
+            else
+              echo "**Version:** from \`pubspec.yaml\` (manual build — not a tagged release)."
+              echo ""
+            fi
             echo "**Artifacts:** \`${{ steps.mode.outputs.asset_base }}.apk\`, \`${{ steps.mode.outputs.asset_base }}.aab\`"
             echo ""
             if [ "${{ steps.mode.outputs.signing }}" = "release-signed" ]; then

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,6 +62,7 @@ android {
         applicationId = "io.github.thezupzup.linthra"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
+        // From Flutter (pubspec.yaml); tag release builds override these via --build-name/--build-number derived from the git tag — see docs/release-process.md §1.
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/docs/development.md
+++ b/docs/development.md
@@ -174,6 +174,28 @@ stable tags **require release signing** and only attach to a Release you created
 manually. Full versioning/tagging flow is in
 [release-process.md](release-process.md).
 
+### Versioning
+
+Local `flutter build`/`flutter run` use the `pubspec.yaml` version, and so does
+the in-app **Settings ▸ About** version (`AppInfo.version`). A **tagged** release
+build instead derives the version from the tag and bakes it into both the
+APK/AAB metadata and the in-app display, so they always match — see
+[release-process.md §1](release-process.md#1-versioning-model).
+
+Preview what a tag maps to, or reproduce a tag build locally:
+
+```bash
+# What versionName/versionCode does a tag produce?
+dart run tool/version_from_tag.dart v0.1.0-alpha.16
+# LINTHRA_VERSION_NAME=0.1.0-alpha.16
+# LINTHRA_VERSION_CODE=100016
+
+# Build exactly as a tag build would (version baked into metadata + in-app UI):
+flutter build apk --release \
+  --build-name=0.1.0-alpha.16 --build-number=100016 \
+  --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.16
+```
+
 ### Signing status
 
 Release signing is **wired up but not yet provisioned**. `android/app/build.gradle`

--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -117,11 +117,18 @@ process (and the GitHub-Release flow) is in
 [docs/release-process.md](./release-process.md), and it is consistent with
 [fdroid-readiness.md §6](./fdroid-readiness.md):
 
-1. **Single source of truth:** `pubspec.yaml` `version: x.y.z+<versionCode>`
-   (currently `0.1.0+1`). `versionName` = `x.y.z`, `versionCode` = the integer
-   after `+`.
-2. **`versionCode` must increase monotonically** on every release; never reuse
-   or decrease it.
+1. **Source of truth:** for a release the **git tag** drives
+   `versionName`/`versionCode` (derived by `tool/version_from_tag.dart`, see
+   [release-process.md §1](./release-process.md#1-versioning-model));
+   `pubspec.yaml` `version: x.y.z+<versionCode>` is the local/dev default.
+   **Note:** F-Droid builds from source and does not run our workflow, so its
+   `flutter build` takes the version from `pubspec.yaml` — set the metadata
+   `versionCode`/`versionName` to the tag-derived values and either bump
+   `pubspec.yaml` at the tagged commit or have the recipe pass
+   `--build-name`/`--build-number` (see the F-Droid caveat in
+   [fdroid-readiness.md §6](./fdroid-readiness.md)).
+2. **`versionCode` increases monotonically** by construction (the encoding can
+   never go backwards); never reuse or decrease it.
 3. **Tag format suggestion:** annotated tag `vX.Y.Z` (e.g. `v0.1.0`) on the
    commit to be built. This matches the `UpdateCheckMode`/`AutoUpdateMode`
    recommendation in §2.

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -150,15 +150,27 @@ F-Droid builds from a git tag. Summary (the canonical, step-by-step process —
 including the GitHub-Release flow — is in
 [docs/release-process.md](./release-process.md)):
 
-1. Keep version in `pubspec.yaml` as the single source of truth
-   (`version: x.y.z+<versionCode>`; currently `0.1.0+1`).
-2. Tag releases as `vX.Y.Z` (annotated tag) on the commit to be built.
-3. Each release bumps both `versionName` (`x.y.z`) and `versionCode` (the
-   integer after `+`); `versionCode` must increase monotonically.
+1. The **git tag** is the source of truth for a release's version; the build
+   derives `versionName`/`versionCode` from it (see
+   [release-process.md §1](./release-process.md#1-versioning-model)).
+   `pubspec.yaml` only sets the version for local/dev builds.
+2. Tag releases as `vX.Y.Z[-suffix]` (annotated tag) on the commit to be built.
+3. `versionCode` is derived to be **strictly monotonic** automatically (encoded
+   from the version); never reuse or decrease it.
 4. Add a matching changelog file at
-   `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
+   `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`, named by the
+   **derived** code (e.g. `100016.txt` for `v0.1.0-alpha.16`).
 5. The F-Droid recipe should use `AutoUpdateMode`/`UpdateCheckMode` tied to tags
    so new tagged releases are picked up.
+
+> **F-Droid caveat.** F-Droid builds **from source** at the tag and does **not**
+> run our release workflow, so a plain `flutter build` there takes the version
+> from `pubspec.yaml`, not the tag. When Linthra is submitted, keep the F-Droid
+> build consistent by either (a) bumping `pubspec.yaml` to the tag-derived
+> `versionName`/`versionCode` at the tagged commit, or (b) having the recipe's
+> build pass `--build-name`/`--build-number` and pinning the metadata
+> `versionCode` to the derived value. This affects only the F-Droid channel — the
+> GitHub-Release build already bakes in the tag-derived version.
 
 ## 7. Metadata checklist
 

--- a/docs/play-store-readiness.md
+++ b/docs/play-store-readiness.md
@@ -225,27 +225,31 @@ internal/closed testing.
 
 Play enforces a **strictly increasing `versionCode`** per package: an upload
 with an equal or lower code than any previous upload (on any track) is rejected.
-Linthra's versioning model already supports this safely:
+Linthra's versioning model supports this safely:
 
-- `pubspec.yaml` is the **single source of truth**:
-  `version: x.y.z+<versionCode>` (currently `0.1.0-alpha.9+9`). Android reads
-  both `versionName` and `versionCode` from Flutter — they are not hard-coded in
-  Gradle.
+- **The Git tag is the source of truth for a release.** The release build derives
+  `versionName`/`versionCode` from the tag and bakes them in — the strictly
+  monotonic, fully-encoded `versionCode` (e.g. `v0.1.0-alpha.16` → `100016`)
+  satisfies Play's strictly-increasing requirement by construction. `pubspec.yaml`
+  only sets the version for local/dev builds. See
+  [release-process.md §1](./release-process.md#1-versioning-model).
 - The in-app About/Settings string (`AppInfo.version` in
-  `lib/core/app_info.dart`) mirrors the `versionName`. A CI test
-  (`test/core/app_info_version_test.dart`) **fails the build if the two drift**,
-  so the displayed version can never silently diverge from the shipped one. This
-  guard already exists; **no new versioning code is needed for Play.**
+  `lib/core/app_info.dart`) shows the **effective** version: the tag-derived value
+  on a release build (via `--dart-define`), or a `const` mirror of `pubspec.yaml`
+  on dev builds that a CI test (`test/core/app_info_version_test.dart`) **fails
+  the build if it drifts**. Either way the displayed version matches the shipped
+  one. **No manual versioning edits are needed for Play.**
 
 **Per-upload checklist (in addition to
 [release-process.md §3](./release-process.md#3-pre-tag-checklist)):**
 
+- [ ] The upload is built from a `vX.Y.Z[-suffix]` tag, so `versionName`,
+      `versionCode`, and the in-app `AppInfo.version` are all tag-derived and
+      consistent — no manual version edits.
 - [ ] `versionCode` is **strictly greater** than every code ever uploaded to
-      Play — across **all** tracks, not just the current one. Once a code is
-      consumed by an upload it can never be reused, even if that upload is
-      discarded.
-- [ ] `versionName` and `AppInfo.version` are bumped together in the same commit
-      (the drift test enforces this).
+      Play — across **all** tracks, not just the current one (the encoded scheme
+      guarantees this for increasing tags). Once a code is consumed by an upload
+      it can never be reused, even if that upload is discarded.
 - [ ] A matching changelog exists at
       `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`.
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,41 +15,125 @@ docs reference this document rather than restating the plan.
 
 ## 1. Versioning model
 
-`pubspec.yaml` is the **single source of truth** for the version:
+**The Git tag is the source of truth for a release; `pubspec.yaml` is the
+default for local/dev builds.** A tagged release build derives its version from
+the tag and bakes the same value into the APK/AAB metadata *and* the in-app
+display, so they can never drift. You do **not** edit any version constant to
+cut a release — you just push the tag.
 
 ```
-version: x.y.z+<versionCode>      # currently 0.1.0-alpha.15+15
+                       ┌─ --build-name / --build-number ─▶ Android versionName/versionCode (APK/AAB)
+push tag  ─▶  parse ───┤
+v0.1.0-alpha.16        └─ --dart-define=LINTHRA_VERSION_NAME ─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
 ```
 
-- **`versionName` = `x.y.z`** — the human-facing [SemVer](https://semver.org/)
-  string.
-- **`versionCode` = the integer after `+`** — Android's internal build number.
+### versionName
 
-Android reads both from Flutter (`flutter.versionName` / `flutter.versionCode`
-in `android/app/build.gradle`); they are **not** hard-coded in Gradle, so
-bumping `pubspec.yaml` is enough for the installed APK's version.
+The tag with its leading `v` stripped, **pre-release suffix preserved**:
 
-**The in-app version display has its own copy.** The Settings/About screen and
-the Jellyfin client-version header read `AppInfo.version` in
-`lib/core/app_info.dart`, a `const` string. It must mirror the `versionName`
-part of `pubspec.yaml` (without the `+versionCode`). This second copy is what
-drifted in earlier alphas — the APK shipped `alpha.9` while Settings still said
-`alpha.1`. To keep it honest, `test/core/app_info_version_test.dart` reads
-`pubspec.yaml` and **fails CI if `AppInfo.version` does not match**, so the two
-must be bumped together in the same commit. (Runtime package-metadata lookup via
-a plugin was deliberately not used: `AppInfo.version` is a `const` consumed
-synchronously, and a test-guarded mirror keeps the change small and dependency-
-free.)
+| Tag               | versionName      |
+| ----------------- | ---------------- |
+| `v0.1.0-alpha.16` | `0.1.0-alpha.16` |
+| `v0.1.0-beta.1`   | `0.1.0-beta.1`   |
+| `v0.1.0-rc.1`     | `0.1.0-rc.1`     |
+| `v0.1.0`          | `0.1.0`          |
+| `v1.2.3`          | `1.2.3`          |
 
-**Rules:**
+### versionCode (fully encoded, strictly monotonic)
 
-- `versionCode` **must increase monotonically** on every release. Never reuse or
-  decrease it — Android refuses to install an update with an equal/lower code,
-  and F-Droid relies on it to order versions.
+`versionCode` is computed from the version so it can **never go backwards**, with
+no manual counter to maintain:
+
+```
+versionCode = MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + preReleaseRank
+```
+
+`preReleaseRank` orders the pre-release tiers below the stable release of the
+*same* `x.y.z`: `alpha.N → N`, `beta.N → 300 + N`, `rc.N → 600 + N`, stable
+`→ 999`. Worked examples:
+
+| Tag               | versionCode |
+| ----------------- | ----------- |
+| `v0.1.0-alpha.16` | `100016`    |
+| `v0.1.0-beta.1`   | `100301`    |
+| `v0.1.0-rc.1`     | `100601`    |
+| `v0.1.0`          | `100999`    |
+| `v0.1.1-alpha.1`  | `101001`    |
+| `v0.2.0-alpha.1`  | `200001`    |
+| `v1.2.3`          | `10203999`  |
+
+The fields are bounded (minor/patch ≤ 99, pre-release `N` ≤ 299) so the result
+stays a valid Android `versionCode` (1‥2,100,000,000) and the tiers never
+collide. A tag that violates these bounds, or is otherwise malformed, **fails
+the build** (see "Malformed tags" below) instead of shipping guessed metadata.
+
+> **Note — the encoding intentionally jumps from the legacy hand-numbered
+> codes.** Alphas through `0.1.0-alpha.15` used `versionCode = N` (so `+15`).
+> The first encoded build, `v0.1.0-alpha.16`, is `100016` — far larger than `15`,
+> so it is still a strict increase (Android only requires monotonicity; gaps are
+> fine). F-Droid changelog files are named by `versionCode`, so new entries live
+> at `fastlane/metadata/android/en-US/changelogs/<encoded code>.txt` (e.g.
+> `100016.txt`); the historical `1.txt`/`9.txt`/`15.txt` stay as-is.
+
+The parsing/encoding rules live in **`tool/version_from_tag.dart`** (the single
+source of truth), exercised by `test/tooling/version_from_tag_test.dart`. The
+release workflow calls it; nothing else needs to know the formula.
+
+### In-app version (`AppInfo.version`)
+
+Settings/About, the diagnostics / "Report a bug" output, and the Jellyfin
+client-version header all read `AppInfo.version` in `lib/core/app_info.dart`:
+
+- **Tagged release build:** the workflow passes
+  `--dart-define=LINTHRA_VERSION_NAME=<derived versionName>`, so `AppInfo.version`
+  is exactly the tag's version — matching the APK/AAB metadata.
+- **Local/dev build & the test suite** (no dart-define): `AppInfo.version` falls
+  back to `AppInfo._devVersionName`, a `const` that mirrors `pubspec.yaml`'s
+  `versionName`. `test/core/app_info_version_test.dart` **fails CI if that
+  fallback drifts from `pubspec.yaml`**, so the two stay aligned for dev builds.
+
+A runtime package-metadata plugin was deliberately avoided: the dart-define keeps
+`AppInfo.version` resolvable without a plugin and uses the *same* value the
+Android build metadata gets, so there is only one effective version per build.
+
+### Rules
+
+- `versionCode` **increases monotonically** by construction — never reuse or
+  decrease it. Android refuses to install an update with an equal/lower code, and
+  F-Droid relies on it to order versions.
 - `versionName` follows SemVer. Pre-1.0, treat `0.y.z` as "still early; the API
-  and feature set can change between minor versions." A SemVer pre-release
-  suffix (e.g. `0.1.0-alpha.1`) marks an explicitly unstable build; the matching
-  tag is `vX.Y.Z-suffix` and the GitHub Release should be marked **pre-release**.
+  and feature set can change between minor versions." A SemVer pre-release suffix
+  (e.g. `0.1.0-alpha.1`) marks an explicitly unstable build; its tag is
+  `vX.Y.Z-suffix` and the GitHub Release should be marked **pre-release**.
+
+### Malformed tags
+
+The build **fails fast** — before producing any artifact — when the tag is not a
+supported release tag. `tool/version_from_tag.dart` exits non-zero (failing the
+"Derive version from tag" step) for, e.g.:
+
+- a non-`X.Y.Z` core (`v1.2`, `v1.2.3.4`, `vfoo`);
+- an unknown or numberless pre-release (`v1.2.3-alpha`, `v1.2.3-preview.1`);
+- SemVer build metadata (`v1.2.3-alpha.1+build`);
+- fields outside the encodable range (`v0.100.0`, `v0.1.0-alpha.300`).
+
+The error names the offending tag and the expected format. Fix it (delete the
+bad tag, push a corrected one) and re-run — nothing stale is ever published.
+
+### Manual builds vs. tag builds
+
+A manual `workflow_dispatch` run is **not** a release: it passes none of the
+version flags, builds the `pubspec.yaml` version, and names its artifacts without
+a tag (`linthra-<signing>.apk`) so it can't be mistaken for a tagged release.
+Only a `v*` tag push derives the version from the tag.
+
+### Do not hand-edit version metadata
+
+There is **no generated version file to edit.** For a release, edit nothing — push
+the tag. `AppInfo._devVersionName` and `pubspec.yaml` only affect local/dev builds
+and are kept in lock-step by the drift test; bump them together (in one commit) if
+you want dev builds to show a newer baseline, but they are not what a release
+ships.
 
 ## 2. Tagging
 
@@ -73,21 +157,28 @@ F-Droid (and our own release tracking) builds from a **git tag**.
 
 Before creating a release tag:
 
-1. **Bump the version** in `pubspec.yaml` (`versionName` and `versionCode`).
-   The `versionCode` **must** be strictly greater than every previous build's
-   (the current release is `+15`, so the next is `+16`).
-2. **Sync the in-app version.** Set `AppInfo.version` in
-   `lib/core/app_info.dart` to the new `versionName` (no `+versionCode`). The
-   drift test (`test/core/app_info_version_test.dart`) fails CI if you forget,
-   so do this in the same commit as step 1.
-3. **Add a changelog** for the new `versionCode` at
-   `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` (e.g.
-   `9.txt` for `0.1.0-alpha.9+9`). Keep it short and factual; this is what
-   F-Droid shows. A longer GitHub-Release body lives under
-   `docs/release-notes/vX.Y.Z*.md` (see the
-   [v0.1.0-alpha.9 notes](./release-notes/v0.1.0-alpha.9.md)). The
-   `vX.Y.Z` in the file name and the version inside it must match the tag and
-   `pubspec.yaml`.
+1. **Choose the version** = the tag you will push, e.g. `v0.1.0-alpha.16`. The
+   build derives `versionName`/`versionCode` from it automatically (§1); there is
+   **no version constant to bump** for the release. Preview the derived values:
+
+   ```sh
+   dart run tool/version_from_tag.dart v0.1.0-alpha.16
+   # LINTHRA_VERSION_NAME=0.1.0-alpha.16
+   # LINTHRA_VERSION_CODE=100016
+   ```
+
+2. **(Optional) Refresh the dev baseline.** `pubspec.yaml`'s `version:` and
+   `AppInfo._devVersionName` only drive local/dev builds; bump them together (the
+   drift test `test/core/app_info_version_test.dart` enforces they match) if you
+   want `flutter run` to show the new version. **Not required** for the release —
+   the tag overrides both.
+3. **Add a changelog** named by the **derived `versionCode`** at
+   `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` — e.g.
+   `100016.txt` for `v0.1.0-alpha.16` (use the value `tool/version_from_tag.dart`
+   prints). Keep it short and factual; this is what F-Droid shows. A longer
+   GitHub-Release body lives under `docs/release-notes/vX.Y.Z*.md` (see the
+   [v0.1.0-alpha.9 notes](./release-notes/v0.1.0-alpha.9.md)). The `vX.Y.Z` in the
+   file name and the version inside it must match the tag.
 4. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
    schema at the tagged commit — run the
    [Generate Drift files workflow](../README.md#generating-drift-files-in-ci) or
@@ -104,7 +195,9 @@ Before creating a release tag:
 
 Pushing a `v*` tag starts the build. The **Android Release Build** workflow
 (`.github/workflows/android-release-build.yml`) runs automatically on a `v*`
-tag, builds the APK/AAB, and attaches them to a GitHub Release. **Writing the
+tag, **derives the version from the tag** (§1), builds the APK/AAB with that
+version, verifies the built APK carries it, and attaches them to a GitHub
+Release. **Writing the
 release notes stays manual** — the workflow never authors production notes,
 publishes to a store, or submits to F-Droid. It listens only to the tag `push`
 (not to `release: published`), so a tag builds exactly once. See
@@ -192,6 +285,7 @@ F-Droid does **not** consume our signed artifacts. When/if Linthra is submitted:
 | Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
 | Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
+| Deriving versionName/versionCode + in-app version from the tag | **Automatic** on a `v*` tag build (`tool/version_from_tag.dart`); manual runs use `pubspec.yaml`. |
 | Attaching APK/AAB to a Release | **Automatic** on a `v*` tag build. Alpha/beta/rc tags attach (debug- or release-signed) to a **pre-release**; stable tags attach **release-signed** assets to an existing Release only. |
 | Creating a GitHub **pre-release** (alpha/beta/rc) | **Automatic** on the tag build if no Release exists yet (placeholder notes; edit afterwards). |
 | Creating a stable GitHub Release | **Manual** (operator, §4); never auto-created. |

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -66,7 +66,11 @@ Artifacts are named with the version (tag) and signing label, e.g.
 `linthra-v0.1.0-alpha.1-debug-signed.apk` or
 `linthra-v0.1.0-alpha.1-release-signed.aab`, so a debug-signed build can never
 be confused with a production release. They are uploaded as workflow artifacts
-(`linthra-<signing>-apk` / `linthra-<signing>-aab`).
+(`linthra-<signing>-apk` / `linthra-<signing>-aab`). On a tag build the
+`versionName`/`versionCode` baked into the APK/AAB (and the in-app version) are
+derived from the tag — see
+[release-process.md §1](./release-process.md#1-versioning-model). Signing is
+independent of this and unchanged.
 
 - **Manual unsigned preview (default):** run with `signed = false` →
   debug-signed artifacts. Manual runs never touch any GitHub Release.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -3,13 +3,36 @@ abstract final class AppInfo {
   static const String name = 'Linthra';
   static const String tagline = 'Your music, beautifully yours.';
 
-  /// App `versionName`, mirroring the `x.y.z(-suffix)` part of `pubspec.yaml`'s
-  /// `version` (the `+versionCode` is Android-only and not shown here). Used for
-  /// the Settings/About display and sent (informationally) to Jellyfin as the
-  /// client version in the auth header so the server can label this device.
+  /// Dev/local default `versionName`, mirroring the `x.y.z(-suffix)` part of
+  /// `pubspec.yaml`'s `version` (the `+versionCode` is Android-only and not
+  /// shown here). Used as the fallback when no release override is supplied —
+  /// i.e. for local `flutter run`/`flutter build` and the test suite.
   ///
-  /// `pubspec.yaml` is the single source of truth; this constant must match it.
-  /// `test/core/app_info_version_test.dart` fails CI if the two ever drift, so
-  /// bump both in the same commit (see docs/release-process.md §3).
-  static const String version = '0.1.0-alpha.15';
+  /// `pubspec.yaml` is the source of truth for dev builds; this constant must
+  /// match its `versionName`. `test/core/app_info_version_test.dart` fails CI if
+  /// the two ever drift, so bump both together (see docs/release-process.md §1).
+  static const String _devVersionName = '0.1.0-alpha.15';
+
+  /// The release `versionName` injected by the release workflow via
+  /// `--dart-define=LINTHRA_VERSION_NAME=<tag-derived version>`. Empty on local
+  /// and CI-test builds (no dart-define), which is how [version] knows to fall
+  /// back to [_devVersionName]. On a tagged release build it is the exact
+  /// tag-derived version (see tool/version_from_tag.dart), so the in-app version
+  /// always matches the released APK/AAB.
+  static const String _definedVersionName =
+      String.fromEnvironment('LINTHRA_VERSION_NAME');
+
+  /// The effective app `versionName` shown in Settings/About, embedded in the
+  /// diagnostics / "Report a bug" output, and sent to Jellyfin as the client
+  /// version. Reads the release override when present, else the dev fallback —
+  /// the same value Android's build metadata uses on a tagged build.
+  static String get version =>
+      resolveVersion(_definedVersionName, _devVersionName);
+
+  /// Pure selection rule behind [version]: prefer the release-injected
+  /// [defined] value, falling back to [devFallback] when it is empty (no
+  /// dart-define). Exposed so the override/fallback behavior is unit-testable
+  /// without recompiling the suite with a dart-define.
+  static String resolveVersion(String defined, String devFallback) =>
+      defined.isEmpty ? devFallback : defined;
 }

--- a/test/core/app_info_version_test.dart
+++ b/test/core/app_info_version_test.dart
@@ -2,54 +2,86 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/app_info.dart';
+import 'package:linthra/core/diagnostics/app_diagnostics.dart';
 
-/// Guards against version drift between the two places a version string lives:
-/// `pubspec.yaml` (the single source of truth, which also drives Android's
-/// `versionName`/`versionCode` via Flutter) and [AppInfo.version] (what the
-/// Settings/About screen shows and what is sent to Jellyfin). Before this test
-/// existed the app shipped `alpha.9` while still displaying `alpha.1`.
+/// Guards the version strategy described in docs/release-process.md §1:
+///
+/// * On a **tagged release build**, the version comes from the Git tag, injected
+///   via `--dart-define=LINTHRA_VERSION_NAME=...` (see tool/version_from_tag.dart),
+///   so the in-app version always matches the released APK/AAB.
+/// * On **local/dev and CI-test builds** (no dart-define), [AppInfo.version]
+///   falls back to a `const` mirror of `pubspec.yaml`'s `versionName`. This is
+///   the value the suite below sees, since `flutter test` passes no dart-define.
+///
+/// Before this guard existed the app shipped `alpha.9` while still displaying
+/// `alpha.1`; the drift test keeps the dev fallback honest against pubspec.
 void main() {
   // `version: x.y.z(-suffix)(+buildNumber)` — capture the SemVer part only;
   // the `+versionCode` is Android-internal and intentionally not in AppInfo.
-  final versionLine = RegExp(r'^version:\s*([^\s+]+)', multiLine: true);
+  final RegExp versionLine = RegExp(r'^version:\s*([^\s+]+)', multiLine: true);
 
   ({String name, int? code}) readPubspecVersion() {
-    final pubspec = File('pubspec.yaml').readAsStringSync();
-    final match =
+    final String pubspec = File('pubspec.yaml').readAsStringSync();
+    final RegExpMatch? match =
         RegExp(r'^version:\s*(\S+)', multiLine: true).firstMatch(pubspec);
     expect(match, isNotNull, reason: 'pubspec.yaml has no `version:` line');
-    final raw = match!.group(1)!;
-    final plus = raw.indexOf('+');
-    final name = plus == -1 ? raw : raw.substring(0, plus);
-    final code = plus == -1 ? null : int.tryParse(raw.substring(plus + 1));
+    final String raw = match!.group(1)!;
+    final int plus = raw.indexOf('+');
+    final String name = plus == -1 ? raw : raw.substring(0, plus);
+    final int? code = plus == -1 ? null : int.tryParse(raw.substring(plus + 1));
     return (name: name, code: code);
   }
 
-  test('AppInfo.version matches the versionName in pubspec.yaml', () {
-    final pubspec = readPubspecVersion();
-    expect(
-      AppInfo.version,
-      pubspec.name,
-      reason: 'AppInfo.version (${AppInfo.version}) drifted from pubspec.yaml '
-          '(${pubspec.name}). Bump both in the same commit — see '
-          'docs/release-process.md §3.',
-    );
+  group('AppInfo.version dev fallback', () {
+    test('matches the versionName in pubspec.yaml (no dart-define in tests)',
+        () {
+      final ({String name, int? code}) pubspec = readPubspecVersion();
+      expect(
+        AppInfo.version,
+        pubspec.name,
+        reason: 'AppInfo.version (${AppInfo.version}) drifted from '
+            'pubspec.yaml (${pubspec.name}). Bump both in the same commit — '
+            'see docs/release-process.md §1.',
+      );
+    });
+
+    test('pubspec.yaml carries an integer Android versionCode', () {
+      final ({String name, int? code}) pubspec = readPubspecVersion();
+      expect(
+        pubspec.code,
+        isNotNull,
+        reason: 'pubspec.yaml `version:` must end in `+<versionCode>` so local '
+            'Android builds get a monotonic build number.',
+      );
+      expect(pubspec.code, greaterThan(0));
+    });
+
+    test('is a SemVer string without a build suffix', () {
+      // No `+buildNumber` should leak into the user-facing version.
+      expect(AppInfo.version, isNot(contains('+')));
+      expect(versionLine.hasMatch('version: ${AppInfo.version}'), isTrue);
+    });
   });
 
-  test('pubspec.yaml carries an integer Android versionCode', () {
-    final pubspec = readPubspecVersion();
-    expect(
-      pubspec.code,
-      isNotNull,
-      reason: 'pubspec.yaml `version:` must end in `+<versionCode>` so Android '
-          'gets a monotonic build number.',
-    );
-    expect(pubspec.code, greaterThan(0));
+  group('AppInfo.resolveVersion', () {
+    test('prefers the release-injected version when present', () {
+      expect(
+        AppInfo.resolveVersion('0.1.0-alpha.16', '0.1.0-alpha.15'),
+        '0.1.0-alpha.16',
+      );
+    });
+
+    test('falls back to the dev version when no override is supplied', () {
+      expect(AppInfo.resolveVersion('', '0.1.0-alpha.15'), '0.1.0-alpha.15');
+    });
   });
 
-  test('AppInfo.version is a SemVer string without a build suffix', () {
-    // No `+buildNumber` should leak into the user-facing version.
-    expect(AppInfo.version, isNot(contains('+')));
-    expect(versionLine.hasMatch('version: ${AppInfo.version}'), isTrue);
+  test('diagnostics report carries the effective app version', () {
+    // Settings ▸ Diagnostics and "Report a bug" both render the version through
+    // AppDiagnostics.report(appVersion: AppInfo.version); confirm the effective
+    // version flows into that output.
+    final String report =
+        AppDiagnostics.report(AppDiagnosticsData(appVersion: AppInfo.version));
+    expect(report, contains('App version: ${AppInfo.version}'));
   });
 }

--- a/test/tooling/version_from_tag_test.dart
+++ b/test/tooling/version_from_tag_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/version_from_tag.dart';
+
+/// Specifies tool/version_from_tag.dart — the single source of truth that turns
+/// a `v*` release tag into the `versionName`/`versionCode` baked into a build.
+/// See docs/release-process.md §1.
+void main() {
+  group('versionFromTag — supported tags', () {
+    test('v0.1.0-alpha.16 → 0.1.0-alpha.16 / 100016', () {
+      final TagVersion v = versionFromTag('v0.1.0-alpha.16');
+      expect(v.name, '0.1.0-alpha.16');
+      expect(v.code, 100016);
+    });
+
+    test('v0.1.0-beta.1 → 0.1.0-beta.1 / 100301', () {
+      final TagVersion v = versionFromTag('v0.1.0-beta.1');
+      expect(v.name, '0.1.0-beta.1');
+      expect(v.code, 100301);
+    });
+
+    test('v0.1.0-rc.1 → 0.1.0-rc.1 / 100601', () {
+      final TagVersion v = versionFromTag('v0.1.0-rc.1');
+      expect(v.name, '0.1.0-rc.1');
+      expect(v.code, 100601);
+    });
+
+    test('v0.1.0 (stable) → 0.1.0 / 100999', () {
+      final TagVersion v = versionFromTag('v0.1.0');
+      expect(v.name, '0.1.0');
+      expect(v.code, 100999);
+    });
+
+    test('v1.2.3 (stable) → 1.2.3 / 10203999', () {
+      final TagVersion v = versionFromTag('v1.2.3');
+      expect(v.name, '1.2.3');
+      expect(v.code, 10203999);
+    });
+
+    test('strips the leading v but keeps the pre-release suffix', () {
+      expect(versionFromTag('v0.1.0-alpha.16').name, '0.1.0-alpha.16');
+      expect(versionFromTag('v2.0.0').name, '2.0.0');
+    });
+
+    test('accepts a tag with no leading v', () {
+      final TagVersion v = versionFromTag('0.1.0-alpha.16');
+      expect(v.name, '0.1.0-alpha.16');
+      expect(v.code, 100016);
+    });
+
+    test('tolerates surrounding whitespace', () {
+      expect(versionFromTag('  v0.1.0  ').name, '0.1.0');
+    });
+  });
+
+  group('versionFromTag — versionCode is strictly monotonic', () {
+    test('orders the tiers below the stable release of the same x.y.z', () {
+      final int alpha = versionFromTag('v0.1.0-alpha.16').code;
+      final int beta = versionFromTag('v0.1.0-beta.1').code;
+      final int rc = versionFromTag('v0.1.0-rc.1').code;
+      final int stable = versionFromTag('v0.1.0').code;
+      expect(alpha, lessThan(beta));
+      expect(beta, lessThan(rc));
+      expect(rc, lessThan(stable));
+    });
+
+    test('never goes backwards along a realistic release path', () {
+      const List<String> path = <String>[
+        'v0.1.0-alpha.15',
+        'v0.1.0-alpha.16',
+        'v0.1.0-alpha.99',
+        'v0.1.0-beta.1',
+        'v0.1.0-beta.2',
+        'v0.1.0-rc.1',
+        'v0.1.0',
+        'v0.1.1-alpha.1',
+        'v0.1.1',
+        'v0.2.0-alpha.1',
+        'v0.2.0',
+        'v1.0.0-alpha.1',
+        'v1.0.0',
+        'v1.2.3',
+      ];
+      final List<int> codes =
+          path.map((String t) => versionFromTag(t).code).toList();
+      for (int i = 1; i < codes.length; i++) {
+        expect(
+          codes[i],
+          greaterThan(codes[i - 1]),
+          reason: '${path[i]} (${codes[i]}) must exceed '
+              '${path[i - 1]} (${codes[i - 1]})',
+        );
+      }
+    });
+
+    test('a higher pre-release number yields a higher code', () {
+      expect(
+        versionFromTag('v0.1.0-alpha.17').code,
+        greaterThan(versionFromTag('v0.1.0-alpha.16').code),
+      );
+    });
+
+    test('stays within the valid Android versionCode ceiling', () {
+      expect(versionFromTag('v1.2.3').code, lessThanOrEqualTo(2100000000));
+    });
+  });
+
+  group('versionFromTag — malformed tags fail clearly', () {
+    test('rejects a two-part version', () {
+      expect(() => versionFromTag('v1.2'), throwsFormatException);
+    });
+
+    test('rejects a four-part version', () {
+      expect(() => versionFromTag('v1.2.3.4'), throwsFormatException);
+    });
+
+    test('rejects a non-numeric version', () {
+      expect(() => versionFromTag('vfoo'), throwsFormatException);
+      expect(() => versionFromTag(''), throwsFormatException);
+    });
+
+    test('rejects a pre-release tier with no number', () {
+      expect(() => versionFromTag('v1.2.3-alpha'), throwsFormatException);
+    });
+
+    test('rejects a non-numeric pre-release number', () {
+      expect(() => versionFromTag('v1.2.3-alpha.x'), throwsFormatException);
+    });
+
+    test('rejects an unknown pre-release tier', () {
+      expect(() => versionFromTag('v1.2.3-preview.1'), throwsFormatException);
+      expect(() => versionFromTag('v1.2.3-dev.1'), throwsFormatException);
+    });
+
+    test('rejects SemVer build metadata', () {
+      expect(
+        () => versionFromTag('v1.2.3-alpha.1+build'),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects fields that overflow the encoding', () {
+      expect(() => versionFromTag('v0.100.0'), throwsFormatException);
+      expect(() => versionFromTag('v0.1.100'), throwsFormatException);
+      expect(() => versionFromTag('v0.1.0-alpha.300'), throwsFormatException);
+    });
+
+    test('rejects a major version too large to encode safely', () {
+      expect(() => versionFromTag('v210.0.0'), throwsFormatException);
+    });
+  });
+}

--- a/tool/version_from_tag.dart
+++ b/tool/version_from_tag.dart
@@ -1,0 +1,192 @@
+/// Derives Android/app version metadata from a Git release tag.
+///
+/// This is the **single source of truth** for how a `v*` tag becomes the
+/// `versionName`/`versionCode` baked into a release build. The release workflow
+/// (`.github/workflows/android-release-build.yml`) runs this on the pushed tag
+/// and feeds the result to `flutter build` (`--build-name`/`--build-number`)
+/// and to the in-app version (`--dart-define=LINTHRA_VERSION_NAME=...`).
+/// `test/tooling/version_from_tag_test.dart` exercises the rules below.
+///
+/// ## Tag format
+///
+/// `vMAJOR.MINOR.PATCH` with an optional `-alpha.N` / `-beta.N` / `-rc.N`
+/// pre-release suffix. A leading `v` is optional and stripped. Examples:
+/// `v0.1.0-alpha.16`, `v0.1.0-beta.1`, `v0.1.0-rc.1`, `v0.1.0`, `v1.2.3`.
+/// Anything else (`v1.2`, `v1.2.3-preview.1`, `v1.2.3-alpha`, …) is rejected
+/// with a non-zero exit so a release never ships stale or guessed metadata.
+///
+/// ## versionName
+///
+/// The tag with its leading `v` stripped, pre-release suffix preserved:
+/// `v0.1.0-alpha.16` → `0.1.0-alpha.16`.
+///
+/// ## versionCode (fully encoded, strictly monotonic)
+///
+/// ```
+/// versionCode = MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + preReleaseRank
+/// ```
+///
+/// where `preReleaseRank` orders the pre-release tiers below the stable
+/// release of the *same* `x.y.z`:
+///
+/// | release   | rank        |
+/// | --------- | ----------- |
+/// | `alpha.N` | `N`         |
+/// | `beta.N`  | `300 + N`   |
+/// | `rc.N`    | `600 + N`   |
+/// | stable    | `999`       |
+///
+/// Because every field has a fixed weight, the code **strictly increases** for
+/// every higher version with no special cases and can never go backwards:
+///
+/// ```
+/// v0.1.0-alpha.16 -> 100016
+/// v0.1.0-beta.1   -> 100301
+/// v0.1.0-rc.1     -> 100601
+/// v0.1.0          -> 100999
+/// v0.1.1-alpha.1  -> 101001
+/// v0.2.0-alpha.1  -> 200001
+/// v1.2.3          -> 10203999
+/// ```
+///
+/// The fields are bounded so the result stays a valid Android `versionCode`
+/// (1..2_100_000_000) and the tiers never collide: minor/patch ≤ 99, the
+/// pre-release `N` ≤ 299. Out-of-range values fail loudly rather than wrapping.
+library;
+
+import 'dart:io';
+
+/// The `versionName`/`versionCode` pair derived from a release tag.
+class TagVersion {
+  const TagVersion(this.name, this.code);
+
+  /// The user-facing `versionName`, e.g. `0.1.0-alpha.16` (no leading `v`).
+  final String name;
+
+  /// The Android `versionCode`, e.g. `100016`.
+  final int code;
+}
+
+const int _majorWeight = 10000000;
+const int _minorWeight = 100000;
+const int _patchWeight = 1000;
+
+/// The maximum `versionCode` Android / Google Play accept.
+const int _maxVersionCode = 2100000000;
+
+/// Field bounds that keep the encoding unambiguous and within [_maxVersionCode].
+const int _maxMinor = 99;
+const int _maxPatch = 99;
+const int _maxPreNumber = 299;
+
+/// The stable (no pre-release) rank — above every pre-release of the same patch.
+const int _stableRank = 999;
+
+/// Per-tier base rank; the pre-release number is added on top.
+const Map<String, int> _tierBase = <String, int>{
+  'alpha': 0,
+  'beta': 300,
+  'rc': 600,
+};
+
+final RegExp _tagPattern =
+    RegExp(r'^v?(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d+))?$');
+
+/// Parses [tag] into its [TagVersion], throwing [FormatException] (with an
+/// actionable message) for anything that is not a supported release tag or
+/// whose fields fall outside the encodable range.
+TagVersion versionFromTag(String tag) {
+  final RegExpMatch? match = _tagPattern.firstMatch(tag.trim());
+  if (match == null) {
+    throw FormatException(
+      'Malformed release tag "$tag". Expected vMAJOR.MINOR.PATCH with an '
+      'optional -alpha.N / -beta.N / -rc.N pre-release suffix, e.g. '
+      'v0.1.0-alpha.16, v0.1.0-rc.1, or v1.2.3.',
+    );
+  }
+
+  final int major = int.parse(match.group(1)!);
+  final int minor = int.parse(match.group(2)!);
+  final int patch = int.parse(match.group(3)!);
+  final String? tier = match.group(4); // null for a stable release
+  final String? preNumber = match.group(5);
+
+  if (minor > _maxMinor) {
+    throw FormatException(
+      'Minor version $minor in tag "$tag" exceeds the supported range '
+      '(0..$_maxMinor); the versionCode encoding cannot represent it.',
+    );
+  }
+  if (patch > _maxPatch) {
+    throw FormatException(
+      'Patch version $patch in tag "$tag" exceeds the supported range '
+      '(0..$_maxPatch); the versionCode encoding cannot represent it.',
+    );
+  }
+
+  final int rank;
+  final String name;
+  if (tier == null) {
+    rank = _stableRank;
+    name = '$major.$minor.$patch';
+  } else {
+    final int n = int.parse(preNumber!);
+    if (n > _maxPreNumber) {
+      throw FormatException(
+        'Pre-release number $n in tag "$tag" exceeds the supported range '
+        '(0..$_maxPreNumber); raise the encoding bounds or use a higher '
+        'patch/minor.',
+      );
+    }
+    rank = _tierBase[tier]! + n;
+    name = '$major.$minor.$patch-$tier.$n';
+  }
+
+  final int code =
+      major * _majorWeight + minor * _minorWeight + patch * _patchWeight + rank;
+  if (code <= 0 || code > _maxVersionCode) {
+    throw FormatException(
+      'Derived versionCode $code for tag "$tag" is outside the valid Android '
+      'range (1..$_maxVersionCode); the major version is too large to encode.',
+    );
+  }
+  return TagVersion(name, code);
+}
+
+/// CLI entry point.
+///
+/// Reads the tag from the first argument, falling back to `GITHUB_REF_NAME`,
+/// and prints two `KEY=VALUE` lines on success so the workflow can append them
+/// straight to `$GITHUB_ENV` / `$GITHUB_OUTPUT`:
+///
+/// ```
+/// LINTHRA_VERSION_NAME=0.1.0-alpha.16
+/// LINTHRA_VERSION_CODE=100016
+/// ```
+///
+/// Exits non-zero (writing the reason to stderr, nothing to stdout) for a
+/// missing or malformed tag, so a release build fails fast instead of shipping
+/// stale version metadata.
+void main(List<String> args) {
+  final String? tag =
+      args.isNotEmpty ? args.first : Platform.environment['GITHUB_REF_NAME'];
+  if (tag == null || tag.trim().isEmpty) {
+    stderr.writeln(
+      'version_from_tag: no tag provided. Pass the tag as the first argument '
+      'or set GITHUB_REF_NAME, e.g. `dart run tool/version_from_tag.dart '
+      'v0.1.0-alpha.16`.',
+    );
+    exit(64); // EX_USAGE
+  }
+
+  final TagVersion version;
+  try {
+    version = versionFromTag(tag);
+  } on FormatException catch (e) {
+    stderr.writeln('version_from_tag: ${e.message}');
+    exit(1);
+  }
+
+  stdout.writeln('LINTHRA_VERSION_NAME=${version.name}');
+  stdout.writeln('LINTHRA_VERSION_CODE=${version.code}');
+}


### PR DESCRIPTION
## Problem

Cutting a release required hand-bumping `pubspec.yaml` **and** `AppInfo.version` (and the `+versionCode`) in lockstep. Forgetting any of them meant the built APK/AAB or the in-app Settings/About version could lag the actual release (e.g. shipping `alpha.15` while a `v0.1.0-alpha.16` tag was pushed).

## Versioning strategy

**The git tag is now the source of truth for a release; `pubspec.yaml` is only the default for local/dev builds.** A tagged build derives the version from the tag and bakes the *same* value into both the Android build metadata and the in-app display, so they can't drift. You no longer edit any version constant to cut a release — you just push the tag.

```
                       ┌─ --build-name / --build-number ─▶ Android versionName/versionCode (APK/AAB)
push tag  ─▶  parse ───┤
v0.1.0-alpha.16        └─ --dart-define=LINTHRA_VERSION_NAME ─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
```

Both channels come from one parsed value, so they're always consistent. `tool/version_from_tag.dart` is the single source of truth for the rules.

## Tag parsing behavior

`vMAJOR.MINOR.PATCH` with an optional `-alpha.N` / `-beta.N` / `-rc.N` suffix (leading `v` optional/stripped).

- **versionName** = the tag minus the leading `v`, pre-release suffix preserved.
- **versionCode** = fully encoded, strictly monotonic — `MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + preReleaseRank`, where `alpha.N → N`, `beta.N → 300+N`, `rc.N → 600+N`, stable `→ 999`. It can **never go backwards** with no manual counter.
- Malformed tags (`v1.2`, `v1.2.3-alpha`, `v1.2.3-preview.1`, `v1.2.3-alpha.1+build`, `v0.100.0`, `v0.1.0-alpha.300`, …) **fail the build before any artifact is produced**, with an actionable error.

### versionName / versionCode examples

| Tag | versionName | versionCode |
| --- | --- | --- |
| `v0.1.0-alpha.16` | `0.1.0-alpha.16` | `100016` |
| `v0.1.0-beta.1` | `0.1.0-beta.1` | `100301` |
| `v0.1.0-rc.1` | `0.1.0-rc.1` | `100601` |
| `v0.1.0` | `0.1.0` | `100999` |
| `v0.2.0-alpha.1` | `0.2.0-alpha.1` | `200001` |
| `v1.2.3` | `1.2.3` | `10203999` |

> The encoding intentionally jumps from the legacy hand-numbered codes (`…+15`) to `100016` — still a strict increase, which is all Android/F-Droid require. Chosen over continuing the small `+N` convention because it can never regress across minor/patch bumps.

## In-app version behavior

`AppInfo.version` is now a getter: it returns `--dart-define=LINTHRA_VERSION_NAME` when set (tagged release), else falls back to `AppInfo._devVersionName`, a `const` mirror of `pubspec.yaml` for local/dev builds and the test suite. The drift test still fails CI if that dev fallback diverges from `pubspec.yaml`. Settings/About, the diagnostics / "Report a bug" output, and the Jellyfin client-version header all read this effective version. No new runtime dependency (no `package_info_plus`).

## Workflow changes (`android-release-build.yml`)

- New **"Derive version from tag"** step runs `tool/version_from_tag.dart` on `GITHUB_REF_NAME`, exports `LINTHRA_VERSION_NAME` / `LINTHRA_VERSION_CODE`, and fails fast on a malformed tag.
- APK/AAB builds pass `--build-name`/`--build-number` (Android metadata) and `--dart-define` (in-app version) on tag builds; manual `workflow_dispatch` runs pass none and build the `pubspec.yaml` version, named without a tag so they can't pass as a release.
- New **"Verify APK version matches the tag"** step uses `aapt` to confirm the built APK actually carries the derived version (warns-and-skips only if `aapt` can't be located).
- Build summary surfaces the derived version. Artifact names already carried the tag. **Gradle/signing untouched** (`--build-name`/`--build-number` flow through the existing `flutter.versionName/versionCode`), so no signing regression.

## Tests added

- `test/tooling/version_from_tag_test.dart` — supported tags (alpha/beta/rc/stable, leading-`v` optional, whitespace), strict monotonicity across a realistic release path, tier ordering, and clear failure on every malformed/over-range tag.
- `test/core/app_info_version_test.dart` — adds `resolveVersion` override/fallback cases and a check that the diagnostics report carries the effective `AppInfo.version`; keeps the pubspec drift guard for the dev fallback.

## Docs updated

`docs/release-process.md` (§1 versioning model rewritten with derivation tables, malformed-tag behavior, manual-vs-tag, "do not hand-edit"; §3 checklist), `docs/development.md` (preview/reproduce a tag build locally), `docs/release-signing.md`, `docs/play-store-readiness.md`, and the F-Droid docs (with the caveat below).

## Known limitations

- **F-Droid builds from source** at the tag and does **not** run this workflow, so a plain `flutter build` there still takes the version from `pubspec.yaml`, not the tag. Linthra isn't on F-Droid yet; the F-Droid docs now flag that a submission must either bump `pubspec.yaml` at the tagged commit or have the recipe pass `--build-name`/`--build-number`. The GitHub-Release channel is fully tag-driven.
- The APK-version verification depends on `aapt` from the runner's Android SDK; if it can't be found it warns and skips rather than failing.
- versionCode bounds: minor/patch ≤ 99, pre-release `N` ≤ 299, major ≤ 209 (kept within Android's 2,100,000,000 ceiling); out-of-range tags fail clearly.

## Verification

`flutter`/`dart` aren't installed in this environment, so `flutter pub get` / `dart format` / `flutter analyze` / `flutter test` were **not** run here — CI will. Offline I validated: the versionCode formula and every test expectation (ported to Python), strict monotonicity across the full release path, all malformed cases raising, all touched Dart code ≤ 80 cols, balanced delimiters, the workflow shell parsing (`grep` filter + `aapt`/`sed` extraction), and that all workflow YAML parses.

https://claude.ai/code/session_01GnbggWYHXEujW98WLvHYmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnbggWYHXEujW98WLvHYmN)_