### PR TITLE
ci(android): pin release/debug builds to Temurin JDK 17

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -20,14 +20,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Build on JDK 21 to match F-Droid's build servers, so this PR's CI
-      # exercises the same Java the F-Droid build uses. The Android Gradle
-      # tooling (AGP 8.2.1 / Gradle 8.7 / Kotlin 1.9.24) supports JDK 21.
+      # Pin to Temurin JDK 17 — the version this Android toolchain
+      # (AGP 8.2.1 / Gradle 8.7 / Kotlin 1.9.24) is built and tested against.
+      # Kept in sync with android-release-build.yml so debug and release CI
+      # builds use the same JDK as the release artifacts. setup-java exports
+      # JAVA_HOME, which Flutter and the Gradle daemon pick up for the build.
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "17"
 
       # Keep this Flutter version in sync with .github/workflows/ci.yml.
       - name: Set up Flutter

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -185,14 +185,25 @@ jobs:
           echo "LINTHRA_KEYSTORE_PATH=$keystore_path" >> "$GITHUB_ENV"
           echo "Release keystore decoded to a temporary path."
 
-      # Build on JDK 21 to match F-Droid's build servers and modern Android
-      # toolchains. The Android Gradle tooling (AGP 8.2.1 / Gradle 8.7 / Kotlin
-      # 1.9.24) supports JDK 21; the release artifacts build identically on it.
+      # Pin to Temurin JDK 17 — the version this Android toolchain
+      # (AGP 8.2.1 / Gradle 8.7 / Kotlin 1.9.24) is built and tested against.
+      # Newer JDKs on the GitHub runner have caused the lint/Jetifier step to
+      # die on byte-buddy's multi-release classes ("Unsupported class file
+      # major version 68"); JDK 17 keeps Gradle's bundled ASM compatible with
+      # every class file it has to scan. setup-java exports JAVA_HOME, which
+      # Flutter and the Gradle daemon pick up as the JDK for the build.
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "17"
+
+      # Quick sanity check so a future JDK drift shows up directly in the log
+      # instead of as a confusing lint/Jetifier crash.
+      - name: Show Java environment
+        run: |
+          java -version
+          echo "JAVA_HOME=$JAVA_HOME"
 
       # Keep this Flutter version in sync with .github/workflows/ci.yml.
       - name: Set up Flutter


### PR DESCRIPTION
## Summary

- Pin `.github/workflows/android-release-build.yml` and `.github/workflows/android-debug-apk.yml` to Temurin JDK **17** (was 21).
- Add a small `Show Java environment` diagnostic step to the release workflow.
- No app code, no Gradle/AGP/Kotlin upgrades, no version/pubspec/F-Droid changes.

## Why

The `v0.1.0-alpha.32` release workflow reached `assembleRelease` and died inside Gradle's lint/Jetifier:

```
Unsupported class file major version 68
in byte-buddy-1.17.5.jar
while running :flutter_plugin_android_lifecycle:generateReleaseLintModel
```

Flutter additionally warned that the project's Gradle version was incompatible with the JDK it was using for Gradle.

`byte-buddy 1.17.5` is a multi-release JAR that ships Java 24 (class major 68) entries under `META-INF/versions/24/`. The lint model task scans those entries with the ASM bundled by AGP 8.2.1 / Gradle 8.7, which doesn't know about major 68. The previous workflow asked for JDK 21, but the failure mode shows the lint/Jetifier scan is the limiting factor regardless — the toolchain is built and tested against JDK 17, and pinning the runner to JDK 17 keeps Gradle's bundled ASM compatible with every class file it has to scan.

`setup-java` exports `JAVA_HOME`, which the Flutter tool and the Gradle daemon both pick up, so this also restores a single, explicit JDK for the build (instead of whatever default the runner now ships).

## Test plan

- [ ] Re-run the failed `Android Release Build` for tag `v0.1.0-alpha.32`. The `:flutter_plugin_android_lifecycle:generateReleaseLintModel` step should no longer fail with "Unsupported class file major version 68", and both APK and AAB should build and upload.
- [ ] Confirm the new `Show Java environment` step logs `openjdk version "17..."` and `JAVA_HOME=.../jdk-17.../`.
- [ ] Confirm `Android Debug APK` PR CI still passes on this PR.
- [ ] `flutter pub get` / `dart format --set-exit-if-changed .` / `flutter analyze` / `flutter test` — covered by the existing `CI` workflow on this PR (no Java/Gradle involvement; unchanged).

https://claude.ai/code/session_01SRuKiG3Tz2WQ6sZzcfLQpR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRuKiG3Tz2WQ6sZzcfLQpR)_