### PR TITLE
docs(fdroid): retarget the F-Droid prep at v0.1.0-alpha.29

### DIFF
--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -126,7 +126,7 @@ process (and the GitHub-Release flow) is in
    `pubspec.yaml` version (versionCode **15** for every tag). The draft recipe
    therefore derives the version from the checked-out tag with
    `tool/version_from_tag.dart` and passes `--build-name`/`--build-number`, so
-   `v0.1.0-alpha.25` builds to `0.1.0-alpha.25` / **100025** — matching the
+   `v0.1.0-alpha.29` builds to `0.1.0-alpha.29` / **100029** — matching the
    metadata and the GitHub channel, and AutoUpdate-safe for future tags. See
    [fdroid-submission.md §2](./fdroid-submission.md).
 2. **`versionCode` increases monotonically** by construction (the encoding can
@@ -165,8 +165,8 @@ These must be resolved before an actual F-Droid submission (see also
 **Resolved:** the store icon, feature graphic, and eight real phone screenshots
 are committed (the core set tracked by issue #77; see
 [docs/listing-assets.md §6](./listing-assets.md)); a `v*` tag now exists (target
-`v0.1.0-alpha.25`; the broken `v0.1.0-alpha.24` is excluded); the versionCode
-scheme is decided (tag-derived `100025`, §5.1); and the full transitive
+`v0.1.0-alpha.29`; the broken `v0.1.0-alpha.24` is excluded); the versionCode
+scheme is decided (tag-derived `100029`, §5.1); and the full transitive
 dependency audit is complete
 ([dependency-license-audit.md](./dependency-license-audit.md)).
 
@@ -174,8 +174,8 @@ dependency audit is complete
 
 A complete, current draft recipe now lives in the repo at
 [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml),
-pinned to the latest working alpha (`commit: v0.1.0-alpha.25`, versionName
-`0.1.0-alpha.25`, versionCode `100025`). That file is the canonical draft; edit
+pinned to the latest working alpha (`commit: v0.1.0-alpha.29`, versionName
+`0.1.0-alpha.29`, versionCode `100029`). That file is the canonical draft; edit
 it there rather than duplicating a snippet here.
 
 > **Still a draft — not submitted.** The exact Flutter-on-F-Droid build

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -17,18 +17,18 @@ availability.
   isn't production-stable, and the rough edges are documented.
 - **Distribution:** GitHub Releases only, as a sideloaded APK (Obtainium works
   too). No F-Droid metadata has been submitted, and Linthra isn't on F-Droid.
-- **Tagged releases now exist:** `v0.1.0-alpha.1` … `v0.1.0-alpha.25`, each built
+- **Tagged releases now exist:** `v0.1.0-alpha.1` … `v0.1.0-alpha.29`, each built
   by `.github/workflows/android-release-build.yml`. The F-Droid target is the
-  latest one that launches, `v0.1.0-alpha.25` (versionName `0.1.0-alpha.25`,
-  tag-derived versionCode `100025`). Skip `v0.1.0-alpha.24`: its GitHub Release
-  is marked "Broken release — do not install … startup regression", and alpha.25
-  is the hotfix that reverts it.
+  latest one that launches, `v0.1.0-alpha.29` (versionName `0.1.0-alpha.29`,
+  tag-derived versionCode `100029`). Skip `v0.1.0-alpha.24`: its GitHub Release
+  is marked "Broken release — do not install … startup regression"; alpha.25 was
+  the hotfix that reverted it, and the target has since moved on to alpha.29.
 - **Groundwork in place:** a stable application ID, the MPL-2.0 license, a real
   app/launcher icon, Fastlane-style store metadata under
   `fastlane/metadata/android/en-US/` (text plus the real icon, feature graphic,
   and eight real phone screenshots), a finished dependency/license audit, the
   draft recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
-  (pinned to `v0.1.0-alpha.25`), and the submission package at
+  (pinned to `v0.1.0-alpha.29`), and the submission package at
   [`docs/fdroid-submission.md`](./fdroid-submission.md).
 - **Not submitted yet.** See [Remaining blockers](#8-remaining-blockers-before-submission).
 
@@ -223,7 +223,7 @@ including the GitHub-Release flow — is in
 > tag as versionCode 15 — which F-Droid can't tell apart. The draft recipe avoids
 > that by deriving the version from the checked-out tag with
 > `tool/version_from_tag.dart` and passing `--build-name`/`--build-number`, so
-> `v0.1.0-alpha.25` builds to `0.1.0-alpha.25` / `100025` — the same value the
+> `v0.1.0-alpha.29` builds to `0.1.0-alpha.29` / `100029` — the same value the
 > GitHub release build uses, distinct and increasing per tag, and still correct
 > under `AutoUpdateMode` for future tags. (Bumping `pubspec.yaml` at each tagged
 > commit would also work and is cleaner long-term, but it changes the release
@@ -241,9 +241,13 @@ Stored under `fastlane/metadata/android/en-US/`:
   Description.
 - [x] `changelogs/1.txt`, `9.txt`, `15.txt` — legacy per-version notes (named by
   the old hand-numbered `versionCode`); kept as-is.
-- [x] `changelogs/100025.txt` — notes for the F-Droid target `v0.1.0-alpha.25`,
-  named by the **derived** versionCode `100025` (the convention going forward —
-  see [release-process.md §1](./release-process.md#1-versioning-model)). Keep new
+- [x] `changelogs/100025.txt` — notes for the earlier alpha.25 target, named by
+  its derived versionCode `100025`; kept as history now that the target has moved
+  on to alpha.29.
+- [x] `changelogs/100029.txt` — notes for the current F-Droid target
+  `v0.1.0-alpha.29`, named by the **derived** versionCode `100029` (the
+  convention going forward — see
+  [release-process.md §1](./release-process.md#1-versioning-model)). Keep new
   changelog filenames in lockstep with the built APK's derived `versionCode`.
 - [x] `images/icon.png` — 512×512 real Linthra store icon. The launcher icons
   under `android/app/src/main/res/mipmap-*` are now the same real mark (adaptive
@@ -298,11 +302,11 @@ What each one shows, plus the privacy review and the still-optional extras, is i
   [docs/listing-assets.md §6](./listing-assets.md). Optional extras
   (Downloads-with-tracks, Android Auto, Cast, tablet) remain nice-to-haves, not
   blockers.
-- **A tagged release now exists.** `v0.1.0-alpha.25` is the latest **working**
+- **A tagged release now exists.** `v0.1.0-alpha.29` is the latest **working**
   alpha and is the recipe's `commit:`. The withdrawn, broken `v0.1.0-alpha.24` is
   explicitly **not** targeted.
 - **versionCode reconciliation decided.** The recipe derives the version from the
-  tag (→ `0.1.0-alpha.25` / `100025`), matching the GitHub channel and staying
+  tag (→ `0.1.0-alpha.29` / `100029`), matching the GitHub channel and staying
   monotonic/AutoUpdate-safe (§6).
 - **Fastlane description refreshed** to match the current alpha, with the
   "unofficial / not affiliated" framing (§7).
@@ -319,8 +323,8 @@ The full step-by-step submission flow and the ready-to-adapt MR text live in
    [audit doc](./dependency-license-audit.md)). Re-run on any dependency change.
 2. ✅ **Fastlane `full_description.txt` refreshed** to match the current alpha,
    with the "unofficial / not affiliated" framing (§7).
-3. ✅ **Target tag + versionCode decided** — `v0.1.0-alpha.25` / `100025`, with a
-   matching `changelogs/100025.txt`; the recipe derives the version from the tag
+3. ✅ **Target tag + versionCode decided** — `v0.1.0-alpha.29` / `100029`, with a
+   matching `changelogs/100029.txt`; the recipe derives the version from the tag
    (§6). The broken `v0.1.0-alpha.24` is excluded.
 4. ✅ **Screenshots committed** — eight real phone screenshots under
    `images/phoneScreenshots/` (§7; see [docs/listing-assets.md §6](./listing-assets.md);
@@ -374,7 +378,7 @@ readiness pass with the pinned toolchain (Flutter 3.27.4 / Dart 3.6.2); they are
 
 | Check | Result |
 | ----- | ------ |
-| Metadata YAML parses (PyYAML) | ✅ this pass — valid YAML; fields/types as expected (Summary 57 ≤ 80 chars; versionCode integer `100025`). Not a full `fdroid lint`. |
+| Metadata YAML parses (PyYAML) | ✅ this pass — valid YAML; fields/types as expected (Summary 57 ≤ 80 chars; versionCode integer `100029`). Not a full `fdroid lint`. |
 | `dart format` / `flutter analyze` / `flutter test` | ✅ green in CI (`ci.yml`) on every PR. Not re-run in this pass (no toolchain). |
 | transitive license audit | ✅ all permissive, no GMS (§4). |
 | `flutter build apk --debug` | ✅ built by CI per PR (`android-debug-apk.yml`). |

--- a/docs/fdroid-submission.md
+++ b/docs/fdroid-submission.md
@@ -31,22 +31,23 @@ tagging), and the draft recipe at
 ## 2. Target version: the latest working alpha
 
 F-Droid builds from a git tag, and Linthra now has tags (`v0.1.0-alpha.1` …
-`v0.1.0-alpha.25`, built by the Android Release Build workflow). The submission
+`v0.1.0-alpha.29`, built by the Android Release Build workflow). The submission
 targets the latest one that launches cleanly:
 
 | Item            | Value                                   |
 | --------------- | --------------------------------------- |
-| Target tag      | `v0.1.0-alpha.25` (commit `c9c1fb3`)     |
-| versionName     | `0.1.0-alpha.25`                        |
-| versionCode     | `100025`                                |
-| Changelog file  | `fastlane/metadata/android/en-US/changelogs/100025.txt` |
+| Target tag      | `v0.1.0-alpha.29` (commit `ab0006b`)     |
+| versionName     | `0.1.0-alpha.29`                        |
+| versionCode     | `100029`                                |
+| Changelog file  | `fastlane/metadata/android/en-US/changelogs/100029.txt` |
 
 One thing to be careful about: don't target `v0.1.0-alpha.24`. Its GitHub
-Release is marked "Broken release — do not install … startup regression."
-alpha.25 is the hotfix that reverts it, so the recipe's `commit:` and the
-`CurrentVersion`/`CurrentVersionCode` all point at alpha.25.
+Release is marked "Broken release — do not install … startup regression," and
+alpha.25 was the hotfix that reverted it. The target here is the latest working
+alpha, `v0.1.0-alpha.29`, so the recipe's `commit:` and the
+`CurrentVersion`/`CurrentVersionCode` all point at alpha.29.
 
-### Why versionCode `100025` and not `15`
+### Why versionCode `100029` and not `15`
 
 `pubspec.yaml` keeps a fixed dev version, `0.1.0-alpha.15+15`, that's the same at
 every tagged commit (the release workflow overrides it per release, so it never
@@ -58,15 +59,15 @@ gets bumped). That has two consequences:
   detail.
 - The upstream GitHub release build avoids that by deriving the version from the
   tag with `tool/version_from_tag.dart` (the single source of truth):
-  `v0.1.0-alpha.25` → `0.1.0-alpha.25` / `100025`.
+  `v0.1.0-alpha.29` → `0.1.0-alpha.29` / `100029`.
 
 So the F-Droid recipe does the same thing — it derives the version from the
 checked-out tag and passes `--build-name`/`--build-number`. The APK then reports
-`0.1.0-alpha.25` / `100025`, matching the metadata and the GitHub build. That
+`0.1.0-alpha.29` / `100029`, matching the metadata and the GitHub build. That
 keeps each tag's versionCode distinct and increasing, keeps the F-Droid and
 GitHub codes identical for the same tag, and stays correct under `AutoUpdateMode`
 for future tags (since the version isn't hard-coded). The changelog file is
-named by that derived code (`100025.txt`), in line with
+named by that derived code (`100029.txt`), in line with
 [release-process.md §1](./release-process.md#1-versioning-model) (the older
 `1.txt`/`9.txt`/`15.txt` stay as they are).
 
@@ -105,7 +106,7 @@ A few things still need checking against fdroiddata before submitting:
    pinned version, which is normal for Flutter on F-Droid and stays pinned and
    reproducible.
 2. The `git describe --tags --exact-match HEAD` the build uses to find the tag —
-   confirm F-Droid's checkout of `commit: v0.1.0-alpha.25` leaves the tag
+   confirm F-Droid's checkout of `commit: v0.1.0-alpha.29` leaves the tag
    resolvable (it should, since F-Droid checks out the tag ref).
 3. The output path. `build/app/outputs/flutter-apk/app-release.apk` is the
    single-APK output; adjust `output:` if you'd rather split per ABI.
@@ -172,13 +173,13 @@ submitting.
 
 | Check | Status |
 | ----- | ------ |
-| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (Summary 57 chars, versionCode an integer, `100025`). This only checks the YAML, not F-Droid's schema (see below). |
+| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (Summary 57 chars, versionCode an integer, `100029`). This only checks the YAML, not F-Droid's schema (see below). |
 | `flutter pub get` | Not run here (no toolchain). Run locally / in CI. |
 | `dart format --set-exit-if-changed .` | Not run here. CI (`ci.yml`) runs it on every PR. |
 | `flutter analyze` | Not run here. CI runs it on every PR. |
 | `flutter test` | Not run here. CI runs it on every PR. |
 | `flutter build apk --debug` | Not run here (no Android SDK). CI (`android-debug-apk.yml`) builds it on every PR. |
-| `flutter build apk --release` | Not run here. The tag build (`android-release-build.yml`) produced the alpha.25 APK; re-confirm a clean from-source release build on a machine with the SDK. |
+| `flutter build apk --release` | Not run here. The tag build (`android-release-build.yml`) produced the alpha.29 APK; re-confirm a clean from-source release build on a machine with the SDK. |
 | `fdroid lint` / `fdroid build -l io.github.thezupzup.linthra` | Not run here (no fdroidserver). Run inside an fdroiddata checkout (§8). |
 
 A note on that first row: a YAML parse isn't the same as F-Droid validation. The
@@ -194,7 +195,7 @@ dart format --set-exit-if-changed .
 flutter analyze
 flutter test
 flutter build apk --release \
-  --build-name=0.1.0-alpha.25 --build-number=100025   # what the recipe derives
+  --build-name=0.1.0-alpha.29 --build-number=100029   # what the recipe derives
 
 # In an fdroiddata checkout, once metadata/io.github.thezupzup.linthra.yml is in:
 fdroid readmeta
@@ -254,12 +255,12 @@ Why I think it's a good fit for F-Droid:
 
 Source and issues: https://github.com/thezupzup/linthra (issues at `/issues`).
 
-**Build target:** tag `v0.1.0-alpha.25`, versionName `0.1.0-alpha.25`,
-versionCode `100025`. The build derives the version from the tag (using the
+**Build target:** tag `v0.1.0-alpha.29`, versionName `0.1.0-alpha.29`,
+versionCode `100029`. The build derives the version from the tag (using the
 project's `tool/version_from_tag.dart`), so the versionCode is distinct and
 increasing per release and matches the upstream GitHub-release APK. (For context:
-`v0.1.0-alpha.24` was a broken release that's been withdrawn; alpha.25 is the
-hotfix.)
+`v0.1.0-alpha.24` was a broken release that was withdrawn; alpha.25 was the
+hotfix, and alpha.29 is the current working build.)
 
 **On status — being honest about scope:** this is early-alpha, pre-release
 software. It's usable for testing on a real device, but it isn't
@@ -297,8 +298,9 @@ Tracks the actual submission of Linthra to
 Linthra is on F-Droid — it's the submission work itself. The readiness
 groundwork is done (#87); this covers cutting the merge request.
 
-The target is the latest alpha that launches, `v0.1.0-alpha.25` (versionCode
-`100025`) — the hotfix that supersedes the withdrawn, broken `v0.1.0-alpha.24`.
+The target is the latest alpha that launches, `v0.1.0-alpha.29` (versionCode
+`100029`). The withdrawn, broken `v0.1.0-alpha.24` is skipped — alpha.25 was its
+hotfix, and the target has since moved on to alpha.29.
 
 ### Checklist
 
@@ -333,6 +335,6 @@ The target is the latest alpha that launches, `v0.1.0-alpha.25` (versionCode
 ### Status
 
 The metadata, audit, permissions, anti-feature review, build recipe, screenshots,
-and submission text are ready and point at `v0.1.0-alpha.25`. What's left before
+and submission text are ready and point at `v0.1.0-alpha.29`. What's left before
 the merge request: an SDK-machine release-build re-confirmation, and `fdroid lint`
 / `fdroid build` in an fdroiddata checkout.

--- a/fastlane/metadata/android/en-US/changelogs/100029.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100029.txt
@@ -1,0 +1,14 @@
+Linthra 0.1.0-alpha.29 — cumulative alpha since alpha.25.
+
+New:
+- Android Auto: the play queue now mirrors to the car, you can tap a queued
+  track to jump straight to it, and the browse tree adds Albums, Artists, and
+  Offline.
+- Connecting a Jellyfin server now starts its first library sync automatically.
+
+Fixed:
+- Audio no longer cuts out when the screen turns off mid-playback.
+
+Also: the store listing now ships eight real phone screenshots.
+
+Still an alpha — expect rough edges.

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -10,12 +10,13 @@
 #   * Linthra is an early-alpha, unofficial community client. It is not
 #     affiliated with Jellyfin, Navidrome, or Subsonic.
 #   * No tracking, no analytics, no ads, no crash-reporting SDK.
-#   * Tagged releases exist (v0.1.0-alpha.1 … v0.1.0-alpha.25, built by
+#   * Tagged releases exist (v0.1.0-alpha.1 … v0.1.0-alpha.29, built by
 #     .github/workflows/android-release-build.yml). We target the latest one
-#     that actually launches, v0.1.0-alpha.25.
+#     that actually launches, v0.1.0-alpha.29.
 #   * Skip v0.1.0-alpha.24 — it has a startup regression, and its GitHub Release
-#     is marked "Broken release — do not install". alpha.25 is the hotfix that
-#     reverts it, so that's the build target and CurrentVersion, not alpha.24.
+#     is marked "Broken release — do not install". alpha.25 was the hotfix that
+#     reverted it; alpha.29 is the current working build, so that's the build
+#     target and CurrentVersion, not alpha.24.
 #   * F-Droid takes Summary/Description from the Fastlane files under
 #     fastlane/metadata/android/en-US/. The inline copies below are here so the
 #     listing is easy to review in one place; in the real fdroiddata entry you'd
@@ -66,7 +67,7 @@ RepoType: git
 Repo: https://github.com/thezupzup/linthra.git
 
 # -----------------------------------------------------------------------------
-# Build — draft, targeting v0.1.0-alpha.25 (the latest alpha that launches; see
+# Build — draft, targeting v0.1.0-alpha.29 (the latest alpha that launches; see
 # the note above about skipping alpha.24).
 #
 # On the version handling: pubspec.yaml keeps a fixed dev version
@@ -74,7 +75,7 @@ Repo: https://github.com/thezupzup/linthra.git
 # would label every tag as versionCode 15 and F-Droid couldn't tell releases
 # apart. Instead the build derives the version from the checked-out tag with
 # tool/version_from_tag.dart — the same tool the GitHub release build uses — so
-# v0.1.0-alpha.25 becomes 0.1.0-alpha.25 / 100025. Both channels then agree on
+# v0.1.0-alpha.29 becomes 0.1.0-alpha.29 / 100029. Both channels then agree on
 # the versionCode, and AutoUpdateMode still works for future tags because nothing
 # is hard-coded.
 #
@@ -90,9 +91,9 @@ Repo: https://github.com/thezupzup/linthra.git
 # docs/fdroid-build-recipe.md.
 # -----------------------------------------------------------------------------
 Builds:
-  - versionName: 0.1.0-alpha.25
-    versionCode: 100025
-    commit: v0.1.0-alpha.25
+  - versionName: 0.1.0-alpha.29
+    versionCode: 100029
+    commit: v0.1.0-alpha.29
     # Provision the pinned Flutter 3.27.4 toolchain (matches .flutter-version and
     # CI). An alternative is fdroiddata's `flutter` srclib
     # (srclibs: [flutter@3.27.4], referenced as $$flutter$$) — use whichever fits
@@ -125,5 +126,5 @@ AutoUpdateMode: Version v%v
 # tracking an -alpha tag or would rather wait for a stable one — see
 # docs/fdroid-readiness.md §8.
 UpdateCheckMode: Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$
-CurrentVersion: 0.1.0-alpha.25
-CurrentVersionCode: 100025
+CurrentVersion: 0.1.0-alpha.29
+CurrentVersionCode: 100029


### PR DESCRIPTION
Moves the F-Droid submission materials from the previous `v0.1.0-alpha.25`
target to the latest working alpha, **`v0.1.0-alpha.29`** (versionName
`0.1.0-alpha.29`, tag-derived versionCode `100029`, commit `ab0006b`).

This is prep only — nothing is submitted, and Linthra still isn't on F-Droid.
The merge request to [fdroiddata](https://gitlab.com/fdroid/fdroiddata) is
written and ready to copy across, but opening it is a deliberate manual step.

### What changed
- **`metadata/io.github.thezupzup.linthra.yml`** — `Builds` entry and
  `CurrentVersion`/`CurrentVersionCode` now point at alpha.29 / `100029`; header
  notes updated.
- **`docs/fdroid-submission.md`**, **`fdroid-readiness.md`**,
  **`fdroid-build-recipe.md`** — target tag, the versionCode rationale, the
  ready-to-adapt MR text, and the checklists all reference alpha.29.
- **`fastlane/.../changelogs/100029.txt`** — new changelog for the target build;
  `100025.txt` is kept as history.

### Still honoured
- The broken, withdrawn **`v0.1.0-alpha.24`** is explicitly skipped (alpha.25 was
  its hotfix).
- The eight finalized phone screenshots and the rest of the listing assets are
  reused as-is.
- The not-yet-submitted / not-on-F-Droid framing is intact throughout.

### Not done here (out of scope, as intended)
- Opening the actual fdroiddata MR.
- The SDK-machine `flutter build apk --release` re-confirmation and
  `fdroid lint` / `fdroid build -l` in an fdroiddata checkout — still the
  remaining blockers in the readiness checklist.

https://claude.ai/code/session_016qgYP1ghyBP42gxG3Mmw3P

---
_Generated by [Claude Code](https://claude.ai/code/session_016qgYP1ghyBP42gxG3Mmw3P)_