### PR TITLE
Auto-start the first Jellyfin sync after a successful connect

### DIFF
--- a/docs/jellyfin-sync.md
+++ b/docs/jellyfin-sync.md
@@ -9,10 +9,23 @@ guarantees. For connectivity (URLs, Cloudflare, version floor) see
 model and the capability matrix see
 [playlists-and-delete.md](playlists-and-delete.md).
 
+## When it syncs
+
+- **Automatically, once, right after you connect.** The first time you sign in
+  to a given server/account, Linthra starts a sync on its own so the library
+  fills in without you hunting for a button. It runs the **same** path as the
+  manual sync below. To avoid surprising background work, this only happens for a
+  **new** server/account — reconnecting an already-synced account, reopening
+  Settings, or relaunching the app does **not** trigger another full sync.
+  Signing in to a **different** server or as a **different** user starts a fresh
+  first sync.
+- **Manually, any time.** The **Sync library** button stays available for an
+  on-demand refresh, and is also the **Retry** if the first sync couldn't finish.
+
 ## What syncs by default
 
-When you sign in to Jellyfin and run **Sync library** (and on each app launch),
-Linthra pulls:
+When you connect to Jellyfin (the automatic first sync), tap **Sync library**, or
+on each app launch, Linthra pulls:
 
 - **Tracks**, **albums**, and **artists** into the local catalog (the Library).
 - **Playlists** — your Jellyfin playlists are imported and listed on the
@@ -96,6 +109,18 @@ favourites and **local-only** playlists are kept.
 
 ## Troubleshooting
 
+- **The first sync is taking a while.** A large library takes a moment to pull;
+  the app stays responsive and the Library shows a "syncing" note until the
+  tracks land. There's nothing to do but wait — it finishes in the background.
+- **"Connected, but the library sync didn't finish."** The connection is fine,
+  but the sync hit a snag (server briefly unreachable, an expired session, a
+  hiccup saving locally). Tap **Retry** on the Jellyfin card. Your sign-in is
+  untouched, and nothing was half-written.
+- **Server unreachable.** If the sync can't reach the server, you'll see a
+  friendly "couldn't reach your Jellyfin server" message — check the server is
+  online and reachable from the device, then Retry.
+- **Session expired.** A sync (or stream) may report your session has expired;
+  sign out and sign in again to refresh it, and the next connect re-syncs.
 - **Playlists not showing.** Make sure you're signed in (Settings → Jellyfin)
   and run **Sync library**. The Playlists tab's empty state tells you whether
   you're signed in. If the status line says "playlists could not be loaded", the
@@ -118,6 +143,12 @@ favourites and **local-only** playlists are kept.
 - **No authenticated URLs persisted.** Stream/download URLs are minted on demand
   at play/download time from the live session and discarded; the persisted track
   URI stays the token-free `jellyfin:<id>`.
+- **The auto-sync marker is a one-way fingerprint.** To remember which account
+  has already had its first sync, Linthra stores a SHA-256 hash of the server
+  URL + user id — never the token, the URL, or the user id themselves — so the
+  marker reveals nothing and lives in plain storage safely.
+- **Metadata only.** This sync never starts a download or cache fetch; offline
+  copies stay explicit and user-initiated, exactly as before.
 - **Friendly, redacted errors.** Sync/favourite/playlist failures surface as
   friendly messages branched on a typed error kind (not signed in, expired
   session, server unreachable, permission/API error) — never a raw error or a

--- a/docs/jellyfin.md
+++ b/docs/jellyfin.md
@@ -20,9 +20,20 @@ Open **Settings → Jellyfin** and:
    gentle "untested" note; it is never blocked.
 3. **Username + password → Sign in** — authenticates and stores the resulting
    session encrypted on-device. Your **password is never saved**.
-4. **Sync library** — pulls your artists/albums/tracks **and your playlists and
+   - **Linthra starts a first sync automatically** right after you sign in, so
+     your library fills in on its own — you don't have to find the Sync button.
+     The Jellyfin card shows _"Syncing your Jellyfin library…"_ while it runs and
+     a short summary when it's done, and the Library shows a friendly _"Your
+     Jellyfin library is syncing"_ note instead of looking empty.
+   - This first sync runs **once per server/account**. Reconnecting the same
+     account (or just reopening Settings or relaunching the app) won't kick off
+     another full sync on its own. Connecting a **different** server or signing
+     in as a **different** user starts a fresh first sync.
+4. **Sync library** — the manual sync is always available for an on-demand
+   refresh. It pulls your artists/albums/tracks **and your playlists and
    liked/favourite tracks** into the local catalog so they appear in Library,
-   Playlists, and Favorites.
+   Playlists, and Favorites. If the first sync didn't finish (e.g. the server
+   was briefly unreachable), the card shows a friendly message and a **Retry**.
 5. Tap a synced track to **stream** it, or use the download control to keep it
    **offline** (see [offline-cache.md](offline-cache.md)).
 6. **Copy Jellyfin diagnostics** — a short, **secret-free** report for bug

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -38,7 +38,9 @@ Legend: ☑ = verified on a real device for the current alpha · ☐ = re-verify
 ## 2. Library
 
 - ☑ Local tracks appear after picking a folder (SAF) and a sync.
-- ☑ Jellyfin tracks appear after sign-in + sync.
+- ☑ Jellyfin tracks appear automatically after sign-in (no manual Sync needed).
+- ☐ While that first sync runs, the empty Library shows "Your Jellyfin library
+  is syncing" rather than the folder-pick prompt.
 - ☐ Alphabet fast-scroller jumps to the right section and does not overlap rows
   or the overflow menu (narrow phones included).
 - ☐ Row overflow menu (download / add to playlist / favorite / delete) works.
@@ -202,6 +204,13 @@ Additional cast checks:
 ## 11. Settings
 
 - ☐ Jellyfin connect: test, sign in, sign out & clear.
+- ☐ **Auto-sync on connect**: signing in starts a sync on its own (card shows
+  "Syncing your Jellyfin library…", then a summary). *(New this release.)*
+- ☐ Closing/reopening Settings, or relaunching the app, does **not** start
+  another full sync for the same account. *(New this release.)*
+- ☐ Connecting a **different** server/user starts a fresh first sync.
+- ☐ A failed first sync shows "Connected, but the library sync didn't finish."
+  with a **Retry** that works. *(New this release.)*
 - ☐ Subsonic/Navidrome connect: test, sign in, sign out & clear.
 - ☐ Sign out resets the sync status line (no stale "Synced N tracks" after
   signing back in). *(Fixed this release.)*

--- a/lib/core/repositories/jellyfin_auto_sync_store.dart
+++ b/lib/core/repositories/jellyfin_auto_sync_store.dart
@@ -1,0 +1,23 @@
+/// Remembers which Jellyfin server/account has already had its **first**
+/// (automatic) library sync, so onboarding can sync once on a fresh connection
+/// without re-pulling the whole library every time the same account reconnects.
+///
+/// It stores a single opaque [String] fingerprint (see
+/// `jellyfinAccountFingerprint`) — the account whose initial auto-sync has
+/// completed — or `null` when no account has been auto-synced yet. Kept behind
+/// this seam so the backing store swaps freely (in-memory for tests, key/value
+/// in the app), mirroring [LibraryAddedStore].
+///
+/// Privacy: only the non-secret, one-way fingerprint is stored — never a token,
+/// server URL, user id, or authenticated URL — and it never leaves the device.
+abstract interface class JellyfinAutoSyncStore {
+  /// The fingerprint of the account whose initial auto-sync has completed, or
+  /// `null` if none has yet.
+  Future<String?> read();
+
+  /// Records [fingerprint] as the account whose initial auto-sync has completed.
+  Future<void> write(String fingerprint);
+
+  /// Forgets the recorded fingerprint (e.g. on a hard reset). Never throws.
+  Future<void> clear();
+}

--- a/lib/core/sources/jellyfin/jellyfin_account_fingerprint.dart
+++ b/lib/core/sources/jellyfin/jellyfin_account_fingerprint.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+import '../../models/jellyfin_session.dart';
+
+/// An opaque, non-secret fingerprint identifying a Jellyfin **server + account**.
+///
+/// Used by the auto-sync gate to answer one question: "have we already run the
+/// first sync for *this* server/user?" so a fresh connection to a new server or
+/// account syncs once, while reconnecting an already-synced account doesn't
+/// re-pull the whole library on its own.
+///
+/// Security: the inputs are the (non-secret) base URL and user id — never the
+/// access token — and they are SHA-256 hashed, so the stored value is a
+/// one-way fingerprint that reveals neither the server address nor the user id.
+/// It is safe to persist in plaintext `shared_preferences` and to surface in
+/// diagnostics. The token is never part of the material.
+String jellyfinAccountFingerprint(JellyfinSession session) {
+  // A NUL separator keeps e.g. ("ab","c") distinct from ("a","bc").
+  final String material = '${session.baseUrl}\u0000${session.userId}';
+  return sha256.convert(utf8.encode(material)).toString();
+}

--- a/lib/data/repositories/in_memory_jellyfin_auto_sync_store.dart
+++ b/lib/data/repositories/in_memory_jellyfin_auto_sync_store.dart
@@ -1,0 +1,26 @@
+import '../../core/repositories/jellyfin_auto_sync_store.dart';
+
+/// A non-persistent [JellyfinAutoSyncStore] for development and tests.
+///
+/// Holds the fingerprint in a single field, so it's forgotten when the instance
+/// is dropped. This is the default binding (mirroring the other repositories);
+/// the running app swaps in the `shared_preferences` binding so the
+/// "already auto-synced this account" memory survives restarts.
+class InMemoryJellyfinAutoSyncStore implements JellyfinAutoSyncStore {
+  InMemoryJellyfinAutoSyncStore([this._fingerprint]);
+
+  String? _fingerprint;
+
+  @override
+  Future<String?> read() async => _fingerprint;
+
+  @override
+  Future<void> write(String fingerprint) async {
+    _fingerprint = fingerprint;
+  }
+
+  @override
+  Future<void> clear() async {
+    _fingerprint = null;
+  }
+}

--- a/lib/data/repositories/jellyfin_auto_sync_store_provider.dart
+++ b/lib/data/repositories/jellyfin_auto_sync_store_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/jellyfin_auto_sync_store.dart';
+import 'in_memory_jellyfin_auto_sync_store.dart';
+import 'shared_preferences_jellyfin_auto_sync_store.dart';
+
+/// Remembers which Jellyfin account has already had its first auto-sync, so
+/// onboarding syncs once on a fresh connection without re-pulling on every
+/// reconnect of the same account. Defaults to in-memory so tests and dev runs
+/// need no plugins; the app overrides it with the `shared_preferences` binding
+/// below so the memory survives a restart.
+final jellyfinAutoSyncStoreProvider = Provider<JellyfinAutoSyncStore>((ref) {
+  return InMemoryJellyfinAutoSyncStore();
+});
+
+/// Production binding: persist the "already auto-synced this account"
+/// fingerprint via `shared_preferences` so a reconnect after a restart doesn't
+/// trigger an unsolicited full re-sync. Applied in `main`; tests keep the
+/// in-memory default.
+final sharedPreferencesJellyfinAutoSyncStoreOverride =
+    jellyfinAutoSyncStoreProvider.overrideWithValue(
+  const SharedPreferencesJellyfinAutoSyncStore(),
+);

--- a/lib/data/repositories/shared_preferences_jellyfin_auto_sync_store.dart
+++ b/lib/data/repositories/shared_preferences_jellyfin_auto_sync_store.dart
@@ -1,0 +1,39 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/jellyfin_auto_sync_store.dart';
+
+/// A [JellyfinAutoSyncStore] backed by `shared_preferences`.
+///
+/// Persists a single opaque account fingerprint under one key, so a fresh
+/// connection to a new server/account auto-syncs once and a reconnect of an
+/// already-synced account does not re-pull the whole library on its own.
+///
+/// Privacy: the stored value is the non-secret, one-way fingerprint only —
+/// never a token, server URL, user id, or authenticated URL — and it stays on
+/// the device. Plain `shared_preferences` (not encrypted storage) is fine
+/// precisely because there is no secret here.
+class SharedPreferencesJellyfinAutoSyncStore implements JellyfinAutoSyncStore {
+  const SharedPreferencesJellyfinAutoSyncStore();
+
+  static const String _key = 'jellyfin_auto_sync_account_v1';
+
+  @override
+  Future<String?> read() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? value = prefs.getString(_key);
+    if (value == null || value.isEmpty) return null;
+    return value;
+  }
+
+  @override
+  Future<void> write(String fingerprint) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, fingerprint);
+  }
+
+  @override
+  Future<void> clear() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -10,6 +10,7 @@ import '../../core/models/track.dart';
 import '../../core/services/bulk_track_actions.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
+import '../settings/jellyfin/jellyfin_sync_controller.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_search.dart';
@@ -86,6 +87,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     final LibraryState state = ref.watch(libraryControllerProvider);
     final AsyncValue<String?> selectedFolder =
         ref.watch(selectedFolderControllerProvider);
+    // While the first Jellyfin sync is running, an empty catalog should read as
+    // "filling up", not "nothing here" — so the library never looks broken
+    // during onboarding.
+    final bool jellyfinSyncing = ref.watch(
+      jellyfinSyncControllerProvider.select((s) => s.isSyncing),
+    );
 
     // Drop any selected ids that are no longer in the catalog (e.g. after a
     // removal) so the count and actions stay accurate.
@@ -127,7 +134,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       ),
       body: browsing
           ? _browseBody(state)
-          : _statusBody(state, selectedFolder.valueOrNull),
+          : _statusBody(state, selectedFolder.valueOrNull, jellyfinSyncing),
     );
   }
 
@@ -149,7 +156,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   }
 
   /// Loading / error / folder-pick states, shown full-body without tabs.
-  Widget _statusBody(LibraryState state, String? selectedFolder) {
+  Widget _statusBody(
+    LibraryState state,
+    String? selectedFolder,
+    bool jellyfinSyncing,
+  ) {
     switch (state.status) {
       case LibraryStatus.loading:
         return const Center(child: CircularProgressIndicator());
@@ -159,6 +170,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
           onRetry: () => ref.read(libraryControllerProvider.notifier).refresh(),
         );
       case LibraryStatus.loaded:
+        // A first Jellyfin sync in flight takes precedence over the folder-pick
+        // prompt: tell the user their library is on its way rather than implying
+        // it's empty.
+        if (jellyfinSyncing) {
+          return const _LibrarySyncing();
+        }
         return _LibraryEmpty(
           selectedFolder: selectedFolder,
           onPick: _pickAndScan,
@@ -356,6 +373,47 @@ class _NoResults extends StatelessWidget {
       icon: Icons.search_off,
       title: 'No results found.',
       message: 'Try a different search.',
+    );
+  }
+}
+
+/// Shown when the catalog is still empty but a first Jellyfin sync is running,
+/// so onboarding reads as "your library is on its way" rather than "nothing
+/// here". Replaced automatically once the synced tracks land.
+class _LibrarySyncing extends StatelessWidget {
+  const _LibrarySyncing();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox.square(
+              dimension: 36,
+              child: CircularProgressIndicator(strokeWidth: 3),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              'Your Jellyfin library is syncing',
+              style: theme.textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'This may take a moment. Your songs will appear here as soon as '
+              "they're in.",
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/app_info.dart';
@@ -142,6 +144,15 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
         serverVersion: newSession.serverVersion,
         productName: newSession.productName,
         statusMessage: _connectedMessage(newSession),
+      );
+      // Onboarding: start the first library sync for this connection so the
+      // library fills in on its own, without the user hunting for "Sync
+      // library". Fire-and-forget — sign-in returns now and the UI reflects the
+      // sync's progress/result through JellyfinSyncState — and it only actually
+      // syncs the first time for a given server/account (see autoSyncIfNeeded),
+      // so reconnecting the same account won't trigger an unsolicited resync.
+      unawaited(
+        ref.read(jellyfinSyncControllerProvider.notifier).autoSyncIfNeeded(),
       );
       return true;
     } on JellyfinException catch (error) {

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -326,6 +326,10 @@ class _ConnectedView extends StatelessWidget {
           ),
         ],
         const SizedBox(height: AppSpacing.md),
+        // The manual "Sync library" stays available at all times (disabled only
+        // while a sync is running). After sign-in the first sync starts on its
+        // own down the same path, so this button doubles as the on-demand
+        // refresh — and, after a failure, the retry below points back to it.
         FilledButton.tonalIcon(
           onPressed: onSync,
           icon: syncState.isSyncing
@@ -336,9 +340,33 @@ class _ConnectedView extends StatelessWidget {
               : const Icon(Icons.sync_outlined),
           label: Text(syncState.isSyncing ? 'Syncing…' : 'Sync library'),
         ),
-        if (syncState.message != null && !syncState.isSyncing) ...[
+        if (syncState.isError) ...[
           const SizedBox(height: AppSpacing.sm),
-          _StatusLine(message: syncState.message!, isError: syncState.isError),
+          // Keep the connection plainly intact ("you're still signed in"), then
+          // the specific, secret-free reason from the sync controller, then a
+          // clear way to try again.
+          const _StatusLine(
+            message: "Connected, but the library sync didn't finish.",
+            isError: true,
+          ),
+          if (syncState.message != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            _StatusLine(message: syncState.message!, isError: true),
+          ],
+          const SizedBox(height: AppSpacing.sm),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: OutlinedButton.icon(
+              onPressed: onSync,
+              icon: const Icon(Icons.refresh, size: 18),
+              label: const Text('Retry sync'),
+            ),
+          ),
+        ] else if (syncState.message != null) ...[
+          // Syncing ("Syncing your Jellyfin library…") or the success summary
+          // ("Synced N tracks…"); both read as friendly status, not an error.
+          const SizedBox(height: AppSpacing.sm),
+          _StatusLine(message: syncState.message!, isError: false),
         ],
         const SizedBox(height: AppSpacing.sm),
         OutlinedButton.icon(

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -1,9 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/repositories/jellyfin_auto_sync_store.dart';
 import '../../../core/repositories/remote_sync_result.dart';
+import '../../../core/sources/jellyfin/jellyfin_account_fingerprint.dart';
 import '../../../core/sources/jellyfin/jellyfin_exception.dart';
 import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
+import '../../../data/repositories/jellyfin_auto_sync_store_provider.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
 import '../../library/library_controller.dart';
@@ -26,18 +29,74 @@ import 'jellyfin_sync_state.dart';
 /// a partial outcome reads honestly ("Tracks synced, but playlists could not be
 /// loaded.").
 ///
+/// Onboarding: a fresh Jellyfin connection triggers [autoSyncIfNeeded] once, so
+/// the library populates on its own without the user discovering the manual
+/// "Sync library" button. It runs the exact same path as the manual [sync] and
+/// is gated by a persisted per-account fingerprint, so it fires for a new
+/// server/account but not on a reconnect, a rebuild, a reopened Settings screen,
+/// or an app restart of an already-synced account. The manual [sync] is always
+/// available.
+///
 /// Security: the source mints any authenticated streaming URL lazily at play
 /// time, so nothing persisted here carries a token. This controller never logs
 /// the session, and surfaces only friendly, secret-free messages through
 /// [JellyfinSyncState].
 class JellyfinSyncController extends Notifier<JellyfinSyncState> {
+  /// Guards against overlapping syncs (an auto-sync racing a manual tap). Set
+  /// synchronously before any await so a second concurrent call simply bails,
+  /// satisfying "never run two syncs at once" without cancelling the first.
+  bool _syncing = false;
+
   @override
   JellyfinSyncState build() => const JellyfinSyncState();
 
-  /// Pulls artists/albums/tracks from Jellyfin and upserts them into the local
-  /// catalog, then refreshes Jellyfin playlists and favourites. Reflects
-  /// loading/success/error through [state]; never throws.
-  Future<void> sync() async {
+  /// The manual "Sync library" action. Pulls artists/albums/tracks and upserts
+  /// them into the local catalog, then refreshes Jellyfin playlists and
+  /// favourites. Reflects loading/success/error through [state]; never throws.
+  Future<void> sync() => _runSync();
+
+  /// Runs the **first** automatic sync for a freshly connected server/account.
+  ///
+  /// Idempotent by account: if this exact server+user has already been
+  /// auto-synced before, it does nothing — so a reconnect, a provider rebuild, a
+  /// reopened Settings screen, or an app restart never re-pulls the whole
+  /// library on its own. Changing the server URL or signing in as a different
+  /// user is a new account, and syncs again. The manual [sync] stays available
+  /// for an on-demand refresh. Never throws.
+  Future<void> autoSyncIfNeeded() async {
+    final JellyfinMusicSource? source = ref.read(jellyfinMusicSourceProvider);
+    if (source == null) {
+      // Not connected (shouldn't happen right after a sign-in) — nothing to do.
+      return;
+    }
+    final String fingerprint = jellyfinAccountFingerprint(source.session);
+    final JellyfinAutoSyncStore store = ref.read(jellyfinAutoSyncStoreProvider);
+    String? lastSynced;
+    try {
+      lastSynced = await store.read();
+    } catch (_) {
+      // A storage hiccup must never block onboarding; treat it as "not synced
+      // yet" and let the sync proceed — re-running it is safe and idempotent.
+      lastSynced = null;
+    }
+    if (lastSynced == fingerprint) {
+      // This account's first sync already happened; don't resync on its own.
+      return;
+    }
+    await _runSync(recordFingerprint: fingerprint);
+  }
+
+  /// The shared sync path behind both [sync] and [autoSyncIfNeeded].
+  ///
+  /// When [recordFingerprint] is non-null (an auto-sync), the account is
+  /// remembered **only after a successful sync**, so a sync that failed is
+  /// retried automatically on the next fresh connection rather than being
+  /// silently marked done.
+  Future<void> _runSync({String? recordFingerprint}) async {
+    if (_syncing) {
+      // A sync is already in flight; never stack a second concurrent one.
+      return;
+    }
     final JellyfinMusicSource? source = ref.read(jellyfinMusicSourceProvider);
     if (source == null) {
       state = const JellyfinSyncState.error(
@@ -46,6 +105,7 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
       return;
     }
 
+    _syncing = true;
     state = const JellyfinSyncState.syncing();
     try {
       final tracks = await source.fetchTracks();
@@ -83,6 +143,19 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
           favorites: favorites,
         ),
       );
+
+      // Remember this account only now that the sync landed, so an auto-sync
+      // that failed above is retried on the next fresh connection.
+      if (recordFingerprint != null) {
+        try {
+          await ref
+              .read(jellyfinAutoSyncStoreProvider)
+              .write(recordFingerprint);
+        } catch (_) {
+          // Failing to persist the marker only risks one extra (idempotent)
+          // auto-sync next time — harmless, and never surfaced to the user.
+        }
+      }
     } on JellyfinException catch (error) {
       state = JellyfinSyncState.error(_friendlyMessage(error));
     } catch (_) {
@@ -91,6 +164,8 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
       state = const JellyfinSyncState.error(
         "Something went wrong saving your Jellyfin library. Please try again.",
       );
+    } finally {
+      _syncing = false;
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'app/linthra_app.dart';
 import 'core/services/linthra_audio_handler.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/favorites_repository_provider.dart';
+import 'data/repositories/jellyfin_auto_sync_store_provider.dart';
 import 'data/repositories/jellyfin_session_store_provider.dart';
 import 'data/repositories/library_added_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
@@ -52,6 +53,9 @@ Future<void> main() async {
       remoteTrackDownloaderOverride,
       currentlyPlayingTrackIdOverride,
       secureJellyfinSessionStoreOverride,
+      // Remember which Jellyfin account has had its first auto-sync, so a
+      // reconnect after a restart doesn't trigger an unsolicited full re-sync.
+      sharedPreferencesJellyfinAutoSyncStoreOverride,
       secureSubsonicSessionStoreOverride,
       sharedPreferencesFavoritesStoreOverride,
       jellyfinFavoritesOverride,

--- a/test/core/sources/jellyfin/jellyfin_account_fingerprint_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_account_fingerprint_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_account_fingerprint.dart';
+
+const _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: 'super-secret-token-value',
+  deviceId: 'device-1',
+  userName: 'alice',
+);
+
+void main() {
+  group('jellyfinAccountFingerprint', () {
+    test('is stable for the same server + account', () {
+      // The same connection always fingerprints the same, so the auto-sync gate
+      // can recognise an already-synced account.
+      expect(
+        jellyfinAccountFingerprint(_session),
+        jellyfinAccountFingerprint(_session),
+      );
+    });
+
+    test('changes when the server URL changes', () {
+      final other = _session.copyWith(baseUrl: 'https://other.example.com');
+      expect(
+        jellyfinAccountFingerprint(other),
+        isNot(jellyfinAccountFingerprint(_session)),
+      );
+    });
+
+    test('changes when the user changes', () {
+      final other = _session.copyWith(userId: 'user-2');
+      expect(
+        jellyfinAccountFingerprint(other),
+        isNot(jellyfinAccountFingerprint(_session)),
+      );
+    });
+
+    test('a token change alone never changes the fingerprint', () {
+      // It identifies the *account*, not the session secret — so refreshing the
+      // token (a new sign-in to the same account) is still "the same account".
+      final reauthed = _session.copyWith(accessToken: 'a-different-token');
+      expect(
+        jellyfinAccountFingerprint(reauthed),
+        jellyfinAccountFingerprint(_session),
+      );
+    });
+
+    test('does not contain the token, the URL, or the user id', () {
+      // The stored fingerprint is a one-way hash: it must reveal no secret and
+      // no authenticated/identifying value, since it lives in plain storage.
+      final String fingerprint = jellyfinAccountFingerprint(_session);
+      expect(fingerprint, isNot(contains('super-secret-token-value')));
+      expect(fingerprint, isNot(contains('music.example.com')));
+      expect(fingerprint, isNot(contains('user-1')));
+      expect(fingerprint, isNot(contains('alice')));
+      // A hex SHA-256 digest.
+      expect(fingerprint, matches(RegExp(r'^[0-9a-f]{64}$')));
+    });
+  });
+}

--- a/test/data/repositories/in_memory_jellyfin_auto_sync_store_test.dart
+++ b/test/data/repositories/in_memory_jellyfin_auto_sync_store_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_auto_sync_store.dart';
+
+void main() {
+  group('InMemoryJellyfinAutoSyncStore', () {
+    test('reads null before anything is written', () async {
+      final store = InMemoryJellyfinAutoSyncStore();
+      expect(await store.read(), isNull);
+    });
+
+    test('round-trips a written fingerprint', () async {
+      final store = InMemoryJellyfinAutoSyncStore();
+      await store.write('abc123');
+      expect(await store.read(), 'abc123');
+    });
+
+    test('a later write replaces the earlier fingerprint', () async {
+      final store = InMemoryJellyfinAutoSyncStore();
+      await store.write('first');
+      await store.write('second');
+      expect(await store.read(), 'second');
+    });
+
+    test('clear forgets the fingerprint', () async {
+      final store = InMemoryJellyfinAutoSyncStore('seeded');
+      await store.clear();
+      expect(await store.read(), isNull);
+    });
+  });
+}

--- a/test/features/library/library_jellyfin_syncing_test.dart
+++ b/test/features/library/library_jellyfin_syncing_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
+
+import 'fake_music_library_repository.dart';
+
+/// Holds the Jellyfin sync controller in a fixed state for the empty-state test.
+class _FixedSyncController extends JellyfinSyncController {
+  _FixedSyncController(this._fixed);
+  final JellyfinSyncState _fixed;
+  @override
+  JellyfinSyncState build() => _fixed;
+}
+
+Future<void> _pumpLibrary(
+  WidgetTester tester, {
+  required JellyfinSyncState syncState,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        // An empty catalog — the case onboarding starts from.
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository()),
+        jellyfinSyncControllerProvider
+            .overrideWith(() => _FixedSyncController(syncState)),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+  // Let the (empty) catalog load resolve. Don't pumpAndSettle: the syncing
+  // state shows an endless progress spinner.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  group('Library empty state during a Jellyfin sync', () {
+    testWidgets('reads as "syncing", not "no music", while a sync runs',
+        (tester) async {
+      await _pumpLibrary(tester, syncState: const JellyfinSyncState.syncing());
+
+      expect(find.text('Your Jellyfin library is syncing'), findsOneWidget);
+      expect(find.textContaining('This may take a moment'), findsOneWidget);
+      // It must not look broken / empty.
+      expect(find.text('No music folder selected'), findsNothing);
+      expect(find.text('No music found'), findsNothing);
+    });
+
+    testWidgets('falls back to the normal empty state when not syncing',
+        (tester) async {
+      await _pumpLibrary(tester, syncState: const JellyfinSyncState());
+
+      // No sync in flight, empty catalog → the usual folder-pick prompt.
+      expect(find.text('Your Jellyfin library is syncing'), findsNothing);
+      expect(find.text('No music folder selected'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
@@ -1,0 +1,416 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/download_progress.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_account_fingerprint.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_auto_sync_store.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
+import 'package:linthra/data/repositories/jellyfin_auto_sync_store_provider.dart';
+import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_state.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
+
+import '../../../core/sources/jellyfin/fake_jellyfin_client.dart';
+import 'fake_jellyfin_authenticator.dart';
+
+JellyfinSession _sessionFor({
+  String baseUrl = 'https://music.example.com',
+  String userId = 'user-1',
+  String userName = 'alice',
+}) =>
+    JellyfinSession(
+      baseUrl: baseUrl,
+      userId: userId,
+      accessToken: 'secret-token-value',
+      deviceId: 'device-1',
+      userName: userName,
+      serverName: 'Home',
+    );
+
+JellyfinItemDto _audio(String id) => JellyfinItemDto(
+      id: id,
+      name: 'Track $id',
+      album: 'Album',
+      artists: const <String>['Artist'],
+      runTimeTicks: 1000000,
+      indexNumber: 1,
+    );
+
+/// A recording [MusicLibraryRepository] that counts upserts and remembers the
+/// last one, so a test can prove auto-sync went down the same upsert path as a
+/// manual sync (and how many times it ran).
+class _RecordingRepository implements MusicLibraryRepository {
+  int upsertCount = 0;
+  String? lastSourceId;
+  List<Track> lastTracks = const <Track>[];
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    upsertCount++;
+    lastSourceId = sourceId;
+    lastTracks = tracks;
+  }
+
+  @override
+  Future<List<Track>> getAllTracks() async => lastTracks;
+
+  @override
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
+
+  @override
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
+
+  @override
+  Future<Track?> getTrackById(String id) async => null;
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {}
+}
+
+/// Counts download requests so a test can prove the metadata sync never kicks
+/// off a download/cache fetch on its own.
+class _SpyDownloadRepository implements DownloadRepository {
+  int requestCount = 0;
+
+  @override
+  Future<DownloadRequestOutcome> requestDownload(Track track) async {
+    requestCount++;
+    return DownloadRequestOutcome.started;
+  }
+
+  @override
+  Stream<Map<String, DownloadStatus>> get statusStream =>
+      const Stream<Map<String, DownloadStatus>>.empty();
+
+  @override
+  Stream<Map<String, DownloadProgress>> get progressStream =>
+      const Stream<Map<String, DownloadProgress>>.empty();
+
+  @override
+  Future<DownloadStatus> statusFor(String trackId) async =>
+      DownloadStatus.notDownloaded;
+
+  @override
+  Future<void> removeDownload(String trackId) async {}
+
+  @override
+  Future<List<String>> downloadedTrackIds() async => const <String>[];
+}
+
+ProviderContainer _container({
+  required FakeJellyfinAuthenticator authenticator,
+  required _RecordingRepository repository,
+  InMemoryJellyfinAutoSyncStore? autoSyncStore,
+  FakeJellyfinClient? client,
+  _SpyDownloadRepository? downloads,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      jellyfinAuthenticatorProvider.overrideWithValue(authenticator),
+      jellyfinSessionStoreProvider
+          .overrideWithValue(InMemoryJellyfinSessionStore()),
+      jellyfinClientProvider.overrideWithValue(
+        client ??
+            FakeJellyfinClient(
+              itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+                JellyfinItemKind.audio: <JellyfinItemDto>[
+                  _audio('a'),
+                  _audio('b'),
+                ],
+              },
+            ),
+      ),
+      jellyfinAutoSyncStoreProvider
+          .overrideWithValue(autoSyncStore ?? InMemoryJellyfinAutoSyncStore()),
+      musicLibraryRepositoryProvider.overrideWithValue(repository),
+      if (downloads != null)
+        downloadRepositoryProvider.overrideWithValue(downloads),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+/// Lets the controller's async load settle.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+/// Drains the fire-and-forget auto-sync started by sign-in to completion.
+Future<void> _drainAutoSync() => pumpEventQueue(times: 50);
+
+Future<bool> _signIn(
+  ProviderContainer container, {
+  String url = 'music.example.com',
+  String username = 'alice',
+}) =>
+    container.read(jellyfinSettingsControllerProvider.notifier).signIn(
+          url: url,
+          username: username,
+          password: 'pw',
+        );
+
+void main() {
+  group('Jellyfin auto-sync on connect', () {
+    test('a successful sign-in triggers exactly one auto-sync', () async {
+      final repo = _RecordingRepository();
+      final store = InMemoryJellyfinAutoSyncStore();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: repo,
+        autoSyncStore: store,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      expect(await _signIn(container), isTrue);
+      await _drainAutoSync();
+
+      // One sync ran down the normal upsert path…
+      expect(repo.upsertCount, 1);
+      expect(repo.lastSourceId, 'jellyfin');
+      expect(repo.lastTracks, hasLength(2));
+      // …and finished as a success the UI can show.
+      expect(
+        container.read(jellyfinSyncControllerProvider).status,
+        JellyfinSyncStatus.success,
+      );
+      // The account is now remembered so it won't auto-sync again on its own.
+      expect(await store.read(), jellyfinAccountFingerprint(_sessionFor()));
+    });
+
+    test('a failed sign-in does not trigger a sync', () async {
+      final repo = _RecordingRepository();
+      final store = InMemoryJellyfinAutoSyncStore();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(
+          signInError: JellyfinException.unauthorized(),
+        ),
+        repository: repo,
+        autoSyncStore: store,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      expect(await _signIn(container), isFalse);
+      await _drainAutoSync();
+
+      expect(repo.upsertCount, 0);
+      expect(
+        container.read(jellyfinSyncControllerProvider).status,
+        JellyfinSyncStatus.idle,
+      );
+      expect(await store.read(), isNull);
+    });
+
+    test('reconnecting the same account does not auto-sync again', () async {
+      final repo = _RecordingRepository();
+      // The store already remembers this exact account from a prior run.
+      final store = InMemoryJellyfinAutoSyncStore(
+          jellyfinAccountFingerprint(_sessionFor()));
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: repo,
+        autoSyncStore: store,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      expect(await _signIn(container), isTrue);
+      await _drainAutoSync();
+
+      // Connected, but no unsolicited full re-sync — the manual button remains.
+      expect(repo.upsertCount, 0);
+      expect(
+        container.read(jellyfinSyncControllerProvider).status,
+        JellyfinSyncStatus.idle,
+      );
+    });
+
+    test('changing server/account allows a new initial auto-sync', () async {
+      final repo = _RecordingRepository();
+      final store = InMemoryJellyfinAutoSyncStore();
+      final auth = FakeJellyfinAuthenticator(session: _sessionFor());
+      final container = _container(
+        authenticator: auth,
+        repository: repo,
+        autoSyncStore: store,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      // First account.
+      await _signIn(container);
+      await _drainAutoSync();
+      expect(repo.upsertCount, 1);
+
+      // Sign out, then sign in to a *different* server + user.
+      await container.read(jellyfinSettingsControllerProvider.notifier).clear();
+      auth.session = _sessionFor(
+        baseUrl: 'https://other.example.com',
+        userId: 'user-2',
+        userName: 'bob',
+      );
+      await _signIn(container, url: 'other.example.com', username: 'bob');
+      await _drainAutoSync();
+
+      // The new account is a fresh connection, so it auto-syncs once more.
+      expect(repo.upsertCount, 2);
+      expect(
+        await store.read(),
+        jellyfinAccountFingerprint(
+          _sessionFor(baseUrl: 'https://other.example.com', userId: 'user-2'),
+        ),
+      );
+    });
+
+    test('manual sync still works after the auto-sync', () async {
+      final repo = _RecordingRepository();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: repo,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      await _signIn(container);
+      await _drainAutoSync();
+      expect(repo.upsertCount, 1);
+
+      // The user can still pull a refresh on demand.
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+      expect(repo.upsertCount, 2);
+      expect(
+        container.read(jellyfinSyncControllerProvider).status,
+        JellyfinSyncStatus.success,
+      );
+    });
+
+    test('auto-sync uses the same path as a manual sync', () async {
+      // Drive the manual sync and the auto-sync over identical inputs and prove
+      // they store the same catalog under the same source id.
+      final manualRepo = _RecordingRepository();
+      final manual = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: manualRepo,
+        // A store that already knows the account, so sign-in won't auto-sync —
+        // leaving the manual call as the only sync.
+        autoSyncStore: InMemoryJellyfinAutoSyncStore(
+          jellyfinAccountFingerprint(_sessionFor()),
+        ),
+      );
+      manual.read(jellyfinSettingsControllerProvider);
+      await _settle();
+      await _signIn(manual);
+      await _drainAutoSync();
+      expect(manualRepo.upsertCount, 0); // confirmed: auto-sync was skipped
+      await manual.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final autoRepo = _RecordingRepository();
+      final auto = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: autoRepo,
+      );
+      auto.read(jellyfinSettingsControllerProvider);
+      await _settle();
+      await _signIn(auto);
+      await _drainAutoSync();
+
+      expect(autoRepo.lastSourceId, manualRepo.lastSourceId);
+      expect(
+        autoRepo.lastTracks.map((t) => t.id),
+        manualRepo.lastTracks.map((t) => t.id),
+      );
+    });
+
+    test('a sync failure after sign-in surfaces a friendly retry state',
+        () async {
+      final repo = _RecordingRepository();
+      final store = InMemoryJellyfinAutoSyncStore();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: repo,
+        autoSyncStore: store,
+        // The catalog fetch fails (server unreachable) once connected.
+        client:
+            FakeJellyfinClient(itemsError: JellyfinException.notReachable()),
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      expect(await _signIn(container), isTrue);
+      await _drainAutoSync();
+
+      // Still connected, sync errored with a friendly, secret-free message.
+      expect(
+        container.read(jellyfinSettingsControllerProvider).phase,
+        JellyfinConnectionPhase.connected,
+      );
+      final syncState = container.read(jellyfinSyncControllerProvider);
+      expect(syncState.status, JellyfinSyncStatus.error);
+      expect(syncState.message, contains("Couldn't reach"));
+      expect(syncState.message, isNot(contains('secret-token-value')));
+      // The account is NOT recorded, so the next fresh connection retries.
+      expect(await store.read(), isNull);
+    });
+
+    test('the auto-sync starts no downloads or cache fetches', () async {
+      final repo = _RecordingRepository();
+      final downloads = _SpyDownloadRepository();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: repo,
+        downloads: downloads,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      await _signIn(container);
+      await _drainAutoSync();
+
+      expect(repo.upsertCount, 1); // metadata synced…
+      expect(downloads.requestCount, 0); // …but nothing was downloaded.
+    });
+
+    test('repeated provider rebuilds do not resync', () async {
+      final repo = _RecordingRepository();
+      final container = _container(
+        authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
+        repository: repo,
+      );
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+      await _signIn(container);
+      await _drainAutoSync();
+      expect(repo.upsertCount, 1);
+
+      // The sync path reads the live source through jellyfinMusicSourceProvider.
+      // Rebuilding it repeatedly (as a connection-state change or a widget
+      // rebuild would) re-mints the source but, since auto-sync lives in
+      // sign-in and not in any build(), must never kick off another sync.
+      for (int i = 0; i < 5; i++) {
+        container.invalidate(jellyfinMusicSourceProvider);
+        container.read(jellyfinMusicSourceProvider);
+        container.read(jellyfinSyncControllerProvider);
+        await _drainAutoSync();
+      }
+
+      expect(repo.upsertCount, 1);
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_settings_section_sync_ui_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_section_sync_ui_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_auto_sync_store.dart';
+import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
+import 'package:linthra/data/repositories/jellyfin_auto_sync_store_provider.dart';
+import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_settings_section.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
+
+import '../../../core/sources/jellyfin/fake_jellyfin_client.dart';
+import 'fake_jellyfin_authenticator.dart';
+
+const _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: 'secret-token',
+  deviceId: 'device-1',
+  userName: 'alice',
+  serverName: 'Home',
+);
+
+/// Holds the sync controller in a fixed state so the connected-view rendering
+/// can be asserted without driving (and timing) a real sync.
+class _FixedSyncController extends JellyfinSyncController {
+  _FixedSyncController(this._fixed);
+  final JellyfinSyncState _fixed;
+  @override
+  JellyfinSyncState build() => _fixed;
+}
+
+/// A recording repo that counts upserts, so the "reopen doesn't resync" test can
+/// prove sign-in synced exactly once across a screen close + reopen.
+class _RecordingRepository implements MusicLibraryRepository {
+  int upsertCount = 0;
+  List<Track> _tracks = const <Track>[];
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    upsertCount++;
+    _tracks = tracks;
+  }
+
+  @override
+  Future<List<Track>> getAllTracks() async => _tracks;
+  @override
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
+  @override
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
+  @override
+  Future<Track?> getTrackById(String id) async => null;
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {}
+}
+
+Future<void> _pumpConnected(
+  WidgetTester tester,
+  JellyfinSyncState syncState,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        jellyfinAuthenticatorProvider
+            .overrideWithValue(FakeJellyfinAuthenticator()),
+        jellyfinSessionStoreProvider.overrideWithValue(
+          InMemoryJellyfinSessionStore(initialSession: _session),
+        ),
+        jellyfinClientProvider.overrideWithValue(FakeJellyfinClient()),
+        jellyfinSyncControllerProvider
+            .overrideWith(() => _FixedSyncController(syncState)),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: JellyfinSettingsSection()),
+      ),
+    ),
+  );
+  // Let the controller's persisted-session load settle into the connected view.
+  // Avoid pumpAndSettle: a syncing state shows an endless spinner.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  group('connected-view sync states', () {
+    testWidgets('shows a friendly syncing line while a sync runs',
+        (tester) async {
+      await _pumpConnected(tester, const JellyfinSyncState.syncing());
+
+      expect(find.text('Syncing…'), findsOneWidget);
+      expect(
+          find.textContaining('Syncing your Jellyfin library'), findsOneWidget);
+      // No retry while it's still going.
+      expect(find.text('Retry sync'), findsNothing);
+    });
+
+    testWidgets('shows the success summary when a sync lands', (tester) async {
+      await _pumpConnected(
+        tester,
+        const JellyfinSyncState.success(
+          trackCount: 12,
+          message: 'Synced 12 tracks from your Jellyfin library.',
+        ),
+      );
+
+      expect(find.textContaining('Synced 12 tracks'), findsOneWidget);
+      expect(find.text('Retry sync'), findsNothing);
+    });
+
+    testWidgets('shows a friendly failure with a Retry action', (tester) async {
+      await _pumpConnected(
+        tester,
+        const JellyfinSyncState.error(
+          "Couldn't reach your Jellyfin server. Check your connection.",
+        ),
+      );
+
+      // Connection is intact, the failure is framed gently, and Retry is there.
+      expect(find.textContaining("didn't finish"), findsOneWidget);
+      expect(find.textContaining("Couldn't reach"), findsOneWidget);
+      expect(find.text('Retry sync'), findsOneWidget);
+      // Sign-out is still offered; the user isn't stuck.
+      expect(find.text('Sign out & clear'), findsOneWidget);
+    });
+  });
+
+  group('reopening the settings screen', () {
+    testWidgets('does not start a second sync', (tester) async {
+      final repo = _RecordingRepository();
+      final container = ProviderContainer(overrides: <Override>[
+        jellyfinAuthenticatorProvider
+            .overrideWithValue(FakeJellyfinAuthenticator(session: _session)),
+        jellyfinSessionStoreProvider
+            .overrideWithValue(InMemoryJellyfinSessionStore()),
+        jellyfinClientProvider.overrideWithValue(
+          FakeJellyfinClient(
+            itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+              JellyfinItemKind.audio: <JellyfinItemDto>[
+                const JellyfinItemDto(id: 'a', name: 'A'),
+              ],
+            },
+          ),
+        ),
+        jellyfinAutoSyncStoreProvider
+            .overrideWithValue(InMemoryJellyfinAutoSyncStore()),
+        musicLibraryRepositoryProvider.overrideWithValue(repo),
+      ]);
+      addTearDown(container.dispose);
+
+      Widget section() => UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: Scaffold(body: JellyfinSettingsSection()),
+            ),
+          );
+
+      // Open Settings and sign in.
+      await tester.pumpWidget(section());
+      await tester.pump();
+      final fields = find.byType(TextField);
+      await tester.enterText(fields.at(0), 'music.example.com');
+      await tester.enterText(fields.at(1), 'alice');
+      await tester.enterText(fields.at(2), 'pw');
+      await tester.pump();
+      await tester.tap(find.text('Sign in'));
+      // Let sign-in connect and the fire-and-forget auto-sync finish.
+      for (int i = 0; i < 12; i++) {
+        await tester.pump();
+      }
+      expect(repo.upsertCount, 1);
+
+      // Close Settings, then reopen it (same container, as the app would).
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: Scaffold(body: SizedBox.shrink())),
+        ),
+      );
+      await tester.pump();
+      await tester.pumpWidget(section());
+      for (int i = 0; i < 12; i++) {
+        await tester.pump();
+      }
+
+      // Reopening rebuilt the widget but must not re-trigger the sync.
+      expect(repo.upsertCount, 1);
+      expect(find.text('Sign out & clear'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## The onboarding problem

After connecting to Jellyfin, the library stayed empty until the user
discovered and tapped **Sync library**. That made a fresh sign-in feel
broken or empty. This change makes onboarding self-explanatory: connecting
just works, and the library fills in on its own.

## What changed

- **Auto-sync on connect.** A successful Jellyfin sign-in now starts the
  first library sync automatically (fire-and-forget, so sign-in returns
  immediately and the UI reflects the sync's progress).
- It runs the **same** path as the manual sync — tracks/albums/artists +
  playlists + favourites — so nothing about what syncs changes.
- The manual **Sync library** button stays available for on-demand refresh
  and doubles as the retry after a failure.

## Duplicate-sync prevention

Gated by a persisted **per-account fingerprint** (`jellyfinAccountFingerprint`):

- ✅ First connection to a server/account → auto-syncs once, then records the
  fingerprint.
- ✅ Reconnecting the **same** account, a provider rebuild, reopening Settings,
  or relaunching the app → **does not** resync (the trigger lives only in
  sign-in, never in a `build()`).
- ✅ Connecting a **different** server / signing in as a **different** user →
  fingerprint differs → fresh first sync. (Both accounts share the `jellyfin`
  source id, so a switch replaces the catalog — re-syncing is correct.)
- ✅ A synchronous `_syncing` guard prevents two overlapping syncs.
- ✅ The fingerprint is recorded **only on success**, so a failed first sync is
  retried on the next fresh connection.

## UI states

- **Syncing** — the Jellyfin card shows a spinner + _"Syncing your Jellyfin
  library…"_; the Library's empty state reads _"Your Jellyfin library is
  syncing. This may take a moment."_ instead of the folder-pick prompt.
- **Success** — _"Synced N tracks…"_ summary (with playlists/favourites).
- **Failure** — _"Connected, but the library sync didn't finish."_ + the
  specific friendly reason + a **Retry sync** button. The connection stays
  intact and sign-out is still offered.

## Security / token notes

- The auto-sync marker is a **one-way SHA-256 fingerprint** of server URL +
  user id — **never** the access token, the URL, or the user id themselves —
  so it's safe in plain `shared_preferences`.
- No token in `Track.uri`, no authenticated URLs persisted, no tokens in
  logs/errors/diagnostics (unchanged guarantees; covered by tests).
- The sync is **metadata-only** — it starts no downloads or cache fetches.

## Tests added

- `jellyfin_account_fingerprint_test` — stable per account, changes on
  server/user change, ignores token changes, leaks no token/URL/id.
- `in_memory_jellyfin_auto_sync_store_test` — round-trip + clear.
- `jellyfin_auto_sync_test` — one auto-sync on sign-in; none on failed
  sign-in; skip on same-account reconnect; fresh sync on account change;
  manual sync still works; auto-sync uses the same path; failure → friendly
  retry state with no token; no downloads started; repeated rebuilds don't
  resync.
- `jellyfin_settings_section_sync_ui_test` — syncing/success/failure+Retry
  rendering; reopening Settings doesn't start a second sync.
- `library_jellyfin_syncing_test` — empty Library shows the syncing message
  during a sync, and the normal empty state otherwise.

Full suite green locally: **1180 tests pass**, `flutter analyze` clean,
`dart format --set-exit-if-changed .` clean.

## Known limitations

- Same-account **sign-out → sign-in** intentionally skips the full auto-sync
  (the catalog tracks persist across sign-out). Server-synced favourites/
  playlists, which sign-out clears, return on the next app launch's refresh or
  a manual sync — consistent with "avoid unnecessary repeated full sync".
- Single-server only (unchanged): the catalog tracks one Jellyfin account at a
  time under the `jellyfin` source id.
- `flutter build apk --debug` was **not** run here (no Android SDK in this
  environment); CI builds the debug APK.

## Manual Android checklist

1. Fresh install Linthra.
2. Connect to Jellyfin.
3. Confirm sync starts automatically (card shows "Syncing…").
4. Confirm Library populates without pressing Sync.
5. Close/reopen Settings → confirm no duplicate sync.
6. Reopen the app → confirm it does not constantly resync.
7. Change Jellyfin server/account → confirm auto-sync runs for the new
   connection.
8. Disconnect network and try the login/sync failure path.
9. Confirm **Retry** works.
10. Confirm no tokens or authenticated URLs appear in UI/logs/diagnostics.

https://claude.ai/code/session_0188ns2je6oWq3Qb4arV7czf

---
_Generated by [Claude Code](https://claude.ai/code/session_0188ns2je6oWq3Qb4arV7czf)_