### PR TITLE
Mirror the play queue to the car media session and wire skip-to-queue-item

### DIFF
--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -19,6 +19,10 @@ troubleshoot.
 | Browsable tree (Library / Queue / Playlists / Favorites) | ✅ |
 | Play a track from the car; queue the rest | ✅ |
 | Transport controls (play / pause / next / previous / seek) | ✅ |
+| Hardware / steering-wheel / Bluetooth Next / Previous | ✅ (same media session) |
+| Lock-screen / notification Next / Previous | ✅ |
+| Now-playing **queue / Up Next** on the head unit | ✅ (mirrors the app's queue) |
+| Tap a row in the car's Up Next list (skip-to-queue-item) | ✅ |
 | Shuffle / repeat from the car | ✅ |
 | Now-playing metadata (title / artist / album / artwork) | ✅ (artwork depends on `Track.artworkUri`) |
 | Cast-safe (no duplicate local playback while casting) | ✅ |
@@ -59,7 +63,36 @@ recommended model for a media app.
 - `lib/core/services/linthra_audio_handler.dart` (`LinthraAudioHandler`) is the
   only file that imports `audio_service`. It maps `MediaNode`s to media items,
   forwards transport commands to the single `PlaybackController`, and turns a
-  selected item into a `PlaybackController.playTracks(...)` call.
+  selected item into a `PlaybackController.playTracks(...)` call. It also mirrors
+  the controller's queue out as the session's **Up Next** list and maps a tapped
+  queue row (`skipToQueueItem`) back onto the controller's history / up-next
+  jumps — so the car's queue stays in sync and is navigable without the handler
+  ever touching `just_audio` or the cast SDK.
+
+### Transport controls & hardware buttons
+
+The car's Next / Previous / Play / Pause — whether tapped on the head-unit
+screen, pressed on the steering wheel, or sent over Bluetooth / a wired headset
+— all arrive as the same media-session callbacks (`onSkipToNext`,
+`onSkipToPrevious`, `onPlay`, …). audio_service forwards them to
+`LinthraAudioHandler`, which calls the matching `PlaybackController` method
+(`skipToNext`, `skipToPrevious`, `play`, `pause`, `seek`, `skipToQueueItem`).
+There is no separate Android-Auto playback path: the car drives the **same**
+controller as the in-app player, so playback, queue, history, shuffle, and
+repeat stay consistent however you press a button.
+
+- The handler advertises the transport capabilities it implements (skip,
+  skip-to-queue-item, seek, shuffle, repeat) **steadily** in `systemActions`, so
+  a head unit that caches the capability set when it connects keeps its
+  Next / Previous and queue-row buttons live regardless of where you are in the
+  queue.
+- The **visible** notification / lock-screen buttons are still gated: the
+  `skipToPrevious` button only appears once a previous track exists and
+  `skipToNext` only while one is queued, so no dead button is ever shown.
+- At a queue boundary (Next on the last track, Previous on the first) the action
+  is a safe no-op — the queue and the now-playing state are left untouched.
+- Previous always steps to the previous track (it does not restart the current
+  track first); there is no "double-press to go back" behaviour.
 
 ### Browse tree
 
@@ -187,10 +220,24 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 8. Open Linthra.
 9. Browse **Library** (and **Playlists** / **Favorites** if you have any).
 10. Play a track — confirm it starts and the rest of the list becomes up-next.
-11. Test **play / pause / next / previous** (and shuffle/repeat).
-12. Disconnect and reconnect — confirm the app still appears and resumes.
-13. With a **Cast** session active, select a track from Android Auto and confirm
-    **no duplicate audio starts on the phone** (it should follow the receiver).
+11. Press the car / head-unit **Next** — confirm Linthra skips to the next track.
+12. Press the car / head-unit **Previous** — confirm it goes to the previous
+    track (it steps back; it does not restart the current track first).
+13. Press **Play / Pause** — confirm the play state stays in sync both ways.
+14. Open the car's **Up Next** list and tap a row — confirm playback jumps to it.
+15. Test **shuffle / repeat** from the car.
+16. **Lock the phone screen** and press car **Next** — confirm music keeps
+    playing and skips correctly (no drop-out during the track change).
+17. If you have a steering wheel or **Bluetooth** remote / headset, test its
+    **Next / Previous / Play-Pause** — they should drive Linthra too.
+18. Reopen Linthra on the phone — confirm it shows the **correct current track**
+    after using the car controls.
+19. Disconnect and reconnect — confirm the app still appears and resumes.
+20. With a **Cast** session active, select a track (and press Next) from Android
+    Auto and confirm **no duplicate audio starts on the phone** (it follows the
+    receiver).
+21. Skim `adb logcat | grep Linthra.AndroidAuto` — confirm **no tokens or
+    authenticated stream URLs** appear (only category labels and counts).
 
 ## Troubleshooting
 
@@ -244,7 +291,14 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   not something Linthra can change.
 - The browse tree is **flat**: no album/artist/folder grouping and no
   search-from-Auto; large libraries are not paged.
-- **Queue** browsing is read + jump only (no reorder/remove from the car).
+- The now-playing **Up Next** list mirrors the app's queue and you can tap a row
+  to jump to it, but you **can't reorder or remove** queue items from the car
+  (do that in the app). The browsable **Queue** category is likewise read + jump.
+- **Previous** always steps to the previous track; there's no restart-then-go-back
+  (single vs. double press) behaviour some apps use.
+- Next on the last track / Previous on the first is a **no-op**; Next does not
+  wrap to the start even with repeat-all on (only auto-advance at end-of-track
+  wraps).
 - The car experience is **basic browsing**, not a custom/polished car UI (no
   tabs, content-style hints, lyrics, or now-playing artwork tuning).
 - Lock-screen / car artwork depends on `Track.artworkUri`; local-folder scanning

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -76,6 +76,12 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   // has drifted enough to re-sync.
   audio.MediaItem? _lastItem;
   audio.PlaybackState? _lastPlaybackState;
+
+  // The queue (as a flat track list) last published to the platform session.
+  // Re-publishing the queue on every position tick would thrash the car's
+  // "Up Next" list, so [_broadcast] pushes it only when the queue's contents or
+  // order actually change. Null until the first broadcast.
+  List<Track>? _lastQueueTracks;
   bool _seeded = false;
 
   /// How far the reported position may drift before a fresh playback-state push
@@ -100,6 +106,27 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   @override
   Future<void> skipToPrevious() => _controller.skipToPrevious();
+
+  /// Jumps to the [index]-th item of the published [queue] — the row a head
+  /// unit / Android Auto's "Up Next" list reports when tapped. The queue is
+  /// published as history, then the current track, then up-next (see
+  /// [_queueTracksFor]), so this maps the flat index back onto the controller's
+  /// history/up-next jumps. Out-of-range (a stale row after the queue shrank)
+  /// and the current row are safe no-ops; it never bypasses the controller, so
+  /// Cast routing and "no duplicate local playback" hold exactly as for a skip.
+  @override
+  Future<void> skipToQueueItem(int index) async {
+    final PlaybackState state = _controller.state;
+    final int historyLength = state.previous.length;
+    final int total = _queueTracksFor(state).length;
+    if (index < 0 || index >= total) return;
+    if (index < historyLength) {
+      await _controller.playFromHistory(index);
+    } else if (index > historyLength) {
+      await _controller.playFromQueue(index - historyLength - 1);
+    }
+    // index == historyLength is the current track: leave it playing untouched.
+  }
 
   @override
   Future<void> seek(Duration position) => _controller.seek(position);
@@ -164,6 +191,17 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       _lastItem = item;
       mediaItem.add(item);
     }
+    // Publish the play queue so the car / head-unit "Up Next" list mirrors the
+    // controller's queue and a tapped row (skipToQueueItem) lands on the right
+    // track. Like the media item, it is pushed only when the queue's contents
+    // or order change — never on a position tick (which would thrash the list).
+    final List<Track> queueTracks = _queueTracksFor(state);
+    if (!_seeded || !_sameQueue(queueTracks, _lastQueueTracks)) {
+      _lastQueueTracks = queueTracks;
+      queue.add(<audio.MediaItem>[
+        for (final Track t in queueTracks) _trackMediaItem(t, id: t.id),
+      ]);
+    }
     final audio.PlaybackState next = _playbackStateFor(state);
     if (!_seeded || _shouldPushPlayback(next, _lastPlaybackState)) {
       _lastPlaybackState = next;
@@ -219,6 +257,30 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     return true;
   }
 
+  /// The live queue as one flat, ordered list: history, then the current track,
+  /// then up-next. This is the exact order published to the platform session's
+  /// [queue], so [skipToQueueItem] can map a flat row index straight back onto
+  /// the controller's history / up-next jumps.
+  static List<Track> _queueTracksFor(PlaybackState state) {
+    final Track? current = state.currentTrack;
+    return <Track>[
+      ...state.previous,
+      if (current != null) current,
+      ...state.upNext,
+    ];
+  }
+
+  /// Whether two queues would show the same list (same tracks, same order), so a
+  /// re-push can be skipped. [Track] equality is by id, which is all the queue
+  /// rows render from; the now-playing item carries any live metadata.
+  static bool _sameQueue(List<Track> a, List<Track>? b) {
+    if (b == null || a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+
   audio.MediaItem _mediaItemForNode(MediaNode node) {
     final track = node.track;
     if (node.playable && track != null) {
@@ -253,10 +315,19 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   audio.PlaybackState _playbackStateFor(PlaybackState state) {
     return audio.PlaybackState(
       controls: _controlsFor(state),
+      // The transport capabilities the platform (notification, lock screen,
+      // Android Auto, Bluetooth/steering-wheel media buttons) may invoke on the
+      // session. Every action here is implemented by this handler, so none is
+      // "unsupported": skip is advertised steadily (rather than toggled at queue
+      // edges) so a head unit that caches the capability set at connect time
+      // keeps its Next/Previous and queue-row buttons live; the *visible*
+      // notification controls are still gated on hasNext/hasPrevious by
+      // [_controlsFor], so no dead button is ever shown.
       systemActions: const <audio.MediaAction>{
         audio.MediaAction.seek,
         audio.MediaAction.skipToNext,
         audio.MediaAction.skipToPrevious,
+        audio.MediaAction.skipToQueueItem,
         audio.MediaAction.setShuffleMode,
         audio.MediaAction.setRepeatMode,
       },

--- a/test/core/services/android_auto_cast_test.dart
+++ b/test/core/services/android_auto_cast_test.dart
@@ -69,6 +69,48 @@ void main() {
     expect(controller.state.currentTrack?.id, 'b');
   });
 
+  test(
+      'with Cast active, a car skip advances the queue but plays nothing local',
+      () async {
+    // Requirement: a media-session skip (car / steering-wheel Next) while
+    // casting must route through the single PlaybackController and advance the
+    // queue, but must NOT start a second, duplicate stream on the phone — the
+    // local engine is suspended for the cast session's duration.
+    final library = <Track>[_track('a'), _track('b'), _track('c')];
+    final local = FakePlaybackController();
+    final cast = FakeCastService();
+    final controller = ActivePlaybackController(local: local, cast: cast);
+    final handler = LinthraAudioHandler(
+      controller,
+      MediaBrowserTree(FakeMusicLibraryRepository(tracks: library)),
+    );
+    addTearDown(() async {
+      await handler.dispose();
+      await controller.dispose();
+      await cast.dispose();
+      await local.dispose();
+    });
+
+    // A real queue exists locally first (current a, up-next b, c).
+    await controller.playTracks(library);
+    await _settle();
+
+    // Casting begins → the local engine is suspended.
+    cast.emit(_casting());
+    await _settle();
+    expect(local.isSuspended, isTrue);
+    final int playedBefore = local.playedTracks.length;
+
+    // Car Next.
+    await handler.skipToNext();
+    await _settle();
+
+    // The queue advanced so the receiver can be told what to play, but the
+    // local engine started no new track — no duplicate audio on the phone.
+    expect(controller.state.currentTrack?.id, 'b');
+    expect(local.playedTracks.length, playedBefore);
+  });
+
   test('without Cast, an Android Auto selection plays locally as normal',
       () async {
     final library = <Track>[_track('a'), _track('b'), _track('c')];

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -249,6 +249,26 @@ void main() {
         expect(state.processingState, audio.AudioProcessingState.loading);
       });
 
+      test('a car skip that loads the next track stays playing', () async {
+        // A skip (from the car/notification, screen off) briefly enters loading
+        // while the next track opens. The session must stay `playing` so the
+        // foreground service isn't demoted mid-transition — and the media item
+        // must already reflect the track being loaded.
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+
+        controller.emit(controller.state.copyWith(
+          currentTrack: _track('b'),
+          status: PlaybackStatus.loading,
+        ));
+        await _settle();
+
+        final state = handler.playbackState.value;
+        expect(state.playing, isTrue);
+        expect(state.processingState, audio.AudioProcessingState.loading);
+        expect(handler.mediaItem.value?.id, 'b');
+      });
+
       test('a real user pause reports not-playing', () async {
         await controller.playTracks(<Track>[_track('a')]);
         await _settle();
@@ -348,6 +368,159 @@ void main() {
       });
     });
 
+    group('media-session queue (car / head-unit Up Next)', () {
+      test('publishes the queue as history + current + up-next, in order',
+          () async {
+        // Start at the middle track so there is both history and up-next.
+        await controller.playTracks(_library, startIndex: 1);
+        await _settle();
+
+        // history (a), current (b), up-next (c) — the flat order a head unit's
+        // Up Next list shows and skipToQueueItem indexes into.
+        expect(handler.queue.value.map((i) => i.id), ['a', 'b', 'c']);
+        // The now-playing item shares its id with its queue row, so the car
+        // highlights the right row.
+        expect(handler.mediaItem.value?.id, 'b');
+      });
+
+      test('republishes the queue on an edit, not on a position tick',
+          () async {
+        await controller.playTracks(<Track>[_track('a'), _track('b')]);
+        await _settle();
+
+        final List<List<audio.MediaItem>> pushes = <List<audio.MediaItem>>[];
+        final sub = handler.queue.listen(pushes.add);
+        addTearDown(sub.cancel);
+        await _settle();
+        // Listening replays the current value; count only pushes after that.
+        final int baseline = pushes.length;
+
+        // Position ticks don't change the queue contents → no new push.
+        for (int ms = 200; ms <= 800; ms += 200) {
+          controller.emit(
+            controller.state.copyWith(position: Duration(milliseconds: ms)),
+          );
+          await _settle();
+        }
+        expect(pushes.length, baseline);
+
+        // Adding a track grows up-next → exactly the queue is re-published.
+        controller.addToQueue(_track('c'));
+        await _settle();
+        expect(pushes.length, greaterThan(baseline));
+        expect(pushes.last.map((i) => i.id), ['a', 'b', 'c']);
+      });
+
+      test('skipToQueueItem jumps forward to an up-next row', () async {
+        await controller.playTracks(_library); // a current, [b, c] up-next
+        await _settle();
+
+        // queue = [a, b, c]; row 2 is up-next 'c'.
+        await handler.skipToQueueItem(2);
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'c');
+        expect(handler.mediaItem.value?.id, 'c');
+      });
+
+      test('skipToQueueItem steps back to a history row', () async {
+        await controller.playTracks(_library);
+        await controller.skipToNext();
+        await controller.skipToNext(); // current c, history [a, b]
+        await _settle();
+
+        // queue = [a, b, c]; row 0 is history 'a'.
+        await handler.skipToQueueItem(0);
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'a');
+        expect(handler.mediaItem.value?.id, 'a');
+      });
+
+      test('skipToQueueItem on the current row leaves it playing', () async {
+        await controller.playTracks(_library);
+        await controller.skipToNext(); // current b, history [a]
+        await _settle();
+        final int playedBefore = controller.playedTracks.length;
+
+        await handler.skipToQueueItem(1); // row 1 == current
+
+        await _settle();
+        expect(controller.state.currentTrack?.id, 'b');
+        expect(controller.playedTracks.length, playedBefore);
+      });
+
+      test('skipToQueueItem out of range is a safe no-op', () async {
+        await controller.playTracks(_library);
+        await _settle();
+        final int playedBefore = controller.playedTracks.length;
+
+        await handler.skipToQueueItem(99);
+        await handler.skipToQueueItem(-1);
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'a');
+        expect(controller.playedTracks.length, playedBefore);
+      });
+    });
+
+    group('car skip keeps the queue & metadata correct', () {
+      test('skipToNext updates the current media item', () async {
+        await controller.playTracks(_library);
+        await _settle();
+        expect(handler.mediaItem.value?.id, 'a');
+
+        await handler.skipToNext();
+        await _settle();
+
+        expect(handler.mediaItem.value?.id, 'b');
+        expect(handler.mediaItem.value?.title, 'Song b');
+        expect(handler.mediaItem.value?.artist, 'Artist b');
+      });
+
+      test('skipToPrevious updates the current media item', () async {
+        await controller.playTracks(_library, startIndex: 1);
+        await _settle();
+        expect(handler.mediaItem.value?.id, 'b');
+
+        await handler.skipToPrevious();
+        await _settle();
+
+        expect(handler.mediaItem.value?.id, 'a');
+      });
+
+      test('a queue selected from the car supports next & previous', () async {
+        // Selecting a library track in the car builds the queue (the rest of
+        // the library becomes up-next), then car skip moves within that queue.
+        await handler.playFromMediaId(MediaId.libraryTrack('a'));
+        await _settle();
+        expect(handler.mediaItem.value?.id, 'a');
+
+        await handler.skipToNext();
+        await _settle();
+        expect(controller.state.currentTrack?.id, 'b');
+        expect(handler.mediaItem.value?.id, 'b');
+
+        await handler.skipToPrevious();
+        await _settle();
+        expect(controller.state.currentTrack?.id, 'a');
+      });
+
+      test('car Next at the end and Previous at the start are safe no-ops',
+          () async {
+        await controller.playTracks(<Track>[_track('a')]); // single track
+        await _settle();
+
+        await handler.skipToNext();
+        await handler.skipToPrevious();
+        await _settle();
+
+        expect(controller.state.currentTrack?.id, 'a');
+        expect(controller.skipCount, 1);
+        expect(controller.previousCount, 1);
+      });
+    });
+
     group('shuffle & repeat', () {
       test('forwards setShuffleMode to the controller', () async {
         await handler.setShuffleMode(audio.AudioServiceShuffleMode.all);
@@ -434,6 +607,46 @@ void main() {
           // We attach no extras, so nothing can leak through them.
           expect(item.extras, isNull);
           // The artwork URL (when present) is the token-free image endpoint.
+          final String art = item.artUri?.toString() ?? '';
+          expect(art, isNot(contains('api_key')));
+          expect(art.toLowerCase(), isNot(contains('token')));
+        }
+      });
+
+      test('now-playing item and queue rows are token-free, with no extras',
+          () async {
+        // The same secret-free guarantee must hold for what the car shows while
+        // playing — the now-playing media item and every published queue row —
+        // not just the browse tree.
+        final playController = FakePlaybackController();
+        final playHandler = LinthraAudioHandler(
+          playController,
+          MediaBrowserTree(
+            FakeMusicLibraryRepository(tracks: <Track>[jellyfin, local]),
+          ),
+        );
+        addTearDown(() async {
+          await playHandler.dispose();
+          await playController.dispose();
+        });
+
+        await playController.playTracks(<Track>[jellyfin, local]);
+        await _settle();
+
+        final nowPlaying = playHandler.mediaItem.value;
+        expect(nowPlaying, isNotNull);
+        // The id is the opaque catalog id, never the `jellyfin:` uri.
+        expect(nowPlaying!.id, 'jf-guid-123');
+
+        final queueRows = playHandler.queue.value;
+        expect(queueRows.map((i) => i.id), ['jf-guid-123', 'local-1']);
+
+        for (final item in <audio.MediaItem>[nowPlaying, ...queueRows]) {
+          expect(item.id, isNot(contains('api_key')));
+          expect(item.id.toLowerCase(), isNot(contains('token')));
+          expect(item.id, isNot(contains('jellyfin:')));
+          expect(item.id, isNot(contains('://')));
+          expect(item.extras, isNull);
           final String art = item.artUri?.toString() ?? '';
           expect(art, isNot(contains('api_key')));
           expect(art.toLowerCase(), isNot(contains('token')));


### PR DESCRIPTION
## What & why

Goal: make in-car control reliable — the car/head-unit and steering-wheel/Bluetooth
**Next / Previous / Play / Pause** should drive Linthra like a real music app.

While auditing the media-session layer, the transport wiring turned out to be
**already in place**: `LinthraAudioHandler` overrides `play`/`pause`/`stop`/
`skipToNext`/`skipToPrevious`/`seek` and forwards each to the single
`PlaybackController`, the Android manifest declares the `MediaBrowserService`,
`MediaButtonReceiver`, and the `com.google.android.gms.car.application`
automotive descriptor, and Cast-safe routing already runs through
`ActivePlaybackController`. So car/Bluetooth Next/Previous and play/pause were
functional.

The real gap: **the media session never published its queue.** audio_service's
`queue` subject stayed empty, so the car's **Up Next** list was blank and
tapping a queue row (`skipToQueueItem`) did nothing. This PR fills that gap and
hardens the queue/skip behaviour.

## Changes

- **Publish the play queue** to the session as the head-unit **Up Next** list —
  history + current track + up-next, in play order. Re-pushed only when the
  queue's contents/order actually change (not on a position tick), so it never
  thrashes the car's list.
- **Wire `skipToQueueItem`**: a tapped queue row maps back onto the controller's
  `playFromHistory` / `playFromQueue` jumps. Out-of-range rows and the current
  row are safe no-ops. It routes through the controller like every other
  command — no `just_audio` access from the Android Auto path.
- **Advertise `skipToQueueItem`** alongside the existing skip actions in
  `systemActions`.

The now-playing media item, queue rows, and skip-forwarding were already
correct; this builds on them rather than replacing them.

## Media session actions (section A)

`play`, `pause`, `skipToNext`, `skipToPrevious`, `seek`, `stop`, and now
`skipToQueueItem` are all handled and forwarded to the existing
`PlaybackController`. Nothing bypasses the controller; the handler never touches
`just_audio`; Cast/local routing stays centralised in `ActivePlaybackController`.

## Queue behaviour (section B)

- Current `MediaItem` is updated on every track change (unchanged).
- The **queue is now published** and mirrors current + up-next (+ history).
- The now-playing item shares its id with its queue row, so the car highlights
  the right row.
- Transport capabilities are advertised **steadily** in `systemActions` (every
  one is implemented, so none is "unsupported") so a head unit that caches the
  capability set at connect keeps Next/Previous live; the **visible**
  notification/lock-screen buttons stay gated on `hasNext`/`hasPrevious`, so no
  dead button is shown.
- Title/artist/artwork stay correct after a skip.

## Cast / local safety (section 8)

All car controls — including skip and queue-row taps — route through the single
`PlaybackController`. While casting, the local engine is suspended, so they
advance the queue and mirror onto the receiver **without** starting a second,
duplicate stream on the phone. Covered by a new test.

## Background / lock-screen (section D)

No regression to the screen-off background-playback fix: the session still
reports `playing` through loading/buffering, the foreground service isn't
demoted during a track transition, and publishing the queue doesn't touch the
`playing` flag. Covered by a skip-while-loading test.

## Security (sections B7 / E10)

Queue rows reuse the now-playing item's secret-free metadata: ids are the opaque
catalog id (never the `jellyfin:`/`subsonic:` uri or a token), no `extras` are
attached, and artwork is the token-free image endpoint. The Android Auto log
still prints only id *categories* and counts. Covered by a test asserting the
now-playing item and every queue row are token-free.

## Tests added

- audio handler `skipToNext`/`skipToPrevious` update the now-playing media item
- queue is published as history + current + up-next, in order
- queue is re-published on a queue edit but **not** on a position tick
- `skipToQueueItem` jumps forward / steps back / is a no-op on the current row
- `skipToQueueItem` out-of-range is a safe no-op
- a queue selected from Android Auto supports Next/Previous
- car Next at the end / Previous at the start are safe no-ops
- a car skip that enters `loading` stays `playing` and updates the item
- a car skip while **Cast** is active advances the queue but plays nothing local
- the now-playing item and queue rows are token-free with no extras

(`skipToNext`/`skipToPrevious`/`play`/`pause` forwarding was already covered.)

## Verification

- `flutter pub get` — ok
- `dart format --set-exit-if-changed .` — ok (0 changed)
- `flutter analyze` — No issues found
- `flutter test` — **1193 passing**
- `flutter build apk --debug` — **skipped**: no Android SDK in this environment
  (the Flutter SDK is bootstrapped via `scripts/setup_flutter.sh`, but no
  Android toolchain is installed here). Needs a manual debug build before
  merge.

## Manual Android / car checklist

> Needs a real head unit / DHU + a phone build (Android SDK required); not runnable in CI.

1. Connect phone to Android Auto.
2. Open Linthra from Android Auto.
3. Start playback from Android Auto.
4. Press car/head-unit **Next**.
5. Confirm Linthra skips to the next track.
6. Press car/head-unit **Previous**.
7. Confirm Linthra goes to the previous track (it steps back; it does not restart the current track first).
8. Press **Play/Pause**.
9. Confirm playback state stays synced both ways.
10. Lock the phone screen and press car **Next**.
11. Confirm music continues and skips correctly (no drop-out during the transition).
12. Test **Bluetooth/headset** Next/Previous if available.
13. Test **Cast** active state — select/skip from the car and confirm the receiver follows, no phone audio.
14. Reopen Linthra and confirm the correct current track is shown.
15. Confirm no duplicate local playback.
16. Confirm no tokens/authenticated URLs appear in `adb logcat | grep Linthra.AndroidAuto`.

## Known limitations

- Up Next is **read + jump** from the car (tap a row to jump); reorder/remove
  must be done in the app.
- **Previous** always steps back; no restart-then-go-back (single vs. double
  press) behaviour.
- Next on the last track / Previous on the first is a no-op; manual Next does not
  wrap even with repeat-all on (only end-of-track auto-advance wraps).
- No search-from-Auto, no album/artist/folder grouping (flat lists), no MPRIS.

https://claude.ai/code/session_017bMN1new7SFMap6RFWJDC6

---
_Generated by [Claude Code](https://claude.ai/code/session_017bMN1new7SFMap6RFWJDC6)_