### PR TITLE
fix(library): reliable SAF/SD-card local scan + scan diagnostics (#143)

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -27,6 +27,17 @@ class MainActivity : AudioServiceActivity() {
                                 .listAudioDocuments(treeUri, result)
                         }
                     }
+                    "hasPersistedPermission" -> {
+                        val treeUri = call.argument<String>("treeUri")
+                        if (treeUri == null) {
+                            result.error("bad_args", "treeUri is required", null)
+                        } else {
+                            result.success(
+                                SafDocumentScanner(applicationContext)
+                                    .hasPersistedPermission(treeUri),
+                            )
+                        }
+                    }
                     else -> result.notImplemented()
                 }
             }

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -9,8 +9,8 @@ import java.util.ArrayDeque
 
 /**
  * Walks a user-picked Storage Access Framework tree URI through the content
- * resolver and returns the audio documents under it (recursively) as
- * `{uri, name}` maps.
+ * resolver and returns the audio documents under it (recursively), together
+ * with secret-free counts the Dart diagnostics layer surfaces.
  *
  * This is the scoped-storage way to read a chosen folder: it uses only the
  * access the system granted when the user picked the tree, so it needs no
@@ -18,6 +18,12 @@ import java.util.ArrayDeque
  * audio is intentionally generous (an "audio/" MIME type or a known
  * extension); the Dart layer re-filters by its own supported-types list,
  * keeping that list in one place.
+ *
+ * Resilience: an unreadable subfolder (a provider hiccup, a vanished entry on a
+ * removable SD card) is counted and skipped rather than aborting the whole
+ * walk, so one bad subtree can't zero out an otherwise-readable library. A
+ * total access denial (a revoked grant) still surfaces as a SecurityException
+ * so the user sees a clear "no access" message instead of a silent empty.
  */
 class SafDocumentScanner(private val context: Context) {
 
@@ -32,7 +38,19 @@ class SafDocumentScanner(private val context: Context) {
         }
     }
 
-    private fun walk(treeUri: Uri): List<Map<String, String>> {
+    /**
+     * Whether the app currently holds a persisted *read* grant for [treeUri] —
+     * the diagnostic that tells "no music found" apart from a lost folder grant
+     * (e.g. after a reboot, or a removable SD card that was remounted).
+     */
+    fun hasPersistedPermission(treeUri: String): Boolean {
+        val target = Uri.parse(treeUri)
+        return context.contentResolver.persistedUriPermissions.any {
+            it.uri == target && it.isReadPermission
+        }
+    }
+
+    private fun walk(treeUri: Uri): Map<String, Any?> {
         // Persist the grant when possible so a folder picked once can still be
         // scanned after a restart; harmless (and ignored) when not persistable.
         try {
@@ -44,39 +62,72 @@ class SafDocumentScanner(private val context: Context) {
             // The grant wasn't persistable; traversal still works this session.
         }
 
-        val out = ArrayList<Map<String, String>>()
+        val documents = ArrayList<Map<String, String?>>()
+        var filesVisited = 0
+        var readFailures = 0
         val queue = ArrayDeque<String>()
         queue.add(DocumentsContract.getTreeDocumentId(treeUri))
         while (queue.isNotEmpty()) {
             val parentDocId = queue.poll()
             val childrenUri =
                 DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, parentDocId)
-            context.contentResolver.query(
-                childrenUri,
-                arrayOf(
-                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
-                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
-                    DocumentsContract.Document.COLUMN_MIME_TYPE,
-                ),
-                null,
-                null,
-                null,
-            )?.use { cursor ->
-                while (cursor.moveToNext()) {
-                    val docId = cursor.getString(0) ?: continue
-                    val name = cursor.getString(1) ?: continue
-                    val mime = cursor.getString(2)
-                    if (mime == DocumentsContract.Document.MIME_TYPE_DIR) {
-                        queue.add(docId)
-                    } else if (isAudio(mime, name)) {
-                        val docUri =
-                            DocumentsContract.buildDocumentUriUsingTree(treeUri, docId)
-                        out.add(mapOf("uri" to docUri.toString(), "name" to name))
+            try {
+                val cursor = context.contentResolver.query(
+                    childrenUri,
+                    arrayOf(
+                        DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                        DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                        DocumentsContract.Document.COLUMN_MIME_TYPE,
+                    ),
+                    null,
+                    null,
+                    null,
+                )
+                if (cursor == null) {
+                    // The provider returned nothing for this subtree; count it
+                    // as a read failure and move on.
+                    readFailures++
+                    continue
+                }
+                cursor.use { c ->
+                    while (c.moveToNext()) {
+                        val docId = c.getString(0) ?: continue
+                        val name = c.getString(1) ?: continue
+                        val mime = c.getString(2)
+                        if (mime == DocumentsContract.Document.MIME_TYPE_DIR) {
+                            queue.add(docId)
+                        } else {
+                            filesVisited++
+                            if (isAudio(mime, name)) {
+                                val docUri = DocumentsContract.buildDocumentUriUsingTree(
+                                    treeUri,
+                                    docId,
+                                )
+                                documents.add(
+                                    mapOf(
+                                        "uri" to docUri.toString(),
+                                        "name" to name,
+                                        "mime" to mime,
+                                    ),
+                                )
+                            }
+                        }
                     }
                 }
+            } catch (e: SecurityException) {
+                // A total access denial must surface as a clear error, not a
+                // silent empty — rethrow so listAudioDocuments reports it.
+                throw e
+            } catch (e: Exception) {
+                // One unreadable subtree shouldn't fail the whole scan.
+                readFailures++
             }
         }
-        return out
+        return mapOf(
+            "documents" to documents,
+            "filesVisited" to filesVisited,
+            "readFailures" to readFailures,
+        )
     }
 
     private fun isAudio(mime: String?, name: String): Boolean {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,22 @@ How a selection is addressed (path vs `content://`) is decided once by
 `FolderLocation`; nothing downstream re-parses the string, SAF traversal stays
 behind the `SafDocumentLister` seam, and the UI never sees a platform channel.
 
+**Resilience.** Neither walk lets one bad entry zero out the library. The native
+SAF walk skips (and counts) a subfolder whose listing fails — a provider hiccup,
+a vanished entry on a removable SD card — instead of aborting; only a *total*
+access denial (a revoked grant) still surfaces as a clear error. The filesystem
+walk likewise skips an unreadable subtree rather than throwing. An audio file is
+kept when **either** its name has a known extension **or** the provider reports
+an `audio/*` MIME type, so a file recognised only by content type isn't dropped.
+
+**Diagnostics.** Each scan records a secret-free `LocalScanReport` into
+`LocalScanDiagnostics` — files visited, audio candidates, skipped-unsupported,
+read failures, and the last error *kind* (an enum name, never a path/URI). The
+Settings ▸ Diagnostics report surfaces these alongside whether a folder is
+selected and whether a persisted SAF read grant is still held, so a "no music
+found" report distinguishes an empty folder from a permission loss (the common
+removable-SD-card cause) without revealing anything private.
+
 > **No broad storage permission is requested.** `MANAGE_EXTERNAL_STORAGE` ("all
 > files access") is intentionally *not* used — it is the opposite of the
 > scoped-storage approach this project prefers. A narrow `READ_MEDIA_AUDIO` flow

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -22,6 +22,13 @@ class AppDiagnosticsData {
     this.subsonicState,
     this.subsonicHost,
     this.libraryTrackCount,
+    this.localFolderSelected,
+    this.localPersistedPermission,
+    this.localScanFilesVisited,
+    this.localScanAudioCandidates,
+    this.localScanSkippedUnsupported,
+    this.localScanReadFailures,
+    this.localScanError,
     this.cacheUsedBytes,
     this.cacheLimitBytes,
     this.playbackOutput,
@@ -65,6 +72,33 @@ class AppDiagnosticsData {
 
   /// How many tracks are in the local catalog, when known.
   final int? libraryTrackCount;
+
+  /// Whether a local music folder is currently selected, when known. The folder
+  /// path/URI itself is never carried — only its presence.
+  final bool? localFolderSelected;
+
+  /// For a `content://` (SAF) selection: whether the app still holds a persisted
+  /// read grant for it. Null when not applicable (no selection, a plain path) or
+  /// not determinable (off Android). The removable-SD-card "no access" signal.
+  final bool? localPersistedPermission;
+
+  /// How many non-directory entries the last local scan walked, when a scan has
+  /// run. Counts only — never a path or file name.
+  final int? localScanFilesVisited;
+
+  /// How many of those entries the last scan kept as playable audio.
+  final int? localScanAudioCandidates;
+
+  /// How many entries the last scan skipped as unsupported (e.g. artwork/notes).
+  final int? localScanSkippedUnsupported;
+
+  /// How many entries/subfolders the last scan could not read and skipped — the
+  /// scoped-storage / removable-storage signal.
+  final int? localScanReadFailures;
+
+  /// The last local-scan failure kind (a stable enum name like `safTraversal`),
+  /// when the last scan threw. Null when it completed (even with zero audio).
+  final String? localScanError;
 
   /// App-managed cache bytes in use, when known.
   final int? cacheUsedBytes;
@@ -156,6 +190,13 @@ abstract final class AppDiagnostics {
       if (subsonicHost != null) 'Subsonic host: $subsonicHost',
       if (data.libraryTrackCount != null)
         'Library tracks: ${data.libraryTrackCount}',
+      if (data.localFolderSelected != null)
+        'Local folder: ${data.localFolderSelected! ? 'selected' : 'not selected'}',
+      if (data.localPersistedPermission != null)
+        'Local folder access: '
+            '${data.localPersistedPermission! ? 'persisted' : 'not persisted'}',
+      if (data.localScanFilesVisited != null) _localScanLine(data),
+      if (_has(data.localScanError)) 'Local scan error: ${data.localScanError}',
       if (cache != null) cache,
       if (includePlayback && data.playbackOutput != null)
         'Playback output: ${data.playbackOutput}',
@@ -180,6 +221,16 @@ abstract final class AppDiagnostics {
         'Smart pre-cache: ${_enabledDisabled(data.smartPrecacheEnabled!)}',
     ];
     return lines.join('\n');
+  }
+
+  /// The single-line local-scan summary: how many entries the last scan walked,
+  /// how many were kept as audio, how many were skipped as unsupported, and how
+  /// many could not be read. Only counts — never a path or file name.
+  static String _localScanLine(AppDiagnosticsData data) {
+    return 'Local scan: visited ${data.localScanFilesVisited ?? 0}, '
+        'audio ${data.localScanAudioCandidates ?? 0}, '
+        'skipped ${data.localScanSkippedUnsupported ?? 0}, '
+        'read failures ${data.localScanReadFailures ?? 0}';
   }
 
   static String? _cacheLine(AppDiagnosticsData data) {

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -33,19 +33,33 @@ class IoAudioFileScanner implements AudioFileScanner {
 
   @override
   Future<List<String>> listFiles(String folder) async {
-    final Directory directory = Directory(folder);
-    if (!await directory.exists()) {
+    final Directory root = Directory(folder);
+    if (!await root.exists()) {
       return const <String>[];
     }
 
+    // Walk one directory at a time (rather than `list(recursive: true)`) so a
+    // single unreadable subfolder — common under scoped storage / on removable
+    // SD cards — is skipped instead of aborting the whole scan and zeroing out
+    // the library. `followLinks: false` keeps symlinked directories from being
+    // descended, avoiding cycles.
     final List<String> paths = <String>[];
-    final Stream<FileSystemEntity> entities = directory.list(
-      recursive: true,
-      followLinks: false,
-    );
-    await for (final FileSystemEntity entity in entities) {
-      if (entity is File) {
-        paths.add(entity.absolute.path);
+    final List<Directory> pending = <Directory>[root];
+    while (pending.isNotEmpty) {
+      final Directory directory = pending.removeLast();
+      try {
+        await for (final FileSystemEntity entity in directory.list(
+          followLinks: false,
+        )) {
+          if (entity is File) {
+            paths.add(entity.absolute.path);
+          } else if (entity is Directory) {
+            pending.add(entity);
+          }
+        }
+      } on FileSystemException {
+        // Unreadable subtree: skip it and keep scanning the rest.
+        continue;
       }
     }
     return paths;

--- a/lib/core/sources/local/audio_file_types.dart
+++ b/lib/core/sources/local/audio_file_types.dart
@@ -29,4 +29,24 @@ abstract final class AudioFileTypes {
     }
     return supportedExtensions.contains(ext.substring(1));
   }
+
+  /// Whether [mimeType] denotes audio content (an `audio/*` type), regardless of
+  /// the file name. Lets the scanner keep a file the platform recognized by
+  /// content type even when its display name lacks a known extension. Matching
+  /// is case-insensitive; null/blank is not audio.
+  static bool isAudioMimeType(String? mimeType) {
+    if (mimeType == null) {
+      return false;
+    }
+    return mimeType.trim().toLowerCase().startsWith('audio/');
+  }
+
+  /// Whether a discovered document should be treated as audio: either its [name]
+  /// carries a recognized extension or its [mimeType] is `audio/*`.
+  ///
+  /// This keeps the supported-types decision in one place while accepting both
+  /// signals a content provider can offer, so neither an unknown MIME with a
+  /// valid extension nor a valid audio MIME with an odd extension is dropped.
+  static bool isSupportedDocument(String name, String? mimeType) =>
+      isSupported(name) || isAudioMimeType(mimeType);
 }

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -6,8 +6,20 @@ import '../../services/music_source.dart';
 import 'audio_file_scanner.dart';
 import 'audio_file_types.dart';
 import 'folder_location.dart';
+import 'local_scan_report.dart';
 import 'local_track_mapper.dart';
 import 'saf_document_lister.dart';
+
+/// The tracks a local scan discovered, paired with a secret-free
+/// [LocalScanReport] describing what the scan saw (visited/candidates/skipped/
+/// read-failure counts). The controller persists the [tracks] and records the
+/// [report] for diagnostics.
+class LocalScan {
+  const LocalScan({required this.tracks, required this.report});
+
+  final List<Track> tracks;
+  final LocalScanReport report;
+}
 
 /// A [MusicSource] that scans audio files already present on the device.
 ///
@@ -49,45 +61,102 @@ class LocalMusicSource implements MusicSource {
   String get displayName => 'On this device';
 
   @override
-  Future<List<Track>> fetchTracks() async {
+  Future<List<Track>> fetchTracks() async => (await scanTracks()).tracks;
+
+  /// Scans the selected folder and returns the discovered [Track]s alongside a
+  /// secret-free [LocalScanReport]. This is the richer entry point the library
+  /// controller uses so it can both persist the tracks and record diagnostics;
+  /// [fetchTracks] is the thin [MusicSource] view over it.
+  ///
+  /// A genuine traversal failure still throws a `FolderScanException` (the
+  /// caller turns it into a clear message and an error report); an empty or
+  /// permission-blocked folder instead returns an empty result whose report
+  /// counts explain why.
+  Future<LocalScan> scanTracks() async {
     final String? folder = folderPath;
     if (folder == null || folder.isEmpty) {
-      return const <Track>[];
+      return const LocalScan(
+        tracks: <Track>[],
+        report: LocalScanReport(
+          folderSelected: false,
+          isContentUri: false,
+          filesVisited: 0,
+          audioCandidates: 0,
+          skippedUnsupported: 0,
+          readFailures: 0,
+        ),
+      );
     }
     if (FolderLocation.parse(folder).isContentUri) {
-      return _fetchSafTracks(folder);
+      return _scanSaf(folder);
     }
-    return _fetchFileTracks(await _scanner.listFiles(folder));
+    return _scanFiles(folder, isContentUri: false);
   }
 
   /// Walks an Android SAF tree through the content resolver. Falls back to the
   /// filesystem path scanner only when SAF traversal isn't available on this
   /// build (e.g. desktop); a genuine traversal failure propagates as a
   /// `FolderScanException`.
-  Future<List<Track>> _fetchSafTracks(String folder) async {
+  Future<LocalScan> _scanSaf(String folder) async {
     try {
-      final List<SafAudioDocument> documents =
+      final SafScanResult result =
           await _safDocumentLister.listAudioDocuments(folder);
       final List<Track> tracks = <Track>[];
-      for (final SafAudioDocument document in documents) {
-        if (AudioFileTypes.isSupported(document.name)) {
+      for (final SafAudioDocument document in result.documents) {
+        // Accept either signal the provider offered — a known extension or an
+        // `audio/*` MIME — so an audio file the platform recognised by content
+        // type isn't dropped just because its name has no known extension.
+        if (AudioFileTypes.isSupportedDocument(
+          document.name,
+          document.mimeType,
+        )) {
           tracks.add(LocalTrackMapper.fromSafDocument(document));
         }
       }
-      return tracks;
+      final int candidates = tracks.length;
+      final int skipped = result.filesVisited > candidates
+          ? result.filesVisited - candidates
+          : 0;
+      return LocalScan(
+        tracks: tracks,
+        report: LocalScanReport(
+          folderSelected: true,
+          isContentUri: true,
+          filesVisited: result.filesVisited,
+          audioCandidates: candidates,
+          skippedUnsupported: skipped,
+          readFailures: result.readFailures,
+        ),
+      );
     } on SafUnsupportedException {
-      return _fetchFileTracks(await _scanner.listFiles(folder));
+      return _scanFiles(folder, isContentUri: true);
     }
   }
 
-  List<Track> _fetchFileTracks(List<String> files) {
+  Future<LocalScan> _scanFiles(
+    String folder, {
+    required bool isContentUri,
+  }) async {
+    final List<String> files = await _scanner.listFiles(folder);
     final List<Track> tracks = <Track>[];
     for (final String path in files) {
       if (AudioFileTypes.isSupported(path)) {
         tracks.add(LocalTrackMapper.fromPath(path));
       }
     }
-    return tracks;
+    final int visited = files.length;
+    final int candidates = tracks.length;
+    return LocalScan(
+      tracks: tracks,
+      report: LocalScanReport(
+        folderSelected: true,
+        isContentUri: isContentUri,
+        filesVisited: visited,
+        audioCandidates: candidates,
+        skippedUnsupported: visited - candidates,
+        readFailures: 0,
+      ),
+    );
   }
 
   /// Empty until tag parsing exists: albums can't be grouped from file paths

--- a/lib/core/sources/local/local_scan_diagnostics.dart
+++ b/lib/core/sources/local/local_scan_diagnostics.dart
@@ -1,0 +1,55 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+import '../../diagnostics/safe_event_log.dart';
+import 'local_scan_report.dart';
+
+/// Holds the last local-folder scan outcome so the diagnostics report and the
+/// "Report a bug" flow can show *why* a scan found no music — selected-folder
+/// presence, files visited, audio candidates, skipped/unsupported, read
+/// failures, and the last error — without anyone re-running a scan.
+///
+/// Secret-free by construction: it stores only a [LocalScanReport], which holds
+/// booleans, counts, and a fixed error enum — no folder path, file name, or raw
+/// error string. The breadcrumb mirrored into [SafeEventLog] is likewise just
+/// `category: detail` with structural counts, so nothing sensitive is recorded.
+///
+/// A process-wide static, matching the plugin-free style of the other
+/// diagnostics utilities (`StabilityDiagnostics`) that the report already reads.
+abstract final class LocalScanDiagnostics {
+  /// The developer-log channel these breadcrumbs go to (debug builds only).
+  static const String name = 'linthra.scan';
+
+  /// The most recent scan outcome, or null until the first scan runs.
+  static LocalScanReport? last;
+
+  /// Records [report] as the latest scan outcome and drops a secret-free
+  /// breadcrumb into the shared event log.
+  static void record(LocalScanReport report) {
+    last = report;
+    SafeEventLog.instance.record('scan', describe(report));
+    if (kDebugMode) {
+      developer.log(describe(report), name: name);
+    }
+  }
+
+  /// Clears the retained outcome. For tests, so one case can't leak into the
+  /// next.
+  static void reset() => last = null;
+
+  /// A one-line, secret-free summary of [report] — counts and a fixed error
+  /// label only. Pure and public so a test can assert it carries no secret (it
+  /// cannot: there is no parameter for a path, name, or raw error).
+  static String describe(LocalScanReport report) {
+    return <String>[
+      'folder=${report.folderSelected ? 'selected' : 'none'}',
+      if (report.folderSelected) 'kind=${report.isContentUri ? 'saf' : 'path'}',
+      'visited=${report.filesVisited}',
+      'audio=${report.audioCandidates}',
+      'skipped=${report.skippedUnsupported}',
+      'readFailures=${report.readFailures}',
+      if (report.error != null) 'error=${report.error!.name}',
+    ].join(' ');
+  }
+}

--- a/lib/core/sources/local/local_scan_report.dart
+++ b/lib/core/sources/local/local_scan_report.dart
@@ -1,0 +1,70 @@
+/// Why the most recent local-folder scan ended the way it did, recorded as a
+/// failure *kind* (an enum name) — never a raw error string that could carry a
+/// folder path, file name, or device detail.
+enum LocalScanError {
+  /// The selected folder could not be traversed through Android's Storage
+  /// Access Framework (revoked grant, unresolvable provider, unreadable path).
+  safTraversal,
+
+  /// Any other unexpected scan failure (a `dart:io` fault, a plugin error).
+  unexpected,
+}
+
+/// A secret-free snapshot of the last local-folder scan, so a bug report can
+/// show *why* a scan turned up empty without revealing anything private.
+///
+/// Security: by construction this holds only booleans, counts, and a fixed
+/// [LocalScanError] enum name. There is deliberately **no** field for the folder
+/// path/URI, a file name, or a raw error message — the things that could leak a
+/// user's library layout. This mirrors the "diagnostic, never secret" rule the
+/// rest of the diagnostics utilities follow.
+class LocalScanReport {
+  const LocalScanReport({
+    required this.folderSelected,
+    required this.isContentUri,
+    required this.filesVisited,
+    required this.audioCandidates,
+    required this.skippedUnsupported,
+    required this.readFailures,
+    this.error,
+  });
+
+  /// Builds a failure report (all counts zero) from what the caller knows about
+  /// the selection — used when the scan threw before producing any counts.
+  const LocalScanReport.failure({
+    required this.folderSelected,
+    required this.isContentUri,
+    required LocalScanError this.error,
+  })  : filesVisited = 0,
+        audioCandidates = 0,
+        skippedUnsupported = 0,
+        readFailures = 0;
+
+  /// Whether a music folder was selected at all when the scan ran.
+  final bool folderSelected;
+
+  /// Whether the selection was an Android SAF `content://` tree URI (vs a plain
+  /// filesystem path). Tells a "no music found" report apart by storage kind.
+  final bool isContentUri;
+
+  /// How many non-directory entries the scan walked (audio and non-audio).
+  final int filesVisited;
+
+  /// How many of those entries were kept as playable audio candidates.
+  final int audioCandidates;
+
+  /// How many entries were skipped because they were not a recognized audio
+  /// file (the usual `cover.jpg`/`notes.txt` case).
+  final int skippedUnsupported;
+
+  /// How many entries or subfolders could not be read and were skipped — the
+  /// scoped-storage / removable-SD-card signal. A non-zero value with zero
+  /// candidates points at a permission problem rather than an empty folder.
+  final int readFailures;
+
+  /// The failure kind when the scan threw, or null when it completed (even if it
+  /// completed with zero candidates).
+  final LocalScanError? error;
+
+  bool get hadError => error != null;
+}

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -24,14 +24,14 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
   static const MethodChannel _channel = MethodChannel(_channelName);
 
   @override
-  Future<List<SafAudioDocument>> listAudioDocuments(String treeUri) async {
+  Future<SafScanResult> listAudioDocuments(String treeUri) async {
     if (!Platform.isAndroid) {
       throw const SafUnsupportedException();
     }
 
-    final List<Object?>? result;
+    final Map<Object?, Object?>? result;
     try {
-      result = await _channel.invokeListMethod<Object?>(
+      result = await _channel.invokeMapMethod<Object?, Object?>(
         'listAudioDocuments',
         <String, Object?>{'treeUri': treeUri},
       );
@@ -47,19 +47,45 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
       );
     }
 
+    return parseScanResult(result);
+  }
+
+  /// Parses the native `listAudioDocuments` reply into a [SafScanResult].
+  ///
+  /// Pure and public so the parsing — the part with real logic — is unit-testable
+  /// without a device or platform channel. Deliberately tolerant: a null reply,
+  /// a malformed entry, or a missing count never throws; counts fall back so an
+  /// older native build that only returned documents still scans.
+  static SafScanResult parseScanResult(Map<Object?, Object?>? result) {
     if (result == null) {
-      return const <SafAudioDocument>[];
+      return const SafScanResult();
     }
     final List<SafAudioDocument> documents = <SafAudioDocument>[];
-    for (final Object? entry in result) {
-      if (entry is Map) {
-        final Object? uri = entry['uri'];
-        final Object? name = entry['name'];
-        if (uri is String && uri.isNotEmpty && name is String) {
-          documents.add(SafAudioDocument(uri: uri, name: name));
+    final Object? rawDocuments = result['documents'];
+    if (rawDocuments is List) {
+      for (final Object? entry in rawDocuments) {
+        if (entry is Map) {
+          final Object? uri = entry['uri'];
+          final Object? name = entry['name'];
+          final Object? mime = entry['mime'];
+          if (uri is String && uri.isNotEmpty && name is String) {
+            documents.add(SafAudioDocument(
+              uri: uri,
+              name: name,
+              mimeType: mime is String ? mime : null,
+            ));
+          }
         }
       }
     }
-    return documents;
+    final Object? filesVisited = result['filesVisited'];
+    final Object? readFailures = result['readFailures'];
+    return SafScanResult(
+      documents: documents,
+      // Fall back to the document count if the native side is an older build
+      // that didn't report a visited total, so the scan still works.
+      filesVisited: filesVisited is int ? filesVisited : documents.length,
+      readFailures: readFailures is int ? readFailures : 0,
+    );
   }
 }

--- a/lib/core/sources/local/method_channel_saf_permission_probe.dart
+++ b/lib/core/sources/local/method_channel_saf_permission_probe.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'saf_permission_probe.dart';
+
+/// A [SafPermissionProbe] backed by the same native Android SAF method channel
+/// the document lister uses. It asks the content resolver whether a persisted
+/// read grant for the given tree URI is still held.
+///
+/// This is the only Dart file (besides the lister) that talks to that channel.
+/// Off Android, or when the native handler isn't registered, it reports `null`
+/// so the diagnostics line is simply omitted instead of guessing.
+class MethodChannelSafPermissionProbe implements SafPermissionProbe {
+  const MethodChannelSafPermissionProbe();
+
+  // Mirrors MethodChannelSafDocumentLister / MainActivity.kt's SAF_CHANNEL.
+  static const MethodChannel _channel =
+      MethodChannel('io.github.thezupzup.linthra/saf');
+
+  @override
+  Future<bool?> hasPersistedPermission(String treeUri) async {
+    if (!Platform.isAndroid) {
+      return null;
+    }
+    try {
+      return await _channel.invokeMethod<bool>(
+        'hasPersistedPermission',
+        <String, Object?>{'treeUri': treeUri},
+      );
+    } on MissingPluginException {
+      return null;
+    } on PlatformException {
+      // The native side failed to answer; treat as "unknown" rather than
+      // surfacing a raw platform error into a diagnostic line.
+      return null;
+    }
+  }
+}

--- a/lib/core/sources/local/saf_document_lister.dart
+++ b/lib/core/sources/local/saf_document_lister.dart
@@ -1,11 +1,17 @@
 /// One audio document discovered by walking an Android SAF tree.
 ///
-/// Carries the `content://` document [uri] the platform can open and the
-/// display [name] (with extension). The name is kept because a bare content URI
-/// does not reliably expose a real title or file type, and the catalog needs
-/// both — a readable title and a way to recognise the audio format.
+/// Carries the `content://` document [uri] the platform can open, the display
+/// [name] (with extension), and the provider-reported [mimeType] when known. The
+/// name is kept because a bare content URI does not reliably expose a real title
+/// or file type; the MIME type is kept so an audio file the platform recognises
+/// by content (e.g. `audio/mpeg`) is still treated as audio even when its name
+/// lacks a known extension — the catalog needs both signals to recognise audio.
 class SafAudioDocument {
-  const SafAudioDocument({required this.uri, required this.name});
+  const SafAudioDocument({
+    required this.uri,
+    required this.name,
+    this.mimeType,
+  });
 
   /// The `content://` document URI, openable by the platform and stable enough
   /// to use as a track id.
@@ -13,6 +19,29 @@ class SafAudioDocument {
 
   /// The document's display name, including its extension (e.g. `Song.flac`).
   final String name;
+
+  /// The provider-reported MIME type (e.g. `audio/flac`), or null when the
+  /// provider did not expose one.
+  final String? mimeType;
+}
+
+/// The result of walking an Android SAF tree: the audio documents found plus
+/// secret-free counters the diagnostics layer surfaces.
+///
+/// [filesVisited] counts every non-directory entry the walk saw (audio and
+/// non-audio); [documents] are the audio ones; [readFailures] counts subfolders
+/// whose listing failed and were skipped — the scoped-storage / removable-SD
+/// signal that tells an empty result apart from a permission problem.
+class SafScanResult {
+  const SafScanResult({
+    this.documents = const <SafAudioDocument>[],
+    this.filesVisited = 0,
+    this.readFailures = 0,
+  });
+
+  final List<SafAudioDocument> documents;
+  final int filesVisited;
+  final int readFailures;
 }
 
 /// Thrown when SAF document traversal is not available on this build/platform,
@@ -33,12 +62,12 @@ class SafUnsupportedException implements Exception {
 /// This is the seam that lets a content-URI folder actually be scanned. The
 /// production binding is `MethodChannelSafDocumentLister` (Android only); tests
 /// inject a fake. An implementation either:
-///  - returns the audio documents under the tree (possibly empty), or
+///  - returns a [SafScanResult] for the tree (possibly with no documents), or
 ///  - throws [SafUnsupportedException] when traversal isn't available on this
 ///    build (the caller then falls back to filesystem path resolution), or
 ///  - throws a `FolderScanException` when traversal is available but fails.
 abstract interface class SafDocumentLister {
-  Future<List<SafAudioDocument>> listAudioDocuments(String treeUri);
+  Future<SafScanResult> listAudioDocuments(String treeUri);
 }
 
 /// The default [SafDocumentLister] for platforms without native SAF traversal
@@ -49,7 +78,7 @@ class UnsupportedSafDocumentLister implements SafDocumentLister {
   const UnsupportedSafDocumentLister();
 
   @override
-  Future<List<SafAudioDocument>> listAudioDocuments(String treeUri) async {
+  Future<SafScanResult> listAudioDocuments(String treeUri) async {
     throw const SafUnsupportedException();
   }
 }

--- a/lib/core/sources/local/saf_permission_probe.dart
+++ b/lib/core/sources/local/saf_permission_probe.dart
@@ -1,0 +1,29 @@
+/// Answers one diagnostic question: does the app still hold a *persisted* SAF
+/// read grant for a previously picked `content://` tree URI?
+///
+/// On Android the folder chooser's grant is what lets a scan read the selected
+/// tree after a restart. If it was never persisted (or was revoked), scanning a
+/// removable SD card silently turns up nothing. Surfacing the grant's presence
+/// in diagnostics tells a "no music found" report apart from a permission loss.
+///
+/// Kept behind an interface so the diagnostics collector stays testable without
+/// a device or platform channel: the production binding is
+/// `MethodChannelSafPermissionProbe` (Android only); elsewhere the unsupported
+/// binding reports `null` ("not determinable here").
+abstract interface class SafPermissionProbe {
+  /// Whether a persisted read grant for [treeUri] is currently held.
+  ///
+  /// Returns `null` when the answer can't be determined on this platform (off
+  /// Android, or the native handler isn't registered) — never a guess.
+  Future<bool?> hasPersistedPermission(String treeUri);
+}
+
+/// The default [SafPermissionProbe] for platforms without the native SAF channel
+/// (desktop, tests): it always reports `null`, so diagnostics simply omit the
+/// persisted-permission line rather than implying an answer it can't know.
+class UnsupportedSafPermissionProbe implements SafPermissionProbe {
+  const UnsupportedSafPermissionProbe();
+
+  @override
+  Future<bool?> hasPersistedPermission(String treeUri) async => null;
+}

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -1,7 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/sources/local/folder_location.dart';
 import '../../core/sources/local/folder_scan_exception.dart';
 import '../../core/sources/local/local_music_source.dart';
+import '../../core/sources/local/local_scan_diagnostics.dart';
+import '../../core/sources/local/local_scan_report.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
 import 'library_providers.dart';
 import 'library_state.dart';
@@ -25,31 +28,45 @@ class LibraryController extends Notifier<LibraryState> {
   /// shows what was just stored. Any failure surfaces as an error state.
   Future<void> scanFolder(String folderPath) async {
     state = const LibraryState.loading();
+    final FolderLocation location = FolderLocation.parse(folderPath);
     try {
       final source = LocalMusicSource(
         folderPath: folderPath,
         scanner: ref.read(audioFileScannerProvider),
         safDocumentLister: ref.read(safDocumentListerProvider),
       );
-      final tracks = await source.fetchTracks();
+      final LocalScan scan = await source.scanTracks();
       final albums = await source.fetchAlbums();
       final artists = await source.fetchArtists();
       final repository = ref.read(musicLibraryRepositoryProvider);
       await repository.upsertCatalog(
         sourceId: source.id,
-        tracks: tracks,
+        tracks: scan.tracks,
         albums: albums,
         artists: artists,
       );
+      // Record the counts (visited / audio / skipped / read failures) so a
+      // "no music found" report can show what the scan actually saw.
+      LocalScanDiagnostics.record(scan.report);
       await _load();
     } on FolderScanException catch (error) {
       // The scanning layer already phrased a clear, secret-free message
       // (unreachable SAF tree, unreadable scoped-storage path, …); show it.
+      LocalScanDiagnostics.record(LocalScanReport.failure(
+        folderSelected: folderPath.isNotEmpty,
+        isContentUri: location.isContentUri,
+        error: LocalScanError.safTraversal,
+      ));
       state = LibraryState.error(error.message);
     } catch (_) {
       // Anything else is an unexpected scan failure — a raw `dart:io`
       // permission error or a plugin fault. Don't leak its text (errno codes,
       // paths) to the user; show one friendly, actionable line instead.
+      LocalScanDiagnostics.record(LocalScanReport.failure(
+        folderSelected: folderPath.isNotEmpty,
+        isContentUri: location.isContentUri,
+        error: LocalScanError.unexpected,
+      ));
       state = const LibraryState.error(_scanFailedMessage);
     }
   }

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -6,7 +6,9 @@ import '../../core/services/file_picker_folder_picker_service.dart';
 import '../../core/services/folder_picker_service.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
 import '../../core/sources/local/method_channel_saf_document_lister.dart';
+import '../../core/sources/local/method_channel_saf_permission_probe.dart';
 import '../../core/sources/local/saf_document_lister.dart';
+import '../../core/sources/local/saf_permission_probe.dart';
 
 /// The storage seam the library scan uses to discover audio files.
 ///
@@ -36,4 +38,15 @@ final safDocumentListerProvider = Provider<SafDocumentLister>((ref) {
   return Platform.isAndroid
       ? const MethodChannelSafDocumentLister()
       : const UnsupportedSafDocumentLister();
+});
+
+/// The seam diagnostics use to check whether a persisted SAF read grant is still
+/// held for the selected `content://` folder — the removable-SD-card signal that
+/// tells "no music found" apart from a lost folder permission. Android-only;
+/// elsewhere (desktop, tests) the unsupported binding reports `null` so the
+/// persisted-permission line is simply omitted. Tests override it with a fake.
+final safPermissionProbeProvider = Provider<SafPermissionProbe>((ref) {
+  return Platform.isAndroid
+      ? const MethodChannelSafPermissionProbe()
+      : const UnsupportedSafPermissionProbe();
 });

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -11,8 +11,13 @@ import '../../../core/services/active_playback_controller.dart';
 import '../../../core/services/notification_permission.dart';
 import '../../../core/services/playback_diagnostics.dart';
 import '../../../core/services/stability_diagnostics.dart';
+import '../../../core/sources/local/folder_location.dart';
+import '../../../core/sources/local/local_scan_diagnostics.dart';
+import '../../../core/sources/local/local_scan_report.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../../data/repositories/selected_music_folder_repository_provider.dart';
 import '../../downloads/download_providers.dart';
+import '../../library/library_providers.dart';
 import '../../player/cast/cast_providers.dart';
 import '../../player/player_providers.dart';
 import '../jellyfin/jellyfin_settings_controller.dart';
@@ -49,6 +54,19 @@ class DiagnosticsCollector {
         _ref.read(subsonicSettingsControllerProvider);
     final CastState cast = _ref.read(castServiceProvider).state;
 
+    // Local-folder scan diagnostics: whether a folder is selected, whether a
+    // persisted SAF grant is still held for it (the removable-SD-card signal),
+    // and the counts from the last scan. All secret-free — never the path/URI.
+    final String? selectedFolder = await _selectedFolder();
+    final bool folderSelected =
+        selectedFolder != null && selectedFolder.isNotEmpty;
+    final bool isContentFolder = selectedFolder != null &&
+        selectedFolder.isNotEmpty &&
+        FolderLocation.parse(selectedFolder).isContentUri;
+    final bool? persistedPermission =
+        await _persistedPermission(selectedFolder, isContentFolder);
+    final LocalScanReport? scan = LocalScanDiagnostics.last;
+
     return AppDiagnosticsData(
       appVersion: AppInfo.version,
       androidVersion: _androidVersion(),
@@ -60,6 +78,13 @@ class DiagnosticsCollector {
       subsonicState: _subsonicStateLabel(subsonic),
       subsonicHost: subsonic.baseUrl,
       libraryTrackCount: await _libraryTrackCount(),
+      localFolderSelected: folderSelected,
+      localPersistedPermission: persistedPermission,
+      localScanFilesVisited: scan?.filesVisited,
+      localScanAudioCandidates: scan?.audioCandidates,
+      localScanSkippedUnsupported: scan?.skippedUnsupported,
+      localScanReadFailures: scan?.readFailures,
+      localScanError: scan?.error?.name,
       cacheUsedBytes: _cacheUsedBytes(),
       cacheLimitBytes: _cacheLimitBytes(),
       playbackOutput: _playbackOutput(),
@@ -133,6 +158,39 @@ class DiagnosticsCollector {
       return tracks.length;
     } catch (_) {
       // A storage hiccup must not break the report; just omit the count.
+      return null;
+    }
+  }
+
+  /// The selected music folder path/URI, read best-effort. Used only to derive
+  /// the secret-free "selected / not selected" and persisted-permission flags —
+  /// the value itself never reaches the report.
+  Future<String?> _selectedFolder() async {
+    try {
+      return await _ref
+          .read(selectedMusicFolderRepositoryProvider)
+          .getSelectedFolder();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Whether a persisted SAF read grant is still held for a `content://`
+  /// selection. Null when not applicable (no selection or a plain path) or not
+  /// determinable (off Android); best-effort so a probe failure can't break the
+  /// report.
+  Future<bool?> _persistedPermission(
+    String? folder,
+    bool isContentFolder,
+  ) async {
+    if (folder == null || !isContentFolder) {
+      return null;
+    }
+    try {
+      return await _ref
+          .read(safPermissionProbeProvider)
+          .hasPersistedPermission(folder);
+    } catch (_) {
       return null;
     }
   }

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -289,4 +289,99 @@ void main() {
       expect(report.toLowerCase(), isNot(contains('bearer')));
     });
   });
+
+  group('AppDiagnostics.report local scan diagnostics', () {
+    test('reports the selected folder, access, scan counts, and error', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          localFolderSelected: true,
+          localPersistedPermission: true,
+          localScanFilesVisited: 120,
+          localScanAudioCandidates: 98,
+          localScanSkippedUnsupported: 22,
+          localScanReadFailures: 0,
+        ),
+      );
+
+      expect(report, contains('Local folder: selected'));
+      expect(report, contains('Local folder access: persisted'));
+      expect(
+        report,
+        contains('Local scan: visited 120, audio 98, skipped 22, '
+            'read failures 0'),
+      );
+    });
+
+    test('reports a missing folder and a lost grant plainly', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          localFolderSelected: false,
+        ),
+      );
+
+      expect(report, contains('Local folder: not selected'));
+      // No persisted-permission line when the flag is unknown/not applicable.
+      expect(report, isNot(contains('Local folder access:')));
+    });
+
+    test('reports a not-persisted SAF grant — the removable-SD signal', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          localFolderSelected: true,
+          localPersistedPermission: false,
+          localScanFilesVisited: 0,
+          localScanAudioCandidates: 0,
+          localScanSkippedUnsupported: 0,
+          localScanReadFailures: 4,
+        ),
+      );
+
+      expect(report, contains('Local folder access: not persisted'));
+      expect(report, contains('read failures 4'));
+    });
+
+    test('reports the last scan error kind when present', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          localScanError: 'safTraversal',
+        ),
+      );
+
+      expect(report, contains('Local scan error: safTraversal'));
+    });
+
+    test('omits the local-scan lines when the fields are absent', () {
+      final String report =
+          AppDiagnostics.report(const AppDiagnosticsData(appVersion: '0.1.0'));
+
+      expect(report, isNot(contains('Local folder:')));
+      expect(report, isNot(contains('Local folder access:')));
+      expect(report, isNot(contains('Local scan:')));
+      expect(report, isNot(contains('Local scan error:')));
+    });
+
+    test('the local-scan lines carry no path, URI, or file name', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          localFolderSelected: true,
+          localPersistedPermission: false,
+          localScanFilesVisited: 3,
+          localScanAudioCandidates: 1,
+          localScanSkippedUnsupported: 2,
+          localScanReadFailures: 1,
+          localScanError: 'safTraversal',
+        ),
+      );
+
+      expect(report.toLowerCase(), isNot(contains('content://')));
+      expect(report, isNot(contains('/storage/')));
+      expect(report.toLowerCase(), isNot(contains('.mp3')));
+      expect(report.toLowerCase(), isNot(contains('http')));
+    });
+  });
 }

--- a/test/core/sources/local/audio_file_scanner_test.dart
+++ b/test/core/sources/local/audio_file_scanner_test.dart
@@ -33,6 +33,26 @@ void main() {
       expect(files.any((path) => path.endsWith('notes.txt')), isTrue);
     });
 
+    test('walks several directory levels deep', () async {
+      final albumDir = Directory('${root.path}/Artist/Album');
+      albumDir.createSync(recursive: true);
+      final discDir = Directory('${albumDir.path}/Disc 2');
+      discDir.createSync();
+      // An empty directory in the tree must not break the walk.
+      Directory('${root.path}/Empty').createSync();
+      File('${root.path}/top.mp3').writeAsStringSync('x');
+      File('${albumDir.path}/mid.flac').writeAsStringSync('x');
+      File('${discDir.path}/deep.ogg').writeAsStringSync('x');
+
+      const scanner = IoAudioFileScanner();
+      final files = await scanner.listFiles(root.path);
+
+      expect(files, hasLength(3));
+      expect(files.any((path) => path.endsWith('top.mp3')), isTrue);
+      expect(files.any((path) => path.endsWith('mid.flac')), isTrue);
+      expect(files.any((path) => path.endsWith('deep.ogg')), isTrue);
+    });
+
     test('returns an empty list for a folder that does not exist', () async {
       const scanner = IoAudioFileScanner();
       final files = await scanner.listFiles('${root.path}/missing');

--- a/test/core/sources/local/audio_file_types_test.dart
+++ b/test/core/sources/local/audio_file_types_test.dart
@@ -67,4 +67,51 @@ void main() {
       );
     });
   });
+
+  group('AudioFileTypes.isAudioMimeType', () {
+    test('recognizes any audio/* MIME type, case-insensitively', () {
+      expect(AudioFileTypes.isAudioMimeType('audio/mpeg'), isTrue);
+      expect(AudioFileTypes.isAudioMimeType('audio/flac'), isTrue);
+      expect(AudioFileTypes.isAudioMimeType('AUDIO/MP4'), isTrue);
+      expect(AudioFileTypes.isAudioMimeType('  audio/ogg  '), isTrue);
+    });
+
+    test('rejects non-audio and missing MIME types', () {
+      expect(AudioFileTypes.isAudioMimeType('image/jpeg'), isFalse);
+      expect(AudioFileTypes.isAudioMimeType('text/plain'), isFalse);
+      expect(AudioFileTypes.isAudioMimeType(''), isFalse);
+      expect(AudioFileTypes.isAudioMimeType(null), isFalse);
+    });
+  });
+
+  group('AudioFileTypes.isSupportedDocument', () {
+    test('keeps a known extension even when the MIME is unknown', () {
+      // A valid extension with an opaque/unknown MIME is still audio.
+      expect(
+        AudioFileTypes.isSupportedDocument('Song.mp3', 'text/plain'),
+        isTrue,
+      );
+      expect(AudioFileTypes.isSupportedDocument('Song.flac', null), isTrue);
+    });
+
+    test('keeps an audio MIME even when the extension is unknown', () {
+      // No recognised extension, but the provider reported audio content.
+      expect(
+        AudioFileTypes.isSupportedDocument('recording', 'audio/mpeg'),
+        isTrue,
+      );
+      expect(
+        AudioFileTypes.isSupportedDocument('track.weird', 'audio/x-wav'),
+        isTrue,
+      );
+    });
+
+    test('drops a document that is neither a known extension nor audio', () {
+      expect(
+        AudioFileTypes.isSupportedDocument('cover.jpg', 'image/jpeg'),
+        isFalse,
+      );
+      expect(AudioFileTypes.isSupportedDocument('notes.txt', null), isFalse);
+    });
+  });
 }

--- a/test/core/sources/local/fake_saf_document_lister.dart
+++ b/test/core/sources/local/fake_saf_document_lister.dart
@@ -1,22 +1,30 @@
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 
-/// A [SafDocumentLister] that returns canned documents, reports SAF traversal
-/// unavailable, or throws an arbitrary error — so content-URI scanning can be
-/// driven without a device or a platform channel.
+/// A [SafDocumentLister] that returns a canned [SafScanResult], reports SAF
+/// traversal unavailable, or throws an arbitrary error — so content-URI
+/// scanning can be driven without a device or a platform channel.
+///
+/// [documents] are the audio documents the native walk would return; pass
+/// [filesVisited]/[readFailures] to model the diagnostic counts (visited
+/// defaults to the document count, the common all-audio case).
 class FakeSafDocumentLister implements SafDocumentLister {
   FakeSafDocumentLister({
     this.documents = const <SafAudioDocument>[],
+    int? filesVisited,
+    this.readFailures = 0,
     this.unsupported = false,
     this.error,
-  });
+  }) : filesVisited = filesVisited ?? documents.length;
 
   final List<SafAudioDocument> documents;
+  final int filesVisited;
+  final int readFailures;
   final bool unsupported;
   final Object? error;
   String? requestedTreeUri;
 
   @override
-  Future<List<SafAudioDocument>> listAudioDocuments(String treeUri) async {
+  Future<SafScanResult> listAudioDocuments(String treeUri) async {
     requestedTreeUri = treeUri;
     if (unsupported) {
       throw const SafUnsupportedException();
@@ -25,6 +33,10 @@ class FakeSafDocumentLister implements SafDocumentLister {
     if (thrown != null) {
       throw thrown;
     }
-    return documents;
+    return SafScanResult(
+      documents: documents,
+      filesVisited: filesVisited,
+      readFailures: readFailures,
+    );
   }
 }

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -162,4 +162,152 @@ void main() {
       );
     });
   });
+
+  group('LocalMusicSource.scanTracks reports', () {
+    test('reports the counts for a filesystem scan', () async {
+      final scanner = _FakeScanner(<String>[
+        '/music/One.mp3',
+        '/music/cover.jpg',
+        '/music/Two.flac',
+        '/music/notes.txt',
+      ]);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks.map((track) => track.title), <String>['One', 'Two']);
+      expect(scan.report.folderSelected, isTrue);
+      expect(scan.report.isContentUri, isFalse);
+      expect(scan.report.filesVisited, 4);
+      expect(scan.report.audioCandidates, 2);
+      expect(scan.report.skippedUnsupported, 2);
+      expect(scan.report.readFailures, 0);
+      expect(scan.report.error, isNull);
+    });
+
+    test('counts every recursively discovered file as visited', () async {
+      final scanner = _FakeScanner(<String>[
+        '/music/A.mp3',
+        '/music/Album/B.flac',
+        '/music/Album/Disc 2/C.ogg',
+      ]);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks, hasLength(3));
+      expect(scan.report.filesVisited, 3);
+      expect(scan.report.audioCandidates, 3);
+      expect(scan.report.skippedUnsupported, 0);
+    });
+
+    test('no folder selected reports folderSelected = false', () async {
+      const source = LocalMusicSource(folderPath: null);
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks, isEmpty);
+      expect(scan.report.folderSelected, isFalse);
+      expect(scan.report.filesVisited, 0);
+      expect(scan.report.hadError, isFalse);
+    });
+
+    test('an empty SAF folder returns a clear, error-free empty result',
+        () async {
+      final source = LocalMusicSource(
+        folderPath: _safFolder,
+        scanner: _FakeScanner(const <String>[]),
+        safDocumentLister: FakeSafDocumentLister(),
+      );
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks, isEmpty);
+      expect(scan.report.folderSelected, isTrue);
+      expect(scan.report.isContentUri, isTrue);
+      expect(scan.report.filesVisited, 0);
+      expect(scan.report.audioCandidates, 0);
+      expect(scan.report.skippedUnsupported, 0);
+      expect(scan.report.readFailures, 0);
+      expect(scan.report.hadError, isFalse);
+    });
+
+    test('keeps a SAF document with a valid extension but unknown MIME',
+        () async {
+      final saf = FakeSafDocumentLister(
+        documents: const <SafAudioDocument>[
+          SafAudioDocument(
+            uri: 'content://doc/1',
+            name: 'Song.mp3',
+            mimeType: 'application/octet-stream',
+          ),
+        ],
+        filesVisited: 1,
+      );
+      final source = LocalMusicSource(
+        folderPath: _safFolder,
+        scanner: _FakeScanner(const <String>[]),
+        safDocumentLister: saf,
+      );
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks.single.title, 'Song');
+      expect(scan.report.audioCandidates, 1);
+      expect(scan.report.skippedUnsupported, 0);
+    });
+
+    test('keeps a SAF document with an audio MIME but no known extension',
+        () async {
+      final saf = FakeSafDocumentLister(
+        documents: const <SafAudioDocument>[
+          // No recognised extension, but the provider reported audio content,
+          // so it must not be dropped.
+          SafAudioDocument(
+            uri: 'content://doc/9',
+            name: 'recording',
+            mimeType: 'audio/mpeg',
+          ),
+        ],
+        filesVisited: 1,
+      );
+      final source = LocalMusicSource(
+        folderPath: _safFolder,
+        scanner: _FakeScanner(const <String>[]),
+        safDocumentLister: saf,
+      );
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks, hasLength(1));
+      expect(scan.tracks.single.uri, 'content://doc/9');
+      expect(scan.report.audioCandidates, 1);
+    });
+
+    test('an unreadable subtree is skipped, counted, and never fatal',
+        () async {
+      // The native walk found one good audio document but also reported a
+      // subtree it could not read; the scan must still return the track and
+      // record the failure rather than throwing.
+      final saf = FakeSafDocumentLister(
+        documents: const <SafAudioDocument>[
+          SafAudioDocument(uri: 'content://doc/1', name: 'Good.mp3'),
+        ],
+        filesVisited: 1,
+        readFailures: 2,
+      );
+      final source = LocalMusicSource(
+        folderPath: _safFolder,
+        scanner: _FakeScanner(const <String>[]),
+        safDocumentLister: saf,
+      );
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks.single.title, 'Good');
+      expect(scan.report.readFailures, 2);
+      expect(scan.report.audioCandidates, 1);
+      expect(scan.report.hadError, isFalse);
+    });
+  });
 }

--- a/test/core/sources/local/local_scan_diagnostics_test.dart
+++ b/test/core/sources/local/local_scan_diagnostics_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/safe_event_log.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/core/sources/local/local_scan_report.dart';
+
+void main() {
+  setUp(() {
+    LocalScanDiagnostics.reset();
+    SafeEventLog.instance.clear();
+  });
+
+  tearDown(() {
+    LocalScanDiagnostics.reset();
+    SafeEventLog.instance.clear();
+  });
+
+  group('LocalScanDiagnostics', () {
+    test('starts with no recorded scan', () {
+      expect(LocalScanDiagnostics.last, isNull);
+    });
+
+    test('record stores the latest report', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 5,
+        audioCandidates: 4,
+        skippedUnsupported: 1,
+        readFailures: 0,
+      );
+
+      LocalScanDiagnostics.record(report);
+
+      expect(LocalScanDiagnostics.last, same(report));
+    });
+
+    test('record drops a breadcrumb into the shared event log', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 5,
+        audioCandidates: 4,
+        skippedUnsupported: 1,
+        readFailures: 2,
+      );
+
+      LocalScanDiagnostics.record(report);
+
+      expect(SafeEventLog.instance.lines, contains(startsWith('scan: ')));
+    });
+  });
+
+  group('LocalScanDiagnostics.describe', () {
+    test('summarizes a completed scan as structural counts only', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 10,
+        audioCandidates: 7,
+        skippedUnsupported: 3,
+        readFailures: 1,
+      );
+
+      final summary = LocalScanDiagnostics.describe(report);
+
+      expect(summary, contains('folder=selected'));
+      expect(summary, contains('kind=saf'));
+      expect(summary, contains('visited=10'));
+      expect(summary, contains('audio=7'));
+      expect(summary, contains('skipped=3'));
+      expect(summary, contains('readFailures=1'));
+      expect(summary, isNot(contains('error=')));
+    });
+
+    test('summarizes a failure with the error kind', () {
+      const report = LocalScanReport.failure(
+        folderSelected: true,
+        isContentUri: false,
+        error: LocalScanError.unexpected,
+      );
+
+      final summary = LocalScanDiagnostics.describe(report);
+
+      expect(summary, contains('kind=path'));
+      expect(summary, contains('error=unexpected'));
+    });
+
+    test('a summary carries no path, URI, or file name', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 1,
+        audioCandidates: 1,
+        skippedUnsupported: 0,
+        readFailures: 0,
+      );
+
+      final summary = LocalScanDiagnostics.describe(report);
+
+      expect(summary.toLowerCase(), isNot(contains('content://')));
+      expect(summary, isNot(contains('/storage/')));
+      expect(summary.toLowerCase(), isNot(contains('.mp3')));
+    });
+  });
+}

--- a/test/core/sources/local/local_scan_report_test.dart
+++ b/test/core/sources/local/local_scan_report_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/local_scan_report.dart';
+
+void main() {
+  group('LocalScanReport', () {
+    test('a completed scan carries its counts and no error', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 12,
+        audioCandidates: 9,
+        skippedUnsupported: 3,
+        readFailures: 0,
+      );
+
+      expect(report.folderSelected, isTrue);
+      expect(report.isContentUri, isTrue);
+      expect(report.filesVisited, 12);
+      expect(report.audioCandidates, 9);
+      expect(report.skippedUnsupported, 3);
+      expect(report.readFailures, 0);
+      expect(report.error, isNull);
+      expect(report.hadError, isFalse);
+    });
+
+    test('the failure factory zeroes the counts and records the kind', () {
+      const report = LocalScanReport.failure(
+        folderSelected: true,
+        isContentUri: true,
+        error: LocalScanError.safTraversal,
+      );
+
+      expect(report.error, LocalScanError.safTraversal);
+      expect(report.hadError, isTrue);
+      expect(report.filesVisited, 0);
+      expect(report.audioCandidates, 0);
+      expect(report.skippedUnsupported, 0);
+      expect(report.readFailures, 0);
+    });
+
+    test('a zero-count completed scan is distinct from a failure', () {
+      const empty = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 0,
+        audioCandidates: 0,
+        skippedUnsupported: 0,
+        readFailures: 0,
+      );
+
+      // An empty folder completed without error — not the same as a failure.
+      expect(empty.hadError, isFalse);
+    });
+  });
+}

--- a/test/core/sources/local/method_channel_saf_document_lister_test.dart
+++ b/test/core/sources/local/method_channel_saf_document_lister_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/method_channel_saf_document_lister.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
+
+void main() {
+  group('MethodChannelSafDocumentLister.parseScanResult', () {
+    test('a null reply is an empty, failure-free result', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(null);
+
+      expect(result.documents, isEmpty);
+      expect(result.filesVisited, 0);
+      expect(result.readFailures, 0);
+    });
+
+    test('parses documents, mime types, and the diagnostic counts', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://doc/1',
+              'name': 'One.mp3',
+              'mime': 'audio/mpeg',
+            },
+            <Object?, Object?>{
+              'uri': 'content://doc/2',
+              'name': 'Two.flac',
+              'mime': 'audio/flac',
+            },
+          ],
+          'filesVisited': 5,
+          'readFailures': 1,
+        },
+      );
+
+      expect(result.documents, hasLength(2));
+      expect(result.documents.first.uri, 'content://doc/1');
+      expect(result.documents.first.name, 'One.mp3');
+      expect(result.documents.first.mimeType, 'audio/mpeg');
+      expect(result.filesVisited, 5);
+      expect(result.readFailures, 1);
+    });
+
+    test('falls back to the document count when no visited total is reported',
+        () {
+      // An older native build that returned only documents must still scan.
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{'uri': 'content://doc/1', 'name': 'One.mp3'},
+          ],
+        },
+      );
+
+      expect(result.documents, hasLength(1));
+      expect(result.filesVisited, 1);
+      expect(result.readFailures, 0);
+      expect(result.documents.single.mimeType, isNull);
+    });
+
+    test('skips malformed entries without throwing', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{'uri': 'content://doc/1', 'name': 'Good.mp3'},
+            <Object?, Object?>{'uri': '', 'name': 'EmptyUri.mp3'},
+            <Object?, Object?>{'uri': 'content://doc/3'}, // missing name
+            'not-a-map',
+          ],
+          'filesVisited': 4,
+        },
+      );
+
+      expect(result.documents, hasLength(1));
+      expect(result.documents.single.name, 'Good.mp3');
+      expect(result.filesVisited, 4);
+    });
+
+    test('a non-string mime is treated as unknown', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://doc/1',
+              'name': 'One.mp3',
+              'mime': 42,
+            },
+          ],
+        },
+      );
+
+      expect(result.documents.single.mimeType, isNull);
+    });
+  });
+
+  group('MethodChannelSafDocumentLister.listAudioDocuments', () {
+    test('reports SAF traversal unavailable off Android', () async {
+      // The unit-test host is never Android, so the channel is never reached and
+      // the caller falls back to the filesystem path scanner.
+      const lister = MethodChannelSafDocumentLister();
+
+      await expectLater(
+        lister.listAudioDocuments('content://x/tree/y'),
+        throwsA(isA<SafUnsupportedException>()),
+      );
+    });
+  });
+}

--- a/test/core/sources/local/method_channel_saf_permission_probe_test.dart
+++ b/test/core/sources/local/method_channel_saf_permission_probe_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/method_channel_saf_permission_probe.dart';
+import 'package:linthra/core/sources/local/saf_permission_probe.dart';
+
+void main() {
+  group('MethodChannelSafPermissionProbe', () {
+    test('reports "unknown" (null) off Android', () async {
+      // The unit-test host is never Android, so the probe can't determine the
+      // grant state and must report null rather than guess — the report then
+      // simply omits the persisted-permission line.
+      const probe = MethodChannelSafPermissionProbe();
+
+      expect(await probe.hasPersistedPermission('content://x/tree/y'), isNull);
+    });
+  });
+
+  group('UnsupportedSafPermissionProbe', () {
+    test('always reports "unknown" (null)', () async {
+      const probe = UnsupportedSafPermissionProbe();
+
+      expect(await probe.hasPersistedPermission('content://x/tree/y'), isNull);
+    });
+  });
+}

--- a/test/core/sources/local/saf_document_lister_test.dart
+++ b/test/core/sources/local/saf_document_lister_test.dart
@@ -19,6 +19,41 @@ void main() {
 
       expect(doc.uri, 'content://x/1');
       expect(doc.name, 'One.mp3');
+      expect(doc.mimeType, isNull);
+    });
+
+    test('carries the provider MIME type when known', () {
+      const doc = SafAudioDocument(
+        uri: 'content://x/2',
+        name: 'Two.flac',
+        mimeType: 'audio/flac',
+      );
+
+      expect(doc.mimeType, 'audio/flac');
+    });
+  });
+
+  group('SafScanResult', () {
+    test('defaults to an empty, failure-free result', () {
+      const result = SafScanResult();
+
+      expect(result.documents, isEmpty);
+      expect(result.filesVisited, 0);
+      expect(result.readFailures, 0);
+    });
+
+    test('carries the documents and the diagnostic counts', () {
+      const result = SafScanResult(
+        documents: <SafAudioDocument>[
+          SafAudioDocument(uri: 'content://x/1', name: 'One.mp3'),
+        ],
+        filesVisited: 3,
+        readFailures: 1,
+      );
+
+      expect(result.documents, hasLength(1));
+      expect(result.filesVisited, 3);
+      expect(result.readFailures, 1);
     });
   });
 }


### PR DESCRIPTION
## Investigating #143 — "no music found", especially on removable SD cards

Reporters see an empty library and a diagnostics report with `Library tracks: 0` / `Last error: none`, with at least one confirming the library lives on an **external removable SD card**. The local-scan flow is architecturally sound (native SAF content‑resolver traversal in `SafDocumentScanner.kt`), but three concrete gaps explain the symptom and make it undiagnosable.

### Root causes
1. **Audio filter mismatch (drops real audio).** The native SAF walk keeps a document when its MIME is `audio/*` **or** it has a known extension, but the Dart side (`LocalMusicSource`) re‑filtered by **extension only** — so an audio file the platform recognised by *content type* (no/odd extension) was silently dropped.
2. **No scan resilience.** In the native walk, a single failing subtree query threw and aborted the **whole** walk; `IoAudioFileScanner` used `list(recursive: true)`, which also aborts on the first unreadable subdir. One bad folder zeroed out the library.
3. **Scan failures invisible in diagnostics.** Scan errors were never recorded, so the report showed `Last error: none` and gave no way to tell *permission‑denied* from *empty folder* from *filtered‑out* — and nothing showed whether a persisted SAF grant (the SD‑card‑after‑restart failure) was still held.

## What this changes

**Reliability**
- Keep a document when **either** signal says audio: a known extension **or** an `audio/*` MIME (`AudioFileTypes.isSupportedDocument`).
- Native SAF walk now **skips and counts** an unreadable subfolder instead of aborting; only a *total* access denial still surfaces as a clear error. The filesystem walk skips an unreadable subtree rather than throwing on the first one.

**Diagnostics (secret‑free by construction)**
- New `LocalScanReport` + `LocalScanDiagnostics` recorder. Every scan records: files visited, audio candidates, skipped‑unsupported, read failures, and the last error *kind* (an enum name — never a path, URI, or file name).
- New native `hasPersistedPermission` probe (`SafPermissionProbe`) so the report can show whether a persisted SAF read grant is still held for the selected `content://` folder.
- Settings ▸ Diagnostics now also reports:
  - `Local folder: selected | not selected`
  - `Local folder access: persisted | not persisted` (SAF selections)
  - `Local scan: visited N, audio A, skipped S, read failures R`
  - `Local scan error: <kind>` (when the last scan threw)

So a future "no music found" report distinguishes an empty folder from a permission loss without revealing anything private.

## Tests
Added/extended coverage for: recursive & deep scans, supported extensions, **unknown‑MIME‑but‑valid‑extension** and **valid‑MIME‑but‑unknown‑extension**, an **inaccessible entry skipped (not fatal) with a diagnostic**, an **empty folder returning a clear result**, the channel‑reply parser, and report rendering + secret‑safety.

Local run (Flutter 3.27.4): `dart format` clean, `flutter analyze` clean, **`flutter test` — all 1478 passing**.

## Scope / constraints
- **No** version bump, **no** tag, **no** fdroiddata, v0.1.2 untouched. Targets the next version.
- Native changes are additive (new channel method, richer payload, per‑subtree resilience); the method channel is internal so Dart + Kotlin ship together.

Closes #143 once verified on a device with a removable SD card.

https://claude.ai/code/session_01NFokHsEGmwM7qwhTzGqXeD

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFokHsEGmwM7qwhTzGqXeD)_