### PR TITLE
Prepare clean release v0.1.0-alpha.32

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,7 +5,7 @@ git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
 docs reference this document rather than restating the plan.
 
 > **Sideloadable alphas only; nothing here publishes to a store.** Linthra has
-> tagged pre-release alphas (latest `v0.1.0-alpha.30`) attached to GitHub
+> tagged pre-release alphas (latest `v0.1.0-alpha.32`) attached to GitHub
 > Releases as sideloadable APKs/AABs, but is **not** on F-Droid. Pushing a `v*`
 > tag builds the release artifacts automatically. For **alpha/beta/rc** tags the
 > build can create a GitHub **pre-release** and attach the APK/AAB to it; for
@@ -27,8 +27,8 @@ tag the matching version (§3) — there are no per-release `--build-name`/
 
 ```
 pubspec.yaml                     ┌─▶ Android versionName/versionCode (APK/AAB)
-version: 0.1.0-alpha.30+100030  ─┤
-   ( == tag v0.1.0-alpha.30 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
+version: 0.1.0-alpha.32+100032  ─┤
+   ( == tag v0.1.0-alpha.32 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
 ```
 
 > **Why this matters for F-Droid.** Because the version lives in `pubspec.yaml`
@@ -343,7 +343,7 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
    GitHub-Release artifact is wanted — see
    [release-signing.md](./release-signing.md). (Not needed for F-Droid itself,
    which signs its own builds.)
-2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.30` have been
+2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.32` have been
    cut; F-Droid submission itself is still pending the other blockers.
 3. **Decide the `pubspec.lock` policy** for reproducible release builds
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).

--- a/fastlane/metadata/android/en-US/changelogs/100032.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100032.txt
@@ -1,0 +1,8 @@
+Linthra 0.1.0-alpha.32 — release & packaging maintenance.
+
+Changed:
+- Release builds now take the version straight from pubspec.yaml, so the in-app
+  version, the published APK, and the release tag always stay in lockstep. No
+  app features, permissions, or behavior change.
+
+Still an alpha — expect rough edges. Not on F-Droid yet.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.0-alpha.30';
+  static const String _devVersionName = '0.1.0-alpha.32';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -100,5 +100,5 @@ Builds:
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 0.1.0-alpha.30
-CurrentVersionCode: 100030
+CurrentVersion: 0.1.0-alpha.32
+CurrentVersionCode: 100032

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ publish_to: "none"
 # Single source of truth for the release version: <versionName>+<versionCode>.
 # Bumped to match each release tag (see docs/release-process.md §1 & §3). The
 # versionCode is the canonical encoding of the versionName from
-# tool/version_from_tag.dart (0.1.0-alpha.30 -> 100030);
+# tool/version_from_tag.dart (0.1.0-alpha.32 -> 100032);
 # test/core/app_info_version_test.dart enforces that. Flutter reads both into the
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.0-alpha.30+100030
+version: 0.1.0-alpha.32+100032
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Why

`v0.1.0-alpha.31` was tagged on a commit where `pubspec.yaml` still read `0.1.0-alpha.30+100030`, so the Android Release Build workflow failed its tag ↔ `pubspec.yaml` version-match check (`tool/version_from_tag.dart`).

The existing `v0.1.0-alpha.31` tag is **left untouched**. This PR prepares a clean `v0.1.0-alpha.32` release instead.

## What changed

| File | Change |
|------|--------|
| `pubspec.yaml` | `version: 0.1.0-alpha.32+100032` (canonical versionCode for the tag) + encoding-example comment |
| `lib/core/app_info.dart` | `_devVersionName` → `0.1.0-alpha.32` (kept in lockstep with pubspec; the version-drift test enforces it) |
| `fastlane/metadata/android/en-US/changelogs/100032.txt` | **new** — short, factual; no feature claims |
| `metadata/io.github.thezupzup.linthra.yml` | `CurrentVersion`/`CurrentVersionCode` → `0.1.0-alpha.32` / `100032` only |
| `docs/release-process.md` | refreshed current-version mentions (latest, version diagram, "tags through") |

## Intentionally NOT changed
- **No app features. No release automation.**
- F-Droid **auto-update logic** and the one-time **alpha.30 transition seed `Builds` entry** are untouched — only `CurrentVersion`/`CurrentVersionCode` were bumped.
- The F-Droid / Play submission docs (`fdroid-readiness.md`, `fdroid-submission.md`, `fdroid-build-recipe.md`, `play-store-readiness.md`) deliberately keep targeting `v0.1.0-alpha.30`, the last alpha verified to launch (per maintainer decision in this session).

## Verification (local, Flutter 3.27.4)
- `dart run tool/version_from_tag.dart v0.1.0-alpha.32` → `100032` (matches pubspec) ✅
- `dart format --set-exit-if-changed .` → 422 files, 0 changed ✅
- `flutter analyze` → No issues found ✅
- `flutter test` → 1215 tests passing ✅

## Next step (manual — after this merges)
Tag the release commit and push to trigger the Android Release Build workflow:
```sh
git checkout main && git pull origin main
git tag -a v0.1.0-alpha.32 -m "Linthra 0.1.0-alpha.32"
git push origin v0.1.0-alpha.32
```

https://claude.ai/code/session_01E1155MQyg3dBpQecmSg1Y8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1155MQyg3dBpQecmSg1Y8)_