### PR TITLE
Settings: clarify Storage & offline, separate it from music sources

### DIFF
--- a/lib/features/settings/cache/cache_settings_section.dart
+++ b/lib/features/settings/cache/cache_settings_section.dart
@@ -41,15 +41,18 @@ class CacheSettingsSection extends ConsumerWidget {
                 Icon(Icons.sd_storage_outlined,
                     color: theme.colorScheme.primary),
                 const SizedBox(width: AppSpacing.sm),
-                Text('Offline cache', style: theme.textTheme.titleMedium),
+                Text('Offline downloads & cache',
+                    style: theme.textTheme.titleMedium),
               ],
             ),
             const SizedBox(height: AppSpacing.xs),
             Text(
-              'Downloads and smart pre-cached upcoming tracks stay under your '
-              'limit. When it fills, pre-cached then least-recently-played '
-              'unpinned tracks are removed first — pinned tracks and the track '
-              'playing now are kept.',
+              'Offline downloads are songs you download to play offline. Cache '
+              'is storage Linthra manages automatically to make playback faster '
+              'and available offline. Both share this space and stay under your '
+              'limit; when it fills, cached then least-recently-played tracks go '
+              'first — your offline downloads and the track playing now are '
+              'kept. (Local music lives on the device and is not stored here.)',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
               ),
@@ -97,7 +100,7 @@ class CacheSettingsSection extends ConsumerWidget {
                         ? null
                         : () => _clearCache(context, ref),
                     icon: const Icon(Icons.delete_sweep_outlined),
-                    label: const Text('Clear cache'),
+                    label: const Text('Free up storage'),
                   ),
                 ),
               ],
@@ -250,22 +253,26 @@ class _ClearCacheDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text('Clear offline cache'),
+      title: const Text('Free up storage'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           ListTile(
             contentPadding: EdgeInsets.zero,
             leading: const Icon(Icons.cleaning_services_outlined),
-            title: const Text('Clear unpinned'),
-            subtitle: const Text('Keep tracks you marked "Keep offline"'),
+            title: const Text('Clear cache'),
+            subtitle: const Text(
+              'Free cached tracks. Keeps songs you downloaded for offline.',
+            ),
             onTap: () => Navigator.of(context).pop(_ClearChoice.unpinned),
           ),
           ListTile(
             contentPadding: EdgeInsets.zero,
             leading: const Icon(Icons.delete_forever_outlined),
-            title: const Text('Clear all'),
-            subtitle: const Text('Remove every offline download'),
+            title: const Text('Clear offline downloads'),
+            subtitle: const Text(
+              'Remove every downloaded and cached track.',
+            ),
             onTap: () => Navigator.of(context).pop(_ClearChoice.all),
           ),
         ],

--- a/lib/features/settings/network/network_settings_section.dart
+++ b/lib/features/settings/network/network_settings_section.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import '../../downloads/download_providers.dart';
 
-/// The "Downloads & network" card on the Settings screen.
+/// The "Wi-Fi & mobile data" card on the Settings screen.
 ///
 /// Hosts the single mobile-data choice that the whole download/cache stack
 /// keys off: with it off (the safe default) downloads and smart pre-cache run
@@ -36,14 +36,14 @@ class NetworkSettingsSection extends StatelessWidget {
                 Icon(Icons.network_cell_outlined,
                     color: theme.colorScheme.primary),
                 const SizedBox(width: AppSpacing.sm),
-                Text('Downloads & network', style: theme.textTheme.titleMedium),
+                Text('Wi-Fi & mobile data', style: theme.textTheme.titleMedium),
               ],
             ),
             const SizedBox(height: AppSpacing.xs),
             Text(
-              'By default Linthra downloads and pre-caches only on Wi-Fi. Allow '
-              'mobile data to let downloads and smart pre-cache run on mobile '
-              'data too. The cache size limit always applies.',
+              'By default Linthra downloads and caches only on Wi-Fi. Allow '
+              'mobile data to let offline downloads and cache run on mobile '
+              'data too. The storage limit always applies.',
               style: theme.textTheme.bodySmall?.copyWith(color: muted),
             ),
             const SizedBox(height: AppSpacing.xs),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../app/dimens.dart';
 import '../../core/app_info.dart';
 import '../../shared/widgets/linthra_logo_mark.dart';
+import '../../shared/widgets/settings_section_header.dart';
 import 'bug_report/report_bug_settings_section.dart';
 import 'cache/cache_settings_section.dart';
 import 'diagnostics/diagnostics_settings_section.dart';
@@ -27,6 +28,11 @@ class SettingsScreen extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
         children: const [
+          // Music sources — where Linthra finds music to play. Local music is a
+          // source here, deliberately kept away from the Storage & offline
+          // group below so it is not confused with offline downloads.
+          SettingsSectionHeader('Music sources'),
+          SizedBox(height: AppSpacing.sm),
           JellyfinSettingsSection(),
           SizedBox(height: AppSpacing.md),
           SubsonicSettingsSection(),
@@ -36,15 +42,23 @@ class SettingsScreen extends StatelessWidget {
           DefaultProviderSettingsSection(),
           SizedBox(height: AppSpacing.md),
           PlaybackSourceStrategySettingsSection(),
-          SizedBox(height: AppSpacing.md),
+          SizedBox(height: AppSpacing.lg),
+          // Storage & offline — Linthra-managed on-device storage: songs you
+          // download for offline playback and the cache that speeds playback up.
+          SettingsSectionHeader('Storage & offline'),
+          SizedBox(height: AppSpacing.sm),
           CacheSettingsSection(),
-          SizedBox(height: AppSpacing.md),
-          PlaybackSettingsSection(),
           SizedBox(height: AppSpacing.md),
           NetworkSettingsSection(),
           SizedBox(height: AppSpacing.md),
           PrecacheSettingsSection(),
-          SizedBox(height: AppSpacing.md),
+          SizedBox(height: AppSpacing.lg),
+          SettingsSectionHeader('Playback'),
+          SizedBox(height: AppSpacing.sm),
+          PlaybackSettingsSection(),
+          SizedBox(height: AppSpacing.lg),
+          SettingsSectionHeader('Help & diagnostics'),
+          SizedBox(height: AppSpacing.sm),
           ReportBugSettingsSection(),
           SizedBox(height: AppSpacing.md),
           DiagnosticsSettingsSection(),

--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -17,10 +17,11 @@ import 'local_music_controller.dart';
 /// in sync. Everything it shows is read reactively from the selected-folder and
 /// last-scan providers; the card itself holds no scanning logic.
 ///
-/// "Local music" is deliberately distinct from two neighbours users conflate:
+/// "Local music" is deliberately distinct from two neighbours users conflate,
+/// both of which live under Settings ▸ Storage & offline:
 ///  - Offline downloads — copies Linthra makes for offline playback of a server
-///    track (Settings ▸ Offline / the download action), and
-///  - Cache — Linthra-managed temporary storage (Settings ▸ Cache).
+///    track (the download action), and
+///  - Cache — Linthra-managed storage that speeds playback up.
 /// This card only points Linthra at music that already lives on the device.
 class LocalMusicSettingsSection extends ConsumerWidget {
   const LocalMusicSettingsSection({super.key});

--- a/lib/shared/widgets/settings_section_header.dart
+++ b/lib/shared/widgets/settings_section_header.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../../app/dimens.dart';
+
+/// A small, quiet group heading used to organise the Settings screen into
+/// labelled sections (e.g. "Music sources", "Storage & offline").
+///
+/// It carries no behaviour — it only gives a run of setting cards a clear,
+/// scannable title so related options read as a group and unrelated ones (like
+/// music sources vs. storage) stop blurring together.
+class SettingsSectionHeader extends StatelessWidget {
+  const SettingsSectionHeader(this.title, {super.key});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xs,
+        AppSpacing.sm,
+        AppSpacing.xs,
+        AppSpacing.xs,
+      ),
+      child: Text(
+        title.toUpperCase(),
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/settings/cache/cache_settings_section_test.dart
+++ b/test/features/settings/cache/cache_settings_section_test.dart
@@ -34,7 +34,7 @@ void main() {
     testWidgets('shows usage against the default 4 GB limit', (tester) async {
       await pump(tester);
 
-      expect(find.text('Offline cache'), findsOneWidget);
+      expect(find.text('Offline downloads & cache'), findsOneWidget);
       expect(find.textContaining('of 4 GB used'), findsOneWidget);
       expect(find.textContaining('0 B of'), findsOneWidget);
     });
@@ -65,12 +65,42 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.textContaining('4 B of'), findsOneWidget);
 
-      await tester.tap(find.text('Clear cache'));
+      await tester.tap(find.text('Free up storage'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Clear all'));
+
+      // The dialog separates clearing the cache from removing downloads.
+      expect(find.text('Clear cache'), findsOneWidget);
+      expect(find.text('Clear offline downloads'), findsOneWidget);
+
+      await tester.tap(find.text('Clear offline downloads'));
       await tester.pumpAndSettle();
 
       expect(find.textContaining('0 B of'), findsOneWidget);
+    });
+
+    testWidgets('clear cache keeps pinned offline downloads', (tester) async {
+      final container = await pump(tester);
+
+      // Two downloads: one pinned ("Keep offline"), one not. Clearing the
+      // cache should free the unpinned one but keep the pinned download.
+      final repo = container.read(downloadRepositoryProvider);
+      await repo.requestDownload(
+        const Track(id: 'j1', title: 'Kept', uri: 'jellyfin:j1'),
+      );
+      await repo.requestDownload(
+        const Track(id: 'j2', title: 'Cached', uri: 'jellyfin:j2'),
+      );
+      await container.read(offlineCacheManagerProvider).setPinned('j1', true);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('8 B of'), findsOneWidget);
+
+      await tester.tap(find.text('Free up storage'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear cache'));
+      await tester.pumpAndSettle();
+
+      // The pinned 4 B download survives; the unpinned one is gone.
+      expect(find.textContaining('4 B of'), findsOneWidget);
     });
   });
 }

--- a/test/features/settings/network/network_settings_section_test.dart
+++ b/test/features/settings/network/network_settings_section_test.dart
@@ -34,7 +34,7 @@ void main() {
         (tester) async {
       await pump(tester);
 
-      expect(find.text('Downloads & network'), findsOneWidget);
+      expect(find.text('Wi-Fi & mobile data'), findsOneWidget);
       expect(
         find.text('Allow mobile data for downloads'),
         findsOneWidget,

--- a/test/shared/widgets/settings_section_header_test.dart
+++ b/test/shared/widgets/settings_section_header_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/settings_section_header.dart';
+
+void main() {
+  group('SettingsSectionHeader', () {
+    testWidgets('renders its title in upper case', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SettingsSectionHeader('Storage & offline'),
+          ),
+        ),
+      );
+
+      expect(find.text('STORAGE & OFFLINE'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

A small Settings UX cleanup. Now that Local music is a real music source, the
Settings screen lumped on-device storage in with where music comes from, and
the storage copy blurred three different things: offline downloads, the cache,
and local music. This PR labels and groups the screen so each reads clearly.

No playback, download/cache, or local-scanner logic changes. No new
permissions. No version bump, tag, or fdroiddata changes.

## Settings structure now

**Music sources** — Jellyfin · Navidrome/Subsonic · Local music · Default
source · Playback source strategy

**Storage & offline** — Offline downloads & cache · Wi-Fi & mobile data ·
Smart pre-cache

**Playback** · **Help & diagnostics** · About

## Changes

- **New `SettingsSectionHeader`** (reusable, in `shared/widgets`) and group
  headings on the Settings screen so music sources and storage no longer blur
  together. Local music stays a *source*, away from the storage group.
- **Cache card** retitled `Offline cache` → **`Offline downloads & cache`**,
  with copy that defines both terms — *offline downloads* are songs you
  download for offline playback; *cache* is storage Linthra manages
  automatically — and notes that **Local music is not stored here**.
- **Clear dialog** split into two clearly-named choices: **Clear cache**
  (frees cached tracks, keeps your downloads) and **Clear offline downloads**
  (removes everything). The card button that opens it is now **Free up
  storage** to avoid a duplicate "Clear cache" label.
- **Network card** retitled `Downloads & network` → **`Wi-Fi & mobile data`**
  with slightly clearer copy ("storage limit" rather than "cache size limit").

## Tests

- Updated the cache and network widget tests for the new labels.
- Added a cache test asserting **Clear cache** keeps a pinned ("Keep offline")
  download while freeing an unpinned one — verifying the two clear paths stay
  distinct.
- Added a widget test for `SettingsSectionHeader`.

Verification (Flutter 3.27.4, the pinned version):

- `dart format --set-exit-if-changed .` → clean
- `flutter analyze` → No issues found
- `flutter test` → all 1551 tests pass

https://claude.ai/code/session_011xD1rCEBTFExAJutLSAryt

---
_Generated by [Claude Code](https://claude.ai/code/session_011xD1rCEBTFExAJutLSAryt)_