### PR TITLE
docs(play-store): freshen Play Store readiness pass; add key.properties template

### DIFF
--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,28 @@
+# Example release-signing configuration for LOCAL release builds.
+#
+# This is a TEMPLATE ONLY. It contains no secrets and is safe to commit.
+# To use it:
+#
+#   1. Copy it to android/key.properties
+#        cp android/key.properties.example android/key.properties
+#   2. Fill in the four values below with your own release keystore details.
+#   3. NEVER commit android/key.properties or the keystore itself — both are
+#      git-ignored (see android/.gitignore: `key.properties`, `**/*.keystore`,
+#      `**/*.jks`). Do not paste real passwords into code, CI YAML, or a commit
+#      message.
+#
+# These four keys are read by android/app/build.gradle. If all four are present
+# AND the keystore file exists, release builds are signed with this key;
+# otherwise they fall back to the DEBUG key (not a real release). CI supplies
+# the same values via the LINTHRA_* environment variables instead of this file
+# (env vars take precedence). See docs/release-signing.md for keystore
+# generation, CI secrets, rotation, and Google Play App Signing notes.
+
+# Absolute path to your release keystore (e.g. /home/you/keys/linthra-release.keystore).
+storeFile=/absolute/path/to/linthra-release.keystore
+# The keystore (store) password.
+storePassword=CHANGEME
+# The key alias inside the keystore (matches the -alias used with keytool).
+keyAlias=linthra
+# The password for that key.
+keyPassword=CHANGEME

--- a/docs/google-play-data-safety.md
+++ b/docs/google-play-data-safety.md
@@ -17,13 +17,14 @@ Google Play's Data Safety form distinguishes:
 
 The key fact for Linthra: **the Linthra project operates no backend.** There is
 no Linthra account and no Linthra server. The app only talks to sources **the
-user** configures (their own Jellyfin server) and to the user's own local files
-and local-network Cast devices. So the Linthra developer does not receive any
-user data.
+user** configures (their own Jellyfin or Subsonic/Navidrome server) and to the
+user's own local files and local-network Cast devices. So the Linthra developer
+does not receive any user data.
 
 > **Nuance to confirm in the Console.** When a user connects their **own**
-> Jellyfin server, data (credentials, library requests) is sent to **that
-> server**, which the user controls and the developer has no access to. Whether
+> Jellyfin or Subsonic/Navidrome server, data (credentials, library requests) is
+> sent to **that server**, which the user controls and the developer has no
+> access to. Whether
 > Google's form treats "data sent to a user-designated server the developer
 > can't access" as developer *collection* is a judgment call; the honest
 > position is that **the developer collects nothing**. Decide the exact form
@@ -38,8 +39,8 @@ user data.
   `pubspec.yaml` at submission time — see the dependency list below.)
 - **Data sold:** **no.** Linthra does not sell user data.
 - **Data shared with third parties:** **no** (the developer has no backend; data
-  the user sends to their own Jellyfin server is not shared with the developer
-  or anyone else by Linthra).
+  the user sends to their own Jellyfin or Subsonic/Navidrome server is not shared
+  with the developer or anyone else by Linthra).
 - **Data collected by the developer:** **none** (no Linthra backend; see nuance
   above for the user's own server).
 - **App functionality / local app activity:** stored **on the device** for the
@@ -56,35 +57,38 @@ Linthra developer (there is no developer backend).
 
 | Data | Purpose | Where stored | Leaves device? |
 | ---- | ------- | ------------ | -------------- |
-| Jellyfin **server URL** | Connect to the user's chosen server | Encrypted secure storage (Android Keystore-backed) | Only to the user's own server, only if configured |
-| Jellyfin **username** + server identity | Display the signed-in account; auth | Encrypted secure storage | Sent to the user's own server during auth |
-| Jellyfin **session token** | Keep the user signed in | Encrypted secure storage (never plaintext, never logged) | Sent to the user's own server as the auth header |
-| Jellyfin **password** | One-time sign-in only | **Not stored** — used once then discarded | Sent once to the user's own server to obtain a token |
+| **Server URL** (Jellyfin or Subsonic/Navidrome) | Connect to the user's chosen server | Encrypted secure storage (Android Keystore-backed) | Only to the user's own server, only if configured |
+| **Username** + server identity | Display the signed-in account; auth | Encrypted secure storage | Sent to the user's own server during auth |
+| **Session credential** — a Jellyfin session token, or a Subsonic/Navidrome `salt`+`token` (`token = md5(password + salt)`) | Keep the user signed in | Encrypted secure storage (never plaintext, never logged) | Sent to the user's own server as the auth header/params |
+| **Password** | One-time sign-in only | **Not stored** — used once to derive the token/credential, then discarded | Sent once to the user's own server (Jellyfin), or used only locally to derive the Subsonic token, to authenticate |
 | **Music library metadata** (track/album/artist) | Browse/play, work offline | Local SQLite database on device | No |
 | **Offline cache / downloaded tracks** | User-requested offline playback | Local app file storage on device | No (downloaded *from* the user's server on request) |
 | **App settings** (selected folder, cache size, download prefs) | App functionality | Local Android preference storage | No |
 
 Notes for the form:
 
-- The **server URL, username, and session token** are the only
-  account/credential-style data, and they live in **encrypted** on-device
-  storage. The **password is never stored.**
+- The **server URL, username, and session credential** (a Jellyfin token, or a
+  Subsonic/Navidrome salt+token) are the only account/credential-style data, and
+  they live in **encrypted** on-device storage. The **password is never
+  stored** — for Subsonic/Navidrome it is only used locally to compute the
+  `md5(password + salt)` token, then discarded.
 - The user-selected **music folder** uses Android's Storage Access Framework
   grant; Linthra requests **no** broad storage / "all files" permission.
 
 ## Security practices (Data Safety "Security practices" section)
 
-- **Encrypted in transit:** traffic to a Jellyfin server is encrypted **when the
-  user's server uses HTTPS**. Because the user supplies the server URL, Linthra
-  cannot guarantee HTTPS for every user — answer this question honestly
-  ("encrypted in transit when the configured server uses HTTPS") rather than an
-  unqualified "yes."
-- **Encrypted at rest:** the Jellyfin session (URL, username, token) is stored in
-  Android Keystore-backed encrypted storage.
-- **Data deletion mechanism:** users can **sign out & clear** the Jellyfin
-  session, **clear the offline cache**, and **uninstall** the app to remove
-  locally stored data. There is no server-side data to request deletion of,
-  because there is no Linthra server.
+- **Encrypted in transit:** traffic to a Jellyfin or Subsonic/Navidrome server is
+  encrypted **when the user's server uses HTTPS**. Because the user supplies the
+  server URL, Linthra cannot guarantee HTTPS for every user — answer this
+  question honestly ("encrypted in transit when the configured server uses
+  HTTPS") rather than an unqualified "yes."
+- **Encrypted at rest:** the server session (URL, username, and the Jellyfin
+  token or Subsonic/Navidrome salt+token) is stored in Android Keystore-backed
+  encrypted storage.
+- **Data deletion mechanism:** users can **sign out & clear** the server session
+  (Jellyfin or Subsonic/Navidrome), **clear the offline cache**, and
+  **uninstall** the app to remove locally stored data. There is no server-side
+  data to request deletion of, because there is no Linthra server.
 
 ## Casting / Google dependencies — implications
 
@@ -106,10 +110,20 @@ Notes for the form:
 For verifying "no analytics / no ads" at submission time, the shipped runtime
 dependencies (from `pubspec.yaml`) are: `flutter_riverpod`, `go_router`, `path`,
 `drift`, `sqlite3_flutter_libs`, `path_provider`, `just_audio`, `audio_service`,
-`file_picker`, `shared_preferences`, `http`, `permission_handler`,
-`flutter_secure_storage`, `cast`, `bonsoir`. **None** is an ads, analytics,
-telemetry, or crash-reporting SDK. If any future dependency adds such behavior,
-the Data Safety form (and the privacy policy) must be updated.
+`file_picker`, `shared_preferences`, `http`, `crypto`, `permission_handler`,
+`flutter_secure_storage`, `cast`, `bonsoir`, `url_launcher`. **None** is an ads,
+analytics, telemetry, or crash-reporting SDK. Two are worth a one-line note for
+reviewers:
+
+- `crypto` computes the Subsonic/Navidrome `md5(password + salt)` token
+  **locally on the device** — it has no network access of its own and sends
+  nothing anywhere.
+- `url_launcher` only opens an **external browser**, and only when the user
+  explicitly taps "Open GitHub issue" in the bug-report flow. It collects
+  nothing and auto-opens nothing.
+
+If any future dependency adds ads/analytics/telemetry behavior, the Data Safety
+form (and the privacy policy) must be updated.
 
 ## Before submitting — checklist
 

--- a/docs/google-play-listing.md
+++ b/docs/google-play-listing.md
@@ -24,105 +24,69 @@ Open-source, local-first music player for music you own. No forced sync.
 
 ## 2. Full description
 
-Play limit: **4000 characters.** Suggested draft (keep the "works today" vs
-"planned" split honest):
+Play limit: **4000 characters.**
 
-```
-Linthra is an open-source, local-first music player for people who own their
-music. Your library lives on your device, and you stay in control of it.
+The **canonical full description is
+[`fastlane/metadata/android/en-US/full_description.txt`](../fastlane/metadata/android/en-US/full_description.txt)**
+— it is kept current with the shipped build, separates "works today" from
+"planned," states the privacy posture (no ads, no tracking, no analytics, no
+crash-reporting / telemetry SDK, no Google Play Services), and makes clear that
+Linthra is an **unofficial community client, not affiliated with Jellyfin,
+Navidrome, or Subsonic**. It is comfortably under 4000 characters.
 
-Linthra is early-stage alpha software. This listing separates what works today
-from what is planned, so nothing here overpromises.
-
-WHAT LINTHRA IS ABOUT
-• Local-first — your music files stay on your device; the app reads from a
-  local catalog rather than depending on a remote service.
-• Music you own — Linthra plays files you already have. No store, no account,
-  no requirement to use anyone's cloud.
-• Privacy-focused — no ads, no telemetry, no forced sync. The app does not
-  phone home or upload your library, and offline downloads only happen when you
-  ask for them.
-• Open source — released under the Mozilla Public License 2.0; anyone can read,
-  audit, build, and contribute.
-
-WORKS TODAY
-• Pick a folder of music with the Android folder picker, scan it, and browse
-  your tracks. Your folder and scanned library survive a restart.
-• Play your local tracks with an up-next queue, plus shuffle and repeat.
-• Background playback with a media notification and lock-screen, Bluetooth, and
-  wired-headset controls.
-• Android Auto: browse your Library and Queue from the car screen.
-• Connect to your own Jellyfin server, sign in, sync your library, and stream.
-  The session token is stored encrypted and your password is never saved.
-• Explicit, user-initiated offline downloads with a smart cache and a size
-  limit you set — Wi-Fi only by default, with an optional "Allow mobile data"
-  toggle. Never automatic.
-• Cast to Chromecast-compatible devices on your local network.
-
-PLANNED (NOT FINISHED YET)
-• Tag/metadata parsing and album artwork (tracks currently show file names).
-• Browsing by artist and album, plus search.
-• Playlist creation and editing, and queue reorder.
-• Album- and playlist-level "download all" and a background download manager.
-• Additional sources such as WebDAV and NAS, behind the same interface.
-
-SELF-HOSTED FRIENDLY
-Linthra works great with a self-hosted Jellyfin server you run yourself — on a
-home server or NAS. The server is entirely optional and entirely yours; Linthra
-bundles no server and runs no cloud service of its own.
-
-NO SURPRISES
-No ads. No account. No forced sync. No surprise downloads — Linthra never
-downloads your library in the background; downloads happen only when you ask,
-and they use Wi-Fi only by default unless you allow mobile data.
-
-Linthra is alpha software with honest, documented limitations. Expect rough
-edges, and please share feedback.
-```
-
-If this exceeds 4000 characters after edits, trim the "Planned" section first.
+**Paste that file's contents into the Play Console.** Do **not** keep a second
+full-description copy in this doc — a duplicate drifts from the shipped app (as
+it did before). The sections below are Play-Console guidance only (limits,
+keywords, screenshots, do's and don'ts) and defer to that file for the actual
+copy.
 
 ## 3. Feature list (for the listing / promo copy)
 
-- Local-first library: scan a folder, browse, and play music you own.
+- Local-first library: scan a folder (Storage Access Framework — no broad
+  storage permission), then browse Songs, Albums, and Artists with search.
 - Background playback with media notification and lock-screen / Bluetooth /
-  headset controls.
-- Up-next queue, shuffle, and repeat.
-- Android Auto browsing (Library and Queue).
-- Optional Jellyfin connection: sign in, sync, and stream from **your** server.
+  headset controls, plus shuffle, repeat, and synced lyrics.
+- Up-next queue, playlists, favourites, and automatic "smart mixes."
+- Android Auto browsing.
+- Optional self-hosted connection: sign in, sync, and stream from **your own**
+  Jellyfin or Navidrome / Subsonic server (including over HTTPS).
 - Explicit offline downloads with a smart, size-limited cache and a "Wi-Fi
-  only" option.
-- Casting to Chromecast-compatible devices on the local network.
+  only" default.
+- Casting to Chromecast-compatible devices on the local network (pure-Dart, no
+  Google Play Services).
 - Open source (MPL-2.0), no ads, no telemetry, no forced sync.
 
 ## 4. What works today
 
-Use this as the truthful baseline; do not list planned items as if shipped.
+Use this as the truthful baseline; keep it consistent with the canonical
+description (§2). The shipped feature set:
 
-- Folder selection (Android folder picker), scanning, and a persisted track
-  list.
-- Local playback with an up-next queue, shuffle, and repeat.
+- Folder selection (Storage Access Framework), scanning, and browsing Songs,
+  Albums, and Artists **with search**; the library persists across restarts.
+- Local playback with an up-next queue, shuffle, repeat, and synced lyrics.
+- Playlists, favourites, and automatic "smart mixes."
 - Background playback + media session (notification, lock screen, Bluetooth,
   wired headset).
-- Android Auto: browse Library and Queue.
-- Jellyfin: connect, sign in (token stored encrypted; password never saved),
-  sync, stream, and synced favorites/lyrics.
-- Explicit offline downloads with a smart cache and a configurable size limit.
-- Chromecast/Cast foundation to local-network devices.
+- Android Auto browsing.
+- Jellyfin **and** Navidrome / Subsonic: connect, sign in (the session
+  credential is stored encrypted; the password is never saved), sync, and stream
+  — including over HTTPS.
+- Explicit, user-initiated offline downloads with a smart cache and a
+  configurable size limit (Wi-Fi only by default).
+- Casting to Chromecast-compatible local-network devices (pure-Dart, no Google
+  Play Services).
 
 ## 5. Known alpha limitations
 
-Be upfront in the listing and/or release notes:
+Be upfront in the listing and/or release notes (keep consistent with the
+"planned" section of the canonical description in §2):
 
-- Tracks currently show **file names**; tag/metadata parsing and **album
-  artwork** are not implemented yet.
-- No browse-by-artist/album and **no search** yet.
-- **No playlist** creation/editing yet; queue reordering is limited.
-- No album/playlist "download all" or background download manager yet.
-- The Wi-Fi / mobile-data gate relies on basic connectivity handling; robust
-  connectivity detection is still planned.
-- Some Android 11+ scoped-storage folders may be unreadable; the app surfaces a
-  clear error rather than a silent empty library.
+- Local files currently show **file names**; reading **tags and album art** from
+  local files is not implemented yet.
+- For **Subsonic/Navidrome**, favourites, lyrics, cover art, and fuller playlist
+  sync are still in progress.
+- No album/playlist **"download all"** yet.
+- Additional sources (WebDAV / NAS) are planned, behind the same interface.
 - Alpha overall — expect rough edges and changing behavior between versions.
 
 ## 6. Suggested keywords
@@ -130,14 +94,16 @@ Be upfront in the listing and/or release notes:
 For the title/short description and ASO thinking (Play has no separate keyword
 field — weave naturally, do not keyword-stuff):
 
-`music player`, `local music`, `offline music`, `Jellyfin`, `self-hosted`,
-`open source`, `privacy`, `no ads`, `Chromecast`, `Android Auto`, `NAS`,
-`media player`, `audio player`.
+`music player`, `local music`, `offline music`, `Jellyfin`, `Navidrome`,
+`Subsonic`, `self-hosted`, `open source`, `privacy`, `no ads`, `Chromecast`,
+`Android Auto`, `NAS`, `media player`, `audio player`.
 
-> Use third-party names like **Jellyfin**, **Chromecast**, **Android Auto**, and
-> **NAS** only to describe genuine compatibility — never in a way that implies
-> endorsement or affiliation. Do **not** describe Linthra as a clone of, or
-> drop-in replacement for, any specific commercial app.
+> Use third-party names like **Jellyfin**, **Navidrome**, **Subsonic**,
+> **Chromecast**, **Android Auto**, and **NAS** only to describe genuine
+> compatibility — never in a way that implies endorsement or affiliation.
+> Linthra is an **unofficial community client and is not affiliated with
+> Jellyfin, Navidrome, or Subsonic.** Do **not** describe Linthra as a clone of,
+> or drop-in replacement for, any specific commercial app.
 
 ## 7. Screenshot checklist
 
@@ -170,8 +136,9 @@ A core promise worth stating plainly in the listing and release notes:
 ## 9. Jellyfin / NAS / self-hosted positioning
 
 - Position Linthra as a **player for music you own**, that **optionally** works
-  with a **self-hosted Jellyfin server** (e.g. on a home server or NAS).
-- The Jellyfin connection is **optional and user-configured**: Linthra bundles
+  with a **self-hosted Jellyfin or Navidrome / Subsonic server** (e.g. on a home
+  server or NAS).
+- The server connection is **optional and user-configured**: Linthra bundles
   no server, promotes no hosted service, and runs **no cloud service of its
   own**.
 - Frame self-hosting as a benefit for people who want their library on their own
@@ -185,8 +152,9 @@ A core promise worth stating plainly in the listing and release notes:
 - **Do not** overclaim production stability — it is alpha; say so.
 - **Do not** claim availability on F-Droid or Google Play before it is actually
   published there.
-- **Do not** use third-party trademark names (Jellyfin, Chromecast, Android
-  Auto, NAS vendors) in a confusing way that implies affiliation or endorsement.
+- **Do not** use third-party trademark names (Jellyfin, Navidrome, Subsonic,
+  Chromecast, Android Auto, NAS vendors) in a confusing way that implies
+  affiliation or endorsement. Linthra is an unofficial community client.
 
 ## 11. Related docs
 

--- a/docs/play-store-readiness.md
+++ b/docs/play-store-readiness.md
@@ -15,7 +15,13 @@ identity, version source, and assets but differ on signing and submission.
 
 ## 1. Current status
 
-- **Stage:** early alpha. Current version `0.1.0-alpha.9+9` (see `pubspec.yaml`).
+- **Stage:** early alpha. The released version comes from the pushed `v*` tag,
+  not `pubspec.yaml`: the latest released alpha is `v0.1.0-alpha.29` (versionName
+  `0.1.0-alpha.29`, tag-derived `versionCode` `100029`). `pubspec.yaml`'s
+  `version:` (currently `0.1.0-alpha.15+15`) only seeds local/dev builds and
+  intentionally trails the tags. See [§11](#11-versioning-for-play-uploads) and
+  [release-process.md §1](./release-process.md#1-versioning-model) — the tag is
+  the source of truth.
 - **Distribution:** sideloadable pre-release APK/AAB attached to GitHub
   Releases. **Not** on Google Play, **not** on F-Droid; nothing publishes
   automatically.
@@ -87,8 +93,10 @@ them.
 
 - Linthra's release build reads signing material from environment variables or a
   git-ignored `android/key.properties`, falling back to the **debug** key when
-  none is present. Full details, secret names, and `keytool` generation steps
-  are in [docs/release-signing.md](./release-signing.md).
+  none is present. A secret-free template lives at
+  [`android/key.properties.example`](../android/key.properties.example). Full
+  details, secret names, and `keytool` generation steps are in
+  [docs/release-signing.md](./release-signing.md).
 - For Play, generate a release keystore (see release-signing.md §4) and use it
   as the **upload key**. Keep it backed up; reuse it for every upload.
 - **Debug-signed builds must never be uploaded to Play**, not even to internal
@@ -154,12 +162,13 @@ submission:
 - [ ] Confirm **no ads** SDK is present (none today).
 - [ ] Confirm **no third-party analytics / crash-reporting** SDK is present
       (none today — verify against `pubspec.yaml` at submission time).
-- [ ] Declare the Jellyfin **server URL + credentials/session token** as data
-      stored **on the device** (encrypted), not collected by us — Linthra runs
-      no server of its own.
+- [ ] Declare the **server URL + credentials/session token** (for a user's
+      Jellyfin **or** Subsonic/Navidrome server) as data stored **on the device**
+      (encrypted), not collected by us — Linthra runs no server of its own.
 - [ ] Declare **no data sold** and **no data shared** with third parties.
-- [ ] State that traffic to a Jellyfin server is **encrypted in transit when the
-      user's server uses HTTPS** (the user controls this).
+- [ ] State that traffic to a Jellyfin or Subsonic/Navidrome server is
+      **encrypted in transit when the user's server uses HTTPS** (the user
+      controls this).
 - [ ] Re-check the form whenever a dependency is added (a new SDK can change the
       honest answers).
 
@@ -263,7 +272,7 @@ Play's Data Safety and review process expects each to be justified.
 
 | Permission | Why Linthra needs it |
 | ---------- | -------------------- |
-| `INTERNET` | Reach the **user-configured** Jellyfin server (connection test, sign-in, library sync, streaming) and run the Cast session to a chosen device. No server is bundled or contacted unless the user configures one. |
+| `INTERNET` | Reach the **user-configured** Jellyfin or Subsonic/Navidrome server (connection test, sign-in, library sync, streaming) and run the Cast session to a chosen device. No server is bundled or contacted unless the user configures one. |
 | `FOREGROUND_SERVICE` | Run the `audio_service` playback service in the foreground so audio keeps playing while the app is backgrounded. |
 | `FOREGROUND_SERVICE_MEDIA_PLAYBACK` | The typed-foreground-service grant required on Android 14+ (API 34) for a `mediaPlayback` service; without it the playback service cannot start on new devices. |
 | `POST_NOTIFICATIONS` | Android 13+ runtime permission for the media notification and its lock-screen / transport controls. Requested once on first launch; denial only suppresses the notification, playback still works. |
@@ -284,7 +293,67 @@ Notes:
 - The same permission rationale, with more F-Droid framing, is in
   [docs/fdroid-readiness.md §5](./fdroid-readiness.md#5-anti-features-review).
 
-## 13. Related docs
+## 13. Play Console declarations to prepare (category, target audience, app access)
+
+Beyond the listing copy and Data Safety form, the Play Console asks for a few
+**store-presence declarations**. None require code changes; decide and enter
+them honestly in the Console. Drafted answers for Linthra:
+
+### App category and tags
+
+- **App or game:** App.
+- **Category:** **Music & Audio** — Linthra is a music player.
+- **Tags:** Play allows a few descriptive tags; pick the relevant ones (e.g.
+  *music player*, *audio player*) without keyword-stuffing. These are distinct
+  from the listing keywords in
+  [google-play-listing.md §6](./google-play-listing.md#6-suggested-keywords).
+- **Contains ads:** **No.** Linthra has no ad SDK and shows no ads (keep this
+  consistent with the Data Safety form and listing).
+
+### Target audience and content
+
+Play's **"Target audience and content"** section asks which age groups the app
+targets, then drives the Families policy and the ads/data declarations.
+
+- **Target age group:** Linthra is a **general-audience utility** (a music
+  player), **not** designed for or directed at children. Select an adult/teen
+  target (e.g. **13+**, or 18+ if preferred) and **do not** opt into the
+  **"Designed for Families"** program. Answer the Console's exact questions
+  honestly rather than copying a number from here.
+- This is easy for Linthra because there are **no ads** and **no data
+  collection** (see §7), so the follow-up questions about ads/data shown to
+  children do not apply.
+- The separate **content rating questionnaire** (§9 item 8) still has to be
+  completed; a no-ads, no-objectionable-content music player typically lands at
+  the lowest ratings, but answer the questionnaire from the shipped build.
+
+### App access (important — Linthra's server login is optional)
+
+Play's **"App access"** section asks whether any functionality is behind a login
+or other access restriction, so a reviewer can reach it.
+
+- **Linthra is local-first and usable with no account.** The core experience —
+  pick a music folder, scan, browse, play, queue, background playback, Android
+  Auto, cast — works **without signing in to anything**. There is **no Linthra
+  account** and **no universal login gate**.
+- Connecting a **self-hosted server (Jellyfin or Subsonic/Navidrome)** is
+  **optional** and entirely user-configured. So the honest default answer is
+  **"All functionality is available without special access"** for the
+  local-first features.
+- **If you want reviewers to evaluate server sync/streaming**, provide a
+  **demo/throwaway server URL and a test account** in the App-access
+  *instructions* field (server URL, username, password, and a one-line "Settings
+  → connect a server" walkthrough). Use a **disposable test account on a server
+  you control** — **never** a personal account, and **never** commit any
+  credentials to the repo or this doc. This is optional: the reviewer can fully
+  exercise the local-playback experience without it.
+
+### Government / financial / health declarations
+
+- Linthra is **none of these** (it is a music player). Answer the Console's
+  "Is your app a government app / financial app / health app?" prompts **No**.
+
+## 14. Related docs
 
 - [docs/privacy-policy.md](./privacy-policy.md) — privacy policy draft.
 - [docs/google-play-listing.md](./google-play-listing.md) — store listing draft.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -112,7 +112,14 @@ keytool -genkey -v \
 distinguished-name details. Record the alias and both passwords in your
 password manager.
 
-For a **local** release build, create `android/key.properties` (git-ignored):
+For a **local** release build, create `android/key.properties` (git-ignored).
+A committed, secret-free template is provided at
+[`android/key.properties.example`](../android/key.properties.example) — copy it
+and fill in your own values:
+
+```sh
+cp android/key.properties.example android/key.properties
+```
 
 ```properties
 storeFile=/absolute/path/to/linthra-release.keystore


### PR DESCRIPTION
## What this is

A **verification + accuracy pass** over Linthra's existing Google Play readiness
docs (they were already substantial — this fills genuine gaps and removes
drift). **Docs/templates only.** No app behavior change, no version bump, no
secrets, no keystore. **The F-Droid `fdroiddata` work and `metadata/` file are
untouched.**

## Changes

**`docs/play-store-readiness.md`**
- Fix the stale "current version" (was `0.1.0-alpha.9`). The released version is
  tag-derived (latest `v0.1.0-alpha.29` → `versionCode 100029`); `pubspec.yaml`
  only seeds local/dev builds and intentionally trails the tags — framed so it
  won't re-drift.
- New **"Play Console declarations to prepare"** section covering the three
  items not previously documented: **app category** (Music & Audio), **target
  audience / age group**, and **App access** answers for the **optional**
  self-hosted login (local-first works with no account; provide a *throwaway*
  demo server only if reviewers should test server sync — never a personal
  account, never committed).
- Note Subsonic/Navidrome alongside Jellyfin in the Data Safety + permission
  notes; link the new signing template.

**`docs/google-play-data-safety.md`**
- Generalize from Jellyfin-only to **Jellyfin AND Subsonic/Navidrome** (both are
  implemented). Both store server URL/username + a derived session credential
  (Jellyfin token, or Subsonic `salt`+`token` = `md5(password+salt)`) in
  **encrypted on-device storage**; the **password is never persisted**. Verified
  against `lib/` and the secure session stores.
- Add `crypto` and `url_launcher` to the dependency audit (they were missing),
  with honest notes — `crypto` hashes the Subsonic token locally; `url_launcher`
  only opens an external browser on an explicit user tap. Neither collects data.

**`docs/google-play-listing.md`**
- Defer the full description to the canonical
  `fastlane/metadata/android/en-US/full_description.txt` (single source of truth)
  instead of a second, **drifted** embedded copy.
- Correct the feature lists to the **shipped** app (browse Songs/Albums/Artists
  with search, playlists, favourites, smart mixes) and add Subsonic/Navidrome +
  the "unofficial, unaffiliated" framing.

**`docs/release-signing.md`** — reference the new template.

**`android/key.properties.example`** (new) — secret-free signing template
(`CHANGEME` placeholders). The real `key.properties` and all keystores stay
git-ignored.

## Checks run (project-local Flutter 3.27.4 via `scripts/setup_flutter.sh`)

| Check | Result |
| --- | --- |
| `dart format` | clean (422 files, 0 changed) |
| `flutter analyze` | **No issues found** |
| `flutter test` | **1214 passing** |
| `flutter build appbundle --release` | **Could not run here** — `No Android SDK found` in this container. Unblocked by code/signing; builds in CI on a `v*` tag (`.github/workflows/android-release-build.yml`). |

## Remaining manual steps (Play Console / maintainer)

- Build/upload the **release-signed AAB** from a `v*` tag (CI), with an Android SDK present.
- Provision the **upload keystore** + enrol in **Play App Signing** (`docs/release-signing.md`).
- **Crop screenshots** to Play's ≤ 2:1 ratio (the 8 real captures are ≈9:20).
- Publish the **privacy policy** at a public URL and paste it into the listing.
- Complete the **Data Safety form**, **content rating**, **target audience**, and **App access** in the Console (drafts in the docs above).
- Confirm the built AAB's `targetSdkVersion` meets Play's current minimum.

https://claude.ai/code/session_0146i5JFz3K5fDKWDebzhNF6

---
_Generated by [Claude Code](https://claude.ai/code/session_0146i5JFz3K5fDKWDebzhNF6)_