### PR TITLE
Fix screen-off background playback cutout (transient reload idle demotes foreground service)

### DIFF
--- a/docs/background-playback.md
+++ b/docs/background-playback.md
@@ -36,6 +36,23 @@ track — and reports `playing: false` only on a real user pause, stop, idle,
 completion, or error. The buffering/loading state still drives the notification
 spinner; the foreground service stays up.
 
+### A second screen-off cause: the transient reload idle
+
+Keeping the session `playing` across buffering and `loading` closed most of the
+gap, but one transition could still demote the service. The `just_audio` engine
+pushes a fresh, default playback event — whose processing state is `idle` — at
+the very *start* of every source load (`setUrl`), i.e. on **every track change
+and every mid-stream retry reload**, while it is still "playing". Forwarding
+that momentary `idle` made the session report `playing: false` for an instant
+exactly as the next track loaded — long enough, with the screen off, for the OS
+to freeze the backgrounded process (so audio cut out a short time in, typically
+at the first track boundary, and only resumed when the app was reopened).
+
+The fix: the controller is the **sole authority on going idle** — it starts idle
+and emits its own idle from `stop()` — so it drops the engine's raw `idle` event
+entirely. A reload now moves `playing → loading → playing` with no
+`playing: false` gap, while a real stop still releases the service.
+
 ## Notification permission (Android 13+)
 
 On Android 13+ the media notification and its lock-screen / Bluetooth transport

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -39,7 +39,15 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(notificationPermissionProvider).ensureGranted();
+      // Best-effort and defensive: a notification-permission seam that fails (a
+      // plugin hiccup, or a denied/unavailable grant) must never crash startup
+      // or playback — background audio works without the notification. The
+      // production seam already swallows its own errors; guarding the call site
+      // too keeps "permission denied does not crash the app" true end to end.
+      ref
+          .read(notificationPermissionProvider)
+          .ensureGranted()
+          .catchError((Object _) {});
     });
   }
 

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -132,25 +132,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   Stream<PlaybackState> get stateStream => _states.stream;
 
   void _wire() {
-    _subscriptions.add(_player.playerStateStream.listen((playerState) {
-      // While suspended a cast receiver owns playback; ignore the (paused) local
-      // engine's events entirely, so it can never auto-advance or report stale
-      // status underneath the cast session.
-      if (_suspended) return;
-      final status = _statusFor(playerState);
-      // Playback is healthy again: give a later, independent drop a fresh retry.
-      if (status == PlaybackStatus.playing) _retriesForCurrent = 0;
-      // When a track finishes, what happens next depends on the repeat mode.
-      if (status == PlaybackStatus.completed) {
-        _onCompleted();
-        return;
-      }
-      _emit(_state.copyWith(status: status));
-    }, onError: (Object _, StackTrace __) {
-      // Engine errors are recovered via [playbackEventStream] below; swallow any
-      // duplicate that the player-state stream may forward so it never becomes
-      // an unhandled async error (and so we never act on it twice).
-    }));
+    _subscriptions.add(_player.playerStateStream.listen(
+      handleEngineState,
+      onError: (Object _, StackTrace __) {
+        // Engine errors are recovered via [playbackEventStream] below; swallow
+        // any duplicate that the player-state stream may forward so it never
+        // becomes an unhandled async error (and so we never act on it twice).
+      },
+    ));
     _subscriptions.add(_player.positionStream.listen((position) {
       if (_suspended) return;
       // Coalesce raw position ticks onto a steady ~4 Hz flush so a high (or
@@ -168,6 +157,43 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _subscriptions.add(
       _player.playbackEventStream.listen((_) {}, onError: _onEngineError),
     );
+  }
+
+  /// Maps one raw engine [PlayerState] onto the unified [PlaybackState] and
+  /// emits it. The [_wire] player-state subscription forwards every event here;
+  /// it is exposed for tests so the screen-off transient-idle guard below can be
+  /// exercised without a platform channel.
+  @visibleForTesting
+  void handleEngineState(PlayerState playerState) {
+    // While suspended a cast receiver owns playback; ignore the (paused) local
+    // engine's events entirely, so it can never auto-advance or report stale
+    // status underneath the cast session.
+    if (_suspended) return;
+    final status = _statusFor(playerState);
+    // just_audio pushes a fresh, default PlaybackEvent — whose processingState
+    // is `idle` — synchronously at the *start* of every setAudioSource/setUrl
+    // call, before the new source begins loading. That happens on every track
+    // transition and every mid-stream retry reload, while `playing` is still
+    // true. Forwarding that idle would make the media session report
+    // `playing: false` + `idle` mid-transition, demoting audio_service's
+    // foreground media service (and dropping the CPU/Wi-Fi wake locks it holds)
+    // at the exact moment a new track loads with the screen off — letting the
+    // OS freeze the backgrounded process so audio only resumes when the app is
+    // reopened (the screen-off cutout bug). The controller is the sole
+    // authority on going idle: it starts idle and emits its own idle from
+    // stop(), so a raw engine idle is never needed here — drop it so a reload
+    // can never demote the service. Buffering/loading still flow through (they
+    // map to a still-`playing` session) and a real pause/completion/error is
+    // unaffected.
+    if (status == PlaybackStatus.idle) return;
+    // Playback is healthy again: give a later, independent drop a fresh retry.
+    if (status == PlaybackStatus.playing) _retriesForCurrent = 0;
+    // When a track finishes, what happens next depends on the repeat mode.
+    if (status == PlaybackStatus.completed) {
+      _onCompleted();
+      return;
+    }
+    _emit(_state.copyWith(status: status));
   }
 
   /// Recovers from an engine error that happens **while streaming**. A transient

--- a/test/app/playback_lifecycle_test.dart
+++ b/test/app/playback_lifecycle_test.dart
@@ -21,6 +21,20 @@ class _SilentNotificationPermission implements NotificationPermission {
       NotificationPermissionStatus.unknown;
 }
 
+/// Notification-permission seam whose request *fails* (denied + a plugin
+/// hiccup), so a test can prove a failing request never crashes startup. The
+/// async throw becomes a rejected Future, exactly as a real plugin failure
+/// would surface to the fire-and-forget call site.
+class _FailingNotificationPermission implements NotificationPermission {
+  @override
+  Future<void> ensureGranted() async =>
+      throw Exception('notification permission request failed');
+
+  @override
+  Future<NotificationPermissionStatus> status() async =>
+      NotificationPermissionStatus.denied;
+}
+
 const _playingTrack = Track(id: 'a', title: 'Song A', uri: '/a.mp3');
 
 /// Drives the app from `resumed` down to `paused` through the legal lifecycle
@@ -40,7 +54,10 @@ Future<void> _foreground(WidgetTester tester) async {
   await tester.pump();
 }
 
-Future<FakePlaybackController> _pumpApp(WidgetTester tester) async {
+Future<FakePlaybackController> _pumpApp(
+  WidgetTester tester, {
+  NotificationPermission? permission,
+}) async {
   final controller = FakePlaybackController(
     initial: const PlaybackState(
       status: PlaybackStatus.playing,
@@ -51,7 +68,7 @@ Future<FakePlaybackController> _pumpApp(WidgetTester tester) async {
     ProviderScope(
       overrides: [
         notificationPermissionProvider
-            .overrideWithValue(_SilentNotificationPermission()),
+            .overrideWithValue(permission ?? _SilentNotificationPermission()),
         playbackControllerProvider.overrideWithValue(controller),
       ],
       child: const LinthraApp(),
@@ -100,5 +117,20 @@ void main() {
     // background boundary is captured (here, playing) for the bug report.
     expect(StabilityDiagnostics.playbackStateAtBackground, 'playing');
     expect(StabilityDiagnostics.lastLifecycleState, 'paused');
+  });
+
+  testWidgets(
+      'a failing notification-permission request never crashes startup or '
+      'disturbs playback', (tester) async {
+    final controller =
+        await _pumpApp(tester, permission: _FailingNotificationPermission());
+
+    // The Android 13+ POST_NOTIFICATIONS request rejected, but the app built
+    // and playback was untouched — background audio works without the grant
+    // (only the notification / lock-screen controls are suppressed).
+    expect(tester.takeException(), isNull);
+    expect(controller.pauseCount, 0);
+    expect(controller.stopCount, 0);
+    expect(controller.playedTracks, isEmpty);
   });
 }

--- a/test/core/services/just_audio_playback_controller_test.dart
+++ b/test/core/services/just_audio_playback_controller_test.dart
@@ -111,4 +111,73 @@ void main() {
       expect(map(false, ProcessingState.completed), PlaybackStatus.completed);
     });
   });
+
+  group('engine state forwarding (foreground-service safety)', () {
+    // The screen-off cutout bug: just_audio emits a transient
+    // ProcessingState.idle at the *start* of every setUrl/setAudioSource (it
+    // pushes a fresh, default PlaybackEvent before loading) — so on every track
+    // transition and every mid-stream retry reload, while `playing` is still
+    // true. If that idle reached the media session, audio_service would report
+    // `playing: false` + `idle` and demote the foreground media service
+    // mid-transition, letting the OS freeze background playback until the app is
+    // reopened. The controller must drop it.
+
+    test('a transient engine idle during a reload is not forwarded', () async {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      final statuses = <PlaybackStatus>[];
+      final sub = controller.stateStream.listen((s) => statuses.add(s.status));
+      addTearDown(sub.cancel);
+
+      // Steady playback, then the exact sequence a setUrl reload produces: a
+      // fresh (idle) PlaybackEvent while still "playing", then loading, then
+      // ready again.
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      controller.handleEngineState(PlayerState(true, ProcessingState.idle));
+      controller.handleEngineState(PlayerState(true, ProcessingState.loading));
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        statuses,
+        isNot(contains(PlaybackStatus.idle)),
+        reason: 'a transient engine idle mid-reload would demote the '
+            'foreground media service with the screen off',
+      );
+      expect(controller.state.status, PlaybackStatus.playing);
+    });
+
+    test('engine buffering and loading are still forwarded (kept playing)', () {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      // A mid-stream re-buffer must reach the session (it maps to a still-
+      // playing buffering state), so the service is never demoted on a stall.
+      controller
+          .handleEngineState(PlayerState(true, ProcessingState.buffering));
+      expect(controller.state.status, PlaybackStatus.buffering);
+
+      controller.handleEngineState(PlayerState(true, ProcessingState.loading));
+      expect(controller.state.status, PlaybackStatus.loading);
+    });
+
+    test('a real engine pause is still forwarded (the filter is idle-only)',
+        () {
+      final controller = JustAudioPlaybackController();
+      addTearDown(controller.dispose);
+
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      expect(controller.state.status, PlaybackStatus.playing);
+
+      // ready + not-playing is a genuine user pause: it must still report
+      // not-playing so the service is released on a real pause (not suppressed
+      // like the transient reload idle).
+      controller.handleEngineState(PlayerState(false, ProcessingState.ready));
+      expect(controller.state.status, PlaybackStatus.paused);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Critical, release-blocking playback-stability fix: music cuts out a short time after the screen is locked, then resumes when the app is reopened.

This is the **residual cause left after #92**. That PR kept the media session `playing` across buffering and the `loading` state, but one transition still demoted the foreground service.

> The new work in this branch is a single focused commit (`Fix screen-off cutout: drop just_audio's transient reload idle`). The branch sits ahead of the stale `main`, so the diff against `main` shows prior alpha history too — review the latest commit for this change.

## Root cause

`just_audio` pushes a **fresh, default `PlaybackEvent`** — whose `processingState` is `idle` — *synchronously at the start of every* `setAudioSource`/`setUrl` call, before the new source begins loading (`just_audio.dart` `setAudioSource`, then `playerStateStream = combineLatest2(playing, event).distinct()`). That fires on **every track transition and every mid-stream retry reload**, while `playing` is still `true`.

`JustAudioPlaybackController` forwarded that momentary `idle`, so `LinthraAudioHandler` reported `playing: false` + `AudioProcessingState.idle` to `audio_service` exactly as the next track loaded. With the screen off, that demotes the foreground media service (dropping the CPU/Wi‑Fi wake locks it holds) long enough for the OS to freeze the backgrounded process — so audio went silent (typically right at the first track boundary) and only resumed when the app was reopened and the process un-froze.

For a single steady track this never fired, which is why it looked intermittent and "after a short time."

## Fix summary

- **Drop the engine's transient `idle`.** The controller is the *sole authority* on going idle — it starts idle and emits its own idle from `stop()` — so a raw engine `idle` is never needed. A reload now moves `playing → loading → playing` with **no `playing: false` gap**, while a real pause/stop/completion/error is unaffected and still releases the service. This also repairs the mid-stream retry path (which reloads via `setUrl`), so a Wi‑Fi power‑save stall recovers without demoting the service.
- The player-state listener is extracted to a testable `handleEngineState` seam (`@visibleForTesting`), so the guard is unit-tested without a platform channel.
- **Harden the Android 13+ notification-permission request** at its fire-and-forget call site (`linthra_app.dart`) so a failing seam can never crash startup — background audio works without the grant; only the notification/lock-screen controls are suppressed.

No native/Gradle/manifest changes, no new features, no redesign. The #92 layer (foreground config, `_isSessionPlaying` for buffering/loading, lifecycle observer that never pauses/disposes, pinned controller providers, manifest permissions) is intact.

## Files changed

- `lib/core/services/just_audio_playback_controller.dart` — drop transient engine `idle`; extract `handleEngineState`.
- `lib/app/linthra_app.dart` — guard the notification-permission request so a failure can't crash startup.
- `test/core/services/just_audio_playback_controller_test.dart` — new regression tests.
- `test/app/playback_lifecycle_test.dart` — notification-permission-failure test.
- `docs/background-playback.md` — document the second screen-off cause.

## Tests added

- A transient engine `idle` during a reload is **not** forwarded (foreground service stays alive).
- Engine buffering/loading are still forwarded (kept "playing" for the service).
- A real engine pause is still forwarded as not-playing (the filter is idle-only).
- A failing notification-permission request never crashes startup or disturbs playback.

Existing coverage already locks in: buffering/loading report `playing: true` to `audio_service`; lifecycle paused/resumed never pause/restart playback; the controller isn't disposed on background; Cast output stays Cast across background/foreground; diagnostics/logs are token-free.

Verification in this environment:
- `flutter pub get` ✓
- `dart format --set-exit-if-changed .` ✓ (0 changed)
- `flutter analyze` ✓ (no issues)
- `flutter test` ✓ (1153 tests passed)
- `flutter build apk --debug` — **could not run here**: the Android SDK download host (`dl.google.com`) is blocked by this environment's network policy (HTTP 403). The change is Dart-only (no Android-native/Gradle/manifest changes), and the repo's `verify_android.sh`/CI treats a missing SDK as a non-fatal skip. Needs a run on an SDK-equipped machine.

## Manual Android checklist (screen-off / lock-screen)

Run on a physical device against real servers where possible:

1. Play a **local** track, lock the screen for 5 minutes → audio continues (incl. across the track boundary).
2. Play a **cached/offline** track, lock for 5 minutes → continues.
3. Stream **Jellyfin**, lock for 5 minutes → continues (no silence on re-buffer or track change).
4. Stream **Navidrome/Subsonic** if available, lock for 5 minutes → continues.
5. **Cast** to Chromecast, lock for 5 minutes → Cast continues; phone stays a remote (no second local stream).
6. Lock-screen / notification transport controls work (play/pause/next/prev/seek).
7. Bluetooth/headset controls work if available.
8. Reopen Linthra → playback state is correct (not restarted).
9. No duplicate local playback starts.
10. Diagnostics/logs are secret-free (no token or authenticated URL).

## Known limitations

- **OEM battery optimization / Doze** can still freeze background apps on some vendors even with the foreground media service correct. Documented as a troubleshooting step in `docs/background-playback.md` (per‑vendor exemptions + dontkillmyapp.com); it is *not* the primary fix.
- Foreground-service-active / battery-optimization state are not reported in diagnostics (would need extra native code); the existing notification-permission / lifecycle / playback-at-background breadcrumbs cover the actionable cases.

https://claude.ai/code/session_01PP79dCGj3JFM644vA9sQ7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PP79dCGj3JFM644vA9sQ7y)_