### PR TITLE
fix(android): register per-ABI versionCode override outside afterEvaluate

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,7 +123,7 @@ android {
 //     versionCodeOverride = baseVersionCode * 10 + abiRank
 //
 // with armeabi-v7a=1, arm64-v8a=2, x86_64=3. The matching `VercodeOperation`
-// and per-ABI `Builds` entries live in
+// and per-ABI `Builds` entries (versionCodes 1000391/1000392/1000393) live in
 // metadata/io.github.thezupzup.linthra.yml.
 //
 // MUST run AFTER the Flutter Gradle plugin's per-ABI override. The Flutter
@@ -143,29 +143,36 @@ android {
 // which is what alpha.39's F-Droid build hit: `Unexpected versionCode in
 // output; APK: '101039', Expected: '1000391'`.
 //
-// The previous override sat inside the `android { }` block as
-// `applicationVariants.configureEach { ... }`. Empirically that callback
-// fired BEFORE Flutter's `.all` on each variant in AGP 8.2 — even though it
-// was registered second — so Flutter's eager `.all` ran last and silently
-// overwrote our `base * 10 + abi` with its own `abi * 1000 + base`. (In a
-// vanilla `DomainObjectSet` both hooks fire in registration order, but AGP's
-// legacy variants collection appears to drain `.configureEach` callbacks at
-// a different lifecycle point than `.all`, and `.all` wins.)
+// Registration / lifecycle ordering — why this is at script top-level and
+// NOT inside an `afterEvaluate { }`:
 //
-// Switching to `.all` puts our callback in the same hook lane as Flutter's,
-// and wrapping it in `afterEvaluate` defers our registration until after the
-// Flutter plugin's `apply()` has already registered its `.all` — so within
-// that single lane our action is queued last and fires last per variant,
-// making the maintainer-requested scheme win.
-def abiCodes = ["armeabi-v7a": 1, "arm64-v8a": 2, "x86_64": 3]
-afterEvaluate {
-    android.applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def abiName = output.filters.find { it.filterType == "ABI" }?.identifier
-            def abiCode = abiCodes[abiName]
-            if (abiCode != null) {
-                output.versionCodeOverride = variant.versionCode * 10 + abiCode
-            }
+//   * The Flutter plugin registers its own `applicationVariants.all { ... }`
+//     callback eagerly from `apply()` (at the `id "dev.flutter..."` line at
+//     the top of this script), i.e. during the script's configuration phase.
+//   * AGP's `DomainObjectCollection.all { }` queues actions in registration
+//     order and fires them per variant as each variant is realized. So a
+//     second `.all { }` registered later in the same script is guaranteed
+//     to run AFTER Flutter's action on every variant, which is exactly what
+//     "last writer wins" needs for `output.versionCodeOverride`.
+//   * `afterEvaluate { }` (what alpha.39 used) is too late: by the time the
+//     afterEvaluate queue drains, AGP has already locked the variant output
+//     DSL properties as part of finalizing the project — assigning
+//     `output.versionCodeOverride` then throws "The value for this property
+//     cannot be changed any further", which is the F-Droid build failure
+//     after PR #134.
+//   * Registering here — at script top-level, AFTER the `android { }` block
+//     so `android.applicationVariants` is reachable, but BEFORE
+//     `flutter { source = "../.." }` and BEFORE project evaluation finishes
+//     — puts our callback in the same hook lane as Flutter's and after
+//     Flutter's registration, but still inside the configuration phase, so
+//     AGP has not yet finalized the output properties when our action runs.
+def fdroidAbiCodes = ["armeabi-v7a": 1, "arm64-v8a": 2, "x86_64": 3]
+android.applicationVariants.all { variant ->
+    variant.outputs.all { output ->
+        def abiName = output.filters.find { it.filterType == "ABI" }?.identifier
+        def abiCode = fdroidAbiCodes[abiName]
+        if (abiCode != null) {
+            output.versionCodeOverride = variant.versionCode * 10 + abiCode
         }
     }
 }


### PR DESCRIPTION
## Summary

The F-Droid build started failing after #134 with:

```
A problem occurred evaluating root project 'android'.
A problem occurred configuring project ':app'.
The value for this property cannot be changed any further.
```

#134 wrapped the per-ABI `output.versionCodeOverride` assignment in `afterEvaluate { ... }` so our `applicationVariants.all { }` would register after the Flutter Gradle plugin's. On the F-Droid builder that's too late: by the time the `afterEvaluate` queue drains, AGP has already finalized the variant output DSL properties as part of project finalization, so writing to `output.versionCodeOverride` throws.

This PR drops the `afterEvaluate` wrapper and registers `android.applicationVariants.all { ... }` at script top-level — right after the `android { }` block, before `flutter { source = "../.." }`. The maintainer-requested scheme is preserved (`armeabi-v7a=1000391`, `arm64-v8a=1000392`, `x86_64=1000393`).

## Why top-level `applicationVariants.all` is the right hook

- The Flutter plugin registers its own `applicationVariants.all { }` callback eagerly from `apply()` (the `id "dev.flutter..."` line at the top of `android/app/build.gradle`) — during the script's configuration phase.
- AGP's `DomainObjectCollection.all { }` queues actions in registration order and fires them per variant as each variant is realized. A second `.all { }` registered later in the same script is guaranteed to run AFTER Flutter's on every variant, which gives us "last writer wins" for `output.versionCodeOverride`.
- `afterEvaluate { }` is too late: AGP locks the variant output properties at project finalization, before the `afterEvaluate` queue drains. That's the failure mode we just hit.
- Registering at script top-level after `android { }` but before `flutter { }` is still inside the configuration phase, so AGP has not yet finalized the output properties when our action runs — but our `.all` callback is queued after Flutter's, so we still win the ordering.

## Scope kept minimal

- Only `android/app/build.gradle` changed.
- No app version bump, no `alpha.40`, no package id change.
- F-Droid metadata YAML (`metadata/io.github.thezupzup.linthra.yml`) untouched — `VercodeOperation` stays `%c*10 + 1/2/3`, per-ABI `Builds` versionCodes stay `1000391`/`1000392`/`1000393`.
- A plain `flutter build apk --release` (universal APK, GitHub releases CI) still ships at base `100039` because the override block is a no-op when no ABI filter is present.

## Test plan

- [ ] Re-run the F-Droid build for alpha.39 against this branch and verify all three split APKs are produced without the "value for this property cannot be changed any further" error.
- [ ] Confirm the produced APKs have `versionCode` `1000391` (armeabi-v7a), `1000392` (arm64-v8a), `1000393` (x86_64).
- [ ] Confirm a plain `flutter build apk --release` (no `--split-per-abi`) still produces a universal APK with `versionCode` `100039`.
- [ ] Confirm `flutter run --release` on a connected device still works (debug-key fallback path unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMSDz4AXpuLXDZrq5TwvUY)_