### PR TITLE
fix(library): pick & persist a SAF tree URI for local music (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Sources sit behind one interface, so the app treats them uniformly:
 
 | Source | Status |
 | --- | --- |
-| **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) |
+| **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) — [docs](./docs/local-music.md) |
 | **Jellyfin** | ✅ Stream, cache, cast, playlists & favourites — [docs](./docs/jellyfin.md) |
 | **Navidrome / Subsonic** | ✅ Stream, cache, cast (favourites & lyrics are follow-ups) — [docs](./docs/providers.md) |
 | **WebDAV / NAS** | 🔜 Planned — same `MusicSource` seam |
@@ -194,6 +194,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Architecture & extension points | [docs/architecture.md](./docs/architecture.md) |
 | Development, build & CI | [docs/development.md](./docs/development.md) |
 | Library browsing & search | [docs/library.md](./docs/library.md) |
+| Local music (on-device folders) | [docs/local-music.md](./docs/local-music.md) |
 | Music providers (overview) | [docs/providers.md](./docs/providers.md) |
 | Jellyfin setup | [docs/jellyfin.md](./docs/jellyfin.md) · [compatibility](./docs/jellyfin-compatibility.md) · [sync](./docs/jellyfin-sync.md) |
 | Streaming, buffering & recovery | [docs/streaming.md](./docs/streaming.md) |

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -1,5 +1,9 @@
 package io.github.thezupzup.linthra
 
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import com.ryanheise.audioservice.AudioServiceActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -10,14 +14,29 @@ import io.flutter.plugin.common.MethodChannel
 // plain FlutterActivity would leave the background service unable to attach.
 //
 // It also registers the SAF method channel that backs content-resolver folder
-// scanning (see SafDocumentScanner). The channel name is mirrored by
-// MethodChannelSafDocumentLister on the Dart side.
+// scanning (see SafDocumentScanner) and the folder *chooser*. The channel name
+// is mirrored by MethodChannelSafDocumentLister / MethodChannelSafFolderPicker
+// on the Dart side.
 class MainActivity : AudioServiceActivity() {
+    // The pending reply for an in-flight folder pick. A SAF chooser is a separate
+    // activity, so the answer arrives asynchronously in onActivityResult; we hold
+    // the channel reply until then. Only one pick can be in flight at a time.
+    private var pendingFolderPickResult: MethodChannel.Result? = null
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SAF_CHANNEL)
             .setMethodCallHandler { call, result ->
                 when (call.method) {
+                    // Open the system folder chooser (ACTION_OPEN_DOCUMENT_TREE)
+                    // and return the picked content:// tree URI — the scoped-
+                    // storage-correct selection — *with its read grant persisted*.
+                    // This is the fix for "no music found": file_picker's
+                    // getDirectoryPath resolves the pick to a raw /storage path
+                    // that dart:io cannot read under scoped storage, so the SAF
+                    // walk was never reached. Returning the tree URI routes the
+                    // scan through SafDocumentScanner instead.
+                    "pickFolderTree" -> startFolderPick(result)
                     "listAudioDocuments" -> {
                         val treeUri = call.argument<String>("treeUri")
                         if (treeUri == null) {
@@ -43,7 +62,76 @@ class MainActivity : AudioServiceActivity() {
             }
     }
 
+    private fun startFolderPick(result: MethodChannel.Result) {
+        // Guard against overlapping picks: a second request while one is open
+        // would orphan the first reply. Surface it rather than silently dropping.
+        if (pendingFolderPickResult != null) {
+            result.error(
+                "pick_in_progress",
+                "A folder pick is already in progress.",
+                null,
+            )
+            return
+        }
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            // Ask for a persistable read grant so the folder picked once can be
+            // re-scanned after a restart (the removable-SD-card-after-reboot case)
+            // without re-prompting. We take the grant in onActivityResult.
+            addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION,
+            )
+        }
+        try {
+            pendingFolderPickResult = result
+            startActivityForResult(intent, REQUEST_CODE_PICK_FOLDER)
+        } catch (e: ActivityNotFoundException) {
+            // No document-tree provider on this device (rare). Report it instead
+            // of leaving the Dart future hanging.
+            pendingFolderPickResult = null
+            result.error("no_picker", "No folder chooser is available.", null)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode != REQUEST_CODE_PICK_FOLDER) {
+            // Not ours — let the engine forward it to plugins as usual.
+            super.onActivityResult(requestCode, resultCode, data)
+            return
+        }
+        val result = pendingFolderPickResult
+        pendingFolderPickResult = null
+        if (result == null) {
+            // The activity was recreated mid-pick and the reply was lost; nothing
+            // to deliver. Don't crash.
+            return
+        }
+        val treeUri: Uri? = if (resultCode == Activity.RESULT_OK) data?.data else null
+        if (treeUri == null) {
+            // User cancelled (or no URI came back). null == "no selection" on the
+            // Dart side, which the controller treats as a cancelled pick.
+            result.success(null)
+            return
+        }
+        // Persist the read grant so a later scan/rescan still has access.
+        // Best-effort: if the grant isn't persistable the URI still works this
+        // session, and diagnostics will report the lost grant later.
+        try {
+            contentResolver.takePersistableUriPermission(
+                treeUri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        } catch (e: SecurityException) {
+            // Not persistable on this provider; the session grant still stands.
+        }
+        result.success(treeUri.toString())
+    }
+
     companion object {
         private const val SAF_CHANNEL = "io.github.thezupzup.linthra/saf"
+
+        // Arbitrary, app-local request code for the folder chooser. Kept within
+        // 16 bits to stay compatible with how Activity dispatches results.
+        private const val REQUEST_CODE_PICK_FOLDER = 0x5AF0
     }
 }

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -64,7 +64,12 @@ class SafDocumentScanner(private val context: Context) {
 
         val documents = ArrayList<Map<String, String?>>()
         var filesVisited = 0
+        var foldersVisited = 0
         var readFailures = 0
+        // The first entry is the selected root. A failure there is fatal (no
+        // access at all), not a skippable subtree — surfacing it keeps a dead
+        // root from looking like a successful empty scan that wipes the catalog.
+        var isRoot = true
         val queue = ArrayDeque<String>()
         queue.add(DocumentsContract.getTreeDocumentId(treeUri))
         while (queue.isNotEmpty()) {
@@ -84,11 +89,20 @@ class SafDocumentScanner(private val context: Context) {
                     null,
                 )
                 if (cursor == null) {
+                    if (isRoot) {
+                        // The selected folder itself can't be listed — a real
+                        // failure, not an empty folder. Surface it.
+                        throw IllegalStateException("root folder is not listable")
+                    }
                     // The provider returned nothing for this subtree; count it
                     // as a read failure and move on.
                     readFailures++
+                    isRoot = false
                     continue
                 }
+                // A listable folder (the root or a subfolder) — count it.
+                foldersVisited++
+                isRoot = false
                 cursor.use { c ->
                     while (c.moveToNext()) {
                         val docId = c.getString(0) ?: continue
@@ -119,6 +133,11 @@ class SafDocumentScanner(private val context: Context) {
                 // silent empty — rethrow so listAudioDocuments reports it.
                 throw e
             } catch (e: Exception) {
+                if (isRoot) {
+                    // A failure listing the selected root is fatal, not a
+                    // skippable subtree — surface it instead of returning empty.
+                    throw e
+                }
                 // One unreadable subtree shouldn't fail the whole scan.
                 readFailures++
             }
@@ -126,6 +145,7 @@ class SafDocumentScanner(private val context: Context) {
         return mapOf(
             "documents" to documents,
             "filesVisited" to filesVisited,
+            "foldersVisited" to foldersVisited,
             "readFailures" to readFailures,
         )
     }

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -1,0 +1,98 @@
+# Local music (on-device folders)
+
+Linthra can play music that already lives on the phone — internal storage, a
+removable SD card, or any folder you point it at — alongside (or instead of) a
+Jellyfin or Navidrome / Subsonic server.
+
+## How to set it up
+
+There are two equivalent entry points; both end up at the same place:
+
+- **Settings ▸ Local music** — the primary home, grouped with the other music
+  sources (Jellyfin, Navidrome / Subsonic). Choose a folder, **Rescan** it after
+  you add files, **Change** it, or **Forget** it.
+- **Library ▸ (empty state) ▸ Select / Change folder** — the same pick-and-scan
+  flow, offered where you first notice an empty library.
+
+When you pick a folder, Android shows its system folder chooser. Linthra keeps
+**only** the access you grant for that one folder — no broad "all files" or media
+permission is requested.
+
+## What's supported
+
+- Internal phone storage and **removable / external SD cards**.
+- Any folder chosen through Android's file picker (Storage Access Framework).
+- Files **directly inside** the chosen folder *and* **nested** artist/album
+  subfolders — the scan is recursive.
+- Audio formats: **mp3, m4a, aac, flac, ogg, opus, wav**. A file is treated as
+  audio if it has one of those extensions **or** the system reports an `audio/*`
+  content type, so an oddly-named file the platform still recognises as audio is
+  not dropped.
+
+Tag reading (album/artist/artwork/duration) for local files is a separate
+follow-up; until then local tracks group under **Unknown Album / Artist** (see
+[library.md](./library.md)).
+
+## How it works (and why it's reliable)
+
+On Android 11+ ("scoped storage"), an app **cannot** read arbitrary
+`/storage/...` paths with normal file APIs. The reliable, permission-free way to
+read a user-chosen folder is the **Storage Access Framework (SAF)**:
+
+1. The folder chooser returns a `content://…/tree/…` **tree URI**, not a raw
+   filesystem path.
+2. Linthra **persists the read grant** for that URI, so the same folder can be
+   re-scanned after a reboot (important for removable SD cards) without
+   re-prompting.
+3. The scan walks the tree through the **content resolver**
+   (`DocumentsContract`), visiting the root's direct files first and then
+   descending into subfolders. One unreadable subfolder is skipped and counted,
+   not fatal; a totally unreadable selected folder surfaces a clear error rather
+   than a silent empty result.
+
+This is why a raw path like `/storage/emulated/0/Music/...` is the wrong thing to
+store — it looks fine but can't be read under scoped storage. If you selected a
+folder in a much older build and see "no music found", just **choose the folder
+again**: the new selection grants and persists proper access.
+
+## Local music vs Offline downloads vs Cache
+
+These three are easy to confuse but are distinct:
+
+| Concept | What it is | Where |
+| --- | --- | --- |
+| **Local music** | Music files that already live on the device or SD card, played in place from a folder you chose via SAF. Linthra never moves or copies them. | Settings ▸ Local music |
+| **Offline downloads** | Copies Linthra makes of **server** tracks (Jellyfin / Subsonic) so they play without a network. You choose what to download. | The download action / Settings ▸ Offline |
+| **Cache** | Linthra-managed **temporary** storage (e.g. streamed/pre-cached audio), bounded by a size limit and reclaimable at any time. | Settings ▸ Cache — see [offline-cache.md](./offline-cache.md) |
+
+"Forget folder" only removes Linthra's index of the local source — it **deletes
+nothing on disk**. Your files stay exactly where they are, and re-selecting the
+folder brings them back.
+
+## Troubleshooting "no music found"
+
+Settings ▸ Diagnostics (and the "Report a bug" flow) include **secret-free** scan
+counters — counts only, never a path, file name, or URI:
+
+- **Local folder**: selected / not selected
+- **Local folder access**: persisted / not persisted (the SAF grant — the
+  removable-SD-card-after-reboot signal)
+- **Local scan**: files visited, folders visited, audio candidates, imported,
+  skipped (unsupported), read failures
+- **Local scan recursive**: yes / no
+- **Local supported types**: the extensions Linthra accepts
+- **Local scan status**: ok, or the failure kind
+
+Reading them:
+
+- `folders 0` with a selected folder usually means the root couldn't be read —
+  pick the folder again to refresh access.
+- `read failures > 0` points at a permission / removable-storage problem rather
+  than an empty folder.
+- `audio 0, skipped N` means files were found but none matched a supported audio
+  type.
+- `access: not persisted` after a reboot means the SD-card grant was lost —
+  re-select the folder.
+
+Please don't paste full private paths into public bug reports; the diagnostics
+above are designed so you don't have to.

--- a/lib/core/diagnostics/app_diagnostics.dart
+++ b/lib/core/diagnostics/app_diagnostics.dart
@@ -25,9 +25,13 @@ class AppDiagnosticsData {
     this.localFolderSelected,
     this.localPersistedPermission,
     this.localScanFilesVisited,
+    this.localScanFoldersVisited,
     this.localScanAudioCandidates,
+    this.localScanImportedTracks,
     this.localScanSkippedUnsupported,
     this.localScanReadFailures,
+    this.localScanRecursive,
+    this.localSupportedExtensions,
     this.localScanError,
     this.cacheUsedBytes,
     this.cacheLimitBytes,
@@ -86,8 +90,15 @@ class AppDiagnosticsData {
   /// run. Counts only — never a path or file name.
   final int? localScanFilesVisited;
 
-  /// How many of those entries the last scan kept as playable audio.
+  /// How many directories the last scan successfully listed (root + readable
+  /// subfolders), when known. Confirms nested folders were searched.
+  final int? localScanFoldersVisited;
+
+  /// How many of those entries the last scan flagged as audio candidates.
   final int? localScanAudioCandidates;
+
+  /// How many candidates actually became catalog tracks, when known.
+  final int? localScanImportedTracks;
 
   /// How many entries the last scan skipped as unsupported (e.g. artwork/notes).
   final int? localScanSkippedUnsupported;
@@ -95,6 +106,15 @@ class AppDiagnosticsData {
   /// How many entries/subfolders the last scan could not read and skipped — the
   /// scoped-storage / removable-storage signal.
   final int? localScanReadFailures;
+
+  /// Whether the last scan descended into subfolders, when known. Always true in
+  /// practice; surfaced so a report can confirm the scan was recursive.
+  final bool? localScanRecursive;
+
+  /// The audio file extensions the scanner recognizes (e.g. `mp3`, `m4a`,
+  /// `flac`), when collected. Static capability, useful for a "my format isn't
+  /// picked up" report. Never a path or file name.
+  final List<String>? localSupportedExtensions;
 
   /// The last local-scan failure kind (a stable enum name like `safTraversal`),
   /// when the last scan threw. Null when it completed (even with zero audio).
@@ -196,7 +216,15 @@ abstract final class AppDiagnostics {
         'Local folder access: '
             '${data.localPersistedPermission! ? 'persisted' : 'not persisted'}',
       if (data.localScanFilesVisited != null) _localScanLine(data),
-      if (_has(data.localScanError)) 'Local scan error: ${data.localScanError}',
+      if (data.localScanRecursive != null)
+        'Local scan recursive: ${_yesNo(data.localScanRecursive!)}',
+      if (data.localSupportedExtensions != null &&
+          data.localSupportedExtensions!.isNotEmpty)
+        'Local supported types: ${data.localSupportedExtensions!.join(', ')}',
+      if (_has(data.localScanError))
+        'Local scan error: ${data.localScanError}'
+      else if (data.localScanFilesVisited != null)
+        'Local scan status: ok',
       if (cache != null) cache,
       if (includePlayback && data.playbackOutput != null)
         'Playback output: ${data.playbackOutput}',
@@ -223,12 +251,16 @@ abstract final class AppDiagnostics {
     return lines.join('\n');
   }
 
-  /// The single-line local-scan summary: how many entries the last scan walked,
-  /// how many were kept as audio, how many were skipped as unsupported, and how
-  /// many could not be read. Only counts — never a path or file name.
+  /// The single-line local-scan summary: how many files and folders the last
+  /// scan walked, how many looked like audio, how many were imported, how many
+  /// were skipped as unsupported, and how many could not be read. Only counts —
+  /// never a path or file name.
   static String _localScanLine(AppDiagnosticsData data) {
-    return 'Local scan: visited ${data.localScanFilesVisited ?? 0}, '
-        'audio ${data.localScanAudioCandidates ?? 0}, '
+    final int audio = data.localScanAudioCandidates ?? 0;
+    return 'Local scan: visited ${data.localScanFilesVisited ?? 0} files, '
+        '${data.localScanFoldersVisited ?? 0} folders, '
+        'audio $audio, '
+        'imported ${data.localScanImportedTracks ?? audio}, '
         'skipped ${data.localScanSkippedUnsupported ?? 0}, '
         'read failures ${data.localScanReadFailures ?? 0}';
   }

--- a/lib/core/services/file_picker_folder_picker_service.dart
+++ b/lib/core/services/file_picker_folder_picker_service.dart
@@ -2,12 +2,16 @@ import 'package:file_picker/file_picker.dart';
 
 import 'folder_picker_service.dart';
 
-/// A [FolderPickerService] backed by the `file_picker` plugin.
+/// A [FolderPickerService] backed by the `file_picker` plugin — the desktop
+/// (GTK/Win32) folder chooser.
 ///
-/// `getDirectoryPath` shows the OS folder chooser on Android (Storage Access
-/// Framework) and on desktop (GTK/Win32). On Android the returned value can be
-/// a `content://` tree URI rather than a filesystem path — see the README's
-/// "Android folder selection" notes for the implications for scanning.
+/// It is **not** used on Android: there, `getDirectoryPath` resolves the picked
+/// folder to a raw `/storage/...` filesystem path (via `getFullPathFromTreeUri`)
+/// and takes no persistable URI grant, so under scoped storage the scan can't
+/// read it — the cause of the "no music found" reports. `PlatformFolderPickerService`
+/// routes Android to the native SAF chooser (`MethodChannelSafFolderPicker`),
+/// which returns a `content://` tree URI with a persisted read grant, and uses
+/// this class only as the desktop fallback (where a filesystem path is correct).
 class FilePickerFolderPickerService implements FolderPickerService {
   const FilePickerFolderPickerService();
 

--- a/lib/core/services/method_channel_saf_folder_picker.dart
+++ b/lib/core/services/method_channel_saf_folder_picker.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'folder_picker_service.dart';
+
+/// A [FolderPickerService] that opens Android's Storage Access Framework folder
+/// chooser through the native SAF method channel and returns the picked
+/// `content://` tree URI — with its read grant persisted by the native side.
+///
+/// This exists because the `file_picker` plugin's `getDirectoryPath` resolves an
+/// Android folder pick to a raw `/storage/...` filesystem path (and takes no
+/// persistable URI permission). Under scoped storage (Android 11+) the app
+/// cannot read that path with `dart:io`, so the scan turned up nothing even
+/// though the folder was full of music. Returning the tree URI instead routes
+/// the scan through the content resolver (`SafDocumentScanner`), the only path
+/// scoped storage actually allows.
+///
+/// Off Android — or when the native handler isn't registered — it returns `null`
+/// (treated as "no selection") so callers can fall back to another picker.
+class MethodChannelSafFolderPicker implements FolderPickerService {
+  const MethodChannelSafFolderPicker();
+
+  // Mirrors MainActivity.kt's SAF_CHANNEL and the lister/probe channel name.
+  static const MethodChannel _channel =
+      MethodChannel('io.github.thezupzup.linthra/saf');
+
+  @override
+  Future<String?> pickFolder() async {
+    if (!Platform.isAndroid) {
+      return null;
+    }
+    try {
+      // Returns the picked tree URI, or null when the user cancelled.
+      return await _channel.invokeMethod<String>('pickFolderTree');
+    } on MissingPluginException {
+      // The native handler isn't registered (shouldn't happen on a real build);
+      // let the caller fall back rather than throwing into the UI.
+      return null;
+    } on PlatformException {
+      // No chooser available, or a pick already in flight. Treat as no
+      // selection rather than surfacing a raw platform error.
+      return null;
+    }
+  }
+}

--- a/lib/core/services/platform_folder_picker_service.dart
+++ b/lib/core/services/platform_folder_picker_service.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'file_picker_folder_picker_service.dart';
+import 'folder_picker_service.dart';
+import 'method_channel_saf_folder_picker.dart';
+
+/// The default [FolderPickerService]: routes folder selection to the chooser
+/// that returns a usable handle on each platform.
+///
+/// On Android it uses [MethodChannelSafFolderPicker], which returns the picked
+/// `content://` tree URI with a persisted read grant — the scoped-storage-
+/// correct selection. Everywhere else (desktop, where the chooser returns a real
+/// filesystem path) it uses the `file_picker`-backed
+/// [FilePickerFolderPickerService]. This is the one place that knows about the
+/// platform split, mirroring [PlatformAudioFileScanner] on the scan side.
+class PlatformFolderPickerService implements FolderPickerService {
+  const PlatformFolderPickerService({
+    FolderPickerService androidPicker = const MethodChannelSafFolderPicker(),
+    FolderPickerService fallbackPicker = const FilePickerFolderPickerService(),
+  })  : _androidPicker = androidPicker,
+        _fallbackPicker = fallbackPicker;
+
+  final FolderPickerService _androidPicker;
+  final FolderPickerService _fallbackPicker;
+
+  @override
+  Future<String?> pickFolder() {
+    if (Platform.isAndroid) {
+      return _androidPicker.pickFolder();
+    }
+    return _fallbackPicker.pickFolder();
+  }
+}

--- a/lib/core/sources/local/audio_file_scanner.dart
+++ b/lib/core/sources/local/audio_file_scanner.dart
@@ -39,14 +39,22 @@ class IoAudioFileScanner implements AudioFileScanner {
     }
 
     // Walk one directory at a time (rather than `list(recursive: true)`) so a
-    // single unreadable subfolder — common under scoped storage / on removable
+    // single unreadable *subfolder* — common under scoped storage / on removable
     // SD cards — is skipped instead of aborting the whole scan and zeroing out
     // the library. `followLinks: false` keeps symlinked directories from being
     // descended, avoiding cycles.
+    //
+    // The selected *root* is different: if it exists but cannot be listed
+    // (access revoked, the mount went away), surface that as a failure rather
+    // than returning an empty list — an empty result would be persisted as a
+    // successful "no music" scan and wipe the existing catalog.
     final List<String> paths = <String>[];
     final List<Directory> pending = <Directory>[root];
+    bool isRoot = true;
     while (pending.isNotEmpty) {
       final Directory directory = pending.removeLast();
+      final bool wasRoot = isRoot;
+      isRoot = false;
       try {
         await for (final FileSystemEntity entity in directory.list(
           followLinks: false,
@@ -58,6 +66,14 @@ class IoAudioFileScanner implements AudioFileScanner {
           }
         }
       } on FileSystemException {
+        if (wasRoot) {
+          throw FolderScanException(
+            "Linthra couldn't read the selected folder. Android may have "
+            'revoked access to it, or the storage was removed. Try selecting '
+            'the folder again.',
+            folder: folder,
+          );
+        }
         // Unreadable subtree: skip it and keep scanning the rest.
         continue;
       }

--- a/lib/core/sources/local/folder_location.dart
+++ b/lib/core/sources/local/folder_location.dart
@@ -37,4 +37,27 @@ class FolderLocation {
 
   bool get isContentUri => kind == FolderLocationKind.contentUri;
   bool get isFilesystemPath => kind == FolderLocationKind.filesystemPath;
+
+  /// A human-readable label for showing the user *their own* chosen folder in
+  /// the app (never a public bug report). A SAF `content://` tree URI is reduced
+  /// to its document id — e.g. `content://…/tree/primary%3AMusic%2Fmusi5`
+  /// becomes `primary:Music/musi5` — so the user sees a recognizable folder
+  /// instead of an opaque URI. A filesystem path is returned unchanged.
+  String get displayLabel {
+    if (!isContentUri) {
+      return raw;
+    }
+    final Uri? uri = Uri.tryParse(raw);
+    if (uri == null) {
+      return raw;
+    }
+    final List<String> segments = uri.pathSegments;
+    final int treeIndex = segments.indexOf('tree');
+    if (treeIndex >= 0 && treeIndex + 1 < segments.length) {
+      // pathSegments are percent-decoded, so this is already e.g.
+      // `primary:Music/musi5` rather than `primary%3AMusic%2Fmusi5`.
+      return segments[treeIndex + 1];
+    }
+    return raw;
+  }
 }

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -113,7 +113,13 @@ class LocalMusicSource implements MusicSource {
           tracks.add(LocalTrackMapper.fromSafDocument(document));
         }
       }
-      final int candidates = tracks.length;
+      // `candidates` is what the provider's audio filter (extension OR audio/*
+      // MIME) returned; `imported` is what the catalog's own filter kept. The
+      // two predicates match today, so these are normally equal — reported
+      // separately so a future divergence (a stricter catalog filter) is visible
+      // in diagnostics rather than silent.
+      final int candidates = result.documents.length;
+      final int imported = tracks.length;
       final int skipped = result.filesVisited > candidates
           ? result.filesVisited - candidates
           : 0;
@@ -123,7 +129,9 @@ class LocalMusicSource implements MusicSource {
           folderSelected: true,
           isContentUri: true,
           filesVisited: result.filesVisited,
+          foldersVisited: result.foldersVisited,
           audioCandidates: candidates,
+          importedTracks: imported,
           skippedUnsupported: skipped,
           readFailures: result.readFailures,
         ),
@@ -152,7 +160,10 @@ class LocalMusicSource implements MusicSource {
         folderSelected: true,
         isContentUri: isContentUri,
         filesVisited: visited,
+        // The filesystem walk reports files, not a directory count.
+        foldersVisited: 0,
         audioCandidates: candidates,
+        importedTracks: candidates,
         skippedUnsupported: visited - candidates,
         readFailures: 0,
       ),

--- a/lib/core/sources/local/local_scan_diagnostics.dart
+++ b/lib/core/sources/local/local_scan_diagnostics.dart
@@ -46,9 +46,12 @@ abstract final class LocalScanDiagnostics {
       'folder=${report.folderSelected ? 'selected' : 'none'}',
       if (report.folderSelected) 'kind=${report.isContentUri ? 'saf' : 'path'}',
       'visited=${report.filesVisited}',
+      'folders=${report.foldersVisited}',
       'audio=${report.audioCandidates}',
+      'imported=${report.importedTracks}',
       'skipped=${report.skippedUnsupported}',
       'readFailures=${report.readFailures}',
+      'recursive=${report.recursive ? 'yes' : 'no'}',
       if (report.error != null) 'error=${report.error!.name}',
     ].join(' ');
   }

--- a/lib/core/sources/local/local_scan_report.dart
+++ b/lib/core/sources/local/local_scan_report.dart
@@ -26,6 +26,9 @@ class LocalScanReport {
     required this.audioCandidates,
     required this.skippedUnsupported,
     required this.readFailures,
+    this.foldersVisited = 0,
+    this.importedTracks = 0,
+    this.recursive = true,
     this.error,
   });
 
@@ -36,9 +39,12 @@ class LocalScanReport {
     required this.isContentUri,
     required LocalScanError this.error,
   })  : filesVisited = 0,
+        foldersVisited = 0,
         audioCandidates = 0,
+        importedTracks = 0,
         skippedUnsupported = 0,
-        readFailures = 0;
+        readFailures = 0,
+        recursive = true;
 
   /// Whether a music folder was selected at all when the scan ran.
   final bool folderSelected;
@@ -50,8 +56,19 @@ class LocalScanReport {
   /// How many non-directory entries the scan walked (audio and non-audio).
   final int filesVisited;
 
-  /// How many of those entries were kept as playable audio candidates.
+  /// How many directories the scan successfully listed — the selected root plus
+  /// any readable subfolders. Surfaced on the SAF path (the Android case);
+  /// filesystem-path scans report 0 here.
+  final int foldersVisited;
+
+  /// How many of those entries looked like audio (a recognized extension or an
+  /// `audio/*` content type) — the candidates before the catalog's own filter.
   final int audioCandidates;
+
+  /// How many candidates actually became tracks in the catalog. Normally equal
+  /// to [audioCandidates] — the catalog's supported-types filter mirrors the
+  /// provider's — but kept distinct so a future divergence stays visible.
+  final int importedTracks;
 
   /// How many entries were skipped because they were not a recognized audio
   /// file (the usual `cover.jpg`/`notes.txt` case).
@@ -61,6 +78,10 @@ class LocalScanReport {
   /// scoped-storage / removable-SD-card signal. A non-zero value with zero
   /// candidates points at a permission problem rather than an empty folder.
   final int readFailures;
+
+  /// Whether the scan descended into subfolders (it always does; surfaced so a
+  /// report can confirm nested artist/album folders were searched).
+  final bool recursive;
 
   /// The failure kind when the scan threw, or null when it completed (even if it
   /// completed with zero candidates).

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -79,12 +79,14 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
       }
     }
     final Object? filesVisited = result['filesVisited'];
+    final Object? foldersVisited = result['foldersVisited'];
     final Object? readFailures = result['readFailures'];
     return SafScanResult(
       documents: documents,
       // Fall back to the document count if the native side is an older build
       // that didn't report a visited total, so the scan still works.
       filesVisited: filesVisited is int ? filesVisited : documents.length,
+      foldersVisited: foldersVisited is int ? foldersVisited : 0,
       readFailures: readFailures is int ? readFailures : 0,
     );
   }

--- a/lib/core/sources/local/saf_document_lister.dart
+++ b/lib/core/sources/local/saf_document_lister.dart
@@ -29,18 +29,22 @@ class SafAudioDocument {
 /// secret-free counters the diagnostics layer surfaces.
 ///
 /// [filesVisited] counts every non-directory entry the walk saw (audio and
-/// non-audio); [documents] are the audio ones; [readFailures] counts subfolders
-/// whose listing failed and were skipped — the scoped-storage / removable-SD
-/// signal that tells an empty result apart from a permission problem.
+/// non-audio); [foldersVisited] counts the directories it successfully listed
+/// (the selected root plus any readable subfolders); [documents] are the audio
+/// ones; [readFailures] counts subfolders whose listing failed and were
+/// skipped — the scoped-storage / removable-SD signal that tells an empty
+/// result apart from a permission problem.
 class SafScanResult {
   const SafScanResult({
     this.documents = const <SafAudioDocument>[],
     this.filesVisited = 0,
+    this.foldersVisited = 0,
     this.readFailures = 0,
   });
 
   final List<SafAudioDocument> documents;
   final int filesVisited;
+  final int foldersVisited;
   final int readFailures;
 }
 

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -3,11 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/sources/local/folder_location.dart';
 import '../../core/sources/local/folder_scan_exception.dart';
 import '../../core/sources/local/local_music_source.dart';
-import '../../core/sources/local/local_scan_diagnostics.dart';
 import '../../core/sources/local/local_scan_report.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
 import 'library_providers.dart';
 import 'library_state.dart';
+import 'local_scan_report_provider.dart';
 
 /// Drives the Library screen: loads tracks from the [MusicLibraryRepository]
 /// and exposes them as a [LibraryState]. Keeps the UI free of any direct
@@ -45,28 +45,29 @@ class LibraryController extends Notifier<LibraryState> {
         albums: albums,
         artists: artists,
       );
-      // Record the counts (visited / audio / skipped / read failures) so a
-      // "no music found" report can show what the scan actually saw.
-      LocalScanDiagnostics.record(scan.report);
+      // Record the counts (visited / folders / audio / imported / skipped /
+      // read failures) so a "no music found" report can show what the scan
+      // actually saw — reactively (Settings ▸ Local music) and in diagnostics.
+      ref.read(localScanReportProvider.notifier).record(scan.report);
       await _load();
     } on FolderScanException catch (error) {
       // The scanning layer already phrased a clear, secret-free message
       // (unreachable SAF tree, unreadable scoped-storage path, …); show it.
-      LocalScanDiagnostics.record(LocalScanReport.failure(
-        folderSelected: folderPath.isNotEmpty,
-        isContentUri: location.isContentUri,
-        error: LocalScanError.safTraversal,
-      ));
+      ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
+            folderSelected: folderPath.isNotEmpty,
+            isContentUri: location.isContentUri,
+            error: LocalScanError.safTraversal,
+          ));
       state = LibraryState.error(error.message);
     } catch (_) {
       // Anything else is an unexpected scan failure — a raw `dart:io`
       // permission error or a plugin fault. Don't leak its text (errno codes,
       // paths) to the user; show one friendly, actionable line instead.
-      LocalScanDiagnostics.record(LocalScanReport.failure(
-        folderSelected: folderPath.isNotEmpty,
-        isContentUri: location.isContentUri,
-        error: LocalScanError.unexpected,
-      ));
+      ref.read(localScanReportProvider.notifier).record(LocalScanReport.failure(
+            folderSelected: folderPath.isNotEmpty,
+            isContentUri: location.isContentUri,
+            error: LocalScanError.unexpected,
+          ));
       state = const LibraryState.error(_scanFailedMessage);
     }
   }

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/services/file_picker_folder_picker_service.dart';
 import '../../core/services/folder_picker_service.dart';
+import '../../core/services/platform_folder_picker_service.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
 import '../../core/sources/local/method_channel_saf_document_lister.dart';
 import '../../core/sources/local/method_channel_saf_permission_probe.dart';
@@ -24,10 +24,12 @@ final audioFileScannerProvider = Provider<AudioFileScanner>((ref) {
 });
 
 /// The folder-chooser seam the Library uses to let the user pick a music
-/// folder. Defaults to the `file_picker`-backed implementation; tests override
-/// it with a fake so the pick-and-scan flow runs without a real OS dialog.
+/// folder. Defaults to [PlatformFolderPickerService], which on Android returns
+/// the picked `content://` tree URI (with a persisted read grant) and elsewhere
+/// falls back to the `file_picker` filesystem chooser. Tests override it with a
+/// fake so the pick-and-scan flow runs without a real OS dialog.
 final folderPickerServiceProvider = Provider<FolderPickerService>((ref) {
-  return const FilePickerFolderPickerService();
+  return const PlatformFolderPickerService();
 });
 
 /// The SAF traversal seam used to scan an Android `content://` folder through

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -8,6 +10,7 @@ import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
 import '../../core/services/bulk_track_actions.dart';
+import '../../core/sources/local/folder_location.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
 import '../settings/jellyfin/jellyfin_sync_controller.dart';
@@ -447,6 +450,12 @@ class _LibraryEmpty extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasFolder = selectedFolder != null;
+    // A folder selected as a plain filesystem path on Android is the legacy/
+    // broken case: scoped storage won't let Linthra read it, so it turns up
+    // empty. Nudge the user to pick it again, which now returns a SAF grant.
+    final bool needsRepick = hasFolder &&
+        Platform.isAndroid &&
+        !FolderLocation.parse(selectedFolder!).isContentUri;
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.xl),
@@ -469,13 +478,24 @@ class _LibraryEmpty extends StatelessWidget {
             const SizedBox(height: AppSpacing.sm),
             Text(
               hasFolder
-                  ? 'Nothing playable turned up in:\n$selectedFolder'
+                  ? 'Nothing playable turned up in:\n'
+                      '${FolderLocation.parse(selectedFolder!).displayLabel}'
                   : 'Choose a folder on your device to scan for music.',
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
               ),
               textAlign: TextAlign.center,
             ),
+            if (needsRepick) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Choose the folder again so Linthra can read it.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
             const SizedBox(height: AppSpacing.md),
             if (hasFolder) ...[
               FilledButton.tonal(

--- a/lib/features/library/local_scan_report_provider.dart
+++ b/lib/features/library/local_scan_report_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/sources/local/local_scan_diagnostics.dart';
+import '../../core/sources/local/local_scan_report.dart';
+
+/// The latest local-folder scan outcome, exposed reactively so the Settings
+/// "Local music" card can show what the last scan saw (counts, read failures,
+/// error) and refresh the moment a new scan finishes.
+///
+/// It mirrors the process-wide [LocalScanDiagnostics] static (which the
+/// secret-free diagnostics export reads independently of Riverpod): recording a
+/// report here also records it there, so the two never drift. Seeded from
+/// [LocalScanDiagnostics.last] so a report survives navigating away and back.
+class LocalScanReportController extends Notifier<LocalScanReport?> {
+  @override
+  LocalScanReport? build() => LocalScanDiagnostics.last;
+
+  /// Records [report] as the latest scan outcome — both reactively (this
+  /// provider's state) and in the static diagnostics recorder/event log.
+  void record(LocalScanReport report) {
+    LocalScanDiagnostics.record(report);
+    state = report;
+  }
+
+  /// Forgets the retained outcome (e.g. after the user clears the folder).
+  void clear() {
+    LocalScanDiagnostics.reset();
+    state = null;
+  }
+}
+
+final localScanReportProvider =
+    NotifierProvider<LocalScanReportController, LocalScanReport?>(
+  LocalScanReportController.new,
+);

--- a/lib/features/settings/diagnostics/diagnostics_collector.dart
+++ b/lib/features/settings/diagnostics/diagnostics_collector.dart
@@ -11,6 +11,7 @@ import '../../../core/services/active_playback_controller.dart';
 import '../../../core/services/notification_permission.dart';
 import '../../../core/services/playback_diagnostics.dart';
 import '../../../core/services/stability_diagnostics.dart';
+import '../../../core/sources/local/audio_file_types.dart';
 import '../../../core/sources/local/folder_location.dart';
 import '../../../core/sources/local/local_scan_diagnostics.dart';
 import '../../../core/sources/local/local_scan_report.dart';
@@ -81,9 +82,15 @@ class DiagnosticsCollector {
       localFolderSelected: folderSelected,
       localPersistedPermission: persistedPermission,
       localScanFilesVisited: scan?.filesVisited,
+      localScanFoldersVisited: scan?.foldersVisited,
       localScanAudioCandidates: scan?.audioCandidates,
+      localScanImportedTracks: scan?.importedTracks,
       localScanSkippedUnsupported: scan?.skippedUnsupported,
       localScanReadFailures: scan?.readFailures,
+      localScanRecursive: scan?.recursive,
+      // Static capability — always reportable, even before the first scan — so a
+      // "my format isn't recognized" report shows what Linthra accepts.
+      localSupportedExtensions: _supportedExtensions(),
       localScanError: scan?.error?.name,
       cacheUsedBytes: _cacheUsedBytes(),
       cacheLimitBytes: _cacheLimitBytes(),
@@ -103,6 +110,13 @@ class DiagnosticsCollector {
       offlineCacheEnabled: true,
       smartPrecacheEnabled: _ref.read(smartPrecacheEnabledProvider).valueOrNull,
     );
+  }
+
+  /// The recognized audio extensions, sorted for a stable report line.
+  List<String> _supportedExtensions() {
+    final List<String> extensions = AudioFileTypes.supportedExtensions.toList()
+      ..sort();
+    return extensions;
   }
 
   /// Reads (never prompts for) the notification permission state, so the report

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -11,6 +11,7 @@ import 'network/network_settings_section.dart';
 import 'playback/playback_settings_section.dart';
 import 'precache/precache_settings_section.dart';
 import 'source/default_provider_section.dart';
+import 'source/local_music_settings_section.dart';
 import 'source/playback_source_strategy_section.dart';
 import 'subsonic/subsonic_settings_section.dart';
 
@@ -29,6 +30,8 @@ class SettingsScreen extends StatelessWidget {
           JellyfinSettingsSection(),
           SizedBox(height: AppSpacing.md),
           SubsonicSettingsSection(),
+          SizedBox(height: AppSpacing.md),
+          LocalMusicSettingsSection(),
           SizedBox(height: AppSpacing.md),
           DefaultProviderSettingsSection(),
           SizedBox(height: AppSpacing.md),

--- a/lib/features/settings/source/local_music_controller.dart
+++ b/lib/features/settings/source/local_music_controller.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sources/local/folder_location.dart';
+import '../../../core/sources/local/local_music_source.dart';
+import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../library/library_controller.dart';
+import '../../library/library_providers.dart';
+import '../../library/local_scan_report_provider.dart';
+import '../../library/selected_folder_controller.dart';
+
+/// Transient state for the Settings ▸ Local music card: whether an action is
+/// running and the last one-line outcome to surface.
+class LocalMusicActionState {
+  const LocalMusicActionState({
+    this.busy = false,
+    this.message,
+    this.isError = false,
+  });
+
+  /// True while a pick/rescan/forget is in flight (drives the spinner).
+  final bool busy;
+
+  /// A short, secret-free outcome line for the card, or null when there's
+  /// nothing to say. Never a path or file name.
+  final String? message;
+
+  /// Whether [message] reports a failure (rendered in the error colour).
+  final bool isError;
+}
+
+/// Drives the Settings ▸ Local music source card: choose a folder, rescan it,
+/// or forget it. It is the source-shaped peer of the Jellyfin/Subsonic settings
+/// controllers, and the configuration home the empty-state "Change folder"
+/// button mirrors.
+///
+/// It owns no scanning logic of its own — it reuses the same pick/scan path the
+/// Library screen uses ([SelectedFolderController] + [LibraryController]) so a
+/// folder configured here and one configured from the Library behave
+/// identically and both refresh the catalog. The selected folder and the last
+/// scan counts are read reactively from their own providers by the widget; this
+/// controller only carries the in-flight/outcome state and the actions.
+class LocalMusicController extends Notifier<LocalMusicActionState> {
+  @override
+  LocalMusicActionState build() => const LocalMusicActionState();
+
+  /// Opens the folder chooser, persists the choice, and scans it. On Android
+  /// this returns a `content://` tree URI with a persisted read grant — the
+  /// scoped-storage-correct selection. A cancelled pick leaves everything as it
+  /// was.
+  Future<void> pickFolder() async {
+    state = const LocalMusicActionState(busy: true);
+    final String? picked = await ref
+        .read(selectedFolderControllerProvider.notifier)
+        .pickAndPersist();
+    if (picked == null || picked.isEmpty) {
+      // Cancelled — say nothing, change nothing.
+      state = const LocalMusicActionState();
+      return;
+    }
+    await _scan(picked);
+  }
+
+  /// Re-scans the folder already selected, without opening the chooser. No-op
+  /// when nothing is selected yet.
+  Future<void> rescan() async {
+    final String? folder =
+        ref.read(selectedFolderControllerProvider).valueOrNull;
+    if (folder == null || folder.isEmpty) {
+      return;
+    }
+    state = const LocalMusicActionState(busy: true);
+    await _scan(folder);
+  }
+
+  /// Forgets the selected folder and removes the local tracks from the catalog.
+  /// Deletes nothing on disk — it only clears Linthra's index for the `local`
+  /// source, so re-selecting the folder brings everything back.
+  Future<void> forget() async {
+    state = const LocalMusicActionState(busy: true);
+    await ref.read(selectedFolderControllerProvider.notifier).clear();
+    await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+      sourceId: const LocalMusicSource(folderPath: null).id,
+      tracks: const [],
+      albums: const [],
+      artists: const [],
+    );
+    ref.read(localScanReportProvider.notifier).clear();
+    await ref.read(libraryControllerProvider.notifier).refresh();
+    state = const LocalMusicActionState(
+      message: 'Local folder forgotten. Your files were not deleted.',
+    );
+  }
+
+  /// Runs the shared scan-and-persist path, then summarizes the outcome from the
+  /// recorded scan report (counts only — never a path or file name).
+  Future<void> _scan(String folder) async {
+    await ref.read(libraryControllerProvider.notifier).scanFolder(folder);
+    final report = ref.read(localScanReportProvider);
+    final bool isContentUri = FolderLocation.parse(folder).isContentUri;
+    if (report == null) {
+      state = const LocalMusicActionState();
+      return;
+    }
+    if (report.hadError) {
+      state = const LocalMusicActionState(
+        message: "Couldn't scan that folder. Try selecting it again.",
+        isError: true,
+      );
+      return;
+    }
+    if (report.importedTracks > 0) {
+      state = LocalMusicActionState(
+        message: 'Added ${report.importedTracks} '
+            '${report.importedTracks == 1 ? 'track' : 'tracks'} from this '
+            'folder.',
+      );
+      return;
+    }
+    // Completed, but nothing playable. Distinguish a likely access problem from
+    // a genuinely empty folder so the message is actionable.
+    final bool looksBlocked =
+        report.readFailures > 0 || (isContentUri && report.filesVisited == 0);
+    state = LocalMusicActionState(
+      message: looksBlocked
+          ? 'No music found. Linthra may not have access to that folder — try '
+              'selecting it again.'
+          : 'No playable audio found in that folder.',
+      isError: looksBlocked,
+    );
+  }
+}
+
+final localMusicControllerProvider =
+    NotifierProvider<LocalMusicController, LocalMusicActionState>(
+  LocalMusicController.new,
+);
+
+/// Whether Linthra still holds a persisted read grant for the selected
+/// `content://` folder — the removable-SD-card / lost-access signal shown on the
+/// Local music card. Re-evaluated whenever the selection changes.
+///
+/// Returns `null` when it doesn't apply (no folder, or a plain filesystem path)
+/// or can't be determined (off Android), so the card simply omits the line.
+final localFolderAccessProvider = FutureProvider<bool?>((ref) async {
+  final String? folder =
+      ref.watch(selectedFolderControllerProvider).valueOrNull;
+  if (folder == null || folder.isEmpty) {
+    return null;
+  }
+  if (!FolderLocation.parse(folder).isContentUri) {
+    return null;
+  }
+  return ref.read(safPermissionProbeProvider).hasPersistedPermission(folder);
+});

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/sources/local/folder_location.dart';
+import '../../../core/sources/local/local_scan_report.dart';
+import '../../library/local_scan_report_provider.dart';
+import '../../library/selected_folder_controller.dart';
+import 'local_music_controller.dart';
+
+/// The "Local music" source card on the Settings screen, grouped with the other
+/// music sources (Jellyfin, Navidrome/Subsonic).
+///
+/// This is the primary place to configure on-device music: choose a folder on
+/// this phone or an SD card, rescan it, or forget it. It reuses the same pick +
+/// scan path as the Library empty-state "Change folder" button, so the two stay
+/// in sync. Everything it shows is read reactively from the selected-folder and
+/// last-scan providers; the card itself holds no scanning logic.
+///
+/// "Local music" is deliberately distinct from two neighbours users conflate:
+///  - Offline downloads — copies Linthra makes for offline playback of a server
+///    track (Settings ▸ Offline / the download action), and
+///  - Cache — Linthra-managed temporary storage (Settings ▸ Cache).
+/// This card only points Linthra at music that already lives on the device.
+class LocalMusicSettingsSection extends ConsumerWidget {
+  const LocalMusicSettingsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    final String? folder =
+        ref.watch(selectedFolderControllerProvider).valueOrNull;
+    final LocalScanReport? report = ref.watch(localScanReportProvider);
+    final LocalMusicActionState action =
+        ref.watch(localMusicControllerProvider);
+    final bool? persisted = ref.watch(localFolderAccessProvider).valueOrNull;
+    final bool hasFolder = folder != null && folder.isNotEmpty;
+
+    final LocalMusicController controller =
+        ref.read(localMusicControllerProvider.notifier);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.folder_special_outlined,
+                    color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Local music', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Play music from a folder on this device or an SD card. Linthra '
+              "reads it through Android's folder access — it needs no broad "
+              'storage permission, and your files are never moved or copied.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            if (hasFolder)
+              _SelectedFolderView(
+                folderLabel: FolderLocation.parse(folder).displayLabel,
+                persisted: persisted,
+                report: report,
+              )
+            else
+              Text(
+                'No folder selected yet.',
+                style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+              ),
+            const SizedBox(height: AppSpacing.md),
+            if (action.busy)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                child: Center(
+                  child: SizedBox.square(
+                    dimension: 22,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              )
+            else if (hasFolder)
+              _FolderActions(
+                onRescan: controller.rescan,
+                onChange: controller.pickFolder,
+                onForget: controller.forget,
+              )
+            else
+              FilledButton.icon(
+                onPressed: controller.pickFolder,
+                icon: const Icon(Icons.create_new_folder_outlined),
+                label: const Text('Select a folder'),
+              ),
+            if (action.message != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              _StatusLine(message: action.message!, isError: action.isError),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The selected-folder summary: which folder, whether access is still held, and
+/// what the last scan saw.
+class _SelectedFolderView extends StatelessWidget {
+  const _SelectedFolderView({
+    required this.folderLabel,
+    required this.persisted,
+    required this.report,
+  });
+
+  final String folderLabel;
+  final bool? persisted;
+  final LocalScanReport? report;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.folder_outlined, size: 20, color: muted),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text(
+                folderLabel,
+                style: theme.textTheme.bodyMedium,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+        if (persisted == false) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'Access to this folder was lost. Select it again to restore it.',
+            style: theme.textTheme.bodySmall
+                ?.copyWith(color: theme.colorScheme.error),
+          ),
+        ],
+        if (report != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            _scanSummary(report!),
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// A short, secret-free recap of the last scan — counts only.
+  static String _scanSummary(LocalScanReport report) {
+    if (report.hadError) {
+      return 'Last scan: failed. Try selecting the folder again.';
+    }
+    final StringBuffer summary = StringBuffer()
+      ..write('Last scan: ${report.importedTracks} ')
+      ..write(report.importedTracks == 1 ? 'track' : 'tracks')
+      ..write(' from ${report.filesVisited} ')
+      ..write(report.filesVisited == 1 ? 'file' : 'files')
+      ..write(' in ${report.foldersVisited} ')
+      ..write(report.foldersVisited == 1 ? 'folder' : 'folders');
+    if (report.readFailures > 0) {
+      summary.write(' · ${report.readFailures} unreadable');
+    }
+    return summary.toString();
+  }
+}
+
+/// The Rescan / Change / Forget actions shown once a folder is selected.
+class _FolderActions extends StatelessWidget {
+  const _FolderActions({
+    required this.onRescan,
+    required this.onChange,
+    required this.onForget,
+  });
+
+  final VoidCallback onRescan;
+  final VoidCallback onChange;
+  final VoidCallback onForget;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton.tonalIcon(
+                onPressed: onRescan,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Rescan'),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: onChange,
+                icon: const Icon(Icons.folder_open_outlined),
+                label: const Text('Change'),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: onForget,
+            icon: const Icon(Icons.delete_outline, size: 18),
+            label: const Text('Forget folder'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A friendly one-line status or error message under the actions.
+class _StatusLine extends StatelessWidget {
+  const _StatusLine({required this.message, required this.isError});
+
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color color =
+        isError ? theme.colorScheme.error : theme.colorScheme.primary;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          isError ? Icons.error_outline : Icons.info_outline,
+          size: 18,
+          color: color,
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(color: color),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/core/diagnostics/app_diagnostics_test.dart
+++ b/test/core/diagnostics/app_diagnostics_test.dart
@@ -298,9 +298,13 @@ void main() {
           localFolderSelected: true,
           localPersistedPermission: true,
           localScanFilesVisited: 120,
+          localScanFoldersVisited: 7,
           localScanAudioCandidates: 98,
+          localScanImportedTracks: 97,
           localScanSkippedUnsupported: 22,
           localScanReadFailures: 0,
+          localScanRecursive: true,
+          localSupportedExtensions: <String>['flac', 'm4a', 'mp3'],
         ),
       );
 
@@ -308,9 +312,15 @@ void main() {
       expect(report, contains('Local folder access: persisted'));
       expect(
         report,
-        contains('Local scan: visited 120, audio 98, skipped 22, '
-            'read failures 0'),
+        contains('Local scan: visited 120 files, 7 folders, audio 98, '
+            'imported 97, skipped 22, read failures 0'),
       );
+      expect(report, contains('Local scan recursive: yes'));
+      expect(report, contains('Local supported types: flac, m4a, mp3'));
+      // A completed scan reports a positive status, not just the absence of an
+      // error line.
+      expect(report, contains('Local scan status: ok'));
+      expect(report, isNot(contains('Local scan error:')));
     });
 
     test('reports a missing folder and a lost grant plainly', () {
@@ -341,6 +351,23 @@ void main() {
 
       expect(report, contains('Local folder access: not persisted'));
       expect(report, contains('read failures 4'));
+    });
+
+    test('a completed scan with no error still reports a positive status', () {
+      final String report = AppDiagnostics.report(
+        const AppDiagnosticsData(
+          appVersion: '0.1.0',
+          localFolderSelected: true,
+          localScanFilesVisited: 0,
+          localScanFoldersVisited: 1,
+          localScanAudioCandidates: 0,
+          localScanReadFailures: 0,
+        ),
+      );
+
+      // An empty folder completed cleanly: status ok, no error line.
+      expect(report, contains('Local scan status: ok'));
+      expect(report, isNot(contains('Local scan error:')));
     });
 
     test('reports the last scan error kind when present', () {

--- a/test/core/services/method_channel_saf_folder_picker_test.dart
+++ b/test/core/services/method_channel_saf_folder_picker_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/method_channel_saf_folder_picker.dart';
+
+void main() {
+  group('MethodChannelSafFolderPicker', () {
+    test('returns null (no selection) off Android without touching the channel',
+        () async {
+      // Off Android the picker short-circuits, so the host test never reaches a
+      // platform channel — the caller treats null as "no folder chosen".
+      const picker = MethodChannelSafFolderPicker();
+
+      expect(Platform.isAndroid, isFalse, reason: 'precondition for this host');
+      expect(await picker.pickFolder(), isNull);
+    });
+  });
+}

--- a/test/core/services/platform_folder_picker_service_test.dart
+++ b/test/core/services/platform_folder_picker_service_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/folder_picker_service.dart';
+import 'package:linthra/core/services/platform_folder_picker_service.dart';
+
+/// Records which picker was asked and returns a canned answer, so the routing
+/// can be asserted without a real OS dialog or platform channel.
+class _RecordingPicker implements FolderPickerService {
+  _RecordingPicker(this.answer);
+
+  final String? answer;
+  int calls = 0;
+
+  @override
+  Future<String?> pickFolder() async {
+    calls++;
+    return answer;
+  }
+}
+
+void main() {
+  group('PlatformFolderPickerService', () {
+    test('off Android, delegates to the fallback (file_picker) chooser',
+        () async {
+      // The unit-test host is never Android, so the SAF picker must not run and
+      // the filesystem fallback handles the pick.
+      final android = _RecordingPicker('content://should-not-be-used');
+      final fallback = _RecordingPicker('/home/me/Music');
+      final service = PlatformFolderPickerService(
+        androidPicker: android,
+        fallbackPicker: fallback,
+      );
+
+      final result = await service.pickFolder();
+
+      expect(Platform.isAndroid, isFalse, reason: 'precondition for this host');
+      expect(result, '/home/me/Music');
+      expect(fallback.calls, 1);
+      expect(android.calls, 0);
+    });
+  });
+}

--- a/test/core/sources/local/fake_saf_document_lister.dart
+++ b/test/core/sources/local/fake_saf_document_lister.dart
@@ -11,6 +11,7 @@ class FakeSafDocumentLister implements SafDocumentLister {
   FakeSafDocumentLister({
     this.documents = const <SafAudioDocument>[],
     int? filesVisited,
+    this.foldersVisited = 0,
     this.readFailures = 0,
     this.unsupported = false,
     this.error,
@@ -18,6 +19,7 @@ class FakeSafDocumentLister implements SafDocumentLister {
 
   final List<SafAudioDocument> documents;
   final int filesVisited;
+  final int foldersVisited;
   final int readFailures;
   final bool unsupported;
   final Object? error;
@@ -36,6 +38,7 @@ class FakeSafDocumentLister implements SafDocumentLister {
     return SafScanResult(
       documents: documents,
       filesVisited: filesVisited,
+      foldersVisited: foldersVisited,
       readFailures: readFailures,
     );
   }

--- a/test/core/sources/local/folder_location_test.dart
+++ b/test/core/sources/local/folder_location_test.dart
@@ -34,5 +34,35 @@ void main() {
       final location = FolderLocation.parse('file:///home/me/Music');
       expect(location.kind, FolderLocationKind.filesystemPath);
     });
+
+    group('displayLabel', () {
+      test('reduces a SAF tree URI to its decoded document id', () {
+        final location = FolderLocation.parse(
+          'content://com.android.externalstorage.documents/tree/'
+          'primary%3AMusic%2Fmusi5',
+        );
+        expect(location.displayLabel, 'primary:Music/musi5');
+      });
+
+      test('reduces an SD-card SAF tree URI to its volume:path id', () {
+        final location = FolderLocation.parse(
+          'content://com.android.externalstorage.documents/tree/'
+          '1A2B-3C4D%3AMusic',
+        );
+        expect(location.displayLabel, '1A2B-3C4D:Music');
+      });
+
+      test('returns a filesystem path unchanged', () {
+        final location =
+            FolderLocation.parse('/storage/emulated/0/Music/musi5');
+        expect(location.displayLabel, '/storage/emulated/0/Music/musi5');
+      });
+
+      test('falls back to the raw value for an unexpected content URI', () {
+        final location =
+            FolderLocation.parse('content://authority/document/only');
+        expect(location.displayLabel, 'content://authority/document/only');
+      });
+    });
   });
 }

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -309,5 +309,54 @@ void main() {
       expect(scan.report.audioCandidates, 1);
       expect(scan.report.hadError, isFalse);
     });
+
+    test('a SAF scan reports folders visited, imported, and recursive',
+        () async {
+      // Two audio files across three folders (root + two subfolders), with one
+      // non-audio file the provider still counted as visited.
+      final saf = FakeSafDocumentLister(
+        documents: const <SafAudioDocument>[
+          SafAudioDocument(uri: 'content://doc/1', name: 'A.mp3'),
+          SafAudioDocument(uri: 'content://doc/2', name: 'B.flac'),
+        ],
+        filesVisited: 3,
+        foldersVisited: 3,
+      );
+      final source = LocalMusicSource(
+        folderPath: _safFolder,
+        scanner: _FakeScanner(const <String>[]),
+        safDocumentLister: saf,
+      );
+
+      final scan = await source.scanTracks();
+
+      expect(scan.tracks, hasLength(2));
+      expect(scan.report.filesVisited, 3);
+      expect(scan.report.foldersVisited, 3);
+      expect(scan.report.audioCandidates, 2);
+      expect(scan.report.importedTracks, 2);
+      // visited(3) - candidates(2) = 1 non-audio file skipped.
+      expect(scan.report.skippedUnsupported, 1);
+      expect(scan.report.recursive, isTrue);
+    });
+
+    test('a filesystem-path scan reports recursive with no folder count',
+        () async {
+      final source = LocalMusicSource(
+        folderPath: '/music',
+        scanner:
+            _FakeScanner(const <String>['/music/a.mp3', '/music/cover.jpg']),
+      );
+
+      final scan = await source.scanTracks();
+
+      expect(scan.report.isContentUri, isFalse);
+      expect(scan.report.importedTracks, 1);
+      expect(scan.report.audioCandidates, 1);
+      expect(scan.report.skippedUnsupported, 1);
+      expect(scan.report.recursive, isTrue);
+      // The filesystem walk reports files, not a directory count.
+      expect(scan.report.foldersVisited, 0);
+    });
   });
 }

--- a/test/core/sources/local/local_scan_diagnostics_test.dart
+++ b/test/core/sources/local/local_scan_diagnostics_test.dart
@@ -72,6 +72,26 @@ void main() {
       expect(summary, isNot(contains('error=')));
     });
 
+    test('includes folders, imported, and recursive counts', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 10,
+        foldersVisited: 4,
+        audioCandidates: 7,
+        importedTracks: 6,
+        skippedUnsupported: 3,
+        readFailures: 1,
+        recursive: true,
+      );
+
+      final summary = LocalScanDiagnostics.describe(report);
+
+      expect(summary, contains('folders=4'));
+      expect(summary, contains('imported=6'));
+      expect(summary, contains('recursive=yes'));
+    });
+
     test('summarizes a failure with the error kind', () {
       const report = LocalScanReport.failure(
         folderSelected: true,

--- a/test/core/sources/local/local_scan_report_test.dart
+++ b/test/core/sources/local/local_scan_report_test.dart
@@ -38,6 +38,39 @@ void main() {
       expect(report.readFailures, 0);
     });
 
+    test('carries folders-visited, imported, and recursive when given', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: true,
+        filesVisited: 12,
+        foldersVisited: 4,
+        audioCandidates: 9,
+        importedTracks: 8,
+        skippedUnsupported: 3,
+        readFailures: 0,
+        recursive: true,
+      );
+
+      expect(report.foldersVisited, 4);
+      expect(report.importedTracks, 8);
+      expect(report.recursive, isTrue);
+    });
+
+    test('defaults folders/imported to 0 and recursive to true', () {
+      const report = LocalScanReport(
+        folderSelected: true,
+        isContentUri: false,
+        filesVisited: 1,
+        audioCandidates: 1,
+        skippedUnsupported: 0,
+        readFailures: 0,
+      );
+
+      expect(report.foldersVisited, 0);
+      expect(report.importedTracks, 0);
+      expect(report.recursive, isTrue);
+    });
+
     test('a zero-count completed scan is distinct from a failure', () {
       const empty = LocalScanReport(
         folderSelected: true,

--- a/test/core/sources/local/method_channel_saf_document_lister_test.dart
+++ b/test/core/sources/local/method_channel_saf_document_lister_test.dart
@@ -40,6 +40,33 @@ void main() {
       expect(result.readFailures, 1);
     });
 
+    test('parses the folders-visited count when reported', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{'uri': 'content://doc/1', 'name': 'One.mp3'},
+          ],
+          'filesVisited': 1,
+          'foldersVisited': 3,
+          'readFailures': 0,
+        },
+      );
+
+      expect(result.foldersVisited, 3);
+    });
+
+    test('defaults folders-visited to 0 for an older native build', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{'uri': 'content://doc/1', 'name': 'One.mp3'},
+          ],
+        },
+      );
+
+      expect(result.foldersVisited, 0);
+    });
+
     test('falls back to the document count when no visited total is reported',
         () {
       // An older native build that returned only documents must still scan.

--- a/test/features/settings/source/local_music_controller_test.dart
+++ b/test/features/settings/source/local_music_controller_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/library/local_scan_report_provider.dart';
+import 'package:linthra/features/library/selected_folder_controller.dart';
+import 'package:linthra/features/settings/source/local_music_controller.dart';
+
+import '../../library/fake_audio_file_scanner.dart';
+import '../../library/fake_folder_picker_service.dart';
+
+ProviderContainer _container({
+  required FakeFolderPickerService picker,
+  required InMemorySelectedMusicFolderRepository folderRepo,
+  required InMemoryMusicLibraryRepository libraryRepo,
+  required FakeAudioFileScanner scanner,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      folderPickerServiceProvider.overrideWithValue(picker),
+      selectedMusicFolderRepositoryProvider.overrideWithValue(folderRepo),
+      musicLibraryRepositoryProvider.overrideWithValue(libraryRepo),
+      audioFileScannerProvider.overrideWithValue(scanner),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  setUp(LocalScanDiagnostics.reset);
+  tearDown(LocalScanDiagnostics.reset);
+
+  group('LocalMusicController', () {
+    test('pickFolder scans the chosen folder and imports its audio', () async {
+      final libraryRepo = InMemoryMusicLibraryRepository();
+      final container = _container(
+        picker: FakeFolderPickerService(folder: '/music'),
+        folderRepo: InMemorySelectedMusicFolderRepository(),
+        libraryRepo: libraryRepo,
+        scanner: FakeAudioFileScanner(
+          files: const <String>['/music/a.mp3', '/music/cover.jpg'],
+        ),
+      );
+
+      await container.read(localMusicControllerProvider.notifier).pickFolder();
+
+      final tracks = await libraryRepo.getAllTracks();
+      expect(tracks, hasLength(1));
+      expect(tracks.single.title, 'a');
+
+      final state = container.read(localMusicControllerProvider);
+      expect(state.busy, isFalse);
+      expect(state.isError, isFalse);
+      expect(state.message, contains('Added 1 track'));
+
+      // The selection was persisted and the scan report recorded.
+      expect(
+        container.read(selectedFolderControllerProvider).valueOrNull,
+        '/music',
+      );
+      expect(container.read(localScanReportProvider)?.importedTracks, 1);
+    });
+
+    test('a cancelled pick changes nothing and says nothing', () async {
+      final container = _container(
+        picker: FakeFolderPickerService(folder: null),
+        folderRepo: InMemorySelectedMusicFolderRepository(),
+        libraryRepo: InMemoryMusicLibraryRepository(),
+        scanner: FakeAudioFileScanner(),
+      );
+
+      await container.read(localMusicControllerProvider.notifier).pickFolder();
+
+      final state = container.read(localMusicControllerProvider);
+      expect(state.busy, isFalse);
+      expect(state.message, isNull);
+      expect(
+        container.read(selectedFolderControllerProvider).valueOrNull,
+        isNull,
+      );
+    });
+
+    test('a folder with no audio reports nothing playable, not an error',
+        () async {
+      final container = _container(
+        picker: FakeFolderPickerService(folder: '/music'),
+        folderRepo: InMemorySelectedMusicFolderRepository(),
+        libraryRepo: InMemoryMusicLibraryRepository(),
+        scanner: FakeAudioFileScanner(
+          files: const <String>['/music/cover.jpg', '/music/notes.txt'],
+        ),
+      );
+
+      await container.read(localMusicControllerProvider.notifier).pickFolder();
+
+      final state = container.read(localMusicControllerProvider);
+      expect(state.isError, isFalse);
+      expect(state.message, contains('No playable audio'));
+    });
+
+    test('rescan re-scans the selected folder without opening the picker',
+        () async {
+      final picker = FakeFolderPickerService(folder: '/music');
+      final libraryRepo = InMemoryMusicLibraryRepository();
+      final container = _container(
+        picker: picker,
+        folderRepo:
+            InMemorySelectedMusicFolderRepository(initialFolder: '/music'),
+        libraryRepo: libraryRepo,
+        scanner: FakeAudioFileScanner(files: const <String>['/music/a.mp3']),
+      );
+      await container.read(selectedFolderControllerProvider.future);
+
+      await container.read(localMusicControllerProvider.notifier).rescan();
+
+      expect(picker.pickCount, 0, reason: 'rescan must not open the chooser');
+      expect((await libraryRepo.getAllTracks()), hasLength(1));
+      expect(container.read(localMusicControllerProvider).message,
+          contains('Added 1 track'));
+    });
+
+    test('rescan with no folder selected is a no-op', () async {
+      final container = _container(
+        picker: FakeFolderPickerService(),
+        folderRepo: InMemorySelectedMusicFolderRepository(),
+        libraryRepo: InMemoryMusicLibraryRepository(),
+        scanner: FakeAudioFileScanner(),
+      );
+      await container.read(selectedFolderControllerProvider.future);
+
+      await container.read(localMusicControllerProvider.notifier).rescan();
+
+      expect(container.read(localMusicControllerProvider).message, isNull);
+    });
+
+    test('forget clears the selection, the local catalog, and the report',
+        () async {
+      final libraryRepo = InMemoryMusicLibraryRepository();
+      final container = _container(
+        picker: FakeFolderPickerService(folder: '/music'),
+        folderRepo: InMemorySelectedMusicFolderRepository(),
+        libraryRepo: libraryRepo,
+        scanner: FakeAudioFileScanner(files: const <String>['/music/a.mp3']),
+      );
+
+      await container.read(localMusicControllerProvider.notifier).pickFolder();
+      expect(await libraryRepo.getAllTracks(), hasLength(1));
+
+      await container.read(localMusicControllerProvider.notifier).forget();
+
+      expect(
+        container.read(selectedFolderControllerProvider).valueOrNull,
+        isNull,
+      );
+      expect(await libraryRepo.getAllTracks(), isEmpty);
+      expect(container.read(localScanReportProvider), isNull);
+      expect(
+        container.read(localMusicControllerProvider).message,
+        contains('forgotten'),
+      );
+    });
+  });
+}

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
+import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
+import 'package:linthra/features/settings/source/local_music_settings_section.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  String? initialFolder,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        selectedMusicFolderRepositoryProvider.overrideWithValue(
+          InMemorySelectedMusicFolderRepository(initialFolder: initialFolder),
+        ),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: LocalMusicSettingsSection()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('LocalMusicSettingsSection', () {
+    testWidgets('with no folder, invites the user to select one',
+        (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Local music'), findsOneWidget);
+      expect(find.text('No folder selected yet.'), findsOneWidget);
+      expect(find.text('Select a folder'), findsOneWidget);
+      // No rescan/forget actions until a folder exists.
+      expect(find.text('Rescan'), findsNothing);
+      expect(find.text('Forget folder'), findsNothing);
+    });
+
+    testWidgets('with a SAF folder, shows a friendly label and the actions',
+        (tester) async {
+      await _pump(
+        tester,
+        initialFolder: 'content://com.android.externalstorage.documents/tree/'
+            'primary%3AMusic%2Fmusi5',
+      );
+
+      // The opaque content:// URI is reduced to a recognizable folder label.
+      expect(find.text('primary:Music/musi5'), findsOneWidget);
+      expect(find.text('Rescan'), findsOneWidget);
+      expect(find.text('Change'), findsOneWidget);
+      expect(find.text('Forget folder'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Continuing #143 — "no music found", now reproduced on **internal** storage

PR #158 added a solid native SAF content‑resolver scan (`SafDocumentScanner.kt`), but a real‑device test against the #158 debug APK still failed — even on plain internal storage:

> selected `/storage/emulated/0/Music/musi5` → Rescan → **"No music found / Nothing playable turned up in: /storage/emulated/0/Music/musi5"**

That clean filesystem path (not a `content://` URI) in the empty state was the tell.

### Root cause — the SAF walk was never reached

The empty state renders the **persisted selection verbatim**, and it showed a raw path. The folder *chooser* — `file_picker`'s `getDirectoryPath()` — resolves an Android pick to a `/storage/...` path (via `getFullPathFromTreeUri`) and takes **no persistable URI grant**. So:

1. The stored selection is a raw path → classified as a filesystem path,
2. scanned with `dart:io`, which **scoped storage (Android 11+) blocks** for shared storage,
3. → empty result → "No music found".

The whole SAF traversal from #158 was effectively dead code, because the selection was never a `content://` URI. This is why it failed on internal storage **and** SD cards.

## What this changes

**Fix the chooser, not just the walk**
- Native `pickFolderTree` (`ACTION_OPEN_DOCUMENT_TREE`) returns the picked `content://` tree URI and **persists its read grant** in `onActivityResult` (survives reboot — the removable‑SD case).
- `MethodChannelSafFolderPicker` + `PlatformFolderPickerService` route Android to the native chooser; `file_picker` stays only as the **desktop** fallback. Selections are now content URIs, so the existing `SafDocumentScanner` walk runs (direct child files first, then nested artist/album folders). Playback already passes `content://` through unchanged.

**Local music as a real source (UX)**
- New **Settings ▸ Local music** card grouped with Jellyfin and Navidrome/Subsonic: select / rescan / change / forget, a friendly folder label (`primary:Music/musi5`, not the raw URI), and the last‑scan summary. The Library empty‑state "Change folder" mirrors it and now nudges a re‑pick for a stale path selection.
- Docs: [`docs/local-music.md`](./docs/local-music.md) clarifies **Local music** (a SAF folder on the device/SD card) vs **Offline downloads** (copies of *server* tracks) vs **Cache** (Linthra‑managed temp storage). "Forget folder" deletes nothing on disk.

**Secret‑free scan diagnostics** (counts only — never a path, URI, or file name)
- Adds **folders visited**, **imported tracks**, **recursive yes/no**, the **supported‑extensions** list, and an explicit **scan status** to the report — on top of the existing selected/persisted/files‑visited/audio/skipped/read‑failure counters.

**Resilience (addresses #158 review comments)**
- An unreadable selected **root** now surfaces an error instead of a successful empty scan that wipes the catalog — in both the SAF walk and the filesystem walk; only *subfolders* are skipped.

## Tests
Added/extended: native pickers (off‑Android routing), `FolderLocation.displayLabel`, folders/imported/recursive counters end‑to‑end, the channel‑reply parser, the diagnostics report lines, and the `LocalMusicController` (pick/rescan/forget) + the Settings card widget.

Local run (Flutter 3.27.4): `dart format` clean, `flutter analyze` clean, **`flutter test` — 1549 passing**. Kotlin/APK compile is covered by CI's debug‑APK job (no Android SDK in this env).

## Scope / constraints
- **No** version bump, **no** tag, **no** fdroiddata, **v0.1.2 untouched**. Targets the next version.
- Native changes are additive (one new channel method + a richer payload field).

Keeping **#143 open** until this is confirmed on a real device (internal storage **and** a removable SD card). Draft until that device check passes.

https://claude.ai/code/session_01JCZinf3guZTYr5kqzSRhK9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCZinf3guZTYr5kqzSRhK9)_