### PR TITLE
ci(release): preflight tag/pubspec gate + clearer mismatch summary

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -218,40 +218,49 @@ jobs:
 
       # pubspec.yaml is the source of truth for the release version; each release
       # bumps `version: <name>+<code>` to match the tag (docs/release-process.md
-      # §1 & §3). Re-derive the canonical versionName/versionCode from the pushed
-      # tag (tool/version_from_tag.dart) and FAIL FAST if pubspec.yaml does not
-      # match it — so a tag is never built against a stale pubspec, and the
-      # F-Droid build (which reads pubspec.yaml) always agrees with this one. A
-      # malformed tag also stops the run here, before any expensive build. The
-      # verified values are exported for the APK-verification and summary steps.
+      # §1 & §3). scripts/release_preflight.sh re-derives the canonical
+      # versionName/versionCode from the pushed tag (same rules as
+      # tool/version_from_tag.dart, kept in lockstep by
+      # test/tooling/release_preflight_test.dart) and FAILS FAST if pubspec.yaml
+      # does not match it — so a tag is never built against a stale pubspec, and
+      # the F-Droid build (which reads pubspec.yaml) always agrees with this one.
+      # A malformed tag also stops the run here, before any expensive build.
+      #
+      # On a tag/pubspec mismatch we ALSO write a clearly-labeled
+      # "Version mismatch: release was not built." entry to the job summary so
+      # the GitHub Actions run page reads as a release that did not build —
+      # never confused with an APK build failure (the build never ran). The
+      # contributor sees the same wording locally because they ran the same
+      # script (see docs/release-process.md §3 step 9). We pass --no-app-info
+      # here because the AppInfo drift is already covered by the CI workflow's
+      # `flutter test` step (test/core/app_info_version_test.dart).
       - name: Verify the tag matches pubspec.yaml
         if: ${{ steps.mode.outputs.trigger == 'tag' }}
         id: version
         run: |
           set -euo pipefail
-          if ! derived="$(dart run tool/version_from_tag.dart "$GITHUB_REF_NAME")"; then
-            echo "::error::Could not derive a version from tag '$GITHUB_REF_NAME' (see the error above). Use a tag like v0.1.0-alpha.16, v0.1.0-rc.1, or v1.2.3."
-            exit 1
+          out_file="$RUNNER_TEMP/release-preflight.out"
+          status=0
+          scripts/release_preflight.sh "$GITHUB_REF_NAME" --no-app-info > "$out_file" 2>&1 || status=$?
+          cat "$out_file"
+          if [ "$status" -ne 0 ]; then
+            # printf with single-quoted format strings: backslash is preserved
+            # literally inside single quotes, so do not escape the backticks
+            # (they're not metacharacters here either).
+            {
+              printf '### Version mismatch: release was not built.\n\n'
+              printf 'The pushed tag did not match `pubspec.yaml` (or was malformed). '
+              printf 'This is **not** an APK build failure — `flutter build` never ran.\n\n'
+              printf 'See the workflow log for the exact tag/pubspec mismatch and the fix '
+              printf '(usually: bump `pubspec.yaml` in a PR, merge it, then create the next '
+              printf 'release tag from `main` — do not move the existing tag). '
+              printf 'See docs/release-process.md §3.\n'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Version mismatch: release was not built. See log above for the exact tag/pubspec mismatch and fix."
+            exit "$status"
           fi
-          name="$(printf '%s\n' "$derived" | sed -n 's/^LINTHRA_VERSION_NAME=//p')"
-          code="$(printf '%s\n' "$derived" | sed -n 's/^LINTHRA_VERSION_CODE=//p')"
-
-          # Read `version: <name>+<code>` from pubspec.yaml and split on '+'.
-          pubspec="$(sed -n 's/^version:[[:space:]]*//p' pubspec.yaml | head -n1)"
-          pubspec_name="${pubspec%%+*}"
-          pubspec_code="${pubspec#*+}"
-
-          echo "Tag '$GITHUB_REF_NAME' encodes to: ${name}+${code}"
-          echo "pubspec.yaml version:            ${pubspec_name}+${pubspec_code}"
-          if [ "$pubspec_name" != "$name" ] || [ "$pubspec_code" != "$code" ]; then
-            echo "::error::pubspec.yaml version (${pubspec_name}+${pubspec_code}) does not match tag '$GITHUB_REF_NAME' (expected ${name}+${code}). Bump pubspec.yaml's 'version:' to match the tag before tagging — see docs/release-process.md §1 & §3."
-            exit 1
-          fi
-          echo "Verified: pubspec.yaml matches the tag."
-          {
-            printf 'LINTHRA_VERSION_NAME=%s\n' "$name"
-            printf 'LINTHRA_VERSION_CODE=%s\n' "$code"
-          } | tee -a "$GITHUB_ENV" >> "$GITHUB_OUTPUT"
+          grep -E '^LINTHRA_VERSION_(NAME|CODE)=' "$out_file" \
+            | tee -a "$GITHUB_ENV" >> "$GITHUB_OUTPUT"
 
       # Plain release builds: both manual and tag builds read
       # versionName/versionCode (and the in-app version) from pubspec.yaml —

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -189,7 +189,10 @@ F-Droid (and our own release tracking) builds from a **git tag**.
 
 Every release requires three version-linked actions — **bump `pubspec.yaml`**,
 **add the Fastlane changelog**, and **tag the matching version** — plus the usual
-green-CI / generated-files hygiene:
+green-CI / generated-files hygiene. The flow below is the *safe* order; doing
+the version bump in a merged PR **before** creating the tag is what stops the
+"tag pushed against a stale `pubspec.yaml`" failure mode that wasted
+`v0.1.0-alpha.35`.
 
 1. **Choose the version** = the tag you will push, e.g. `v0.1.0-alpha.31`.
    Preview its canonical `versionCode`:
@@ -201,7 +204,7 @@ green-CI / generated-files hygiene:
    ```
 
 2. **Bump the version in `pubspec.yaml` (and its in-app mirror)** — in one
-   commit, since a drift test enforces they agree:
+   commit on a PR, since a drift test enforces they agree:
    - `pubspec.yaml` → `version: 0.1.0-alpha.31+100031` (the `versionName` plus the
      canonical `versionCode` from step 1).
    - `lib/core/app_info.dart` → `AppInfo._devVersionName = '0.1.0-alpha.31'`.
@@ -221,13 +224,74 @@ green-CI / generated-files hygiene:
    `dart run build_runner build --delete-conflicting-outputs` locally, and commit
    the result. The committed output means the F-Droid build needs no `build_runner`
    prebuild (see [fdroid-build-recipe.md §4](./fdroid-build-recipe.md#4-reproducibility-notes)).
-5. **CI is green** (`flutter analyze`, `flutter test`, formatting) on the
-   commit — this includes the version-drift test from step 2.
+5. **Open the version-bump PR and wait for CI green**
+   (`flutter analyze`, `flutter test`, formatting) — this includes the
+   version-drift test from step 2.
 6. **Confirm licensing** is still accurate if dependencies changed — re-run the
    [dependency & license audit](./dependency-license-audit.md).
-7. **Create the annotated tag (§2)** — `vX.Y.Z(-suffix.N)` must equal the
-   `versionName` you set in `pubspec.yaml` (step 2). The tag build re-verifies
-   the match (§4) and fails fast if they diverge.
+7. **Merge the version-bump PR.** Do **not** tag yet — see the warning box
+   below.
+8. **Pull latest `main` locally** so the tag points at the merged bump:
+
+   ```sh
+   git checkout main
+   git pull origin main
+   ```
+
+9. **Run the release preflight script** — the same script the GitHub release
+   workflow runs, so any mismatch fails locally with the same wording instead
+   of wasting a tag:
+
+   ```sh
+   ./scripts/release_preflight.sh v0.1.0-alpha.31
+   # OK: v0.1.0-alpha.31 matches pubspec.yaml version 0.1.0-alpha.31+100031.
+   # ...
+   # Next safe commands:
+   #   git tag -a v0.1.0-alpha.31 -m "Linthra 0.1.0-alpha.31"
+   #   git push origin v0.1.0-alpha.31
+   ```
+
+   The preflight is pure bash — it needs **no** Flutter/Dart toolchain. It
+   checks the same things CI checks: tag shape, canonical `versionCode`,
+   `pubspec.yaml` `version:`, and (locally — CI's `flutter test` already
+   covers it) `AppInfo._devVersionName`. On any mismatch it prints the
+   pushed tag, the expected `pubspec.yaml` version, the actual `pubspec.yaml`
+   version, and the exact fix; nothing is tagged.
+10. **Create the annotated tag (§2)** — `vX.Y.Z(-suffix.N)` must equal the
+    `versionName` you set in `pubspec.yaml` (step 2). The tag build re-verifies
+    the match (§4) and fails fast if they diverge.
+
+    ```sh
+    git tag -a v0.1.0-alpha.31 -m "Linthra 0.1.0-alpha.31"
+    git push origin v0.1.0-alpha.31
+    ```
+
+11. **Watch GitHub Actions.** The Android Release Build workflow runs
+    automatically on a `v*` tag push, re-verifies `pubspec.yaml` matches the
+    tag (§4), builds the APK/AAB, and attaches them to a Release (pre-release
+    for alpha/beta/rc; existing Release only for stable).
+12. **Install the APK and smoke-test** the build before announcing.
+
+> **Warnings (the "lost-tag" failure mode).**
+>
+> * **Never push the tag before the version-bump PR is merged into `main`.**
+>   If `pubspec.yaml` still lists the previous version when the tag lands, the
+>   release workflow's preflight will refuse to build — and the workflow
+>   summary will say so explicitly ("Version mismatch: release was not
+>   built.") so it is not confused with an APK build failure.
+> * **Never reuse or move an already-pushed release tag.** Tags are immutable
+>   to downstream consumers (Android updaters, F-Droid mirrors, GitHub Release
+>   pages). If a wrong tag was pushed, **skip to the next version** — bump
+>   `pubspec.yaml` again, merge, and tag `v0.1.0-alpha.<N+1>`. The skipped
+>   version stays unbuilt; that is the safe outcome.
+> * **The git tag does NOT include the `+versionCode`.** It looks like
+>   `v0.1.0-alpha.31`. `pubspec.yaml`'s `version:` **does** include
+>   `+versionCode` — `0.1.0-alpha.31+100031` — and the canonical encoding
+>   from `tool/version_from_tag.dart` is what `+` must contain.
+> * **A tag/pubspec mismatch is "release was not built"**, not an APK build
+>   failure. The preflight step fails *before* `flutter build` runs, so
+>   nothing was compiled or signed; the fix is to bump `pubspec.yaml` (or
+>   skip to the next version), not to debug Gradle.
 
 ## 4. GitHub Releases (notes manual, artifact build & attachment automatic)
 
@@ -324,7 +388,7 @@ F-Droid does **not** consume our signed artifacts. When/if Linthra is submitted:
 | Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
 | Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
-| Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`tool/version_from_tag.dart`); fails fast on a mismatch. Both manual and tag builds take the version from `pubspec.yaml`. |
+| Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`scripts/release_preflight.sh`, encoding-checked against `tool/version_from_tag.dart`); fails fast on a mismatch and the workflow summary explicitly says "Version mismatch: release was not built." so it is not confused with an APK build failure. The same script is intended to be run locally before tagging (§3 step 9). Both manual and tag builds take the version from `pubspec.yaml`. |
 | Attaching APK/AAB to a Release | **Automatic** on a `v*` tag build. Alpha/beta/rc tags attach (debug- or release-signed) to a **pre-release**; stable tags attach **release-signed** assets to an existing Release only. |
 | Creating a GitHub **pre-release** (alpha/beta/rc) | **Automatic** on the tag build if no Release exists yet (placeholder notes; edit afterwards). |
 | Creating a stable GitHub Release | **Manual** (operator, §4); never auto-created. |

--- a/scripts/release_preflight.sh
+++ b/scripts/release_preflight.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# release_preflight.sh — verify a release tag matches pubspec.yaml *before*
+# pushing it. Pure bash; does not need Flutter or Dart.
+#
+# Usage:
+#
+#   ./scripts/release_preflight.sh v0.1.0-alpha.36
+#
+# Options:
+#
+#   --pubspec PATH     Read pubspec.yaml from PATH (default: ./pubspec.yaml).
+#   --app-info PATH    Read _devVersionName from PATH
+#                      (default: ./lib/core/app_info.dart).
+#   --no-app-info      Skip the AppInfo check.
+#   -h, --help         Show this help.
+#
+# What it does:
+#
+#   1. Encodes the tag to versionName / versionCode using the same rules as
+#      tool/version_from_tag.dart (the canonical Dart encoder, exercised by
+#      test/tooling/version_from_tag_test.dart). The two encodings are kept in
+#      lockstep by test/tooling/release_preflight_test.dart.
+#         versionCode = MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + rank
+#         rank: alpha.N=N, beta.N=300+N, rc.N=600+N, stable=999
+#   2. Reads `version: <name>+<code>` from pubspec.yaml.
+#   3. (Default) Reads `_devVersionName = '<name>'` from lib/core/app_info.dart.
+#   4. Compares them. On any mismatch (or malformed tag) it emits a multi-line
+#      ERROR that names the pushed tag, the expected pubspec version, the
+#      actual pubspec version, and the exact fix — then exits non-zero.
+#   5. On success it prints LINTHRA_VERSION_NAME / LINTHRA_VERSION_CODE for
+#      CI capture, an `OK:` confirmation, and the next safe commands.
+#
+# This is the local twin of the GitHub Actions "Verify the tag matches
+# pubspec.yaml" step in .github/workflows/android-release-build.yml: that step
+# runs THIS script, so CI and a contributor's pre-tag check fail with the same
+# wording. See docs/release-process.md §3 step 9.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PUBSPEC="$REPO_ROOT/pubspec.yaml"
+APP_INFO="$REPO_ROOT/lib/core/app_info.dart"
+CHECK_APP_INFO=true
+TAG=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release_preflight.sh <tag> [--pubspec PATH] [--app-info PATH] [--no-app-info]
+
+  <tag>          Release tag, e.g. v0.1.0-alpha.36 (with or without leading v).
+  --pubspec      Read pubspec.yaml from PATH (default: ./pubspec.yaml).
+  --app-info     Read _devVersionName from PATH (default: ./lib/core/app_info.dart).
+  --no-app-info  Skip the AppInfo check.
+  -h, --help     Show this help.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --pubspec)
+      [ "$#" -ge 2 ] || { echo "ERROR: --pubspec needs a path." >&2; exit 64; }
+      PUBSPEC="$2"; shift 2 ;;
+    --app-info)
+      [ "$#" -ge 2 ] || { echo "ERROR: --app-info needs a path." >&2; exit 64; }
+      APP_INFO="$2"; shift 2 ;;
+    --no-app-info) CHECK_APP_INFO=false; shift ;;
+    --)
+      shift
+      if [ "$#" -gt 0 ] && [ -z "$TAG" ]; then TAG="$1"; shift; fi
+      ;;
+    -*)
+      printf 'ERROR: unknown option: %s\n\n' "$1" >&2
+      usage >&2
+      exit 64
+      ;;
+    *)
+      if [ -z "$TAG" ]; then
+        TAG="$1"
+      else
+        printf 'ERROR: unexpected argument: %s\n\n' "$1" >&2
+        usage >&2
+        exit 64
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$TAG" ]; then
+  printf 'ERROR: missing tag argument.\n\n' >&2
+  usage >&2
+  exit 64
+fi
+
+# Trim surrounding whitespace.
+TAG="${TAG#"${TAG%%[![:space:]]*}"}"
+TAG="${TAG%"${TAG##*[![:space:]]}"}"
+
+# Display form: always carry the leading v so error messages match what a user
+# would type. Parsing strips it.
+display_tag="$TAG"
+[[ "$display_tag" != v* ]] && display_tag="v$display_tag"
+parse="${TAG#v}"
+
+# Mirror tool/version_from_tag.dart's _tagPattern:
+#   ^v?(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|rc)\.(\d+))?$
+re='^([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.([0-9]+))?$'
+if [[ ! "$parse" =~ $re ]]; then
+  cat >&2 <<EOF
+ERROR: Malformed release tag "$display_tag".
+Expected vMAJOR.MINOR.PATCH with an optional -alpha.N / -beta.N / -rc.N suffix,
+e.g. v0.1.0-alpha.36, v0.1.0-rc.1, or v1.2.3.
+EOF
+  exit 1
+fi
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+patch="${BASH_REMATCH[3]}"
+tier="${BASH_REMATCH[5]}"
+pre_n="${BASH_REMATCH[6]}"
+
+# Bounds mirror tool/version_from_tag.dart: minor/patch ≤ 99, pre-release N ≤ 299.
+if [ "$minor" -gt 99 ]; then
+  echo "ERROR: Minor version $minor in tag \"$display_tag\" exceeds the supported range (0..99)." >&2
+  exit 1
+fi
+if [ "$patch" -gt 99 ]; then
+  echo "ERROR: Patch version $patch in tag \"$display_tag\" exceeds the supported range (0..99)." >&2
+  exit 1
+fi
+
+if [ -z "$tier" ]; then
+  rank=999
+  expected_name="${major}.${minor}.${patch}"
+else
+  if [ "$pre_n" -gt 299 ]; then
+    echo "ERROR: Pre-release number $pre_n in tag \"$display_tag\" exceeds the supported range (0..299)." >&2
+    exit 1
+  fi
+  case "$tier" in
+    alpha) base=0 ;;
+    beta)  base=300 ;;
+    rc)    base=600 ;;
+  esac
+  rank=$((base + pre_n))
+  expected_name="${major}.${minor}.${patch}-${tier}.${pre_n}"
+fi
+
+expected_code=$((major * 10000000 + minor * 100000 + patch * 1000 + rank))
+if [ "$expected_code" -le 0 ] || [ "$expected_code" -gt 2100000000 ]; then
+  echo "ERROR: Derived versionCode $expected_code for tag \"$display_tag\" is outside the valid Android range (1..2100000000)." >&2
+  exit 1
+fi
+expected_full="${expected_name}+${expected_code}"
+
+# Read pubspec.yaml's `version: <name>+<code>`.
+if [ ! -f "$PUBSPEC" ]; then
+  echo "ERROR: pubspec.yaml not found at $PUBSPEC" >&2
+  exit 1
+fi
+pubspec_full="$(sed -n 's/^version:[[:space:]]*//p' "$PUBSPEC" | head -n1 | tr -d '[:space:]')"
+if [ -z "$pubspec_full" ]; then
+  echo "ERROR: pubspec.yaml at $PUBSPEC has no \`version:\` line." >&2
+  exit 1
+fi
+pubspec_name="${pubspec_full%%+*}"
+if [[ "$pubspec_full" == *+* ]]; then
+  pubspec_code="${pubspec_full#*+}"
+else
+  pubspec_code=""
+fi
+
+if [ "$pubspec_name" != "$expected_name" ] || [ "$pubspec_code" != "$expected_code" ]; then
+  cat >&2 <<EOF
+ERROR: Release tag $display_tag expects pubspec.yaml version $expected_full.
+Actual pubspec.yaml version is $pubspec_full.
+
+Do not move this tag.
+Bump pubspec.yaml in a PR, merge it, then create the next release tag from main.
+EOF
+  exit 1
+fi
+
+# AppInfo check (default on; CI passes --no-app-info because flutter test
+# covers the drift already via test/core/app_info_version_test.dart).
+if [ "$CHECK_APP_INFO" = "true" ]; then
+  if [ ! -f "$APP_INFO" ]; then
+    printf 'WARNING: app_info not found at %s; skipping AppInfo check.\n' "$APP_INFO" >&2
+  else
+    app_info_name="$(sed -n "s/.*_devVersionName *= *'\\([^']*\\)'.*/\\1/p" "$APP_INFO" | head -n1)"
+    if [ -z "$app_info_name" ]; then
+      printf 'WARNING: could not find _devVersionName in %s; skipping AppInfo check.\n' "$APP_INFO" >&2
+    elif [ "$app_info_name" != "$expected_name" ]; then
+      cat >&2 <<EOF
+ERROR: Release tag $display_tag expects AppInfo._devVersionName = $expected_name.
+Actual AppInfo._devVersionName is $app_info_name (in $APP_INFO).
+
+Bump pubspec.yaml AND AppInfo._devVersionName in the same PR, then create the release tag from main.
+EOF
+      exit 1
+    fi
+  fi
+fi
+
+# Success: KEY=VALUE first so CI can capture them, then the friendly message
+# and the next safe commands a contributor should run.
+printf 'LINTHRA_VERSION_NAME=%s\n' "$expected_name"
+printf 'LINTHRA_VERSION_CODE=%s\n' "$expected_code"
+printf 'OK: %s matches pubspec.yaml version %s.\n' "$display_tag" "$expected_full"
+
+cat <<EOF
+
+Next safe commands (run from a clean checkout of main):
+  git checkout main
+  git pull origin main
+  git tag -a $display_tag -m "Linthra $expected_name"
+  git push origin $display_tag
+
+Then watch GitHub Actions: the release workflow will build and attach artifacts.
+EOF

--- a/test/tooling/release_preflight_test.dart
+++ b/test/tooling/release_preflight_test.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import '../../tool/version_from_tag.dart';
+
+/// Specifies `scripts/release_preflight.sh` — the pure-bash twin of
+/// `tool/version_from_tag.dart` that the GitHub release workflow runs against
+/// every pushed tag (see docs/release-process.md §3 step 9 and
+/// .github/workflows/android-release-build.yml).
+///
+/// The two encodings must agree forever, so this suite shells out to the
+/// script for a corpus of tags and asserts the printed
+/// `LINTHRA_VERSION_NAME` / `LINTHRA_VERSION_CODE` lines match what the Dart
+/// encoder produces. It also exercises the mismatch and malformed-tag flows
+/// the workflow relies on for "Version mismatch: release was not built."
+void main() {
+  final String repoRoot = _findRepoRoot();
+  final String script = p.join(repoRoot, 'scripts', 'release_preflight.sh');
+
+  setUpAll(() {
+    if (!File(script).existsSync()) {
+      fail('Preflight script not found at $script');
+    }
+  });
+
+  group('release_preflight.sh — encoding matches version_from_tag.dart', () {
+    // A representative slice of the corpus from version_from_tag_test.dart:
+    // alpha (the user's two worked examples), beta, rc, and stable. If the
+    // Dart encoding changes, this catches the drift immediately.
+    const List<String> tags = <String>[
+      'v0.1.0-alpha.32',
+      'v0.1.0-alpha.36',
+      'v0.1.0-beta.1',
+      'v0.1.0-rc.1',
+      'v0.1.0',
+      'v1.2.3',
+    ];
+
+    for (final String tag in tags) {
+      test('$tag → same versionName/versionCode as versionFromTag', () async {
+        // We give the script a fixture pubspec/app-info that *matches* the
+        // tag, so the encoding is the only thing under test.
+        final TagVersion expected = versionFromTag(tag);
+        final Directory tmp =
+            await Directory.systemTemp.createTemp('preflight_ok_');
+        addTearDown(() async => tmp.delete(recursive: true));
+        _writePubspec(tmp, expected.name, expected.code);
+        _writeAppInfo(tmp, expected.name);
+
+        final ProcessResult r = _runPreflight(
+          script,
+          tag,
+          pubspec: p.join(tmp.path, 'pubspec.yaml'),
+          appInfo: p.join(tmp.path, 'app_info.dart'),
+        );
+        expect(r.exitCode, 0,
+            reason:
+                'expected success.\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+        final Map<String, String> kv = _parseKeyValues(r.stdout as String);
+        expect(kv['LINTHRA_VERSION_NAME'], expected.name);
+        expect(kv['LINTHRA_VERSION_CODE'], '${expected.code}');
+        expect(r.stdout, contains('OK: $tag matches pubspec.yaml version'));
+      });
+    }
+  });
+
+  group('release_preflight.sh — mismatch and malformed flows', () {
+    test('exits non-zero and shows the exact-fix wording on pubspec drift',
+        () async {
+      final Directory tmp =
+          await Directory.systemTemp.createTemp('preflight_drift_');
+      addTearDown(() async => tmp.delete(recursive: true));
+      // Tag the workflow used in the original failure: v0.1.0-alpha.35 was
+      // pushed while pubspec.yaml still read 0.1.0-alpha.34+100034.
+      _writePubspec(tmp, '0.1.0-alpha.34', 100034);
+
+      final ProcessResult r = _runPreflight(
+        script,
+        'v0.1.0-alpha.35',
+        pubspec: p.join(tmp.path, 'pubspec.yaml'),
+        noAppInfo: true,
+      );
+      expect(r.exitCode, isNot(0));
+      final String stderr = r.stderr as String;
+      expect(
+          stderr,
+          contains(
+              'Release tag v0.1.0-alpha.35 expects pubspec.yaml version 0.1.0-alpha.35+100035'));
+      expect(stderr,
+          contains('Actual pubspec.yaml version is 0.1.0-alpha.34+100034'));
+      expect(stderr, contains('Do not move this tag.'));
+      expect(
+          stderr,
+          contains(
+              'Bump pubspec.yaml in a PR, merge it, then create the next release tag from main.'));
+    });
+
+    test('exits non-zero on a malformed tag with a usage hint', () async {
+      final Directory tmp =
+          await Directory.systemTemp.createTemp('preflight_bad_');
+      addTearDown(() async => tmp.delete(recursive: true));
+      _writePubspec(tmp, '0.1.0-alpha.36', 100036);
+
+      final ProcessResult r = _runPreflight(
+        script,
+        'v1.2',
+        pubspec: p.join(tmp.path, 'pubspec.yaml'),
+        noAppInfo: true,
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('Malformed release tag "v1.2"'));
+      expect(r.stderr, contains('v0.1.0-alpha.36'));
+    });
+
+    test('rejects out-of-range fields the same way as versionFromTag',
+        () async {
+      final Directory tmp =
+          await Directory.systemTemp.createTemp('preflight_oor_');
+      addTearDown(() async => tmp.delete(recursive: true));
+      _writePubspec(tmp, '0.1.0-alpha.36', 100036);
+
+      final ProcessResult r = _runPreflight(
+        script,
+        'v0.100.0',
+        pubspec: p.join(tmp.path, 'pubspec.yaml'),
+        noAppInfo: true,
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('Minor version 100'));
+    });
+
+    test('exits non-zero on AppInfo drift even if pubspec matches', () async {
+      final Directory tmp =
+          await Directory.systemTemp.createTemp('preflight_appinfo_');
+      addTearDown(() async => tmp.delete(recursive: true));
+      _writePubspec(tmp, '0.1.0-alpha.36', 100036);
+      // app_info.dart says an older version — pubspec is fine, AppInfo drifted.
+      _writeAppInfo(tmp, '0.1.0-alpha.35');
+
+      final ProcessResult r = _runPreflight(
+        script,
+        'v0.1.0-alpha.36',
+        pubspec: p.join(tmp.path, 'pubspec.yaml'),
+        appInfo: p.join(tmp.path, 'app_info.dart'),
+      );
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('AppInfo._devVersionName = 0.1.0-alpha.36'));
+      expect(r.stderr,
+          contains('Actual AppInfo._devVersionName is 0.1.0-alpha.35'));
+    });
+
+    test('--no-app-info skips the AppInfo check', () async {
+      final Directory tmp =
+          await Directory.systemTemp.createTemp('preflight_skipappinfo_');
+      addTearDown(() async => tmp.delete(recursive: true));
+      _writePubspec(tmp, '0.1.0-alpha.36', 100036);
+      // No app_info.dart written; with --no-app-info the script must not care.
+
+      final ProcessResult r = _runPreflight(
+        script,
+        'v0.1.0-alpha.36',
+        pubspec: p.join(tmp.path, 'pubspec.yaml'),
+        noAppInfo: true,
+      );
+      expect(r.exitCode, 0,
+          reason: 'stdout:\n${r.stdout}\nstderr:\n${r.stderr}');
+    });
+  });
+
+  group('release_preflight.sh — argument handling', () {
+    test('rejects missing tag with usage hint', () async {
+      final ProcessResult r = Process.runSync(script, <String>[]);
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('missing tag argument'));
+      expect(r.stderr, contains('Usage:'));
+    });
+
+    test('--help prints usage and exits 0', () async {
+      final ProcessResult r = Process.runSync(script, <String>['--help']);
+      expect(r.exitCode, 0);
+      expect(r.stdout, contains('Usage:'));
+      expect(r.stdout, contains('--pubspec'));
+      expect(r.stdout, contains('--app-info'));
+    });
+  });
+}
+
+ProcessResult _runPreflight(
+  String script,
+  String tag, {
+  required String pubspec,
+  String? appInfo,
+  bool noAppInfo = false,
+}) {
+  final List<String> args = <String>[tag, '--pubspec', pubspec];
+  if (noAppInfo) {
+    args.add('--no-app-info');
+  } else if (appInfo != null) {
+    args.addAll(<String>['--app-info', appInfo]);
+  }
+  return Process.runSync(script, args);
+}
+
+Map<String, String> _parseKeyValues(String text) {
+  final Map<String, String> out = <String, String>{};
+  for (final String line in const LineSplitter().convert(text)) {
+    final int eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    final String key = line.substring(0, eq);
+    if (!key.startsWith('LINTHRA_VERSION_')) continue;
+    out[key] = line.substring(eq + 1);
+  }
+  return out;
+}
+
+void _writePubspec(Directory dir, String name, int code) {
+  File(p.join(dir.path, 'pubspec.yaml'))
+      .writeAsStringSync('name: linthra\nversion: $name+$code\n');
+}
+
+void _writeAppInfo(Directory dir, String name) {
+  File(p.join(dir.path, 'app_info.dart')).writeAsStringSync(
+    "abstract final class AppInfo {\n"
+    "  static const String _devVersionName = '$name';\n"
+    "}\n",
+  );
+}
+
+String _findRepoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, 'scripts')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}

--- a/tool/version_from_tag.dart
+++ b/tool/version_from_tag.dart
@@ -1,11 +1,20 @@
-/// Derives Android/app version metadata from a Git release tag.
+/// Canonical encoding of a Git release tag to a `versionName`/`versionCode`
+/// pair.
 ///
-/// This is the **single source of truth** for how a `v*` tag becomes the
-/// `versionName`/`versionCode` baked into a release build. The release workflow
-/// (`.github/workflows/android-release-build.yml`) runs this on the pushed tag
-/// and feeds the result to `flutter build` (`--build-name`/`--build-number`)
-/// and to the in-app version (`--dart-define=LINTHRA_VERSION_NAME=...`).
-/// `test/tooling/version_from_tag_test.dart` exercises the rules below.
+/// `pubspec.yaml` is the single source of truth for what a build actually
+/// ships (see docs/release-process.md §1) — a plain `flutter build` (CI,
+/// local, and F-Droid alike) reads `versionName`/`versionCode` straight from
+/// it, with no `--build-name`/`--build-number`/`--dart-define` flags.
+///
+/// What this tool defines is the *rule* a tag's `+versionCode` must follow:
+/// for any supported `v*` tag, the canonical `versionCode` is the one this
+/// tool computes. `scripts/release_preflight.sh` (called locally before
+/// tagging and by the GitHub release workflow on a `v*` push) verifies that
+/// `pubspec.yaml`'s `version: <name>+<code>` matches that canonical encoding —
+/// so the tag, `pubspec.yaml`, and F-Droid can never disagree. The bash
+/// encoding in that script mirrors this Dart encoding, and
+/// `test/tooling/version_from_tag_test.dart` plus
+/// `test/tooling/release_preflight_test.dart` keep the two in lockstep.
 ///
 /// ## Tag format
 ///


### PR DESCRIPTION
## Summary

GitHub Actions release/build workflow hardening only — no app features,
UI, playback, Cast, Android Auto, cache, Jellyfin/Navidrome, F-Droid
metadata, or Gradle/AGP behavior is changed. No new release tag is
created in this PR.

### Root cause of the repeated release failures

`v0.1.0-alpha.35` was pushed while `pubspec.yaml` still read
`0.1.0-alpha.34+100034`, so the release workflow's tag/pubspec check
failed before any build. The check itself was correct — the failure mode
the user wanted addressed was that:

1. The local process didn't catch the drift before tagging, so the
   contributor "spent" a tag on a build that never happened.
2. The CI failure was easy to misread as an APK build failure, because
   the workflow summary stayed silent on the version mismatch and the
   only signal was a buried log line.

(The earlier `Failed to transform byte-buddy-1.17.5.jar using Jetifier.
Unsupported class file major version 68` error is **already** fixed on
`main`: PR #119 pinned the Android jobs to Temurin JDK 17 and PR #121
disabled Jetifier in `android/gradle.properties`. This PR does not
re-do that work — it just builds on top of it.)

### What changed

- **New `scripts/release_preflight.sh`** — pure-bash twin of
  `tool/version_from_tag.dart`. Locally:

  ```sh
  ./scripts/release_preflight.sh v0.1.0-alpha.36
  # OK: v0.1.0-alpha.36 matches pubspec.yaml version 0.1.0-alpha.36+100036.
  #
  # Next safe commands (run from a clean checkout of main):
  #   git checkout main
  #   git pull origin main
  #   git tag -a v0.1.0-alpha.36 -m "Linthra 0.1.0-alpha.36"
  #   git push origin v0.1.0-alpha.36
  ```

  On a mismatch (the `v0.1.0-alpha.35` failure mode) it prints exactly:

  ```
  ERROR: Release tag v0.1.0-alpha.35 expects pubspec.yaml version 0.1.0-alpha.35+100035.
  Actual pubspec.yaml version is 0.1.0-alpha.34+100034.

  Do not move this tag.
  Bump pubspec.yaml in a PR, merge it, then create the next release tag from main.
  ```

  Pure bash — no Flutter/Dart toolchain needed (so a contributor can
  run it on a fresh clone). Default-on `--app-info` check covers
  `lib/core/app_info.dart` too; CI passes `--no-app-info` because
  `flutter test` already enforces that drift via
  `test/core/app_info_version_test.dart`. Optional `--pubspec PATH` and
  `--app-info PATH` flags exist for the tests.

- **`.github/workflows/android-release-build.yml`** — the
  "Verify the tag matches pubspec.yaml" step now runs the same
  preflight script (same wording in CI and locally), and on failure
  writes a clearly labelled `### Version mismatch: release was not
  built.` section to the workflow's job summary plus a
  `::error::Version mismatch: release was not built.` annotation, so
  the run page reads as "release didn't build" instead of looking
  like an APK build failure. Captured `LINTHRA_VERSION_NAME` /
  `LINTHRA_VERSION_CODE` continue to flow through to the APK
  verification and the success summary unchanged.

- **`test/tooling/release_preflight_test.dart`** — shells out to the
  script for `v0.1.0-alpha.32`, `v0.1.0-alpha.36`, `v0.1.0-beta.1`,
  `v0.1.0-rc.1`, `v0.1.0`, `v1.2.3` and asserts the bash encoding
  produces the same `versionName`/`versionCode` as `versionFromTag`
  in Dart (so the two encodings cannot silently drift). Also covers
  the malformed-tag, pubspec-drift, AppInfo-drift, and `--no-app-info`
  flows.

- **`tool/version_from_tag.dart`** — docstring updated. It previously
  said the workflow fed the result to `flutter build` via
  `--build-name`/`--build-number` and to the in-app version via
  `--dart-define=LINTHRA_VERSION_NAME=…`. That hasn't been true since
  `pubspec.yaml` became the source of truth — a plain `flutter build`
  (CI, local, and F-Droid alike) reads `versionName`/`versionCode`
  straight from `pubspec.yaml`. The docstring now reflects that and
  points at `scripts/release_preflight.sh`.

- **`docs/release-process.md`** §3 now lists the **safe release flow
  end-to-end** (choose version → bump in a PR → changelog → regen →
  CI green → licensing → **merge** → pull main → **preflight** → tag
  → push → watch Actions → smoke test), and §6 names the preflight
  script in the automation table. A warning block at the end spells
  out the rules:

  > * Never push the tag before the version-bump PR is merged.
  > * Never reuse or move an already-pushed release tag — skip to the next
  >   version if a wrong tag was pushed.
  > * The git tag does **not** include `+versionCode`; `pubspec.yaml` does.
  > * A tag/pubspec mismatch is "release was not built", not an APK
  >   build failure — fix `pubspec.yaml`, don't debug Gradle.

### Java / Gradle / Jetifier decision

No change in this PR. The Java/Jetifier crash is already addressed on
`main`:

- `android/gradle.properties` — `android.useAndroidX=true`,
  `android.enableJetifier=false` (PR #121, with an audit note pointing
  at `docs/dependency-license-audit.md` §3).
- Both `.github/workflows/android-release-build.yml` and
  `.github/workflows/android-debug-apk.yml` — `actions/setup-java@v4`
  pinned to `distribution: temurin, java-version: "17"` (PR #119), and
  a "Show Java environment" diagnostic step (`java -version` +
  `echo "JAVA_HOME=$JAVA_HOME"`) right after it.
- Gradle 8.7 + AGP 8.2.1 + Kotlin 1.9.24 in `android/settings.gradle`
  and `android/gradle/wrapper/gradle-wrapper.properties` are unchanged
  — JDK 17 + no Jetifier is the supported combination this toolchain
  is tested against, so no AGP/Gradle upgrade is needed.

### F-Droid compatibility notes

The F-Droid plain-source build model is preserved:

- `pubspec.yaml` remains the single source of truth (currently
  `0.1.0-alpha.36+100036`).
- `flutter build apk --release` and `flutter build appbundle --release`
  in CI take the version straight from `pubspec.yaml` — no
  `--build-name`, `--build-number`, or `--dart-define` overrides
  required (CI uses none; the optional `LINTHRA_VERSION_NAME`
  dart-define in `AppInfo` is empty by default and only an escape
  hatch).
- The release preflight script is GitHub-only tooling and is not part
  of the F-Droid build recipe. F-Droid still reads versionName /
  versionCode from `pubspec.yaml` at the tagged commit, exactly as
  documented in `docs/fdroid-build-recipe.md` §2.

### Release preflight usage

Before pushing a release tag, on a clean checkout of `main`:

```sh
git checkout main
git pull origin main
./scripts/release_preflight.sh v0.1.0-alpha.<N>
```

Tag only after the script prints `OK:`. The same script runs in CI on
every `v*` push, so a mismatch can never silently slip through.

### Docs updated

- `docs/release-process.md` — full safe-release flow + warnings.
- `tool/version_from_tag.dart` — docstring rewritten to match how the
  workflow actually consumes it.

### Tests / verification

Ran in the dev container against the project-local Flutter
(`.tool/flutter`, 3.27.4 — the version `.flutter-version` pins):

- `dart format --set-exit-if-changed .` → clean.
- `flutter analyze` → `No issues found!`
- `flutter test` → 1228 passed (including the 13 new
  `release_preflight_test.dart` cases).
- `bash -n scripts/release_preflight.sh` → syntax clean.
- Workflow YAML parses with `python3 -c "import yaml; …"`.

No Android SDK is available in this remote container, so I did **not**
run `flutter build apk --release` / `flutter build appbundle --release`
locally — GitHub Actions remains the final Android build verification.
The Android Release Build workflow itself is unchanged in everything
except the verify step's mechanism and summary; the build/sign/attach
behavior is identical.

### Next safe release steps (for whoever cuts the next alpha)

1. Pick the version, e.g. `v0.1.0-alpha.37`.
2. Open a version-bump PR: `pubspec.yaml` → `0.1.0-alpha.37+100037`,
   `lib/core/app_info.dart` → `_devVersionName = '0.1.0-alpha.37'`,
   add `fastlane/metadata/android/en-US/changelogs/100037.txt`.
3. Get CI green, merge.
4. `git checkout main && git pull origin main`.
5. `./scripts/release_preflight.sh v0.1.0-alpha.37` — wait for the
   `OK:` line.
6. `git tag -a v0.1.0-alpha.37 -m "Linthra 0.1.0-alpha.37"`.
7. `git push origin v0.1.0-alpha.37`.
8. Watch the Android Release Build workflow; install the attached
   APK and smoke-test.

## Test plan

- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze`
- [x] `flutter test` (1228/1228 pass)
- [x] `bash -n scripts/release_preflight.sh`
- [x] `scripts/release_preflight.sh v0.1.0-alpha.36` against the
      current `pubspec.yaml` → `OK:`
- [x] `scripts/release_preflight.sh v0.1.0-alpha.35` against a fixture
      `pubspec.yaml` pinned to `0.1.0-alpha.34+100034` → reproduces the
      exact failure-mode wording from the task description.
- [x] `scripts/release_preflight.sh v1.2` → `Malformed release tag`
      error.
- [ ] CI: confirm `Android Release Build` runs on this branch's debug
      APK job (verify step is gated to `trigger == 'tag'`, so a
      branch push only exercises the build path; the verify path will
      be exercised by the next real tag push).
- [ ] Next real release tag push: confirm the workflow summary shows
      "Linthra release build" on success, or "Version mismatch:
      release was not built." on a mismatch.

https://claude.ai/code/session_01PnUNoq31x1MuMxrWS2oTKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnUNoq31x1MuMxrWS2oTKw)_