### PR TITLE
feat(library): explicit default playback source setting

### DIFF
--- a/lib/core/repositories/default_provider_store.dart
+++ b/lib/core/repositories/default_provider_store.dart
@@ -1,0 +1,17 @@
+/// Persists the user's *explicit* default playback provider — the source they
+/// chose to prefer when the same song exists on more than one provider.
+///
+/// The stored value is a single non-secret source id (`jellyfin`, `subsonic`,
+/// or `local`), or `null` for **Automatic** — no explicit choice, so the
+/// library keeps its most-recently-signed-in behaviour. It carries no
+/// credential, URL, or library content, so a lightweight key/value store is the
+/// right weight — the same reasoning [PreferredSourceStore] follows.
+abstract interface class DefaultProviderStore {
+  /// The persisted explicit default source id, or `null` when the user has not
+  /// chosen one (Automatic).
+  Future<String?> read();
+
+  /// Persists [sourceId] (a source id), or clears the choice (Automatic) when
+  /// `null`.
+  Future<void> write(String? sourceId);
+}

--- a/lib/data/repositories/default_provider_store_provider.dart
+++ b/lib/data/repositories/default_provider_store_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/default_provider_store.dart';
+import 'in_memory_default_provider_store.dart';
+import 'shared_preferences_default_provider_store.dart';
+
+/// The single [DefaultProviderStore] the app reads/writes the explicit default
+/// provider through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesDefaultProviderStoreOverride] so the choice persists across
+/// restarts.
+final defaultProviderStoreProvider = Provider<DefaultProviderStore>((ref) {
+  return InMemoryDefaultProviderStore();
+});
+
+/// Production binding: persists the explicit default provider via
+/// `shared_preferences`. Applied in `main`.
+final sharedPreferencesDefaultProviderStoreOverride =
+    defaultProviderStoreProvider.overrideWithValue(
+  const SharedPreferencesDefaultProviderStore(),
+);

--- a/lib/data/repositories/in_memory_default_provider_store.dart
+++ b/lib/data/repositories/in_memory_default_provider_store.dart
@@ -1,0 +1,17 @@
+import '../../core/repositories/default_provider_store.dart';
+
+/// An in-memory [DefaultProviderStore] for development and tests. Nothing is
+/// persisted; the choice lives only for the lifetime of the instance.
+class InMemoryDefaultProviderStore implements DefaultProviderStore {
+  InMemoryDefaultProviderStore([this._sourceId]);
+
+  String? _sourceId;
+
+  @override
+  Future<String?> read() async => _sourceId;
+
+  @override
+  Future<void> write(String? sourceId) async {
+    _sourceId = sourceId;
+  }
+}

--- a/lib/data/repositories/shared_preferences_default_provider_store.dart
+++ b/lib/data/repositories/shared_preferences_default_provider_store.dart
@@ -1,0 +1,33 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/default_provider_store.dart';
+
+/// A [DefaultProviderStore] backed by `shared_preferences`.
+///
+/// The explicit default is a single non-secret source id, so one string under
+/// one key is plenty — no token, URL, or library content is ever written here.
+/// An absent (or empty) value reads as **Automatic** (`null`) rather than
+/// throwing, so a storage hiccup can never break library loading or playback.
+class SharedPreferencesDefaultProviderStore implements DefaultProviderStore {
+  const SharedPreferencesDefaultProviderStore();
+
+  static const String _key = 'default_provider_source_id_v1';
+
+  @override
+  Future<String?> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? value = prefs.getString(_key);
+    if (value == null || value.isEmpty) return null;
+    return value;
+  }
+
+  @override
+  Future<void> write(String? sourceId) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (sourceId == null || sourceId.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+    await prefs.setString(_key, sourceId);
+  }
+}

--- a/lib/features/library/source_preference_controller.dart
+++ b/lib/features/library/source_preference_controller.dart
@@ -1,46 +1,175 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/catalog/source_priority.dart';
+import '../../data/repositories/default_provider_store_provider.dart';
 import '../../data/repositories/preferred_source_store_provider.dart';
 
-/// Holds the user's preferred provider order as a [SourcePriority] and lets a
-/// successful server sign-in promote that server to the front.
+/// Holds the user's *explicit* default playback provider, or `null` for
+/// **Automatic** (no explicit choice).
 ///
-/// "Active/default first": the server the user most recently signed into becomes
-/// the preferred copy when the same song exists on more than one provider. The
-/// order is loaded from the [PreferredSourceStore] at startup and persisted on
-/// every change, so the choice survives a restart. Until the async load lands
-/// the controller serves an empty preference (the deterministic
-/// [SourcePriority.fallback] default), which only affects *which* duplicate is
-/// preferred — never whether a row is de-duplicated — so a brief default is
-/// harmless.
-class SourcePreferenceController extends Notifier<SourcePriority> {
+/// This is the single setting the user toggles on the Settings screen. When set
+/// to a source id (`jellyfin`, `subsonic`, `local`) the
+/// [SourcePreferenceController] pins that provider to the front of the playback
+/// preference; when `null` the library keeps its automatic, most-recently-
+/// signed-in behaviour. The choice is loaded from the [DefaultProviderStore] at
+/// startup and persisted on every change, so it survives a restart. Until the
+/// async load lands the controller serves `null` (Automatic), which only affects
+/// *which* duplicate is preferred — never whether a row is de-duplicated — so a
+/// brief default is harmless.
+class DefaultProviderController extends Notifier<String?> {
+  bool _loadStarted = false;
+
   @override
-  SourcePriority build() {
-    _load();
-    return SourcePriority.fallback;
+  String? build() {
+    if (!_loadStarted) {
+      _loadStarted = true;
+      _load();
+    }
+    return null;
   }
 
   Future<void> _load() async {
     try {
-      final List<String> order =
-          await ref.read(preferredSourceStoreProvider).read();
-      if (order.isNotEmpty) {
-        state = SourcePriority(order);
-      }
+      final String? stored =
+          await ref.read(defaultProviderStoreProvider).read();
+      if (stored != null && stored.isNotEmpty) state = stored;
     } catch (_) {
-      // A storage hiccup must never break library loading; keep the default.
+      // A storage hiccup must never break library loading; keep Automatic.
     }
   }
 
-  /// Promotes [sourceId] to the front of the preference (the user is actively
-  /// using it) and persists the new order. A no-op for an already-front source.
-  Future<void> markPreferred(String sourceId) async {
-    final SourcePriority next = state.promote(sourceId);
+  /// Sets the explicit default provider to [sourceId], or clears it (`null`,
+  /// Automatic), and persists the choice. A no-op when nothing changes.
+  Future<void> setDefaultProvider(String? sourceId) async {
+    final String? next =
+        (sourceId != null && sourceId.isEmpty) ? null : sourceId;
     if (next == state) return;
     state = next;
     try {
-      await ref.read(preferredSourceStoreProvider).write(next.preferredOrder);
+      await ref.read(defaultProviderStoreProvider).write(next);
+    } catch (_) {
+      // Best-effort persistence: the in-memory choice still applies this session.
+    }
+  }
+}
+
+/// The user's explicit default provider (a source id), or `null` for Automatic.
+/// The settings UI reads and writes this; [SourcePreferenceController] watches it
+/// to fold the choice into the effective playback preference.
+final defaultProviderControllerProvider =
+    NotifierProvider<DefaultProviderController, String?>(
+  DefaultProviderController.new,
+);
+
+/// Resolves the effective [SourcePriority] the library unifies with, by layering
+/// the user's explicit default provider over the automatic, most-recently-
+/// signed-in order.
+///
+/// Two inputs feed the result:
+///
+///  * **Automatic order** — the server the user most recently signed into is
+///    promoted to the front ([markPreferred], called on a successful Jellyfin /
+///    Subsonic sign-in) and persisted across restarts ([PreferredSourceStore]).
+///    This is the behaviour Linthra has always had.
+///  * **Explicit default** — when the user picks a default provider in Settings
+///    ([DefaultProviderController]), that source is *pinned to the head* of the
+///    preference. A later sign-in still updates the automatic order underneath
+///    (so switching back to Automatic restores it), but it never displaces an
+///    explicit pin.
+///
+/// Either way the result is a *total*, deterministic order, so the same catalog
+/// always resolves to the same preferred source — and when the preferred source
+/// does not have a given song, [unifyTracks] simply orders that song's real
+/// candidates by the rest of the preference, falling back to the next available
+/// copy.
+class SourcePreferenceController extends Notifier<SourcePriority> {
+  /// The automatic, most-recently-signed-in order. Maintained even while an
+  /// explicit default is pinned, so switching back to Automatic restores it.
+  List<String> _automaticOrder = const <String>[];
+
+  /// The latest explicit default, cached from [build] so async callbacks
+  /// (`_loadAutomaticOrder`, `markPreferred`) can fold it in without re-reading
+  /// the watched provider — illegal while a dependency change is pending a
+  /// rebuild. [build] re-runs (and refreshes this) whenever the choice changes.
+  String? _explicit;
+
+  /// Whether the one-shot load of [_automaticOrder] has been kicked off, so a
+  /// rebuild (e.g. when the explicit default changes) doesn't re-read it.
+  bool _loadStarted = false;
+
+  /// Whether a sign-in has updated [_automaticOrder] in this session, so a
+  /// late-arriving initial load can't clobber the fresher in-memory order.
+  bool _automaticDirty = false;
+
+  @override
+  SourcePriority build() {
+    _explicit = ref.watch(defaultProviderControllerProvider);
+    if (!_loadStarted) {
+      _loadStarted = true;
+      _loadAutomaticOrder();
+    }
+    return _effectivePriority(_automaticOrder, _explicit);
+  }
+
+  Future<void> _loadAutomaticOrder() async {
+    List<String> order;
+    try {
+      order = await ref.read(preferredSourceStoreProvider).read();
+    } catch (_) {
+      // A storage hiccup must never break library loading; keep the default.
+      return;
+    }
+    // A sign-in may have updated the order while the read was in flight; the
+    // fresher in-memory value wins.
+    if (_automaticDirty) return;
+    _automaticOrder = order;
+    _recompute();
+  }
+
+  /// Recomputes the effective priority from the current automatic order and the
+  /// last-known explicit default. Called when the automatic order changes; an
+  /// explicit change rebuilds [build] on its own via the watched provider.
+  void _recompute() {
+    state = _effectivePriority(_automaticOrder, _explicit);
+  }
+
+  /// The effective preference: an [explicit] default pinned to the head followed
+  /// by the [automatic] order (with the pin de-duplicated out of the tail); or
+  /// just the [automatic] order when Automatic (`null`).
+  static SourcePriority _effectivePriority(
+    List<String> automatic,
+    String? explicit,
+  ) {
+    if (explicit == null || explicit.isEmpty) {
+      return automatic.isEmpty
+          ? SourcePriority.fallback
+          : SourcePriority(automatic);
+    }
+    return SourcePriority(<String>[
+      explicit,
+      for (final String id in automatic)
+        if (id != explicit) id,
+    ]);
+  }
+
+  /// Promotes [sourceId] to the front of the *automatic* order (the user just
+  /// signed into it) and persists it. The effective priority still pins an
+  /// explicit default ahead of it, so a sign-in never overrides the user's
+  /// chosen default. A no-op for an already-front source.
+  Future<void> markPreferred(String sourceId) async {
+    final List<String> next = <String>[
+      sourceId,
+      for (final String id in _automaticOrder)
+        if (id != sourceId) id,
+    ];
+    // Mark dirty even on a no-op so a late initial load can't clobber the order.
+    _automaticDirty = true;
+    if (listEquals(next, _automaticOrder)) return;
+    _automaticOrder = next;
+    _recompute();
+    try {
+      await ref.read(preferredSourceStoreProvider).write(_automaticOrder);
     } catch (_) {
       // Best-effort persistence: the in-memory order still applies this session.
     }
@@ -48,7 +177,8 @@ class SourcePreferenceController extends Notifier<SourcePriority> {
 }
 
 /// The user's live source preference. The unified-library providers watch this
-/// so a freshly-preferred server is reflected without a manual refresh.
+/// so a freshly-preferred server — or a freshly-chosen default — is reflected
+/// without a manual refresh.
 final librarySourcePriorityProvider =
     NotifierProvider<SourcePreferenceController, SourcePriority>(
   SourcePreferenceController.new,

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -10,6 +10,7 @@ import 'jellyfin/jellyfin_settings_section.dart';
 import 'network/network_settings_section.dart';
 import 'playback/playback_settings_section.dart';
 import 'precache/precache_settings_section.dart';
+import 'source/default_provider_section.dart';
 import 'subsonic/subsonic_settings_section.dart';
 
 /// Settings. Hosts the connection/source and offline-storage options, plus a
@@ -27,6 +28,8 @@ class SettingsScreen extends StatelessWidget {
           JellyfinSettingsSection(),
           SizedBox(height: AppSpacing.md),
           SubsonicSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          DefaultProviderSettingsSection(),
           SizedBox(height: AppSpacing.md),
           CacheSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/lib/features/settings/source/default_provider_section.dart
+++ b/lib/features/settings/source/default_provider_section.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/sources/music_provider.dart';
+import '../../library/source_preference_controller.dart';
+
+/// One choice in the "Default source" card.
+typedef _SourceOption = ({String? id, String title, String? subtitle});
+
+/// The "Default source" card on the Settings screen.
+///
+/// Lets the user choose which provider to prefer when the same song is available
+/// from more than one place (a common self-hosting setup where Jellyfin and
+/// Navidrome expose the same library). The choice only changes *which* copy of a
+/// duplicated song plays — never whether a song is de-duplicated, and never the
+/// audio engine. When the chosen source doesn't have a given song, Linthra falls
+/// back to the next available copy.
+///
+/// "Automatic" (the default) keeps Linthra's behaviour of preferring the server
+/// the user most recently signed into.
+class DefaultProviderSettingsSection extends ConsumerWidget {
+  const DefaultProviderSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final String? selected = ref.watch(defaultProviderControllerProvider);
+
+    final List<_SourceOption> options = <_SourceOption>[
+      (
+        id: null,
+        title: 'Automatic',
+        subtitle: 'Use the server you most recently signed into.',
+      ),
+      (
+        id: MusicProviders.jellyfin.sourceId,
+        title: MusicProviders.jellyfin.displayName,
+        subtitle: null,
+      ),
+      (
+        id: MusicProviders.subsonic.sourceId,
+        title: MusicProviders.subsonic.displayName,
+        subtitle: null,
+      ),
+      (
+        id: MusicProviders.local.sourceId,
+        title: 'Local files',
+        subtitle: 'Prefer a copy on this device when one exists.',
+      ),
+    ];
+
+    void choose(String? sourceId) {
+      ref
+          .read(defaultProviderControllerProvider.notifier)
+          .setDefaultProvider(sourceId);
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.library_music_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Default source', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'When the same song is available from more than one place, play it '
+              'from this source. If that source does not have the song, Linthra '
+              'uses another available copy.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            for (final _SourceOption option in options)
+              RadioListTile<String?>(
+                contentPadding: EdgeInsets.zero,
+                value: option.id,
+                groupValue: selected,
+                onChanged: (value) => choose(value),
+                title: Text(option.title),
+                subtitle:
+                    option.subtitle == null ? null : Text(option.subtitle!),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/linthra_app.dart';
 import 'core/services/linthra_audio_handler.dart';
+import 'data/repositories/default_provider_store_provider.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/favorites_repository_provider.dart';
 import 'data/repositories/jellyfin_auto_sync_store_provider.dart';
@@ -50,6 +51,9 @@ Future<void> main() async {
       // Persist which server the user most recently signed into, so the
       // active/default provider for de-duplicated songs survives a restart.
       sharedPreferencesPreferredSourceStoreOverride,
+      // Persist the user's explicit default-source choice (Settings), which
+      // pins a provider ahead of the most-recently-signed-in order.
+      sharedPreferencesDefaultProviderStoreOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
       sharedPreferencesPlaybackPreferencesOverride,

--- a/test/data/repositories/default_provider_store_test.dart
+++ b/test/data/repositories/default_provider_store_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_default_provider_store.dart';
+import 'package:linthra/data/repositories/shared_preferences_default_provider_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('InMemoryDefaultProviderStore', () {
+    test('defaults to Automatic (null) and round-trips', () async {
+      final store = InMemoryDefaultProviderStore();
+      expect(await store.read(), isNull);
+
+      await store.write('jellyfin');
+      expect(await store.read(), 'jellyfin');
+
+      await store.write(null);
+      expect(await store.read(), isNull);
+    });
+
+    test('honours an initial value', () async {
+      final store = InMemoryDefaultProviderStore('subsonic');
+      expect(await store.read(), 'subsonic');
+    });
+  });
+
+  group('SharedPreferencesDefaultProviderStore', () {
+    setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+    test('reads Automatic (null) when nothing is stored', () async {
+      expect(
+        await const SharedPreferencesDefaultProviderStore().read(),
+        isNull,
+      );
+    });
+
+    test('round-trips the choice across separate instances', () async {
+      await const SharedPreferencesDefaultProviderStore().write('subsonic');
+
+      expect(
+        await const SharedPreferencesDefaultProviderStore().read(),
+        'subsonic',
+      );
+    });
+
+    test('writing null clears a stored choice', () async {
+      await const SharedPreferencesDefaultProviderStore().write('jellyfin');
+      await const SharedPreferencesDefaultProviderStore().write(null);
+
+      expect(
+        await const SharedPreferencesDefaultProviderStore().read(),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/library/source_preference_controller_test.dart
+++ b/test/features/library/source_preference_controller_test.dart
@@ -1,14 +1,22 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/data/repositories/default_provider_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_default_provider_store.dart';
 import 'package:linthra/data/repositories/in_memory_preferred_source_store.dart';
 import 'package:linthra/data/repositories/preferred_source_store_provider.dart';
 import 'package:linthra/features/library/source_preference_controller.dart';
 
-ProviderContainer _container(InMemoryPreferredSourceStore store) {
+ProviderContainer _container({
+  InMemoryPreferredSourceStore? preferred,
+  InMemoryDefaultProviderStore? defaultProvider,
+}) {
   final container = ProviderContainer(
     overrides: <Override>[
-      preferredSourceStoreProvider.overrideWithValue(store),
+      preferredSourceStoreProvider
+          .overrideWithValue(preferred ?? InMemoryPreferredSourceStore()),
+      defaultProviderStoreProvider
+          .overrideWithValue(defaultProvider ?? InMemoryDefaultProviderStore()),
     ],
   );
   addTearDown(container.dispose);
@@ -16,16 +24,17 @@ ProviderContainer _container(InMemoryPreferredSourceStore store) {
 }
 
 void main() {
-  group('SourcePreferenceController', () {
+  group('SourcePreferenceController (automatic order)', () {
     test('starts at the deterministic fallback default', () {
-      final container = _container(InMemoryPreferredSourceStore());
+      final container = _container();
       expect(container.read(librarySourcePriorityProvider),
           SourcePriority.fallback);
     });
 
     test('loads a persisted order at startup', () async {
       final container = _container(
-        InMemoryPreferredSourceStore(<String>['subsonic', 'jellyfin']),
+        preferred:
+            InMemoryPreferredSourceStore(<String>['subsonic', 'jellyfin']),
       );
       // Build the controller, then let its fire-and-forget load settle.
       container.read(librarySourcePriorityProvider);
@@ -39,7 +48,7 @@ void main() {
 
     test('markPreferred promotes the server and persists it', () async {
       final store = InMemoryPreferredSourceStore();
-      final container = _container(store);
+      final container = _container(preferred: store);
 
       await container
           .read(librarySourcePriorityProvider.notifier)
@@ -53,12 +62,98 @@ void main() {
     });
 
     test('the most recent sign-in wins', () async {
-      final container = _container(InMemoryPreferredSourceStore());
+      final container = _container();
       final controller = container.read(librarySourcePriorityProvider.notifier);
 
       await controller.markPreferred('jellyfin');
       await controller.markPreferred('subsonic');
 
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder,
+        <String>['subsonic', 'jellyfin'],
+      );
+    });
+  });
+
+  group('SourcePreferenceController (explicit default)', () {
+    test('an explicit default pins it to the head over the automatic order',
+        () async {
+      final container = _container(
+        preferred: InMemoryPreferredSourceStore(<String>['jellyfin']),
+      );
+      // Establish the watch and let the automatic order load.
+      container.read(librarySourcePriorityProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      await container
+          .read(defaultProviderControllerProvider.notifier)
+          .setDefaultProvider('subsonic');
+
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder,
+        <String>['subsonic', 'jellyfin'],
+      );
+    });
+
+    test('a sign-in does not override an explicit pin', () async {
+      final container = _container();
+      container.read(librarySourcePriorityProvider);
+
+      await container
+          .read(defaultProviderControllerProvider.notifier)
+          .setDefaultProvider('jellyfin');
+      await container
+          .read(librarySourcePriorityProvider.notifier)
+          .markPreferred('subsonic');
+
+      final SourcePriority priority =
+          container.read(librarySourcePriorityProvider);
+      expect(priority.preferredOrder.first, 'jellyfin');
+      expect(priority.preferredOrder, <String>['jellyfin', 'subsonic']);
+    });
+
+    test('switching back to Automatic restores the most-recent-sign-in order',
+        () async {
+      final container = _container();
+      container.read(librarySourcePriorityProvider);
+      final defaults =
+          container.read(defaultProviderControllerProvider.notifier);
+
+      await defaults.setDefaultProvider('jellyfin');
+      await container
+          .read(librarySourcePriorityProvider.notifier)
+          .markPreferred('subsonic');
+      await defaults.setDefaultProvider(null);
+
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder,
+        <String>['subsonic'],
+      );
+    });
+
+    test('an explicit default with no automatic order still pins it', () async {
+      final container = _container();
+
+      await container
+          .read(defaultProviderControllerProvider.notifier)
+          .setDefaultProvider('local');
+
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder,
+        <String>['local'],
+      );
+    });
+
+    test('a persisted explicit default is loaded and pinned at startup',
+        () async {
+      final container = _container(
+        preferred: InMemoryPreferredSourceStore(<String>['jellyfin']),
+        defaultProvider: InMemoryDefaultProviderStore('subsonic'),
+      );
+      container.read(librarySourcePriorityProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(defaultProviderControllerProvider), 'subsonic');
       expect(
         container.read(librarySourcePriorityProvider).preferredOrder,
         <String>['subsonic', 'jellyfin'],

--- a/test/features/settings/source/default_provider_section_test.dart
+++ b/test/features/settings/source/default_provider_section_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/default_provider_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_default_provider_store.dart';
+import 'package:linthra/features/library/source_preference_controller.dart';
+import 'package:linthra/features/settings/source/default_provider_section.dart';
+
+void main() {
+  group('DefaultProviderSettingsSection', () {
+    late InMemoryDefaultProviderStore store;
+
+    Future<ProviderContainer> pump(
+      WidgetTester tester, {
+      String? initial,
+    }) async {
+      store = InMemoryDefaultProviderStore(initial);
+      final container = ProviderContainer(
+        overrides: <Override>[
+          defaultProviderStoreProvider.overrideWithValue(store),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(body: DefaultProviderSettingsSection()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets('shows the default-source options', (tester) async {
+      await pump(tester);
+
+      expect(find.text('Default source'), findsOneWidget);
+      expect(find.text('Automatic'), findsOneWidget);
+      expect(find.text('Jellyfin'), findsOneWidget);
+      expect(find.text('Navidrome / Subsonic'), findsOneWidget);
+      expect(find.text('Local files'), findsOneWidget);
+    });
+
+    testWidgets('defaults to Automatic', (tester) async {
+      final container = await pump(tester);
+      expect(container.read(defaultProviderControllerProvider), isNull);
+    });
+
+    testWidgets('choosing a provider persists it and pins it to the head',
+        (tester) async {
+      final container = await pump(tester);
+
+      await tester.tap(find.text('Jellyfin'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(defaultProviderControllerProvider), 'jellyfin');
+      expect(await store.read(), 'jellyfin');
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder.first,
+        'jellyfin',
+      );
+    });
+
+    testWidgets('reflects a persisted choice', (tester) async {
+      final container = await pump(tester, initial: 'subsonic');
+
+      expect(container.read(defaultProviderControllerProvider), 'subsonic');
+      final RadioListTile<String?> tile = tester.widget(
+        find.byWidgetPredicate(
+          (Widget w) => w is RadioListTile<String?> && w.value == 'subsonic',
+        ),
+      );
+      expect(tile.groupValue, 'subsonic');
+    });
+  });
+}


### PR DESCRIPTION
## What

PR 1 of the playback-source-selection plan: an explicit **Default source** setting. The unified library (#149/#150) already prefers a provider for songs that exist on more than one source, but only *implicitly* (the most-recently-signed-in server). This makes that choice explicit and user-controlled.

## Behaviour

- **Automatic** (default) keeps today's behaviour exactly: prefer the server you most recently signed into.
- Choosing **Jellyfin**, **Navidrome / Subsonic**, or **Local files** pins that provider to the head of the source preference.
- A later sign-in still updates the automatic order underneath (so switching back to Automatic restores it), but **never displaces an explicit pin**.
- When the pinned source doesn't have a given song, `unifyTracks` orders that song's real candidates by the rest of the preference — so playback **falls back to the next available copy**.
- The "Playing from …" indicator is unchanged and still reflects the copy actually played.

## Implementation (selection layer only)

- `DefaultProviderStore` (interface + in-memory + `shared_preferences`) persists a single non-secret source id, or `null` for Automatic. **No credentials, URLs, paths, or library content are stored.**
- `DefaultProviderController` owns the choice; `SourcePreferenceController` watches it and folds the explicit pin over the automatic order into the effective `SourcePriority` the unifier already consumes.
- A "Default source" card on the Settings screen, under the connection sections.

## Out of scope (by design)

- ❌ No playback-engine change
- ❌ No de-duplication / matching change
- ❌ No runtime fail-over when a source fails mid-playback (**PR2**)
- ❌ No smart cache/data/battery/quality strategy (**PR3**)
- ❌ No release bump, tag, or fdroiddata change

## Tests

- Store: default Automatic, round-trip, clear-to-null.
- Controller: explicit pins to head; sign-in never overrides an explicit pin; Automatic restores the most-recent-sign-in order; persisted choice loaded at startup.
- Settings card: renders options, defaults to Automatic, choosing a provider persists + pins it, reflects a persisted choice.

Full suite green: **1374 tests pass**; `dart format` and `flutter analyze` clean (Flutter 3.27.4, CI parity).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ95EaRupQiazKSNf6cH2N)_