### PR TITLE
chore(release): prepare v0.1.2

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/102999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/102999.txt
@@ -1,0 +1,19 @@
+Linthra 0.1.2 — unified multi-source library & smarter playback.
+
+Added:
+- Tracks available from more than one source (local files, Jellyfin, and
+  Subsonic/Navidrome) are now unified into a single library entry instead of
+  appearing as duplicates.
+- A default playback source setting, so you can choose which provider a
+  unified track plays from.
+- Smarter playback source selection, with automatic fallback to another
+  source at runtime when the preferred one can't play.
+
+Changed:
+- Clearer Subsonic/Navidrome connection error messages.
+
+Fixed:
+- Artwork now falls back per provider, and duplicate matching is more
+  conservative so distinct tracks are no longer merged by mistake.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.1';
+  static const String _devVersionName = '0.1.2';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.1+101999
+version: 0.1.2+102999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Release-bump-only PR for **v0.1.2**. F-Droid has merged v0.1.1, so this prepares the next release. No tag, no GitHub Release, no fdroiddata/metadata change — just the three version-linked files, matching the v0.1.1 bump (#147).

| Field | Value |
| ----- | ----- |
| versionName | `0.1.2` |
| versionCode | `102999` |
| `pubspec.yaml` `version:` | `0.1.2+102999` |
| `AppInfo._devVersionName` | `0.1.2` |
| Fastlane changelog | `fastlane/metadata/android/en-US/changelogs/102999.txt` |
| Tag (created later, after merge) | `v0.1.2` |

`102999` is the canonical encoding from `tool/version_from_tag.dart` for a stable `0.1.2` (`0*10_000_000 + 1*100_000 + 2*1_000 + 999`), strictly greater than the previous `0.1.1+101999`, so Android and F-Droid both accept it as an update.

## What's included in v0.1.2

Everything that landed on `main` since the `v0.1.1` tag (#148–#154) — themed around the unified multi-provider library and a smarter playback-source strategy:

- **#149** — unify duplicate tracks across providers (local / Jellyfin / Subsonic) into one library entry
- **#151** — explicit default playback source setting
- **#154** — smart playback source strategy (PR3b)
- **#152** — runtime fallback to another source when the preferred one fails
- **#153** — capture playback source capability metadata (PR3a, metadata-only / internal)
- **#150** — provider-aware artwork fallback + conservative scored matching (fix)
- **#148** — local Navidrome dev setup + sharper Subsonic connection errors

## Files changed (3)

- `pubspec.yaml` — `0.1.1+101999` → `0.1.2+102999`
- `lib/core/app_info.dart` — `_devVersionName` → `0.1.2` (kept in lockstep so the version-drift test passes)
- `fastlane/metadata/android/en-US/changelogs/102999.txt` — new F-Droid release notes

## Guardrails honored

- ✅ **Did not** modify old tags or old release assets (immutable to F-Droid mirrors / Android updaters)
- ✅ **Did not** touch fdroiddata — and left `metadata/io.github.thezupzup.linthra.yml` untouched, same as the v0.1.1 bump (F-Droid auto-detects via `AutoUpdateMode: Version` + `UpdateCheckMode: Tags`)
- ✅ **No dependency changes**, so `pubspec.lock` is left untouched (stays in sync for F-Droid's `flutter pub get --enforce-lockfile`)
- ✅ versionCode is strictly monotonic vs. the last release

## Verification

All run against the bump on pinned Flutter `3.27.4`:

- `dart format --set-exit-if-changed .` → 0 files changed
- `flutter analyze` → No issues found
- `flutter test test/tooling/ test/core/app_info_version_test.dart` → 72 passed (F-Droid guardrails + version-drift / canonical-encoding)
- `flutter test` (full suite) → **1439 passed, 0 failed**
- `./scripts/release_preflight.sh v0.1.2` → `OK: v0.1.2 matches pubspec.yaml version 0.1.2+102999.`
- `flutter pub get --enforce-lockfile` → resolves cleanly (lockfile in sync)

## Next steps (manual, after merge)

This PR only bumps the version. Per `docs/release-process.md`, after it merges into `main`: pull `main`, re-run the preflight, then create the annotated `v0.1.2` tag from `main` (`git tag -a v0.1.2 -m "Linthra 0.1.2"`) — the release workflow builds and attaches the signed artifacts. The tag is never pushed before this PR is merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7qFNcZ2QbWYzUENf8pnC8)_