### PR TITLE
Add F-Droid install badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#status)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 
+[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="75">](https://f-droid.org/packages/io.github.thezupzup.linthra/)
+
 ![Linthra](fastlane/metadata/android/en-US/images/featureGraphic.png)
 
 ### Your music, your server.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds the official F-Droid "Get it on F-Droid" badge to the top of README.md, linking directly to the package page at `https://f-droid.org/packages/io.github.thezupzup.linthra/`
- Badge is placed between the existing shields.io badges and the feature graphic, so it's immediately visible to visitors

## Note

The README still contains two passages that say Linthra is "not on F-Droid" (in the **Status** and **Install** sections). Those should be updated separately to avoid contradicting the new badge.

## Test plan

- [ ] Verify the badge renders correctly on GitHub
- [ ] Verify the badge link opens the correct F-Droid package page

https://claude.ai/code/session_01WqmP2NFoXF4HT8M5iP513o
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqmP2NFoXF4HT8M5iP513o)_