### PR TITLE
chore(release): prepare v0.1.3

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/103999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/103999.txt
@@ -1,0 +1,25 @@
+Linthra 0.1.3 — Local music overhaul.
+
+Added:
+- Reliable local music access on Android, including SD cards and folders
+  picked through the system file chooser.
+- Local tracks indexed by title, artist, album, duration, and track number
+  for a tidy, correctly ordered library.
+- Embedded cover art for local tracks that carry it.
+- Synced lyrics for local tracks from a matching ".lrc" or ".txt" file kept
+  next to the song.
+
+Changed:
+- Clearer Local music settings, with music sources grouped together.
+- A clearer scan summary, with guidance when a folder has no playable music.
+- Lighter synced-lyrics highlighting and queue sheet, for better battery and
+  performance.
+
+Fixed:
+- Switching the default playback source no longer breaks fallback for
+  Navidrome/Subsonic tracks already in the queue.
+
+Maintenance:
+- Documentation updates.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.2';
+  static const String _devVersionName = '0.1.3';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.2+102999
+version: 0.1.3+103999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Linthra v0.1.3 — Local music overhaul

Release-preparation PR only. Bumps the version to **`0.1.3+103999`** and adds the Fastlane changelog. **No tag is created and no fdroiddata is edited** — that stays manual after merge (see `docs/release-process.md`).

### What changed (clean, version-only diff)
| File | Change |
| ---- | ------ |
| `pubspec.yaml` | `version: 0.1.2+102999` → `0.1.3+103999` |
| `lib/core/app_info.dart` | `_devVersionName` → `0.1.3` (in-app version mirror) |
| `fastlane/metadata/android/en-US/changelogs/103999.txt` | new F-Droid "What's New" |

This mirrors exactly the three-file set of the previous bump (`chore(release): prepare v0.1.2`, #155).

### Version encoding
`versionCode = MAJOR×10,000,000 + MINOR×100,000 + PATCH×1,000 + 999` → `0 + 100,000 + 3,000 + 999 = 103999`, the canonical encoding of `0.1.3` (`tool/version_from_tag.dart`). Matches the requested `103999`.

### Release notes (since v0.1.2)
- Reliable Android SAF / SD-card local music folder access
- Clearer Local music source settings
- Local music metadata indexing (title, artist, album, duration, track number)
- Embedded cover art for local tracks
- Local `.lrc` / `.txt` sidecar lyrics
- Clearer scan summary and no-results guidance
- Navidrome/Subsonic source-switching fallback fix
- Battery/performance polish for synced lyrics and the queue sheet
- Documentation updates

Notes are user-friendly and secret-free; closing line keeps the "No ads, no tracking, no analytics, no telemetry." pledge.

### Deliberately not done (per the request)
- ❌ No git tag created or moved
- ❌ No fdroiddata / `metadata/io.github.thezupzup.linthra.yml` edits (it was likewise untouched for 0.1.1/0.1.2; the F-Droid guardrail uses `>=`, so it stays green)
- ❌ No `CHANGELOG.md` (the project doesn't use one)
- ❌ No Android `versionName`/`versionCode` edits (Gradle reads them from `pubspec.yaml`)
- ❌ No playback, scanner, or permission changes
- ❌ No old-release modifications

### Verification
- ✅ `scripts/check_secrets.sh` — passed (no secrets/private data)
- ✅ `scripts/check_release_bump_files.sh` — passed (version-only diff)
- ✅ Version encoding checked by hand against `tool/version_from_tag.dart` (`103999`)
- ⚠️ `dart format` / `flutter analyze` / `flutter test` — **not run**: the Flutter/Dart toolchain isn't installed in this environment. The diff is text-only (a version string, a const, and a new `.txt`), so the version-drift, canonical-`versionCode`, and changelog-existence guardrail tests will pass in CI.

https://claude.ai/code/session_013sVURMvbVCGsptzN7qsoLt

---
_Generated by [Claude Code](https://claude.ai/code/session_013sVURMvbVCGsptzN7qsoLt)_