### PR TITLE
feat(local): index local music with audio tags and clean fallbacks

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -2,6 +2,7 @@ package io.github.thezupzup.linthra
 
 import android.content.Context
 import android.content.Intent
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.DocumentsContract
 import io.flutter.plugin.common.MethodChannel
@@ -117,11 +118,23 @@ class SafDocumentScanner(private val context: Context) {
                                     treeUri,
                                     docId,
                                 )
+                                // Read the file's audio tags so a local track
+                                // indexes with a real title/artist/album/duration
+                                // like a server track. Best-effort: a file whose
+                                // tags can't be read just omits them and the Dart
+                                // mapper falls back to the display name.
+                                val metadata = readMetadata(docUri)
                                 documents.add(
                                     mapOf(
                                         "uri" to docUri.toString(),
                                         "name" to name,
                                         "mime" to mime,
+                                        "title" to metadata["title"],
+                                        "artist" to metadata["artist"],
+                                        "albumArtist" to metadata["albumArtist"],
+                                        "album" to metadata["album"],
+                                        "track" to metadata["track"],
+                                        "durationMs" to metadata["durationMs"],
                                     ),
                                 )
                             }
@@ -156,6 +169,53 @@ class SafDocumentScanner(private val context: Context) {
         }
         val lower = name.lowercase()
         return AUDIO_EXTENSIONS.any { lower.endsWith(it) }
+    }
+
+    /**
+     * Reads the audio tags for one document through [MediaMetadataRetriever],
+     * which works on a content:// URI under the existing tree grant — no extra
+     * permission, no broad storage access. Returns the raw tag strings (title,
+     * artist, album artist, album, track, duration in ms); the Dart side parses
+     * the track ("3/12") and duration values.
+     *
+     * Deliberately total: any failure (a malformed file, an unreadable entry, a
+     * codec the device can't open) returns an empty map so the walk keeps going
+     * and the track still indexes from its display name. The retriever is always
+     * released, even on failure, so no native handle leaks across a large scan.
+     */
+    private fun readMetadata(uri: Uri): Map<String, String?> {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(context, uri)
+            mapOf(
+                "title" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_TITLE,
+                ),
+                "artist" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_ARTIST,
+                ),
+                "albumArtist" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST,
+                ),
+                "album" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_ALBUM,
+                ),
+                "track" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_CD_TRACK_NUMBER,
+                ),
+                "durationMs" to retriever.extractMetadata(
+                    MediaMetadataRetriever.METADATA_KEY_DURATION,
+                ),
+            )
+        } catch (e: Exception) {
+            emptyMap()
+        } finally {
+            try {
+                retriever.release()
+            } catch (e: Exception) {
+                // Releasing a retriever that never opened can throw; ignore.
+            }
+        }
     }
 
     companion object {

--- a/docs/library.md
+++ b/docs/library.md
@@ -91,11 +91,13 @@ only at play time.
 
 - **Metadata quality depends on the source.** Grouping is only as good as the
   album/artist tags the source provides.
-- **Local files may lack album/artist tags.** Linthra does not parse on-device
-  tag metadata yet, so local tracks usually have no album or artist and fold
-  into a single **Unknown Album** / **Unknown Artist**. Local files that *do*
-  arrive with album/artist set (e.g. via a future tag-parsing step) will group
-  normally.
+- **Local files group from their tags or folders.** Linthra reads on-device
+  audio tags (title/artist/album/track number/duration) during the scan and, when
+  a tag is missing, falls back to the file name and the `…/Artist/Album/Track`
+  folder layout — so a tagged or well-organized local library groups normally. A
+  file with neither tags nor folder context still folds into a single
+  **Unknown Album** / **Unknown Artist**. Embedded cover art for local files is a
+  separate follow-up (see [local-music.md](./local-music.md)).
 - **Artwork may be missing** for some tracks (notably local files); a calm
   placeholder is shown instead, and the layout never jumps.
 - **No stable source album/artist IDs yet.** Grouping uses folded names because

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -29,9 +29,26 @@ permission is requested.
   content type, so an oddly-named file the platform still recognises as audio is
   not dropped.
 
-Tag reading (album/artist/artwork/duration) for local files is a separate
-follow-up; until then local tracks group under **Unknown Album / Artist** (see
-[library.md](./library.md)).
+### Track metadata (tags)
+
+Local tracks index like a real source, not a flat file list:
+
+- **Audio tags are read** during the scan — title, artist, album, album artist,
+  track number, and duration — so a tagged file shows and groups exactly like a
+  Jellyfin / Navidrome track. On Android the picked folder is read through the
+  content resolver, and each file's tags are read there too (no extra
+  permission — the same folder grant covers it).
+- **Clean fallback when tags are missing.** A file with no (or partial) tags
+  never shows an ugly path: the title and any leading track number come from the
+  file name (`01 - Holocene.flac` → track 1, "Holocene"), and the artist/album
+  come from the conventional `…/Artist/Album/Track` folders. Each field falls
+  back on its own, so a half-tagged file still gets the best of both. A file with
+  nothing to go on still folds into **Unknown Album / Artist** (see
+  [library.md](./library.md)).
+- **Embedded cover art** for local files is a separate follow-up; until then a
+  local track with no `artworkUri` shows the calm placeholder. (A server copy's
+  cover is still used when the same song is also on a server — see
+  [unified-library.md](./unified-library.md).)
 
 ## How it works (and why it's reliable)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -31,7 +31,7 @@ persisted catalog.
 
 | Provider              | sourceId   | Stream | Cache | Favorites | Playlists | Lyrics | Cast |
 | --------------------- | ---------- | :----: | :---: | :-------: | :-------: | :----: | :--: |
-| On this device        | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   —    |  —   |
+| Local music           | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   —    |  —   |
 | Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
 | Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  ✅  |
 
@@ -52,9 +52,14 @@ rules, and the "Playing from …" source indicator.
 ## Local files
 
 Pick a folder with the Android Storage Access Framework picker and scan it.
-Tracks play from their on-device path. The chosen folder and the scanned catalog
-survive a restart. No broad storage permission is requested. On-device files
-cannot be cast (a receiver can't reach a file on your phone).
+Tracks play from their on-device path. The scan **reads each file's audio tags**
+(title/artist/album/track number/duration) so a local library indexes and groups
+like a server source, falling back cleanly to the file name and
+`…/Artist/Album/Track` folders when a tag is missing — see
+[local-music.md](local-music.md). The chosen folder and the scanned catalog
+survive a restart. No broad storage permission is requested (tags are read
+through the same folder grant). Embedded cover art is a documented follow-up.
+On-device files cannot be cast (a receiver can't reach a file on your phone).
 
 ## Jellyfin
 

--- a/docs/unified-library.md
+++ b/docs/unified-library.md
@@ -73,7 +73,8 @@ next reload. (Re-syncing a server brings its copy back, exactly as before.)
 ### Artwork: prefer the displayed copy, fall back to the best available
 
 The displayed copy is the default/preferred provider's — but some providers
-(Subsonic/Navidrome today, untagged local files) carry **no** `artworkUri`. If
+(Subsonic/Navidrome today, local files — whose embedded cover art is a
+follow-up) carry **no** `artworkUri`. If
 the row simply showed the preferred copy's cover, unifying a song that the
 preferred provider lacks a cover for would *blank* a cover another copy still
 has. So `LogicalTrack.displayTrack` keeps the preferred copy's id and uri (play,

--- a/docs/volume-normalization.md
+++ b/docs/volume-normalization.md
@@ -58,7 +58,7 @@ Normalization applies to whatever loudness metadata a `Track` carries in its
 
 | Source                | ReplayGain populated? | Notes |
 | --------------------- | --------------------- | ----- |
-| On this device (local) | Not yet               | Local tag parsing (ID3 `TXXX:REPLAYGAIN_*`, Vorbis `REPLAYGAIN_*`/`R128_*`) has not landed yet (see `lib/core/sources/local/local_track_mapper.dart`). When it does, the gain/peak read from tags flows straight into `Track.replayGain`. |
+| Local music (local)   | Not yet               | Local tag reading now populates title/artist/album/duration/track number (see `lib/core/sources/local/local_track_mapper.dart`), but the ReplayGain-specific tags (ID3 `TXXX:REPLAYGAIN_*`, Vorbis `REPLAYGAIN_*`/`R128_*`) aren't extracted yet. When they are, the gain/peak read from tags flows straight into `Track.replayGain`. |
 | Jellyfin              | Not yet               | The current item DTO doesn't carry a normalization-gain field; reading one is a follow-up and is out of scope here ("no provider expansion"). |
 | Navidrome / Subsonic  | Not yet               | Same as above. |
 

--- a/lib/core/catalog/source_capability.dart
+++ b/lib/core/catalog/source_capability.dart
@@ -9,7 +9,7 @@ import 'track_identity.dart';
 enum SourceProviderType {
   jellyfin('Jellyfin'),
   subsonic('Navidrome / Subsonic'),
-  local('Local files'),
+  local('Local music'),
   unknown('Unknown source');
 
   const SourceProviderType(this.displayName);

--- a/lib/core/services/music_source.dart
+++ b/lib/core/services/music_source.dart
@@ -17,7 +17,7 @@ abstract interface class MusicSource {
   /// Stable identifier for this source, e.g. `'local'` or `'jellyfin:<id>'`.
   String get id;
 
-  /// Human-readable name for settings/UI, e.g. "On this device".
+  /// Human-readable name for settings/UI, e.g. "Local music".
   String get displayName;
 
   Future<List<Track>> fetchTracks();

--- a/lib/core/services/playback_source_label.dart
+++ b/lib/core/services/playback_source_label.dart
@@ -11,12 +11,12 @@ import '../sources/music_provider.dart';
 /// vs a live stream vs an on-device file).
 ///
 /// Security: only fixed, non-identifying display names are ever returned —
-/// "Navidrome", "Jellyfin", "Local files", "Cache", or "Unknown source". A
+/// "Navidrome", "Jellyfin", "Local music", "Cache", or "Unknown source". A
 /// server URL, IP, username, token, or file path is never exposed.
 abstract final class PlaybackSourceLabel {
   static const String navidrome = 'Navidrome';
   static const String jellyfin = 'Jellyfin';
-  static const String local = 'Local files';
+  static const String local = 'Local music';
   static const String cache = 'Cache';
   static const String unknown = 'Unknown source';
 
@@ -24,7 +24,7 @@ abstract final class PlaybackSourceLabel {
   ///
   /// A cached copy reads as "Cache" regardless of which server it came from
   /// (that is what the listener is hearing); an on-device file reads as "Local
-  /// files"; a live stream reads as the owning server's safe name.
+  /// music"; a live stream reads as the owning server's safe name.
   static String of(
       {required String? trackUri, required PlaybackSource? source}) {
     if (source == null) return unknown;

--- a/lib/core/sources/local/local_audio_metadata.dart
+++ b/lib/core/sources/local/local_audio_metadata.dart
@@ -1,0 +1,55 @@
+/// Audio tags read from an on-device item (an Android SAF document via the
+/// native content resolver, or — in a future follow-up — a desktop file).
+///
+/// Every field is optional: a `null` value means "this source had no
+/// trustworthy value for this field", so [LocalTrackMapper] falls back to a
+/// filename/folder-derived value rather than showing a blank or an ugly path.
+/// Blank-string normalization (treating `''`/whitespace as absent) is the
+/// mapper's job, so this stays a dumb, source-agnostic holder that is trivial to
+/// construct in tests and from the native reply alike.
+class LocalAudioMetadata {
+  const LocalAudioMetadata({
+    this.title,
+    this.artist,
+    this.albumArtist,
+    this.album,
+    this.trackNumber,
+    this.duration,
+  });
+
+  /// The track title (e.g. ID3 `TIT2`).
+  final String? title;
+
+  /// The performing/track artist (e.g. ID3 `TPE1`).
+  final String? artist;
+
+  /// The album artist (e.g. ID3 `TPE2`), preferred over [artist] for grouping
+  /// so a single-artist album never splits and the mapping matches the
+  /// Jellyfin/Subsonic sources (which also key a track's displayed artist off
+  /// the album artist when present). See [primaryArtist].
+  final String? albumArtist;
+
+  /// The album title (e.g. ID3 `TALB`).
+  final String? album;
+
+  /// The 1-based track number within its album, when known.
+  final int? trackNumber;
+
+  /// The track's real duration, when the source reported one. Distinct from the
+  /// filename — a filename can never reveal a duration, so this only comes from
+  /// actual tag/stream metadata.
+  final Duration? duration;
+
+  /// Whether every field is absent — i.e. the source carried no usable tag at
+  /// all, so the mapper relies entirely on filename/folder fallback.
+  bool get isEmpty =>
+      title == null &&
+      artist == null &&
+      albumArtist == null &&
+      album == null &&
+      trackNumber == null &&
+      duration == null;
+
+  /// A metadata holder with no fields set.
+  static const LocalAudioMetadata empty = LocalAudioMetadata();
+}

--- a/lib/core/sources/local/local_metadata_reader.dart
+++ b/lib/core/sources/local/local_metadata_reader.dart
@@ -1,0 +1,29 @@
+import 'local_audio_metadata.dart';
+
+/// Reads audio tags from an on-device file *path* (the desktop/Linux and
+/// resolved-path case), the filesystem counterpart of the SAF metadata the
+/// native content-resolver walk returns.
+///
+/// This is a seam, deliberately mirroring [SafDocumentLister]: the source
+/// depends on this interface, never on a concrete reader, so tag reading can be
+/// added without touching the scanner, source, or mapper. The production default
+/// is [UnsupportedLocalMetadataReader], which reads nothing — so a filesystem
+/// scan currently relies on filename/folder fallback, exactly as before. A real
+/// pure-Dart reader (ID3/Vorbis/MP4) can slot in here later as a focused
+/// follow-up without changing any caller.
+abstract interface class LocalMetadataReader {
+  /// Returns the tags for the file at [path], or null when none could be read
+  /// (unsupported here, an unreadable file, or a format without tags). Must
+  /// never throw: an unreadable file is a null result, not a failed scan.
+  Future<LocalAudioMetadata?> readFromPath(String path);
+}
+
+/// The default [LocalMetadataReader] for platforms/builds without a real
+/// filesystem tag reader (desktop today, and tests): it reads nothing, so the
+/// mapper falls back to filename/folder metadata and behaviour is unchanged.
+class UnsupportedLocalMetadataReader implements LocalMetadataReader {
+  const UnsupportedLocalMetadataReader();
+
+  @override
+  Future<LocalAudioMetadata?> readFromPath(String path) async => null;
+}

--- a/lib/core/sources/local/local_music_source.dart
+++ b/lib/core/sources/local/local_music_source.dart
@@ -1,3 +1,4 @@
+import '../../catalog/library_grouping.dart';
 import '../../models/album.dart';
 import '../../models/artist.dart';
 import '../../models/track.dart';
@@ -6,6 +7,8 @@ import '../../services/music_source.dart';
 import 'audio_file_scanner.dart';
 import 'audio_file_types.dart';
 import 'folder_location.dart';
+import 'local_audio_metadata.dart';
+import 'local_metadata_reader.dart';
 import 'local_scan_report.dart';
 import 'local_track_mapper.dart';
 import 'saf_document_lister.dart';
@@ -24,28 +27,34 @@ class LocalScan {
 /// A [MusicSource] that scans audio files already present on the device.
 ///
 /// This is the first concrete source and the reference implementation of the
-/// contract. It does no tag parsing yet: a scan keeps only recognized audio
-/// files (see [AudioFileTypes]) and maps each one to a [Track] via
-/// [LocalTrackMapper]. Album/artist grouping is therefore empty until tag
-/// reading lands.
+/// contract. A scan keeps only recognized audio files (see [AudioFileTypes]) and
+/// maps each one to a [Track] via [LocalTrackMapper], which reads the file's
+/// audio tags (title/artist/album/duration/track number) when they are available
+/// and falls back to a clean filename/folder derivation otherwise — so a local
+/// library indexes and groups like a real source rather than a flat file list.
 ///
 /// Two storage strategies sit behind it, chosen by what the picker returned:
 ///  - a filesystem path (desktop/Linux, and any path Android hands back) is
-///    walked by an [AudioFileScanner];
+///    walked by an [AudioFileScanner]; per-file tags come from the injected
+///    [LocalMetadataReader] (none by default — see [UnsupportedLocalMetadataReader]
+///    — so filesystem scans currently rely on filename/folder metadata);
 ///  - an Android SAF `content://` tree URI is traversed through the content
-///    resolver by a [SafDocumentLister], the scoped-storage-friendly path. When
-///    that traversal isn't available on the build, it falls back to the
-///    filesystem scanner so behaviour never regresses.
+///    resolver by a [SafDocumentLister], the scoped-storage-friendly path, which
+///    also reads each document's tags natively. When that traversal isn't
+///    available on the build, it falls back to the filesystem scanner so
+///    behaviour never regresses.
 ///
-/// Both seams are injectable so scanning stays testable without a real disk,
-/// device, or platform channel.
+/// Every seam is injectable so scanning and tag reading stay testable without a
+/// real disk, device, or platform channel.
 class LocalMusicSource implements MusicSource {
   const LocalMusicSource({
     required this.folderPath,
     AudioFileScanner scanner = const IoAudioFileScanner(),
     SafDocumentLister safDocumentLister = const UnsupportedSafDocumentLister(),
+    LocalMetadataReader metadataReader = const UnsupportedLocalMetadataReader(),
   })  : _scanner = scanner,
-        _safDocumentLister = safDocumentLister;
+        _safDocumentLister = safDocumentLister,
+        _metadataReader = metadataReader;
 
   /// Absolute path or SAF tree URI of the folder to scan, or `null` when the
   /// user has not chosen one yet — in which case scans simply return nothing.
@@ -53,12 +62,13 @@ class LocalMusicSource implements MusicSource {
 
   final AudioFileScanner _scanner;
   final SafDocumentLister _safDocumentLister;
+  final LocalMetadataReader _metadataReader;
 
   @override
   String get id => 'local';
 
   @override
-  String get displayName => 'On this device';
+  String get displayName => 'Local music';
 
   @override
   Future<List<Track>> fetchTracks() async => (await scanTracks()).tracks;
@@ -149,7 +159,15 @@ class LocalMusicSource implements MusicSource {
     final List<Track> tracks = <Track>[];
     for (final String path in files) {
       if (AudioFileTypes.isSupported(path)) {
-        tracks.add(LocalTrackMapper.fromPath(path));
+        // A reader that can't read this file (or this build) returns null, so
+        // the mapper falls back to the filename/folder metadata.
+        final LocalAudioMetadata? metadata =
+            await _metadataReader.readFromPath(path);
+        tracks.add(LocalTrackMapper.fromPath(
+          path,
+          metadata: metadata,
+          scanRoot: folder,
+        ));
       }
     }
     final int visited = files.length;
@@ -170,14 +188,17 @@ class LocalMusicSource implements MusicSource {
     );
   }
 
-  /// Empty until tag parsing exists: albums can't be grouped from file paths
-  /// alone.
+  /// The albums present in the scanned folder, grouped from the tracks' tags the
+  /// same way the unified library groups every source. Empty when nothing was
+  /// scanned. (The library catalog derives its own groupings from the stored
+  /// tracks; this keeps the source contract honest for any direct consumer.)
   @override
-  Future<List<Album>> fetchAlbums() async => const <Album>[];
+  Future<List<Album>> fetchAlbums() async => groupAlbums(await fetchTracks());
 
-  /// Empty until tag parsing exists — see [fetchAlbums].
+  /// The artists present in the scanned folder — see [fetchAlbums].
   @override
-  Future<List<Artist>> fetchArtists() async => const <Artist>[];
+  Future<List<Artist>> fetchArtists() async =>
+      groupArtists(await fetchTracks());
 
   @override
   Future<Uri?> resolvePlayableUri(Track track) async =>

--- a/lib/core/sources/local/local_track_mapper.dart
+++ b/lib/core/sources/local/local_track_mapper.dart
@@ -1,36 +1,172 @@
 import 'package:path/path.dart' as p;
 
 import '../../models/track.dart';
+import 'local_audio_metadata.dart';
 import 'saf_document_lister.dart';
 
 /// Builds a [Track] from an on-device source — a local file path or an Android
-/// SAF document.
+/// SAF document — merging any audio tags the source read over a clean
+/// filename/folder fallback.
 ///
 /// This is intentionally the *only* place that turns an on-device item into a
-/// [Track], so richer metadata (ID3/Vorbis tags, embedded artwork, real
-/// duration) can be added here later without changing the scanner or source.
+/// [Track], so the metadata story lives in one tested spot.
+///
+/// ## Tags first, then a clean fallback
+///
+/// When [LocalAudioMetadata] is present (the native SAF walk read tags, or a
+/// future desktop reader did), its fields win — so a tagged file indexes with a
+/// proper title, artist, album, duration, and track number, exactly like a
+/// Jellyfin/Subsonic track. Each field falls back **independently** when its tag
+/// is missing or blank, so a half-tagged file still gets the best of both.
+///
+/// The fallback never shows an ugly path. From the file's own name it derives a
+/// leading track number and a clean title (`01 - Holocene` → #1, "Holocene");
+/// from a filesystem layout it reads the conventional `…/Artist/Album/Track`
+/// folders for the artist and album. (A SAF content URI exposes no folder path,
+/// so SAF album/artist come only from tags — usually present on Android.)
+///
+/// The path / content URI is always both the stable [Track.id] and the
+/// [Track.uri], independent of the (mutable) tags, so a re-scan after an edit
+/// keeps the same identity.
 abstract final class LocalTrackMapper {
-  /// Maps [path] to a [Track] using only what the path itself reveals.
+  /// Maps [path] to a [Track].
   ///
-  /// The title is the file name without its extension. Artist, album and
-  /// duration are left unset until tag parsing lands. The path doubles as both
-  /// the stable [Track.id] and the [Track.uri].
-  static Track fromPath(String path) {
-    return Track(
+  /// [metadata] are the file's tags when a reader provided them; [scanRoot] is
+  /// the scanned folder, used to read the `Artist/Album` folders *relative to
+  /// it* (so the scan root itself is never mistaken for an album). Both are
+  /// optional: with neither, the title and any leading track number still come
+  /// from the file name.
+  static Track fromPath(
+    String path, {
+    LocalAudioMetadata? metadata,
+    String? scanRoot,
+  }) {
+    final String base = p.basenameWithoutExtension(path);
+    final _FolderNames folders = _folderNamesFor(path, scanRoot);
+    return _build(
       id: path,
-      title: p.basenameWithoutExtension(path),
       uri: path,
+      nameWithoutExtension: base,
+      metadata: metadata,
+      folderArtist: folders.artist,
+      folderAlbum: folders.album,
     );
   }
 
-  /// Maps a SAF [document] to a [Track]. The `content://` URI is both the
-  /// stable id and the playable uri; the title is the display name without its
-  /// extension (the URI alone has no reliable name to show).
+  /// Maps a SAF [document] to a [Track]. The `content://` URI is both the stable
+  /// id and the playable uri; tags come from [SafAudioDocument.metadata] and the
+  /// title/track-number fallback from the display name.
   static Track fromSafDocument(SafAudioDocument document) {
-    return Track(
+    return _build(
       id: document.uri,
-      title: p.basenameWithoutExtension(document.name),
       uri: document.uri,
+      nameWithoutExtension: p.basenameWithoutExtension(document.name),
+      metadata: document.metadata,
     );
   }
+
+  /// Merges [metadata] over the name/folder fallback into a [Track]. Every field
+  /// falls back independently, and a blank tag value is treated as absent.
+  static Track _build({
+    required String id,
+    required String uri,
+    required String nameWithoutExtension,
+    LocalAudioMetadata? metadata,
+    String? folderArtist,
+    String? folderAlbum,
+  }) {
+    final _NameParts parts = _parseName(nameWithoutExtension);
+    return Track(
+      id: id,
+      uri: uri,
+      title: _firstNonBlank(<String?>[metadata?.title, parts.title]) ??
+          parts.title,
+      artistName: _firstNonBlank(<String?>[
+        metadata?.albumArtist,
+        metadata?.artist,
+        folderArtist,
+      ]),
+      albumName: _firstNonBlank(<String?>[metadata?.album, folderAlbum]),
+      trackNumber: metadata?.trackNumber ?? parts.trackNumber,
+      duration: metadata?.duration ?? Duration.zero,
+    );
+  }
+
+  /// A leading track number (`01 - `, `01.`, `01 `, …) and the remaining title,
+  /// parsed from a file/display name without its extension.
+  ///
+  /// A number is only taken when a separator follows it and a non-empty title
+  /// remains, so a name that *is* a number ("1984") or has no separator keeps
+  /// its whole self as the title and reports no track number. A real tag title,
+  /// when present, is used verbatim instead — this only shapes the fallback.
+  static _NameParts _parseName(String nameWithoutExtension) {
+    final String trimmed = nameWithoutExtension.trim();
+    final RegExpMatch? match = _leadingTrackNumber.firstMatch(trimmed);
+    if (match != null) {
+      final String rest = match.group(2)!.trim();
+      if (rest.isNotEmpty) {
+        return _NameParts(int.tryParse(match.group(1)!), rest);
+      }
+    }
+    // No usable leading number: the whole (trimmed) name is the title. Guard the
+    // pathological empty name so a track is never titled "".
+    return _NameParts(null, trimmed.isEmpty ? nameWithoutExtension : trimmed);
+  }
+
+  /// `1`–`3` leading digits, then at least one separator, then a non-empty rest.
+  /// The separators cover the common `01 - `, `01.`, `01_`, `01)` and bare-space
+  /// conventions without stripping a number that is part of the title.
+  static final RegExp _leadingTrackNumber =
+      RegExp(r'^(\d{1,3})[\s._\-)\]]+(.+)$');
+
+  /// The conventional `Artist/Album` folder names for [path], read *relative to*
+  /// [scanRoot] so the scanned root is never treated as an album/artist. Returns
+  /// empty names when there is no folder context (no root, or the file is not
+  /// under it — e.g. a content-URI scan resolved to a path elsewhere).
+  static _FolderNames _folderNamesFor(String path, String? scanRoot) {
+    if (scanRoot == null || scanRoot.isEmpty) return const _FolderNames();
+    final String root = p.normalize(scanRoot);
+    final String full = p.normalize(path);
+    if (!p.isWithin(root, full)) return const _FolderNames();
+    final List<String> segments = p.split(p.relative(full, from: root));
+    // Drop the file name itself; what's left are the folders below the root.
+    final List<String> folders = segments.sublist(0, segments.length - 1);
+    final String? album =
+        folders.isNotEmpty ? _blankToNull(folders.last) : null;
+    final String? artist =
+        folders.length >= 2 ? _blankToNull(folders[folders.length - 2]) : null;
+    return _FolderNames(artist: artist, album: album);
+  }
+
+  /// The first non-null, non-blank (after trimming) value, or null when none.
+  static String? _firstNonBlank(List<String?> values) {
+    for (final String? value in values) {
+      final String? cleaned = _blankToNull(value);
+      if (cleaned != null) return cleaned;
+    }
+    return null;
+  }
+
+  /// [value] trimmed, or null when it is null or blank.
+  static String? _blankToNull(String? value) {
+    if (value == null) return null;
+    final String trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+/// A leading track number and the remaining title parsed from a name.
+class _NameParts {
+  const _NameParts(this.trackNumber, this.title);
+
+  final int? trackNumber;
+  final String title;
+}
+
+/// The conventional `Artist/Album` folder names derived from a file's path.
+class _FolderNames {
+  const _FolderNames({this.artist, this.album});
+
+  final String? artist;
+  final String? album;
 }

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 
 import 'folder_scan_exception.dart';
+import 'local_audio_metadata.dart';
 import 'saf_document_lister.dart';
 
 /// A [SafDocumentLister] backed by a platform method channel into native
@@ -73,6 +74,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
               uri: uri,
               name: name,
               mimeType: mime is String ? mime : null,
+              metadata: parseMetadata(entry),
             ));
           }
         }
@@ -89,5 +91,73 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
       foldersVisited: foldersVisited is int ? foldersVisited : 0,
       readFailures: readFailures is int ? readFailures : 0,
     );
+  }
+
+  /// Builds the [LocalAudioMetadata] for one document [entry] from the optional
+  /// tag fields the native walk attached (`title`, `artist`, `albumArtist`,
+  /// `album`, `track`, `durationMs`), or null when none are present — an older
+  /// native build, or a file the platform could not read tags from.
+  ///
+  /// Pure and tolerant so it is unit-testable and never throws on a malformed or
+  /// partial reply: a non-string text field, a `track` like `"3/12"`, and a
+  /// `durationMs` sent as either an int or a numeric string are all handled, and
+  /// a blank or unparseable value simply drops to null (the mapper then falls
+  /// back to the file name).
+  static LocalAudioMetadata? parseMetadata(Map<Object?, Object?> entry) {
+    final String? title = _string(entry['title']);
+    final String? artist = _string(entry['artist']);
+    final String? albumArtist = _string(entry['albumArtist']);
+    final String? album = _string(entry['album']);
+    final int? trackNumber = _trackNumber(entry['track']);
+    final Duration? duration = _durationMs(entry['durationMs']);
+    if (title == null &&
+        artist == null &&
+        albumArtist == null &&
+        album == null &&
+        trackNumber == null &&
+        duration == null) {
+      return null;
+    }
+    return LocalAudioMetadata(
+      title: title,
+      artist: artist,
+      albumArtist: albumArtist,
+      album: album,
+      trackNumber: trackNumber,
+      duration: duration,
+    );
+  }
+
+  /// A non-blank trimmed string, or null for anything else (absent, non-string,
+  /// or blank).
+  static String? _string(Object? value) {
+    if (value is! String) return null;
+    final String trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  /// The leading integer of a track field, which a tagger may store as `"3"` or
+  /// `"3/12"` (track/total). Non-positive or unparseable values are null.
+  static int? _trackNumber(Object? value) {
+    if (value is int) return value > 0 ? value : null;
+    if (value is! String) return null;
+    final RegExpMatch? match = RegExp(r'\d+').firstMatch(value);
+    if (match == null) return null;
+    final int? parsed = int.tryParse(match.group(0)!);
+    return (parsed != null && parsed > 0) ? parsed : null;
+  }
+
+  /// A duration from a milliseconds value sent as an int or a numeric string.
+  /// Zero/negative/unparseable maps to null (unknown), so the mapper leaves the
+  /// duration at zero rather than inventing one.
+  static Duration? _durationMs(Object? value) {
+    int? ms;
+    if (value is int) {
+      ms = value;
+    } else if (value is String) {
+      ms = int.tryParse(value.trim());
+    }
+    if (ms == null || ms <= 0) return null;
+    return Duration(milliseconds: ms);
   }
 }

--- a/lib/core/sources/local/saf_document_lister.dart
+++ b/lib/core/sources/local/saf_document_lister.dart
@@ -1,3 +1,5 @@
+import 'local_audio_metadata.dart';
+
 /// One audio document discovered by walking an Android SAF tree.
 ///
 /// Carries the `content://` document [uri] the platform can open, the display
@@ -6,11 +8,18 @@
 /// or file type; the MIME type is kept so an audio file the platform recognises
 /// by content (e.g. `audio/mpeg`) is still treated as audio even when its name
 /// lacks a known extension — the catalog needs both signals to recognise audio.
+///
+/// [metadata] carries the audio tags the native walk extracted for this document
+/// (title/artist/album/duration/track number), or null when none were available
+/// — an older native build, an unreadable file, or a format with no tags. It is
+/// only a *hint*: [LocalTrackMapper] still falls back to the name when a field is
+/// missing, so a document without metadata indexes exactly as before.
 class SafAudioDocument {
   const SafAudioDocument({
     required this.uri,
     required this.name,
     this.mimeType,
+    this.metadata,
   });
 
   /// The `content://` document URI, openable by the platform and stable enough
@@ -23,6 +32,10 @@ class SafAudioDocument {
   /// The provider-reported MIME type (e.g. `audio/flac`), or null when the
   /// provider did not expose one.
   final String? mimeType;
+
+  /// The audio tags the native side read for this document, or null when none
+  /// were available. See the class doc — purely a hint over the name fallback.
+  final LocalAudioMetadata? metadata;
 }
 
 /// The result of walking an Android SAF tree: the audio documents found plus

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -166,7 +166,7 @@ class MusicProvider {
 abstract final class MusicProviders {
   static const MusicProvider local = MusicProvider(
     sourceId: 'local',
-    displayName: 'On this device',
+    displayName: 'Local music',
     serverUrlLabel: null,
     capabilities: MusicProviderCapabilities(
       canStream: true,

--- a/lib/features/library/library_controller.dart
+++ b/lib/features/library/library_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/catalog/library_grouping.dart';
 import '../../core/sources/local/folder_location.dart';
 import '../../core/sources/local/folder_scan_exception.dart';
 import '../../core/sources/local/local_music_source.dart';
@@ -34,16 +35,19 @@ class LibraryController extends Notifier<LibraryState> {
         folderPath: folderPath,
         scanner: ref.read(audioFileScannerProvider),
         safDocumentLister: ref.read(safDocumentListerProvider),
+        metadataReader: ref.read(localMetadataReaderProvider),
       );
       final LocalScan scan = await source.scanTracks();
-      final albums = await source.fetchAlbums();
-      final artists = await source.fetchArtists();
       final repository = ref.read(musicLibraryRepositoryProvider);
+      // Derive the album/artist groupings from the just-scanned tracks rather
+      // than re-scanning the folder (which would re-read every file's tags); the
+      // unified library derives its own groupings from the stored tracks the same
+      // way, so this only feeds repositories that persist them.
       await repository.upsertCatalog(
         sourceId: source.id,
         tracks: scan.tracks,
-        albums: albums,
-        artists: artists,
+        albums: groupAlbums(scan.tracks),
+        artists: groupArtists(scan.tracks),
       );
       // Record the counts (visited / folders / audio / imported / skipped /
       // read failures) so a "no music found" report can show what the scan

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/services/folder_picker_service.dart';
 import '../../core/services/platform_folder_picker_service.dart';
 import '../../core/sources/local/audio_file_scanner.dart';
+import '../../core/sources/local/local_metadata_reader.dart';
 import '../../core/sources/local/method_channel_saf_document_lister.dart';
 import '../../core/sources/local/method_channel_saf_permission_probe.dart';
 import '../../core/sources/local/saf_document_lister.dart';
@@ -51,4 +52,14 @@ final safPermissionProbeProvider = Provider<SafPermissionProbe>((ref) {
   return Platform.isAndroid
       ? const MethodChannelSafPermissionProbe()
       : const UnsupportedSafPermissionProbe();
+});
+
+/// The tag-reading seam used to enrich *filesystem* (desktop/Linux and
+/// resolved-path) tracks with their audio metadata. Android SAF documents read
+/// their tags natively during the content-resolver walk, so this only covers the
+/// filesystem path; until a real pure-Dart reader lands it is the unsupported
+/// binding, which reads nothing and leaves the mapper on filename/folder
+/// fallback. Tests override it with a fake to drive the tag-merge path.
+final localMetadataReaderProvider = Provider<LocalMetadataReader>((ref) {
+  return const UnsupportedLocalMetadataReader();
 });

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -54,7 +54,7 @@ class MiniPlayer extends ConsumerWidget {
       castStateProvider.select((s) => s.valueOrNull?.isConnected ?? false),
     );
     final subtitle = _subtitle(track);
-    // The copy actually playing (Navidrome / Jellyfin / Local files / Cache),
+    // The copy actually playing (Navidrome / Jellyfin / Local music / Cache),
     // shown as a faint tag beside the metadata. Hidden while casting, where the
     // cast indicator already says where the audio is going.
     final String? sourceName = (!isCasting && source != null)
@@ -137,7 +137,7 @@ class MiniPlayer extends ConsumerWidget {
 
 /// The mini-player's second line: the artist • album metadata and, when known, a
 /// faint trailing tag for the copy actually playing (Navidrome / Jellyfin /
-/// Local files / Cache). Both halves shrink and ellipsize so a long title or a
+/// Local music / Cache). Both halves shrink and ellipsize so a long title or a
 /// narrow screen never overflows the bar.
 class _MiniSubtitle extends StatelessWidget {
   const _MiniSubtitle({required this.subtitle, required this.sourceName});

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -199,7 +199,7 @@ class _LiveControls extends ConsumerWidget {
 
 /// Under the metadata: while casting, a clear `Casting to …` indicator;
 /// otherwise a friendly error message when playback failed, or the
-/// playback-source badge ("Playing from Navidrome / Jellyfin / Local files /
+/// playback-source badge ("Playing from Navidrome / Jellyfin / Local music /
 /// Cache") once a track has resolved — naming the copy actually playing, not the
 /// active/default provider. Shows nothing while a track is still loading locally.
 class _SourceOrError extends ConsumerWidget {

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -67,7 +67,7 @@ class TrackMetadata extends StatelessWidget {
 }
 
 /// A small badge stating where the audio is *actually* coming from, e.g.
-/// "Playing from Navidrome", "Playing from Jellyfin", "Playing from Local files",
+/// "Playing from Navidrome", "Playing from Jellyfin", "Playing from Local music",
 /// or "Playing from Cache".
 ///
 /// Because a logical track can have several source candidates, the indicator

--- a/lib/features/settings/source/default_provider_section.dart
+++ b/lib/features/settings/source/default_provider_section.dart
@@ -46,7 +46,7 @@ class DefaultProviderSettingsSection extends ConsumerWidget {
       ),
       (
         id: MusicProviders.local.sourceId,
-        title: 'Local files',
+        title: MusicProviders.local.displayName,
         subtitle: 'Prefer a copy on this device when one exists.',
       ),
     ];

--- a/test/core/services/playback_source_label_test.dart
+++ b/test/core/services/playback_source_label_test.dart
@@ -4,13 +4,13 @@ import 'package:linthra/core/services/playback_source_label.dart';
 
 void main() {
   group('PlaybackSourceLabel.of — the copy actually playing', () {
-    test('an on-device file reads as Local files', () {
+    test('an on-device file reads as Local music', () {
       expect(
         PlaybackSourceLabel.of(
           trackUri: '/music/song.mp3',
           source: PlaybackSource.localFile,
         ),
-        'Local files',
+        'Local music',
       );
     });
 

--- a/test/core/sources/local/local_library_integration_test.dart
+++ b/test/core/sources/local/local_library_integration_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
+import 'package:linthra/core/catalog/logical_track.dart';
+import 'package:linthra/core/catalog/source_priority.dart';
+import 'package:linthra/core/catalog/track_unifier.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/local/local_audio_metadata.dart';
+import 'package:linthra/core/sources/local/local_track_mapper.dart';
+
+/// End-to-end checks that a *locally mapped* track (built by the real
+/// [LocalTrackMapper], not a hand-made [Track]) flows through the same grouping
+/// and unification the server sources use — so local music indexes like a real
+/// source rather than a flat file list.
+
+/// A Jellyfin-shaped catalog track: an opaque `jellyfin:<id>` uri and full tags.
+Track _jelly(
+  String id, {
+  required String title,
+  required String artist,
+  required String album,
+  required Duration duration,
+  int? trackNumber,
+}) =>
+    Track(
+      id: id,
+      title: title,
+      uri: 'jellyfin:$id',
+      artistName: artist,
+      albumName: album,
+      duration: duration,
+      trackNumber: trackNumber,
+    );
+
+void main() {
+  group('local tracks group like a real source', () {
+    test('a foldered library groups into its albums and artists', () {
+      final List<Track> tracks = <Track>[
+        for (final String path in <String>[
+          '/music/Bon Iver/For Emma/01 - Flume.mp3',
+          '/music/Bon Iver/For Emma/02 - Lump Sum.mp3',
+          '/music/Adele/25/01 - Hello.mp3',
+        ])
+          LocalTrackMapper.fromPath(path, scanRoot: '/music'),
+      ];
+
+      final albums = groupAlbums(tracks);
+      final artists = groupArtists(tracks);
+
+      expect(albums.map((a) => a.title).toList(), <String>['25', 'For Emma']);
+      final forEmma = albums.firstWhere((a) => a.title == 'For Emma');
+      expect(forEmma.artistName, 'Bon Iver');
+      expect(forEmma.trackCount, 2);
+      expect(
+          artists.map((a) => a.name).toList(), <String>['Adele', 'Bon Iver']);
+    });
+
+    test('untagged files still fold into Unknown Album / Unknown Artist', () {
+      final List<Track> tracks = <Track>[
+        LocalTrackMapper.fromPath('/music/song one.mp3'),
+        LocalTrackMapper.fromPath('/music/song two.mp3'),
+      ];
+
+      final albums = groupAlbums(tracks);
+      final artists = groupArtists(tracks);
+
+      expect(albums.single.title, kUnknownAlbum);
+      expect(artists.single.name, kUnknownArtist);
+    });
+  });
+
+  group('conservative-but-useful cross-provider dedup', () {
+    test('an untagged local file never merges with a server copy', () {
+      // No duration and no tags → ineligible to match, so it always stands as
+      // its own row (the safety invariant for local-only libraries).
+      final Track local = LocalTrackMapper.fromPath('/music/Holocene.mp3');
+      final Track jelly = _jelly(
+        'j1',
+        title: 'Holocene',
+        artist: 'Bon Iver',
+        album: 'Bon Iver',
+        duration: const Duration(seconds: 337),
+      );
+
+      final List<LogicalTrack> unified =
+          unifyTracks(<Track>[local, jelly], SourcePriority.fallback);
+
+      expect(unified, hasLength(2));
+      expect(unified.every((t) => t.candidates.length == 1), isTrue);
+    });
+
+    test('a fully tagged local file merges with the matching server copy', () {
+      // Tags (incl. a real duration) make the local copy eligible; it matches
+      // the Jellyfin copy, so the two collapse into one row with both copies.
+      final Track local = LocalTrackMapper.fromPath(
+        '/music/Bon Iver/Bon Iver/03 - Holocene.mp3',
+        scanRoot: '/music',
+        metadata: const LocalAudioMetadata(
+          title: 'Holocene',
+          artist: 'Bon Iver',
+          albumArtist: 'Bon Iver',
+          album: 'Bon Iver',
+          trackNumber: 3,
+          duration: Duration(seconds: 337),
+        ),
+      );
+      final Track jelly = _jelly(
+        'j1',
+        title: 'Holocene',
+        artist: 'Bon Iver',
+        album: 'Bon Iver',
+        duration: const Duration(seconds: 338), // within the 2s tolerance
+        trackNumber: 3,
+      );
+
+      final List<LogicalTrack> unified =
+          unifyTracks(<Track>[local, jelly], SourcePriority.fallback);
+
+      expect(unified, hasLength(1));
+      final LogicalTrack row = unified.single;
+      expect(row.hasMultipleSources, isTrue);
+      expect(row.sourceIds.toSet(), <String>{'local', 'jellyfin'});
+    });
+  });
+}

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/sources/local/audio_file_scanner.dart';
 import 'package:linthra/core/sources/local/folder_scan_exception.dart';
+import 'package:linthra/core/sources/local/local_audio_metadata.dart';
+import 'package:linthra/core/sources/local/local_metadata_reader.dart';
 import 'package:linthra/core/sources/local/local_music_source.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 
@@ -21,6 +23,20 @@ class _FakeScanner implements AudioFileScanner {
   Future<List<String>> listFiles(String folderPath) async {
     requestedFolder = folderPath;
     return _files;
+  }
+}
+
+/// Returns canned tags per path, standing in for a real filesystem tag reader.
+class _FakeMetadataReader implements LocalMetadataReader {
+  _FakeMetadataReader(this._byPath);
+
+  final Map<String, LocalAudioMetadata> _byPath;
+  final List<String> requestedPaths = <String>[];
+
+  @override
+  Future<LocalAudioMetadata?> readFromPath(String path) async {
+    requestedPaths.add(path);
+    return _byPath[path];
   }
 }
 
@@ -80,12 +96,67 @@ void main() {
       expect(tracks.single.title, 'song');
     });
 
-    test('exposes no albums or artists yet', () async {
-      final scanner = _FakeScanner(<String>['/music/song.mp3']);
+    test('groups scanned tracks into albums and artists by their folders',
+        () async {
+      final scanner = _FakeScanner(<String>[
+        '/music/Bon Iver/For Emma/01 - Flume.mp3',
+        '/music/Bon Iver/For Emma/02 - Lump Sum.flac',
+      ]);
       final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
 
-      expect(await source.fetchAlbums(), isEmpty);
-      expect(await source.fetchArtists(), isEmpty);
+      final albums = await source.fetchAlbums();
+      final artists = await source.fetchArtists();
+
+      expect(albums.map((album) => album.title).toList(), <String>['For Emma']);
+      expect(albums.single.artistName, 'Bon Iver');
+      expect(albums.single.trackCount, 2);
+      expect(
+          artists.map((artist) => artist.name).toList(), <String>['Bon Iver']);
+    });
+
+    test('derives title, track number, album, and artist for a foldered file',
+        () async {
+      final scanner = _FakeScanner(<String>[
+        '/music/Bon Iver/For Emma/01 - Flume.mp3',
+      ]);
+      final source = LocalMusicSource(folderPath: '/music', scanner: scanner);
+
+      final track = (await source.fetchTracks()).single;
+
+      expect(track.title, 'Flume');
+      expect(track.trackNumber, 1);
+      expect(track.albumName, 'For Emma');
+      expect(track.artistName, 'Bon Iver');
+      // The path stays the stable id/uri, independent of the derived metadata.
+      expect(track.id, '/music/Bon Iver/For Emma/01 - Flume.mp3');
+    });
+
+    test('enriches a filesystem track with tags from the metadata reader',
+        () async {
+      final scanner = _FakeScanner(<String>['/music/01 - file.mp3']);
+      final reader = _FakeMetadataReader(<String, LocalAudioMetadata>{
+        '/music/01 - file.mp3': const LocalAudioMetadata(
+          title: 'Tagged Title',
+          artist: 'Tagged Artist',
+          album: 'Tagged Album',
+          duration: Duration(seconds: 123),
+        ),
+      });
+      final source = LocalMusicSource(
+        folderPath: '/music',
+        scanner: scanner,
+        metadataReader: reader,
+      );
+
+      final track = (await source.fetchTracks()).single;
+
+      expect(track.title, 'Tagged Title');
+      expect(track.artistName, 'Tagged Artist');
+      expect(track.albumName, 'Tagged Album');
+      expect(track.duration, const Duration(seconds: 123));
+      // No track number in the tags, so it falls back to the file name.
+      expect(track.trackNumber, 1);
+      expect(reader.requestedPaths, <String>['/music/01 - file.mp3']);
     });
 
     test('resolves a track to a file uri', () async {

--- a/test/core/sources/local/local_track_mapper_test.dart
+++ b/test/core/sources/local/local_track_mapper_test.dart
@@ -1,12 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/local_audio_metadata.dart';
 import 'package:linthra/core/sources/local/local_track_mapper.dart';
 import 'package:linthra/core/sources/local/saf_document_lister.dart';
 
 void main() {
-  group('LocalTrackMapper.fromPath', () {
+  group('LocalTrackMapper.fromPath — filename/folder fallback', () {
     test('uses the file name without extension as the title', () {
       final track = LocalTrackMapper.fromPath('/music/Holocene.mp3');
       expect(track.title, 'Holocene');
+      expect(track.trackNumber, isNull);
     });
 
     test('keeps the full path as both id and uri', () {
@@ -16,23 +18,71 @@ void main() {
       expect(track.uri, path);
     });
 
-    test('preserves spaces and punctuation in the title', () {
+    test('splits a leading track number from the title', () {
       final track = LocalTrackMapper.fromPath('/music/01 - Intro (Live).m4a');
-      expect(track.title, '01 - Intro (Live)');
+      expect(track.trackNumber, 1);
+      expect(track.title, 'Intro (Live)');
+    });
+
+    test('handles "01. Title", "01 Title", and "01_Title" separators', () {
+      expect(LocalTrackMapper.fromPath('/m/03. Song.mp3').trackNumber, 3);
+      expect(LocalTrackMapper.fromPath('/m/03. Song.mp3').title, 'Song');
+      expect(LocalTrackMapper.fromPath('/m/4 Song.mp3').trackNumber, 4);
+      expect(LocalTrackMapper.fromPath('/m/4 Song.mp3').title, 'Song');
+      expect(LocalTrackMapper.fromPath('/m/05_Song.mp3').trackNumber, 5);
+      expect(LocalTrackMapper.fromPath('/m/05_Song.mp3').title, 'Song');
+    });
+
+    test('does not treat a number with no separator as a track number', () {
+      final track = LocalTrackMapper.fromPath('/music/1984.flac');
+      expect(track.trackNumber, isNull);
+      expect(track.title, '1984');
     });
 
     test('only strips the final extension when the name has dots', () {
       final track = LocalTrackMapper.fromPath('/music/a.b.c.opus');
       expect(track.title, 'a.b.c');
+      expect(track.trackNumber, isNull);
     });
 
-    test('leaves metadata minimal until tag parsing exists', () {
-      final track = LocalTrackMapper.fromPath('/music/song.wav');
+    test('derives album and artist from the Artist/Album folders below a root',
+        () {
+      final track = LocalTrackMapper.fromPath(
+        '/music/Bon Iver/For Emma/01 - Flume.mp3',
+        scanRoot: '/music',
+      );
+      expect(track.artistName, 'Bon Iver');
+      expect(track.albumName, 'For Emma');
+      expect(track.title, 'Flume');
+      expect(track.trackNumber, 1);
+    });
+
+    test('uses the single folder below the root as the album, artist unknown',
+        () {
+      final track = LocalTrackMapper.fromPath(
+        '/music/25/01 Hello.mp3',
+        scanRoot: '/music',
+      );
+      expect(track.albumName, '25');
       expect(track.artistName, isNull);
+    });
+
+    test('never treats the scan root itself as an album', () {
+      // A file directly inside the chosen root has no folder context, so album
+      // and artist stay null rather than borrowing the root folder's name.
+      final track = LocalTrackMapper.fromPath(
+        '/music/song.wav',
+        scanRoot: '/music',
+      );
       expect(track.albumName, isNull);
+      expect(track.artistName, isNull);
+    });
+
+    test('derives no folder metadata without a scan root', () {
+      final track = LocalTrackMapper.fromPath('/music/Artist/Album/song.wav');
+      expect(track.albumName, isNull);
+      expect(track.artistName, isNull);
       expect(track.duration, Duration.zero);
-      expect(track.trackNumber, isNull);
-      expect(track.artworkUri, isNull);
     });
 
     test('produces tracks that are equal by path identity', () {
@@ -42,11 +92,73 @@ void main() {
     });
   });
 
+  group('LocalTrackMapper.fromPath — tags override the fallback', () {
+    test('tag fields win over filename/folder, each independently', () {
+      final track = LocalTrackMapper.fromPath(
+        '/music/Folder Artist/Folder Album/01 - Folder Title.mp3',
+        scanRoot: '/music',
+        metadata: const LocalAudioMetadata(
+          title: 'Tagged Title',
+          artist: 'Tagged Artist',
+          album: 'Tagged Album',
+          trackNumber: 7,
+          duration: Duration(seconds: 200),
+        ),
+      );
+      expect(track.title, 'Tagged Title');
+      expect(track.artistName, 'Tagged Artist');
+      expect(track.albumName, 'Tagged Album');
+      expect(track.trackNumber, 7);
+      expect(track.duration, const Duration(seconds: 200));
+    });
+
+    test('a missing or blank tag falls back to the name/folder per field', () {
+      final track = LocalTrackMapper.fromPath(
+        '/music/Folder Artist/Folder Album/02 - Folder Title.mp3',
+        scanRoot: '/music',
+        // Only the album is tagged (and a blank title is ignored).
+        metadata: const LocalAudioMetadata(title: '  ', album: 'Tagged Album'),
+      );
+      expect(track.title, 'Folder Title');
+      expect(track.albumName, 'Tagged Album');
+      expect(track.artistName, 'Folder Artist');
+      expect(track.trackNumber, 2);
+      expect(track.duration, Duration.zero);
+    });
+
+    test('prefers the album artist over the track artist for grouping', () {
+      final withBoth = LocalTrackMapper.fromPath(
+        '/music/song.mp3',
+        metadata: const LocalAudioMetadata(
+          artist: 'Track Artist',
+          albumArtist: 'Album Artist',
+        ),
+      );
+      expect(withBoth.artistName, 'Album Artist');
+
+      final artistOnly = LocalTrackMapper.fromPath(
+        '/music/song.mp3',
+        metadata: const LocalAudioMetadata(artist: 'Track Artist'),
+      );
+      expect(artistOnly.artistName, 'Track Artist');
+    });
+  });
+
   group('LocalTrackMapper.fromSafDocument', () {
     test('uses the display name without extension as the title', () {
       const doc = SafAudioDocument(uri: 'content://x/1', name: 'Holocene.mp3');
       final track = LocalTrackMapper.fromSafDocument(doc);
       expect(track.title, 'Holocene');
+      expect(track.artistName, isNull);
+      expect(track.albumName, isNull);
+      expect(track.trackNumber, isNull);
+    });
+
+    test('splits a leading track number from the display name', () {
+      const doc = SafAudioDocument(uri: 'content://x/1', name: '03. Song.flac');
+      final track = LocalTrackMapper.fromSafDocument(doc);
+      expect(track.trackNumber, 3);
+      expect(track.title, 'Song');
     });
 
     test('keeps the content URI as both id and uri', () {
@@ -54,6 +166,26 @@ void main() {
       final track = LocalTrackMapper.fromSafDocument(doc);
       expect(track.id, 'content://x/1');
       expect(track.uri, 'content://x/1');
+    });
+
+    test('uses native tags when present, name as the per-field fallback', () {
+      const doc = SafAudioDocument(
+        uri: 'content://x/1',
+        name: '05 - Name Fallback.mp3',
+        metadata: LocalAudioMetadata(
+          title: 'Tagged',
+          artist: 'Artist',
+          album: 'Album',
+          duration: Duration(minutes: 3),
+        ),
+      );
+      final track = LocalTrackMapper.fromSafDocument(doc);
+      expect(track.title, 'Tagged');
+      expect(track.artistName, 'Artist');
+      expect(track.albumName, 'Album');
+      expect(track.duration, const Duration(minutes: 3));
+      // No track number in the tags, so it comes from the display name.
+      expect(track.trackNumber, 5);
     });
   });
 }

--- a/test/core/sources/local/method_channel_saf_document_lister_test.dart
+++ b/test/core/sources/local/method_channel_saf_document_lister_test.dart
@@ -117,6 +117,114 @@ void main() {
 
       expect(result.documents.single.mimeType, isNull);
     });
+
+    test('attaches the native tags to the parsed document', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://doc/1',
+              'name': 'One.mp3',
+              'mime': 'audio/mpeg',
+              'title': 'Holocene',
+              'artist': 'Bon Iver',
+              'albumArtist': 'Bon Iver',
+              'album': 'Bon Iver',
+              'track': '3/10',
+              'durationMs': '337000',
+            },
+          ],
+        },
+      );
+
+      final metadata = result.documents.single.metadata!;
+      expect(metadata.title, 'Holocene');
+      expect(metadata.artist, 'Bon Iver');
+      expect(metadata.albumArtist, 'Bon Iver');
+      expect(metadata.album, 'Bon Iver');
+      expect(metadata.trackNumber, 3);
+      expect(metadata.duration, const Duration(milliseconds: 337000));
+    });
+
+    test('a document with no tag fields has null metadata', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{'uri': 'content://doc/1', 'name': 'One.mp3'},
+          ],
+        },
+      );
+
+      expect(result.documents.single.metadata, isNull);
+    });
+  });
+
+  group('MethodChannelSafDocumentLister.parseMetadata', () {
+    test('null for an entry with no tag fields', () {
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'uri': 'content://doc/1', 'name': 'One.mp3'},
+        ),
+        isNull,
+      );
+    });
+
+    test('drops blank text fields to null', () {
+      final metadata = MethodChannelSafDocumentLister.parseMetadata(
+        <Object?, Object?>{'title': '  ', 'artist': '', 'album': 'Real'},
+      );
+      expect(metadata, isNotNull);
+      expect(metadata!.title, isNull);
+      expect(metadata.artist, isNull);
+      expect(metadata.album, 'Real');
+    });
+
+    test('parses a plain or "n/m" track number, ignoring non-positive', () {
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'track': '5'},
+        )!
+            .trackNumber,
+        5,
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'track': '3/12'},
+        )!
+            .trackNumber,
+        3,
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'track': '0'},
+        ),
+        isNull,
+      );
+    });
+
+    test('parses durationMs sent as an int or a numeric string', () {
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'durationMs': 200000},
+        )!
+            .duration,
+        const Duration(milliseconds: 200000),
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'durationMs': '200000'},
+        )!
+            .duration,
+        const Duration(milliseconds: 200000),
+      );
+      // Zero/garbage duration is unknown, not a real value.
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'durationMs': '0'},
+        ),
+        isNull,
+      );
+    });
   });
 
   group('MethodChannelSafDocumentLister.listAudioDocuments', () {

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -87,11 +87,11 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('shows the Local files source for an on-device track',
+    testWidgets('shows the Local music source for an on-device track',
         (tester) async {
       await _pumpScreen(tester, _playing(source: PlaybackSource.localFile));
 
-      expect(find.text('Playing from Local files'), findsOneWidget);
+      expect(find.text('Playing from Local music'), findsOneWidget);
     });
 
     testWidgets('names the owning server (Jellyfin) for a direct stream',

--- a/test/features/settings/source/default_provider_section_test.dart
+++ b/test/features/settings/source/default_provider_section_test.dart
@@ -40,7 +40,7 @@ void main() {
       expect(find.text('Automatic'), findsOneWidget);
       expect(find.text('Jellyfin'), findsOneWidget);
       expect(find.text('Navidrome / Subsonic'), findsOneWidget);
-      expect(find.text('Local files'), findsOneWidget);
+      expect(find.text('Local music'), findsOneWidget);
     });
 
     testWidgets('defaults to Automatic', (tester) async {


### PR DESCRIPTION
## Goal

Make **Local music** index like a real music source (Jellyfin / Navidrome-Subsonic), not just a file list.

## Investigation (what was wrong)

- `LocalTrackMapper` set **only the title** from the file/display name; artist, album, duration, and track number were always unset. No audio tags were read anywhere (it was the documented follow-up in `docs/local-music.md`).
- So every local track folded into a single **Unknown Album / Unknown Artist** in `library_grouping`.
- Local tracks already used the same `Track` model and flowed through the same unifier as provider tracks, and already had **stable ids** (the path / content URI). With `duration == 0` they correctly never merged across providers — but they also couldn't usefully merge a real duplicate, and couldn't group.
- Albums/artists are **derived from `Track` fields** at display time (not persisted), so the fix is to populate `Track` fields well.

## What this PR does

**Tag reading (Android SAF — the primary path):** the existing content-resolver walk (`SafDocumentScanner.kt`) now reads each file's tags via `MediaMetadataRetriever` (title/artist/album-artist/album/track number/duration). This needs **no new permission** (the picked-folder grant covers it) and **does not touch the SAF picker**. It's additive and defensive — an older native build or an unreadable file just omits tags. The Dart reply parsing is pure and unit-tested.

**Clean fallback (all platforms):** `LocalTrackMapper` merges tags over a filename/folder fallback, each field independently, never showing an ugly path:
- leading track number + clean title from the file name (`01 - Holocene.flac` → #1, "Holocene"), and
- artist/album from the conventional `…/Artist/Album/Track` folders, read **relative to the scan root** so the root is never mistaken for an album.

The path / content URI stays the stable `id` and `uri`, independent of the (mutable) tags.

**Seam for desktop tags:** a `LocalMetadataReader` interface with an unsupported default (mirroring `SafDocumentLister`) so a future pure-Dart desktop tag reader slots in without touching callers.

**Library integration:** local albums/artists group from the scanned tracks like any source. Tagged local files now take part in the **conservative** cross-provider dedup; untagged ones (no real duration) still never merge — the safety invariant is preserved.

**Source indicator:** local now displays as **"Local music"** (was "Local files" / "On this device").

## Constraints honored

- ✅ Jellyfin and Navidrome/Subsonic indexing untouched
- ✅ Playback engine untouched
- ✅ SAF **picker** untouched (only the scanner reads tags)
- ✅ No broad storage permissions
- ✅ No release bump / tag / fdroiddata change
- ↪️ **Embedded cover art** intentionally left as a follow-up (kept this PR focused on text metadata)

## Tests

- `local_track_mapper_test` — tag-over-fallback merge, per-field fallback, track-number parsing, folder derivation, blank handling, album-artist preference.
- `method_channel_saf_document_lister_test` — native tag parsing (`"3/12"` track, int/string duration, blank-to-null).
- `local_music_source_test` — filesystem tag reader path + folder grouping.
- `local_library_integration_test` — mapping → grouping → unified-library dedup (tagged merges with a server copy; untagged never does).
- Updated the "Local music" label tests.

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` (1573 tests) all pass.

## Follow-ups

- Embedded local cover art (`Track.artworkUri`).
- Pure-Dart desktop tag reader behind `LocalMetadataReader`.
- ReplayGain-from-tags for local files.

https://claude.ai/code/session_018mMRMZucXwWqW98VJSW85H

---
_Generated by [Claude Code](https://claude.ai/code/session_018mMRMZucXwWqW98VJSW85H)_