### PR TITLE
docs: contributor onboarding, roadmap, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/android_auto_report.yml
+++ b/.github/ISSUE_TEMPLATE/android_auto_report.yml
@@ -1,0 +1,48 @@
+name: Android Auto test report
+description: Tell us how Linthra behaves in your car or head unit.
+labels: ["testing", "android-auto"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing Android Auto! Head units and car displays vary widely,
+        so reports from real setups are genuinely useful.
+
+        **Heads up:** sideloaded builds only appear after you enable Android
+        Auto's developer **"Unknown sources"** toggle — a one-time step described
+        in [docs/android-auto.md](../../docs/android-auto.md). Flag any
+        **duplicate playback** (phone + car at once) explicitly.
+  - type: input
+    id: head-unit
+    attributes:
+      label: Car make / model or head unit type
+      placeholder: "e.g. VW Golf 2021 built-in, or Desktop Head Unit"
+    validations:
+      required: true
+  - type: checkboxes
+    id: results
+    attributes:
+      label: What worked?
+      options:
+        - label: App appears in the Android Auto launcher
+        - label: Library browsing
+        - label: Queue browsing
+        - label: Play / pause / next / previous
+        - label: No duplicate playback (phone + car at once)
+        - label: No token or secret visible in any text on screen
+  - type: textarea
+    id: details
+    attributes:
+      label: What happened?
+      description: Describe anything that broke or behaved oddly.
+      placeholder: App showed up, but the Queue tab was empty until I…
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (optional)
+      description: Paste the output of Settings → Diagnostics → Copy diagnostics.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/cast_device_report.yml
+++ b/.github/ISSUE_TEMPLATE/cast_device_report.yml
@@ -1,0 +1,48 @@
+name: Cast device test report
+description: Tell us how casting works with your Chromecast / speaker / TV.
+labels: ["testing", "cast"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing Cast! Linthra uses a pure-Dart Cast implementation (no
+        Google Play Services), and devices vary a lot — so real results are
+        really helpful.
+
+        Watch specifically for **duplicate playback** (audio playing locally and
+        on the Cast device at the same time) and call it out if you see it.
+  - type: input
+    id: device
+    attributes:
+      label: Cast device make / model
+      placeholder: "e.g. Chromecast with Google TV, Nest Audio, Sony Bravia"
+    validations:
+      required: true
+  - type: checkboxes
+    id: results
+    attributes:
+      label: What worked?
+      options:
+        - label: Device shows up in discovery
+        - label: Connect / disconnect is reliable
+        - label: Playback (start, pause, seek, track changes)
+        - label: Volume control
+        - label: Mute
+        - label: Disconnect behaves correctly (playback stops/returns cleanly)
+        - label: No duplicate local + Cast playback
+  - type: textarea
+    id: details
+    attributes:
+      label: What happened?
+      description: Describe anything that broke or behaved oddly.
+      placeholder: Connected fine, but seeking jumped back to the start on…
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (optional)
+      description: Paste the output of Settings → Diagnostics → Copy diagnostics.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,32 @@
+name: Documentation improvement
+description: Suggest a fix or addition to the docs, README, or setup guides.
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping make Linthra easier to understand! Confusing steps,
+        missing gotchas, and out-of-date instructions are all worth flagging —
+        and fixing the docs is a great first contribution.
+  - type: input
+    id: location
+    attributes:
+      label: Which doc or page?
+      description: A file path or URL is ideal.
+      placeholder: "e.g. docs/jellyfin.md, or the README 'Try it' section"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's confusing, missing, or wrong?
+      placeholder: The Cloudflare Tunnel step doesn't mention that…
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement (optional)
+      description: If you already know how you'd word it, drop it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/jellyfin_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/jellyfin_compatibility.yml
@@ -1,0 +1,69 @@
+name: Jellyfin compatibility report
+description: Tell us how Linthra works (or doesn't) with your Jellyfin server.
+labels: ["testing", "jellyfin"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing against a real Jellyfin server! Reports like this are
+        the fastest way to make Linthra solid.
+
+        **Please don't paste tokens, passwords, or full private server URLs.** A
+        version number and a description are plenty. **Settings → Report a bug**
+        builds a secret-free diagnostics blob you can paste below.
+  - type: input
+    id: jellyfin-version
+    attributes:
+      label: Jellyfin server version
+      placeholder: "e.g. 10.9.11"
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version (and phone model if handy)
+      placeholder: "e.g. Android 14, Pixel 7"
+    validations:
+      required: false
+  - type: input
+    id: proxy
+    attributes:
+      label: Reverse proxy / Cloudflare Tunnel, if any
+      placeholder: "e.g. nginx + Cloudflare Tunnel, or direct"
+    validations:
+      required: false
+  - type: input
+    id: library-size
+    attributes:
+      label: Approximate library size
+      placeholder: "e.g. ~8,000 tracks / ~600 albums"
+    validations:
+      required: false
+  - type: checkboxes
+    id: results
+    attributes:
+      label: What worked?
+      options:
+        - label: Test connection + sign-in
+        - label: Library sync
+        - label: Streaming
+        - label: Playlists sync
+        - label: Favorites sync
+        - label: Cache / download
+        - label: Cast
+  - type: textarea
+    id: details
+    attributes:
+      label: What happened?
+      description: Anything that broke, behaved oddly, or was slower than expected.
+      placeholder: Sync finished but album artwork was missing for…
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (optional)
+      description: Paste the output of Settings → Diagnostics → Copy diagnostics.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/navidrome_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/navidrome_compatibility.yml
@@ -1,0 +1,54 @@
+name: Navidrome / Subsonic compatibility report
+description: Tell us how Linthra works with your Navidrome or Subsonic-compatible server.
+labels: ["testing", "navidrome"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing the Subsonic path! Linthra speaks the Subsonic API, so
+        it should work with Navidrome and other compatible servers — real reports
+        help confirm that.
+
+        **Please don't paste tokens, passwords, or full private server URLs.**
+        Known follow-ups on this path are **favourites, lyrics, and cover art** —
+        if those are missing, note it here rather than filing separate bugs.
+  - type: input
+    id: server
+    attributes:
+      label: Server type and version
+      placeholder: "e.g. Navidrome 0.52.5, or Gonic / Airsonic-Advanced"
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version (and phone model if handy)
+      placeholder: "e.g. Android 13, Samsung S22"
+    validations:
+      required: false
+  - type: checkboxes
+    id: results
+    attributes:
+      label: What worked?
+      options:
+        - label: Login / test connection
+        - label: Library sync
+        - label: Streaming
+        - label: Cache / download
+        - label: Cast
+  - type: textarea
+    id: details
+    attributes:
+      label: What happened?
+      description: Anything that broke or behaved unexpectedly.
+      placeholder: Streaming worked, but favourites didn't sync back to the server…
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (optional)
+      description: Paste the output of Settings → Diagnostics → Copy diagnostics.
+      render: text
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to Linthra
+
+Hey — thanks for being here. Linthra is a self-hosted Android music player, and
+it's early alpha, which is honestly the best time to get involved: small changes
+land fast and genuinely shape where the project goes.
+
+You don't need to be a Flutter expert to help. Testing the app against your own
+server, capturing a screenshot, or fixing a confusing line in the docs are all
+real, useful contributions. If you're not sure where to start, the
+[contributor roadmap](./docs/contributor-roadmap.md) lays out where help matters
+most right now.
+
+## Setting up the project
+
+Linthra is a standard Flutter app with a committed Android scaffold, so there's
+no `flutter create` step. In most environments you only need two commands:
+
+```bash
+./scripts/setup_flutter.sh    # installs the pinned Flutter (no sudo, cached locally)
+./scripts/verify_android.sh   # runs the same checks CI runs
+```
+
+`setup_flutter.sh` reuses a matching Flutter if you already have one, or
+downloads the pinned version into the git-ignored `.tool/flutter`.
+`verify_android.sh` runs `flutter pub get`, `dart format`, `flutter analyze`,
+`flutter test`, and an APK build (only if an Android SDK is present). Full
+details, troubleshooting, and the manual path are in
+[docs/development.md](./docs/development.md).
+
+## Picking something to work on
+
+- Browse the [issue tracker](https://github.com/thezupzup/linthra/issues).
+  Issues tagged **`good first issue`** are scoped to be approachable, and
+  **`help wanted`** flags where an extra pair of hands would help most.
+- Comment on an issue before you start so we don't double up.
+- Opening a small PR for something not yet tracked is fine too — just explain
+  what and why in the description.
+
+### Good first contributions
+
+A few that don't go too deep into the codebase:
+
+- Test Linthra against your **Jellyfin** or **Navidrome / Subsonic** server and
+  file a compatibility report.
+- Try **Cast** or **Android Auto** on real hardware and tell us what happened.
+- Capture **screenshots** of a running build for the README and store listing.
+- Improve a doc — fix a step that tripped you up, add a setup gotcha.
+- Add or improve **accessibility labels** so screen readers announce controls
+  clearly.
+- Polish an **empty state** so a blank screen explains what to do next.
+
+## Pull requests
+
+- **Keep PRs small and focused.** One change per PR is much easier to review and
+  merge than a big bundle.
+- **Write a clear description** — what changed and why. Link the issue it closes.
+- **Add tests when it makes sense** — bug fixes and new logic especially.
+- **No unrelated changes.** Resist the urge to reformat or refactor nearby code
+  in the same PR; open a separate one if it's worth doing.
+- Run `./scripts/verify_android.sh` (or the CI commands) before pushing — CI runs
+  `dart format --set-exit-if-changed`, so unformatted code will fail.
+
+## Code style
+
+Nothing exotic here — just code that's easy to read and easy to maintain:
+
+- **Readable over clever.** Clear names and straightforward control flow beat a
+  one-liner that needs a comment to decode.
+- **Modular.** Keep files and functions focused; split things up before they
+  grow into a single huge file.
+- **No premature abstraction.** Don't add a layer or a generic helper until
+  there's a real second use for it. Three similar lines are fine.
+- **Comment the why, not the what.** Most code shouldn't need a comment; when it
+  does, explain the non-obvious reason.
+
+## Privacy & security
+
+Respecting the people who run Linthra is a core part of the project, so a few
+rules are non-negotiable in any contribution:
+
+- **Never log tokens, passwords, or secrets.** Linthra's own log lines are
+  secret-free by design — keep them that way.
+- **Don't persist authenticated URLs.** Stream URLs are minted on demand and
+  must not be written to disk, logs, or diagnostics.
+- **Keep credentials encrypted at rest.** A server password is used once to get
+  a token, then discarded; the token is encrypted and never displayed.
+- **No telemetry, no phoning home.** Nothing should leave the device unless the
+  user explicitly chooses it.
+
+If a change touches auth, streaming, or diagnostics, call out the security
+implications in your PR description so they're easy to review.
+
+## Testing on Android
+
+Some behaviour only shows up on real hardware. If your change touches any of
+these, please test on a device and note what you checked:
+
+- **Jellyfin / Navidrome** — connect, sync, stream; confirm no secrets appear
+  on screen or in logs.
+- **Offline cache** — downloads stay user-initiated and Wi-Fi-only by default;
+  pinned ("Keep offline") tracks aren't evicted.
+- **Cast** — discovery, connect/disconnect, playback, volume; watch for
+  duplicate local + Cast playback.
+- **Android Auto** — sideloaded builds only appear after enabling Android Auto's
+  developer **"Unknown sources"** toggle (see
+  [docs/android-auto.md](./docs/android-auto.md)); check browsing and playback.
+
+The [manual QA checklist](./docs/manual-test-checklist.md) walks through the
+paths that matter most on a real phone.
+
+## Reporting bugs
+
+The friendliest way is right in the app: **Settings → Report a bug** builds a
+secret-free report locally (versions, connection state, host, counts — no
+tokens or passwords), which you can review and then open as a prefilled GitHub
+issue. Details in [docs/reporting-bugs.md](./docs/reporting-bugs.md).
+
+## License
+
+Linthra is [MPL-2.0](./LICENSE). By contributing, you agree your contributions
+are licensed under the same terms.
+
+Thanks again — see you in the issues.

--- a/README.md
+++ b/README.md
@@ -121,22 +121,28 @@ pinned Flutter toolchain and run the same checks as CI.
 Linthra is small and friendly — good first contributions are very welcome, and
 many don't need a single line of code:
 
--  **Test with your server** — does it work with your **Jellyfin**? Your
+- **Test with your server** — does it work with your **Jellyfin**? Your
   **Navidrome / Subsonic**? Tell us what broke.
-   **Try Cast** — connect a Chromecast/speaker/TV and report device
+- **Try Cast** — connect a Chromecast / speaker / TV and report device
   compatibility.
--  **Test Android Auto** — on a head unit or the Desktop Head Unit.
--  **Capture screenshots** for the README and store listing.
--  **Improve docs** — fix a confusing step, add a setup gotcha.
--  **Report bugs in one tap** — **Settings → Report a bug** builds a
+- **Test Android Auto** — on a head unit or the Desktop Head Unit.
+- **Capture screenshots** for the README and store listing.
+- **Improve docs** — fix a confusing step, add a setup gotcha.
+- **Report bugs in one tap** — **Settings → Report a bug** builds a
   **secret-free** report on your device (no tokens, no passwords); review it,
   then copy it or open a prefilled GitHub issue.
   ([how it works](./docs/reporting-bugs.md))
--  **Polish UI/UX** — small refinements add up.
--  **Help future providers** — WebDAV/NAS support behind the same interface.
+- **Improve accessibility** — better screen-reader labels and TalkBack support.
+- **Polish UI/UX** — small refinements add up.
+- **Help future providers** — WebDAV / NAS support behind the same interface.
 
-Found Linthra useful? A **GitHub star** helps others discover it. Start at the
-[issue tracker](https://github.com/thezupzup/linthra/issues).
+New here? [CONTRIBUTING.md](./CONTRIBUTING.md) walks through setup in two
+commands, and the [contributor roadmap](./docs/contributor-roadmap.md) shows
+where help is most useful right now. The
+[issue tracker](https://github.com/thezupzup/linthra/issues) has tasks tagged
+`good first issue` and `help wanted`.
+
+Found Linthra useful? A **GitHub star** helps others discover it.
 
 ## Self-hosted sources
 
@@ -181,6 +187,8 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 
 | Topic | Doc |
 | --- | --- |
+| Contributing & setup | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Where to help (contributor roadmap) | [docs/contributor-roadmap.md](./docs/contributor-roadmap.md) |
 | Architecture & extension points | [docs/architecture.md](./docs/architecture.md) |
 | Development, build & CI | [docs/development.md](./docs/development.md) |
 | Library browsing & search | [docs/library.md](./docs/library.md) |

--- a/docs/contributor-roadmap.md
+++ b/docs/contributor-roadmap.md
@@ -1,0 +1,100 @@
+# Contributor roadmap
+
+This is a map of where help is genuinely useful right now — not a corporate
+roadmap or a promise of dates. Linthra is early alpha, built by a small group of
+people who care about owning their music. Pick whatever looks fun; small
+contributions are welcome and land fast.
+
+New to the project? Start with [CONTRIBUTING.md](../CONTRIBUTING.md) for setup,
+then come back here to find something to work on.
+
+## Testing
+
+Real-world testing is the single most valuable thing right now, and most of it
+needs no code. File a report (there are issue templates for each) with what you
+ran and what happened:
+
+- **Jellyfin** — different versions, reverse proxies, Cloudflare Tunnels, big
+  vs. small libraries. ([#79](https://github.com/thezupzup/linthra/issues/79))
+- **Navidrome / Subsonic** — Navidrome and other Subsonic-compatible servers.
+  ([#80](https://github.com/thezupzup/linthra/issues/80))
+- **Cast devices** — speakers, TVs, displays. Watch for duplicate local + Cast
+  playback. ([#81](https://github.com/thezupzup/linthra/issues/81))
+- **Android Auto** — real head units and the Desktop Head Unit.
+  ([#82](https://github.com/thezupzup/linthra/issues/82))
+- **Different Android versions** — especially Android 13+ where the runtime
+  notification permission applies.
+
+Reminder: no tokens, passwords, or full private server URLs in reports — a
+version number and a description are plenty.
+
+## Documentation
+
+- **Screenshots** of a running build for the README and store listing
+  ([#77](https://github.com/thezupzup/linthra/issues/77)), and a short demo
+  GIF/video ([#91](https://github.com/thezupzup/linthra/issues/91)).
+- **Install & setup guides** — make first-run smoother for newcomers.
+- **Troubleshooting** — capture the gotchas you hit so the next person doesn't.
+- **Bug-report docs** — help testers write clear, secret-free reports
+  ([#78](https://github.com/thezupzup/linthra/issues/78)).
+
+## UI / UX
+
+- **Empty states** — blank screens that explain what to do next
+  ([#89](https://github.com/thezupzup/linthra/issues/89)).
+- **Accessibility** — clearer screen-reader labels and TalkBack support
+  ([#90](https://github.com/thezupzup/linthra/issues/90)).
+- **Library polish** — browsing, sorting, and search refinements.
+- **Now Playing polish** — small touches on the most-used screen.
+
+## Providers
+
+Sources sit behind one `MusicSource` interface, so new backends slot in without
+touching the rest of the app.
+
+- **WebDAV / NAS** — research and design first, then implementation
+  ([#86](https://github.com/thezupzup/linthra/issues/86)).
+- **Future self-hosted sources** — ideas welcome if they fit the streaming-first,
+  secret-safe model.
+
+## Playback
+
+- **Streaming resilience** — graceful recovery on weak networks, without
+  duplicate playback or leaked tokens
+  ([#83](https://github.com/thezupzup/linthra/issues/83)).
+- **Queue polish** — reordering, "play next", and saving the queue.
+- **ReplayGain / volume normalization** — a later, nice-to-have refinement.
+
+## Release readiness
+
+These are honest checklists, not claims that Linthra is on any store yet.
+
+- **F-Droid prep** — metadata, license/dependency audit, reproducible build
+  notes ([#87](https://github.com/thezupzup/linthra/issues/87)).
+- **Play Store closed-testing prep** — data safety, signing, screenshots,
+  testing group ([#88](https://github.com/thezupzup/linthra/issues/88)).
+
+## Suggested issue labels
+
+If you maintain or triage issues, these labels keep things easy to navigate.
+Most map directly to the areas above:
+
+| Label | For |
+| --- | --- |
+| `good first issue` | Scoped, approachable, light on context |
+| `help wanted` | Where an extra pair of hands would help most |
+| `testing` | Compatibility and real-hardware reports |
+| `documentation` | Docs, guides, screenshots |
+| `ui-polish` | Visual and interaction refinements |
+| `accessibility` | Screen-reader and TalkBack work |
+| `jellyfin` | Jellyfin-specific |
+| `navidrome` | Navidrome / Subsonic-specific |
+| `cast` | Chromecast / Cast |
+| `android-auto` | Android Auto / head units |
+| `playback` | Streaming, queue, audio behaviour |
+| `privacy` | Secrets, permissions, data handling |
+| `f-droid` | F-Droid readiness |
+| `play-store` | Google Play readiness |
+
+Don't see your idea here? Open an issue anyway — this list isn't exhaustive, and
+fresh perspectives are how the roadmap grows.


### PR DESCRIPTION
Makes the repo feel like a real, welcoming open-source project — docs only, no app or workflow changes.

## README tone improvements
- Fixed the "Ways to help" list: the **Try Cast** bullet had lost its marker and merged into the Jellyfin line; tidied spacing across the list.
- Added **Improve accessibility** as a way to help.
- Added a short "New here?" pointer to `CONTRIBUTING.md`, the contributor roadmap, and the `good first issue` / `help wanted` tags.
- Added **Contributing & setup** and **Where to help** rows to the documentation table.

## Contributor onboarding
- New `CONTRIBUTING.md` — short welcome, two-command setup (`./scripts/setup_flutter.sh`, `./scripts/verify_android.sh`), how to pick an issue, good first contributions, PR expectations (small/focused, clear description, tests when relevant, no unrelated changes), code style, privacy/security rules (no token leaks, no persisted authenticated URLs, no secrets in logs), and Android testing notes (Cast, Android Auto, Jellyfin/Navidrome, offline cache).

## Issue templates added/updated
Added five GitHub Form templates alongside the existing bug/feature ones:
- Jellyfin compatibility report (`testing`, `jellyfin`)
- Navidrome / Subsonic compatibility report (`testing`, `navidrome`)
- Cast device test report (`testing`, `cast`)
- Android Auto test report (`testing`, `android-auto`)
- Documentation improvement (`documentation`)

Each is short, asks for useful specifics, reminds testers not to paste secrets, and points to **Settings → Report a bug** diagnostics.

## Contributor roadmap
- New `docs/contributor-roadmap.md` covering Testing, Documentation, UI/UX, Providers, Playback, and Release readiness — cross-linked to the matching open issues — plus a suggested issue-label table (`good first issue`, `help wanted`, `testing`, `documentation`, `ui-polish`, `accessibility`, `jellyfin`, `navidrome`, `cast`, `android-auto`, `playback`, `privacy`, `f-droid`, `play-store`).

## Docs changed
- `README.md`, `CONTRIBUTING.md` (new), `docs/contributor-roadmap.md` (new), and 5 new `.github/ISSUE_TEMPLATE/*.yml` files.

## Intentionally NOT changed
- No app code or behaviour.
- No release/CI workflows (only docs and links touched).
- Existing `bug_report.yml`, `feature_request.yml`, and `config.yml` left as-is — they already follow the tone.
- No new screenshots committed (still tracked as a contribution in #77 / #91).

## Verification
- All five new templates pass YAML parsing.
- All internal markdown links in the README, CONTRIBUTING, and roadmap resolve to real files.


---
_Generated by [Claude Code](https://claude.ai/code/session_014PN4J29L5wmYBc2pSafTNP)_