### PR TITLE
feat(player): runtime fallback to another source when the preferred one fails

### DIFF
--- a/docs/unified-library.md
+++ b/docs/unified-library.md
@@ -107,10 +107,42 @@ to another source when the preferred one does not have the song:
 - Song only on Navidrome → plays from Navidrome.
 - Song only local → plays from the device.
 
-> Fallback here is **selection-time** (pick the best source that *has* the song).
-> Runtime fail-over (preferred server unreachable mid-resolve → automatically try
-> another copy) is **not** in this change; the offline cache already provides
-> resilience (see below). It is a noted follow-up.
+Selection-time fallback (above) picks the best source that *has* the song.
+**Runtime fail-over** then handles the preferred copy *failing at play time*: if
+the preferred candidate can't resolve or start (server unreachable, session
+expired, a stream URL that won't open), playback tries the next candidate of the
+same logical track, in the same deterministic order — and the source indicator,
+queue, and mini-player follow the copy that actually started.
+
+- Default Jellyfin, song on both, Jellyfin fails → plays from Navidrome; the
+  indicator shows **Navidrome**.
+- Default Navidrome, Navidrome fails, song also on Jellyfin → plays from
+  Jellyfin; the indicator shows **Jellyfin**.
+- Each candidate is tried at most once per attempt (no loops); if all fail, one
+  clear, secret-free error is shown.
+
+### How runtime fail-over is wired
+
+The candidates are re-supplied to playback through a small seam, because the
+browse UI plays a logical row by passing only its single displayed `Track` (the
+sibling copies are lost at that boundary):
+
+- `PlaybackCandidateSource` (`core/services/playback_candidate_source.dart`)
+  returns a track's ordered candidates, or just `[track]` (no fallback) for a
+  single-source song or any non-library track — so single-source playback is
+  unchanged.
+- `playbackCandidatesProvider` (`features/library`) builds the map of display
+  track id → ordered candidates (each carrying the row's best cover) from the
+  unified library; `main` wires it in. It is read lazily at play time, so the
+  session-pinned engine always sees the latest catalog and default-source choice.
+- `JustAudioPlaybackController` tries the candidates in order, swapping the
+  queue's current entry to the copy that started (so `PlaybackState.source` and
+  the "Playing from …" indicator are honest), and shows one safe error if every
+  copy fails.
+
+> Mid-stream drops (a copy that *was* playing and then fails) keep their existing
+> one-shot retry of the same copy; the offline cache (below) still provides
+> offline resilience. Cast output resolves through its own path and is unchanged.
 
 ## Offline cache mapping
 

--- a/lib/core/models/playback_queue.dart
+++ b/lib/core/models/playback_queue.dart
@@ -259,6 +259,30 @@ class PlaybackQueue {
     );
   }
 
+  /// Replaces the current track *in place* with [track], keeping its position,
+  /// up-next, history, and shuffle intact. Used when playback fell back to
+  /// another source copy of the same song, so the queue (and the now-playing UI)
+  /// reflects the copy that actually started. A no-op on an empty queue or when
+  /// [track] equals the current one. When shuffled, the same swap is applied to
+  /// [originalOrder] so a later [unshuffled] keeps the copy that played.
+  PlaybackQueue replaceCurrent(Track track) {
+    final Track? old = current;
+    if (old == null || old == track) return this;
+    final updated = List<Track>.of(tracks)..[currentIndex] = track;
+    List<Track>? updatedOriginal = originalOrder;
+    if (originalOrder != null) {
+      final int i = originalOrder!.indexOf(old);
+      if (i >= 0) {
+        updatedOriginal = List<Track>.of(originalOrder!)..[i] = track;
+      }
+    }
+    return PlaybackQueue(
+      tracks: updated,
+      currentIndex: currentIndex,
+      originalOrder: updatedOriginal,
+    );
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -13,6 +13,7 @@ import '../models/track.dart';
 import 'local_playable_uri_resolver.dart';
 import 'local_playback_controller.dart';
 import 'playable_uri_resolver.dart';
+import 'playback_candidate_source.dart';
 import 'playback_controller.dart';
 import 'stability_diagnostics.dart';
 import 'stream_interruption.dart';
@@ -39,10 +40,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   JustAudioPlaybackController({
     AudioPlayer? player,
     PlayableUriResolver resolver = const LocalPlayableUriResolver(),
+    PlaybackCandidateSource candidates = const NoFallbackCandidateSource(),
     Random? random,
     TrackCompletionCallback? onTrackCompleted,
   })  : _player = player ?? _defaultPlayer(),
         _resolver = resolver,
+        _candidates = candidates,
         _random = random ?? Random(),
         _onTrackCompleted = onTrackCompleted {
     _wire();
@@ -80,6 +83,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
 
   final AudioPlayer _player;
   final PlayableUriResolver _resolver;
+
+  /// Supplies the ordered source candidates for the track being played, so a
+  /// failed preferred copy can fall back to another copy of the same song. The
+  /// default returns just the track itself (no fallback), so single-source
+  /// playback is unchanged.
+  final PlaybackCandidateSource _candidates;
   final Random _random;
 
   /// Invoked once each time a track reaches its natural end, before the repeat
@@ -541,48 +550,98 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       ));
     }
 
-    final ResolvedPlayable resolved;
+    // Try the track's source candidates in deterministic, most-preferred-first
+    // order, falling back to the next copy of the same song when the preferred
+    // one can't resolve or start. A single-source track has just one candidate,
+    // so this behaves exactly as a direct load did.
+    final List<Track> candidates = _candidates.candidatesFor(track);
+    final ({Track track, ResolvedPlayable resolved}) outcome;
     try {
-      resolved = await _resolver.resolve(track);
+      outcome = await _loadFirstWorkingCandidate(candidates);
     } on PlaybackResolutionException catch (error) {
-      // A resolver failure carries its own friendly, secret-free message.
-      StabilityDiagnostics.playbackError('resolution');
+      // Every candidate failed: surface one friendly, secret-free message.
       _emitError(track, error.message);
       return;
-    } catch (_) {
-      // An unexpected error before we even know the source: stay generic.
-      StabilityDiagnostics.playbackError('resolution-unknown');
-      _emitError(track, "Couldn't play this track.");
-      return;
     }
 
-    // Record where the audio is coming from so the UI can show an honest
-    // source badge. It rides along on every later position/status update via
-    // copyWith until the next track loads (which resets it).
-    _emit(_state.copyWith(source: resolved.source));
+    // Make the copy that actually started the current one, so the queue, the
+    // mini-player, and the "Playing from …" indicator all reflect the source
+    // that succeeded — not the preferred one that may have failed. The resolved
+    // source rides along on later position/status updates until the next load.
+    final Track played = outcome.track;
+    if (played.id != track.id) _queue = _queue.replaceCurrent(played);
+    _emit(_state.copyWith(
+      currentTrack: played,
+      source: outcome.resolved.source,
+      upNext: _queue.upNext,
+      previous: _queue.history,
+      hasPrevious: _queue.hasPrevious,
+    ));
 
-    try {
-      // setUrl handles file://, content:// (Android), and https:// URIs alike,
-      // so local files, SAF documents, and Jellyfin streams share one path. The
-      // resolver guarantees this is never a bare `jellyfin:<id>` — that scheme
-      // is turned into an authenticated stream URL (or a friendly error) before
-      // it ever reaches here.
-      await _player.setUrl(resolved.uri.toString());
-      // Level this track before it's heard: apply its ReplayGain (or full
-      // volume when normalization is off), so the very first moment of audio is
-      // already at the right loudness rather than jumping after a beat.
-      await _applyVolume();
-      // Resuming on this device after casting picks up where the receiver left
-      // off, paused unless asked to play.
-      if (startAt > Duration.zero) await _player.seek(startAt);
-      // play()'s future completes when playback ends, so we don't await it.
-      if (autoplay) unawaited(_player.play());
-    } catch (_) {
-      // The URL resolved and (for streams) probed OK, so a failure here is the
-      // engine itself. Word it for the source the listener can see on the badge.
-      StabilityDiagnostics.playbackError('load');
-      _emitError(track, _loadErrorFor(resolved.source));
+    // Level this track before it's heard (its ReplayGain, or full volume when
+    // normalization is off); resume at the preserved position after a cast
+    // handoff; then start — the source is already loaded.
+    await _applyVolume();
+    if (startAt > Duration.zero) await _player.seek(startAt);
+    // play()'s future completes when playback ends, so we don't await it.
+    if (autoplay) unawaited(_player.play());
+  }
+
+  /// Tries [candidates] in order — **at most once each** — resolving and loading
+  /// the first that works, returning it with its resolved source. Throws a
+  /// single, safe [PlaybackResolutionException] when every candidate fails.
+  ///
+  /// A one-candidate list (the common, single-source case) rethrows that
+  /// candidate's own specific failure, so single-source playback errors are
+  /// worded exactly as before; only a genuine multi-source all-fail collapses to
+  /// the generic "any available source" message. It makes a single pass and
+  /// never retries, so it always terminates.
+  Future<({Track track, ResolvedPlayable resolved})> _loadFirstWorkingCandidate(
+    List<Track> candidates,
+  ) async {
+    final List<PlaybackResolutionException> failures =
+        <PlaybackResolutionException>[];
+    for (final Track candidate in candidates) {
+      final ResolvedPlayable resolved;
+      try {
+        resolved = await _resolver.resolve(candidate);
+      } on PlaybackResolutionException catch (error) {
+        // A resolver failure carries its own friendly, secret-free message.
+        StabilityDiagnostics.playbackError('resolution');
+        failures.add(error);
+        continue;
+      } catch (_) {
+        // An unexpected error before we even know the source: stay generic.
+        StabilityDiagnostics.playbackError('resolution-unknown');
+        failures.add(const PlaybackResolutionException(
+          "Couldn't play this track.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        ));
+        continue;
+      }
+      try {
+        // setUrl handles file://, content:// (Android), and https:// URIs alike,
+        // so local files, SAF documents, and remote streams share one path. The
+        // resolver guarantees this is never a bare `jellyfin:`/`subsonic:` scheme
+        // — that is turned into an authenticated stream URL before it gets here.
+        await _player.setUrl(resolved.uri.toString());
+        return (track: candidate, resolved: resolved);
+      } catch (_) {
+        // Resolved (and, for streams, probed) OK but the engine couldn't open
+        // it: a start failure. Word it for the source, then try the next copy.
+        StabilityDiagnostics.playbackError('load');
+        failures.add(PlaybackResolutionException(
+          _loadErrorFor(resolved.source),
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        ));
+        continue;
+      }
     }
+    if (failures.length == 1) throw failures.first;
+    throw const PlaybackResolutionException(
+      "Couldn't play this track from any available source.",
+      kind: PlaybackResolutionErrorKind.streamUnavailable,
+    );
   }
 
   /// The generic message for an engine load failure *after* a successful

--- a/lib/core/services/playback_candidate_source.dart
+++ b/lib/core/services/playback_candidate_source.dart
@@ -1,0 +1,55 @@
+import '../models/track.dart';
+
+/// Looks up the ordered source candidates for a track at play time, so the
+/// playback controller can fall back to another copy of the *same song* when the
+/// preferred one fails to resolve or start.
+///
+/// A logical (de-duplicated) library row can be backed by the same song on more
+/// than one provider (Jellyfin + Navidrome/Subsonic + local). The UI plays the
+/// preferred copy, but only passes that single [Track] into playback — the
+/// sibling copies are lost at that boundary. This seam re-supplies them, ordered
+/// most-preferred first, so a failed preferred copy can deterministically fall
+/// back to the next.
+///
+/// Returning `[track]` (just the track itself) means "no fallback": that is the
+/// answer for a single-source song, a non-library track (e.g. a specific playlist
+/// entry), or the default implementation — so existing single-source playback
+/// behaves exactly as it did before runtime fallback existed.
+abstract interface class PlaybackCandidateSource {
+  /// The ordered candidates to try for [track], most-preferred first. Never
+  /// empty; the first element corresponds to [track] itself.
+  List<Track> candidatesFor(Track track);
+}
+
+/// The default [PlaybackCandidateSource]: no cross-provider fallback. Every track
+/// is its own only candidate, so playback is byte-for-byte what it was before
+/// runtime fallback. Used wherever the unified library isn't wired in (and as the
+/// safe default the production override replaces).
+class NoFallbackCandidateSource implements PlaybackCandidateSource {
+  const NoFallbackCandidateSource();
+
+  @override
+  List<Track> candidatesFor(Track track) => <Track>[track];
+}
+
+/// A [PlaybackCandidateSource] backed by a lazily-read map of *display track id*
+/// → ordered candidates.
+///
+/// The map is read through a callback at every [candidatesFor] call, never cached,
+/// so the session-pinned playback controller always sees the latest library
+/// (after a scan, sync, sign-in, or a change to the default-source setting)
+/// without being rebuilt. A track absent from the map — a single-source song, or
+/// any track that isn't a unified library row — yields `[track]`, i.e. no
+/// fallback.
+class MapPlaybackCandidateSource implements PlaybackCandidateSource {
+  const MapPlaybackCandidateSource(this._candidatesById);
+
+  final Map<String, List<Track>> Function() _candidatesById;
+
+  @override
+  List<Track> candidatesFor(Track track) {
+    final List<Track>? candidates = _candidatesById()[track.id];
+    if (candidates == null || candidates.isEmpty) return <Track>[track];
+    return candidates;
+  }
+}

--- a/lib/features/library/playback_candidates_provider.dart
+++ b/lib/features/library/playback_candidates_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/catalog/logical_track.dart';
+import '../../core/models/track.dart';
+import '../../core/services/playback_candidate_source.dart';
+import '../player/player_providers.dart';
+import 'unified_library_providers.dart';
+
+/// Maps each *displayed* (logical) track id to its ordered source candidates, so
+/// playback can fall back to another copy of the same song when the preferred one
+/// fails.
+///
+/// Only de-duplicated rows that actually span more than one provider are listed —
+/// a single-source song needs no fallback and is left out (the controller treats
+/// an absent id as "no fallback"). Candidates are in the same deterministic,
+/// most-preferred-first order [unifyTracks] produced (honouring the default-source
+/// setting), and each carries the row's best-available cover
+/// ([LogicalTrack.displayArtworkUri]) so a fallback copy keeps the artwork the
+/// displayed row showed. The map recomputes whenever the library or the source
+/// preference changes.
+final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
+  final List<LogicalTrack> logicals = ref.watch(libraryLogicalTracksProvider);
+  final Map<String, List<Track>> byDisplayId = <String, List<Track>>{};
+  for (final LogicalTrack logical in logicals) {
+    if (!logical.hasMultipleSources) continue;
+    byDisplayId[logical.id] = <Track>[
+      for (final TrackSourceCandidate c in logical.candidates)
+        c.track.copyWith(artworkUri: logical.displayArtworkUri),
+    ];
+  }
+  return byDisplayId;
+});
+
+/// Wires the real, library-backed [PlaybackCandidateSource] into the playback
+/// controller, replacing the no-fallback default. Applied in `main`.
+///
+/// The candidate source reads [playbackCandidatesProvider] lazily on every
+/// lookup, so the session-pinned controller always sees the latest catalog and
+/// default-source choice without being rebuilt.
+final playbackCandidateSourceOverride =
+    playbackCandidateSourceProvider.overrideWith(
+  (ref) =>
+      MapPlaybackCandidateSource(() => ref.read(playbackCandidatesProvider)),
+);

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -9,6 +9,7 @@ import '../../core/services/local_playable_uri_resolver.dart';
 import '../../core/services/local_playback_controller.dart';
 import '../../core/services/offline_first_playable_uri_resolver.dart';
 import '../../core/services/playable_uri_resolver.dart';
+import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/services/smart_precache_service.dart';
@@ -74,10 +75,23 @@ final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
 /// would dispose the live `AudioPlayer` and cut the music. The resolver still
 /// reads the live signed-in Jellyfin source lazily at play time, so sign-in/out
 /// is picked up without rebuilding the engine.
+/// Supplies a track's ordered source candidates to the playback controller for
+/// runtime fallback. The default has **no** fallback (each track is its own only
+/// candidate), so playback is unchanged until a real, library-backed source is
+/// wired in. `main` overrides this with [playbackCandidateSourceOverride] so a
+/// failed preferred copy can fall back to another copy of the same song.
+final playbackCandidateSourceProvider = Provider<PlaybackCandidateSource>(
+  (ref) => const NoFallbackCandidateSource(),
+);
+
 final localPlaybackControllerProvider =
     Provider<LocalPlaybackController>((ref) {
   final controller = JustAudioPlaybackController(
     resolver: ref.read(playableUriResolverProvider),
+    // Read once at construction; the candidate source itself reads the live
+    // library lazily at play time, so the session-pinned engine still sees a
+    // fresh catalog (and default-source change) without being rebuilt.
+    candidates: ref.read(playbackCandidateSourceProvider),
     // Record a completed play when a track reaches its end. Read lazily at
     // completion time (not watched), so the play-history repository never ties
     // into the engine's lifecycle. Only the track id is recorded; it stays

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'data/repositories/preferred_source_store_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
 import 'features/downloads/download_providers.dart';
+import 'features/library/playback_candidates_provider.dart';
 import 'features/player/cast/cast_providers.dart';
 import 'features/player/favorites_providers.dart';
 import 'features/player/lyrics_providers.dart';
@@ -59,6 +60,10 @@ Future<void> main() async {
       sharedPreferencesPlaybackPreferencesOverride,
       fileSystemOfflineFileStoreOverride,
       remoteTrackDownloaderOverride,
+      // Let playback fall back to another copy of the same song when the
+      // preferred source fails to resolve or start (the candidates come from the
+      // unified library, in default-source-first order).
+      playbackCandidateSourceOverride,
       currentlyPlayingTrackIdOverride,
       secureJellyfinSessionStoreOverride,
       // Remember which Jellyfin account has had its first auto-sync, so a

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -360,4 +360,46 @@ void main() {
       expect(shuffled.isShuffled, isTrue);
     });
   });
+
+  group('replaceCurrent (runtime source fallback)', () {
+    test('swaps the current track in place, keeping position and queue', () {
+      final queue = PlaybackQueue.of(
+        [_track('a'), _track('b'), _track('c')],
+        startIndex: 1,
+      );
+
+      final replaced = queue.replaceCurrent(_track('B'));
+
+      expect(replaced.current, _track('B'));
+      expect(replaced.currentIndex, 1);
+      expect(replaced.history, [_track('a')]);
+      expect(replaced.upNext, [_track('c')]);
+    });
+
+    test('is a no-op on an empty queue', () {
+      expect(
+        PlaybackQueue.empty.replaceCurrent(_track('a')),
+        PlaybackQueue.empty,
+      );
+    });
+
+    test('is a no-op when replacing the current with an equal track', () {
+      final queue = PlaybackQueue.of([_track('a')]);
+      expect(identical(queue.replaceCurrent(_track('a')), queue), isTrue);
+    });
+
+    test('a later unshuffle keeps the replaced copy, not the original', () {
+      final queue = PlaybackQueue.of([_track('a'), _track('b'), _track('c')])
+          .shuffled(Random(1));
+      // shuffled keeps the current track ('a') at the front.
+      final replaced = queue.replaceCurrent(_track('A'));
+
+      final restored = replaced.unshuffled();
+
+      final ids = restored.tracks.map((Track t) => t.id);
+      expect(ids, contains('A'));
+      expect(ids, isNot(contains('a')));
+      expect(restored.current, _track('A'));
+    });
+  });
 }

--- a/test/core/services/just_audio_playback_controller_fallback_test.dart
+++ b/test/core/services/just_audio_playback_controller_fallback_test.dart
@@ -1,0 +1,372 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/playback_candidate_source.dart';
+import 'package:linthra/core/services/playback_source_label.dart';
+
+/// A fake engine that records what it was asked to open and can be told to fail
+/// opening specific URLs (a "couldn't start playback" failure), without touching
+/// any platform channel. Only the members the controller uses are overridden.
+class _FakePlayer extends Fake implements AudioPlayer {
+  _FakePlayer({this.failUrls = const <String>{}});
+
+  /// Resolved URLs whose [setUrl] should throw, simulating an engine that can
+  /// resolve a stream but fail to open it.
+  final Set<String> failUrls;
+  final List<String> setUrlCalls = <String>[];
+
+  @override
+  Stream<PlayerState> get playerStateStream =>
+      const Stream<PlayerState>.empty();
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream<Duration?>.empty();
+  @override
+  Stream<PlaybackEvent> get playbackEventStream =>
+      const Stream<PlaybackEvent>.empty();
+
+  @override
+  Future<Duration?> setUrl(
+    String url, {
+    Map<String, String>? headers,
+    Duration? initialPosition,
+    bool preload = true,
+    dynamic tag,
+  }) async {
+    setUrlCalls.add(url);
+    if (failUrls.contains(url)) throw Exception('engine could not open source');
+    return const Duration(minutes: 3);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> play() async {}
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {}
+  @override
+  Future<void> dispose() async {}
+}
+
+/// A fake resolver driven by the track's opaque uri: a uri in [resolveFailures]
+/// throws (server down / session expired); one in [resolved] returns its mapped
+/// [ResolvedPlayable]; anything else throws a generic, safe failure.
+class _FakeResolver implements PlayableUriResolver {
+  _FakeResolver({
+    this.resolved = const <String, ResolvedPlayable>{},
+    this.resolveFailures = const <String>{},
+  });
+
+  final Map<String, ResolvedPlayable> resolved;
+  final Set<String> resolveFailures;
+  final List<String> calls = <String>[];
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    calls.add(track.uri);
+    if (resolveFailures.contains(track.uri)) {
+      throw const PlaybackResolutionException(
+        'That source needs attention.',
+        kind: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+    }
+    final ResolvedPlayable? r = resolved[track.uri];
+    if (r == null) {
+      throw const PlaybackResolutionException(
+        "Couldn't reach this source.",
+        kind: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+    }
+    return r;
+  }
+}
+
+Track _track(String id, String uri) => Track(
+      id: id,
+      title: 'Hello',
+      uri: uri,
+      artistName: 'Adele',
+      albumName: '25',
+      duration: const Duration(minutes: 3),
+    );
+
+ResolvedPlayable _stream(String url) =>
+    ResolvedPlayable(Uri.parse(url), PlaybackSource.streamingDirect);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // A song available on both providers. Which one is the displayed/primary copy
+  // depends on the default source; the candidate list is ordered to match.
+  final Track jelly = _track('j', 'jellyfin:j');
+  final Track sub = _track('s', 'subsonic:s');
+
+  JustAudioPlaybackController build({
+    required _FakePlayer player,
+    required _FakeResolver resolver,
+    required Map<String, List<Track>> candidates,
+  }) {
+    final controller = JustAudioPlaybackController(
+      player: player,
+      resolver: resolver,
+      candidates: MapPlaybackCandidateSource(() => candidates),
+    );
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  group('runtime source fallback', () {
+    test('default Jellyfin fails to resolve → plays Navidrome, shows Navidrome',
+        () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'jellyfin:j'},
+        resolved: <String, ResolvedPlayable>{
+          'subsonic:s': _stream('https://sub/stream/s'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        // Jellyfin is the default, so it leads the candidate order.
+        candidates: <String, List<Track>>{
+          'j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      final PlaybackState s = controller.state;
+      expect(s.currentTrack?.uri, 'subsonic:s');
+      expect(s.source, PlaybackSource.streamingDirect);
+      // The indicator reflects the copy that actually started.
+      expect(
+        PlaybackSourceLabel.of(trackUri: s.currentTrack?.uri, source: s.source),
+        'Navidrome',
+      );
+      // Each candidate tried at most once, in order.
+      expect(resolver.calls, <String>['jellyfin:j', 'subsonic:s']);
+    });
+
+    test('default Navidrome fails → plays Jellyfin, shows Jellyfin', () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'subsonic:s'},
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        // Navidrome is the default, so the displayed copy is the Subsonic one.
+        candidates: <String, List<Track>>{
+          's': <Track>[sub, jelly],
+        },
+      );
+
+      await controller.playTracks(<Track>[sub]);
+
+      final PlaybackState s = controller.state;
+      expect(s.currentTrack?.uri, 'jellyfin:j');
+      expect(s.source, PlaybackSource.streamingDirect);
+      expect(
+        PlaybackSourceLabel.of(trackUri: s.currentTrack?.uri, source: s.source),
+        'Jellyfin',
+      );
+      expect(resolver.calls, <String>['subsonic:s', 'jellyfin:j']);
+    });
+
+    test('a preferred copy that resolves but won\'t start falls back',
+        () async {
+      // Jellyfin resolves fine, but the engine can't open its stream URL — a
+      // "start playback" failure, which must also trigger fallback.
+      final player = _FakePlayer(failUrls: <String>{'https://jelly/stream/j'});
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+          'subsonic:s': _stream('https://sub/stream/s'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      expect(controller.state.currentTrack?.uri, 'subsonic:s');
+      expect(controller.state.source, PlaybackSource.streamingDirect);
+      // It really tried to open Jellyfin first, then Navidrome.
+      expect(player.setUrlCalls,
+          <String>['https://jelly/stream/j', 'https://sub/stream/s']);
+    });
+
+    test('the preferred copy succeeding never attempts a fallback', () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j': _stream('https://jelly/stream/j'),
+          'subsonic:s': _stream('https://sub/stream/s'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+      // The secondary copy was never resolved or opened.
+      expect(resolver.calls, <String>['jellyfin:j']);
+      expect(player.setUrlCalls, <String>['https://jelly/stream/j']);
+    });
+
+    test('a cached preferred copy wins first (cache behaviour preserved)',
+        () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          // The offline-first resolver reports a cache hit for the preferred
+          // copy; fallback must not override that.
+          'jellyfin:j': ResolvedPlayable(
+            Uri.file('/cache/j.mp3'),
+            PlaybackSource.offlineCache,
+          ),
+          'subsonic:s': _stream('https://sub/stream/s'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+      expect(controller.state.source, PlaybackSource.offlineCache);
+      expect(resolver.calls, <String>['jellyfin:j']);
+    });
+
+    test('all candidates failing shows one clear, safe error', () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'jellyfin:j', 'subsonic:s'},
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+
+      final PlaybackState s = controller.state;
+      expect(s.status, PlaybackStatus.error);
+      expect(s.errorMessage,
+          "Couldn't play this track from any available source.");
+      // No URLs/credentials in the surfaced message.
+      expect(s.errorMessage, isNot(contains('http')));
+      // Each candidate was tried exactly once — no looping.
+      expect(resolver.calls, <String>['jellyfin:j', 'subsonic:s']);
+    });
+  });
+
+  group('single-source playback is unchanged', () {
+    test('a local-only track plays from its file with no fallback', () async {
+      final Track local = _track('l', '/music/one.mp3');
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          '/music/one.mp3': ResolvedPlayable(
+              Uri.file('/music/one.mp3'), PlaybackSource.localFile),
+        },
+      );
+      // No candidate entry for a single-source track.
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[local]);
+
+      expect(controller.state.currentTrack?.uri, '/music/one.mp3');
+      expect(controller.state.source, PlaybackSource.localFile);
+      expect(resolver.calls, <String>['/music/one.mp3']);
+    });
+
+    test('a single-source failure keeps its own specific message', () async {
+      final Track local = _track('l', '/music/one.mp3');
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'/music/one.mp3'},
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[local]);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      // Not collapsed to the generic multi-source message.
+      expect(controller.state.errorMessage, 'That source needs attention.');
+    });
+  });
+
+  group('queue reflects the copy that actually started', () {
+    test('up-next is preserved and the current entry becomes the fallback',
+        () async {
+      final Track other = _track('o', 'jellyfin:o');
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'jellyfin:j'},
+        resolved: <String, ResolvedPlayable>{
+          'subsonic:s': _stream('https://sub/stream/s'),
+          'jellyfin:o': _stream('https://jelly/stream/o'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly, other]);
+
+      // The current entry is now the Navidrome copy; the rest of the queue is
+      // untouched.
+      expect(controller.state.currentTrack?.uri, 'subsonic:s');
+      expect(controller.state.upNext.map((Track t) => t.uri).toList(),
+          <String>['jellyfin:o']);
+    });
+  });
+}

--- a/test/core/services/playback_candidate_source_test.dart
+++ b/test/core/services/playback_candidate_source_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_candidate_source.dart';
+
+Track _t(String id, String uri) => Track(id: id, title: 'Hello', uri: uri);
+
+void main() {
+  group('NoFallbackCandidateSource', () {
+    test('every track is its own only candidate', () {
+      const source = NoFallbackCandidateSource();
+      final Track t = _t('j', 'jellyfin:j');
+      expect(source.candidatesFor(t), <Track>[t]);
+    });
+  });
+
+  group('MapPlaybackCandidateSource', () {
+    final Track jelly = _t('j', 'jellyfin:j');
+    final Track sub = _t('s', 'subsonic:s');
+
+    test('returns the mapped, ordered candidates for a known track', () {
+      final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
+            'j': <Track>[jelly, sub],
+          });
+      expect(source.candidatesFor(jelly), <Track>[jelly, sub]);
+    });
+
+    test('an unknown (single-source) track yields just itself', () {
+      final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
+            'j': <Track>[jelly, sub],
+          });
+      final Track lonely = _t('x', 'jellyfin:x');
+      expect(source.candidatesFor(lonely), <Track>[lonely]);
+    });
+
+    test('an empty mapped list falls back to the track itself', () {
+      final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
+            'j': <Track>[],
+          });
+      expect(source.candidatesFor(jelly), <Track>[jelly]);
+    });
+
+    test('the map is read lazily on every call (live library)', () {
+      Map<String, List<Track>> map = <String, List<Track>>{};
+      final source = MapPlaybackCandidateSource(() => map);
+
+      // Before the library knows about this song: no fallback.
+      expect(source.candidatesFor(jelly), <Track>[jelly]);
+
+      // The library updates; the same source now sees the new candidates.
+      map = <String, List<Track>>{
+        'j': <Track>[jelly, sub],
+      };
+      expect(source.candidatesFor(jelly), <Track>[jelly, sub]);
+    });
+  });
+}

--- a/test/features/library/playback_candidates_provider_test.dart
+++ b/test/features/library/playback_candidates_provider_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/library_controller.dart';
+import 'package:linthra/features/library/playback_candidates_provider.dart';
+import 'package:linthra/features/library/source_preference_controller.dart';
+
+final Uri _jellyArt =
+    Uri.parse('https://music.example.com/Items/j/Images/Primary');
+
+Track _jelly(String id, {required String title, Uri? artwork}) => Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: 'Adele',
+      albumName: '25',
+      duration: const Duration(minutes: 3),
+      artworkUri: artwork,
+    );
+
+Track _sub(String id, {required String title}) => Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: 'Adele',
+      albumName: '25',
+      duration: const Duration(minutes: 3),
+    );
+
+/// Pins the source preference for a deterministic test.
+class _FixedPreference extends SourcePreferenceController {
+  _FixedPreference(this._priority);
+  final SourcePriority _priority;
+  @override
+  SourcePriority build() => _priority;
+}
+
+Future<ProviderContainer> _seed({
+  required SourcePriority priority,
+  required List<Track> jellyfin,
+  required List<Track> subsonic,
+}) async {
+  final repo = InMemoryMusicLibraryRepository();
+  final container = ProviderContainer(
+    overrides: <Override>[
+      musicLibraryRepositoryProvider.overrideWithValue(repo),
+      librarySourcePriorityProvider
+          .overrideWith(() => _FixedPreference(priority)),
+    ],
+  );
+  addTearDown(container.dispose);
+  await repo.upsertCatalog(
+    sourceId: 'jellyfin',
+    tracks: jellyfin,
+    albums: const <Album>[],
+    artists: const <Artist>[],
+  );
+  await repo.upsertCatalog(
+    sourceId: 'subsonic',
+    tracks: subsonic,
+    albums: const <Album>[],
+    artists: const <Artist>[],
+  );
+  await container.read(libraryControllerProvider.notifier).refresh();
+  return container;
+}
+
+void main() {
+  group('playbackCandidatesProvider', () {
+    test('a cross-provider song maps to ordered candidates, Jellyfin first',
+        () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['jellyfin', 'subsonic']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello', artwork: _jellyArt)],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+
+      // Keyed by the displayed (primary) track id; Jellyfin is preferred.
+      expect(map.keys, <String>['j']);
+      expect(
+        map['j']!.map((Track t) => t.uri).toList(),
+        <String>['jellyfin:j', 'subsonic:s'],
+      );
+    });
+
+    test('every candidate carries the row\'s best-available cover', () async {
+      // Subsonic is preferred (and carries no artwork), but the Jellyfin copy
+      // has a cover — so both candidates must carry it, so a fallback keeps art.
+      final container = await _seed(
+        priority: const SourcePriority(<String>['subsonic', 'jellyfin']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello', artwork: _jellyArt)],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+
+      // Displayed copy is the Subsonic one; Jellyfin is the fallback.
+      final List<Track> candidates = map['s']!;
+      expect(candidates.map((Track t) => t.uri).toList(),
+          <String>['subsonic:s', 'jellyfin:j']);
+      expect(candidates.every((Track t) => t.artworkUri == _jellyArt), isTrue);
+    });
+
+    test('single-source songs are not listed (no fallback needed)', () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['jellyfin', 'subsonic']),
+        jellyfin: <Track>[_jelly('only', title: 'Jelly Only')],
+        subsonic: <Track>[_sub('s', title: 'Navi Only')],
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+
+      expect(map, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Next phase after the explicit default-source setting (#151): **runtime** fail-over. If the preferred copy of a de-duplicated song fails to resolve or start at play time, playback now falls back to another copy of the same logical track.

Scope guardrails honored: no PR3 smart strategy, no default-source UI change, no dedup/matching change, **no telemetry/analytics/3rd-party**, **no release, no version bump, no tag, no fdroiddata**. No schema change/migration; source rows are never deleted or rewritten.

## Inspection (the 5 requested points)

1. **Logical row → playable Track.** `libraryUnifiedTracksProvider` projects each `LogicalTrack` to one displayed `Track`; `track_tile`'s tap calls `playTracks(List<Track>)`. The candidate list is dropped here.
2. **Where candidates are lost.** `PlaybackQueue` holds `List<Track>`; `JustAudioPlaybackController._playCurrent` resolves one `Track`. Nothing below `playTracks` knew about sibling copies.
3. **Resolver success/failure.** `RoutingPlayableUriResolver`/`OfflineFirstPlayableUriResolver` throw a typed, secret-free `PlaybackResolutionException` on failure; cache hits return early. A copy that resolves but won't open throws later at the engine's `setUrl`.
4. **Best fallback point.** The local engine controller — the only place that sees *both* resolve and start failures and can update `currentTrack`/queue + emit `source` so the indicator is honest.
5. **Small model needed?** Yes — a `PlaybackCandidateSource` seam so candidates are re-supplied at play time without changing `playTracks` or the public `PlaybackController` API.

## Changes

- **`PlaybackCandidateSource`** (`core/services/playback_candidate_source.dart`) — returns a track's ordered candidates, or `[track]` (no fallback) for single-source/non-library tracks. Default `NoFallbackCandidateSource` ⇒ existing playback unchanged.
- **`playbackCandidatesProvider` + override** (`features/library`) — builds display-id → ordered candidates (default-source-first; each carries the row's best cover) from the unified library; `main` wires it in. Read lazily ⇒ the session-pinned engine always sees the latest catalog/default-source choice.
- **`JustAudioPlaybackController`** — tries candidates in order, **at most once each, no loops**, stopping at the first that resolves *and* starts; swaps the queue's current entry (`PlaybackQueue.replaceCurrent`) to the copy that started so the queue, mini-player, and "Playing from …" reflect the real source; one clear, secret-free error if all fail (single-source keeps its own specific message).

## Behavior

- Default Jellyfin, song on both, Jellyfin fails → plays Navidrome; indicator shows **Navidrome**.
- Default Navidrome, Navidrome fails, song on Jellyfin → plays Jellyfin; indicator shows **Jellyfin**.
- Preferred succeeds → no fallback attempted. All fail → one safe error.
- Cache/local preserved: each candidate resolves offline-first, so a cached/local preferred copy wins before any fallback. Cast output unchanged.

## Tests & checks
- Controller fallback integration (both directions, resolve- and start-failures, preferred-succeeds, all-fail-one-error, each-candidate-once, "Playing from" reflects the winner, local-only, cached-not-regressed, queue tracks the winner); the candidate-source seam; the library-backed candidate map; `PlaybackQueue.replaceCurrent`.
- `dart format --set-exit-if-changed .` clean · `flutter analyze` no issues · `flutter test` **1395 passing**.

https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL)_