### PR TITLE
Prepare clean release v0.1.0-alpha.34

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,7 +5,7 @@ git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
 docs reference this document rather than restating the plan.
 
 > **Sideloadable alphas only; nothing here publishes to a store.** Linthra has
-> tagged pre-release alphas (latest `v0.1.0-alpha.32`) attached to GitHub
+> tagged pre-release alphas (latest `v0.1.0-alpha.34`) attached to GitHub
 > Releases as sideloadable APKs/AABs, but is **not** on F-Droid. Pushing a `v*`
 > tag builds the release artifacts automatically. For **alpha/beta/rc** tags the
 > build can create a GitHub **pre-release** and attach the APK/AAB to it; for
@@ -27,8 +27,8 @@ tag the matching version (§3) — there are no per-release `--build-name`/
 
 ```
 pubspec.yaml                     ┌─▶ Android versionName/versionCode (APK/AAB)
-version: 0.1.0-alpha.32+100032  ─┤
-   ( == tag v0.1.0-alpha.32 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
+version: 0.1.0-alpha.34+100034  ─┤
+   ( == tag v0.1.0-alpha.34 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
 ```
 
 > **Why this matters for F-Droid.** Because the version lives in `pubspec.yaml`
@@ -343,7 +343,7 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
    GitHub-Release artifact is wanted — see
    [release-signing.md](./release-signing.md). (Not needed for F-Droid itself,
    which signs its own builds.)
-2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.32` have been
+2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.34` have been
    cut; F-Droid submission itself is still pending the other blockers.
 3. **Decide the `pubspec.lock` policy** for reproducible release builds
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).

--- a/fastlane/metadata/android/en-US/changelogs/100034.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100034.txt
@@ -1,0 +1,8 @@
+Linthra 0.1.0-alpha.34 — build & packaging maintenance.
+
+Changed:
+- The Android release and debug CI builds are now pinned to Temurin JDK 17, so
+  the published APK/AAB matches the JDK F-Droid's build servers use. No app
+  features, permissions, or behavior change.
+
+Still an alpha — expect rough edges. Not on F-Droid yet.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.0-alpha.32';
+  static const String _devVersionName = '0.1.0-alpha.34';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -100,5 +100,5 @@ Builds:
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 0.1.0-alpha.32
-CurrentVersionCode: 100032
+CurrentVersion: 0.1.0-alpha.34
+CurrentVersionCode: 100034

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ publish_to: "none"
 # Single source of truth for the release version: <versionName>+<versionCode>.
 # Bumped to match each release tag (see docs/release-process.md §1 & §3). The
 # versionCode is the canonical encoding of the versionName from
-# tool/version_from_tag.dart (0.1.0-alpha.32 -> 100032);
+# tool/version_from_tag.dart (0.1.0-alpha.34 -> 100034);
 # test/core/app_info_version_test.dart enforces that. Flutter reads both into the
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.0-alpha.32+100032
+version: 0.1.0-alpha.34+100034
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

`v0.1.0-alpha.33` was pushed as a tag while `pubspec.yaml` still read `0.1.0-alpha.32+100032`, so the release build failed its tag/pubspec version-match check. The existing `v0.1.0-alpha.33` tag is left untouched; this PR skips the botched code and prepares a clean `v0.1.0-alpha.34` instead.

- `pubspec.yaml` → `version: 0.1.0-alpha.34+100034` (the canonical `versionCode` for the tag, per `tool/version_from_tag.dart`).
- `lib/core/app_info.dart` → `_devVersionName` mirror bumped to `0.1.0-alpha.34`, kept in lockstep with `pubspec.yaml` (the `app_info` version-drift test enforces it).
- `fastlane/metadata/android/en-US/changelogs/100034.txt` added.
- F-Droid metadata: `CurrentVersion`/`CurrentVersionCode` → `0.1.0-alpha.34` / `100034` only — auto-update logic and the `alpha.30` transition seed `Builds` entry are unchanged.
- `docs/release-process.md`: refresh current-version mentions.

No app features, release automation, F-Droid auto-update logic, or the Java workflow were changed.

After merge, an annotated `v0.1.0-alpha.34` tag will be cut from `main`.

## Test plan

- [x] `dart format --set-exit-if-changed .` — 0 changed (422 files)
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 1215 passing (Flutter 3.27.4)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LWyCtRhLhwuvG6LAaQpC)_