### PR TITLE
feat(player): global now-playing indicator across track rows

### DIFF
--- a/lib/core/catalog/now_playing_match.dart
+++ b/lib/core/catalog/now_playing_match.dart
@@ -1,0 +1,30 @@
+import '../models/track.dart';
+import 'track_identity.dart';
+
+/// Whether a displayed track [row] represents the same *logical* song as the
+/// current playback track [current] — the decision a track row uses to show the
+/// now-playing indicator.
+///
+/// Two deterministic, deliberately conservative layers:
+///
+///  * **Exact id.** The everyday case: the row is literally the playing copy
+///    (same provider, same track id). This is also the only thing that can match
+///    an untagged local file, which carries too little metadata to be matched any
+///    other way — so it only ever lights up its own row.
+///  * **Cross-provider fallback.** When [row] and [current] come from *different*
+///    providers, they count as the same song only when [isLikelySameTrack]
+///    confidently agrees. This is the exact predicate the library unifier merges
+///    duplicates on, so the indicator stays consistent with how the rest of the
+///    app already reasons about "the same song across sources": if the user
+///    tapped a Jellyfin row but playback fell back to the Navidrome copy, the
+///    Jellyfin row still reads as currently playing.
+///
+/// Two rows from the *same* provider never match by metadata (only by id),
+/// mirroring the unifier's rule that a single provider's own rows are assumed
+/// already de-duplicated — so two distinct rows from one source can't both claim
+/// to be the playing track.
+bool isCurrentPlaybackTrack(Track row, Track current) {
+  if (row.id == current.id) return true;
+  if (trackSourceId(row) == trackSourceId(current)) return false;
+  return isLikelySameTrack(row, current);
+}

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -10,7 +10,8 @@ import '../../core/repositories/download_store.dart';
 import '../../core/services/offline_cache_manager.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../shared/widgets/empty_state.dart';
-import '../player/widgets/album_artwork.dart';
+import '../player/now_playing.dart';
+import '../player/widgets/track_artwork.dart';
 import '../settings/network/network_settings_section.dart';
 import 'download_providers.dart';
 
@@ -202,14 +203,14 @@ class _ActiveDownloadTile extends ConsumerWidget {
     final DownloadProgress? progress = status == DownloadStatus.downloading
         ? ref.watch(trackDownloadProgressProvider(track.id)).valueOrNull
         : null;
+    final NowPlayingRowState? nowPlaying =
+        ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
 
     return ListTile(
-      leading: SizedBox.square(
+      leading: TrackArtwork(
+        artworkUri: track.artworkUri,
+        nowPlaying: nowPlaying,
         dimension: 44,
-        child: AlbumArtwork(
-          artworkUri: track.artworkUri,
-          borderRadius: BorderRadius.circular(AppRadii.sm),
-        ),
       ),
       title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: _ActiveSubtitle(status: status, progress: progress),
@@ -344,13 +345,13 @@ class _DownloadedTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final CachedTrack? entry = ref.watch(cacheEntriesByIdProvider)[track.id];
     final bool pinned = entry?.pinned ?? false;
+    final NowPlayingRowState? nowPlaying =
+        ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
     return ListTile(
-      leading: SizedBox.square(
+      leading: TrackArtwork(
+        artworkUri: track.artworkUri,
+        nowPlaying: nowPlaying,
         dimension: 44,
-        child: AlbumArtwork(
-          artworkUri: track.artworkUri,
-          borderRadius: BorderRadius.circular(AppRadii.sm),
-        ),
       ),
       title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: _subtitle(track, entry),

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../app/dimens.dart';
 import '../../../app/routes.dart';
 import '../../../core/models/track.dart';
 import '../../../core/repositories/download_repository.dart';
 import '../../../data/repositories/download_repository_provider.dart';
 import '../../downloads/download_providers.dart';
+import '../../player/now_playing.dart';
 import '../../player/player_providers.dart';
-import '../../player/widgets/album_artwork.dart';
+import '../../player/widgets/track_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../song_actions.dart';
 
@@ -80,6 +80,10 @@ class TrackTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final track = tracks[index];
     final theme = Theme.of(context);
+    // Only this row's own now-playing state is selected, so a track change that
+    // doesn't affect this row never rebuilds it.
+    final NowPlayingRowState? nowPlaying =
+        ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
     final status =
         ref.watch(trackDownloadStatusProvider(track.id)).valueOrNull ??
             DownloadStatus.notDownloaded;
@@ -95,12 +99,9 @@ class TrackTile extends ConsumerWidget {
 
     return ListTile(
       selected: selectionActive && selected,
-      leading: SizedBox.square(
-        dimension: 48,
-        child: AlbumArtwork(
-          artworkUri: track.artworkUri,
-          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
-        ),
+      leading: TrackArtwork(
+        artworkUri: track.artworkUri,
+        nowPlaying: nowPlaying,
       ),
       title: Text(
         track.title,

--- a/lib/features/player/now_playing.dart
+++ b/lib/features/player/now_playing.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/catalog/now_playing_match.dart';
+import '../../core/models/track.dart';
+
+/// How a track row should mark itself relative to the current playback track.
+enum NowPlayingRowState {
+  /// The row is the current track and playback is actively playing — the
+  /// indicator animates.
+  playing,
+
+  /// The row is the current track but playback is paused (or otherwise not
+  /// actively playing) — the indicator is shown, but static.
+  paused,
+}
+
+/// A tiny, position-independent snapshot of "what is playing", shared by every
+/// track-row surface so the now-playing matching logic lives in exactly one
+/// place rather than being re-derived per screen.
+///
+/// It carries only the current [Track] and whether playback [isPlaying] — never
+/// the position — and has value equality, so it (and the rows watching it) only
+/// change on a track change or a play/pause flip, not on every position tick.
+@immutable
+class NowPlaying {
+  const NowPlaying({this.currentTrack, this.isPlaying = false});
+
+  /// The current logical playback track, or null when nothing is playing. May be
+  /// a fallback source copy of what the user tapped (see [stateForRow]).
+  final Track? currentTrack;
+
+  /// Whether playback is actively playing — drives whether the indicator
+  /// animates. False while paused, buffering, idle, errored, or stopped.
+  final bool isPlaying;
+
+  /// The indicator state for the row showing [row], or null when [row] is not
+  /// the current track and so should show nothing. Matching is logical, so a
+  /// different provider's copy of the current song still counts as current (see
+  /// [isCurrentPlaybackTrack]).
+  NowPlayingRowState? stateForRow(Track row) {
+    final Track? current = currentTrack;
+    if (current == null) return null;
+    if (!isCurrentPlaybackTrack(row, current)) return null;
+    return isPlaying ? NowPlayingRowState.playing : NowPlayingRowState.paused;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is NowPlaying &&
+          other.currentTrack == currentTrack &&
+          other.isPlaying == isPlaying);
+
+  @override
+  int get hashCode => Object.hash(currentTrack, isPlaying);
+}
+
+/// What is currently playing, for the now-playing indicator on track rows.
+///
+/// The default is deliberately inert — nothing playing — and has **no**
+/// dependency on the playback engine, so any surface that shows track rows can
+/// watch it without pulling in `just_audio`/cast (and tests render rows without a
+/// perpetually-animating indicator or a real audio plugin). Production wires it
+/// to the live `PlaybackState` via `nowPlayingOverride` in `main.dart`, mirroring
+/// `currentlyPlayingTrackIdProvider`/`currentlyPlayingTrackIdOverride`.
+final nowPlayingProvider = Provider<NowPlaying>((ref) => const NowPlaying());

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -22,6 +22,7 @@ import '../../data/repositories/play_history_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'cast/cast_providers.dart';
+import 'now_playing.dart';
 
 /// The source router wrapped in the stream-preloading decorator.
 ///
@@ -180,3 +181,22 @@ final currentlyPlayingTrackIdOverride =
     currentlyPlayingTrackIdProvider.overrideWith(
   (ref) => () => ref.read(playbackControllerProvider).state.currentTrack?.id,
 );
+
+/// Production binding: drives the now-playing indicator on every track row from
+/// the live [PlaybackState]. Selected down to `(current track, isPlaying)` so it
+/// updates only on a track change or a play/pause flip — never on a position
+/// tick — keeping the indicator's rebuilds rare. Applied in `main`; tests keep
+/// the inert default ([nowPlayingProvider] — nothing playing) unless they
+/// override it, so no row animates and no audio plugin is touched in a test.
+final nowPlayingOverride = nowPlayingProvider.overrideWith((ref) {
+  final controller = ref.watch(playbackControllerProvider);
+  return ref.watch(
+    playbackStateProvider.select((async) {
+      final PlaybackState state = async.valueOrNull ?? controller.state;
+      return NowPlaying(
+        currentTrack: state.currentTrack,
+        isPlaying: state.isPlaying,
+      );
+    }),
+  );
+});

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -7,7 +7,9 @@ import '../../../core/models/playback_state.dart';
 import '../../../core/models/playlist.dart';
 import '../../../core/models/track.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
+import '../../../shared/widgets/now_playing_indicator.dart';
 import '../../playlists/widgets/create_playlist_dialog.dart';
+import '../now_playing.dart';
 import '../player_providers.dart';
 import 'album_artwork.dart';
 
@@ -225,16 +227,19 @@ class _SectionLabel extends StatelessWidget {
 }
 
 /// The current track row, highlighted with the warm "live" accent so it reads
-/// as the one playing now. Non-draggable and non-removable on purpose: the
-/// queue manager never yanks the playing track out from under playback.
-class _CurrentTile extends StatelessWidget {
+/// as the one playing now. Its trailing equalizer animates while playback is
+/// playing and rests while paused. Non-draggable and non-removable on purpose:
+/// the queue manager never yanks the playing track out from under playback.
+class _CurrentTile extends ConsumerWidget {
   const _CurrentTile({required this.track});
 
   final Track track;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final bool isPlaying =
+        ref.watch(nowPlayingProvider.select((n) => n.isPlaying));
     final String? artist = track.artistName;
     return ListTile(
       leading: SizedBox.square(
@@ -256,11 +261,7 @@ class _CurrentTile extends StatelessWidget {
       subtitle: artist == null || artist.isEmpty
           ? null
           : Text(artist, maxLines: 1, overflow: TextOverflow.ellipsis),
-      trailing: const Icon(
-        Icons.graphic_eq,
-        color: AppColors.accent,
-        semanticLabel: 'Now playing',
-      ),
+      trailing: NowPlayingIndicator(animating: isPlaying),
     );
   }
 }

--- a/lib/features/player/widgets/track_artwork.dart
+++ b/lib/features/player/widgets/track_artwork.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../shared/widgets/now_playing_indicator.dart';
+import '../now_playing.dart';
+import 'album_artwork.dart';
+
+/// Album artwork for a track row, with the [NowPlayingIndicator] overlaid when
+/// [nowPlaying] says this row is the current track.
+///
+/// Centralizes the artwork-plus-overlay so every track-row surface (library,
+/// search, album/artist/mix detail, playlists, downloads) marks the playing song
+/// the same way — the indicator animates while playing and rests while paused,
+/// over a subtle scrim so the cover stays legible.
+class TrackArtwork extends StatelessWidget {
+  const TrackArtwork({
+    required this.artworkUri,
+    required this.nowPlaying,
+    this.dimension = 48,
+    this.borderRadius = const BorderRadius.all(Radius.circular(AppRadii.sm)),
+    super.key,
+  });
+
+  final Uri? artworkUri;
+
+  /// This row's now-playing state, or null when it is not the current track.
+  final NowPlayingRowState? nowPlaying;
+
+  final double dimension;
+  final BorderRadius borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: dimension,
+      child: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          AlbumArtwork(artworkUri: artworkUri, borderRadius: borderRadius),
+          if (nowPlaying != null)
+            NowPlayingIndicator(
+              overlay: true,
+              animating: nowPlaying == NowPlayingRowState.playing,
+              borderRadius: borderRadius,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -11,8 +11,10 @@ import '../../data/repositories/playlist_repository_provider.dart';
 import '../../shared/widgets/confirm_dialog.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../library/song_actions.dart';
+import '../player/now_playing.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
+import '../player/widgets/track_artwork.dart';
 import 'playlist_providers.dart';
 import 'widgets/add_to_playlist_sheet.dart';
 import 'widgets/create_playlist_dialog.dart';
@@ -231,14 +233,14 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     required bool draggable,
   }) {
     final Track track = tracks[index];
+    final NowPlayingRowState? nowPlaying =
+        ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
     return ListTile(
       key: ValueKey<String>(track.id),
-      leading: SizedBox.square(
+      leading: TrackArtwork(
+        artworkUri: track.artworkUri,
+        nowPlaying: nowPlaying,
         dimension: 44,
-        child: AlbumArtwork(
-          artworkUri: track.artworkUri,
-          borderRadius: const BorderRadius.all(Radius.circular(AppRadii.sm)),
-        ),
       ),
       title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
       subtitle: _subtitleWidget(track),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -71,6 +71,10 @@ Future<void> main() async {
       // unified library, in default-source-first order).
       playbackCandidateSourceOverride,
       currentlyPlayingTrackIdOverride,
+      // Drive the now-playing indicator on track rows from live playback (the
+      // current logical track + play/pause), so every list surface marks the
+      // playing song. Inert by default in tests.
+      nowPlayingOverride,
       secureJellyfinSessionStoreOverride,
       // Remember which Jellyfin account has had its first auto-sync, so a
       // reconnect after a restart doesn't trigger an unsolicited full re-sync.

--- a/lib/shared/widgets/now_playing_indicator.dart
+++ b/lib/shared/widgets/now_playing_indicator.dart
@@ -1,0 +1,187 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../app/colors.dart';
+
+/// A small, subtle "now playing" marker for track rows.
+///
+/// While playback is playing it animates as an equalizer — a few accent-coloured
+/// bars rising and falling; while paused it shows the same bars at rest, static.
+/// It uses Linthra's warm "live" accent so it reads natively as the active track.
+///
+/// It stays cheap by design: a single [AnimationController] drives one
+/// [CustomPainter] (a single repaint boundary), and that controller only runs
+/// while [animating] — and never when the platform or user asks for reduced
+/// motion ([MediaQueryData.disableAnimations]). So a paused, off-screen, or
+/// reduce-motion indicator costs no frames and no battery.
+///
+/// Pass [overlay] (with a [borderRadius] matching the artwork) to lay it over an
+/// album thumbnail: it then fills its parent and paints a subtle scrim behind the
+/// centred bars so they stay legible on bright covers and in either theme.
+/// Without [overlay] it is just the bars at [size], for inline use.
+class NowPlayingIndicator extends StatefulWidget {
+  const NowPlayingIndicator({
+    required this.animating,
+    this.size = 18,
+    this.color,
+    this.overlay = false,
+    this.borderRadius,
+    super.key,
+  });
+
+  /// Whether playback is actively playing. The bars animate only when this is
+  /// true *and* motion is allowed; otherwise they are static.
+  final bool animating;
+
+  /// The edge length of the painted equalizer. When [overlay] is set the scrim
+  /// fills the parent and the bars are centred at this size.
+  final double size;
+
+  /// The bar colour. Defaults to the app's "live" accent.
+  final Color? color;
+
+  /// Lay the indicator over artwork: fill the parent and paint a scrim behind the
+  /// centred bars for contrast.
+  final bool overlay;
+
+  /// The scrim's corner radius, to match the artwork it covers. Only used when
+  /// [overlay] is set.
+  final BorderRadius? borderRadius;
+
+  @override
+  State<NowPlayingIndicator> createState() => _NowPlayingIndicatorState();
+}
+
+class _NowPlayingIndicatorState extends State<NowPlayingIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 900),
+  );
+
+  bool _reduceMotion = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _reduceMotion = MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    _syncController();
+  }
+
+  @override
+  void didUpdateWidget(NowPlayingIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.animating != widget.animating) _syncController();
+  }
+
+  /// Run the loop only while playing and motion is allowed; otherwise stop it so
+  /// a paused or reduce-motion indicator schedules no frames.
+  void _syncController() {
+    if (widget.animating && !_reduceMotion) {
+      if (!_controller.isAnimating) _controller.repeat();
+    } else if (_controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool animate = widget.animating && !_reduceMotion;
+    final Widget bars = SizedBox.square(
+      dimension: widget.size,
+      child: CustomPaint(
+        painter: _EqualizerPainter(
+          animation: _controller,
+          animate: animate,
+          color: widget.color ?? AppColors.accent,
+        ),
+      ),
+    );
+    final Widget content = widget.overlay
+        ? SizedBox.expand(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.4),
+                borderRadius: widget.borderRadius,
+              ),
+              child: Center(child: bars),
+            ),
+          )
+        : bars;
+    return Semantics(
+      label: widget.animating ? 'Now playing' : 'Now playing, paused',
+      child: content,
+    );
+  }
+}
+
+/// Paints the equalizer bars. When [animate] is true it reads [animation] each
+/// frame for a smooth, looping, per-bar phase-shifted motion; when false it draws
+/// a fixed resting silhouette so a paused marker still reads as an equalizer.
+class _EqualizerPainter extends CustomPainter {
+  _EqualizerPainter({
+    required this.animation,
+    required this.animate,
+    required this.color,
+  }) : super(repaint: animation);
+
+  final Animation<double> animation;
+  final bool animate;
+  final Color color;
+
+  /// The static (paused) heights, centre bar tallest, as fractions of height.
+  /// Its length is the number of bars drawn.
+  static const List<double> _restingHeights = <double>[0.5, 0.85, 0.65];
+
+  static int get _barCount => _restingHeights.length;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty) return;
+    final double t = animate ? animation.value : 0.0;
+    // Bars and the gaps between them share one width unit; a gap is a fraction of
+    // a bar so the cluster stays balanced at any [size].
+    const double gapRatio = 0.55;
+    final double unit = size.width / (_barCount + (_barCount - 1) * gapRatio);
+    final double barWidth = unit;
+    final double gap = unit * gapRatio;
+    final double radius = barWidth / 2;
+    final Paint paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+    for (int i = 0; i < _barCount; i++) {
+      final double fraction =
+          animate ? _animatedFraction(i, t) : _restingHeights[i];
+      final double barHeight = size.height * fraction;
+      final double left = i * (barWidth + gap);
+      final double top = size.height - barHeight;
+      canvas.drawRRect(
+        RRect.fromRectAndCorners(
+          Rect.fromLTWH(left, top, barWidth, barHeight),
+          topLeft: Radius.circular(radius),
+          topRight: Radius.circular(radius),
+        ),
+        paint,
+      );
+    }
+  }
+
+  /// A smooth, looping height in `[0.2, 1.0]` for bar [i], phase-shifted per bar
+  /// so the bars don't rise and fall in lockstep.
+  double _animatedFraction(int i, double t) {
+    final double phase = i * (2 * math.pi / _barCount);
+    final double wave = math.sin(t * 2 * math.pi + phase);
+    return 0.2 + (wave + 1) / 2 * 0.8;
+  }
+
+  @override
+  bool shouldRepaint(_EqualizerPainter oldDelegate) =>
+      oldDelegate.animate != animate || oldDelegate.color != color;
+}

--- a/test/core/catalog/now_playing_match_test.dart
+++ b/test/core/catalog/now_playing_match_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/now_playing_match.dart';
+import 'package:linthra/core/models/track.dart';
+
+Track _jelly(
+  String id, {
+  String title = 'Careful',
+  String artist = 'NF',
+  String album = 'Perception',
+  Duration duration = const Duration(seconds: 200),
+  int? trackNumber,
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+      trackNumber: trackNumber,
+    );
+
+Track _sub(
+  String id, {
+  String title = 'Careful',
+  String artist = 'NF',
+  String album = 'Perception',
+  Duration duration = const Duration(seconds: 200),
+  int? trackNumber,
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+      trackNumber: trackNumber,
+    );
+
+void main() {
+  group('isCurrentPlaybackTrack', () {
+    test('matches the exact same track', () {
+      final Track t = _jelly('a');
+      expect(isCurrentPlaybackTrack(t, t), isTrue);
+    });
+
+    test('a different song on the same provider is not current', () {
+      expect(
+        isCurrentPlaybackTrack(
+          _jelly('a', title: 'Alpha', album: 'A'),
+          _jelly('b', title: 'Beta', album: 'B'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('two distinct same-provider ids never match by metadata alone', () {
+      // Identical metadata but different ids on one provider: only the exact id
+      // counts, mirroring the unifier never merging a single source's own rows.
+      expect(isCurrentPlaybackTrack(_jelly('a'), _jelly('b')), isFalse);
+    });
+
+    test('the same song on a different provider matches (fallback)', () {
+      // Tapped the Jellyfin row, playback fell back to the Navidrome copy.
+      expect(isCurrentPlaybackTrack(_jelly('j1'), _sub('s1')), isTrue);
+      // ...and the relation is symmetric.
+      expect(isCurrentPlaybackTrack(_sub('s1'), _jelly('j1')), isTrue);
+    });
+
+    test('different songs on different providers do not match', () {
+      expect(
+        isCurrentPlaybackTrack(
+          _jelly('j1', title: 'Alpha', album: 'A'),
+          _sub('s1', title: 'Beta', album: 'B'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('a different track number vetoes a cross-provider match', () {
+      expect(
+        isCurrentPlaybackTrack(
+          _jelly('j1', trackNumber: 1),
+          _sub('s1', trackNumber: 4),
+        ),
+        isFalse,
+      );
+    });
+
+    test('untagged local files only match by exact id', () {
+      const Track a =
+          Track(id: 'file:///a.mp3', title: 'a', uri: 'file:///a.mp3');
+      const Track b =
+          Track(id: 'file:///b.mp3', title: 'b', uri: 'file:///b.mp3');
+      expect(isCurrentPlaybackTrack(a, a), isTrue);
+      expect(isCurrentPlaybackTrack(a, b), isFalse);
+    });
+  });
+}

--- a/test/features/library/track_tile_now_playing_test.dart
+++ b/test/features/library/track_tile_now_playing_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/now_playing.dart';
+import 'package:linthra/shared/widgets/now_playing_indicator.dart';
+
+import 'fake_remote_track_downloader.dart';
+
+Track _jelly(String id, {String title = 'Careful'}) => Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: 'NF',
+      albumName: 'Perception',
+      duration: const Duration(seconds: 200),
+    );
+
+Track _sub(String id, {String title = 'Careful'}) => Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: 'NF',
+      albumName: 'Perception',
+      duration: const Duration(seconds: 200),
+    );
+
+/// Pumps one list of [tracks] with [nowPlaying] overridden. Uses a single
+/// [WidgetTester.pump] (not pumpAndSettle) because a *playing* indicator animates
+/// forever, just like a progress spinner.
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<Track> tracks,
+  required NowPlaying nowPlaying,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        remoteTrackDownloaderProvider
+            .overrideWithValue(FakeRemoteTrackDownloader()),
+        nowPlayingProvider.overrideWithValue(nowPlaying),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: ListView(
+            children: <Widget>[
+              for (int i = 0; i < tracks.length; i++)
+                TrackTile(tracks: tracks, index: i),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  group('TrackTile now-playing indicator', () {
+    testWidgets('only the current track row shows the indicator',
+        (WidgetTester tester) async {
+      final Track a = _jelly('a', title: 'Alpha');
+      final Track b = _jelly('b', title: 'Beta');
+      await _pump(
+        tester,
+        tracks: <Track>[a, b],
+        nowPlaying: NowPlaying(currentTrack: a, isPlaying: true),
+      );
+
+      expect(find.byType(NowPlayingIndicator), findsOneWidget);
+      expect(
+        tester
+            .widget<NowPlayingIndicator>(find.byType(NowPlayingIndicator))
+            .animating,
+        isTrue,
+      );
+    });
+
+    testWidgets('a paused current track shows a static indicator',
+        (WidgetTester tester) async {
+      final Track a = _jelly('a');
+      await _pump(
+        tester,
+        tracks: <Track>[a],
+        nowPlaying: NowPlaying(currentTrack: a, isPlaying: false),
+      );
+      // Static: the tree settles.
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<NowPlayingIndicator>(find.byType(NowPlayingIndicator))
+            .animating,
+        isFalse,
+      );
+    });
+
+    testWidgets('no indicator when nothing is playing',
+        (WidgetTester tester) async {
+      await _pump(
+        tester,
+        tracks: <Track>[_jelly('a')],
+        nowPlaying: const NowPlaying(),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NowPlayingIndicator), findsNothing);
+    });
+
+    testWidgets('a Jellyfin row marks the Navidrome fallback as current',
+        (WidgetTester tester) async {
+      // What plays is the Navidrome copy; the displayed Jellyfin row still reads
+      // as currently playing.
+      await _pump(
+        tester,
+        tracks: <Track>[_jelly('j1')],
+        nowPlaying: NowPlaying(currentTrack: _sub('s1'), isPlaying: true),
+      );
+
+      expect(find.byType(NowPlayingIndicator), findsOneWidget);
+    });
+
+    testWidgets('the same logical song is marked in two separate lists',
+        (WidgetTester tester) async {
+      final Track current = _jelly('a');
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            remoteTrackDownloaderProvider
+                .overrideWithValue(FakeRemoteTrackDownloader()),
+            nowPlayingProvider.overrideWithValue(
+              NowPlaying(currentTrack: current, isPlaying: false),
+            ),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: ListView(
+                children: <Widget>[
+                  // "Library" list.
+                  TrackTile(tracks: <Track>[_jelly('a')], index: 0),
+                  // "Playlist" list: same logical song (same id), own instance.
+                  TrackTile(
+                    tracks: <Track>[_jelly('a', title: 'Careful (playlist)')],
+                    index: 0,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NowPlayingIndicator), findsNWidgets(2));
+    });
+
+    testWidgets('the current row is accessible as now playing',
+        (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final Track a = _jelly('a');
+      await _pump(
+        tester,
+        tracks: <Track>[a],
+        nowPlaying: NowPlaying(currentTrack: a, isPlaying: true),
+      );
+
+      // The tappable row merges its parts' semantics, so "Now playing" is part
+      // of the row's combined label (announced when the row is focused).
+      expect(find.bySemanticsLabel(RegExp('Now playing')), findsOneWidget);
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/player/now_playing_test.dart
+++ b/test/features/player/now_playing_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/now_playing.dart';
+
+Track _jelly(String id, {String title = 'Careful'}) => Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: 'NF',
+      albumName: 'Perception',
+      duration: const Duration(seconds: 200),
+    );
+
+Track _sub(String id, {String title = 'Careful'}) => Track(
+      id: id,
+      title: title,
+      uri: 'subsonic:$id',
+      artistName: 'NF',
+      albumName: 'Perception',
+      duration: const Duration(seconds: 200),
+    );
+
+void main() {
+  group('NowPlaying.stateForRow', () {
+    test('nothing playing -> no row is current', () {
+      expect(const NowPlaying().stateForRow(_jelly('a')), isNull);
+    });
+
+    test('the current row animates while playback is playing', () {
+      final Track track = _jelly('a');
+      expect(
+        NowPlaying(currentTrack: track, isPlaying: true).stateForRow(track),
+        NowPlayingRowState.playing,
+      );
+    });
+
+    test('the current row is static while playback is paused', () {
+      final Track track = _jelly('a');
+      expect(
+        NowPlaying(currentTrack: track, isPlaying: false).stateForRow(track),
+        NowPlayingRowState.paused,
+      );
+    });
+
+    test('a different song shows nothing', () {
+      final NowPlaying np = NowPlaying(
+          currentTrack: _jelly('a', title: 'Alpha'), isPlaying: true);
+      expect(np.stateForRow(_jelly('b', title: 'Beta')), isNull);
+    });
+
+    test('a fallback source copy still marks the logical song as current', () {
+      // Navidrome copy is what actually plays; the Jellyfin row still lights up.
+      final NowPlaying np =
+          NowPlaying(currentTrack: _sub('s1'), isPlaying: true);
+      expect(np.stateForRow(_jelly('j1')), NowPlayingRowState.playing);
+    });
+
+    test('the same logical song is current wherever it is shown', () {
+      final Track current = _jelly('a');
+      final NowPlaying np = NowPlaying(currentTrack: current, isPlaying: false);
+      // Library row and a playlist row that are the same logical track (same id,
+      // separate instances) both report current.
+      final Track libraryRow = _jelly('a');
+      final Track playlistRow = _jelly('a', title: 'Careful (from a playlist)');
+      expect(np.stateForRow(libraryRow), NowPlayingRowState.paused);
+      expect(np.stateForRow(playlistRow), NowPlayingRowState.paused);
+    });
+  });
+
+  group('NowPlaying value', () {
+    test('equals ignores everything but track + isPlaying', () {
+      final Track t = _jelly('a');
+      expect(
+        NowPlaying(currentTrack: t, isPlaying: true),
+        NowPlaying(currentTrack: t, isPlaying: true),
+      );
+      expect(
+        NowPlaying(currentTrack: t, isPlaying: true),
+        isNot(NowPlaying(currentTrack: t, isPlaying: false)),
+      );
+    });
+  });
+
+  group('nowPlayingProvider', () {
+    test('defaults to nothing playing, with no engine dependency', () {
+      final ProviderContainer container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(nowPlayingProvider), const NowPlaying());
+    });
+  });
+}

--- a/test/shared/widgets/now_playing_indicator_test.dart
+++ b/test/shared/widgets/now_playing_indicator_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/now_playing_indicator.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required bool animating,
+  bool reduceMotion = false,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (BuildContext context) => MediaQuery(
+          data:
+              MediaQuery.of(context).copyWith(disableAnimations: reduceMotion),
+          child: Scaffold(
+            body: Center(
+              child: SizedBox.square(
+                dimension: 48,
+                child: NowPlayingIndicator(animating: animating),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('NowPlayingIndicator', () {
+    testWidgets('renders the indicator', (WidgetTester tester) async {
+      await _pump(tester, animating: false);
+      await tester.pumpAndSettle();
+      expect(find.byType(NowPlayingIndicator), findsOneWidget);
+    });
+
+    testWidgets('animates while playing', (WidgetTester tester) async {
+      await _pump(tester, animating: true);
+      await tester.pump(const Duration(milliseconds: 100));
+      // A running equalizer keeps requesting frames.
+      expect(tester.binding.hasScheduledFrame, isTrue);
+    });
+
+    testWidgets('is static while paused', (WidgetTester tester) async {
+      await _pump(tester, animating: false);
+      // Settling at all proves nothing is animating perpetually.
+      await tester.pumpAndSettle();
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
+
+    testWidgets('does not animate when reduce-motion is requested',
+        (WidgetTester tester) async {
+      await _pump(tester, animating: true, reduceMotion: true);
+      await tester.pumpAndSettle();
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
+
+    testWidgets('exposes a now-playing semantics label while playing',
+        (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, animating: true);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(find.bySemanticsLabel('Now playing'), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('exposes a paused semantics label while paused',
+        (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pump(tester, animating: false);
+      await tester.pumpAndSettle();
+      expect(find.bySemanticsLabel('Now playing, paused'), findsOneWidget);
+      handle.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a global "currently playing" indicator so every track row — wherever it appears — clearly shows which song is playing.

A subtle, accent-coloured equalizer is overlaid on the row's artwork. It **animates** while playback is playing and shows a **static** resting silhouette while paused.

### Covered surfaces
All go through the shared track row/tile or a shared `TrackArtwork` helper, so there's no per-screen logic duplication:

- Library songs & **search results** (`TrackTile` via `AlphabetTrackList`)
- Album / Artist / Smart-mix detail (`TrackTile`)
- Favorites (`TrackTile`)
- Playlists detail (`_trackRow`)
- Downloads / offline tracks (downloaded + in-flight tiles)
- Queue → "Now playing" row (upgrades the old static `graphic_eq` icon to the animated indicator)

## How the matching works

A row counts as current when it is the **same logical song** as the actual playback track — not just an id match:

- **Exact id** for the everyday case (and the only thing that matches untagged local files).
- **Cross-provider fallback**: if the row and the playing track come from *different* providers, they match only when the unifier's conservative `isLikelySameTrack` agrees. So:
  - Tapped a Jellyfin row but playback fell back to the Navidrome copy → the Jellyfin row still reads as playing.
  - The same song shown in a Playlist and the Library → both indicate.

The pure helper `isCurrentPlaybackTrack(row, current)` lives in `core/catalog` next to the existing identity logic and reuses the same predicate the library unifier merges on, so identity stays consistent app-wide and deterministic.

## Design / performance

- **`NowPlayingIndicator`** (new, `shared/widgets`): one `AnimationController` drives one `CustomPainter` (a single repaint boundary). The controller runs **only** while playing and **never** under reduce-motion (`MediaQuery.disableAnimations`), so paused / off-screen / reduce-motion rows cost no frames.
- **`nowPlayingProvider`** (+ `NowPlaying` value type, new): inert by default (nothing playing, **no** playback-engine dependency) and wired to the live `PlaybackState` via `nowPlayingOverride` in `main.dart`, mirroring the existing `currentlyPlayingTrackIdProvider` pattern. Rows watch it with `.select`, so a row rebuilds only when *its own* state changes — never on a position tick.
- **`TrackArtwork`** (new): centralizes the artwork-plus-overlay (subtle scrim + indicator) so every surface marks the playing song identically and stays readable on bright covers / dark theme.

## Safety / scope

- No text is ever rendered by the indicator; no uri / path / token / username is exposed.
- Playback behaviour and source-strategy behaviour are unchanged.
- No release bump, no tag, no fdroiddata changes.
- Because the provider default is inert, **no existing test needed changes** (no indicator, no perpetual animation, no audio plugin pulled in).

## Tests

- `now_playing_match_test` — exact id, same-provider non-match, cross-provider fallback (symmetric), track-number veto, untagged-local id-only.
- `now_playing_test` — `stateForRow` (playing/paused/none), fallback, same song across screens, value equality, inert provider default.
- `now_playing_indicator_test` — renders, animates only while playing, static while paused, no animation under reduce-motion, semantics.
- `track_tile_now_playing_test` — current vs non-current rows, paused static, cross-provider fallback, same song in two lists, accessible row semantics.

## Verification

- `dart format --output=none --set-exit-if-changed .` → clean
- `flutter analyze` → No issues found
- `flutter test` → all 1466 tests pass

https://claude.ai/code/session_012hLSMmJSvrhjbKjTSMnwnS

---
_Generated by [Claude Code](https://claude.ai/code/session_012hLSMmJSvrhjbKjTSMnwnS)_