### PR TITLE
F-Droid readiness: metadata draft, dependency audit, permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Play or F-Droid**, and it has honest, documented rough edges (see
 [Roadmap](#-roadmap) and the per-feature docs). That's exactly why it's a great
 time to jump in — small contributions land fast and shape where it goes.
 
+> **F-Droid readiness is in progress** (not yet submitted, not yet on F-Droid) —
+> see [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
+
 ## 📸 Screenshots
 
 Linthra ships with real branding — an equalizer mark carrying a violet→orange

--- a/docs/dependency-license-audit.md
+++ b/docs/dependency-license-audit.md
@@ -26,12 +26,19 @@ alongside MPL-2.0 code.
 - **Scope:** the **direct** dependencies declared in
   [`pubspec.yaml`](../pubspec.yaml). Licenses below are the ones each package
   publishes on [pub.dev](https://pub.dev) / in its bundled `LICENSE` file.
-- **Not yet run mechanically:** a full **transitive** dependency walk was not
-  generated for this document (the Dart/Flutter toolchain and a resolved
-  `pubspec.lock` were not available in the environment that produced it, and
-  `pubspec.lock` is currently git-ignored — see
-  [reproducibility notes](./fdroid-build-recipe.md#4-reproducibility-notes)).
-  Confirming the complete transitive set is still an open item (§6).
+- **Transitive walk — now run.** The full transitive dependency set has since
+  been resolved and audited with the pinned toolchain (Flutter 3.27.4 /
+  Dart 3.6.2). `flutter pub get` + `flutter pub deps` resolve **152** packages;
+  a license scan of every resolved package (reading each package's bundled
+  `LICENSE`) classifies them as **101 BSD-3-Clause, 34 MIT, 6 Apache-2.0,
+  6 BSD-2-Clause, 2 MPL-2.0** — every one a permissive free-software license,
+  MPL-2.0-compatible, with **no GPL/LGPL, proprietary, or unknown license**.
+  The only two packages without their own `LICENSE` file are `flutter_test` and
+  `flutter_web_plugins`, both bundled inside the Flutter SDK and covered by the
+  SDK's own BSD-3-Clause license. No `com.google.android.gms` / `play-services`
+  / Firebase / analytics / ads / crash-reporting package appears anywhere in the
+  resolved tree (§5, §6). `pubspec.lock` remains git-ignored, so this reflects
+  the set resolved at audit time; re-run on a dependency change.
 - **To reproduce / extend this audit** with the toolchain available:
 
   ```sh
@@ -66,8 +73,9 @@ compatible with MPL-2.0 and acceptable to F-Droid.
 | `audio_service`          | `^0.18.15`   | ryanheise.com       | MIT            | Background playback / media session. |
 | `file_picker`            | `^8.1.4`     | (miguelpruivo)      | MIT            | Native folder chooser (SAF). |
 | `shared_preferences`     | `^2.3.3`     | flutter.dev         | BSD-3-Clause   | Persists the selected folder. |
-| `http`                   | `^1.2.0`     | dart.dev            | BSD-3-Clause   | HTTP client for the optional Jellyfin source (§7). |
-| `flutter_secure_storage` | `^9.2.2`     | (juliansteenbakker) | BSD-3-Clause   | Encrypted store for the Jellyfin session token (§7). |
+| `http`                   | `^1.2.0`     | dart.dev            | BSD-3-Clause   | HTTP client for the optional self-hosted sources — Jellyfin and Navidrome/Subsonic (§7). |
+| `crypto`                 | `^3.0.3`     | dart.dev            | BSD-3-Clause   | MD5 hashing for the Subsonic/Navidrome `token = md5(password + salt)` auth scheme, so only the derived `(salt, token)` is stored — never the plaintext password (§7). Also pulled in transitively by `just_audio`. |
+| `flutter_secure_storage` | `^9.2.2`     | (juliansteenbakker) | BSD-3-Clause   | Encrypted store for the Jellyfin/Subsonic session token (§7). |
 | `cast`                   | `^2.1.0`     | (johnvuko)          | MIT            | Pure-Dart Google Cast v2 protocol for real Chromecast — **no** Google Play Services / proprietary Cast SDK. See §5 (Casting). |
 | `bonsoir`                | `^5.1.11`    | (Skyost)            | MIT            | mDNS/Bonjour service discovery used by `cast`; Android side is AOSP `NsdManager`, not GMS. Pinned to 5.x for Dart 3.6 (6.x+ needs Dart ≥3.8). See §5 (Casting). |
 | `url_launcher`           | `^6.3.0`     | flutter.dev         | BSD-3-Clause   | Opens the browser for the "Report a bug" → "Open GitHub issue" action (a prefilled, **unsubmitted** issue the user reviews). AOSP `ACTION_VIEW` intent; **no** GMS. See note below and §7 (Reporting a bug). |
@@ -108,11 +116,24 @@ source (no prebuilt proprietary blobs).
 - **Android Keystore / EncryptedSharedPreferences** (used by
   `flutter_secure_storage`): part of the **AOSP** platform, not Google Play
   Services. No proprietary dependency is introduced.
-- **No Google Play Services / Firebase / GMS.** None of the direct dependencies
-  require Google Play Services, Firebase, or other proprietary Google libraries.
-  The Android Auto declaration uses the standard `MediaBrowserService` /
+- **AndroidX Media3 / ExoPlayer** (Maven AAR pulled by `just_audio`):
+  `androidx.media3:media3-exoplayer:1.4.1` (+ the `-dash`, `-hls`,
+  `-smoothstreaming` modules) is the playback engine for both local files and
+  streaming. **Media3 is part of AndroidX/Jetpack and is licensed Apache-2.0 —
+  open source and buildable from source. It is _not_ Google Play Services / the
+  proprietary Cast SDK.** `audio_service` and `audio_session` likewise use only
+  `androidx.media:media:1.7.0` and `androidx.core:core` (AndroidX, Apache-2.0).
+  Media3's bundled manifest is the source of the merged `ACCESS_NETWORK_STATE`
+  permission (it reads connectivity state for adaptive streaming); see the
+  permissions table in [fdroid-readiness.md](./fdroid-readiness.md).
+- **No Google Play Services / Firebase / GMS.** Confirmed by the transitive walk
+  (§2): no `com.google.android.gms`, `play-services`, Firebase, or other
+  proprietary Google library appears in the resolved dependency tree. The
+  Android Auto declaration uses the standard `MediaBrowserService` /
   `media-session` APIs from `audio_service` (AOSP media APIs), not a proprietary
-  car SDK. _(Confirm there is no transitive GMS pull-in as part of §6.)_
+  car SDK — the `com.google.android.gms.car.application` manifest entry is just
+  the meta-data key name Android Auto reads to list a media app; it links no GMS
+  library.
 
 ### Casting (Chromecast) — real Cast without Google Play Services
 
@@ -160,36 +181,36 @@ Mapped to F-Droid's [anti-features](https://f-droid.org/docs/Anti-Features/):
 | -------------------------- | ------ | ----- |
 | Ads                        | None   | No advertising libraries or code. |
 | Tracking / analytics       | None   | No telemetry, analytics, or crash-reporting SDK is present. |
-| Proprietary dependencies   | None found in **direct** deps | All direct deps are MIT/BSD-3-Clause; transitive set still to be confirmed mechanically (§2). Chromecast deliberately avoids the GMS Cast SDK (pure-Dart `cast` + AOSP `NsdManager` via `bonsoir`); see §5 (Casting). |
-| Non-free network services  | See §7 | Local-first core needs no network; Jellyfin is optional and user-configured. |
+| Proprietary dependencies   | **None** (transitive walk confirmed) | All 152 resolved packages are permissive free software (MIT/BSD/Apache-2.0/MPL-2.0); no GMS/Firebase/proprietary package present (§2). Native AARs are AndroidX Media3/`media`/`core` (Apache-2.0) and SQLite (public domain) — all open source (§5). Chromecast deliberately avoids the GMS Cast SDK (pure-Dart `cast` + AOSP `NsdManager` via `bonsoir`); see §5 (Casting). |
+| Non-free network services  | See §7 | Local-first core needs no network; the self-hosted Jellyfin/Navidrome/Subsonic sources are optional and user-configured. |
 
-## 7. Network use & the optional Jellyfin source
+## 7. Network use & the optional self-hosted sources
 
 Linthra is **local-first**: the core (folder selection, scanning, the persisted
-catalog) works with **no network access at all**. The production
-`AndroidManifest.xml` declares no `INTERNET` permission of its own; `INTERNET`
-appears only in the debug/profile manifests (for Flutter hot reload).
+catalog) works with **no network access at all**. Optional self-hosted sources —
+**Jellyfin** and **Navidrome / Subsonic** — let the user stream from a server
+they run themselves. These are the reason `http`, `crypto`, and
+`flutter_secure_storage` are dependencies. The production
+`AndroidManifest.xml` now declares the `INTERNET` permission (so release builds
+can reach the user's server); this is a normal, expected permission for a
+user-opted-in remote source and is not an anti-feature by itself. F-Droid
+implications:
 
-A **Jellyfin** source foundation has since landed (server settings, sign-in,
-encrypted session token, a library source behind an interface). It is the reason
-`http` and `flutter_secure_storage` are dependencies. F-Droid implications:
-
-- **Optional and user-configured.** No Jellyfin server is bundled, promoted, or
-  required; the user supplies their own server URL and credentials. The app does
-  not depend on any specific hosted service.
-- **Jellyfin is free software.** The Jellyfin server is itself
-  free/open-source, and Linthra only speaks plain HTTP(S) to it via the
-  permissive `http` package.
-- **Anti-feature judgement:** because the non-local source is optional,
-  user-supplied, and points at free software, it does not obviously warrant the
-  `NonFreeNet` anti-feature. This should still be **reviewed at submission time**
-  — if any future source defaults to or promotes a non-free hosted service, it
-  must be reassessed (the [readiness doc](./fdroid-readiness.md#5-anti-features-review)
-  carries the same caveat).
-- When the Jellyfin client begins making real network calls, the production
-  manifest will need an `INTERNET` permission; that is a normal, expected
-  permission for a user-opted-in remote source and is not an anti-feature by
-  itself.
+- **Optional and user-configured.** No server is bundled, promoted, or required;
+  the user supplies their own server URL and credentials. The app does not
+  depend on, default to, or promote any specific hosted service, and the
+  local-first core remains fully functional with no network at all.
+- **The servers are free software.** Jellyfin, Navidrome, and the Subsonic API
+  ecosystem are themselves free/open-source. Linthra only speaks plain HTTP(S)
+  to them via the permissive `http` package; the Subsonic/Navidrome
+  `token = md5(password + salt)` scheme is computed locally with `crypto`.
+- **Anti-feature judgement (`NonFreeNet`):** because every non-local source is
+  optional, user-supplied, and points at free software the user hosts, it does
+  **not** warrant the `NonFreeNet` anti-feature. This should still be **reviewed
+  at submission time** — if any future source defaults to or promotes a non-free
+  hosted service, it must be reassessed (the
+  [readiness doc](./fdroid-readiness.md#5-anti-features-review) carries the same
+  caveat).
 
 ### Reporting a bug (browser hand-off, no auto-send)
 
@@ -220,18 +241,19 @@ The in-app "Report a bug" flow (Settings → Report a bug) is the reason
 - **Project license:** MPL-2.0 (free, F-Droid-accepted).
 - **Direct dependencies:** all MIT or BSD-3-Clause — permissive, free, and
   MPL-2.0-compatible. No copyleft conflicts, no proprietary direct deps.
-- **Native bits:** SQLite (public domain, built from source) and Android Keystore
-  (AOSP). No Google Play Services / Firebase in the direct dependency set.
-- **Bottom line:** nothing in the **declared** dependency set blocks F-Droid on
-  licensing grounds. The remaining work is mechanical verification of the full
-  transitive tree (§6 below).
+- **Transitive set:** the full resolved tree (152 packages) was audited (§2) —
+  all permissive (BSD/MIT/Apache-2.0/MPL-2.0), no GMS/Firebase/proprietary.
+- **Native bits:** SQLite (public domain, built from source), AndroidX Media3 /
+  `media` / `core` (Apache-2.0, open source — the playback engine, not GMS), and
+  Android Keystore (AOSP). No Google Play Services / Firebase anywhere.
+- **Bottom line:** nothing in the dependency set — direct or transitive — blocks
+  F-Droid on licensing grounds.
 
 ## 9. Outstanding before submission
 
-1. **Run the mechanical transitive audit** (§2 commands) and confirm every
-   transitive package is free software with no Google-only / proprietary binary
-   pull-in. This is the last open piece of the dependency blocker tracked in
-   [fdroid-readiness.md §8](./fdroid-readiness.md#8-remaining-blockers-before-submission).
+1. ~~**Run the mechanical transitive audit.**~~ **Done** (§2): 152 resolved
+   packages, all permissive free software, no GMS/Firebase/proprietary pull-in.
+   Re-run on any dependency change (item 3).
 2. **Decide the `pubspec.lock` policy** for releases so the audited dependency
    set is pinned at the tagged commit (see
    [fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).

--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -163,47 +163,17 @@ These must be resolved before an actual F-Droid submission (see also
 6. **Gradle wrapper jar.** Confirm the recipe handles the missing committed
    `gradle-wrapper.jar` (§3) reproducibly.
 
-## 7. Suggested draft F-Droid metadata snippet
+## 7. Draft F-Droid metadata recipe
 
-Draft only — to be finalized and verified against a real tagged build before any
-fdroiddata merge request. `commit`/`versionName`/`versionCode` are placeholders
-for the first real release.
+A complete, current draft recipe now lives in the repo at
+[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
+(versioned to the current `0.1.0-alpha.15`, with the `commit:` left as a
+placeholder until the first real `v*` tag). That file is the canonical draft;
+edit it there rather than duplicating a snippet here.
 
-```yaml
-# metadata/io.github.thezupzup.linthra.yml  (DRAFT — not submitted)
-Categories:
-  - Multimedia
-License: MPL-2.0
-SourceCode: https://github.com/thezupzup/linthra
-IssueTracker: https://github.com/thezupzup/linthra/issues
-# Changelog: https://github.com/thezupzup/linthra/releases  # only once Releases exist
-
-AutoName: Linthra
-
-RepoType: git
-Repo: https://github.com/thezupzup/linthra.git
-
-Builds:
-  - versionName: 0.1.0
-    versionCode: 1
-    commit: v0.1.0
-    # Generated Drift files are committed, so no build_runner prebuild is needed.
-    sudo:
-      - # (toolchain provisioning, if the recipe installs Flutter itself)
-    output: build/app/outputs/flutter-apk/app-release.apk
-    srclibs:
-      - # Flutter 3.27.4 srclib, if used
-    build: |
-      flutter pub get
-      flutter build apk --release
-
-AutoUpdateMode: Version v%v
-UpdateCheckMode: Tags ^v[0-9.]+$
-CurrentVersion: 0.1.0
-CurrentVersionCode: 1
-```
-
-> The exact Flutter-on-F-Droid build incantation (srclib vs. `sudo`-installed
-> SDK, ABI splitting, `output` path) must be validated against fdroiddata's
-> current Flutter recipes at submission time. Treat the block above as a
-> starting point, not a finished recipe.
+> **Still a draft — not submitted.** The exact Flutter-on-F-Droid build
+> incantation (Flutter srclib vs. `sudo`-installed SDK, ABI splitting, `output`
+> path) must be validated against fdroiddata's current Flutter recipes at
+> submission time, and the `commit:`/`versionName`/`versionCode` must be set to a
+> real tagged release. See the [readiness checklist](./fdroid-readiness.md#8-remaining-blockers-before-submission)
+> for the version-reconciliation and pre-release-tag caveats.

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -9,15 +9,20 @@ availability.
 
 ## 1. Current status
 
-- **Stage:** early development. Library v1 (folder selection, scanning,
-  persisted listing) works end to end; playback, playlists, and offline
-  downloads are still planned.
-- **Distribution:** none yet. No tagged release, no published APK, no F-Droid
-  metadata submission.
+- **Stage:** early **alpha** (`0.1.0-alpha.15`), usable for testing on a real
+  device. Working today: local-folder library (SAF scan + browse), self-hosted
+  streaming from Jellyfin and Navidrome/Subsonic, smart offline cache, queue,
+  playlists & favourites, smart mixes, background playback (media notification /
+  lock screen / Bluetooth), Android Auto, and Cast (pure-Dart, no Google Play
+  Services). Not production-stable; documented rough edges remain.
+- **Distribution:** GitHub Releases only (sideloaded APK / Obtainium). **No
+  tagged release exists yet**, no F-Droid metadata has been submitted, and
+  Linthra is **not on F-Droid**.
 - **Groundwork in place:** stable application ID, MPL-2.0 license, a real
-  Linthra app/launcher icon, and Fastlane-style store metadata under
-  `fastlane/metadata/android/en-US/` (text plus a real icon and feature
-  graphic; screenshots still pending).
+  Linthra app/launcher icon, Fastlane-style store metadata under
+  `fastlane/metadata/android/en-US/` (text + real icon and feature graphic;
+  screenshots still pending), a completed dependency/license audit, and a draft
+  F-Droid recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
 - **Not ready to submit.** See [Remaining blockers](#8-remaining-blockers-before-submission).
 
 ## 2. App identity
@@ -34,22 +39,38 @@ availability.
   an [FSF/OSI-approved free license](https://www.gnu.org/licenses/license-list.html)
   accepted by F-Droid.
 
-## 3. Build requirements
+## 3. Build-from-source requirements
 
-Linthra is a Flutter (Dart) application targeting Android.
+Linthra is a Flutter (Dart) application targeting Android. The toolchain is
+pinned and matches CI (`.github/workflows/ci.yml`, `android-debug-apk.yml`).
 
-- **Flutter SDK:** stable channel; Dart SDK `>=3.6.0 <4.0.0` (see
-  `pubspec.yaml` / `.metadata`).
-- **Build command:** `flutter build apk --release` (or split-per-ABI / appbundle
-  as appropriate).
-- **Native components:** `sqlite3_flutter_libs` bundles a native SQLite engine;
-  the F-Droid build must be able to fetch/build it reproducibly.
-- **Code generation:** Drift `*.g.dart` files are generated via
-  `build_runner`. The F-Droid build recipe must either include committed
-  generated files or run `dart run build_runner build` as a prebuild step.
-- **F-Droid build server constraint:** all dependencies must be free software
-  and buildable from source on F-Droid's infrastructure (no proprietary SDKs,
-  no Google/Firebase binaries, no prebuilt closed blobs).
+| Question | Answer |
+| -------- | ------ |
+| **Flutter version required?** | **3.27.4**, `stable` channel — pinned in [`.flutter-version`](../.flutter-version) and both CI workflows. `scripts/setup_flutter.sh` installs exactly this version locally. |
+| **Dart SDK?** | `>=3.6.0 <4.0.0` (`pubspec.yaml`); satisfied by Flutter 3.27.4 (Dart 3.6.2). |
+| **JDK / Gradle?** | JDK 17 (Temurin in CI), Gradle 8.3, Android Gradle Plugin 8.1.0, Kotlin 1.8.22. |
+| **Android SDK required?** | **Yes.** A standard Android SDK (`platform-tools`, `platforms;android-35`, `build-tools;35.0.0`) plus the NDK + CMake are needed to compile the one native component (SQLite, below). `compileSdk`/`minSdk`/`targetSdk` come from Flutter, not hard-coded. |
+| **Signing keys required to build?** | **No.** A from-source build needs no signing material; F-Droid signs its own builds. Linthra's release signing is optional and supplied at build time via env vars / `android/key.properties`, falling back to the debug key when absent (see [release-signing.md](./release-signing.md)). No keystore or secret is committed. |
+| **Build commands** | `flutter pub get` then `flutter build apk --release` (or `--debug`; split-per-ABI is fine — appbundle is for Play, not F-Droid). |
+| **Generated files: committed or generated?** | **Committed.** The Drift output `lib/data/database/linthra_database.g.dart` is committed, so **no `build_runner`/codegen prebuild step is required** for the F-Droid build. It must be kept in sync with the schema on the tagged commit (regenerate with the `generate-drift.yml` workflow or `dart run build_runner build`). |
+| **How version tags work** | A `v*` git tag is the source of truth; `tool/version_from_tag.dart` derives `versionName`/`versionCode` for GitHub-Release builds. F-Droid builds from source and runs a plain `flutter build`, which takes the version from `pubspec.yaml` — see §6 for the reconciliation caveat. |
+| **Native components** | Only SQLite, via `sqlite3_flutter_libs` — compiled **from source** (the SQLite amalgamation is public domain) using the NDK + CMake; no prebuilt closed blob. The playback engine is AndroidX Media3 (Apache-2.0 Maven AAR), not GMS. |
+| **F-Droid build-server constraint** | All dependencies must be free software and buildable from source (no proprietary SDKs, no Google/Firebase binaries, no prebuilt closed blobs). The dependency/license audit confirms this for the full resolved tree — see §4. |
+
+**Repository & build hygiene** (audited for this pass):
+
+- **No proprietary binary blobs committed.** The only committed binaries are PNG
+  image assets (launcher icons under `android/app/src/main/res/mipmap-*` and the
+  store `icon.png`/`featureGraphic.png`), all generated deterministically from
+  the committed source SVG via `tool/branding/generate_icons.py` (regenerate with
+  `python3 tool/branding/generate_icons.py`). No `.so`/`.jar`/`.aar`/`.keystore`
+  or other closed binary is tracked.
+- **No secrets or API keys committed.** No keystore, token, password, or API key
+  is in the repository; release signing material is git-ignored and injected at
+  build time only (see [release-signing.md](./release-signing.md)).
+- **No build step needs private credentials.** Building from source is
+  `flutter pub get` + `flutter build apk` — the CI debug-APK build runs with
+  read-only repo access and no secrets (`android-debug-apk.yml`).
 
 ## 4. Dependencies review
 
@@ -68,8 +89,9 @@ accepted on F-Droid:
 | `audio_service`          | Background playback / media session      | MIT | OK |
 | `file_picker`            | Native folder chooser                    | MIT | OK |
 | `shared_preferences`     | Persists selected folder                 | BSD-3-Clause | OK |
-| `http`                   | HTTP client for the optional Jellyfin source | BSD-3-Clause | OK (network is opt-in; see §5) |
-| `flutter_secure_storage` | Encrypted Jellyfin session-token store   | BSD-3-Clause | OK (Android Keystore; AOSP, not GMS) |
+| `http`                   | HTTP client for the optional self-hosted sources | BSD-3-Clause | OK (network is opt-in; see §5) |
+| `crypto`                 | MD5 for the Subsonic/Navidrome token auth | BSD-3-Clause | OK (Dart-team package; hashing only) |
+| `flutter_secure_storage` | Encrypted Jellyfin/Subsonic session-token store | BSD-3-Clause | OK (Android Keystore; AOSP, not GMS) |
 | `cast`                   | Real Chromecast (pure-Dart Cast v2 protocol) | MIT | OK — **no** GMS / Google Cast SDK; see [audit §5 (Casting)](./dependency-license-audit.md#casting-chromecast--real-cast-without-google-play-services) |
 | `bonsoir`                | mDNS discovery used by `cast`            | MIT | OK — Android side is AOSP `NsdManager`, not GMS; pinned to 5.x for Dart 3.6 |
 | `url_launcher`           | Opens the browser for "Report a bug" → "Open GitHub issue" | BSD-3-Clause | OK — official Flutter plugin; AOSP `ACTION_VIEW` intent, no GMS; fired only on an explicit user tap. See [audit §7 (Reporting a bug)](./dependency-license-audit.md#reporting-a-bug-browser-hand-off-no-auto-send) |
@@ -82,67 +104,92 @@ the methodology live in [docs/dependency-license-audit.md](./dependency-license-
 All direct dependencies are permissive (MIT / BSD-3-Clause) and MPL-2.0
 compatible.
 
+**Transitive audit — done.** The full resolved tree was walked with the pinned
+toolchain (`flutter pub get` + `flutter pub deps`): **152 packages**, every one a
+permissive free-software license (101 BSD-3-Clause, 34 MIT, 6 Apache-2.0,
+6 BSD-2-Clause, 2 MPL-2.0), with **no Google Play Services / Firebase / analytics
+/ ads / crash-reporting package anywhere** in the tree. The only native AAR is
+AndroidX Media3 (Apache-2.0, the playback engine — not GMS). Full results and
+methodology in [dependency-license-audit.md §2 & §5](./dependency-license-audit.md#2-how-this-audit-was-produced-and-its-limits).
+
 **Action items:**
-- **Mechanical transitive audit still pending.** The direct-dependency license
-  review is done (audit doc above); a tool-driven walk of the full transitive
-  tree (`flutter pub deps`, license collector) confirming no Google Play
-  Services / Firebase / proprietary pull-in has not yet been run. See
-  [audit §6 & §9](./dependency-license-audit.md#6-anti-features--non-free-check).
 - Verify each plugin builds cleanly on the F-Droid build server (some Flutter
-  plugins need specific recipe tweaks).
+  plugins need specific recipe tweaks); confirm the NDK/CMake native build of
+  `sqlite3_flutter_libs` works there.
+- Decide the `pubspec.lock` policy (still git-ignored) so the audited set is
+  pinned at the tagged commit (see [build-recipe §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
 
 ## 5. Anti-features review
 
 F-Droid labels apps with [anti-features](https://f-droid.org/docs/Anti-Features/)
 where applicable. Current assessment:
 
-| Anti-feature              | Present? | Notes |
-| ------------------------- | -------- | ----- |
-| Ads                       | **No**   | No advertising of any kind. |
-| Tracking / analytics      | **No**   | No telemetry, analytics, or crash reporting SDKs. |
-| Non-free network services | **No** (optional Jellyfin source — see below) | Local-first core needs no network. The optional Jellyfin source is user-configured and points at free software. |
-| Non-free dependencies     | No (TBC) | Direct deps cleared (all MIT/BSD-3-Clause); transitive walk still to be confirmed by the audit above. |
+| Anti-feature (F-Droid flag) | Apply? | Reasoning |
+| --------------------------- | ------ | --------- |
+| `Ads`              | **No** | No advertising libraries or code of any kind; no ad SDK in the resolved tree (§4). |
+| `Tracking`         | **No** | No telemetry, analytics, or crash-reporting SDK. Play history, smart-mix signals, and the "Report a bug" breadcrumb buffer all stay on-device; nothing is auto-sent. Confirmed by the transitive audit (no analytics/crash package). |
+| `NonFreeAdd`       | **No** | The app promotes/installs no non-free add-ons. |
+| `NonFreeDep`       | **No** | Every resolved dependency is permissive free software (§4 transitive audit); the playback AAR is AndroidX Media3 (Apache-2.0), and Cast is the pure-Dart `cast` package — **not** the GMS Cast SDK. |
+| `NonFreeNet`       | **No** (see note) | The local-first core needs no network. The optional Jellyfin / Navidrome / Subsonic sources are user-supplied and point at free-software servers the user hosts — not a mandatory or promoted proprietary service. |
+| `UpstreamNonFree`  | **No** | The upstream project (this repo) is entirely MPL-2.0 free software; no non-free build inputs or assets (icons are generated from a committed SVG — §7). |
+| `KnownVuln`        | **No (as of this audit)** | No dependency in the resolved tree is a known-vulnerable version at audit time; re-check on dependency bumps. F-Droid's own scanner will flag any `KnownVuln` at submission. |
+| `NoSourceSince`    | **No** | Source is fully published and builds are from source. |
 
-> **Optional Jellyfin source.** A Jellyfin source foundation has landed (server
-> settings, sign-in, encrypted session token, a library source). It is optional
-> and entirely user-configured — no server is bundled, promoted, or required, and
-> the local-first core works with no network at all. The Jellyfin server is
-> itself free software, and Linthra only speaks HTTP(S) to it via the permissive
-> `http` package, so it does not obviously warrant the `NonFreeNet`
-> anti-feature. This is reviewed in detail in
-> [dependency-license-audit.md §7](./dependency-license-audit.md#7-network-use--the-optional-jellyfin-source).
+> **Optional self-hosted sources (`NonFreeNet` reasoning).** Linthra can stream
+> from a user's own **Jellyfin** or **Navidrome / Subsonic** server (server
+> settings, sign-in, encrypted session token, a library source behind an
+> interface). These are **optional and entirely user-configured** — no server is
+> bundled, promoted, defaulted-to, or required, and the local-first core works
+> with no network at all. Jellyfin, Navidrome, and the Subsonic API ecosystem are
+> themselves free/open-source, and Linthra only speaks plain HTTP(S) to them. So
+> the optional remote sources do **not** warrant the `NonFreeNet` anti-feature.
+> Reviewed in detail in
+> [dependency-license-audit.md §7](./dependency-license-audit.md#7-network-use--the-optional-self-hosted-sources).
 >
 > **Future caveat:** any further online provider must be reviewed individually
 > and may warrant `NonFreeNet` if it defaults to or promotes a non-free hosted
 > service. The local-first core must remain fully functional without any remote
 > source.
 
-### Android storage / permissions status
+### Android permissions
 
-- **No storage permissions are declared** in `AndroidManifest.xml`. Folder
-  selection uses the Storage Access Framework via the system folder chooser
-  (`file_picker`'s `ACTION_OPEN_DOCUMENT_TREE`), which needs no manifest
-  permission.
-- **`MANAGE_EXTERNAL_STORAGE` is intentionally not used.** It is an
-  "all files access" permission Google restricts and F-Droid users distrust; it
-  is the opposite of the scoped-storage approach this project prefers. It must
-  not be added without an explicit, documented justification.
-- **`CHANGE_WIFI_MULTICAST_STATE` (added for Chromecast discovery).** Real cast
-  discovery must receive multicast Wi-Fi packets for mDNS (`_googlecast._tcp`).
-  This **AOSP** permission (merged from the `bonsoir` plugin and declared
-  explicitly in the manifest for auditability) enables only local-network
-  service discovery — no internet or storage access of its own; the cast session
-  reaches the device over the existing `INTERNET` permission. Casting uses **no**
-  Google Play Services / Cast SDK (pure-Dart `cast` + AOSP `NsdManager`), so it
-  adds no anti-feature — see
-  [audit §5 (Casting)](./dependency-license-audit.md#casting-chromecast--real-cast-without-google-play-services).
-- **Known limitation:** a SAF folder is resolved to a filesystem path and walked
-  with `dart:io`. On Android 11+ that path is frequently unreadable under scoped
-  storage; the scanner now surfaces a clear in-app error in that case
+Every permission Linthra ships is justified below. Six are declared explicitly
+in [`android/app/src/main/AndroidManifest.xml`](../android/app/src/main/AndroidManifest.xml)
+(each with an inline comment); `ACCESS_NETWORK_STATE` is contributed by a
+dependency's bundled manifest at merge time. The set is deliberately minimal:
+**no storage, location, contacts, camera, microphone, or phone permission**, and
+crucially **no broad-storage `MANAGE_EXTERNAL_STORAGE`**.
+
+| Permission | Source | Why it is needed |
+| ---------- | ------ | ---------------- |
+| `INTERNET` | App manifest (also `bonsoir`, Media3, others) | Reach the user's self-hosted Jellyfin/Navidrome/Subsonic server (connection test, sign-in, sync, streaming) and carry the Cast session to a device on the LAN. The local-first core works without it. |
+| `ACCESS_NETWORK_STATE` | Merged from AndroidX **Media3** (`just_audio`'s playback engine) | Lets the player read connectivity *state* (e.g. for adaptive streaming / recovery). It grants **no** network access of its own and is a standard AOSP/AndroidX permission. Not declared by Linthra directly. |
+| `FOREGROUND_SERVICE` | App manifest (also `audio_service`) | Run the `audio_service` playback service in the foreground so audio keeps playing when the app is backgrounded. |
+| `FOREGROUND_SERVICE_MEDIA_PLAYBACK` | App manifest | The typed foreground-service grant required on Android 14+ (API 34) for a service of type `mediaPlayback`; without it the playback service cannot start on new devices. |
+| `POST_NOTIFICATIONS` | App manifest | Android 13+ (API 33) runtime permission for the media notification and its lock-screen/transport controls to appear; requested once on first launch. Playback still works if denied, just without the notification. |
+| `WAKE_LOCK` | App manifest (also `audio_service` / Media3) | Keep the CPU (and, via the foreground media service, the Wi-Fi radio) awake while audio plays so playback and streaming survive the screen turning off. Held only while the service reports `playing`. |
+| `CHANGE_WIFI_MULTICAST_STATE` | App manifest (merged from `bonsoir_android`) | Receive multicast Wi-Fi packets for mDNS (`_googlecast._tcp`) Chromecast discovery. An **AOSP** permission (Android `NsdManager`) for local-network discovery only — no internet or storage access. Cast uses **no** Google Play Services / Cast SDK. |
+| _storage_ | — (none) | **No storage permission is declared.** Folder selection uses the Storage Access Framework (`ACTION_OPEN_DOCUMENT_TREE` via `file_picker`), which needs none. |
+
+> **Verification note.** The six explicit permissions are read directly from the
+> committed manifest. `ACCESS_NETWORK_STATE` is contributed by the Media3 AAR at
+> Gradle manifest-merge time; the exact merged set should be re-confirmed against
+> the merged manifest of a release build (`flutter build apk --release`) at
+> submission time — this readiness pass could not run the Android build locally
+> (see [§11 Verification](#11-verification-performed-in-this-readiness-pass) and
+> §8.5). No permission is requested speculatively in code.
+
+- **`MANAGE_EXTERNAL_STORAGE` is intentionally not used.** It is an "all files
+  access" permission Google restricts and F-Droid users distrust; it is the
+  opposite of the scoped-storage approach this project prefers. It must not be
+  added without an explicit, documented justification.
+- **Known SAF limitation:** a SAF folder is resolved to a filesystem path and
+  walked with `dart:io`. On Android 11+ that path is frequently unreadable under
+  scoped storage; the scanner surfaces a clear in-app error in that case
   (`DirectoryReadability` probe + `FolderScanException`) rather than a silent
-  empty library. Lifting the restriction needs content-resolver SAF traversal
-  (native plugin); a narrow `READ_MEDIA_AUDIO` request is a separate future
-  option. Neither permission is requested today.
+  empty library. Lifting the restriction needs content-resolver SAF traversal (a
+  native plugin); a narrow `READ_MEDIA_AUDIO` request is a separate future
+  option. Neither is requested today.
 
 ## 6. Release / tagging plan
 
@@ -178,8 +225,13 @@ Stored under `fastlane/metadata/android/en-US/`:
 
 - [x] `title.txt` — app name.
 - [x] `short_description.txt` — one-line summary (under F-Droid's 80-char limit).
-- [x] `full_description.txt` — long description (separates shipped vs. planned).
-- [x] `changelogs/1.txt` — placeholder notes for `versionCode` 1.
+- [x] `full_description.txt` — long description. **Stale — refresh before
+  submission** (§8.3): it still lists now-shipped features as "planned" and lacks
+  the "unofficial / not affiliated" framing. F-Droid uses this as the listing
+  Description.
+- [x] `changelogs/1.txt`, `9.txt`, `15.txt` — per-version notes (named by the
+  current `pubspec.yaml` `versionCode`). Keep the filename in lockstep with the
+  built APK's `versionCode` (§6, §8.2).
 - [x] `images/icon.png` — 512×512 real Linthra store icon. The launcher icons
   under `android/app/src/main/res/mipmap-*` are now the same real mark (adaptive
   + legacy), generated from `tool/branding/` — no longer the default Flutter
@@ -198,41 +250,102 @@ step-by-step capture instructions live in
 
 ## 8. Remaining blockers before submission
 
-1. **Release signing.** Release signing can now be supplied via env vars /
-   `android/key.properties`, with CI decoding a keystore from secrets; builds
-   fall back to the debug key only when no signing material is present (see
-   [docs/release-signing.md](./release-signing.md)). F-Droid signs its own
-   builds, so this matters mainly for GitHub-Release artifacts. Remaining work:
-   configure the actual release secrets and decide the GitHub-Release flow.
-2. **Screenshots missing.** The real icon and feature graphic are committed;
-   only screenshots remain, and must be captured from a real build (see
+1. **No tagged release yet.** A `v*` tag (e.g. `v0.1.0-alpha.15`) must exist for
+   F-Droid to build; the draft recipe's `commit:` is a placeholder until then.
+2. **versionCode reconciliation.** A from-source F-Droid build takes the version
+   from `pubspec.yaml` (`0.1.0-alpha.15+15` → versionCode **15**), while the
+   GitHub-Release workflow derives **100015** from the tag. Pick one scheme for
+   the F-Droid channel (bump `pubspec.yaml` at the tagged commit, or pass
+   `--build-name/--build-number` in the recipe) so the metadata `versionCode`
+   and the `changelogs/<code>.txt` filename match the built APK. See §6.
+3. **Fastlane description is stale.** `fastlane/metadata/android/en-US/full_description.txt`
+   still lists shipped features (artist/album browsing, search, playlists,
+   Navidrome/Subsonic) as "planned". Because F-Droid pulls the listing
+   Description from this file, refresh it to match the current alpha — and add
+   the "unofficial / not affiliated" framing — before submission. (The draft
+   `metadata/<appid>.yml` Description is already accurate.)
+4. **Screenshots missing.** The real icon and feature graphic are committed; only
+   screenshots remain, captured from a real build (see
    [docs/listing-assets.md](./listing-assets.md)).
-3. **Dependency audit (partly done).** The direct-dependency license review is
-   complete — all MIT/BSD-3-Clause, MPL-2.0 compatible
-   ([docs/dependency-license-audit.md](./dependency-license-audit.md)). Still
-   open: a mechanical walk of the full transitive tree confirming no non-free /
-   Google-only components.
-4. **Reproducible build verification.** Confirm the app builds on F-Droid's
-   build server, including Drift codegen as a prebuild step.
-5. **No tagged release yet.** A `vX.Y.Z` tag must exist for F-Droid to build.
-6. **Feature maturity (judgment call).** Decide whether to submit at the current
-   early stage or wait until core playback ships.
-
-## 9. Suggested order before F-Droid submission
-
-1. Finish the dependency audit (§4): the direct-dep license review is done
-   ([audit doc](./dependency-license-audit.md)); run the mechanical transitive
-   walk and resolve any non-free findings.
-2. Sort out release signing config (§8.1; see
+5. **Reproducible build verification.** `flutter pub get`, `dart format`,
+   `flutter analyze`, and `flutter test` (1149 tests) all pass with the pinned
+   toolchain. The **Android APK build could not be run in this readiness
+   environment** (no Android SDK; the network policy here blocks the Android SDK
+   / JDK download hosts) — but CI builds the debug APK on every PR
+   (`android-debug-apk.yml`, JDK 17 + Flutter 3.27.4). Confirm a clean
+   `flutter build apk --release` and the NDK/CMake native build of
+   `sqlite3_flutter_libs` on F-Droid's build server.
+6. **Release signing (GitHub channel only).** Not an F-Droid blocker (F-Droid
+   signs its own builds), but the debug-key fallback should be replaced with real
+   release signing for GitHub-Release artifacts (see
    [docs/release-signing.md](./release-signing.md)).
-3. Verify a clean release build, including codegen (§3, §8.4).
-4. Capture and commit real screenshots (§7; the icon and feature graphic are
-   already done — see [docs/listing-assets.md](./listing-assets.md)).
-5. Finalize the version and cut a `vX.Y.Z` tag with a matching changelog (§6;
-   full steps in [docs/release-process.md](./release-process.md)).
-6. Prepare the F-Droid `metadata/<appid>.yml` build recipe and submit a merge
-   request to [fdroiddata](https://gitlab.com/fdroid/fdroiddata).
+7. **Feature maturity (judgment call).** Decide whether to submit at the current
+   early-alpha stage or wait for a stable (non-pre-release) tag — F-Droid may
+   need configuring to accept pre-release tags at all.
 
-The build recipe itself — expected metadata fields, build-source and toolchain
-expectations, reproducibility notes, and a draft `metadata/<appid>.yml` snippet
-— is planned in [docs/fdroid-build-recipe.md](./fdroid-build-recipe.md).
+**Resolved since the previous pass:** the full transitive dependency/license
+audit is complete (§4 — 152 packages, all permissive, no GMS); Drift generated
+files are committed so no codegen prebuild is needed; the full permission set is
+documented (§5).
+
+## 9. Submission checklist (suggested order)
+
+1. ✅ **Dependency/license audit** — done (§4;
+   [audit doc](./dependency-license-audit.md)). Re-run on any dependency change.
+2. **Refresh the Fastlane `full_description.txt`** to match the current alpha and
+   add the "unofficial / not affiliated" framing (§8.3).
+3. **Verify a clean `flutter build apk --release`** on a machine with the Android
+   SDK + NDK (the from-source path F-Droid uses), and re-confirm the merged
+   manifest permission set (§5 verification note).
+4. **Capture and commit real screenshots** (§7; icon and feature graphic already
+   done — see [docs/listing-assets.md](./listing-assets.md)).
+5. **Decide the `versionCode` scheme and `pubspec.lock` policy** for the F-Droid
+   channel (§8.2, §4), then **cut a `v*` tag** with a matching
+   `changelogs/<code>.txt` (§6; steps in
+   [docs/release-process.md](./release-process.md)).
+6. **Finalize the recipe** from the draft
+   [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
+   (set the real `commit:`/version, validate the Flutter build incantation), then
+   submit a merge request to
+   [fdroiddata](https://gitlab.com/fdroid/fdroiddata).
+
+The metadata field reference, build-source/toolchain expectations, and
+reproducibility notes are in
+[docs/fdroid-build-recipe.md](./fdroid-build-recipe.md); a runnable draft recipe
+now lives at
+[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
+
+## 10. Manual test checklist before submission
+
+F-Droid builds and signs the APK itself, so the build it ships is **not** the one
+tested during development. Before (and after) submission, smoke-test a
+**release** build from the tagged commit on a real device using the full
+[docs/manual-test-checklist.md](./manual-test-checklist.md). The F-Droid-specific
+must-pass items:
+
+- [ ] App installs and launches from a clean `flutter build apk --release`
+      (no debug key, no dev tooling).
+- [ ] Local-folder library: pick a folder (SAF), scan, browse, and play — with
+      **no** storage permission prompt.
+- [ ] Self-hosted source: add a Jellyfin and a Navidrome/Subsonic server, sign
+      in, sync, and stream over HTTPS.
+- [ ] Background playback: media notification + lock-screen controls appear
+      (grant `POST_NOTIFICATIONS`) and survive backgrounding.
+- [ ] Cast discovery finds a device on the LAN (multicast permission works) and
+      playback hands off — confirming the pure-Dart Cast path needs no GMS.
+- [ ] Android Auto lists the app and loads the browse tree (DHU or head unit).
+- [ ] No crash/telemetry network traffic at rest (verify with a network monitor:
+      nothing leaves the device unless the user configures a server).
+
+## 11. Verification performed in this readiness pass
+
+Run with the pinned toolchain (Flutter 3.27.4 / Dart 3.6.2):
+
+| Check | Result |
+| ----- | ------ |
+| `flutter pub get` | ✅ resolves (152 packages) |
+| `dart format --set-exit-if-changed .` | ✅ 410 files, 0 changed |
+| `flutter analyze` | ✅ no issues |
+| `flutter test` | ✅ all 1149 tests passed |
+| transitive license audit | ✅ all permissive, no GMS (§4) |
+| `flutter build apk --debug/--release` | ⚠️ **not run here** — no Android SDK; this environment's network policy blocks the Android SDK/JDK download hosts. CI builds the debug APK on every PR. Run on an SDK-equipped machine (next step §9.3). |

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -1,0 +1,126 @@
+# =============================================================================
+# F-Droid metadata DRAFT for Linthra — NOT SUBMITTED.
+#
+# Linthra is NOT on F-Droid and no submission/merge request has been made. This
+# file is a *draft* kept in the app repository so a future submission to
+# fdroiddata (https://gitlab.com/fdroid/fdroiddata) is straightforward and
+# accurate. The real entry lives in fdroiddata's `metadata/` directory, not
+# here; copy/adapt this file there when submitting.
+#
+# Status notes for reviewers:
+#   * Early alpha, unofficial community project. Not affiliated with or endorsed
+#     by Jellyfin, Navidrome, or the Subsonic project.
+#   * No tracking, no analytics, no ads, no telemetry/crash-reporting SDK.
+#   * No tagged release exists yet, so the `Builds:` `commit:` below is a
+#     PLACEHOLDER for the first real `v*` tag and MUST be set to a real tag
+#     before submission.
+#   * When F-Droid builds, `Summary`/`Description` are normally taken from the
+#     Fastlane files under `fastlane/metadata/android/en-US/`. The inline
+#     `Summary`/`Description` here are provided for review per the readiness
+#     task; the Fastlane `full_description.txt` should be refreshed to match the
+#     current feature set before submission (see docs/fdroid-readiness.md).
+#
+# See docs/fdroid-readiness.md, docs/fdroid-build-recipe.md, and
+# docs/dependency-license-audit.md for the full reasoning behind every value.
+# =============================================================================
+
+Categories:
+  - Multimedia
+License: MPL-2.0
+AuthorName: TheZupZup
+# WebSite: intentionally omitted — there is no separate project website; the
+# source repository below is the canonical home. F-Droid falls back to
+# SourceCode when WebSite is unset.
+SourceCode: https://github.com/thezupzup/linthra
+IssueTracker: https://github.com/thezupzup/linthra/issues
+# Changelog: set this only once tagged GitHub Releases exist. Until then,
+# per-version notes live in fastlane/metadata/android/en-US/changelogs/.
+# Changelog: https://github.com/thezupzup/linthra/releases
+
+Name: Linthra
+AutoName: Linthra
+Summary: Local-first music player for your own self-hosted library
+
+Description: |-
+  Linthra is an open-source, local-first music player for Android, for people
+  who own their music. Point it at a folder of local files, or connect your own
+  self-hosted Jellyfin, Navidrome, or Subsonic server — your library, your
+  server, your rules.
+
+  Linthra is an unofficial community project. It is not affiliated with or
+  endorsed by Jellyfin, Navidrome, or the Subsonic project; you bring your own
+  server and credentials.
+
+  Privacy by design:
+
+  * No tracking, no analytics, no ads, and no crash-reporting/telemetry SDK.
+  * No account and no phoning home — nothing leaves your device unless you ask
+    for it.
+  * Streaming is the default; offline downloads are always explicit and
+    user-initiated (Wi-Fi only unless you opt in to mobile data).
+  * The server password is used once to obtain a session token, then discarded;
+    the token is stored encrypted and never logged.
+
+  What works today:
+
+  * Local library: pick a folder via the Storage Access Framework (no broad
+    storage permission), scan it, and browse Songs / Albums / Artists.
+  * Self-hosted streaming from your own Jellyfin or Navidrome / Subsonic server,
+    including over HTTPS.
+  * Smart offline cache, queue / up-next, playlists and favourites, and
+    automatic "smart mixes" built from on-device signals.
+  * Background playback with a media notification and lock-screen, Bluetooth,
+    and wired-headset controls.
+  * Android Auto browsing, and Cast to a Chromecast / speaker / TV using a
+    pure-Dart Cast implementation — no Google Play Services.
+
+  This is early-alpha software: it is usable for testing on a real device, but
+  it is not production-stable and has documented rough edges. It is distributed
+  for testing today only via GitHub Releases (sideloaded APK), and is NOT yet on
+  F-Droid.
+
+RepoType: git
+Repo: https://github.com/thezupzup/linthra.git
+
+# -----------------------------------------------------------------------------
+# Builds — DRAFT. Verify against a real tagged build before submitting.
+#
+#  * `commit:` is a PLACEHOLDER. No `v*` tag exists yet; set it to the real
+#    annotated release tag (e.g. v0.1.0-alpha.15) at submission time.
+#  * versionName/versionCode below match pubspec.yaml (0.1.0-alpha.15+15), which
+#    is what a plain `flutter build` (what F-Droid runs) produces.
+#    NOTE: the GitHub-Release workflow derives a different, larger versionCode
+#    from the tag (v0.1.0-alpha.15 -> 100015 via tool/version_from_tag.dart).
+#    These two channels MUST be reconciled before submission — either bump
+#    pubspec.yaml at the tagged commit or pass --build-name/--build-number in
+#    the recipe so the F-Droid versionCode matches. See docs/fdroid-readiness.md
+#    §"Release / tagging" and docs/fdroid-build-recipe.md §5.
+#  * Generated Drift files (lib/data/database/linthra_database.g.dart) are
+#    committed, so NO build_runner/codegen prebuild step is required.
+#  * The only native component is SQLite via sqlite3_flutter_libs, compiled from
+#    source (public domain) — no prebuilt closed blobs.
+#  * The exact Flutter-on-F-Droid build incantation (Flutter srclib vs. a
+#    sudo-installed SDK, ABI splitting, output path) must be validated against
+#    fdroiddata's current Flutter recipes at submission time.
+# -----------------------------------------------------------------------------
+Builds:
+  - versionName: 0.1.0-alpha.15
+    versionCode: 15
+    commit: PLACEHOLDER_SET_TO_REAL_TAG # e.g. v0.1.0-alpha.15 — no tag exists yet
+    sudo:
+      - # toolchain provisioning, if the recipe installs Flutter itself
+    output: build/app/outputs/flutter-apk/app-release.apk
+    srclibs:
+      - # Flutter 3.27.4 srclib, if used (Dart 3.6.x, JDK 17, Gradle 8.3)
+    build: |
+      flutter pub get
+      flutter build apk --release
+
+AutoUpdateMode: Version v%v
+# UpdateCheckMode: track v* tags. Linthra currently ships only pre-release
+# (-alpha.N) versions, so the regex must accept the alpha/beta/rc suffix and be
+# validated against the first real tag. F-Droid may need configuring to accept
+# pre-release tags at all; revisit when a stable (non-pre-release) tag exists.
+UpdateCheckMode: Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$
+CurrentVersion: 0.1.0-alpha.15
+CurrentVersionCode: 15


### PR DESCRIPTION
## F-Droid readiness summary

**This PR is F-Droid _readiness_ only.** Nothing is submitted to F-Droid, no
submission/merge request is made, and Linthra is **not** claimed to be on
F-Droid. It is docs + a draft metadata recipe so a future submission is accurate
and straightforward. No app feature, UI, playback, Cast, cache, Jellyfin, or
release-automation changes.

Linthra is at `0.1.0-alpha.15` (early alpha, MPL-2.0, app ID
`io.github.thezupzup.linthra`). The previous F-Droid docs were stale (they said
playback was "still planned"); they now reflect the shipped feature set and the
audit work that was outstanding is now done.

## Dependency / license audit result

The previously-pending **mechanical transitive audit is now complete** (run with
the pinned toolchain, Flutter 3.27.4 / Dart 3.6.2):

- **152 resolved packages, every one permissive** — 101 BSD-3-Clause, 34 MIT,
  6 Apache-2.0, 6 BSD-2-Clause, 2 MPL-2.0. No GPL/LGPL/proprietary/unknown.
- **No Google Play Services, Firebase, analytics, ads, or crash-reporting**
  package anywhere in the tree.
- Cast is the **pure-Dart `cast` package** (Cast v2 wire protocol + AOSP
  `NsdManager` via `bonsoir`) — **not** the proprietary GMS Cast SDK.
- The playback engine is **AndroidX Media3 (Apache-2.0)** — open source, not GMS.
- Added the missing **`crypto`** direct dependency (Subsonic/Navidrome token
  auth) to the audit tables.
- Project license **MPL-2.0** is FSF/OSI-approved and F-Droid-accepted.

## Anti-feature assessment

| Flag | Apply? | Why |
| --- | --- | --- |
| `Ads` | **No** | No ad libraries/code. |
| `Tracking` | **No** | No telemetry/analytics/crash SDK; signals stay on-device. |
| `NonFreeDep` | **No** | All deps permissive; Media3 not GMS; Cast pure-Dart. |
| `NonFreeNet` | **No** | Optional Jellyfin/Navidrome/Subsonic sources are user-supplied and point at free-software servers the user hosts — not mandatory or promoted. Local-first core needs no network. |
| `UpstreamNonFree` | **No** | Repo is fully MPL-2.0; icons generated from a committed SVG. |
| `KnownVuln` | **No (at audit time)** | Re-check on dependency bumps. |

## Metadata draft added

New **`metadata/io.github.thezupzup.linthra.yml`** (draft, clearly marked
NOT-submitted): Categories, License, AuthorName, SourceCode, IssueTracker, Name,
Summary, Description, RepoType/Repo, a draft `Builds` block, AutoUpdate/
UpdateCheck modes, and CurrentVersion/Code. Kept honest — early alpha, unofficial
community project, not affiliated with Jellyfin/Navidrome/Subsonic, no
tracking/ads. The `Builds` `commit:` is a **placeholder** until the first `v*`
tag exists.

## Permissions documented

Full justification table in `docs/fdroid-readiness.md` §5 for every shipped
permission — `INTERNET`, `ACCESS_NETWORK_STATE`, `FOREGROUND_SERVICE`,
`FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `POST_NOTIFICATIONS`, `WAKE_LOCK`,
`CHANGE_WIFI_MULTICAST_STATE` — each with its source (six are in the app
manifest; `ACCESS_NETWORK_STATE` merges from the Media3 AAR). **No storage,
location, contacts, camera, mic, or phone permission, and no broad-storage
`MANAGE_EXTERNAL_STORAGE`.** Also recorded: no committed binary blobs (only PNGs
generated from a committed SVG), no committed secrets/keys, and no
private-credential build step.

## Build-from-source notes

`docs/fdroid-readiness.md` §3 now answers, explicitly: Flutter **3.27.4** (pinned
in `.flutter-version`/CI), Dart `>=3.6.0 <4.0.0`, JDK 17 / Gradle 8.3 / AGP
8.1.0; **Android SDK + NDK + CMake required** (one native component, SQLite, is
compiled from source); **no signing keys needed to build** (F-Droid signs its
own); **Drift generated files are committed** so no `build_runner` prebuild is
needed; and how `v*` tags drive versioning.

## Verification performed

| Check | Result |
| --- | --- |
| `flutter pub get` | ✅ resolves (152 packages) |
| `dart format --set-exit-if-changed .` | ✅ 410 files, 0 changed |
| `flutter analyze` | ✅ no issues |
| `flutter test` | ✅ **all 1149 tests passed** |
| transitive license audit | ✅ all permissive, no GMS |
| `flutter build apk --debug/--release` | ⚠️ **could not run in this environment** — no Android SDK, and the network policy here blocks the Android SDK / JDK download hosts (`dl.google.com`, Adoptium). CI builds the debug APK on every PR (`android-debug-apk.yml`, JDK 17 + Flutter 3.27.4). |

**Next step for the build:** on an SDK-equipped machine, run
`flutter build apk --release`, confirm the SQLite NDK/CMake native build, and
re-check the merged-manifest permission set.

## What remains before actual F-Droid submission

1. Cut a real `v*` tag (none exists yet) and set the recipe's `commit:`.
2. Reconcile the `versionCode` scheme for the F-Droid channel (pubspec `15` vs.
   tag-derived `100015`) so metadata + `changelogs/<code>.txt` match the build.
3. Refresh the stale Fastlane `full_description.txt` (F-Droid uses it as the
   listing Description) to match the current alpha + add the unofficial framing.
4. Capture and commit real screenshots.
5. Verify a clean from-source release build on F-Droid's infra.
6. Decide whether to submit at alpha or wait for a stable tag (F-Droid may need
   configuring to accept pre-release tags).

## Test plan

- [ ] Review `metadata/io.github.thezupzup.linthra.yml` field values.
- [ ] Review the permission justifications and anti-feature reasoning.
- [ ] Confirm the README note does not over-claim (still "not on F-Droid").
- [ ] On an SDK-equipped machine: `flutter build apk --release` and re-check the
      merged manifest.

https://claude.ai/code/session_01AriMPyVAU4vKGhauNTZzqH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AriMPyVAU4vKGhauNTZzqH)_