### PR TITLE
feat(subsonic): local Navidrome dev setup + sharper connection errors

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,10 +49,17 @@
          docs/fdroid-readiness.md. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
+    <!-- networkSecurityConfig: permits cleartext (http) traffic so a self-hosted
+         Navidrome/Subsonic or Jellyfin server on the local network (e.g.
+         http://192.168.1.50:4533) can be reached. Android blocks cleartext by
+         default on modern targets; see res/xml/network_security_config.xml for
+         the rationale. System certificate trust is unchanged, so self-signed
+         certificates are still rejected. -->
     <application
         android:label="Linthra"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Network security configuration.
+
+    Linthra is a self-hosted music player: people commonly run their own
+    Navidrome / Subsonic or Jellyfin server on the local network, reached over
+    plain http:// at an address like http://192.168.1.50:4533. Android blocks
+    cleartext (http) traffic by default on modern targets, so without this the
+    app could not connect to a LAN server at all — only to HTTPS endpoints.
+
+    Android's Network Security Config can only whitelist specific domains, not
+    private-IP ranges, and LAN servers use arbitrary private IPs, so cleartext
+    is permitted app-wide here. This is a deliberate connectivity choice for a
+    self-hosted app; it adds no tracking and sends nothing to any third party.
+    HTTPS is always preferred and is recommended for any server reachable from
+    outside the local network. The default (system) certificate trust anchors
+    are kept, so self-signed certificates are still rejected (the app surfaces a
+    clear "couldn't verify your server's certificate" message instead).
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/docs/navidrome-dev-setup.md
+++ b/docs/navidrome-dev-setup.md
@@ -1,0 +1,172 @@
+# Navidrome / Subsonic dev setup & testing
+
+How to run a local [Navidrome](https://www.navidrome.org/) server to test
+Linthra's Subsonic-compatible provider end to end, plus the URL rules, the error
+messages you might see, and a manual test checklist — so the integration can be
+exercised without a production server.
+
+Linthra speaks the **Subsonic REST API**, so this also applies to other
+Subsonic-compatible servers (Airsonic-Advanced, Gonic, …). The behavior here is
+enforced by the Subsonic source under `lib/core/sources/subsonic/` and its tests
+under `test/core/sources/subsonic/`.
+
+## 1. Run Navidrome locally
+
+A ready-to-use Docker Compose file lives in
+[`tools/dev/navidrome/`](../tools/dev/navidrome/).
+
+```bash
+# 1. Put a few audio files in the music folder (anything Navidrome can read:
+#    mp3, flac, m4a, ogg…). Tagged files browse best.
+cp ~/some-music/*.mp3 tools/dev/navidrome/music/
+
+# 2. Start the server
+docker compose -f tools/dev/navidrome/docker-compose.yml up -d
+
+# 3. Open the web UI to confirm it scanned your files
+#    http://localhost:4533   (user: admin   pass: admin)
+
+# Stop it later:
+docker compose -f tools/dev/navidrome/docker-compose.yml down
+```
+
+The compose file auto-creates an **`admin` / `admin`** user on first run
+(`ND_DEVAUTOCREATEADMINPASSWORD`) and rescans `./music` every minute. The
+database lives in `./data` (delete it to start fresh). Both folders are
+git-ignored.
+
+> This is a **local-testing** server: plain http, a throwaway password. Don't
+> expose it to the internet or reuse the password anywhere.
+
+### No test music handy?
+
+Any audio files work. For freely-licensed tracks to test with, the Free Music
+Archive (https://freemusicarchive.org/) and the Internet Archive
+(https://archive.org/details/audio) offer Creative Commons / public-domain
+music. A handful of tagged files is enough to exercise browse, stream, cache,
+and cast.
+
+## 2. Connect Linthra to it
+
+In Linthra: **Settings → Navidrome / Subsonic**, then enter the **server root
+URL** — Linthra appends the `/rest/...` API paths itself, so you never type
+`/rest`.
+
+| Running Linthra on… | Server URL to enter |
+| --- | --- |
+| Android **emulator** (same machine as Docker) | `http://10.0.2.2:4533` |
+| Android **device** on the same Wi-Fi | `http://<your-computer-LAN-IP>:4533` (e.g. `http://192.168.1.50:4533`) |
+| Desktop / `flutter run -d linux` | `http://localhost:4533` |
+
+Find your computer's LAN IP with `ip addr` / `ifconfig` (Linux/macOS) or
+`ipconfig` (Windows). Username `admin`, password `admin`.
+
+Tap **Test connection** (Subsonic's `ping` is authenticated, so a successful
+test also confirms sign-in will work), then **Sign in**, then **Sync Navidrome
+library**.
+
+### HTTP / cleartext on Android
+
+A LAN server reached over plain `http://` works because Linthra ships a
+[network security config](../android/app/src/main/res/xml/network_security_config.xml)
+that permits cleartext. Android blocks cleartext by default on modern targets;
+without that config, `http://192.168.1.50:4533` would fail. HTTPS is still
+preferred for anything reachable beyond your LAN. (This config also lets a
+self-hosted **Jellyfin** server be reached over http on the LAN.)
+
+## 3. URL normalization
+
+`SubsonicServerUrl.normalize` cleans up what you type so the connection test and
+sign-in always agree:
+
+| You type | Linthra uses | Why |
+| --- | --- | --- |
+| `192.168.1.50:4533` | `https://192.168.1.50:4533` | A bare host defaults to **HTTPS**. Add `http://` for a LAN server. |
+| `http://192.168.1.50:4533` | `http://192.168.1.50:4533` | Explicit scheme + port kept (LAN). |
+| `music.example.com` | `https://music.example.com` | Bare host → HTTPS. |
+| `https://example.com/navidrome` | `https://example.com/navidrome` | A reverse-proxy **subpath** is preserved. |
+| `http://host:4533/rest` | `http://host:4533` | A trailing **`/rest`** is stripped — Linthra adds it itself, so keeping it would double to `/rest/rest/...`. |
+| `https://host/?x=1#y` | `https://host` | Trailing slash, query and fragment dropped. |
+
+Endpoints are built in **one place** — `SubsonicEndpoints`
+(`lib/core/sources/subsonic/subsonic_endpoints.dart`) — as
+`<base>/rest/<method>.view` with the token+salt auth woven into the query
+(`u`,`t`,`s`,`v`,`c`,`f`). The salt/token ride in the query only, never the path,
+and are never stored on a track or in the catalog.
+
+## 4. Error messages you might see
+
+Failures map to a typed `SubsonicErrorKind`, each with a friendly, **secret-free**
+message (never the password, salt, token, or a credentialed URL):
+
+| Situation | Kind | What the message tells the user |
+| --- | --- | --- |
+| Address isn't a usable URL | `invalidUrl` | "Enter your server address, e.g. …" / "must start with https://". |
+| Wrong username/password | `unauthorized` | "Your username or password was not accepted by the server." |
+| `http://` blocked by Android | `cleartextBlocked` | "The insecure http:// connection … was blocked. Use https://, or allow cleartext for a local-network server." |
+| Self-signed / untrusted TLS cert | `insecureConnection` | "Couldn't verify your server's security certificate…" |
+| Server down / wrong host / DNS / timeout | `notReachable` | "Couldn't reach the server. Check the address and that you're online." |
+| Reachable, but not a Subsonic API (HTML page, 404 on `/rest`, reverse-proxy error, wrong path) | `notSubsonic` | "That address responded, but it doesn't look like a Subsonic-compatible server… point it at the server root, not a sub-page." |
+| Server-side error (HTTP 5xx) | `serverError` | "Your music server reported an error (HTTP …)." |
+| Item missing (Subsonic code 70) | `streamUnavailable` | "This track isn't available from your server right now." |
+| Incompatible/odd response | `unsupportedResponse` | "…returned a response Linthra could not use. It may be an unsupported version." |
+
+### Mapping the common failure reports
+
+- **Wrong URL** → `invalidUrl` (format) or `notReachable` (host not found).
+- **Wrong username/password** → `unauthorized`.
+- **HTTP blocked / cleartext** → `cleartextBlocked` (with the cleartext config
+  shipped, this is rare; it would mean a build/policy that re-blocked http).
+- **Self-signed certificate** → `insecureConnection`. Linthra does **not**
+  auto-trust self-signed certs (that would be unsafe); put the server behind a
+  reverse proxy with a trusted certificate, or use `http://` on a trusted LAN.
+- **Reverse-proxy path issue** → usually `notSubsonic`: the proxy serves the web
+  UI but `/rest` isn't reachable at that base. Point the URL at the base where
+  `/rest/ping.view` resolves.
+- **Reachable in a browser but API ping fails** → `notSubsonic`: the browser
+  loads the **web UI** at `/`, while the app calls the **API** at `/rest`. Make
+  sure the `/rest` path is proxied/reachable and the address is the server root
+  (not a sub-page).
+
+## 5. Manual test checklist (Navidrome)
+
+Run against the local server above (and, ideally, once over an HTTPS reverse
+proxy). Tick what passes; file gaps via the **Navidrome / Subsonic compatibility
+report** issue template.
+
+**Connection & URL handling**
+- [ ] `http://<LAN-IP>:4533` (root, no `/rest`) → Test connection succeeds and
+      shows the product/version (e.g. "Connected to Navidrome 0.5x").
+- [ ] Pasting `http://<LAN-IP>:4533/rest` also connects (trailing `/rest`
+      stripped).
+- [ ] Trailing slash / query (`…:4533/?x=1`) still connects.
+- [ ] Wrong password → "username or password was not accepted" (`unauthorized`),
+      and any existing connection is **kept**.
+- [ ] Wrong host/port → "Couldn't reach the server" (`notReachable`).
+- [ ] A non-Subsonic address (e.g. a random website) → "doesn't look like a
+      Subsonic-compatible server" (`notSubsonic`).
+
+**Library & playback**
+- [ ] Sign in, then **Sync Navidrome library** → artists/albums/tracks appear.
+- [ ] Tap an uncached track → it streams.
+- [ ] Mark a track for **offline** → it downloads and then plays from cache
+      (airplane mode confirms it plays offline).
+- [ ] **Cast** a track to a Chromecast (if available) → it plays on the
+      receiver.
+- [ ] Sign out & clear → library/session cleared; a stale "Synced N" line is
+      gone.
+
+**Security spot-checks** (should always hold)
+- [ ] No password/token/salt appears in any on-screen message, the connected
+      server line, or copied diagnostics.
+- [ ] The connected-server line shows the host/URL but no `t=`/`s=` query.
+
+## 6. Notes & follow-ups
+
+- **Jellyfin is unaffected** by the Subsonic error-handling changes (separate
+  files under `lib/core/sources/jellyfin/`). The shared cleartext config benefits
+  a LAN Jellyfin server too. Mirroring the granular `cleartextBlocked` /
+  `insecureConnection` messages into the Jellyfin client is a possible follow-up.
+- Favourites, lyrics, and cover art remain **planned** for the Subsonic provider
+  (see [providers.md](providers.md)); they're declared unsupported in the
+  capability model, so their actions stay hidden rather than failing.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -78,6 +78,20 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
   original file via `download.view`).
 - **Cast**: a Subsonic track casts to a Chromecast as a live stream.
 
+### Server URL & local testing
+
+Enter the **server root** (e.g. `http://192.168.1.50:4533`) — Linthra appends
+the `/rest/<method>.view` API paths itself, so you never type `/rest` (and a
+trailing `/rest` you paste is stripped). A bare host defaults to HTTPS; an
+explicit `http://` is kept for a LAN server, and reverse-proxy subpaths are
+preserved. A shipped Android network-security config permits cleartext so a LAN
+`http://` server is reachable.
+
+No production server? A one-command local Navidrome (Docker Compose) and a manual
+test checklist live in
+**[navidrome-dev-setup.md](navidrome-dev-setup.md)** /
+[`tools/dev/navidrome/`](../tools/dev/navidrome/).
+
 ### Authentication & security (token+salt)
 
 Subsonic's modern auth sends, on every request,

--- a/lib/core/sources/subsonic/http_subsonic_client.dart
+++ b/lib/core/sources/subsonic/http_subsonic_client.dart
@@ -187,21 +187,43 @@ class HttpSubsonicClient implements SubsonicClient {
     return envelope;
   }
 
-  /// Runs a request with a timeout, turning any transport-level failure (DNS,
-  /// refused connection, TLS handshake, timeout) into a single friendly "not
-  /// reachable" error without leaking low-level details (which could include the
-  /// credential-bearing URL).
+  /// Runs a request with a timeout, turning any transport-level failure into a
+  /// friendly [SubsonicException] without leaking low-level details (which could
+  /// include the credential-bearing URL). A blocked cleartext request and a
+  /// failed TLS handshake get their own precise kinds; everything else (DNS,
+  /// refused connection, timeout) is "not reachable".
   Future<http.Response> _send(Future<http.Response> Function() request) async {
     try {
       return await request().timeout(_timeout);
     } on TimeoutException {
       throw SubsonicException.notReachable();
-    } on http.ClientException {
-      throw SubsonicException.notReachable();
-    } on Exception {
-      // SocketException / HandshakeException and friends: all "can't reach it".
-      throw SubsonicException.notReachable();
+    } on Exception catch (error) {
+      throw _classifyTransportError(error);
     }
+  }
+
+  /// Infers the *kind* of a transport failure from [error] and returns the
+  /// matching friendly exception.
+  ///
+  /// Security: the error text can contain the request URL (and thus the
+  /// salt+token), so it is only inspected here to classify — it is NEVER placed
+  /// into the thrown message, which is always one of the static, secret-free
+  /// factories. A platform cleartext block surfaces with "Cleartext HTTP
+  /// traffic … not permitted"; a self-signed/untrusted certificate surfaces as
+  /// a `HandshakeException`/TLS error.
+  SubsonicException _classifyTransportError(Object error) {
+    final String text = '${error.runtimeType} $error'.toLowerCase();
+    if (text.contains('cleartext')) {
+      return SubsonicException.cleartextBlocked();
+    }
+    if (text.contains('handshake') ||
+        text.contains('certificate') ||
+        text.contains('tlsexception')) {
+      return SubsonicException.insecureConnection();
+    }
+    // SocketException (DNS / refused) and any other transport error: all "can't
+    // reach it".
+    return SubsonicException.notReachable();
   }
 
   /// Maps an HTTP status to a [SubsonicException]. 2xx passes (the envelope is

--- a/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_cast_media_resolver.dart
@@ -91,6 +91,8 @@ class SubsonicCastMediaResolver implements CastMediaResolver {
       case SubsonicErrorKind.streamUnavailable:
       case SubsonicErrorKind.unsupportedResponse:
       case SubsonicErrorKind.notReachable:
+      case SubsonicErrorKind.cleartextBlocked:
+      case SubsonicErrorKind.insecureConnection:
       case SubsonicErrorKind.serverError:
       case SubsonicErrorKind.invalidUrl:
       case SubsonicErrorKind.unexpected:

--- a/lib/core/sources/subsonic/subsonic_exception.dart
+++ b/lib/core/sources/subsonic/subsonic_exception.dart
@@ -7,9 +7,20 @@ enum SubsonicErrorKind {
   /// The address the user typed isn't a usable http(s) URL.
   invalidUrl,
 
-  /// The server couldn't be reached at all (DNS, connection refused, TLS
-  /// handshake, or timeout). Often a wrong address or an offline tunnel.
+  /// The server couldn't be reached at all (DNS, connection refused, or
+  /// timeout). Often a wrong address or an offline tunnel.
   notReachable,
+
+  /// The platform blocked an insecure cleartext `http://` request (Android
+  /// blocks cleartext by default on modern targets). Distinct from
+  /// [notReachable] so the user is told to use `https://` rather than to
+  /// "check the address".
+  cleartextBlocked,
+
+  /// The TLS handshake failed — typically a self-signed or otherwise untrusted
+  /// certificate. Distinct from [notReachable] so the user knows the server was
+  /// found but its certificate couldn't be verified.
+  insecureConnection,
 
   /// The server answered but rejected the credentials (Subsonic error 40/41/44,
   /// or HTTP 401/403).
@@ -61,6 +72,20 @@ class SubsonicException implements Exception {
         'If your server is behind a reverse proxy or Cloudflare, make sure it '
         'is running.',
         kind: SubsonicErrorKind.notReachable,
+      );
+
+  factory SubsonicException.cleartextBlocked() => const SubsonicException(
+        'The insecure http:// connection to your server was blocked. Use an '
+        'https:// address, or allow cleartext (http) access for a server on '
+        'your local network.',
+        kind: SubsonicErrorKind.cleartextBlocked,
+      );
+
+  factory SubsonicException.insecureConnection() => const SubsonicException(
+        "Couldn't verify your server's security certificate. If it uses a "
+        'self-signed certificate, put it behind a reverse proxy with a trusted '
+        'certificate, or use http:// on a trusted local network.',
+        kind: SubsonicErrorKind.insecureConnection,
       );
 
   factory SubsonicException.unauthorized() => const SubsonicException(

--- a/lib/core/sources/subsonic/subsonic_playable_uri_resolver.dart
+++ b/lib/core/sources/subsonic/subsonic_playable_uri_resolver.dart
@@ -88,6 +88,12 @@ class SubsonicPlayableUriResolver implements PlayableUriResolver {
           "Couldn't reach your music server.",
           kind: PlaybackResolutionErrorKind.serverUnreachable,
         );
+      case SubsonicErrorKind.cleartextBlocked:
+      case SubsonicErrorKind.insecureConnection:
+        return const PlaybackResolutionException(
+          "Couldn't make a secure connection to your music server.",
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
       case SubsonicErrorKind.invalidUrl:
       case SubsonicErrorKind.unexpected:
         return const PlaybackResolutionException(

--- a/lib/core/sources/subsonic/subsonic_server_url.dart
+++ b/lib/core/sources/subsonic/subsonic_server_url.dart
@@ -16,6 +16,10 @@ import 'subsonic_exception.dart';
 ///    whatever base survives here.
 ///  - A trailing slash, query, and fragment are stripped so the result is a
 ///    clean base to append to.
+///  - A trailing `/rest` is stripped, so a user who pastes the API path
+///    (`http://host:4533/rest`) still gets a clean root — Linthra appends
+///    `/rest/<method>.view` itself, so a kept `/rest` would double it into
+///    `/rest/rest/ping.view`.
 abstract final class SubsonicServerUrl {
   /// Returns a clean base URL (no trailing slash) for [input], or throws a
   /// [SubsonicException] of kind [SubsonicErrorKind.invalidUrl] with a friendly
@@ -61,7 +65,7 @@ abstract final class SubsonicServerUrl {
         ..write(':')
         ..write(uri.port);
     }
-    base.write(_trimTrailingSlashes(uri.path));
+    base.write(_stripRestSuffix(_trimTrailingSlashes(uri.path)));
     return base.toString();
   }
 
@@ -81,5 +85,22 @@ abstract final class SubsonicServerUrl {
       end--;
     }
     return path.substring(0, end);
+  }
+
+  /// Drops a trailing `/rest` segment (the Subsonic API mount) from an otherwise
+  /// clean [path], so a pasted API path collapses back to the server root. Only
+  /// a whole final segment named `rest` is removed (case-insensitive): `/rest`
+  /// and `/navidrome/rest` lose it, while `/myrest` or `/restful` keep theirs.
+  /// A Navidrome base is never itself `…/rest` (that path is always the API
+  /// under the root), so this can't strip a legitimate reverse-proxy mount.
+  static String _stripRestSuffix(String path) {
+    const String marker = '/rest';
+    if (path.toLowerCase() == marker) {
+      return '';
+    }
+    if (path.toLowerCase().endsWith(marker)) {
+      return path.substring(0, path.length - marker.length);
+    }
+    return path;
   }
 }

--- a/lib/features/settings/subsonic/subsonic_sync_controller.dart
+++ b/lib/features/settings/subsonic/subsonic_sync_controller.dart
@@ -88,6 +88,10 @@ class SubsonicSyncController extends Notifier<SubsonicSyncState> {
             'server address in Settings.';
       case SubsonicErrorKind.serverError:
         return 'Your music server reported an error. Try again in a moment.';
+      // The factory messages for these already carry specific, actionable
+      // wording (which scheme to use, the certificate hint, …), so surface them.
+      case SubsonicErrorKind.cleartextBlocked:
+      case SubsonicErrorKind.insecureConnection:
       case SubsonicErrorKind.invalidUrl:
       case SubsonicErrorKind.streamUnavailable:
       case SubsonicErrorKind.unsupportedResponse:

--- a/test/core/sources/subsonic/http_subsonic_client_test.dart
+++ b/test/core/sources/subsonic/http_subsonic_client_test.dart
@@ -114,6 +114,43 @@ void main() {
             .having((e) => e.kind, 'kind', SubsonicErrorKind.notReachable)),
       );
     });
+
+    test('maps a blocked cleartext request to cleartextBlocked', () async {
+      final client = _client(MockClient((_) async => throw http.ClientException(
+            'Cleartext HTTP traffic to 192.168.1.50 not permitted',
+          )));
+      expect(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.cleartextBlocked)),
+      );
+    });
+
+    test('maps a TLS handshake failure to insecureConnection', () async {
+      final client = _client(MockClient((_) async => throw http.ClientException(
+            'HandshakeException: Handshake error in client '
+            '(OS Error: CERTIFICATE_VERIFY_FAILED: self signed certificate)',
+          )));
+      expect(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>().having(
+            (e) => e.kind, 'kind', SubsonicErrorKind.insecureConnection)),
+      );
+    });
+
+    test('never echoes a credential-bearing error message', () async {
+      // A ClientException's text can include the request URL (token+salt). The
+      // thrown message must be the static factory text, never the raw error.
+      final client = _client(MockClient((_) async => throw http.ClientException(
+            'Connection failed: $_base/rest/ping.view?u=a&t=tok1&s=salt1',
+          )));
+      await expectLater(
+        () => client.ping(_base, username: 'a', credentials: _credentials),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.message, 'message', isNot(contains('tok1')))
+            .having((e) => e.message, 'message', isNot(contains('salt1')))),
+      );
+    });
   });
 
   group('library listing', () {

--- a/test/core/sources/subsonic/subsonic_endpoints_test.dart
+++ b/test/core/sources/subsonic/subsonic_endpoints_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_auth.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_endpoints.dart';
+
+const String _base = 'https://music.example.com';
+const String _user = 'alice';
+const SubsonicCredentials _creds = SubsonicCredentials(
+  salt: 'the-salt',
+  token: 'the-secret-token',
+);
+
+void main() {
+  group('SubsonicEndpoints builds the /rest API path internally', () {
+    test('ping targets /rest/ping.view (user never types /rest)', () {
+      final Uri uri =
+          SubsonicEndpoints.ping(_base, username: _user, credentials: _creds);
+      expect(uri.path, '/rest/ping.view');
+    });
+
+    test('getArtists targets /rest/getArtists.view', () {
+      final Uri uri = SubsonicEndpoints.getArtists(
+        _base,
+        username: _user,
+        credentials: _creds,
+      );
+      expect(uri.path, '/rest/getArtists.view');
+    });
+
+    test('getAlbumList2 carries the type, size and offset', () {
+      final Uri uri = SubsonicEndpoints.getAlbumList2(
+        _base,
+        username: _user,
+        credentials: _creds,
+        size: 500,
+        offset: 1000,
+      );
+      expect(uri.path, '/rest/getAlbumList2.view');
+      expect(uri.queryParameters['type'], 'alphabeticalByName');
+      expect(uri.queryParameters['size'], '500');
+      expect(uri.queryParameters['offset'], '1000');
+    });
+
+    test('getAlbum carries the album id', () {
+      final Uri uri = SubsonicEndpoints.getAlbum(
+        _base,
+        username: _user,
+        credentials: _creds,
+        albumId: 'al-1',
+      );
+      expect(uri.path, '/rest/getAlbum.view');
+      expect(uri.queryParameters['id'], 'al-1');
+    });
+
+    test('stream and download carry the song id on their own endpoints', () {
+      final Uri stream = SubsonicEndpoints.stream(
+        _base,
+        username: _user,
+        credentials: _creds,
+        songId: 's-7',
+      );
+      final Uri download = SubsonicEndpoints.download(
+        _base,
+        username: _user,
+        credentials: _creds,
+        songId: 's-7',
+      );
+      expect(stream.path, '/rest/stream.view');
+      expect(download.path, '/rest/download.view');
+      expect(stream.queryParameters['id'], 's-7');
+      expect(download.queryParameters['id'], 's-7');
+    });
+
+    test('preserves a reverse-proxy subpath, then appends /rest', () {
+      // A server mounted under a subpath keeps it ahead of the API path.
+      final Uri uri = SubsonicEndpoints.ping(
+        'https://example.com/navidrome',
+        username: _user,
+        credentials: _creds,
+      );
+      expect(uri.path, '/navidrome/rest/ping.view');
+    });
+  });
+
+  group('SubsonicEndpoints weaves the standard auth + format query', () {
+    final Uri uri =
+        SubsonicEndpoints.ping(_base, username: _user, credentials: _creds);
+
+    test('sends u/t/s/v/c/f for token+salt auth', () {
+      final Map<String, String> q = uri.queryParameters;
+      expect(q['u'], _user);
+      expect(q['t'], _creds.token);
+      expect(q['s'], _creds.salt);
+      expect(q['v'], SubsonicEndpoints.apiVersion);
+      expect(q['c'], 'Linthra');
+      expect(q['f'], 'json');
+    });
+
+    test('the token/salt ride in the query only, never in the path', () {
+      // The path the catalog/logs see must never carry the credential.
+      expect(uri.path, isNot(contains(_creds.token)));
+      expect(uri.path, isNot(contains(_creds.salt)));
+      expect(uri.queryParameters['t'], _creds.token);
+      expect(uri.queryParameters['s'], _creds.salt);
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_server_url_test.dart
+++ b/test/core/sources/subsonic/subsonic_server_url_test.dart
@@ -39,6 +39,44 @@ void main() {
       );
     });
 
+    test('normalizes the task example (LAN root, no /rest needed)', () {
+      // Linthra appends /rest/<method>.view itself, so the user types the root.
+      expect(
+        SubsonicServerUrl.normalize('http://192.168.1.50:4533'),
+        'http://192.168.1.50:4533',
+      );
+    });
+
+    test('strips a trailing /rest the user pasted by mistake', () {
+      // Linthra appends /rest itself; keeping it would double to /rest/rest/…
+      expect(
+        SubsonicServerUrl.normalize('http://192.168.1.50:4533/rest'),
+        'http://192.168.1.50:4533',
+      );
+    });
+
+    test('strips a trailing /rest/ (with slash) too', () {
+      expect(
+        SubsonicServerUrl.normalize('https://music.example.com/rest/'),
+        'https://music.example.com',
+      );
+    });
+
+    test('strips /rest while preserving a reverse-proxy subpath', () {
+      expect(
+        SubsonicServerUrl.normalize('https://example.com/navidrome/rest'),
+        'https://example.com/navidrome',
+      );
+    });
+
+    test('does not strip a subpath that merely ends in "rest"', () {
+      // Only a whole final segment named "rest" is removed, not "…rest".
+      expect(
+        SubsonicServerUrl.normalize('https://example.com/myrest'),
+        'https://example.com/myrest',
+      );
+    });
+
     test('trims surrounding whitespace', () {
       expect(
         SubsonicServerUrl.normalize('  music.example.com  '),

--- a/tools/dev/navidrome/.gitignore
+++ b/tools/dev/navidrome/.gitignore
@@ -1,0 +1,5 @@
+# Local-only test data — never commit music files or the Navidrome database.
+/music/*
+/data/*
+!/music/.gitkeep
+!/data/.gitkeep

--- a/tools/dev/navidrome/README.md
+++ b/tools/dev/navidrome/README.md
@@ -1,0 +1,22 @@
+# Local Navidrome dev server
+
+A throwaway [Navidrome](https://www.navidrome.org/) (Subsonic-compatible) server
+for testing Linthra's Navidrome / Subsonic provider without a production server.
+
+```bash
+# 1. Add a few audio files
+cp ~/some-music/*.mp3 tools/dev/navidrome/music/
+
+# 2. Start it (http://localhost:4533)
+docker compose -f tools/dev/navidrome/docker-compose.yml up -d
+
+# 3. Connect Linthra → Settings → Navidrome / Subsonic
+#    URL: http://<your-LAN-IP>:4533   user: admin   pass: admin
+```
+
+See **[docs/navidrome-dev-setup.md](../../../docs/navidrome-dev-setup.md)** for
+the full walkthrough (connecting from an emulator vs. a real device, the HTTP /
+cleartext note, troubleshooting, and the manual test checklist).
+
+> Local testing only — plain http, a throwaway `admin/admin` user. Don't expose
+> it to the internet or reuse the password.

--- a/tools/dev/navidrome/data/.gitkeep
+++ b/tools/dev/navidrome/data/.gitkeep
@@ -1,0 +1,2 @@
+# Navidrome writes its database and cache here. Contents are gitignored;
+# only this placeholder is tracked. Delete the contents to start fresh.

--- a/tools/dev/navidrome/docker-compose.yml
+++ b/tools/dev/navidrome/docker-compose.yml
@@ -1,0 +1,40 @@
+# Local Navidrome for testing Linthra's Subsonic/Navidrome provider.
+#
+# Navidrome (https://www.navidrome.org/) is a lightweight, self-hosted,
+# Subsonic-compatible music server. This compose file is for LOCAL DEVELOPMENT
+# ONLY: it serves over plain http and auto-creates a throwaway admin user on
+# first run. Do NOT expose it to the internet or reuse the password anywhere.
+#
+# Quick start (full walkthrough: docs/navidrome-dev-setup.md):
+#   1. Copy a few audio files into ./music
+#   2. docker compose -f tools/dev/navidrome/docker-compose.yml up -d
+#   3. Open http://localhost:4533 — the admin user below already exists.
+#   4. In Linthra → Settings → Navidrome / Subsonic:
+#        Server URL: http://<your-computer-LAN-IP>:4533  (e.g. http://192.168.1.50:4533)
+#        Username:   admin
+#        Password:   admin
+#      (From the Android emulator, use http://10.0.2.2:4533 instead.)
+#
+# Stop & remove:    docker compose -f tools/dev/navidrome/docker-compose.yml down
+# Wipe the library: delete ./data (keeps ./music)
+
+services:
+  navidrome:
+    image: deluan/navidrome:latest
+    container_name: linthra-navidrome-dev
+    ports:
+      - "4533:4533"
+    environment:
+      ND_LOGLEVEL: info
+      # Rescan the music folder every minute so files you drop in show up fast.
+      ND_SCANSCHEDULE: 1m
+      # LOCAL-TESTING CONVENIENCE ONLY: auto-create an "admin" user with this
+      # password on first run (when no users exist yet). Never use a real
+      # password here, and never run this config on a public server.
+      ND_DEVAUTOCREATEADMINPASSWORD: admin
+    volumes:
+      # Your test music (read-only — Navidrome only needs to read it).
+      - ./music:/music:ro
+      # Navidrome's database, cache and config (safe to delete to start fresh).
+      - ./data:/data
+    restart: unless-stopped

--- a/tools/dev/navidrome/music/.gitkeep
+++ b/tools/dev/navidrome/music/.gitkeep
@@ -1,0 +1,2 @@
+# Drop a few audio files here for the local Navidrome dev server to index.
+# Contents are gitignored; only this placeholder is tracked.


### PR DESCRIPTION
## Goal

Make the Navidrome/Subsonic connection flow **testable without a production
server** and improve its error messages. Scoped to the Subsonic provider —
**Jellyfin runtime code is untouched**. No telemetry/analytics/third‑party
services added.

## Audit findings (current behavior)

- ✅ **Already correct:** users enter the **server root** (e.g.
  `http://192.168.1.50:4533`); `SubsonicEndpoints` appends `/rest/<method>.view`
  internally. No `/rest` typing required.
- ⚠️ **Cleartext blocked on Android:** there was **no `network_security_config`**,
  so `http://<LAN-IP>:4533` failed by default on modern targets — and the failure
  was reported as a generic "couldn't reach the server".
- ⚠️ **Pasted `…/rest` doubled the path** (`/rest/rest/ping.view`).
- ⚠️ **Self‑signed cert** fell through to the generic "not reachable".

## Changes

**Local dev setup & docs**
- `tools/dev/navidrome/`: one‑command Docker Compose Navidrome (throwaway
  `admin`/`admin`, 1‑minute rescan, gitignored `music/` + `data/`).
- `docs/navidrome-dev-setup.md`: run it with a small test music folder, connect
  from emulator/device/desktop, the cleartext note, an error/troubleshooting
  table, and a **manual test checklist**.
- `docs/providers.md`: documents the server‑root URL rule and links the setup.

**URL handling** — `SubsonicServerUrl.normalize` now strips a trailing `/rest`
(or `/rest/`) so a pasted API path collapses to the root (only a whole final
`rest` segment; `/myrest` is preserved).

**Sharper, secret‑free errors**
- New `SubsonicErrorKind.cleartextBlocked` and `.insecureConnection`.
- `HttpSubsonicClient` classifies a blocked cleartext request and a failed TLS
  handshake into those kinds. The error text is inspected **only to classify**
  and is **never** placed into the thrown message (it can carry the token URL).
- New kinds handled in the playback resolver, cast resolver, and sync controller.

**Android cleartext** (decision: *permit app‑wide*) — adds
`res/xml/network_security_config.xml` (`cleartextTrafficPermitted="true"`,
system trust anchors unchanged) referenced from the manifest, so a LAN `http://`
server is reachable. Self‑signed certs are **still rejected** and surfaced as
`insecureConnection`. This also benefits a LAN **Jellyfin** server. *(Android's
Network Security Config can't whitelist IP ranges, only domains, so app‑wide is
the only option that supports arbitrary LAN IPs.)*

## Tests
- `subsonic_server_url_test`: trailing `/rest` stripping, subpath preservation, LAN root example.
- `subsonic_endpoints_test` (new): `/rest/<method>.view` built internally, auth query woven in, token/salt only in the query, subpath preserved.
- `http_subsonic_client_test`: cleartext → `cleartextBlocked`, handshake → `insecureConnection`, and a **no‑leak** check that a credential‑bearing error message is never echoed.

`dart format`, `flutter analyze`, and `flutter test` are all green (**1279 tests pass**).

## Manual verification still needed
The Android APK build wasn't run here (no Android SDK in this environment). The
manifest/network‑security‑config wiring is standard but should be smoke‑tested on
a device/emulator against the local Navidrome (see the checklist in the new doc).

## Follow‑ups (not in scope)
Mirroring the granular `cleartextBlocked`/`insecureConnection` messages into the
Jellyfin client; Subsonic favourites/lyrics/cover art (already tracked as planned).

https://claude.ai/code/session_015F4xmcv87A5aUbBdZXJNyY

---
_Generated by [Claude Code](https://claude.ai/code/session_015F4xmcv87A5aUbBdZXJNyY)_