### PR TITLE
Prepare clean release v0.1.0-alpha.36

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,7 +5,7 @@ git tagging, changelogs, and the (manual) GitHub-Release flow. The F-Droid
 docs reference this document rather than restating the plan.
 
 > **Sideloadable alphas only; nothing here publishes to a store.** Linthra has
-> tagged pre-release alphas (latest `v0.1.0-alpha.34`) attached to GitHub
+> tagged pre-release alphas (latest `v0.1.0-alpha.36`) attached to GitHub
 > Releases as sideloadable APKs/AABs, but is **not** on F-Droid. Pushing a `v*`
 > tag builds the release artifacts automatically. For **alpha/beta/rc** tags the
 > build can create a GitHub **pre-release** and attach the APK/AAB to it; for
@@ -27,8 +27,8 @@ tag the matching version (§3) — there are no per-release `--build-name`/
 
 ```
 pubspec.yaml                     ┌─▶ Android versionName/versionCode (APK/AAB)
-version: 0.1.0-alpha.34+100034  ─┤
-   ( == tag v0.1.0-alpha.34 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
+version: 0.1.0-alpha.36+100036  ─┤
+   ( == tag v0.1.0-alpha.36 )    └─▶ AppInfo.version (Settings/About, diagnostics, Jellyfin header)
 ```
 
 > **Why this matters for F-Droid.** Because the version lives in `pubspec.yaml`
@@ -343,7 +343,7 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
    GitHub-Release artifact is wanted — see
    [release-signing.md](./release-signing.md). (Not needed for F-Droid itself,
    which signs its own builds.)
-2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.34` have been
+2. **A `vX.Y.Z` tag** exists — alpha tags through `v0.1.0-alpha.36` have been
    cut; F-Droid submission itself is still pending the other blockers.
 3. **Decide the `pubspec.lock` policy** for reproducible release builds
    ([fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).

--- a/fastlane/metadata/android/en-US/changelogs/100036.txt
+++ b/fastlane/metadata/android/en-US/changelogs/100036.txt
@@ -1,0 +1,14 @@
+Linthra 0.1.0-alpha.36 — build & packaging maintenance.
+
+Changed:
+- The Android build no longer runs Jetifier. Every dependency is already
+  AndroidX, so the rewrite step was redundant overhead. No app features,
+  permissions, or behavior change.
+
+Note:
+- v0.1.0-alpha.35 was skipped: that tag was pushed while pubspec.yaml still
+  read 0.1.0-alpha.34+100034, so its build failed the tag/pubspec
+  version-match check. The existing v0.1.0-alpha.35 tag is left untouched;
+  this is a clean v0.1.0-alpha.36 instead.
+
+Still an alpha — expect rough edges. Not on F-Droid yet.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.0-alpha.34';
+  static const String _devVersionName = '0.1.0-alpha.36';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -100,5 +100,5 @@ Builds:
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
-CurrentVersion: 0.1.0-alpha.34
-CurrentVersionCode: 100034
+CurrentVersion: 0.1.0-alpha.36
+CurrentVersionCode: 100036

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ publish_to: "none"
 # Single source of truth for the release version: <versionName>+<versionCode>.
 # Bumped to match each release tag (see docs/release-process.md §1 & §3). The
 # versionCode is the canonical encoding of the versionName from
-# tool/version_from_tag.dart (0.1.0-alpha.34 -> 100034);
+# tool/version_from_tag.dart (0.1.0-alpha.36 -> 100036);
 # test/core/app_info_version_test.dart enforces that. Flutter reads both into the
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.0-alpha.34+100034
+version: 0.1.0-alpha.36+100036
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

`v0.1.0-alpha.35` was pushed as a tag while `pubspec.yaml` still read `0.1.0-alpha.34+100034`, so the release build failed its tag/pubspec version-match check. The existing `v0.1.0-alpha.35` tag is left untouched; this prepares a clean `v0.1.0-alpha.36` instead, skipping the botched code.

After this PR is merged, tag `v0.1.0-alpha.36` from `main` only.

## Changes

- `pubspec.yaml` → `version: 0.1.0-alpha.36+100036` (the canonical `versionCode` for the tag, per `tool/version_from_tag.dart`).
- `lib/core/app_info.dart` → `_devVersionName = '0.1.0-alpha.36'`, kept in lockstep with `pubspec.yaml` (the app_info version-drift test enforces it).
- `fastlane/metadata/android/en-US/changelogs/100036.txt` → new Fastlane changelog naming the Jetifier-disable change and the skipped `v0.1.0-alpha.35`.
- `metadata/io.github.thezupzup.linthra.yml` → `CurrentVersion`/`CurrentVersionCode` → `0.1.0-alpha.36` / `100036`. Auto-update logic (`AutoUpdateMode`, `UpdateCheckMode`, `UpdateCheckData`) and the `alpha.30` transition seed `Builds` entry are unchanged.
- `docs/release-process.md` → refresh current-version mentions (latest sideloadable alpha; pubspec/tag example; "alpha tags through ..." blocker line).

The Jetifier disable (#121) and Temurin JDK 17 pin (#119) already on `main` are preserved. No app features, release automation, or F-Droid auto-update logic changed.

## Test plan

- [x] `dart format --set-exit-if-changed .` → Formatted 422 files (0 changed).
- [x] `flutter analyze` → No issues found.
- [x] `flutter test` → All 1215 tests passed (incl. `test/core/app_info_version_test.dart`, which enforces that `AppInfo._devVersionName`, `pubspec.yaml`'s `versionName`, and the canonical `versionCode` from `tool/version_from_tag.dart` all agree).
- [ ] After merge: tag `v0.1.0-alpha.36` from `main` — the release workflow will verify the tag matches `pubspec.yaml` and attach signed artifacts to the pre-release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVe1kSPMJiuU4rSVqQvSUA)_