### PR TITLE
chore(release): prepare v0.1.1

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/101999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/101999.txt
@@ -1,0 +1,12 @@
+Linthra 0.1.1 — now available on F-Droid.
+
+Changed:
+- Improved Chromecast battery behavior while paused: receiver polling now
+  stops while paused/idle and resumes on play, cutting background CPU wake-ups.
+
+Maintenance (no app behavior change):
+- Added audit coverage for Bluetooth, BLE/LE Audio output, and CPU efficiency.
+- Added F-Droid release guardrails (version code and release-asset checks).
+- Cleaned up the release-process documentation.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.0-alpha.40';
+  static const String _devVersionName = '0.1.1';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.0-alpha.40+100040
+version: 0.1.1+101999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Release bump: v0.1.1

Bumps the release version from `0.1.0-alpha.40+100040` to **`0.1.1+101999`** and adds the matching Fastlane changelog. This is the **version-bump PR only** — it does not tag, publish, or touch `fdroiddata`. (See `docs/release-process.md` § "Next release: `v0.1.1`".)

### Changes
| File | Change |
| --- | --- |
| `pubspec.yaml` | `version: 0.1.0-alpha.40+100040` → `0.1.1+101999` |
| `lib/core/app_info.dart` | `_devVersionName` → `0.1.1` (kept in lockstep with pubspec) |
| `fastlane/metadata/android/en-US/changelogs/101999.txt` | new F-Droid release notes |

`101999` is the canonical encoding of `0.1.1` from `tool/version_from_tag.dart` (`MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + 999` for a stable release), and is strictly greater than the on-F-Droid `0.1.0-alpha.40` (`100040`), so it stays monotonic.

### Changelog (`101999.txt`)
```
Linthra 0.1.1 — now available on F-Droid.

Changed:
- Improved Chromecast battery behavior while paused: receiver polling now
  stops while paused/idle and resumes on play, cutting background CPU wake-ups.

Maintenance (no app behavior change):
- Added audit coverage for Bluetooth, BLE/LE Audio output, and CPU efficiency.
- Added F-Droid release guardrails (version code and release-asset checks).
- Cleaned up the release-process documentation.

No ads, no tracking, no analytics, no telemetry.
```

### Verification (Flutter 3.27.4, the pinned `.flutter-version`)
- `dart format --set-exit-if-changed .` → 0 files changed
- `flutter analyze` → No issues found
- `flutter test` → **1263 passed**, incl. the version-drift suite (`test/core/app_info_version_test.dart`) and the F-Droid guardrails (`test/tooling/fdroid_release_guardrails_test.dart`)
- `pubspec.lock` left unchanged (no dependency changes)

### Out of scope (intentionally not done)
- No git tag and no GitHub Release (those stay manual, after merge)
- No `fdroiddata` edits
- No release-workflow or release-script changes
- No unrelated app-code changes

After merge, the tag `v0.1.1` and the Release are created manually per `docs/release-process.md` §3–§4.

https://claude.ai/code/session_013utHjZLLw972Koz8VEWa6r

---
_Generated by [Claude Code](https://claude.ai/code/session_013utHjZLLw972Koz8VEWa6r)_