### PR TITLE
docs(fdroid): apply maintainer feedback on MR !39253 — hash, Binaries, AllowedAPKSigningKeys

### DIFF
--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -1,64 +1,3 @@
-# -----------------------------------------------------------------------------
-# Draft F-Droid metadata for Linthra — a working copy kept in the app repo.
-#
-# Linthra has NOT been accepted on F-Droid. This is the entry proposed in
-# fdroiddata merge request !39253. The real entry lives in fdroiddata's
-# metadata/ directory (https://gitlab.com/fdroid/fdroiddata). To submit, copy
-# the non-comment content below into fdroiddata's
-# metadata/io.github.thezupzup.linthra.yml, then run:
-#
-#   fdroid rewritemeta io.github.thezupzup.linthra   # canonicalises + strips comments
-#   fdroid lint        io.github.thezupzup.linthra
-#   fdroid build -v -l io.github.thezupzup.linthra   # full from-source build test
-#
-# docs/fdroid-submission.md has the merge-request checklist (use fdroiddata's
-# "App inclusion" template) and the remaining steps.
-#
-# Summary and Description are intentionally NOT set here. F-Droid pulls them from
-# the upstream Fastlane metadata in this repo, which is the fdroiddata
-# maintainer's request on !39253 ("Do not add summary and description in
-# fdroiddata"):
-#   * Summary     <- fastlane/metadata/android/en-US/short_description.txt
-#   * Description <- fastlane/metadata/android/en-US/full_description.txt
-# The icon, feature graphic, screenshots, and per-versionCode changelogs under
-# fastlane/metadata/android/en-US/ are pulled the same way.
-#
-# The build follows fdroiddata's templates/build-flutter.yml using the `flutter`
-# srclib method, with Flutter pinned to the version in .flutter-version (3.27.4,
-# matching CI). No Flutter submodule is added upstream and no SDK is cloned by
-# hand.
-#
-# Auto-update is ENABLED. pubspec.yaml now carries the release version
-# (version: <versionName>+<versionCode>, e.g. 0.1.0-alpha.30+100030) in lockstep
-# with the release tag, so:
-#   * UpdateCheckMode: Tags scans the v* tags;
-#   * UpdateCheckData reads the versionCode/versionName from pubspec.yaml at each
-#     tag (F-Droid does not parse pubspec.yaml on its own — its default Tags path
-#     reads only AndroidManifest.xml/build.gradle, which for Flutter hold no
-#     literal version — so UpdateCheckData is REQUIRED for a Flutter app);
-#   * AutoUpdateMode: Version adds a build for each new tag;
-#   * a plain `flutter build apk --release` takes versionName/versionCode straight
-#     from pubspec.yaml, so the F-Droid APK and the upstream GitHub-release APK
-#     agree without any --build-name/--build-number flags.
-#
-# TRANSITION CAVEAT: the v0.1.0-alpha.30 tag below was cut BEFORE pubspec.yaml
-# tracked the release version, so at that exact tag pubspec.yaml is still
-# 0.1.0-alpha.15+15. The single Builds entry therefore passes explicit
-# --build-name/--build-number/--dart-define to build it as 0.1.0-alpha.30 /
-# 100030. From v0.1.0-alpha.31 onward pubspec.yaml matches the tag, so new
-# entries — including those AutoUpdateMode adds — must DROP those flags and be a
-# plain `flutter build apk --release`.
-#
-# Native code: the only native component is SQLite via sqlite3_flutter_libs,
-# compiled from source by the Android Gradle build (no prebuilt blobs). If
-# `fdroid build -l` reports a missing toolchain, pin the build server's NDK with
-# an `ndk:` field and/or install CMake in prebuild (e.g. sudo sdkmanager
-# 'cmake;<version>'), as some Flutter recipes do.
-#
-# More reasoning: docs/fdroid-submission.md, docs/fdroid-readiness.md,
-# docs/fdroid-build-recipe.md, docs/dependency-license-audit.md.
-# -----------------------------------------------------------------------------
-
 Categories:
   - Multimedia
 License: MPL-2.0
@@ -68,14 +7,16 @@ IssueTracker: https://github.com/TheZupZup/Linthra/issues
 Changelog: https://github.com/TheZupZup/Linthra/releases
 
 Name: Linthra
+AutoName: Linthra
 
 RepoType: git
 Repo: https://github.com/TheZupZup/Linthra.git
+Binaries: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-debug-signed.apk
 
 Builds:
-  - versionName: 0.1.0-alpha.30
-    versionCode: 100030
-    commit: v0.1.0-alpha.30
+  - versionName: 0.1.0-alpha.39
+    versionCode: 100039
+    commit: 1e015a18bc9ec412b9ce52a400c4f00c00419bea
     output: build/app/outputs/flutter-apk/app-release.apk
     srclibs:
       - flutter@stable
@@ -90,15 +31,12 @@ Builds:
       - .pub-cache
     build:
       - export PUB_CACHE=$(pwd)/.pub-cache
-      # TRANSITION (see header): the v0.1.0-alpha.30 tag predates pubspec.yaml
-      # version tracking (its committed pubspec is 0.1.0-alpha.15+15), so these
-      # explicit flags override it to build as 0.1.0-alpha.30 / 100030. From
-      # v0.1.0-alpha.31 onward, DROP these flags — a plain `flutter build apk
-      # --release` reads the version from pubspec.yaml.
-      - $$flutter$$/bin/flutter build apk --release --build-name=0.1.0-alpha.30 --build-number=100030 --dart-define=LINTHRA_VERSION_NAME=0.1.0-alpha.30
+      - $$flutter$$/bin/flutter build apk --release
+
+AllowedAPKSigningKeys: 93ab06094c6f07780f862ed585a433c5e175d61685f09242bbbc9eeddf692528
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-UpdateCheckData: pubspec.yaml|version:\s.+\+(\d+)|.|version:\s(.+)\+
+UpdateCheckData: pubspec.yaml|version:\s*[^+]+\+(\d+)|.|version:\s*([^\+]+)\+
 CurrentVersion: 0.1.0-alpha.39
 CurrentVersionCode: 100039


### PR DESCRIPTION
## Summary

Applies the fdroiddata maintainer's review on MR !39253 to the draft metadata for `io.github.thezupzup.linthra`:

- **Replace tag with full commit hash.** `commit:` for the v0.1.0-alpha.39 target is now the full 40-char hash `1e015a18bc9ec412b9ce52a400c4f00c00419bea` — the build is pinned to the exact commit even if the tag is ever moved.
- **Move the Builds entry from alpha.30 → alpha.39.** `CurrentVersion` / `CurrentVersionCode` were already on alpha.39 / 100039 but the single seed `Builds` entry still pointed at the alpha.30 transition build. The new entry is a plain `flutter build apk --release` — pubspec.yaml at the alpha.39 tag carries `0.1.0-alpha.39+100039`, so no `--build-name`/`--build-number`/`--dart-define` flags are needed. The alpha.30 release also has no APK assets, so its old `commit:` could not have been verified against a Binaries URL.
- **Add `Binaries:`** pointing at the upstream GitHub-release APK (`linthra-v%v-debug-signed.apk`). After fdroid builds from source, the fdroiddata pipeline downloads this APK and compares it against the from-source build for reproducible-build verification.
- **Add `AllowedAPKSigningKeys:`** pinning the SHA-256 fingerprint of the upstream signing cert (lowercase, no colons): `93ab06094c6f07780f862ed585a433c5e175d61685f09242bbbc9eeddf692528`. APKs signed with any other key are rejected.
- **Canonicalise via `fdroid rewritemeta`** (strips the long header comment block and reorders fields). `fdroid lint` is clean. `fdroid checkupdates` finds no newer tag (CurrentVersion already at alpha.39) and adds `AutoName: Linthra`.

App code, GitHub releases, and the alpha.39 tag are unchanged.

## Verification

Run from the project root with `fdroidserver` installed:

```sh
fdroid rewritemeta io.github.thezupzup.linthra   # canonicalises (already applied)
fdroid lint        io.github.thezupzup.linthra   # clean (exit 0)
fdroid checkupdates io.github.thezupzup.linthra  # no newer tag; adds AutoName
fdroid build -v -l --skip-scan io.github.thezupzup.linthra
# In this environment the build stops at `srclib flutter not found` because the
# fdroiddata srclibs directory isn't present locally; on fdroiddata it picks up
# templates/build-flutter.yml and runs the plain `flutter build apk --release`.
```

The certificate fingerprint was confirmed against the actual GitHub-release APK:

```sh
apksigner verify --print-certs linthra-v0.1.0-alpha.39-debug-signed.apk
# Signer #1 certificate SHA-256 digest: 93ab06094c6f07780f862ed585a433c5e175d61685f09242bbbc9eeddf692528
```

## Test plan

- [ ] Confirm `fdroid lint`, `fdroid checkupdates`, and `fdroid build -v -l io.github.thezupzup.linthra` are green inside an actual fdroiddata checkout (where the `flutter` srclib resolves).
- [ ] On the next release (alpha.40+), confirm `AutoUpdateMode: Version` appends a build entry using the new tag's full commit hash (the autoupdater writes the tag's hash, not the tag string).
- [ ] Reply to the maintainer on !39253.


---
_Generated by [Claude Code](https://claude.ai/code/session_018VnKjSGqqbX3huCayTVhiU)_