### PR TITLE
feat(library): provider-aware unified library (de-duplicate the same song across providers)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,6 +77,13 @@ lib/
 - **`MusicLibraryRepository`** (`core/repositories/`) — the local SQLite cache
   the UI reads from. Sources *sync into* it; the UI never talks to a source
   directly. This is what keeps the app fast and fully offline.
+- **Unified library layer** (`core/catalog/track_unifier.dart`) — a pure,
+  display-time transform that collapses the per-provider rows the repository
+  stores (*source tracks*) into one *logical track* per song, keeping every copy
+  as an ordered playback candidate. The browse UI reads the logical tracks; the
+  repository and storage are untouched (no migration). Source preference
+  (active/default-first, with deterministic fallback) decides which copy plays.
+  See [unified-library.md](unified-library.md).
 - **`PlaybackController`** (`core/services/playback_controller.dart`) — playback
   *and* the up-next queue, fully decoupled from `just_audio`. It owns a pure
   `PlaybackQueue` model (current track + upcoming tracks) and exposes

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -39,6 +39,16 @@ persisted catalog.
 playlists stay on-device; "synced" ones mirror with the server (server is the
 source of truth on refresh).
 
+## One library across providers
+
+Because two servers can expose the **same** music, Linthra unifies the catalog:
+it **stores** every provider's copy of a song but **displays** one row per
+logical track, and plays the copy from your active/default provider (the server
+you most recently signed into), falling back to another source when that
+provider doesn't have the song. De-duplication is conservative and never deletes
+data. See [unified-library.md](unified-library.md) for the model, the matching
+rules, and the "Playing from …" source indicator.
+
 ## Local files
 
 Pick a folder with the Android Storage Access Framework picker and scan it.

--- a/docs/unified-library.md
+++ b/docs/unified-library.md
@@ -1,0 +1,120 @@
+# Unified library & source model
+
+Linthra can play the same music from more than one place at once — a local
+folder, a Jellyfin server, a Navidrome/Subsonic server. When two servers expose
+the **same** library (a very common self-hosting setup), the same song arrives
+through two providers. This note explains how Linthra shows that song **once**
+while keeping every playable copy, and how it decides which copy to play.
+
+> TL;DR — Linthra **stores** provider-specific *source tracks* but **displays**
+> *logical tracks*. De-duplication is a pure, display-time transform; nothing is
+> deleted from the catalog, and a single-provider or local-only library behaves
+> exactly as it did before.
+
+## The three layers
+
+| Concept | What it is | Where |
+| ------- | ---------- | ----- |
+| **Source track** | One physical/provider-specific copy of a song (a `Track` with its opaque `jellyfin:` / `subsonic:` / local-path URI). The repository stores these, one row per provider copy. | `core/models/track.dart` |
+| **`TrackSourceCandidate`** | A source track paired with the `sourceId` that owns it — a playable candidate for a logical track. | `core/catalog/logical_track.dart` |
+| **`LogicalTrack`** | One displayed library item, wrapping one or more candidates ordered best-first. `primary` is the copy the row shows and plays; the rest are deterministic fallbacks. | `core/catalog/logical_track.dart` |
+
+The repository (`MusicLibraryRepository`) is unchanged: it still stores every
+per-provider row under its `sourceId`, and `getAllTracks()` still returns them
+all. **No schema change and no migration** were needed — de-duplication happens
+above storage, at display time.
+
+## How de-duplication works
+
+`unifyTracks(tracks, priority)` (`core/catalog/track_unifier.dart`) collapses the
+flat catalog into `LogicalTrack`s. The browse UI reads the result through
+`libraryUnifiedTracksProvider`; the Songs/Albums/Artists tabs, search, and the
+album/artist detail screens all render the de-duplicated primaries, so none of
+them shows a song twice.
+
+The matching is deliberately **conservative** — it would rather leave two rows
+separate than merge songs that might be different:
+
+- A **match key** (`logicalMatchKey`) is built from the *folded* title, artist,
+  and album plus a coarse (2-second) duration bucket. Case and accents are
+  folded (`Beyoncé` ≡ `beyonce`); distinguishing words are **kept**, so
+  `Hello`, `Hello (Live)`, and `Hello (Radio Edit)` never collapse together.
+- A track with too little metadata to match — **missing** title, artist, album,
+  **or** a zero/unknown duration — gets **no key** and is **always** its own
+  row. Untagged local files therefore never merge.
+- Two tracks merge **only** when they share a key **and** come from **two or
+  more distinct providers**. A group that is entirely one provider's rows is
+  never merged. This is the safety invariant that guarantees an existing
+  single-provider (or local-only) library is returned one-row-per-track,
+  unchanged.
+
+Removing a logical row from the library forgets **every** provider copy (via
+`logicalSourceIdsProvider`), so a hidden duplicate can't resurrect the row on the
+next reload. (Re-syncing a server brings its copy back, exactly as before.)
+
+## Source preference & fallback
+
+When a logical track has several candidates, the order is decided by
+`SourcePriority` (`core/catalog/source_priority.dart`):
+
+1. **Active/default first.** The server you **most recently signed into** is
+   promoted to the front of your preference (`SourcePreferenceController.markPreferred`,
+   called on a successful Jellyfin/Subsonic sign-in) and persisted across
+   restarts (`PreferredSourceStore`). So if you connect Navidrome after already
+   using Jellyfin, a song on both now prefers **Navidrome**.
+2. **Deterministic fallback tail.** Anything not in your preference falls back to
+   a fixed order (`jellyfin`, `subsonic`, `local`), with local last so a server
+   copy — which can also cast and sync — is preferred over a device copy of the
+   same song. Ties break on the track id, so the choice is always total and
+   predictable.
+
+`primary = candidates.first` is the chosen copy. Selecting a logical row plays
+**that** copy, so playback prefers the active/default provider and **falls back**
+to another source when the preferred one does not have the song:
+
+- Song on Navidrome **and** Jellyfin, Navidrome active → plays from Navidrome.
+- Song only on Jellyfin → plays from Jellyfin (even if Navidrome is active).
+- Song only on Navidrome → plays from Navidrome.
+- Song only local → plays from the device.
+
+> Fallback here is **selection-time** (pick the best source that *has* the song).
+> Runtime fail-over (preferred server unreachable mid-resolve → automatically try
+> another copy) is **not** in this change; the offline cache already provides
+> resilience (see below). It is a noted follow-up.
+
+## Offline cache mapping
+
+The offline cache is keyed by a **source track id**. A logical track maps to
+whichever candidate is its `primary`, and the offline-first resolver
+(`OfflineFirstPlayableUriResolver`) prefers that candidate's cached copy when one
+exists. So downloading the played copy works unchanged; the cache is per-source,
+and the logical layer simply chooses *which* source is in play.
+
+## Playback source indicator
+
+Because a logical track can resolve to different sources, the now-playing UI
+shows the copy **actually** playing — not the active/default provider.
+`PlaybackSourceLabel` (`core/services/playback_source_label.dart`) derives a safe
+name from the resolved track's URI and the `PlaybackSource` the resolver
+reported:
+
+- on-device file → **Local files**
+- cached copy → **Cache** (whichever server it came from)
+- live Jellyfin stream → **Jellyfin**
+- live Navidrome/Subsonic stream → **Navidrome**
+
+The Now Playing screen shows a "Playing from …" chip and the mini-player a faint
+tag beside the metadata. Only fixed display names are ever shown — never a server
+URL, IP, username, token, or path.
+
+## Scope / follow-ups
+
+- The **in-app** Library (the reported duplicate problem) is de-duplicated. The
+  **Android Auto** browse tree (`core/services/media_browser_tree.dart`) still
+  lists per-provider rows; unifying it cleanly (its `_allTracks()` also backs
+  favourites/downloads/playlist id-resolution) is a tracked follow-up that can
+  reuse `unifyTracks`.
+- An explicit user-facing "preferred provider" setting could replace the
+  implicit most-recently-signed-in rule later; the model already supports it.
+- Source-specific views ("show all copies of this song") can be built on the
+  retained `LogicalTrack.candidates` without further storage changes.

--- a/lib/core/catalog/logical_track.dart
+++ b/lib/core/catalog/logical_track.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/track.dart';
+
+/// One playable copy of a song from a single provider — a "source track".
+///
+/// It pairs the catalog [Track] (which already carries the opaque
+/// `jellyfin:` / `subsonic:` / local-path URI, never a credential) with the
+/// [sourceId] that owns it, so the unifier and the UI can reason about *where*
+/// a copy lives without re-parsing the URI at every call site.
+@immutable
+class TrackSourceCandidate {
+  const TrackSourceCandidate({required this.track, required this.sourceId});
+
+  /// The source-specific catalog track (its own id, URI, and metadata).
+  final Track track;
+
+  /// The provider that owns [track] — `local`, `jellyfin`, or `subsonic`.
+  final String sourceId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is TrackSourceCandidate &&
+          other.sourceId == sourceId &&
+          other.track == track);
+
+  @override
+  int get hashCode => Object.hash(sourceId, track);
+}
+
+/// One displayed library item, representing the same song across one or more
+/// [TrackSourceCandidate]s.
+///
+/// The candidates are ordered best-first by source preference, so [primary] is
+/// the copy playback should use and the rest are deterministic fallbacks. A
+/// logical track with a single candidate is the common case — a track that
+/// exists on only one provider — and behaves exactly like that provider's track
+/// did before unification.
+@immutable
+class LogicalTrack {
+  /// Wraps the ordered [candidates] of a song. Callers must pass a non-empty,
+  /// preference-ordered list — `unifyTracks` and [LogicalTrack.single] are the
+  /// only constructors used in practice and both uphold that.
+  const LogicalTrack(this.candidates);
+
+  /// A logical track wrapping a single source copy. The everyday case.
+  LogicalTrack.single(TrackSourceCandidate candidate)
+      : candidates = <TrackSourceCandidate>[candidate];
+
+  /// Source copies of this song, ordered most-preferred first.
+  final List<TrackSourceCandidate> candidates;
+
+  /// The preferred copy — what the row displays and what playback resolves to.
+  TrackSourceCandidate get primary => candidates.first;
+
+  /// The preferred copy's catalog track (the playable, displayable [Track]).
+  Track get primaryTrack => primary.track;
+
+  /// A stable id for the logical row: the preferred copy's track id. Stable for
+  /// a given catalog + preference, which is all the UI (keys, selection) needs.
+  String get id => primaryTrack.id;
+
+  /// Every source id this song can be played from, in preference order.
+  List<String> get sourceIds =>
+      <String>[for (final TrackSourceCandidate c in candidates) c.sourceId];
+
+  /// Every source copy's track id. Removing a logical track from the library
+  /// forgets *all* of these, so a hidden duplicate can't resurrect the row.
+  List<String> get allTrackIds =>
+      <String>[for (final TrackSourceCandidate c in candidates) c.track.id];
+
+  /// Whether this song is available from more than one provider.
+  bool get hasMultipleSources => candidates.length > 1;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is LogicalTrack && listEquals(other.candidates, candidates));
+
+  @override
+  int get hashCode => Object.hashAll(candidates);
+}

--- a/lib/core/catalog/source_priority.dart
+++ b/lib/core/catalog/source_priority.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+
+/// The deterministic order in which providers are preferred for playback when a
+/// single logical track can be played from more than one source.
+///
+/// "Active/default first": the user's preferred order (most-recently-signed-in
+/// server at the front) is consulted first; any source not named there falls
+/// back to a fixed default tail so the ordering is *total* and predictable —
+/// the same catalog always resolves to the same preferred source. Local files
+/// sit last by default, so a server copy (which can also cast and sync) is
+/// preferred when the same song exists both on a server and on the device,
+/// while a device-only track still plays locally.
+@immutable
+class SourcePriority {
+  const SourcePriority(this.preferredOrder);
+
+  /// The fixed fallback order used for any source the user's [preferredOrder]
+  /// does not mention. Remote servers before local; among servers this is just a
+  /// stable, documented default that the live preference normally overrides.
+  static const List<String> defaultOrder = <String>[
+    'jellyfin',
+    'subsonic',
+    'local',
+  ];
+
+  /// A priority with no explicit user preference — everything falls back to
+  /// [defaultOrder]. Used by surfaces that only need *a* deterministic choice
+  /// (e.g. the Android Auto browse tree) rather than the user's live preference.
+  static const SourcePriority fallback = SourcePriority(<String>[]);
+
+  /// The user-preferred source ids, most-preferred first. May be empty (then
+  /// only [defaultOrder] applies) and may omit sources (they fall back).
+  final List<String> preferredOrder;
+
+  /// The rank of [sourceId] — lower is more preferred. A source named in
+  /// [preferredOrder] always outranks one that is only in [defaultOrder], which
+  /// in turn outranks a wholly unknown source; ties never occur for distinct
+  /// known ids. Unknown ids share a single trailing rank and are then separated
+  /// by the candidate comparator's stable id tiebreak.
+  int rankOf(String sourceId) {
+    final int preferred = preferredOrder.indexOf(sourceId);
+    if (preferred >= 0) return preferred;
+    final int fallbackIndex = defaultOrder.indexOf(sourceId);
+    if (fallbackIndex >= 0) return preferredOrder.length + fallbackIndex;
+    // An unknown source: after everything else, but still deterministic.
+    return preferredOrder.length + defaultOrder.length;
+  }
+
+  /// Moves [sourceId] to the front of the preference, returning a new priority.
+  /// Used when the user signs into a server: the one they are actively using
+  /// becomes the default for picking among duplicate sources.
+  SourcePriority promote(String sourceId) {
+    return SourcePriority(<String>[
+      sourceId,
+      for (final String id in preferredOrder)
+        if (id != sourceId) id,
+    ]);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SourcePriority &&
+          listEquals(other.preferredOrder, preferredOrder));
+
+  @override
+  int get hashCode => Object.hashAll(preferredOrder);
+}

--- a/lib/core/catalog/track_identity.dart
+++ b/lib/core/catalog/track_identity.dart
@@ -1,0 +1,65 @@
+import '../models/track.dart';
+import '../sources/music_provider.dart';
+import 'text_folding.dart';
+
+/// Cross-provider identity for a [Track]: the `sourceId` that owns it and a
+/// conservative "is this the same song?" match key used to unify duplicates that
+/// the same library exposes through more than one provider (e.g. the same album
+/// served by both Jellyfin and Navidrome/Subsonic).
+///
+/// Why a *key* rather than pairwise similarity: a single normalized key makes
+/// unification a deterministic, order-independent `O(n)` grouping that is an
+/// equivalence relation (so the result never depends on which two rows were
+/// compared first). It also makes the matching trivially unit-testable.
+///
+/// The guiding rule is conservative: prefer keeping two rows separate over
+/// merging songs that might be different. A merge therefore requires every
+/// strong, tag-derived signal to agree, never the title alone.
+
+/// The `sourceId` of the provider that owns [track], derived from its opaque
+/// `scheme:` URI (`jellyfin:` / `subsonic:` / a local path). This is the same
+/// mapping the capability model and the playback resolvers key off, so source
+/// identity can never disagree across the app.
+String trackSourceId(Track track) =>
+    MusicProviders.forTrackUri(track.uri).sourceId;
+
+/// Duration bucket width, in seconds. Two providers reading the same file report
+/// the same whole-second duration (both floor it), so a 2-second bucket folds
+/// any incidental rounding together while still separating genuinely different
+/// lengths (a radio edit vs an extended mix) into different keys.
+const int _durationBucketSeconds = 2;
+
+/// A conservative match key for [track], or `null` when the track does not carry
+/// enough trustworthy metadata to be matched against another provider's copy.
+///
+/// A non-null key requires all of: a folded title, a folded artist, a folded
+/// album, and a known (non-zero) duration. Tracks missing any of these — most
+/// untagged local files, for instance — return `null` and are therefore never
+/// merged with anything; they always stand as their own library row. This is
+/// what keeps local-only and lightly-tagged libraries behaving exactly as they
+/// did before unification existed.
+///
+/// When every signal is present the key is built from the folded title, artist,
+/// and album plus a coarse duration bucket. Each text part is length-prefixed
+/// (the idiom `library_grouping` uses) so no separator char is needed and two
+/// different splits can never collide. Case and accents are folded (via
+/// [foldText]) so "Beyonce" and the accented "Beyoncé" match, but distinguishing
+/// words are kept — "(Live)", "(Remix)", "(Radio Edit)" stay in the title — so
+/// different versions of a song never collapse into one row.
+String? logicalMatchKey(Track track) {
+  final String title = foldText(track.title);
+  final String artist = foldText(track.artistName ?? '');
+  final String album = foldText(track.albumName ?? '');
+  final int seconds = track.duration.inSeconds;
+  if (title.isEmpty || artist.isEmpty || album.isEmpty || seconds <= 0) {
+    return null;
+  }
+  final int bucket = seconds ~/ _durationBucketSeconds;
+  return 'v1|${title.length}|$title|${artist.length}|$artist|'
+      '${album.length}|$album|$bucket';
+}
+
+/// Whether [track] carries enough metadata to ever be unified with a copy from
+/// another provider. Sugar over [logicalMatchKey] for call sites that only need
+/// the yes/no.
+bool canMatchAcrossProviders(Track track) => logicalMatchKey(track) != null;

--- a/lib/core/catalog/track_unifier.dart
+++ b/lib/core/catalog/track_unifier.dart
@@ -1,0 +1,85 @@
+import '../models/track.dart';
+import 'logical_track.dart';
+import 'source_priority.dart';
+import 'track_identity.dart';
+
+/// Collapses a flat list of source [Track]s (the per-provider catalog rows the
+/// repository stores) into [LogicalTrack]s — one displayed item per song, with
+/// every provider copy retained as an ordered playback candidate.
+///
+/// The rules are deliberately conservative (see [logicalMatchKey]):
+///
+///  * A track with too little metadata to match (`logicalMatchKey == null`) is
+///    always its own logical track. Untagged local files never merge.
+///  * Tracks merge only when they share a match key **and** come from two or
+///    more *distinct* providers. A group that is entirely one provider's rows is
+///    never merged — so a single-provider (or local-only) library is returned
+///    one-logical-track-per-row, byte-for-byte as before. This is the safety
+///    invariant that guarantees we never make an existing library worse.
+///  * Within a merged group the candidates are ordered by [priority], so
+///    [LogicalTrack.primary] is the active/default provider's copy when it has
+///    one, and a deterministic fallback otherwise.
+///
+/// Output order follows the first appearance of each logical track in [tracks],
+/// so a caller that relied on the catalog's order (before re-sorting for the A–Z
+/// list, say) sees the same ordering it always did.
+List<LogicalTrack> unifyTracks(List<Track> tracks, SourcePriority priority) {
+  // First pass: bucket eligible tracks by match key, preserving encounter order.
+  final Map<String, List<Track>> byKey = <String, List<Track>>{};
+  for (final Track track in tracks) {
+    final String? key = logicalMatchKey(track);
+    if (key == null) continue;
+    byKey.putIfAbsent(key, () => <Track>[]).add(track);
+  }
+
+  // Second pass: emit logical tracks in first-appearance order. A key that spans
+  // two or more sources merges (once, at its first occurrence); everything else
+  // — ineligible tracks and single-source groups — stays one row per track.
+  final Set<String> emittedMergedKeys = <String>{};
+  final List<LogicalTrack> result = <LogicalTrack>[];
+  for (final Track track in tracks) {
+    final String? key = logicalMatchKey(track);
+    if (key == null) {
+      result.add(LogicalTrack.single(_candidate(track)));
+      continue;
+    }
+    final List<Track> members = byKey[key]!;
+    if (_distinctSourceCount(members) < 2) {
+      // Single-provider group: never merge — each row stands alone.
+      result.add(LogicalTrack.single(_candidate(track)));
+      continue;
+    }
+    if (!emittedMergedKeys.add(key)) continue; // already emitted at first sight
+    result.add(LogicalTrack(_orderedCandidates(members, priority)));
+  }
+  return result;
+}
+
+TrackSourceCandidate _candidate(Track track) =>
+    TrackSourceCandidate(track: track, sourceId: trackSourceId(track));
+
+int _distinctSourceCount(List<Track> members) {
+  final Set<String> sources = <String>{};
+  for (final Track t in members) {
+    sources.add(trackSourceId(t));
+  }
+  return sources.length;
+}
+
+/// Orders a merged group's copies best-first by source preference, breaking ties
+/// on the track id so the result is total and deterministic.
+List<TrackSourceCandidate> _orderedCandidates(
+  List<Track> members,
+  SourcePriority priority,
+) {
+  final List<TrackSourceCandidate> candidates = <TrackSourceCandidate>[
+    for (final Track t in members) _candidate(t)
+  ];
+  candidates.sort((TrackSourceCandidate a, TrackSourceCandidate b) {
+    final int byRank =
+        priority.rankOf(a.sourceId).compareTo(priority.rankOf(b.sourceId));
+    if (byRank != 0) return byRank;
+    return a.track.id.compareTo(b.track.id);
+  });
+  return candidates;
+}

--- a/lib/core/repositories/preferred_source_store.dart
+++ b/lib/core/repositories/preferred_source_store.dart
@@ -1,0 +1,16 @@
+/// Persists the user's preferred provider order — the "active/default first"
+/// signal the library uses to pick which copy of a duplicated song to play.
+///
+/// The stored value is a small ordered list of non-secret source ids
+/// (`subsonic`, `jellyfin`, `local`), most-preferred first. It carries no
+/// credential, URL, or library content, so a lightweight key/value store is the
+/// right weight — the same reasoning the selected-folder and download stores
+/// follow.
+abstract interface class PreferredSourceStore {
+  /// The persisted order, most-preferred first. Empty when nothing is stored yet
+  /// (the library then falls back to its deterministic default order).
+  Future<List<String>> read();
+
+  /// Persists [order] verbatim (most-preferred first).
+  Future<void> write(List<String> order);
+}

--- a/lib/core/services/playback_source_label.dart
+++ b/lib/core/services/playback_source_label.dart
@@ -1,0 +1,62 @@
+import '../models/playback_source.dart';
+import '../sources/music_provider.dart';
+
+/// Safe, human-readable names for *where playback is actually coming from*, for
+/// the now-playing source indicator.
+///
+/// A logical track can have several source candidates, so the indicator must
+/// reflect the copy the resolver actually played — not the active/default
+/// provider. The value is derived from the resolved track's opaque URI (which
+/// provider owns it) and the [PlaybackSource] the resolver reported (a cache hit
+/// vs a live stream vs an on-device file).
+///
+/// Security: only fixed, non-identifying display names are ever returned —
+/// "Navidrome", "Jellyfin", "Local files", "Cache", or "Unknown source". A
+/// server URL, IP, username, token, or file path is never exposed.
+abstract final class PlaybackSourceLabel {
+  static const String navidrome = 'Navidrome';
+  static const String jellyfin = 'Jellyfin';
+  static const String local = 'Local files';
+  static const String cache = 'Cache';
+  static const String unknown = 'Unknown source';
+
+  /// The safe display name for audio resolved from [trackUri] via [source].
+  ///
+  /// A cached copy reads as "Cache" regardless of which server it came from
+  /// (that is what the listener is hearing); an on-device file reads as "Local
+  /// files"; a live stream reads as the owning server's safe name.
+  static String of(
+      {required String? trackUri, required PlaybackSource? source}) {
+    if (source == null) return unknown;
+    switch (source) {
+      case PlaybackSource.offlineCache:
+        return cache;
+      case PlaybackSource.localFile:
+        return local;
+      case PlaybackSource.streamingDirect:
+        return _serverName(trackUri);
+    }
+  }
+
+  /// The safe name of the server that owns [trackUri], for a live stream.
+  static String _serverName(String? trackUri) {
+    if (trackUri == null) return unknown;
+    switch (MusicProviders.forTrackUri(trackUri).sourceId) {
+      case 'jellyfin':
+        return jellyfin;
+      case 'subsonic':
+        return navidrome;
+      case 'local':
+        // An on-device file should resolve as localFile, not streamingDirect;
+        // reaching here means an unexpected pairing, so stay vague but safe.
+        return local;
+      default:
+        return unknown;
+    }
+  }
+
+  /// "Playing from X" — the full phrase the indicator shows.
+  static String phrase(
+          {required String? trackUri, required PlaybackSource? source}) =>
+      'Playing from ${of(trackUri: trackUri, source: source)}';
+}

--- a/lib/data/repositories/in_memory_preferred_source_store.dart
+++ b/lib/data/repositories/in_memory_preferred_source_store.dart
@@ -1,0 +1,18 @@
+import '../../core/repositories/preferred_source_store.dart';
+
+/// An in-memory [PreferredSourceStore] for development and tests. Nothing is
+/// persisted; the order lives only for the lifetime of the instance.
+class InMemoryPreferredSourceStore implements PreferredSourceStore {
+  InMemoryPreferredSourceStore([List<String> initial = const <String>[]])
+      : _order = List<String>.of(initial);
+
+  List<String> _order;
+
+  @override
+  Future<List<String>> read() async => List<String>.of(_order);
+
+  @override
+  Future<void> write(List<String> order) async {
+    _order = List<String>.of(order);
+  }
+}

--- a/lib/data/repositories/preferred_source_store_provider.dart
+++ b/lib/data/repositories/preferred_source_store_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/preferred_source_store.dart';
+import 'in_memory_preferred_source_store.dart';
+import 'shared_preferences_preferred_source_store.dart';
+
+/// The single [PreferredSourceStore] the app reads/writes the preferred provider
+/// order through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesPreferredSourceStoreOverride] so the choice persists across
+/// restarts.
+final preferredSourceStoreProvider = Provider<PreferredSourceStore>((ref) {
+  return InMemoryPreferredSourceStore();
+});
+
+/// Production binding: persists the preferred provider order via
+/// `shared_preferences`. Applied in `main`.
+final sharedPreferencesPreferredSourceStoreOverride =
+    preferredSourceStoreProvider.overrideWithValue(
+  SharedPreferencesPreferredSourceStore(),
+);

--- a/lib/data/repositories/shared_preferences_preferred_source_store.dart
+++ b/lib/data/repositories/shared_preferences_preferred_source_store.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/preferred_source_store.dart';
+
+/// A [PreferredSourceStore] backed by `shared_preferences`.
+///
+/// The preferred provider order is a tiny list of non-secret source ids, so a
+/// single JSON string under one key is plenty — no token, URL, or library
+/// content is ever written here. A corrupt or absent value reads as "no
+/// preference yet" rather than throwing, so a storage hiccup can never break
+/// library loading or playback.
+class SharedPreferencesPreferredSourceStore implements PreferredSourceStore {
+  SharedPreferencesPreferredSourceStore();
+
+  static const String _key = 'preferred_source_order_v1';
+
+  @override
+  Future<List<String>> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return const <String>[];
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return const <String>[];
+    }
+    if (decoded is! List) return const <String>[];
+    return <String>[
+      for (final Object? id in decoded)
+        if (id is String && id.isNotEmpty) id,
+    ];
+  }
+
+  @override
+  Future<void> write(List<String> order) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode(order));
+  }
+}

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -13,6 +13,7 @@ import '../player/widgets/album_artwork.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
+import 'unified_library_providers.dart';
 import 'widgets/track_tile.dart';
 
 /// One album's tracks, in album order, with Play / Shuffle and tap-to-play.
@@ -49,7 +50,8 @@ class AlbumDetailScreen extends ConsumerWidget {
         break;
       }
     }
-    final List<Track> tracks = tracksForAlbum(state.tracks, albumId);
+    final List<Track> tracks =
+        tracksForAlbum(ref.watch(libraryUnifiedTracksProvider), albumId);
     if (album == null || tracks.isEmpty) {
       return Scaffold(
         appBar: AppBar(),

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -13,6 +13,7 @@ import '../player/player_providers.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
+import 'unified_library_providers.dart';
 import 'widgets/album_tile.dart';
 import 'widgets/track_tile.dart';
 
@@ -50,7 +51,8 @@ class ArtistDetailScreen extends ConsumerWidget {
         break;
       }
     }
-    final List<Track> tracks = tracksForArtist(state.tracks, artistId);
+    final List<Track> songs = ref.watch(libraryUnifiedTracksProvider);
+    final List<Track> tracks = tracksForArtist(songs, artistId);
     if (artist == null || tracks.isEmpty) {
       return Scaffold(
         appBar: AppBar(),
@@ -62,7 +64,7 @@ class ArtistDetailScreen extends ConsumerWidget {
       );
     }
 
-    final List<Album> albums = albumsForArtist(state.tracks, artistId);
+    final List<Album> albums = albumsForArtist(songs, artistId);
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/features/library/library_browse_providers.dart
+++ b/lib/features/library/library_browse_providers.dart
@@ -3,16 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
-import 'library_controller.dart';
+import 'unified_library_providers.dart';
 
-/// Albums derived from the loaded track catalog, recomputed whenever the
-/// library reloads (scan, sync, or a removal). The Albums tab and the artist
-/// detail read from here so grouping lives in exactly one place.
+/// Albums derived from the unified (de-duplicated) catalog, recomputed whenever
+/// the library reloads (scan, sync, or a removal) or the source preference
+/// changes. The Albums tab and the artist detail read from here so grouping
+/// lives in exactly one place — and grouping logical tracks (not raw per-provider
+/// rows) keeps a song that exists on two servers from being counted twice.
 final libraryAlbumsProvider = Provider<List<Album>>((ref) {
-  return groupAlbums(ref.watch(libraryControllerProvider).tracks);
+  return groupAlbums(ref.watch(libraryUnifiedTracksProvider));
 });
 
-/// Artists derived from the loaded track catalog. See [libraryAlbumsProvider].
+/// Artists derived from the unified catalog. See [libraryAlbumsProvider].
 final libraryArtistsProvider = Provider<List<Artist>>((ref) {
-  return groupArtists(ref.watch(libraryControllerProvider).tracks);
+  return groupArtists(ref.watch(libraryUnifiedTracksProvider));
 });

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -17,6 +17,7 @@ import 'library_search.dart';
 import 'library_state.dart';
 import 'selected_folder_controller.dart';
 import 'song_actions.dart';
+import 'unified_library_providers.dart';
 import 'widgets/album_tile.dart';
 import 'widgets/alphabet_track_list.dart';
 import 'widgets/artist_tile.dart';
@@ -85,6 +86,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   @override
   Widget build(BuildContext context) {
     final LibraryState state = ref.watch(libraryControllerProvider);
+    // The de-duplicated catalog the whole screen renders from: one row per
+    // logical song, even when the same track is served by more than one provider.
+    final List<Track> songs = ref.watch(libraryUnifiedTracksProvider);
     final AsyncValue<String?> selectedFolder =
         ref.watch(selectedFolderControllerProvider);
     // While the first Jellyfin sync is running, an empty catalog should read as
@@ -97,7 +101,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // Drop any selected ids that are no longer in the catalog (e.g. after a
     // removal) so the count and actions stay accurate.
     final List<Track> selected = <Track>[
-      for (final Track track in state.tracks)
+      for (final Track track in songs)
         if (_selectedIds.contains(track.id)) track,
     ];
 
@@ -109,7 +113,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         },
         child: Scaffold(
           appBar: _selectionAppBar(selected),
-          body: _songsList(_filteredSongs(state)),
+          body: _songsList(_filteredSongs(songs)),
         ),
       );
     }
@@ -118,7 +122,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     // browse; loading, error, and the folder-pick empty state take the whole
     // body (and no tabs), exactly as before.
     final bool browsing =
-        state.status == LibraryStatus.loaded && state.tracks.isNotEmpty;
+        state.status == LibraryStatus.loaded && songs.isNotEmpty;
 
     return Scaffold(
       appBar: AppBar(
@@ -133,7 +137,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         bottom: browsing ? _tabBar() : null,
       ),
       body: browsing
-          ? _browseBody(state)
+          ? _browseBody(songs)
           : _statusBody(state, selectedFolder.valueOrNull, jellyfinSyncing),
     );
   }
@@ -186,7 +190,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   }
 
   /// Search box + the three browse tabs. Only built when there's content.
-  Widget _browseBody(LibraryState state) {
+  Widget _browseBody(List<Track> songs) {
     return Column(
       children: <Widget>[
         LibrarySearchField(
@@ -198,7 +202,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
           child: TabBarView(
             controller: _tabController,
             children: <Widget>[
-              _songsTab(state),
+              _songsTab(songs),
               _albumsTab(),
               _artistsTab(),
             ],
@@ -210,8 +214,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
   // --- Tabs -------------------------------------------------------------
 
-  Widget _songsTab(LibraryState state) {
-    final List<Track> filtered = _filteredSongs(state);
+  Widget _songsTab(List<Track> songs) {
+    final List<Track> filtered = _filteredSongs(songs);
     if (filtered.isEmpty) return const _NoResults();
     return _songsList(filtered);
   }
@@ -250,8 +254,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     );
   }
 
-  List<Track> _filteredSongs(LibraryState state) =>
-      filterTracks(state.tracks, _query);
+  List<Track> _filteredSongs(List<Track> songs) => filterTracks(songs, _query);
 
   Widget _songsList(List<Track> tracks) {
     return AlphabetTrackList(
@@ -331,8 +334,14 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   }
 
   Future<void> _removeFromLibrary(List<Track> selected) async {
-    final bool removed =
-        await SongActions.removeFromLibrary(context, ref, selected);
+    // Removing a logical row forgets every provider copy of the song, so a
+    // hidden duplicate can't resurrect the row on the next reload.
+    final bool removed = await SongActions.removeFromLibrary(
+      context,
+      ref,
+      selected,
+      expandLogicalSources: true,
+    );
     if (removed) _exitSelection();
   }
 

--- a/lib/features/library/song_actions.dart
+++ b/lib/features/library/song_actions.dart
@@ -8,6 +8,7 @@ import '../../shared/widgets/confirm_dialog.dart';
 import '../player/player_providers.dart';
 import '../playlists/playlist_providers.dart';
 import 'library_controller.dart';
+import 'unified_library_providers.dart';
 
 /// The shared, safe song remove/delete actions used by the Library and playlist
 /// screens. Centralized so the confirmation wording, the currently-playing
@@ -30,6 +31,7 @@ abstract final class SongActions {
     WidgetRef ref,
     List<Track> tracks, {
     String? playlistId,
+    bool expandLogicalSources = false,
   }) async {
     if (tracks.isEmpty) return false;
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
@@ -45,9 +47,9 @@ abstract final class SongActions {
     );
     if (!confirmed) return false;
 
-    await ref.read(musicLibraryRepositoryProvider).removeTracks(
-      <String>[for (final Track track in tracks) track.id],
-    );
+    await ref
+        .read(musicLibraryRepositoryProvider)
+        .removeTracks(_removalIds(ref, tracks, expandLogicalSources));
     // Refresh the library view; if we're inside a playlist, re-resolve its
     // tracks so a now-removed item is reflected.
     await ref.read(libraryControllerProvider.notifier).refresh();
@@ -113,6 +115,28 @@ abstract final class SongActions {
       SnackBar(content: Text(_offlineSummary(removed, failed, skipped))),
     );
     return true;
+  }
+
+  /// The track ids to forget for [tracks]. When [expandLogicalSources] is set
+  /// (library/album/artist surfaces, where each row is a logical track), a
+  /// row's id is expanded to every provider copy via [logicalSourceIdsProvider]
+  /// so removing the row can't leave a hidden duplicate behind. Elsewhere (a
+  /// playlist's specific tracks) the ids are taken verbatim.
+  static List<String> _removalIds(
+    WidgetRef ref,
+    List<Track> tracks,
+    bool expandLogicalSources,
+  ) {
+    if (!expandLogicalSources) {
+      return <String>[for (final Track track in tracks) track.id];
+    }
+    final Map<String, List<String>> bySource =
+        ref.read(logicalSourceIdsProvider);
+    final List<String> ids = <String>[];
+    for (final Track track in tracks) {
+      ids.addAll(bySource[track.id] ?? <String>[track.id]);
+    }
+    return ids;
   }
 
   static String _offlineSummary(int removed, int failed, int skipped) {

--- a/lib/features/library/source_preference_controller.dart
+++ b/lib/features/library/source_preference_controller.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/catalog/source_priority.dart';
+import '../../data/repositories/preferred_source_store_provider.dart';
+
+/// Holds the user's preferred provider order as a [SourcePriority] and lets a
+/// successful server sign-in promote that server to the front.
+///
+/// "Active/default first": the server the user most recently signed into becomes
+/// the preferred copy when the same song exists on more than one provider. The
+/// order is loaded from the [PreferredSourceStore] at startup and persisted on
+/// every change, so the choice survives a restart. Until the async load lands
+/// the controller serves an empty preference (the deterministic
+/// [SourcePriority.fallback] default), which only affects *which* duplicate is
+/// preferred — never whether a row is de-duplicated — so a brief default is
+/// harmless.
+class SourcePreferenceController extends Notifier<SourcePriority> {
+  @override
+  SourcePriority build() {
+    _load();
+    return SourcePriority.fallback;
+  }
+
+  Future<void> _load() async {
+    try {
+      final List<String> order =
+          await ref.read(preferredSourceStoreProvider).read();
+      if (order.isNotEmpty) {
+        state = SourcePriority(order);
+      }
+    } catch (_) {
+      // A storage hiccup must never break library loading; keep the default.
+    }
+  }
+
+  /// Promotes [sourceId] to the front of the preference (the user is actively
+  /// using it) and persists the new order. A no-op for an already-front source.
+  Future<void> markPreferred(String sourceId) async {
+    final SourcePriority next = state.promote(sourceId);
+    if (next == state) return;
+    state = next;
+    try {
+      await ref.read(preferredSourceStoreProvider).write(next.preferredOrder);
+    } catch (_) {
+      // Best-effort persistence: the in-memory order still applies this session.
+    }
+  }
+}
+
+/// The user's live source preference. The unified-library providers watch this
+/// so a freshly-preferred server is reflected without a manual refresh.
+final librarySourcePriorityProvider =
+    NotifierProvider<SourcePreferenceController, SourcePriority>(
+  SourcePreferenceController.new,
+);

--- a/lib/features/library/unified_library_providers.dart
+++ b/lib/features/library/unified_library_providers.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/catalog/logical_track.dart';
+import '../../core/catalog/track_unifier.dart';
+import '../../core/models/track.dart';
+import 'library_controller.dart';
+import 'source_preference_controller.dart';
+
+/// The library as unified [LogicalTrack]s: one item per song, with every
+/// provider copy retained as an ordered playback candidate.
+///
+/// This is the single place display-level de-duplication happens. It recomputes
+/// whenever the catalog reloads (scan, sync, removal) or the source preference
+/// changes, so every browse surface that reads it stays consistent. The
+/// repository still stores all per-provider rows untouched — nothing is deleted.
+final libraryLogicalTracksProvider = Provider<List<LogicalTrack>>((ref) {
+  final List<Track> tracks = ref.watch(libraryControllerProvider).tracks;
+  final priority = ref.watch(librarySourcePriorityProvider);
+  return unifyTracks(tracks, priority);
+});
+
+/// The de-duplicated catalog the Library UI renders and plays: the preferred
+/// copy ([LogicalTrack.primaryTrack]) of each logical track, in catalog order.
+///
+/// Tapping one of these plays the active/default provider's copy (or the best
+/// available fallback) because the primary *is* that copy. The Songs/Albums/
+/// Artists tabs, search, and the album/artist detail screens all read from here
+/// so none of them shows the same song twice.
+final libraryUnifiedTracksProvider = Provider<List<Track>>((ref) {
+  return <Track>[
+    for (final LogicalTrack logical in ref.watch(libraryLogicalTracksProvider))
+      logical.primaryTrack,
+  ];
+});
+
+/// Maps a preferred-copy track id to every source copy's track id, so removing a
+/// displayed (logical) row from the library forgets all of its provider copies —
+/// otherwise a hidden duplicate would resurrect the row on the next reload.
+///
+/// Ids that aren't a logical primary (e.g. a specific track chosen inside a
+/// playlist) map to just themselves, so non-library callers are unaffected.
+final logicalSourceIdsProvider = Provider<Map<String, List<String>>>((ref) {
+  final Map<String, List<String>> byPrimary = <String, List<String>>{};
+  for (final LogicalTrack logical in ref.watch(libraryLogicalTracksProvider)) {
+    byPrimary[logical.id] = logical.allTrackIds;
+  }
+  return byPrimary;
+});

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -306,7 +306,12 @@ class _OverflowMenu extends ConsumerWidget {
       case _TrackAction.removeOffline:
         await SongActions.removeOfflineCopies(context, ref, <Track>[track]);
       case _TrackAction.removeFromLibrary:
-        await SongActions.removeFromLibrary(context, ref, <Track>[track]);
+        await SongActions.removeFromLibrary(
+          context,
+          ref,
+          <Track>[track],
+          expandLogicalSources: true,
+        );
     }
   }
 

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -5,7 +5,10 @@ import 'package:go_router/go_router.dart';
 import '../../app/colors.dart';
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
+import '../../core/models/playback_source.dart';
+import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
+import '../../core/services/playback_source_label.dart';
 import 'cast/cast_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
@@ -25,15 +28,20 @@ class MiniPlayer extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watch only the current track (id-distinct), so the ~5 Hz position ticks
-    // rebuild just the thin progress line and the play/pause button below — not
-    // the whole bar (artwork, text) on every screen, every tick. Falls back to
-    // the controller's latest state until the first stream event arrives.
-    final Track? streamed = ref.watch(
-      playbackStateProvider.select((s) => s.valueOrNull?.currentTrack),
+    // Watch only the current track (id-distinct) and its resolved source, so the
+    // ~5 Hz position ticks rebuild just the thin progress line and the play/pause
+    // button below — not the whole bar (artwork, text) on every screen, every
+    // tick. The source changes only when the track does, so including it adds no
+    // tick rebuilds. Falls back to the controller's latest state until the first
+    // stream event arrives.
+    final (Track?, PlaybackSource?) streamed = ref.watch(
+      playbackStateProvider.select(
+        (s) => (s.valueOrNull?.currentTrack, s.valueOrNull?.source),
+      ),
     );
-    final Track? track =
-        streamed ?? ref.read(playbackControllerProvider).state.currentTrack;
+    final PlaybackState fallback = ref.read(playbackControllerProvider).state;
+    final Track? track = streamed.$1 ?? fallback.currentTrack;
+    final PlaybackSource? source = streamed.$2 ?? fallback.source;
 
     // Collapse entirely when there is nothing to show, so screens without a
     // loaded track look exactly as they did before.
@@ -46,6 +54,12 @@ class MiniPlayer extends ConsumerWidget {
       castStateProvider.select((s) => s.valueOrNull?.isConnected ?? false),
     );
     final subtitle = _subtitle(track);
+    // The copy actually playing (Navidrome / Jellyfin / Local files / Cache),
+    // shown as a faint tag beside the metadata. Hidden while casting, where the
+    // cast indicator already says where the audio is going.
+    final String? sourceName = (!isCasting && source != null)
+        ? PlaybackSourceLabel.of(trackUri: track.uri, source: source)
+        : null;
 
     return Material(
       color: theme.colorScheme.surfaceContainerHigh,
@@ -84,15 +98,10 @@ class MiniPlayer extends ConsumerWidget {
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            if (subtitle != null)
-                              Text(
-                                subtitle,
-                                style: theme.textTheme.bodySmall?.copyWith(
-                                  color: theme.colorScheme.onSurface
-                                      .withValues(alpha: 0.6),
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
+                            if (subtitle != null || sourceName != null)
+                              _MiniSubtitle(
+                                subtitle: subtitle,
+                                sourceName: sourceName,
                               ),
                           ],
                         ),
@@ -123,6 +132,53 @@ class MiniPlayer extends ConsumerWidget {
   static String? _subtitle(Track track) {
     final String label = track.artistAlbumLabel;
     return label.isEmpty ? null : label;
+  }
+}
+
+/// The mini-player's second line: the artist • album metadata and, when known, a
+/// faint trailing tag for the copy actually playing (Navidrome / Jellyfin /
+/// Local files / Cache). Both halves shrink and ellipsize so a long title or a
+/// narrow screen never overflows the bar.
+class _MiniSubtitle extends StatelessWidget {
+  const _MiniSubtitle({required this.subtitle, required this.sourceName});
+
+  final String? subtitle;
+  final String? sourceName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final TextStyle? metaStyle = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+    );
+    final TextStyle? sourceStyle = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurface.withValues(alpha: 0.45),
+    );
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (subtitle != null)
+          Flexible(
+            child: Text(
+              subtitle!,
+              style: metaStyle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        if (subtitle != null && sourceName != null)
+          Text('  •  ', style: sourceStyle),
+        if (sourceName != null)
+          Flexible(
+            child: Text(
+              sourceName!,
+              style: sourceStyle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+      ],
+    );
   }
 }
 

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -199,8 +199,9 @@ class _LiveControls extends ConsumerWidget {
 
 /// Under the metadata: while casting, a clear `Casting to …` indicator;
 /// otherwise a friendly error message when playback failed, or the
-/// playback-source badge (LOCAL FILE / STREAMING DIRECT / OFFLINE CACHE) once a
-/// track has resolved. Shows nothing while a track is still loading locally.
+/// playback-source badge ("Playing from Navidrome / Jellyfin / Local files /
+/// Cache") once a track has resolved — naming the copy actually playing, not the
+/// active/default provider. Shows nothing while a track is still loading locally.
 class _SourceOrError extends ConsumerWidget {
   const _SourceOrError({required this.state});
 
@@ -239,7 +240,10 @@ class _SourceOrError extends ConsumerWidget {
     if (source == null) {
       return const SizedBox(height: 28);
     }
-    return PlaybackSourceChip(source: source);
+    return PlaybackSourceChip(
+      source: source,
+      trackUri: state.currentTrack?.uri,
+    );
   }
 }
 

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/models/playback_source.dart';
+import '../../../core/services/playback_source_label.dart';
 
 /// Title / artist / album block for the now-playing screen.
 ///
@@ -65,13 +66,27 @@ class TrackMetadata extends StatelessWidget {
   }
 }
 
-/// A small badge that states where the audio is coming from: LOCAL FILE,
-/// STREAMING DIRECT, or OFFLINE CACHE. Its text comes from
-/// [PlaybackSource.label] so the wording stays in one place.
+/// A small badge stating where the audio is *actually* coming from, e.g.
+/// "Playing from Navidrome", "Playing from Jellyfin", "Playing from Local files",
+/// or "Playing from Cache".
+///
+/// Because a logical track can have several source candidates, the indicator
+/// reflects the resolved copy — the owning provider derived from [trackUri] plus
+/// the [source] the resolver reported — not the active/default provider. Only
+/// safe display names are shown (see [PlaybackSourceLabel]); no server URL,
+/// username, token, or path is ever exposed.
 class PlaybackSourceChip extends StatelessWidget {
-  const PlaybackSourceChip({required this.source, super.key});
+  const PlaybackSourceChip({
+    required this.source,
+    required this.trackUri,
+    super.key,
+  });
 
   final PlaybackSource source;
+
+  /// The resolved track's opaque URI, used only to name the owning server
+  /// safely (`jellyfin:` → Jellyfin, `subsonic:` → Navidrome).
+  final String? trackUri;
 
   @override
   Widget build(BuildContext context) {
@@ -98,10 +113,9 @@ class PlaybackSourceChip extends StatelessWidget {
           ),
           const SizedBox(width: AppSpacing.xs + 2),
           Text(
-            source.label,
-            style: theme.textTheme.labelSmall?.copyWith(
-              letterSpacing: 0.8,
-              fontWeight: FontWeight.w700,
+            PlaybackSourceLabel.phrase(trackUri: trackUri, source: source),
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w600,
               color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
             ),
           ),

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -9,9 +9,11 @@ import '../../../core/sources/jellyfin/jellyfin_diagnostics.dart';
 import '../../../core/sources/jellyfin/jellyfin_exception.dart';
 import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
 import '../../../core/sources/jellyfin/jellyfin_server_capabilities.dart';
+import '../../../core/sources/music_provider.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../data/repositories/jellyfin_session_store_provider.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
+import '../../library/source_preference_controller.dart';
 import 'jellyfin_settings_providers.dart';
 import 'jellyfin_settings_state.dart';
 import 'jellyfin_sync_controller.dart';
@@ -136,6 +138,14 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
               );
       await ref.read(jellyfinSessionStoreProvider).write(newSession);
       _session = newSession;
+      // The just-signed-in server becomes the active/default provider for
+      // picking among duplicate sources, so a song that also lives on another
+      // server now prefers Jellyfin. Persisted and best-effort.
+      unawaited(
+        ref
+            .read(librarySourcePriorityProvider.notifier)
+            .markPreferred(MusicProviders.jellyfin.sourceId),
+      );
       state = JellyfinSettingsState(
         phase: JellyfinConnectionPhase.connected,
         baseUrl: newSession.baseUrl,

--- a/lib/features/settings/subsonic/subsonic_settings_controller.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_controller.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/subsonic_session.dart';
+import '../../../core/sources/music_provider.dart';
 import '../../../core/sources/subsonic/subsonic_api.dart';
 import '../../../core/sources/subsonic/subsonic_exception.dart';
 import '../../../core/sources/subsonic/subsonic_music_source.dart';
 import '../../../data/repositories/subsonic_session_store_provider.dart';
+import '../../library/source_preference_controller.dart';
 import 'subsonic_settings_providers.dart';
 import 'subsonic_settings_state.dart';
 import 'subsonic_sync_controller.dart';
@@ -123,6 +127,14 @@ class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
               );
       await ref.read(subsonicSessionStoreProvider).write(newSession);
       _session = newSession;
+      // The just-signed-in server becomes the active/default provider for
+      // picking among duplicate sources: a song that also lives on Jellyfin now
+      // prefers Navidrome/Subsonic. Persisted and best-effort.
+      unawaited(
+        ref
+            .read(librarySourcePriorityProvider.notifier)
+            .markPreferred(MusicProviders.subsonic.sourceId),
+      );
       state = SubsonicSettingsState(
         phase: SubsonicConnectionPhase.connected,
         baseUrl: newSession.baseUrl,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/play_history_repository_provider.dart';
 import 'data/repositories/playback_preferences_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
+import 'data/repositories/preferred_source_store_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
 import 'features/downloads/download_providers.dart';
@@ -46,6 +47,9 @@ Future<void> main() async {
       recordingDriftMusicLibraryRepositoryOverride,
       sharedPreferencesLibraryAddedStoreOverride,
       sharedPreferencesSelectedMusicFolderRepositoryOverride,
+      // Persist which server the user most recently signed into, so the
+      // active/default provider for de-duplicated songs survives a restart.
+      sharedPreferencesPreferredSourceStoreOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
       sharedPreferencesPlaybackPreferencesOverride,

--- a/test/core/catalog/source_priority_test.dart
+++ b/test/core/catalog/source_priority_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+
+void main() {
+  group('SourcePriority.rankOf', () {
+    test('honours the preferred order first', () {
+      const priority = SourcePriority(<String>['subsonic', 'jellyfin']);
+      expect(
+        priority.rankOf('subsonic'),
+        lessThan(priority.rankOf('jellyfin')),
+      );
+      expect(
+        priority.rankOf('jellyfin'),
+        lessThan(priority.rankOf('local')),
+      );
+    });
+
+    test('falls back to the default order for unlisted sources', () {
+      // Nothing preferred: jellyfin < subsonic < local by the fixed default.
+      expect(
+        SourcePriority.fallback.rankOf('jellyfin'),
+        lessThan(SourcePriority.fallback.rankOf('subsonic')),
+      );
+      expect(
+        SourcePriority.fallback.rankOf('subsonic'),
+        lessThan(SourcePriority.fallback.rankOf('local')),
+      );
+    });
+
+    test('a preferred source always outranks an only-default one', () {
+      const priority = SourcePriority(<String>['local']);
+      // Local is promoted, so it now beats jellyfin even though the default
+      // order puts jellyfin first.
+      expect(priority.rankOf('local'), lessThan(priority.rankOf('jellyfin')));
+    });
+
+    test('an unknown source sorts after every known one', () {
+      const priority = SourcePriority(<String>['subsonic']);
+      expect(
+        priority.rankOf('webdav'),
+        greaterThan(priority.rankOf('local')),
+      );
+    });
+  });
+
+  group('SourcePriority.promote', () {
+    test('moves a source to the front without duplicating it', () {
+      const priority = SourcePriority(<String>['jellyfin', 'subsonic']);
+      final promoted = priority.promote('subsonic');
+      expect(promoted.preferredOrder, <String>['subsonic', 'jellyfin']);
+    });
+
+    test('adds a new source at the front', () {
+      const priority = SourcePriority(<String>['jellyfin']);
+      expect(
+        priority.promote('subsonic').preferredOrder,
+        <String>['subsonic', 'jellyfin'],
+      );
+    });
+
+    test('is value-equal when nothing changes', () {
+      const priority = SourcePriority(<String>['subsonic', 'jellyfin']);
+      expect(priority.promote('subsonic'), priority);
+    });
+  });
+}

--- a/test/core/catalog/track_identity_test.dart
+++ b/test/core/catalog/track_identity_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/track_identity.dart';
+import 'package:linthra/core/models/track.dart';
+
+/// A Jellyfin-shaped track: opaque `jellyfin:<id>` uri and full tags.
+Track _jelly(
+  String id, {
+  required String title,
+  String? artist = 'Adele',
+  String? album = '25',
+  Duration duration = const Duration(minutes: 3),
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+    );
+
+/// A Subsonic/Navidrome-shaped track: opaque `subsonic:<id>` uri and full tags.
+Track _sub(
+  String id, {
+  required String title,
+  String? artist = 'Adele',
+  String? album = '25',
+  Duration duration = const Duration(minutes: 3),
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+    );
+
+void main() {
+  group('trackSourceId', () {
+    test('reads the owning provider from the uri scheme', () {
+      expect(trackSourceId(_jelly('1', title: 'x')), 'jellyfin');
+      expect(trackSourceId(_sub('1', title: 'x')), 'subsonic');
+      expect(
+        trackSourceId(const Track(id: 'p', title: 'x', uri: '/music/x.mp3')),
+        'local',
+      );
+      expect(
+        trackSourceId(
+          const Track(id: 'p', title: 'x', uri: 'content://media/x'),
+        ),
+        'local',
+      );
+    });
+  });
+
+  group('logicalMatchKey — the same song across providers', () {
+    test('Jellyfin and Subsonic copies of one song share a key', () {
+      final String? a = logicalMatchKey(_jelly('j', title: 'Hello'));
+      final String? b = logicalMatchKey(_sub('s', title: 'Hello'));
+      expect(a, isNotNull);
+      expect(a, b);
+    });
+
+    test('case and accents fold, so they never split a match', () {
+      final String? a =
+          logicalMatchKey(_jelly('j', title: 'Café', artist: 'Beyoncé'));
+      final String? b =
+          logicalMatchKey(_sub('s', title: 'cafe', artist: 'beyonce'));
+      expect(a, isNotNull);
+      expect(a, b);
+    });
+
+    test('a 1-second rounding difference still matches', () {
+      final String? a = logicalMatchKey(
+        _jelly('j', title: 'Hello', duration: const Duration(seconds: 180)),
+      );
+      final String? b = logicalMatchKey(
+        _sub('s', title: 'Hello', duration: const Duration(seconds: 181)),
+      );
+      expect(a, b);
+    });
+  });
+
+  group('logicalMatchKey — staying conservative', () {
+    test('a different album is a different key', () {
+      expect(
+        logicalMatchKey(_jelly('j', title: 'Hello', album: '25')),
+        isNot(logicalMatchKey(_sub('s', title: 'Hello', album: '21'))),
+      );
+    });
+
+    test('a different artist is a different key', () {
+      expect(
+        logicalMatchKey(_jelly('j', title: 'Hello', artist: 'Adele')),
+        isNot(logicalMatchKey(_sub('s', title: 'Hello', artist: 'Lionel'))),
+      );
+    });
+
+    test('a clearly different duration is a different key', () {
+      expect(
+        logicalMatchKey(
+          _jelly('j', title: 'Hello', duration: const Duration(minutes: 3)),
+        ),
+        isNot(
+          logicalMatchKey(
+            _sub('s', title: 'Hello', duration: const Duration(minutes: 5)),
+          ),
+        ),
+      );
+    });
+
+    test('a version qualifier in the title keeps a remix/live distinct', () {
+      expect(
+        logicalMatchKey(_jelly('j', title: 'Hello')),
+        isNot(logicalMatchKey(_sub('s', title: 'Hello (Live)'))),
+      );
+    });
+  });
+
+  group('logicalMatchKey — ineligible tracks never match', () {
+    test('no artist yields no key', () {
+      expect(
+          logicalMatchKey(_jelly('j', title: 'Hello', artist: null)), isNull);
+      expect(
+        canMatchAcrossProviders(_jelly('j', title: 'Hello', artist: null)),
+        isFalse,
+      );
+    });
+
+    test('no album yields no key', () {
+      expect(logicalMatchKey(_jelly('j', title: 'Hello', album: null)), isNull);
+    });
+
+    test('an unknown (zero) duration yields no key', () {
+      expect(
+        logicalMatchKey(
+          _jelly('j', title: 'Hello', duration: Duration.zero),
+        ),
+        isNull,
+      );
+    });
+
+    test('an untagged local file (title only) is never matchable', () {
+      const Track local = Track(id: '/m/x.mp3', title: 'x', uri: '/m/x.mp3');
+      expect(logicalMatchKey(local), isNull);
+    });
+  });
+}

--- a/test/core/catalog/track_unifier_test.dart
+++ b/test/core/catalog/track_unifier_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/logical_track.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/core/catalog/track_unifier.dart';
+import 'package:linthra/core/models/track.dart';
+
+Track _jelly(
+  String id, {
+  required String title,
+  String artist = 'Adele',
+  String album = '25',
+  Duration duration = const Duration(minutes: 3),
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+    );
+
+Track _sub(
+  String id, {
+  required String title,
+  String artist = 'Adele',
+  String album = '25',
+  Duration duration = const Duration(minutes: 3),
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+    );
+
+/// An untagged local file: a path for id+uri, the file name as title, and no
+/// artist/album/duration — the shape the local scanner produces for bare files.
+Track _local(String name) =>
+    Track(id: '/m/$name', title: name, uri: '/m/$name');
+
+const _subsonicPreferred = SourcePriority(<String>['subsonic', 'jellyfin']);
+const _jellyfinPreferred = SourcePriority(<String>['jellyfin', 'subsonic']);
+
+void main() {
+  group('unifyTracks — collapsing cross-provider duplicates', () {
+    test('the same song on Jellyfin + Navidrome becomes one row', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[_jelly('j', title: 'Hello'), _sub('s', title: 'Hello')],
+        _subsonicPreferred,
+      );
+
+      expect(logical, hasLength(1));
+      expect(logical.single.hasMultipleSources, isTrue);
+      expect(logical.single.allTrackIds, containsAll(<String>['j', 's']));
+    });
+
+    test('prefers the active/default provider for the playable copy', () {
+      final List<Track> tracks = <Track>[
+        _jelly('j', title: 'Hello'),
+        _sub('s', title: 'Hello'),
+      ];
+
+      // Navidrome active -> the Subsonic copy is primary (and would be queued).
+      expect(
+        unifyTracks(tracks, _subsonicPreferred).single.primary.sourceId,
+        'subsonic',
+      );
+      // Jellyfin active -> the Jellyfin copy is primary instead.
+      expect(
+        unifyTracks(tracks, _jellyfinPreferred).single.primary.sourceId,
+        'jellyfin',
+      );
+    });
+
+    test('candidates are ordered best-first so fallback is deterministic', () {
+      final LogicalTrack row = unifyTracks(
+        <Track>[_jelly('j', title: 'Hello'), _sub('s', title: 'Hello')],
+        _subsonicPreferred,
+      ).single;
+
+      expect(row.sourceIds, <String>['subsonic', 'jellyfin']);
+    });
+  });
+
+  group('unifyTracks — single-source songs are untouched', () {
+    test('a Jellyfin-only track still appears and plays from Jellyfin', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[_jelly('j', title: 'Solo')],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(1));
+      expect(logical.single.primary.sourceId, 'jellyfin');
+    });
+
+    test('a Navidrome-only track still appears and plays from Navidrome', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[_sub('s', title: 'Solo')],
+        _jellyfinPreferred,
+      );
+      expect(logical, hasLength(1));
+      expect(logical.single.primary.sourceId, 'subsonic');
+    });
+
+    test(
+        'the active provider missing a track falls back to the one that has it',
+        () {
+      // Navidrome is preferred, but this song only exists on Jellyfin.
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[_jelly('j', title: 'Only On Jellyfin')],
+        _subsonicPreferred,
+      );
+      expect(logical.single.primary.sourceId, 'jellyfin');
+    });
+  });
+
+  group('unifyTracks — local files behave exactly as before', () {
+    test('local-only tracks each stay their own row', () {
+      final List<Track> local = <Track>[_local('a.mp3'), _local('b.mp3')];
+      final List<LogicalTrack> logical = unifyTracks(local, _subsonicPreferred);
+
+      expect(logical, hasLength(2));
+      expect(
+        logical.map((LogicalTrack l) => l.primaryTrack).toList(),
+        local,
+      );
+      expect(logical.every((LogicalTrack l) => !l.hasMultipleSources), isTrue);
+    });
+  });
+
+  group('unifyTracks — conservative, never over-merging', () {
+    test('different songs that share a title are not merged', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('j', title: 'Intro', album: 'Album A'),
+          _sub('s', title: 'Intro', album: 'Album B'),
+        ],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(2));
+    });
+
+    test('same title + artist but a different duration stays separate', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('j', title: 'Hello', duration: const Duration(minutes: 3)),
+          _sub('s', title: 'Hello', duration: const Duration(minutes: 6)),
+        ],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(2));
+    });
+
+    test('a single provider is returned one-row-per-track, never merged', () {
+      // Two distinct Jellyfin tracks that happen to share a key are NOT merged,
+      // because a single source is assumed already de-duplicated. This is the
+      // guarantee that an existing single-provider library is unchanged.
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('j1', title: 'Hello'),
+          _jelly('j2', title: 'Hello'),
+        ],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(2));
+    });
+
+    test('untagged duplicates across providers are not merged', () {
+      // Without trustworthy tags there is no confident match, so two same-named
+      // local-ish files stay separate even though the names match.
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[_local('song.mp3'), _local('song.mp3')],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(2));
+    });
+  });
+
+  group('unifyTracks — output ordering', () {
+    test('a merged row appears at its first occurrence; order is preserved',
+        () {
+      final Track jellyHello = _jelly('j', title: 'Hello');
+      final Track localOnly = _local('b.mp3');
+      final Track subHello = _sub('s', title: 'Hello');
+
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[jellyHello, localOnly, subHello],
+        _subsonicPreferred,
+      );
+
+      // Two rows: the merged "Hello" (first seen at index 0) then the local file.
+      expect(logical, hasLength(2));
+      expect(logical.first.hasMultipleSources, isTrue);
+      expect(logical.first.allTrackIds, containsAll(<String>['j', 's']));
+      expect(logical.last.primaryTrack.id, localOnly.id);
+    });
+  });
+}

--- a/test/core/services/playback_source_label_test.dart
+++ b/test/core/services/playback_source_label_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/services/playback_source_label.dart';
+
+void main() {
+  group('PlaybackSourceLabel.of — the copy actually playing', () {
+    test('an on-device file reads as Local files', () {
+      expect(
+        PlaybackSourceLabel.of(
+          trackUri: '/music/song.mp3',
+          source: PlaybackSource.localFile,
+        ),
+        'Local files',
+      );
+    });
+
+    test('a direct Jellyfin stream names Jellyfin', () {
+      expect(
+        PlaybackSourceLabel.of(
+          trackUri: 'jellyfin:abc',
+          source: PlaybackSource.streamingDirect,
+        ),
+        'Jellyfin',
+      );
+    });
+
+    test('a direct Subsonic stream names Navidrome', () {
+      expect(
+        PlaybackSourceLabel.of(
+          trackUri: 'subsonic:abc',
+          source: PlaybackSource.streamingDirect,
+        ),
+        'Navidrome',
+      );
+    });
+
+    test('a cached copy reads as Cache regardless of the owning server', () {
+      expect(
+        PlaybackSourceLabel.of(
+          trackUri: 'jellyfin:abc',
+          source: PlaybackSource.offlineCache,
+        ),
+        'Cache',
+      );
+      expect(
+        PlaybackSourceLabel.of(
+          trackUri: 'subsonic:abc',
+          source: PlaybackSource.offlineCache,
+        ),
+        'Cache',
+      );
+    });
+
+    test('no resolved source reads as Unknown source', () {
+      expect(
+        PlaybackSourceLabel.of(trackUri: 'jellyfin:abc', source: null),
+        'Unknown source',
+      );
+    });
+  });
+
+  group('PlaybackSourceLabel.phrase', () {
+    test('prefixes the safe name with "Playing from"', () {
+      expect(
+        PlaybackSourceLabel.phrase(
+          trackUri: 'subsonic:abc',
+          source: PlaybackSource.streamingDirect,
+        ),
+        'Playing from Navidrome',
+      );
+    });
+  });
+}

--- a/test/data/repositories/shared_preferences_preferred_source_store_test.dart
+++ b/test/data/repositories/shared_preferences_preferred_source_store_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/shared_preferences_preferred_source_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  group('SharedPreferencesPreferredSourceStore', () {
+    test('reads an empty order when nothing is stored', () async {
+      expect(await SharedPreferencesPreferredSourceStore().read(), isEmpty);
+    });
+
+    test('round-trips the order across separate instances', () async {
+      await SharedPreferencesPreferredSourceStore()
+          .write(<String>['subsonic', 'jellyfin', 'local']);
+
+      expect(
+        await SharedPreferencesPreferredSourceStore().read(),
+        <String>['subsonic', 'jellyfin', 'local'],
+      );
+    });
+
+    test('a corrupt value reads as no preference rather than throwing',
+        () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'preferred_source_order_v1': 'not-json',
+      });
+      expect(await SharedPreferencesPreferredSourceStore().read(), isEmpty);
+    });
+  });
+}

--- a/test/features/library/source_preference_controller_test.dart
+++ b/test/features/library/source_preference_controller_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/data/repositories/in_memory_preferred_source_store.dart';
+import 'package:linthra/data/repositories/preferred_source_store_provider.dart';
+import 'package:linthra/features/library/source_preference_controller.dart';
+
+ProviderContainer _container(InMemoryPreferredSourceStore store) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      preferredSourceStoreProvider.overrideWithValue(store),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('SourcePreferenceController', () {
+    test('starts at the deterministic fallback default', () {
+      final container = _container(InMemoryPreferredSourceStore());
+      expect(container.read(librarySourcePriorityProvider),
+          SourcePriority.fallback);
+    });
+
+    test('loads a persisted order at startup', () async {
+      final container = _container(
+        InMemoryPreferredSourceStore(<String>['subsonic', 'jellyfin']),
+      );
+      // Build the controller, then let its fire-and-forget load settle.
+      container.read(librarySourcePriorityProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder,
+        <String>['subsonic', 'jellyfin'],
+      );
+    });
+
+    test('markPreferred promotes the server and persists it', () async {
+      final store = InMemoryPreferredSourceStore();
+      final container = _container(store);
+
+      await container
+          .read(librarySourcePriorityProvider.notifier)
+          .markPreferred('subsonic');
+
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder.first,
+        'subsonic',
+      );
+      expect(await store.read(), <String>['subsonic']);
+    });
+
+    test('the most recent sign-in wins', () async {
+      final container = _container(InMemoryPreferredSourceStore());
+      final controller = container.read(librarySourcePriorityProvider.notifier);
+
+      await controller.markPreferred('jellyfin');
+      await controller.markPreferred('subsonic');
+
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder,
+        <String>['subsonic', 'jellyfin'],
+      );
+    });
+  });
+}

--- a/test/features/library/unified_library_providers_test.dart
+++ b/test/features/library/unified_library_providers_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/library_search.dart';
+import 'package:linthra/features/library/source_preference_controller.dart';
+import 'package:linthra/features/library/unified_library_providers.dart';
+
+Track _jelly(String id, {required String title, String album = '25'}) => Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: 'Adele',
+      albumName: album,
+      duration: const Duration(minutes: 3),
+    );
+
+Track _sub(String id, {required String title, String album = '25'}) => Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: 'Adele',
+      albumName: album,
+      duration: const Duration(minutes: 3),
+    );
+
+/// Pins the source preference for a deterministic test, bypassing the async
+/// load from the store.
+class _FixedPreference extends SourcePreferenceController {
+  _FixedPreference(this._priority);
+  final SourcePriority _priority;
+  @override
+  SourcePriority build() => _priority;
+}
+
+/// A container seeded with a per-source catalog and a fixed source preference.
+Future<ProviderContainer> _seed({
+  required SourcePriority priority,
+  required List<Track> jellyfin,
+  required List<Track> subsonic,
+}) async {
+  final repo = InMemoryMusicLibraryRepository();
+  final container = ProviderContainer(
+    overrides: <Override>[
+      musicLibraryRepositoryProvider.overrideWithValue(repo),
+      librarySourcePriorityProvider
+          .overrideWith(() => _FixedPreference(priority)),
+    ],
+  );
+  addTearDown(container.dispose);
+  await repo.upsertCatalog(
+    sourceId: 'jellyfin',
+    tracks: jellyfin,
+    albums: const <Album>[],
+    artists: const <Artist>[],
+  );
+  await repo.upsertCatalog(
+    sourceId: 'subsonic',
+    tracks: subsonic,
+    albums: const <Album>[],
+    artists: const <Artist>[],
+  );
+  await container.read(libraryControllerProvider.notifier).refresh();
+  return container;
+}
+
+void main() {
+  group('libraryUnifiedTracksProvider', () {
+    test('shows one row for a song served by both providers', () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello')],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final List<Track> songs = container.read(libraryUnifiedTracksProvider);
+      expect(songs, hasLength(1));
+      // Navidrome is active, so the playable/queued copy is the Subsonic one.
+      expect(songs.single.uri, 'subsonic:s');
+    });
+
+    test('a Jellyfin-only song still appears and plays from Jellyfin',
+        () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Only Jelly')],
+        subsonic: <Track>[_sub('s', title: 'Shared')],
+      );
+
+      final List<Track> songs = container.read(libraryUnifiedTracksProvider);
+      final Track jellyOnly =
+          songs.firstWhere((Track t) => t.title == 'Only Jelly');
+      expect(jellyOnly.uri, 'jellyfin:j');
+    });
+
+    test('search over the unified list never duplicates a logical track',
+        () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello')],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final List<Track> results = filterTracks(
+        container.read(libraryUnifiedTracksProvider),
+        'hello',
+      );
+      expect(results, hasLength(1));
+    });
+  });
+
+  group('logicalSourceIdsProvider', () {
+    test('maps a displayed row to every provider copy for removal', () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello')],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final Map<String, List<String>> bySource =
+          container.read(logicalSourceIdsProvider);
+      // The visible row is the Subsonic primary; removing it forgets both copies.
+      expect(bySource['s'], containsAll(<String>['j', 's']));
+    });
+  });
+}

--- a/test/features/player/mini_player_test.dart
+++ b/test/features/player/mini_player_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/features/player/mini_player.dart';
@@ -79,6 +80,23 @@ void main() {
       expect(find.text('Artist A • Album B'), findsOneWidget);
       // While playing it offers a Pause control.
       expect(find.byTooltip('Pause'), findsOneWidget);
+    });
+
+    testWidgets('shows the resolved source beside the metadata',
+        (tester) async {
+      final controller = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(id: 'r', title: 'Remote', uri: 'subsonic:r'),
+          source: PlaybackSource.streamingDirect,
+        ),
+      );
+      await _pump(tester, controller);
+      await tester.pumpAndSettle();
+
+      // The mini-player names the copy actually playing (a Navidrome stream),
+      // not the active/default provider.
+      expect(find.text('Navidrome'), findsOneWidget);
     });
 
     testWidgets('play/pause delegates to the controller', (tester) async {

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -87,13 +87,15 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('shows the LOCAL FILE badge', (tester) async {
+    testWidgets('shows the Local files source for an on-device track',
+        (tester) async {
       await _pumpScreen(tester, _playing(source: PlaybackSource.localFile));
 
-      expect(find.text('LOCAL FILE'), findsOneWidget);
+      expect(find.text('Playing from Local files'), findsOneWidget);
     });
 
-    testWidgets('shows the STREAMING DIRECT badge', (tester) async {
+    testWidgets('names the owning server (Jellyfin) for a direct stream',
+        (tester) async {
       await _pumpScreen(
         tester,
         _playing(
@@ -102,10 +104,22 @@ void main() {
         ),
       );
 
-      expect(find.text('STREAMING DIRECT'), findsOneWidget);
+      expect(find.text('Playing from Jellyfin'), findsOneWidget);
     });
 
-    testWidgets('shows the OFFLINE CACHE badge', (tester) async {
+    testWidgets('names Navidrome for a Subsonic direct stream', (tester) async {
+      await _pumpScreen(
+        tester,
+        _playing(
+          track: const Track(id: 't1', title: 'Remote', uri: 'subsonic:t1'),
+          source: PlaybackSource.streamingDirect,
+        ),
+      );
+
+      expect(find.text('Playing from Navidrome'), findsOneWidget);
+    });
+
+    testWidgets('shows the Cache source for offline playback', (tester) async {
       await _pumpScreen(
         tester,
         _playing(
@@ -114,7 +128,7 @@ void main() {
         ),
       );
 
-      expect(find.text('OFFLINE CACHE'), findsOneWidget);
+      expect(find.text('Playing from Cache'), findsOneWidget);
     });
 
     testWidgets('play/pause delegates to the controller', (tester) async {


### PR DESCRIPTION
## Problem

When a second server (Navidrome/Subsonic) is connected after Jellyfin, both can
expose the **same** music library, so the Songs list shows every song twice. This
is a library/source-model problem, not a UI glitch.

**Goal:** show one row per logical song while keeping every playable source, and
prefer the active/default provider for playback with a deterministic fallback.

---

## Audit (current behaviour, before this change)

1. **How tracks are stored** — `MusicLibraryRepository` (Drift/SQLite, `tracks`
   table) keyed by `id`, with a `sourceId` column. `upsertCatalog(sourceId, …)`
   replaces just that source's rows. `getAllTracks()` flattens **all** sources
   into one list — **this is where duplicates surface.**
2. **Per-track source identity** — the DB row has `sourceId`, but the domain
   `Track` does **not**; the provider is re-derived from the opaque URI scheme
   (`jellyfin:` / `subsonic:` / local path) via `MusicProviders.forTrackUri`.
3. **How sources load in** — local scan and Jellyfin/Subsonic syncs each call
   `upsertCatalog` under their own `sourceId`; the UI reads the flattened result
   through `LibraryController` → `LibraryState.tracks`.
4. **Playback resolution** — `RoutingPlayableUriResolver` picks the per-source
   resolver by URI scheme; `OfflineFirstPlayableUriResolver` prefers a cached
   copy. There was **no** notion of an active/default provider.
5. **Matching metadata available** — `title`, `artistName`, `albumName`,
   `duration`, `trackNumber`, source-specific `id`, opaque URI, `artworkUri`
   (Jellyfin only). No disc number; no separate filename beyond the local path.
6. **Where duplicates are introduced** — purely at display: `getAllTracks()` →
   `LibraryState.tracks` → Songs/Albums/Artists/search. Storage is correct.
7. **Migration/back-compat risk** — **none required.** De-duplication is a pure
   display-time transform over the existing rows, so there is **no schema change
   and no migration**, and single-provider/local-only libraries are unchanged.

---

## Design

Three layers (see `docs/unified-library.md`):

- **Source track** = the existing `Track` (one provider copy; repository stores
  all of them, untouched).
- **`TrackSourceCandidate`** = a source track + its `sourceId`.
- **`LogicalTrack`** = one displayed row wrapping ordered candidates; `primary`
  is the copy shown and played.

`unifyTracks(tracks, priority)` collapses the flat catalog into logical tracks.
Matching is **conservative**:

- key = folded **title + artist + album + 2s duration bucket** (case/accents
  folded; `(Live)`/`(Remix)` kept distinct);
- a track missing title/artist/album/duration gets **no key** → always its own
  row (untagged local files never merge);
- rows merge **only** across **≥2 distinct providers** — a single provider's rows
  are never merged, so an existing library is returned one-row-per-track.

**Source preference / fallback** (`SourcePriority`): the server you most recently
signed into is promoted to the front and **persisted** (`PreferredSourceStore`,
SharedPreferences); everything else falls back to a fixed `jellyfin → subsonic →
local` tail (local last so a castable/syncable server copy wins). `primary =
candidates.first`, so playback prefers the active provider and falls back to
whichever source actually has the song. (Runtime fail-over when the preferred
server is unreachable mid-resolve is a noted follow-up; the offline cache already
provides resilience.)

**Playback source indicator** — Now Playing shows a "Playing from …" chip and the
mini-player a faint tag for the copy **actually** playing
(`Navidrome` / `Jellyfin` / `Local files` / `Cache`), derived from the resolved
track + `PlaybackSource`. Safe display names only — no URL, IP, username, token,
or path.

---

## Tests (all green: 1329 passed, analyze clean, `dart format` clean)

New: match key & eligibility, `SourcePriority`, `unifyTracks` (same song on
Jellyfin+Navidrome → one row, prefers active provider, Jellyfin-only/Navidrome-
only/local-only still appear & play from their source, conservative non-merges,
order preservation), `PlaybackSourceLabel`, the preference controller/store, and
the unified providers (incl. search-doesn't-duplicate + removal maps to all
copies). Updated the Now Playing/mini-player source-badge tests.

---

## Scope / constraints honoured

- No release bump, no tag, no `fdroiddata` changes, no unrelated redesign.
- No DB migration (de-dup is display-level).
- In-app Library (the reported bug) is fixed. The **Android Auto** browse tree is
  intentionally **out of scope** here — its `_allTracks()` also backs
  favourites/downloads/playlist id-resolution, so unifying it needs separate care
  and can reuse `unifyTracks`; tracked as a follow-up in the doc.

🤖 Draft for review.

https://claude.ai/code/session_01EAz7Q4SSswGrSiHVKKkAcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAz7Q4SSswGrSiHVKKkAcG)_