### PR TITLE
feat(local): clearer scan summary and no-results guidance on the Local music card

### DIFF
--- a/lib/features/settings/source/local_music_settings_section.dart
+++ b/lib/features/settings/source/local_music_settings_section.dart
@@ -153,32 +153,136 @@ class _SelectedFolderView extends StatelessWidget {
           ),
         ],
         if (report != null) ...[
+          const SizedBox(height: AppSpacing.sm),
+          _ScanSummary(report: report!),
+        ],
+      ],
+    );
+  }
+}
+
+/// A clear, secret-free recap of the last local scan, shown under the selected
+/// folder: a status headline, the safe counts the scan produced, and — when the
+/// scan turned up nothing playable — a calm, non-blaming hint on what to try.
+///
+/// Everything here derives from [LocalScanReport], which by construction holds
+/// only booleans and counts (never a path, file name, or raw error), so nothing
+/// private about the user's library can reach the card.
+class _ScanSummary extends StatelessWidget {
+  const _ScanSummary({required this.report});
+
+  final LocalScanReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    // A scan that threw produced no trustworthy counts, so the breakdown is
+    // dropped and only the status + hint are shown.
+    final String? counts = report.hadError ? null : _counts(report);
+    final String? hint = _hint(report);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(_headline(report), style: theme.textTheme.bodyMedium),
+        if (counts != null) ...[
           const SizedBox(height: AppSpacing.xs),
           Text(
-            _scanSummary(report!),
+            counts,
             style: theme.textTheme.bodySmall?.copyWith(color: muted),
           ),
+        ],
+        if (hint != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          _ScanHintLine(message: hint),
         ],
       ],
     );
   }
 
-  /// A short, secret-free recap of the last scan — counts only.
-  static String _scanSummary(LocalScanReport report) {
+  /// The headline: what the scan did, in the user's terms. Imported-count first
+  /// (the thing they care about), then the "nothing found" and "couldn't finish"
+  /// cases — never a path or file name.
+  static String _headline(LocalScanReport report) {
     if (report.hadError) {
-      return 'Last scan: failed. Try selecting the folder again.';
+      return "Last scan couldn't finish";
     }
-    final StringBuffer summary = StringBuffer()
-      ..write('Last scan: ${report.importedTracks} ')
-      ..write(report.importedTracks == 1 ? 'track' : 'tracks')
-      ..write(' from ${report.filesVisited} ')
-      ..write(report.filesVisited == 1 ? 'file' : 'files')
-      ..write(' in ${report.foldersVisited} ')
-      ..write(report.foldersVisited == 1 ? 'folder' : 'folders');
+    if (report.importedTracks > 0) {
+      final String word = report.importedTracks == 1 ? 'track' : 'tracks';
+      return 'Last scan: ${report.importedTracks} $word added';
+    }
+    return 'Last scan: no tracks found';
+  }
+
+  /// The secret-free count breakdown — folders and files seen, how many looked
+  /// like audio, and how many were skipped or unreadable. Folders are omitted
+  /// when zero (a filesystem-path scan reports no folder count).
+  static String _counts(LocalScanReport report) {
+    final List<String> parts = <String>[
+      if (report.foldersVisited > 0)
+        '${report.foldersVisited} '
+            '${report.foldersVisited == 1 ? 'folder' : 'folders'}',
+      '${report.filesVisited} ${report.filesVisited == 1 ? 'file' : 'files'}',
+      '${report.audioCandidates} audio',
+    ];
+    if (report.skippedUnsupported > 0) {
+      parts.add('${report.skippedUnsupported} skipped');
+    }
     if (report.readFailures > 0) {
-      summary.write(' · ${report.readFailures} unreadable');
+      parts.add('${report.readFailures} unreadable');
     }
-    return summary.toString();
+    return parts.join(' · ');
+  }
+
+  /// A calm, non-blaming next step when the scan imported nothing. Two shapes: a
+  /// likely access problem (the SD-card / lost-grant case) versus a folder that
+  /// simply held no recognized audio. Both point at re-picking the folder with
+  /// the Android chooser; neither faults the user.
+  static String? _hint(LocalScanReport report) {
+    if (report.importedTracks > 0) {
+      return null;
+    }
+    final bool blocked = report.hadError ||
+        report.readFailures > 0 ||
+        (report.isContentUri && report.filesVisited == 0);
+    if (blocked) {
+      final String sdNote =
+          report.isContentUri ? ' — common with SD cards' : '';
+      return "Linthra couldn't read this folder$sdNote. Select it again with "
+          "Android's folder chooser to restore access.";
+    }
+    return "This folder doesn't seem to contain audio Linthra recognizes. Check "
+        'that it has supported audio files (like MP3, M4A, FLAC, or OGG), or '
+        "select the folder again with Android's folder chooser.";
+  }
+}
+
+/// One line of calm guidance (info icon + muted text) shown when a scan needs a
+/// follow-up action. Kept visually lighter than [_StatusLine] so a longer hint
+/// reads as help, not an alarm.
+class _ScanHintLine extends StatelessWidget {
+  const _ScanHintLine({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(Icons.info_outline, size: 18, color: theme.colorScheme.primary),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/test/features/settings/source/local_music_settings_section_test.dart
+++ b/test/features/settings/source/local_music_settings_section_test.dart
@@ -1,14 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/local/local_scan_diagnostics.dart';
+import 'package:linthra/core/sources/local/local_scan_report.dart';
 import 'package:linthra/data/repositories/in_memory_selected_music_folder_repository.dart';
 import 'package:linthra/data/repositories/selected_music_folder_repository_provider.dart';
 import 'package:linthra/features/settings/source/local_music_settings_section.dart';
 
+const String _safFolder =
+    'content://com.android.externalstorage.documents/tree/primary%3AMusic';
+
 Future<void> _pump(
   WidgetTester tester, {
   String? initialFolder,
+  LocalScanReport? report,
 }) async {
+  // The card reads the last scan reactively from localScanReportProvider, which
+  // seeds itself from LocalScanDiagnostics.last — so recording here is how a
+  // test stages "the last scan looked like this".
+  if (report != null) {
+    LocalScanDiagnostics.record(report);
+  }
   await tester.pumpWidget(
     ProviderScope(
       overrides: <Override>[
@@ -25,6 +37,11 @@ Future<void> _pump(
 }
 
 void main() {
+  // Keep one test's recorded scan from leaking into the next (the diagnostics
+  // store is a process-wide static).
+  setUp(LocalScanDiagnostics.reset);
+  tearDown(LocalScanDiagnostics.reset);
+
   group('LocalMusicSettingsSection', () {
     testWidgets('with no folder, invites the user to select one',
         (tester) async {
@@ -51,6 +68,145 @@ void main() {
       expect(find.text('Rescan'), findsOneWidget);
       expect(find.text('Change'), findsOneWidget);
       expect(find.text('Forget folder'), findsOneWidget);
+    });
+
+    testWidgets('after a successful scan, shows a clear summary with counts',
+        (tester) async {
+      await _pump(
+        tester,
+        initialFolder: _safFolder,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: true,
+          filesVisited: 12,
+          foldersVisited: 4,
+          audioCandidates: 9,
+          importedTracks: 8,
+          skippedUnsupported: 3,
+          readFailures: 0,
+        ),
+      );
+
+      // Headline states what the user cares about: tracks added.
+      expect(find.textContaining('8 tracks added'), findsOneWidget);
+      // Secret-free breakdown of the safe counters.
+      expect(find.textContaining('4 folders'), findsOneWidget);
+      expect(find.textContaining('12 files'), findsOneWidget);
+      expect(find.textContaining('9 audio'), findsOneWidget);
+      expect(find.textContaining('3 skipped'), findsOneWidget);
+      // A successful scan shows no "try again" hint.
+      expect(find.textContaining("Android's folder chooser"), findsNothing);
+    });
+
+    testWidgets('a single imported track is summarized in the singular',
+        (tester) async {
+      await _pump(
+        tester,
+        initialFolder: _safFolder,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: true,
+          filesVisited: 1,
+          foldersVisited: 1,
+          audioCandidates: 1,
+          importedTracks: 1,
+          skippedUnsupported: 0,
+          readFailures: 0,
+        ),
+      );
+
+      expect(find.textContaining('1 track added'), findsOneWidget);
+      expect(find.textContaining('1 folder'), findsOneWidget);
+      expect(find.textContaining('1 file'), findsOneWidget);
+    });
+
+    testWidgets(
+        'when no audio is found, suggests supported files and reselecting '
+        'without blaming the user', (tester) async {
+      await _pump(
+        tester,
+        initialFolder: _safFolder,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: true,
+          filesVisited: 5,
+          foldersVisited: 2,
+          audioCandidates: 0,
+          importedTracks: 0,
+          skippedUnsupported: 5,
+          readFailures: 0,
+        ),
+      );
+
+      expect(find.textContaining('no tracks found'), findsOneWidget);
+      // Helpful, actionable guidance — both requested suggestions.
+      expect(find.textContaining('supported audio files'), findsOneWidget);
+      expect(find.textContaining("Android's folder chooser"), findsOneWidget);
+    });
+
+    testWidgets(
+        'when the folder cannot be read, suggests reselecting to restore '
+        'access', (tester) async {
+      await _pump(
+        tester,
+        initialFolder: _safFolder,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: true,
+          filesVisited: 0,
+          foldersVisited: 0,
+          audioCandidates: 0,
+          importedTracks: 0,
+          skippedUnsupported: 0,
+          readFailures: 3,
+        ),
+      );
+
+      expect(find.textContaining('no tracks found'), findsOneWidget);
+      expect(find.textContaining("couldn't read this folder"), findsOneWidget);
+      expect(find.textContaining('restore access'), findsOneWidget);
+    });
+
+    testWidgets('a failed scan shows a gentle status and a reselect hint',
+        (tester) async {
+      await _pump(
+        tester,
+        initialFolder: _safFolder,
+        report: const LocalScanReport.failure(
+          folderSelected: true,
+          isContentUri: true,
+          error: LocalScanError.safTraversal,
+        ),
+      );
+
+      expect(find.textContaining("couldn't finish"), findsOneWidget);
+      expect(find.textContaining("Android's folder chooser"), findsOneWidget);
+    });
+
+    testWidgets('the scan recap never shows a path, URI, or file name',
+        (tester) async {
+      await _pump(
+        tester,
+        initialFolder: _safFolder,
+        report: const LocalScanReport(
+          folderSelected: true,
+          isContentUri: true,
+          filesVisited: 5,
+          foldersVisited: 2,
+          audioCandidates: 0,
+          importedTracks: 0,
+          skippedUnsupported: 5,
+          readFailures: 0,
+        ),
+      );
+
+      // Walk every rendered string and assert nothing path-shaped leaks.
+      for (final Text text in tester.widgetList<Text>(find.byType(Text))) {
+        final String value = text.data ?? '';
+        expect(value, isNot(contains('content://')));
+        expect(value, isNot(contains('/storage/')));
+        expect(value.toLowerCase(), isNot(contains('.mp3')));
+      }
     });
   });
 }


### PR DESCRIPTION
## What & why

Ahead of v0.1.3, make the **Local music** scan result clearer for people with SD cards or local-folder libraries. After a scan, users should understand what happened — and, when nothing imports, what to try next — without anyone having to open the diagnostics export.

This touches only the user-facing recap on the Local music source card. The scanner, the secret-free diagnostics export, playback, permissions, and the app version are all untouched.

## Changes

The single dense recap line on the card is replaced with a small `_ScanSummary` widget:

- **Status headline** in plain terms: `Last scan: N tracks added` · `Last scan: no tracks found` · `Last scan couldn't finish` (singular/plural handled).
- **Secret-free count breakdown**: folders scanned, files visited, audio candidates, plus skipped-unsupported and unreadable when non-zero. Folders are omitted when zero (a filesystem-path scan reports no folder count).
- **Calm, non-blaming hint when nothing imported**, in two shapes:
  - *Likely access problem* (read failures, a SAF folder that listed nothing, or a thrown scan): "Linthra couldn't read this folder — common with SD cards. Select it again with Android's folder chooser to restore access."
  - *No recognized audio*: "This folder doesn't seem to contain audio Linthra recognizes. Check that it has supported audio files (like MP3, M4A, FLAC, or OGG), or select the folder again with Android's folder chooser."

The hint keeps the subject on the app/folder (never the user) and points at re-picking with the Android system picker.

## Safety

Every string is derived only from `LocalScanReport` — booleans and counts, never a path, file name, or raw error — so no private library detail can reach the card. A widget test walks every rendered `Text` and asserts the recap never contains a `content://` URI, a `/storage/` path, or a file extension.

## Scope (per the request)

- No scanner logic change (the report already carried every counter shown).
- No playback change. No new permissions. No version bump, tag, or fdroiddata change.
- Diagnostics export text is unchanged (it already includes these counters), so no diagnostics tests needed updating.

## Tests

Adds widget tests for the summary labels, singular/plural counts, the empty / blocked / failed hints, and the secret-safety assertion. The existing scan-report and controller tests are unchanged and still pass.

Verified locally with Flutter 3.27.4:

- `dart format --set-exit-if-changed .` — 0 files changed
- `flutter analyze` — No issues found
- `flutter test` — 1627 tests passed
- `./scripts/check_secrets.sh` — passed

https://claude.ai/code/session_015E3hc13yZ1s4SJvtCGD8Kx

---
_Generated by [Claude Code](https://claude.ai/code/session_015E3hc13yZ1s4SJvtCGD8Kx)_