### PR TITLE
docs(readme): add Install (Obtainium / GitHub Releases) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Linthra
 
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](./LICENSE)
-[![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#-try-it)
+[![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#-status)
+[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#status)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 
 ![Linthra](fastlane/metadata/android/en-US/images/featureGraphic.png)
@@ -82,15 +82,20 @@ design — not mockups.
 
 Each feature has a deep-dive in [the docs](#-documentation).
 
-## Try it
+## Install
 
 > Linthra is **not on Google Play or F-Droid**. It's distributed as a
 > sideloadable APK from **[GitHub Releases](https://github.com/thezupzup/linthra/releases)**.
 > Alpha releases are GitHub **pre-releases**.
 
 **Obtainium (recommended)** — [Obtainium](https://github.com/ImranR98/Obtainium)
-installs straight from GitHub Releases and keeps you updated. Add app, paste
-`https://github.com/thezupzup/linthra`, enable **"Include prereleases"**, install.
+installs straight from GitHub Releases and keeps Linthra updated:
+
+1. Install Obtainium.
+2. Tap **Add App** and paste the source URL:
+   `https://github.com/thezupzup/linthra`
+3. Enable **"Include prereleases"** — alpha builds are GitHub pre-releases.
+4. Install the latest release; Obtainium handles updates from then on.
 
 **Manual APK** — download the `.apk` from the
 [latest release](https://github.com/thezupzup/linthra/releases), open it on your


### PR DESCRIPTION
## Summary

Make it obvious how a tester can install Linthra **today**, while F-Droid and the Play Store are still in progress.

- **Added Obtainium / GitHub Releases install instructions.** Renamed the README's `Try it` section to **`Install`** (more discoverable for testers) and expanded the Obtainium one-liner into clear numbered steps — keeping the **"Include prereleases"** step, since alpha builds ship as GitHub *pre-releases* and Obtainium won't otherwise see them. The Manual-APK and build-from-source paths are unchanged.
- **Clarified F-Droid / Play Store status.** The Install section keeps the accurate note that Linthra is **not on Google Play or F-Droid** yet. The detailed status (submission not opened yet) stays in the `Status` section and `docs/fdroid-readiness.md`. **No availability is claimed** for either store.
- **No app code changes** — documentation only.
- Also fixed two broken top-badge in-page anchors (`#-try-it` / `#-status` → `#install` / `#status`) left over from an earlier emoji removal.

## Scope

One commit, **`README.md` only** (+10 / −5). No app code, release-automation, or F-Droid-metadata changes.

## Verification

- Markdown + link/path review of the Install section.
- No "available on F-Droid" / "available on Google Play" claims.
- Existing install/release sections are not duplicated (the section was renamed, not added).
- README stays short.