### PR TITLE
feat(player): capture playback source capability metadata (PR3a, metadata-only)

### DIFF
--- a/docs/playback-source-strategy.md
+++ b/docs/playback-source-strategy.md
@@ -1,0 +1,70 @@
+# Playback source strategy (capability metadata)
+
+When the same song exists on more than one provider, Linthra already decides
+*which copy to play* in two ways (see [unified-library.md](unified-library.md)):
+
+1. **Default source** — the user's chosen/most-recently-signed-in provider is
+   preferred (PR1).
+2. **Runtime fallback** — if the preferred copy fails to resolve or start,
+   playback tries the next candidate of the same song (PR2).
+
+A future **smart strategy** (PR3b) will go further and pick a copy by *cost and
+quality*, e.g.:
+
+- Prefer local/cache
+- Prefer highest quality
+- Prefer lower data usage
+- Automatic (balanced)
+
+To decide that well, the strategy needs to know *what each candidate is*. **PR3a
+(this change) only captures that metadata.** It does not change which source is
+chosen, the default-source behaviour, runtime fallback, or de-duplication.
+
+## The model: `PlaybackSourceCapability`
+
+`core/catalog/source_capability.dart` defines a small, immutable
+`PlaybackSourceCapability` — an honest snapshot of what Linthra knows about one
+source candidate. It is derived from existing data only and **decides nothing**.
+
+| Field | Meaning | Source today |
+| ----- | ------- | ------------ |
+| `sourceId` / `providerType` | Owning provider (`jellyfin` / `subsonic` / `local` / unknown) | the track URI scheme |
+| `delivery` | How bytes arrive: `localFile` / `cache` / `remoteStream` / unknown | URI scheme, or the resolver's `PlaybackSource` |
+| `isLocalFile` / `isCachedOffline` / `isRemoteStream` | Convenience flags over `delivery` | derived |
+| `duration` | Track length when known | `Track.duration` |
+| `codec`, `bitrateKbps`, `fileSizeBytes` | Audio quality / data cost | **not captured yet → `null` (unknown)** |
+| `transcoded` | Whether the server would transcode | **unknown (`null`)** |
+| `isLikelyLan` | LAN vs. public internet | **unknown (`null`)** — never guessed from a URL/IP |
+| `transcodingKnown` / `qualityKnown` / `dataCostKnown` | Whether those are known at all | derived |
+
+It is built two ways, both pure (no network, no disk, no background work):
+
+- `PlaybackSourceCapability.fromTrack(track)` — owning provider, inherent
+  delivery (local file vs. remote stream), and duration.
+- `PlaybackSourceCapability.fromResolvedSource(track, playbackSource)` — refines
+  delivery with what the resolver actually chose, so a downloaded copy is marked
+  `cache` using the existing, safe `PlaybackSource.offlineCache` signal.
+
+> Not to be confused with `MusicProviderCapabilities` (in
+> `core/sources/music_provider.dart`), which describes a *provider's abilities*
+> (can stream, can cache, can cast …). `PlaybackSourceCapability` describes a
+> *single candidate* for *one* song.
+
+## Principles (kept deliberately strict)
+
+- **Unknown stays unknown.** Anything not safely derivable is `null` / `unknown`,
+  never a fabricated value.
+- **No new I/O.** No network calls, no probing, no background polling, no extra
+  battery use — only existing in-memory `Track` / resolver data is read.
+- **No private data.** The model stores only a non-identifying `sourceId` plus
+  enums and numbers. The track URI, file path, server host, username, and tokens
+  are never stored or printed; `toString()` is safe to log.
+- **No decisions.** PR3a never ranks or selects a candidate.
+
+## What PR3b will add (not in this change)
+
+- Plumb real `codec` / `bitrateKbps` / `fileSizeBytes` from the Subsonic/Jellyfin
+  wire data onto `Track` (and thus into the profile), where available.
+- A strategy that ranks candidates from these profiles (prefer local/cache,
+  highest quality, lowest data, or balanced), feeding the same ordered-candidate
+  mechanism the default-source and runtime-fallback layers already use.

--- a/lib/core/catalog/source_capability.dart
+++ b/lib/core/catalog/source_capability.dart
@@ -1,0 +1,240 @@
+import '../models/playback_source.dart';
+import '../models/track.dart';
+import '../sources/music_provider.dart';
+import 'track_identity.dart';
+
+/// The owning provider of a source candidate. Distinct from *where the bytes come
+/// from* this time ([SourceDelivery]): a Jellyfin track played from a downloaded
+/// copy is still `jellyfin` here, with [SourceDelivery.cache] delivery.
+enum SourceProviderType {
+  jellyfin('Jellyfin'),
+  subsonic('Navidrome / Subsonic'),
+  local('Local files'),
+  unknown('Unknown source');
+
+  const SourceProviderType(this.displayName);
+
+  /// A fixed, non-identifying display name — never a URL, host, or path.
+  final String displayName;
+}
+
+/// How a candidate's audio would actually reach the player. Separate from the
+/// owning [SourceProviderType] so "prefer cache/local" or "prefer lower data"
+/// strategies (PR3b) can reason about delivery cost without re-deriving it.
+enum SourceDelivery {
+  /// An on-device file (or Android SAF document) played from its own path.
+  localFile,
+
+  /// A remote track served from its downloaded, on-disk copy (no network).
+  cache,
+
+  /// A remote track streamed live from its server.
+  remoteStream,
+
+  /// Not known (e.g. an unrecognised source).
+  unknown;
+}
+
+/// An immutable snapshot of *what Linthra knows* about one playback source
+/// candidate — the foundation for future smart source strategies (PR3b: prefer
+/// local/cache, prefer highest quality, prefer lower data, automatic balanced).
+///
+/// **PR3a is metadata-only.** This model describes a candidate; it never decides
+/// the winner and is not yet wired into playback selection, the default-source
+/// behaviour, or runtime fallback. PR3b will consume it.
+///
+/// ## Honesty over guessing
+///
+/// Every field that isn't safely derivable from existing data is left `null` /
+/// `unknown` rather than guessed. Today only the owning provider, the inherent
+/// delivery, and the [duration] are known from a [Track]; codec, bitrate, file
+/// size, transcoding, and LAN-vs-remote are **not** captured anywhere yet (the
+/// Subsonic/Jellyfin DTOs don't parse them and `Track` doesn't store them), so
+/// they read as unknown. Capturing them later (e.g. onto `Track` from the wire)
+/// is a separate change; the structure here is ready for it.
+///
+/// ## Safety
+///
+/// Only a non-identifying [sourceId] (`jellyfin` / `subsonic` / `local`) plus
+/// enums and plain numbers are stored. The track's URI, file path, server host,
+/// username, and tokens are **never** held or printed — [toString] is safe to log.
+class PlaybackSourceCapability {
+  const PlaybackSourceCapability({
+    required this.sourceId,
+    required this.providerType,
+    required this.delivery,
+    this.isLikelyLan,
+    this.codec,
+    this.bitrateKbps,
+    this.fileSizeBytes,
+    this.duration,
+    this.transcoded,
+  });
+
+  /// The owning provider's id (`jellyfin` / `subsonic` / `local`, or another
+  /// known scheme). A stable, non-sensitive identifier — never a URL or path.
+  final String sourceId;
+
+  /// The owning provider type (see [SourceProviderType]).
+  final SourceProviderType providerType;
+
+  /// How the audio would reach the player (see [SourceDelivery]).
+  final SourceDelivery delivery;
+
+  /// Whether the source is *likely* on the local network rather than the public
+  /// internet, when that is safely knowable without inspecting a URL/IP. `null`
+  /// (unknown) by default — Linthra does not guess this from an address.
+  final bool? isLikelyLan;
+
+  /// Audio codec/container (e.g. `flac`, `mp3`) when already known; else `null`.
+  final String? codec;
+
+  /// Stream/file bitrate in kbps when already known; else `null`.
+  final int? bitrateKbps;
+
+  /// File size in bytes when already known; else `null`.
+  final int? fileSizeBytes;
+
+  /// Track duration when known (a positive value); else `null`.
+  final Duration? duration;
+
+  /// Whether the server would transcode rather than serve the original: `true`
+  /// (transcoded), `false` (original), or `null` (unknown). Never guessed.
+  final bool? transcoded;
+
+  /// The source is an on-device file.
+  bool get isLocalFile => delivery == SourceDelivery.localFile;
+
+  /// The source would play from a downloaded, on-disk copy (no network).
+  bool get isCachedOffline => delivery == SourceDelivery.cache;
+
+  /// The source would stream live from a remote server.
+  bool get isRemoteStream => delivery == SourceDelivery.remoteStream;
+
+  /// Whether the transcoding state is known (vs. [transcoded] being `null`).
+  bool get transcodingKnown => transcoded != null;
+
+  /// Whether anything about audio quality (codec or bitrate) is known.
+  bool get qualityKnown => codec != null || bitrateKbps != null;
+
+  /// Whether the data cost (bitrate or file size) is known. A local/cached
+  /// source costs no network data regardless, which PR3b can treat as cheap.
+  bool get dataCostKnown => bitrateKbps != null || fileSizeBytes != null;
+
+  /// Describes a candidate from its catalog [Track] alone: the owning provider
+  /// and its *inherent* delivery (local file vs. remote stream), plus the
+  /// duration when present. Quality, size, transcoding, and LAN-vs-remote are
+  /// unknown (not carried by `Track`). No network call, no disk read, no guess.
+  factory PlaybackSourceCapability.fromTrack(Track track) {
+    final String id = trackSourceId(track);
+    final SourceProviderType provider = _providerTypeFor(id);
+    return PlaybackSourceCapability(
+      sourceId: id,
+      providerType: provider,
+      delivery: _inherentDeliveryFor(provider),
+      duration: track.duration > Duration.zero ? track.duration : null,
+    );
+  }
+
+  /// Refines a candidate's profile with the delivery the resolver actually chose
+  /// ([PlaybackSource]) — the safe way to learn a copy is being served from
+  /// [SourceDelivery.cache]. The owning provider and duration are kept from
+  /// [PlaybackSourceCapability.fromTrack]; nothing else is invented.
+  factory PlaybackSourceCapability.fromResolvedSource(
+    Track track,
+    PlaybackSource source,
+  ) {
+    final PlaybackSourceCapability base =
+        PlaybackSourceCapability.fromTrack(track);
+    return PlaybackSourceCapability(
+      sourceId: base.sourceId,
+      providerType: base.providerType,
+      delivery: _deliveryForResolved(source),
+      isLikelyLan: base.isLikelyLan,
+      codec: base.codec,
+      bitrateKbps: base.bitrateKbps,
+      fileSizeBytes: base.fileSizeBytes,
+      duration: base.duration,
+      transcoded: base.transcoded,
+    );
+  }
+
+  static SourceProviderType _providerTypeFor(String sourceId) {
+    if (sourceId == MusicProviders.jellyfin.sourceId) {
+      return SourceProviderType.jellyfin;
+    }
+    if (sourceId == MusicProviders.subsonic.sourceId) {
+      return SourceProviderType.subsonic;
+    }
+    if (sourceId == MusicProviders.local.sourceId) {
+      return SourceProviderType.local;
+    }
+    return SourceProviderType.unknown;
+  }
+
+  static SourceDelivery _inherentDeliveryFor(SourceProviderType provider) {
+    switch (provider) {
+      case SourceProviderType.local:
+        return SourceDelivery.localFile;
+      case SourceProviderType.jellyfin:
+      case SourceProviderType.subsonic:
+        return SourceDelivery.remoteStream;
+      case SourceProviderType.unknown:
+        return SourceDelivery.unknown;
+    }
+  }
+
+  static SourceDelivery _deliveryForResolved(PlaybackSource source) {
+    switch (source) {
+      case PlaybackSource.localFile:
+        return SourceDelivery.localFile;
+      case PlaybackSource.offlineCache:
+        return SourceDelivery.cache;
+      case PlaybackSource.streamingDirect:
+        return SourceDelivery.remoteStream;
+    }
+  }
+
+  /// A safe, debug-friendly description. Contains only the provider id, enums,
+  /// and known/unknown values — never a URL, path, host, username, or token.
+  @override
+  String toString() {
+    return 'PlaybackSourceCapability('
+        'sourceId: $sourceId, '
+        'provider: ${providerType.name}, '
+        'delivery: ${delivery.name}, '
+        'duration: ${duration ?? 'unknown'}, '
+        'codec: ${codec ?? 'unknown'}, '
+        'bitrateKbps: ${bitrateKbps ?? 'unknown'}, '
+        'fileSizeBytes: ${fileSizeBytes ?? 'unknown'}, '
+        'transcoded: ${transcoded ?? 'unknown'}, '
+        'isLikelyLan: ${isLikelyLan ?? 'unknown'})';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PlaybackSourceCapability &&
+          other.sourceId == sourceId &&
+          other.providerType == providerType &&
+          other.delivery == delivery &&
+          other.isLikelyLan == isLikelyLan &&
+          other.codec == codec &&
+          other.bitrateKbps == bitrateKbps &&
+          other.fileSizeBytes == fileSizeBytes &&
+          other.duration == duration &&
+          other.transcoded == transcoded);
+
+  @override
+  int get hashCode => Object.hash(
+        sourceId,
+        providerType,
+        delivery,
+        isLikelyLan,
+        codec,
+        bitrateKbps,
+        fileSizeBytes,
+        duration,
+        transcoded,
+      );
+}

--- a/test/core/catalog/source_capability_test.dart
+++ b/test/core/catalog/source_capability_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_capability.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/track.dart';
+
+Track _track(
+  String id,
+  String uri, {
+  Duration duration = const Duration(minutes: 3),
+}) =>
+    Track(id: id, title: 'Hello', uri: uri, duration: duration);
+
+void main() {
+  group('PlaybackSourceCapability.fromTrack — provider type', () {
+    test('a Jellyfin candidate gets provider type Jellyfin', () {
+      final cap = PlaybackSourceCapability.fromTrack(_track('j', 'jellyfin:j'));
+      expect(cap.providerType, SourceProviderType.jellyfin);
+      expect(cap.sourceId, 'jellyfin');
+      expect(cap.isRemoteStream, isTrue);
+      expect(cap.isLocalFile, isFalse);
+    });
+
+    test('a Navidrome/Subsonic candidate gets provider type subsonic', () {
+      final cap = PlaybackSourceCapability.fromTrack(_track('s', 'subsonic:s'));
+      expect(cap.providerType, SourceProviderType.subsonic);
+      expect(cap.providerType.displayName, 'Navidrome / Subsonic');
+      expect(cap.isRemoteStream, isTrue);
+    });
+
+    test('a local-file candidate is marked local', () {
+      final cap =
+          PlaybackSourceCapability.fromTrack(_track('l', '/music/one.mp3'));
+      expect(cap.providerType, SourceProviderType.local);
+      expect(cap.isLocalFile, isTrue);
+      expect(cap.delivery, SourceDelivery.localFile);
+      expect(cap.isRemoteStream, isFalse);
+      expect(cap.isCachedOffline, isFalse);
+    });
+
+    test('a content:// (SAF) candidate is local', () {
+      final cap = PlaybackSourceCapability.fromTrack(
+        _track('c', 'content://media/external/audio/media/42'),
+      );
+      expect(cap.providerType, SourceProviderType.local);
+      expect(cap.isLocalFile, isTrue);
+    });
+  });
+
+  group('PlaybackSourceCapability — delivery & cache detection', () {
+    test('a resolved offline-cache copy is marked cache/offline', () {
+      // The existing resolver reports PlaybackSource.offlineCache (a safe, no-
+      // network signal); the profile reflects it while keeping the owning
+      // provider.
+      final cap = PlaybackSourceCapability.fromResolvedSource(
+        _track('j', 'jellyfin:j'),
+        PlaybackSource.offlineCache,
+      );
+      expect(cap.isCachedOffline, isTrue);
+      expect(cap.delivery, SourceDelivery.cache);
+      // Still owned by Jellyfin, even though it plays from cache.
+      expect(cap.providerType, SourceProviderType.jellyfin);
+    });
+
+    test('a resolved direct stream is a remote stream', () {
+      final cap = PlaybackSourceCapability.fromResolvedSource(
+        _track('s', 'subsonic:s'),
+        PlaybackSource.streamingDirect,
+      );
+      expect(cap.isRemoteStream, isTrue);
+      expect(cap.delivery, SourceDelivery.remoteStream);
+    });
+
+    test('a resolved local file is a local delivery', () {
+      final cap = PlaybackSourceCapability.fromResolvedSource(
+        _track('l', '/music/one.mp3'),
+        PlaybackSource.localFile,
+      );
+      expect(cap.isLocalFile, isTrue);
+      expect(cap.delivery, SourceDelivery.localFile);
+    });
+  });
+
+  group('PlaybackSourceCapability — unknown is never faked', () {
+    test('bitrate, codec, and file size are unknown (null), not invented', () {
+      final cap = PlaybackSourceCapability.fromTrack(_track('j', 'jellyfin:j'));
+      expect(cap.codec, isNull);
+      expect(cap.bitrateKbps, isNull);
+      expect(cap.fileSizeBytes, isNull);
+      expect(cap.qualityKnown, isFalse);
+      expect(cap.dataCostKnown, isFalse);
+    });
+
+    test('transcoding and LAN-vs-remote are unknown, not guessed', () {
+      final cap = PlaybackSourceCapability.fromTrack(_track('j', 'jellyfin:j'));
+      expect(cap.transcoded, isNull);
+      expect(cap.transcodingKnown, isFalse);
+      expect(cap.isLikelyLan, isNull);
+    });
+
+    test('duration is captured when present and null when unknown (zero)', () {
+      final known = PlaybackSourceCapability.fromTrack(
+        _track('j', 'jellyfin:j', duration: const Duration(minutes: 4)),
+      );
+      expect(known.duration, const Duration(minutes: 4));
+
+      final unknown = PlaybackSourceCapability.fromTrack(
+        _track('u', 'jellyfin:u', duration: Duration.zero),
+      );
+      expect(unknown.duration, isNull);
+    });
+
+    test('a known signal flips the *known* getters', () {
+      const cap = PlaybackSourceCapability(
+        sourceId: 'jellyfin',
+        providerType: SourceProviderType.jellyfin,
+        delivery: SourceDelivery.remoteStream,
+        codec: 'flac',
+        bitrateKbps: 1024,
+        fileSizeBytes: 30000000,
+        transcoded: false,
+      );
+      expect(cap.qualityKnown, isTrue);
+      expect(cap.dataCostKnown, isTrue);
+      expect(cap.transcodingKnown, isTrue);
+    });
+  });
+
+  group('PlaybackSourceCapability — no private data leaks', () {
+    test('toString never exposes a local path', () {
+      final cap = PlaybackSourceCapability.fromTrack(
+        _track('l', '/Users/alice/Music/Secret Album/01 song.mp3'),
+      );
+      final String text = cap.toString();
+      expect(text, isNot(contains('alice')));
+      expect(text, isNot(contains('Secret')));
+      expect(text, isNot(contains('.mp3')));
+      expect(text, isNot(contains('/')));
+    });
+
+    test('toString never exposes the opaque remote uri/item id', () {
+      final cap = PlaybackSourceCapability.fromTrack(
+          _track('item-42', 'jellyfin:item-42'));
+      final String text = cap.toString();
+      expect(text, isNot(contains('item-42')));
+      expect(text, isNot(contains('jellyfin:')));
+      // The safe provider id is fine to show.
+      expect(text, contains('jellyfin'));
+    });
+  });
+
+  group('PlaybackSourceCapability — value semantics', () {
+    test('equal field sets are equal', () {
+      final a = PlaybackSourceCapability.fromTrack(_track('j', 'jellyfin:j'));
+      final b = PlaybackSourceCapability.fromTrack(_track('j', 'jellyfin:j'));
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('a different delivery is not equal', () {
+      final stream =
+          PlaybackSourceCapability.fromTrack(_track('j', 'jellyfin:j'));
+      final cached = PlaybackSourceCapability.fromResolvedSource(
+        _track('j', 'jellyfin:j'),
+        PlaybackSource.offlineCache,
+      );
+      expect(stream, isNot(cached));
+    });
+  });
+}


### PR DESCRIPTION
Groundwork for future smart playback-source strategies — **metadata-only**. Adds a model describing what Linthra knows about a source candidate, but does **not** change playback selection, default-source behavior, runtime fallback, or de-duplication, and nothing consumes it yet.

Scope guardrails honored: no PR3b strategy/decisions, no default-source change, no fallback change, no dedup/matching change, **no telemetry/analytics/3rd-party**, **no release, no version bump, no tag, no fdroiddata**. Purely additive — no existing `lib/` file is touched.

## Audit (before coding)
- Provider ids are `jellyfin`/`subsonic`/`local` (`MusicProviders`); there's already a `MusicProviderCapabilities` for *provider abilities* — this new model is distinct (a *single candidate* for *one* song).
- `Track` carries only `duration` among the quality fields; the Subsonic/Jellyfin DTOs **don't parse** bitrate/codec/size, so those are genuinely unknown today.
- Cache delivery is safely knowable from the existing `PlaybackSource.offlineCache` signal (no network).

## `PlaybackSourceCapability` (`core/catalog/source_capability.dart`)
A small immutable snapshot derived from existing data only:
- **Owning provider** (`SourceProviderType`: jellyfin / subsonic / local / unknown) + non-identifying `sourceId`, from the URI scheme.
- **Delivery** (`SourceDelivery`: localFile / cache / remoteStream / unknown) with `isLocalFile` / `isCachedOffline` / `isRemoteStream`; cache learned safely from `PlaybackSource.offlineCache`.
- **`duration`** when known; **codec / bitrate / file size / transcoding / LAN-vs-remote** left `null`/unknown (never faked), with `transcodingKnown` / `qualityKnown` / `dataCostKnown` getters for PR3b.
- Two pure factories: `fromTrack` and `fromResolvedSource` — no network, no disk, no background work, no battery cost.

## Safety
Stores only the safe `sourceId` plus enums/numbers; the URI, file path, server host, username, and tokens are **never** held or printed, so `toString()` is safe to log (covered by a test).

## Tests & checks
Provider-type mapping (Jellyfin / Navidrome-Subsonic / local / SAF), local/cache/stream delivery, unknown-stays-null (no fake values), the *known* getters, no-private-data `toString`, and value semantics.
`dart format --set-exit-if-changed .` clean · `flutter analyze` no issues · `flutter test` **1410 passing**.

## Docs
`docs/playback-source-strategy.md` — PR3a captures metadata only; PR3b will make the decisions.

https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL)_