### PR TITLE
fix(player): keep queued copies' fallback after a default-source switch

### DIFF
--- a/lib/features/library/playback_candidates_provider.dart
+++ b/lib/features/library/playback_candidates_provider.dart
@@ -10,9 +10,17 @@ import '../player/player_providers.dart';
 import 'playback_source_strategy_controller.dart';
 import 'unified_library_providers.dart';
 
-/// Maps each *displayed* (logical) track id to its ordered source candidates, so
-/// playback can fall back to another copy of the same song when the preferred one
-/// fails.
+/// Maps *every source copy's* track id to its song's ordered source candidates,
+/// so playback can fall back to another copy of the same song when the preferred
+/// one fails — no matter which copy was the one actually queued.
+///
+/// Keying by every copy's id (not just the displayed/primary one) is what keeps
+/// the queue honest when the user changes the default source: the displayed copy
+/// flips to the new provider, but a copy already sitting in the queue (or saved in
+/// a playlist) keeps its old id. Mapping that id to the *same* freshly-ordered
+/// candidate list means the next play of that queued copy uses the new preferred
+/// source — and still has its fallbacks — instead of being orphaned to the old
+/// source until the queue is rebuilt (an app restart).
 ///
 /// Only de-duplicated rows that actually span more than one provider are listed —
 /// a single-source song needs no fallback and is left out (the controller treats
@@ -41,7 +49,7 @@ final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
         cachedOffline: cachedIds.contains(track.id),
       );
 
-  final Map<String, List<Track>> byDisplayId = <String, List<Track>>{};
+  final Map<String, List<Track>> byTrackId = <String, List<Track>>{};
   for (final LogicalTrack logical in logicals) {
     if (!logical.hasMultipleSources) continue;
     final List<Track> candidates = <Track>[
@@ -50,10 +58,16 @@ final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
     ];
     // Reorder by the chosen strategy. preferDefault is the identity, so the
     // PR1/PR2 default-source order (and runtime fallback over it) is unchanged.
-    byDisplayId[logical.id] =
+    final List<Track> ordered =
         orderBySourceStrategy(candidates, strategy, profileOf);
+    // Index the same list under every copy's id, so whichever copy is queued
+    // resolves to it. Ids are unique to one logical song, so the keys never
+    // collide across rows.
+    for (final Track candidate in candidates) {
+      byTrackId[candidate.id] = ordered;
+    }
   }
-  return byDisplayId;
+  return byTrackId;
 });
 
 /// Wires the real, library-backed [PlaybackCandidateSource] into the playback

--- a/test/core/services/just_audio_playback_controller_fallback_test.dart
+++ b/test/core/services/just_audio_playback_controller_fallback_test.dart
@@ -369,4 +369,105 @@ void main() {
           <String>['jellyfin:o']);
     });
   });
+
+  // Regression: when the user changes the default source mid-queue, the candidate
+  // source recomputes under the controller (it reads it lazily). End-of-track
+  // continuation must pick up the new order for the *next* queued copy — and must
+  // never get stuck on stale source state. The map is keyed by every copy's id,
+  // so a queued Jellyfin copy still resolves to its candidates after the switch.
+  group('end-of-track continuation after a source change', () {
+    final Track j1 = _track('j1', 'jellyfin:j1');
+    final Track s1 = _track('s1', 'subsonic:s1');
+    final Track j2 = _track('j2', 'jellyfin:j2');
+    final Track s2 = _track('s2', 'subsonic:s2');
+
+    // The live candidate map, keyed by every copy's id (what
+    // playbackCandidatesProvider produces). Mutated in place to model a switch.
+    Map<String, List<Track>> jellyfinFirst() => <String, List<Track>>{
+          'j1': <Track>[j1, s1],
+          's1': <Track>[j1, s1],
+          'j2': <Track>[j2, s2],
+          's2': <Track>[j2, s2],
+        };
+    Map<String, List<Track>> subsonicFirst() => <String, List<Track>>{
+          'j1': <Track>[s1, j1],
+          's1': <Track>[s1, j1],
+          'j2': <Track>[s2, j2],
+          's2': <Track>[s2, j2],
+        };
+
+    void completeCurrent(JustAudioPlaybackController controller) {
+      // Mirrors just_audio reporting the track reached its natural end.
+      controller
+          .handleEngineState(PlayerState(false, ProcessingState.completed));
+    }
+
+    test('the next queued copy uses the newly chosen source', () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j1': _stream('https://jelly/stream/j1'),
+          'jellyfin:j2': _stream('https://jelly/stream/j2'),
+          'subsonic:s1': _stream('https://sub/stream/s1'),
+          'subsonic:s2': _stream('https://sub/stream/s2'),
+        },
+      );
+      final Map<String, List<Track>> candidates = jellyfinFirst();
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: candidates,
+      );
+
+      // Plays the queue under the default (Automatic) order: Jellyfin first.
+      await controller.playTracks(<Track>[j1, j2]);
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j1');
+
+      // The user switches the default source to Navidrome/Subsonic. The live
+      // candidate map recomputes in place under the session-pinned controller.
+      candidates
+        ..clear()
+        ..addAll(subsonicFirst());
+
+      // The first track finishes and the queue advances.
+      completeCurrent(controller);
+      await Future<void>.delayed(Duration.zero);
+
+      // Continuation used the newly chosen source for the next track.
+      expect(controller.state.currentTrack?.uri, 'subsonic:s2');
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+    });
+
+    test('continuation still falls back when the new source fails', () async {
+      // After the switch Subsonic leads, but the Subsonic copy of song 2 is
+      // unreachable — continuation must fall back to Jellyfin rather than stall.
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'subsonic:s2'},
+        resolved: <String, ResolvedPlayable>{
+          'jellyfin:j1': _stream('https://jelly/stream/j1'),
+          'jellyfin:j2': _stream('https://jelly/stream/j2'),
+          'subsonic:s1': _stream('https://sub/stream/s1'),
+        },
+      );
+      final Map<String, List<Track>> candidates = jellyfinFirst();
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: candidates,
+      );
+
+      await controller.playTracks(<Track>[j1, j2]);
+      candidates
+        ..clear()
+        ..addAll(subsonicFirst());
+
+      completeCurrent(controller);
+      await Future<void>.delayed(Duration.zero);
+
+      // It tried Subsonic first, then fell back to Jellyfin — playback continues.
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j2');
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+    });
+  });
 }

--- a/test/features/library/playback_candidates_provider_test.dart
+++ b/test/features/library/playback_candidates_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:linthra/core/catalog/source_strategy.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_candidate_source.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/features/downloads/download_providers.dart';
@@ -12,6 +13,7 @@ import 'package:linthra/features/library/library_controller.dart';
 import 'package:linthra/features/library/playback_candidates_provider.dart';
 import 'package:linthra/features/library/playback_source_strategy_controller.dart';
 import 'package:linthra/features/library/source_preference_controller.dart';
+import 'package:linthra/features/player/player_providers.dart';
 
 final Uri _jellyArt =
     Uri.parse('https://music.example.com/Items/j/Images/Primary');
@@ -99,12 +101,13 @@ void main() {
       final Map<String, List<Track>> map =
           container.read(playbackCandidatesProvider);
 
-      // Keyed by the displayed (primary) track id; Jellyfin is preferred.
-      expect(map.keys, <String>['j']);
-      expect(
-        map['j']!.map((Track t) => t.uri).toList(),
-        <String>['jellyfin:j', 'subsonic:s'],
-      );
+      // Keyed by *every* copy's id (not just the displayed/primary one), so a
+      // copy already in the queue resolves to the song's candidates whichever
+      // one it is. Both ids map to the same ordered list; Jellyfin is preferred.
+      expect(map.keys, unorderedEquals(<String>['j', 's']));
+      const List<String> order = <String>['jellyfin:j', 'subsonic:s'];
+      expect(map['j']!.map((Track t) => t.uri).toList(), order);
+      expect(map['s']!.map((Track t) => t.uri).toList(), order);
     });
 
     test('every candidate carries the row\'s best-available cover', () async {
@@ -189,6 +192,85 @@ void main() {
           container.read(playbackCandidatesProvider);
       expect(map['j']!.map((Track t) => t.uri).toList(),
           <String>['jellyfin:j', 'subsonic:s']);
+    });
+  });
+
+  // Regression: switching the default source to Navidrome/Subsonic must take
+  // effect on the *next* play immediately — without restarting the app — even for
+  // a copy that is already sitting in the queue. The candidate source is read the
+  // way the playback controller reads it (lazily, through the production
+  // override), and the user's default-source choice is the live controller, so
+  // this exercises the real switch path rather than a fixed preference.
+  group('manual switch to Navidrome/Subsonic', () {
+    Future<ProviderContainer> seedSwitchable() async {
+      final repo = InMemoryMusicLibraryRepository();
+      final container = ProviderContainer(overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(repo),
+        offlineAvailableTrackIdsProvider.overrideWithValue(const <String>{}),
+        // The exact production wiring the playback controller uses.
+        playbackCandidateSourceOverride,
+      ]);
+      addTearDown(container.dispose);
+      await repo.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_jelly('j', title: 'Hello')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repo.upsertCatalog(
+        sourceId: 'subsonic',
+        tracks: <Track>[_sub('s', title: 'Hello')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await container.read(libraryControllerProvider.notifier).refresh();
+      return container;
+    }
+
+    test(
+        'an already-queued Jellyfin copy resolves Subsonic first after the '
+        'switch (not orphaned to the old source)', () async {
+      final container = await seedSwitchable();
+      // Read the candidate source once, exactly as the session-pinned controller
+      // does — it must reflect later changes without being rebuilt.
+      final PlaybackCandidateSource candidates =
+          container.read(playbackCandidateSourceProvider);
+
+      // The user tapped/enqueued the displayed Jellyfin copy under the default
+      // (Automatic) order, so the queue holds the Jellyfin track.
+      final Track queued = _jelly('j', title: 'Hello');
+      expect(
+        candidates.candidatesFor(queued).map((Track t) => t.uri).toList(),
+        <String>['jellyfin:j', 'subsonic:s'],
+      );
+
+      // The user switches the default source to Navidrome/Subsonic.
+      await container
+          .read(defaultProviderControllerProvider.notifier)
+          .setDefaultProvider('subsonic');
+
+      // The next play of that *same queued copy* now leads with Subsonic (and
+      // still keeps Jellyfin as a fallback) — so playback uses the chosen source
+      // immediately, instead of staying stuck on Jellyfin until a restart.
+      expect(
+        candidates.candidatesFor(queued).map((Track t) => t.uri).toList(),
+        <String>['subsonic:s', 'jellyfin:j'],
+      );
+    });
+
+    test('switching back to Automatic restores the previous order', () async {
+      final container = await seedSwitchable();
+      final PlaybackCandidateSource candidates =
+          container.read(playbackCandidateSourceProvider);
+      final Track queued = _jelly('j', title: 'Hello');
+
+      final notifier =
+          container.read(defaultProviderControllerProvider.notifier);
+      await notifier.setDefaultProvider('subsonic');
+      expect(candidates.candidatesFor(queued).first.uri, 'subsonic:s');
+
+      await notifier.setDefaultProvider(null); // Automatic
+      expect(candidates.candidatesFor(queued).first.uri, 'jellyfin:j');
     });
   });
 }


### PR DESCRIPTION
## Problem

Switching the default playback source to **Navidrome/Subsonic** (Settings ▸ Default source) didn't take effect until the app was restarted:

- A copy already sitting in the queue kept playing the **old** source.
- If that old source then failed, it had **no fallback** to the other copy.
- End‑of‑track continuation could get stuck on stale source state.

Restarting "fixed" it only because the queue was rebuilt from scratch with the new primaries.

## Root cause

`playbackCandidatesProvider` keyed its candidate map **only by each song's primary (displayed) track id**. Changing the default source flips which copy is primary (e.g. `jellyfin:x` → `subsonic:x`), so the map **re‑keys** to the new primary and the copy already in the queue becomes **orphaned**:

```dart
// before the switch
candidatesFor(jellyfin:j) -> [jellyfin:j, subsonic:s]   // full fallback
// after switching default to Subsonic (queue still holds jellyfin:j)
candidatesFor(jellyfin:j) -> [jellyfin:j]               // orphaned: no Subsonic, no fallback
```

The queued copy is pinned to the old source until the queue is rebuilt (a restart).

## Fix

Key the candidate map by **every copy's track id**, all pointing at the same freshly‑ordered candidate list. A queued copy now resolves to its song's candidates led by the newly chosen source:

```dart
// after the fix, after switching default to Subsonic
candidatesFor(jellyfin:j) -> [subsonic:s, jellyfin:j]   // new source first, Jellyfin as fallback
```

So the next play — a tap, a skip, or end‑of‑track continuation — uses the chosen source immediately and still falls back if it fails. Track ids are unique to one logical song, so the extra keys never collide; single‑source songs stay absent from the map (the controller treats that as "no fallback"), so Jellyfin / Local / Navidrome single‑source playback is byte‑for‑byte unchanged.

The change is one provider's map keying (~10 lines). The playback engine, resolver, audio quality, Android Auto, and permissions are untouched. No version/release/fdroiddata changes.

## Tests

New regression coverage (all green; full suite **1636 passing**):

- **Manual switch to Navidrome/Subsonic** (`playback_candidates_provider_test.dart`): an already‑queued Jellyfin copy resolves Subsonic first after the switch, and switching back to Automatic restores the order.
- **End‑of‑track continuation after a source change** (`just_audio_playback_controller_fallback_test.dart`): the next queued copy uses the newly chosen source, and continuation still falls back to the other copy when the new source fails (never stalls).

`dart format` clean, `flutter analyze` clean.

https://claude.ai/code/session_01Wv7GLs861cdS7P2kEQy5nA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wv7GLs861cdS7P2kEQy5nA)_