### PR TITLE
Apply fdroid rewritemeta canonical formatting to metadata

### DIFF
--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -6,37 +6,14 @@ SourceCode: https://github.com/TheZupZup/Linthra
 IssueTracker: https://github.com/TheZupZup/Linthra/issues
 Changelog: https://github.com/TheZupZup/Linthra/releases
 
-Name: Linthra
+AllowedAPKSigningKeys: 835189ae30df4d23588580e0a86e5e9b67ea2a2745fda510759f22a3d0a78b6c
+
 AutoName: Linthra
+Name: Linthra
 
 RepoType: git
 Repo: https://github.com/TheZupZup/Linthra.git
 
-# Per-ABI APK split (MR !39329). The base versionCode in `pubspec.yaml` is
-# `MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + preReleaseRank` (see
-# docs/release-process.md §1). For each tag F-Droid derives the per-ABI
-# versionCode by multiplying the base by ten and adding the ABI rank — the
-# same `versionCodeOverride` rule applied by `android/app/build.gradle`, so
-# the F-Droid build and the gradle override always agree:
-#
-#     armeabi-v7a → %c*10 + 1
-#     arm64-v8a   → %c*10 + 2
-#     x86_64      → %c*10 + 3
-#
-# AutoUpdateMode below uses these operations to add one Build entry per ABI
-# per tag (so v0.1.0-alpha.40 → 1000401/1000402/1000403, and so on).
-VercodeOperation:
-  - "%c*10 + 1"
-  - "%c*10 + 2"
-  - "%c*10 + 3"
-
-# Three per-ABI Builds entries for v0.1.0-alpha.39 — the same source tag as
-# before; only the per-APK versionCode and output path differ. The build
-# command is the universal `flutter build apk --release --split-per-abi`,
-# which produces all three per-ABI APKs in one invocation; each entry just
-# selects its own output. The `--split-per-abi` flag (combined with the
-# `applicationVariants.configureEach` override in `android/app/build.gradle`)
-# is what gives each APK the matching `versionCodeOverride`.
 Builds:
   - versionName: 0.1.0-alpha.39
     versionCode: 1000391
@@ -140,18 +117,13 @@ Builds:
       - popd
       - mv $repo io.github.thezupzup.linthra
 
-# AllowedAPKSigningKeys is kept so an F-Droid client can still warn users who
-# sideload a wrong-keyed APK with the same App ID. The `Binaries:` URL used to
-# point at the upstream GitHub release artifact, but that artifact is a single
-# universal APK while every Build above is now per-ABI at a different
-# versionCode — so F-Droid's reproducible-build comparison cannot match. The
-# field is removed deliberately (per the maintainer's "unless the split APK
-# flow requires changing Binaries" carve-out); the GitHub release itself is
-# untouched and v0.1.0-alpha.39 remains downloadable from there for sideload.
-AllowedAPKSigningKeys: 835189ae30df4d23588580e0a86e5e9b67ea2a2745fda510759f22a3d0a78b6c
-
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
+VercodeOperation:
+  - "%c*10 + 1"
+  - "%c*10 + 2"
+  - "%c*10 + 3"
 UpdateCheckData: pubspec.yaml|version:\s*[^+]+\+(\d+)|.|version:\s*([^\+]+)\+
+
 CurrentVersion: 0.1.0-alpha.39
 CurrentVersionCode: 1000393


### PR DESCRIPTION
## Summary
- Reformats `metadata/io.github.thezupzup.linthra.yml` to match the output of `fdroid rewritemeta` so CI no longer fails on the rewrite diff.
- Strips explanatory `#` comments (rewritemeta does not preserve them).
- Reorders fields to fdroid's canonical order: `AllowedAPKSigningKeys` after `Changelog`, `AutoName` before `Name`, `VercodeOperation` between `UpdateCheckMode` and `UpdateCheckData`.

## What is preserved
- Three per-ABI `Builds` entries (versionCodes `1000391`/`1000392`/`1000393`).
- `AllowedAPKSigningKeys: 835189ae...8b6c`.
- `Binaries` remains absent.
- `CurrentVersionCode: 1000393`, `CurrentVersion: 0.1.0-alpha.39`, commit hash `1e015a18bc9ec412b9ce52a400c4f00c00419bea`, and the `%c*10 + N` ABI split logic.

## Test plan
- [ ] Run `fdroid rewritemeta io.github.thezupzup.linthra` against this branch in fdroiddata and confirm an empty diff.
- [ ] Confirm CI `fdroid rewritemeta` check is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011XYJSGadFNKTmEsDbMNAvm)_