### PR TITLE
Make release versioning compatible with F-Droid auto-updates

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -52,18 +52,21 @@ name: Android Release Build
 #
 # Version derivation (tag builds):
 #
-#   * The tag is the single source of truth for the release version. A "Derive
-#     version from tag" step runs `tool/version_from_tag.dart` on GITHUB_REF_NAME
-#     to produce LINTHRA_VERSION_NAME (e.g. 0.1.0-alpha.16) and a strictly
-#     monotonic LINTHRA_VERSION_CODE (e.g. 100016). A malformed tag fails the run
-#     there, before any build, so a release never ships stale/guessed metadata.
-#   * The build bakes those in: `--build-name`/`--build-number` set Android's
-#     versionName/versionCode, and `--dart-define=LINTHRA_VERSION_NAME=...` sets
-#     the in-app version (AppInfo.version) to the same value. A verification step
-#     then confirms the built APK actually carries the derived version.
-#   * Manual `workflow_dispatch` runs pass none of these, so they build the
-#     pubspec.yaml version and are named without a tag (never passed off as a
-#     tagged release). See docs/release-process.md §1 for the full strategy.
+#   * pubspec.yaml is the single source of truth for the release version
+#     (`version: <name>+<code>`), kept in lockstep with the release tag. A "Verify
+#     the tag matches pubspec.yaml" step runs `tool/version_from_tag.dart` on
+#     GITHUB_REF_NAME to compute the canonical LINTHRA_VERSION_NAME (e.g.
+#     0.1.0-alpha.30) and strictly monotonic LINTHRA_VERSION_CODE (e.g. 100030),
+#     then FAILS FAST if pubspec.yaml does not match it — so a tag can never be
+#     built against a stale pubspec, and a malformed tag stops the run before any
+#     build.
+#   * Both manual and tag builds are a plain `flutter build` that reads
+#     versionName/versionCode from pubspec.yaml — exactly what the F-Droid build
+#     does — so the APK/AAB metadata and the in-app version (AppInfo.version) all
+#     agree without any build-time injection. A verification step then confirms
+#     the built APK carries the verified version. Manual `workflow_dispatch` runs
+#     are named without a tag (never passed off as a tagged release). See
+#     docs/release-process.md §1 for the full strategy.
 #
 # See docs/release-signing.md for the required secrets and keystore handling,
 # and docs/release-process.md for the overall release flow.
@@ -202,51 +205,53 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
-      # Tag is the single source of truth for the release version. Parse it once
-      # (tool/version_from_tag.dart), export the result for the build steps, and
-      # fail fast here on a malformed tag — before any expensive build. The grep
-      # guarantees only the two expected KEY=VALUE lines ever reach the env file.
-      - name: Derive version from tag
+      # pubspec.yaml is the source of truth for the release version; each release
+      # bumps `version: <name>+<code>` to match the tag (docs/release-process.md
+      # §1 & §3). Re-derive the canonical versionName/versionCode from the pushed
+      # tag (tool/version_from_tag.dart) and FAIL FAST if pubspec.yaml does not
+      # match it — so a tag is never built against a stale pubspec, and the
+      # F-Droid build (which reads pubspec.yaml) always agrees with this one. A
+      # malformed tag also stops the run here, before any expensive build. The
+      # verified values are exported for the APK-verification and summary steps.
+      - name: Verify the tag matches pubspec.yaml
         if: ${{ steps.mode.outputs.trigger == 'tag' }}
         id: version
         run: |
           set -euo pipefail
-          if ! out="$(dart run tool/version_from_tag.dart "$GITHUB_REF_NAME")"; then
+          if ! derived="$(dart run tool/version_from_tag.dart "$GITHUB_REF_NAME")"; then
             echo "::error::Could not derive a version from tag '$GITHUB_REF_NAME' (see the error above). Use a tag like v0.1.0-alpha.16, v0.1.0-rc.1, or v1.2.3."
             exit 1
           fi
-          echo "Derived from tag '$GITHUB_REF_NAME':"
-          echo "$out"
-          printf '%s\n' "$out" | grep -E '^LINTHRA_VERSION_(NAME|CODE)=' >> "$GITHUB_ENV"
-          printf '%s\n' "$out" | grep -E '^LINTHRA_VERSION_(NAME|CODE)=' >> "$GITHUB_OUTPUT"
+          name="$(printf '%s\n' "$derived" | sed -n 's/^LINTHRA_VERSION_NAME=//p')"
+          code="$(printf '%s\n' "$derived" | sed -n 's/^LINTHRA_VERSION_CODE=//p')"
 
-      # On a tag build, bake the tag-derived version into both the Android build
-      # metadata (--build-name/--build-number) and the in-app version
-      # (--dart-define), so the APK/AAB and Settings/About all agree. A manual
-      # run passes neither, building the pubspec.yaml version instead.
-      - name: Build release APK
-        run: |
-          set -euo pipefail
-          if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
-            flutter build apk --release \
-              --build-name="$LINTHRA_VERSION_NAME" \
-              --build-number="$LINTHRA_VERSION_CODE" \
-              --dart-define=LINTHRA_VERSION_NAME="$LINTHRA_VERSION_NAME"
-          else
-            flutter build apk --release
+          # Read `version: <name>+<code>` from pubspec.yaml and split on '+'.
+          pubspec="$(sed -n 's/^version:[[:space:]]*//p' pubspec.yaml | head -n1)"
+          pubspec_name="${pubspec%%+*}"
+          pubspec_code="${pubspec#*+}"
+
+          echo "Tag '$GITHUB_REF_NAME' encodes to: ${name}+${code}"
+          echo "pubspec.yaml version:            ${pubspec_name}+${pubspec_code}"
+          if [ "$pubspec_name" != "$name" ] || [ "$pubspec_code" != "$code" ]; then
+            echo "::error::pubspec.yaml version (${pubspec_name}+${pubspec_code}) does not match tag '$GITHUB_REF_NAME' (expected ${name}+${code}). Bump pubspec.yaml's 'version:' to match the tag before tagging — see docs/release-process.md §1 & §3."
+            exit 1
           fi
+          echo "Verified: pubspec.yaml matches the tag."
+          {
+            printf 'LINTHRA_VERSION_NAME=%s\n' "$name"
+            printf 'LINTHRA_VERSION_CODE=%s\n' "$code"
+          } | tee -a "$GITHUB_ENV" >> "$GITHUB_OUTPUT"
+
+      # Plain release builds: both manual and tag builds read
+      # versionName/versionCode (and the in-app version) from pubspec.yaml —
+      # exactly as the F-Droid build does. For a tag build the step above has
+      # already verified pubspec.yaml matches the tag, and the verification step
+      # below confirms the built APK carries that version.
+      - name: Build release APK
+        run: flutter build apk --release
 
       - name: Build release AAB
-        run: |
-          set -euo pipefail
-          if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
-            flutter build appbundle --release \
-              --build-name="$LINTHRA_VERSION_NAME" \
-              --build-number="$LINTHRA_VERSION_CODE" \
-              --dart-define=LINTHRA_VERSION_NAME="$LINTHRA_VERSION_NAME"
-          else
-            flutter build appbundle --release
-          fi
+        run: flutter build appbundle --release
 
       # Confirm the built APK actually carries the tag-derived version, so a
       # release can never ship stale metadata. Uses aapt from the Android SDK the
@@ -310,7 +315,7 @@ jobs:
             echo "**Trigger:** ${{ steps.mode.outputs.trigger }}${{ github.event_name == 'push' && format(' (tag {0})', github.ref_name) || '' }}"
             echo ""
             if [ "${{ steps.mode.outputs.trigger }}" = "tag" ]; then
-              echo "**Version:** \`${LINTHRA_VERSION_NAME}\` (versionName) / \`${LINTHRA_VERSION_CODE}\` (versionCode), derived from the tag. The APK/AAB metadata and the in-app Settings/About version all use this value."
+              echo "**Version:** \`${LINTHRA_VERSION_NAME}\` (versionName) / \`${LINTHRA_VERSION_CODE}\` (versionCode), from \`pubspec.yaml\` and verified to match the tag. The APK/AAB metadata and the in-app Settings/About version all use this value."
               echo ""
             else
               echo "**Version:** from \`pubspec.yaml\` (manual build — not a tagged release)."

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,7 +62,11 @@ android {
         applicationId = "io.github.thezupzup.linthra"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
-        // From Flutter (pubspec.yaml); tag release builds override these via --build-name/--build-number derived from the git tag — see docs/release-process.md §1.
+        // From Flutter (pubspec.yaml's `version: <name>+<code>`), the single
+        // source of truth for the release version, kept in lockstep with the
+        // release tag (CI verifies the match before building). A plain
+        // `flutter build` — here and on F-Droid — reads both from pubspec.yaml;
+        // no build-time override. See docs/release-process.md §1.
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/docs/fdroid-build-recipe.md
+++ b/docs/fdroid-build-recipe.md
@@ -40,17 +40,30 @@ submission time.
 | `SourceCode`      | `https://github.com/TheZupZup/Linthra` | Public repository. |
 | `IssueTracker`    | `https://github.com/TheZupZup/Linthra/issues` | GitHub issues. |
 | `Changelog`       | `https://github.com/TheZupZup/Linthra/releases` | Tagged GitHub Releases now exist, so this is set. |
-| `AutoUpdateMode`  | `None` | Disabled on purpose — see the note below. |
-| `UpdateCheckMode` | `None` | Disabled on purpose — see the note below. |
+| `AutoUpdateMode`  | `Version` | **Enabled** — adds a build per new tag. See the note. |
+| `UpdateCheckMode` | `Tags` (with `UpdateCheckData`) | **Enabled** — scans `v*` tags, reading the version from `pubspec.yaml`. See the note. |
 
-`AutoUpdateMode`/`UpdateCheckMode` are **disabled** (`None`). They would only
-work if the release tag and the `pubspec.yaml` version stayed in lockstep, but
-`pubspec.yaml` keeps a fixed dev version (`0.1.0-alpha.15+15`) that does not move
-with the tags — the real version is derived at build time (§5). F-Droid's
-pubspec/tag update detection would therefore read the wrong versionCode, so each
-release is added as a manual `Builds` entry with explicit
-`versionName`/`versionCode`. (This is also what the fdroiddata maintainer
-confirmed on MR !39253.)
+`AutoUpdateMode`/`UpdateCheckMode` are now **enabled**, because `pubspec.yaml`
+carries the release version (`version: <versionName>+<versionCode>`) in lockstep
+with the tag (see [release-process.md §1](./release-process.md#1-versioning-model)).
+F-Droid's default `Tags` path reads only `AndroidManifest.xml`/`build.gradle`,
+which for a Flutter app hold no literal version, so an `UpdateCheckData` entry
+points it at `pubspec.yaml`:
+
+```
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+AutoUpdateMode: Version
+```
+
+At each tag F-Droid extracts the `versionCode` (digits after `+`) and the
+`versionName` (before `+`), picks the highest `versionCode`, and `AutoUpdateMode:
+Version` adds a **plain-build** entry for it. (The earlier MR !39253 used
+`None`/`None` with manual `Builds` entries because `pubspec.yaml` then kept a
+fixed dev version that didn't track the tags; that no longer applies.) The exact
+fdroiddata changes — and the one-time transition for the pre-change
+`v0.1.0-alpha.30` tag — are in
+[fdroid-submission.md §2](./fdroid-submission.md#2-target-version-the-latest-working-alpha).
 
 ## 3. Build source expectations
 
@@ -122,28 +135,27 @@ process (and the GitHub-Release flow) is in
 [docs/release-process.md](./release-process.md), and it is consistent with
 [fdroid-readiness.md §6](./fdroid-readiness.md):
 
-1. **Source of truth:** for a release the **git tag** drives
-   `versionName`/`versionCode` (derived by `tool/version_from_tag.dart`, see
-   [release-process.md §1](./release-process.md#1-versioning-model));
-   `pubspec.yaml` `version: x.y.z+<versionCode>` is the local/dev default.
-   **F-Droid handling (decided):** F-Droid builds from source and does not run
-   our workflow, so a plain `flutter build` would take the static
-   `pubspec.yaml` version (versionCode **15** for every tag). The recipe
-   therefore passes explicit `--build-name`/`--build-number` matching what
-   `tool/version_from_tag.dart` produces for the tag, so `v0.1.0-alpha.29` builds
-   to `0.1.0-alpha.29` / **100029** — matching the metadata and the GitHub
-   channel. Because `pubspec.yaml` doesn't track the tags, `AutoUpdateMode`/
-   `UpdateCheckMode` are `None` and each release is a manual entry (§2). See
-   [fdroid-submission.md §2](./fdroid-submission.md).
+1. **Source of truth:** `pubspec.yaml`'s `version: <versionName>+<versionCode>`
+   drives the version and is bumped to match the tag each release (see
+   [release-process.md §1](./release-process.md#1-versioning-model)). A plain
+   `flutter build apk --release` — the upstream CI build *and* the F-Droid build
+   alike — takes `versionName`/`versionCode` straight from `pubspec.yaml`, so the
+   two channels agree with **no** `--build-name`/`--build-number` flags. Because
+   `pubspec.yaml` now tracks the tags, `AutoUpdateMode`/`UpdateCheckMode` are
+   enabled (§2) — F-Droid auto-detects new releases instead of needing a manual
+   entry each time. (Transition: the pre-change `v0.1.0-alpha.30` tag still
+   carries the old fixed `pubspec.yaml`, so its single entry passes explicit
+   flags as a one-time bridge; new tags don't — see
+   [fdroid-submission.md §2](./fdroid-submission.md#2-target-version-the-latest-working-alpha).)
 2. **`versionCode` increases monotonically** by construction (the encoding can
    never go backwards); never reuse or decrease it.
-3. **Tag format suggestion:** annotated tag `vX.Y.Z` (e.g. `v0.1.0`) on the
-   commit to be built. This matches the `UpdateCheckMode`/`AutoUpdateMode`
-   recommendation in §2.
+3. **Tag format:** annotated tag `vX.Y.Z(-suffix.N)` (e.g. `v0.1.0`) on the
+   commit to be built, matching `pubspec.yaml`'s `versionName`. This is what
+   `UpdateCheckMode: Tags` / `AutoUpdateMode: Version` track in §2.
 4. **Changelog expectations:** add a per-version Fastlane changelog at
    `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` for each
-   release (e.g. `1.txt` for `0.1.0+1`). If GitHub Releases are also published,
-   the `Changelog` metadata field (§2) can point there.
+   release (e.g. `100030.txt` for `0.1.0-alpha.30+100030`). If GitHub Releases are
+   also published, the `Changelog` metadata field (§2) can point there.
 5. Ensure committed generated files (§4.1) are current on the tagged commit.
 
 ## 6. Known blockers
@@ -172,24 +184,26 @@ These must be resolved before an actual F-Droid submission (see also
 **Resolved:** the store icon, feature graphic, and eight real phone screenshots
 are committed (the core set tracked by issue #77; see
 [docs/listing-assets.md §6](./listing-assets.md)); a `v*` tag now exists (target
-`v0.1.0-alpha.29`; the broken `v0.1.0-alpha.24` is excluded); the versionCode
-scheme is decided (tag-derived `100029`, §5.1); and the full transitive
-dependency audit is complete
+`v0.1.0-alpha.30`; the broken `v0.1.0-alpha.24` is excluded); the versionCode
+scheme is decided and now lives in `pubspec.yaml` (`0.1.0-alpha.30+100030`, §5.1),
+enabling auto-update (§2); and the full transitive dependency audit is complete
 ([dependency-license-audit.md](./dependency-license-audit.md)).
 
 ## 7. Draft F-Droid metadata recipe
 
 A complete, current draft recipe now lives in the repo at
 [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml),
-pinned to the latest working alpha (`commit: v0.1.0-alpha.29`, versionName
-`0.1.0-alpha.29`, versionCode `100029`). That file is the canonical draft; edit
-it there rather than duplicating a snippet here.
+pinned to the latest working alpha (`commit: v0.1.0-alpha.30`, versionName
+`0.1.0-alpha.30`, versionCode `100030`) with auto-update enabled
+(`AutoUpdateMode: Version`, `UpdateCheckMode: Tags`, `UpdateCheckData` reading
+`pubspec.yaml`). That file is the canonical draft; edit it there rather than
+duplicating a snippet here.
 
 > **Still a draft — not submitted.** The recipe now uses the `flutter` srclib
 > method from `templates/build-flutter.yml` and a single universal APK, but it
 > must still be validated against fdroiddata via an actual `fdroid build` at
 > submission time (in particular any NDK/CMake the native SQLite build needs).
-> The version target and tag-derived versionCode are set; see the
+> The version target lives in `pubspec.yaml` and auto-update is wired up; see the
 > [submission package](./fdroid-submission.md) for the MR checklist and next
 > steps and the [readiness checklist](./fdroid-readiness.md#8-remaining-blockers-before-submission)
 > for the remaining blockers.

--- a/docs/fdroid-readiness.md
+++ b/docs/fdroid-readiness.md
@@ -17,19 +17,20 @@ availability.
   isn't production-stable, and the rough edges are documented.
 - **Distribution:** GitHub Releases only, as a sideloaded APK (Obtainium works
   too). No F-Droid metadata has been submitted, and Linthra isn't on F-Droid.
-- **Tagged releases now exist:** `v0.1.0-alpha.1` … `v0.1.0-alpha.29`, each built
+- **Tagged releases now exist:** `v0.1.0-alpha.1` … `v0.1.0-alpha.30`, each built
   by `.github/workflows/android-release-build.yml`. The F-Droid target is the
-  latest one that launches, `v0.1.0-alpha.29` (versionName `0.1.0-alpha.29`,
-  tag-derived versionCode `100029`). Skip `v0.1.0-alpha.24`: its GitHub Release
-  is marked "Broken release — do not install … startup regression"; alpha.25 was
-  the hotfix that reverted it, and the target has since moved on to alpha.29.
+  latest one that launches, `v0.1.0-alpha.30` (versionName `0.1.0-alpha.30`,
+  versionCode `100030`, carried in `pubspec.yaml`). Skip `v0.1.0-alpha.24`: its
+  GitHub Release is marked "Broken release — do not install … startup
+  regression"; alpha.25 was the hotfix that reverted it, and the target has since
+  moved on to alpha.30.
 - **Groundwork in place:** a stable application ID, the MPL-2.0 license, a real
   app/launcher icon, Fastlane-style store metadata under
   `fastlane/metadata/android/en-US/` (text plus the real icon, feature graphic,
   and eight real phone screenshots), a finished dependency/license audit, the
   draft recipe at [`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
-  (pinned to `v0.1.0-alpha.29`), and the submission package at
-  [`docs/fdroid-submission.md`](./fdroid-submission.md).
+  (pinned to `v0.1.0-alpha.30`, auto-update enabled), and the submission package
+  at [`docs/fdroid-submission.md`](./fdroid-submission.md).
 - **Not submitted yet.** See [Remaining blockers](#8-remaining-blockers-before-submission).
 
 ## 2. App identity
@@ -204,30 +205,31 @@ F-Droid builds from a git tag. Summary (the canonical, step-by-step process —
 including the GitHub-Release flow — is in
 [docs/release-process.md](./release-process.md)):
 
-1. The **git tag** is the source of truth for a release's version; the build
-   derives `versionName`/`versionCode` from it (see
-   [release-process.md §1](./release-process.md#1-versioning-model)).
-   `pubspec.yaml` only sets the version for local/dev builds.
-2. Tag releases as `vX.Y.Z[-suffix]` (annotated tag) on the commit to be built.
-3. `versionCode` is derived to be **strictly monotonic** automatically (encoded
-   from the version); never reuse or decrease it.
+1. **`pubspec.yaml`** is the source of truth for a release's version
+   (`version: <versionName>+<versionCode>`), bumped to match the tag each release
+   (see [release-process.md §1](./release-process.md#1-versioning-model)). A plain
+   `flutter build` reads it.
+2. Tag releases as `vX.Y.Z[-suffix.N]` (annotated tag) on the commit to be built,
+   matching `pubspec.yaml`'s `versionName`.
+3. `versionCode` is the **strictly monotonic** canonical encoding of the version
+   (`tool/version_from_tag.dart`); never reuse or decrease it.
 4. Add a matching changelog file at
    `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`, named by the
-   **derived** code (e.g. `100016.txt` for `v0.1.0-alpha.16`).
-5. The F-Droid recipe should use `AutoUpdateMode`/`UpdateCheckMode` tied to tags
-   so new tagged releases are picked up.
+   code (e.g. `100030.txt` for `0.1.0-alpha.30+100030`).
+5. The F-Droid recipe uses `AutoUpdateMode: Version` / `UpdateCheckMode: Tags`
+   (with `UpdateCheckData` reading `pubspec.yaml`) so new tagged releases are
+   picked up automatically.
 
 > **How the F-Droid build gets the right version.** F-Droid builds from source at
-> the tag and doesn't run our release workflow, so a plain `flutter build` there
-> would read the version from `pubspec.yaml` (`0.1.0-alpha.15+15`) and label every
-> tag as versionCode 15 — which F-Droid can't tell apart. The draft recipe avoids
-> that by deriving the version from the checked-out tag with
-> `tool/version_from_tag.dart` and passing `--build-name`/`--build-number`, so
-> `v0.1.0-alpha.29` builds to `0.1.0-alpha.29` / `100029` — the same value the
-> GitHub release build uses, distinct and increasing per tag, and still correct
-> under `AutoUpdateMode` for future tags. (Bumping `pubspec.yaml` at each tagged
-> commit would also work and is cleaner long-term, but it changes the release
-> process; see [docs/fdroid-submission.md §2](./fdroid-submission.md).)
+> the tag and doesn't run our release workflow, but `pubspec.yaml` now carries the
+> release version in lockstep with the tag, so a plain `flutter build apk
+> --release` reads `0.1.0-alpha.30` / `100030` directly — the same value the
+> GitHub release build uses, distinct and increasing per tag. F-Droid's default
+> `Tags` path doesn't read `pubspec.yaml`, so the recipe adds an `UpdateCheckData`
+> entry pointing at it; see
+> [docs/fdroid-submission.md §2](./fdroid-submission.md#2-target-version-and-auto-update).
+> (Transition: the pre-change `v0.1.0-alpha.30` tag still has the old fixed
+> `pubspec.yaml`, so its one seed entry passes explicit flags; new tags don't.)
 
 ## 7. Metadata checklist
 
@@ -241,14 +243,14 @@ Stored under `fastlane/metadata/android/en-US/`:
   Description.
 - [x] `changelogs/1.txt`, `9.txt`, `15.txt` — legacy per-version notes (named by
   the old hand-numbered `versionCode`); kept as-is.
-- [x] `changelogs/100025.txt` — notes for the earlier alpha.25 target, named by
-  its derived versionCode `100025`; kept as history now that the target has moved
-  on to alpha.29.
-- [x] `changelogs/100029.txt` — notes for the current F-Droid target
-  `v0.1.0-alpha.29`, named by the **derived** versionCode `100029` (the
-  convention going forward — see
+- [x] `changelogs/100025.txt`, `100029.txt` — notes for the earlier alpha.25 /
+  alpha.29 targets, named by their `versionCode`; kept as history now that the
+  target has moved on to alpha.30.
+- [x] `changelogs/100030.txt` — notes for the current F-Droid target
+  `v0.1.0-alpha.30`, named by its `versionCode` `100030` (the convention going
+  forward — see
   [release-process.md §1](./release-process.md#1-versioning-model)). Keep new
-  changelog filenames in lockstep with the built APK's derived `versionCode`.
+  changelog filenames in lockstep with `pubspec.yaml`'s `versionCode`.
 - [x] `images/icon.png` — 512×512 real Linthra store icon. The launcher icons
   under `android/app/src/main/res/mipmap-*` are now the same real mark (adaptive
   + legacy), generated from `tool/branding/` — no longer the default Flutter
@@ -302,12 +304,12 @@ What each one shows, plus the privacy review and the still-optional extras, is i
   [docs/listing-assets.md §6](./listing-assets.md). Optional extras
   (Downloads-with-tracks, Android Auto, Cast, tablet) remain nice-to-haves, not
   blockers.
-- **A tagged release now exists.** `v0.1.0-alpha.29` is the latest **working**
+- **A tagged release now exists.** `v0.1.0-alpha.30` is the latest **working**
   alpha and is the recipe's `commit:`. The withdrawn, broken `v0.1.0-alpha.24` is
   explicitly **not** targeted.
-- **versionCode reconciliation decided.** The recipe derives the version from the
-  tag (→ `0.1.0-alpha.29` / `100029`), matching the GitHub channel and staying
-  monotonic/AutoUpdate-safe (§6).
+- **versionCode reconciliation decided.** `pubspec.yaml` now carries the version
+  (`0.1.0-alpha.30` / `100030`), matching the GitHub channel and staying
+  monotonic; auto-update is enabled off the tags (§6).
 - **Fastlane description refreshed** to match the current alpha, with the
   "unofficial / not affiliated" framing (§7).
 - Full transitive dependency/license audit complete (§4 — 152 packages, all
@@ -323,9 +325,9 @@ The full step-by-step submission flow and the ready-to-adapt MR text live in
    [audit doc](./dependency-license-audit.md)). Re-run on any dependency change.
 2. ✅ **Fastlane `full_description.txt` refreshed** to match the current alpha,
    with the "unofficial / not affiliated" framing (§7).
-3. ✅ **Target tag + versionCode decided** — `v0.1.0-alpha.29` / `100029`, with a
-   matching `changelogs/100029.txt`; the recipe derives the version from the tag
-   (§6). The broken `v0.1.0-alpha.24` is excluded.
+3. ✅ **Target tag + versionCode decided** — `v0.1.0-alpha.30` / `100030`, with a
+   matching `changelogs/100030.txt`; `pubspec.yaml` carries the version and
+   auto-update tracks the tags (§6). The broken `v0.1.0-alpha.24` is excluded.
 4. ✅ **Screenshots committed** — eight real phone screenshots under
    `images/phoneScreenshots/` (§7; see [docs/listing-assets.md §6](./listing-assets.md);
    the core set for #77). Optional extras (Downloads-with-tracks, Android Auto,
@@ -378,7 +380,7 @@ readiness pass with the pinned toolchain (Flutter 3.27.4 / Dart 3.6.2); they are
 
 | Check | Result |
 | ----- | ------ |
-| Metadata YAML parses (PyYAML) | ✅ this pass — valid YAML; fields/types as expected (Summary 57 ≤ 80 chars; versionCode integer `100029`). Not a full `fdroid lint`. |
+| Metadata YAML parses (PyYAML) | ✅ this pass — valid YAML; fields/types as expected (Summary 57 ≤ 80 chars; versionCode integer `100030`; `UpdateCheckData` regexes match the `pubspec.yaml` `version:` line). Not a full `fdroid lint`. |
 | `dart format` / `flutter analyze` / `flutter test` | ✅ green in CI (`ci.yml`) on every PR. Not re-run in this pass (no toolchain). |
 | transitive license audit | ✅ all permissive, no GMS (§4). |
 | `flutter build apk --debug` | ✅ built by CI per PR (`android-debug-apk.yml`). |

--- a/docs/fdroid-submission.md
+++ b/docs/fdroid-submission.md
@@ -28,53 +28,64 @@ tagging), and the draft recipe at
 | Issues  | https://github.com/TheZupZup/Linthra/issues |
 | Category| Multimedia                    |
 
-## 2. Target version: the latest working alpha
+## 2. Target version and auto-update
 
 F-Droid builds from a git tag, and Linthra now has tags (`v0.1.0-alpha.1` …
-`v0.1.0-alpha.29`, built by the Android Release Build workflow). The submission
+`v0.1.0-alpha.30`, built by the Android Release Build workflow). The submission
 targets the latest one that launches cleanly:
 
 | Item            | Value                                   |
 | --------------- | --------------------------------------- |
-| Target tag      | `v0.1.0-alpha.29` (commit `ab0006b`)     |
-| versionName     | `0.1.0-alpha.29`                        |
-| versionCode     | `100029`                                |
-| Changelog file  | `fastlane/metadata/android/en-US/changelogs/100029.txt` |
+| Target tag      | `v0.1.0-alpha.30`                        |
+| versionName     | `0.1.0-alpha.30`                        |
+| versionCode     | `100030`                                |
+| Changelog file  | `fastlane/metadata/android/en-US/changelogs/100030.txt` |
 
-One thing to be careful about: don't target `v0.1.0-alpha.24`. Its GitHub
-Release is marked "Broken release — do not install … startup regression," and
-alpha.25 was the hotfix that reverted it. The target here is the latest working
-alpha, `v0.1.0-alpha.29`, so the recipe's `commit:` and the
-`CurrentVersion`/`CurrentVersionCode` all point at alpha.29.
+Don't target `v0.1.0-alpha.24`: its GitHub Release is marked "Broken release — do
+not install … startup regression," and alpha.25 was the hotfix that reverted it.
 
-### Why versionCode `100029` and not `15`
+### Auto-update is enabled (versionName/versionCode come from `pubspec.yaml`)
 
-`pubspec.yaml` keeps a fixed dev version, `0.1.0-alpha.15+15`, that's the same at
-every tagged commit (the release workflow overrides it per release, so it never
-gets bumped). That has two consequences:
+`pubspec.yaml` now carries the release version in lockstep with the tag
+(`version: 0.1.0-alpha.30+100030`; see
+[release-process.md §1](./release-process.md#1-versioning-model)), so F-Droid
+reads it at each tag and tracks new releases **automatically**. The fields that
+enable this:
 
-- A plain `flutter build apk` at any tag produces versionName `0.1.0-alpha.15`
-  and versionCode `15`. Every F-Droid build would then look like the same
-  version, which F-Droid can't work with — so this is a real blocker, not a
-  detail.
-- The upstream GitHub release build avoids that by deriving the version from the
-  tag with `tool/version_from_tag.dart` (the single source of truth):
-  `v0.1.0-alpha.29` → `0.1.0-alpha.29` / `100029`.
+```yaml
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+CurrentVersion: 0.1.0-alpha.30
+CurrentVersionCode: 100030
+```
 
-So the F-Droid recipe does the same thing — it derives the version from the
-checked-out tag and passes `--build-name`/`--build-number`. The APK then reports
-`0.1.0-alpha.29` / `100029`, matching the metadata and the GitHub build. That
-keeps each tag's versionCode distinct and increasing, keeps the F-Droid and
-GitHub codes identical for the same tag, and stays correct under `AutoUpdateMode`
-for future tags (since the version isn't hard-coded). The changelog file is
-named by that derived code (`100029.txt`), in line with
+`UpdateCheckData` is **required** for a Flutter app: F-Droid's default `Tags`
+path reads only `AndroidManifest.xml`/`build.gradle`, which carry no literal
+version for Flutter, so it must be pointed at `pubspec.yaml`. It splits the
+`version:` line on `+` — group 1 of the first regex is the `versionCode` (after
+`+`), group 1 of the second is the `versionName` (before `+`). F-Droid picks the
+highest `versionCode` across the tags, and `AutoUpdateMode: Version` adds a
+**plain-build** entry (`flutter build apk --release`, no
+`--build-name`/`--build-number`) using the tag as the commit. The changelog file
+is named by that `versionCode` (`100030.txt`), in line with
 [release-process.md §1](./release-process.md#1-versioning-model) (the older
 `1.txt`/`9.txt`/`15.txt` stay as they are).
 
-There's a cleaner long-term option — bump `pubspec.yaml` to the tag version at
-each tagged commit, so a plain build is correct and the recipe needs no flags —
-but that changes the release process, so it's out of scope here. The
-derive-from-tag approach works for this submission without touching anything.
+### One-time transition for the `v0.1.0-alpha.30` tag
+
+`v0.1.0-alpha.30` was tagged **before** `pubspec.yaml` started tracking the
+version, so at that exact commit `pubspec.yaml` is still `0.1.0-alpha.15+15` and a
+plain build there would report `0.1.0-alpha.15` / `15`. So the single seed
+`Builds` entry passes explicit
+`--build-name=0.1.0-alpha.30 --build-number=100030 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.30`
+to build it as `0.1.0-alpha.30` / `100030`. **From `v0.1.0-alpha.31` onward** the
+committed `pubspec.yaml` matches the tag, so those flags are dropped and the build
+is a plain `flutter build apk --release`; when `AutoUpdateMode` adds the first new
+entry, remove the flags it inherits from the seed (a one-time edit). The draft
+recipe at
+[`metadata/io.github.thezupzup.linthra.yml`](../metadata/io.github.thezupzup.linthra.yml)
+carries exactly this, with the transition spelled out in comments.
 
 ## 3. Build recipe status
 
@@ -177,13 +188,13 @@ submitting.
 
 | Check | Status |
 | ----- | ------ |
-| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (no inline Summary/Description; F-Droid pulls them from Fastlane; versionCode an integer, `100029`). This only checks the YAML, not F-Droid's schema (see below). |
+| Metadata YAML parses (PyYAML) | Done here — valid YAML, fields and types as expected (no inline Summary/Description; F-Droid pulls them from Fastlane; versionCode an integer, `100030`; `UpdateCheckData` regexes extract `100030` / `0.1.0-alpha.30` from the `pubspec.yaml` `version:` line). This only checks the YAML, not F-Droid's schema (see below). |
 | `flutter pub get` | Not run here (no toolchain). Run locally / in CI. |
 | `dart format --set-exit-if-changed .` | Not run here. CI (`ci.yml`) runs it on every PR. |
 | `flutter analyze` | Not run here. CI runs it on every PR. |
 | `flutter test` | Not run here. CI runs it on every PR. |
 | `flutter build apk --debug` | Not run here (no Android SDK). CI (`android-debug-apk.yml`) builds it on every PR. |
-| `flutter build apk --release` | Not run here. The tag build (`android-release-build.yml`) produced the alpha.29 APK; re-confirm a clean from-source release build on a machine with the SDK. |
+| `flutter build apk --release` | Not run here. The tag build (`android-release-build.yml`) produced the alpha.30 APK; re-confirm a clean from-source release build on a machine with the SDK. |
 | `fdroid lint` / `fdroid build -l io.github.thezupzup.linthra` | Not run here (no fdroidserver). Run inside an fdroiddata checkout (§8). |
 
 A note on that first row: a YAML parse isn't the same as F-Droid validation. The
@@ -198,8 +209,10 @@ flutter pub get
 dart format --set-exit-if-changed .
 flutter analyze
 flutter test
-flutter build apk --release \
-  --build-name=0.1.0-alpha.29 --build-number=100029   # what the recipe derives
+flutter build apk --release    # reads versionName/versionCode from pubspec.yaml
+# NOTE: at the pre-change v0.1.0-alpha.30 tag pubspec.yaml is still
+# 0.1.0-alpha.15+15, so to reproduce that exact tag add (one-time, see §2):
+#   --build-name=0.1.0-alpha.30 --build-number=100030 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.30
 
 # In an fdroiddata checkout, once metadata/io.github.thezupzup.linthra.yml is in:
 fdroid readmeta
@@ -225,9 +238,9 @@ fdroid build -v -l io.github.thezupzup.linthra        # full from-source build t
    there.
 6. Open or update the merge request using fdroiddata's **"App inclusion"**
    merge-request template (§9) and check the boxes that apply. Be upfront that
-   it's an early-alpha, pre-release submission, and that auto-update is disabled
-   on purpose (pubspec doesn't track the tags), so each version is added
-   manually.
+   it's an early-alpha, pre-release submission, and that auto-update is enabled
+   (pubspec.yaml tracks the tags) with a one-time explicit-flag entry for the
+   pre-change `v0.1.0-alpha.30` tag (§2).
 7. Don't describe Linthra as being on F-Droid until the merge request is merged
    and the build publishes.
 
@@ -246,7 +259,7 @@ Adds Linthra, an open-source, local-first Android music player for local files
 and self-hosted servers (Jellyfin, Navidrome/Subsonic). Unofficial community
 client — not affiliated with Jellyfin, Navidrome, or Subsonic. MPL-2.0; no ads,
 tracking, analytics, crash-reporting SDK, or Google Play Services. Initial
-target: `v0.1.0-alpha.29` (versionCode `100029`); the broken `v0.1.0-alpha.24`
+target: `v0.1.0-alpha.30` (versionCode `100030`); the broken `v0.1.0-alpha.24`
 is skipped. Early alpha, usable for testing.
 
 ### Required
@@ -260,7 +273,7 @@ is skipped. Early alpha, usable for testing.
 ### Strongly Recommended
 
 - [x] The upstream repo contains the app metadata (summary/description/images/changelog) in a Fastlane structure — `fastlane/metadata/android/en-US/` (short_description, full_description, title, changelogs, icon, feature graphic, 8 screenshots). Summary/Description are intentionally **not** set in fdroiddata; F-Droid pulls them from Fastlane.
-- [ ] Releases are tagged and auto update is enabled — releases are tagged (`v0.1.0-alpha.29`), but auto-update is intentionally **disabled** (`AutoUpdateMode`/`UpdateCheckMode: None`): `pubspec.yaml` carries a fixed dev version that does not track the tags, so each release is added manually with explicit `versionName`/`versionCode`.
+- [x] Releases are tagged and auto update is enabled — releases are tagged (`v0.1.0-alpha.30`), and auto-update is **enabled**: `AutoUpdateMode: Version`, `UpdateCheckMode: Tags`, and `UpdateCheckData` reading `versionName`/`versionCode` from `pubspec.yaml` (which now tracks the tags). The single seed `Builds` entry passes explicit `versionName`/`versionCode` only because the pre-change `v0.1.0-alpha.30` tag predates pubspec tracking; new tags build plainly (§2).
 
 ### Suggested
 
@@ -292,9 +305,9 @@ Tracks the actual submission of Linthra to
 Linthra is on F-Droid — it's the submission work itself. The readiness
 groundwork is done (#87); this covers cutting the merge request.
 
-The target is the latest alpha that launches, `v0.1.0-alpha.29` (versionCode
-`100029`). The withdrawn, broken `v0.1.0-alpha.24` is skipped — alpha.25 was its
-hotfix, and the target has since moved on to alpha.29.
+The target is the latest alpha that launches, `v0.1.0-alpha.30` (versionCode
+`100030`). The withdrawn, broken `v0.1.0-alpha.24` is skipped — alpha.25 was its
+hotfix, and the target has since moved on to alpha.30.
 
 ### Checklist
 
@@ -329,6 +342,6 @@ hotfix, and the target has since moved on to alpha.29.
 ### Status
 
 The metadata, audit, permissions, anti-feature review, build recipe, screenshots,
-and submission text are ready and point at `v0.1.0-alpha.29`. What's left before
+and submission text are ready and point at `v0.1.0-alpha.30`. What's left before
 the merge request: an SDK-machine release-build re-confirmation, and `fdroid lint`
 / `fdroid build` in an fdroiddata checkout.

--- a/docs/play-store-readiness.md
+++ b/docs/play-store-readiness.md
@@ -15,13 +15,12 @@ identity, version source, and assets but differ on signing and submission.
 
 ## 1. Current status
 
-- **Stage:** early alpha. The released version comes from the pushed `v*` tag,
-  not `pubspec.yaml`: the latest released alpha is `v0.1.0-alpha.29` (versionName
-  `0.1.0-alpha.29`, tag-derived `versionCode` `100029`). `pubspec.yaml`'s
-  `version:` (currently `0.1.0-alpha.15+15`) only seeds local/dev builds and
-  intentionally trails the tags. See [§11](#11-versioning-for-play-uploads) and
-  [release-process.md §1](./release-process.md#1-versioning-model) — the tag is
-  the source of truth.
+- **Stage:** early alpha. The released version lives in `pubspec.yaml`
+  (`version: <versionName>+<versionCode>`) in lockstep with the pushed `v*` tag:
+  the latest released alpha is `v0.1.0-alpha.30` (versionName `0.1.0-alpha.30`,
+  versionCode `100030`). See [§11](#11-versioning-for-play-uploads) and
+  [release-process.md §1](./release-process.md#1-versioning-model) — `pubspec.yaml`
+  is the source of truth and the tag must match it.
 - **Distribution:** sideloadable pre-release APK/AAB attached to GitHub
   Releases. **Not** on Google Play, **not** on F-Droid; nothing publishes
   automatically.
@@ -239,25 +238,25 @@ Play enforces a **strictly increasing `versionCode`** per package: an upload
 with an equal or lower code than any previous upload (on any track) is rejected.
 Linthra's versioning model supports this safely:
 
-- **The Git tag is the source of truth for a release.** The release build derives
-  `versionName`/`versionCode` from the tag and bakes them in — the strictly
-  monotonic, fully-encoded `versionCode` (e.g. `v0.1.0-alpha.16` → `100016`)
-  satisfies Play's strictly-increasing requirement by construction. `pubspec.yaml`
-  only sets the version for local/dev builds. See
+- **`pubspec.yaml` is the source of truth for a release's version**, bumped to
+  match the tag each release. The strictly monotonic, fully-encoded `versionCode`
+  (e.g. `0.1.0-alpha.16` → `100016`) satisfies Play's strictly-increasing
+  requirement by construction. A plain `flutter build appbundle --release` reads
+  `versionName`/`versionCode` straight from `pubspec.yaml`. See
   [release-process.md §1](./release-process.md#1-versioning-model).
 - The in-app About/Settings string (`AppInfo.version` in
-  `lib/core/app_info.dart`) shows the **effective** version: the tag-derived value
-  on a release build (via `--dart-define`), or a `const` mirror of `pubspec.yaml`
-  on dev builds that a CI test (`test/core/app_info_version_test.dart`) **fails
-  the build if it drifts**. Either way the displayed version matches the shipped
-  one. **No manual versioning edits are needed for Play.**
+  `lib/core/app_info.dart`) mirrors `pubspec.yaml`'s `versionName` via a `const`
+  that a CI test (`test/core/app_info_version_test.dart`) **fails the build if it
+  drifts**, so the displayed version matches the shipped one. **No manual
+  versioning edits beyond bumping `pubspec.yaml` (and that mirror) are needed for
+  Play.**
 
 **Per-upload checklist (in addition to
 [release-process.md §3](./release-process.md#3-pre-tag-checklist)):**
 
-- [ ] The upload is built from a `vX.Y.Z[-suffix]` tag, so `versionName`,
-      `versionCode`, and the in-app `AppInfo.version` are all tag-derived and
-      consistent — no manual version edits.
+- [ ] The upload is built from a `vX.Y.Z[-suffix.N]` tag whose `versionName`
+      matches `pubspec.yaml`, so `versionName`, `versionCode`, and the in-app
+      `AppInfo.version` are all consistent — CI verifies the tag matches pubspec.
 - [ ] `versionCode` is **strictly greater** than every code ever uploaded to
       Play — across **all** tracks, not just the current one (the encoded scheme
       guarantees this for increasing tags). Once a code is consumed by an upload
@@ -367,11 +366,12 @@ maintainer.**
 ### Before the Play Console
 
 - [ ] Merge the stable release PR(s) to `main`; CI green (analyze, test, format).
-- [ ] Create the release **tag** (`vX.Y.Z[-suffix]`) — the version source of
-      truth (§11, [release-process.md §2](./release-process.md#2-tagging)).
-- [ ] Verify **versionName / versionCode** are tag-derived and `versionCode` is
-      **strictly greater** than every code ever uploaded to Play, on any track
-      (§11). Preview with `dart run tool/version_from_tag.dart vX.Y.Z`.
+- [ ] Bump `pubspec.yaml` (and `AppInfo._devVersionName`) and create the matching
+      release **tag** (`vX.Y.Z[-suffix.N]`) — the version source of truth (§11,
+      [release-process.md §2](./release-process.md#2-tagging)).
+- [ ] Verify **versionName / versionCode** in `pubspec.yaml` match the tag and the
+      `versionCode` is **strictly greater** than every code ever uploaded to Play,
+      on any track (§11). Preview with `dart run tool/version_from_tag.dart vX.Y.Z`.
 - [ ] Build a **release-signed AAB** locally or via the release workflow
       (§3–§4, [release-signing.md](./release-signing.md)). A **debug-signed**
       build must never be uploaded.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,7 +5,7 @@ git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
 docs reference this document rather than restating the plan.
 
 > **Sideloadable alphas only; nothing here publishes to a store.** Linthra has
-> tagged pre-release alphas (latest `v0.1.0-alpha.15`) attached to GitHub
+> tagged pre-release alphas (latest `v0.1.0-alpha.30`) attached to GitHub
 > Releases as sideloadable APKs/AABs, but is **not** on F-Droid. Pushing a `v*`
 > tag builds the release artifacts automatically. For **alpha/beta/rc** tags the
 > build can create a GitHub **pre-release** and attach the APK/AAB to it; for
@@ -15,17 +15,28 @@ docs reference this document rather than restating the plan.
 
 ## 1. Versioning model
 
-**The Git tag is the source of truth for a release; `pubspec.yaml` is the
-default for local/dev builds.** A tagged release build derives its version from
-the tag and bakes the same value into the APK/AAB metadata *and* the in-app
-display, so they can never drift. You do **not** edit any version constant to
-cut a release — you just push the tag.
+**`pubspec.yaml` is the single source of truth for the version; each release
+bumps it to match the tag.** Its `version: <versionName>+<versionCode>` feeds
+Android's `versionName`/`versionCode` *and* the in-app display alike, for **every**
+build — a plain `flutter build` locally, in CI, and on F-Droid. The release tag
+must match it, and CI **fails the build** if they disagree (§4), so the tag,
+`pubspec.yaml`, the APK/AAB metadata, and the in-app version can never drift. To
+cut a release you bump the version in `pubspec.yaml` (and its in-app mirror) and
+tag the matching version (§3) — there are no per-release `--build-name`/
+`--build-number` flags to pass anywhere.
 
 ```
-                       ┌─ --build-name / --build-number ─▶ Android versionName/versionCode (APK/AAB)
-push tag  ─▶  parse ───┤
-v0.1.0-alpha.16        └─ --dart-define=LINTHRA_VERSION_NAME ─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
+pubspec.yaml                     ┌─▶ Android versionName/versionCode (APK/AAB)
+version: 0.1.0-alpha.30+100030  ─┤
+   ( == tag v0.1.0-alpha.30 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
 ```
+
+> **Why this matters for F-Droid.** Because the version lives in `pubspec.yaml`
+> at each tagged commit, F-Droid reads it directly and **auto-detects new
+> releases** (`UpdateCheckMode: Tags` + `UpdateCheckData`, `AutoUpdateMode:
+> Version`) from a plain build, instead of needing a hand-written `Builds` entry
+> per release. See
+> [fdroid-build-recipe.md §2](./fdroid-build-recipe.md#2-expected-f-droid-metadata-repo-fields).
 
 ### versionName
 
@@ -75,26 +86,31 @@ the build** (see "Malformed tags" below) instead of shipping guessed metadata.
 > at `fastlane/metadata/android/en-US/changelogs/<encoded code>.txt` (e.g.
 > `100016.txt`); the historical `1.txt`/`9.txt`/`15.txt` stay as-is.
 
-The parsing/encoding rules live in **`tool/version_from_tag.dart`** (the single
-source of truth), exercised by `test/tooling/version_from_tag_test.dart`. The
-release workflow calls it; nothing else needs to know the formula.
+The encoding rules live in **`tool/version_from_tag.dart`**, exercised by
+`test/tooling/version_from_tag_test.dart`. You use it to **preview** the
+`versionCode` for a version before bumping `pubspec.yaml` (§3); CI uses it to
+**verify** the tag matches `pubspec.yaml` (§4); and
+`test/core/app_info_version_test.dart` uses it to confirm `pubspec.yaml`'s
+`versionCode` is the canonical encoding of its `versionName`. Nothing bakes the
+version in from the tag — `pubspec.yaml` carries it.
 
 ### In-app version (`AppInfo.version`)
 
 Settings/About, the diagnostics / "Report a bug" output, and the Jellyfin
-client-version header all read `AppInfo.version` in `lib/core/app_info.dart`:
+client-version header all read `AppInfo.version` in `lib/core/app_info.dart`.
+For **every** build — local, CI release, and F-Droid — it resolves to
+`AppInfo._devVersionName`, a `const` that mirrors `pubspec.yaml`'s `versionName`,
+so the in-app version always matches the released APK/AAB.
+`test/core/app_info_version_test.dart` **fails CI** if `_devVersionName` drifts
+from `pubspec.yaml`, or if `pubspec.yaml`'s `versionCode` is not the canonical
+encoding of its `versionName` — so the two files (and the tag) can never diverge.
 
-- **Tagged release build:** the workflow passes
-  `--dart-define=LINTHRA_VERSION_NAME=<derived versionName>`, so `AppInfo.version`
-  is exactly the tag's version — matching the APK/AAB metadata.
-- **Local/dev build & the test suite** (no dart-define): `AppInfo.version` falls
-  back to `AppInfo._devVersionName`, a `const` that mirrors `pubspec.yaml`'s
-  `versionName`. `test/core/app_info_version_test.dart` **fails CI if that
-  fallback drifts from `pubspec.yaml`**, so the two stay aligned for dev builds.
-
-A runtime package-metadata plugin was deliberately avoided: the dart-define keeps
+A runtime package-metadata plugin was deliberately avoided: the `const` keeps
 `AppInfo.version` resolvable without a plugin and uses the *same* value the
 Android build metadata gets, so there is only one effective version per build.
+An optional `--dart-define=LINTHRA_VERSION_NAME=...` override remains as an
+escape hatch (normally unused; see `AppInfo._definedVersionName`), but standard
+builds need it nowhere.
 
 ### Rules
 
@@ -109,31 +125,43 @@ Android build metadata gets, so there is only one effective version per build.
 ### Malformed tags
 
 The build **fails fast** — before producing any artifact — when the tag is not a
-supported release tag. `tool/version_from_tag.dart` exits non-zero (failing the
-"Derive version from tag" step) for, e.g.:
+supported release tag, **or when `pubspec.yaml` does not match the tag** (§4).
+The "Verify the tag matches pubspec.yaml" step runs `tool/version_from_tag.dart`,
+which exits non-zero for, e.g.:
 
 - a non-`X.Y.Z` core (`v1.2`, `v1.2.3.4`, `vfoo`);
 - an unknown or numberless pre-release (`v1.2.3-alpha`, `v1.2.3-preview.1`);
 - SemVer build metadata (`v1.2.3-alpha.1+build`);
 - fields outside the encodable range (`v0.100.0`, `v0.1.0-alpha.300`).
 
-The error names the offending tag and the expected format. Fix it (delete the
-bad tag, push a corrected one) and re-run — nothing stale is ever published.
+The error names the offending tag (or the `pubspec.yaml` mismatch) and the
+expected value. Fix it — bump `pubspec.yaml` to match, or delete the bad tag and
+push a corrected one — and re-run; nothing stale is ever published.
 
 ### Manual builds vs. tag builds
 
-A manual `workflow_dispatch` run is **not** a release: it passes none of the
-version flags, builds the `pubspec.yaml` version, and names its artifacts without
-a tag (`linthra-<signing>.apk`) so it can't be mistaken for a tagged release.
-Only a `v*` tag push derives the version from the tag.
+Both a manual `workflow_dispatch` run and a tag build are a plain `flutter build`
+that takes the version from `pubspec.yaml`. The difference is only naming and
+attachment: a manual run names its artifacts without a tag
+(`linthra-<signing>.apk`) so it can't be mistaken for a tagged release, and it
+neither verifies against nor attaches to any tag. Only a `v*` tag push verifies
+that `pubspec.yaml` matches the tag (§4) and can attach to a Release.
 
-### Do not hand-edit version metadata
+### What to bump for a release
 
-There is **no generated version file to edit.** For a release, edit nothing — push
-the tag. `AppInfo._devVersionName` and `pubspec.yaml` only affect local/dev builds
-and are kept in lock-step by the drift test; bump them together (in one commit) if
-you want dev builds to show a newer baseline, but they are not what a release
-ships.
+To cut a release you edit the version in **two files in the same commit** (a
+drift test enforces they agree), then tag:
+
+1. `pubspec.yaml` → `version: <versionName>+<versionCode>` (e.g.
+   `0.1.0-alpha.31+100031`).
+2. `lib/core/app_info.dart` → `AppInfo._devVersionName` = the same `versionName`
+   (e.g. `0.1.0-alpha.31`).
+
+That's the whole version change. `test/core/app_info_version_test.dart` fails CI
+if the two drift, or if the `versionCode` is not the canonical encoding of the
+`versionName` (preview it with `tool/version_from_tag.dart`). There is **no
+generated version file** and **no `--build-name`/`--build-number` to pass** — the
+tag (§2) just has to match what you put in `pubspec.yaml`.
 
 ## 2. Tagging
 
@@ -147,40 +175,46 @@ F-Droid (and our own release tracking) builds from a **git tag**.
   git push origin v0.1.0
   ```
 
-- The tag's `vX.Y.Z` should match the released `versionName`. Note that
-  `pubspec.yaml` currently keeps a fixed dev version that does **not** track the
-  tags, so F-Droid uses manual `Builds` entries with `AutoUpdateMode`/
-  `UpdateCheckMode: None` (see [fdroid-build-recipe.md §2](./fdroid-build-recipe.md#2-expected-f-droid-metadata-repo-fields)).
-  Keeping `pubspec.yaml` in lockstep with the tag is the future option that would
-  let F-Droid auto-update instead.
+- **The tag must match `pubspec.yaml`'s version.** `vX.Y.Z(-suffix.N)` is the
+  `versionName`, and the `+<versionCode>` in `pubspec.yaml` must be its canonical
+  encoding (§1). Bump `pubspec.yaml` (and `AppInfo._devVersionName`) **before**
+  tagging (§3); the tag build verifies the match and fails fast if they diverge
+  (§4). Because `pubspec.yaml` now tracks the tag in lockstep, F-Droid
+  auto-detects new releases (`AutoUpdateMode: Version`, `UpdateCheckMode: Tags`)
+  instead of needing a manual `Builds` entry per release — see
+  [fdroid-build-recipe.md §2](./fdroid-build-recipe.md#2-expected-f-droid-metadata-repo-fields).
 - Tag only commits where CI is green **and** generated files are current (§3).
 
 ## 3. Pre-tag checklist
 
-Before creating a release tag:
+Every release requires three version-linked actions — **bump `pubspec.yaml`**,
+**add the Fastlane changelog**, and **tag the matching version** — plus the usual
+green-CI / generated-files hygiene:
 
-1. **Choose the version** = the tag you will push, e.g. `v0.1.0-alpha.16`. The
-   build derives `versionName`/`versionCode` from it automatically (§1); there is
-   **no version constant to bump** for the release. Preview the derived values:
+1. **Choose the version** = the tag you will push, e.g. `v0.1.0-alpha.31`.
+   Preview its canonical `versionCode`:
 
    ```sh
-   dart run tool/version_from_tag.dart v0.1.0-alpha.16
-   # LINTHRA_VERSION_NAME=0.1.0-alpha.16
-   # LINTHRA_VERSION_CODE=100016
+   dart run tool/version_from_tag.dart v0.1.0-alpha.31
+   # LINTHRA_VERSION_NAME=0.1.0-alpha.31
+   # LINTHRA_VERSION_CODE=100031
    ```
 
-2. **(Optional) Refresh the dev baseline.** `pubspec.yaml`'s `version:` and
-   `AppInfo._devVersionName` only drive local/dev builds; bump them together (the
-   drift test `test/core/app_info_version_test.dart` enforces they match) if you
-   want `flutter run` to show the new version. **Not required** for the release —
-   the tag overrides both.
-3. **Add a changelog** named by the **derived `versionCode`** at
+2. **Bump the version in `pubspec.yaml` (and its in-app mirror)** — in one
+   commit, since a drift test enforces they agree:
+   - `pubspec.yaml` → `version: 0.1.0-alpha.31+100031` (the `versionName` plus the
+     canonical `versionCode` from step 1).
+   - `lib/core/app_info.dart` → `AppInfo._devVersionName = '0.1.0-alpha.31'`.
+
+   This is **required** — it is the version the release (and F-Droid) ships.
+   `test/core/app_info_version_test.dart` fails CI if the two files drift or if
+   the `versionCode` is not the canonical encoding of the `versionName`.
+3. **Add the Fastlane changelog** named by that `versionCode` at
    `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` — e.g.
-   `100016.txt` for `v0.1.0-alpha.16` (use the value `tool/version_from_tag.dart`
-   prints). Keep it short and factual; this is what F-Droid shows. A longer
-   GitHub-Release body lives under `docs/release-notes/vX.Y.Z*.md` (see the
-   [v0.1.0-alpha.9 notes](./release-notes/v0.1.0-alpha.9.md)). The `vX.Y.Z` in the
-   file name and the version inside it must match the tag.
+   `100031.txt`. Keep it short and factual; this is what F-Droid shows. A longer
+   GitHub-Release body can live under `docs/release-notes/vX.Y.Z*.md` (see the
+   [v0.1.0-alpha.9 notes](./release-notes/v0.1.0-alpha.9.md)); the version inside
+   it must match the tag.
 4. **Regenerate committed generated files** (Drift `*.g.dart`) so they match the
    schema at the tagged commit — run the
    [Generate Drift files workflow](../README.md#generating-drift-files-in-ci) or
@@ -191,19 +225,22 @@ Before creating a release tag:
    commit — this includes the version-drift test from step 2.
 6. **Confirm licensing** is still accurate if dependencies changed — re-run the
    [dependency & license audit](./dependency-license-audit.md).
-7. Create the annotated tag (§2).
+7. **Create the annotated tag (§2)** — `vX.Y.Z(-suffix.N)` must equal the
+   `versionName` you set in `pubspec.yaml` (step 2). The tag build re-verifies
+   the match (§4) and fails fast if they diverge.
 
 ## 4. GitHub Releases (notes manual, artifact build & attachment automatic)
 
 Pushing a `v*` tag starts the build. The **Android Release Build** workflow
 (`.github/workflows/android-release-build.yml`) runs automatically on a `v*`
-tag, **derives the version from the tag** (§1), builds the APK/AAB with that
-version, verifies the built APK carries it, and attaches them to a GitHub
-Release. **Writing the
-release notes stays manual** — the workflow never authors production notes,
-publishes to a store, or submits to F-Droid. It listens only to the tag `push`
-(not to `release: published`), so a tag builds exactly once. See
-[docs/release-signing.md](./release-signing.md) for the signing details.
+tag, **verifies that `pubspec.yaml` matches the tag** (§1; it fails fast on a
+mismatch or a malformed tag, before any build), builds the APK/AAB with the
+`pubspec.yaml` version, verifies the built APK carries it, and attaches them to a
+GitHub Release. **Writing the release notes stays manual** — the workflow never
+authors production notes, publishes to a store, or submits to F-Droid. It listens
+only to the tag `push` (not to `release: published`), so a tag builds exactly
+once. See [docs/release-signing.md](./release-signing.md) for the signing
+details.
 
 The attachment behavior depends on whether the tag is a **pre-release**:
 
@@ -287,7 +324,7 @@ F-Droid does **not** consume our signed artifacts. When/if Linthra is submitted:
 | Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
 | Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
-| Deriving versionName/versionCode + in-app version from the tag | **Automatic** on a `v*` tag build (`tool/version_from_tag.dart`); manual runs use `pubspec.yaml`. |
+| Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`tool/version_from_tag.dart`); fails fast on a mismatch. Both manual and tag builds take the version from `pubspec.yaml`. |
 | Attaching APK/AAB to a Release | **Automatic** on a `v*` tag build. Alpha/beta/rc tags attach (debug- or release-signed) to a **pre-release**; stable tags attach **release-signed** assets to an existing Release only. |
 | Creating a GitHub **pre-release** (alpha/beta/rc) | **Automatic** on the tag build if no Release exists yet (placeholder notes; edit afterwards). |
 | Creating a stable GitHub Release | **Manual** (operator, §4); never auto-created. |
@@ -306,7 +343,7 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
    GitHub-Release artifact is wanted — see
    [release-signing.md](./release-signing.md). (Not needed for F-Droid itself,
    which signs its own builds.)
-2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.15` have been
+2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.30` have been
    cut; F-Droid submission itself is still pending the other blockers.
 3. **Decide the `pubspec.lock` policy** for reproducible release builds
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -3,29 +3,32 @@ abstract final class AppInfo {
   static const String name = 'Linthra';
   static const String tagline = 'Your music, beautifully yours.';
 
-  /// Dev/local default `versionName`, mirroring the `x.y.z(-suffix)` part of
+  /// The `versionName` shown in-app, mirroring the `x.y.z(-suffix)` part of
   /// `pubspec.yaml`'s `version` (the `+versionCode` is Android-only and not
-  /// shown here). Used as the fallback when no release override is supplied —
-  /// i.e. for local `flutter run`/`flutter build` and the test suite.
+  /// shown here).
   ///
-  /// `pubspec.yaml` is the source of truth for dev builds; this constant must
-  /// match its `versionName`. `test/core/app_info_version_test.dart` fails CI if
-  /// the two ever drift, so bump both together (see docs/release-process.md §1).
-  static const String _devVersionName = '0.1.0-alpha.15';
+  /// `pubspec.yaml` is the single source of truth for the version and is kept in
+  /// lockstep with the release tag (see docs/release-process.md §1), so this
+  /// constant must match its `versionName`. A plain `flutter build` — local, CI
+  /// release, and F-Droid alike — supplies the version from `pubspec.yaml`, so
+  /// the in-app version always matches the released APK/AAB without any
+  /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
+  /// this constant ever drifts from `pubspec.yaml`, so bump both together.
+  static const String _devVersionName = '0.1.0-alpha.30';
 
-  /// The release `versionName` injected by the release workflow via
-  /// `--dart-define=LINTHRA_VERSION_NAME=<tag-derived version>`. Empty on local
-  /// and CI-test builds (no dart-define), which is how [version] knows to fall
-  /// back to [_devVersionName]. On a tagged release build it is the exact
-  /// tag-derived version (see tool/version_from_tag.dart), so the in-app version
-  /// always matches the released APK/AAB.
+  /// Optional build-time override for the in-app `versionName`, read from
+  /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`
+  /// (mirrored by [_devVersionName]) is the source of truth and supplies the
+  /// version for every standard build. Retained as an escape hatch so a one-off
+  /// build can stamp a different in-app version without editing `pubspec.yaml`;
+  /// when empty, [version] falls back to [_devVersionName].
   static const String _definedVersionName =
       String.fromEnvironment('LINTHRA_VERSION_NAME');
 
   /// The effective app `versionName` shown in Settings/About, embedded in the
   /// diagnostics / "Report a bug" output, and sent to Jellyfin as the client
-  /// version. Reads the release override when present, else the dev fallback —
-  /// the same value Android's build metadata uses on a tagged build.
+  /// version. Uses the optional override when present, else the `pubspec.yaml`
+  /// value — the same value Android's build metadata carries.
   static String get version =>
       resolveVersion(_definedVersionName, _devVersionName);
 

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -39,7 +39,7 @@ class AppDiagnosticsData {
     this.smartPrecacheEnabled,
   });
 
-  /// The app `versionName` (e.g. `0.1.0-alpha.15`). Always present.
+  /// The app `versionName` (e.g. `0.1.0-alpha.30`). Always present.
   final String appVersion;
 
   /// The Android OS version string, when running on Android. Null elsewhere.

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -28,14 +28,26 @@
 # matching CI). No Flutter submodule is added upstream and no SDK is cloned by
 # hand.
 #
-# AutoUpdateMode/UpdateCheckMode are disabled on purpose. pubspec.yaml carries a
-# fixed dev version (0.1.0-alpha.15+15) that does NOT track the release tags, so
-# F-Droid's pubspec/tag update detection would read the wrong versionCode. Each
-# release is therefore a manual Builds entry whose versionName/versionCode are
-# set explicitly via --build-name/--build-number. Those values match what
-# tool/version_from_tag.dart derives from the tag (v0.1.0-alpha.29 -> versionName
-# 0.1.0-alpha.29, versionCode 100029), so the F-Droid APK and the upstream
-# GitHub-release APK agree.
+# Auto-update is ENABLED. pubspec.yaml now carries the release version
+# (version: <versionName>+<versionCode>, e.g. 0.1.0-alpha.30+100030) in lockstep
+# with the release tag, so:
+#   * UpdateCheckMode: Tags scans the v* tags;
+#   * UpdateCheckData reads the versionCode/versionName from pubspec.yaml at each
+#     tag (F-Droid does not parse pubspec.yaml on its own — its default Tags path
+#     reads only AndroidManifest.xml/build.gradle, which for Flutter hold no
+#     literal version — so UpdateCheckData is REQUIRED for a Flutter app);
+#   * AutoUpdateMode: Version adds a build for each new tag;
+#   * a plain `flutter build apk --release` takes versionName/versionCode straight
+#     from pubspec.yaml, so the F-Droid APK and the upstream GitHub-release APK
+#     agree without any --build-name/--build-number flags.
+#
+# TRANSITION CAVEAT: the v0.1.0-alpha.30 tag below was cut BEFORE pubspec.yaml
+# tracked the release version, so at that exact tag pubspec.yaml is still
+# 0.1.0-alpha.15+15. The single Builds entry therefore passes explicit
+# --build-name/--build-number/--dart-define to build it as 0.1.0-alpha.30 /
+# 100030. From v0.1.0-alpha.31 onward pubspec.yaml matches the tag, so new
+# entries — including those AutoUpdateMode adds — must DROP those flags and be a
+# plain `flutter build apk --release`.
 #
 # Native code: the only native component is SQLite via sqlite3_flutter_libs,
 # compiled from source by the Android Gradle build (no prebuilt blobs). If
@@ -61,9 +73,9 @@ RepoType: git
 Repo: https://github.com/TheZupZup/Linthra.git
 
 Builds:
-  - versionName: 0.1.0-alpha.29
-    versionCode: 100029
-    commit: v0.1.0-alpha.29
+  - versionName: 0.1.0-alpha.30
+    versionCode: 100030
+    commit: v0.1.0-alpha.30
     output: build/app/outputs/flutter-apk/app-release.apk
     srclibs:
       - flutter@stable
@@ -78,9 +90,15 @@ Builds:
       - .pub-cache
     build:
       - export PUB_CACHE=$(pwd)/.pub-cache
-      - $$flutter$$/bin/flutter build apk --release --build-name=0.1.0-alpha.29 --build-number=100029 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.29
+      # TRANSITION (see header): the v0.1.0-alpha.30 tag predates pubspec.yaml
+      # version tracking (its committed pubspec is 0.1.0-alpha.15+15), so these
+      # explicit flags override it to build as 0.1.0-alpha.30 / 100030. From
+      # v0.1.0-alpha.31 onward, DROP these flags — a plain `flutter build apk
+      # --release` reads the version from pubspec.yaml.
+      - $$flutter$$/bin/flutter build apk --release --build-name=0.1.0-alpha.30 --build-number=100030 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.30
 
-AutoUpdateMode: None
-UpdateCheckMode: None
-CurrentVersion: 0.1.0-alpha.29
-CurrentVersionCode: 100029
+AutoUpdateMode: Version
+UpdateCheckMode: Tags
+UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+CurrentVersion: 0.1.0-alpha.30
+CurrentVersionCode: 100030

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,15 @@
 name: linthra
 description: A modern, local-first, privacy-focused music player.
 publish_to: "none"
-version: 0.1.0-alpha.15+15
+# Single source of truth for the release version: <versionName>+<versionCode>.
+# Bumped to match each release tag (see docs/release-process.md §1 & §3). The
+# versionCode is the canonical encoding of the versionName from
+# tool/version_from_tag.dart (0.1.0-alpha.30 -> 100030);
+# test/core/app_info_version_test.dart enforces that. Flutter reads both into the
+# Android build (versionName/versionCode) and the in-app version mirrors it via
+# AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
+# the tag all agree.
+version: 0.1.0-alpha.30+100030
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/test/core/app_info_version_test.dart
+++ b/test/core/app_info_version_test.dart
@@ -4,17 +4,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/diagnostics/app_diagnostics.dart';
 
+import '../../tool/version_from_tag.dart';
+
 /// Guards the version strategy described in docs/release-process.md §1:
 ///
-/// * On a **tagged release build**, the version comes from the Git tag, injected
-///   via `--dart-define=LINTHRA_VERSION_NAME=...` (see tool/version_from_tag.dart),
-///   so the in-app version always matches the released APK/AAB.
-/// * On **local/dev and CI-test builds** (no dart-define), [AppInfo.version]
-///   falls back to a `const` mirror of `pubspec.yaml`'s `versionName`. This is
-///   the value the suite below sees, since `flutter test` passes no dart-define.
+/// * `pubspec.yaml`'s `version: <name>+<code>` is the single source of truth and
+///   is kept in lockstep with the release tag. A plain `flutter build` — local,
+///   CI release, and F-Droid alike — takes the version from there.
+/// * [AppInfo.version] mirrors `pubspec.yaml`'s `versionName` via a `const`
+///   ([AppInfo] reads no override in tests, since `flutter test` passes no
+///   dart-define), and the `+versionCode` must be the canonical encoding of that
+///   name (tool/version_from_tag.dart), so the tag, `pubspec.yaml`, and the
+///   F-Droid build can never disagree.
 ///
 /// Before this guard existed the app shipped `alpha.9` while still displaying
-/// `alpha.1`; the drift test keeps the dev fallback honest against pubspec.
+/// `alpha.1`; the drift tests keep the in-app version and the encoded
+/// versionCode honest against `pubspec.yaml`.
 void main() {
   // `version: x.y.z(-suffix)(+buildNumber)` — capture the SemVer part only;
   // the `+versionCode` is Android-internal and intentionally not in AppInfo.
@@ -50,10 +55,30 @@ void main() {
       expect(
         pubspec.code,
         isNotNull,
-        reason: 'pubspec.yaml `version:` must end in `+<versionCode>` so local '
+        reason: 'pubspec.yaml `version:` must end in `+<versionCode>` so '
             'Android builds get a monotonic build number.',
       );
       expect(pubspec.code, greaterThan(0));
+    });
+
+    test('versionCode is the canonical encoding of the versionName', () {
+      // pubspec.yaml is now in lockstep with the release tag, so its
+      // versionCode must be exactly what tool/version_from_tag.dart encodes for
+      // the versionName. This keeps the tag, pubspec.yaml, and the F-Droid build
+      // (which reads versionName/versionCode straight from pubspec.yaml) in
+      // agreement — see docs/release-process.md §1 & §3.
+      final ({String name, int? code}) pubspec = readPubspecVersion();
+      expect(
+        pubspec.code,
+        versionFromTag(pubspec.name).code,
+        reason:
+            'pubspec.yaml versionCode (${pubspec.code}) is not the canonical '
+            'encoding of its versionName (${pubspec.name}); '
+            'tool/version_from_tag.dart encodes that as '
+            '${versionFromTag(pubspec.name).code}. Use that exact value so the '
+            'tag, pubspec.yaml, and F-Droid agree. Preview it with '
+            '`dart run tool/version_from_tag.dart ${pubspec.name}`.',
+      );
     });
 
     test('is a SemVer string without a build suffix', () {


### PR DESCRIPTION
## Why

Linthra kept `pubspec.yaml` at a fixed dev version (`0.1.0-alpha.15+15`) and derived the real release version from the git tag at build time. That works for our own builds, but it forces fdroiddata to use `AutoUpdateMode: None` / `UpdateCheckMode: None` — every release has to be added to fdroiddata by hand.

This makes **`pubspec.yaml` the single source of truth** for the version, bumped to match each release tag, so F-Droid can read `versionName`/`versionCode` straight from `pubspec.yaml` at each tag and auto-detect new releases.

## What changed

- **`pubspec.yaml`** → `version: 0.1.0-alpha.30+100030` (the current release). `lib/core/app_info.dart`'s `_devVersionName` mirrors it. The in-app version now comes from `pubspec.yaml` for **every** build (CI, local, F-Droid), so the displayed value is unchanged — **no app behavior change**.
- **Release workflow** (`android-release-build.yml`): the old "derive version from tag" + `--build-name`/`--build-number`/`--dart-define` is replaced by a **"verify the tag matches `pubspec.yaml`"** guard (fails fast on a mismatch or malformed tag) followed by a **plain** `flutter build apk/appbundle --release` — exactly how F-Droid builds. The APK-version verification step is kept.
- **`tool/version_from_tag.dart`** is kept (still useful): it previews the canonical `versionCode` when bumping `pubspec.yaml`, CI uses it to verify the tag, and a **new test** asserts `pubspec.yaml`'s `versionCode` is the canonical encoding of its `versionName`.
- **F-Droid recipe** (`metadata/io.github.thezupzup.linthra.yml`): plain build + auto-update enabled (see below), bumped to `alpha.30`/`100030`. The single seed entry keeps explicit flags **only** as a one-time bridge for the pre-change `v0.1.0-alpha.30` tag (its committed `pubspec.yaml` is still `0.1.0-alpha.15+15`); from `v0.1.0-alpha.31` on, builds are plain.
- **Docs** (`release-process`, `fdroid-build-recipe`, `fdroid-submission`, `fdroid-readiness`, `play-store-readiness`): updated to the new model and the per-release steps — **bump `pubspec.yaml`**, **add the fastlane changelog**, **tag the matching version**.

No new dependencies, Google Play Services, ads, analytics, telemetry, crash reporting, or proprietary services.

## fdroiddata changes to enable auto-update (requirement 7)

In fdroiddata's `metadata/io.github.thezupzup.linthra.yml`, replace:

```yaml
AutoUpdateMode: None
UpdateCheckMode: None
```

with:

```yaml
AutoUpdateMode: Version
UpdateCheckMode: Tags
UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
```

and make the `Builds` template a **plain** `flutter build apk --release` (drop `--build-name`/`--build-number`/`--dart-define`).

**`UpdateCheckData` is required** for a Flutter app: F-Droid's default `Tags` path reads only `AndroidManifest.xml`/`build.gradle`, which carry no literal version for Flutter, so it must be pointed at `pubspec.yaml`. The regex splits `version:` on `+` — group 1 of the first regex is the `versionCode` (after `+`), group 1 of the second is the `versionName` (before `+`). Verified against `0.1.0-alpha.30+100030` → `100030` / `0.1.0-alpha.30`. (Same pattern LocalSend and FluffyChat use.) F-Droid then picks the highest `versionCode` across the tags, and `AutoUpdateMode: Version` appends a plain-build entry using the tag as the commit.

**One-time transition:** the `v0.1.0-alpha.30` tag predates this change, so a plain build at that exact tag would report `0.1.0-alpha.15` / `15`. The seed `Builds` entry therefore keeps `--build-name=0.1.0-alpha.30 --build-number=100030 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.30`. From `v0.1.0-alpha.31` onward `pubspec.yaml` matches the tag; drop those flags (including from the first entry `AutoUpdateMode` inherits from the seed). Full detail in `docs/fdroid-submission.md §2`.

## Verification

Ran with the pinned Flutter 3.27.4:

- `flutter pub get` — 151 deps resolved
- `flutter analyze` — No issues found
- `dart format --output=none --set-exit-if-changed .` — clean
- `flutter test` — **all 1215 tests pass** (incl. the new "versionCode is the canonical encoding" guard)

Also locally simulated the workflow guard: it passes for `v0.1.0-alpha.30` (matches `pubspec.yaml`) and fails fast for a mismatched tag.

https://claude.ai/code/session_01J4eEvkg1fAFpNDBv1g4RuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4eEvkg1fAFpNDBv1g4RuG)_