### PR TITLE
perf(player): battery — throttle lyrics highlight and queue sheet to real changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Streaming, buffering & recovery | [docs/streaming.md](./docs/streaming.md) |
 | Queue / Up Next | [docs/queue.md](./docs/queue.md) |
 | Offline cache & downloads | [docs/offline-cache.md](./docs/offline-cache.md) |
+| Battery usage | [docs/battery.md](./docs/battery.md) |
 | Cast / Chromecast | [docs/cast.md](./docs/cast.md) |
 | Android Auto | [docs/android-auto.md](./docs/android-auto.md) |
 | Reporting a bug | [docs/reporting-bugs.md](./docs/reporting-bugs.md) |

--- a/docs/battery.md
+++ b/docs/battery.md
@@ -1,0 +1,194 @@
+# Battery usage
+
+Linthra aims to be as battery-friendly as a self-hosted music player can be
+**without ever lowering audio quality or weakening playback.** Audio fidelity,
+gapless behaviour, background playback, and Android Auto are non-negotiable; the
+battery work is about avoiding *unnecessary* CPU, network, wake-ups, rebuilds,
+scans, and cache work around that fixed audio path — never about doing less for
+the sound itself.
+
+This document is the user-and-contributor-facing summary. The read-only
+engineering audit of the media/CPU path lives in
+[docs/audio-bluetooth-cpu-audit.md](./audio-bluetooth-cpu-audit.md); the
+streaming/buffering rationale is in [docs/streaming.md](./streaming.md), and the
+cache/pre-cache behaviour in [docs/offline-cache.md](./offline-cache.md).
+
+## What Linthra does to save battery
+
+### Playback service & wake locks
+
+- **The foreground service runs only while audio is actually working.**
+  `audio_service`'s media service (and the CPU/Wi-Fi wake locks it holds) is
+  promoted to the foreground while the session reports `playing` and demoted on a
+  real pause (`androidStopForegroundOnPause: true`). A paused track holds no wake
+  lock. See `connectMediaSession` in
+  `lib/core/services/linthra_audio_handler.dart`.
+- **A mid-stream re-buffer or a track transition never drops the service.**
+  The session is reported as `playing` while the engine is actively working
+  toward sound — steadily playing, re-buffering, or loading the next track — so
+  the OS can't freeze the process with the screen off (which would silence
+  streaming until the app is reopened). It only reports `false` on a genuine
+  pause/stop/idle/completion/error. See `LinthraAudioHandler._isSessionPlaying`.
+- **No custom Bluetooth, audio-focus, or routing code.** Pause-on-disconnect,
+  ducking, and media routing are handled by the standard Android
+  `MediaSession` + `just_audio`/`audio_service` path — there is no extra polling
+  or background machinery layered on top.
+
+### Timers & wake-ups are gated to "only when needed"
+
+The only periodic timers in the app are tightly scoped and self-cancelling:
+
+- **Position flush (~4 Hz)** — the engine's raw position stream is coalesced onto
+  a steady ~250 ms cadence so a bursty tick rate can't flood the UI, media
+  session, and pre-cache services. The flush timer **stops itself when nothing
+  new arrives** (paused/stopped) and restarts on the next position event. See
+  `JustAudioPlaybackController._flushPosition`.
+- **Media-session pushes (~1 Hz)** — the platform session is updated only when
+  something it renders changes (controls, play-state, mode) or when the reported
+  position drifts past ~1 s; `audio_service` interpolates the displayed position
+  from the wall clock, so steady playback produces ~1 correction a second instead
+  of ~5 pushes. Queue and now-playing metadata are de-duplicated and pushed only
+  when they actually change. See `LinthraAudioHandler._shouldPushPlayback`.
+- **Cast status poll & position ticker** — both run **only while casting and the
+  receiver is actually playing**, and stop the moment it pauses. See
+  `chromecast_cast_transport.dart` and `ActivePlaybackController._syncTicker`.
+
+### UI rebuilds follow real changes, not the clock
+
+A music player's UI is driven by a position that updates several times a second.
+Linthra isolates that so the expensive parts of the tree don't rebuild on every
+tick:
+
+- **Now-playing indicator** (the little equalizer on the playing row) uses a
+  single animation controller and painter, **stops animating when paused**, and
+  **honours the OS reduced-motion setting** (`MediaQuery.disableAnimations`) — a
+  paused, off-screen, or reduce-motion indicator schedules no frames. See
+  `lib/shared/widgets/now_playing_indicator.dart`.
+- **Track rows** watch a position-*independent* now-playing snapshot
+  (`current track + isPlaying`), so they rebuild only on a track change or a
+  play/pause flip — never on a position tick. See `lib/features/player/now_playing.dart`.
+- **Mini-player & now-playing screen** select just the fields they show; only the
+  thin progress line and the controls follow the position, not the artwork and
+  text around them. See `lib/features/player/mini_player.dart`.
+- **Synced lyrics** select the *active line index* (not the raw position), so the
+  highlighted-line list rebuilds only when the line actually changes — a handful
+  of times per song rather than four times a second for the whole track. The
+  sync still moves exactly on each line boundary. See
+  `lib/features/player/widgets/lyrics_view.dart`.
+- **Queue sheet** selects only the queue identity (current + up-next + history),
+  so the open sheet doesn't rebuild on position ticks while you browse it. See
+  `lib/features/player/widgets/queue_sheet.dart`.
+
+### Network: event-driven, never polled
+
+- **No background polling, heartbeats, or keep-alives** for Jellyfin or
+  Navidrome/Subsonic. The HTTP clients are request/response only.
+- **Library sync runs on an explicit "Sync library" action**, with a one-time
+  auto-sync on first connecting an account. There is no recurring sync loop.
+- **Connectivity is observed, not polled** — Linthra reacts to OS connectivity
+  events rather than waking up to test the network.
+- **During playback there are no extra network calls per tick** — lyrics are
+  fetched once per track (keyed by id, auto-disposed when no longer current), and
+  artwork URLs are stable.
+
+### Scans, cache, and artwork: once, on demand
+
+- **Local music is scanned only when you ask** — picking or rescanning a folder,
+  retrying after an error, or as a side effect of removing a local file. Opening
+  the Library screen reads the already-persisted catalog from the on-device
+  database; it does **not** re-walk the filesystem. There is no scan on a timer,
+  on resume, or on connectivity change.
+- **Embedded cover art is extracted once during the scan** and cached to a
+  private `file://` URI; displaying a row loads that cached image and never
+  re-extracts tags. See `lib/core/sources/local/`.
+- **Cache eviction is event-driven** — it runs when a download/pre-cache commits,
+  not on a timer, and the cache snapshot is recomputed only when the cache
+  actually changes (and only surfaced while a cache/downloads screen is open).
+
+### Smart pre-cache is bounded and network-aware
+
+Smart pre-cache warms a few upcoming tracks into the offline cache so the next
+song starts instantly. It is deliberately modest (see
+`lib/core/services/smart_precache_service.dart`):
+
+- It reacts only to changes in **what** to cache (the playing track, up-next,
+  shuffle, repeat) — **not** to position ticks.
+- It **honours the mobile-data policy**: Wi-Fi always, mobile data only when you
+  allow it, never while offline.
+- It **stays quiet under repeat-one** (the up-next won't play soon, so caching it
+  would waste data and storage).
+- It runs **one fetch at a time**, off the playback path, bounded by your
+  pre-cache count and the cache size limit, and its entries are evicted before
+  any track you pinned with "Keep offline".
+
+### Diagnostics cost nothing in normal playback
+
+All stability/playback diagnostics are gated behind `kDebugMode`, so a release
+build does **zero** diagnostics work during playback. Nothing logs per position
+tick; the secret-free breadcrumbs that do exist fire only on events (errors,
+track changes, output switches) into a small in-memory ring buffer — never to
+disk during playback. See `lib/core/diagnostics/` and `*_diagnostics.dart`.
+
+## What Linthra intentionally does **not** do
+
+These are deliberate non-goals — doing them would "save battery" by degrading the
+experience, so Linthra does not:
+
+- **Lower audio quality or downsample music.** Bitrate, sample rate, and format
+  are never reduced to save power. ReplayGain volume normalization is
+  attenuation-only and **off by default**, and only ever changes loudness, never
+  fidelity.
+- **Disable gapless or other playback features** to cut CPU.
+- **Stop or throttle background playback / Android Auto.** Audio keeps playing
+  with the screen off and in the car; that is the whole point of the app.
+- **Aggressively suppress sync freshness.** Sync is on-demand rather than
+  battery-throttled, so your library is correct when you ask for it.
+- **Add invasive permissions** (background location, alarms, unrestricted
+  background, broad storage) to chase battery wins.
+
+## How you can improve battery life
+
+- **Download / keep tracks offline** for trips and commutes. Playing a cached
+  `file://` copy needs no radio and no streaming buffer, which is the single
+  biggest battery win for self-hosted libraries. See
+  [docs/offline-cache.md](./offline-cache.md).
+- **Keep downloads on Wi-Fi.** Leave **"Allow mobile data"** off
+  (Settings ▸ Storage & offline) so downloads and pre-cache wait for Wi-Fi
+  instead of waking the cellular radio.
+- **Tune or turn off smart pre-cache.** Lowering the pre-cache count (or turning
+  it off) reduces speculative background fetching if you rarely skip ahead.
+- **Enable the system's reduced-motion setting** if you want the now-playing
+  equalizer to stay static — Linthra honours it automatically.
+- **Pick a nearby/efficient server connection.** A flaky link makes the engine
+  re-buffer (and stream) more; a stable connection (or offline copies) keeps the
+  radio idle.
+
+## Measuring battery use
+
+Battery work is only safe if it's measurable. Useful levers:
+
+- **`adb shell dumpsys batterystats --charged com.linthra…`** (and
+  [Battery Historian](https://github.com/google/battery-historian)) to see wake
+  locks, alarms, and radio time attributed to the app across a real session.
+- **Flutter DevTools → Performance/CPU** and the **"Track widget builds"** /
+  rebuild stats to confirm the now-playing surfaces aren't rebuilding on every
+  position tick. The throttling above is covered by tests
+  (`test/features/player/lyrics_highlight_throttle_test.dart`,
+  `test/features/player/queue_sheet_throttle_test.dart`,
+  `test/shared/widgets/now_playing_indicator_test.dart`) so a regression that
+  reintroduces per-tick rebuilds fails CI.
+
+## Possible future work (not done here)
+
+Documented for contributors; intentionally left out of the focused battery PR to
+avoid risky changes:
+
+- **Incremental local scan.** Today a rescan re-reads every file's tags and
+  artwork. Skipping unchanged files (by modification time, where the platform
+  exposes it) would make large-library rescans cheaper. It's user-triggered
+  today, so it isn't a background drain — just a one-off cost worth trimming.
+- **Charging-/power-save-aware pre-cache.** Smart pre-cache already respects
+  Wi-Fi vs mobile data; a future option could also pause speculative pre-caching
+  under the OS battery-saver or when unplugged below a threshold. This needs a
+  battery-state signal and a user-facing setting, so it's deferred rather than
+  guessed.

--- a/lib/features/player/widgets/lyrics_view.dart
+++ b/lib/features/player/widgets/lyrics_view.dart
@@ -135,20 +135,32 @@ class _SyncedLyricsState extends ConsumerState<_SyncedLyrics> {
     super.dispose();
   }
 
-  /// The unified playback position, falling back to the controller's latest
-  /// state until the first stream event arrives. Reads only — never triggers
-  /// playback.
-  Duration _position() {
-    final Duration? streamed = ref.watch(
-      playbackStateProvider.select((s) => s.valueOrNull?.position),
+  /// The lyric line active at the current playback position.
+  ///
+  /// Battery: the active-line index is computed *inside* the provider
+  /// [select], so this widget rebuilds only when the highlighted line actually
+  /// changes (a handful of times per song) — not on every ~4 Hz position tick.
+  /// The whole synced list (with its per-line [AnimatedDefaultTextStyle]s) would
+  /// otherwise rebuild four times a second for the entire length of a track. The
+  /// per-tick cost is now just one cheap [Lyrics.activeLineIndex] scan with no
+  /// rebuild while the line is unchanged. Falls back to the controller's latest
+  /// position until the first stream event arrives, mirroring the rest of the
+  /// player UI. Reads only — never triggers playback.
+  int _activeLine() {
+    final Lyrics lyrics = widget.lyrics;
+    final Duration fallback =
+        ref.read(playbackControllerProvider).state.position;
+    return ref.watch(
+      playbackStateProvider.select(
+        (s) => lyrics.activeLineIndex(s.valueOrNull?.position ?? fallback),
+      ),
     );
-    return streamed ?? ref.read(playbackControllerProvider).state.position;
   }
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final int active = widget.lyrics.activeLineIndex(_position());
+    final int active = _activeLine();
 
     if (active != _activeIndex) {
       _activeIndex = active;

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -43,12 +43,24 @@ class QueueSheet extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final controller = ref.watch(playbackControllerProvider);
-    final PlaybackState state =
-        ref.watch(playbackStateProvider).valueOrNull ?? controller.state;
+    // Battery: select only the queue identity (current track + up-next +
+    // history), not the whole PlaybackState, so the ~4 Hz position ticks don't
+    // rebuild the entire sheet while it's open. The controller reuses the same
+    // up-next/history list instances on a position tick (copyWith carries them
+    // through), so this record compares equal and the sheet stays put; it
+    // rebuilds only on a real queue change — skip, reorder, add, remove, clear,
+    // or a track change. The current-track equalizer still animates on
+    // play/pause via [_CurrentTile]'s own nowPlayingProvider watch.
+    final (Track?, List<Track>, List<Track>) queue = ref.watch(
+      playbackStateProvider.select((s) {
+        final PlaybackState state = s.valueOrNull ?? controller.state;
+        return (state.currentTrack, state.upNext, state.previous);
+      }),
+    );
 
-    final Track? current = state.currentTrack;
-    final List<Track> upNext = state.upNext;
-    final List<Track> history = state.previous;
+    final Track? current = queue.$1;
+    final List<Track> upNext = queue.$2;
+    final List<Track> history = queue.$3;
     final bool canClear = upNext.isNotEmpty || history.isNotEmpty;
     final bool canSave = current != null;
 
@@ -75,9 +87,8 @@ class QueueSheet extends ConsumerWidget {
                   Text('Queue', style: theme.textTheme.titleMedium),
                   const Spacer(),
                   IconButton(
-                    onPressed: canSave
-                        ? () => _saveAsPlaylist(context, ref, state)
-                        : null,
+                    onPressed:
+                        canSave ? () => _saveAsPlaylist(context, ref) : null,
                     icon: const Icon(Icons.playlist_add),
                     tooltip: 'Save queue as playlist',
                   ),
@@ -161,9 +172,12 @@ class QueueSheet extends ConsumerWidget {
   Future<void> _saveAsPlaylist(
     BuildContext context,
     WidgetRef ref,
-    PlaybackState state,
   ) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    // Read the freshest full queue at tap time rather than capturing it in
+    // build — build now selects only the queue identity (see above), and a save
+    // is a one-off action, not a hot path.
+    final PlaybackState state = ref.read(playbackControllerProvider).state;
     final List<Track> tracks = <Track>[
       ...state.previous,
       if (state.currentTrack != null) state.currentTrack!,

--- a/test/features/player/lyrics_highlight_throttle_test.dart
+++ b/test/features/player/lyrics_highlight_throttle_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import 'fake_playback_controller.dart';
+
+/// Battery-sensitive contract for the synced lyrics highlight.
+///
+/// The synced lyrics view selects the *active line index* from the unified
+/// playback position (see `_SyncedLyrics._activeLine`), so it rebuilds only when
+/// the highlighted line changes — not on every ~4 Hz position tick. These tests
+/// exercise that exact selection through a [ProviderContainer], so a regression
+/// back to watching the raw position (which would rebuild the whole synced list
+/// four times a second for the length of a track) fails here.
+const _track = Track(id: 'a', title: 'Song A', uri: 'jellyfin:a');
+
+const _synced = Lyrics(lines: <LyricLine>[
+  LyricLine(text: 'line one', start: Duration.zero),
+  LyricLine(text: 'line two', start: Duration(seconds: 10)),
+  LyricLine(text: 'line three', start: Duration(seconds: 20)),
+]);
+
+PlaybackState _playingAt(Duration position) => PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+      position: position,
+      duration: const Duration(seconds: 30),
+    );
+
+/// Mirrors `_SyncedLyrics._activeLine`: the active line index, selected from the
+/// unified position with a controller fallback before the first stream event.
+ProviderListenable<int> _activeLineOf(FakePlaybackController controller) {
+  return playbackStateProvider.select(
+    (s) => _synced
+        .activeLineIndex(s.valueOrNull?.position ?? controller.state.position),
+  );
+}
+
+void main() {
+  group('synced lyrics highlight throttling', () {
+    test('sub-line position ticks do not change the highlighted line',
+        () async {
+      final controller = FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)));
+      addTearDown(controller.dispose);
+      final container = ProviderContainer(overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ]);
+      addTearDown(container.dispose);
+
+      final List<int> changes = <int>[];
+      container.listen<int>(
+        _activeLineOf(controller),
+        (int? previous, int next) => changes.add(next),
+        fireImmediately: true,
+      );
+
+      // 12s lands on "line two" (10s..20s) → index 1, the initial highlight.
+      expect(changes, <int>[1]);
+
+      // Several position ticks that all stay within line two: the highlight must
+      // not change, so the widget never rebuilds across these ticks.
+      for (final int ms in <int>[12500, 13000, 15000, 19000, 19999]) {
+        controller.emit(
+          controller.state.copyWith(position: Duration(milliseconds: ms)),
+        );
+        await pumpEventQueue();
+      }
+      expect(
+        changes,
+        <int>[1],
+        reason: 'sub-line position ticks must not retrigger the highlight',
+      );
+
+      // Crossing into line three (>=20s) is exactly one change.
+      controller.emit(
+        controller.state.copyWith(position: const Duration(seconds: 21)),
+      );
+      await pumpEventQueue();
+      expect(changes, <int>[1, 2]);
+    });
+
+    test('the highlight still follows every real line boundary', () async {
+      final controller =
+          FakePlaybackController(initial: _playingAt(Duration.zero));
+      addTearDown(controller.dispose);
+      final container = ProviderContainer(overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ]);
+      addTearDown(container.dispose);
+
+      final List<int> seen = <int>[];
+      container.listen<int>(
+        _activeLineOf(controller),
+        (int? previous, int next) => seen.add(next),
+        fireImmediately: true,
+      );
+
+      for (final int seconds in <int>[5, 10, 20, 25]) {
+        controller.emit(
+          controller.state.copyWith(position: Duration(seconds: seconds)),
+        );
+        await pumpEventQueue();
+      }
+
+      // Starts on line one (index 0), then advances once per crossed boundary:
+      // 5s stays on line one (no extra event), 10s → 1, 20s → 2, 25s stays.
+      expect(seen, <int>[0, 1, 2]);
+    });
+  });
+}

--- a/test/features/player/queue_sheet_throttle_test.dart
+++ b/test/features/player/queue_sheet_throttle_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import 'fake_playback_controller.dart';
+
+/// Battery-sensitive contract for the Queue sheet.
+///
+/// The sheet selects only the queue identity — `(currentTrack, upNext,
+/// previous)` — from the unified playback state (see `QueueSheet.build`), so the
+/// whole sheet (history, current, and the reorderable up-next list) does not
+/// rebuild on every ~4 Hz position tick while it is open. These tests exercise
+/// that exact selection through a [ProviderContainer]: position ticks reuse the
+/// same list instances (so the record compares equal and nothing rebuilds),
+/// while a real queue edit swaps the list and does rebuild.
+Track _track(String id) =>
+    Track(id: id, title: 'Song $id', uri: '/$id.mp3', artistName: 'Artist $id');
+
+/// Mirrors `QueueSheet.build`'s selection of the queue identity.
+ProviderListenable<(Track?, List<Track>, List<Track>)> _queueOf(
+  FakePlaybackController controller,
+) {
+  return playbackStateProvider.select((s) {
+    final PlaybackState state = s.valueOrNull ?? controller.state;
+    return (state.currentTrack, state.upNext, state.previous);
+  });
+}
+
+void main() {
+  group('QueueSheet rebuild throttling', () {
+    test('position ticks do not rebuild the queue identity', () async {
+      final controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      final container = ProviderContainer(overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ]);
+      addTearDown(container.dispose);
+
+      int rebuilds = 0;
+      container.listen<(Track?, List<Track>, List<Track>)>(
+        _queueOf(controller),
+        (_, __) => rebuilds++,
+        fireImmediately: true,
+      );
+      expect(rebuilds, 1, reason: 'the initial selection');
+
+      // Pure position ticks: copyWith carries the same up-next/history list
+      // instances through, so the selected record is unchanged — no rebuild.
+      for (final int ms in <int>[500, 1000, 2000, 3000]) {
+        controller.emit(
+          controller.state.copyWith(position: Duration(milliseconds: ms)),
+        );
+        await pumpEventQueue();
+      }
+      expect(
+        rebuilds,
+        1,
+        reason: 'position ticks must not rebuild the whole queue sheet',
+      );
+    });
+
+    test('a queue edit does rebuild the queue identity', () async {
+      final controller = FakePlaybackController();
+      addTearDown(controller.dispose);
+      await controller
+          .playTracks(<Track>[_track('A'), _track('B'), _track('C')]);
+
+      final container = ProviderContainer(overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+      ]);
+      addTearDown(container.dispose);
+
+      int rebuilds = 0;
+      container.listen<(Track?, List<Track>, List<Track>)>(
+        _queueOf(controller),
+        (_, __) => rebuilds++,
+        fireImmediately: true,
+      );
+      expect(rebuilds, 1);
+
+      // Removing an up-next entry swaps the list instance → the record differs
+      // → exactly one rebuild for a real queue change.
+      controller.removeFromQueue(0);
+      await pumpEventQueue();
+      expect(rebuilds, 2);
+      expect(controller.state.upNext, <Track>[_track('C')]);
+
+      // A position tick after the edit still does not rebuild.
+      controller.emit(
+        controller.state.copyWith(position: const Duration(seconds: 4)),
+      );
+      await pumpEventQueue();
+      expect(rebuilds, 2);
+    });
+  });
+}

--- a/test/features/player/synced_lyrics_test.dart
+++ b/test/features/player/synced_lyrics_test.dart
@@ -121,6 +121,28 @@ void main() {
       expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w500);
     });
 
+    testWidgets('keeps the highlight steady across sub-line position ticks',
+        (tester) async {
+      // The highlight is throttled to line changes (it follows the active-line
+      // index, not the raw position), so several ticks within one line must
+      // leave the same line highlighted — correctness is preserved while the
+      // synced list avoids rebuilding on every ~4 Hz tick.
+      final controller = FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 11)));
+      await pump(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w700);
+
+      for (final int ms in <int>[12000, 14000, 17500, 19500]) {
+        controller.emit(
+          controller.state.copyWith(position: Duration(milliseconds: ms)),
+        );
+        await tester.pump();
+        expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w700);
+        expect(_styleOf(tester, 'line three').fontWeight, FontWeight.w500);
+      }
+    });
+
     testWidgets('plain lyrics render without timed highlighting',
         (tester) async {
       await pump(


### PR DESCRIPTION
## Goal

Make Linthra more battery-friendly **without lowering audio quality, breaking playback, or weakening the UX.** This PR is deliberately small and safe: it removes two sources of unnecessary per-tick UI rebuilds during playback and documents the battery posture. No playback-engine rewrite, no audio changes, no version/release/tag/fdroid changes.

## Investigation summary

I audited the 13 areas in the brief (wakelocks, foreground service, now-playing indicators/animations, lyrics ticking, queue/position listeners, artwork extraction, local scan/cache triggers, smart pre-cache Wi-Fi/battery gating, remote network polling, app-wide provider rebuilds, leaked timers/streams, and diagnostics). **The codebase is already remarkably battery-conscious** — most areas needed no change, only documentation. Highlights of what's already correct:

- **Wakelocks / foreground service** — held by `audio_service` only while the session reports `playing`; demoted on a real pause (`androidStopForegroundOnPause: true`). A mid-stream re-buffer/track transition is reported as still-playing so the screen-off process isn't frozen. No custom Bluetooth/polling.
- **Position cadence** — the engine's raw position stream is coalesced to ~4 Hz and the flush timer self-cancels when paused/stopped. Media-session pushes are de-duplicated and re-synced only ~1 Hz.
- **Now-playing indicator** — single painter, stops when paused, and already honours `MediaQuery.disableAnimations` (reduced motion). Track rows watch a position-*independent* snapshot.
- **Network** — no polling/heartbeats for Jellyfin/Navidrome/Subsonic; sync is on-demand; connectivity is observed, not polled.
- **Scans / cache / artwork** — local scans run only on an explicit trigger (opening Library just reads the persisted catalog); embedded art is extracted once per scan and cached; eviction is event-driven.
- **Smart pre-cache** — reacts to queue changes (not position ticks), honours the Wi-Fi/mobile-data policy, stays quiet under repeat-one, runs one-at-a-time, and is bounded/evictable.
- **Diagnostics** — gated behind `kDebugMode`; nothing logs per tick in release.

The two genuine offenders were **per-tick (~4 Hz) widget rebuilds** in the synced lyrics view and the queue sheet.

## Changes

### 1. Synced lyrics highlight — rebuild per line, not per tick
`_SyncedLyrics` watched the raw `position`, so the whole synced list (with per-line `AnimatedDefaultTextStyle`s) rebuilt ~4×/second for the entire length of a track. It now computes the **active line index inside the provider `select`**, so it rebuilds only when the highlighted line actually changes (a handful of times per song). Sync still moves exactly on each line boundary; the per-tick cost is one cheap `Lyrics.activeLineIndex` scan with no rebuild while the line is unchanged.

### 2. Queue sheet — rebuild on queue changes, not position ticks
`QueueSheet.build` watched the whole `PlaybackState`, so an open sheet rebuilt all its slivers ~4×/second while playing. It now **selects only the queue identity** `(currentTrack, upNext, previous)`. The controller reuses the same up-next/history list instances on a position tick (`copyWith` carries them through), so the record compares equal and the sheet stays put; it rebuilds only on a real queue change. The current-track equalizer still animates via `_CurrentTile`'s own `nowPlayingProvider` watch.

### 3. `docs/battery.md` (+ README link)
Documents what Linthra does to reduce battery use, what it **intentionally does not do** (no audio-quality reduction, no downsampling, no breaking background playback/Android Auto), how users can improve battery life (offline/cache, Wi‑Fi‑only downloads, pre-cache tuning, OS reduced-motion), how to measure, and documented follow-ups (incremental local scan; charging/power-save-aware pre-cache) left out to keep this PR safe.

## Tests
- `lyrics_highlight_throttle_test.dart` — sub-line position ticks do **not** change the selected active-line index; every real boundary still advances it.
- `queue_sheet_throttle_test.dart` — position ticks do **not** rebuild the queue identity; a real queue edit does.
- `synced_lyrics_test.dart` — extended: the highlight stays correct across several sub-line ticks.
- Reduced-motion behaviour is already covered by `now_playing_indicator_test.dart`.

## Verification
Run with Flutter 3.27.4 (matches CI):
- `dart format --set-exit-if-changed .` → clean (0 changed)
- `flutter analyze` → No issues found
- `flutter test` → **1632 tests, all passed**

## Explicitly NOT changed
No audio quality / downsampling; no gapless/playback feature disabled; background playback, Android Auto, and Jellyfin/Navidrome/Subsonic/Local playback untouched; no new permissions; no version bump, tag, or fdroiddata changes.

https://claude.ai/code/session_01KVYJBpxv3DvZSpuiejGbS7

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVYJBpxv3DvZSpuiejGbS7)_