### PR TITLE
metadata: point F-Droid builds at per-ABI versionCode fix commit

### DIFF
--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -17,7 +17,7 @@ Repo: https://github.com/TheZupZup/Linthra.git
 Builds:
   - versionName: 0.1.0-alpha.39
     versionCode: 1000391
-    commit: 1e015a18bc9ec412b9ce52a400c4f00c00419bea
+    commit: 0c7ca8d1fe55576e869e3ecc5c1d43f2dbeda871
     sudo:
       - mkdir -p /home/runner/work/Linthra
       - chown -R vagrant /home/runner/work
@@ -51,7 +51,7 @@ Builds:
 
   - versionName: 0.1.0-alpha.39
     versionCode: 1000392
-    commit: 1e015a18bc9ec412b9ce52a400c4f00c00419bea
+    commit: 0c7ca8d1fe55576e869e3ecc5c1d43f2dbeda871
     sudo:
       - mkdir -p /home/runner/work/Linthra
       - chown -R vagrant /home/runner/work
@@ -85,7 +85,7 @@ Builds:
 
   - versionName: 0.1.0-alpha.39
     versionCode: 1000393
-    commit: 1e015a18bc9ec412b9ce52a400c4f00c00419bea
+    commit: 0c7ca8d1fe55576e869e3ecc5c1d43f2dbeda871
     sudo:
       - mkdir -p /home/runner/work/Linthra
       - chown -R vagrant /home/runner/work


### PR DESCRIPTION
## Summary
- Update all three `Builds` entries in `metadata/io.github.thezupzup.linthra.yml` from `1e015a1` to `0c7ca8d` so F-Droid builds the merged main commit that contains the Gradle per-ABI versionCode fix from PR #135.
- No version bump: `versionName`, `versionCode`, `VercodeOperation`, and `AllowedAPKSigningKeys` are unchanged; no new alpha cut.

## Test plan
- [ ] F-Droid lint / fdroid build picks up the new commit for all three ABIs (armeabi-v7a, arm64-v8a, x86_64).
- [ ] Resulting APKs have versionCodes 1000391 / 1000392 / 1000393 and report versionName `0.1.0-alpha.39`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeeHgm5WeW3svGNHB2Z3Ek)_