### PR TITLE
feat(local): read sidecar .lrc/.txt lyrics for local tracks

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -57,6 +57,25 @@ class MainActivity : AudioServiceActivity() {
                             )
                         }
                     }
+                    // Read a track's sidecar lyrics file (Song.lrc / Song.txt
+                    // next to Song.mp3) from within the existing folder grant.
+                    // Returns the text, or null when there's no such sidecar.
+                    "readSidecarText" -> {
+                        val uri = call.argument<String>("uri")
+                        val extension = call.argument<String>("extension")
+                        if (uri == null || extension == null) {
+                            result.error(
+                                "bad_args",
+                                "uri and extension are required",
+                                null,
+                            )
+                        } else {
+                            result.success(
+                                SafDocumentScanner(applicationContext)
+                                    .readSidecarText(uri, extension),
+                            )
+                        }
+                    }
                     else -> result.notImplemented()
                 }
             }

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -6,6 +6,7 @@ import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.DocumentsContract
 import io.flutter.plugin.common.MethodChannel
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
 import java.util.ArrayDeque
@@ -50,6 +51,82 @@ class SafDocumentScanner(private val context: Context) {
         val target = Uri.parse(treeUri)
         return context.contentResolver.persistedUriPermissions.any {
             it.uri == target && it.isReadPermission
+        }
+    }
+
+    /**
+     * Reads the text of a sidecar lyrics file sitting next to the audio document
+     * at [audioUri] — `Song.lrc` / `Song.txt` beside `Song.mp3` — and returns
+     * it, or null when there's no such sibling or it can't be read.
+     *
+     * The audio URI is a tree-based document URI (built by the walk via
+     * buildDocumentUriUsingTree), so the sibling is reached under the *same*
+     * folder grant: swap the file's extension in the document id and rebuild the
+     * document URI within the tree. This needs no extra permission and never
+     * touches a raw /storage path. [extension] is the bare suffix ("lrc", "txt").
+     *
+     * Deliberately total: any failure (a non-tree URI, an opaque provider whose
+     * ids aren't path-like, a missing file, an oversized or unreadable stream)
+     * returns null so the Dart side falls back to "no lyrics" — never an error,
+     * and never a leaked file name or path.
+     */
+    fun readSidecarText(audioUri: String, extension: String): String? {
+        return try {
+            val uri = Uri.parse(audioUri)
+            val authority = uri.authority ?: return null
+            val documentId = DocumentsContract.getDocumentId(uri)
+            val siblingId = swapExtension(documentId, extension) ?: return null
+            val treeId = DocumentsContract.getTreeDocumentId(uri)
+            val treeUri = DocumentsContract.buildTreeDocumentUri(authority, treeId)
+            val siblingUri =
+                DocumentsContract.buildDocumentUriUsingTree(treeUri, siblingId)
+            readText(siblingUri)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Replaces the extension of the last path segment of a (path-like) document
+     * id with [extension], e.g. `primary:Music/Song.mp3` -> `primary:Music/Song.lrc`.
+     * A segment with no extension simply gains one. Returns null only for an
+     * empty id. Opaque ids (cloud providers) yield a sibling id that won't
+     * resolve, which surfaces as "no lyrics" — acceptable for non-local sources.
+     */
+    private fun swapExtension(documentId: String, extension: String): String? {
+        if (documentId.isEmpty()) return null
+        val slash = documentId.lastIndexOf('/')
+        val dot = documentId.lastIndexOf('.')
+        return if (dot > slash && dot > 0) {
+            documentId.substring(0, dot) + "." + extension
+        } else {
+            "$documentId.$extension"
+        }
+    }
+
+    /**
+     * Reads [uri]'s bytes as UTF-8 text under the existing tree grant, or null
+     * when it can't be opened (no such sibling) or exceeds [MAX_SIDECAR_BYTES]
+     * (a real lyrics file is tiny; an oversized one is more likely a mis-matched
+     * document than lyrics). The stream is always closed.
+     */
+    private fun readText(uri: Uri): String? {
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { stream ->
+                val buffer = ByteArrayOutputStream()
+                val chunk = ByteArray(8192)
+                var total = 0
+                while (true) {
+                    val read = stream.read(chunk)
+                    if (read < 0) break
+                    total += read
+                    if (total > MAX_SIDECAR_BYTES) return null
+                    buffer.write(chunk, 0, read)
+                }
+                String(buffer.toByteArray(), Charsets.UTF_8)
+            }
+        } catch (e: Exception) {
+            null
         }
     }
 
@@ -298,5 +375,10 @@ class SafDocumentScanner(private val context: Context) {
         // Subfolder of cacheDir holding extracted embedded cover art. App-private
         // and OS-reclaimable; never contains a user file name or path.
         private const val ARTWORK_CACHE_DIR = "linthra_local_artwork"
+
+        // Cap on a sidecar lyrics file we'll read into memory. Real .lrc/.txt
+        // lyrics are a few KB; a larger match is more likely a wrong document
+        // than lyrics, so it's ignored (-> "no lyrics") rather than loaded.
+        private const val MAX_SIDECAR_BYTES = 1 * 1024 * 1024
     }
 }

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -31,7 +31,7 @@ persisted catalog.
 
 | Provider              | sourceId   | Stream | Cache | Favorites | Playlists | Lyrics | Cast |
 | --------------------- | ---------- | :----: | :---: | :-------: | :-------: | :----: | :--: |
-| Local music           | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   —    |  —   |
+| Local music           | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   ✅   |  —   |
 | Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
 | Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  ✅  |
 
@@ -60,6 +60,12 @@ like a server source, falling back cleanly to the file name and
 survive a restart. No broad storage permission is requested (tags are read
 through the same folder grant). A file's **embedded** cover art is read during
 the same scan and cached privately, so local tracks show their artwork too.
+A track's **lyrics** are read on demand from a sidecar file sitting next to the
+audio — `Song.lrc` (synced) or `Song.txt` (plain) beside `Song.mp3` — located
+through the same folder grant (never a raw `/storage/…` path); when present they
+appear in the normal Lyrics panel, synced highlighting included, and a track
+with none (or one that can't be read) keeps the calm "no lyrics" state. Reading
+**embedded** lyrics tags from the audio file is a planned follow-up.
 On-device files cannot be cast (a receiver can't reach a file on your phone).
 
 ## Jellyfin

--- a/lib/core/services/local_lyrics_service.dart
+++ b/lib/core/services/local_lyrics_service.dart
@@ -1,0 +1,71 @@
+import '../models/lyrics.dart';
+import '../models/track.dart';
+import '../sources/local/local_lyrics_reader.dart';
+import 'lyrics_service.dart';
+import 'lyrics_text_parser.dart';
+
+/// A [LyricsService] for on-device tracks: it reads lyrics from a sidecar file
+/// sitting next to the audio — `Song.lrc` (synced) or `Song.txt` (plain) beside
+/// `Song.mp3` — located through a [LocalLyricsReader] (the Android binding finds
+/// the sibling SAF document under the folder's existing grant; desktop reads the
+/// neighbouring file). It slots into the same [CompositeLyricsService] seam as
+/// the remote services, so local lyrics behave like provider lyrics in the UI.
+///
+/// Only on-device tracks are claimed: a Jellyfin (`jellyfin:`) or Subsonic
+/// (`subsonic:`) track returns `null` so its own service answers — mirroring how
+/// each remote service self-filters by URI scheme, and reusing the same
+/// remote-scheme set as `LocalPlayableUriResolver`.
+///
+/// Local lyrics are deliberately *best-effort and silent*: unlike the remote
+/// services (which throw so the UI can say "couldn't load"), a missing or
+/// unreadable sidecar resolves to `null` → the calm "no lyrics" state. A read
+/// failure never surfaces an error and never leaks the file's name or path.
+/// `.lrc` is preferred over `.txt` so a track with both shows synced lyrics.
+class LocalLyricsService implements LyricsService {
+  const LocalLyricsService(this._reader);
+
+  final LocalLyricsReader _reader;
+
+  /// Remote schemes whose tracks this on-device service must not claim, leaving
+  /// them to their own services. Kept in step with `LocalPlayableUriResolver`.
+  static const Set<String> _remoteSchemes = <String>{'jellyfin', 'subsonic'};
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async {
+    if (!_isLocal(track.uri)) return null;
+    // Prefer a synced `.lrc`; fall back to a plain `.txt`.
+    final Lyrics? synced =
+        await _read(track.uri, 'lrc', LyricsTextParser.parseLrc);
+    if (synced != null) return synced;
+    return _read(track.uri, 'txt', LyricsTextParser.parsePlain);
+  }
+
+  /// Reads the sidecar with [extension] and runs [parse] on it, returning the
+  /// resulting non-empty [Lyrics] or `null`. Any reader error is swallowed (fail
+  /// silently → "no lyrics"); the reader's own contract is to not throw, but the
+  /// guard means a misbehaving binding can't break the lyrics screen either.
+  Future<Lyrics?> _read(
+    String uri,
+    String extension,
+    Lyrics? Function(String) parse,
+  ) async {
+    String? text;
+    try {
+      text = await _reader.readSidecar(uri, extension);
+    } catch (_) {
+      return null;
+    }
+    if (text == null) return null;
+    final Lyrics? lyrics = parse(text);
+    return (lyrics != null && lyrics.isNotEmpty) ? lyrics : null;
+  }
+
+  /// Whether [uri] is an on-device track (anything that isn't a known remote
+  /// scheme — a `content://` SAF document or a file path/URI), matching
+  /// `LocalPlayableUriResolver.handles`.
+  static bool _isLocal(String uri) {
+    final Uri? parsed = Uri.tryParse(uri);
+    final String scheme = parsed?.scheme.toLowerCase() ?? '';
+    return !_remoteSchemes.contains(scheme);
+  }
+}

--- a/lib/core/services/lyrics_text_parser.dart
+++ b/lib/core/services/lyrics_text_parser.dart
@@ -1,0 +1,145 @@
+import '../models/lyrics.dart';
+
+/// Turns raw sidecar text into the source-agnostic [Lyrics] model the player
+/// renders — the local counterpart to the structured lyrics the Jellyfin and
+/// Subsonic clients build from their servers' JSON.
+///
+/// Two shapes, matching the two sidecar kinds a local track can carry:
+///  - [parseLrc] reads an `.lrc` file: `[mm:ss.xx]` timestamp tags become timed
+///    [LyricLine]s (the synced view, with the same model the remote sources
+///    feed), and a timestamp-free `.lrc` degrades to plain lines. Non-timing ID
+///    tags (`[ar:…]`, `[ti:…]`, `[offset:…]`, …) are ignored rather than shown.
+///  - [parsePlain] reads a `.txt` file: every line is a plain, untimed
+///    [LyricLine] — no timestamp parsing — so it renders in the static view.
+///
+/// Both return `null` when the text carries no usable line, so the caller can
+/// fall through to the next sidecar (or the calm "no lyrics" state) instead of
+/// showing an empty box. Pure and total: malformed input never throws — an
+/// unparseable timestamp just leaves that line untimed.
+abstract final class LyricsTextParser {
+  /// A leading `[mm:ss]`, `[mm:ss.xx]`, or `[mm:ss.xxx]` timestamp tag. Minutes
+  /// are unbounded (a long track can exceed 99), seconds are 1–2 digits, and the
+  /// optional fraction is 1–3 digits (tenths / centiseconds / milliseconds).
+  static final RegExp _timeTag =
+      RegExp(r'\[(\d+):(\d{1,2})(?:[.:](\d{1,3}))?\]');
+
+  /// An LRC ID/metadata tag like `[ar:Artist]` or `[offset:+250]`: a leading
+  /// alpha key, a colon, then a value. Distinguished from a timestamp (whose key
+  /// is digits) so it can be dropped rather than rendered as a lyric line.
+  static final RegExp _idTag = RegExp(r'^\[[a-zA-Z][a-zA-Z0-9_]*:.*\]$');
+
+  /// Parses `.lrc` text. Timed lines win: when any `[mm:ss]` tag is present the
+  /// result is synced (lines ordered by time, untimed leftovers dropped);
+  /// otherwise the non-tag lines become plain lyrics. `null` when nothing usable
+  /// remains.
+  static Lyrics? parseLrc(String text) {
+    final List<LyricLine> timed = <LyricLine>[];
+    final List<LyricLine> plain = <LyricLine>[];
+    for (final String raw in _splitLines(text)) {
+      final _LrcLine parsed = _parseLrcLine(raw);
+      if (parsed.timestamps.isNotEmpty) {
+        // `[t1][t2]Text` repeats the same line at each timestamp.
+        for (final Duration start in parsed.timestamps) {
+          timed.add(LyricLine(text: parsed.text, start: start));
+        }
+      } else if (!parsed.isMetadata) {
+        plain.add(LyricLine(text: parsed.text));
+      }
+    }
+    if (timed.isNotEmpty) {
+      // Order by time so the model's active-line search (which assumes ascending
+      // order) holds even when stamps are listed out of order or repeated.
+      timed.sort((LyricLine a, LyricLine b) => a.start!.compareTo(b.start!));
+      return Lyrics(lines: timed);
+    }
+    return _plainOrNull(plain);
+  }
+
+  /// Parses `.txt` text as plain, untimed lyrics: every line becomes a
+  /// [LyricLine] (interior blank lines kept for stanza rhythm), with no
+  /// timestamp parsing. `null` when the text is blank.
+  static Lyrics? parsePlain(String text) {
+    final List<LyricLine> lines = _splitLines(text)
+        .map((String line) => LyricLine(text: line.trimRight()))
+        .toList();
+    return _plainOrNull(lines);
+  }
+
+  /// Splits [text] into lines, normalizing CRLF/CR so a Windows-authored sidecar
+  /// parses identically.
+  static List<String> _splitLines(String text) =>
+      text.replaceAll('\r\n', '\n').replaceAll('\r', '\n').split('\n');
+
+  /// Parses one `.lrc` line into its leading timestamps and remaining text, or
+  /// flags it as an ID/metadata tag to be ignored.
+  static _LrcLine _parseLrcLine(String raw) {
+    final String line = raw.trim();
+    final List<Duration> stamps = <Duration>[];
+    int index = 0;
+    while (true) {
+      final Match? match = _timeTag.matchAsPrefix(line, index);
+      if (match == null) break;
+      stamps.add(_durationOf(match));
+      index = match.end;
+    }
+    if (stamps.isNotEmpty) {
+      return _LrcLine(timestamps: stamps, text: line.substring(index).trim());
+    }
+    return _LrcLine(
+      timestamps: const <Duration>[],
+      text: line,
+      isMetadata: _idTag.hasMatch(line),
+    );
+  }
+
+  /// The [Duration] for a `[mm:ss(.fff)]` match. The fraction's digit count sets
+  /// its scale: 1 digit → tenths, 2 → centiseconds, 3 → milliseconds.
+  static Duration _durationOf(Match match) {
+    final int minutes = int.parse(match.group(1)!);
+    final int seconds = int.parse(match.group(2)!);
+    final String? fraction = match.group(3);
+    int milliseconds = 0;
+    if (fraction != null) {
+      final int value = int.parse(fraction);
+      milliseconds = switch (fraction.length) {
+        1 => value * 100,
+        2 => value * 10,
+        _ => value,
+      };
+    }
+    return Duration(
+      minutes: minutes,
+      seconds: seconds,
+      milliseconds: milliseconds,
+    );
+  }
+
+  /// [lines] with fully-blank leading/trailing lines trimmed (interior blanks
+  /// kept), or `null` when nothing but blanks remain.
+  static Lyrics? _plainOrNull(List<LyricLine> lines) {
+    int start = 0;
+    int end = lines.length;
+    while (start < end && lines[start].text.trim().isEmpty) {
+      start++;
+    }
+    while (end > start && lines[end - 1].text.trim().isEmpty) {
+      end--;
+    }
+    if (start >= end) return null;
+    return Lyrics(lines: lines.sublist(start, end));
+  }
+}
+
+/// One parsed `.lrc` line: its (zero or more) leading [timestamps], the [text]
+/// after them, and whether the whole line was an ID/metadata tag to ignore.
+class _LrcLine {
+  const _LrcLine({
+    required this.timestamps,
+    required this.text,
+    this.isMetadata = false,
+  });
+
+  final List<Duration> timestamps;
+  final String text;
+  final bool isMetadata;
+}

--- a/lib/core/sources/local/io_local_lyrics_reader.dart
+++ b/lib/core/sources/local/io_local_lyrics_reader.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'local_lyrics_reader.dart';
+
+/// A [LocalLyricsReader] that finds a sidecar lyrics file *on the filesystem*,
+/// next to a local track addressed by a file path or `file://` URI — the
+/// desktop/Linux counterpart to the Android SAF reader.
+///
+/// Given a track at `…/Album/Song.mp3` and extension `lrc`, it reads
+/// `…/Album/Song.lrc` (same folder, same base name). A `content://` URI (an
+/// Android SAF document, which has no filesystem path) is not its job, so it
+/// returns `null` and the SAF reader handles those.
+///
+/// Best-effort and total: a missing file, a permission error, or invalid bytes
+/// all resolve to `null`, so a sidecar that can't be read is simply "no lyrics"
+/// — never a thrown error. Text is decoded as UTF-8 with malformed bytes
+/// allowed, so one stray byte can't lose an otherwise-readable file.
+class IoLocalLyricsReader implements LocalLyricsReader {
+  const IoLocalLyricsReader();
+
+  @override
+  Future<String?> readSidecar(String trackUri, String extension) async {
+    final String? path = _filesystemPath(trackUri);
+    if (path == null) return null;
+    final String sidecar = p.join(
+      p.dirname(path),
+      '${p.basenameWithoutExtension(path)}.$extension',
+    );
+    try {
+      final File file = File(sidecar);
+      if (!await file.exists()) return null;
+      return await file.readAsString(
+        encoding: const Utf8Codec(allowMalformed: true),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The filesystem path for [trackUri], or `null` when it isn't a local file
+  /// location (a `content://` SAF document, or a remote scheme this reader can't
+  /// open). A bare path and a `file://` URI both resolve to a path.
+  static String? _filesystemPath(String trackUri) {
+    final Uri? uri = Uri.tryParse(trackUri);
+    if (uri == null || uri.scheme.isEmpty) return trackUri;
+    if (uri.scheme.toLowerCase() == 'file') return uri.toFilePath();
+    return null;
+  }
+}

--- a/lib/core/sources/local/local_lyrics_reader.dart
+++ b/lib/core/sources/local/local_lyrics_reader.dart
@@ -1,0 +1,31 @@
+/// Reads the raw text of a *sidecar* lyrics file sitting next to a local track —
+/// `Song.lrc` (synced) or `Song.txt` (plain) beside `Song.mp3`.
+///
+/// This is a seam, deliberately mirroring [LocalMetadataReader] and
+/// [SafDocumentLister]: [LocalLyricsService] depends on this interface, never on
+/// a concrete reader, so *how* a sidecar is located stays platform-specific and
+/// swappable — the Android binding finds the sibling SAF document through the
+/// content resolver under the folder's existing grant (no broad storage
+/// permission, no raw `/storage/...` path), while the desktop binding reads the
+/// neighbouring file from the filesystem.
+///
+/// Contract: [readSidecar] returns the file's text, or `null` when there is no
+/// such sidecar (the common case) or it can't be read. It must **never throw** —
+/// a missing or unreadable sidecar is just "no lyrics", never a failed lookup,
+/// so the lyrics screen, the scan, and playback are never blocked by it.
+abstract interface class LocalLyricsReader {
+  /// The text of the sidecar with [extension] (e.g. `lrc`, `txt`) next to the
+  /// track at [trackUri] (a `content://` SAF document or a file path/URI), or
+  /// `null` when absent or unreadable.
+  Future<String?> readSidecar(String trackUri, String extension);
+}
+
+/// The default [LocalLyricsReader] for platforms/builds with no sidecar support
+/// (and tests): it reads nothing, so every local track resolves to "no lyrics"
+/// and behaviour is unchanged. Mirrors [UnsupportedLocalMetadataReader].
+class UnsupportedLocalLyricsReader implements LocalLyricsReader {
+  const UnsupportedLocalLyricsReader();
+
+  @override
+  Future<String?> readSidecar(String trackUri, String extension) async => null;
+}

--- a/lib/core/sources/local/method_channel_saf_lyrics_reader.dart
+++ b/lib/core/sources/local/method_channel_saf_lyrics_reader.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'local_lyrics_reader.dart';
+
+/// A [LocalLyricsReader] that reads a sidecar lyrics file sitting next to an
+/// Android SAF audio document, through the same native `…/saf` method channel
+/// the document lister uses. The native side finds the sibling document with the
+/// same base name and the requested extension *within the tree the user already
+/// granted*, reads its text, and returns it — so it needs no extra storage
+/// permission and never touches a raw `/storage/...` path.
+///
+/// Only `content://` document URIs are its job; a filesystem path (desktop) is
+/// [IoLocalLyricsReader]'s, so this returns `null` for those. Off Android, or
+/// when the native handler isn't registered, it returns `null` too.
+///
+/// Best-effort and total: a [MissingPluginException] or [PlatformException]
+/// becomes `null` (no lyrics), never a surfaced error — and the native message,
+/// which could carry a file detail, is never propagated.
+class MethodChannelSafLyricsReader implements LocalLyricsReader {
+  const MethodChannelSafLyricsReader();
+
+  // Mirrors MethodChannelSafDocumentLister / MainActivity.kt's SAF_CHANNEL.
+  static const MethodChannel _channel =
+      MethodChannel('io.github.thezupzup.linthra/saf');
+
+  @override
+  Future<String?> readSidecar(String trackUri, String extension) async {
+    if (!Platform.isAndroid) return null;
+    if (!trackUri.startsWith('content://')) return null;
+    try {
+      return await _channel.invokeMethod<String>(
+        'readSidecarText',
+        <String, Object?>{'uri': trackUri, 'extension': extension},
+      );
+    } on MissingPluginException {
+      return null;
+    } on PlatformException {
+      // The native side couldn't read it; treat as "no lyrics" rather than
+      // surfacing a raw platform error (or any file detail it might carry).
+      return null;
+    }
+  }
+}

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -1,11 +1,17 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/lyrics.dart';
 import '../../core/models/track.dart';
 import '../../core/services/composite_lyrics_service.dart';
 import '../../core/services/jellyfin_lyrics_service.dart';
+import '../../core/services/local_lyrics_service.dart';
 import '../../core/services/lyrics_service.dart';
 import '../../core/services/subsonic_lyrics_service.dart';
+import '../../core/sources/local/io_local_lyrics_reader.dart';
+import '../../core/sources/local/local_lyrics_reader.dart';
+import '../../core/sources/local/method_channel_saf_lyrics_reader.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
@@ -55,13 +61,27 @@ final currentTrackLyricsProvider =
   return ref.watch(trackLyricsProvider(track));
 });
 
-/// Production binding: read lyrics from whichever signed-in remote server owns
-/// the track — Jellyfin or Subsonic/Navidrome. Each backend filters by the
-/// track's URI scheme, so a track resolves through exactly one of them (or none,
-/// for a local track). The live clients + sessions are read lazily so signing
-/// in/out is picked up without a rebuild. Applied in `main`; tests keep the
-/// no-lyrics default.
-final remoteLyricsServiceOverride = lyricsServiceProvider.overrideWith((ref) {
+/// The platform binding that reads a local track's sidecar lyrics file. Android
+/// reads the sibling SAF document through the native content resolver (under the
+/// folder's existing grant, no broad storage permission); elsewhere (desktop) it
+/// reads the neighbouring file from the filesystem. Tests override
+/// [lyricsServiceProvider] directly, so this is only exercised in a real app
+/// build.
+final localLyricsReaderProvider = Provider<LocalLyricsReader>((ref) {
+  return Platform.isAndroid
+      ? const MethodChannelSafLyricsReader()
+      : const IoLocalLyricsReader();
+});
+
+/// Production binding: read lyrics from whichever source owns the track — a
+/// signed-in Jellyfin or Subsonic/Navidrome server, or a sidecar file next to a
+/// local track. Each backend filters by the track's URI scheme (local claims
+/// anything that isn't a remote scheme), so a track resolves through exactly one
+/// of them (or none). The live clients + sessions are read lazily so signing
+/// in/out is picked up without a rebuild; the local reader is platform-bound via
+/// [localLyricsReaderProvider]. Applied in `main`; tests keep the no-lyrics
+/// default.
+final lyricsServiceOverride = lyricsServiceProvider.overrideWith((ref) {
   return CompositeLyricsService(<LyricsService>[
     JellyfinLyricsService(
       client: ref.read(jellyfinClientProvider),
@@ -73,6 +93,7 @@ final remoteLyricsServiceOverride = lyricsServiceProvider.overrideWith((ref) {
       session: () =>
           ref.read(subsonicSettingsControllerProvider.notifier).session,
     ),
+    LocalLyricsService(ref.read(localLyricsReaderProvider)),
   ]);
 });
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,9 +87,9 @@ Future<void> main() async {
       // Persist on-device play history (counts + last-played) for the
       // "Recently played" / "Most played" / "Never played" smart mixes.
       sharedPreferencesPlayHistoryStoreOverride,
-      // Lyrics from whichever signed-in remote server owns the track (Jellyfin
-      // or Subsonic/Navidrome).
-      remoteLyricsServiceOverride,
+      // Lyrics from whichever source owns the track: a signed-in Jellyfin or
+      // Subsonic/Navidrome server, or a sidecar .lrc/.txt next to a local file.
+      lyricsServiceOverride,
       // Real Chromecast backend (Android/iOS only); see cast_providers.dart.
       chromecastCastServiceOverride,
     ],

--- a/test/core/services/local_lyrics_service_test.dart
+++ b/test/core/services/local_lyrics_service_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/composite_lyrics_service.dart';
+import 'package:linthra/core/services/jellyfin_lyrics_service.dart';
+import 'package:linthra/core/services/local_lyrics_service.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/core/services/subsonic_lyrics_service.dart';
+import 'package:linthra/core/sources/local/local_lyrics_reader.dart';
+
+import '../sources/jellyfin/fake_jellyfin_client.dart';
+import '../sources/subsonic/fake_subsonic_client.dart';
+
+/// A [LocalLyricsReader] that serves canned sidecar text by extension and
+/// records what it was asked for — so order, short-circuit, and "never asked"
+/// behaviour can be asserted. Can be made to throw to model a read failure.
+class _FakeLocalLyricsReader implements LocalLyricsReader {
+  _FakeLocalLyricsReader(
+      {this.byExtension = const <String, String>{}, this.error});
+
+  final Map<String, String> byExtension;
+  final Object? error;
+  final List<String> requestedExtensions = <String>[];
+  String? lastUri;
+
+  @override
+  Future<String?> readSidecar(String trackUri, String extension) async {
+    lastUri = trackUri;
+    requestedExtensions.add(extension);
+    if (error != null) throw error!;
+    return byExtension[extension];
+  }
+}
+
+const _localUri = 'content://com.android.externalstorage.documents'
+    '/tree/primary%3AMusic/document/primary%3AMusic%2FSong.mp3';
+
+Track _local() => const Track(id: _localUri, title: 'Song', uri: _localUri);
+
+void main() {
+  group('LocalLyricsService', () {
+    test('reads a synced .lrc sidecar for a local track', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[00:00.00]first\n[00:05.00]second\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics? lyrics = await service.lyricsFor(_local());
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isTrue);
+      expect(lyrics.lines, <LyricLine>[
+        const LyricLine(text: 'first', start: Duration.zero),
+        const LyricLine(text: 'second', start: Duration(seconds: 5)),
+      ]);
+      expect(reader.lastUri, _localUri);
+    });
+
+    test('reads a plain .txt sidecar when there is no .lrc', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'txt': 'plain one\nplain two\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics? lyrics = await service.lyricsFor(_local());
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isFalse);
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text).toList(),
+        <String>['plain one', 'plain two'],
+      );
+      // It tried the synced .lrc first, then fell back to the plain .txt.
+      expect(reader.requestedExtensions, <String>['lrc', 'txt']);
+    });
+
+    test('prefers the synced .lrc over a .txt when both exist', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[00:01.00]synced\n',
+        'txt': 'plain\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics? lyrics = await service.lyricsFor(_local());
+
+      expect(lyrics!.isSynced, isTrue);
+      expect(lyrics.lines.single.text, 'synced');
+      // The .txt is never even read once the .lrc answered.
+      expect(reader.requestedExtensions, <String>['lrc']);
+    });
+
+    test('returns null (no lyrics) when there is no sidecar', () async {
+      final reader = _FakeLocalLyricsReader();
+      final service = LocalLyricsService(reader);
+
+      expect(await service.lyricsFor(_local()), isNull);
+      // Both candidate sidecars were tried before giving up.
+      expect(reader.requestedExtensions, <String>['lrc', 'txt']);
+    });
+
+    test('fails silently (null) when the reader throws', () async {
+      final reader = _FakeLocalLyricsReader(error: Exception('I/O error'));
+      final service = LocalLyricsService(reader);
+
+      // No throw escapes — a read failure is just "no lyrics".
+      expect(await service.lyricsFor(_local()), isNull);
+    });
+
+    test('treats an empty/metadata-only sidecar as no lyrics', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[ar:Artist]\n[ti:Title]\n', // metadata only -> empty
+        'txt': '   \n\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      expect(await service.lyricsFor(_local()), isNull);
+    });
+
+    test('ignores a Jellyfin track without touching the reader', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[00:01.00]should not be used\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics? lyrics = await service.lyricsFor(
+        const Track(id: 'j-1', title: 'Song', uri: 'jellyfin:j-1'),
+      );
+
+      expect(lyrics, isNull);
+      expect(reader.requestedExtensions, isEmpty);
+      expect(reader.lastUri, isNull);
+    });
+
+    test('ignores a Subsonic track without touching the reader', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[00:01.00]should not be used\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics? lyrics = await service.lyricsFor(
+        const Track(id: 's-1', title: 'Song', uri: 'subsonic:s-1'),
+      );
+
+      expect(lyrics, isNull);
+      expect(reader.requestedExtensions, isEmpty);
+    });
+
+    test('handles a plain file:// path track (desktop case)', () async {
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[00:02.00]from a file path\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics? lyrics = await service.lyricsFor(
+        const Track(id: '1', title: 'Song', uri: 'file:///music/Song.mp3'),
+      );
+
+      expect(lyrics!.lines.single.text, 'from a file path');
+    });
+
+    test('never surfaces the track path/name in the rendered lyrics', () async {
+      // A revealing URI: a private folder + file name. The displayed lyrics must
+      // come only from the sidecar's content, never echo the path.
+      const String revealing = 'content://com.android.externalstorage.documents'
+          '/tree/primary%3AMusic/document'
+          '/primary%3AMusic%2FPrivate%20Folder%2FMy%20Secret%20Song.mp3';
+      final reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'txt': 'la la la\nfade out\n',
+      });
+      final service = LocalLyricsService(reader);
+
+      final Lyrics lyrics = (await service.lyricsFor(
+        const Track(id: revealing, title: 'Song', uri: revealing),
+      ))!;
+
+      for (final LyricLine line in lyrics.lines) {
+        expect(line.text, isNot(contains('Secret')));
+        expect(line.text, isNot(contains('Private')));
+        expect(line.text, isNot(contains('primary')));
+        expect(line.text, isNot(contains('content://')));
+      }
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text).toList(),
+        <String>['la la la', 'fade out'],
+      );
+    });
+  });
+
+  // The local service shares the same CompositeLyricsService seam as the remote
+  // ones. These prove adding it leaves Jellyfin and Subsonic/Navidrome lyrics
+  // exactly as before — each source still resolves through its own backend.
+  group('CompositeLyricsService with local + remote backends', () {
+    const jellyfinSession = JellyfinSession(
+      baseUrl: 'https://music.example.com',
+      userId: 'user-1',
+      accessToken: 'tok',
+      deviceId: 'device-1',
+    );
+    const subsonicSession = SubsonicSession(
+      baseUrl: 'https://music.example.com',
+      username: 'alice',
+      salt: 'salt1',
+      token: 'tok1',
+    );
+
+    late FakeJellyfinClient jellyfin;
+    late FakeSubsonicClient subsonic;
+    late _FakeLocalLyricsReader reader;
+    late CompositeLyricsService service;
+
+    setUp(() {
+      jellyfin = FakeJellyfinClient();
+      subsonic = FakeSubsonicClient();
+      reader = _FakeLocalLyricsReader(byExtension: <String, String>{
+        'lrc': '[00:01.00]local line\n',
+      });
+      service = CompositeLyricsService(<LyricsService>[
+        JellyfinLyricsService(
+          client: jellyfin,
+          session: () => jellyfinSession,
+        ),
+        SubsonicLyricsService(
+          client: subsonic,
+          session: () => subsonicSession,
+        ),
+        LocalLyricsService(reader),
+      ]);
+    });
+
+    test('a Jellyfin track still resolves via Jellyfin, untouched by local',
+        () async {
+      jellyfin.lyrics = const Lyrics(lines: <LyricLine>[LyricLine(text: 'jf')]);
+
+      final Lyrics? lyrics = await service.lyricsFor(
+        const Track(id: 'j-7', title: 'Song', uri: 'jellyfin:j-7'),
+      );
+
+      expect(lyrics?.lines.single.text, 'jf');
+      expect(jellyfin.lastLyricsItemId, 'j-7');
+      // The local reader was never consulted for a remote track.
+      expect(reader.requestedExtensions, isEmpty);
+    });
+
+    test('a Subsonic track still resolves via Subsonic, untouched by local',
+        () async {
+      subsonic.lyrics =
+          const Lyrics(lines: <LyricLine>[LyricLine(text: 'sub')]);
+
+      final Lyrics? lyrics = await service.lyricsFor(
+        const Track(id: 's-7', title: 'Song', uri: 'subsonic:s-7'),
+      );
+
+      expect(lyrics?.lines.single.text, 'sub');
+      expect(subsonic.lastLyricsSongId, 's-7');
+      expect(reader.requestedExtensions, isEmpty);
+    });
+
+    test('a local track resolves via the local sidecar', () async {
+      final Lyrics? lyrics = await service.lyricsFor(_local());
+
+      expect(lyrics?.lines.single.text, 'local line');
+      // The remote backends declined a local track without hitting a server.
+      expect(jellyfin.lastLyricsItemId, isNull);
+      expect(subsonic.lastLyricsSongId, isNull);
+    });
+  });
+}

--- a/test/core/services/lyrics_text_parser_test.dart
+++ b/test/core/services/lyrics_text_parser_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/services/lyrics_text_parser.dart';
+
+void main() {
+  group('LyricsTextParser.parseLrc', () {
+    test('reads timestamped lines into synced lyrics', () {
+      final Lyrics? lyrics = LyricsTextParser.parseLrc(
+        '[00:00.00]First line\n'
+        '[00:12.34]Second line\n'
+        '[01:02.50]Third line\n',
+      );
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isTrue);
+      expect(lyrics.lines, <LyricLine>[
+        const LyricLine(text: 'First line', start: Duration.zero),
+        const LyricLine(
+          text: 'Second line',
+          start: Duration(seconds: 12, milliseconds: 340),
+        ),
+        const LyricLine(
+          text: 'Third line',
+          start: Duration(minutes: 1, seconds: 2, milliseconds: 500),
+        ),
+      ]);
+    });
+
+    test('scales the fraction by its digit count (tenths/centis/millis)', () {
+      final Lyrics lyrics = LyricsTextParser.parseLrc(
+        '[00:01.5]tenths\n' // 1 digit -> 500ms
+        '[00:02.05]centis\n' // 2 digits -> 50ms
+        '[00:03.250]millis\n' // 3 digits -> 250ms
+        '[00:04]whole\n', // no fraction -> 0ms
+      )!;
+
+      expect(lyrics.lines.map((LyricLine l) => l.start).toList(), <Duration>[
+        const Duration(seconds: 1, milliseconds: 500),
+        const Duration(seconds: 2, milliseconds: 50),
+        const Duration(seconds: 3, milliseconds: 250),
+        const Duration(seconds: 4),
+      ]);
+    });
+
+    test('repeats a line for each of its leading timestamps', () {
+      final Lyrics lyrics = LyricsTextParser.parseLrc(
+        '[00:05.00][00:10.00]Chorus\n',
+      )!;
+
+      expect(lyrics.lines, <LyricLine>[
+        const LyricLine(text: 'Chorus', start: Duration(seconds: 5)),
+        const LyricLine(text: 'Chorus', start: Duration(seconds: 10)),
+      ]);
+    });
+
+    test('orders lines by time even when listed out of order', () {
+      final Lyrics lyrics = LyricsTextParser.parseLrc(
+        '[00:20.00]late\n'
+        '[00:05.00]early\n'
+        '[00:10.00]middle\n',
+      )!;
+
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text).toList(),
+        <String>['early', 'middle', 'late'],
+      );
+    });
+
+    test('ignores ID/metadata tags rather than rendering them', () {
+      final Lyrics lyrics = LyricsTextParser.parseLrc(
+        '[ar:Some Artist]\n'
+        '[ti:Some Title]\n'
+        '[offset:+250]\n'
+        '[00:01.00]Only real line\n',
+      )!;
+
+      expect(lyrics.lines, <LyricLine>[
+        const LyricLine(text: 'Only real line', start: Duration(seconds: 1)),
+      ]);
+    });
+
+    test('falls back to plain lines for a timestamp-free .lrc', () {
+      final Lyrics lyrics = LyricsTextParser.parseLrc(
+        'Just some lyrics\n'
+        'with no timing\n',
+      )!;
+
+      expect(lyrics.isSynced, isFalse);
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text).toList(),
+        <String>['Just some lyrics', 'with no timing'],
+      );
+    });
+
+    test('returns null for blank or metadata-only text', () {
+      expect(LyricsTextParser.parseLrc(''), isNull);
+      expect(LyricsTextParser.parseLrc('   \n\n  '), isNull);
+      expect(LyricsTextParser.parseLrc('[ar:Artist]\n[ti:Title]\n'), isNull);
+    });
+
+    test('normalizes CRLF line endings', () {
+      final Lyrics lyrics = LyricsTextParser.parseLrc(
+        '[00:01.00]one\r\n[00:02.00]two\r\n',
+      )!;
+
+      expect(lyrics.lines.length, 2);
+      expect(lyrics.lines.last.text, 'two');
+    });
+  });
+
+  group('LyricsTextParser.parsePlain', () {
+    test('reads every line as an untimed lyric line', () {
+      final Lyrics? lyrics = LyricsTextParser.parsePlain(
+        'line one\n'
+        'line two\n'
+        'line three\n',
+      );
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isFalse);
+      expect(lyrics.lines, <LyricLine>[
+        const LyricLine(text: 'line one'),
+        const LyricLine(text: 'line two'),
+        const LyricLine(text: 'line three'),
+      ]);
+    });
+
+    test('keeps interior blank lines but trims leading/trailing blanks', () {
+      final Lyrics lyrics = LyricsTextParser.parsePlain(
+        '\n\n'
+        'verse one\n'
+        '\n'
+        'verse two\n'
+        '\n\n',
+      )!;
+
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text).toList(),
+        <String>['verse one', '', 'verse two'],
+      );
+    });
+
+    test('does not parse timestamps — text is literal', () {
+      final Lyrics lyrics = LyricsTextParser.parsePlain('[00:01.00]Hello')!;
+
+      expect(lyrics.isSynced, isFalse);
+      expect(lyrics.lines.single.text, '[00:01.00]Hello');
+    });
+
+    test('returns null for blank text', () {
+      expect(LyricsTextParser.parsePlain(''), isNull);
+      expect(LyricsTextParser.parsePlain('   \n  \n'), isNull);
+    });
+  });
+}

--- a/test/core/sources/local/io_local_lyrics_reader_test.dart
+++ b/test/core/sources/local/io_local_lyrics_reader_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/io_local_lyrics_reader.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('IoLocalLyricsReader', () {
+    late Directory dir;
+    const IoLocalLyricsReader reader = IoLocalLyricsReader();
+
+    setUp(() {
+      dir = Directory.systemTemp.createTempSync('linthra_lyrics_test');
+    });
+    tearDown(() {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    });
+
+    String trackPath() => p.join(dir.path, 'Song.mp3');
+
+    test('reads the sidecar with the matching base name and extension',
+        () async {
+      File(p.join(dir.path, 'Song.lrc')).writeAsStringSync('[00:01.00]hello\n');
+
+      final String? text = await reader.readSidecar(trackPath(), 'lrc');
+
+      expect(text, '[00:01.00]hello\n');
+    });
+
+    test('reads a .txt sidecar', () async {
+      File(p.join(dir.path, 'Song.txt')).writeAsStringSync('plain lyrics\n');
+
+      expect(await reader.readSidecar(trackPath(), 'txt'), 'plain lyrics\n');
+    });
+
+    test('returns null when no sidecar exists', () async {
+      expect(await reader.readSidecar(trackPath(), 'lrc'), isNull);
+      expect(await reader.readSidecar(trackPath(), 'txt'), isNull);
+    });
+
+    test('does not match a different base name', () async {
+      File(p.join(dir.path, 'Other.lrc')).writeAsStringSync('nope\n');
+
+      expect(await reader.readSidecar(trackPath(), 'lrc'), isNull);
+    });
+
+    test('accepts a file:// URI', () async {
+      File(p.join(dir.path, 'Song.lrc')).writeAsStringSync('from uri\n');
+      final String fileUri = Uri.file(trackPath()).toString();
+
+      expect(await reader.readSidecar(fileUri, 'lrc'), 'from uri\n');
+    });
+
+    test('returns null for a content:// URI (not its job)', () async {
+      const String contentUri = 'content://com.android.externalstorage'
+          '.documents/tree/primary%3AMusic/document/primary%3AMusic%2FSong.mp3';
+
+      expect(await reader.readSidecar(contentUri, 'lrc'), isNull);
+    });
+
+    test('finds the sidecar in the same nested folder as the track', () async {
+      final Directory nested = Directory(p.join(dir.path, 'Artist', 'Album'))
+        ..createSync(
+          recursive: true,
+        );
+      final String track = p.join(nested.path, 'Track.flac');
+      File(p.join(nested.path, 'Track.lrc')).writeAsStringSync('nested\n');
+
+      expect(await reader.readSidecar(track, 'lrc'), 'nested\n');
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Local music scans tags and shows embedded cover art, but had no lyrics. This adds lyrics for **on-device tracks** from a **sidecar file** next to the audio — `Song.lrc` (synced) or `Song.txt` (plain) beside `Song.mp3` — shown in the **existing** Lyrics UI, synced highlighting included. When a track has no readable sidecar, it keeps the calm "No lyrics available" state.

Scoped to local lyrics only. No playback changes, no version/tag/F-Droid changes, no new permissions, and the SAF picker is untouched.

## How it fits the existing design

The codebase already has a clean lyrics seam (`LyricsService` → `CompositeLyricsService`), and `lyrics_service.dart` even anticipated this: *"A future local `.lrc`/tag reader slots in behind this same seam without the player changing."* The `Lyrics` model and the player UI already render **synced** lyrics. So this is additive:

- **`LocalLyricsService`** (`LyricsService`) self-filters to on-device tracks — anything that isn't a `jellyfin:`/`subsonic:` scheme, reusing the same remote-scheme set as `LocalPlayableUriResolver` — and is appended to the `CompositeLyricsService`. A remote track still resolves through its own backend, untouched; a local track resolves through this one. Unlike the remote services (which throw so the UI can say "couldn't load"), local lyrics **fail silently** to `null` → "no lyrics", so a read error never blocks the screen, the scan, or playback, and never leaks a path.
- **`LyricsTextParser`** turns sidecar text into the existing `Lyrics` model. `parseLrc` reads `[mm:ss.xx]` timestamps into timed lines (fraction scaled by digit count; multiple/out-of-order stamps handled; `[ar:]`/`[ti:]`/`[offset:]` ID tags ignored) and degrades to plain when a `.lrc` has no timestamps. `parsePlain` reads `.txt` as plain lines. `.lrc` is preferred over `.txt`.
- **`LocalLyricsReader`** is the platform seam (mirrors `LocalMetadataReader`/`SafDocumentLister`). Lyrics load **lazily** when the screen opens (never during scan).
  - **Android**: the sibling SAF document is found and read through the **same content-resolver folder grant** the user already gave, via a new `readSidecarText` method-channel call (`MainActivity.kt` + `SafDocumentScanner.kt`). It rebuilds the sibling document URI within the granted tree — no broad storage permission, no raw `/storage/…` path. Best-effort and total: any failure → `null`.
  - **Desktop/tests**: a `dart:io` reader reads the neighbouring file.

## Investigation notes (answering the brief)

- **Representation / loading**: lyrics aren't stored on `Track`; they're fetched on demand through `LyricsService` (`trackLyricsProvider` → `lyricsServiceProvider`). Jellyfin and Subsonic each fetch from their server and self-filter by URI scheme; `CompositeLyricsService` returns the first non-`null`. Local lyrics follow the same lazy path.
- **Indexed vs. lazy**: lazy — to behave like provider lyrics and to keep lyrics text out of the catalog/DB.
- **SAF without raw paths**: the audio track's URI is a tree-based `content://` document URI, so the sidecar is reached under the existing grant by rebuilding the sibling document URI within the tree.
- **`.lrc` timestamps**: not previously parsed anywhere (servers return structured JSON); this PR adds the parser. The model/UI already support synced display.
- **Privacy**: no file names/paths in UI, diagnostics, or logs; the native bridge swallows platform errors instead of surfacing them.

## Embedded lyrics

Deferred as a documented follow-up (per the brief — embedded extraction on Android is the less reliable path), with the parser/service structure already in place to accept embedded text when added. Noted in `docs/providers.md`.

## Tests

`flutter test` (full suite: **1621 passing**), plus new coverage:
- LRC synced parsing, plain `.lrc` fallback, plain `.txt`, ID-tag/ordering/fraction-scaling edge cases
- local track with sidecar `.lrc`; with sidecar `.txt`; `.lrc` preferred over `.txt`
- missing-lyrics fallback; reader-throws fail-silent fallback; empty/metadata-only sidecar
- no raw local path/name in the rendered lyrics
- filesystem reader against real temp files (incl. nested folders, `file://`, and `content://` not-its-job)
- composite integration proving **Jellyfin** and **Navidrome/Subsonic** lyrics are unaffected

## Verification

- `dart format --set-exit-if-changed .` → clean
- `flutter analyze` → No issues found
- `flutter test` → all pass
- `./scripts/check_secrets.sh` → passed

https://claude.ai/code/session_0148x8Bjokmvqj1L1N2dCTiS

---
_Generated by [Claude Code](https://claude.ai/code/session_0148x8Bjokmvqj1L1N2dCTiS)_