### PR TITLE
fix: stop cast receiver polling while paused (battery)

### DIFF
--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -106,6 +106,11 @@ files can't cast):
 14. ☐ Adjust the **Cast volume** slider / mute — it drives the *device* volume and
     follows the receiver's reported level; a fixed-volume device shows an honest
     disabled state.
+14b.☐ **Cast-paused battery check**: start a track casting, then pause it. Turn
+    the screen off for ≥ 5 minutes. Verify via *Settings → Battery → Linthra*
+    (or `adb shell dumpsys batterystats`) that Linthra's background CPU use is
+    negligible — confirming the 1 Hz poll stopped when paused (it must not
+    wake the CPU every second while the session is idle).
 15. ☐ **Disconnect** cast.
 16. ☐ Local playback returns **paused** at the receiver's last position (never
     surprise-starts audio).

--- a/lib/core/services/cast/chromecast_cast_transport.dart
+++ b/lib/core/services/cast/chromecast_cast_transport.dart
@@ -235,6 +235,23 @@ class _ChromecastSessionHandle implements CastSessionHandle {
     _poll = null;
   }
 
+  /// Adjusts polling to the receiver's current play state: polls only while
+  /// actively playing (or loading/buffering) so the CPU is not woken every
+  /// second when the session is paused or idle.
+  void _adjustPolling(PlaybackStatus playbackStatus) {
+    switch (playbackStatus) {
+      case PlaybackStatus.playing:
+      case PlaybackStatus.buffering:
+      case PlaybackStatus.loading:
+        _startPolling();
+      case PlaybackStatus.paused:
+      case PlaybackStatus.idle:
+      case PlaybackStatus.completed:
+      case PlaybackStatus.error:
+        _stopPolling();
+    }
+  }
+
   /// Routes an incoming receiver message: media status drives playback, receiver
   /// status carries the device volume. Other types are ignored.
   void _onMessage(Map<String, dynamic> payload) {
@@ -275,6 +292,9 @@ class _ChromecastSessionHandle implements CastSessionHandle {
       duration: _lastDuration,
     );
     if (!_status.isClosed) _status.add(status);
+    // Stop polling when paused/idle so the CPU is not woken every second with
+    // the screen off; resume polling when playing again.
+    _adjustPolling(status.status);
   }
 
   /// Parses the device volume out of a `RECEIVER_STATUS` payload and forwards a


### PR DESCRIPTION
## What and why

`ChromecastCastTransport` polled the Default Media Receiver every 1 second from the moment `loadMedia()` was called until the cast session ended — including while playback was paused. With the screen off and a paused cast session, this woke the CPU every second, draining battery for no benefit (position doesn't change while paused, and the receiver sends spontaneous status updates on state changes anyway).

## The fix

Adds `_adjustPolling()` — a tiny switch over `PlaybackStatus` — and calls it after every `MEDIA_STATUS` from the receiver:

- `PLAYING / BUFFERING / LOADING` → `_startPolling()` (idempotent: no-op if already running)
- `PAUSED / IDLE / COMPLETED / ERROR` → `_stopPolling()`

The receiver already sends a spontaneous `MEDIA_STATUS` whenever the play state changes, so polling resumes the moment the user or a media control resumes playback. The initial `_startPolling()` in `loadMedia()` is kept — we need it to eagerly poll for the session ID and first position before the first spontaneous status arrives.

## Files changed

- `lib/core/services/cast/chromecast_cast_transport.dart` — `_adjustPolling()` + one call site in `_onMediaStatus()`
- `docs/manual-test-checklist.md` — adds §4 item 14b: cast-paused battery check

## Architecture audit summary (no other code changes needed)

A full audit of the playback architecture was done before this change. Everything else is already correctly implemented:

| Area | Status |
|---|---|
| Foreground service lifecycle | ✅ `androidStopForegroundOnPause: true`; service demotes on real pause/stop |
| Wake locks | ✅ Held only by `audio_service` while session `playing`, released on pause |
| Media buttons (Bluetooth) | ✅ `BaseAudioHandler` + Android `MediaButtonReceiver` in manifest |
| Lock screen / notification controls | ✅ All controls wired; metadata pushed only on change |
| Audio focus | ✅ Handled by `just_audio` / `audio_service` by default |
| Bluetooth disconnect (becoming noisy) | ✅ `audio_service` fires `pause()` on `ACTION_AUDIO_BECOMING_NOISY` |
| Metadata (title/artist/album/artwork) | ✅ Pushed via `_trackMediaItem()`; skipped if unchanged |
| Position coalescing | ✅ 250 ms flush; platform interpolates between pushes |
| Screen-off cutout fix | ✅ Raw engine `idle` events dropped during track transitions |
| Pre-cache / stream preload | ✅ Event-driven, not polling |
| Cast ticker (position interpolation) | ✅ Runs only while casting AND playing |
| Cast session lifecycle on disconnect | ✅ Returns to local paused at receiver's last position |
| Android Auto | ✅ Browse tree answerable cold; no token in media IDs |
| Download parallelism | ✅ Bounded at 3 concurrent |

**Cast polling while paused** was the only actionable battery issue found.

## Testing

CI runs `dart format --set-exit-if-changed . && flutter analyze && flutter test`.

`ChromecastCastTransport` can't be unit-tested (it opens real TLS sockets to a Chromecast), so this is verified by static analysis + on-device. The manual QA checklist (`docs/manual-test-checklist.md` §4 item 14b) now includes the specific battery check:

> **Cast-paused battery check**: start a track casting, then pause it. Turn the screen off for ≥ 5 minutes. Verify via *Settings → Battery → Linthra* (or `adb shell dumpsys batterystats`) that Linthra's background CPU use is negligible.

https://claude.ai/code/session_01CRWG8bVDrw8oT8pWXRkrbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRWG8bVDrw8oT8pWXRkrbb)_