### PR TITLE
Expand the Android Auto browse tree (Albums, Artists, Offline)

### DIFF
--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -16,7 +16,8 @@ troubleshoot.
 | Capability | Status |
 | --- | --- |
 | Listed as an Android Auto **media app** | ✅ (manifest + automotive descriptor; needs "unknown sources" for sideloaded builds — see below) |
-| Browsable tree (Library / Queue / Playlists / Favorites) | ✅ |
+| Browsable tree (Songs / Albums / Artists / Playlists / Favorites / Offline / Queue) | ✅ |
+| Album / artist grouping in the car | ✅ (derived from the synced catalog, same grouping as the phone) |
 | Play a track from the car; queue the rest | ✅ |
 | Transport controls (play / pause / next / previous / seek) | ✅ |
 | Hardware / steering-wheel / Bluetooth Next / Previous | ✅ (same media session) |
@@ -25,9 +26,11 @@ troubleshoot.
 | Tap a row in the car's Up Next list (skip-to-queue-item) | ✅ |
 | Shuffle / repeat from the car | ✅ |
 | Now-playing metadata (title / artist / album / artwork) | ✅ (artwork depends on `Track.artworkUri`) |
+| Offline / downloaded section | ✅ (user downloads only — smart pre-cache is not listed) |
 | Cast-safe (no duplicate local playback while casting) | ✅ |
-| Search from Android Auto | ❌ (not implemented) |
-| Album / artist / folder grouping in the car | ❌ (flat lists) |
+| Search from Android Auto | ❌ (not implemented — [follow-up](#known-limitations)) |
+| Folder grouping in the car | ❌ (Songs is a flat list; albums/artists are grouped) |
+| Recently added / smart mixes in the car | ❌ ([follow-up](#known-limitations)) |
 | Custom car screens / content-style hints | ❌ (intentionally — safe browsing only) |
 
 Linthra exposes a **standard `MediaBrowserService` + media session** via the
@@ -58,8 +61,18 @@ recommended model for a media app.
 - `lib/core/services/media_browser_tree.dart` (`MediaBrowserTree`) is **pure
   Dart**: it builds the browse tree from the `MusicLibraryRepository`, a
   `PlaybackState` snapshot, and (when wired) the `PlaylistRepository` /
-  `FavoritesRepository`. No `audio_service` type and no widget dependency, so it
-  is fully unit-tested.
+  `FavoritesRepository` / `DownloadRepository`. No `audio_service` type and no
+  widget dependency, so it is fully unit-tested.
+- Albums and artists are **derived from the track catalog** (Linthra stores no
+  album/artist ids), via the shared grouping in
+  `lib/core/catalog/library_grouping.dart` — the **same** grouping the in-app
+  Library tabs use, so the car and the phone show identical albums/artists.
+  Browsing reads only the local synced catalog; it never calls a remote server
+  or mints a stream URL.
+- The **Offline** section reads `DownloadRepository.downloadedTrackIds()`, which
+  reports only **user-initiated downloads** — smart pre-cached tracks are
+  deliberately not marked downloaded, so they never appear here (it mirrors the
+  in-app Downloads screen exactly).
 - `lib/core/services/linthra_audio_handler.dart` (`LinthraAudioHandler`) is the
   only file that imports `audio_service`. It maps `MediaNode`s to media items,
   forwards transport commands to the single `PlaybackController`, and turns a
@@ -98,30 +111,57 @@ repeat stay consistent however you press a button.
 
 ```
 root
-├── Library    → every catalog track
-├── Queue      → current track + up-next (only populated while something plays)
+├── Songs      → every catalog track (flat list)
+├── Albums     → albums (browsable)
+│   └── <album>   → that album's tracks, in track-number order
+├── Artists    → artists (browsable)
+│   └── <artist>  → that artist's tracks, album by album
 ├── Playlists  → your playlists (only shown when you have some)
 │   └── <playlist> → that playlist's tracks
-└── Favorites  → your favourited tracks (only shown when you have some)
+├── Favorites  → your liked tracks (only shown when you have some)
+├── Offline    → your downloaded tracks (only shown when you have some)
+└── Queue      → current track + up-next (only populated while something plays)
 ```
+
+Selecting a track plays it and queues the rest of **the list it was opened
+from** (the album's tracks for an album track, the artist's for an artist track,
+the playlist's for a playlist track, …) — exactly like tapping a track in that
+screen on the phone.
 
 Stable media IDs:
 
 | Node | ID form |
 | --- | --- |
-| Library category | `library` |
-| Library track | `library/<trackId>` |
-| Queue category | `queue` |
-| Queue item | `queue/<index>` |
+| Songs category | `library` |
+| Song / library track | `library/<trackId>` |
+| Albums category | `albums` |
+| An album (container) | `album/<albumId>` |
+| Album track | `album/<albumId>/<index>` |
+| Artists category | `artists` |
+| An artist (container) | `artist/<artistId>` |
+| Artist track | `artist/<artistId>/<index>` |
 | Playlists category | `playlists` |
-| A playlist | `playlist/<playlistId>` |
+| A playlist (container) | `playlist/<playlistId>` |
 | Playlist track | `playlist/<playlistId>/<index>` |
 | Favorites category | `favorites` |
 | Favorite track | `favorite/<index>` |
+| Offline category | `offline` |
+| Offline track | `offline/<index>` |
+| Queue category | `queue` |
+| Queue item | `queue/<index>` |
+| Empty-state placeholder | `empty` |
 
-`Playlists` and `Favorites` only appear when you actually have some, so the car
-never shows an empty dead-end. A favourite / playlist track id that isn't in the
-on-device catalog yet is skipped (it can't be played until synced).
+`<albumId>` / `<artistId>` are URL-safe, **opaque** grouping ids (a base64url
+token, or an `unknown-album` / `unknown-artist` sentinel) — never a name, path,
+or token.
+
+- **Songs / Albums / Artists** are always shown (they reflect the catalog). When
+  the catalog is empty, opening one shows a friendly placeholder ("Sync your
+  library first", "No albums yet", …) instead of a blank screen.
+- **Playlists / Favorites / Offline** only appear when you actually have some, so
+  the car never shows an empty dead-end. A favourite / playlist / downloaded
+  track id that isn't in the on-device catalog yet is skipped (it can't be played
+  until synced).
 
 ## Security / token notes
 
@@ -138,8 +178,11 @@ Android Auto media items are deliberately **secret-free**:
   Jellyfin, and `null` for Subsonic/local — so no credential rides along in
   artwork either.
 - The diagnostic log (see below) prints only the **category** of a media id
-  (e.g. `library`, `playlist`, `favorite`) and small counts — never a raw id,
-  title, URI, or token.
+  (e.g. `library`, `album`, `artist`, `playlist`, `favorite`, `offline`) and
+  small counts — never a raw id, title, URI, or token.
+- Album/artist grouping ids and the cover-art URL never carry a token: art is
+  the **token-free** `Track.artworkUri` (the public image endpoint, or null),
+  the same source the now-playing card already uses.
 
 ## Diagnostics / logging
 
@@ -160,9 +203,10 @@ You should see, in order:
 - `browse: root -> N children` — Android Auto bound and requested the root. If
   you never see a `browse:` line after connecting, Android Auto isn't binding
   (usually the "unknown sources" gate — see troubleshooting).
-- `browse: library -> N children` — a category was opened; `N` tells you whether
-  the catalog is populated.
-- `play: library resolved=true` — a selection resolved to something playable.
+- `browse: albums -> N children` (or `library`, `artists`, `offline`, …) — a
+  category was opened; `N` tells you whether the catalog is populated.
+- `play: album-track resolved=true` — a selection resolved to something
+  playable. `resolved=false` means a stale id resolved to nothing.
 
 ## Build / install
 
@@ -198,8 +242,8 @@ verify the browse tree and playback from a desk.
    $ANDROID_SDK/extras/google/auto/desktop-head-unit
    ```
 5. In the DHU, open the **media app launcher** and confirm **Linthra** is listed.
-   Open it, browse **Library / Playlists / Favorites**, play a track, and test
-   the transport controls.
+   Open it, browse **Songs / Albums / Artists** (and **Playlists / Favorites /
+   Offline** if you have any), play a track, and test the transport controls.
 
 Reference: <https://developer.android.com/training/cars/testing/dhu>
 
@@ -212,31 +256,36 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 
 1. Build and install the debug or release APK (see [Build / install](#build--install)).
 2. **Open Linthra once on the phone.**
-3. Sign in / sync Jellyfin or Navidrome if you use one (so the catalog persists).
+3. Sign in / sync Jellyfin or Navidrome if you use one (so the catalog persists);
+   download a couple of tracks for offline if you want to test the Offline row.
 4. Enable Android Auto **Developer mode → Add unknown sources** (sideloaded builds).
 5. Connect the phone to Android Auto (USB or wireless) — or start the DHU.
-6. Open the Android Auto **app launcher / media list**.
-7. Confirm **Linthra appears**.
-8. Open Linthra.
-9. Browse **Library** (and **Playlists** / **Favorites** if you have any).
-10. Play a track — confirm it starts and the rest of the list becomes up-next.
-11. Press the car / head-unit **Next** — confirm Linthra skips to the next track.
-12. Press the car / head-unit **Previous** — confirm it goes to the previous
-    track (it steps back; it does not restart the current track first).
-13. Press **Play / Pause** — confirm the play state stays in sync both ways.
+6. Open the Android Auto **app launcher / media list** and confirm **Linthra
+   appears**; open it.
+7. Browse **Songs** and play a track — confirm it starts and the rest of the list
+   becomes up-next.
+8. Browse **Albums**, open an album, play a track — confirm the queue is that
+   album, in track order.
+9. Browse **Artists**, open an artist, play a track — confirm the queue is that
+   artist's tracks.
+10. Browse **Playlists**, open a playlist, play a track (if you have any).
+11. Browse **Favorites** and play a track (if you have any liked tracks).
+12. Browse **Offline** and play a downloaded track (if you have any) — confirm it
+    plays (ideally with the phone offline, to prove no network is needed).
+13. Press the car / head-unit **Next** / **Previous** — confirm Linthra skips
+    correctly (Previous steps back; it does not restart the current track first).
 14. Open the car's **Up Next** list and tap a row — confirm playback jumps to it.
-15. Test **shuffle / repeat** from the car.
+15. Test **shuffle / repeat** and **Play / Pause** — confirm both stay in sync.
 16. **Lock the phone screen** and press car **Next** — confirm music keeps
     playing and skips correctly (no drop-out during the track change).
-17. If you have a steering wheel or **Bluetooth** remote / headset, test its
-    **Next / Previous / Play-Pause** — they should drive Linthra too.
-18. Reopen Linthra on the phone — confirm it shows the **correct current track**
-    after using the car controls.
-19. Disconnect and reconnect — confirm the app still appears and resumes.
-20. With a **Cast** session active, select a track (and press Next) from Android
+17. Reopen Linthra on the phone — confirm it shows the **correct current track**
+    and **no duplicate playback**.
+18. With a **Cast** session active, select a track (and press Next) from Android
     Auto and confirm **no duplicate audio starts on the phone** (it follows the
     receiver).
-21. Skim `adb logcat | grep Linthra.AndroidAuto` — confirm **no tokens or
+19. On the car screen, confirm **no private server URL, token, or file path** is
+    ever shown (only titles, artists, albums).
+20. Skim `adb logcat | grep Linthra.AndroidAuto` — confirm **no tokens or
     authenticated stream URLs** appear (only category labels and counts).
 
 ## Troubleshooting
@@ -257,13 +306,19 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 4. **Re-install and reconnect.** Android Auto caches its media-app list; toggling
    the connection or restarting Android Auto refreshes it.
 
-### Library (or a category) is empty
+### A section is empty
 
 - The browse tree reads the **persisted** catalog. Open Linthra on the phone and
   let it scan a local folder and/or sync your Jellyfin/Navidrome library first.
-- `Playlists` / `Favorites` only show when you have some; a favourite or playlist
-  track that hasn't been synced to the on-device catalog is skipped.
-- Check `adb logcat | grep Linthra.AndroidAuto` for `browse: library -> 0
+  Until then, **Songs / Albums / Artists** show a friendly placeholder ("Sync
+  your library first", "No albums yet", …) rather than a blank screen.
+- `Playlists` / `Favorites` / `Offline` only show at the root when you have some;
+  a favourite / playlist / downloaded track that hasn't been synced to the
+  on-device catalog is skipped.
+- **Offline** lists only **user-downloaded** tracks. Smart pre-cached tracks are
+  not counted as downloads, so they don't appear here — download a track from the
+  app to see it in the car.
+- Check `adb logcat | grep Linthra.AndroidAuto` for `browse: albums -> 0
   children` — that confirms the bind works but the catalog is empty.
 
 ### Playback controls don't work
@@ -289,8 +344,19 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 
 - **Sideloaded builds need "unknown sources"** (see above) — a device setting,
   not something Linthra can change.
-- The browse tree is **flat**: no album/artist/folder grouping and no
-  search-from-Auto; large libraries are not paged.
+- **Search from Android Auto is not implemented** (voice "play …" and the car's
+  search box). It's a planned follow-up: the browse leaves already have stable,
+  resolvable ids, so search can return them without new playback plumbing.
+- **No folder grouping** and **no "Recently added" / smart-mixes** rows in the
+  car yet (both are deliberate follow-ups to keep this change focused and the car
+  tree simple). Songs is a flat list; Albums and Artists are grouped.
+- **Large libraries are not paged**: the browse tree reads the whole synced
+  catalog into memory and groups it per request. This is local-only (it never
+  calls a server), but a very large catalog builds a long list. Paging via the
+  `MediaBrowser` page options is a follow-up.
+- **Artists open a flat track list** (album by album), not a list of album
+  sub-folders. Selecting a track queues the whole artist; album sub-folders under
+  an artist are a possible follow-up.
 - The now-playing **Up Next** list mirrors the app's queue and you can tap a row
   to jump to it, but you **can't reorder or remove** queue items from the car
   (do that in the app). The browsable **Queue** category is likewise read + jump.

--- a/docs/codebase-tour.md
+++ b/docs/codebase-tour.md
@@ -61,7 +61,8 @@ class is bound to its interface, and where tests swap in fakes.
 | Downloads & offline cache | `lib/data/repositories/cache_download_repository.dart` |
 | Smart pre-cache | `lib/core/services/smart_precache_service.dart` |
 | The local library the UI reads | `lib/core/repositories/music_library_repository.dart` + `lib/data/database/` |
-| Search / albums / artists grouping | `lib/features/library/library_search.dart`, `library_grouping.dart` |
+| Search | `lib/features/library/library_search.dart` |
+| Albums / artists grouping + text folding | `lib/core/catalog/library_grouping.dart`, `lib/core/catalog/text_folding.dart` (shared by the Library UI and the Android Auto browse tree) |
 | Playlists & favorites | `lib/features/playlists/`, `lib/features/favorites/` |
 | Smart mixes | `lib/features/smart_mixes/`, `lib/core/services/smart_playlist_resolver.dart` |
 | Diagnostics & "Report a bug" | `lib/core/diagnostics/`, `lib/features/settings/bug_report/` |
@@ -224,8 +225,9 @@ reads the local catalog through `MusicLibraryRepository`
   `library_search.dart` filter the in-memory list as you type, normalizing case
   and accents so "Bjork" finds "Björk".
 - **Albums & artists** aren't stored as separate rows — they're *derived* from
-  the track list by `library_grouping.dart`, which is the one place grouping
-  and stable IDs live so the list and the detail screens never disagree.
+  the track list by `lib/core/catalog/library_grouping.dart`, which is the one
+  place grouping and stable IDs live so the list, the detail screens, and the
+  Android Auto browse tree never disagree.
 - **Playlists** (`lib/features/playlists/`) are user-authored and have their own
   lifecycle (`PlaylistRepository`), separate from the source-derived catalog;
   they sync to Jellyfin where supported.

--- a/lib/core/catalog/library_grouping.dart
+++ b/lib/core/catalog/library_grouping.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
-import '../../core/models/album.dart';
-import '../../core/models/artist.dart';
-import '../../core/models/track.dart';
-import 'library_search.dart' show foldText;
+import '../models/album.dart';
+import '../models/artist.dart';
+import '../models/track.dart';
+import 'text_folding.dart';
 
 /// Derives [Album] and [Artist] groupings from the flat track catalog.
 ///
@@ -16,10 +16,12 @@ import 'library_search.dart' show foldText;
 /// and so fold into a single "Unknown Album" / "Unknown Artist"). Persisting
 /// source album/artist IDs for sharper grouping is a documented follow-up.
 ///
-/// Grouping keys are built from [foldText], so case and accents never split one
-/// album/artist into two. Album identity is (album title + artist) so two
-/// different artists' "Greatest Hits" stay distinct; tracks with no album fold
-/// into one "Unknown Album" regardless of artist. All ordering uses total
+/// Lives in `core` so both the Library UI and the Android Auto browse tree share
+/// one grouping implementation (the browse tree must not reach into the library
+/// feature). Grouping keys are built from [foldText], so case and accents never
+/// split one album/artist into two. Album identity is (album title + artist) so
+/// two different artists' "Greatest Hits" stay distinct; tracks with no album
+/// fold into one "Unknown Album" regardless of artist. All ordering uses total
 /// comparators (every tie broken down to the stable id), so a given catalog
 /// always produces the exact same order — sorting is predictable and stable.
 
@@ -44,8 +46,8 @@ String _albumKey(String album, String artist) =>
 /// The stable album id [track] belongs to. Tracks with no album title share the
 /// single [_unknownAlbumId]; otherwise the id is `al-` + a base64url encoding of
 /// the (title, artist) key. Every character is URL-safe (so the id can ride in
-/// a route path untouched) and the `al-` prefix can never produce the unknown
-/// sentinel, so the two never collide.
+/// a route path — or an Android Auto media id — untouched) and the `al-` prefix
+/// can never produce the unknown sentinel, so the two never collide.
 String albumIdForTrack(Track track) {
   final String album = foldText(track.albumName ?? '');
   if (album.isEmpty) return _unknownAlbumId;

--- a/lib/core/catalog/text_folding.dart
+++ b/lib/core/catalog/text_folding.dart
@@ -1,0 +1,105 @@
+// Pure, dependency-free text folding shared by Library search and the
+// album/artist grouping.
+//
+// Folding is intentionally small and offline (a fixed Latin diacritics table
+// rather than a Unicode-normalization package), so it adds no dependency and
+// never reaches the network — there is nothing here that could expose a token
+// or an authenticated URL. It lives in `core` so both the UI search box and the
+// Android Auto browse tree (which derives albums/artists from the catalog) fold
+// identically, without the browse tree reaching up into the library feature.
+
+/// Common single-codepoint Latin diacritics mapped to their unaccented base, so
+/// folding stays a cheap table lookup. Keys are lower-case; callers lower-case
+/// first. Anything not listed passes through unchanged.
+const Map<String, String> _diacritics = <String, String>{
+  'á': 'a',
+  'à': 'a',
+  'â': 'a',
+  'ä': 'a',
+  'ã': 'a',
+  'å': 'a',
+  'ā': 'a',
+  'ă': 'a',
+  'ą': 'a',
+  'ç': 'c',
+  'ć': 'c',
+  'č': 'c',
+  'ċ': 'c',
+  'ď': 'd',
+  'đ': 'd',
+  'é': 'e',
+  'è': 'e',
+  'ê': 'e',
+  'ë': 'e',
+  'ē': 'e',
+  'ė': 'e',
+  'ę': 'e',
+  'ě': 'e',
+  'ğ': 'g',
+  'í': 'i',
+  'ì': 'i',
+  'î': 'i',
+  'ï': 'i',
+  'ī': 'i',
+  'į': 'i',
+  'ı': 'i',
+  'ł': 'l',
+  'ľ': 'l',
+  'ñ': 'n',
+  'ń': 'n',
+  'ň': 'n',
+  'ó': 'o',
+  'ò': 'o',
+  'ô': 'o',
+  'ö': 'o',
+  'õ': 'o',
+  'ø': 'o',
+  'ō': 'o',
+  'ő': 'o',
+  'ŕ': 'r',
+  'ř': 'r',
+  'š': 's',
+  'ś': 's',
+  'ş': 's',
+  'ș': 's',
+  'ť': 't',
+  'ț': 't',
+  'ú': 'u',
+  'ù': 'u',
+  'û': 'u',
+  'ü': 'u',
+  'ū': 'u',
+  'ů': 'u',
+  'ű': 'u',
+  'ý': 'y',
+  'ÿ': 'y',
+  'ž': 'z',
+  'ź': 'z',
+  'ż': 'z',
+  'ß': 'ss',
+  'œ': 'oe',
+  'æ': 'ae',
+};
+
+/// Lower-cases [input], strips common diacritics, and collapses runs of
+/// whitespace to a single space (trimmed). The result is the canonical form
+/// used both for matching and for stable grouping keys, so "  The   Café " and
+/// "the cafe" fold to the same value.
+String foldText(String input) {
+  final String lower = input.toLowerCase();
+  final StringBuffer out = StringBuffer();
+  bool lastWasSpace = false;
+  for (int i = 0; i < lower.length; i++) {
+    final String ch = lower[i];
+    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
+      if (!lastWasSpace) {
+        out.write(' ');
+        lastWasSpace = true;
+      }
+      continue;
+    }
+    lastWasSpace = false;
+    out.write(_diacritics[ch] ?? ch);
+  }
+  return out.toString().trim();
+}

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -6,6 +6,7 @@ import 'package:audio_service/audio_service.dart' as audio;
 import '../models/playback_state.dart';
 import '../models/repeat_mode.dart';
 import '../models/track.dart';
+import '../repositories/download_repository.dart';
 import '../repositories/favorites_repository.dart';
 import '../repositories/music_library_repository.dart';
 import '../repositories/playlist_repository.dart';
@@ -29,14 +30,23 @@ void _log(String message) => developer.log(message, name: _logName);
 String _categoryOf(String id) {
   if (id == MediaId.root) return 'root';
   if (id == MediaId.library) return 'library';
+  if (id == MediaId.albums) return 'albums';
+  if (id == MediaId.artists) return 'artists';
   if (id == MediaId.queue) return 'queue';
   if (id == MediaId.playlists) return 'playlists';
   if (id == MediaId.favorites) return 'favorites';
+  if (id == MediaId.offline) return 'offline';
+  if (id == MediaId.empty) return 'empty';
+  if (MediaId.isAlbumTrack(id)) return 'album-track';
+  if (MediaId.isAlbumCategory(id)) return 'album';
+  if (MediaId.isArtistTrack(id)) return 'artist-track';
+  if (MediaId.isArtistCategory(id)) return 'artist';
   if (MediaId.isPlaylistTrack(id)) return 'playlist-track';
   if (MediaId.isPlaylistCategory(id)) return 'playlist';
   if (MediaId.isLibraryTrack(id)) return 'library-track';
   if (MediaId.isQueueItem(id)) return 'queue-item';
   if (MediaId.isFavoriteItem(id)) return 'favorite';
+  if (MediaId.isOfflineItem(id)) return 'offline-item';
   return 'other';
 }
 
@@ -49,8 +59,9 @@ String _categoryOf(String id) {
 /// controller and mirrors the controller's [PlaybackState] back out as
 /// audio_service playback state + media item, so the notification, lock screen,
 /// and Android Auto reflect what is playing. For Android Auto it also exposes a
-/// browsable tree (Library / Queue) built by [MediaBrowserTree] and turns a
-/// selected item into a [PlaybackController.playTracks] call. The controller
+/// browsable tree (Songs / Albums / Artists / Playlists / Favorites / Offline /
+/// Queue) built by [MediaBrowserTree] and turns a selected item into a
+/// [PlaybackController.playTracks] call. The controller
 /// stays the single source of truth and owns `just_audio`; the UI never touches
 /// this class.
 class LinthraAudioHandler extends audio.BaseAudioHandler {
@@ -286,11 +297,14 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     if (node.playable && track != null) {
       return _trackMediaItem(track, id: node.id);
     }
+    // A browsable container (album/artist) may carry token-free cover art so the
+    // car shows artwork on the row; categories and placeholders leave it null.
     return audio.MediaItem(
       id: node.id,
       title: node.title,
       playable: false,
       displaySubtitle: node.subtitle,
+      artUri: node.artworkUri,
     );
   }
 
@@ -434,12 +448,12 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 /// Registers [controller] with the platform media session so playback appears
 /// in the notification / lock screen and is reachable from Android Auto, with a
 /// browsable tree backed by [library] and — when supplied — the user's
-/// [playlists] and [favorites].
+/// [playlists], [favorites], and offline [downloads].
 ///
 /// Runs entirely off repository seams, so when Android Auto starts the media
 /// service cold (before any phone screen is opened) the browse tree is already
-/// answerable from the persisted catalog/playlists/favourites — it does not wait
-/// on the Flutter UI.
+/// answerable from the persisted catalog/playlists/favourites/downloads — it
+/// does not wait on the Flutter UI.
 ///
 /// Best-effort by design: returns `null` when `audio_service` can't initialise
 /// (a platform without the native setup, or a test environment). Playback still
@@ -452,12 +466,18 @@ Future<LinthraAudioHandler?> connectMediaSession(
   MusicLibraryRepository library, {
   PlaylistRepository? playlists,
   FavoritesRepository? favorites,
+  DownloadRepository? downloads,
 }) async {
   try {
     final handler = await audio.AudioService.init(
       builder: () => LinthraAudioHandler(
         controller,
-        MediaBrowserTree(library, playlists: playlists, favorites: favorites),
+        MediaBrowserTree(
+          library,
+          playlists: playlists,
+          favorites: favorites,
+          downloads: downloads,
+        ),
       ),
       config: const audio.AudioServiceConfig(
         androidNotificationChannelId: 'com.linthra.audio',

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/foundation.dart';
 
+import '../catalog/library_grouping.dart';
+import '../models/album.dart';
+import '../models/artist.dart';
 import '../models/playback_state.dart';
 import '../models/playlist.dart';
 import '../models/track.dart';
+import '../repositories/download_repository.dart';
 import '../repositories/favorites_repository.dart';
 import '../repositories/music_library_repository.dart';
 import '../repositories/playlist_repository.dart';
@@ -10,39 +14,76 @@ import '../repositories/playlist_repository.dart';
 /// Stable media IDs for the browsable tree exposed to Android Auto and other
 /// media browsers.
 ///
-/// Category IDs are plain constants; leaf IDs encode where the item lives so a
-/// later `playFromMediaId` can be resolved back to a track without extra state:
-///  - `library/<trackId>` — a catalog track.
+/// Category IDs are plain constants; leaf and container IDs encode where the
+/// item lives so a later `playFromMediaId` can be resolved back to a track
+/// without extra state:
+///  - `library/<trackId>` — a catalog track (the Songs list).
+///  - `album/<albumId>` — an album *container* (browsable); its children are
+///    `album/<albumId>/<index>` track leaves.
+///  - `artist/<artistId>` — an artist *container* (browsable); its children are
+///    `artist/<artistId>/<index>` track leaves.
+///  - `playlist/<playlistId>` — a playlist *container* (browsable); its children
+///    are `playlist/<playlistId>/<index>` track leaves.
 ///  - `queue/<index>` — a position in the live play queue.
-///  - `playlist/<playlistId>` — a playlist *category* (browsable).
-///  - `playlist/<playlistId>/<index>` — a position within that playlist.
 ///  - `favorite/<index>` — a position in the (catalog-ordered) favourites list.
+///  - `offline/<index>` — a position in the (catalog-ordered) downloaded list.
 ///
-/// The namespaces never collide (`library` vs. `library/...`; a playlist
-/// category `playlist/<id>` has no trailing `/<index>`, a playlist track does).
+/// The namespaces never collide: a bare category word (`albums`) never starts
+/// with the matching container prefix (`album/`), a container `album/<id>` has
+/// no trailing `/<index>`, and an album/artist id is a URL-safe base64url token
+/// (or an `al-`/`ar-`/`unknown-...` sentinel) that never itself contains a `/`.
 ///
 /// Security invariant: every id is built only from non-secret, opaque ids — a
-/// catalog/track id (e.g. the `jellyfin:` scheme is *not* used here; the bare
-/// item id is), a local playlist id, or a small integer index. No id ever
-/// carries a Jellyfin/Subsonic access token or an authenticated stream URL; the
-/// stream URL is minted lazily at play time by the resolver, never here.
+/// catalog/track id (the bare item id, never the `jellyfin:`/`subsonic:` uri), a
+/// derived album/artist grouping id, a local playlist id, or a small integer
+/// index. No id ever carries a Jellyfin/Subsonic access token or an
+/// authenticated stream URL; the stream URL is minted lazily at play time by the
+/// resolver, never here.
 abstract final class MediaId {
   /// The root the platform requests first (audio_service's `browsableRootId`).
   static const String root = 'root';
+
+  /// The flat "Songs" list (every catalog track). Kept as `library` for id
+  /// stability; its displayed title is "Songs".
   static const String library = 'library';
+  static const String albums = 'albums';
+  static const String artists = 'artists';
   static const String queue = 'queue';
   static const String playlists = 'playlists';
   static const String favorites = 'favorites';
+  static const String offline = 'offline';
+
+  /// A non-playable placeholder shown when a section has no content yet (e.g.
+  /// "No albums yet"). Browsing into it yields nothing and it never resolves to
+  /// a playable track, so an empty section is a friendly dead-stop, not a crash.
+  static const String empty = 'empty';
 
   static const String _libraryPrefix = 'library/';
+  static const String _albumPrefix = 'album/';
+  static const String _artistPrefix = 'artist/';
   static const String _queuePrefix = 'queue/';
   static const String _playlistPrefix = 'playlist/';
   static const String _favoritePrefix = 'favorite/';
+  static const String _offlinePrefix = 'offline/';
 
   static String libraryTrack(String trackId) => '$_libraryPrefix$trackId';
   static String queueItem(int index) => '$_queuePrefix$index';
 
-  /// A playlist *category* node id (its children are the playlist's tracks).
+  /// An album *container* node id (its children are the album's tracks).
+  static String album(String albumId) => '$_albumPrefix$albumId';
+
+  /// A playable leaf for the track at [index] within album [albumId].
+  static String albumTrack(String albumId, int index) =>
+      '$_albumPrefix$albumId/$index';
+
+  /// An artist *container* node id (its children are the artist's tracks).
+  static String artist(String artistId) => '$_artistPrefix$artistId';
+
+  /// A playable leaf for the track at [index] within artist [artistId].
+  static String artistTrack(String artistId, int index) =>
+      '$_artistPrefix$artistId/$index';
+
+  /// A playlist *container* node id (its children are the playlist's tracks).
   static String playlist(String playlistId) => '$_playlistPrefix$playlistId';
 
   /// A playable leaf for the track at [index] within playlist [playlistId].
@@ -50,44 +91,47 @@ abstract final class MediaId {
       '$_playlistPrefix$playlistId/$index';
 
   static String favoriteItem(int index) => '$_favoritePrefix$index';
+  static String offlineItem(int index) => '$_offlinePrefix$index';
 
   static bool isLibraryTrack(String id) => id.startsWith(_libraryPrefix);
   static bool isQueueItem(String id) => id.startsWith(_queuePrefix);
   static bool isFavoriteItem(String id) => id.startsWith(_favoritePrefix);
+  static bool isOfflineItem(String id) => id.startsWith(_offlinePrefix);
 
-  /// A playlist *category* node: `playlist/<id>` with no further `/<index>`.
+  /// An album/artist/playlist *container*: `<prefix>/<id>` with no further
+  /// `/<index>`.
+  static bool isAlbumCategory(String id) => _isContainer(id, _albumPrefix);
+  static bool isArtistCategory(String id) => _isContainer(id, _artistPrefix);
   static bool isPlaylistCategory(String id) =>
-      id.startsWith(_playlistPrefix) &&
-      !id.substring(_playlistPrefix.length).contains('/');
+      _isContainer(id, _playlistPrefix);
 
-  /// A playlist *track* leaf: `playlist/<id>/<index>`.
-  static bool isPlaylistTrack(String id) =>
-      id.startsWith(_playlistPrefix) &&
-      id.substring(_playlistPrefix.length).contains('/');
+  /// An album/artist/playlist *track* leaf: `<prefix>/<id>/<index>`.
+  static bool isAlbumTrack(String id) => _isLeaf(id, _albumPrefix);
+  static bool isArtistTrack(String id) => _isLeaf(id, _artistPrefix);
+  static bool isPlaylistTrack(String id) => _isLeaf(id, _playlistPrefix);
 
   static String libraryTrackId(String id) =>
       id.substring(_libraryPrefix.length);
 
+  static String albumCategoryId(String id) => id.substring(_albumPrefix.length);
+  static String artistCategoryId(String id) =>
+      id.substring(_artistPrefix.length);
   static String playlistCategoryId(String id) =>
       id.substring(_playlistPrefix.length);
 
-  /// The playlist id encoded in a playlist-track leaf `playlist/<id>/<index>`.
-  /// Parsed from the right so an id containing a `/` (it shouldn't) is still
+  /// The container id encoded in a track leaf `<prefix>/<id>/<index>`. Parsed
+  /// from the right so an id that somehow contains a `/` (it shouldn't) is still
   /// handled safely.
-  static String playlistTrackPlaylistId(String id) {
-    final String rest = id.substring(_playlistPrefix.length);
-    final int slash = rest.lastIndexOf('/');
-    return slash < 0 ? rest : rest.substring(0, slash);
-  }
+  static String albumTrackAlbumId(String id) => _containerId(id, _albumPrefix);
+  static String artistTrackArtistId(String id) =>
+      _containerId(id, _artistPrefix);
+  static String playlistTrackPlaylistId(String id) =>
+      _containerId(id, _playlistPrefix);
 
-  /// The position encoded in a playlist-track leaf, or -1 when it isn't a valid
-  /// number.
-  static int playlistTrackIndex(String id) {
-    final String rest = id.substring(_playlistPrefix.length);
-    final int slash = rest.lastIndexOf('/');
-    if (slash < 0) return -1;
-    return int.tryParse(rest.substring(slash + 1)) ?? -1;
-  }
+  /// The position encoded in a track leaf, or -1 when it isn't a valid number.
+  static int albumTrackIndex(String id) => _leafIndex(id, _albumPrefix);
+  static int artistTrackIndex(String id) => _leafIndex(id, _artistPrefix);
+  static int playlistTrackIndex(String id) => _leafIndex(id, _playlistPrefix);
 
   /// The queue position encoded in [id], or -1 when it isn't a valid number.
   static int queueIndex(String id) =>
@@ -96,13 +140,36 @@ abstract final class MediaId {
   /// The favourites position encoded in [id], or -1 when it isn't a number.
   static int favoriteIndex(String id) =>
       int.tryParse(id.substring(_favoritePrefix.length)) ?? -1;
+
+  /// The downloads position encoded in [id], or -1 when it isn't a number.
+  static int offlineIndex(String id) =>
+      int.tryParse(id.substring(_offlinePrefix.length)) ?? -1;
+
+  static bool _isContainer(String id, String prefix) =>
+      id.startsWith(prefix) && !id.substring(prefix.length).contains('/');
+
+  static bool _isLeaf(String id, String prefix) =>
+      id.startsWith(prefix) && id.substring(prefix.length).contains('/');
+
+  static String _containerId(String id, String prefix) {
+    final String rest = id.substring(prefix.length);
+    final int slash = rest.lastIndexOf('/');
+    return slash < 0 ? rest : rest.substring(0, slash);
+  }
+
+  static int _leafIndex(String id, String prefix) {
+    final String rest = id.substring(prefix.length);
+    final int slash = rest.lastIndexOf('/');
+    if (slash < 0) return -1;
+    return int.tryParse(rest.substring(slash + 1)) ?? -1;
+  }
 }
 
 /// One node in the browsable media tree, kept free of any `audio_service` type.
 ///
-/// Browsable nodes (categories) have [playable] `false`; track leaves have it
-/// `true` and carry their [track] so the handler can build a rich media item
-/// (artist, album, duration, artwork) without re-reading the catalog.
+/// Browsable nodes (categories/containers) have [playable] `false`; track leaves
+/// have it `true` and carry their [track] so the handler can build a rich media
+/// item (artist, album, duration, artwork) without re-reading the catalog.
 @immutable
 class MediaNode {
   const MediaNode({
@@ -111,6 +178,7 @@ class MediaNode {
     this.subtitle,
     this.playable = false,
     this.track,
+    this.artworkUri,
   });
 
   final String id;
@@ -118,6 +186,11 @@ class MediaNode {
   final String? subtitle;
   final bool playable;
   final Track? track;
+
+  /// Cover art for a *browsable* node (an album/artist container). Track leaves
+  /// carry their art on [track] instead. Always a token-free image URL (the same
+  /// `Track.artworkUri` source) or null — never a credentialed endpoint.
+  final Uri? artworkUri;
 }
 
 /// What to play when a browsable item is selected: the [tracks] to load and the
@@ -134,14 +207,20 @@ class MediaPlaybackRequest {
 
 /// Builds the browsable media tree from the [MusicLibraryRepository] (catalog),
 /// a [PlaybackState] snapshot (the live queue), and — when wired — the user's
-/// [PlaylistRepository] and [FavoritesRepository], and resolves a selected media
-/// ID back to a playback request.
+/// [PlaylistRepository], [FavoritesRepository], and [DownloadRepository], and
+/// resolves a selected media ID back to a playback request.
 ///
 /// Pure application logic with no audio backend and no UI dependency: it reads
-/// only repository seams, so Android Auto can browse it the moment the media
-/// service starts — before any phone screen is opened. The handler maps its
-/// [MediaNode]s onto `audio_service` media items and drives playback through the
+/// only repository seams (and the pure album/artist grouping in
+/// `core/catalog`), so Android Auto can browse it the moment the media service
+/// starts — before any phone screen is opened. The handler maps its [MediaNode]s
+/// onto `audio_service` media items and drives playback through the
 /// [PlaybackController]. That keeps this fully testable with fake repositories.
+///
+/// Albums and artists are *derived* from the track catalog (the catalog has no
+/// persisted album/artist ids), via the same grouping the in-app Library uses,
+/// so the car and the phone show identical groupings. Browsing reads only the
+/// local synced catalog — it never calls a remote server or mints a stream URL.
 ///
 /// Defensive by design: every repository read is guarded, and an unknown or
 /// stale id yields an empty list / null rather than throwing, so a browse or
@@ -151,8 +230,10 @@ class MediaBrowserTree {
     this._library, {
     PlaylistRepository? playlists,
     FavoritesRepository? favorites,
+    DownloadRepository? downloads,
   })  : _playlists = playlists,
-        _favorites = favorites;
+        _favorites = favorites,
+        _downloads = downloads;
 
   final MusicLibraryRepository _library;
 
@@ -163,6 +244,10 @@ class MediaBrowserTree {
   /// User favourites, or null when not wired. When null, no Favorites node is
   /// offered.
   final FavoritesRepository? _favorites;
+
+  /// Offline downloads, or null when not wired. When null, no Offline node is
+  /// offered.
+  final DownloadRepository? _downloads;
 
   /// The children of [parentId], for the given live [playback] snapshot.
   /// Unknown parents yield an empty list rather than throwing, so an unexpected
@@ -175,13 +260,27 @@ class MediaBrowserTree {
       case MediaId.root:
         return _rootNodes();
       case MediaId.library:
-        return _libraryNodes();
+        return _songNodes();
+      case MediaId.albums:
+        return _albumCategoryNodes();
+      case MediaId.artists:
+        return _artistCategoryNodes();
       case MediaId.queue:
         return _queueNodes(playback);
       case MediaId.playlists:
         return _playlistCategoryNodes();
       case MediaId.favorites:
         return _favoriteNodes();
+      case MediaId.offline:
+        return _offlineNodes();
+      case MediaId.empty:
+        return const <MediaNode>[];
+    }
+    if (MediaId.isAlbumCategory(parentId)) {
+      return _albumTrackNodes(MediaId.albumCategoryId(parentId));
+    }
+    if (MediaId.isArtistCategory(parentId)) {
+      return _artistTrackNodes(MediaId.artistCategoryId(parentId));
     }
     if (MediaId.isPlaylistCategory(parentId)) {
       return _playlistTrackNodes(MediaId.playlistCategoryId(parentId));
@@ -190,7 +289,7 @@ class MediaBrowserTree {
   }
 
   /// Resolves a selected leaf [mediaId] to what should play, or null when it
-  /// doesn't name a playable track (e.g. a stale id, or a category).
+  /// doesn't name a playable track (e.g. a stale id, or a category/container).
   Future<MediaPlaybackRequest?> resolve(
     String mediaId,
     PlaybackState playback,
@@ -202,6 +301,16 @@ class MediaBrowserTree {
       if (index < 0) return null;
       return MediaPlaybackRequest(tracks: tracks, startIndex: index);
     }
+    if (MediaId.isAlbumTrack(mediaId)) {
+      final List<Track> tracks = tracksForAlbum(
+          await _allTracks(), MediaId.albumTrackAlbumId(mediaId));
+      return _requestAt(tracks, MediaId.albumTrackIndex(mediaId));
+    }
+    if (MediaId.isArtistTrack(mediaId)) {
+      final List<Track> tracks = tracksForArtist(
+          await _allTracks(), MediaId.artistTrackArtistId(mediaId));
+      return _requestAt(tracks, MediaId.artistTrackIndex(mediaId));
+    }
     if (MediaId.isQueueItem(mediaId)) {
       final List<Track> tracks = _currentQueue(playback);
       return _requestAt(tracks, MediaId.queueIndex(mediaId));
@@ -212,8 +321,11 @@ class MediaBrowserTree {
       return _requestAt(tracks, MediaId.playlistTrackIndex(mediaId));
     }
     if (MediaId.isFavoriteItem(mediaId)) {
-      final List<Track> tracks = await _favoriteTracks();
-      return _requestAt(tracks, MediaId.favoriteIndex(mediaId));
+      return _requestAt(
+          await _favoriteTracks(), MediaId.favoriteIndex(mediaId));
+    }
+    if (MediaId.isOfflineItem(mediaId)) {
+      return _requestAt(await _offlineTracks(), MediaId.offlineIndex(mediaId));
     }
     return null;
   }
@@ -225,17 +337,22 @@ class MediaBrowserTree {
     return MediaPlaybackRequest(tracks: tracks, startIndex: index);
   }
 
-  /// The top-level categories. Library and Queue are always present; Playlists
-  /// and Favorites appear only when the user actually has some, so Android Auto
-  /// never shows a dead-end category. Always non-empty.
+  /// The top-level categories. Songs / Albums / Artists (the library) and Queue
+  /// are always present; Playlists, Favorites, and Offline appear only when the
+  /// user actually has some, so the car never shows an empty user-data category.
+  /// Always non-empty.
   Future<List<MediaNode>> _rootNodes() async {
     return <MediaNode>[
-      const MediaNode(id: MediaId.library, title: 'Library'),
-      const MediaNode(id: MediaId.queue, title: 'Queue'),
+      const MediaNode(id: MediaId.library, title: 'Songs'),
+      const MediaNode(id: MediaId.albums, title: 'Albums'),
+      const MediaNode(id: MediaId.artists, title: 'Artists'),
       if (await _hasPlaylists())
         const MediaNode(id: MediaId.playlists, title: 'Playlists'),
       if (await _hasFavorites())
         const MediaNode(id: MediaId.favorites, title: 'Favorites'),
+      if (await _hasOffline())
+        const MediaNode(id: MediaId.offline, title: 'Offline'),
+      const MediaNode(id: MediaId.queue, title: 'Queue'),
     ];
   }
 
@@ -243,11 +360,58 @@ class MediaBrowserTree {
 
   Future<bool> _hasFavorites() async => (await _favoriteIds()).isNotEmpty;
 
-  Future<List<MediaNode>> _libraryNodes() async {
+  Future<bool> _hasOffline() async => (await _downloadedIds()).isNotEmpty;
+
+  Future<List<MediaNode>> _songNodes() async {
     final List<Track> tracks = await _allTracks();
+    if (tracks.isEmpty) return _placeholder('Sync your library first');
     return <MediaNode>[
       for (final Track track in tracks)
         _trackNode(MediaId.libraryTrack(track.id), track),
+    ];
+  }
+
+  Future<List<MediaNode>> _albumCategoryNodes() async {
+    final List<Album> albums = groupAlbums(await _allTracks());
+    if (albums.isEmpty) return _placeholder('No albums yet');
+    return <MediaNode>[
+      for (final Album album in albums)
+        MediaNode(
+          id: MediaId.album(album.id),
+          title: album.title,
+          subtitle: album.artistName,
+          artworkUri: album.artworkUri,
+        ),
+    ];
+  }
+
+  Future<List<MediaNode>> _albumTrackNodes(String albumId) async {
+    final List<Track> tracks = tracksForAlbum(await _allTracks(), albumId);
+    return <MediaNode>[
+      for (int i = 0; i < tracks.length; i++)
+        _trackNode(MediaId.albumTrack(albumId, i), tracks[i]),
+    ];
+  }
+
+  Future<List<MediaNode>> _artistCategoryNodes() async {
+    final List<Artist> artists = groupArtists(await _allTracks());
+    if (artists.isEmpty) return _placeholder('No artists yet');
+    return <MediaNode>[
+      for (final Artist artist in artists)
+        MediaNode(
+          id: MediaId.artist(artist.id),
+          title: artist.name,
+          subtitle: _artistSubtitle(artist),
+          artworkUri: artist.artworkUri,
+        ),
+    ];
+  }
+
+  Future<List<MediaNode>> _artistTrackNodes(String artistId) async {
+    final List<Track> tracks = tracksForArtist(await _allTracks(), artistId);
+    return <MediaNode>[
+      for (int i = 0; i < tracks.length; i++)
+        _trackNode(MediaId.artistTrack(artistId, i), tracks[i]),
     ];
   }
 
@@ -261,6 +425,7 @@ class MediaBrowserTree {
 
   Future<List<MediaNode>> _playlistCategoryNodes() async {
     final List<Playlist> playlists = await _allPlaylists();
+    if (playlists.isEmpty) return _placeholder('No playlists yet');
     return <MediaNode>[
       for (final Playlist playlist in playlists)
         MediaNode(
@@ -281,11 +446,27 @@ class MediaBrowserTree {
 
   Future<List<MediaNode>> _favoriteNodes() async {
     final List<Track> tracks = await _favoriteTracks();
+    if (tracks.isEmpty) return _placeholder('No favorites yet');
     return <MediaNode>[
       for (int i = 0; i < tracks.length; i++)
         _trackNode(MediaId.favoriteItem(i), tracks[i]),
     ];
   }
+
+  Future<List<MediaNode>> _offlineNodes() async {
+    final List<Track> tracks = await _offlineTracks();
+    if (tracks.isEmpty) return _placeholder('No offline tracks yet');
+    return <MediaNode>[
+      for (int i = 0; i < tracks.length; i++)
+        _trackNode(MediaId.offlineItem(i), tracks[i]),
+    ];
+  }
+
+  /// A single non-playable placeholder row carrying a friendly, secret-free
+  /// [message], so an empty section explains itself instead of showing a blank
+  /// car screen. Browsing into it (id [MediaId.empty]) yields nothing.
+  List<MediaNode> _placeholder(String message) =>
+      <MediaNode>[MediaNode(id: MediaId.empty, title: message)];
 
   /// The full live queue as a flat list: the current track followed by up-next,
   /// matching the `queue/<index>` ids the queue nodes are built with.
@@ -300,6 +481,22 @@ class MediaBrowserTree {
   /// favourite not synced to this device) are dropped — they can't be played.
   Future<List<Track>> _favoriteTracks() async {
     final Set<String> ids = await _favoriteIds();
+    if (ids.isEmpty) return const <Track>[];
+    final List<Track> tracks = await _allTracks();
+    return <Track>[
+      for (final Track track in tracks)
+        if (ids.contains(track.id)) track,
+    ];
+  }
+
+  /// The downloaded (offline) tracks in stable catalog order, so an
+  /// `offline/<index>` leaf listed and resolved in the same browse session
+  /// refers to the same track. Only user-downloaded tracks appear — smart
+  /// pre-cached tracks are deliberately not reported as downloaded by the
+  /// repository, so they never leak into this section. Ids with no catalog track
+  /// are dropped.
+  Future<List<Track>> _offlineTracks() async {
+    final Set<String> ids = await _downloadedIds();
     if (ids.isEmpty) return const <Track>[];
     final List<Track> tracks = await _allTracks();
     return <Track>[
@@ -350,6 +547,18 @@ class MediaBrowserTree {
     }
   }
 
+  /// The current downloaded track-id set. Guarded: any failure yields an empty
+  /// set so a misbehaving download backend can't break browsing.
+  Future<Set<String>> _downloadedIds() async {
+    final DownloadRepository? downloads = _downloads;
+    if (downloads == null) return const <String>{};
+    try {
+      return (await downloads.downloadedTrackIds()).toSet();
+    } catch (_) {
+      return const <String>{};
+    }
+  }
+
   Future<List<Playlist>> _allPlaylists() async {
     final PlaylistRepository? playlists = _playlists;
     if (playlists == null) return const <Playlist>[];
@@ -386,9 +595,20 @@ class MediaBrowserTree {
     return label.isEmpty ? null : label;
   }
 
-  /// A track count for a playlist category row, e.g. "1 track" / "12 tracks".
+  /// A track count for a playlist container row, e.g. "1 track" / "12 tracks".
   static String _playlistSubtitle(Playlist playlist) {
     final int n = playlist.length;
     return n == 1 ? '1 track' : '$n tracks';
+  }
+
+  /// "N albums • M songs" (or just the song count), like the in-app artist
+  /// header, so an artist row reads at a glance.
+  static String _artistSubtitle(Artist artist) {
+    final String songs =
+        artist.trackCount == 1 ? '1 song' : '${artist.trackCount} songs';
+    if (artist.albumCount <= 0) return songs;
+    final String albums =
+        artist.albumCount == 1 ? '1 album' : '${artist.albumCount} albums';
+    return '$albums • $songs';
   }
 }

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
+import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
@@ -11,7 +12,6 @@ import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
-import 'library_grouping.dart';
 import 'library_state.dart';
 import 'widgets/track_tile.dart';
 

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
+import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
@@ -11,7 +12,6 @@ import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
-import 'library_grouping.dart';
 import 'library_state.dart';
 import 'widgets/album_tile.dart';
 import 'widgets/track_tile.dart';

--- a/lib/features/library/library_browse_providers.dart
+++ b/lib/features/library/library_browse_providers.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import 'library_controller.dart';
-import 'library_grouping.dart';
 
 /// Albums derived from the loaded track catalog, recomputed whenever the
 /// library reloads (scan, sync, or a removal). The Albums tab and the artist

--- a/lib/features/library/library_search.dart
+++ b/lib/features/library/library_search.dart
@@ -1,111 +1,13 @@
+import '../../core/catalog/text_folding.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 
 /// Pure, dependency-free text matching for the Library search box.
 ///
-/// All comparisons run through [foldText] so search is case-insensitive and,
-/// where practical, accent-insensitive: typing "beyonce" finds "Beyoncé" and
-/// "amelie" finds "Amélie". The folding is intentionally small and offline (a
-/// fixed Latin diacritics table rather than a Unicode-normalization package), so
-/// it adds no dependency and never reaches the network — there is nothing here
-/// that could expose a token or an authenticated URL.
-
-/// Common single-codepoint Latin diacritics mapped to their unaccented base, so
-/// folding stays a cheap table lookup. Keys are lower-case; callers lower-case
-/// first. Anything not listed passes through unchanged.
-const Map<String, String> _diacritics = <String, String>{
-  'á': 'a',
-  'à': 'a',
-  'â': 'a',
-  'ä': 'a',
-  'ã': 'a',
-  'å': 'a',
-  'ā': 'a',
-  'ă': 'a',
-  'ą': 'a',
-  'ç': 'c',
-  'ć': 'c',
-  'č': 'c',
-  'ċ': 'c',
-  'ď': 'd',
-  'đ': 'd',
-  'é': 'e',
-  'è': 'e',
-  'ê': 'e',
-  'ë': 'e',
-  'ē': 'e',
-  'ė': 'e',
-  'ę': 'e',
-  'ě': 'e',
-  'ğ': 'g',
-  'í': 'i',
-  'ì': 'i',
-  'î': 'i',
-  'ï': 'i',
-  'ī': 'i',
-  'į': 'i',
-  'ı': 'i',
-  'ł': 'l',
-  'ľ': 'l',
-  'ñ': 'n',
-  'ń': 'n',
-  'ň': 'n',
-  'ó': 'o',
-  'ò': 'o',
-  'ô': 'o',
-  'ö': 'o',
-  'õ': 'o',
-  'ø': 'o',
-  'ō': 'o',
-  'ő': 'o',
-  'ŕ': 'r',
-  'ř': 'r',
-  'š': 's',
-  'ś': 's',
-  'ş': 's',
-  'ș': 's',
-  'ť': 't',
-  'ț': 't',
-  'ú': 'u',
-  'ù': 'u',
-  'û': 'u',
-  'ü': 'u',
-  'ū': 'u',
-  'ů': 'u',
-  'ű': 'u',
-  'ý': 'y',
-  'ÿ': 'y',
-  'ž': 'z',
-  'ź': 'z',
-  'ż': 'z',
-  'ß': 'ss',
-  'œ': 'oe',
-  'æ': 'ae',
-};
-
-/// Lower-cases [input], strips common diacritics, and collapses runs of
-/// whitespace to a single space (trimmed). The result is the canonical form
-/// used both for matching and for stable grouping keys, so "  The   Café " and
-/// "the cafe" fold to the same value.
-String foldText(String input) {
-  final String lower = input.toLowerCase();
-  final StringBuffer out = StringBuffer();
-  bool lastWasSpace = false;
-  for (int i = 0; i < lower.length; i++) {
-    final String ch = lower[i];
-    if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-      if (!lastWasSpace) {
-        out.write(' ');
-        lastWasSpace = true;
-      }
-      continue;
-    }
-    lastWasSpace = false;
-    out.write(_diacritics[ch] ?? ch);
-  }
-  return out.toString().trim();
-}
+/// All comparisons run through [foldText] (in `core/catalog`) so search is
+/// case-insensitive and, where practical, accent-insensitive: typing "beyonce"
+/// finds "Beyoncé" and "amelie" finds "Amélie".
 
 bool _contains(String? field, String foldedQuery) =>
     field != null && field.isNotEmpty && foldText(field).contains(foldedQuery);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -73,15 +73,16 @@ Future<void> main() async {
   // Attaching the session is best-effort: on a platform without the native
   // audio_service setup it returns null and basic playback still works. The
   // handler mirrors the controller and outlives this scope with the container.
-  // Passing the playlist + favourites repositories lets Android Auto browse
-  // Playlists/Favorites (when the user has any) alongside Library/Queue — all
-  // read straight from the persisted stores, so the car tree is answerable even
-  // before any phone screen is opened.
+  // Passing the playlist + favourites + downloads repositories lets Android Auto
+  // browse Playlists/Favorites/Offline (when the user has any) alongside
+  // Songs/Albums/Artists/Queue — all read straight from the persisted stores, so
+  // the car tree is answerable even before any phone screen is opened.
   await connectMediaSession(
     container.read(playbackControllerProvider),
     container.read(musicLibraryRepositoryProvider),
     playlists: container.read(playlistRepositoryProvider),
     favorites: container.read(favoritesRepositoryProvider),
+    downloads: container.read(downloadRepositoryProvider),
   );
 
   // Start smart pre-cache: as playback advances it warms the next queued tracks

--- a/test/core/services/fake_browse_repositories.dart
+++ b/test/core/services/fake_browse_repositories.dart
@@ -1,5 +1,7 @@
+import 'package:linthra/core/models/download_progress.dart';
 import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
 import 'package:linthra/core/repositories/playlist_repository.dart';
 import 'package:linthra/core/repositories/remote_sync_result.dart';
@@ -110,4 +112,38 @@ class FakeFavoritesRepository implements FavoritesRepository {
 
   @override
   Future<void> clearRemote() async {}
+}
+
+/// Minimal [DownloadRepository] for browse-tree tests: reports a fixed set of
+/// downloaded (offline) track ids. Only the read the media browser uses
+/// ([downloadedTrackIds]) is implemented; the download lifecycle surface throws,
+/// so a test that accidentally relied on it would fail loudly.
+class FakeDownloadRepository implements DownloadRepository {
+  FakeDownloadRepository(Set<String> downloadedIds) : _ids = downloadedIds;
+
+  final Set<String> _ids;
+
+  @override
+  Future<List<String>> downloadedTrackIds() async => _ids.toList();
+
+  // Download lifecycle surface — not exercised by the media browser, so it
+  // throws to fail loudly if a test ever depends on it.
+  @override
+  Stream<Map<String, DownloadStatus>> get statusStream =>
+      throw UnimplementedError();
+
+  @override
+  Stream<Map<String, DownloadProgress>> get progressStream =>
+      throw UnimplementedError();
+
+  @override
+  Future<DownloadStatus> statusFor(String trackId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<DownloadRequestOutcome> requestDownload(Track track) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> removeDownload(String trackId) => throw UnimplementedError();
 }

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -8,6 +8,7 @@ import 'package:linthra/core/services/media_browser_tree.dart';
 
 import '../../features/library/fake_music_library_repository.dart';
 import '../../features/player/fake_playback_controller.dart';
+import 'fake_browse_repositories.dart';
 
 Track _track(String id) {
   return Track(
@@ -307,10 +308,19 @@ void main() {
     });
 
     group('media browser', () {
-      test('root lists Library and Queue as browsable categories', () async {
+      test('root lists the library categories and Queue', () async {
         final children = await handler.getChildren(MediaId.root);
 
-        expect(children.map((i) => i.id), [MediaId.library, MediaId.queue]);
+        // No playlists/favorites/downloads wired here, so just the always-on
+        // library categories plus Queue.
+        expect(children.map((i) => i.id), [
+          MediaId.library,
+          MediaId.albums,
+          MediaId.artists,
+          MediaId.queue,
+        ]);
+        expect(children.map((i) => i.title),
+            ['Songs', 'Albums', 'Artists', 'Queue']);
         expect(children.every((i) => i.playable == false), isTrue);
       });
 
@@ -324,6 +334,41 @@ void main() {
         ]);
         expect(children.first.title, 'Song a');
         expect(children.first.playable, isTrue);
+      });
+
+      test('albums are browsable containers; opening one lists playable tracks',
+          () async {
+        final albums = await handler.getChildren(MediaId.albums);
+        // Each _track('x') has album 'Album x', so there is one album per track.
+        expect(albums, hasLength(3));
+        expect(albums.every((i) => i.playable == false), isTrue);
+
+        final tracks = await handler.getChildren(albums.first.id);
+        expect(tracks, isNotEmpty);
+        expect(tracks.every((i) => i.playable == true), isTrue);
+      });
+
+      test('selecting an album track plays the album queue', () async {
+        final albums = await handler.getChildren(MediaId.albums);
+        final albumTracks = await handler.getChildren(albums.first.id);
+
+        await handler.playFromMediaId(albumTracks.first.id);
+        await _settle();
+
+        expect(controller.state.currentTrack, isNotNull);
+        expect(controller.playedTracks, isNotEmpty);
+      });
+
+      test(
+          'artists are browsable containers; opening one lists playable tracks',
+          () async {
+        final artists = await handler.getChildren(MediaId.artists);
+        expect(artists, hasLength(3));
+        expect(artists.every((i) => i.playable == false), isTrue);
+
+        final tracks = await handler.getChildren(artists.first.id);
+        expect(tracks, isNotEmpty);
+        expect(tracks.every((i) => i.playable == true), isTrue);
       });
 
       test('queue reflects the controller current track and up-next', () async {
@@ -365,6 +410,53 @@ void main() {
         await _settle();
 
         expect(controller.playedTracks, isEmpty);
+      });
+    });
+
+    group('offline & favorites browsing', () {
+      late FakePlaybackController offController;
+      late LinthraAudioHandler offHandler;
+
+      setUp(() {
+        offController = FakePlaybackController();
+        offHandler = LinthraAudioHandler(
+          offController,
+          MediaBrowserTree(
+            FakeMusicLibraryRepository(tracks: _library),
+            favorites: FakeFavoritesRepository({'a'}),
+            downloads: FakeDownloadRepository({'b', 'c'}),
+          ),
+        );
+      });
+
+      tearDown(() async {
+        await offHandler.dispose();
+        await offController.dispose();
+      });
+
+      test('root surfaces Favorites and Offline when the user has some',
+          () async {
+        final ids =
+            (await offHandler.getChildren(MediaId.root)).map((i) => i.id);
+        expect(
+            ids,
+            containsAllInOrder(<String>[
+              MediaId.favorites,
+              MediaId.offline,
+            ]));
+      });
+
+      test('offline lists the downloaded tracks; selecting one plays it',
+          () async {
+        final offline = await offHandler.getChildren(MediaId.offline);
+        expect(offline.map((i) => i.title), ['Song b', 'Song c']);
+        expect(offline.every((i) => i.playable == true), isTrue);
+
+        await offHandler.playFromMediaId(offline.first.id);
+        await _settle();
+        expect(offController.state.currentTrack?.id, 'b');
+        // The offline section seeds the queue with the offline list.
+        expect(offController.state.upNext.map((t) => t.id), ['c']);
       });
     });
 
@@ -647,6 +739,34 @@ void main() {
           expect(item.id, isNot(contains('jellyfin:')));
           expect(item.id, isNot(contains('://')));
           expect(item.extras, isNull);
+          final String art = item.artUri?.toString() ?? '';
+          expect(art, isNot(contains('api_key')));
+          expect(art.toLowerCase(), isNot(contains('token')));
+        }
+      });
+
+      test('album containers carry token-free art and no extras', () async {
+        final albController = FakePlaybackController();
+        final albHandler = LinthraAudioHandler(
+          albController,
+          MediaBrowserTree(
+            FakeMusicLibraryRepository(tracks: <Track>[jellyfin, local]),
+          ),
+        );
+        addTearDown(() async {
+          await albHandler.dispose();
+          await albController.dispose();
+        });
+
+        final albums = await albHandler.getChildren(MediaId.albums);
+        expect(albums, isNotEmpty);
+        for (final item in albums) {
+          // Browsable container: not playable, but may carry the album's
+          // token-free cover art for the car row.
+          expect(item.playable, isFalse);
+          expect(item.extras, isNull);
+          expect(item.id, isNot(contains('jellyfin:')));
+          expect(item.id, isNot(contains('://')));
           final String art = item.artUri?.toString() ?? '';
           expect(art, isNot(contains('api_key')));
           expect(art.toLowerCase(), isNot(contains('token')));

--- a/test/core/services/media_browser_tree_test.dart
+++ b/test/core/services/media_browser_tree_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
@@ -7,13 +8,14 @@ import 'package:linthra/core/services/media_browser_tree.dart';
 import '../../features/library/fake_music_library_repository.dart';
 import 'fake_browse_repositories.dart';
 
-Track _track(String id, {String? artist, String? album}) {
+Track _track(String id, {String? artist, String? album, int? trackNumber}) {
   return Track(
     id: id,
     title: 'Song $id',
     uri: '/$id.mp3',
     artistName: artist,
     albumName: album,
+    trackNumber: trackNumber,
   );
 }
 
@@ -43,19 +45,127 @@ void main() {
     MediaBrowserTree treeOf(List<Track> tracks) =>
         MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks));
 
-    group('childrenOf', () {
-      test('root lists Library and Queue as browsable categories', () async {
-        final nodes =
-            await treeOf(library).childrenOf(MediaId.root, PlaybackState.idle);
+    group('root', () {
+      MediaBrowserTree treeWith({
+        List<Track> tracks = const <Track>[],
+        List<Playlist> playlists = const <Playlist>[],
+        Set<String> favorites = const <String>{},
+        Set<String> downloads = const <String>{},
+      }) {
+        return MediaBrowserTree(
+          FakeMusicLibraryRepository(tracks: tracks),
+          playlists: FakePlaylistRepository(playlists),
+          favorites: FakeFavoritesRepository(favorites),
+          downloads: FakeDownloadRepository(downloads),
+        );
+      }
 
-        expect(nodes.map((n) => n.id), [MediaId.library, MediaId.queue]);
-        expect(nodes.map((n) => n.title), ['Library', 'Queue']);
+      test('always offers Songs, Albums, Artists and Queue', () async {
+        // The library categories are always present (they reflect the catalog,
+        // even when it is empty); the user-data categories are not, here.
+        final nodes = await _kids(treeOf(library), MediaId.root);
+
+        expect(nodes.map((n) => n.id), [
+          MediaId.library,
+          MediaId.albums,
+          MediaId.artists,
+          MediaId.queue,
+        ]);
+        expect(
+            nodes.map((n) => n.title), ['Songs', 'Albums', 'Artists', 'Queue']);
         expect(nodes.every((n) => n.playable), isFalse);
       });
 
-      test('library exposes every catalog track as a playable leaf', () async {
-        final nodes = await treeOf(library)
-            .childrenOf(MediaId.library, PlaybackState.idle);
+      test('contains every section, in order, when data exists', () async {
+        final tree = treeWith(
+          tracks: library,
+          playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
+          favorites: {'a'},
+          downloads: {'b'},
+        );
+
+        final nodes = await _kids(tree, MediaId.root);
+
+        expect(nodes.map((n) => n.id), [
+          MediaId.library,
+          MediaId.albums,
+          MediaId.artists,
+          MediaId.playlists,
+          MediaId.favorites,
+          MediaId.offline,
+          MediaId.queue,
+        ]);
+        expect(nodes.map((n) => n.title), [
+          'Songs',
+          'Albums',
+          'Artists',
+          'Playlists',
+          'Favorites',
+          'Offline',
+          'Queue',
+        ]);
+        expect(nodes.every((n) => n.playable), isFalse);
+      });
+
+      test('Playlists appears only when a playlist exists', () async {
+        expect(
+          (await _kids(treeWith(tracks: library), MediaId.root))
+              .map((n) => n.id),
+          isNot(contains(MediaId.playlists)),
+        );
+        final tree = treeWith(
+          tracks: library,
+          playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
+        );
+        expect((await _kids(tree, MediaId.root)).map((n) => n.id),
+            contains(MediaId.playlists));
+      });
+
+      test('Favorites appears only when a favourite exists', () async {
+        expect(
+          (await _kids(treeWith(tracks: library), MediaId.root))
+              .map((n) => n.id),
+          isNot(contains(MediaId.favorites)),
+        );
+        final tree = treeWith(tracks: library, favorites: {'a'});
+        expect((await _kids(tree, MediaId.root)).map((n) => n.id),
+            contains(MediaId.favorites));
+      });
+
+      test('Offline appears only when a download exists', () async {
+        expect(
+          (await _kids(treeWith(tracks: library), MediaId.root))
+              .map((n) => n.id),
+          isNot(contains(MediaId.offline)),
+        );
+        final tree = treeWith(tracks: library, downloads: {'a'});
+        expect((await _kids(tree, MediaId.root)).map((n) => n.id),
+            contains(MediaId.offline));
+      });
+
+      test('browses from cold repositories before any UI', () async {
+        // Depends only on repositories and a PlaybackState snapshot, never on a
+        // widget, so Android Auto can load it the moment the service starts.
+        final tree = treeWith(
+          tracks: library,
+          playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
+          favorites: {'a'},
+          downloads: {'b'},
+        );
+
+        final root = await _kids(tree, MediaId.root);
+        final songs = await _kids(tree, MediaId.library);
+        final albums = await _kids(tree, MediaId.albums);
+
+        expect(root, isNotEmpty);
+        expect(songs, isNotEmpty);
+        expect(albums, isNotEmpty);
+      });
+    });
+
+    group('songs', () {
+      test('exposes every catalog track as a playable leaf', () async {
+        final nodes = await _kids(treeOf(library), MediaId.library);
 
         expect(nodes.map((n) => n.id), [
           MediaId.libraryTrack('a'),
@@ -66,24 +176,167 @@ void main() {
         expect(nodes.first.track, library.first);
       });
 
-      test('library track subtitle joins the present artist/album parts',
-          () async {
-        final nodes = await treeOf(library)
-            .childrenOf(MediaId.library, PlaybackState.idle);
+      test('track subtitle joins the present artist/album parts', () async {
+        final nodes = await _kids(treeOf(library), MediaId.library);
 
         expect(nodes[0].subtitle, 'Artist a • Album a');
         expect(nodes[1].subtitle, 'Artist b');
         expect(nodes[2].subtitle, isNull);
       });
 
-      test('empty library yields no track nodes', () async {
-        final nodes = await treeOf(const <Track>[])
-            .childrenOf(MediaId.library, PlaybackState.idle);
+      test('an empty catalog shows a friendly placeholder', () async {
+        final nodes = await _kids(treeOf(const <Track>[]), MediaId.library);
 
-        expect(nodes, isEmpty);
+        expect(nodes.single.title, 'Sync your library first');
+        expect(nodes.single.playable, isFalse);
+        expect(nodes.single.id, MediaId.empty);
+        // Browsing into the placeholder is a safe dead-stop, not a crash.
+        expect(await _kids(treeOf(const <Track>[]), MediaId.empty), isEmpty);
       });
 
-      test('queue lists the current track followed by up-next', () async {
+      test('a library track resolves to the whole catalog at its index',
+          () async {
+        final request = await _pick(treeOf(library), MediaId.libraryTrack('b'));
+
+        expect(request, isNotNull);
+        expect(request!.tracks, library);
+        expect(request.startIndex, 1);
+      });
+
+      test('a missing library track resolves to null', () async {
+        expect(
+          await _pick(treeOf(library), MediaId.libraryTrack('zzz')),
+          isNull,
+        );
+      });
+    });
+
+    group('albums', () {
+      // Two tracks of one album, deliberately out of track-number order, plus a
+      // standalone track, so album grouping and album ordering are both tested.
+      final catalog = <Track>[
+        _track('t2', album: 'Discovery', artist: 'Daft Punk', trackNumber: 2),
+        _track('t1', album: 'Discovery', artist: 'Daft Punk', trackNumber: 1),
+        _track('s', album: 'Solo', artist: 'Someone'),
+      ];
+
+      test('lists albums as browsable containers, with art and artist subtitle',
+          () async {
+        final albums = groupAlbums(catalog);
+        final nodes = await _kids(treeOf(catalog), MediaId.albums);
+
+        expect(nodes.map((n) => n.id),
+            [for (final a in albums) MediaId.album(a.id)]);
+        expect(nodes.map((n) => n.title), albums.map((a) => a.title));
+        expect(nodes.map((n) => n.subtitle), albums.map((a) => a.artistName));
+        expect(nodes.every((n) => n.playable), isFalse);
+      });
+
+      test('an empty catalog shows a friendly placeholder', () async {
+        final nodes = await _kids(treeOf(const <Track>[]), MediaId.albums);
+
+        expect(nodes.single.title, 'No albums yet');
+        expect(nodes.single.playable, isFalse);
+      });
+
+      test('opening an album lists its tracks in track-number order', () async {
+        final albumId = albumIdForTrack(catalog.first); // Discovery
+        final nodes = await _kids(treeOf(catalog), MediaId.album(albumId));
+
+        // t1 before t2 despite catalog order, by track number.
+        expect(nodes.map((n) => n.title), ['Song t1', 'Song t2']);
+        expect(nodes.map((n) => n.id), [
+          MediaId.albumTrack(albumId, 0),
+          MediaId.albumTrack(albumId, 1),
+        ]);
+        expect(nodes.every((n) => n.playable), isTrue);
+      });
+
+      test('selecting an album track plays the album queue at its index',
+          () async {
+        final albumId = albumIdForTrack(catalog.first);
+        final request =
+            await _pick(treeOf(catalog), MediaId.albumTrack(albumId, 1));
+
+        expect(request, isNotNull);
+        expect(request!.tracks.map((t) => t.id), ['t1', 't2']);
+        expect(request.startIndex, 1);
+      });
+
+      test('an out-of-range or unknown album id is safe', () async {
+        final albumId = albumIdForTrack(catalog.first);
+        expect(await _pick(treeOf(catalog), MediaId.albumTrack(albumId, 9)),
+            isNull);
+        expect(await _pick(treeOf(catalog), MediaId.albumTrack('nope', 0)),
+            isNull);
+        expect(await _kids(treeOf(catalog), MediaId.album('nope')), isEmpty);
+      });
+    });
+
+    group('artists', () {
+      final catalog = <Track>[
+        _track('m1', album: 'Discovery', artist: 'Daft Punk', trackNumber: 1),
+        _track('m2', album: 'Homework', artist: 'Daft Punk', trackNumber: 1),
+        _track('s', album: 'Solo', artist: 'Someone'),
+      ];
+
+      test('lists artists as browsable containers with a summary subtitle',
+          () async {
+        final artists = groupArtists(catalog);
+        final nodes = await _kids(treeOf(catalog), MediaId.artists);
+
+        expect(nodes.map((n) => n.id),
+            [for (final a in artists) MediaId.artist(a.id)]);
+        expect(nodes.map((n) => n.title), artists.map((a) => a.name));
+        expect(nodes.every((n) => n.playable), isFalse);
+        // Daft Punk: 2 albums • 2 songs.
+        final daft = nodes.firstWhere((n) => n.title == 'Daft Punk');
+        expect(daft.subtitle, '2 albums • 2 songs');
+      });
+
+      test('an empty catalog shows a friendly placeholder', () async {
+        final nodes = await _kids(treeOf(const <Track>[]), MediaId.artists);
+
+        expect(nodes.single.title, 'No artists yet');
+        expect(nodes.single.playable, isFalse);
+      });
+
+      test('opening an artist lists their tracks, album by album', () async {
+        final artistId = artistIdForTrack(catalog.first); // Daft Punk
+        final nodes = await _kids(treeOf(catalog), MediaId.artist(artistId));
+
+        // Both Daft Punk tracks, ordered by album (Discovery before Homework).
+        expect(nodes.map((n) => n.title), ['Song m1', 'Song m2']);
+        expect(nodes.map((n) => n.id), [
+          MediaId.artistTrack(artistId, 0),
+          MediaId.artistTrack(artistId, 1),
+        ]);
+        expect(nodes.every((n) => n.playable), isTrue);
+      });
+
+      test('selecting an artist track plays the artist queue at its index',
+          () async {
+        final artistId = artistIdForTrack(catalog.first);
+        final request =
+            await _pick(treeOf(catalog), MediaId.artistTrack(artistId, 1));
+
+        expect(request, isNotNull);
+        expect(request!.tracks.map((t) => t.id), ['m1', 'm2']);
+        expect(request.startIndex, 1);
+      });
+
+      test('an out-of-range or unknown artist id is safe', () async {
+        final artistId = artistIdForTrack(catalog.first);
+        expect(await _pick(treeOf(catalog), MediaId.artistTrack(artistId, 9)),
+            isNull);
+        expect(await _pick(treeOf(catalog), MediaId.artistTrack('nope', 0)),
+            isNull);
+        expect(await _kids(treeOf(catalog), MediaId.artist('nope')), isEmpty);
+      });
+    });
+
+    group('queue', () {
+      test('lists the current track followed by up-next', () async {
         final playback = _playing(library[0], upNext: [library[1], library[2]]);
 
         final nodes = await treeOf(library).childrenOf(MediaId.queue, playback);
@@ -96,37 +349,8 @@ void main() {
         ]);
       });
 
-      test('queue is empty when nothing is playing', () async {
-        final nodes =
-            await treeOf(library).childrenOf(MediaId.queue, PlaybackState.idle);
-
-        expect(nodes, isEmpty);
-      });
-
-      test('an unknown parent id yields an empty list', () async {
-        final nodes =
-            await treeOf(library).childrenOf('nonsense', PlaybackState.idle);
-
-        expect(nodes, isEmpty);
-      });
-    });
-
-    group('resolve', () {
-      test('a library track resolves to the whole catalog at its index',
-          () async {
-        final request = await treeOf(library)
-            .resolve(MediaId.libraryTrack('b'), PlaybackState.idle);
-
-        expect(request, isNotNull);
-        expect(request!.tracks, library);
-        expect(request.startIndex, 1);
-      });
-
-      test('a missing library track resolves to null', () async {
-        final request = await treeOf(library)
-            .resolve(MediaId.libraryTrack('zzz'), PlaybackState.idle);
-
-        expect(request, isNull);
+      test('is empty when nothing is playing', () async {
+        expect(await _kids(treeOf(library), MediaId.queue), isEmpty);
       });
 
       test('a queue item resolves to the live queue at its index', () async {
@@ -140,103 +364,24 @@ void main() {
         expect(request.startIndex, 2);
       });
 
-      test('an out-of-range queue index resolves to null', () async {
-        final playback = _playing(library[0]);
-
-        final request =
-            await treeOf(library).resolve(MediaId.queueItem(5), playback);
-
-        expect(request, isNull);
-      });
-
-      test('a non-numeric queue id resolves to null', () async {
-        final request = await treeOf(library)
-            .resolve('queue/not-a-number', PlaybackState.idle);
-
-        expect(request, isNull);
-      });
-
-      test('a category id is not playable', () async {
+      test('an out-of-range / non-numeric queue id resolves to null', () async {
         expect(
-          await treeOf(library).resolve(MediaId.library, PlaybackState.idle),
+          await treeOf(library)
+              .resolve(MediaId.queueItem(5), _playing(library[0])),
           isNull,
         );
         expect(
-          await treeOf(library).resolve(MediaId.root, PlaybackState.idle),
+          await treeOf(library)
+              .resolve('queue/not-a-number', PlaybackState.idle),
           isNull,
         );
       });
-    });
 
-    group('root categories', () {
-      MediaBrowserTree treeWith({
-        List<Playlist> playlists = const <Playlist>[],
-        Set<String> favorites = const <String>{},
-      }) {
-        return MediaBrowserTree(
-          FakeMusicLibraryRepository(tracks: library),
-          playlists: FakePlaylistRepository(playlists),
-          favorites: FakeFavoritesRepository(favorites),
-        );
-      }
-
-      test('only Library and Queue without playlist/favorites', () async {
-        final nodes = await _kids(treeOf(library), MediaId.root);
-
-        expect(nodes.map((n) => n.id), [MediaId.library, MediaId.queue]);
-      });
-
-      test('Playlists node appears only when a playlist exists', () async {
-        final without = await _kids(treeWith(), MediaId.root);
-        expect(without.map((n) => n.id), isNot(contains(MediaId.playlists)));
-
-        final tree = treeWith(
-          playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
-        );
-        final nodes = await _kids(tree, MediaId.root);
-        expect(nodes.map((n) => n.id), contains(MediaId.playlists));
-      });
-
-      test('Favorites node appears only when a favourite exists', () async {
-        final without = await _kids(treeWith(), MediaId.root);
-        expect(without.map((n) => n.id), isNot(contains(MediaId.favorites)));
-
-        final tree = treeWith(favorites: {'a'});
-        final nodes = await _kids(tree, MediaId.root);
-        expect(nodes.map((n) => n.id), contains(MediaId.favorites));
-      });
-
-      test('all four categories show when both exist', () async {
-        final tree = treeWith(
-          playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
-          favorites: {'a'},
-        );
-
-        final nodes = await _kids(tree, MediaId.root);
-
-        expect(nodes.map((n) => n.id), [
-          MediaId.library,
-          MediaId.queue,
-          MediaId.playlists,
-          MediaId.favorites,
-        ]);
-        expect(nodes.every((n) => n.playable), isFalse);
-      });
-
-      test('browses from cold repositories before any UI', () async {
-        // Depends only on repositories and a PlaybackState snapshot, never on a
-        // widget, so Android Auto can load it the moment the service starts.
-        final tree = treeWith(
-          playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
-          favorites: {'a'},
-        );
-
-        final root = await _kids(tree, MediaId.root);
-        final lib = await _kids(tree, MediaId.library);
-
-        expect(root, isNotEmpty);
-        expect(root.map((n) => n.id), contains(MediaId.library));
-        expect(lib, isNotEmpty);
+      test('an unknown parent id and a category are safe', () async {
+        expect(await _kids(treeOf(library), 'nonsense'), isEmpty);
+        expect(await _pick(treeOf(library), MediaId.library), isNull);
+        expect(await _pick(treeOf(library), MediaId.root), isNull);
+        expect(await _pick(treeOf(library), MediaId.albums), isNull);
       });
     });
 
@@ -254,7 +399,7 @@ void main() {
         );
       }
 
-      test('lists each playlist as a browsable category', () async {
+      test('lists each playlist as a browsable container', () async {
         final nodes = await _kids(buildTree(), MediaId.playlists);
 
         expect(nodes.map((n) => n.id), [
@@ -262,11 +407,17 @@ void main() {
           MediaId.playlist('p2'),
         ]);
         expect(nodes.map((n) => n.title), ['Roadtrip', 'Empty']);
-        // The subtitle is the playlist's declared track count (3 for p1,
-        // including 'x'); opening it then lists only the 2 catalog-resolved
-        // tracks — see the next test.
         expect(nodes.map((n) => n.subtitle), ['3 tracks', '0 tracks']);
         expect(nodes.every((n) => n.playable), isFalse);
+      });
+
+      test('no playlists shows a friendly placeholder', () async {
+        final tree = MediaBrowserTree(
+          FakeMusicLibraryRepository(tracks: library),
+          playlists: FakePlaylistRepository(const <Playlist>[]),
+        );
+        expect((await _kids(tree, MediaId.playlists)).single.title,
+            'No playlists yet');
       });
 
       test('opening a playlist lists its tracks in order', () async {
@@ -282,30 +433,23 @@ void main() {
       });
 
       test('an empty playlist yields no track nodes', () async {
-        final nodes = await _kids(buildTree(), MediaId.playlist('p2'));
-
-        expect(nodes, isEmpty);
+        expect(await _kids(buildTree(), MediaId.playlist('p2')), isEmpty);
       });
 
       test('a playlist track resolves to the playlist at its index', () async {
-        final id = MediaId.playlistTrack('p1', 1);
-        final request = await _pick(buildTree(), id);
+        final request =
+            await _pick(buildTree(), MediaId.playlistTrack('p1', 1));
 
         expect(request, isNotNull);
         expect(request!.tracks.map((t) => t.id), ['c', 'a']);
         expect(request.startIndex, 1);
       });
 
-      test('an out-of-range playlist index resolves to null', () async {
-        final id = MediaId.playlistTrack('p1', 9);
-        final request = await _pick(buildTree(), id);
-
-        expect(request, isNull);
-      });
-
-      test('an unknown playlist id is safe', () async {
-        final id = MediaId.playlistTrack('nope', 0);
-        expect(await _pick(buildTree(), id), isNull);
+      test('an out-of-range / unknown playlist id is safe', () async {
+        expect(
+            await _pick(buildTree(), MediaId.playlistTrack('p1', 9)), isNull);
+        expect(
+            await _pick(buildTree(), MediaId.playlistTrack('nope', 0)), isNull);
         expect(await _kids(buildTree(), MediaId.playlist('nope')), isEmpty);
       });
     });
@@ -313,10 +457,10 @@ void main() {
     group('favorites', () {
       // Catalog order is a, b, c; favouriting a and c (plus a stale 'x' not in
       // the catalog) must list/resolve as [a, c] in catalog order.
-      MediaBrowserTree buildTree() {
+      MediaBrowserTree buildTree([Set<String> ids = const {'a', 'c', 'x'}]) {
         return MediaBrowserTree(
           FakeMusicLibraryRepository(tracks: library),
-          favorites: FakeFavoritesRepository({'a', 'c', 'x'}),
+          favorites: FakeFavoritesRepository(ids),
         );
       }
 
@@ -331,6 +475,14 @@ void main() {
         expect(nodes.every((n) => n.playable), isTrue);
       });
 
+      test('no favourites shows a friendly placeholder', () async {
+        expect(
+            (await _kids(buildTree(const <String>{}), MediaId.favorites))
+                .single
+                .title,
+            'No favorites yet');
+      });
+
       test('a favourite resolves to the favourites at its index', () async {
         final request = await _pick(buildTree(), MediaId.favoriteItem(1));
 
@@ -340,9 +492,75 @@ void main() {
       });
 
       test('an out-of-range favourite index resolves to null', () async {
-        final request = await _pick(buildTree(), MediaId.favoriteItem(9));
+        expect(await _pick(buildTree(), MediaId.favoriteItem(9)), isNull);
+      });
+    });
 
-        expect(request, isNull);
+    group('offline', () {
+      // Downloaded ids b and c (plus a stale 'x' not in the catalog) list and
+      // resolve as [b, c] in catalog order, exactly like favourites.
+      MediaBrowserTree buildTree([Set<String> ids = const {'b', 'c', 'x'}]) {
+        return MediaBrowserTree(
+          FakeMusicLibraryRepository(tracks: library),
+          downloads: FakeDownloadRepository(ids),
+        );
+      }
+
+      test('lists downloaded tracks in stable catalog order', () async {
+        final nodes = await _kids(buildTree(), MediaId.offline);
+
+        expect(nodes.map((n) => n.title), ['Song b', 'Song c']);
+        expect(nodes.map((n) => n.id), [
+          MediaId.offlineItem(0),
+          MediaId.offlineItem(1),
+        ]);
+        expect(nodes.every((n) => n.playable), isTrue);
+      });
+
+      test('no downloads shows a friendly placeholder', () async {
+        expect(
+            (await _kids(buildTree(const <String>{}), MediaId.offline))
+                .single
+                .title,
+            'No offline tracks yet');
+      });
+
+      test('a downloaded track resolves to the offline list at its index',
+          () async {
+        final request = await _pick(buildTree(), MediaId.offlineItem(1));
+
+        expect(request, isNotNull);
+        expect(request!.tracks.map((t) => t.id), ['b', 'c']);
+        expect(request.startIndex, 1);
+      });
+
+      test('an out-of-range offline index resolves to null', () async {
+        expect(await _pick(buildTree(), MediaId.offlineItem(9)), isNull);
+      });
+    });
+
+    group('large catalogs are browsed from the local repository only', () {
+      // A repo that records how many times the catalog was read, so we can show
+      // browsing never reaches past it to a remote server (the tree has no
+      // source/server seam at all — only this local repository).
+      test('browsing a large catalog reads only the synced catalog', () async {
+        final big = <Track>[
+          for (int i = 0; i < 600; i++)
+            _track('t$i',
+                artist: 'Artist ${i % 50}', album: 'Album ${i % 100}'),
+        ];
+        final repo = _CountingLibraryRepository(big);
+        final tree = MediaBrowserTree(repo);
+
+        final songs = await _kids(tree, MediaId.library);
+        final albums = await _kids(tree, MediaId.albums);
+        final artists = await _kids(tree, MediaId.artists);
+
+        expect(songs, hasLength(600));
+        expect(albums, hasLength(groupAlbums(big).length));
+        expect(artists, hasLength(groupArtists(big).length));
+        // Each browse is one bounded catalog read — no per-track or remote fan-out.
+        expect(repo.getAllTracksCalls, 3);
       });
     });
 
@@ -352,6 +570,7 @@ void main() {
         title: 'Remote Song',
         uri: 'jellyfin:jf-guid-123',
         artistName: 'Remote Artist',
+        albumName: 'Remote Album',
         artworkUri: Uri.parse(
           'https://music.example.com/Items/jf-guid-123/Images/Primary',
         ),
@@ -362,28 +581,61 @@ void main() {
         uri: '/storage/music/local.mp3',
       );
 
-      test('local and Jellyfin both map to token-free leaves', () async {
+      void expectSafeId(String id) {
+        expect(id, isNot(contains('api_key')));
+        expect(id.toLowerCase(), isNot(contains('token')));
+        expect(id, isNot(contains('jellyfin:')));
+        expect(id, isNot(contains('://')));
+        expect(id, isNot(contains('/storage/')));
+      }
+
+      test('songs, albums and artists all map to token-free ids and art',
+          () async {
         final tree = MediaBrowserTree(
           FakeMusicLibraryRepository(tracks: <Track>[jellyfin, localTrack]),
         );
-        final nodes = await _kids(tree, MediaId.library);
 
-        expect(nodes.map((n) => n.id), [
-          MediaId.libraryTrack('jf-guid-123'),
-          MediaId.libraryTrack('local-1'),
-        ]);
-        expect(nodes.every((n) => n.id.isNotEmpty), isTrue);
-        expect(nodes.every((n) => n.title.isNotEmpty), isTrue);
-        expect(nodes.every((n) => n.playable), isTrue);
-
-        // No id leaks a token, an auth query, a URI scheme, or a stream URL.
-        for (final node in nodes) {
-          expect(node.id, isNot(contains('api_key')));
-          expect(node.id, isNot(contains('token')));
-          expect(node.id, isNot(contains('jellyfin:')));
-          expect(node.id, isNot(contains('://')));
+        for (final parent in <String>[
+          MediaId.library,
+          MediaId.albums,
+          MediaId.artists,
+        ]) {
+          for (final node in await _kids(tree, parent)) {
+            expectSafeId(node.id);
+            expect(node.title.isNotEmpty, isTrue);
+            // Container artwork (when present) is the token-free image endpoint,
+            // never a credentialed/stream URL or a local path.
+            final String art = node.artworkUri?.toString() ?? '';
+            expect(art, isNot(contains('api_key')));
+            expect(art.toLowerCase(), isNot(contains('token')));
+            expect(art, isNot(contains('/storage/')));
+          }
         }
+      });
+
+      test('album and artist container ids carry no path, token or scheme', () {
+        final albumId = albumIdForTrack(jellyfin);
+        final artistId = artistIdForTrack(jellyfin);
+
+        expectSafeId(MediaId.album(albumId));
+        expectSafeId(MediaId.artist(artistId));
+        expectSafeId(MediaId.albumTrack(albumId, 0));
+        expectSafeId(MediaId.artistTrack(artistId, 0));
       });
     });
   });
+}
+
+/// A [FakeMusicLibraryRepository] that counts catalog reads, so a test can show
+/// browse stays a bounded local read and never fans out to a remote server.
+class _CountingLibraryRepository extends FakeMusicLibraryRepository {
+  _CountingLibraryRepository(List<Track> tracks) : super(tracks: tracks);
+
+  int getAllTracksCalls = 0;
+
+  @override
+  Future<List<Track>> getAllTracks() {
+    getAllTracksCalls++;
+    return super.getAllTracks();
+  }
 }

--- a/test/features/library/library_grouping_test.dart
+++ b/test/features/library/library_grouping_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/track.dart';
-import 'package:linthra/features/library/library_grouping.dart';
 
 /// A track shaped like the Jellyfin mapper's output: an opaque `jellyfin:<id>`
 /// uri (never a stream URL) and a token-free primary-image artwork URL.

--- a/test/features/library/library_search_test.dart
+++ b/test/features/library/library_search_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/text_folding.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/track.dart';


### PR DESCRIPTION
## Summary

Makes Android Auto browse like a real music app. The car root used to be just
**Library** + **Queue**; it now exposes the main library areas:

```
root
├── Songs      → every catalog track (flat)
├── Albums     → albums (browsable) → album tracks (track-number order)
├── Artists    → artists (browsable) → that artist's tracks, album by album
├── Playlists  → your playlists (shown when you have some) → playlist tracks
├── Favorites  → your liked tracks (shown when you have some)
├── Offline    → your downloaded tracks (shown when you have some)
└── Queue      → current track + up-next
```

Selecting a track plays it and queues the rest of **the list it was opened from**
(album / artist / playlist / favorites / offline / songs), exactly like tapping a
track in that screen on the phone.

No UI redesign, no logo/theme/release/F-Droid changes, no audio-controls/equalizer
work, no playback-engine changes.

## Browse sections added

- **Songs** (was "Library") — flat catalog list.
- **Albums** — browsable containers; open one to see its tracks in track-number
  order, with album cover art on the row.
- **Artists** — browsable containers (subtitle "N albums • M songs"); open one to
  see that artist's tracks, album by album.
- **Offline** — user-downloaded tracks (catalog order).
- Playlists / Favorites / Queue retained.

## Data sources

- **Albums/Artists** are *derived* from the track catalog (Linthra stores no
  album/artist ids), via the **same** grouping the in-app Library tabs use. To
  share that grouping with the core browse tree without the tree reaching up into
  the library feature, the pure grouping + text-folding helpers moved to
  `lib/core/catalog/library_grouping.dart` and `lib/core/catalog/text_folding.dart`
  (the Library UI now imports them from there). One source of truth → the car and
  the phone never disagree.
- **Offline** reads `DownloadRepository.downloadedTrackIds()`, which reports only
  **user-initiated downloads** — smart pre-cached tracks are deliberately not
  marked downloaded, so they never leak into this section (it mirrors the in-app
  Downloads screen exactly).
- Everything reads the **local synced catalog/repositories** — never a remote
  server, and no stream URL is minted during browsing.

## Queue behavior

- Consistent with the queue mirroring from #108: `getChildren`/`playFromMediaId`
  still route through the single `PlaybackController`, so the session queue,
  Up Next, and `skipToQueueItem` are unchanged.
- Selecting an album/artist/playlist/favorite/offline track seeds the queue with
  that list at the picked index (the rest becomes up-next).

## Privacy / token safety

- All media ids stay **opaque and token-free**: `library/<trackId>`,
  `album/<albumId>`, `artist/<artistId>`, `…/<index>`, where `<albumId>`/
  `<artistId>` are URL-safe base64url grouping ids (or `unknown-album`/
  `unknown-artist` sentinels) — never a name, path, token, or stream URL.
- Container cover art is the **token-free** `Track.artworkUri` (public image
  endpoint or null) — the same source the now-playing card already uses.
- Diagnostics log only the **category** of an id (`album`, `artist`, `offline`, …)
  and counts — never a raw id, title, URI, or token.
- Tests assert ids/extras/artwork carry no `api_key`, `token`, `jellyfin:`, `://`,
  or `/storage/` path.

## Performance

- Browsing is **local-only** — the tree has no source/server seam; a regression
  test counts catalog reads to prove a large library browses with bounded reads
  and no remote fan-out.
- Empty states are friendly placeholders ("Sync your library first", "No albums
  yet", "No offline tracks yet") instead of a blank car screen.
- Not paged yet (documented follow-up): a very large catalog is grouped in memory
  per browse.

## Tests added/updated

- Rewrote `media_browser_tree_test.dart`: root composition + ordering, empty-state
  placeholders, Albums/Artists browsable containers + track ordering + queue
  context, Offline section, "large catalog browses from the local repository only"
  (read-count assertion), and token/path-free media ids incl. container art.
- Extended `linthra_audio_handler_test.dart`: new root, album/artist container
  browse + selection, Offline browse + play (queue context), album-container art
  is token-free with no extras. Existing queue (#108), foreground-service, and
  cast-safe tests unchanged and passing.
- Added `FakeDownloadRepository`; repointed grouping/search tests at
  `lib/core/catalog/`.

## Verification

- `dart format --set-exit-if-changed .` — clean
- `flutter analyze` — No issues found
- `flutter test` — **1214 passed**
- `flutter build apk --debug` — **not run** (no Android SDK in this environment)

## Known limitations / follow-ups

- **Search from Android Auto** is not implemented (planned follow-up; browse
  leaves already have resolvable ids, so it slots in cleanly).
- **No folder grouping** and **no Recently-added / smart-mixes** rows yet
  (deliberate, to keep this change focused and the car tree simple).
- **Artists open a flat track list** (album by album), not album sub-folders.
- **Large libraries are not paged** (local-only, but builds a long list).

## Manual car checklist

1. Connect phone to Android Auto (or DHU); open Linthra.
2. Browse **Songs** → play a track (rest becomes up-next).
3. Browse **Albums** → open an album → play a track (album queue, track order).
4. Browse **Artists** → open an artist → play a track (artist queue).
5. Browse **Playlists** → open a playlist → play a track.
6. Browse **Favorites** → play a track.
7. Browse **Offline** → play a downloaded track (ideally with the phone offline).
8. Use **Next/Previous**; tap an **Up Next** row.
9. **Lock the screen** → confirm playback continues; reopen → correct current
   track, no duplicate playback.
10. With **Cast** active, select a track → no duplicate local audio.
11. Confirm **no private server URL/token/path** appears on the car screen, and
    `adb logcat | grep Linthra.AndroidAuto` shows only categories + counts.

https://claude.ai/code/session_01BeCad5KZFdKevq7o1LX6C7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeCad5KZFdKevq7o1LX6C7)_