### PR TITLE
F-Droid: rely on Fastlane for Summary/Description and follow build-flutter.yml (MR !39253)

### DIFF
--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -37,15 +37,20 @@ submission time.
 | `Categories`      | `Multimedia` _(draft)_ | A music player fits Multimedia; `Internet` is **not** appropriate (local-first, no required network). |
 | `License`         | `MPL-2.0` | SPDX identifier; matches `LICENSE`. |
 | `AuthorName`      | TheZupZup _(draft)_ | Optional; confirm preferred attribution. |
-| `SourceCode`      | `https://github.com/thezupzup/linthra` | Public repository. |
-| `IssueTracker`    | `https://github.com/thezupzup/linthra/issues` | GitHub issues. |
-| `Changelog`       | `https://github.com/thezupzup/linthra/releases` | Tagged GitHub Releases now exist, so this is set. |
-| `AutoUpdateMode`  | `Version v%v` | Track annotated git tags of the form `v<versionName>` (see § release plan). |
-| `UpdateCheckMode` | `Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha\|beta\|rc)\.[0-9]+)?$` | Linthra ships only pre-release `-alpha.N` tags so far; the regex must accept the alpha/beta/rc suffix. Confirm with F-Droid whether it will track a pre-release CurrentVersion (see [fdroid-readiness.md §8](./fdroid-readiness.md#8-remaining-blockers-before-submission)). |
+| `SourceCode`      | `https://github.com/TheZupZup/Linthra` | Public repository. |
+| `IssueTracker`    | `https://github.com/TheZupZup/Linthra/issues` | GitHub issues. |
+| `Changelog`       | `https://github.com/TheZupZup/Linthra/releases` | Tagged GitHub Releases now exist, so this is set. |
+| `AutoUpdateMode`  | `None` | Disabled on purpose — see the note below. |
+| `UpdateCheckMode` | `None` | Disabled on purpose — see the note below. |
 
-`AutoUpdateMode`/`UpdateCheckMode` only work cleanly if the tag and the
-`pubspec.yaml` version stay in lockstep (§5). Confirm the exact regex against
-the first real tag before submission.
+`AutoUpdateMode`/`UpdateCheckMode` are **disabled** (`None`). They would only
+work if the release tag and the `pubspec.yaml` version stayed in lockstep, but
+`pubspec.yaml` keeps a fixed dev version (`0.1.0-alpha.15+15`) that does not move
+with the tags — the real version is derived at build time (§5). F-Droid's
+pubspec/tag update detection would therefore read the wrong versionCode, so each
+release is added as a manual `Builds` entry with explicit
+`versionName`/`versionCode`. (This is also what the fdroiddata maintainer
+confirmed on MR !39253.)
 
 ## 3. Build source expectations
 
@@ -123,11 +128,12 @@ process (and the GitHub-Release flow) is in
    `pubspec.yaml` `version: x.y.z+<versionCode>` is the local/dev default.
    **F-Droid handling (decided):** F-Droid builds from source and does not run
    our workflow, so a plain `flutter build` would take the static
-   `pubspec.yaml` version (versionCode **15** for every tag). The draft recipe
-   therefore derives the version from the checked-out tag with
-   `tool/version_from_tag.dart` and passes `--build-name`/`--build-number`, so
-   `v0.1.0-alpha.29` builds to `0.1.0-alpha.29` / **100029** — matching the
-   metadata and the GitHub channel, and AutoUpdate-safe for future tags. See
+   `pubspec.yaml` version (versionCode **15** for every tag). The recipe
+   therefore passes explicit `--build-name`/`--build-number` matching what
+   `tool/version_from_tag.dart` produces for the tag, so `v0.1.0-alpha.29` builds
+   to `0.1.0-alpha.29` / **100029** — matching the metadata and the GitHub
+   channel. Because `pubspec.yaml` doesn't track the tags, `AutoUpdateMode`/
+   `UpdateCheckMode` are `None` and each release is a manual entry (§2). See
    [fdroid-submission.md §2](./fdroid-submission.md).
 2. **`versionCode` increases monotonically** by construction (the encoding can
    never go backwards); never reuse or decrease it.
@@ -156,9 +162,10 @@ These must be resolved before an actual F-Droid submission (see also
    SAF providers / fully content-resolver-based scanning are still follow-ups
    (see README "Android folder selection & known limitations"). This is a
    functionality maturity note, not an F-Droid build blocker per se.
-3. **Toolchain provisioning + `fdroid build` validation.** The Flutter-on-F-Droid
-   incantation (sudo git-clone vs. `flutter` srclib) must match fdroiddata's
-   current convention and be validated by an actual `fdroid build`.
+3. **`fdroid build` validation.** The recipe uses the `flutter` srclib method
+   (matching `templates/build-flutter.yml`); a real `fdroid build` must still
+   confirm it builds from source, including any NDK/CMake the native SQLite
+   component needs.
 4. **Gradle wrapper jar.** Confirm the recipe handles the missing committed
    `gradle-wrapper.jar` (§3) reproducibly.
 
@@ -178,11 +185,11 @@ pinned to the latest working alpha (`commit: v0.1.0-alpha.29`, versionName
 `0.1.0-alpha.29`, versionCode `100029`). That file is the canonical draft; edit
 it there rather than duplicating a snippet here.
 
-> **Still a draft — not submitted.** The exact Flutter-on-F-Droid build
-> incantation (Flutter srclib vs. `sudo`-installed SDK, ABI splitting, `output`
-> path) must still be validated against fdroiddata's current Flutter recipes via
-> an actual `fdroid build` at submission time. The version target and
-> tag-derived versionCode are now set; see the
-> [submission package](./fdroid-submission.md) for the MR text and next steps and
-> the [readiness checklist](./fdroid-readiness.md#8-remaining-blockers-before-submission)
+> **Still a draft — not submitted.** The recipe now uses the `flutter` srclib
+> method from `templates/build-flutter.yml` and a single universal APK, but it
+> must still be validated against fdroiddata via an actual `fdroid build` at
+> submission time (in particular any NDK/CMake the native SQLite build needs).
+> The version target and tag-derived versionCode are set; see the
+> [submission package](./fdroid-submission.md) for the MR checklist and next
+> steps and the [readiness checklist](./fdroid-readiness.md#8-remaining-blockers-before-submission)
 > for the remaining blockers.

--- a/docs/fdroid-submission.md
+++ b/docs/fdroid-submission.md
@@ -24,8 +24,8 @@ tagging), and the draft recipe at
 | Name    | Linthra                       |
 | App ID  | `io.github.thezupzup.linthra` |
 | License | `MPL-2.0` (SPDX)              |
-| Source  | https://github.com/thezupzup/linthra |
-| Issues  | https://github.com/thezupzup/linthra/issues |
+| Source  | https://github.com/TheZupZup/Linthra |
+| Issues  | https://github.com/TheZupZup/Linthra/issues |
 | Category| Multimedia                    |
 
 ## 2. Target version: the latest working alpha
@@ -99,17 +99,21 @@ What makes it a good fit for building from source:
 
 A few things still need checking against fdroiddata before submitting:
 
-1. How Flutter gets provisioned. The draft clones `flutter/flutter` at the
-   `3.27.4` tag in a `sudo:` step; fdroiddata may prefer its `flutter` srclib
-   (`srclibs: [flutter@3.27.4]`, referenced as `$$flutter$$`). Either is fine —
-   match the current convention. Flutter's engine artifacts are fetched at the
-   pinned version, which is normal for Flutter on F-Droid and stays pinned and
-   reproducible.
-2. The `git describe --tags --exact-match HEAD` the build uses to find the tag —
-   confirm F-Droid's checkout of `commit: v0.1.0-alpha.29` leaves the tag
-   resolvable (it should, since F-Droid checks out the tag ref).
-3. The output path. `build/app/outputs/flutter-apk/app-release.apk` is the
-   single-APK output; adjust `output:` if you'd rather split per ABI.
+1. How Flutter gets provisioned. The draft now uses the **`flutter` srclib**
+   method from `templates/build-flutter.yml` (`srclibs: [flutter@stable]`,
+   referenced as `$$flutter$$`), checking out the version from `.flutter-version`
+   (3.27.4) in `prebuild`. No Flutter submodule is added upstream and no SDK is
+   cloned by hand. Flutter's engine artifacts are fetched at the pinned version,
+   which is normal for Flutter on F-Droid and stays pinned and reproducible.
+2. Native toolchain. The only native component is SQLite (`sqlite3_flutter_libs`,
+   built from source). If `fdroid build -l` reports a missing NDK/CMake, pin the
+   build server's NDK with an `ndk:` field and/or install CMake in `prebuild`
+   (`sudo sdkmanager 'cmake;<version>'`), as some Flutter recipes do.
+3. The output path. `build/app/outputs/flutter-apk/app-release.apk` is the single
+   universal-APK output, matching the upstream GitHub-release artifact. Splitting
+   per ABI would also need a per-ABI `versionCode` scheme (a `VercodeOperation`
+   plus a `build.gradle` override) that upstream does not currently use, so a
+   single universal APK is built.
 4. The `pubspec.lock` policy — still git-ignored. Decide whether to commit it at
    the tagged commit for a fully pinned dependency set
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
@@ -173,7 +177,7 @@ submitting.
 
 | Check | Status |
 | ----- | ------ |
-| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (Summary 57 chars, versionCode an integer, `100029`). This only checks the YAML, not F-Droid's schema (see below). |
+| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (no inline Summary/Description; F-Droid pulls them from Fastlane; versionCode an integer, `100029`). This only checks the YAML, not F-Droid's schema (see below). |
 | `flutter pub get` | Not run here (no toolchain). Run locally / in CI. |
 | `dart format --set-exit-if-changed .` | Not run here. CI (`ci.yml`) runs it on every PR. |
 | `flutter analyze` | Not run here. CI runs it on every PR. |
@@ -210,73 +214,63 @@ fdroid build -v -l io.github.thezupzup.linthra        # full from-source build t
 2. Re-confirm a clean `flutter build apk --release` from source on a machine with
    the Android SDK, and re-check the merged-manifest permission set.
 3. Fork https://gitlab.com/fdroid/fdroiddata and make a branch.
-4. Copy `metadata/io.github.thezupzup.linthra.yml` into fdroiddata's `metadata/`
-   directory. In the real entry you'd normally drop the inline `Summary`/
-   `Description` and let the Fastlane files provide them, unless you specifically
-   want to override them.
-5. Settle the Builds toolchain to fdroiddata's current Flutter convention
-   (srclib vs. sudo-clone — §3), and run `fdroid lint` + `fdroid build -l` until
-   they're green (§7).
-6. Open the merge request using the text in §9. Be upfront that it's an
-   early-alpha, pre-release submission, and ask the maintainers whether they're
-   happy tracking an `-alpha` tag or would rather wait for a stable one.
+4. Copy the non-comment content of `metadata/io.github.thezupzup.linthra.yml`
+   into fdroiddata's `metadata/` directory. It deliberately has **no** inline
+   `Summary`/`Description` — F-Droid pulls them from the Fastlane files (the
+   fdroiddata maintainer's request on !39253). Then run `fdroid rewritemeta
+   io.github.thezupzup.linthra` (it canonicalises the file and strips comments).
+5. Run `fdroid lint io.github.thezupzup.linthra` and `fdroid build -v -l
+   io.github.thezupzup.linthra` until green (§7). The draft uses the `flutter`
+   srclib method (§3); if the native build needs an NDK/CMake, add it as noted
+   there.
+6. Open or update the merge request using fdroiddata's **"App inclusion"**
+   merge-request template (§9) and check the boxes that apply. Be upfront that
+   it's an early-alpha, pre-release submission, and that auto-update is disabled
+   on purpose (pubspec doesn't track the tags), so each version is added
+   manually.
 7. Don't describe Linthra as being on F-Droid until the merge request is merged
    and the build publishes.
 
-## 9. Merge-request description (ready to adapt)
+## 9. Merge-request description — use fdroiddata's "App inclusion" template
 
-Paste this into the fdroiddata merge request and adjust as needed.
+Edit the existing merge request (!39253 — do **not** open a new one) and select
+fdroiddata's **"App inclusion"** merge-request template, delete the instruction
+lines it tells you to remove, then check the boxes that apply. A short intro plus
+the filled checklist below works. The app's summary/description are **not**
+restated here — F-Droid takes them from the Fastlane files (§6), which is what
+the maintainer asked for.
 
 ---
 
-**New app: Linthra — `io.github.thezupzup.linthra`**
+Adds Linthra, an open-source, local-first Android music player for local files
+and self-hosted servers (Jellyfin, Navidrome/Subsonic). Unofficial community
+client — not affiliated with Jellyfin, Navidrome, or Subsonic. MPL-2.0; no ads,
+tracking, analytics, crash-reporting SDK, or Google Play Services. Initial
+target: `v0.1.0-alpha.29` (versionCode `100029`); the broken `v0.1.0-alpha.24`
+is skipped. Early alpha, usable for testing.
 
-Linthra is an open-source Android music player for people who keep their music on
-their own devices or self-hosted servers. It plays local files and streams from
-self-hosted servers such as Jellyfin and Navidrome/Subsonic. It's an unofficial
-community client — not affiliated with Jellyfin, Navidrome, or Subsonic.
+### Required
 
-Why I think it's a good fit for F-Droid:
+- [x] The app complies with the [inclusion criteria](https://f-droid.org/docs/Inclusion_Policy)
+- [x] The original app author has been notified (and does not oppose the inclusion) — I am the upstream author/maintainer.
+- [ ] All related fdroiddata and RFP issues have been referenced — there is no existing RFP or fdroiddata issue.
+- [ ] Builds with `fdroid build` and all pipelines pass — pending CI / `fdroid build -l`.
+- [x] There is an issue tracker and contact info of the author — https://github.com/TheZupZup/Linthra/issues
 
-- **License:** MPL-2.0 (FSF/OSI-approved), in `LICENSE`.
-- **Builds from source** with no signing keys — F-Droid signs its own builds.
-- **No proprietary dependencies.** I audited the full transitive tree (152
-  packages) and found only permissive licenses (BSD/MIT/Apache-2.0/MPL-2.0) and
-  no Google Play Services, Firebase, analytics, ads, or crash-reporting. The one
-  native component is SQLite (public domain, built from source); playback is
-  AndroidX Media3 (Apache-2.0); casting is a pure-Dart implementation, not the
-  GMS Cast SDK.
-- **No anti-features.** No ads, no tracking, nothing phones home. The self-hosted
-  sources are optional servers the user runs themselves, so I don't think
-  `NonFreeNet` applies — happy to add it if you read it differently.
-- **Minimal permissions.** No storage, location, contacts, camera, mic, or phone
-  permission, and no `MANAGE_EXTERNAL_STORAGE` — folder access uses the Storage
-  Access Framework.
+### Strongly Recommended
 
-Source and issues: https://github.com/thezupzup/linthra (issues at `/issues`).
+- [x] The upstream repo contains the app metadata (summary/description/images/changelog) in a Fastlane structure — `fastlane/metadata/android/en-US/` (short_description, full_description, title, changelogs, icon, feature graphic, 8 screenshots). Summary/Description are intentionally **not** set in fdroiddata; F-Droid pulls them from Fastlane.
+- [ ] Releases are tagged and auto update is enabled — releases are tagged (`v0.1.0-alpha.29`), but auto-update is intentionally **disabled** (`AutoUpdateMode`/`UpdateCheckMode: None`): `pubspec.yaml` carries a fixed dev version that does not track the tags, so each release is added manually with explicit `versionName`/`versionCode`.
 
-**Build target:** tag `v0.1.0-alpha.29`, versionName `0.1.0-alpha.29`,
-versionCode `100029`. The build derives the version from the tag (using the
-project's `tool/version_from_tag.dart`), so the versionCode is distinct and
-increasing per release and matches the upstream GitHub-release APK. (For context:
-`v0.1.0-alpha.24` was a broken release that was withdrawn; alpha.25 was the
-hotfix, and alpha.29 is the current working build.)
+### Suggested
 
-**On status — being honest about scope:** this is early-alpha, pre-release
-software. It's usable for testing on a real device, but it isn't
-production-stable and has some documented rough edges, and right now it's only
-distributed as a sideloaded APK from GitHub Releases. I'd welcome your guidance
-on whether you'd prefer to track this `-alpha` tag now or wait for a first stable
-(`vX.Y.Z`) release.
+- [ ] External repos are added as git submodules instead of srclibs — this recipe uses the `flutter` srclib (per `templates/build-flutter.yml`); no Flutter submodule is added upstream.
+- [ ] Enable Reproducible Builds — not enabled yet (early alpha); the APK is signed with F-Droid's key.
+- [ ] Multiple apks for native code — a single universal APK is built (matching the upstream release); the only native code is SQLite, which is small.
 
-**Build verification:** `flutter analyze`, `flutter test`, and formatting run
-green in CI on every PR, and CI builds a debug APK per PR; the tagged release APK
-builds via the release workflow. I'll also run `fdroid lint` and `fdroid build
--l` and confirm a clean from-source `flutter build apk --release`.
+No RFP or fdroiddata issue to close.
 
-**Known limitations:** it's early alpha; local files show file names until tag
-parsing lands; one Jellyfin server at a time; some Subsonic features (favourites,
-lyrics, cover art) are still follow-ups.
+`/label ~"New App"`
 
 ---
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -147,10 +147,12 @@ F-Droid (and our own release tracking) builds from a **git tag**.
   git push origin v0.1.0
   ```
 
-- The tag's `vX.Y.Z` must match `pubspec.yaml`'s `versionName`. This keeps the
-  F-Droid `UpdateCheckMode: Tags ^v[0-9.]+$` / `AutoUpdateMode: Version v%v`
-  recommendation (see [fdroid-build-recipe.md §2](./fdroid-build-recipe.md#2-expected-f-droid-metadata-repo-fields))
-  working without false positives.
+- The tag's `vX.Y.Z` should match the released `versionName`. Note that
+  `pubspec.yaml` currently keeps a fixed dev version that does **not** track the
+  tags, so F-Droid uses manual `Builds` entries with `AutoUpdateMode`/
+  `UpdateCheckMode: None` (see [fdroid-build-recipe.md §2](./fdroid-build-recipe.md#2-expected-f-droid-metadata-repo-fields)).
+  Keeping `pubspec.yaml` in lockstep with the tag is the future option that would
+  let F-Droid auto-update instead.
 - Tag only commits where CI is green **and** generated files are current (§3).
 
 ## 3. Pre-tag checklist

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -1,130 +1,86 @@
 # -----------------------------------------------------------------------------
-# Draft F-Droid metadata for Linthra. This is a working copy kept in the app
-# repo; Linthra hasn't been submitted to F-Droid yet, and isn't on it. When we
-# do submit, the real entry lives in fdroiddata's metadata/ directory
-# (https://gitlab.com/fdroid/fdroiddata) — copy this there and adapt it.
-# docs/fdroid-submission.md has the rest: the merge-request text, the remaining
-# steps, and the open questions.
+# Draft F-Droid metadata for Linthra — a working copy kept in the app repo.
 #
-# A few things worth knowing:
-#   * Linthra is an early-alpha, unofficial community client. It is not
-#     affiliated with Jellyfin, Navidrome, or Subsonic.
-#   * No tracking, no analytics, no ads, no crash-reporting SDK.
-#   * Tagged releases exist (v0.1.0-alpha.1 … v0.1.0-alpha.29, built by
-#     .github/workflows/android-release-build.yml). We target the latest one
-#     that actually launches, v0.1.0-alpha.29.
-#   * Skip v0.1.0-alpha.24 — it has a startup regression, and its GitHub Release
-#     is marked "Broken release — do not install". alpha.25 was the hotfix that
-#     reverted it; alpha.29 is the current working build, so that's the build
-#     target and CurrentVersion, not alpha.24.
-#   * F-Droid takes Summary/Description from the Fastlane files under
-#     fastlane/metadata/android/en-US/. The inline copies below are here so the
-#     listing is easy to review in one place; in the real fdroiddata entry you'd
-#     usually drop them and let Fastlane provide them.
+# Linthra has NOT been accepted on F-Droid. This is the entry proposed in
+# fdroiddata merge request !39253. The real entry lives in fdroiddata's
+# metadata/ directory (https://gitlab.com/fdroid/fdroiddata). To submit, copy
+# the non-comment content below into fdroiddata's
+# metadata/io.github.thezupzup.linthra.yml, then run:
 #
-# The reasoning behind each value lives in docs/fdroid-submission.md,
-# docs/fdroid-readiness.md, docs/fdroid-build-recipe.md, and
-# docs/dependency-license-audit.md.
+#   fdroid rewritemeta io.github.thezupzup.linthra   # canonicalises + strips comments
+#   fdroid lint        io.github.thezupzup.linthra
+#   fdroid build -v -l io.github.thezupzup.linthra   # full from-source build test
+#
+# docs/fdroid-submission.md has the merge-request checklist (use fdroiddata's
+# "App inclusion" template) and the remaining steps.
+#
+# Summary and Description are intentionally NOT set here. F-Droid pulls them from
+# the upstream Fastlane metadata in this repo, which is the fdroiddata
+# maintainer's request on !39253 ("Do not add summary and description in
+# fdroiddata"):
+#   * Summary     <- fastlane/metadata/android/en-US/short_description.txt
+#   * Description <- fastlane/metadata/android/en-US/full_description.txt
+# The icon, feature graphic, screenshots, and per-versionCode changelogs under
+# fastlane/metadata/android/en-US/ are pulled the same way.
+#
+# The build follows fdroiddata's templates/build-flutter.yml using the `flutter`
+# srclib method, with Flutter pinned to the version in .flutter-version (3.27.4,
+# matching CI). No Flutter submodule is added upstream and no SDK is cloned by
+# hand.
+#
+# AutoUpdateMode/UpdateCheckMode are disabled on purpose. pubspec.yaml carries a
+# fixed dev version (0.1.0-alpha.15+15) that does NOT track the release tags, so
+# F-Droid's pubspec/tag update detection would read the wrong versionCode. Each
+# release is therefore a manual Builds entry whose versionName/versionCode are
+# set explicitly via --build-name/--build-number. Those values match what
+# tool/version_from_tag.dart derives from the tag (v0.1.0-alpha.29 -> versionName
+# 0.1.0-alpha.29, versionCode 100029), so the F-Droid APK and the upstream
+# GitHub-release APK agree.
+#
+# Native code: the only native component is SQLite via sqlite3_flutter_libs,
+# compiled from source by the Android Gradle build (no prebuilt blobs). If
+# `fdroid build -l` reports a missing toolchain, pin the build server's NDK with
+# an `ndk:` field and/or install CMake in prebuild (e.g. sudo sdkmanager
+# 'cmake;<version>'), as some Flutter recipes do.
+#
+# More reasoning: docs/fdroid-submission.md, docs/fdroid-readiness.md,
+# docs/fdroid-build-recipe.md, docs/dependency-license-audit.md.
 # -----------------------------------------------------------------------------
 
 Categories:
   - Multimedia
 License: MPL-2.0
 AuthorName: TheZupZup
-# No WebSite on purpose — there's no separate project site; the source repo is
-# the canonical home, and F-Droid falls back to SourceCode when WebSite is unset.
-SourceCode: https://github.com/thezupzup/linthra
-IssueTracker: https://github.com/thezupzup/linthra/issues
-# Tagged GitHub Releases exist now, so the changelog can point at them.
-Changelog: https://github.com/thezupzup/linthra/releases
+SourceCode: https://github.com/TheZupZup/Linthra
+IssueTracker: https://github.com/TheZupZup/Linthra/issues
+Changelog: https://github.com/TheZupZup/Linthra/releases
 
 Name: Linthra
-Summary: Local-first music player for your own self-hosted library
-
-Description: |-
-  Linthra is an open-source Android music player for people who keep their music
-  on their own devices or self-hosted servers. It plays local files, and it
-  streams from self-hosted music servers such as Jellyfin and Navidrome/Subsonic
-  — you bring your own server and sign in with your own account.
-
-  Linthra is an unofficial community client. It is not affiliated with Jellyfin,
-  Navidrome, or Subsonic.
-
-  It tries to stay out of your way and respect your privacy: no ads, no tracking,
-  no analytics, and no crash-reporting SDK. There's no account to create and
-  nothing phones home — streaming is the default, and downloads only happen when
-  you ask for them. When you sign in to a server, the password is used once to
-  get a session token and then dropped; the token is stored encrypted and never
-  logged.
-
-  The app is still early alpha. It's usable for testing on a real device, but it
-  isn't production-stable and has a few rough edges. For now it's distributed
-  only as a sideloaded APK from GitHub Releases — it isn't on F-Droid yet. The
-  full feature list is in the Fastlane description
-  (fastlane/metadata/android/en-US/full_description.txt).
 
 RepoType: git
-Repo: https://github.com/thezupzup/linthra.git
+Repo: https://github.com/TheZupZup/Linthra.git
 
-# -----------------------------------------------------------------------------
-# Build — draft, targeting v0.1.0-alpha.29 (the latest alpha that launches; see
-# the note above about skipping alpha.24).
-#
-# On the version handling: pubspec.yaml keeps a fixed dev version
-# (0.1.0-alpha.15+15) that doesn't move with the tags, so a plain `flutter build`
-# would label every tag as versionCode 15 and F-Droid couldn't tell releases
-# apart. Instead the build derives the version from the checked-out tag with
-# tool/version_from_tag.dart — the same tool the GitHub release build uses — so
-# v0.1.0-alpha.29 becomes 0.1.0-alpha.29 / 100029. Both channels then agree on
-# the versionCode, and AutoUpdateMode still works for future tags because nothing
-# is hard-coded.
-#
-# A few things that keep this easy to build from source: the generated Drift file
-# (lib/data/database/linthra_database.g.dart) is committed, so there's no
-# build_runner/codegen step; the only native piece is SQLite (via
-# sqlite3_flutter_libs, built from source, public domain), with no prebuilt
-# blobs; and no signing keys are needed, since F-Droid signs its own builds.
-#
-# Still to confirm: how Flutter 3.27.4 is provisioned (the sudo git-clone shown
-# here vs. fdroiddata's `flutter` srclib), ABI splitting, and the output path all
-# need checking against fdroiddata's current Flutter recipes — see
-# docs/fdroid-build-recipe.md.
-# -----------------------------------------------------------------------------
 Builds:
   - versionName: 0.1.0-alpha.29
     versionCode: 100029
     commit: v0.1.0-alpha.29
-    # Provision the pinned Flutter 3.27.4 toolchain (matches .flutter-version and
-    # CI). An alternative is fdroiddata's `flutter` srclib
-    # (srclibs: [flutter@3.27.4], referenced as $$flutter$$) — use whichever fits
-    # fdroiddata's current convention.
-    sudo:
-      - apt-get update
-      - apt-get install -y git curl unzip xz-utils
-      - git clone --branch 3.27.4 --depth 1 https://github.com/flutter/flutter /opt/flutter
-      - chown -R vagrant:vagrant /opt/flutter
     output: build/app/outputs/flutter-apk/app-release.apk
-    build: |
-      export PATH="/opt/flutter/bin:$PATH"
-      git config --global --add safe.directory /opt/flutter
-      flutter config --no-analytics
-      flutter pub get
-      # Work out the real version from the tag (see the build note above).
-      tag="$(git describe --tags --exact-match HEAD)"
-      eval "$(dart run tool/version_from_tag.dart "$tag")"
-      flutter build apk --release \
-        --build-name="$LINTHRA_VERSION_NAME" \
-        --build-number="$LINTHRA_VERSION_CODE"
+    srclibs:
+      - flutter@stable
+    prebuild:
+      - flutterVersion=$(cat .flutter-version)
+      - '[[ $flutterVersion ]]'
+      - git -C $$flutter$$ checkout -f $flutterVersion
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get
+    scandelete:
+      - .pub-cache
+    build:
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter build apk --release --build-name=0.1.0-alpha.29 --build-number=100029 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.29
 
-# Track annotated tags shaped like v<versionName>. Because the build derives the
-# versionCode from the tag, an auto-generated entry for a future tag will build
-# the right version without anyone editing it by hand.
-AutoUpdateMode: Version v%v
-# Linthra has only shipped pre-release (-alpha.N) tags so far, so the pattern has
-# to allow the alpha/beta/rc suffix. F-Droid usually prefers a non-pre-release
-# CurrentVersion, so it's worth checking whether the maintainers are happy
-# tracking an -alpha tag or would rather wait for a stable one — see
-# docs/fdroid-readiness.md §8.
-UpdateCheckMode: Tags ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$
+AutoUpdateMode: None
+UpdateCheckMode: None
 CurrentVersion: 0.1.0-alpha.29
 CurrentVersionCode: 100029


### PR DESCRIPTION
## What & why

Addresses the fdroiddata maintainer's review of merge request [!39253](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/39253) ("Add Linthra"). The maintainer asked to: keep Summary/Description in the upstream Fastlane structure (not inline in the fdroiddata YAML), follow `templates/build-flutter.yml`, and use the **App inclusion** MR template.

This PR updates the **upstream side** that those changes depend on — the draft F-Droid metadata kept in this repo and the submission docs. The actual fdroiddata MR lives on GitLab and is handed off below (this repo can't push there).

## Changes (this repo only)

- **`metadata/io.github.thezupzup.linthra.yml`** (the draft copied into fdroiddata):
  - Removed inline `Summary` and `Description` → F-Droid now pulls them from the upstream Fastlane files (`short_description.txt` / `full_description.txt`).
  - Reworked the build to follow `templates/build-flutter.yml` — the **`flutter` srclib** method (grounded in the accepted FluffyChat recipe) instead of a hand-rolled `sudo: git clone` of the SDK; pins Flutter to `.flutter-version` (3.27.4); `scandelete: [.pub-cache]`; single universal APK.
  - Kept `AutoUpdateMode`/`UpdateCheckMode: None` (pubspec carries a fixed dev version `0.1.0-alpha.15+15` that doesn't track tags, so each release is a manual entry with explicit `--build-name`/`--build-number`). The old draft incorrectly had `Version`/`Tags`; this matches the live MR and the maintainer's guidance.
- **`docs/fdroid-submission.md`**: submission steps now run `fdroid rewritemeta`; §9 is the filled-in **App inclusion** MR template.
- **`docs/fdroid-build-recipe.md`, `docs/release-process.md`**: reflect `None` update modes + the srclib method.

## Already in place (no change needed)

Upstream Fastlane metadata under `fastlane/metadata/android/en-US/` is complete — `title.txt`, `short_description.txt` (72 chars, the F-Droid Summary), `full_description.txt` (the Description), 5 changelogs, `icon.png`, `featureGraphic.png`, and 8 phone screenshots — so F-Droid can pull all listing text/images from upstream.

## Not changed
No app behavior, dependencies, signing, tracking/analytics/ads/crash-SDK, or Google Play Services. Linthra is **not** claimed to be on F-Droid.

## Hand-off — manual steps on GitLab fdroiddata (out of this repo's reach)
1. In `TheZupZup/fdroiddata:add-linthra`, replace `metadata/io.github.thezupzup.linthra.yml` with the non-comment content of the draft here, then run `fdroid rewritemeta`, `fdroid lint`, and `fdroid build -v -l io.github.thezupzup.linthra` (the only likely build follow-up is pinning an `ndk:`/CMake for the native SQLite component, if the build reports it).
2. Edit MR !39253 (don't open a new one) → choose the **App inclusion** template → check the boxes (see `docs/fdroid-submission.md` §9).
3. Optional: squash the `add-linthra` history (it has a merge commit + fixups) into one clean commit on top of `master` and force-push the fork branch.

https://claude.ai/code/session_0166D3uqKAtDfoQAg1fgazqw

---
_Generated by [Claude Code](https://claude.ai/code/session_0166D3uqKAtDfoQAg1fgazqw)_