### PR TITLE
docs: F-Droid submission package targeting the working v0.1.0-alpha.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Play or F-Droid**, and it has honest, documented rough edges (see
 [Roadmap](#-roadmap) and the per-feature docs). That's exactly why it's a great
 time to jump in — small contributions land fast and shape where it goes.
 
-> **F-Droid readiness is in progress** (not yet submitted, not yet on F-Droid) —
-> see [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
+> **On F-Droid:** not yet. Preparation is underway, but Linthra hasn't been
+> submitted and isn't on F-Droid — see [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
 
 ## 📸 Screenshots
 

--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -39,9 +39,9 @@ submission time.
 | `AuthorName`      | TheZupZup _(draft)_ | Optional; confirm preferred attribution. |
 | `SourceCode`      | `https://github.com/thezupzup/linthra` | Public repository. |
 | `IssueTracker`    | `https://github.com/thezupzup/linthra/issues` | GitHub issues. |
-| `Changelog`       | `https://github.com/thezupzup/linthra/releases` _(draft)_ | Only set once tagged GitHub Releases exist; otherwise rely on per-version Fastlane changelogs (§ readiness doc). |
-| `AutoUpdateMode`  | `Version v%v` | Recommended: track annotated git tags of the form `v<versionName>` (see § release plan). |
-| `UpdateCheckMode` | `Tags ^v[0-9.]+$` | Recommended: detect new releases from `vX.Y.Z` tags. Avoids false positives from non-release tags. |
+| `Changelog`       | `https://github.com/thezupzup/linthra/releases` | Tagged GitHub Releases now exist, so this is set. |
+| `AutoUpdateMode`  | `Version v%v` | Track annotated git tags of the form `v<versionName>` (see § release plan). |
+| `UpdateCheckMode` | `Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha\|beta\|rc)\.[0-9]+)?$` | Linthra ships only pre-release `-alpha.N` tags so far; the regex must accept the alpha/beta/rc suffix. Confirm with F-Droid whether it will track a pre-release CurrentVersion (see [fdroid-readiness.md §8](./fdroid-readiness.md#8-remaining-blockers-before-submission)). |
 
 `AutoUpdateMode`/`UpdateCheckMode` only work cleanly if the tag and the
 `pubspec.yaml` version stay in lockstep (§5). Confirm the exact regex against
@@ -121,12 +121,14 @@ process (and the GitHub-Release flow) is in
    `versionName`/`versionCode` (derived by `tool/version_from_tag.dart`, see
    [release-process.md §1](./release-process.md#1-versioning-model));
    `pubspec.yaml` `version: x.y.z+<versionCode>` is the local/dev default.
-   **Note:** F-Droid builds from source and does not run our workflow, so its
-   `flutter build` takes the version from `pubspec.yaml` — set the metadata
-   `versionCode`/`versionName` to the tag-derived values and either bump
-   `pubspec.yaml` at the tagged commit or have the recipe pass
-   `--build-name`/`--build-number` (see the F-Droid caveat in
-   [fdroid-readiness.md §6](./fdroid-readiness.md)).
+   **F-Droid handling (decided):** F-Droid builds from source and does not run
+   our workflow, so a plain `flutter build` would take the static
+   `pubspec.yaml` version (versionCode **15** for every tag). The draft recipe
+   therefore derives the version from the checked-out tag with
+   `tool/version_from_tag.dart` and passes `--build-name`/`--build-number`, so
+   `v0.1.0-alpha.25` builds to `0.1.0-alpha.25` / **100025** — matching the
+   metadata and the GitHub channel, and AutoUpdate-safe for future tags. See
+   [fdroid-submission.md §2](./fdroid-submission.md).
 2. **`versionCode` increases monotonically** by construction (the encoding can
    never go backwards); never reuse or decrease it.
 3. **Tag format suggestion:** annotated tag `vX.Y.Z` (e.g. `v0.1.0`) on the
@@ -148,32 +150,39 @@ These must be resolved before an actual F-Droid submission (see also
    signs its own builds, so this does not block F-Droid functionally, but the
    debug-key fallback should be removed / replaced with a proper release signing
    story before publishing anywhere. **No signing secrets are added in this PR.**
-2. **Real screenshots / assets.** No store icon, feature graphic, or
-   screenshots are committed (only `NEEDED-ASSETS.txt`). See
-   [docs/listing-assets.md](./listing-assets.md).
-3. **Final dependency review.** A transitive-dependency audit confirming no
-   non-free / Google-only components is still outstanding (§4.4).
-4. **Android storage / SAF limitations.** Scanning relies on the Storage Access
+2. **Screenshots.** The store **icon and feature graphic are committed**; only
+   **screenshots** remain, captured from a real build (tracked by issue #77). See
+   [docs/listing-assets.md](./listing-assets.md). Not a hard MR blocker.
+3. **Android storage / SAF limitations.** Scanning relies on the Storage Access
    Framework; `SafTreeUriResolver` currently maps only the common
    `com.android.externalstorage.documents` provider to a real path, and other
    SAF providers / fully content-resolver-based scanning are still follow-ups
    (see README "Android folder selection & known limitations"). This is a
    functionality maturity note, not an F-Droid build blocker per se.
-5. **No tagged release yet.** A `vX.Y.Z` tag must exist for F-Droid to build.
-6. **Gradle wrapper jar.** Confirm the recipe handles the missing committed
+4. **Toolchain provisioning + `fdroid build` validation.** The Flutter-on-F-Droid
+   incantation (sudo git-clone vs. `flutter` srclib) must match fdroiddata's
+   current convention and be validated by an actual `fdroid build`.
+5. **Gradle wrapper jar.** Confirm the recipe handles the missing committed
    `gradle-wrapper.jar` (§3) reproducibly.
+
+**Resolved:** a `v*` tag now exists (target `v0.1.0-alpha.25`; the broken
+`v0.1.0-alpha.24` is excluded); the versionCode scheme is decided (tag-derived
+`100025`, §5.1); and the full transitive dependency audit is complete
+([dependency-license-audit.md](./dependency-license-audit.md)).
 
 ## 7. Draft F-Droid metadata recipe
 
 A complete, current draft recipe now lives in the repo at
-[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
-(versioned to the current `0.1.0-alpha.15`, with the `commit:` left as a
-placeholder until the first real `v*` tag). That file is the canonical draft;
-edit it there rather than duplicating a snippet here.
+[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml),
+pinned to the latest working alpha (`commit: v0.1.0-alpha.25`, versionName
+`0.1.0-alpha.25`, versionCode `100025`). That file is the canonical draft; edit
+it there rather than duplicating a snippet here.
 
 > **Still a draft — not submitted.** The exact Flutter-on-F-Droid build
 > incantation (Flutter srclib vs. `sudo`-installed SDK, ABI splitting, `output`
-> path) must be validated against fdroiddata's current Flutter recipes at
-> submission time, and the `commit:`/`versionName`/`versionCode` must be set to a
-> real tagged release. See the [readiness checklist](./fdroid-readiness.md#8-remaining-blockers-before-submission)
-> for the version-reconciliation and pre-release-tag caveats.
+> path) must still be validated against fdroiddata's current Flutter recipes via
+> an actual `fdroid build` at submission time. The version target and
+> tag-derived versionCode are now set; see the
+> [submission package](./fdroid-submission.md) for the MR text and next steps and
+> the [readiness checklist](./fdroid-readiness.md#8-remaining-blockers-before-submission)
+> for the remaining blockers.

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -9,21 +9,29 @@ availability.
 
 ## 1. Current status
 
-- **Stage:** early **alpha** (`0.1.0-alpha.15`), usable for testing on a real
-  device. Working today: local-folder library (SAF scan + browse), self-hosted
-  streaming from Jellyfin and Navidrome/Subsonic, smart offline cache, queue,
-  playlists & favourites, smart mixes, background playback (media notification /
-  lock screen / Bluetooth), Android Auto, and Cast (pure-Dart, no Google Play
-  Services). Not production-stable; documented rough edges remain.
+- **Stage:** early **alpha**, usable for testing on a real device. Working
+  today: local-folder library (SAF scan + browse), self-hosted streaming from
+  Jellyfin and Navidrome/Subsonic, smart offline cache, queue, playlists &
+  favourites, smart mixes, background playback (media notification / lock screen
+  / Bluetooth), Android Auto, and Cast (pure-Dart, no Google Play Services). Not
+  production-stable; documented rough edges remain.
 - **Distribution:** GitHub Releases only (sideloaded APK / Obtainium). **No
-  tagged release exists yet**, no F-Droid metadata has been submitted, and
-  Linthra is **not on F-Droid**.
+  F-Droid metadata has been submitted, and Linthra is not on F-Droid.**
+- **Tagged releases now exist:** `v0.1.0-alpha.1` … `v0.1.0-alpha.25`, each built
+  by `.github/workflows/android-release-build.yml`. The **F-Droid target is the
+  latest working alpha, `v0.1.0-alpha.25`** (versionName `0.1.0-alpha.25`,
+  tag-derived versionCode `100025`). **`v0.1.0-alpha.24` is a withdrawn, broken
+  release** (its GitHub Release says "Broken release — do not install … startup
+  regression"); `alpha.25` is the hotfix that reverts it and **must** be the
+  target instead.
 - **Groundwork in place:** stable application ID, MPL-2.0 license, a real
   Linthra app/launcher icon, Fastlane-style store metadata under
   `fastlane/metadata/android/en-US/` (text + real icon and feature graphic;
-  screenshots still pending), a completed dependency/license audit, and a draft
-  F-Droid recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
-- **Not ready to submit.** See [Remaining blockers](#8-remaining-blockers-before-submission).
+  screenshots still pending), a completed dependency/license audit, a draft
+  F-Droid recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
+  pinned to `v0.1.0-alpha.25`, and the submission package (MR text, next steps)
+  at [`docs/fdroid-submission.md`](./fdroid-submission.md).
+- **Not yet submitted.** See [Remaining blockers](#8-remaining-blockers-before-submission).
 
 ## 2. App identity
 
@@ -175,9 +183,9 @@ crucially **no broad-storage `MANAGE_EXTERNAL_STORAGE`**.
 > committed manifest. `ACCESS_NETWORK_STATE` is contributed by the Media3 AAR at
 > Gradle manifest-merge time; the exact merged set should be re-confirmed against
 > the merged manifest of a release build (`flutter build apk --release`) at
-> submission time — this readiness pass could not run the Android build locally
-> (see [§11 Verification](#11-verification-performed-in-this-readiness-pass) and
-> §8.5). No permission is requested speculatively in code.
+> submission time — this preparation pass could not run the Android build locally
+> (see [§11 Verification](#11-verification-status) and
+> §8.2). No permission is requested speculatively in code.
 
 - **`MANAGE_EXTERNAL_STORAGE` is intentionally not used.** It is an "all files
   access" permission Google restricts and F-Droid users distrust; it is the
@@ -210,14 +218,18 @@ including the GitHub-Release flow — is in
 5. The F-Droid recipe should use `AutoUpdateMode`/`UpdateCheckMode` tied to tags
    so new tagged releases are picked up.
 
-> **F-Droid caveat.** F-Droid builds **from source** at the tag and does **not**
-> run our release workflow, so a plain `flutter build` there takes the version
-> from `pubspec.yaml`, not the tag. When Linthra is submitted, keep the F-Droid
-> build consistent by either (a) bumping `pubspec.yaml` to the tag-derived
-> `versionName`/`versionCode` at the tagged commit, or (b) having the recipe's
-> build pass `--build-name`/`--build-number` and pinning the metadata
-> `versionCode` to the derived value. This affects only the F-Droid channel — the
-> GitHub-Release build already bakes in the tag-derived version.
+> **F-Droid caveat — resolved in the draft recipe.** F-Droid builds **from
+> source** at the tag and does **not** run our release workflow, so a plain
+> `flutter build` there would take the version from `pubspec.yaml`
+> (`0.1.0-alpha.15+15`), giving versionCode **15 for every tag** — F-Droid could
+> not tell releases apart. The draft recipe therefore **derives the version from
+> the checked-out tag** with `tool/version_from_tag.dart` and passes
+> `--build-name`/`--build-number`, so `v0.1.0-alpha.25` builds to
+> `0.1.0-alpha.25` / **100025** — the same value the GitHub-Release build bakes
+> in, distinct and monotonic per tag, and correct under `AutoUpdateMode` for
+> future tags. (The alternative — bumping `pubspec.yaml` at each tagged commit —
+> is cleaner long-term but changes the release process; see
+> [docs/fdroid-submission.md §2](./fdroid-submission.md).)
 
 ## 7. Metadata checklist
 
@@ -225,13 +237,16 @@ Stored under `fastlane/metadata/android/en-US/`:
 
 - [x] `title.txt` — app name.
 - [x] `short_description.txt` — one-line summary (under F-Droid's 80-char limit).
-- [x] `full_description.txt` — long description. **Stale — refresh before
-  submission** (§8.3): it still lists now-shipped features as "planned" and lacks
+- [x] `full_description.txt` — long description. **Refreshed** to match the
+  current alpha (shipped features no longer listed as "planned") and now carries
   the "unofficial / not affiliated" framing. F-Droid uses this as the listing
   Description.
-- [x] `changelogs/1.txt`, `9.txt`, `15.txt` — per-version notes (named by the
-  current `pubspec.yaml` `versionCode`). Keep the filename in lockstep with the
-  built APK's `versionCode` (§6, §8.2).
+- [x] `changelogs/1.txt`, `9.txt`, `15.txt` — legacy per-version notes (named by
+  the old hand-numbered `versionCode`); kept as-is.
+- [x] `changelogs/100025.txt` — notes for the F-Droid target `v0.1.0-alpha.25`,
+  named by the **derived** versionCode `100025` (the convention going forward —
+  see [release-process.md §1](./release-process.md#1-versioning-model)). Keep new
+  changelog filenames in lockstep with the built APK's derived `versionCode`.
 - [x] `images/icon.png` — 512×512 real Linthra store icon. The launcher icons
   under `android/app/src/main/res/mipmap-*` are now the same real mark (adaptive
   + legacy), generated from `tool/branding/` — no longer the default Flutter
@@ -250,64 +265,74 @@ step-by-step capture instructions live in
 
 ## 8. Remaining blockers before submission
 
-1. **No tagged release yet.** A `v*` tag (e.g. `v0.1.0-alpha.15`) must exist for
-   F-Droid to build; the draft recipe's `commit:` is a placeholder until then.
-2. **versionCode reconciliation.** A from-source F-Droid build takes the version
-   from `pubspec.yaml` (`0.1.0-alpha.15+15` → versionCode **15**), while the
-   GitHub-Release workflow derives **100015** from the tag. Pick one scheme for
-   the F-Droid channel (bump `pubspec.yaml` at the tagged commit, or pass
-   `--build-name/--build-number` in the recipe) so the metadata `versionCode`
-   and the `changelogs/<code>.txt` filename match the built APK. See §6.
-3. **Fastlane description is stale.** `fastlane/metadata/android/en-US/full_description.txt`
-   still lists shipped features (artist/album browsing, search, playlists,
-   Navidrome/Subsonic) as "planned". Because F-Droid pulls the listing
-   Description from this file, refresh it to match the current alpha — and add
-   the "unofficial / not affiliated" framing — before submission. (The draft
-   `metadata/<appid>.yml` Description is already accurate.)
-4. **Screenshots missing.** The real icon and feature graphic are committed; only
+1. **Screenshots missing.** The real icon and feature graphic are committed; only
    screenshots remain, captured from a real build (see
-   [docs/listing-assets.md](./listing-assets.md)).
-5. **Reproducible build verification.** `flutter pub get`, `dart format`,
-   `flutter analyze`, and `flutter test` (1149 tests) all pass with the pinned
-   toolchain. The **Android APK build could not be run in this readiness
-   environment** (no Android SDK; the network policy here blocks the Android SDK
-   / JDK download hosts) — but CI builds the debug APK on every PR
-   (`android-debug-apk.yml`, JDK 17 + Flutter 3.27.4). Confirm a clean
-   `flutter build apk --release` and the NDK/CMake native build of
-   `sqlite3_flutter_libs` on F-Droid's build server.
-6. **Release signing (GitHub channel only).** Not an F-Droid blocker (F-Droid
+   [docs/listing-assets.md](./listing-assets.md)). Tracked by **issue #77**.
+   Not strictly required for an fdroiddata MR, but strongly recommended for the
+   listing.
+2. **Reproducible build verification.** CI runs `dart format`, `flutter analyze`,
+   and `flutter test` green on every PR (`ci.yml`) and builds a debug APK per PR
+   (`android-debug-apk.yml`, JDK 17 + Flutter 3.27.4); the tagged release APK is
+   built by `android-release-build.yml`. This preparation pass could only
+   validate the **metadata YAML** (no Flutter/Android SDK / fdroidserver in the
+   environment). Before submitting, re-confirm a clean from-source
+   `flutter build apk --release` (incl. the NDK/CMake native build of
+   `sqlite3_flutter_libs`) on an SDK-equipped machine, and run `fdroid lint` +
+   `fdroid build -l` in an fdroiddata checkout (commands in
+   [docs/fdroid-submission.md §7](./fdroid-submission.md)).
+3. **Toolchain provisioning in the recipe** must be matched to fdroiddata's
+   current Flutter convention (sudo git-clone vs. the `flutter` srclib) and
+   validated by an actual `fdroid build` — see
+   [docs/fdroid-submission.md §3](./fdroid-submission.md) and
+   [fdroid-build-recipe.md](./fdroid-build-recipe.md).
+4. **Feature maturity / pre-release tag (judgment call).** Decide whether to
+   submit at the current early-alpha stage or wait for a stable (non-pre-release)
+   tag — and confirm whether F-Droid will track/suggest an `-alpha`
+   CurrentVersion at all.
+5. **Release signing (GitHub channel only).** Not an F-Droid blocker (F-Droid
    signs its own builds), but the debug-key fallback should be replaced with real
    release signing for GitHub-Release artifacts (see
    [docs/release-signing.md](./release-signing.md)).
-7. **Feature maturity (judgment call).** Decide whether to submit at the current
-   early-alpha stage or wait for a stable (non-pre-release) tag — F-Droid may
-   need configuring to accept pre-release tags at all.
+6. **`pubspec.lock` policy** for reproducibility — still git-ignored; decide
+   whether to commit it at the tagged commit (§4 action items).
 
-**Resolved since the previous pass:** the full transitive dependency/license
-audit is complete (§4 — 152 packages, all permissive, no GMS); Drift generated
-files are committed so no codegen prebuild is needed; the full permission set is
-documented (§5).
+**Resolved since the previous passes:**
+
+- **A tagged release now exists.** `v0.1.0-alpha.25` is the latest **working**
+  alpha and is the recipe's `commit:`. The withdrawn, broken `v0.1.0-alpha.24` is
+  explicitly **not** targeted.
+- **versionCode reconciliation decided.** The recipe derives the version from the
+  tag (→ `0.1.0-alpha.25` / `100025`), matching the GitHub channel and staying
+  monotonic/AutoUpdate-safe (§6).
+- **Fastlane description refreshed** to match the current alpha, with the
+  "unofficial / not affiliated" framing (§7).
+- Full transitive dependency/license audit complete (§4 — 152 packages, all
+  permissive, no GMS); Drift generated files committed so no codegen prebuild is
+  needed; full permission set documented (§5).
 
 ## 9. Submission checklist (suggested order)
 
+The full step-by-step submission flow and the ready-to-adapt MR text live in
+[docs/fdroid-submission.md](./fdroid-submission.md). Summary:
+
 1. ✅ **Dependency/license audit** — done (§4;
    [audit doc](./dependency-license-audit.md)). Re-run on any dependency change.
-2. **Refresh the Fastlane `full_description.txt`** to match the current alpha and
-   add the "unofficial / not affiliated" framing (§8.3).
-3. **Verify a clean `flutter build apk --release`** on a machine with the Android
+2. ✅ **Fastlane `full_description.txt` refreshed** to match the current alpha,
+   with the "unofficial / not affiliated" framing (§7).
+3. ✅ **Target tag + versionCode decided** — `v0.1.0-alpha.25` / `100025`, with a
+   matching `changelogs/100025.txt`; the recipe derives the version from the tag
+   (§6). The broken `v0.1.0-alpha.24` is excluded.
+4. **Capture and commit real screenshots** (§7; icon and feature graphic already
+   done — see [docs/listing-assets.md](./listing-assets.md); tracked by #77).
+5. **Verify a clean `flutter build apk --release`** on a machine with the Android
    SDK + NDK (the from-source path F-Droid uses), and re-confirm the merged
    manifest permission set (§5 verification note).
-4. **Capture and commit real screenshots** (§7; icon and feature graphic already
-   done — see [docs/listing-assets.md](./listing-assets.md)).
-5. **Decide the `versionCode` scheme and `pubspec.lock` policy** for the F-Droid
-   channel (§8.2, §4), then **cut a `v*` tag** with a matching
-   `changelogs/<code>.txt` (§6; steps in
-   [docs/release-process.md](./release-process.md)).
 6. **Finalize the recipe** from the draft
    [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
-   (set the real `commit:`/version, validate the Flutter build incantation), then
-   submit a merge request to
-   [fdroiddata](https://gitlab.com/fdroid/fdroiddata).
+   (match fdroiddata's Flutter convention, run `fdroid lint`/`fdroid build -l`),
+   then submit a merge request to
+   [fdroiddata](https://gitlab.com/fdroid/fdroiddata) using the text in
+   [docs/fdroid-submission.md §9](./fdroid-submission.md).
 
 The metadata field reference, build-source/toolchain expectations, and
 reproducibility notes are in
@@ -337,15 +362,19 @@ must-pass items:
 - [ ] No crash/telemetry network traffic at rest (verify with a network monitor:
       nothing leaves the device unless the user configures a server).
 
-## 11. Verification performed in this readiness pass
+## 11. Verification status
 
-Run with the pinned toolchain (Flutter 3.27.4 / Dart 3.6.2):
+**This submission-prep pass had no Flutter/Dart/Android SDK and no fdroidserver
+in the environment**, so it validated only the metadata YAML. The Flutter checks
+below run **green in CI on every PR** (`ci.yml`) and were green in the earlier
+readiness pass with the pinned toolchain (Flutter 3.27.4 / Dart 3.6.2); they are
+**not** re-asserted as run here.
 
 | Check | Result |
 | ----- | ------ |
-| `flutter pub get` | ✅ resolves (152 packages) |
-| `dart format --set-exit-if-changed .` | ✅ 410 files, 0 changed |
-| `flutter analyze` | ✅ no issues |
-| `flutter test` | ✅ all 1149 tests passed |
-| transitive license audit | ✅ all permissive, no GMS (§4) |
-| `flutter build apk --debug/--release` | ⚠️ **not run here** — no Android SDK; this environment's network policy blocks the Android SDK/JDK download hosts. CI builds the debug APK on every PR. Run on an SDK-equipped machine (next step §9.3). |
+| Metadata YAML parses (PyYAML) | ✅ this pass — valid YAML; fields/types as expected (Summary 57 ≤ 80 chars; versionCode integer `100025`). Not a full `fdroid lint`. |
+| `dart format` / `flutter analyze` / `flutter test` | ✅ green in CI (`ci.yml`) on every PR. Not re-run in this pass (no toolchain). |
+| transitive license audit | ✅ all permissive, no GMS (§4). |
+| `flutter build apk --debug` | ✅ built by CI per PR (`android-debug-apk.yml`). |
+| `flutter build apk --release` (from source) | ⏳ re-confirm on an SDK-equipped machine before submitting (§8.2). The tagged release APK is built by `android-release-build.yml`. |
+| `fdroid lint` / `fdroid build -l` | ⏳ run in an fdroiddata checkout (commands in [docs/fdroid-submission.md §7](./fdroid-submission.md)). |

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -4,34 +4,33 @@ This document tracks what Linthra needs before it can be submitted to
 [F-Droid](https://f-droid.org/). It is a planning aid, not a claim of
 availability.
 
-> **Linthra is _not_ on F-Droid, and no submission has been made.** This
-> checklist exists so that a future submission is straightforward and accurate.
+> Linthra isn't on F-Droid, and nothing has been submitted yet. This checklist is
+> here so that when we do submit, it's accurate and goes smoothly.
 
 ## 1. Current status
 
-- **Stage:** early **alpha**, usable for testing on a real device. Working
-  today: local-folder library (SAF scan + browse), self-hosted streaming from
-  Jellyfin and Navidrome/Subsonic, smart offline cache, queue, playlists &
-  favourites, smart mixes, background playback (media notification / lock screen
-  / Bluetooth), Android Auto, and Cast (pure-Dart, no Google Play Services). Not
-  production-stable; documented rough edges remain.
-- **Distribution:** GitHub Releases only (sideloaded APK / Obtainium). **No
-  F-Droid metadata has been submitted, and Linthra is not on F-Droid.**
+- **Stage:** early alpha, usable for testing on a real device. Working today:
+  local-folder library (SAF scan and browse), streaming from Jellyfin and
+  Navidrome/Subsonic, a smart offline cache, queue, playlists and favourites,
+  smart mixes, background playback (media notification / lock screen /
+  Bluetooth), Android Auto, and Cast (pure-Dart, no Google Play Services). It
+  isn't production-stable, and the rough edges are documented.
+- **Distribution:** GitHub Releases only, as a sideloaded APK (Obtainium works
+  too). No F-Droid metadata has been submitted, and Linthra isn't on F-Droid.
 - **Tagged releases now exist:** `v0.1.0-alpha.1` … `v0.1.0-alpha.25`, each built
-  by `.github/workflows/android-release-build.yml`. The **F-Droid target is the
-  latest working alpha, `v0.1.0-alpha.25`** (versionName `0.1.0-alpha.25`,
-  tag-derived versionCode `100025`). **`v0.1.0-alpha.24` is a withdrawn, broken
-  release** (its GitHub Release says "Broken release — do not install … startup
-  regression"); `alpha.25` is the hotfix that reverts it and **must** be the
-  target instead.
-- **Groundwork in place:** stable application ID, MPL-2.0 license, a real
-  Linthra app/launcher icon, Fastlane-style store metadata under
-  `fastlane/metadata/android/en-US/` (text + real icon and feature graphic;
-  screenshots still pending), a completed dependency/license audit, a draft
-  F-Droid recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
-  pinned to `v0.1.0-alpha.25`, and the submission package (MR text, next steps)
-  at [`docs/fdroid-submission.md`](./fdroid-submission.md).
-- **Not yet submitted.** See [Remaining blockers](#8-remaining-blockers-before-submission).
+  by `.github/workflows/android-release-build.yml`. The F-Droid target is the
+  latest one that launches, `v0.1.0-alpha.25` (versionName `0.1.0-alpha.25`,
+  tag-derived versionCode `100025`). Skip `v0.1.0-alpha.24`: its GitHub Release
+  is marked "Broken release — do not install … startup regression", and alpha.25
+  is the hotfix that reverts it.
+- **Groundwork in place:** a stable application ID, the MPL-2.0 license, a real
+  app/launcher icon, Fastlane-style store metadata under
+  `fastlane/metadata/android/en-US/` (text plus the real icon and feature
+  graphic; screenshots still to come), a finished dependency/license audit, the
+  draft recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
+  (pinned to `v0.1.0-alpha.25`), and the submission package at
+  [`docs/fdroid-submission.md`](./fdroid-submission.md).
+- **Not submitted yet.** See [Remaining blockers](#8-remaining-blockers-before-submission).
 
 ## 2. App identity
 
@@ -218,18 +217,17 @@ including the GitHub-Release flow — is in
 5. The F-Droid recipe should use `AutoUpdateMode`/`UpdateCheckMode` tied to tags
    so new tagged releases are picked up.
 
-> **F-Droid caveat — resolved in the draft recipe.** F-Droid builds **from
-> source** at the tag and does **not** run our release workflow, so a plain
-> `flutter build` there would take the version from `pubspec.yaml`
-> (`0.1.0-alpha.15+15`), giving versionCode **15 for every tag** — F-Droid could
-> not tell releases apart. The draft recipe therefore **derives the version from
-> the checked-out tag** with `tool/version_from_tag.dart` and passes
-> `--build-name`/`--build-number`, so `v0.1.0-alpha.25` builds to
-> `0.1.0-alpha.25` / **100025** — the same value the GitHub-Release build bakes
-> in, distinct and monotonic per tag, and correct under `AutoUpdateMode` for
-> future tags. (The alternative — bumping `pubspec.yaml` at each tagged commit —
-> is cleaner long-term but changes the release process; see
-> [docs/fdroid-submission.md §2](./fdroid-submission.md).)
+> **How the F-Droid build gets the right version.** F-Droid builds from source at
+> the tag and doesn't run our release workflow, so a plain `flutter build` there
+> would read the version from `pubspec.yaml` (`0.1.0-alpha.15+15`) and label every
+> tag as versionCode 15 — which F-Droid can't tell apart. The draft recipe avoids
+> that by deriving the version from the checked-out tag with
+> `tool/version_from_tag.dart` and passing `--build-name`/`--build-number`, so
+> `v0.1.0-alpha.25` builds to `0.1.0-alpha.25` / `100025` — the same value the
+> GitHub release build uses, distinct and increasing per tag, and still correct
+> under `AutoUpdateMode` for future tags. (Bumping `pubspec.yaml` at each tagged
+> commit would also work and is cleaner long-term, but it changes the release
+> process; see [docs/fdroid-submission.md §2](./fdroid-submission.md).)
 
 ## 7. Metadata checklist
 

--- a/docs/fdroid-submission.md
+++ b/docs/fdroid-submission.md
@@ -1,22 +1,21 @@
 # F-Droid submission package (draft)
 
-This document is the **submission package** for proposing Linthra to F-Droid: a
-ready-to-adapt merge-request description for
-[fdroiddata](https://gitlab.com/fdroid/fdroiddata), the build-recipe and
-version decisions, the verification status, the remaining blockers, and the
-exact next steps. It is a planning/preparation aid.
+This is the working material for proposing Linthra to F-Droid: a merge-request
+description you can adapt for [fdroiddata](https://gitlab.com/fdroid/fdroiddata),
+the build-recipe and version decisions, where verification stands, the remaining
+blockers, and the steps to actually submit.
 
-> **Linthra is NOT on F-Droid and NO submission/merge request has been made.**
-> Nothing here publishes, signs, or submits anything. This is the material to
-> review before a human opens a merge request to fdroiddata. Do not present
-> Linthra as accepted on, or available from, F-Droid.
+Linthra hasn't been submitted to F-Droid and isn't on it — this is the prep that
+comes before someone opens the merge request. Nothing here publishes or submits
+anything.
 
-See also: [fdroid-readiness.md](./fdroid-readiness.md) (overall checklist),
-[fdroid-build-recipe.md](./fdroid-build-recipe.md) (recipe/reproducibility),
-[dependency-license-audit.md](./dependency-license-audit.md) (licensing),
-[listing-assets.md](./listing-assets.md) (icon/graphic/screenshots),
-[release-process.md](./release-process.md) (versioning & tagging), and the draft
-recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
+Related docs: [fdroid-readiness.md](./fdroid-readiness.md) (the overall
+checklist), [fdroid-build-recipe.md](./fdroid-build-recipe.md) (recipe and
+reproducibility), [dependency-license-audit.md](./dependency-license-audit.md)
+(licensing), [listing-assets.md](./listing-assets.md) (icon, graphic,
+screenshots), [release-process.md](./release-process.md) (versioning and
+tagging), and the draft recipe at
+[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
 
 ## 1. App identity
 
@@ -29,169 +28,161 @@ recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.the
 | Issues  | https://github.com/thezupzup/linthra/issues |
 | Category| Multimedia                    |
 
-## 2. Target version — the latest WORKING alpha
+## 2. Target version: the latest working alpha
 
-F-Droid builds from a git tag, and Linthra now has tagged releases
-(`v0.1.0-alpha.1` … `v0.1.0-alpha.25`), each built by the Android Release Build
-workflow. The submission targets the **latest working** alpha:
+F-Droid builds from a git tag, and Linthra now has tags (`v0.1.0-alpha.1` …
+`v0.1.0-alpha.25`, built by the Android Release Build workflow). The submission
+targets the latest one that launches cleanly:
 
 | Item            | Value                                   |
 | --------------- | --------------------------------------- |
-| **Target tag**  | `v0.1.0-alpha.25` (commit `c9c1fb3`)     |
+| Target tag      | `v0.1.0-alpha.25` (commit `c9c1fb3`)     |
 | versionName     | `0.1.0-alpha.25`                        |
 | versionCode     | `100025`                                |
 | Changelog file  | `fastlane/metadata/android/en-US/changelogs/100025.txt` |
 
-> **Do NOT target `v0.1.0-alpha.24`.** Its GitHub Release is explicitly marked
-> **"Broken release — do not install … startup regression."** `v0.1.0-alpha.25`
-> is the hotfix that reverts that regression; it is the correct, launchable
-> target. The metadata `commit:` and `CurrentVersion`/`CurrentVersionCode` point
-> at alpha.25, never alpha.24.
+One thing to be careful about: don't target `v0.1.0-alpha.24`. Its GitHub
+Release is marked "Broken release — do not install … startup regression."
+alpha.25 is the hotfix that reverts it, so the recipe's `commit:` and the
+`CurrentVersion`/`CurrentVersionCode` all point at alpha.25.
 
-### Why versionCode `100025` (and not `15`)
+### Why versionCode `100025` and not `15`
 
-`pubspec.yaml` carries a **static** dev version, `0.1.0-alpha.15+15`, that is the
-same at every tagged commit (it does not track tags — the release workflow
-overrides it). Consequences:
+`pubspec.yaml` keeps a fixed dev version, `0.1.0-alpha.15+15`, that's the same at
+every tagged commit (the release workflow overrides it per release, so it never
+gets bumped). That has two consequences:
 
-- A plain `flutter build apk` at *any* tag produces versionName `0.1.0-alpha.15`
-  / versionCode **15**. F-Droid could not tell releases apart (every build would
-  be versionCode 15) — this is a hard blocker, not a cosmetic one.
-- The upstream **GitHub release** build derives the version from the tag via
-  `tool/version_from_tag.dart` (the single source of truth), giving
-  `v0.1.0-alpha.25` → `0.1.0-alpha.25` / **100025**.
+- A plain `flutter build apk` at any tag produces versionName `0.1.0-alpha.15`
+  and versionCode `15`. Every F-Droid build would then look like the same
+  version, which F-Droid can't work with — so this is a real blocker, not a
+  detail.
+- The upstream GitHub release build avoids that by deriving the version from the
+  tag with `tool/version_from_tag.dart` (the single source of truth):
+  `v0.1.0-alpha.25` → `0.1.0-alpha.25` / `100025`.
 
-**Decision:** the F-Droid recipe derives the version from the checked-out tag the
-same way (passing `--build-name`/`--build-number`), so the produced APK reports
-`0.1.0-alpha.25` / `100025` — matching the metadata and the GitHub channel. This:
+So the F-Droid recipe does the same thing — it derives the version from the
+checked-out tag and passes `--build-name`/`--build-number`. The APK then reports
+`0.1.0-alpha.25` / `100025`, matching the metadata and the GitHub build. That
+keeps each tag's versionCode distinct and increasing, keeps the F-Droid and
+GitHub codes identical for the same tag, and stays correct under `AutoUpdateMode`
+for future tags (since the version isn't hard-coded). The changelog file is
+named by that derived code (`100025.txt`), in line with
+[release-process.md §1](./release-process.md#1-versioning-model) (the older
+`1.txt`/`9.txt`/`15.txt` stay as they are).
 
-- gives each tag a distinct, strictly-monotonic versionCode (F-Droid can order
-  releases and offer updates);
-- keeps the F-Droid and GitHub versionCodes **identical** for the same tag (no
-  cross-channel inversion); and
-- stays correct under `AutoUpdateMode` for future tags (the build derives, rather
-  than hard-codes, the version).
-
-The changelog file is therefore named by the **derived** code (`100025.txt`),
-consistent with [release-process.md §1](./release-process.md#1-versioning-model)
-(the historical `1.txt`/`9.txt`/`15.txt` stay as-is).
-
-> **Alternative considered:** bump `pubspec.yaml`'s `version:` to the tag value
-> at each tagged commit, so a plain `flutter build` yields the right code and the
-> recipe needs no flags. That is cleaner long-term but changes the release
-> process (out of scope here), so the recipe-derives-from-tag approach is used
-> for the first submission.
+There's a cleaner long-term option — bump `pubspec.yaml` to the tag version at
+each tagged commit, so a plain build is correct and the recipe needs no flags —
+but that changes the release process, so it's out of scope here. The
+derive-from-tag approach works for this submission without touching anything.
 
 ## 3. Build recipe status
 
 The draft recipe is in
 [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
-Key properties (mapped to F-Droid's expectations):
+What makes it a good fit for building from source:
 
-- **Builds from source**, no signing keys required — F-Droid signs its own
-  builds; Linthra's release signing is optional and injected only on the GitHub
-  channel (see [release-signing.md](./release-signing.md)). No keystore/secret is
-  committed.
-- **Pinned toolchain:** Flutter `3.27.4` (stable), Dart `3.6.x`, JDK 17,
-  Gradle 8.3 — identical to `.flutter-version` and all CI workflows.
-- **No codegen prebuild:** the Drift output
-  `lib/data/database/linthra_database.g.dart` is committed, so no `build_runner`
-  step is needed.
-- **One native component:** SQLite via `sqlite3_flutter_libs`, compiled from
-  source (public domain). No prebuilt closed blobs; no Google Play Services /
-  Firebase anywhere in the resolved tree (152 packages audited).
-- **No GitHub Actions secrets / Play signing** are involved in the from-source
+- It builds with no signing keys — F-Droid signs its own builds. Linthra's
+  optional release signing only applies to the GitHub channel and is injected at
+  build time (see [release-signing.md](./release-signing.md)); no keystore or
+  secret is committed.
+- The toolchain is pinned: Flutter `3.27.4` (stable), Dart `3.6.x`, JDK 17,
+  Gradle 8.3 — the same versions as `.flutter-version` and CI.
+- No codegen step: the Drift output
+  `lib/data/database/linthra_database.g.dart` is committed, so there's no
+  `build_runner` to run.
+- One native component, SQLite via `sqlite3_flutter_libs`, built from source
+  (public domain). No prebuilt closed blobs, and no Google Play Services or
+  Firebase anywhere in the resolved tree (152 packages, all audited).
+- No GitHub Actions secrets or Play signing are involved in the from-source
   build.
 
-**To validate at submission time (draft caveats):**
+A few things still need checking against fdroiddata before submitting:
 
-1. **Flutter provisioning mechanism.** The draft provisions Flutter 3.27.4 via a
-   `sudo:` git-clone of `flutter/flutter` at the `3.27.4` tag. fdroiddata may
-   prefer its `flutter` **srclib** (`srclibs: [flutter@3.27.4]`, referenced as
-   `$$flutter$$`). Match whichever convention current fdroiddata Flutter recipes
-   use. Flutter's pinned engine artifacts are fetched at the pinned version —
-   standard for Flutter-on-F-Droid, and pinned/reproducible (not an uncontrolled
-   blob download).
-2. **`git describe` at the tag.** The build derives the version with
-   `git describe --tags --exact-match HEAD`; confirm F-Droid's checkout of
-   `commit: v0.1.0-alpha.25` leaves the tag resolvable (it should — F-Droid
-   checks out the tag ref).
-3. **Output path / ABI splitting.** `build/app/outputs/flutter-apk/app-release.apk`
-   is the single-APK output; if per-ABI splitting is preferred, adjust `output:`
-   accordingly.
-4. **`pubspec.lock` policy.** Still git-ignored; decide whether to commit it at
+1. How Flutter gets provisioned. The draft clones `flutter/flutter` at the
+   `3.27.4` tag in a `sudo:` step; fdroiddata may prefer its `flutter` srclib
+   (`srclibs: [flutter@3.27.4]`, referenced as `$$flutter$$`). Either is fine —
+   match the current convention. Flutter's engine artifacts are fetched at the
+   pinned version, which is normal for Flutter on F-Droid and stays pinned and
+   reproducible.
+2. The `git describe --tags --exact-match HEAD` the build uses to find the tag —
+   confirm F-Droid's checkout of `commit: v0.1.0-alpha.25` leaves the tag
+   resolvable (it should, since F-Droid checks out the tag ref).
+3. The output path. `build/app/outputs/flutter-apk/app-release.apk` is the
+   single-APK output; adjust `output:` if you'd rather split per ABI.
+4. The `pubspec.lock` policy — still git-ignored. Decide whether to commit it at
    the tagged commit for a fully pinned dependency set
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
-5. **Gradle wrapper jar** is not committed; F-Droid restores it, but confirm the
-   recipe handles it (a `flutter build` provisions the wrapper).
+5. The Gradle wrapper jar isn't committed; F-Droid restores it, but confirm the
+   recipe handles that (a `flutter build` provisions the wrapper).
 
-## 4. Anti-feature assessment
+## 4. Anti-features
 
-Full reasoning in [fdroid-readiness.md §5](./fdroid-readiness.md#5-anti-features-review)
+The reasoning is in [fdroid-readiness.md §5](./fdroid-readiness.md#5-anti-features-review)
 and [dependency-license-audit.md §6](./dependency-license-audit.md#6-anti-features--non-free-check).
-Conclusion: **no anti-features to declare.**
+The short version: there's nothing to declare.
 
-| Anti-feature  | Apply? | One-line reason |
-| ------------- | ------ | --------------- |
-| Ads           | No  | No ad libraries/code anywhere. |
-| Tracking      | No  | No telemetry/analytics/crash SDK; on-device signals only; nothing auto-sent. |
-| NonFreeAdd    | No  | Promotes/installs no non-free add-ons. |
-| NonFreeDep    | No  | All 152 resolved packages permissive; playback is AndroidX Media3 (Apache-2.0); Cast is pure-Dart (no GMS Cast SDK). |
-| NonFreeNet    | No  | Local-first core needs no network; Jellyfin/Navidrome/Subsonic are optional, user-supplied, free-software servers — none bundled/promoted/required. |
-| UpstreamNonFree | No | Repo is entirely MPL-2.0; icons generated from a committed SVG. |
-| KnownVuln     | No  | No known-vulnerable version in the resolved tree at audit time; F-Droid's scanner re-checks. |
-| NoSourceSince | No  | Source fully published; builds from source. |
+| Anti-feature  | Apply? | Why |
+| ------------- | ------ | --- |
+| Ads           | No  | No ad libraries or code. |
+| Tracking      | No  | No telemetry/analytics/crash SDK; on-device signals only; nothing is auto-sent. |
+| NonFreeAdd    | No  | It promotes or installs no non-free add-ons. |
+| NonFreeDep    | No  | All 152 resolved packages are permissive; playback is AndroidX Media3 (Apache-2.0); Cast is pure-Dart, not the GMS Cast SDK. |
+| NonFreeNet    | No  | The local-first core needs no network; Jellyfin/Navidrome/Subsonic are optional, user-supplied, free-software servers — none bundled, promoted, or required. |
+| UpstreamNonFree | No | The repo is entirely MPL-2.0; the icons are generated from a committed SVG. |
+| KnownVuln     | No  | Nothing in the resolved tree was a known-vulnerable version at audit time; F-Droid's scanner re-checks. |
+| NoSourceSince | No  | The source is fully published and builds from source. |
 
-> **Re-review trigger:** any *future* online provider that defaults to or
-> promotes a non-free hosted service would need a fresh `NonFreeNet` assessment.
+Worth revisiting if a future online provider ever defaults to or promotes a
+non-free hosted service — that would need a fresh `NonFreeNet` look.
 
-## 5. Permissions summary
+## 5. Permissions
 
-Six permissions are declared explicitly in `AndroidManifest.xml`;
-`ACCESS_NETWORK_STATE` is merged in from the AndroidX Media3 AAR. The set is
-deliberately minimal — **no storage, location, contacts, camera, microphone, or
-phone permission, and no `MANAGE_EXTERNAL_STORAGE`** (folder access uses the
-Storage Access Framework). Each is justified in
+Six permissions are declared in `AndroidManifest.xml`, and `ACCESS_NETWORK_STATE`
+is merged in from the AndroidX Media3 AAR. The set is deliberately small — no
+storage, location, contacts, camera, microphone, or phone permission, and no
+`MANAGE_EXTERNAL_STORAGE` (folder access goes through the Storage Access
+Framework). Each one is explained in
 [fdroid-readiness.md §5 (Android permissions)](./fdroid-readiness.md#android-permissions):
 `INTERNET`, `ACCESS_NETWORK_STATE`, `FOREGROUND_SERVICE`,
-`FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `POST_NOTIFICATIONS`, `WAKE_LOCK`,
-`CHANGE_WIFI_MULTICAST_STATE` (mDNS for Cast discovery; AOSP `NsdManager`, not
-GMS). The exact merged set should be re-confirmed against a release build's
-merged manifest at submission time.
+`FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `POST_NOTIFICATIONS`, `WAKE_LOCK`, and
+`CHANGE_WIFI_MULTICAST_STATE` (mDNS for Cast discovery, via AOSP `NsdManager`,
+not GMS). Re-confirm the merged set against a release build's manifest before
+submitting.
 
-## 6. Listing assets status
+## 6. Listing assets
 
-Tracked in [listing-assets.md](./listing-assets.md). The real app **icon**
-(512×512) and **feature graphic** (1024×500) are committed (generated from
-`tool/branding/linthra_icon.svg`). **Screenshots are the only missing listing
-asset** — they must be captured from a real build, never mocked. Collection is
-already tracked by **issue #77** ("Add real app screenshots to the README and
-store metadata"), which lists the target screens (Now Playing, Library,
+Tracked in [listing-assets.md](./listing-assets.md). The app icon (512×512) and
+feature graphic (1024×500) are committed, generated from
+`tool/branding/linthra_icon.svg`. The one thing missing is screenshots, which
+need to be captured from a real build rather than mocked. That's already tracked
+by issue #77, which lists the screens to capture (Now Playing, Library,
 Settings → Jellyfin, Downloads, Cast, Android Auto) and the no-private-data rule.
-Screenshots are **not** strictly required for an fdroiddata MR, but are strongly
-recommended for the listing; capture before/soon after submitting.
+Screenshots aren't strictly required for the merge request, but they help the
+listing, so it's worth capturing them around the same time.
 
 ## 7. Verification status
 
-Run in this preparation pass (this environment has **no Flutter/Dart/Android SDK
-and no fdroidserver**, so app/build/lint checks could not run here):
+What ran in this prep pass, and what didn't. This environment has no Flutter,
+Dart, or Android SDK and no fdroidserver, so the app and build checks couldn't
+run here — they run in CI and need re-running on a proper machine before
+submitting.
 
 | Check | Status |
 | ----- | ------ |
-| Metadata YAML parses (PyYAML) | ✅ parses; fields/types as expected (Summary 57 chars ≤ 80; versionCode integer 100025). A plain YAML parse is **not** a full F-Droid schema check (see below). |
-| `flutter pub get` | ⏳ not run here (no toolchain). Run locally / in CI. |
-| `dart format --set-exit-if-changed .` | ⏳ not run here. CI (`ci.yml`) runs it on every PR. |
-| `flutter analyze` | ⏳ not run here. CI runs it on every PR. |
-| `flutter test` | ⏳ not run here. CI runs it on every PR. |
-| `flutter build apk --debug` | ⏳ not run here (no Android SDK). CI (`android-debug-apk.yml`) builds the debug APK on every PR. |
-| `flutter build apk --release` | ⏳ not run here. The tag build (`android-release-build.yml`) produced the alpha.25 release APK; re-confirm a clean from-source release build on an SDK-equipped machine. |
-| `fdroid lint` / `fdroid build -l io.github.thezupzup.linthra` | ⏳ not run here (no fdroidserver). Run inside an fdroiddata checkout (see §8). |
+| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (Summary 57 chars, versionCode an integer, `100025`). This only checks the YAML, not F-Droid's schema (see below). |
+| `flutter pub get` | Not run here (no toolchain). Run locally / in CI. |
+| `dart format --set-exit-if-changed .` | Not run here. CI (`ci.yml`) runs it on every PR. |
+| `flutter analyze` | Not run here. CI runs it on every PR. |
+| `flutter test` | Not run here. CI runs it on every PR. |
+| `flutter build apk --debug` | Not run here (no Android SDK). CI (`android-debug-apk.yml`) builds it on every PR. |
+| `flutter build apk --release` | Not run here. The tag build (`android-release-build.yml`) produced the alpha.25 APK; re-confirm a clean from-source release build on a machine with the SDK. |
+| `fdroid lint` / `fdroid build -l io.github.thezupzup.linthra` | Not run here (no fdroidserver). Run inside an fdroiddata checkout (§8). |
 
-> **Do not treat the YAML parse as F-Droid validation.** It only confirms the
-> file is syntactically valid YAML with the expected fields. Real validation is
-> `fdroid lint` + an actual `fdroid build` in an fdroiddata checkout.
+A note on that first row: a YAML parse isn't the same as F-Droid validation. The
+real check is `fdroid lint` plus an actual `fdroid build` in an fdroiddata
+checkout.
 
-**Exact commands to run locally / in an fdroiddata checkout:**
+Commands to run locally and in an fdroiddata checkout:
 
 ```sh
 # In the Linthra repo (pinned Flutter 3.27.4 — see scripts/setup_flutter.sh):
@@ -202,94 +193,95 @@ flutter test
 flutter build apk --release \
   --build-name=0.1.0-alpha.25 --build-number=100025   # what the recipe derives
 
-# In an fdroiddata checkout, after copying metadata/io.github.thezupzup.linthra.yml in:
+# In an fdroiddata checkout, once metadata/io.github.thezupzup.linthra.yml is in:
 fdroid readmeta
 fdroid lint io.github.thezupzup.linthra
 fdroid build -v -l io.github.thezupzup.linthra        # full from-source build test
 ```
 
-## 8. Next steps to submit to fdroiddata
+## 8. Steps to submit to fdroiddata
 
-1. **Capture & commit screenshots** (issue #77) — recommended before submitting.
-2. **Re-confirm a clean `flutter build apk --release`** from source on an
-   SDK-equipped machine (and the merged-manifest permission set).
-3. **Fork** https://gitlab.com/fdroid/fdroiddata and create a branch.
-4. **Copy** `metadata/io.github.thezupzup.linthra.yml` into fdroiddata's
-   `metadata/` directory. In the real entry, drop the inline `Summary`/
-   `Description` (F-Droid pulls them from the Fastlane files) unless you
-   deliberately want to override them.
-5. **Finalize the Builds toolchain** to fdroiddata's current Flutter convention
-   (srclib vs. sudo-clone — §3) and run `fdroid lint` + `fdroid build -l` until
-   green (§7).
-6. **Open the merge request** using the description in §9. Mark it clearly as an
-   **early-alpha, pre-release** submission and confirm with reviewers whether
-   F-Droid will track an `-alpha` tag or wants to wait for a stable tag.
-7. **Do not** state Linthra is on F-Droid until the MR is merged and the build
-   publishes.
+1. Capture and commit screenshots (issue #77) — nice to have before submitting.
+2. Re-confirm a clean `flutter build apk --release` from source on a machine with
+   the Android SDK, and re-check the merged-manifest permission set.
+3. Fork https://gitlab.com/fdroid/fdroiddata and make a branch.
+4. Copy `metadata/io.github.thezupzup.linthra.yml` into fdroiddata's `metadata/`
+   directory. In the real entry you'd normally drop the inline `Summary`/
+   `Description` and let the Fastlane files provide them, unless you specifically
+   want to override them.
+5. Settle the Builds toolchain to fdroiddata's current Flutter convention
+   (srclib vs. sudo-clone — §3), and run `fdroid lint` + `fdroid build -l` until
+   they're green (§7).
+6. Open the merge request using the text in §9. Be upfront that it's an
+   early-alpha, pre-release submission, and ask the maintainers whether they're
+   happy tracking an `-alpha` tag or would rather wait for a stable one.
+7. Don't describe Linthra as being on F-Droid until the merge request is merged
+   and the build publishes.
 
 ## 9. Merge-request description (ready to adapt)
 
-> Paste into the fdroiddata MR. Honest, not overhyped.
+Paste this into the fdroiddata merge request and adjust as needed.
 
 ---
 
 **New app: Linthra — `io.github.thezupzup.linthra`**
 
-**Summary:** Local-first music player for your own self-hosted library.
+Linthra is an open-source Android music player for people who keep their music on
+their own devices or self-hosted servers. It plays local files and streams from
+self-hosted servers such as Jellyfin and Navidrome/Subsonic. It's an unofficial
+community client — not affiliated with Jellyfin, Navidrome, or Subsonic.
 
-**What it is.** Linthra is an open-source, local-first Android music player for
-people who own their music: play a local folder, or stream from your own
-self-hosted Jellyfin or Navidrome / Subsonic server. It is an **unofficial
-community project**, not affiliated with or endorsed by Jellyfin, Navidrome, or
-the Subsonic project.
+Why I think it's a good fit for F-Droid:
 
-**Why it fits F-Droid.**
-- **License:** MPL-2.0 (FSF/OSI-approved), declared in `LICENSE`.
-- **Builds from source**, no signing keys needed (F-Droid signs its own builds).
-- **No proprietary dependencies.** A full transitive audit (152 packages) found
-  only permissive licenses (BSD/MIT/Apache-2.0/MPL-2.0) and **no Google Play
-  Services / Firebase / analytics / ads / crash-reporting** package. The only
+- **License:** MPL-2.0 (FSF/OSI-approved), in `LICENSE`.
+- **Builds from source** with no signing keys — F-Droid signs its own builds.
+- **No proprietary dependencies.** I audited the full transitive tree (152
+  packages) and found only permissive licenses (BSD/MIT/Apache-2.0/MPL-2.0) and
+  no Google Play Services, Firebase, analytics, ads, or crash-reporting. The one
   native component is SQLite (public domain, built from source); playback is
-  AndroidX Media3 (Apache-2.0); Cast is a **pure-Dart** implementation (no GMS
-  Cast SDK).
-- **No anti-features.** No ads, no tracking/telemetry, nothing phones home. The
-  optional self-hosted sources are user-supplied free-software servers (none
-  bundled/promoted/required), so `NonFreeNet` does not apply.
-- **Minimal permissions.** No storage/location/contacts/camera/mic/phone
-  permission and no `MANAGE_EXTERNAL_STORAGE`; folder access uses the Storage
+  AndroidX Media3 (Apache-2.0); casting is a pure-Dart implementation, not the
+  GMS Cast SDK.
+- **No anti-features.** No ads, no tracking, nothing phones home. The self-hosted
+  sources are optional servers the user runs themselves, so I don't think
+  `NonFreeNet` applies — happy to add it if you read it differently.
+- **Minimal permissions.** No storage, location, contacts, camera, mic, or phone
+  permission, and no `MANAGE_EXTERNAL_STORAGE` — folder access uses the Storage
   Access Framework.
 
-**Source / tracker.** https://github.com/thezupzup/linthra (issues at `/issues`).
+Source and issues: https://github.com/thezupzup/linthra (issues at `/issues`).
 
-**Build target.** Tag `v0.1.0-alpha.25`, versionName `0.1.0-alpha.25`,
-versionCode `100025`. The build derives the version from the tag (the upstream
-single-source-of-truth `tool/version_from_tag.dart`), so the versionCode is
-distinct/monotonic per release and matches the upstream GitHub-release APK.
-(Note: `v0.1.0-alpha.24` was a withdrawn broken release; alpha.25 is the hotfix.)
+**Build target:** tag `v0.1.0-alpha.25`, versionName `0.1.0-alpha.25`,
+versionCode `100025`. The build derives the version from the tag (using the
+project's `tool/version_from_tag.dart`), so the versionCode is distinct and
+increasing per release and matches the upstream GitHub-release APK. (For context:
+`v0.1.0-alpha.24` was a broken release that's been withdrawn; alpha.25 is the
+hotfix.)
 
-**Status — honest scope.** This is **early-alpha, pre-release** software: usable
-for testing on a real device, not production-stable, with documented rough edges.
-It is currently distributed only via GitHub Releases (sideloaded APK). I'd
-welcome guidance on whether F-Droid prefers to track this `-alpha` tag now or
-wait for a first stable (`vX.Y.Z`) tag.
+**On status — being honest about scope:** this is early-alpha, pre-release
+software. It's usable for testing on a real device, but it isn't
+production-stable and has some documented rough edges, and right now it's only
+distributed as a sideloaded APK from GitHub Releases. I'd welcome your guidance
+on whether you'd prefer to track this `-alpha` tag now or wait for a first stable
+(`vX.Y.Z`) release.
 
-**Build verification.** `flutter analyze` / `flutter test` / formatting run green
-in CI on every PR, and CI builds a debug APK per PR; the tagged release APK
-builds via the release workflow. I will additionally run `fdroid lint` +
-`fdroid build -l` and confirm a clean from-source `flutter build apk --release`.
+**Build verification:** `flutter analyze`, `flutter test`, and formatting run
+green in CI on every PR, and CI builds a debug APK per PR; the tagged release APK
+builds via the release workflow. I'll also run `fdroid lint` and `fdroid build
+-l` and confirm a clean from-source `flutter build apk --release`.
 
-**Known limitations.** Early alpha; local files show file names until tag parsing
-lands; single Jellyfin server; some Subsonic features (favourites/lyrics/cover
-art) are follow-ups; screenshots are being captured from real builds.
+**Known limitations:** it's early alpha; local files show file names until tag
+parsing lands; one Jellyfin server at a time; some Subsonic features (favourites,
+lyrics, cover art) are still follow-ups; and screenshots are being captured from
+real builds.
 
 ---
 
 ## 10. GitHub issue draft — "Submit Linthra to F-Droid"
 
-> Body for a tracking issue in this repo. **Provided as a draft — not created
-> automatically.** A separate readiness issue (#87) and the screenshots issue
-> (#77) already exist; this one tracks the actual submission. Suggested labels:
-> `documentation`, `f-droid`.
+This is a draft body for a tracking issue in this repo. It isn't created
+automatically — file it if/when it's useful. A readiness issue (#87) and a
+screenshots issue (#77) already exist; this one would track the submission
+itself. Suggested labels: `documentation`, `f-droid`.
 
 **Title:** Submit Linthra to F-Droid
 
@@ -297,32 +289,33 @@ art) are follow-ups; screenshots are being captured from real builds.
 
 ### Overview
 
-Track the actual submission of Linthra to
-[fdroiddata](https://gitlab.com/fdroid/fdroiddata). This is **not** a claim that
-Linthra is on F-Droid — it is the submission work itself. Readiness groundwork is
-done (#87); this issue covers cutting the MR.
+Tracks the actual submission of Linthra to
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata). This isn't a claim that
+Linthra is on F-Droid — it's the submission work itself. The readiness
+groundwork is done (#87); this covers cutting the merge request.
 
-The target is the latest **working** alpha, **`v0.1.0-alpha.25`** (versionCode
+The target is the latest alpha that launches, `v0.1.0-alpha.25` (versionCode
 `100025`) — the hotfix that supersedes the withdrawn, broken `v0.1.0-alpha.24`.
 
 ### Checklist
 
-- [ ] Capture & commit real screenshots (#77) — recommended before submitting.
-- [ ] Re-confirm a clean from-source `flutter build apk --release` on an
-      SDK-equipped machine; re-check the merged-manifest permission set.
-- [ ] Decide `pubspec.lock` policy for the tagged commit.
+- [ ] Capture and commit real screenshots (#77) — nice to have before
+      submitting.
+- [ ] Re-confirm a clean from-source `flutter build apk --release` on a machine
+      with the SDK; re-check the merged-manifest permissions.
+- [ ] Decide the `pubspec.lock` policy for the tagged commit.
 - [ ] Fork fdroiddata; copy in `metadata/io.github.thezupzup.linthra.yml`.
-- [ ] Finalize the Builds toolchain to fdroiddata's Flutter convention
-      (srclib vs. sudo-clone).
+- [ ] Settle the Builds toolchain to fdroiddata's Flutter convention (srclib vs.
+      sudo-clone).
 - [ ] `fdroid readmeta` + `fdroid lint` + `fdroid build -l` all green.
-- [ ] Open the MR (description in `docs/fdroid-submission.md` §9); flag the
-      early-alpha / pre-release status and ask about `-alpha` tag tracking.
+- [ ] Open the merge request (text in `docs/fdroid-submission.md` §9); mention
+      the early-alpha status and ask about tracking an `-alpha` tag.
 
-### Blockers / open questions
+### Open questions
 
-- F-Droid's stance on tracking a **pre-release `-alpha`** CurrentVersion (vs.
-  waiting for a stable tag) — judgement call to confirm with reviewers.
-- Final Flutter-on-F-Droid build incantation must be validated in an fdroiddata
+- Whether F-Droid will track a pre-release `-alpha` CurrentVersion, or would
+  rather wait for a stable tag — one to raise with the maintainers.
+- The exact Flutter-on-F-Droid build setup, to be confirmed in an fdroiddata
   checkout.
 
 ### Links
@@ -334,9 +327,9 @@ The target is the latest **working** alpha, **`v0.1.0-alpha.25`** (versionCode
 - Dependency/license audit: `docs/dependency-license-audit.md`
 - Listing assets: `docs/listing-assets.md`
 
-### Current status
+### Status
 
-Metadata, audit, permissions, anti-feature review, build recipe, and submission
-text are prepared and target `v0.1.0-alpha.25`. Remaining before the MR:
-screenshots, an SDK-machine release-build re-confirmation, and `fdroid lint` /
-`fdroid build` validation in an fdroiddata checkout.
+The metadata, audit, permissions, anti-feature review, build recipe, and
+submission text are ready and point at `v0.1.0-alpha.25`. What's left before the
+merge request: screenshots, an SDK-machine release-build re-confirmation, and
+`fdroid lint` / `fdroid build` in an fdroiddata checkout.

--- a/docs/fdroid-submission.md
+++ b/docs/fdroid-submission.md
@@ -1,0 +1,342 @@
+# F-Droid submission package (draft)
+
+This document is the **submission package** for proposing Linthra to F-Droid: a
+ready-to-adapt merge-request description for
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata), the build-recipe and
+version decisions, the verification status, the remaining blockers, and the
+exact next steps. It is a planning/preparation aid.
+
+> **Linthra is NOT on F-Droid and NO submission/merge request has been made.**
+> Nothing here publishes, signs, or submits anything. This is the material to
+> review before a human opens a merge request to fdroiddata. Do not present
+> Linthra as accepted on, or available from, F-Droid.
+
+See also: [fdroid-readiness.md](./fdroid-readiness.md) (overall checklist),
+[fdroid-build-recipe.md](./fdroid-build-recipe.md) (recipe/reproducibility),
+[dependency-license-audit.md](./dependency-license-audit.md) (licensing),
+[listing-assets.md](./listing-assets.md) (icon/graphic/screenshots),
+[release-process.md](./release-process.md) (versioning & tagging), and the draft
+recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
+
+## 1. App identity
+
+| Field   | Value                         |
+| ------- | ----------------------------- |
+| Name    | Linthra                       |
+| App ID  | `io.github.thezupzup.linthra` |
+| License | `MPL-2.0` (SPDX)              |
+| Source  | https://github.com/thezupzup/linthra |
+| Issues  | https://github.com/thezupzup/linthra/issues |
+| Category| Multimedia                    |
+
+## 2. Target version — the latest WORKING alpha
+
+F-Droid builds from a git tag, and Linthra now has tagged releases
+(`v0.1.0-alpha.1` … `v0.1.0-alpha.25`), each built by the Android Release Build
+workflow. The submission targets the **latest working** alpha:
+
+| Item            | Value                                   |
+| --------------- | --------------------------------------- |
+| **Target tag**  | `v0.1.0-alpha.25` (commit `c9c1fb3`)     |
+| versionName     | `0.1.0-alpha.25`                        |
+| versionCode     | `100025`                                |
+| Changelog file  | `fastlane/metadata/android/en-US/changelogs/100025.txt` |
+
+> **Do NOT target `v0.1.0-alpha.24`.** Its GitHub Release is explicitly marked
+> **"Broken release — do not install … startup regression."** `v0.1.0-alpha.25`
+> is the hotfix that reverts that regression; it is the correct, launchable
+> target. The metadata `commit:` and `CurrentVersion`/`CurrentVersionCode` point
+> at alpha.25, never alpha.24.
+
+### Why versionCode `100025` (and not `15`)
+
+`pubspec.yaml` carries a **static** dev version, `0.1.0-alpha.15+15`, that is the
+same at every tagged commit (it does not track tags — the release workflow
+overrides it). Consequences:
+
+- A plain `flutter build apk` at *any* tag produces versionName `0.1.0-alpha.15`
+  / versionCode **15**. F-Droid could not tell releases apart (every build would
+  be versionCode 15) — this is a hard blocker, not a cosmetic one.
+- The upstream **GitHub release** build derives the version from the tag via
+  `tool/version_from_tag.dart` (the single source of truth), giving
+  `v0.1.0-alpha.25` → `0.1.0-alpha.25` / **100025**.
+
+**Decision:** the F-Droid recipe derives the version from the checked-out tag the
+same way (passing `--build-name`/`--build-number`), so the produced APK reports
+`0.1.0-alpha.25` / `100025` — matching the metadata and the GitHub channel. This:
+
+- gives each tag a distinct, strictly-monotonic versionCode (F-Droid can order
+  releases and offer updates);
+- keeps the F-Droid and GitHub versionCodes **identical** for the same tag (no
+  cross-channel inversion); and
+- stays correct under `AutoUpdateMode` for future tags (the build derives, rather
+  than hard-codes, the version).
+
+The changelog file is therefore named by the **derived** code (`100025.txt`),
+consistent with [release-process.md §1](./release-process.md#1-versioning-model)
+(the historical `1.txt`/`9.txt`/`15.txt` stay as-is).
+
+> **Alternative considered:** bump `pubspec.yaml`'s `version:` to the tag value
+> at each tagged commit, so a plain `flutter build` yields the right code and the
+> recipe needs no flags. That is cleaner long-term but changes the release
+> process (out of scope here), so the recipe-derives-from-tag approach is used
+> for the first submission.
+
+## 3. Build recipe status
+
+The draft recipe is in
+[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml).
+Key properties (mapped to F-Droid's expectations):
+
+- **Builds from source**, no signing keys required — F-Droid signs its own
+  builds; Linthra's release signing is optional and injected only on the GitHub
+  channel (see [release-signing.md](./release-signing.md)). No keystore/secret is
+  committed.
+- **Pinned toolchain:** Flutter `3.27.4` (stable), Dart `3.6.x`, JDK 17,
+  Gradle 8.3 — identical to `.flutter-version` and all CI workflows.
+- **No codegen prebuild:** the Drift output
+  `lib/data/database/linthra_database.g.dart` is committed, so no `build_runner`
+  step is needed.
+- **One native component:** SQLite via `sqlite3_flutter_libs`, compiled from
+  source (public domain). No prebuilt closed blobs; no Google Play Services /
+  Firebase anywhere in the resolved tree (152 packages audited).
+- **No GitHub Actions secrets / Play signing** are involved in the from-source
+  build.
+
+**To validate at submission time (draft caveats):**
+
+1. **Flutter provisioning mechanism.** The draft provisions Flutter 3.27.4 via a
+   `sudo:` git-clone of `flutter/flutter` at the `3.27.4` tag. fdroiddata may
+   prefer its `flutter` **srclib** (`srclibs: [flutter@3.27.4]`, referenced as
+   `$$flutter$$`). Match whichever convention current fdroiddata Flutter recipes
+   use. Flutter's pinned engine artifacts are fetched at the pinned version —
+   standard for Flutter-on-F-Droid, and pinned/reproducible (not an uncontrolled
+   blob download).
+2. **`git describe` at the tag.** The build derives the version with
+   `git describe --tags --exact-match HEAD`; confirm F-Droid's checkout of
+   `commit: v0.1.0-alpha.25` leaves the tag resolvable (it should — F-Droid
+   checks out the tag ref).
+3. **Output path / ABI splitting.** `build/app/outputs/flutter-apk/app-release.apk`
+   is the single-APK output; if per-ABI splitting is preferred, adjust `output:`
+   accordingly.
+4. **`pubspec.lock` policy.** Still git-ignored; decide whether to commit it at
+   the tagged commit for a fully pinned dependency set
+   ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
+5. **Gradle wrapper jar** is not committed; F-Droid restores it, but confirm the
+   recipe handles it (a `flutter build` provisions the wrapper).
+
+## 4. Anti-feature assessment
+
+Full reasoning in [fdroid-readiness.md §5](./fdroid-readiness.md#5-anti-features-review)
+and [dependency-license-audit.md §6](./dependency-license-audit.md#6-anti-features--non-free-check).
+Conclusion: **no anti-features to declare.**
+
+| Anti-feature  | Apply? | One-line reason |
+| ------------- | ------ | --------------- |
+| Ads           | No  | No ad libraries/code anywhere. |
+| Tracking      | No  | No telemetry/analytics/crash SDK; on-device signals only; nothing auto-sent. |
+| NonFreeAdd    | No  | Promotes/installs no non-free add-ons. |
+| NonFreeDep    | No  | All 152 resolved packages permissive; playback is AndroidX Media3 (Apache-2.0); Cast is pure-Dart (no GMS Cast SDK). |
+| NonFreeNet    | No  | Local-first core needs no network; Jellyfin/Navidrome/Subsonic are optional, user-supplied, free-software servers — none bundled/promoted/required. |
+| UpstreamNonFree | No | Repo is entirely MPL-2.0; icons generated from a committed SVG. |
+| KnownVuln     | No  | No known-vulnerable version in the resolved tree at audit time; F-Droid's scanner re-checks. |
+| NoSourceSince | No  | Source fully published; builds from source. |
+
+> **Re-review trigger:** any *future* online provider that defaults to or
+> promotes a non-free hosted service would need a fresh `NonFreeNet` assessment.
+
+## 5. Permissions summary
+
+Six permissions are declared explicitly in `AndroidManifest.xml`;
+`ACCESS_NETWORK_STATE` is merged in from the AndroidX Media3 AAR. The set is
+deliberately minimal — **no storage, location, contacts, camera, microphone, or
+phone permission, and no `MANAGE_EXTERNAL_STORAGE`** (folder access uses the
+Storage Access Framework). Each is justified in
+[fdroid-readiness.md §5 (Android permissions)](./fdroid-readiness.md#android-permissions):
+`INTERNET`, `ACCESS_NETWORK_STATE`, `FOREGROUND_SERVICE`,
+`FOREGROUND_SERVICE_MEDIA_PLAYBACK`, `POST_NOTIFICATIONS`, `WAKE_LOCK`,
+`CHANGE_WIFI_MULTICAST_STATE` (mDNS for Cast discovery; AOSP `NsdManager`, not
+GMS). The exact merged set should be re-confirmed against a release build's
+merged manifest at submission time.
+
+## 6. Listing assets status
+
+Tracked in [listing-assets.md](./listing-assets.md). The real app **icon**
+(512×512) and **feature graphic** (1024×500) are committed (generated from
+`tool/branding/linthra_icon.svg`). **Screenshots are the only missing listing
+asset** — they must be captured from a real build, never mocked. Collection is
+already tracked by **issue #77** ("Add real app screenshots to the README and
+store metadata"), which lists the target screens (Now Playing, Library,
+Settings → Jellyfin, Downloads, Cast, Android Auto) and the no-private-data rule.
+Screenshots are **not** strictly required for an fdroiddata MR, but are strongly
+recommended for the listing; capture before/soon after submitting.
+
+## 7. Verification status
+
+Run in this preparation pass (this environment has **no Flutter/Dart/Android SDK
+and no fdroidserver**, so app/build/lint checks could not run here):
+
+| Check | Status |
+| ----- | ------ |
+| Metadata YAML parses (PyYAML) | ✅ parses; fields/types as expected (Summary 57 chars ≤ 80; versionCode integer 100025). A plain YAML parse is **not** a full F-Droid schema check (see below). |
+| `flutter pub get` | ⏳ not run here (no toolchain). Run locally / in CI. |
+| `dart format --set-exit-if-changed .` | ⏳ not run here. CI (`ci.yml`) runs it on every PR. |
+| `flutter analyze` | ⏳ not run here. CI runs it on every PR. |
+| `flutter test` | ⏳ not run here. CI runs it on every PR. |
+| `flutter build apk --debug` | ⏳ not run here (no Android SDK). CI (`android-debug-apk.yml`) builds the debug APK on every PR. |
+| `flutter build apk --release` | ⏳ not run here. The tag build (`android-release-build.yml`) produced the alpha.25 release APK; re-confirm a clean from-source release build on an SDK-equipped machine. |
+| `fdroid lint` / `fdroid build -l io.github.thezupzup.linthra` | ⏳ not run here (no fdroidserver). Run inside an fdroiddata checkout (see §8). |
+
+> **Do not treat the YAML parse as F-Droid validation.** It only confirms the
+> file is syntactically valid YAML with the expected fields. Real validation is
+> `fdroid lint` + an actual `fdroid build` in an fdroiddata checkout.
+
+**Exact commands to run locally / in an fdroiddata checkout:**
+
+```sh
+# In the Linthra repo (pinned Flutter 3.27.4 — see scripts/setup_flutter.sh):
+flutter pub get
+dart format --set-exit-if-changed .
+flutter analyze
+flutter test
+flutter build apk --release \
+  --build-name=0.1.0-alpha.25 --build-number=100025   # what the recipe derives
+
+# In an fdroiddata checkout, after copying metadata/io.github.thezupzup.linthra.yml in:
+fdroid readmeta
+fdroid lint io.github.thezupzup.linthra
+fdroid build -v -l io.github.thezupzup.linthra        # full from-source build test
+```
+
+## 8. Next steps to submit to fdroiddata
+
+1. **Capture & commit screenshots** (issue #77) — recommended before submitting.
+2. **Re-confirm a clean `flutter build apk --release`** from source on an
+   SDK-equipped machine (and the merged-manifest permission set).
+3. **Fork** https://gitlab.com/fdroid/fdroiddata and create a branch.
+4. **Copy** `metadata/io.github.thezupzup.linthra.yml` into fdroiddata's
+   `metadata/` directory. In the real entry, drop the inline `Summary`/
+   `Description` (F-Droid pulls them from the Fastlane files) unless you
+   deliberately want to override them.
+5. **Finalize the Builds toolchain** to fdroiddata's current Flutter convention
+   (srclib vs. sudo-clone — §3) and run `fdroid lint` + `fdroid build -l` until
+   green (§7).
+6. **Open the merge request** using the description in §9. Mark it clearly as an
+   **early-alpha, pre-release** submission and confirm with reviewers whether
+   F-Droid will track an `-alpha` tag or wants to wait for a stable tag.
+7. **Do not** state Linthra is on F-Droid until the MR is merged and the build
+   publishes.
+
+## 9. Merge-request description (ready to adapt)
+
+> Paste into the fdroiddata MR. Honest, not overhyped.
+
+---
+
+**New app: Linthra — `io.github.thezupzup.linthra`**
+
+**Summary:** Local-first music player for your own self-hosted library.
+
+**What it is.** Linthra is an open-source, local-first Android music player for
+people who own their music: play a local folder, or stream from your own
+self-hosted Jellyfin or Navidrome / Subsonic server. It is an **unofficial
+community project**, not affiliated with or endorsed by Jellyfin, Navidrome, or
+the Subsonic project.
+
+**Why it fits F-Droid.**
+- **License:** MPL-2.0 (FSF/OSI-approved), declared in `LICENSE`.
+- **Builds from source**, no signing keys needed (F-Droid signs its own builds).
+- **No proprietary dependencies.** A full transitive audit (152 packages) found
+  only permissive licenses (BSD/MIT/Apache-2.0/MPL-2.0) and **no Google Play
+  Services / Firebase / analytics / ads / crash-reporting** package. The only
+  native component is SQLite (public domain, built from source); playback is
+  AndroidX Media3 (Apache-2.0); Cast is a **pure-Dart** implementation (no GMS
+  Cast SDK).
+- **No anti-features.** No ads, no tracking/telemetry, nothing phones home. The
+  optional self-hosted sources are user-supplied free-software servers (none
+  bundled/promoted/required), so `NonFreeNet` does not apply.
+- **Minimal permissions.** No storage/location/contacts/camera/mic/phone
+  permission and no `MANAGE_EXTERNAL_STORAGE`; folder access uses the Storage
+  Access Framework.
+
+**Source / tracker.** https://github.com/thezupzup/linthra (issues at `/issues`).
+
+**Build target.** Tag `v0.1.0-alpha.25`, versionName `0.1.0-alpha.25`,
+versionCode `100025`. The build derives the version from the tag (the upstream
+single-source-of-truth `tool/version_from_tag.dart`), so the versionCode is
+distinct/monotonic per release and matches the upstream GitHub-release APK.
+(Note: `v0.1.0-alpha.24` was a withdrawn broken release; alpha.25 is the hotfix.)
+
+**Status — honest scope.** This is **early-alpha, pre-release** software: usable
+for testing on a real device, not production-stable, with documented rough edges.
+It is currently distributed only via GitHub Releases (sideloaded APK). I'd
+welcome guidance on whether F-Droid prefers to track this `-alpha` tag now or
+wait for a first stable (`vX.Y.Z`) tag.
+
+**Build verification.** `flutter analyze` / `flutter test` / formatting run green
+in CI on every PR, and CI builds a debug APK per PR; the tagged release APK
+builds via the release workflow. I will additionally run `fdroid lint` +
+`fdroid build -l` and confirm a clean from-source `flutter build apk --release`.
+
+**Known limitations.** Early alpha; local files show file names until tag parsing
+lands; single Jellyfin server; some Subsonic features (favourites/lyrics/cover
+art) are follow-ups; screenshots are being captured from real builds.
+
+---
+
+## 10. GitHub issue draft — "Submit Linthra to F-Droid"
+
+> Body for a tracking issue in this repo. **Provided as a draft — not created
+> automatically.** A separate readiness issue (#87) and the screenshots issue
+> (#77) already exist; this one tracks the actual submission. Suggested labels:
+> `documentation`, `f-droid`.
+
+**Title:** Submit Linthra to F-Droid
+
+**Body:**
+
+### Overview
+
+Track the actual submission of Linthra to
+[fdroiddata](https://gitlab.com/fdroid/fdroiddata). This is **not** a claim that
+Linthra is on F-Droid — it is the submission work itself. Readiness groundwork is
+done (#87); this issue covers cutting the MR.
+
+The target is the latest **working** alpha, **`v0.1.0-alpha.25`** (versionCode
+`100025`) — the hotfix that supersedes the withdrawn, broken `v0.1.0-alpha.24`.
+
+### Checklist
+
+- [ ] Capture & commit real screenshots (#77) — recommended before submitting.
+- [ ] Re-confirm a clean from-source `flutter build apk --release` on an
+      SDK-equipped machine; re-check the merged-manifest permission set.
+- [ ] Decide `pubspec.lock` policy for the tagged commit.
+- [ ] Fork fdroiddata; copy in `metadata/io.github.thezupzup.linthra.yml`.
+- [ ] Finalize the Builds toolchain to fdroiddata's Flutter convention
+      (srclib vs. sudo-clone).
+- [ ] `fdroid readmeta` + `fdroid lint` + `fdroid build -l` all green.
+- [ ] Open the MR (description in `docs/fdroid-submission.md` §9); flag the
+      early-alpha / pre-release status and ask about `-alpha` tag tracking.
+
+### Blockers / open questions
+
+- F-Droid's stance on tracking a **pre-release `-alpha`** CurrentVersion (vs.
+  waiting for a stable tag) — judgement call to confirm with reviewers.
+- Final Flutter-on-F-Droid build incantation must be validated in an fdroiddata
+  checkout.
+
+### Links
+
+- Metadata draft: `metadata/io.github.thezupzup.linthra.yml`
+- Submission package: `docs/fdroid-submission.md`
+- Readiness checklist: `docs/fdroid-readiness.md`
+- Build recipe notes: `docs/fdroid-build-recipe.md`
+- Dependency/license audit: `docs/dependency-license-audit.md`
+- Listing assets: `docs/listing-assets.md`
+
+### Current status
+
+Metadata, audit, permissions, anti-feature review, build recipe, and submission
+text are prepared and target `v0.1.0-alpha.25`. Remaining before the MR:
+screenshots, an SDK-machine release-build re-confirmation, and `fdroid lint` /
+`fdroid build` validation in an fdroiddata checkout.

--- a/docs/listing-assets.md
+++ b/docs/listing-assets.md
@@ -51,6 +51,26 @@ embeds, Releases page), so they only need to be produced once.
 
 All paths are relative to `fastlane/metadata/android/en-US/`.
 
+### Recommended phone shot list (capture from a real build)
+
+Show the flows that actually work today. A good 4–6 shot set (collection is
+tracked by issue #77):
+
+- [ ] **Library** — Songs / Albums / Artists with search.
+- [ ] **Now Playing** — the player (artwork, controls, queue).
+- [ ] **Settings → Jellyfin** (or Subsonic) connection screen.
+- [ ] **Downloads / offline cache**.
+- [ ] _Optional:_ **Cast** device picker, if a Cast device is available.
+- [ ] _Optional:_ **Android Auto** (DHU or head unit), if available.
+
+Capture rules (non-negotiable):
+
+- **No personal server URL** visible (blank it, or use a throwaway/local server).
+- **No private library/account data** unless you are intentionally fine with it.
+- **No fake or mocked screenshots** — real captures only (a mockup, if ever used
+  elsewhere, must be clearly labelled as such and never placed in the F-Droid
+  `phoneScreenshots/` folder).
+
 ## 3. Exact sizes and formats
 
 | Asset            | Format    | Size / constraints                                              |

--- a/docs/listing-assets.md
+++ b/docs/listing-assets.md
@@ -51,25 +51,26 @@ embeds, Releases page), so they only need to be produced once.
 
 All paths are relative to `fastlane/metadata/android/en-US/`.
 
-### Recommended phone shot list (capture from a real build)
+### A good phone shot list
 
-Show the flows that actually work today. A good 4–6 shot set (collection is
-tracked by issue #77):
+Show the things that actually work today — four to six shots is plenty
+(collection is tracked by issue #77):
 
-- [ ] **Library** — Songs / Albums / Artists with search.
-- [ ] **Now Playing** — the player (artwork, controls, queue).
-- [ ] **Settings → Jellyfin** (or Subsonic) connection screen.
-- [ ] **Downloads / offline cache**.
-- [ ] _Optional:_ **Cast** device picker, if a Cast device is available.
-- [ ] _Optional:_ **Android Auto** (DHU or head unit), if available.
+- [ ] Library — Songs / Albums / Artists with search.
+- [ ] Now Playing — the player (artwork, controls, queue).
+- [ ] Settings → Jellyfin (or Subsonic) connection screen.
+- [ ] Downloads / offline cache.
+- [ ] Cast device picker, if you have a Cast device (optional).
+- [ ] Android Auto, on a head unit or the Desktop Head Unit (optional).
 
-Capture rules (non-negotiable):
+A few things to keep in mind while capturing:
 
-- **No personal server URL** visible (blank it, or use a throwaway/local server).
-- **No private library/account data** unless you are intentionally fine with it.
-- **No fake or mocked screenshots** — real captures only (a mockup, if ever used
-  elsewhere, must be clearly labelled as such and never placed in the F-Droid
-  `phoneScreenshots/` folder).
+- Don't show a personal server URL — blank it out, or use a throwaway/local
+  server.
+- Don't show private library or account data unless you're happy for it to be
+  public.
+- Real captures only, no mockups. If a mockup is ever used somewhere else, label
+  it clearly and keep it out of the F-Droid `phoneScreenshots/` folder.
 
 ## 3. Exact sizes and formats
 

--- a/fastlane/metadata/android/en-US/changelogs/100025.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100025.txt
@@ -1,0 +1,10 @@
+Linthra 0.1.0-alpha.25 — startup hotfix.
+
+Fixed:
+- Reverts the change that caused a startup regression in 0.1.0-alpha.24, which
+  could fail to launch on Android. The app launches reliably again.
+
+If you installed 0.1.0-alpha.24, update to this build — alpha.24 is withdrawn
+and should not be used.
+
+Still an alpha — expect rough edges. Not on F-Droid yet.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,46 +1,53 @@
-Linthra is an open-source, local-first music player for people who own their
-music. Your library lives on your device, and you stay in control of it.
+Linthra is an open-source, local-first music player for Android, for people who
+own their music. Point it at a folder of local files, or connect your own
+self-hosted Jellyfin, Navidrome, or Subsonic server — your library, your server,
+your rules.
 
-Linthra is early-stage software in its first alpha. The sections below clearly
-separate what works today from what is planned, so nothing here overpromises.
+Linthra is an unofficial community project. It is not affiliated with or
+endorsed by Jellyfin, Navidrome, or the Subsonic project; you bring your own
+server and credentials.
 
-What Linthra is about:
+This is early-alpha software. It is usable for testing on a real device, but it
+is not production-stable and has documented rough edges. The sections below
+separate what works today from what is still planned, so nothing here
+overpromises.
 
-* Local-first — your music files stay on your device; the app reads from a
-  local catalog rather than depending on a remote service.
-* User-owned music — Linthra plays the files you already have. There is no
-  store, no account, and no requirement to use anyone's cloud.
-* Privacy-focused — no telemetry and no forced sync. The app does not phone
-  home or upload your library, and offline downloads only ever happen when you
-  ask for them.
-* Open-source — released under the Mozilla Public License 2.0. Anyone can
-  read, audit, build, and contribute to the code.
+Privacy by design:
+
+* No tracking, no analytics, no ads, and no crash-reporting or telemetry SDK.
+* No account and no phoning home — nothing leaves your device unless you ask
+  for it.
+* Streaming is the default; offline downloads are always explicit and
+  user-initiated (Wi-Fi only unless you opt in to mobile data).
+* The server password is used once to obtain a session token, then discarded;
+  the token is stored encrypted and never logged.
+* Open-source under the Mozilla Public License 2.0 — anyone can read, audit,
+  build, and contribute to the code.
 
 Working today:
 
-* Pick a folder of music using the native Android folder picker, scan it, and
-  list your tracks. The chosen folder and the scanned catalog survive a
-  restart.
-* Play your local tracks, with an up-next queue.
+* Local library — pick a folder using the Storage Access Framework (no broad
+  storage permission), scan it, and browse Songs, Albums, and Artists with
+  search.
+* Self-hosted streaming from your own Jellyfin or Navidrome / Subsonic server:
+  test, sign in, sync, and stream, including over HTTPS.
+* Smart offline cache — tap to download tracks for offline play, with a size
+  limit and "Keep offline" pinning.
+* Queue / Up Next, playlists and favourites (synced with Jellyfin where
+  supported), and automatic "smart mixes" built from on-device signals.
 * Background playback with a media notification and lock-screen, Bluetooth, and
-  wired-headset controls.
-* Android Auto: browse your Library and Queue from the car screen.
-* Connect to your own Jellyfin server, sign in, sync your library, and stream
-  tracks. The session token is stored encrypted and passwords are never saved.
-* Explicit, user-initiated offline downloads of Jellyfin tracks, with a
-  "Wi-Fi only" option — never automatic.
+  wired-headset controls, plus shuffle / repeat and synced lyrics.
+* Android Auto browsing, and Cast to a Chromecast, speaker, or TV using a
+  pure-Dart Cast implementation — no Google Play Services.
 
 Planned (not finished yet):
 
-* Tag/metadata parsing and album artwork (tracks currently show file names).
-* Browsing by artist and album, plus search.
-* Playlist creation and editing, plus queue reorder/shuffle/repeat.
-* Album- and playlist-level "download all" and a background download manager.
-* Additional sources (such as WebDAV and NAS) behind the same interface.
+* Local tag/metadata parsing and album artwork (local files currently show
+  file names; "Unknown Artist/Album" until tags are read).
+* Subsonic favourites, lyrics, and cover art, and fuller playlist sync.
+* Album- and playlist-level "download all".
+* Additional sources such as WebDAV / NAS, behind the same interface.
+* Linux desktop, later, from the same codebase.
 
-Platforms:
-
-* Android first. Linux desktop is planned later, from the same codebase.
-
-Linthra is built to respect the people who use it: no lock-in, no surprise
-network activity, and no downloads you did not ask for.
+Distribution: Linthra is distributed for testing via GitHub Releases as a
+sideloadable APK, and is NOT yet on F-Droid or Google Play.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,53 +1,49 @@
-Linthra is an open-source, local-first music player for Android, for people who
-own their music. Point it at a folder of local files, or connect your own
-self-hosted Jellyfin, Navidrome, or Subsonic server — your library, your server,
-your rules.
+Linthra is an open-source Android music player for people who keep their music on
+their own devices or self-hosted servers. It plays local files, and it streams
+from self-hosted music servers such as Jellyfin and Navidrome/Subsonic — you
+bring your own server and sign in with your own account.
 
-Linthra is an unofficial community project. It is not affiliated with or
-endorsed by Jellyfin, Navidrome, or the Subsonic project; you bring your own
-server and credentials.
+Linthra is an unofficial community client. It is not affiliated with Jellyfin,
+Navidrome, or Subsonic.
 
-This is early-alpha software. It is usable for testing on a real device, but it
-is not production-stable and has documented rough edges. The sections below
-separate what works today from what is still planned, so nothing here
-overpromises.
+The app is still early alpha. It's usable for testing on a real device, but it
+isn't production-stable and has a few rough edges. The lists below separate what
+works today from what's still planned.
 
-Privacy by design:
+On privacy:
 
-* No tracking, no analytics, no ads, and no crash-reporting or telemetry SDK.
-* No account and no phoning home — nothing leaves your device unless you ask
-  for it.
-* Streaming is the default; offline downloads are always explicit and
-  user-initiated (Wi-Fi only unless you opt in to mobile data).
-* The server password is used once to obtain a session token, then discarded;
-  the token is stored encrypted and never logged.
-* Open-source under the Mozilla Public License 2.0 — anyone can read, audit,
-  build, and contribute to the code.
+* No ads, no tracking, no analytics, and no crash-reporting or telemetry SDK.
+* No account to create, and nothing phones home — streaming is the default, and
+  downloads only happen when you ask for them (Wi-Fi only unless you opt in to
+  mobile data).
+* When you sign in to a server, the password is used once to get a session
+  token, then dropped; the token is stored encrypted and never logged.
+* Open-source under the Mozilla Public License 2.0, so anyone can read, build,
+  and contribute to it.
 
-Working today:
+What works today:
 
-* Local library — pick a folder using the Storage Access Framework (no broad
+* Local library — pick a folder with the Storage Access Framework (no broad
   storage permission), scan it, and browse Songs, Albums, and Artists with
   search.
-* Self-hosted streaming from your own Jellyfin or Navidrome / Subsonic server:
-  test, sign in, sync, and stream, including over HTTPS.
-* Smart offline cache — tap to download tracks for offline play, with a size
-  limit and "Keep offline" pinning.
-* Queue / Up Next, playlists and favourites (synced with Jellyfin where
+* Streaming from your own Jellyfin or Navidrome / Subsonic server: test the
+  connection, sign in, sync, and play, including over HTTPS.
+* A smart offline cache — download tracks for offline play, with a size limit
+  and a "Keep offline" pin.
+* Queue / Up Next, playlists and favourites (synced with Jellyfin where it's
   supported), and automatic "smart mixes" built from on-device signals.
 * Background playback with a media notification and lock-screen, Bluetooth, and
   wired-headset controls, plus shuffle / repeat and synced lyrics.
-* Android Auto browsing, and Cast to a Chromecast, speaker, or TV using a
-  pure-Dart Cast implementation — no Google Play Services.
+* Android Auto browsing, and casting to a Chromecast, speaker, or TV through a
+  pure-Dart Cast implementation (no Google Play Services).
 
-Planned (not finished yet):
+Still to come:
 
-* Local tag/metadata parsing and album artwork (local files currently show
-  file names; "Unknown Artist/Album" until tags are read).
+* Reading tags and album art from local files (for now they show file names).
 * Subsonic favourites, lyrics, and cover art, and fuller playlist sync.
-* Album- and playlist-level "download all".
-* Additional sources such as WebDAV / NAS, behind the same interface.
-* Linux desktop, later, from the same codebase.
+* "Download all" for an album or playlist.
+* More sources, such as WebDAV / NAS, behind the same interface.
+* A Linux desktop build later, from the same codebase.
 
-Distribution: Linthra is distributed for testing via GitHub Releases as a
-sideloadable APK, and is NOT yet on F-Droid or Google Play.
+Linthra is distributed for testing as a sideloaded APK from GitHub Releases. It
+isn't on F-Droid or Google Play yet.

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -1,126 +1,102 @@
-# =============================================================================
-# F-Droid metadata DRAFT for Linthra — NOT SUBMITTED.
+# -----------------------------------------------------------------------------
+# Draft F-Droid metadata for Linthra. This is a working copy kept in the app
+# repo; Linthra hasn't been submitted to F-Droid yet, and isn't on it. When we
+# do submit, the real entry lives in fdroiddata's metadata/ directory
+# (https://gitlab.com/fdroid/fdroiddata) — copy this there and adapt it.
+# docs/fdroid-submission.md has the rest: the merge-request text, the remaining
+# steps, and the open questions.
 #
-# Linthra is NOT on F-Droid and no submission/merge request has been made. This
-# file is a *draft* kept in the app repository so a future submission to
-# fdroiddata (https://gitlab.com/fdroid/fdroiddata) is straightforward and
-# accurate. The real entry lives in fdroiddata's `metadata/` directory, not
-# here; copy/adapt this file there when submitting. See docs/fdroid-submission.md
-# for the full submission package (MR text, next steps, blockers).
+# A few things worth knowing:
+#   * Linthra is an early-alpha, unofficial community client. It is not
+#     affiliated with Jellyfin, Navidrome, or Subsonic.
+#   * No tracking, no analytics, no ads, no crash-reporting SDK.
+#   * Tagged releases exist (v0.1.0-alpha.1 … v0.1.0-alpha.25, built by
+#     .github/workflows/android-release-build.yml). We target the latest one
+#     that actually launches, v0.1.0-alpha.25.
+#   * Skip v0.1.0-alpha.24 — it has a startup regression, and its GitHub Release
+#     is marked "Broken release — do not install". alpha.25 is the hotfix that
+#     reverts it, so that's the build target and CurrentVersion, not alpha.24.
+#   * F-Droid takes Summary/Description from the Fastlane files under
+#     fastlane/metadata/android/en-US/. The inline copies below are here so the
+#     listing is easy to review in one place; in the real fdroiddata entry you'd
+#     usually drop them and let Fastlane provide them.
 #
-# Status notes for reviewers:
-#   * Early alpha, unofficial community project. Not affiliated with or endorsed
-#     by Jellyfin, Navidrome, or the Subsonic project.
-#   * No tracking, no analytics, no ads, no telemetry/crash-reporting SDK.
-#   * Tagged releases now exist (v0.1.0-alpha.1 … v0.1.0-alpha.25, built by
-#     .github/workflows/android-release-build.yml). The F-Droid target below is
-#     the latest WORKING alpha, v0.1.0-alpha.25 — the hotfix that reverts the
-#     startup regression in v0.1.0-alpha.24.
-#   * v0.1.0-alpha.24 is a KNOWN-BROKEN release (GitHub Release body: "Broken
-#     release — do not install … startup regression"). It MUST NOT be selected
-#     as a build target / CurrentVersion. v0.1.0-alpha.25 supersedes it.
-#   * When F-Droid builds, `Summary`/`Description` are taken from the Fastlane
-#     files under `fastlane/metadata/android/en-US/`. The inline `Summary`/
-#     `Description` here are provided for review; in the real fdroiddata MR they
-#     are usually omitted in favour of the Fastlane files (now refreshed to match
-#     the current alpha — see docs/fdroid-readiness.md §8).
-#
-# See docs/fdroid-submission.md, docs/fdroid-readiness.md,
-# docs/fdroid-build-recipe.md, and docs/dependency-license-audit.md for the full
-# reasoning behind every value.
-# =============================================================================
+# The reasoning behind each value lives in docs/fdroid-submission.md,
+# docs/fdroid-readiness.md, docs/fdroid-build-recipe.md, and
+# docs/dependency-license-audit.md.
+# -----------------------------------------------------------------------------
 
 Categories:
   - Multimedia
 License: MPL-2.0
 AuthorName: TheZupZup
-# WebSite: intentionally omitted — there is no separate project website; the
-# source repository below is the canonical home. F-Droid falls back to
-# SourceCode when WebSite is unset.
+# No WebSite on purpose — there's no separate project site; the source repo is
+# the canonical home, and F-Droid falls back to SourceCode when WebSite is unset.
 SourceCode: https://github.com/thezupzup/linthra
 IssueTracker: https://github.com/thezupzup/linthra/issues
-# Tagged GitHub Releases now exist, so the Changelog can point at them.
+# Tagged GitHub Releases exist now, so the changelog can point at them.
 Changelog: https://github.com/thezupzup/linthra/releases
 
 Name: Linthra
 Summary: Local-first music player for your own self-hosted library
 
 Description: |-
-  Linthra is an open-source, local-first music player for Android, for people
-  who own their music. Point it at a folder of local files, or connect your own
-  self-hosted Jellyfin, Navidrome, or Subsonic server — your library, your
-  server, your rules.
+  Linthra is an open-source Android music player for people who keep their music
+  on their own devices or self-hosted servers. It plays local files, and it
+  streams from self-hosted music servers such as Jellyfin and Navidrome/Subsonic
+  — you bring your own server and sign in with your own account.
 
-  Linthra is an unofficial community project. It is not affiliated with or
-  endorsed by Jellyfin, Navidrome, or the Subsonic project; you bring your own
-  server and credentials.
+  Linthra is an unofficial community client. It is not affiliated with Jellyfin,
+  Navidrome, or Subsonic.
 
-  Privacy by design:
+  It tries to stay out of your way and respect your privacy: no ads, no tracking,
+  no analytics, and no crash-reporting SDK. There's no account to create and
+  nothing phones home — streaming is the default, and downloads only happen when
+  you ask for them. When you sign in to a server, the password is used once to
+  get a session token and then dropped; the token is stored encrypted and never
+  logged.
 
-  * No tracking, no analytics, no ads, and no crash-reporting/telemetry SDK.
-  * No account and no phoning home — nothing leaves your device unless you ask
-    for it.
-  * Streaming is the default; offline downloads are always explicit and
-    user-initiated (Wi-Fi only unless you opt in to mobile data).
-  * The server password is used once to obtain a session token, then discarded;
-    the token is stored encrypted and never logged.
-
-  What works today:
-
-  * Local library: pick a folder via the Storage Access Framework (no broad
-    storage permission), scan it, and browse Songs / Albums / Artists.
-  * Self-hosted streaming from your own Jellyfin or Navidrome / Subsonic server,
-    including over HTTPS.
-  * Smart offline cache, queue / up-next, playlists and favourites, and
-    automatic "smart mixes" built from on-device signals.
-  * Background playback with a media notification and lock-screen, Bluetooth,
-    and wired-headset controls.
-  * Android Auto browsing, and Cast to a Chromecast / speaker / TV using a
-    pure-Dart Cast implementation — no Google Play Services.
-
-  This is early-alpha software: it is usable for testing on a real device, but
-  it is not production-stable and has documented rough edges. It is distributed
-  for testing today only via GitHub Releases (sideloaded APK), and is NOT yet on
-  F-Droid.
+  The app is still early alpha. It's usable for testing on a real device, but it
+  isn't production-stable and has a few rough edges. For now it's distributed
+  only as a sideloaded APK from GitHub Releases — it isn't on F-Droid yet. The
+  full feature list is in the Fastlane description
+  (fastlane/metadata/android/en-US/full_description.txt).
 
 RepoType: git
 Repo: https://github.com/thezupzup/linthra.git
 
 # -----------------------------------------------------------------------------
-# Builds — DRAFT targeting the latest WORKING alpha, v0.1.0-alpha.25.
+# Build — draft, targeting v0.1.0-alpha.25 (the latest alpha that launches; see
+# the note above about skipping alpha.24).
 #
-#  * commit: v0.1.0-alpha.25 — the hotfix tag that reverts the v0.1.0-alpha.24
-#    startup regression (do NOT target alpha.24).
-#  * versionName/versionCode are the tag-derived values produced by
-#    tool/version_from_tag.dart (v0.1.0-alpha.25 -> 0.1.0-alpha.25 / 100025) —
-#    the SAME values the upstream GitHub release build bakes in, so the F-Droid
-#    and GitHub channels agree on versionCode.
-#  * WHY the build derives the version instead of using pubspec.yaml:
-#    pubspec.yaml carries a STATIC dev version (0.1.0-alpha.15+15) that does not
-#    track tags, so a plain `flutter build` would stamp EVERY tag with
-#    versionCode 15 — F-Droid could not tell releases apart. The build below
-#    derives versionName/versionCode from the checked-out tag via the project's
-#    single source of truth (tool/version_from_tag.dart) and passes them with
-#    --build-name/--build-number. This also keeps AutoUpdateMode correct for
-#    future tags (the derivation does not hard-code a version).
-#  * Generated Drift files (lib/data/database/linthra_database.g.dart) are
-#    committed, so NO build_runner/codegen prebuild step is required.
-#  * The only native component is SQLite via sqlite3_flutter_libs, compiled from
-#    source (public domain) — no prebuilt closed blobs. No signing keys are
-#    needed to build (F-Droid signs its own builds).
-#  * TOOLCHAIN PROVISIONING IS A DRAFT. The exact Flutter-on-F-Droid mechanism
-#    (the sudo git-clone shown here vs. fdroiddata's `flutter` srclib), ABI
-#    splitting, and the output path MUST be validated against fdroiddata's
-#    current Flutter recipes at submission time. See docs/fdroid-build-recipe.md.
+# On the version handling: pubspec.yaml keeps a fixed dev version
+# (0.1.0-alpha.15+15) that doesn't move with the tags, so a plain `flutter build`
+# would label every tag as versionCode 15 and F-Droid couldn't tell releases
+# apart. Instead the build derives the version from the checked-out tag with
+# tool/version_from_tag.dart — the same tool the GitHub release build uses — so
+# v0.1.0-alpha.25 becomes 0.1.0-alpha.25 / 100025. Both channels then agree on
+# the versionCode, and AutoUpdateMode still works for future tags because nothing
+# is hard-coded.
+#
+# A few things that keep this easy to build from source: the generated Drift file
+# (lib/data/database/linthra_database.g.dart) is committed, so there's no
+# build_runner/codegen step; the only native piece is SQLite (via
+# sqlite3_flutter_libs, built from source, public domain), with no prebuilt
+# blobs; and no signing keys are needed, since F-Droid signs its own builds.
+#
+# Still to confirm: how Flutter 3.27.4 is provisioned (the sudo git-clone shown
+# here vs. fdroiddata's `flutter` srclib), ABI splitting, and the output path all
+# need checking against fdroiddata's current Flutter recipes — see
+# docs/fdroid-build-recipe.md.
 # -----------------------------------------------------------------------------
 Builds:
   - versionName: 0.1.0-alpha.25
     versionCode: 100025
     commit: v0.1.0-alpha.25
     # Provision the pinned Flutter 3.27.4 toolchain (matches .flutter-version and
-    # all CI workflows). DRAFT: an alternative is fdroiddata's `flutter` srclib
-    # (srclibs: [flutter@3.27.4]) referenced as $$flutter$$ — pick whichever
-    # matches fdroiddata's current Flutter convention at submission time.
+    # CI). An alternative is fdroiddata's `flutter` srclib
+    # (srclibs: [flutter@3.27.4], referenced as $$flutter$$) — use whichever fits
+    # fdroiddata's current convention.
     sudo:
       - apt-get update
       - apt-get install -y git curl unzip xz-utils
@@ -132,22 +108,22 @@ Builds:
       git config --global --add safe.directory /opt/flutter
       flutter config --no-analytics
       flutter pub get
-      # Derive the tag-derived versionName/versionCode (see header note above).
+      # Work out the real version from the tag (see the build note above).
       tag="$(git describe --tags --exact-match HEAD)"
       eval "$(dart run tool/version_from_tag.dart "$tag")"
       flutter build apk --release \
         --build-name="$LINTHRA_VERSION_NAME" \
         --build-number="$LINTHRA_VERSION_CODE"
 
-# AutoUpdateMode: track annotated tags of the form v<versionName>. The build
-# above derives the versionCode from the tag, so an auto-generated build entry
-# for a future tag builds the correct version without hand-editing.
+# Track annotated tags shaped like v<versionName>. Because the build derives the
+# versionCode from the tag, an auto-generated entry for a future tag will build
+# the right version without anyone editing it by hand.
 AutoUpdateMode: Version v%v
-# UpdateCheckMode: Linthra currently ships only pre-release (-alpha.N) tags, so
-# the regex must accept the alpha/beta/rc suffix. NOTE: F-Droid generally
-# prefers a non-pre-release CurrentVersion; whether it will track/suggest an
-# -alpha tag (and whether to submit at the alpha stage at all) is a judgement
-# call to confirm with F-Droid — see docs/fdroid-readiness.md §8.
+# Linthra has only shipped pre-release (-alpha.N) tags so far, so the pattern has
+# to allow the alpha/beta/rc suffix. F-Droid usually prefers a non-pre-release
+# CurrentVersion, so it's worth checking whether the maintainers are happy
+# tracking an -alpha tag or would rather wait for a stable one — see
+# docs/fdroid-readiness.md §8.
 UpdateCheckMode: Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$
 CurrentVersion: 0.1.0-alpha.25
 CurrentVersionCode: 100025

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -5,23 +5,29 @@
 # file is a *draft* kept in the app repository so a future submission to
 # fdroiddata (https://gitlab.com/fdroid/fdroiddata) is straightforward and
 # accurate. The real entry lives in fdroiddata's `metadata/` directory, not
-# here; copy/adapt this file there when submitting.
+# here; copy/adapt this file there when submitting. See docs/fdroid-submission.md
+# for the full submission package (MR text, next steps, blockers).
 #
 # Status notes for reviewers:
 #   * Early alpha, unofficial community project. Not affiliated with or endorsed
 #     by Jellyfin, Navidrome, or the Subsonic project.
 #   * No tracking, no analytics, no ads, no telemetry/crash-reporting SDK.
-#   * No tagged release exists yet, so the `Builds:` `commit:` below is a
-#     PLACEHOLDER for the first real `v*` tag and MUST be set to a real tag
-#     before submission.
-#   * When F-Droid builds, `Summary`/`Description` are normally taken from the
-#     Fastlane files under `fastlane/metadata/android/en-US/`. The inline
-#     `Summary`/`Description` here are provided for review per the readiness
-#     task; the Fastlane `full_description.txt` should be refreshed to match the
-#     current feature set before submission (see docs/fdroid-readiness.md).
+#   * Tagged releases now exist (v0.1.0-alpha.1 … v0.1.0-alpha.25, built by
+#     .github/workflows/android-release-build.yml). The F-Droid target below is
+#     the latest WORKING alpha, v0.1.0-alpha.25 — the hotfix that reverts the
+#     startup regression in v0.1.0-alpha.24.
+#   * v0.1.0-alpha.24 is a KNOWN-BROKEN release (GitHub Release body: "Broken
+#     release — do not install … startup regression"). It MUST NOT be selected
+#     as a build target / CurrentVersion. v0.1.0-alpha.25 supersedes it.
+#   * When F-Droid builds, `Summary`/`Description` are taken from the Fastlane
+#     files under `fastlane/metadata/android/en-US/`. The inline `Summary`/
+#     `Description` here are provided for review; in the real fdroiddata MR they
+#     are usually omitted in favour of the Fastlane files (now refreshed to match
+#     the current alpha — see docs/fdroid-readiness.md §8).
 #
-# See docs/fdroid-readiness.md, docs/fdroid-build-recipe.md, and
-# docs/dependency-license-audit.md for the full reasoning behind every value.
+# See docs/fdroid-submission.md, docs/fdroid-readiness.md,
+# docs/fdroid-build-recipe.md, and docs/dependency-license-audit.md for the full
+# reasoning behind every value.
 # =============================================================================
 
 Categories:
@@ -33,12 +39,10 @@ AuthorName: TheZupZup
 # SourceCode when WebSite is unset.
 SourceCode: https://github.com/thezupzup/linthra
 IssueTracker: https://github.com/thezupzup/linthra/issues
-# Changelog: set this only once tagged GitHub Releases exist. Until then,
-# per-version notes live in fastlane/metadata/android/en-US/changelogs/.
-# Changelog: https://github.com/thezupzup/linthra/releases
+# Tagged GitHub Releases now exist, so the Changelog can point at them.
+Changelog: https://github.com/thezupzup/linthra/releases
 
 Name: Linthra
-AutoName: Linthra
 Summary: Local-first music player for your own self-hosted library
 
 Description: |-
@@ -83,44 +87,67 @@ RepoType: git
 Repo: https://github.com/thezupzup/linthra.git
 
 # -----------------------------------------------------------------------------
-# Builds — DRAFT. Verify against a real tagged build before submitting.
+# Builds — DRAFT targeting the latest WORKING alpha, v0.1.0-alpha.25.
 #
-#  * `commit:` is a PLACEHOLDER. No `v*` tag exists yet; set it to the real
-#    annotated release tag (e.g. v0.1.0-alpha.15) at submission time.
-#  * versionName/versionCode below match pubspec.yaml (0.1.0-alpha.15+15), which
-#    is what a plain `flutter build` (what F-Droid runs) produces.
-#    NOTE: the GitHub-Release workflow derives a different, larger versionCode
-#    from the tag (v0.1.0-alpha.15 -> 100015 via tool/version_from_tag.dart).
-#    These two channels MUST be reconciled before submission — either bump
-#    pubspec.yaml at the tagged commit or pass --build-name/--build-number in
-#    the recipe so the F-Droid versionCode matches. See docs/fdroid-readiness.md
-#    §"Release / tagging" and docs/fdroid-build-recipe.md §5.
+#  * commit: v0.1.0-alpha.25 — the hotfix tag that reverts the v0.1.0-alpha.24
+#    startup regression (do NOT target alpha.24).
+#  * versionName/versionCode are the tag-derived values produced by
+#    tool/version_from_tag.dart (v0.1.0-alpha.25 -> 0.1.0-alpha.25 / 100025) —
+#    the SAME values the upstream GitHub release build bakes in, so the F-Droid
+#    and GitHub channels agree on versionCode.
+#  * WHY the build derives the version instead of using pubspec.yaml:
+#    pubspec.yaml carries a STATIC dev version (0.1.0-alpha.15+15) that does not
+#    track tags, so a plain `flutter build` would stamp EVERY tag with
+#    versionCode 15 — F-Droid could not tell releases apart. The build below
+#    derives versionName/versionCode from the checked-out tag via the project's
+#    single source of truth (tool/version_from_tag.dart) and passes them with
+#    --build-name/--build-number. This also keeps AutoUpdateMode correct for
+#    future tags (the derivation does not hard-code a version).
 #  * Generated Drift files (lib/data/database/linthra_database.g.dart) are
 #    committed, so NO build_runner/codegen prebuild step is required.
 #  * The only native component is SQLite via sqlite3_flutter_libs, compiled from
-#    source (public domain) — no prebuilt closed blobs.
-#  * The exact Flutter-on-F-Droid build incantation (Flutter srclib vs. a
-#    sudo-installed SDK, ABI splitting, output path) must be validated against
-#    fdroiddata's current Flutter recipes at submission time.
+#    source (public domain) — no prebuilt closed blobs. No signing keys are
+#    needed to build (F-Droid signs its own builds).
+#  * TOOLCHAIN PROVISIONING IS A DRAFT. The exact Flutter-on-F-Droid mechanism
+#    (the sudo git-clone shown here vs. fdroiddata's `flutter` srclib), ABI
+#    splitting, and the output path MUST be validated against fdroiddata's
+#    current Flutter recipes at submission time. See docs/fdroid-build-recipe.md.
 # -----------------------------------------------------------------------------
 Builds:
-  - versionName: 0.1.0-alpha.15
-    versionCode: 15
-    commit: PLACEHOLDER_SET_TO_REAL_TAG # e.g. v0.1.0-alpha.15 — no tag exists yet
+  - versionName: 0.1.0-alpha.25
+    versionCode: 100025
+    commit: v0.1.0-alpha.25
+    # Provision the pinned Flutter 3.27.4 toolchain (matches .flutter-version and
+    # all CI workflows). DRAFT: an alternative is fdroiddata's `flutter` srclib
+    # (srclibs: [flutter@3.27.4]) referenced as $$flutter$$ — pick whichever
+    # matches fdroiddata's current Flutter convention at submission time.
     sudo:
-      - # toolchain provisioning, if the recipe installs Flutter itself
+      - apt-get update
+      - apt-get install -y git curl unzip xz-utils
+      - git clone --branch 3.27.4 --depth 1 https://github.com/flutter/flutter /opt/flutter
+      - chown -R vagrant:vagrant /opt/flutter
     output: build/app/outputs/flutter-apk/app-release.apk
-    srclibs:
-      - # Flutter 3.27.4 srclib, if used (Dart 3.6.x, JDK 17, Gradle 8.3)
     build: |
+      export PATH="/opt/flutter/bin:$PATH"
+      git config --global --add safe.directory /opt/flutter
+      flutter config --no-analytics
       flutter pub get
-      flutter build apk --release
+      # Derive the tag-derived versionName/versionCode (see header note above).
+      tag="$(git describe --tags --exact-match HEAD)"
+      eval "$(dart run tool/version_from_tag.dart "$tag")"
+      flutter build apk --release \
+        --build-name="$LINTHRA_VERSION_NAME" \
+        --build-number="$LINTHRA_VERSION_CODE"
 
+# AutoUpdateMode: track annotated tags of the form v<versionName>. The build
+# above derives the versionCode from the tag, so an auto-generated build entry
+# for a future tag builds the correct version without hand-editing.
 AutoUpdateMode: Version v%v
-# UpdateCheckMode: track v* tags. Linthra currently ships only pre-release
-# (-alpha.N) versions, so the regex must accept the alpha/beta/rc suffix and be
-# validated against the first real tag. F-Droid may need configuring to accept
-# pre-release tags at all; revisit when a stable (non-pre-release) tag exists.
+# UpdateCheckMode: Linthra currently ships only pre-release (-alpha.N) tags, so
+# the regex must accept the alpha/beta/rc suffix. NOTE: F-Droid generally
+# prefers a non-pre-release CurrentVersion; whether it will track/suggest an
+# -alpha tag (and whether to submit at the alpha stage at all) is a judgement
+# call to confirm with F-Droid — see docs/fdroid-readiness.md §8.
 UpdateCheckMode: Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$
-CurrentVersion: 0.1.0-alpha.15
-CurrentVersionCode: 15
+CurrentVersion: 0.1.0-alpha.25
+CurrentVersionCode: 100025


### PR DESCRIPTION
## F-Droid submission prep summary

Prepares everything needed to submit Linthra to [fdroiddata](https://gitlab.com/fdroid/fdroiddata), and **reconciles the metadata with reality**: 25 tagged releases now exist (`v0.1.0-alpha.1` … `v0.1.0-alpha.25`), so the recipe — which previously claimed "no tagged release exists yet" and pointed at alpha.15 — now targets the latest **working** alpha.

> **Not submitted. Not on F-Droid.** Nothing here publishes, signs, or submits anything. This is the material to review before a human opens the fdroiddata MR. No app code, workflows, logo/theme, or `pubspec.yaml` were touched.

## Latest working alpha selected

| | |
| --- | --- |
| **Target tag** | `v0.1.0-alpha.25` (commit `c9c1fb3`) — the hotfix |
| versionName / versionCode | `0.1.0-alpha.25` / **`100025`** |
| Changelog | `fastlane/metadata/android/en-US/changelogs/100025.txt` |

**`v0.1.0-alpha.24` is explicitly excluded** — its GitHub Release is flagged "Broken release — do not install … startup regression." alpha.25 is the revert/hotfix and is the launchable target.

### versionCode `100025` (not `15`)
`pubspec.yaml` is a **static** `0.1.0-alpha.15+15`, so a plain `flutter build` stamps **every** tag with versionCode 15 — F-Droid couldn't tell releases apart. The recipe instead derives the version from the checked-out tag via the project's own `tool/version_from_tag.dart` and passes `--build-name/--build-number`, giving `100025` — distinct, monotonic, identical to the GitHub-release APK, and AutoUpdate-safe for future tags.

## Metadata validation
All 16 requested checks pass: correct app id (`io.github.thezupzup.linthra`), license (`MPL-2.0`), source/issue/changelog URLs, `Multimedia` category, 57-char summary, honest description, **no** "official Jellyfin/Navidrome/Subsonic" claim, **no** "already on F-Droid" claim, version matches the working tag, no private signing keys, no proprietary deps. Validated as well-formed YAML here (PyYAML); deprecated `AutoName` dropped.

## Build recipe status
Builds from source, no signing keys (F-Droid signs its own); pinned Flutter 3.27.4 / JDK 17 / Gradle 8.3; `flutter pub get` + release APK; Drift `*.g.dart` committed so **no** `build_runner` prebuild; only native bit is SQLite (public domain, from source); no GHA secrets / Play signing / unpublished SDK blob. The Flutter-on-F-Droid provisioning (sudo git-clone vs. `flutter` srclib) and `git describe` at the tag are flagged as **draft — validate via `fdroid build` at submission**.

## Anti-feature conclusion
**None to declare.** Ads ✗, Tracking ✗, NonFreeDep ✗ (152-package audit, no GMS; Cast is pure-Dart, playback is AndroidX Media3), NonFreeNet ✗ (optional user-hosted free-software servers), UpstreamNonFree ✗, KnownVuln ✗.

## Screenshots / listing status
Icon (512×512) and feature graphic (1024×500) are committed. **Screenshots are the only missing listing asset** (real captures only — not required for the MR but recommended). Collection is already tracked by **#77**; added a per-screen shot list + privacy rules (no personal server URL / private data / mockups) to `docs/listing-assets.md`.

## Known blockers
1. Screenshots (#77) — recommended before submitting.
2. Re-confirm a clean from-source `flutter build apk --release` on an SDK machine; re-check merged-manifest permissions.
3. Match toolchain provisioning to fdroiddata's Flutter convention + validate with `fdroid lint` / `fdroid build -l`.
4. Pre-release `-alpha` tag acceptance — judgement call to confirm with F-Droid.
5. (GitHub channel only) replace debug-key fallback with real release signing.
6. `pubspec.lock` policy for reproducibility.

## Exact next steps to submit to fdroiddata
Documented in `docs/fdroid-submission.md` (§7–§9): run `flutter` checks + `fdroid readmeta` / `fdroid lint` / `fdroid build -l`; fork fdroiddata; copy the metadata in (dropping the inline Summary/Description in favour of the Fastlane files); finalize the Builds toolchain; open the MR using the **ready-to-adapt MR description** in §9. A **"Submit Linthra to F-Droid" GitHub issue draft** is in §10 (not created — provided for you to file).

## Verification performed here
- ✅ Metadata YAML parses (PyYAML); fields/types as expected.
- ⏳ `flutter` analyze/test/format + APK build and `fdroid lint`/`build` **not run** — this environment has no Flutter/Android SDK / fdroidserver. CI runs the Flutter checks + debug APK on every PR; exact commands for an SDK-equipped machine are documented. **No validation is claimed that wasn't run.**

## Files
- `metadata/io.github.thezupzup.linthra.yml` — retarget alpha.25, tag-derived versionCode, Changelog URL, build recipe.
- `fastlane/.../full_description.txt` — refreshed (clears the stale-description blocker); `changelogs/100025.txt` — new.
- `docs/fdroid-submission.md` — **new** (MR text, rationale, blockers, next steps, issue draft).
- `docs/fdroid-readiness.md`, `docs/fdroid-build-recipe.md`, `docs/listing-assets.md` — updated.

Relates to #87 (readiness checklist) and #77 (screenshots).

https://claude.ai/code/session_01SaKpg3gzsAQEMcq3zEzMAR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaKpg3gzsAQEMcq3zEzMAR)_