### PR TITLE
chore(ci): add release & security guardrails

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -39,11 +39,33 @@ jobs:
           flutter-version: 3.27.4
           cache: true
 
+      # --enforce-lockfile builds the APK from the exact committed dependency
+      # set (same as the CI quality job and the reproducible F-Droid build),
+      # failing loudly if pubspec.lock has drifted rather than resolving anew.
       - name: Install dependencies
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Build debug APK
         run: flutter build apk --debug
+
+      # Fail fast if the build produced no usable artifact. The upload step
+      # below also guards with if-no-files-found: error, but checking here gives
+      # a clearer "build produced nothing" signal independent of the uploader,
+      # and rejects a truncated/empty APK a debug build should never emit.
+      - name: Verify build output exists
+        run: |
+          set -euo pipefail
+          apk="build/app/outputs/flutter-apk/app-debug.apk"
+          if [ ! -f "$apk" ]; then
+            echo "::error::Expected debug APK not found at $apk after the build."
+            exit 1
+          fi
+          bytes=$(stat -c%s "$apk")
+          if [ "$bytes" -lt 1000000 ]; then
+            echo "::error::Debug APK at $apk is only ${bytes} bytes (<1 MB); the build looks broken."
+            exit 1
+          fi
+          echo "Debug APK present: $apk (${bytes} bytes)."
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,19 @@
 name: CI
 
-# Run the Flutter quality checks on every PR and on pushes to main.
+# Quality, security, and release-hygiene checks on every PR and on pushes to
+# main. Three independent jobs run in parallel:
+#   * flutter             — format, analyze, test, lockfile-enforced pub get.
+#   * secret-scan         — offline scan for committed secrets / private data.
+#   * release-bump-guard  — release/* PRs only: the bump must be version-only.
 on:
   push:
     branches: [main]
   pull_request:
+
+# Read-only: every job here only inspects the checkout. No secrets are used, so
+# these checks run identically on fork PRs.
+permissions:
+  contents: read
 
 jobs:
   flutter:
@@ -24,8 +33,14 @@ jobs:
           flutter-version: 3.27.4
           cache: true
 
-      - name: Install dependencies
-        run: flutter pub get
+      # --enforce-lockfile makes `pub get` FAIL instead of silently rewriting
+      # pubspec.lock when it has drifted from pubspec.yaml. This is the same
+      # resolution the reproducible F-Droid build depends on — the lockfile is
+      # committed for exactly this reason (docs/release-process.md §7) — so a PR
+      # that changes a dependency without refreshing the lockfile is caught here
+      # instead of at release time.
+      - name: Install dependencies (lockfile-enforced)
+        run: flutter pub get --enforce-lockfile
 
       - name: Verify formatting
         run: dart format --set-exit-if-changed .
@@ -35,3 +50,42 @@ jobs:
 
       - name: Run tests
         run: flutter test
+
+  secret-scan:
+    name: Secret & privacy scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pure bash + git: no Flutter, no network, no secrets. Catches an
+      # accidentally committed keystore / .env / private key / token and a
+      # diagnostics fixture carrying a real URL or home path. Local twin:
+      # `./scripts/check_secrets.sh` (also wired into scripts/verify_android.sh).
+      - name: Scan for secrets and private data
+        run: ./scripts/check_secrets.sh
+
+  release-bump-guard:
+    name: Release bump touches only version files
+    runs-on: ubuntu-latest
+    # Only meaningful for the version-bump PRs the "Prepare release bump"
+    # workflow opens (it pushes a release/v<version> branch). github.head_ref is
+    # set only for pull_request events, so this naturally skips pushes to main
+    # and every non-release PR.
+    if: ${{ startsWith(github.head_ref, 'release/') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Diff the PR against its base and assert the changed files stay within the
+      # version-bump allowlist (pubspec, app_info, Fastlane changelog, F-Droid
+      # metadata, …). Local twin: scripts/check_release_bump_files.sh.
+      - name: Check changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA" HEAD \
+            | ./scripts/check_release_bump_files.sh

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -593,8 +593,11 @@ consume our signed artifacts:
 
 | Action | Automated? |
 | ------ | ---------- |
-| Quality CI (analyze/test/format) on PRs & `main` | **Automatic** (`ci.yml`). |
-| Debug APK build | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`). |
+| Quality CI (format/analyze/test) + lockfile-enforced `pub get` on PRs & `main` | **Automatic** (`ci.yml`, job `flutter`; `flutter pub get --enforce-lockfile` catches a dependency change that forgot to refresh `pubspec.lock`). |
+| Secret & privacy scan on PRs & `main` | **Automatic** (`ci.yml`, job `secret-scan`; runs `scripts/check_secrets.sh` — offline, no secrets). |
+| Fastlane changelog exists for the current `versionCode` | **Automatic** on PRs & `main` (`flutter test` ▸ `test/tooling/release_changelog_test.dart`). |
+| Release-bump PR touches only version files | **Automatic** on `release/*` PRs only (`ci.yml`, job `release-bump-guard`; `scripts/check_release_bump_files.sh`). |
+| Debug APK build + build-output verification | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`; a "Verify build output exists" step rejects a missing/empty APK). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
 | Preparing the version-bump PR (pubspec, in-app mirror, Fastlane changelog, F-Droid `CurrentVersion`) | **Manual** (`workflow_dispatch`, `prepare-release-bump.yml`); opens a draft PR but never tags, builds, or publishes. The same edits are reproducible locally with `scripts/prepare_release_bump.py`. |
 | Verifying the tag matches `pubspec.yaml` (versionName/versionCode) | **Automatic** on a `v*` tag build (`scripts/release_preflight.sh`, encoding-checked against `tool/version_from_tag.dart`); fails fast on a mismatch and the workflow summary explicitly says "Version mismatch: release was not built." so it is not confused with an APK build failure. The same script is intended to be run locally before tagging (§3 step 9). Both manual and tag builds take the version from `pubspec.yaml`. |
@@ -609,6 +612,68 @@ consume our signed artifacts:
 CI builds release artifacts on a tag and attaches them: it can auto-create a
 **pre-release** for alpha/beta/rc tags, but it never auto-creates a stable
 Release, writes production notes, signs a store build, or submits to F-Droid.
+
+### Which workflow runs on PRs, `main`, and tags
+
+| Workflow · job | PR | Push to `main` | `v*` tag | Manual |
+| -------------- | -- | -------------- | -------- | ------ |
+| `ci.yml` · `flutter` — format, analyze, test, `pub get --enforce-lockfile` | ✅ | ✅ | — | — |
+| `ci.yml` · `secret-scan` — `scripts/check_secrets.sh` | ✅ | ✅ | — | — |
+| `ci.yml` · `release-bump-guard` — `scripts/check_release_bump_files.sh` | ✅ (only `release/*` branches) | — | — | — |
+| `android-debug-apk.yml` — build debug APK + verify output | ✅ | — | — | ✅ |
+| `android-release-build.yml` — release APK/AAB, tag↔pubspec preflight, attach | — | — | ✅ | ✅ |
+| `prepare-release-bump.yml` — open the version-bump PR | — | — | — | ✅ |
+| `generate-drift.yml` — regenerate `*.g.dart` | — | — | — | ✅ |
+
+The `flutter` job also runs the whole `test/` suite, which includes the
+release-safety guardrail tests below — so those gate every PR, not just release
+PRs. Nothing in `ci.yml` uses a secret, so all three jobs run identically on
+fork PRs.
+
+### What the guardrails catch (and how to run them locally)
+
+These complement, and do not replace, the release invariants already enforced
+elsewhere: the in-app/`pubspec.yaml` version-drift and canonical-`versionCode`
+checks (`test/core/app_info_version_test.dart`); the cross-file F-Droid
+invariants — monotonic `versionCode`, per-ABI `base*10 + rank`, stable release
+asset names, tracked `pubspec.lock` (`test/tooling/fdroid_release_guardrails_test.dart`);
+and the tag↔`pubspec.yaml` preflight (`scripts/release_preflight.sh`, run on a
+`v*` tag and locally before tagging — §3 step 9, §4).
+
+- **Lockfile drift** — `flutter pub get --enforce-lockfile` (CI `flutter` job;
+  also in `scripts/verify_android.sh` and `android-debug-apk.yml`). Fails if a
+  dependency change did not refresh `pubspec.lock`, keeping it in sync with the
+  lockfile the reproducible F-Droid build resolves against (§7).
+- **Committed secrets / private data** — `./scripts/check_secrets.sh` (CI
+  `secret-scan` job). Offline, dependency-free. Flags committed `.env` files,
+  keystores (`*.jks`/`*.keystore`), private keys, `key.properties`, Play
+  service-account JSON, and high-signal tokens (GitHub / Slack / AWS / Google);
+  `*.example`/`*.sample`/`*.template` placeholders are allowed. It also scans any
+  committed diagnostics **fixture/snapshot** for a real private URL, credential,
+  token, or home path — reserved example hosts (`example.com`, `localhost`,
+  RFC1918, TEST-NET) are allowed. The runtime diagnostics redaction itself is
+  unit-tested in `test/core/diagnostics/`.
+- **Missing release changelog** — `test/tooling/release_changelog_test.dart`
+  (runs in `flutter test`). Fails if there is no non-empty
+  `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt` for the version
+  in `pubspec.yaml`. The `Prepare release bump` workflow creates it; this catches
+  a hand-edited bump that forgot it.
+- **Release-bump scope creep** — `./scripts/check_release_bump_files.sh` (CI
+  `release-bump-guard`, `release/*` PRs only). A version bump must be a clean,
+  version-only diff (pubspec, `app_info.dart`, the Fastlane changelog, the
+  F-Droid metadata, optionally `pubspec.lock`/`docs/release-notes/**`).
+- **Debug build sanity** — `android-debug-apk.yml` verifies the debug APK exists
+  and is a sane size before uploading, so a silent build failure is caught.
+
+Run the Flutter checks plus the secret scan in one local pass with
+`./scripts/verify_android.sh`. The two guard scripts also run standalone with no
+Flutter toolchain:
+
+```sh
+./scripts/check_secrets.sh
+# A release-bump PR's changed files (compare against the base branch):
+git diff --name-only origin/main...HEAD | ./scripts/check_release_bump_files.sh
+```
 
 ## 7. Release status
 

--- a/scripts/check_release_bump_files.sh
+++ b/scripts/check_release_bump_files.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# check_release_bump_files.sh — assert a release-bump PR only touches the files
+# a version bump is supposed to touch.
+#
+# The "Prepare release bump" workflow (and its local twin
+# scripts/prepare_release_bump.py) edits exactly four files:
+#
+#   * pubspec.yaml                                            (version: line)
+#   * lib/core/app_info.dart                                  (_devVersionName)
+#   * fastlane/metadata/android/en-US/changelogs/<code>.txt   (Fastlane changelog)
+#   * metadata/io.github.thezupzup.linthra.yml                (F-Droid Current*)
+#
+# A release-bump PR that also carries an unrelated source/UI change is almost
+# always a mistake: those changes belong in their own PR so the release commit
+# stays a clean, reviewable "version only" diff (and so it is obvious nothing
+# in the build changed between the tagged commit and its parent). This guard
+# fails such a PR with the offending paths named.
+#
+# It is intentionally scoped: CI only runs it for PRs whose branch starts with
+# `release/` (the branch the prepare workflow pushes). It is read-only, makes
+# no network calls, and needs no secrets.
+#
+# Usage:
+#
+#   # Explicit list (one path per line) on stdin:
+#   git diff --name-only <base>..HEAD | scripts/check_release_bump_files.sh
+#
+#   # Or as arguments:
+#   scripts/check_release_bump_files.sh pubspec.yaml lib/core/app_info.dart
+#
+# The allowed set also permits pubspec.lock (a dependency refresh may ride
+# along) and docs/release-notes/** (longer GitHub-Release notes), since both
+# are part of cutting a release. Anything else is reported and fails.
+
+set -uo pipefail
+
+# Collect candidate paths from arguments, else from stdin.
+paths=()
+if [ "$#" -gt 0 ]; then
+  paths=("$@")
+else
+  while IFS= read -r line; do
+    [ -n "$line" ] && paths+=("$line")
+  done
+fi
+
+if [ "${#paths[@]}" -eq 0 ]; then
+  echo "No changed files provided; nothing to check."
+  exit 0
+fi
+
+# Returns 0 if the given path is allowed in a release-bump PR.
+is_allowed() {
+  case "$1" in
+    pubspec.yaml|pubspec.lock|\
+    lib/core/app_info.dart|\
+    metadata/io.github.thezupzup.linthra.yml|\
+    fastlane/metadata/android/*/changelogs/*.txt|\
+    docs/release-notes/*)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+offenders=()
+for p in "${paths[@]}"; do
+  is_allowed "$p" || offenders+=("$p")
+done
+
+if [ "${#offenders[@]}" -eq 0 ]; then
+  echo "OK: release-bump PR touches only allowed version files (${#paths[@]} file(s))."
+  exit 0
+fi
+
+{
+  echo "ERROR: this looks like a release-bump PR, but it changes files outside"
+  echo "the allowed version-bump set:"
+  echo
+  for p in "${offenders[@]}"; do
+    echo "  - $p"
+  done
+  echo
+  echo "A release bump should be a clean, version-only diff. Allowed files:"
+  echo "  - pubspec.yaml, pubspec.lock"
+  echo "  - lib/core/app_info.dart"
+  echo "  - metadata/io.github.thezupzup.linthra.yml"
+  echo "  - fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt"
+  echo "  - docs/release-notes/**"
+  echo
+  echo "Move the unrelated change to its own PR, or — if it genuinely belongs"
+  echo "with the release — widen the allowlist in scripts/check_release_bump_files.sh."
+} >&2
+exit 1

--- a/scripts/check_secrets.sh
+++ b/scripts/check_secrets.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# check_secrets.sh — a lightweight, offline secret & privacy scan.
+#
+# This is a guardrail, not a vault scanner: it catches the *obvious* mistakes
+# (a committed keystore, a pasted private key, an API token, a diagnostics
+# snapshot with a real server URL) before they reach a PR or a release. It is
+# deliberately:
+#
+#   * Offline — no network calls, no downloads, no external services.
+#   * Dependency-free — pure bash + git/grep, nothing to install.
+#   * Fast — it scans only tracked files (git ls-files), skipping binaries.
+#   * Local-twin — the CI "secret-scan" job runs exactly this script, so a
+#     contributor sees the same result with `./scripts/check_secrets.sh`.
+#
+# It checks three things:
+#
+#   1. Forbidden files — a tracked file whose name marks it as a secret
+#      (.env, *.keystore/*.jks, *.pem/*.key/*.p12, an SSH private key,
+#      key.properties, a Play service-account JSON, …). `*.example` /
+#      `*.sample` / `*.template` placeholders are allowed.
+#   2. Secret content — high-signal secret *formats* anywhere in tracked text
+#      (a PEM "BEGIN … PRIVATE KEY" block, a GitHub/Slack/AWS/Google token).
+#      The patterns are specific on purpose so they do NOT flag the redaction
+#      test inputs (e.g. `?api_key=secret`, `user:pass@…`) the diagnostics
+#      suite deliberately carries.
+#   3. Diagnostics privacy — any committed diagnostics *fixture/snapshot* must
+#      not carry a real private URL, credential, token, or home path. Reserved
+#      example hosts (example.com, localhost, RFC1918, TEST-NET) are allowed.
+#
+# Exit status: 0 if clean, 1 if anything was found (each finding is printed
+# with its file:line so it is easy to fix or, if it is a deliberate sample,
+# move under an *.example name or a fixture allowlist host).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# This script intentionally contains the secret *patterns* as literals, so it
+# would otherwise flag itself in the content scan. Exclude it (and nothing
+# else) from the surfaces below.
+SELF="scripts/check_secrets.sh"
+
+RED=""; YELLOW=""; BOLD=""; RESET=""
+if [ -t 1 ]; then
+  RED=$'\033[31m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; RESET=$'\033[0m'
+fi
+
+findings=0
+note()  { printf '%s\n' "$*"; }
+fail()  { findings=$((findings + 1)); printf '%s%s%s\n' "$RED" "$*" "$RESET"; }
+header(){ printf '\n%s==> %s%s\n' "$BOLD" "$*" "$RESET"; }
+
+# Tracked files only — deterministic and fast. NUL-separated for odd names.
+mapfile -d '' -t TRACKED < <(git ls-files -z 2>/dev/null)
+if [ "${#TRACKED[@]}" -eq 0 ]; then
+  note "WARNING: no tracked files found (not a git checkout?). Nothing to scan."
+  exit 0
+fi
+
+# A path is an allowed placeholder if it ends in a clearly-non-secret suffix
+# or carries an example/sample/template marker in its name.
+is_placeholder() {
+  case "$1" in
+    *.example|*.sample|*.template|*.dist|*.tmpl) return 0 ;;
+    *example*|*sample*|*template*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ----------------------------------------------------------------------------
+# 1. Forbidden files (by name). These should never be committed at all.
+# ----------------------------------------------------------------------------
+header "Checking for committed secret files"
+secret_file_hits=0
+for f in "${TRACKED[@]}"; do
+  base="${f##*/}"
+  case "$base" in
+    .env|.env.*|\
+    *.keystore|*.jks|*.p12|*.pfx|*.pem|*.key|*.der|*.mobileprovision|\
+    id_rsa|id_dsa|id_ecdsa|id_ed25519|*.ppk|\
+    key.properties|\
+    secring.*|*.gpg|\
+    service-account*.json|play-console*.json|google-services-account*.json)
+      if is_placeholder "$f"; then
+        continue
+      fi
+      fail "  secret file committed: $f"
+      secret_file_hits=$((secret_file_hits + 1))
+      ;;
+  esac
+done
+[ "$secret_file_hits" -eq 0 ] && note "  none"
+
+# ----------------------------------------------------------------------------
+# 2. Secret content (high-signal formats). git grep skips binaries with -I.
+# ----------------------------------------------------------------------------
+header "Scanning tracked text for secret material"
+
+# One alternation of *specific* secret shapes. Specificity is the whole point:
+# a generic "password" keyword would drown in the diagnostics code/tests that
+# legitimately mention tokens/passwords while asserting they are redacted.
+SECRET_RE='-----BEGIN ([A-Z0-9]+ )?PRIVATE KEY-----'      # PEM/OpenSSH private keys
+SECRET_RE="$SECRET_RE|gh[opsu]_[0-9A-Za-z]{36}"            # GitHub tokens
+SECRET_RE="$SECRET_RE|github_pat_[0-9A-Za-z_]{40,}"        # GitHub fine-grained PAT
+SECRET_RE="$SECRET_RE|xox[baprs]-[0-9A-Za-z-]{10,}"        # Slack tokens
+SECRET_RE="$SECRET_RE|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}"  # AWS access key id
+SECRET_RE="$SECRET_RE|AIza[0-9A-Za-z_-]{35}"              # Google API key
+SECRET_RE="$SECRET_RE|-----BEGIN PGP PRIVATE KEY BLOCK-----"
+
+if git grep -nIE -e "$SECRET_RE" -- . ":(exclude)$SELF" >/tmp/linthra_secret_hits 2>/dev/null; then
+  while IFS= read -r line; do
+    fail "  $line"
+  done < /tmp/linthra_secret_hits
+  note ""
+  note "  ${YELLOW}If a hit is a deliberate placeholder, rename the file to *.example${RESET}"
+  note "  ${YELLOW}or replace the value with a clearly-fake token.${RESET}"
+else
+  note "  none"
+fi
+rm -f /tmp/linthra_secret_hits
+
+# ----------------------------------------------------------------------------
+# 3. Diagnostics privacy — only committed fixture/snapshot artifacts, never the
+#    unit-test sources (which carry redaction inputs on purpose). The runtime
+#    redaction itself is unit-tested in test/core/diagnostics/.
+# ----------------------------------------------------------------------------
+header "Scanning diagnostics fixtures/snapshots for private data"
+
+FIXTURES=()
+for f in "${TRACKED[@]}"; do
+  case "$f" in
+    *.dart) continue ;;  # source/tests carry redaction inputs deliberately
+    */fixtures/*|*/snapshots/*|*/__snapshots__/*|*/goldens/*|*.golden|\
+    *diagnostics*.txt|*diagnostics*.log|*diagnostics*.json|\
+    *bug-report*.txt|*bug_report*.txt|*bug-report*.md)
+      FIXTURES+=("$f") ;;
+  esac
+done
+
+if [ "${#FIXTURES[@]}" -eq 0 ]; then
+  note "  (no diagnostics fixture/snapshot files tracked; nothing to scan)"
+else
+  # Obvious private data: credentialed URLs, real home paths, password=/token=
+  # assignments, plus the same high-signal secret formats from step 2.
+  PRIV_RE='://[^/[:space:]@]+:[^/[:space:]@]+@[^/[:space:]]+'           # user:pass@host
+  PRIV_RE="$PRIV_RE|/home/[A-Za-z0-9._-]+/|/Users/[A-Za-z0-9._-]+/"     # unix home dirs
+  PRIV_RE="$PRIV_RE|[A-Za-z]:\\\\Users\\\\[A-Za-z0-9._-]+"             # windows home dirs
+  PRIV_RE="$PRIV_RE|(password|passwd|pwd|secret|token|api[_-]?key)[\"'\'']?[[:space:]]*[:=][[:space:]]*[\"'\'']?[A-Za-z0-9._/+-]{6,}"
+  PRIV_RE="$PRIV_RE|$SECRET_RE"
+
+  # Reserved/example hosts, RFC1918, TEST-NET, and obvious placeholders are
+  # allowed so a documentation-style fixture does not trip the scan.
+  ALLOW_RE='example\.(com|org|net)|localhost|127\.0\.0\.1|::1|0\.0\.0\.0'
+  ALLOW_RE="$ALLOW_RE|10\.[0-9]|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\."
+  ALLOW_RE="$ALLOW_RE|192\.0\.2\.|198\.51\.100\.|203\.0\.113\."           # TEST-NET-1/2/3
+  ALLOW_RE="$ALLOW_RE|redacted|placeholder|example|REPLACE|CHANGEME|xxxx|<[A-Za-z]"
+  ALLOW_RE="$ALLOW_RE|your|username|johndoe|janedoe"                       # common placeholder users
+
+  priv_hits=0
+  for f in "${FIXTURES[@]}"; do
+    while IFS= read -r line; do
+      printf '%s\n' "$line" | grep -qE "$ALLOW_RE" && continue
+      fail "  $f: $line"
+      priv_hits=$((priv_hits + 1))
+    done < <(grep -nIE -- "$PRIV_RE" "$f" 2>/dev/null)
+  done
+  [ "$priv_hits" -eq 0 ] && note "  none (scanned ${#FIXTURES[@]} fixture/snapshot file(s))"
+fi
+
+# ----------------------------------------------------------------------------
+header "Summary"
+if [ "$findings" -eq 0 ]; then
+  note "  ${BOLD}Secret/privacy scan passed — no obvious secrets or private data.${RESET}"
+  exit 0
+fi
+fail "  Secret/privacy scan FAILED with $findings finding(s) above."
+note "  Remove the secret from history if it was ever real (rotate it too), or"
+note "  move a deliberate sample under an *.example name / fixture allowlist host."
+exit 1

--- a/scripts/verify_android.sh
+++ b/scripts/verify_android.sh
@@ -3,7 +3,8 @@
 # verify_android.sh — run the same checks CI runs, locally.
 #
 # Order mirrors .github/workflows/ci.yml:
-#   flutter pub get  ->  dart format (check)  ->  flutter analyze  ->  flutter test
+#   flutter pub get --enforce-lockfile  ->  dart format (check)  ->
+#   flutter analyze  ->  flutter test  ->  secret & privacy scan
 #
 # If an Android SDK is available it additionally builds a debug APK. A missing
 # Android SDK only skips the APK build — it never fails verification. Any real
@@ -67,10 +68,15 @@ main() {
   cd "$REPO_ROOT"
   resolve_flutter
 
-  run_step "flutter pub get" "$FLUTTER" pub get
+  run_step "flutter pub get --enforce-lockfile" "$FLUTTER" pub get --enforce-lockfile
   run_step "dart format --set-exit-if-changed ." dart format --set-exit-if-changed .
   run_step "flutter analyze" "$FLUTTER" analyze
   run_step "flutter test" "$FLUTTER" test
+
+  # Flutter-independent guardrail (the CI "secret-scan" job runs the same
+  # script): catches a committed keystore/.env/private key/token or a
+  # diagnostics fixture carrying real private data.
+  run_step "secret & privacy scan" "$REPO_ROOT/scripts/check_secrets.sh"
 
   if android_sdk_available; then
     run_step "flutter build apk --debug" "$FLUTTER" build apk --debug

--- a/test/tooling/release_changelog_test.dart
+++ b/test/tooling/release_changelog_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Release guardrail: the Fastlane changelog for the *current* release version
+/// must exist and be non-empty.
+///
+/// F-Droid names each changelog file by its Android `versionCode`
+/// (`fastlane/metadata/android/en-US/changelogs/<code>.txt`) and shows it as the
+/// release's "What's New". The `Prepare release bump` workflow / its local twin
+/// `scripts/prepare_release_bump.py` always create this file, so the only way to
+/// reach `main` without it is a hand-edited bump that forgot it — exactly what
+/// this test catches, on every PR, before a tag is ever cut.
+///
+/// It reads `pubspec.yaml` (the single source of truth for `<name>+<code>`; see
+/// docs/release-process.md §1) and only checks that the matching changelog
+/// exists — it does not assert anything about the body, so refining the wording
+/// in a PR stays friction-free. Sibling coverage:
+/// test/core/app_info_version_test.dart pins that the `versionCode` is the
+/// canonical encoding of the `versionName`; test/tooling/prepare_release_bump_test.dart
+/// pins how the bump script writes the changelog.
+void main() {
+  final String root = _repoRoot();
+
+  test('a Fastlane changelog exists for the current pubspec versionCode', () {
+    final int code = _pubspecVersionCode(p.join(root, 'pubspec.yaml'));
+    final File changelog = File(p.join(
+      root,
+      'fastlane',
+      'metadata',
+      'android',
+      'en-US',
+      'changelogs',
+      '$code.txt',
+    ));
+
+    expect(
+      changelog.existsSync(),
+      isTrue,
+      reason: 'No Fastlane changelog for the current release versionCode '
+          '($code). Add fastlane/metadata/android/en-US/changelogs/$code.txt — '
+          'the `Prepare release bump` workflow / scripts/prepare_release_bump.py '
+          'do this automatically. See docs/release-process.md §3.',
+    );
+    expect(
+      changelog.readAsStringSync().trim(),
+      isNotEmpty,
+      reason: 'fastlane/metadata/android/en-US/changelogs/$code.txt is empty; '
+          'F-Droid shows this as the release "What\'s New". Add a short, '
+          'factual note.',
+    );
+  });
+}
+
+/// Reads `pubspec.yaml`'s `version: <name>+<code>` and returns `<code>`.
+int _pubspecVersionCode(String pubspecPath) {
+  final String text = File(pubspecPath).readAsStringSync();
+  final RegExpMatch? match =
+      RegExp(r'^version:\s*(\S+)', multiLine: true).firstMatch(text);
+  if (match == null) {
+    fail('pubspec.yaml has no `version:` line');
+  }
+  final String raw = match.group(1)!;
+  final int plus = raw.indexOf('+');
+  if (plus < 0) {
+    fail('pubspec.yaml version "$raw" must be `<versionName>+<versionCode>`.');
+  }
+  final int? code = int.tryParse(raw.substring(plus + 1));
+  if (code == null) {
+    fail('pubspec.yaml versionCode in "$raw" is not an integer.');
+  }
+  return code;
+}
+
+/// Walks up from the current directory to the repo root (the directory that has
+/// both `pubspec.yaml` and the `fastlane/` metadata tree).
+String _repoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, 'fastlane')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}


### PR DESCRIPTION
## Summary

Adds CI / release / security guardrails so problems are caught before merge or
release. **No app behavior, UI, release, version, or tag changes**, and
**fdroiddata is not touched**. Every new check is **offline, secret-free, and
runnable locally**.

This deliberately fills the *gaps* rather than duplicating the substantial
guardrails already in place — `test/core/app_info_version_test.dart`
(version drift + canonical `versionCode`), `test/tooling/fdroid_release_guardrails_test.dart`
(monotonic versionCode, per-ABI `base*10+rank`, asset names, tracked
`pubspec.lock`), and `scripts/release_preflight.sh` (tag↔pubspec preflight).

## What's added

**1. Standard PR checks** — `ci.yml` now runs `flutter pub get --enforce-lockfile`
(format/analyze/test were already there).

**2. Android build checks** — `android-debug-apk.yml` builds the debug APK on
PRs from the enforced lockfile and adds a **"Verify build output exists"** step
(rejects a missing/empty APK). Release/signed builds stay tag-/dispatch-only.

**3. Release safety** — a new test
(`test/tooling/release_changelog_test.dart`) fails a PR if there is no non-empty
Fastlane changelog for the current `pubspec.yaml` versionCode. A new
`release-bump-guard` job (only on `release/*` PRs) asserts a bump is a
version-only diff via `scripts/check_release_bump_files.sh`. (Version format,
AppInfo↔pubspec match, canonical encoding, monotonic versionCode, and the tag
preflight were already covered — see above.)

**4. F-Droid / Obtainium** — `--enforce-lockfile` keeps `pubspec.lock` in sync
with the reproducible F-Droid resolution. Asset names + ABI-split
versionCodes (`base*10+1/2/3`) remain pinned by the existing F-Droid guardrail
test. **No fdroiddata changes.**

**5. Secret / privacy guardrails** — new `scripts/check_secrets.sh` (CI
`secret-scan` job): offline, dependency-free. Flags committed `.env` files,
keystores (`*.jks`/`*.keystore`), private keys, `key.properties`, Play
service-account JSON, and high-signal tokens (GitHub/Slack/AWS/Google);
`*.example` placeholders are allowed. It also scans any committed diagnostics
**fixture/snapshot** for real URLs, credentials, tokens, or home paths
(reserved example hosts / RFC1918 / TEST-NET allowed). The high-specificity
patterns intentionally do **not** trip on the redaction-test inputs the
diagnostics suite carries; the runtime redaction itself stays unit-tested in
`test/core/diagnostics/`.

**6. Docs** — `docs/release-process.md` documents each new check and adds a
matrix of which workflow runs on PRs, `main`, and tags.

## Non-goals (explicitly out of scope)

- No app/UI behavior change, no `flutter build`/runtime code touched.
- No release, no version bump, no tag, no signing changes.
- No edits to `metadata/` or external fdroiddata.

## Run locally

```sh
./scripts/check_secrets.sh
git diff --name-only origin/main...HEAD | ./scripts/check_release_bump_files.sh
./scripts/verify_android.sh   # Flutter checks + secret scan in one pass
```

## Verification done in this session

- `check_secrets.sh` passes clean on the repo, and in a throwaway repo it caught
  a planted keystore, `.env`, GitHub token, credentialed URL, and home path
  while allowing `example.com`/RFC1918 and `*.example` placeholders (self-exclusion
  for its own pattern literals confirmed).
- `check_release_bump_files.sh` passes an allowed-only file list and fails on an
  unrelated source file.
- Both workflow YAMLs parse; `pubspec.yaml` deps are all present in `pubspec.lock`.
- The new Dart test targets the current versionCode's changelog
  (`102999.txt`, present) — it and the Flutter checks run in CI (no Flutter SDK
  in this session to run them here).

https://claude.ai/code/session_0176A6v4Htxb5Ygv4py636iB

---
_Generated by [Claude Code](https://claude.ai/code/session_0176A6v4Htxb5Ygv4py636iB)_