### PR TITLE
feat(player): smart playback source strategy (PR3b)

### DIFF
--- a/docs/playback-source-strategy.md
+++ b/docs/playback-source-strategy.md
@@ -1,24 +1,20 @@
-# Playback source strategy (capability metadata)
+# Playback source strategy
 
-When the same song exists on more than one provider, Linthra already decides
-*which copy to play* in two ways (see [unified-library.md](unified-library.md)):
+When the same song exists on more than one provider, Linthra decides *which copy
+to play* in layers (see [unified-library.md](unified-library.md)):
 
 1. **Default source** — the user's chosen/most-recently-signed-in provider is
    preferred (PR1).
 2. **Runtime fallback** — if the preferred copy fails to resolve or start,
    playback tries the next candidate of the same song (PR2).
+3. **Capability metadata** — an honest, derive-only snapshot of *what each
+   candidate is* (PR3a).
+4. **Source strategy** — a user-selectable rule that *reorders* the candidates
+   using that metadata before playback (PR3b, below).
 
-A future **smart strategy** (PR3b) will go further and pick a copy by *cost and
-quality*, e.g.:
-
-- Prefer local/cache
-- Prefer highest quality
-- Prefer lower data usage
-- Automatic (balanced)
-
-To decide that well, the strategy needs to know *what each candidate is*. **PR3a
-(this change) only captures that metadata.** It does not change which source is
-chosen, the default-source behaviour, runtime fallback, or de-duplication.
+The strategy only changes the **order** candidates are tried. It never invents a
+candidate, never changes de-duplication, and never overrides runtime fallback or
+the now-playing source indicator.
 
 ## The model: `PlaybackSourceCapability`
 
@@ -61,10 +57,50 @@ It is built two ways, both pure (no network, no disk, no background work):
   are never stored or printed; `toString()` is safe to log.
 - **No decisions.** PR3a never ranks or selects a candidate.
 
-## What PR3b will add (not in this change)
+## The strategy (PR3b): `PlaybackSourceStrategy`
+
+`core/catalog/source_strategy.dart` defines the user-selectable strategy and one
+pure function, `orderBySourceStrategy(candidates, strategy, profileOf)`, that
+reorders a song's candidate list. The user picks the strategy in **Settings →
+Playback source strategy**; it is persisted (`PlaybackSourceStrategyStore`) and
+read by `playbackCandidatesProvider`, which reorders each multi-source song's
+candidates before the runtime-fallback controller tries them.
+
+| Strategy | Ordering |
+| -------- | -------- |
+| **Prefer default provider** | Identity — the PR1/PR2 default-source order, unchanged. |
+| **Prefer local/cache** | Downloaded/offline copy first, then on-device file, then server copies. |
+| **Prefer highest quality** | Known higher-bitrate copies first; unknown-quality copies keep their default slot. |
+| **Prefer lower data usage** | Cache/local first, then known lower-bitrate server copies; unknown stays in default order. |
+| **Automatic (balanced)** | Cache/local first, otherwise the default order — no server-vs-server guessing. |
+
+### Guarantees
+
+- **Deterministic & explainable.** Ordering is a stable transform with the
+  original (default-provider) order as the **final tie-breaker**, so equal
+  candidates never swap and `preferDefault` is the exact identity. The same
+  inputs always produce the same order.
+- **Default provider is the fallback tie-breaker.** Every strategy that can't
+  distinguish two candidates leaves them in default-provider order.
+- **Unknown stays unknown.** Quality/data rules move a candidate *only* when the
+  value (e.g. `bitrateKbps`) is actually known. Unknown values never move a row
+  and are never faked — so today, with bitrate/size not yet captured, the quality
+  and lower-data strategies fall back to the default order (after the cache/local
+  step). "Prefer highest quality" therefore never silently picks a lower-quality
+  copy.
+- **Runtime fallback still applies.** Strategy ordering happens *before* the PR2
+  controller, which still tries the next candidate if the first fails.
+- **The indicator shows the real source.** "Playing from …" reflects the copy
+  that actually started, not the strategy's first pick.
+- **Cheap, private, safe.** Cache/local preference uses the in-memory
+  offline-available set (`offlineAvailableTrackIdsProvider`) — no network call,
+  no disk scan, no background polling, no path or URL. The strategy is a
+  non-secret enum name; nothing sensitive is stored or logged.
+
+### What stays for later
 
 - Plumb real `codec` / `bitrateKbps` / `fileSizeBytes` from the Subsonic/Jellyfin
-  wire data onto `Track` (and thus into the profile), where available.
-- A strategy that ranks candidates from these profiles (prefer local/cache,
-  highest quality, lowest data, or balanced), feeding the same ordered-candidate
-  mechanism the default-source and runtime-fallback layers already use.
+  wire data onto `Track` (and thus into the profile). Once present, the quality
+  and lower-data strategies start ordering server copies by real numbers — no
+  code change to the ordering needed, because it already reads those fields and
+  ignores them only while they are unknown.

--- a/lib/core/catalog/source_capability.dart
+++ b/lib/core/catalog/source_capability.dart
@@ -125,13 +125,27 @@ class PlaybackSourceCapability {
   /// and its *inherent* delivery (local file vs. remote stream), plus the
   /// duration when present. Quality, size, transcoding, and LAN-vs-remote are
   /// unknown (not carried by `Track`). No network call, no disk read, no guess.
-  factory PlaybackSourceCapability.fromTrack(Track track) {
+  ///
+  /// [cachedOffline] is a safe, in-memory signal (e.g. the downloaded-track set)
+  /// that a *remote* candidate already has an offline copy: when `true` such a
+  /// candidate's delivery becomes [SourceDelivery.cache], so "prefer cache"
+  /// strategies can favour it without a disk scan. It never upgrades a local
+  /// file (already on device) or an unknown source, and defaults to `false`.
+  factory PlaybackSourceCapability.fromTrack(
+    Track track, {
+    bool cachedOffline = false,
+  }) {
     final String id = trackSourceId(track);
     final SourceProviderType provider = _providerTypeFor(id);
+    final SourceDelivery inherent = _inherentDeliveryFor(provider);
+    final SourceDelivery delivery =
+        (cachedOffline && inherent == SourceDelivery.remoteStream)
+            ? SourceDelivery.cache
+            : inherent;
     return PlaybackSourceCapability(
       sourceId: id,
       providerType: provider,
-      delivery: _inherentDeliveryFor(provider),
+      delivery: delivery,
       duration: track.duration > Duration.zero ? track.duration : null,
     );
   }

--- a/lib/core/catalog/source_strategy.dart
+++ b/lib/core/catalog/source_strategy.dart
@@ -1,0 +1,184 @@
+import 'source_capability.dart';
+
+/// A user-selectable strategy for ordering the source candidates of a song that
+/// exists on more than one provider, so playback tries the best copy first.
+///
+/// The strategy only *reorders* candidates; it never invents one, never changes
+/// de-duplication, and never decides the final source on its own — PR2 runtime
+/// fallback still tries the next candidate if the first fails, and the
+/// "Playing from …" indicator still reflects whichever copy actually started.
+///
+/// Determinism: ordering is a stable transform of the candidate list with the
+/// original (default-provider) order as the final tie-breaker (see
+/// [orderBySourceStrategy]). [preferDefault] is the identity, preserving the
+/// PR1/PR2 behaviour exactly.
+enum PlaybackSourceStrategy {
+  /// Keep the default-provider order (PR1/PR2). The identity ordering.
+  preferDefault(
+    'Prefer default provider',
+    'Use your default source order. Linthra still falls back to another copy '
+        'if it fails.',
+  ),
+
+  /// Prefer copies that need no network — a downloaded/offline copy first, then
+  /// an on-device file — before any server copy. Best for battery and data.
+  preferLocalCache(
+    'Prefer local/cache',
+    'Play a downloaded or on-device copy when there is one. Best for battery '
+        'and data.',
+  ),
+
+  /// Prefer the copy with the higher known quality. When quality is unknown it
+  /// is left in its default position (never guessed), so a lower-quality copy is
+  /// not silently chosen.
+  preferHighestQuality(
+    'Prefer highest quality',
+    'Play the higher-quality copy when Linthra knows the quality; otherwise '
+        'keep your default order.',
+  ),
+
+  /// Prefer the copy that uses less data — cache/local first, then the known
+  /// lower-bitrate server copy. Unknown bitrate/size is left in default order.
+  preferLowerData(
+    'Prefer lower data usage',
+    'Play a cached/on-device copy first, then the lighter server copy when '
+        'Linthra knows the bitrate.',
+  ),
+
+  /// A conservative smart default: cache/local first, otherwise the default
+  /// order. It avoids reordering server copies on guesses, so the chosen source
+  /// stays stable between songs.
+  automaticBalanced(
+    'Automatic (balanced)',
+    'Use cached/on-device copies when handy, otherwise your default order.',
+  );
+
+  const PlaybackSourceStrategy(this.label, this.description);
+
+  /// A short, safe label for the settings UI.
+  final String label;
+
+  /// A one-line, safe explanation for the settings UI.
+  final String description;
+
+  /// Parses a persisted [name], falling back to [preferDefault] for an absent or
+  /// unrecognised value — so a missing/old setting never changes behaviour.
+  static PlaybackSourceStrategy fromStorage(String? name) {
+    for (final PlaybackSourceStrategy s in values) {
+      if (s.name == name) return s;
+    }
+    return preferDefault;
+  }
+}
+
+/// Reorders [candidates] according to [strategy], using [profileOf] to read each
+/// candidate's [PlaybackSourceCapability]. Pure and deterministic: the original
+/// order is the final tie-breaker, so equal candidates never swap and
+/// [PlaybackSourceStrategy.preferDefault] returns the list unchanged.
+///
+/// Conservative by design: a candidate is only moved by a quality/data rule when
+/// the relevant value is actually known; unknown values keep their default slot
+/// and are never faked. Generic over the candidate type so it can order `Track`s
+/// in the app and `PlaybackSourceCapability`s directly in tests.
+List<T> orderBySourceStrategy<T>(
+  List<T> candidates,
+  PlaybackSourceStrategy strategy,
+  PlaybackSourceCapability Function(T) profileOf,
+) {
+  switch (strategy) {
+    case PlaybackSourceStrategy.preferDefault:
+      return List<T>.of(candidates);
+
+    case PlaybackSourceStrategy.preferLocalCache:
+      // Downloaded/offline first, then on-device, then server — default order
+      // within each tier.
+      return _stableByTier(candidates, (T c) => _localCacheTier(profileOf(c)));
+
+    case PlaybackSourceStrategy.automaticBalanced:
+      // Anything that needs no network first; otherwise the default order. No
+      // server-vs-server guessing, so the source stays stable between songs.
+      return _stableByTier(candidates, (T c) => _cheapTier(profileOf(c)));
+
+    case PlaybackSourceStrategy.preferLowerData:
+      // No-network copies first, then reorder *known* lower-bitrate server
+      // copies among themselves; unknown bitrate stays in its default slot.
+      final List<T> cheapFirst =
+          _stableByTier(candidates, (T c) => _cheapTier(profileOf(c)));
+      return _reorderKnownInPlace<T>(
+        cheapFirst,
+        eligible: (T c) => _cheapTier(profileOf(c)) != 0, // server copies only
+        keyOf: (T c) => profileOf(c).bitrateKbps,
+        better: (int a, int b) => a.compareTo(b), // lower bitrate = less data
+      );
+
+    case PlaybackSourceStrategy.preferHighestQuality:
+      // Reorder *known* higher-bitrate copies among themselves; unknown quality
+      // stays in its default slot (never guessed, never silently downgraded).
+      return _reorderKnownInPlace<T>(
+        candidates,
+        eligible: (T c) => true,
+        keyOf: (T c) => profileOf(c).bitrateKbps,
+        better: (int a, int b) => b.compareTo(a), // higher bitrate = better
+      );
+  }
+}
+
+/// Tier for "prefer local/cache": a downloaded/offline copy (0) beats an
+/// on-device file (1) beats a server copy (2).
+int _localCacheTier(PlaybackSourceCapability c) {
+  if (c.isCachedOffline) return 0;
+  if (c.isLocalFile) return 1;
+  return 2;
+}
+
+/// Tier for "needs no network": cache or local (0) beats a server copy (1).
+int _cheapTier(PlaybackSourceCapability c) =>
+    (c.isCachedOffline || c.isLocalFile) ? 0 : 1;
+
+/// Stable sort by an integer [tierOf], with the original index as the final
+/// tie-breaker so equal-tier candidates keep their default order.
+List<T> _stableByTier<T>(List<T> items, int Function(T) tierOf) {
+  final List<({T item, int tier, int index})> indexed =
+      <({T item, int tier, int index})>[
+    for (int i = 0; i < items.length; i++)
+      (item: items[i], tier: tierOf(items[i]), index: i),
+  ];
+  indexed.sort((a, b) {
+    final int byTier = a.tier.compareTo(b.tier);
+    return byTier != 0 ? byTier : a.index.compareTo(b.index);
+  });
+  return <T>[for (final e in indexed) e.item];
+}
+
+/// Reorders only the candidates that are [eligible] *and* have a known [keyOf],
+/// among the slots they already occupy, by [better] (original index breaks
+/// ties). Every other candidate — ineligible, or with an unknown key — stays
+/// exactly where it was, so unknown metadata never moves a row and the result is
+/// fully deterministic.
+List<T> _reorderKnownInPlace<T>(
+  List<T> items, {
+  required bool Function(T) eligible,
+  required int? Function(T) keyOf,
+  required int Function(int a, int b) better,
+}) {
+  final List<int> slots = <int>[];
+  final List<({T item, int key, int index})> movable =
+      <({T item, int key, int index})>[];
+  for (int i = 0; i < items.length; i++) {
+    final int? key = eligible(items[i]) ? keyOf(items[i]) : null;
+    if (key != null) {
+      slots.add(i);
+      movable.add((item: items[i], key: key, index: i));
+    }
+  }
+  if (movable.length < 2) return List<T>.of(items);
+  movable.sort((a, b) {
+    final int byKey = better(a.key, b.key);
+    return byKey != 0 ? byKey : a.index.compareTo(b.index);
+  });
+  final List<T> result = List<T>.of(items);
+  for (int s = 0; s < slots.length; s++) {
+    result[slots[s]] = movable[s].item;
+  }
+  return result;
+}

--- a/lib/core/repositories/playback_source_strategy_store.dart
+++ b/lib/core/repositories/playback_source_strategy_store.dart
@@ -1,0 +1,15 @@
+/// Persists the user's chosen playback **source strategy** — how Linthra orders
+/// the candidates of a song that exists on more than one provider.
+///
+/// The stored value is a single non-secret enum name (e.g. `preferLocalCache`),
+/// or `null` for the default ("prefer default provider"). Like
+/// [DefaultProviderStore] it carries no credential, URL, or library content, so
+/// a lightweight key/value store is the right weight.
+abstract interface class PlaybackSourceStrategyStore {
+  /// The persisted strategy name, or `null` when the user has not chosen one
+  /// (the default strategy applies).
+  Future<String?> read();
+
+  /// Persists [strategyName], or clears the choice (the default) when `null`.
+  Future<void> write(String? strategyName);
+}

--- a/lib/data/repositories/in_memory_playback_source_strategy_store.dart
+++ b/lib/data/repositories/in_memory_playback_source_strategy_store.dart
@@ -1,0 +1,18 @@
+import '../../core/repositories/playback_source_strategy_store.dart';
+
+/// An in-memory [PlaybackSourceStrategyStore] for development and tests. Nothing
+/// is persisted; the choice lives only for the lifetime of the instance.
+class InMemoryPlaybackSourceStrategyStore
+    implements PlaybackSourceStrategyStore {
+  InMemoryPlaybackSourceStrategyStore([this._strategyName]);
+
+  String? _strategyName;
+
+  @override
+  Future<String?> read() async => _strategyName;
+
+  @override
+  Future<void> write(String? strategyName) async {
+    _strategyName = strategyName;
+  }
+}

--- a/lib/data/repositories/playback_source_strategy_store_provider.dart
+++ b/lib/data/repositories/playback_source_strategy_store_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/playback_source_strategy_store.dart';
+import 'in_memory_playback_source_strategy_store.dart';
+import 'shared_preferences_playback_source_strategy_store.dart';
+
+/// The single [PlaybackSourceStrategyStore] the app reads/writes the chosen
+/// playback source strategy through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesPlaybackSourceStrategyStoreOverride] so the choice persists
+/// across restarts.
+final playbackSourceStrategyStoreProvider =
+    Provider<PlaybackSourceStrategyStore>((ref) {
+  return InMemoryPlaybackSourceStrategyStore();
+});
+
+/// Production binding: persists the chosen strategy via `shared_preferences`.
+/// Applied in `main`.
+final sharedPreferencesPlaybackSourceStrategyStoreOverride =
+    playbackSourceStrategyStoreProvider.overrideWithValue(
+  const SharedPreferencesPlaybackSourceStrategyStore(),
+);

--- a/lib/data/repositories/shared_preferences_playback_source_strategy_store.dart
+++ b/lib/data/repositories/shared_preferences_playback_source_strategy_store.dart
@@ -1,0 +1,34 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/playback_source_strategy_store.dart';
+
+/// A [PlaybackSourceStrategyStore] backed by `shared_preferences`.
+///
+/// The strategy is a single non-secret enum name, so one string under one key is
+/// plenty — no token, URL, or library content is ever written here. An absent
+/// (or empty) value reads as the default strategy (`null`) rather than throwing,
+/// so a storage hiccup can never break playback.
+class SharedPreferencesPlaybackSourceStrategyStore
+    implements PlaybackSourceStrategyStore {
+  const SharedPreferencesPlaybackSourceStrategyStore();
+
+  static const String _key = 'playback_source_strategy_v1';
+
+  @override
+  Future<String?> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    final String? value = prefs.getString(_key);
+    if (value == null || value.isEmpty) return null;
+    return value;
+  }
+
+  @override
+  Future<void> write(String? strategyName) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (strategyName == null || strategyName.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+    await prefs.setString(_key, strategyName);
+  }
+}

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -125,6 +125,29 @@ final cacheEntriesByIdProvider = Provider<Map<String, CachedTrack>>((ref) {
   };
 });
 
+/// The ids of tracks that have an offline copy on disk (a downloaded or
+/// pre-cached copy with managed bytes) — the safe, in-memory signal the playback
+/// source strategy uses to favour cache/local copies, without a disk scan or any
+/// path/URL.
+///
+/// Defaults to empty so the library/playback layers don't pull the whole cache
+/// stack in tests; `main` applies [offlineAvailableTrackIdsOverride] to derive
+/// it live from the cache snapshot. Tests override it directly with a set.
+final offlineAvailableTrackIdsProvider =
+    Provider<Set<String>>((ref) => const <String>{});
+
+/// Production binding: the live set of offline-available track ids, recomputed
+/// from [cacheEntriesByIdProvider] whenever the cache changes. Only entries with
+/// managed bytes count (an on-device marker with no file is not a cached copy).
+final offlineAvailableTrackIdsOverride =
+    offlineAvailableTrackIdsProvider.overrideWith((ref) {
+  final Map<String, CachedTrack> entries = ref.watch(cacheEntriesByIdProvider);
+  return <String>{
+    for (final CachedTrack entry in entries.values)
+      if (entry.isManaged) entry.trackId,
+  };
+});
+
 /// Owns the "Maximum cache size" limit: loads the persisted value and writes
 /// changes back through [DownloadPreferences]. Clamped to the supported range.
 class MaxCacheBytesController extends AsyncNotifier<int> {

--- a/lib/features/library/playback_candidates_provider.dart
+++ b/lib/features/library/playback_candidates_provider.dart
@@ -1,9 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/catalog/logical_track.dart';
+import '../../core/catalog/source_capability.dart';
+import '../../core/catalog/source_strategy.dart';
 import '../../core/models/track.dart';
 import '../../core/services/playback_candidate_source.dart';
+import '../downloads/download_providers.dart';
 import '../player/player_providers.dart';
+import 'playback_source_strategy_controller.dart';
 import 'unified_library_providers.dart';
 
 /// Maps each *displayed* (logical) track id to its ordered source candidates, so
@@ -12,21 +16,42 @@ import 'unified_library_providers.dart';
 ///
 /// Only de-duplicated rows that actually span more than one provider are listed —
 /// a single-source song needs no fallback and is left out (the controller treats
-/// an absent id as "no fallback"). Candidates are in the same deterministic,
-/// most-preferred-first order [unifyTracks] produced (honouring the default-source
-/// setting), and each carries the row's best-available cover
-/// ([LogicalTrack.displayArtworkUri]) so a fallback copy keeps the artwork the
-/// displayed row showed. The map recomputes whenever the library or the source
-/// preference changes.
+/// an absent id as "no fallback"). Each candidate carries the row's best-available
+/// cover ([LogicalTrack.displayArtworkUri]) so a fallback copy keeps the artwork
+/// the displayed row showed.
+///
+/// Candidates start in the deterministic, most-preferred-first order
+/// [unifyTracks] produced (honouring the default-source setting), then the chosen
+/// [PlaybackSourceStrategy] reorders them ([orderBySourceStrategy]) — e.g. a
+/// downloaded/local copy first under "prefer local/cache". `preferDefault` is the
+/// identity, so the PR1/PR2 order (and runtime fallback over it) is unchanged.
+/// The map recomputes whenever the library, the source preference, the strategy,
+/// or the offline-available set changes.
 final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
   final List<LogicalTrack> logicals = ref.watch(libraryLogicalTracksProvider);
+  final PlaybackSourceStrategy strategy =
+      ref.watch(playbackSourceStrategyProvider);
+  final Set<String> cachedIds = ref.watch(offlineAvailableTrackIdsProvider);
+
+  // A candidate's capability, made cache-aware from the in-memory offline set so
+  // "prefer cache/local" can favour a downloaded copy without a disk scan.
+  PlaybackSourceCapability profileOf(Track track) =>
+      PlaybackSourceCapability.fromTrack(
+        track,
+        cachedOffline: cachedIds.contains(track.id),
+      );
+
   final Map<String, List<Track>> byDisplayId = <String, List<Track>>{};
   for (final LogicalTrack logical in logicals) {
     if (!logical.hasMultipleSources) continue;
-    byDisplayId[logical.id] = <Track>[
+    final List<Track> candidates = <Track>[
       for (final TrackSourceCandidate c in logical.candidates)
         c.track.copyWith(artworkUri: logical.displayArtworkUri),
     ];
+    // Reorder by the chosen strategy. preferDefault is the identity, so the
+    // PR1/PR2 default-source order (and runtime fallback over it) is unchanged.
+    byDisplayId[logical.id] =
+        orderBySourceStrategy(candidates, strategy, profileOf);
   }
   return byDisplayId;
 });

--- a/lib/features/library/playback_source_strategy_controller.dart
+++ b/lib/features/library/playback_source_strategy_controller.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/catalog/source_strategy.dart';
+import '../../data/repositories/playback_source_strategy_store_provider.dart';
+
+/// Holds the user's chosen [PlaybackSourceStrategy] and persists changes.
+///
+/// Defaults to [PlaybackSourceStrategy.preferDefault] — the PR1/PR2 behaviour —
+/// so until the user picks a smart strategy nothing about source selection
+/// changes. The choice is loaded from the store at startup and written on every
+/// change, so it survives a restart. Until the async load lands the controller
+/// serves the default, which only affects *ordering* of duplicate candidates —
+/// never de-duplication, runtime fallback, or which copy actually plays when one
+/// fails — so a brief default is harmless.
+class PlaybackSourceStrategyController
+    extends Notifier<PlaybackSourceStrategy> {
+  bool _loadStarted = false;
+
+  /// Whether the user has chosen a strategy this session. If a choice lands
+  /// before the async startup load finishes, the load must not clobber it.
+  bool _userChose = false;
+
+  @override
+  PlaybackSourceStrategy build() {
+    if (!_loadStarted) {
+      _loadStarted = true;
+      _load();
+    }
+    return PlaybackSourceStrategy.preferDefault;
+  }
+
+  Future<void> _load() async {
+    try {
+      final String? stored =
+          await ref.read(playbackSourceStrategyStoreProvider).read();
+      // Nothing persisted, or the user already chose while the read was in
+      // flight: keep the current value rather than resetting to the default.
+      if (stored == null || _userChose) return;
+      final PlaybackSourceStrategy parsed =
+          PlaybackSourceStrategy.fromStorage(stored);
+      if (parsed != state) state = parsed;
+    } catch (_) {
+      // A storage hiccup must never break playback; keep the default.
+    }
+  }
+
+  /// Sets the strategy and persists it. A no-op when nothing changes.
+  Future<void> setStrategy(PlaybackSourceStrategy strategy) async {
+    _userChose = true;
+    if (strategy == state) return;
+    state = strategy;
+    try {
+      await ref.read(playbackSourceStrategyStoreProvider).write(strategy.name);
+    } catch (_) {
+      // Best-effort persistence: the in-memory choice still applies this session.
+    }
+  }
+}
+
+/// The user's live playback source strategy. The unified-library candidate
+/// provider watches this so a freshly-chosen strategy reorders candidates
+/// without a manual refresh.
+final playbackSourceStrategyProvider =
+    NotifierProvider<PlaybackSourceStrategyController, PlaybackSourceStrategy>(
+  PlaybackSourceStrategyController.new,
+);

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -11,6 +11,7 @@ import 'network/network_settings_section.dart';
 import 'playback/playback_settings_section.dart';
 import 'precache/precache_settings_section.dart';
 import 'source/default_provider_section.dart';
+import 'source/playback_source_strategy_section.dart';
 import 'subsonic/subsonic_settings_section.dart';
 
 /// Settings. Hosts the connection/source and offline-storage options, plus a
@@ -30,6 +31,8 @@ class SettingsScreen extends StatelessWidget {
           SubsonicSettingsSection(),
           SizedBox(height: AppSpacing.md),
           DefaultProviderSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          PlaybackSourceStrategySettingsSection(),
           SizedBox(height: AppSpacing.md),
           CacheSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/lib/features/settings/source/playback_source_strategy_section.dart
+++ b/lib/features/settings/source/playback_source_strategy_section.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/catalog/source_strategy.dart';
+import '../../library/playback_source_strategy_controller.dart';
+
+/// The "Playback source strategy" card on the Settings screen.
+///
+/// Lets the user pick how Linthra orders the copies of a song that exists on more
+/// than one source (e.g. prefer a downloaded copy to save data). The choice only
+/// reorders candidates before playback; runtime fallback still applies, and the
+/// now-playing indicator still shows the copy that actually played. "Prefer
+/// default provider" keeps the existing behaviour.
+class PlaybackSourceStrategySettingsSection extends ConsumerWidget {
+  const PlaybackSourceStrategySettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final PlaybackSourceStrategy selected =
+        ref.watch(playbackSourceStrategyProvider);
+
+    void choose(PlaybackSourceStrategy? strategy) {
+      if (strategy == null) return;
+      ref.read(playbackSourceStrategyProvider.notifier).setStrategy(strategy);
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.sm,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.tune_outlined, color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Playback source strategy',
+                    style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'When the same song is available from more than one place, choose '
+              'which copy Linthra plays first. If that copy fails, Linthra still '
+              'falls back to another one.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            for (final PlaybackSourceStrategy strategy
+                in PlaybackSourceStrategy.values)
+              RadioListTile<PlaybackSourceStrategy>(
+                contentPadding: EdgeInsets.zero,
+                value: strategy,
+                groupValue: selected,
+                onChanged: choose,
+                title: Text(strategy.label),
+                subtitle: Text(strategy.description),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'data/repositories/library_added_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/play_history_repository_provider.dart';
 import 'data/repositories/playback_preferences_provider.dart';
+import 'data/repositories/playback_source_strategy_store_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/preferred_source_store_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
@@ -55,6 +56,11 @@ Future<void> main() async {
       // Persist the user's explicit default-source choice (Settings), which
       // pins a provider ahead of the most-recently-signed-in order.
       sharedPreferencesDefaultProviderStoreOverride,
+      // Persist the chosen playback source strategy (prefer local/cache, highest
+      // quality, lower data, balanced, or default).
+      sharedPreferencesPlaybackSourceStrategyStoreOverride,
+      // Make the playback source strategy cache-aware from the live offline set.
+      offlineAvailableTrackIdsOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
       sharedPreferencesPlaybackPreferencesOverride,

--- a/test/core/catalog/source_strategy_test.dart
+++ b/test/core/catalog/source_strategy_test.dart
@@ -1,0 +1,237 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_capability.dart';
+import 'package:linthra/core/catalog/source_strategy.dart';
+
+/// A tagged candidate so tests can assert the resulting *order* by tag while the
+/// strategy reads the capability via [profileOf].
+typedef _Cand = ({String tag, PlaybackSourceCapability cap});
+
+SourceProviderType _pt(String provider) {
+  switch (provider) {
+    case 'local':
+      return SourceProviderType.local;
+    case 'subsonic':
+      return SourceProviderType.subsonic;
+    default:
+      return SourceProviderType.jellyfin;
+  }
+}
+
+_Cand _cand(
+  String tag,
+  SourceDelivery delivery, {
+  String provider = 'jellyfin',
+  int? bitrate,
+}) =>
+    (
+      tag: tag,
+      cap: PlaybackSourceCapability(
+        sourceId: provider,
+        providerType: _pt(provider),
+        delivery: delivery,
+        bitrateKbps: bitrate,
+      ),
+    );
+
+List<String> _order(List<_Cand> candidates, PlaybackSourceStrategy strategy) =>
+    orderBySourceStrategy(candidates, strategy, (_Cand c) => c.cap)
+        .map((_Cand c) => c.tag)
+        .toList();
+
+void main() {
+  group('preferDefault — identity (preserves PR1/PR2)', () {
+    test('order is unchanged regardless of delivery or quality', () {
+      final candidates = <_Cand>[
+        _cand('remote', SourceDelivery.remoteStream, bitrate: 128),
+        _cand('cache', SourceDelivery.cache),
+        _cand('local', SourceDelivery.localFile, provider: 'local'),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferDefault),
+        <String>['remote', 'cache', 'local'],
+      );
+    });
+  });
+
+  group('preferLocalCache', () {
+    test('chooses cache, then local, then server', () {
+      final candidates = <_Cand>[
+        _cand('remote', SourceDelivery.remoteStream),
+        _cand('cache', SourceDelivery.cache),
+        _cand('local', SourceDelivery.localFile, provider: 'local'),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferLocalCache),
+        <String>['cache', 'local', 'remote'],
+      );
+    });
+
+    test('falls back to default order when no cache/local exists', () {
+      final candidates = <_Cand>[
+        _cand('jelly', SourceDelivery.remoteStream),
+        _cand('sub', SourceDelivery.remoteStream, provider: 'subsonic'),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferLocalCache),
+        <String>['jelly', 'sub'],
+      );
+    });
+
+    test('default order is the tie-breaker among equal (server) candidates',
+        () {
+      final candidates = <_Cand>[
+        _cand('first', SourceDelivery.remoteStream),
+        _cand('cache', SourceDelivery.cache),
+        _cand('second', SourceDelivery.remoteStream, provider: 'subsonic'),
+      ];
+      // cache rises; the two servers keep their relative default order.
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferLocalCache),
+        <String>['cache', 'first', 'second'],
+      );
+    });
+  });
+
+  group('preferHighestQuality', () {
+    test('uses known quality: higher bitrate first', () {
+      final candidates = <_Cand>[
+        _cand('low', SourceDelivery.remoteStream, bitrate: 128),
+        _cand('high', SourceDelivery.remoteStream,
+            provider: 'subsonic', bitrate: 320),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferHighestQuality),
+        <String>['high', 'low'],
+      );
+    });
+
+    test('falls back to default order when quality is unknown', () {
+      final candidates = <_Cand>[
+        _cand('a', SourceDelivery.remoteStream),
+        _cand('b', SourceDelivery.remoteStream, provider: 'subsonic'),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferHighestQuality),
+        <String>['a', 'b'],
+      );
+    });
+
+    test('an unknown-quality candidate keeps its default slot (no downgrade)',
+        () {
+      // Only the known candidate(s) reorder among their own slots; the unknown
+      // one never moves, so a known-lower is never promoted past an unknown.
+      final candidates = <_Cand>[
+        _cand('unknown', SourceDelivery.remoteStream),
+        _cand('k320', SourceDelivery.remoteStream,
+            provider: 'subsonic', bitrate: 320),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferHighestQuality),
+        <String>['unknown', 'k320'],
+      );
+    });
+  });
+
+  group('preferLowerData', () {
+    test('prefers cache/local first', () {
+      final candidates = <_Cand>[
+        _cand('remote', SourceDelivery.remoteStream, bitrate: 64),
+        _cand('cache', SourceDelivery.cache),
+        _cand('local', SourceDelivery.localFile, provider: 'local'),
+      ];
+      final ordered =
+          _order(candidates, PlaybackSourceStrategy.preferLowerData);
+      expect(ordered.first, anyOf('cache', 'local'));
+      expect(ordered.last, 'remote');
+      expect(ordered.sublist(0, 2), containsAll(<String>['cache', 'local']));
+    });
+
+    test('uses known lower-data (bitrate) among server copies', () {
+      final candidates = <_Cand>[
+        _cand('hi', SourceDelivery.remoteStream, bitrate: 320),
+        _cand('lo', SourceDelivery.remoteStream,
+            provider: 'subsonic', bitrate: 96),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferLowerData),
+        <String>['lo', 'hi'],
+      );
+    });
+
+    test('falls back to default order when bitrate is unknown', () {
+      final candidates = <_Cand>[
+        _cand('a', SourceDelivery.remoteStream),
+        _cand('b', SourceDelivery.remoteStream, provider: 'subsonic'),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.preferLowerData),
+        <String>['a', 'b'],
+      );
+    });
+  });
+
+  group('automaticBalanced', () {
+    test('prefers cache/local when available', () {
+      final candidates = <_Cand>[
+        _cand('remote', SourceDelivery.remoteStream),
+        _cand('cache', SourceDelivery.cache),
+      ];
+      expect(
+        _order(candidates, PlaybackSourceStrategy.automaticBalanced),
+        <String>['cache', 'remote'],
+      );
+    });
+
+    test('falls back to default order when metadata is unknown', () {
+      final candidates = <_Cand>[
+        _cand('jelly', SourceDelivery.remoteStream, bitrate: 999),
+        _cand('sub', SourceDelivery.remoteStream, provider: 'subsonic'),
+      ];
+      // No cache/local, and balanced never reorders servers on quality guesses.
+      expect(
+        _order(candidates, PlaybackSourceStrategy.automaticBalanced),
+        <String>['jelly', 'sub'],
+      );
+    });
+  });
+
+  group('determinism & safety', () {
+    test('a single candidate is returned unchanged for every strategy', () {
+      for (final s in PlaybackSourceStrategy.values) {
+        expect(_order(<_Cand>[_cand('only', SourceDelivery.remoteStream)], s),
+            <String>['only']);
+      }
+    });
+
+    test('the same input always yields the same order', () {
+      final candidates = <_Cand>[
+        _cand('remote', SourceDelivery.remoteStream, bitrate: 200),
+        _cand('cache', SourceDelivery.cache),
+        _cand('local', SourceDelivery.localFile, provider: 'local'),
+      ];
+      final a = _order(candidates, PlaybackSourceStrategy.automaticBalanced);
+      final b = _order(candidates, PlaybackSourceStrategy.automaticBalanced);
+      expect(a, b);
+    });
+
+    test('strategy labels/descriptions expose no URLs, hosts, or paths', () {
+      for (final s in PlaybackSourceStrategy.values) {
+        for (final String text in <String>[s.label, s.description]) {
+          expect(text, isNot(contains('://')));
+          expect(text.toLowerCase(), isNot(contains('http')));
+          expect(text, isNot(contains(r'\')));
+          expect(text, isNot(contains('@')));
+        }
+      }
+    });
+
+    test('fromStorage falls back to the default for unknown/absent values', () {
+      expect(PlaybackSourceStrategy.fromStorage(null),
+          PlaybackSourceStrategy.preferDefault);
+      expect(PlaybackSourceStrategy.fromStorage('nonsense'),
+          PlaybackSourceStrategy.preferDefault);
+      expect(PlaybackSourceStrategy.fromStorage('preferLocalCache'),
+          PlaybackSourceStrategy.preferLocalCache);
+    });
+  });
+}

--- a/test/data/repositories/playback_source_strategy_store_test.dart
+++ b/test/data/repositories/playback_source_strategy_store_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_playback_source_strategy_store.dart';
+import 'package:linthra/data/repositories/shared_preferences_playback_source_strategy_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('InMemoryPlaybackSourceStrategyStore', () {
+    test('defaults to null (the default strategy) and round-trips', () async {
+      final store = InMemoryPlaybackSourceStrategyStore();
+      expect(await store.read(), isNull);
+
+      await store.write('preferLocalCache');
+      expect(await store.read(), 'preferLocalCache');
+
+      await store.write(null);
+      expect(await store.read(), isNull);
+    });
+
+    test('honours an initial value', () async {
+      final store = InMemoryPlaybackSourceStrategyStore('preferLowerData');
+      expect(await store.read(), 'preferLowerData');
+    });
+  });
+
+  group('SharedPreferencesPlaybackSourceStrategyStore', () {
+    setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+    test('reads null (the default) when nothing is stored', () async {
+      expect(
+        await const SharedPreferencesPlaybackSourceStrategyStore().read(),
+        isNull,
+      );
+    });
+
+    test('round-trips the choice across separate instances', () async {
+      await const SharedPreferencesPlaybackSourceStrategyStore()
+          .write('automaticBalanced');
+
+      expect(
+        await const SharedPreferencesPlaybackSourceStrategyStore().read(),
+        'automaticBalanced',
+      );
+    });
+
+    test('writing null clears a stored choice', () async {
+      await const SharedPreferencesPlaybackSourceStrategyStore()
+          .write('preferHighestQuality');
+      await const SharedPreferencesPlaybackSourceStrategyStore().write(null);
+
+      expect(
+        await const SharedPreferencesPlaybackSourceStrategyStore().read(),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/library/playback_candidates_provider_test.dart
+++ b/test/features/library/playback_candidates_provider_test.dart
@@ -1,13 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/core/catalog/source_strategy.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/downloads/download_providers.dart';
 import 'package:linthra/features/library/library_controller.dart';
 import 'package:linthra/features/library/playback_candidates_provider.dart';
+import 'package:linthra/features/library/playback_source_strategy_controller.dart';
 import 'package:linthra/features/library/source_preference_controller.dart';
 
 final Uri _jellyArt =
@@ -40,10 +43,20 @@ class _FixedPreference extends SourcePreferenceController {
   SourcePriority build() => _priority;
 }
 
+/// Pins the playback source strategy for a deterministic test.
+class _FixedStrategy extends PlaybackSourceStrategyController {
+  _FixedStrategy(this._strategy);
+  final PlaybackSourceStrategy _strategy;
+  @override
+  PlaybackSourceStrategy build() => _strategy;
+}
+
 Future<ProviderContainer> _seed({
   required SourcePriority priority,
   required List<Track> jellyfin,
   required List<Track> subsonic,
+  PlaybackSourceStrategy strategy = PlaybackSourceStrategy.preferDefault,
+  Set<String> cachedIds = const <String>{},
 }) async {
   final repo = InMemoryMusicLibraryRepository();
   final container = ProviderContainer(
@@ -51,6 +64,9 @@ Future<ProviderContainer> _seed({
       musicLibraryRepositoryProvider.overrideWithValue(repo),
       librarySourcePriorityProvider
           .overrideWith(() => _FixedPreference(priority)),
+      playbackSourceStrategyProvider
+          .overrideWith(() => _FixedStrategy(strategy)),
+      offlineAvailableTrackIdsProvider.overrideWithValue(cachedIds),
     ],
   );
   addTearDown(container.dispose);
@@ -121,6 +137,58 @@ void main() {
           container.read(playbackCandidatesProvider);
 
       expect(map, isEmpty);
+    });
+  });
+
+  group('playbackCandidatesProvider — strategy ordering', () {
+    test('preferDefault leaves the default-source order unchanged', () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['jellyfin', 'subsonic']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello')],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+        strategy: PlaybackSourceStrategy.preferDefault,
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+      expect(map['j']!.map((Track t) => t.uri).toList(),
+          <String>['jellyfin:j', 'subsonic:s']);
+    });
+
+    test('preferLocalCache promotes a cached copy ahead of the default',
+        () async {
+      // Jellyfin is the default (so leads by default), but the Subsonic copy is
+      // downloaded — "prefer local/cache" must play the cached copy first.
+      final container = await _seed(
+        priority: const SourcePriority(<String>['jellyfin', 'subsonic']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello')],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+        strategy: PlaybackSourceStrategy.preferLocalCache,
+        cachedIds: <String>{'s'},
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+      // Same display id (Jellyfin primary), but the cached Subsonic copy leads.
+      expect(map['j']!.map((Track t) => t.uri).toList(),
+          <String>['subsonic:s', 'jellyfin:j']);
+    });
+
+    test(
+        'preferLocalCache keeps the default order when nothing is cached/local',
+        () async {
+      final container = await _seed(
+        priority: const SourcePriority(<String>['jellyfin', 'subsonic']),
+        jellyfin: <Track>[_jelly('j', title: 'Hello')],
+        subsonic: <Track>[_sub('s', title: 'Hello')],
+        strategy: PlaybackSourceStrategy.preferLocalCache,
+        // No offline copies.
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+      expect(map['j']!.map((Track t) => t.uri).toList(),
+          <String>['jellyfin:j', 'subsonic:s']);
     });
   });
 }

--- a/test/features/library/playback_source_strategy_controller_test.dart
+++ b/test/features/library/playback_source_strategy_controller_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/source_strategy.dart';
+import 'package:linthra/data/repositories/in_memory_playback_source_strategy_store.dart';
+import 'package:linthra/data/repositories/playback_source_strategy_store_provider.dart';
+import 'package:linthra/features/library/playback_source_strategy_controller.dart';
+
+ProviderContainer _container(InMemoryPlaybackSourceStrategyStore store) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      playbackSourceStrategyStoreProvider.overrideWithValue(store),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('PlaybackSourceStrategyController', () {
+    test('defaults to preferDefault before the async load lands', () {
+      final container = _container(InMemoryPlaybackSourceStrategyStore());
+      expect(container.read(playbackSourceStrategyProvider),
+          PlaybackSourceStrategy.preferDefault);
+    });
+
+    test('loads a persisted strategy', () async {
+      final container =
+          _container(InMemoryPlaybackSourceStrategyStore('preferLowerData'));
+      // Reading starts build() + the async load.
+      container.read(playbackSourceStrategyProvider);
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(playbackSourceStrategyProvider),
+          PlaybackSourceStrategy.preferLowerData);
+    });
+
+    test('an unrecognised stored value falls back to the default', () async {
+      final container =
+          _container(InMemoryPlaybackSourceStrategyStore('garbage'));
+      container.read(playbackSourceStrategyProvider);
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(playbackSourceStrategyProvider),
+          PlaybackSourceStrategy.preferDefault);
+    });
+
+    test('setStrategy updates state and persists the enum name', () async {
+      final store = InMemoryPlaybackSourceStrategyStore();
+      final container = _container(store);
+
+      await container
+          .read(playbackSourceStrategyProvider.notifier)
+          .setStrategy(PlaybackSourceStrategy.preferHighestQuality);
+
+      expect(container.read(playbackSourceStrategyProvider),
+          PlaybackSourceStrategy.preferHighestQuality);
+      expect(await store.read(), 'preferHighestQuality');
+    });
+
+    test('setStrategy to the current value is a no-op', () async {
+      final store = InMemoryPlaybackSourceStrategyStore();
+      final container = _container(store);
+
+      await container
+          .read(playbackSourceStrategyProvider.notifier)
+          .setStrategy(PlaybackSourceStrategy.preferDefault);
+
+      // Nothing persisted for the unchanged default.
+      expect(await store.read(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Builds on PR3a's capability metadata to add a **user-selectable** strategy that orders a song's source candidates before playback. It only reorders candidates — PR1 default-source, PR2 runtime fallback, de-duplication, and the "Playing from …" indicator are unchanged, and **Prefer default provider is the exact identity** (existing behavior).

Guardrails honored: no telemetry/analytics/3rd-party; no URLs/paths/hosts/tokens exposed; matching/dedup untouched; Jellyfin/Navidrome/local/cache/Cast/offline paths unaffected; **no release, no version bump, no tag, no fdroiddata**.

## Report (before coding)
1. **PR3a model** — `PlaybackSourceCapability`: owning provider, delivery (local/cache/remote/unknown), duration; bitrate/codec/size/transcoded/LAN all `null` today.
2. **Ordering design** — a pure `orderBySourceStrategy(candidates, strategy, profileOf)` reorders the per-song candidate list PR2 already builds, **before** the controller tries it. Deterministic: a stable transform whose **final tie-breaker is the original default-provider order**, so equal candidates never swap and `preferDefault` is the identity.
3. **Metadata available today** — owning provider + delivery (from URI scheme), cached-offline (from the in-memory download set), duration. That's it.
4. **Stays conservative** — quality/data rules move a candidate *only* when the value is known; unknowns never move and are never faked, so those strategies fall back to default order today.
5. **Files** — listed in the commit.

## Strategies (Settings → Playback source strategy)
| Strategy | Ordering |
| --- | --- |
| Prefer default provider | Identity (PR1/PR2) |
| Prefer local/cache | Downloaded/offline → on-device → server |
| Prefer highest quality | Known higher bitrate first; unknown keeps default slot (no silent downgrade) |
| Prefer lower data usage | Cache/local first, then known lower-bitrate server copies; unknown stays default |
| Automatic (balanced) | Cache/local first, else default; no server-vs-server guessing |

## Implementation
- `core/catalog/source_strategy.dart` — enum + pure `orderBySourceStrategy`.
- Strategy store/controller mirroring the default-provider preference (in-memory + shared_preferences; defaults to `preferDefault`; load never clobbers a user choice).
- `playbackCandidatesProvider` reorders by the chosen strategy, made cache-aware from a new in-memory `offlineAvailableTrackIdsProvider` (no network/disk scan); `source_capability.fromTrack` gains a safe `cachedOffline` flag.
- A compact radio-list settings section.

## Tests & checks
Exhaustive pure-ordering tests for every strategy (cache/local-first, known-quality/known-lower-data, unknown→default fallback, determinism, single-candidate identity, safe labels); the controller (default/load/unknown-fallback/persist/no-clobber); the shared-prefs store; provider integration (preferDefault unchanged, preferLocalCache promotes a cached copy, falls back with no cache). Runtime fallback + "Playing from …" remain covered by PR2's suite.
`dart format --set-exit-if-changed .` clean · `flutter analyze` no issues · `flutter test` **1439 passing**.

## Docs
`docs/playback-source-strategy.md` updated: the PR3b strategies, determinism, unknown-stays-unknown, default-provider as tie-breaker, and the indicator showing the actual source.

https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqbegxGzkX72TYtLoMkHL)_