### PR TITLE
docs(fdroid): align build path with upstream for reproducible build

### DIFF
--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -17,6 +17,9 @@ Builds:
   - versionName: 0.1.0-alpha.39
     versionCode: 100039
     commit: 1e015a18bc9ec412b9ce52a400c4f00c00419bea
+    sudo:
+      - mkdir -p /home/runner/work/Linthra
+      - chown -R vagrant /home/runner/work
     output: build/app/outputs/flutter-apk/app-release.apk
     srclibs:
       - flutter@stable
@@ -24,14 +27,26 @@ Builds:
       - flutterVersion=$(cat .flutter-version)
       - '[[ $flutterVersion ]]'
       - git -C $$flutter$$ checkout -f $flutterVersion
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter config --no-analytics
       - $$flutter$$/bin/flutter pub get
+      - popd
+      - mv $repo io.github.thezupzup.linthra
     scandelete:
       - .pub-cache
     build:
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
       - export PUB_CACHE=$(pwd)/.pub-cache
       - $$flutter$$/bin/flutter build apk --release
+      - popd
+      - mv $repo io.github.thezupzup.linthra
 
 AllowedAPKSigningKeys: 93ab06094c6f07780f862ed585a433c5e175d61685f09242bbbc9eeddf692528
 


### PR DESCRIPTION
## Summary

- Updates `metadata/io.github.thezupzup.linthra.yml` so the F-Droid Flutter build runs at the same absolute build path as the upstream GitHub Actions release build, addressing maintainer feedback on fdroiddata MR !39329 ("See https://gitlab.com/fdroid/fdroiddata/-/blob/master/templates/build-flutter.yml. You need to use the same build path.").
- No upstream workflow change (`.github/workflows/android-release-build.yml` unchanged). No version bump, no new tag, no signing-key change, no removal of `Binaries` or `AllowedAPKSigningKeys`, commit hash stays the full 40-char `1e015a18bc9ec412b9ce52a400c4f00c00419bea`.

## Root cause

Flutter's AOT compiler bakes the absolute project root path into `libapp.so` (via Dart kernel source URIs and symbol metadata). Today the two builds use different paths:

| Build       | Path                                          |
|-------------|-----------------------------------------------|
| GitHub Actions release (`actions/checkout@v4`, no `working-directory` override) | `/home/runner/work/Linthra/Linthra` |
| fdroiddata default build dir | `/build/io.github.thezupzup.linthra/` |

So every `libapp.so` ABI diverges and `fdroid build`'s reproducible-build comparison against the `Binaries:` URL fails — exactly the symptom the maintainer reported on MR !39329.

## Fix

Apply the path-relocation pattern from `templates/build-flutter.yml` on the F-Droid side only:

- `sudo:` creates `/home/runner/work/Linthra` and chowns `/home/runner/work` to `vagrant`.
- `prebuild:` moves `io.github.thezupzup.linthra` to `/home/runner/work/Linthra/Linthra`, runs `flutter pub get` there, then moves it back so subsequent F-Droid scans see the source at its original location.
- `build:` does the same dance around `flutter build apk --release`, then moves the directory back so the unchanged `output: build/app/outputs/flutter-apk/app-release.apk` resolves correctly.

The upstream workflow does not need to change — the GitHub Actions default `$GITHUB_WORKSPACE` is already `/home/runner/work/Linthra/Linthra`, which is what F-Droid will now mirror.

## Test plan

This branch only updates the F-Droid recipe; real validation has to happen in fdroiddata against the maintainer's pipeline:

- [ ] Apply the same hunk to fdroiddata MR !39329 (`metadata/io.github.thezupzup.linthra.yml`).
- [ ] `fdroid rewritemeta io.github.thezupzup.linthra` — confirm no churn beyond formatting.
- [ ] `fdroid lint io.github.thezupzup.linthra` — schema/lint must stay green.
- [ ] `fdroid checkupdates io.github.thezupzup.linthra` — auto-update unchanged.
- [ ] `fdroid build io.github.thezupzup.linthra` — reproducible-build comparison should now pass for `libapp.so` across `arm64-v8a`, `armeabi-v7a`, `x86_64`.

If `libapp.so` still differs after the path alignment, the next likely culprit is the **Flutter SDK install path** (upstream uses `subosito/flutter-action`'s tool-cache path like `/opt/hostedtoolcache/flutter/...`, F-Droid uses the `flutter@stable` srclib path). Project-root alignment is the dominant source of path strings in `libapp.so`, so this is the right first step; SDK-path alignment is a heavier follow-up requiring upstream workflow changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GWmSoLynQffcgFr2egnzB3)_