### PR TITLE
feat(subsonic): fetch Navidrome/Subsonic lyrics (getLyricsBySongId)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -33,7 +33,7 @@ persisted catalog.
 | --------------------- | ---------- | :----: | :---: | :-------: | :-------: | :----: | :--: |
 | On this device        | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   —    |  —   |
 | Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
-| Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   🔜   |  ✅  |
+| Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  ✅  |
 
 ✅ implemented · 🔜 planned follow-up · — not applicable. "local" favourites/
 playlists stay on-device; "synced" ones mirror with the server (server is the
@@ -87,6 +87,12 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
 - **Offline cache**: a Subsonic track can be downloaded for offline use (the
   original file via `download.view`).
 - **Cast**: a Subsonic track casts to a Chromecast as a live stream.
+- **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic
+  `getLyricsBySongId` extension (how Navidrome exposes embedded/sidecar lyrics),
+  with a fallback to the legacy `getLyrics` (plain text, matched by artist +
+  title) for servers without the extension. When a server has none, the lyrics
+  panel keeps its calm "no lyrics" state; the credential is never logged or put
+  in an error.
 
 ### Server URL & local testing
 
@@ -129,7 +135,10 @@ actions stay hidden/disabled rather than failing:
 
 - **Favorites** — Subsonic exposes `star`/`unstar`/`getStarred2`; wiring them
   through Linthra's favorites repository is a follow-up.
-- **Lyrics** — `getLyrics`/`getLyricsBySongId` (OpenSubsonic) is a follow-up.
+- **Synced lyrics from the legacy endpoint** — the OpenSubsonic
+  `getLyricsBySongId` path returns synced lyrics today; the legacy `getLyrics`
+  fallback is treated as plain text, so any LRC-style timestamps embedded in its
+  value aren't time-synced yet. That refinement is a follow-up.
 - **Cover art** — `getCoverArt` requires the auth query, so a cover URL would
   embed the credential, and artwork is persisted in the catalog. To keep the
   security invariant, Subsonic tracks have no `artworkUri` yet; token-free

--- a/lib/core/services/composite_lyrics_service.dart
+++ b/lib/core/services/composite_lyrics_service.dart
@@ -1,0 +1,28 @@
+import '../models/lyrics.dart';
+import '../models/track.dart';
+import 'lyrics_service.dart';
+
+/// A [LyricsService] that delegates to several backends in order, returning the
+/// first one that has lyrics for the track.
+///
+/// Each backend self-filters by the track's URI scheme (a Jellyfin service
+/// ignores `subsonic:` tracks and vice versa), so for any given track at most
+/// one backend does real work — the order is just "ask each until one answers".
+/// A backend that *throws* (e.g. the owning server is offline) propagates, so
+/// the UI can still tell "couldn't load" apart from "no lyrics". Resolves to
+/// `null` when every backend declines, which the UI shows as the calm empty
+/// state.
+class CompositeLyricsService implements LyricsService {
+  CompositeLyricsService(this._services);
+
+  final List<LyricsService> _services;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async {
+    for (final LyricsService service in _services) {
+      final Lyrics? lyrics = await service.lyricsFor(track);
+      if (lyrics != null) return lyrics;
+    }
+    return null;
+  }
+}

--- a/lib/core/services/subsonic_lyrics_service.dart
+++ b/lib/core/services/subsonic_lyrics_service.dart
@@ -1,0 +1,43 @@
+import '../models/lyrics.dart';
+import '../models/subsonic_session.dart';
+import '../models/track.dart';
+import '../sources/subsonic/subsonic_client.dart';
+import '../sources/subsonic/subsonic_track_mapper.dart';
+import 'lyrics_service.dart';
+
+/// A [LyricsService] backed by a signed-in Subsonic/Navidrome server.
+///
+/// Only Subsonic tracks (the `subsonic:<id>` scheme) are looked up; a local or
+/// Jellyfin track, or being signed out, returns `null` so the UI shows "no
+/// lyrics". The session (with its salt+token) is read lazily through [_session]
+/// so signing in/out is picked up without a rebuild, mirroring
+/// [JellyfinLyricsService] and the streaming/download path.
+///
+/// The track's title and artist are forwarded so the client can fall back to
+/// the legacy `getLyrics` (artist + title) lookup on servers that don't
+/// implement the OpenSubsonic `getLyricsBySongId` extension.
+class SubsonicLyricsService implements LyricsService {
+  SubsonicLyricsService({
+    required SubsonicClient client,
+    required SubsonicSession? Function() session,
+  })  : _client = client,
+        _session = session;
+
+  final SubsonicClient _client;
+  final SubsonicSession? Function() _session;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async {
+    if (!track.uri.startsWith(SubsonicTrackMapper.uriScheme)) return null;
+    final SubsonicSession? session = _session();
+    if (session == null) return null;
+    final String songId =
+        track.uri.substring(SubsonicTrackMapper.uriScheme.length);
+    return _client.fetchLyrics(
+      session,
+      songId,
+      artist: track.artistName,
+      title: track.title,
+    );
+  }
+}

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -223,9 +223,9 @@ abstract final class MusicProviders {
     ),
   );
 
-  /// Subsonic/Navidrome. Streaming, offline caching, and casting are
-  /// implemented; favorites and lyrics are documented follow-ups, so they are
-  /// declared unsupported here and their actions stay hidden/disabled.
+  /// Subsonic/Navidrome. Streaming, offline caching, casting, and lyrics are
+  /// implemented; favorites are a documented follow-up, so they are declared
+  /// unsupported here and their actions stay hidden/disabled.
   static const MusicProvider subsonic = MusicProvider(
     sourceId: 'subsonic',
     displayName: 'Navidrome / Subsonic',
@@ -238,7 +238,9 @@ abstract final class MusicProviders {
       canFavoriteTracks: false,
       canReadFavoriteState: false,
       canSyncFavorites: false,
-      canLyrics: false,
+      // Lyrics via the OpenSubsonic getLyricsBySongId extension (Navidrome),
+      // with a legacy getLyrics fallback.
+      canLyrics: true,
       canCast: true,
       canRemoveFromLibrary: true,
       canRemoveOfflineCopy: true,

--- a/lib/core/sources/subsonic/http_subsonic_client.dart
+++ b/lib/core/sources/subsonic/http_subsonic_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../../models/lyrics.dart';
 import '../../models/subsonic_session.dart';
 import 'subsonic_api.dart';
 import 'subsonic_auth.dart';
@@ -145,6 +146,47 @@ class HttpSubsonicClient implements SubsonicClient {
   }
 
   @override
+  Future<Lyrics?> fetchLyrics(
+    SubsonicSession session,
+    String songId, {
+    String? artist,
+    String? title,
+  }) async {
+    final SubsonicCredentials credentials = _credentials(session);
+    // Primary: the OpenSubsonic `getLyricsBySongId` extension, keyed by the song
+    // id we already hold. This is what Navidrome (and other OpenSubsonic
+    // servers) answer with embedded/sidecar lyrics, synced or plain.
+    final Lyrics? structured = await _tryLyrics(
+      SubsonicEndpoints.getLyricsBySongId(
+        session.baseUrl,
+        username: session.username,
+        credentials: credentials,
+        songId: songId,
+      ),
+      _parseStructuredLyrics,
+    );
+    if (structured != null) return structured;
+    // Fallback: the legacy `getLyrics` (plain text, matched by artist + title)
+    // for servers without the extension. Skipped when we lack both fields.
+    if (artist != null &&
+        artist.isNotEmpty &&
+        title != null &&
+        title.isNotEmpty) {
+      return _tryLyrics(
+        SubsonicEndpoints.getLyrics(
+          session.baseUrl,
+          username: session.username,
+          credentials: credentials,
+          artist: artist,
+          title: title,
+        ),
+        _parseLegacyLyrics,
+      );
+    }
+    return null;
+  }
+
+  @override
   Future<SubsonicStreamProbe> probeStream(Uri url) async {
     // A one-byte ranged GET: enough to see the real status and content type the
     // engine will get, without downloading the track. The credential rides in
@@ -165,6 +207,36 @@ class HttpSubsonicClient implements SubsonicClient {
 
   SubsonicCredentials _credentials(SubsonicSession session) =>
       SubsonicCredentials(salt: session.salt, token: session.token);
+
+  /// GETs a lyrics endpoint and runs [parse] on a successful envelope.
+  ///
+  /// Lyrics are best-effort: only a transport failure (from [_send]) propagates
+  /// — surfacing the UI's "couldn't load lyrics" hint when offline. Every other
+  /// outcome (an HTTP error status, a non-Subsonic body, or a Subsonic error
+  /// inside a 200: no match, unsupported method, an old server) means "no lyrics
+  /// here" and yields `null`, so the UI keeps its calm empty state rather than a
+  /// scary error. The credential-bearing URL is never logged or thrown.
+  Future<Lyrics?> _tryLyrics(
+    Uri uri,
+    Lyrics? Function(SubsonicEnvelope envelope) parse,
+  ) async {
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: const <String, String>{
+        'Accept': 'application/json',
+      }),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) return null;
+    final Map<String, dynamic> body;
+    try {
+      body = _decodeObject(response);
+    } on SubsonicException {
+      // A 2xx body that isn't JSON — treat as "no lyrics here", not an error.
+      return null;
+    }
+    final SubsonicEnvelope? envelope = SubsonicEnvelope.fromJson(body);
+    if (envelope == null || !envelope.isOk) return null;
+    return parse(envelope);
+  }
 
   /// Performs a JSON `GET`, then decodes and validates the `subsonic-response`
   /// envelope — throwing a friendly [SubsonicException] for a transport failure,
@@ -263,6 +335,75 @@ class HttpSubsonicClient implements SubsonicClient {
         return SubsonicException.serverError();
     }
   }
+
+  /// Parses an OpenSubsonic `getLyricsBySongId` envelope
+  /// (`lyricsList.structuredLyrics[]`) into [Lyrics], or `null` when it carries
+  /// no usable lines.
+  ///
+  /// Each line has a `value` (text) and, for synced lyrics, a `start` in
+  /// **milliseconds**; an entry-level `offset` (ms, default 0) shifts every
+  /// timestamp. A line with no `start` (or a set explicitly flagged
+  /// `synced: false`) maps to a plain, untimed [LyricLine], so [Lyrics.isSynced]
+  /// then reports plain — exactly what the UI needs to pick the static vs. the
+  /// timed view. The first structured set with lines is used (servers list
+  /// multiple only for alternate languages).
+  static Lyrics? _parseStructuredLyrics(SubsonicEnvelope envelope) {
+    final Object? root = envelope.data['lyricsList'];
+    if (root is! Map<String, dynamic>) return null;
+    final Object? sets = root['structuredLyrics'];
+    if (sets is! List) return null;
+    for (final Object? set in sets) {
+      if (set is! Map<String, dynamic>) continue;
+      final Object? rawLines = set['line'];
+      if (rawLines is! List || rawLines.isEmpty) continue;
+      // Honor an explicit unsynced flag so a server that tags plain lyrics with
+      // stray zero timestamps isn't mistaken for a (mis)timed track; otherwise
+      // per-line `start` presence decides plain vs. synced.
+      final bool unsynced = set['synced'] == false;
+      final int offsetMs = _asInt(set['offset']) ?? 0;
+      final List<LyricLine> lines = <LyricLine>[];
+      for (final Object? raw in rawLines) {
+        if (raw is! Map<String, dynamic>) continue;
+        final Object? value = raw['value'];
+        if (value is! String) continue;
+        final int? startMs = unsynced ? null : _asInt(raw['start']);
+        lines.add(LyricLine(
+          text: value,
+          start: startMs == null ? null : _durationFromMs(startMs + offsetMs),
+        ));
+      }
+      if (lines.isNotEmpty) return Lyrics(lines: lines);
+    }
+    return null;
+  }
+
+  /// Parses a legacy `getLyrics` envelope (`lyrics.value`, plain text) into
+  /// [Lyrics], or `null` when there's no (non-blank) text. The text is split
+  /// into untimed lines on newlines (CRLF normalized), so it renders in the same
+  /// plain-lyrics view. Any LRC-style timestamps embedded in the text are left
+  /// as-is for now (synced parsing here is a documented follow-up).
+  static Lyrics? _parseLegacyLyrics(SubsonicEnvelope envelope) {
+    final Object? root = envelope.data['lyrics'];
+    if (root is! Map<String, dynamic>) return null;
+    final Object? value = root['value'];
+    if (value is! String || value.trim().isEmpty) return null;
+    final List<LyricLine> lines = value
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n')
+        .split('\n')
+        .map((String line) => LyricLine(text: line))
+        .toList();
+    return lines.isEmpty ? null : Lyrics(lines: lines);
+  }
+
+  /// A non-negative [Duration] from milliseconds; clamps a negative result (an
+  /// offset can push an early line below zero) to zero.
+  static Duration _durationFromMs(int milliseconds) =>
+      Duration(milliseconds: milliseconds < 0 ? 0 : milliseconds);
+
+  /// Reads a numeric JSON field as an `int`, or `null` when it's absent or not a
+  /// number — so a malformed `start`/`offset` can't throw or mistime a line.
+  static int? _asInt(Object? value) => value is num ? value.toInt() : null;
 
   /// Decodes a JSON object body, or throws [SubsonicErrorKind.notSubsonic] when
   /// the body isn't JSON (e.g. an HTML error page) or isn't an object.

--- a/lib/core/sources/subsonic/subsonic_client.dart
+++ b/lib/core/sources/subsonic/subsonic_client.dart
@@ -1,3 +1,4 @@
+import '../../models/lyrics.dart';
 import '../../models/subsonic_session.dart';
 import 'subsonic_api.dart';
 import 'subsonic_auth.dart';
@@ -41,6 +42,23 @@ abstract interface class SubsonicClient {
     SubsonicSession session,
     String albumId,
   );
+
+  /// Fetches lyrics for the song [songId], or `null` when none are available.
+  ///
+  /// Tries the OpenSubsonic `getLyricsBySongId` extension first (synced or plain
+  /// lyrics, as Navidrome exposes them), then falls back to the legacy
+  /// `getLyrics` (plain text, matched by [artist] + [title]) for servers without
+  /// the extension. Lyrics are best-effort: only a transport failure throws a
+  /// [SubsonicException]; a server that has no lyrics, doesn't support the
+  /// endpoint, or returns an unusable body yields `null` so the UI keeps its
+  /// calm "no lyrics" state. The credential is woven into the request URL and is
+  /// never logged or placed in a thrown error.
+  Future<Lyrics?> fetchLyrics(
+    SubsonicSession session,
+    String songId, {
+    String? artist,
+    String? title,
+  });
 
   /// Probes a minted stream [url] with a tiny ranged request to confirm the
   /// server returns playable audio *before* the URL is handed to the audio

--- a/lib/core/sources/subsonic/subsonic_endpoints.dart
+++ b/lib/core/sources/subsonic/subsonic_endpoints.dart
@@ -74,6 +74,35 @@ abstract final class SubsonicEndpoints {
       _build(baseUrl, 'getAlbum', username, credentials,
           extra: {idParam: albumId});
 
+  /// `GET /rest/getLyricsBySongId.view?id=` — the OpenSubsonic `songLyrics`
+  /// extension: a song's synced or plain lyrics, keyed by its id (which Linthra
+  /// already holds in the track URI). Navidrome and other OpenSubsonic servers
+  /// expose tagged/sidecar lyrics here, so this is the primary lyrics lookup. A
+  /// server without the extension answers with a Subsonic error, which the
+  /// client treats as "no lyrics" rather than surfacing it.
+  static Uri getLyricsBySongId(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String songId,
+  }) =>
+      _build(baseUrl, 'getLyricsBySongId', username, credentials,
+          extra: {idParam: songId});
+
+  /// `GET /rest/getLyrics.view?artist=&title=` — the legacy Subsonic lyrics
+  /// lookup (plain text only, matched by artist + title). Used as a fallback for
+  /// servers that don't implement the OpenSubsonic `getLyricsBySongId`
+  /// extension.
+  static Uri getLyrics(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String artist,
+    required String title,
+  }) =>
+      _build(baseUrl, 'getLyrics', username, credentials,
+          extra: <String, String>{'artist': artist, 'title': title});
+
   /// The audio stream URL for a song: `/rest/stream.view?id=…` plus auth.
   ///
   /// The server serves a playable stream (transcoding to a broadly compatible

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -2,14 +2,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/lyrics.dart';
 import '../../core/models/track.dart';
+import '../../core/services/composite_lyrics_service.dart';
 import '../../core/services/jellyfin_lyrics_service.dart';
 import '../../core/services/lyrics_service.dart';
+import '../../core/services/subsonic_lyrics_service.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
+import '../settings/subsonic/subsonic_settings_controller.dart';
+import '../settings/subsonic/subsonic_settings_providers.dart';
 import 'player_providers.dart';
 
 /// The lyrics backend. Defaults to "no lyrics" so tests and local-only use need
-/// no Jellyfin wiring; the app overrides it with the Jellyfin-backed service.
+/// no server wiring; the app overrides it with the remote-backed service that
+/// reads from Jellyfin or Subsonic/Navidrome.
 final lyricsServiceProvider = Provider<LyricsService>((ref) {
   return const _NoLyricsService();
 });
@@ -50,15 +55,25 @@ final currentTrackLyricsProvider =
   return ref.watch(trackLyricsProvider(track));
 });
 
-/// Production binding: read lyrics from the signed-in Jellyfin server. Reads the
-/// live client + session lazily so signing in/out is picked up without a
-/// rebuild. Applied in `main`; tests keep the no-lyrics default.
-final jellyfinLyricsOverride = lyricsServiceProvider.overrideWith((ref) {
-  return JellyfinLyricsService(
-    client: ref.read(jellyfinClientProvider),
-    session: () =>
-        ref.read(jellyfinSettingsControllerProvider.notifier).session,
-  );
+/// Production binding: read lyrics from whichever signed-in remote server owns
+/// the track — Jellyfin or Subsonic/Navidrome. Each backend filters by the
+/// track's URI scheme, so a track resolves through exactly one of them (or none,
+/// for a local track). The live clients + sessions are read lazily so signing
+/// in/out is picked up without a rebuild. Applied in `main`; tests keep the
+/// no-lyrics default.
+final remoteLyricsServiceOverride = lyricsServiceProvider.overrideWith((ref) {
+  return CompositeLyricsService(<LyricsService>[
+    JellyfinLyricsService(
+      client: ref.read(jellyfinClientProvider),
+      session: () =>
+          ref.read(jellyfinSettingsControllerProvider.notifier).session,
+    ),
+    SubsonicLyricsService(
+      client: ref.read(subsonicClientProvider),
+      session: () =>
+          ref.read(subsonicSettingsControllerProvider.notifier).session,
+    ),
+  ]);
 });
 
 /// The honest local-only default: no lyrics source wired, so every track

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,7 +83,9 @@ Future<void> main() async {
       // Persist on-device play history (counts + last-played) for the
       // "Recently played" / "Most played" / "Never played" smart mixes.
       sharedPreferencesPlayHistoryStoreOverride,
-      jellyfinLyricsOverride,
+      // Lyrics from whichever signed-in remote server owns the track (Jellyfin
+      // or Subsonic/Navidrome).
+      remoteLyricsServiceOverride,
       // Real Chromecast backend (Android/iOS only); see cast_providers.dart.
       chromecastCastServiceOverride,
     ],

--- a/test/core/services/composite_lyrics_service_test.dart
+++ b/test/core/services/composite_lyrics_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/composite_lyrics_service.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+
+/// A [LyricsService] that returns canned lyrics (or throws), and records whether
+/// it was asked — so order/short-circuit behaviour can be asserted.
+class _StubLyricsService implements LyricsService {
+  _StubLyricsService({this.lyrics, this.error});
+
+  final Lyrics? lyrics;
+  final Object? error;
+  bool called = false;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async {
+    called = true;
+    if (error != null) throw error!;
+    return lyrics;
+  }
+}
+
+const _track = Track(id: '1', title: 'Song', uri: 'subsonic:1');
+const _lyrics = Lyrics(lines: <LyricLine>[LyricLine(text: 'hi')]);
+
+void main() {
+  group('CompositeLyricsService', () {
+    test('returns the first backend with lyrics and stops there', () async {
+      final first = _StubLyricsService(lyrics: _lyrics);
+      final second = _StubLyricsService(lyrics: const Lyrics(lines: []));
+      final service = CompositeLyricsService(<LyricsService>[first, second]);
+
+      final lyrics = await service.lyricsFor(_track);
+
+      expect(lyrics, _lyrics);
+      expect(first.called, isTrue);
+      // Short-circuits: a later backend isn't asked once one answers.
+      expect(second.called, isFalse);
+    });
+
+    test('falls through backends that decline (null)', () async {
+      final first = _StubLyricsService(); // null
+      final second = _StubLyricsService(lyrics: _lyrics);
+      final service = CompositeLyricsService(<LyricsService>[first, second]);
+
+      final lyrics = await service.lyricsFor(_track);
+
+      expect(lyrics, _lyrics);
+      expect(first.called, isTrue);
+      expect(second.called, isTrue);
+    });
+
+    test('returns null when every backend declines', () async {
+      final service = CompositeLyricsService(<LyricsService>[
+        _StubLyricsService(),
+        _StubLyricsService(),
+      ]);
+
+      expect(await service.lyricsFor(_track), isNull);
+    });
+
+    test('propagates an error from a backend (so the UI can show '
+        '"couldn\'t load")', () async {
+      final service = CompositeLyricsService(<LyricsService>[
+        _StubLyricsService(error: StateError('offline')),
+      ]);
+
+      expect(() => service.lyricsFor(_track), throwsA(isA<StateError>()));
+    });
+
+    test('with no backends, resolves to null', () async {
+      final service = CompositeLyricsService(const <LyricsService>[]);
+      expect(await service.lyricsFor(_track), isNull);
+    });
+  });
+}

--- a/test/core/services/composite_lyrics_service_test.dart
+++ b/test/core/services/composite_lyrics_service_test.dart
@@ -60,8 +60,7 @@ void main() {
       expect(await service.lyricsFor(_track), isNull);
     });
 
-    test('propagates an error from a backend (so the UI can show '
-        '"couldn\'t load")', () async {
+    test('propagates an error from a backend', () async {
       final service = CompositeLyricsService(<LyricsService>[
         _StubLyricsService(error: StateError('offline')),
       ]);

--- a/test/core/services/subsonic_lyrics_service_test.dart
+++ b/test/core/services/subsonic_lyrics_service_test.dart
@@ -22,8 +22,8 @@ void main() {
     SubsonicLyricsService build({SubsonicSession? session}) =>
         SubsonicLyricsService(client: client, session: () => session);
 
-    test('fetches lyrics for a Subsonic track by its song id, forwarding '
-        'artist and title for the legacy fallback', () async {
+    test('fetches a Subsonic track by song id, forwarding artist and title',
+        () async {
       client.lyrics = const Lyrics(lines: <LyricLine>[LyricLine(text: 'la la')]);
       final service = build(session: _session);
 

--- a/test/core/services/subsonic_lyrics_service_test.dart
+++ b/test/core/services/subsonic_lyrics_service_test.dart
@@ -24,7 +24,9 @@ void main() {
 
     test('fetches a Subsonic track by song id, forwarding artist and title',
         () async {
-      client.lyrics = const Lyrics(lines: <LyricLine>[LyricLine(text: 'la la')]);
+      client.lyrics = const Lyrics(
+        lines: <LyricLine>[LyricLine(text: 'la la')],
+      );
       final service = build(session: _session);
 
       final lyrics = await service.lyricsFor(

--- a/test/core/services/subsonic_lyrics_service_test.dart
+++ b/test/core/services/subsonic_lyrics_service_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/subsonic_lyrics_service.dart';
+
+import '../sources/subsonic/fake_subsonic_client.dart';
+
+const _session = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'salt1',
+  token: 'tok1',
+);
+
+void main() {
+  group('SubsonicLyricsService', () {
+    late FakeSubsonicClient client;
+
+    setUp(() => client = FakeSubsonicClient());
+
+    SubsonicLyricsService build({SubsonicSession? session}) =>
+        SubsonicLyricsService(client: client, session: () => session);
+
+    test('fetches lyrics for a Subsonic track by its song id, forwarding '
+        'artist and title for the legacy fallback', () async {
+      client.lyrics = const Lyrics(lines: <LyricLine>[LyricLine(text: 'la la')]);
+      final service = build(session: _session);
+
+      final lyrics = await service.lyricsFor(
+        const Track(
+          id: 's-7',
+          title: 'Nightcall',
+          uri: 'subsonic:s-7',
+          artistName: 'Kavinsky',
+        ),
+      );
+
+      expect(client.lastLyricsSongId, 's-7');
+      expect(client.lastLyricsArtist, 'Kavinsky');
+      expect(client.lastLyricsTitle, 'Nightcall');
+      expect(lyrics?.lines.single.text, 'la la');
+    });
+
+    test('returns null for a non-Subsonic track without hitting the server',
+        () async {
+      final service = build(session: _session);
+
+      final jellyfin = await service.lyricsFor(
+        const Track(id: 'j-1', title: 'Song', uri: 'jellyfin:j-1'),
+      );
+      final local = await service.lyricsFor(
+        const Track(id: '1', title: 'Local', uri: 'file:///1.mp3'),
+      );
+
+      expect(jellyfin, isNull);
+      expect(local, isNull);
+      expect(client.lastLyricsSongId, isNull);
+    });
+
+    test('returns null when signed out', () async {
+      final service = build(session: null);
+
+      final lyrics = await service.lyricsFor(
+        const Track(id: 's-7', title: 'Song', uri: 'subsonic:s-7'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.lastLyricsSongId, isNull);
+    });
+  });
+}

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -27,18 +27,20 @@ void main() {
       expect(caps.canCast, isTrue);
     });
 
-    test('subsonic: stream/cache/cast implemented; favorites & lyrics are not',
+    test('subsonic: stream/cache/cast/lyrics implemented; favorites are not',
         () {
       final caps = MusicProviders.subsonic.capabilities;
       expect(caps.canStream, isTrue);
       expect(caps.canCache, isTrue);
       expect(caps.canCast, isTrue);
+      // Lyrics arrive via the OpenSubsonic getLyricsBySongId extension
+      // (Navidrome) with a legacy getLyrics fallback.
+      expect(caps.canLyrics, isTrue);
       // Declared unsupported so their actions stay hidden/disabled.
       expect(caps.canFavoriteTracks, isFalse);
       expect(caps.canReadFavoriteState, isFalse);
       expect(caps.canSyncFavorites, isFalse);
       expect(caps.canListPlaylists, isFalse);
-      expect(caps.canLyrics, isFalse);
     });
 
     test('identity fields', () {

--- a/test/core/sources/subsonic/fake_subsonic_client.dart
+++ b/test/core/sources/subsonic/fake_subsonic_client.dart
@@ -1,3 +1,4 @@
+import 'package:linthra/core/models/lyrics.dart';
 import 'package:linthra/core/models/subsonic_session.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_auth.dart';
@@ -32,6 +33,10 @@ class FakeSubsonicClient implements SubsonicClient {
   SubsonicStreamProbe? streamProbe;
   SubsonicException? probeError;
 
+  /// Canned lyrics for [fetchLyrics]; `null` models "no lyrics".
+  Lyrics? lyrics;
+  SubsonicException? lyricsError;
+
   // Recorded inputs.
   String? lastBaseUrl;
   String? lastUsername;
@@ -39,6 +44,9 @@ class FakeSubsonicClient implements SubsonicClient {
   int verifyCount = 0;
   final List<String> requestedAlbumIds = <String>[];
   Uri? lastProbedUrl;
+  String? lastLyricsSongId;
+  String? lastLyricsArtist;
+  String? lastLyricsTitle;
 
   @override
   Future<SubsonicServerInfo> ping(
@@ -89,6 +97,21 @@ class FakeSubsonicClient implements SubsonicClient {
     final SubsonicException? error = listError;
     if (error != null) throw error;
     return songsByAlbum[albumId] ?? const <SubsonicSongDto>[];
+  }
+
+  @override
+  Future<Lyrics?> fetchLyrics(
+    SubsonicSession session,
+    String songId, {
+    String? artist,
+    String? title,
+  }) async {
+    lastLyricsSongId = songId;
+    lastLyricsArtist = artist;
+    lastLyricsTitle = title;
+    final SubsonicException? error = lyricsError;
+    if (error != null) throw error;
+    return lyrics;
   }
 
   @override

--- a/test/core/sources/subsonic/http_subsonic_client_test.dart
+++ b/test/core/sources/subsonic/http_subsonic_client_test.dart
@@ -251,4 +251,236 @@ void main() {
       expect(probe.isAudio, isTrue);
     });
   });
+
+  group('fetchLyrics', () {
+    // Builds a getLyricsBySongId envelope from one structured-lyrics set.
+    http.Response structured(Map<String, dynamic> set) => _ok(<String, dynamic>{
+          'lyricsList': <String, dynamic>{
+            'structuredLyrics': <Map<String, dynamic>>[set],
+          },
+        });
+
+    test('parses synced structuredLyrics with millisecond starts', () async {
+      final client = _client(MockClient((_) async => structured(
+            <String, dynamic>{
+              'displayArtist': 'Kavinsky',
+              'displayTitle': 'Nightcall',
+              'lang': 'eng',
+              'offset': 0,
+              'synced': true,
+              'line': <Map<String, dynamic>>[
+                <String, dynamic>{'start': 0, 'value': 'First line'},
+                <String, dynamic>{'start': 1500, 'value': 'Second line'},
+              ],
+            },
+          )));
+
+      final lyrics = await client.fetchLyrics(_session, 's1');
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isTrue);
+      expect(
+        lyrics.lines.map((l) => l.text),
+        <String>['First line', 'Second line'],
+      );
+      expect(lyrics.lines.first.start, Duration.zero);
+      expect(lyrics.lines.last.start, const Duration(milliseconds: 1500));
+    });
+
+    test('applies the entry offset to every synced start', () async {
+      final client = _client(MockClient((_) async => structured(
+            <String, dynamic>{
+              'synced': true,
+              'offset': 250,
+              'line': <Map<String, dynamic>>[
+                <String, dynamic>{'start': 1000, 'value': 'x'},
+              ],
+            },
+          )));
+
+      final lyrics = await client.fetchLyrics(_session, 's1');
+
+      expect(lyrics!.lines.single.start, const Duration(milliseconds: 1250));
+    });
+
+    test('parses plain structuredLyrics (no timestamps) as untimed', () async {
+      final client = _client(MockClient((_) async => structured(
+            <String, dynamic>{
+              'line': <Map<String, dynamic>>[
+                <String, dynamic>{'value': 'la la'},
+                <String, dynamic>{'value': 'la la la'},
+              ],
+            },
+          )));
+
+      final lyrics = await client.fetchLyrics(_session, 's1');
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isFalse);
+      expect(lyrics.lines.every((l) => l.start == null), isTrue);
+      expect(lyrics.lines.map((l) => l.text), <String>['la la', 'la la la']);
+    });
+
+    test('treats a set flagged synced:false as plain even with starts',
+        () async {
+      final client = _client(MockClient((_) async => structured(
+            <String, dynamic>{
+              'synced': false,
+              'line': <Map<String, dynamic>>[
+                <String, dynamic>{'start': 0, 'value': 'a'},
+                <String, dynamic>{'start': 0, 'value': 'b'},
+              ],
+            },
+          )));
+
+      final lyrics = await client.fetchLyrics(_session, 's1');
+
+      expect(lyrics!.isSynced, isFalse);
+      expect(lyrics.lines.every((l) => l.start == null), isTrue);
+    });
+
+    test('uses the first structured set when several languages are present',
+        () async {
+      final client = _client(MockClient((_) async => _ok(<String, dynamic>{
+            'lyricsList': <String, dynamic>{
+              'structuredLyrics': <Map<String, dynamic>>[
+                <String, dynamic>{
+                  'lang': 'eng',
+                  'line': <Map<String, dynamic>>[
+                    <String, dynamic>{'value': 'english'},
+                  ],
+                },
+                <String, dynamic>{
+                  'lang': 'fra',
+                  'line': <Map<String, dynamic>>[
+                    <String, dynamic>{'value': 'french'},
+                  ],
+                },
+              ],
+            },
+          })));
+
+      final lyrics = await client.fetchLyrics(_session, 's1');
+
+      expect(lyrics!.lines.single.text, 'english');
+    });
+
+    test('sends the song id and does not fall back when lyrics are found',
+        () async {
+      final List<String> paths = <String>[];
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        paths.add(request.url.path);
+        captured = request;
+        return structured(<String, dynamic>{
+          'line': <Map<String, dynamic>>[
+            <String, dynamic>{'value': 'found'},
+          ],
+        });
+      }));
+
+      final lyrics = await client.fetchLyrics(
+        _session,
+        's-42',
+        artist: 'Kavinsky',
+        title: 'Nightcall',
+      );
+
+      expect(lyrics!.lines.single.text, 'found');
+      // Only the primary endpoint was hit — the legacy fallback is skipped.
+      expect(paths, <String>['/rest/getLyricsBySongId.view']);
+      expect(captured!.url.queryParameters['id'], 's-42');
+    });
+
+    test('falls back to legacy getLyrics when the primary has none', () async {
+      http.Request? legacy;
+      final client = _client(MockClient((http.Request request) async {
+        if (request.url.path.endsWith('getLyricsBySongId.view')) {
+          // Server supports the call but has no lyrics for this song.
+          return _ok(<String, dynamic>{'lyricsList': <String, dynamic>{}});
+        }
+        legacy = request;
+        return _ok(<String, dynamic>{
+          'lyrics': <String, dynamic>{
+            'artist': 'Kavinsky',
+            'title': 'Nightcall',
+            'value': 'Line one\r\nLine two',
+          },
+        });
+      }));
+
+      final lyrics = await client.fetchLyrics(
+        _session,
+        's1',
+        artist: 'Kavinsky',
+        title: 'Nightcall',
+      );
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isFalse);
+      expect(lyrics.lines.map((l) => l.text), <String>['Line one', 'Line two']);
+      expect(legacy!.url.queryParameters['artist'], 'Kavinsky');
+      expect(legacy!.url.queryParameters['title'], 'Nightcall');
+    });
+
+    test('returns null when neither endpoint has lyrics', () async {
+      final client = _client(MockClient((http.Request request) async {
+        if (request.url.path.endsWith('getLyricsBySongId.view')) {
+          return _ok(<String, dynamic>{'lyricsList': <String, dynamic>{}});
+        }
+        return _ok(<String, dynamic>{
+          'lyrics': <String, dynamic>{'value': ''},
+        });
+      }));
+
+      final lyrics = await client.fetchLyrics(
+        _session,
+        's1',
+        artist: 'A',
+        title: 'T',
+      );
+
+      expect(lyrics, isNull);
+    });
+
+    test('a failed/unsupported primary response yields null, never throws',
+        () async {
+      // A server without the extension answers with a Subsonic error envelope;
+      // with no artist/title to fall back on, that's a calm "no lyrics", not an
+      // error.
+      final client = _client(
+        MockClient((_) async => _failed(0, 'Wrong arguments')),
+      );
+
+      final lyrics = await client.fetchLyrics(_session, 's1');
+
+      expect(lyrics, isNull);
+    });
+
+    test('a transport failure throws notReachable', () async {
+      final client = _client(
+        MockClient((_) async => throw http.ClientException('refused')),
+      );
+
+      await expectLater(
+        () => client.fetchLyrics(_session, 's1'),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.notReachable)),
+      );
+    });
+
+    test('never echoes a credential-bearing error message', () async {
+      final client = _client(MockClient((_) async => throw http.ClientException(
+            'Connection failed: '
+            '$_base/rest/getLyricsBySongId.view?u=alice&t=tok1&s=salt1',
+          )));
+
+      await expectLater(
+        () => client.fetchLyrics(_session, 's1'),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.message, 'message', isNot(contains('tok1')))
+            .having((e) => e.message, 'message', isNot(contains('salt1')))),
+      );
+    });
+  });
 }

--- a/test/core/sources/subsonic/http_subsonic_client_test.dart
+++ b/test/core/sources/subsonic/http_subsonic_client_test.dart
@@ -254,26 +254,28 @@ void main() {
 
   group('fetchLyrics', () {
     // Builds a getLyricsBySongId envelope from one structured-lyrics set.
-    http.Response structured(Map<String, dynamic> set) => _ok(<String, dynamic>{
-          'lyricsList': <String, dynamic>{
-            'structuredLyrics': <Map<String, dynamic>>[set],
-          },
-        });
+    http.Response structured(Map<String, dynamic> set) {
+      return _ok(<String, dynamic>{
+        'lyricsList': <String, dynamic>{
+          'structuredLyrics': <Map<String, dynamic>>[set],
+        },
+      });
+    }
 
     test('parses synced structuredLyrics with millisecond starts', () async {
-      final client = _client(MockClient((_) async => structured(
-            <String, dynamic>{
-              'displayArtist': 'Kavinsky',
-              'displayTitle': 'Nightcall',
-              'lang': 'eng',
-              'offset': 0,
-              'synced': true,
-              'line': <Map<String, dynamic>>[
-                <String, dynamic>{'start': 0, 'value': 'First line'},
-                <String, dynamic>{'start': 1500, 'value': 'Second line'},
-              ],
-            },
-          )));
+      final client = _client(MockClient((_) async {
+        return structured(<String, dynamic>{
+          'displayArtist': 'Kavinsky',
+          'displayTitle': 'Nightcall',
+          'lang': 'eng',
+          'offset': 0,
+          'synced': true,
+          'line': <Map<String, dynamic>>[
+            <String, dynamic>{'start': 0, 'value': 'First line'},
+            <String, dynamic>{'start': 1500, 'value': 'Second line'},
+          ],
+        });
+      }));
 
       final lyrics = await client.fetchLyrics(_session, 's1');
 
@@ -288,15 +290,15 @@ void main() {
     });
 
     test('applies the entry offset to every synced start', () async {
-      final client = _client(MockClient((_) async => structured(
-            <String, dynamic>{
-              'synced': true,
-              'offset': 250,
-              'line': <Map<String, dynamic>>[
-                <String, dynamic>{'start': 1000, 'value': 'x'},
-              ],
-            },
-          )));
+      final client = _client(MockClient((_) async {
+        return structured(<String, dynamic>{
+          'synced': true,
+          'offset': 250,
+          'line': <Map<String, dynamic>>[
+            <String, dynamic>{'start': 1000, 'value': 'x'},
+          ],
+        });
+      }));
 
       final lyrics = await client.fetchLyrics(_session, 's1');
 
@@ -304,14 +306,14 @@ void main() {
     });
 
     test('parses plain structuredLyrics (no timestamps) as untimed', () async {
-      final client = _client(MockClient((_) async => structured(
-            <String, dynamic>{
-              'line': <Map<String, dynamic>>[
-                <String, dynamic>{'value': 'la la'},
-                <String, dynamic>{'value': 'la la la'},
-              ],
-            },
-          )));
+      final client = _client(MockClient((_) async {
+        return structured(<String, dynamic>{
+          'line': <Map<String, dynamic>>[
+            <String, dynamic>{'value': 'la la'},
+            <String, dynamic>{'value': 'la la la'},
+          ],
+        });
+      }));
 
       final lyrics = await client.fetchLyrics(_session, 's1');
 
@@ -323,15 +325,15 @@ void main() {
 
     test('treats a set flagged synced:false as plain even with starts',
         () async {
-      final client = _client(MockClient((_) async => structured(
-            <String, dynamic>{
-              'synced': false,
-              'line': <Map<String, dynamic>>[
-                <String, dynamic>{'start': 0, 'value': 'a'},
-                <String, dynamic>{'start': 0, 'value': 'b'},
-              ],
-            },
-          )));
+      final client = _client(MockClient((_) async {
+        return structured(<String, dynamic>{
+          'synced': false,
+          'line': <Map<String, dynamic>>[
+            <String, dynamic>{'start': 0, 'value': 'a'},
+            <String, dynamic>{'start': 0, 'value': 'b'},
+          ],
+        });
+      }));
 
       final lyrics = await client.fetchLyrics(_session, 's1');
 
@@ -341,24 +343,26 @@ void main() {
 
     test('uses the first structured set when several languages are present',
         () async {
-      final client = _client(MockClient((_) async => _ok(<String, dynamic>{
-            'lyricsList': <String, dynamic>{
-              'structuredLyrics': <Map<String, dynamic>>[
-                <String, dynamic>{
-                  'lang': 'eng',
-                  'line': <Map<String, dynamic>>[
-                    <String, dynamic>{'value': 'english'},
-                  ],
-                },
-                <String, dynamic>{
-                  'lang': 'fra',
-                  'line': <Map<String, dynamic>>[
-                    <String, dynamic>{'value': 'french'},
-                  ],
-                },
-              ],
-            },
-          })));
+      final client = _client(MockClient((_) async {
+        return _ok(<String, dynamic>{
+          'lyricsList': <String, dynamic>{
+            'structuredLyrics': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'lang': 'eng',
+                'line': <Map<String, dynamic>>[
+                  <String, dynamic>{'value': 'english'},
+                ],
+              },
+              <String, dynamic>{
+                'lang': 'fra',
+                'line': <Map<String, dynamic>>[
+                  <String, dynamic>{'value': 'french'},
+                ],
+              },
+            ],
+          },
+        });
+      }));
 
       final lyrics = await client.fetchLyrics(_session, 's1');
 
@@ -471,8 +475,7 @@ void main() {
 
     test('never echoes a credential-bearing error message', () async {
       final client = _client(MockClient((_) async => throw http.ClientException(
-            'Connection failed: '
-            '$_base/rest/getLyricsBySongId.view?u=alice&t=tok1&s=salt1',
+            'Connection failed: $_base/rest/getLyricsBySongId.view?t=tok1&s=salt1',
           )));
 
       await expectLater(

--- a/test/core/sources/subsonic/subsonic_endpoints_test.dart
+++ b/test/core/sources/subsonic/subsonic_endpoints_test.dart
@@ -70,6 +70,30 @@ void main() {
       expect(download.queryParameters['id'], 's-7');
     });
 
+    test('getLyricsBySongId targets its endpoint and carries the song id', () {
+      final Uri uri = SubsonicEndpoints.getLyricsBySongId(
+        _base,
+        username: _user,
+        credentials: _creds,
+        songId: 's-7',
+      );
+      expect(uri.path, '/rest/getLyricsBySongId.view');
+      expect(uri.queryParameters['id'], 's-7');
+    });
+
+    test('getLyrics targets its endpoint and carries the artist and title', () {
+      final Uri uri = SubsonicEndpoints.getLyrics(
+        _base,
+        username: _user,
+        credentials: _creds,
+        artist: 'Boards of Canada',
+        title: 'Roygbiv',
+      );
+      expect(uri.path, '/rest/getLyrics.view');
+      expect(uri.queryParameters['artist'], 'Boards of Canada');
+      expect(uri.queryParameters['title'], 'Roygbiv');
+    });
+
     test('preserves a reverse-proxy subpath, then appends /rest', () {
       // A server mounted under a subpath keeps it ahead of the API path.
       final Uri uri = SubsonicEndpoints.ping(

--- a/test/features/settings/subsonic/subsonic_settings_section_test.dart
+++ b/test/features/settings/subsonic/subsonic_settings_section_test.dart
@@ -47,9 +47,9 @@ void main() {
     expect(find.text('Streaming'), findsOneWidget);
     expect(find.text('Offline'), findsOneWidget);
     expect(find.text('Cast'), findsOneWidget);
+    expect(find.text('Lyrics'), findsOneWidget);
     // Not implemented for Subsonic yet → hidden (capability-based visibility).
     expect(find.text('Favorites'), findsNothing);
-    expect(find.text('Lyrics'), findsNothing);
   });
 
   testWidgets('Sign in is disabled until all three fields are filled',


### PR DESCRIPTION
## Summary

Addresses #140 — Navidrome/Subsonic tracks with lyrics showed **"No lyrics available yet."** while other Navidrome clients displayed them.

**Root cause:** there was no lyrics backend for Subsonic at all. `lyricsServiceProvider` was overridden in `main` with **only** `JellyfinLyricsService`, which returns `null` for any non-`jellyfin:` URI. The Now Playing lyrics button is shown for every track (it isn't gated by `canLyrics`), so a `subsonic:` track reached `LyricsView` and fell straight to the empty state. `SubsonicClient` had no lyrics method, and the docs/capability model listed Subsonic lyrics as a known follow-up.

## What this does

- **`SubsonicClient.fetchLyrics`** — tries the OpenSubsonic **`getLyricsBySongId`** extension first (synced *or* plain lyrics, keyed by the song id we already hold — exactly how Navidrome exposes embedded/sidecar lyrics), then falls back to the legacy **`getLyrics`** (plain text, matched by artist + title) for servers without the extension.
- **`SubsonicLyricsService`** filters by the `subsonic:` scheme, mirroring `JellyfinLyricsService`, and forwards the track's artist/title for the fallback.
- **`CompositeLyricsService`** dispatches across the Jellyfin and Subsonic backends by URI scheme; the production override (`remoteLyricsServiceOverride`) wires both. Tests keep the no-lyrics default.
- **Capability flip:** `MusicProviders.subsonic.canLyrics` → `true` (drives the settings capability chip + the provider matrix).

## Plain vs. synced

The model (`LyricLine.start`) and UI (`_SyncedLyrics`, auto-scroll, tap-to-seek) **already** support timestamps safely — it's the same path Jellyfin uses, with dedicated tests. So synced lyrics are supported here too:

- each line's `start` is read in **milliseconds** with the entry `offset` applied (negative results clamped to zero);
- a line with no `start`, or a set explicitly flagged `synced: false`, becomes a plain untimed line, so `Lyrics.isSynced` correctly picks the static vs. timed view;
- the **legacy `getLyrics`** value is treated as plain text (split on newlines). Parsing any LRC-style timestamps embedded in that legacy value is left as a documented follow-up in `docs/providers.md`.

## Error / empty-state handling

Lyrics are **best-effort**: only a transport failure surfaces the existing *"Couldn't load lyrics"* hint. No lyrics, an unsupported endpoint, an old server, or an unusable body all yield `null` so the UI keeps its **calm empty state** (the current safe behavior).

## Security

Credentials and the credential-bearing request URL are never logged or placed in a thrown error — errors are the existing secret-free `SubsonicException` factories, and there's a test asserting a transport error message contains neither the token nor the salt.

## Tests

- `subsonic_endpoints_test.dart` — `getLyricsBySongId` (id) and `getLyrics` (artist/title) URL building.
- `http_subsonic_client_test.dart` — synced/plain/offset/`synced:false` parsing, first-language pick, primary-then-legacy fallback, empty → `null`, unsupported envelope → `null` (no throw), transport → throws, credential redaction, and "no fallback when the primary has lyrics".
- `subsonic_lyrics_service_test.dart`, `composite_lyrics_service_test.dart` — service + dispatch behavior.
- Updated `music_provider_test.dart` and `subsonic_settings_section_test.dart` for the `canLyrics` flip.

> ⚠️ **Note:** Flutter/Dart tooling isn't available in this environment, so `flutter analyze`/`flutter test` were **not** run here. Please run CI / locally before un-drafting.

## Scope guardrails (per task)

No `v0.1.2` change, no version bump, no tag, no F-Droid/changelog edits. Only `docs/providers.md` was updated (matrix + capability notes). Left as a draft for the next version — and `getLyricsBySongId` was chosen as primary because it's keyed by song id and is what Navidrome (the reporter's server) implements.

Addresses #140

https://claude.ai/code/session_01AGwAcTGt5rGsbnxg8LFBxa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGwAcTGt5rGsbnxg8LFBxa)_