### PR TITLE
build(android): enforce dependenciesInfo off-switch via Gradle DSL

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,6 +57,21 @@ android {
         jvmTarget = JavaVersion.VERSION_1_8
     }
 
+    // F-Droid's `check apk` step rejects any APK that carries extra APK
+    // Signing Block entries, and AGP 8.x defaults to embedding a compressed
+    // Maven dependency list (block id 0x504b4453, "Dependency metadata") so
+    // Play Console can flag vulnerable libraries. The matching
+    // android.dependenciesInfo.* flags in android/gradle.properties are NOT a
+    // documented AGP knob — AGP only reads this setting from the DSL block
+    // below, so the properties alone left the metadata in v0.1.0-alpha.38.
+    // This DSL block is the supported off-switch and strips the block from
+    // both APK and AAB outputs. Disabling has no runtime effect; it only
+    // suppresses metadata that Google would have read.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     defaultConfig {
         // Stable application ID for F-Droid / GitHub Releases distribution.
         applicationId = "io.github.thezupzup.linthra"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -10,8 +10,11 @@ android.enableJetifier=false
 # AGP 8.x embeds a compressed Maven dependency list as an extra APK Signing
 # Block entry (id 0x504b4453, "Dependency metadata") so Play Console can flag
 # vulnerable libraries. F-Droid's `check apk` step refuses APKs that contain
-# extra signing blocks ("found extra signing block 'Dependency metadata'"),
-# so we disable the injection for both APK and bundle outputs. Disabling does
-# not affect runtime behaviour, only the metadata Google would have read.
+# extra signing blocks ("found extra signing block 'Dependency metadata'").
+# The authoritative off-switch is the `dependenciesInfo { }` DSL block in
+# android/app/build.gradle — these properties are not a documented AGP knob
+# and were not enough on their own (the v0.1.0-alpha.38 APK still shipped the
+# block). They are kept as belt-and-suspenders in case a future AGP version
+# starts honouring them, and to flag intent to readers of gradle.properties.
 android.dependenciesInfo.includeInApk=false
 android.dependenciesInfo.includeInBundle=false


### PR DESCRIPTION
## Summary

F-Droid `check apk` still failed on **v0.1.0-alpha.38** with
`Found extra signing block 'Dependency metadata'`, even though
`android/gradle.properties` already had:

```
android.dependenciesInfo.includeInApk=false
android.dependenciesInfo.includeInBundle=false
```

Root cause: **AGP 8.x does not read those names from `gradle.properties`.**
The only documented off-switch is the `dependenciesInfo { }` DSL block on
the `android { }` extension. Without it, AGP keeps embedding the
compressed Maven dependency list as APK Signing Block entry
`0x504b4453` ("Dependency metadata"), which F-Droid rejects.

This PR adds the DSL block in `android/app/build.gradle` and keeps the
`gradle.properties` flags as belt-and-suspenders (with a note explaining
why they alone were not enough).

### Why `gradle.properties` was not enough

- `android.useAndroidX`, `android.enableJetifier`, etc. are real,
  documented gradle-property knobs that AGP reads from the project
  properties map.
- `android.dependenciesInfo.includeInApk` / `includeInBundle` are **not**
  in that list. The DslDependenciesInfo configuration on AGP's `android`
  extension is the only path AGP reads. Setting the `android.*` property
  is silently ignored, which is exactly what we observed on alpha.38.
- The DSL form is what AGP's own release notes and the Android docs show
  for disabling the dependency metadata signing block, so we now match
  that.

### Changes

- `android/app/build.gradle`: add
  ```groovy
  dependenciesInfo {
      includeInApk = false
      includeInBundle = false
  }
  ```
  inside the `android { }` block, with a comment explaining why and
  pointing to the F-Droid failure mode.
- `android/gradle.properties`: keep the existing flags but rewrite the
  comment to make clear the DSL block is the authoritative off-switch
  and the properties are a defence-in-depth fallback.

### Out of scope (intentionally untouched)

- No app feature changes.
- `pubspec.yaml` version untouched (release automation owns the bump).
- F-Droid metadata in `metadata/` untouched.
- Jetifier stays disabled; AndroidX stays enabled.

## Test plan

- [x] `dart format --set-exit-if-changed .` — clean (424 files, 0 changed)
- [x] `flutter analyze` — `No issues found!`
- [x] `flutter test` — `All tests passed!` (1249 tests)
- [ ] `flutter build apk --release` — **skipped**: this remote execution
      environment has no Android SDK. The CI workflows
      `.github/workflows/android-release-build.yml` and
      `android-debug-apk.yml` both compile against this same
      `android/app/build.gradle`, so the build is exercised on the PR.
- [ ] APK signing-block inspection: F-Droid `fdroid build` / `check apk`
      on GitLab is the authoritative verifier — alpha.38 surfaced the
      regression there, the next release tag (probably
      `v0.1.0-alpha.39`) will confirm the fix the same way.

## Follow-up

Because tag `v0.1.0-alpha.38` already points to the previous build
config, a new release tag (probably `v0.1.0-alpha.39`) will be needed
after merge so F-Droid sees an APK built with the DSL block applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01278YphNVUuF1SjzgdS2Hqk)_