### PR TITLE
Fix Android Gradle tooling for F-Droid builds

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -20,11 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Build on JDK 21 to match F-Droid's build servers, so this PR's CI
+      # exercises the same Java the F-Droid build uses. The Android Gradle
+      # tooling (AGP 8.2.1 / Gradle 8.7 / Kotlin 1.9.24) supports JDK 21.
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       # Keep this Flutter version in sync with .github/workflows/ci.yml.
       - name: Set up Flutter

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -182,11 +182,14 @@ jobs:
           echo "LINTHRA_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
           echo "Release keystore decoded to a temporary path."
 
+      # Build on JDK 21 to match F-Droid's build servers and modern Android
+      # toolchains. The Android Gradle tooling (AGP 8.2.1 / Gradle 8.7 / Kotlin
+      # 1.9.24) supports JDK 21; the release artifacts build identically on it.
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       # Keep this Flutter version in sync with .github/workflows/ci.yml.
       - name: Set up Flutter

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.2.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.24" apply false
 }
 
 include ":app"

--- a/docs/development.md
+++ b/docs/development.md
@@ -121,8 +121,9 @@ do not.
 ## Building a debug APK (Android)
 
 You need a working Android SDK (`ANDROID_HOME` / `ANDROID_SDK_ROOT` set) and a
-JDK that matches the bundled Gradle wrapper — **JDK 17** is the safe choice for
-the Gradle 8.3 / Android Gradle Plugin 8.1 the scaffold ships with. Run
+JDK that matches the bundled Gradle wrapper — **JDK 21** is the safe choice for
+the Gradle 8.7 / Android Gradle Plugin 8.2.1 the scaffold ships with (JDK 17
+also works). Run
 `flutter doctor` to confirm your toolchain.
 
 ```bash

--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -60,10 +60,10 @@ Linthra is a Flutter (Dart) application targeting Android.
 | ---- | ------------- |
 | Flutter version (pinned in CI) | **3.27.4**, `stable` channel — pinned identically in `ci.yml`, `android-release-build.yml`, and `generate-drift.yml`. The F-Droid recipe's `srclibs`/`sudo`-installed Flutter (or `flutter` build plugin) should target the same version. |
 | Dart SDK constraint | `>=3.6.0 <4.0.0` (`pubspec.yaml`), satisfied by Flutter 3.27.4. |
-| Java / JDK | **JDK 17** (Temurin in CI) — matches the bundled Gradle wrapper. |
-| Gradle | **8.3**, declared in `android/gradle/wrapper/gradle-wrapper.properties` (`gradle-8.3-all.zip`). |
-| Android Gradle Plugin | **8.1.0**, declared in `android/settings.gradle`. |
-| Kotlin Gradle plugin | **1.8.22**, declared in `android/settings.gradle`. |
+| Java / JDK | **JDK 21** (Temurin in CI) — matches F-Droid's build servers; the Gradle wrapper and AGP below support it (JDK 17 also works). |
+| Gradle | **8.7**, declared in `android/gradle/wrapper/gradle-wrapper.properties` (`gradle-8.7-all.zip`). |
+| Android Gradle Plugin | **8.2.1**, declared in `android/settings.gradle`. |
+| Kotlin Gradle plugin | **1.9.24**, declared in `android/settings.gradle`. |
 | Android SDK | `compileSdk`, `minSdk`, `targetSdk`, `versionCode`, and `versionName` all come from Flutter (`flutter.*` in `android/app/build.gradle`); they follow the pinned Flutter version rather than being hard-coded. |
 | Gradle wrapper committed? | **Partly.** `gradle-wrapper.properties` is committed; **`gradle-wrapper.jar` is _not_ committed.** F-Droid's build server can regenerate/restore the wrapper jar, but the recipe must account for this (e.g. `gradle` build type, or a prebuild that runs `flutter build` which provisions the wrapper). Worth re-checking before submission. |
 | Generated files committed? | **Yes for Drift.** `lib/data/database/linthra_database.g.dart` is committed. This means `build_runner` is **not** required during the F-Droid build (see §4). |
@@ -110,7 +110,7 @@ the schema at the tagged commit (§4).
    are permissive (MIT/BSD-3-Clause). A mechanical **transitive** audit is still
    an open blocker (§6).
 5. **Toolchain pinning.** Reproducibility depends on the F-Droid build using the
-   same Flutter (3.27.4), Dart (3.6.x), JDK (17), and Gradle (8.3) versions the
+   same Flutter (3.27.4), Dart (3.6.x), JDK (21), and Gradle (8.7) versions the
    project builds with. Keep the CI pin and any recipe-side pin in sync; a
    Flutter bump may also require reformatting (`dart format`) and regenerating
    Drift output.

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -55,7 +55,7 @@ pinned and matches CI (`.github/workflows/ci.yml`, `android-debug-apk.yml`).
 | -------- | ------ |
 | **Flutter version required?** | **3.27.4**, `stable` channel — pinned in [`.flutter-version`](../.flutter-version) and both CI workflows. `scripts/setup_flutter.sh` installs exactly this version locally. |
 | **Dart SDK?** | `>=3.6.0 <4.0.0` (`pubspec.yaml`); satisfied by Flutter 3.27.4 (Dart 3.6.2). |
-| **JDK / Gradle?** | JDK 17 (Temurin in CI), Gradle 8.3, Android Gradle Plugin 8.1.0, Kotlin 1.8.22. |
+| **JDK / Gradle?** | JDK 21 (Temurin in CI), Gradle 8.7, Android Gradle Plugin 8.2.1, Kotlin 1.9.24. |
 | **Android SDK required?** | **Yes.** A standard Android SDK (`platform-tools`, `platforms;android-35`, `build-tools;35.0.0`) plus the NDK + CMake are needed to compile the one native component (SQLite, below). `compileSdk`/`minSdk`/`targetSdk` come from Flutter, not hard-coded. |
 | **Signing keys required to build?** | **No.** A from-source build needs no signing material; F-Droid signs its own builds. Linthra's release signing is optional and supplied at build time via env vars / `android/key.properties`, falling back to the debug key when absent (see [release-signing.md](./release-signing.md)). No keystore or secret is committed. |
 | **Build commands** | `flutter pub get` then `flutter build apk --release` (or `--debug`; split-per-ABI is fine — appbundle is for Play, not F-Droid). |
@@ -270,7 +270,7 @@ What each one shows, plus the privacy review and the still-optional extras, is i
 
 1. **Reproducible build verification.** CI runs `dart format`, `flutter analyze`,
    and `flutter test` green on every PR (`ci.yml`) and builds a debug APK per PR
-   (`android-debug-apk.yml`, JDK 17 + Flutter 3.27.4); the tagged release APK is
+   (`android-debug-apk.yml`, JDK 21 + Flutter 3.27.4); the tagged release APK is
    built by `android-release-build.yml`. This preparation pass could only
    validate the **metadata YAML** (no Flutter/Android SDK / fdroidserver in the
    environment). Before submitting, re-confirm a clean from-source

--- a/docs/fdroid-submission.md
+++ b/docs/fdroid-submission.md
@@ -86,8 +86,8 @@ What makes it a good fit for building from source:
   optional release signing only applies to the GitHub channel and is injected at
   build time (see [release-signing.md](./release-signing.md)); no keystore or
   secret is committed.
-- The toolchain is pinned: Flutter `3.27.4` (stable), Dart `3.6.x`, JDK 17,
-  Gradle 8.3 — the same versions as `.flutter-version` and CI.
+- The toolchain is pinned: Flutter `3.27.4` (stable), Dart `3.6.x`, JDK 21,
+  Gradle 8.7 — the same versions as `.flutter-version` and CI.
 - No codegen step: the Drift output
   `lib/data/database/linthra_database.g.dart` is committed, so there's no
   `build_runner` to run.

--- a/fastlane/metadata/android/en-US/changelogs/100030.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100030.txt
@@ -1,0 +1,8 @@
+Linthra 0.1.0-alpha.30 — build & packaging maintenance.
+
+Changed:
+- Updated the Android Gradle tooling (Android Gradle Plugin, the Gradle wrapper,
+  and Kotlin) so Linthra builds on Java 21 toolchains, including F-Droid's build
+  servers. No app features, permissions, or behavior change.
+
+Still an alpha — expect rough edges. Not on F-Droid yet.


### PR DESCRIPTION
## Why

The fdroiddata MR for Linthra now passes all metadata checks; the only remaining failure is the **real Android build**, which fails at `Gradle task assembleRelease failed with exit code 1` around `com.android.tools.build:gradle`.

Root cause: **F-Droid builds on JDK 21**, but Linthra's Android tooling predates JDK 21:

- **Gradle 8.3 cannot *run* on JDK 21.** Per Gradle's compatibility matrix, running Gradle on Java 21 requires **Gradle ≥ 8.5** (8.4 can only compile/test for 21, not run on it).
- **Kotlin 1.8.22 predates JDK 21** (the Kotlin compiler gained JDK 21 bytecode support in 1.9.20).

CI was green only because it ran on **JDK 17**, masking the JDK 21 incompatibility F-Droid hits.

## What changed

Minimal, behavior-preserving bump to a Java 21-compatible toolchain:

| Tool | Before | After | Why |
| --- | --- | --- | --- |
| Android Gradle Plugin (`android/settings.gradle`) | 8.1.0 | **8.2.1** | The requested floor; runs on JDK 17–21; needs Gradle ≥ 8.2. |
| Gradle wrapper (`gradle-wrapper.properties`) | 8.3 | **8.7** | **≥ 8.5 required to run Gradle on JDK 21**; 8.7 is mature, JDK-21-proven, and compatible with AGP 8.2.1. |
| Kotlin Gradle plugin (`android/settings.gradle`) | 1.8.22 | **1.9.24** | Compiles/runs on JDK 21 and is compatible with Gradle 8.7. |
| Android build CI Java (`android-debug-apk.yml`, `android-release-build.yml`) | 17 | **21** | So CI exercises the **same Java F-Droid uses** and proves the fix. |

`compileOptions`/`kotlinOptions` stay at **Java 8** — still valid on JDK 21 (only Java 7 source/target was dropped), so the app's bytecode target is unchanged.

Also in this PR:
- **`fastlane/.../changelogs/100030.txt`** — release changelog for **v0.1.0-alpha.30 / versionCode 100030** (the value `tool/version_from_tag.dart` derives from the tag).
- **Docs** — refreshed the toolchain version facts (JDK/Gradle/AGP/Kotlin) in `development.md`, `fdroid-build-recipe.md`, `fdroid-readiness.md`, `fdroid-submission.md` so they match the new build files.

## Privacy / identity preserved

No Google Play Services, ads, analytics, telemetry, or crash reporting added. No app dependencies, permissions, ABIs, application ID, or behavior changed — this is a build-toolchain-only change.

## Verification

Run locally on **JDK 21** with the pinned Flutter 3.27.4:

- ✅ `flutter pub get`
- ✅ `flutter analyze` — *No issues found!*
- ✅ `dart format --set-exit-if-changed .` — 0 changed
- ✅ `flutter test` — **1214 tests passed**
- ✅ `dart run tool/version_from_tag.dart v0.1.0-alpha.30` → `0.1.0-alpha.30` / `100030`

> ⚠️ The full `flutter build apk --release` could **not** be run in this sandbox: there is no Android SDK and Google Maven (`dl.google.com`, source of AGP/AndroidX) is network-blocked here. The Android build is instead verified by **CI on JDK 21**: the `android-debug-apk` workflow (runs on this PR) builds the APK on JDK 21 with the new toolchain — the same Gradle/AGP/Kotlin/Java stack a release build uses. For an explicit release-APK check, run **Android Release Build** via `workflow_dispatch`, or push the `v0.1.0-alpha.30` tag (also JDK 21 now).

## Follow-ups (out of scope here)

- **A new tag `v0.1.0-alpha.30` must be pushed** to cut the release and give fdroiddata a buildable commit. This PR does not tag.
- After tagging + a green from-source build, **re-point fdroiddata** (and the in-repo draft `metadata/io.github.thezupzup.linthra.yml`) to `v0.1.0-alpha.30` / `100030`. Intentionally **not touched here** per the "don't touch fdroiddata" constraint.
- The uncommitted `gradle-wrapper.jar` is a pre-existing item already tracked in the docs; unrelated to this fix.

https://claude.ai/code/session_016PM15bHjZdtEtChvAaw4V1

---
_Generated by [Claude Code](https://claude.ai/code/session_016PM15bHjZdtEtChvAaw4V1)_