### PR TITLE
fix(library): provider-aware artwork fallback + conservative scored matching

### DIFF
--- a/docs/unified-library.md
+++ b/docs/unified-library.md
@@ -33,24 +33,54 @@ album/artist detail screens all render the de-duplicated primaries, so none of
 them shows a song twice.
 
 The matching is deliberately **conservative** — it would rather leave two rows
-separate than merge songs that might be different:
+separate than merge songs that might be different. Because real Jellyfin and
+Navidrome servers rarely tag a song *identically*, matching is a **score with
+hard vetoes** (`core/catalog/track_identity.dart`), not one exact key:
 
-- A **match key** (`logicalMatchKey`) is built from the *folded* title, artist,
-  and album plus a coarse (2-second) duration bucket. Case and accents are
-  folded (`Beyoncé` ≡ `beyonce`); distinguishing words are **kept**, so
-  `Hello`, `Hello (Live)`, and `Hello (Radio Edit)` never collapse together.
+- Eligible tracks are first **blocked** by `matchBlockKey` (the folded primary
+  artist token + first title token, feat. qualifier stripped) so only plausible
+  pairs are ever compared.
+- Within a block, `trackMatchScore(a, b)` rates a pair in `[0, 1]` from the
+  strong, tag-derived signals: **title** token overlap (`1.0` when the
+  feat-stripped titles match), **album** containment (so `25` ⊆ `25 (Deluxe)`),
+  and **artist** containment (so `NF` ⊆ `NF, Cordae`). Two **hard vetoes**
+  force `0.0`: durations more than 2 seconds apart, or two conflicting track
+  numbers. A pair merges only at or above `kTrackMatchScore` (0.9).
+- This tolerates the real-world drift the exact key missed — `CAREFUL` vs
+  `CAREFUL feat. Cordae`, artist `NF` vs `NF, Cordae`, album editions, and a
+  1-second rounding gap that straddled the old bucket edge — while still keeping
+  `Hello`, `Hello (Live)`, and a same-title song on a *different* album as
+  separate rows (their score stays below 0.9).
 - A track with too little metadata to match — **missing** title, artist, album,
-  **or** a zero/unknown duration — gets **no key** and is **always** its own
-  row. Untagged local files therefore never merge.
-- Two tracks merge **only** when they share a key **and** come from **two or
-  more distinct providers**. A group that is entirely one provider's rows is
-  never merged. This is the safety invariant that guarantees an existing
+  **or** a zero/unknown duration — is **never** matchable and is **always** its
+  own row. Untagged local files therefore never merge.
+- Two tracks merge **only** when they are a confident match **and** come from
+  **two or more distinct providers**. A group that is entirely one provider's
+  rows is never merged. This is the safety invariant that guarantees an existing
   single-provider (or local-only) library is returned one-row-per-track,
   unchanged.
+
+Grouping stays **deterministic** even though a score is not a single
+equivalence key: a block's tracks are sorted by `(priority rank, id)` and each
+is attached to the first existing group whose *anchor* it matches (and whose
+provider it does not already duplicate), so the result never depends on the
+catalog's order.
 
 Removing a logical row from the library forgets **every** provider copy (via
 `logicalSourceIdsProvider`), so a hidden duplicate can't resurrect the row on the
 next reload. (Re-syncing a server brings its copy back, exactly as before.)
+
+### Artwork: prefer the displayed copy, fall back to the best available
+
+The displayed copy is the default/preferred provider's — but some providers
+(Subsonic/Navidrome today, untagged local files) carry **no** `artworkUri`. If
+the row simply showed the preferred copy's cover, unifying a song that the
+preferred provider lacks a cover for would *blank* a cover another copy still
+has. So `LogicalTrack.displayTrack` keeps the preferred copy's id and uri (play,
+source label, and removal are unchanged) but fills in `displayArtworkUri`: the
+first candidate, **in preference order**, that actually has artwork. The choice
+is deterministic, prefers the displayed provider, and never regresses an album
+cover that any merged copy provides.
 
 ## Source preference & fallback
 

--- a/lib/core/catalog/logical_track.dart
+++ b/lib/core/catalog/logical_track.dart
@@ -57,6 +57,32 @@ class LogicalTrack {
   /// The preferred copy's catalog track (the playable, displayable [Track]).
   Track get primaryTrack => primary.track;
 
+  /// The artwork to show for this row, chosen deterministically: the displayed
+  /// (preferred) copy's own cover wins; if it has none, the first fallback
+  /// candidate — in the same preference order — that *does* carry artwork is
+  /// used. So unifying never blanks a cover the song actually has on another
+  /// provider (a common regression when the preferred provider — e.g. Subsonic,
+  /// whose mapper stores no `artworkUri` — shadows a Jellyfin copy that has one).
+  /// `null` only when no candidate has any artwork at all.
+  Uri? get displayArtworkUri {
+    for (final TrackSourceCandidate c in candidates) {
+      final Uri? art = c.track.artworkUri;
+      if (art != null) return art;
+    }
+    return null;
+  }
+
+  /// The [Track] the row should display and enqueue: the preferred copy, but
+  /// carrying the best available artwork ([displayArtworkUri]) so a primary that
+  /// lacks a cover does not hide one a fallback copy has. Its [Track.id] and
+  /// [Track.uri] are the primary's, so playback resolution, the "Playing from …"
+  /// source indicator, and removal are all unchanged — only the cover is filled.
+  Track get displayTrack {
+    final Uri? art = displayArtworkUri;
+    if (art == primaryTrack.artworkUri) return primaryTrack;
+    return primaryTrack.copyWith(artworkUri: art);
+  }
+
   /// A stable id for the logical row: the preferred copy's track id. Stable for
   /// a given catalog + preference, which is all the UI (keys, selection) needs.
   String get id => primaryTrack.id;

--- a/lib/core/catalog/track_identity.dart
+++ b/lib/core/catalog/track_identity.dart
@@ -1,20 +1,35 @@
+import 'package:flutter/foundation.dart';
+
 import '../models/track.dart';
 import '../sources/music_provider.dart';
 import 'text_folding.dart';
 
 /// Cross-provider identity for a [Track]: the `sourceId` that owns it and a
-/// conservative "is this the same song?" match key used to unify duplicates that
+/// conservative "is this the same song?" decision used to unify duplicates that
 /// the same library exposes through more than one provider (e.g. the same album
 /// served by both Jellyfin and Navidrome/Subsonic).
 ///
-/// Why a *key* rather than pairwise similarity: a single normalized key makes
-/// unification a deterministic, order-independent `O(n)` grouping that is an
-/// equivalence relation (so the result never depends on which two rows were
-/// compared first). It also makes the matching trivially unit-testable.
+/// ## Why scored matching (not one exact key)
 ///
-/// The guiding rule is conservative: prefer keeping two rows separate over
-/// merging songs that might be different. A merge therefore requires every
-/// strong, tag-derived signal to agree, never the title alone.
+/// The first cut keyed unification on an *exact* folded `title|artist|album` plus
+/// a duration bucket. On a real Jellyfin/Navidrome pair that key is too strict
+/// and leaves duplicates behind, because the two servers rarely tag a song
+/// byte-for-byte identically:
+///
+///  * **Featured artists drift.** One server stores `CAREFUL`, the other
+///    `CAREFUL feat. Cordae`; one stores artist `NF`, the other `NF, Cordae`.
+///    Any of these splits the exact key, so the song shows twice.
+///  * **Album editions drift.** `25` vs `25 (Deluxe)`.
+///  * **Duration bucket boundaries.** A 2-second *bucket* (not a 2-second
+///    *difference*) still split a 1-second rounding gap that straddled a bucket
+///    edge (e.g. 181s in bucket 90, 182s in bucket 91).
+///
+/// So matching is now a conservative **score with hard vetoes**. Two eligible
+/// tracks are compared on the strong, tag-derived signals the request calls out
+/// — near-same duration, normalized album, title-token overlap, artist-token
+/// overlap, and track number — and merge only when the weighted score clears a
+/// high threshold *and* no veto fires. The guiding rule is unchanged: prefer
+/// keeping two rows separate over merging songs that might be different.
 
 /// The `sourceId` of the provider that owns [track], derived from its opaque
 /// `scheme:` URI (`jellyfin:` / `subsonic:` / a local path). This is the same
@@ -23,43 +38,174 @@ import 'text_folding.dart';
 String trackSourceId(Track track) =>
     MusicProviders.forTrackUri(track.uri).sourceId;
 
-/// Duration bucket width, in seconds. Two providers reading the same file report
-/// the same whole-second duration (both floor it), so a 2-second bucket folds
-/// any incidental rounding together while still separating genuinely different
-/// lengths (a radio edit vs an extended mix) into different keys.
-const int _durationBucketSeconds = 2;
+/// Two providers reading the same file report the same whole-second duration
+/// (both floor it). A re-encode/transcode can nudge it by a second, so copies
+/// within this many seconds of each other are treated as the same length; any
+/// wider gap is a hard veto (a radio edit vs an extended mix is a different
+/// song). Compared as an absolute *difference*, so there is no bucket-edge gap.
+const int _nearDurationSeconds = 2;
 
-/// A conservative match key for [track], or `null` when the track does not carry
-/// enough trustworthy metadata to be matched against another provider's copy.
+/// Signal weights (sum to 1.0). Title carries the most weight (it is the most
+/// discriminating field), then album, then artist. Tuned with [kTrackMatchScore]
+/// so that the real-world drifts above merge while the conservative cases below
+/// stay separate:
+///  * same title, same artist, *different* album (containment 0.5) → 0.85 < th.
+///  * same title+album+artist but `(Live)`/`(Remix)` (title Jaccard 0.5) → < th.
+const double _wTitle = 0.45;
+const double _wAlbum = 0.30;
+const double _wArtist = 0.25;
+
+/// The minimum [trackMatchScore] (after vetoes) for two copies to be considered
+/// the same song. High by design: at 0.9 a single strong field disagreeing is
+/// enough to keep two rows separate, so we under-merge rather than over-merge.
+const double kTrackMatchScore = 0.9;
+
+/// Whether [track] carries enough trustworthy metadata to *ever* be unified with
+/// a copy from another provider: a foldable title, artist, and album, plus a
+/// known (non-zero) duration. Tracks missing any of these — most untagged local
+/// files — can never match and always stand as their own library row, exactly as
+/// before unification existed.
+bool canMatchAcrossProviders(Track track) => matchBlockKey(track) != null;
+
+/// A coarse, order-independent *blocking* key that co-locates plausible matches
+/// so scoring is cheap (only tracks in the same block are ever compared), or
+/// `null` when [track] is ineligible (see [canMatchAcrossProviders]).
 ///
-/// A non-null key requires all of: a folded title, a folded artist, a folded
-/// album, and a known (non-zero) duration. Tracks missing any of these — most
-/// untagged local files, for instance — return `null` and are therefore never
-/// merged with anything; they always stand as their own library row. This is
-/// what keeps local-only and lightly-tagged libraries behaving exactly as they
-/// did before unification existed.
-///
-/// When every signal is present the key is built from the folded title, artist,
-/// and album plus a coarse duration bucket. Each text part is length-prefixed
-/// (the idiom `library_grouping` uses) so no separator char is needed and two
-/// different splits can never collide. Case and accents are folded (via
-/// [foldText]) so "Beyonce" and the accented "Beyoncé" match, but distinguishing
-/// words are kept — "(Live)", "(Remix)", "(Radio Edit)" stay in the title — so
-/// different versions of a song never collapse into one row.
-String? logicalMatchKey(Track track) {
-  final String title = foldText(track.title);
-  final String artist = foldText(track.artistName ?? '');
-  final String album = foldText(track.albumName ?? '');
-  final int seconds = track.duration.inSeconds;
-  if (title.isEmpty || artist.isEmpty || album.isEmpty || seconds <= 0) {
-    return null;
-  }
-  final int bucket = seconds ~/ _durationBucketSeconds;
-  return 'v1|${title.length}|$title|${artist.length}|$artist|'
-      '${album.length}|$album|$bucket';
+/// The key is the folded *primary* artist token plus the folded *first* title
+/// token (with any `feat.`/`ft.`/`featuring` qualifier stripped). Both are stable
+/// across providers for the same song even when the *full* artist or title drift
+/// (a featured-artist suffix, a `(Deluxe)` album), so true matches share a block
+/// while the block stays small. Scoring inside the block does the precise work.
+String? matchBlockKey(Track track) {
+  if (track.duration.inSeconds <= 0) return null;
+  final List<String> artist = _tokenize(foldText(track.artistName ?? ''));
+  final List<String> album = _tokenize(foldText(track.albumName ?? ''));
+  final List<String> title = _coreTitleTokens(track.title);
+  if (artist.isEmpty || album.isEmpty || title.isEmpty) return null;
+  // A separator so two tokens can never run together into a third key
+  // ('ab|c' vs 'a|bc'); blocking only needs to be coarse, but stays clean.
+  return '${artist.first}|${title.first}';
 }
 
-/// Whether [track] carries enough metadata to ever be unified with a copy from
-/// another provider. Sugar over [logicalMatchKey] for call sites that only need
-/// the yes/no.
-bool canMatchAcrossProviders(Track track) => logicalMatchKey(track) != null;
+/// A conservative similarity score in `[0.0, 1.0]` for whether [a] and [b] are
+/// the same song. `0.0` for any *veto*: either is ineligible, the durations are
+/// more than [_nearDurationSeconds] apart, or both carry a track number and the
+/// numbers differ (different positions on the same album → different songs).
+///
+/// Otherwise it is the weighted sum of three signals:
+///  * **title** — `1.0` when the feat-stripped titles match token-for-token,
+///    else the Jaccard overlap of their token sets (so `(Live)`/`(Remix)` extra
+///    tokens cost score and keep versions distinct);
+///  * **album** — the containment of the smaller album-token set in the larger,
+///    so `25` ⊆ `25 (Deluxe)` scores `1.0` but `Album A` vs `Album B` scores 0.5;
+///  * **artist** — the containment of the smaller artist-token set in the larger,
+///    so `NF` ⊆ `NF, Cordae` scores `1.0` (featured artists), while two genuinely
+///    different artists share no tokens and score `0.0`.
+double trackMatchScore(Track a, Track b) {
+  if (!canMatchAcrossProviders(a) || !canMatchAcrossProviders(b)) return 0;
+  // Hard vetoes — signals the weighted score cannot express on its own.
+  if ((a.duration.inSeconds - b.duration.inSeconds).abs() >
+      _nearDurationSeconds) {
+    return 0;
+  }
+  if (_trackNumbersConflict(a, b)) return 0;
+
+  final double title = _titleScore(a.title, b.title);
+  final double album = _containment(
+    _tokenize(foldText(a.albumName ?? '')),
+    _tokenize(foldText(b.albumName ?? '')),
+  );
+  final double artist = _containment(
+    _artistTokens(a.artistName),
+    _artistTokens(b.artistName),
+  );
+  return _wTitle * title + _wAlbum * album + _wArtist * artist;
+}
+
+/// Whether [a] and [b] are confidently the same song — [trackMatchScore] at or
+/// above [kTrackMatchScore]. The single predicate the unifier merges on.
+bool isLikelySameTrack(Track a, Track b) =>
+    trackMatchScore(a, b) >= kTrackMatchScore;
+
+// --- scoring helpers --------------------------------------------------------
+
+/// `1.0` when the feat-stripped, folded titles are token-identical; otherwise
+/// the Jaccard overlap of their token *sets*. Jaccard (not containment) is used
+/// for titles because extra title tokens usually signal a different *version*
+/// (`(Live)`, `(Radio Edit)`), which should cost score rather than be forgiven.
+double _titleScore(String a, String b) {
+  final List<String> ta = _coreTitleTokens(a);
+  final List<String> tb = _coreTitleTokens(b);
+  if (listEquals(ta, tb)) return 1.0;
+  return _jaccard(ta.toSet(), tb.toSet());
+}
+
+/// `feat.`/`ft.`/`featuring` qualifiers anywhere in the title, in `(parens)` or
+/// `[brackets]` or trailing bare — but stopping at an opening bracket so a
+/// following version marker (`(Live)`) is preserved.
+final RegExp _parenFeat =
+    RegExp(r'[\(\[][^\)\]]*\b(?:feat|ft|featuring)\b[^\)\]]*[\)\]]');
+final RegExp _trailingFeat = RegExp(r'\b(?:feat|ft|featuring)\b[^\(\[]*$');
+
+/// The folded title with featured-artist qualifiers removed, tokenized. So
+/// `CAREFUL`, `CAREFUL feat. Cordae`, and `Careful (feat. Cordae)` all reduce to
+/// `[careful]`, while `Hello (Live)` keeps `[hello, live]`.
+List<String> _coreTitleTokens(String title) {
+  String s = foldText(title);
+  s = s.replaceAll(_parenFeat, ' ');
+  s = s.replaceAll(_trailingFeat, ' ');
+  return _tokenize(s);
+}
+
+/// Connective words dropped from artist tokens so `NF feat. Cordae`, `NF, Cordae`
+/// and `Hall and Oates` / `Hall & Oates` normalize consistently. Deliberately
+/// small — ambiguous joiners (`x`, `vs`, `with`) are kept so they can still
+/// distinguish acts.
+const Set<String> _artistStopwords = <String>{'feat', 'ft', 'featuring', 'and'};
+
+/// Folded artist tokens with the connective stopwords removed, as a set. `NF` →
+/// `{nf}`; `NF, Cordae` → `{nf, cordae}`; `Hall & Oates` → `{hall, oates}`.
+Set<String> _artistTokens(String? artist) {
+  return <String>{
+    for (final String t in _tokenize(foldText(artist ?? '')))
+      if (!_artistStopwords.contains(t)) t,
+  };
+}
+
+/// Both tracks carry a track number and the numbers differ — a strong signal of
+/// two different tracks (e.g. on the same album), so a veto. A missing number on
+/// either side is not evidence and never vetoes.
+bool _trackNumbersConflict(Track a, Track b) {
+  final int? na = a.trackNumber;
+  final int? nb = b.trackNumber;
+  return na != null && nb != null && na != nb;
+}
+
+/// `|a ∩ b| / |a ∪ b|`, the symmetric overlap of two token sets, in `[0, 1]`.
+double _jaccard(Set<String> a, Set<String> b) {
+  if (a.isEmpty && b.isEmpty) return 1.0;
+  if (a.isEmpty || b.isEmpty) return 0.0;
+  final int intersection = a.where(b.contains).length;
+  final int union = a.length + b.length - intersection;
+  return union == 0 ? 0.0 : intersection / union;
+}
+
+/// `|a ∩ b| / |smaller|`, how fully the smaller token collection sits inside the
+/// larger, in `[0, 1]`. Lenient by design (a subset scores `1.0`) so an added
+/// `(Deluxe)` album word or a featured artist does not cost score; takes
+/// [Iterable]s so it works for both list- and set-shaped token collections.
+double _containment(Iterable<String> a, Iterable<String> b) {
+  final Set<String> sa = a.toSet();
+  final Set<String> sb = b.toSet();
+  if (sa.isEmpty || sb.isEmpty) return 0.0;
+  final int intersection = sa.where(sb.contains).length;
+  final int smaller = sa.length < sb.length ? sa.length : sb.length;
+  return smaller == 0 ? 0.0 : intersection / smaller;
+}
+
+/// Splits folded text into alphanumeric tokens, dropping all punctuation and
+/// whitespace. `"25 (deluxe)"` → `["25", "deluxe"]`.
+List<String> _tokenize(String folded) => folded
+    .split(RegExp(r'[^a-z0-9]+'))
+    .where((String t) => t.isNotEmpty)
+    .toList();

--- a/lib/core/catalog/track_unifier.dart
+++ b/lib/core/catalog/track_unifier.dart
@@ -7,52 +7,106 @@ import 'track_identity.dart';
 /// repository stores) into [LogicalTrack]s — one displayed item per song, with
 /// every provider copy retained as an ordered playback candidate.
 ///
-/// The rules are deliberately conservative (see [logicalMatchKey]):
+/// The rules are deliberately conservative (see [trackMatchScore]):
 ///
-///  * A track with too little metadata to match (`logicalMatchKey == null`) is
-///    always its own logical track. Untagged local files never merge.
-///  * Tracks merge only when they share a match key **and** come from two or
-///    more *distinct* providers. A group that is entirely one provider's rows is
-///    never merged — so a single-provider (or local-only) library is returned
+///  * A track with too little metadata to match (`canMatchAcrossProviders` is
+///    false) is always its own logical track. Untagged local files never merge.
+///  * Tracks merge only when they are a confident match ([isLikelySameTrack])
+///    **and** come from two or more *distinct* providers. Two rows from the same
+///    provider are never merged (a single source is assumed already
+///    de-duplicated), so a single-provider (or local-only) library is returned
 ///    one-logical-track-per-row, byte-for-byte as before. This is the safety
 ///    invariant that guarantees we never make an existing library worse.
 ///  * Within a merged group the candidates are ordered by [priority], so
 ///    [LogicalTrack.primary] is the active/default provider's copy when it has
 ///    one, and a deterministic fallback otherwise.
 ///
+/// ## How matching stays deterministic without an exact key
+///
+/// Scored matching is not a single equivalence key, so grouping is done in two
+/// order-independent steps:
+///
+///  1. **Block.** Eligible tracks are bucketed by [matchBlockKey] (folded
+///     primary-artist + first-title token), which co-locates plausible matches
+///     and keeps each bucket small.
+///  2. **Anchor-group within a block.** The block's tracks are sorted by a stable
+///     `(priority rank, id)` order, then each is attached to the first existing
+///     group whose *anchor* it confidently matches and whose provider it does not
+///     already duplicate — otherwise it starts a new group. Comparing against a
+///     single anchor (rather than chaining transitively) keeps grouping
+///     conservative and independent of the input order.
+///
 /// Output order follows the first appearance of each logical track in [tracks],
 /// so a caller that relied on the catalog's order (before re-sorting for the A–Z
 /// list, say) sees the same ordering it always did.
 List<LogicalTrack> unifyTracks(List<Track> tracks, SourcePriority priority) {
-  // First pass: bucket eligible tracks by match key, preserving encounter order.
-  final Map<String, List<Track>> byKey = <String, List<Track>>{};
+  // First pass: bucket eligible tracks by block key, then resolve each block
+  // into same-song groups. groupByTrackId maps a track id to the members of its
+  // group (a group of one for a track that matched nothing).
+  final Map<String, List<Track>> blocks = <String, List<Track>>{};
   for (final Track track in tracks) {
-    final String? key = logicalMatchKey(track);
+    final String? key = matchBlockKey(track);
     if (key == null) continue;
-    byKey.putIfAbsent(key, () => <Track>[]).add(track);
+    blocks.putIfAbsent(key, () => <Track>[]).add(track);
+  }
+  final Map<String, List<Track>> groupByTrackId = <String, List<Track>>{};
+  for (final List<Track> block in blocks.values) {
+    for (final List<Track> group in _groupBlock(block, priority)) {
+      for (final Track member in group) {
+        groupByTrackId[member.id] = group;
+      }
+    }
   }
 
-  // Second pass: emit logical tracks in first-appearance order. A key that spans
-  // two or more sources merges (once, at its first occurrence); everything else
-  // — ineligible tracks and single-source groups — stays one row per track.
-  final Set<String> emittedMergedKeys = <String>{};
+  // Second pass: emit logical tracks in first-appearance order. A group that
+  // spans two or more sources merges (once, at the first occurrence of any of
+  // its members); everything else — ineligible tracks and single-source groups —
+  // stays one row per track.
+  final Set<String> emittedAnchors = <String>{};
   final List<LogicalTrack> result = <LogicalTrack>[];
   for (final Track track in tracks) {
-    final String? key = logicalMatchKey(track);
-    if (key == null) {
+    final List<Track>? group = groupByTrackId[track.id];
+    if (group == null || _distinctSourceCount(group) < 2) {
       result.add(LogicalTrack.single(_candidate(track)));
       continue;
     }
-    final List<Track> members = byKey[key]!;
-    if (_distinctSourceCount(members) < 2) {
-      // Single-provider group: never merge — each row stands alone.
-      result.add(LogicalTrack.single(_candidate(track)));
-      continue;
-    }
-    if (!emittedMergedKeys.add(key)) continue; // already emitted at first sight
-    result.add(LogicalTrack(_orderedCandidates(members, priority)));
+    // group.first is the block's stable anchor, so it is a deterministic id for
+    // "have I already emitted this merged group?".
+    if (!emittedAnchors.add(group.first.id)) continue;
+    result.add(LogicalTrack(_orderedCandidates(group, priority)));
   }
   return result;
+}
+
+/// Resolves one block (tracks sharing a [matchBlockKey]) into same-song groups.
+///
+/// Tracks are visited in a stable `(priority rank, id)` order so the grouping is
+/// independent of the catalog's order. Each track joins the first existing group
+/// whose anchor it confidently matches and whose provider it does not already
+/// duplicate; otherwise it opens a new group. Refusing to join a provider already
+/// in the group preserves the invariant that a single provider's own rows are
+/// never merged together.
+List<List<Track>> _groupBlock(List<Track> block, SourcePriority priority) {
+  final List<Track> ordered = <Track>[...block]
+    ..sort(_byPriorityThenId(priority));
+  final List<List<Track>> groups = <List<Track>>[];
+  for (final Track track in ordered) {
+    final String sourceId = trackSourceId(track);
+    List<Track>? target;
+    for (final List<Track> group in groups) {
+      if (group.any((Track m) => trackSourceId(m) == sourceId)) continue;
+      if (isLikelySameTrack(group.first, track)) {
+        target = group;
+        break;
+      }
+    }
+    if (target != null) {
+      target.add(track);
+    } else {
+      groups.add(<Track>[track]);
+    }
+  }
+  return groups;
 }
 
 TrackSourceCandidate _candidate(Track track) =>
@@ -82,4 +136,17 @@ List<TrackSourceCandidate> _orderedCandidates(
     return a.track.id.compareTo(b.track.id);
   });
   return candidates;
+}
+
+/// A total comparator ordering tracks by source preference, then by id, so a
+/// block's anchor (its first element) is the most-preferred copy and the grouping
+/// never depends on the input order.
+int Function(Track, Track) _byPriorityThenId(SourcePriority priority) {
+  return (Track a, Track b) {
+    final int byRank = priority
+        .rankOf(trackSourceId(a))
+        .compareTo(priority.rankOf(trackSourceId(b)));
+    if (byRank != 0) return byRank;
+    return a.id.compareTo(b.id);
+  };
 }

--- a/lib/features/library/unified_library_providers.dart
+++ b/lib/features/library/unified_library_providers.dart
@@ -19,17 +19,20 @@ final libraryLogicalTracksProvider = Provider<List<LogicalTrack>>((ref) {
   return unifyTracks(tracks, priority);
 });
 
-/// The de-duplicated catalog the Library UI renders and plays: the preferred
-/// copy ([LogicalTrack.primaryTrack]) of each logical track, in catalog order.
+/// The de-duplicated catalog the Library UI renders and plays: the displayed
+/// copy ([LogicalTrack.displayTrack]) of each logical track, in catalog order.
 ///
 /// Tapping one of these plays the active/default provider's copy (or the best
-/// available fallback) because the primary *is* that copy. The Songs/Albums/
-/// Artists tabs, search, and the album/artist detail screens all read from here
-/// so none of them shows the same song twice.
+/// available fallback) because the display track keeps the primary's id and uri.
+/// It only differs from the raw primary by carrying the best available cover
+/// ([LogicalTrack.displayArtworkUri]), so de-duplication never drops album
+/// artwork that one of the merged copies still has. The Songs/Albums/Artists
+/// tabs, search, and the album/artist detail screens all read from here so none
+/// of them shows the same song twice — or loses its cover.
 final libraryUnifiedTracksProvider = Provider<List<Track>>((ref) {
   return <Track>[
     for (final LogicalTrack logical in ref.watch(libraryLogicalTracksProvider))
-      logical.primaryTrack,
+      logical.displayTrack,
   ];
 });
 

--- a/test/core/catalog/logical_track_test.dart
+++ b/test/core/catalog/logical_track_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/logical_track.dart';
+import 'package:linthra/core/models/track.dart';
+
+final Uri _jellyArt =
+    Uri.parse('https://music.example.com/Items/j/Images/Primary');
+final Uri _localArt = Uri.parse('file:///covers/local.jpg');
+
+TrackSourceCandidate _candidate(
+  String sourceId, {
+  required String id,
+  Uri? artwork,
+}) =>
+    TrackSourceCandidate(
+      track: Track(
+        id: id,
+        title: 'Hello',
+        uri: '$sourceId:$id',
+        artistName: 'Adele',
+        albumName: '25',
+        duration: const Duration(minutes: 3),
+        artworkUri: artwork,
+      ),
+      sourceId: sourceId,
+    );
+
+void main() {
+  group('LogicalTrack.displayArtworkUri — deterministic best-available cover',
+      () {
+    test('uses the preferred copy\'s own artwork when it has some', () {
+      final LogicalTrack row = LogicalTrack(<TrackSourceCandidate>[
+        _candidate('jellyfin', id: 'j', artwork: _jellyArt),
+        _candidate('subsonic', id: 's'),
+      ]);
+      expect(row.displayArtworkUri, _jellyArt);
+    });
+
+    test('falls back to a secondary copy when the preferred copy has none', () {
+      // The reported regression: Subsonic is preferred (its mapper stores no
+      // artwork), so before the fix the merged row showed a blank cover even
+      // though the Jellyfin copy has one.
+      final LogicalTrack row = LogicalTrack(<TrackSourceCandidate>[
+        _candidate('subsonic', id: 's'),
+        _candidate('jellyfin', id: 'j', artwork: _jellyArt),
+      ]);
+      expect(row.displayArtworkUri, _jellyArt);
+    });
+
+    test('the fallback is deterministic: first candidate (in order) with art',
+        () {
+      final LogicalTrack row = LogicalTrack(<TrackSourceCandidate>[
+        _candidate('subsonic', id: 's'),
+        _candidate('local', id: 'l', artwork: _localArt),
+        _candidate('jellyfin', id: 'j', artwork: _jellyArt),
+      ]);
+      // Local is ahead of Jellyfin in the candidate order, so its cover wins.
+      expect(row.displayArtworkUri, _localArt);
+    });
+
+    test('is null only when no candidate carries artwork', () {
+      final LogicalTrack row = LogicalTrack(<TrackSourceCandidate>[
+        _candidate('subsonic', id: 's'),
+        _candidate('jellyfin', id: 'j'),
+      ]);
+      expect(row.displayArtworkUri, isNull);
+    });
+  });
+
+  group('LogicalTrack.displayTrack — primary identity, best cover', () {
+    test('keeps the primary id and uri but fills in the fallback cover', () {
+      final LogicalTrack row = LogicalTrack(<TrackSourceCandidate>[
+        _candidate('subsonic', id: 's'),
+        _candidate('jellyfin', id: 'j', artwork: _jellyArt),
+      ]);
+      final Track display = row.displayTrack;
+      // Identity stays the preferred copy's, so playback/source/removal are
+      // unchanged...
+      expect(display.id, 's');
+      expect(display.uri, 'subsonic:s');
+      // ...only the artwork is filled from the fallback.
+      expect(display.artworkUri, _jellyArt);
+    });
+
+    test('returns the primary unchanged when its cover is already best', () {
+      final TrackSourceCandidate primary =
+          _candidate('jellyfin', id: 'j', artwork: _jellyArt);
+      final LogicalTrack row = LogicalTrack(<TrackSourceCandidate>[
+        primary,
+        _candidate('subsonic', id: 's'),
+      ]);
+      expect(identical(row.displayTrack, primary.track), isTrue);
+    });
+  });
+}

--- a/test/core/catalog/track_identity_test.dart
+++ b/test/core/catalog/track_identity_test.dart
@@ -9,6 +9,7 @@ Track _jelly(
   String? artist = 'Adele',
   String? album = '25',
   Duration duration = const Duration(minutes: 3),
+  int? trackNumber,
 }) =>
     Track(
       id: id,
@@ -17,6 +18,7 @@ Track _jelly(
       artistName: artist,
       albumName: album,
       duration: duration,
+      trackNumber: trackNumber,
     );
 
 /// A Subsonic/Navidrome-shaped track: opaque `subsonic:<id>` uri and full tags.
@@ -26,6 +28,7 @@ Track _sub(
   String? artist = 'Adele',
   String? album = '25',
   Duration duration = const Duration(minutes: 3),
+  int? trackNumber,
 }) =>
     Track(
       id: id,
@@ -34,6 +37,7 @@ Track _sub(
       artistName: artist,
       albumName: album,
       duration: duration,
+      trackNumber: trackNumber,
     );
 
 void main() {
@@ -54,96 +58,293 @@ void main() {
     });
   });
 
-  group('logicalMatchKey — the same song across providers', () {
-    test('Jellyfin and Subsonic copies of one song share a key', () {
-      final String? a = logicalMatchKey(_jelly('j', title: 'Hello'));
-      final String? b = logicalMatchKey(_sub('s', title: 'Hello'));
-      expect(a, isNotNull);
-      expect(a, b);
+  group('canMatchAcrossProviders / matchBlockKey — eligibility', () {
+    test('a fully tagged track is eligible', () {
+      expect(canMatchAcrossProviders(_jelly('j', title: 'Hello')), isTrue);
+      expect(matchBlockKey(_jelly('j', title: 'Hello')), isNotNull);
     });
 
-    test('case and accents fold, so they never split a match', () {
-      final String? a =
-          logicalMatchKey(_jelly('j', title: 'Café', artist: 'Beyoncé'));
-      final String? b =
-          logicalMatchKey(_sub('s', title: 'cafe', artist: 'beyonce'));
-      expect(a, isNotNull);
-      expect(a, b);
-    });
-
-    test('a 1-second rounding difference still matches', () {
-      final String? a = logicalMatchKey(
-        _jelly('j', title: 'Hello', duration: const Duration(seconds: 180)),
-      );
-      final String? b = logicalMatchKey(
-        _sub('s', title: 'Hello', duration: const Duration(seconds: 181)),
-      );
-      expect(a, b);
-    });
-  });
-
-  group('logicalMatchKey — staying conservative', () {
-    test('a different album is a different key', () {
+    test('the same song on two providers shares a block key', () {
       expect(
-        logicalMatchKey(_jelly('j', title: 'Hello', album: '25')),
-        isNot(logicalMatchKey(_sub('s', title: 'Hello', album: '21'))),
+        matchBlockKey(_jelly('j', title: 'Hello')),
+        matchBlockKey(_sub('s', title: 'Hello')),
       );
     });
 
-    test('a different artist is a different key', () {
+    test('a featured-artist title still blocks with the plain copy', () {
+      // The block key strips the feat. qualifier, so the two copies that the
+      // scorer must compare actually land in the same block.
       expect(
-        logicalMatchKey(_jelly('j', title: 'Hello', artist: 'Adele')),
-        isNot(logicalMatchKey(_sub('s', title: 'Hello', artist: 'Lionel'))),
+        matchBlockKey(_jelly('j', title: 'CAREFUL')),
+        matchBlockKey(_sub('s', title: 'CAREFUL feat. Cordae')),
       );
     });
 
-    test('a clearly different duration is a different key', () {
+    test('different songs by the same artist get different block keys', () {
       expect(
-        logicalMatchKey(
-          _jelly('j', title: 'Hello', duration: const Duration(minutes: 3)),
+        matchBlockKey(_jelly('j', title: 'Hello')),
+        isNot(matchBlockKey(_jelly('k', title: 'Skyfall'))),
+      );
+    });
+
+    test('no artist, no album, or a zero duration is ineligible', () {
+      expect(canMatchAcrossProviders(_jelly('j', title: 'X', artist: null)),
+          isFalse);
+      expect(canMatchAcrossProviders(_jelly('j', title: 'X', album: null)),
+          isFalse);
+      expect(
+        canMatchAcrossProviders(
+          _jelly('j', title: 'X', duration: Duration.zero),
         ),
-        isNot(
-          logicalMatchKey(
-            _sub('s', title: 'Hello', duration: const Duration(minutes: 5)),
-          ),
-        ),
-      );
-    });
-
-    test('a version qualifier in the title keeps a remix/live distinct', () {
-      expect(
-        logicalMatchKey(_jelly('j', title: 'Hello')),
-        isNot(logicalMatchKey(_sub('s', title: 'Hello (Live)'))),
-      );
-    });
-  });
-
-  group('logicalMatchKey — ineligible tracks never match', () {
-    test('no artist yields no key', () {
-      expect(
-          logicalMatchKey(_jelly('j', title: 'Hello', artist: null)), isNull);
-      expect(
-        canMatchAcrossProviders(_jelly('j', title: 'Hello', artist: null)),
         isFalse,
-      );
-    });
-
-    test('no album yields no key', () {
-      expect(logicalMatchKey(_jelly('j', title: 'Hello', album: null)), isNull);
-    });
-
-    test('an unknown (zero) duration yields no key', () {
-      expect(
-        logicalMatchKey(
-          _jelly('j', title: 'Hello', duration: Duration.zero),
-        ),
-        isNull,
       );
     });
 
     test('an untagged local file (title only) is never matchable', () {
       const Track local = Track(id: '/m/x.mp3', title: 'x', uri: '/m/x.mp3');
-      expect(logicalMatchKey(local), isNull);
+      expect(canMatchAcrossProviders(local), isFalse);
+      expect(matchBlockKey(local), isNull);
+    });
+  });
+
+  group('isLikelySameTrack — the same song across providers', () {
+    test('identical tags match', () {
+      expect(
+          isLikelySameTrack(
+              _jelly('j', title: 'Hello'), _sub('s', title: 'Hello')),
+          isTrue);
+    });
+
+    test('case and accents fold, so they never split a match', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Café', artist: 'Beyoncé'),
+          _sub('s', title: 'cafe', artist: 'beyonce'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a 1-second rounding difference still matches', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', duration: const Duration(seconds: 180)),
+          _sub('s', title: 'Hello', duration: const Duration(seconds: 181)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a rounding gap that straddled the old bucket edge now matches', () {
+      // 181s and 182s fell in different 2-second *buckets* before; as an
+      // absolute *difference* they are 1s apart and match.
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', duration: const Duration(seconds: 181)),
+          _sub('s', title: 'Hello', duration: const Duration(seconds: 182)),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('isLikelySameTrack — real Jellyfin/Navidrome metadata drift', () {
+    test('a featured artist in the title is ignored (CAREFUL feat. Cordae)',
+        () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'CAREFUL'),
+          _sub('s', title: 'CAREFUL feat. Cordae'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a parenthesised featured artist in the title is ignored', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'CAREFUL'),
+          _sub('s', title: 'CAREFUL (feat. Cordae)'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('an extra featured artist in the artist field is ignored (NF, Cordae)',
+        () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'CAREFUL', artist: 'NF'),
+          _sub('s', title: 'CAREFUL', artist: 'NF, Cordae'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('the full reported drift (title + artist) still matches', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'CAREFUL', artist: 'NF'),
+          _sub('s', title: 'CAREFUL feat. Cordae', artist: 'NF, Cordae'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('an album edition suffix is tolerated (25 vs 25 (Deluxe))', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', album: '25'),
+          _sub('s', title: 'Hello', album: '25 (Deluxe)'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a matching track number reinforces a match', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', trackNumber: 3),
+          _sub('s', title: 'Hello', trackNumber: 3),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('isLikelySameTrack — staying conservative', () {
+    test('a different album is not a match', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', album: '25'),
+          _sub('s', title: 'Hello', album: '21'),
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'two different songs that share a title + artist + duration but sit on '
+        'different albums are not merged', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Intro', album: 'Album A'),
+          _sub('s', title: 'Intro', album: 'Album B'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a different artist is not a match', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', artist: 'Adele'),
+          _sub('s', title: 'Hello', artist: 'Lionel'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a clearly different duration is vetoed', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', duration: const Duration(minutes: 3)),
+          _sub('s', title: 'Hello', duration: const Duration(minutes: 5)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a 3-second duration gap is vetoed', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', duration: const Duration(seconds: 180)),
+          _sub('s', title: 'Hello', duration: const Duration(seconds: 183)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a version qualifier keeps a remix/live distinct', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello'),
+          _sub('s', title: 'Hello (Live)'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('conflicting track numbers veto an otherwise-identical match', () {
+      // Same title/artist/album/duration but a different position on the album:
+      // a strong signal these are different songs, so never merge.
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', trackNumber: 3),
+          _sub('s', title: 'Hello', trackNumber: 4),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a missing track number on one side never vetoes', () {
+      expect(
+        isLikelySameTrack(
+          _jelly('j', title: 'Hello', trackNumber: 3),
+          _sub('s', title: 'Hello'),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('trackMatchScore — the score itself', () {
+    test('an exact match scores 1.0', () {
+      expect(
+        trackMatchScore(_jelly('j', title: 'Hello'), _sub('s', title: 'Hello')),
+        closeTo(1.0, 1e-9),
+      );
+    });
+
+    test('a duration veto scores exactly 0.0', () {
+      // A hard veto (here, durations too far apart) collapses the score to 0,
+      // regardless of how well the other fields agree.
+      expect(
+        trackMatchScore(
+          _jelly('j', title: 'Hello', duration: const Duration(minutes: 3)),
+          _sub('s', title: 'Hello', duration: const Duration(minutes: 5)),
+        ),
+        0.0,
+      );
+    });
+
+    test('a track-number conflict scores exactly 0.0', () {
+      expect(
+        trackMatchScore(
+          _jelly('j', title: 'Hello', trackNumber: 3),
+          _sub('s', title: 'Hello', trackNumber: 4),
+        ),
+        0.0,
+      );
+    });
+
+    test('a different artist scores low but is not a hard veto', () {
+      // Different artists share no tokens, so the artist signal is 0; the score
+      // stays well below the merge threshold without needing a veto.
+      final double score = trackMatchScore(
+        _jelly('j', title: 'Hello', artist: 'Adele'),
+        _sub('s', title: 'Hello', artist: 'Lionel'),
+      );
+      expect(score, lessThan(kTrackMatchScore));
+    });
+
+    test('a low-confidence pair scores below the merge threshold', () {
+      final double score = trackMatchScore(
+        _jelly('j', title: 'Intro', album: 'Album A'),
+        _sub('s', title: 'Intro', album: 'Album B'),
+      );
+      expect(score, lessThan(kTrackMatchScore));
+      expect(score, greaterThan(0.0));
     });
   });
 }

--- a/test/core/catalog/track_unifier_test.dart
+++ b/test/core/catalog/track_unifier_test.dart
@@ -178,6 +178,76 @@ void main() {
     });
   });
 
+  group('unifyTracks — tolerant of real Jellyfin/Navidrome metadata drift', () {
+    test('a featured artist tagged on only one provider still merges', () {
+      // Jellyfin: "CAREFUL" by "NF"; Navidrome: "CAREFUL feat. Cordae" by
+      // "NF, Cordae" — the same song, the exact key used to split them.
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('j', title: 'CAREFUL', artist: 'NF', album: 'The Search'),
+          _sub('s',
+              title: 'CAREFUL feat. Cordae',
+              artist: 'NF, Cordae',
+              album: 'The Search'),
+        ],
+        _subsonicPreferred,
+      );
+
+      expect(logical, hasLength(1));
+      expect(logical.single.allTrackIds, containsAll(<String>['j', 's']));
+    });
+
+    test('an album edition suffix does not split a match', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('j', title: 'Hello', album: '25'),
+          _sub('s', title: 'Hello', album: '25 (Deluxe)'),
+        ],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(1));
+      expect(logical.single.hasMultipleSources, isTrue);
+    });
+
+    test('a near-but-not-equal duration (1s) still merges', () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('j', title: 'Hello', duration: const Duration(seconds: 181)),
+          _sub('s', title: 'Hello', duration: const Duration(seconds: 182)),
+        ],
+        _subsonicPreferred,
+      );
+      expect(logical, hasLength(1));
+    });
+  });
+
+  group('unifyTracks — default-provider-first display & fallback', () {
+    test('a song on both providers shows and plays the default provider copy',
+        () {
+      final List<Track> tracks = <Track>[
+        _jelly('j', title: 'Hello'),
+        _sub('s', title: 'Hello'),
+      ];
+      // Jellyfin is the default/preferred provider here.
+      final LogicalTrack row = unifyTracks(tracks, _jellyfinPreferred).single;
+      expect(row.primary.sourceId, 'jellyfin');
+      expect(row.displayTrack.uri, 'jellyfin:j');
+      // The secondary copy is retained internally as a fallback candidate.
+      expect(row.sourceIds, <String>['jellyfin', 'subsonic']);
+    });
+
+    test('a secondary-only song is included and plays from the secondary', () {
+      // Jellyfin is default, but this song exists only on Navidrome.
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[_sub('s', title: 'Navi Only')],
+        _jellyfinPreferred,
+      );
+      expect(logical, hasLength(1));
+      expect(logical.single.primary.sourceId, 'subsonic');
+      expect(logical.single.displayTrack.uri, 'subsonic:s');
+    });
+  });
+
   group('unifyTracks — output ordering', () {
     test('a merged row appears at its first occurrence; order is preserved',
         () {

--- a/test/features/library/unified_library_providers_test.dart
+++ b/test/features/library/unified_library_providers_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
 import 'package:linthra/core/catalog/source_priority.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
@@ -11,13 +12,16 @@ import 'package:linthra/features/library/library_search.dart';
 import 'package:linthra/features/library/source_preference_controller.dart';
 import 'package:linthra/features/library/unified_library_providers.dart';
 
-Track _jelly(String id, {required String title, String album = '25'}) => Track(
+Track _jelly(String id,
+        {required String title, String album = '25', Uri? artwork}) =>
+    Track(
       id: id,
       title: title,
       uri: 'jellyfin:$id',
       artistName: 'Adele',
       albumName: album,
       duration: const Duration(minutes: 3),
+      artworkUri: artwork,
     );
 
 Track _sub(String id, {required String title, String album = '25'}) => Track(
@@ -28,6 +32,9 @@ Track _sub(String id, {required String title, String album = '25'}) => Track(
       albumName: album,
       duration: const Duration(minutes: 3),
     );
+
+final Uri _jellyArt =
+    Uri.parse('https://music.example.com/Items/j/Images/Primary');
 
 /// Pins the source preference for a deterministic test, bypassing the async
 /// load from the store.
@@ -111,6 +118,40 @@ void main() {
         'hello',
       );
       expect(results, hasLength(1));
+    });
+  });
+
+  group('libraryUnifiedTracksProvider — artwork is not regressed', () {
+    test('a Subsonic-preferred row keeps the Jellyfin copy\'s cover', () async {
+      // Subsonic is active/preferred, but Subsonic tracks carry no artwork. The
+      // merged row must still show the Jellyfin copy's cover instead of going
+      // blank — the reported "covers disappeared after unification" bug.
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello', artwork: _jellyArt)],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final List<Track> songs = container.read(libraryUnifiedTracksProvider);
+      expect(songs, hasLength(1));
+      // Plays from the preferred (Subsonic) copy...
+      expect(songs.single.uri, 'subsonic:s');
+      // ...but displays the Jellyfin cover.
+      expect(songs.single.artworkUri, _jellyArt);
+    });
+
+    test('albums derived from the unified catalog keep their cover', () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello', artwork: _jellyArt)],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final List<Album> albums = groupAlbums(
+        container.read(libraryUnifiedTracksProvider),
+      );
+      expect(albums, hasLength(1));
+      expect(albums.single.artworkUri, _jellyArt);
     });
   });
 


### PR DESCRIPTION
Follow-up fix for the provider-aware unified library (#149) after real-device testing.

Scope guardrails honored: **no release, no version bump, no tag, no fdroiddata changes.** No DB schema change and no migration — every per-provider row is still stored untouched.

## Report (requested before implementing)

**1. Why artwork was missing.** The displayed row is the default/preferred provider's copy (`LogicalTrack.primaryTrack`). But the Subsonic/Navidrome mapper deliberately stores **no** `artworkUri` (a cover URL would embed the credential — `subsonic_track_mapper.dart`), and untagged local files have none either. So when the preferred provider is Subsonic (e.g. most-recently signed in) and a song also exists on Jellyfin, unifying showed the *Subsonic* copy and its blank cover — dropping the Jellyfin cover the song actually had. Album/artist tiles inherit it because they group over the same primaries (`library_grouping.dart`).

**2. Where the primary/display candidate is chosen.** `unifyTracks` orders each merged group's candidates by `SourcePriority` (`_orderedCandidates`); `candidates.first` = `primary`. `libraryUnifiedTracksProvider` projects each `LogicalTrack` to one display `Track`, which the Songs/Albums/Artists tabs, search, detail screens, and tap-to-play all read.

**3. Why matching failed on real Jellyfin/Navidrome.** The old key was an *exact* folded `title|artist|album` + 2-second duration **bucket**. The two servers rarely tag a song identically, so it split on: featured-artist drift (`CAREFUL` vs `CAREFUL feat. Cordae`; artist `NF` vs `NF, Cordae`), album editions (`25` vs `25 (Deluxe)`), and even a 1-second rounding gap that straddled a bucket edge (181s in bucket 90, 182s in bucket 91).

**4. Safest minimal fix.** (a) Add a deterministic best-available-artwork fallback on the display track — id/uri unchanged, so playback/source-label/removal are untouched. (b) Replace the brittle exact key with a conservative **score + hard vetoes**, keeping every "don't over-merge" guarantee. (c) Lock default-provider-first behavior and the source indicator with tests (no code change needed — they already follow from the model).

## Changes

**Artwork (`logical_track.dart`, `unified_library_providers.dart`)**
- `displayArtworkUri`: first candidate, in preference order, that has artwork — prefers the displayed provider, deterministic, `null` only if no copy has any.
- `displayTrack`: the preferred copy with that cover filled in; same `id`/`uri`.
- Provider now emits `displayTrack`, so songs, albums, artists, search, detail, and the now-playing queue all keep covers.

**Matching (`track_identity.dart`, `track_unifier.dart`)**
- Block by a coarse key, then `trackMatchScore(a,b)` ∈ [0,1]: title token overlap (1.0 when feat-stripped titles match), album & artist *containment* (so feat./edition suffixes are tolerated, `NF` ⊆ `NF, Cordae`). Merge only at ≥ `kTrackMatchScore` (0.9).
- Hard vetoes → 0.0: duration > 2s apart (absolute difference, no bucket edge), or conflicting track numbers.
- Deterministic anchor grouping within each block (sorted by `(priority rank, id)`), independent of catalog order.
- Conservative guarantees preserved: untagged tracks never match; a single provider's own rows never merge; `(Live)`/`(Remix)` and same-title-different-album stay separate.

**Default-provider-first & source indicator** — unchanged by design, now covered by tests: default copy displayed/played, secondaries only fill missing songs, all rows retained internally (nothing deleted), and "Playing from Jellyfin/Navidrome/Local files/Cache" reflects the resolved copy with safe names only (no URL/IP/path/user/token).

## Tests & checks
- New `logical_track_test.dart` (artwork fallback); `track_identity_test.dart` rewritten for the scorer; `track_unifier` + unified-library provider tests extended for drift tolerance, default-first display/fallback, and album-cover retention.
- `dart format --set-exit-if-changed .` → clean · `flutter analyze` → no issues · `flutter test` → 1360 passing.

https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL)_