### PR TITLE
feat(local): show embedded cover art for local tracks

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -6,6 +6,8 @@ import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.DocumentsContract
 import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.security.MessageDigest
 import java.util.ArrayDeque
 
 /**
@@ -118,11 +120,14 @@ class SafDocumentScanner(private val context: Context) {
                                     treeUri,
                                     docId,
                                 )
-                                // Read the file's audio tags so a local track
-                                // indexes with a real title/artist/album/duration
-                                // like a server track. Best-effort: a file whose
-                                // tags can't be read just omits them and the Dart
-                                // mapper falls back to the display name.
+                                // Read the file's audio tags (and cache its
+                                // embedded cover art) so a local track indexes
+                                // with a real title/artist/album/duration and
+                                // shows its artwork like a server track. Best-
+                                // effort: a file whose tags can't be read just
+                                // omits them and the Dart mapper falls back to the
+                                // display name; a file with no embedded cover keeps
+                                // the calm placeholder.
                                 val metadata = readMetadata(docUri)
                                 documents.add(
                                     mapOf(
@@ -135,6 +140,7 @@ class SafDocumentScanner(private val context: Context) {
                                         "album" to metadata["album"],
                                         "track" to metadata["track"],
                                         "durationMs" to metadata["durationMs"],
+                                        "artworkUri" to metadata["artworkUri"],
                                     ),
                                 )
                             }
@@ -206,6 +212,10 @@ class SafDocumentScanner(private val context: Context) {
                 "durationMs" to retriever.extractMetadata(
                     MediaMetadataRetriever.METADATA_KEY_DURATION,
                 ),
+                // A file:// URI to the embedded cover art, cached once. Its own
+                // try/catch (inside cacheEmbeddedArtwork) means a missing or
+                // unwritable cover never costs the tags read above.
+                "artworkUri" to cacheEmbeddedArtwork(uri, retriever),
             )
         } catch (e: Exception) {
             emptyMap()
@@ -218,8 +228,75 @@ class SafDocumentScanner(private val context: Context) {
         }
     }
 
+    /**
+     * Extracts this document's embedded cover art (ID3 APIC, FLAC picture, MP4
+     * cover, …) once into Linthra's private cache and returns a file:// URI to
+     * it, or null when the file has no embedded art — or it can't be read or
+     * written. getEmbeddedPicture() reads through the same content-resolver data
+     * source the tags came from, under the folder's existing SAF grant, so it
+     * needs no extra permission and never touches a raw /storage path.
+     *
+     * Cheap and idempotent across re-scans: the cache file is named by a SHA-1 of
+     * the content URI — a stable key that leaks neither the file's name nor its
+     * on-disk path — so a cover already extracted on an earlier scan is reused
+     * *without* pulling the (potentially large) image bytes out of the retriever
+     * again, because the existence check runs before getEmbeddedPicture(). Bytes
+     * are written to a temp file and atomically renamed, so an interrupted scan
+     * can never leave a half-written cover that then fails to decode forever.
+     *
+     * Deliberately total: any failure returns null so the track simply keeps the
+     * calm placeholder, and — crucially — never disturbs the audio tags read
+     * alongside it. The cache lives under cacheDir, so the OS can reclaim it under
+     * storage pressure; the next folder rescan transparently re-extracts.
+     */
+    private fun cacheEmbeddedArtwork(
+        uri: Uri,
+        retriever: MediaMetadataRetriever,
+    ): String? {
+        return try {
+            val dir = File(context.cacheDir, ARTWORK_CACHE_DIR)
+            val cacheFile = File(dir, artworkCacheKey(uri) + ".img")
+            if (cacheFile.isFile && cacheFile.length() > 0L) {
+                return Uri.fromFile(cacheFile).toString()
+            }
+            val picture = retriever.embeddedPicture
+            if (picture == null || picture.isEmpty()) {
+                return null
+            }
+            if (!dir.isDirectory && !dir.mkdirs()) {
+                return null
+            }
+            val tmp = File.createTempFile("art", ".tmp", dir)
+            try {
+                tmp.writeBytes(picture)
+                if (tmp.renameTo(cacheFile)) {
+                    Uri.fromFile(cacheFile).toString()
+                } else {
+                    tmp.delete()
+                    null
+                }
+            } catch (e: Exception) {
+                tmp.delete()
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** A stable, path-free cache key for [uri]'s cover: a SHA-1 hex of the URI. */
+    private fun artworkCacheKey(uri: Uri): String {
+        val digest = MessageDigest.getInstance("SHA-1")
+        val bytes = digest.digest(uri.toString().toByteArray(Charsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
+    }
+
     companion object {
         private val AUDIO_EXTENSIONS =
             listOf(".mp3", ".flac", ".m4a", ".aac", ".ogg", ".opus", ".wav")
+
+        // Subfolder of cacheDir holding extracted embedded cover art. App-private
+        // and OS-reclaimable; never contains a user file name or path.
+        private const val ARTWORK_CACHE_DIR = "linthra_local_artwork"
     }
 }

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -367,6 +367,11 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   wraps).
 - The car experience is **basic browsing**, not a custom/polished car UI (no
   tabs, content-style hints, lyrics, or now-playing artwork tuning).
-- Lock-screen / car artwork depends on `Track.artworkUri`; local-folder scanning
-  does not populate it yet.
+- Lock-screen / now-playing artwork depends on `Track.artworkUri`, which now
+  includes a local file's embedded cover (extracted during the scan) as well as
+  server covers — `audio_service` loads it in-process for the media session. The
+  car **browse-tree** thumbnail for a local file is a private-cache `file://`
+  URI the car's own process may not be able to read, so a server cover remains
+  the most reliable browse thumbnail; this is a known limitation, not a
+  regression (local rows had no art before).
 - No MPRIS (Linux desktop media keys) yet.

--- a/docs/library.md
+++ b/docs/library.md
@@ -96,10 +96,12 @@ only at play time.
   a tag is missing, falls back to the file name and the `…/Artist/Album/Track`
   folder layout — so a tagged or well-organized local library groups normally. A
   file with neither tags nor folder context still folds into a single
-  **Unknown Album** / **Unknown Artist**. Embedded cover art for local files is a
-  separate follow-up (see [local-music.md](./local-music.md)).
-- **Artwork may be missing** for some tracks (notably local files); a calm
-  placeholder is shown instead, and the layout never jumps.
+  **Unknown Album** / **Unknown Artist**. A local file's **embedded** cover art
+  is read during the scan and shown like any other cover (see
+  [local-music.md](./local-music.md)).
+- **Artwork may be missing** for some tracks (a local file with no embedded
+  cover, or a Subsonic/Navidrome track); a calm placeholder is shown instead,
+  and the layout never jumps.
 - **No stable source album/artist IDs yet.** Grouping uses folded names because
   source album/artist IDs (e.g. Jellyfin's `AlbumId`) aren't persisted on a
   track today. Persisting them — for sharper disambiguation and richer
@@ -110,4 +112,3 @@ only at play time.
 - Playlists / favorites integration from album & artist views.
 - Genre browsing.
 - Advanced filters and sort options (by year, recently added, duration).
-- Local tag/metadata parsing so on-device files get real album/artist/artwork.

--- a/docs/local-music.md
+++ b/docs/local-music.md
@@ -45,8 +45,16 @@ Local tracks index like a real source, not a flat file list:
   back on its own, so a half-tagged file still gets the best of both. A file with
   nothing to go on still folds into **Unknown Album / Artist** (see
   [library.md](./library.md)).
-- **Embedded cover art** for local files is a separate follow-up; until then a
-  local track with no `artworkUri` shows the calm placeholder. (A server copy's
+- **Embedded cover art is shown.** During the scan, a file's embedded album art
+  (ID3 `APIC`, FLAC picture, MP4 cover, …) is read through the same content
+  resolver and the same SAF grant as the tags — no extra permission — and cached
+  once inside Linthra's own private storage. The track then carries a `file://`
+  `artworkUri` into that cache, so the cover appears in library rows, the
+  album/artist views, and the queue / now-playing / mini-player. A file with no
+  embedded art keeps the calm placeholder. The cache is keyed by a hash of the
+  file's content URI (never its name or path), so a cover is extracted **once**
+  and reused on later launches and re-scans rather than re-read every time; if
+  the OS reclaims the cache, the next rescan simply re-extracts. (A server copy's
   cover is still used when the same song is also on a server — see
   [unified-library.md](./unified-library.md).)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -58,7 +58,8 @@ like a server source, falling back cleanly to the file name and
 `…/Artist/Album/Track` folders when a tag is missing — see
 [local-music.md](local-music.md). The chosen folder and the scanned catalog
 survive a restart. No broad storage permission is requested (tags are read
-through the same folder grant). Embedded cover art is a documented follow-up.
+through the same folder grant). A file's **embedded** cover art is read during
+the same scan and cached privately, so local tracks show their artwork too.
 On-device files cannot be cast (a receiver can't reach a file on your phone).
 
 ## Jellyfin

--- a/docs/unified-library.md
+++ b/docs/unified-library.md
@@ -72,9 +72,10 @@ next reload. (Re-syncing a server brings its copy back, exactly as before.)
 
 ### Artwork: prefer the displayed copy, fall back to the best available
 
-The displayed copy is the default/preferred provider's — but some providers
-(Subsonic/Navidrome today, local files — whose embedded cover art is a
-follow-up) carry **no** `artworkUri`. If
+The displayed copy is the default/preferred provider's — but some copies carry
+**no** `artworkUri` (Subsonic/Navidrome today, and a local file that has no
+embedded cover art — local files *with* embedded art now carry a `file://`
+cover). If
 the row simply showed the preferred copy's cover, unifying a song that the
 preferred provider lacks a cover for would *blank* a cover another copy still
 has. So `LogicalTrack.displayTrack` keeps the preferred copy's id and uri (play,

--- a/lib/core/sources/local/local_audio_metadata.dart
+++ b/lib/core/sources/local/local_audio_metadata.dart
@@ -15,6 +15,7 @@ class LocalAudioMetadata {
     this.album,
     this.trackNumber,
     this.duration,
+    this.artworkUri,
   });
 
   /// The track title (e.g. ID3 `TIT2`).
@@ -40,15 +41,25 @@ class LocalAudioMetadata {
   /// actual tag/stream metadata.
   final Duration? duration;
 
-  /// Whether every field is absent — i.e. the source carried no usable tag at
-  /// all, so the mapper relies entirely on filename/folder fallback.
+  /// A URI to the file's embedded cover art when one was extracted, or null when
+  /// the file carries none. Unlike the text fields this is not derived from the
+  /// file name — it can only come from real embedded artwork — so it is passed
+  /// straight through to [Track.artworkUri]. On Android the native SAF walk
+  /// caches the embedded picture into Linthra's private cache and reports a
+  /// `file://` URI to it (never a user file path).
+  final Uri? artworkUri;
+
+  /// Whether every field is absent — i.e. the source carried no usable tag (or
+  /// embedded art) at all, so the mapper relies entirely on filename/folder
+  /// fallback.
   bool get isEmpty =>
       title == null &&
       artist == null &&
       albumArtist == null &&
       album == null &&
       trackNumber == null &&
-      duration == null;
+      duration == null &&
+      artworkUri == null;
 
   /// A metadata holder with no fields set.
   static const LocalAudioMetadata empty = LocalAudioMetadata();

--- a/lib/core/sources/local/local_track_mapper.dart
+++ b/lib/core/sources/local/local_track_mapper.dart
@@ -17,7 +17,9 @@ import 'saf_document_lister.dart';
 /// future desktop reader did), its fields win — so a tagged file indexes with a
 /// proper title, artist, album, duration, and track number, exactly like a
 /// Jellyfin/Subsonic track. Each field falls back **independently** when its tag
-/// is missing or blank, so a half-tagged file still gets the best of both.
+/// is missing or blank, so a half-tagged file still gets the best of both. The
+/// file's embedded cover art, when the source extracted one, rides through as
+/// [Track.artworkUri]; a file with none keeps a null artwork (the placeholder).
 ///
 /// The fallback never shows an ugly path. From the file's own name it derives a
 /// leading track number and a clean title (`01 - Holocene` → #1, "Holocene");
@@ -89,6 +91,10 @@ abstract final class LocalTrackMapper {
       albumName: _firstNonBlank(<String?>[metadata?.album, folderAlbum]),
       trackNumber: metadata?.trackNumber ?? parts.trackNumber,
       duration: metadata?.duration ?? Duration.zero,
+      // Embedded cover art has no filename fallback — it is present only when the
+      // source actually extracted one — so it passes straight through, leaving
+      // [Track.artworkUri] null (the calm placeholder) when there is none.
+      artworkUri: metadata?.artworkUri,
     );
   }
 

--- a/lib/core/sources/local/method_channel_saf_document_lister.dart
+++ b/lib/core/sources/local/method_channel_saf_document_lister.dart
@@ -95,14 +95,15 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
 
   /// Builds the [LocalAudioMetadata] for one document [entry] from the optional
   /// tag fields the native walk attached (`title`, `artist`, `albumArtist`,
-  /// `album`, `track`, `durationMs`), or null when none are present — an older
-  /// native build, or a file the platform could not read tags from.
+  /// `album`, `track`, `durationMs`, `artworkUri`), or null when none are present
+  /// — an older native build, or a file the platform could not read tags from.
   ///
   /// Pure and tolerant so it is unit-testable and never throws on a malformed or
-  /// partial reply: a non-string text field, a `track` like `"3/12"`, and a
-  /// `durationMs` sent as either an int or a numeric string are all handled, and
-  /// a blank or unparseable value simply drops to null (the mapper then falls
-  /// back to the file name).
+  /// partial reply: a non-string text field, a `track` like `"3/12"`, a
+  /// `durationMs` sent as either an int or a numeric string, and a malformed
+  /// `artworkUri` are all handled, and a blank or unparseable value simply drops
+  /// to null (the mapper then falls back to the file name, and the row keeps the
+  /// artwork placeholder).
   static LocalAudioMetadata? parseMetadata(Map<Object?, Object?> entry) {
     final String? title = _string(entry['title']);
     final String? artist = _string(entry['artist']);
@@ -110,12 +111,14 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
     final String? album = _string(entry['album']);
     final int? trackNumber = _trackNumber(entry['track']);
     final Duration? duration = _durationMs(entry['durationMs']);
+    final Uri? artworkUri = _artworkUri(entry['artworkUri']);
     if (title == null &&
         artist == null &&
         albumArtist == null &&
         album == null &&
         trackNumber == null &&
-        duration == null) {
+        duration == null &&
+        artworkUri == null) {
       return null;
     }
     return LocalAudioMetadata(
@@ -125,6 +128,7 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
       album: album,
       trackNumber: trackNumber,
       duration: duration,
+      artworkUri: artworkUri,
     );
   }
 
@@ -159,5 +163,16 @@ class MethodChannelSafDocumentLister implements SafDocumentLister {
     }
     if (ms == null || ms <= 0) return null;
     return Duration(milliseconds: ms);
+  }
+
+  /// The native-reported cover-art location parsed to a [Uri], or null when
+  /// absent, blank, or unparseable. The native side sends a `file://` URI into
+  /// Linthra's own cache; an unparseable value simply leaves the track without
+  /// artwork (the calm placeholder) rather than throwing.
+  static Uri? _artworkUri(Object? value) {
+    if (value is! String) return null;
+    final String trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    return Uri.tryParse(trimmed);
   }
 }

--- a/lib/core/sources/local/saf_document_lister.dart
+++ b/lib/core/sources/local/saf_document_lister.dart
@@ -10,10 +10,12 @@ import 'local_audio_metadata.dart';
 /// lacks a known extension — the catalog needs both signals to recognise audio.
 ///
 /// [metadata] carries the audio tags the native walk extracted for this document
-/// (title/artist/album/duration/track number), or null when none were available
-/// — an older native build, an unreadable file, or a format with no tags. It is
-/// only a *hint*: [LocalTrackMapper] still falls back to the name when a field is
-/// missing, so a document without metadata indexes exactly as before.
+/// (title/artist/album/duration/track number) and a `file://` URI to its cached
+/// embedded cover art, or null when none were available — an older native build,
+/// an unreadable file, or a format with no tags. It is only a *hint*:
+/// [LocalTrackMapper] still falls back to the name when a field is missing, so a
+/// document without metadata indexes exactly as before (and shows the artwork
+/// placeholder).
 class SafAudioDocument {
   const SafAudioDocument({
     required this.uri,

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -8,6 +8,7 @@ import '../../core/catalog/library_grouping.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
+import '../../shared/widgets/artwork_image.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import 'library_browse_providers.dart';
@@ -157,7 +158,7 @@ class _ArtistHeader extends StatelessWidget {
                 backgroundColor: theme.colorScheme.surfaceContainerHighest,
                 backgroundImage: artist.artworkUri == null
                     ? null
-                    : NetworkImage(artist.artworkUri!.toString()),
+                    : artworkImageProvider(artist.artworkUri!),
                 child: artist.artworkUri == null
                     ? Icon(
                         Icons.person,

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../core/models/artist.dart';
+import '../../../shared/widgets/artwork_image.dart';
 
 /// One row in the Artists list: a circular avatar (artwork or a placeholder
 /// glyph), the artist name, and an album/track-count subtitle. Long names
@@ -64,7 +65,7 @@ class _ArtistAvatar extends StatelessWidget {
         child: uri == null
             ? _placeholder(theme)
             : Image(
-                image: NetworkImage(uri.toString()),
+                image: artworkImageProvider(uri),
                 fit: BoxFit.cover,
                 gaplessPlayback: true,
                 errorBuilder: (_, __, ___) => _placeholder(theme),

--- a/lib/features/player/widgets/album_artwork.dart
+++ b/lib/features/player/widgets/album_artwork.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
+import '../../../shared/widgets/artwork_image.dart';
 
 /// The single place album artwork is turned into pixels.
 ///
-/// This is the app's *artwork resolver seam*: every artwork render goes through
-/// [_imageProviderFor], so if a source ever needs signed/tokenized image URLs
-/// they can be resolved here — at display time — without persisting a token or
-/// changing call sites. Today Jellyfin's primary-image URL needs no token
-/// (it is built token-free in the track mapper and stored as `Track.artworkUri`)
-/// and local tracks carry none, so a plain [NetworkImage] is enough.
+/// Artwork resolution lives in [artworkImageProvider] (the shared seam): a
+/// Jellyfin primary-image URL needs no token (it is built token-free in the
+/// track mapper and stored as `Track.artworkUri`) so it loads over the network,
+/// while a local file's embedded cover — extracted into Linthra's cache and
+/// stored as a `file://` URI — loads from disk. Subsonic and untagged local
+/// tracks carry no artwork and show the placeholder below.
 ///
 /// It fills whatever box the parent gives it (wrap in a `SizedBox`/`AspectRatio`
 /// to size it) and degrades gracefully: a missing URL, a load error, or a slow
@@ -25,9 +26,6 @@ class AlbumArtwork extends StatelessWidget {
   final Uri? artworkUri;
   final BorderRadius borderRadius;
 
-  static ImageProvider _imageProviderFor(Uri uri) =>
-      NetworkImage(uri.toString());
-
   @override
   Widget build(BuildContext context) {
     final Uri? uri = artworkUri;
@@ -36,7 +34,7 @@ class AlbumArtwork extends StatelessWidget {
       child: uri == null
           ? const _ArtworkPlaceholder()
           : Image(
-              image: _imageProviderFor(uri),
+              image: artworkImageProvider(uri),
               fit: BoxFit.cover,
               width: double.infinity,
               height: double.infinity,

--- a/lib/features/player/widgets/now_playing_background.dart
+++ b/lib/features/player/widgets/now_playing_background.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 import '../../../app/colors.dart';
+import '../../../shared/widgets/artwork_image.dart';
 
 /// The full-bleed backdrop behind the now-playing content.
 ///
@@ -29,7 +30,7 @@ class NowPlayingBackground extends StatelessWidget {
           ImageFiltered(
             imageFilter: ui.ImageFilter.blur(sigmaX: 40, sigmaY: 40),
             child: Image(
-              image: NetworkImage(uri.toString()),
+              image: artworkImageProvider(uri),
               fit: BoxFit.cover,
               gaplessPlayback: true,
               // A failed/decoding image leaves just the gradient showing.

--- a/lib/shared/widgets/artwork_image.dart
+++ b/lib/shared/widgets/artwork_image.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+
+/// Resolves an artwork [Uri] to the right [ImageProvider] — the app's single
+/// artwork-resolver seam.
+///
+/// Every artwork render goes through here (track rows, album/artist tiles and
+/// detail headers, the now-playing background and mini-player), so a local cover
+/// and a server cover are treated identically by every surface.
+///
+/// - A `file:` URI is embedded cover art Linthra extracted from a local audio
+///   file into its own private cache; it loads straight from disk with a
+///   [FileImage].
+/// - Anything else is a server's plain http(s) image URL (Jellyfin builds a
+///   token-free primary-image URL), loaded with a [NetworkImage].
+///
+/// Sources with no cover at all — Subsonic, and untagged local files — carry a
+/// null `artworkUri` and never reach here; the caller shows its placeholder. A
+/// `file:` cover whose bytes are missing or undecodable (e.g. the OS reclaimed
+/// the cache) fails the same way a broken network image does, so the caller's
+/// `errorBuilder` falls back to the placeholder — never a broken-image glyph.
+ImageProvider artworkImageProvider(Uri uri) {
+  if (uri.isScheme('file')) {
+    return FileImage(File(uri.toFilePath()));
+  }
+  return NetworkImage(uri.toString());
+}

--- a/test/core/catalog/logical_track_test.dart
+++ b/test/core/catalog/logical_track_test.dart
@@ -64,6 +64,16 @@ void main() {
       ]);
       expect(row.displayArtworkUri, isNull);
     });
+
+    test('a local-only track surfaces its embedded (file://) cover', () {
+      // A device-only song with extracted embedded art shows that cover, so the
+      // local feature flows through the de-duplication display layer unchanged.
+      final LogicalTrack row = LogicalTrack.single(
+        _candidate('local', id: 'l', artwork: _localArt),
+      );
+      expect(row.displayArtworkUri, _localArt);
+      expect(row.displayTrack.artworkUri, _localArt);
+    });
   });
 
   group('LogicalTrack.displayTrack — primary identity, best cover', () {

--- a/test/core/sources/local/local_music_source_test.dart
+++ b/test/core/sources/local/local_music_source_test.dart
@@ -203,6 +203,33 @@ void main() {
       expect(tracks.first.uri, 'content://doc/1');
     });
 
+    test('carries a document\'s embedded cover art onto the track', () async {
+      final Uri art = Uri.parse(
+        'file:///data/user/0/app/cache/linthra_local_artwork/abc.img',
+      );
+      final saf = FakeSafDocumentLister(
+        documents: <SafAudioDocument>[
+          SafAudioDocument(
+            uri: 'content://doc/1',
+            name: 'WithArt.mp3',
+            metadata: LocalAudioMetadata(title: 'With Art', artworkUri: art),
+          ),
+          const SafAudioDocument(uri: 'content://doc/2', name: 'NoArt.flac'),
+        ],
+      );
+      final source = LocalMusicSource(
+        folderPath: _safFolder,
+        scanner: _FakeScanner(const <String>[]),
+        safDocumentLister: saf,
+      );
+
+      final tracks = await source.fetchTracks();
+
+      expect(tracks.firstWhere((t) => t.title == 'With Art').artworkUri, art);
+      // A document without embedded art keeps a null cover (the placeholder).
+      expect(tracks.firstWhere((t) => t.title == 'NoArt').artworkUri, isNull);
+    });
+
     test('falls back to the path scanner when SAF is unsupported', () async {
       final scanner = _FakeScanner(<String>['/storage/emulated/0/Music/A.mp3']);
       final source = LocalMusicSource(

--- a/test/core/sources/local/local_track_mapper_test.dart
+++ b/test/core/sources/local/local_track_mapper_test.dart
@@ -188,4 +188,60 @@ void main() {
       expect(track.trackNumber, 5);
     });
   });
+
+  group('LocalTrackMapper — embedded cover art', () {
+    final Uri art = Uri.parse(
+      'file:///data/user/0/app/cache/linthra_local_artwork/abc123.img',
+    );
+
+    test('a SAF document with embedded art maps to a usable artworkUri', () {
+      final doc = SafAudioDocument(
+        uri: 'content://x/1',
+        name: 'Song.flac',
+        metadata: LocalAudioMetadata(title: 'Song', artworkUri: art),
+      );
+      expect(LocalTrackMapper.fromSafDocument(doc).artworkUri, art);
+    });
+
+    test('a SAF document with no embedded art keeps a null artworkUri', () {
+      const doc = SafAudioDocument(
+        uri: 'content://x/1',
+        name: 'Song.flac',
+        metadata: LocalAudioMetadata(title: 'Song'),
+      );
+      expect(LocalTrackMapper.fromSafDocument(doc).artworkUri, isNull);
+    });
+
+    test('a SAF document with no metadata at all keeps a null artworkUri', () {
+      const doc = SafAudioDocument(uri: 'content://x/1', name: 'Song.flac');
+      expect(LocalTrackMapper.fromSafDocument(doc).artworkUri, isNull);
+    });
+
+    test('art rides through even when every text tag is absent', () {
+      // An art-only file (cover embedded, no readable tags) still shows its
+      // cover; the title falls back to the display name.
+      final doc = SafAudioDocument(
+        uri: 'content://x/1',
+        name: 'Holocene.mp3',
+        metadata: LocalAudioMetadata(artworkUri: art),
+      );
+      final track = LocalTrackMapper.fromSafDocument(doc);
+      expect(track.artworkUri, art);
+      expect(track.title, 'Holocene');
+    });
+
+    test('fromPath passes embedded art through, and null without it', () {
+      expect(
+        LocalTrackMapper.fromPath(
+          '/music/song.mp3',
+          metadata: LocalAudioMetadata(title: 'Song', artworkUri: art),
+        ).artworkUri,
+        art,
+      );
+      expect(
+        LocalTrackMapper.fromPath('/music/song.mp3').artworkUri,
+        isNull,
+      );
+    });
+  });
 }

--- a/test/core/sources/local/method_channel_saf_document_lister_test.dart
+++ b/test/core/sources/local/method_channel_saf_document_lister_test.dart
@@ -157,6 +157,25 @@ void main() {
 
       expect(result.documents.single.metadata, isNull);
     });
+
+    test('attaches the native cover-art URI to the parsed document', () {
+      final result = MethodChannelSafDocumentLister.parseScanResult(
+        <Object?, Object?>{
+          'documents': <Object?>[
+            <Object?, Object?>{
+              'uri': 'content://doc/1',
+              'name': 'One.mp3',
+              'artworkUri': 'file:///cache/linthra_local_artwork/abc.img',
+            },
+          ],
+        },
+      );
+
+      expect(
+        result.documents.single.metadata!.artworkUri,
+        Uri.parse('file:///cache/linthra_local_artwork/abc.img'),
+      );
+    });
   });
 
   group('MethodChannelSafDocumentLister.parseMetadata', () {
@@ -224,6 +243,47 @@ void main() {
         ),
         isNull,
       );
+    });
+
+    test('parses a file:// cover-art URI', () {
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'artworkUri': 'file:///cache/art/abc.img'},
+        )!
+            .artworkUri,
+        Uri.parse('file:///cache/art/abc.img'),
+      );
+    });
+
+    test('embedded art alone (no text tags) still yields metadata', () {
+      // An art-only file must not drop to null metadata, or the cover is lost.
+      final metadata = MethodChannelSafDocumentLister.parseMetadata(
+        <Object?, Object?>{'artworkUri': 'file:///cache/art/abc.img'},
+      );
+      expect(metadata, isNotNull);
+      expect(metadata!.title, isNull);
+      expect(metadata.artworkUri, Uri.parse('file:///cache/art/abc.img'));
+    });
+
+    test('drops a blank or non-string cover-art value to null', () {
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'artworkUri': '  '},
+        ),
+        isNull,
+      );
+      expect(
+        MethodChannelSafDocumentLister.parseMetadata(
+          <Object?, Object?>{'artworkUri': 42},
+        ),
+        isNull,
+      );
+      // A real tag alongside a blank artwork keeps the tag, drops the artwork.
+      final metadata = MethodChannelSafDocumentLister.parseMetadata(
+        <Object?, Object?>{'album': 'Real', 'artworkUri': ''},
+      );
+      expect(metadata!.album, 'Real');
+      expect(metadata.artworkUri, isNull);
     });
   });
 

--- a/test/data/mappers/track_mapper_test.dart
+++ b/test/data/mappers/track_mapper_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/database/linthra_database.dart';
+import 'package:linthra/data/mappers/track_mapper.dart';
+
+/// The persisted `artworkUri` is what lets the UI reuse an extracted local cover
+/// on the next launch *without* re-extracting it — and what keeps a Jellyfin
+/// cover URL stable in the catalog. These round-trips lock that in.
+void main() {
+  group('track artworkUri persistence', () {
+    test('a local embedded-cover file:// URI survives the round-trip', () {
+      final Uri art = Uri.parse(
+        'file:///data/user/0/app/cache/linthra_local_artwork/abc.img',
+      );
+      final Track track = Track(
+        id: 'content://doc/1',
+        title: 'Song',
+        uri: 'content://doc/1',
+        artworkUri: art,
+      );
+
+      // Flattened to a primitive string for storage...
+      final companion = trackToCompanion(track, 'local');
+      expect(companion.artworkUri.value, art.toString());
+
+      // ...and rebuilt as the same Uri on read, so launch reuses the cover.
+      final TrackRow row = TrackRow(
+        id: track.id,
+        sourceId: 'local',
+        title: track.title,
+        uri: track.uri,
+        durationMs: 0,
+        artworkUri: companion.artworkUri.value,
+      );
+      expect(trackFromRow(row).artworkUri, art);
+    });
+
+    test('a Jellyfin http(s) cover URL round-trips unchanged', () {
+      final Uri art =
+          Uri.parse('https://music.example.com/Items/1/Images/Primary');
+      final companion = trackToCompanion(
+        Track(id: 'jellyfin:1', title: 'X', uri: 'jellyfin:1', artworkUri: art),
+        'jellyfin',
+      );
+      expect(companion.artworkUri.value, art.toString());
+
+      final TrackRow row = TrackRow(
+        id: 'jellyfin:1',
+        sourceId: 'jellyfin',
+        title: 'X',
+        uri: 'jellyfin:1',
+        durationMs: 0,
+        artworkUri: companion.artworkUri.value,
+      );
+      expect(trackFromRow(row).artworkUri, art);
+    });
+
+    test('a track with no cover stores and reads back a null artworkUri', () {
+      final companion = trackToCompanion(
+        const Track(id: 'subsonic:1', title: 'X', uri: 'subsonic:1'),
+        'subsonic',
+      );
+      expect(companion.artworkUri.value, isNull);
+
+      const TrackRow row = TrackRow(
+        id: 'subsonic:1',
+        sourceId: 'subsonic',
+        title: 'X',
+        uri: 'subsonic:1',
+        durationMs: 0,
+      );
+      expect(trackFromRow(row).artworkUri, isNull);
+    });
+  });
+}

--- a/test/shared/widgets/artwork_image_test.dart
+++ b/test/shared/widgets/artwork_image_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/artwork_image.dart';
+
+void main() {
+  group('artworkImageProvider', () {
+    test('loads a file:// cover from disk with a FileImage', () {
+      final provider = artworkImageProvider(
+        Uri.parse('file:///data/app/cache/linthra_local_artwork/abc.img'),
+      );
+      expect(provider, isA<FileImage>());
+      expect(
+        (provider as FileImage).file.path,
+        File('/data/app/cache/linthra_local_artwork/abc.img').path,
+      );
+    });
+
+    test('loads an http(s) cover over the network with a NetworkImage', () {
+      final http = artworkImageProvider(
+        Uri.parse('http://server.example/Items/1/Images/Primary'),
+      );
+      expect(http, isA<NetworkImage>());
+      expect(
+        (http as NetworkImage).url,
+        'http://server.example/Items/1/Images/Primary',
+      );
+
+      final https = artworkImageProvider(
+        Uri.parse('https://music.example.com/Items/2/Images/Primary'),
+      );
+      expect(https, isA<NetworkImage>());
+      expect(
+        (https as NetworkImage).url,
+        'https://music.example.com/Items/2/Images/Primary',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Follow-up to #162 (local index with audio tags + clean fallbacks). Local tracks indexed from a SAF folder now **display their embedded album art** (ID3 `APIC`, FLAC picture, MP4 cover) wherever a server cover would show:

- library track rows
- album / artist views (cover derives from the tracks' `artworkUri`)
- queue / now-playing / mini-player (all read `Track.artworkUri`)

A file with no embedded art keeps the existing calm placeholder, and Jellyfin / Navidrome artwork is untouched.

## How it works

During the content-resolver scan, the native SAF walk already opens a `MediaMetadataRetriever` per file for tags. It now also reads `getEmbeddedPicture()` **through the same data source and SAF grant** and caches the bytes **once** into a private `cacheDir` subfolder, keyed by a **SHA-1 of the content URI**. The track carries a `file://` URI to that cache as `Track.artworkUri`.

Rendering is centralised behind a single shared seam — `artworkImageProvider()`: a `file:` cover loads from disk (`FileImage`), everything else over the network (`NetworkImage`). `AlbumArtwork`, the now-playing background, the artist tile, and the artist-detail header all route through it (they previously built their own `NetworkImage`), so local and server covers are treated identically.

## Investigation notes (as requested)

- **How `Track.artworkUri` is used** — flows into the artwork widgets, into `MediaItem.artUri` (audio_service), and into album/artist grouping (`_AlbumAgg`/`_ArtistAgg` take the first non-null track cover). So populating it on local tracks lights up every surface at once.
- **Provider fallback** — `LogicalTrack.displayArtworkUri` already picks the first candidate (in preference order) that has a cover, so a unified row never blanks a cover another copy has. Unchanged; still covered by tests.
- **How Local mapped `artworkUri`** — it didn't (always null). Now `LocalAudioMetadata.artworkUri` flows through `LocalTrackMapper` to `Track.artworkUri`.
- **`MediaMetadataRetriever.embeddedPicture` + SAF content URI** — safe: once `setDataSource(context, uri)` succeeds (already done for tags), `getEmbeddedPicture()` reads the same source under the existing tree grant. **No new permission.**
- **Where to store** — app-private `cacheDir/linthra_local_artwork/<sha1>.img`, referenced by a `file://` URI. App-private, OS-reclaimable, never a user path.
- **Scan vs lazy** — during the scan (reuses the already-open retriever; only a small path string crosses the platform channel, never the image bytes). Persisted in the catalog, so **launches reuse the cover without re-extracting**.
- **Avoid re-extracting** — existence check **before** `getEmbeddedPicture()` (a re-scan skips already-cached covers) + DB persistence + stable SHA-1 key.

## Privacy / performance

- The artwork URI is an **app-private, hash-named** cache path — never a user file name or `/storage` path — and is only ever **loaded as an image, never shown as text**.
- Extraction is **total**: any failure (no art / unreadable / unwritable) returns null → placeholder, and **never disturbs the tags** read alongside it. Bytes are written to a temp file and atomically renamed (no half-written covers).
- If the OS reclaims the cache, the next rescan transparently re-extracts; a stale `file://` simply hits the `errorBuilder` → placeholder.

## Tests

- local track **with** embedded art maps to a usable `artworkUri`; **without** keeps null
- art-only files (cover, no readable tags) still yield metadata so the cover isn't lost
- channel parses / sanitises the artwork field (blank, non-string, art-only)
- the `file://` cover **round-trips through the persisted catalog** (the "no re-extract on launch" guarantee), Jellyfin URL unchanged
- shared resolver picks `FileImage` vs `NetworkImage`
- a local-only logical row surfaces its `file://` cover; provider fallback + Jellyfin/Subsonic mapping unaffected

`dart format --set-exit-if-changed .`, `flutter analyze`, and `flutter test` (**1589 passed**) are green. The secret/privacy scan passes.

## Scope guardrails honoured

No new permissions · SAF picker unchanged · playback engine unchanged · version unchanged · no release bump / tag / fdroiddata · no lyrics · focused on cover art.

> Note: the Android Kotlin change is reviewed but **not compiled in this environment** (no Android SDK; the `flutter` CI job doesn't build Android — the debug-APK workflow will). The Dart verification suite is green.

https://claude.ai/code/session_017BjAbwMY3XXnKVbpnzTCN7

---
_Generated by [Claude Code](https://claude.ai/code/session_017BjAbwMY3XXnKVbpnzTCN7)_