### PR TITLE
fix(subsonic): show Navidrome/Subsonic cover art across the app (#169)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -99,6 +99,10 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
 - **Offline cache**: a Subsonic track can be downloaded for offline use (the
   original file via `download.view`).
 - **Cast**: a Subsonic track casts to a Chromecast as a live stream.
+- **Cover art**: album/artist/track artwork shows across the app. The catalog
+  stores only a credential-free `subsonic-cover:<coverArtId>` reference; the
+  authenticated `getCoverArt` URL is resolved on demand at render time (the
+  salt+token are woven in then, never persisted), exactly like stream URLs.
 - **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic
   `getLyricsBySongId` extension (how Navidrome exposes embedded/sidecar lyrics),
   with a fallback to the legacy `getLyrics` (plain text, matched by artist +
@@ -135,10 +139,14 @@ Concretely, Linthra:
 - never logs the password, salt, or token;
 - never stores an authenticated stream/download URL in `Track.uri` or the
   database (the URI is the opaque `subsonic:<id>`);
+- never stores an authenticated cover-art URL in `Track.artworkUri` or the
+  database (it stores the credential-free `subsonic-cover:<id>` reference, and
+  weaves the salt+token in only when an image is actually rendered);
 - never puts a credential in a cache filename or cache metadata (the cache file
   extension comes from the response content type, not the URL);
 - never surfaces a credential or credentialed URL in a UI error message;
-- resolves stream/download URLs **only at play/download time**.
+- resolves stream/download URLs **only at play/download time**, and cover-art
+  URLs **only at render time**.
 
 ### What remains (follow-ups)
 
@@ -151,10 +159,13 @@ actions stay hidden/disabled rather than failing:
   `getLyricsBySongId` path returns synced lyrics today; the legacy `getLyrics`
   fallback is treated as plain text, so any LRC-style timestamps embedded in its
   value aren't time-synced yet. That refinement is a follow-up.
-- **Cover art** — `getCoverArt` requires the auth query, so a cover URL would
-  embed the credential, and artwork is persisted in the catalog. To keep the
-  security invariant, Subsonic tracks have no `artworkUri` yet; token-free
-  cover-art resolution (resolved on demand, like stream URLs) is a follow-up.
+- **Cover art on the lock screen / Android Auto** — in-app artwork is resolved
+  at render time (see the "Cover art" capability above), but the platform media
+  session loads `MediaItem.artUri` itself and can't reach Linthra's resolver, so
+  it would need a credential-free image URL Subsonic doesn't offer. Caching the
+  resolved cover to a local `file:` the session can read is the follow-up; until
+  then the notification/lock screen/Android Auto show no Subsonic art (unchanged
+  from before).
 - **Per-track cast content type** — the cast receiver is sent a generic
   `audio/mpeg` hint; an exact per-track type / transcode profile is a follow-up.
 - **In-app browse/search by artist/album** — the synced catalog lists tracks;

--- a/lib/core/catalog/logical_track.dart
+++ b/lib/core/catalog/logical_track.dart
@@ -61,9 +61,12 @@ class LogicalTrack {
   /// (preferred) copy's own cover wins; if it has none, the first fallback
   /// candidate — in the same preference order — that *does* carry artwork is
   /// used. So unifying never blanks a cover the song actually has on another
-  /// provider (a common regression when the preferred provider — e.g. Subsonic,
-  /// whose mapper stores no `artworkUri` — shadows a Jellyfin copy that has one).
-  /// `null` only when no candidate has any artwork at all.
+  /// provider (e.g. a preferred Subsonic copy the server reports no `coverArt`
+  /// for shadowing a Jellyfin copy that has one). Each candidate's artwork is
+  /// whatever its mapper stored — a Jellyfin http URL, a local `file:` cover, or
+  /// a credential-free `subsonic-cover:` reference — and is compared/forwarded
+  /// opaquely here; resolution happens later, at render time. `null` only when
+  /// no candidate has any artwork at all.
   Uri? get displayArtworkUri {
     for (final TrackSourceCandidate c in candidates) {
       final Uri? art = c.track.artworkUri;

--- a/lib/core/sources/subsonic/subsonic_api.dart
+++ b/lib/core/sources/subsonic/subsonic_api.dart
@@ -149,11 +149,17 @@ class SubsonicArtistDto {
     required this.id,
     required this.name,
     this.albumCount = 0,
+    this.coverArt,
   });
 
   final String id;
   final String name;
   final int albumCount;
+
+  /// The server's cover-art id for this artist, when present. An opaque handle
+  /// (e.g. `ar-123`) the `getCoverArt` endpoint resolves to an image — not a
+  /// URL and not a credential. Maps to the artist's artwork.
+  final String? coverArt;
 
   static SubsonicArtistDto? fromJson(Map<String, dynamic> json) {
     final String? id = json['id'] as String?;
@@ -163,6 +169,7 @@ class SubsonicArtistDto {
       id: id,
       name: name,
       albumCount: (json['albumCount'] as num?)?.toInt() ?? 0,
+      coverArt: json['coverArt'] as String?,
     );
   }
 }
@@ -175,6 +182,7 @@ class SubsonicAlbumDto {
     this.artist,
     this.songCount = 0,
     this.year,
+    this.coverArt,
   });
 
   final String id;
@@ -182,6 +190,11 @@ class SubsonicAlbumDto {
   final String? artist;
   final int songCount;
   final int? year;
+
+  /// The server's cover-art id for this album, when present. An opaque handle
+  /// (e.g. `al-123`) the `getCoverArt` endpoint resolves to an image — not a
+  /// URL and not a credential. Maps to the album's artwork.
+  final String? coverArt;
 
   static SubsonicAlbumDto? fromJson(Map<String, dynamic> json) {
     final String? id = json['id'] as String?;
@@ -193,6 +206,7 @@ class SubsonicAlbumDto {
       artist: json['artist'] as String?,
       songCount: (json['songCount'] as num?)?.toInt() ?? 0,
       year: (json['year'] as num?)?.toInt(),
+      coverArt: json['coverArt'] as String?,
     );
   }
 }
@@ -206,6 +220,7 @@ class SubsonicSongDto {
     this.artist,
     this.track,
     this.durationSeconds,
+    this.coverArt,
   });
 
   final String id;
@@ -220,6 +235,12 @@ class SubsonicSongDto {
   /// seconds, unlike Jellyfin's 100-ns ticks).
   final int? durationSeconds;
 
+  /// The server's cover-art id for this song, when present. An opaque handle
+  /// (typically the album's, e.g. `al-123`, or the song's own `mf-123`) the
+  /// `getCoverArt` endpoint resolves to an image — not a URL and not a
+  /// credential. Maps to the track's artwork.
+  final String? coverArt;
+
   static SubsonicSongDto? fromJson(Map<String, dynamic> json) {
     final String? id = json['id'] as String?;
     final String? title = json['title'] as String?;
@@ -231,6 +252,7 @@ class SubsonicSongDto {
       artist: json['artist'] as String?,
       track: (json['track'] as num?)?.toInt(),
       durationSeconds: (json['duration'] as num?)?.toInt(),
+      coverArt: json['coverArt'] as String?,
     );
   }
 }

--- a/lib/core/sources/subsonic/subsonic_artwork.dart
+++ b/lib/core/sources/subsonic/subsonic_artwork.dart
@@ -1,0 +1,61 @@
+import '../../models/subsonic_session.dart';
+import 'subsonic_auth.dart';
+import 'subsonic_endpoints.dart';
+
+/// Subsonic/Navidrome cover art as a *credential-free reference* that is safe to
+/// persist in the catalog, plus its render-time resolution into an authenticated
+/// `getCoverArt` URL.
+///
+/// Why a reference instead of a ready-to-load URL: Subsonic's `getCoverArt`
+/// requires the salt+token auth query on *every* request, so a loadable cover
+/// URL would embed the credential — and `Track.artworkUri` is persisted in the
+/// offline catalog. To keep the same "the credential never reaches the catalog"
+/// invariant the stream/download URLs follow, the mapper stores only an opaque
+/// `subsonic-cover:<coverArtId>` reference (no token, no salt, no server URL),
+/// and [resolve] weaves the live session's credential in on demand at render
+/// time — exactly how `SubsonicMusicSource.resolvePlayableUri` mints audio URLs.
+///
+/// The reference is provider-scoped, not server-scoped: there is a single
+/// signed-in Subsonic session at a time, so resolution reads whichever session
+/// is current. A reference left over after sign-out simply fails to resolve
+/// (the UI shows its placeholder) rather than loading a stale cover.
+abstract final class SubsonicArtwork {
+  /// Scheme marking a [Uri] as a credential-free Subsonic cover reference. A
+  /// dedicated scheme (not `subsonic:`, which marks a track URI) keeps it
+  /// unambiguous for both the artwork resolver and any diagnostics.
+  static const String referenceScheme = 'subsonic-cover';
+
+  /// A persistable, credential-free reference to the server cover art
+  /// [coverArtId] (e.g. `subsonic-cover:al-123`). The id rides as a single path
+  /// segment so it round-trips exactly through [coverArtId] and through the
+  /// catalog's `Uri.toString()` / `Uri.parse` — even for the rare id that needs
+  /// percent-encoding (real Subsonic ids are alphanumeric + hyphen).
+  static Uri reference(String coverArtId) =>
+      Uri(scheme: referenceScheme, pathSegments: <String>[coverArtId]);
+
+  /// The cover-art id behind a [reference], or `null` when [uri] isn't a
+  /// Subsonic cover reference (so a Jellyfin http URL or a local `file:` cover
+  /// passes straight through the resolver untouched).
+  static String? coverArtId(Uri uri) {
+    if (!uri.isScheme(referenceScheme)) return null;
+    if (uri.pathSegments.isEmpty) return null;
+    final String id = uri.pathSegments.first;
+    return id.isEmpty ? null : id;
+  }
+
+  /// Resolves a credential-free cover [reference] into a loadable, authenticated
+  /// `getCoverArt` URL for [session], or `null` when [reference] isn't a
+  /// Subsonic cover reference. The salt+token are woven in here, on demand, and
+  /// never persisted — the stored reference stays credential-free.
+  static Uri? resolve(Uri reference, SubsonicSession session) {
+    final String? id = coverArtId(reference);
+    if (id == null) return null;
+    return SubsonicEndpoints.coverArt(
+      session.baseUrl,
+      username: session.username,
+      credentials:
+          SubsonicCredentials(salt: session.salt, token: session.token),
+      coverArtId: id,
+    );
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_endpoints.dart
+++ b/lib/core/sources/subsonic/subsonic_endpoints.dart
@@ -130,6 +130,25 @@ abstract final class SubsonicEndpoints {
       _build(baseUrl, 'download', username, credentials,
           extra: {idParam: songId});
 
+  /// The cover-art image URL: `/rest/getCoverArt.view?id=…` plus auth.
+  ///
+  /// [coverArtId] is the opaque handle a song/album/artist reports as its
+  /// `coverArt` (e.g. `al-123`). Like [stream] and [download], `getCoverArt`
+  /// requires the salt+token on every request, so this URL carries the
+  /// credential in its query — it is therefore woven in here, on demand at
+  /// render time, and never persisted on a track or in the catalog (the catalog
+  /// stores only a credential-free `subsonic-cover:` reference; see
+  /// `SubsonicArtwork`). No `size` is requested, so the server serves the
+  /// original art — matching how Jellyfin's primary image is loaded full-size.
+  static Uri coverArt(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String coverArtId,
+  }) =>
+      _build(baseUrl, 'getCoverArt', username, credentials,
+          extra: {idParam: coverArtId});
+
   /// Builds `/rest/<method>.view` with the standard auth + format query and any
   /// method-specific [extra] parameters. The single place the salt+token are
   /// woven into a URL.

--- a/lib/core/sources/subsonic/subsonic_track_mapper.dart
+++ b/lib/core/sources/subsonic/subsonic_track_mapper.dart
@@ -2,6 +2,7 @@ import '../../models/album.dart';
 import '../../models/artist.dart';
 import '../../models/track.dart';
 import 'subsonic_api.dart';
+import 'subsonic_artwork.dart';
 
 /// Converts Subsonic wire items into Linthra's source-agnostic domain models.
 ///
@@ -14,10 +15,11 @@ import 'subsonic_api.dart';
 ///    The real stream/download URLs carry the salt+token, so building them
 ///    lazily in `SubsonicMusicSource` keeps the credential out of the persisted
 ///    catalog.
-///  - [Track.artworkUri] is intentionally left null. Subsonic cover art
-///    (`getCoverArt`) requires the auth query, so a cover URL would embed the
-///    credential — and `artworkUri` is persisted in the catalog. Token-free
-///    cover-art resolution is a documented follow-up (see docs/providers.md).
+///  - [Track.artworkUri] is a credential-free `subsonic-cover:<coverArtId>`
+///    reference, never a ready-to-load URL. Subsonic cover art (`getCoverArt`)
+///    requires the auth query, so a loadable URL would embed the credential —
+///    and `artworkUri` is persisted in the catalog. The credential is woven in
+///    on demand at render time instead (see [SubsonicArtwork]).
 abstract final class SubsonicTrackMapper {
   /// Prefix marking a [Track.uri] as a Subsonic item rather than a file path or
   /// a Jellyfin item.
@@ -32,6 +34,7 @@ abstract final class SubsonicTrackMapper {
       albumName: song.album,
       duration: _durationFromSeconds(song.durationSeconds),
       trackNumber: song.track,
+      artworkUri: _artworkReference(song.coverArt),
     );
   }
 
@@ -42,6 +45,7 @@ abstract final class SubsonicTrackMapper {
       artistName: album.artist,
       year: album.year,
       trackCount: album.songCount,
+      artworkUri: _artworkReference(album.coverArt),
     );
   }
 
@@ -50,7 +54,16 @@ abstract final class SubsonicTrackMapper {
       id: artist.id,
       name: artist.name,
       albumCount: artist.albumCount,
+      artworkUri: _artworkReference(artist.coverArt),
     );
+  }
+
+  /// A credential-free [SubsonicArtwork.reference] for a non-empty [coverArtId],
+  /// or `null` when the server reported none — so a track/album/artist without
+  /// cover art keeps a null `artworkUri` and the UI shows its placeholder.
+  static Uri? _artworkReference(String? coverArtId) {
+    if (coverArtId == null || coverArtId.isEmpty) return null;
+    return SubsonicArtwork.reference(coverArtId);
   }
 
   /// Subsonic reports a song's duration in whole seconds; absent or zero maps to

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/linthra_app.dart';
+import 'core/models/subsonic_session.dart';
 import 'core/services/linthra_audio_handler.dart';
+import 'core/sources/subsonic/subsonic_artwork.dart';
 import 'data/repositories/default_provider_store_provider.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/favorites_repository_provider.dart';
@@ -28,6 +30,7 @@ import 'features/player/player_providers.dart';
 import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
 import 'features/settings/playback/normalize_volume_controller.dart';
 import 'features/settings/subsonic/subsonic_settings_controller.dart';
+import 'shared/widgets/artwork_image.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -159,6 +162,22 @@ Future<void> main() async {
   } catch (_) {
     // Ignore: the user can still connect in Settings.
   }
+
+  // Teach the shared artwork seam how to turn a credential-free Subsonic cover
+  // reference (subsonic-cover:<id>, the only artwork the catalog persists) into
+  // an authenticated getCoverArt URL, weaving the live session's salt+token in
+  // at render time — exactly how stream URLs are minted on demand, so the
+  // credential never reaches the catalog. Reads the session live, so signing
+  // in/out is picked up without a rebuild; returns null when signed out (the
+  // row keeps its placeholder) and for any non-Subsonic reference (Jellyfin and
+  // local covers load directly). Secret-free: only the resolved NetworkImage URL
+  // is built, never logged.
+  installArtworkReferenceResolver((Uri reference) {
+    final SubsonicSession? session =
+        container.read(subsonicSettingsControllerProvider.notifier).session;
+    if (session == null) return null;
+    return SubsonicArtwork.resolve(reference, session);
+  });
 
   // With the session loaded, pull the user's Jellyfin favourites so the heart
   // reflects the server from the first frame. Best-effort and offline-tolerant:

--- a/lib/shared/widgets/artwork_image.dart
+++ b/lib/shared/widgets/artwork_image.dart
@@ -2,27 +2,59 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 
-/// Resolves an artwork [Uri] to the right [ImageProvider] — the app's single
+/// Turns a credential-free artwork *reference* into a loadable URL at render
+/// time, or returns `null` for a [reference] it doesn't own.
+///
+/// Some sources can't persist a ready-to-load cover URL because it would embed a
+/// credential (Subsonic's `getCoverArt` carries the salt+token on every
+/// request), and `artworkUri` is persisted in the catalog. Those sources store
+/// an opaque reference instead; the resolver, installed once at startup with the
+/// live session, weaves the credential in here — on demand, never persisted.
+typedef ArtworkReferenceResolver = Uri? Function(Uri reference);
+
+/// The app-level reference resolver, or `null` when none is installed (the
+/// default in tests, where references simply fall through and fail to load —
+/// degrading to the caller's placeholder, never a broken-image glyph).
+ArtworkReferenceResolver? _referenceResolver;
+
+/// Installs the app-level [ArtworkReferenceResolver] (see `main`). Passing
+/// `null` clears it. Idempotent and global on purpose: [artworkImageProvider] is
+/// the app's single artwork seam, called from plain widgets with no Riverpod
+/// scope, so the resolution rule is taught to the seam once rather than threaded
+/// through every call site.
+void installArtworkReferenceResolver(ArtworkReferenceResolver? resolver) {
+  _referenceResolver = resolver;
+}
+
+/// Resolves an artwork [uri] to the right [ImageProvider] — the app's single
 /// artwork-resolver seam.
 ///
 /// Every artwork render goes through here (track rows, album/artist tiles and
-/// detail headers, the now-playing background and mini-player), so a local cover
-/// and a server cover are treated identically by every surface.
+/// detail headers, the now-playing background and mini-player), so a local
+/// cover, a server cover, and a credential-resolved cover are treated
+/// identically by every surface.
 ///
 /// - A `file:` URI is embedded cover art Linthra extracted from a local audio
 ///   file into its own private cache; it loads straight from disk with a
 ///   [FileImage].
+/// - A credential-free *reference* (e.g. Subsonic's `subsonic-cover:<id>`) is
+///   handed to the installed [ArtworkReferenceResolver], which weaves in the
+///   live session's auth to produce a loadable URL; that URL is then loaded with
+///   a [NetworkImage].
 /// - Anything else is a server's plain http(s) image URL (Jellyfin builds a
-///   token-free primary-image URL), loaded with a [NetworkImage].
+///   token-free primary-image URL), loaded with a [NetworkImage] unchanged.
 ///
-/// Sources with no cover at all — Subsonic, and untagged local files — carry a
-/// null `artworkUri` and never reach here; the caller shows its placeholder. A
-/// `file:` cover whose bytes are missing or undecodable (e.g. the OS reclaimed
-/// the cache) fails the same way a broken network image does, so the caller's
-/// `errorBuilder` falls back to the placeholder — never a broken-image glyph.
+/// Sources with no cover at all — an untagged local file, or a Subsonic item the
+/// server reports no `coverArt` for — carry a null `artworkUri` and never reach
+/// here; the caller shows its placeholder. A `file:` cover whose bytes are
+/// missing or undecodable (e.g. the OS reclaimed the cache), an unresolved
+/// reference (signed out), or a failed network fetch all fail the same way, so
+/// the caller's `errorBuilder` falls back to the placeholder — never a
+/// broken-image glyph.
 ImageProvider artworkImageProvider(Uri uri) {
   if (uri.isScheme('file')) {
     return FileImage(File(uri.toFilePath()));
   }
-  return NetworkImage(uri.toString());
+  final Uri? resolved = _referenceResolver?.call(uri);
+  return NetworkImage((resolved ?? uri).toString());
 }

--- a/test/core/sources/subsonic/http_subsonic_client_test.dart
+++ b/test/core/sources/subsonic/http_subsonic_client_test.dart
@@ -162,7 +162,11 @@ void main() {
               <String, dynamic>{
                 'name': 'K',
                 'artist': <Map<String, dynamic>>[
-                  <String, dynamic>{'id': 'ar-1', 'name': 'Kavinsky'},
+                  <String, dynamic>{
+                    'id': 'ar-1',
+                    'name': 'Kavinsky',
+                    'coverArt': 'ar-1',
+                  },
                 ],
               },
               <String, dynamic>{
@@ -184,6 +188,9 @@ void main() {
 
       expect(artists.map((a) => a.id), <String>['ar-1', 'ar-2']);
       expect(artists.last.albumCount, 5);
+      // The cover-art handle is parsed when present, absent otherwise.
+      expect(artists.first.coverArt, 'ar-1');
+      expect(artists.last.coverArt, isNull);
     });
 
     test('getAlbums parses albumList2 and requests the right type', () async {
@@ -199,6 +206,7 @@ void main() {
                 'artist': 'Kavinsky',
                 'songCount': 12,
                 'year': 2011,
+                'coverArt': 'al-1',
               },
             ],
           },
@@ -209,6 +217,7 @@ void main() {
 
       expect(albums.single.id, 'al-1');
       expect(albums.single.songCount, 12);
+      expect(albums.single.coverArt, 'al-1');
       expect(captured!.url.path, '/rest/getAlbumList2.view');
       expect(captured!.url.queryParameters['type'], 'alphabeticalByName');
     });
@@ -224,6 +233,7 @@ void main() {
                 'artist': 'Kavinsky',
                 'duration': 256,
                 'track': 1,
+                'coverArt': 'al-1',
               },
             ],
           },
@@ -234,6 +244,7 @@ void main() {
 
       expect(songs.single.id, 's1');
       expect(songs.single.durationSeconds, 256);
+      expect(songs.single.coverArt, 'al-1');
     });
   });
 

--- a/test/core/sources/subsonic/subsonic_artwork_test.dart
+++ b/test/core/sources/subsonic/subsonic_artwork_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_artwork.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_endpoints.dart';
+
+const _session = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'the-salt',
+  token: 'the-secret-token',
+);
+
+void main() {
+  group('SubsonicArtwork.reference', () {
+    test('builds an opaque subsonic-cover: reference for a cover id', () {
+      final Uri ref = SubsonicArtwork.reference('al-123');
+      expect(ref.scheme, SubsonicArtwork.referenceScheme);
+      expect(ref.scheme, 'subsonic-cover');
+      expect(ref.toString(), 'subsonic-cover:al-123');
+    });
+
+    test('round-trips the cover id through coverArtId', () {
+      for (final String id in <String>[
+        'al-123',
+        'ar-9e2a',
+        'mf-7',
+        '42',
+        // Ids with characters that need URL-encoding still round-trip exactly.
+        'cover with spaces',
+        'a/b',
+      ]) {
+        final Uri ref = SubsonicArtwork.reference(id);
+        expect(SubsonicArtwork.coverArtId(ref), id,
+            reason: 'id "$id" must survive the reference round-trip');
+      }
+    });
+
+    test('the reference is credential-free and carries no server URL', () {
+      // The reference is persisted in the catalog, so it must never embed the
+      // salt/token/username/password or the server address.
+      final String ref = SubsonicArtwork.reference('al-123').toString();
+      expect(ref, isNot(contains(_session.token)));
+      expect(ref, isNot(contains(_session.salt)));
+      expect(ref, isNot(contains(_session.username)));
+      expect(ref, isNot(contains(_session.baseUrl)));
+      expect(ref, isNot(contains('http')));
+    });
+  });
+
+  group('SubsonicArtwork.coverArtId', () {
+    test('returns null for a non-Subsonic-cover uri (passes through)', () {
+      // A Jellyfin http(s) image URL and a local file: cover are not references
+      // and must be left for the resolver to load directly.
+      expect(
+        SubsonicArtwork.coverArtId(
+          Uri.parse('https://server.example/Items/1/Images/Primary'),
+        ),
+        isNull,
+      );
+      expect(
+        SubsonicArtwork.coverArtId(Uri.parse('file:///cache/art/abc.img')),
+        isNull,
+      );
+      // The track URI scheme (subsonic:) is deliberately distinct and not a
+      // cover reference.
+      expect(SubsonicArtwork.coverArtId(Uri.parse('subsonic:song-1')), isNull);
+    });
+
+    test('returns null for an empty reference', () {
+      expect(SubsonicArtwork.coverArtId(Uri.parse('subsonic-cover:')), isNull);
+    });
+  });
+
+  group('SubsonicArtwork.resolve', () {
+    test('weaves the session credential into a getCoverArt URL', () {
+      final Uri ref = SubsonicArtwork.reference('al-123');
+      final Uri? resolved = SubsonicArtwork.resolve(ref, _session);
+
+      expect(resolved, isNotNull);
+      expect(resolved!.host, 'music.example.com');
+      expect(resolved.path, '/rest/getCoverArt.view');
+      final Map<String, String> q = resolved.queryParameters;
+      expect(q['id'], 'al-123');
+      expect(q['u'], 'alice');
+      expect(q['t'], 'the-secret-token');
+      expect(q['s'], 'the-salt');
+      expect(q['v'], SubsonicEndpoints.apiVersion);
+    });
+
+    test('keeps the credential in the query only, never in the path', () {
+      final Uri resolved =
+          SubsonicArtwork.resolve(SubsonicArtwork.reference('al-1'), _session)!;
+      expect(resolved.path, isNot(contains('the-secret-token')));
+      expect(resolved.path, isNot(contains('the-salt')));
+    });
+
+    test('returns null for a non-reference uri so other covers pass through',
+        () {
+      // Jellyfin's already-loadable http URL must not be rewritten.
+      final Uri jellyfin =
+          Uri.parse('https://server.example/Items/1/Images/Primary');
+      expect(SubsonicArtwork.resolve(jellyfin, _session), isNull);
+      // A local file cover is likewise not a Subsonic reference.
+      expect(
+        SubsonicArtwork.resolve(Uri.parse('file:///cache/art/abc.img'), _session),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_artwork_test.dart
+++ b/test/core/sources/subsonic/subsonic_artwork_test.dart
@@ -102,7 +102,8 @@ void main() {
       expect(SubsonicArtwork.resolve(jellyfin, _session), isNull);
       // A local file cover is likewise not a Subsonic reference.
       expect(
-        SubsonicArtwork.resolve(Uri.parse('file:///cache/art/abc.img'), _session),
+        SubsonicArtwork.resolve(
+            Uri.parse('file:///cache/art/abc.img'), _session),
         isNull,
       );
     });

--- a/test/core/sources/subsonic/subsonic_endpoints_test.dart
+++ b/test/core/sources/subsonic/subsonic_endpoints_test.dart
@@ -70,6 +70,40 @@ void main() {
       expect(download.queryParameters['id'], 's-7');
     });
 
+    test('coverArt targets /rest/getCoverArt.view and carries the cover id', () {
+      final Uri uri = SubsonicEndpoints.coverArt(
+        _base,
+        username: _user,
+        credentials: _creds,
+        coverArtId: 'al-123',
+      );
+      expect(uri.path, '/rest/getCoverArt.view');
+      expect(uri.queryParameters['id'], 'al-123');
+      // No size is requested, so the server serves the original art.
+      expect(uri.queryParameters.containsKey('size'), isFalse);
+    });
+
+    test('coverArt weaves the auth query and keeps the credential out of the '
+        'path', () {
+      final Uri uri = SubsonicEndpoints.coverArt(
+        _base,
+        username: _user,
+        credentials: _creds,
+        coverArtId: 'al-123',
+      );
+      // The image URL is fetched plainly (NetworkImage), so the salt+token must
+      // ride in the query exactly like stream/download — and never in the path.
+      final Map<String, String> q = uri.queryParameters;
+      expect(q['u'], _user);
+      expect(q['t'], _creds.token);
+      expect(q['s'], _creds.salt);
+      expect(q['v'], SubsonicEndpoints.apiVersion);
+      expect(q['c'], 'Linthra');
+      expect(q['f'], 'json');
+      expect(uri.path, isNot(contains(_creds.token)));
+      expect(uri.path, isNot(contains(_creds.salt)));
+    });
+
     test('getLyricsBySongId targets its endpoint and carries the song id', () {
       final Uri uri = SubsonicEndpoints.getLyricsBySongId(
         _base,

--- a/test/core/sources/subsonic/subsonic_endpoints_test.dart
+++ b/test/core/sources/subsonic/subsonic_endpoints_test.dart
@@ -70,7 +70,8 @@ void main() {
       expect(download.queryParameters['id'], 's-7');
     });
 
-    test('coverArt targets /rest/getCoverArt.view and carries the cover id', () {
+    test('coverArt targets /rest/getCoverArt.view and carries the cover id',
+        () {
       final Uri uri = SubsonicEndpoints.coverArt(
         _base,
         username: _user,
@@ -83,7 +84,8 @@ void main() {
       expect(uri.queryParameters.containsKey('size'), isFalse);
     });
 
-    test('coverArt weaves the auth query and keeps the credential out of the '
+    test(
+        'coverArt weaves the auth query and keeps the credential out of the '
         'path', () {
       final Uri uri = SubsonicEndpoints.coverArt(
         _base,

--- a/test/core/sources/subsonic/subsonic_track_mapper_test.dart
+++ b/test/core/sources/subsonic/subsonic_track_mapper_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_api.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_artwork.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_track_mapper.dart';
 
 void main() {
@@ -25,8 +26,24 @@ void main() {
       expect(track.duration, const Duration(seconds: 256));
     });
 
-    test('never embeds a credential or artwork URL (auth-bearing)', () {
-      const song = SubsonicSongDto(id: 's1', title: 'x');
+    test('maps the song coverArt to a credential-free artwork reference', () {
+      const song = SubsonicSongDto(
+        id: 'song-42',
+        title: 'Nightcall',
+        coverArt: 'al-7',
+      );
+
+      final track = SubsonicTrackMapper.toTrack(song);
+
+      // The persisted artwork is the opaque, credential-free reference — never
+      // an auth-bearing getCoverArt URL.
+      expect(track.artworkUri, SubsonicArtwork.reference('al-7'));
+      expect(track.artworkUri.toString(), 'subsonic-cover:al-7');
+      expect(SubsonicArtwork.coverArtId(track.artworkUri!), 'al-7');
+    });
+
+    test('the uri and artwork reference never embed a credential', () {
+      const song = SubsonicSongDto(id: 's1', title: 'x', coverArt: 'al-1');
       final track = SubsonicTrackMapper.toTrack(song);
 
       // The uri is the opaque id only — no query, no token/salt.
@@ -34,7 +51,20 @@ void main() {
       expect(track.uri, isNot(contains('?')));
       expect(track.uri, isNot(contains('token')));
       expect(track.uri, isNot(contains('=')));
-      // Cover art needs auth params, so artwork is intentionally not persisted.
+      // The artwork reference is credential-free and points at no server: the
+      // salt+token are woven in only at render time, never persisted here.
+      final String artwork = track.artworkUri.toString();
+      expect(artwork, 'subsonic-cover:al-1');
+      expect(artwork, isNot(contains('?')));
+      expect(artwork, isNot(contains('t=')));
+      expect(artwork, isNot(contains('s=')));
+      expect(artwork, isNot(contains('http')));
+    });
+
+    test('leaves artworkUri null when the server reports no coverArt', () {
+      const song = SubsonicSongDto(id: 's1', title: 'x');
+      final track = SubsonicTrackMapper.toTrack(song);
+      // No cover art → null → the UI shows its placeholder (not a broken image).
       expect(track.artworkUri, isNull);
     });
 
@@ -49,13 +79,14 @@ void main() {
   });
 
   group('SubsonicTrackMapper album/artist', () {
-    test('maps an album', () {
+    test('maps an album, with coverArt as a credential-free reference', () {
       const dto = SubsonicAlbumDto(
         id: 'al-1',
         name: 'Drive',
         artist: 'Kavinsky',
         songCount: 12,
         year: 2011,
+        coverArt: 'al-1',
       );
       final album = SubsonicTrackMapper.toAlbum(dto);
       expect(album.id, 'al-1');
@@ -63,17 +94,28 @@ void main() {
       expect(album.artistName, 'Kavinsky');
       expect(album.trackCount, 12);
       expect(album.year, 2011);
-      expect(album.artworkUri, isNull);
+      expect(album.artworkUri, SubsonicArtwork.reference('al-1'));
     });
 
-    test('maps an artist', () {
-      const dto =
-          SubsonicArtistDto(id: 'ar-1', name: 'Kavinsky', albumCount: 2);
+    test('maps an artist, with coverArt as a credential-free reference', () {
+      const dto = SubsonicArtistDto(
+        id: 'ar-1',
+        name: 'Kavinsky',
+        albumCount: 2,
+        coverArt: 'ar-1',
+      );
       final artist = SubsonicTrackMapper.toArtist(dto);
       expect(artist.id, 'ar-1');
       expect(artist.name, 'Kavinsky');
       expect(artist.albumCount, 2);
-      expect(artist.artworkUri, isNull);
+      expect(artist.artworkUri, SubsonicArtwork.reference('ar-1'));
+    });
+
+    test('album/artist artworkUri is null when there is no coverArt', () {
+      const albumDto = SubsonicAlbumDto(id: 'al-1', name: 'Drive');
+      const artistDto = SubsonicArtistDto(id: 'ar-1', name: 'Kavinsky');
+      expect(SubsonicTrackMapper.toAlbum(albumDto).artworkUri, isNull);
+      expect(SubsonicTrackMapper.toArtist(artistDto).artworkUri, isNull);
     });
   });
 }

--- a/test/shared/widgets/artwork_image_test.dart
+++ b/test/shared/widgets/artwork_image_test.dart
@@ -5,6 +5,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/shared/widgets/artwork_image.dart';
 
 void main() {
+  // The resolver is a process-global on the single artwork seam; always clear it
+  // so one test can't leak its hook into the next.
+  tearDown(() => installArtworkReferenceResolver(null));
+
   group('artworkImageProvider', () {
     test('loads a file:// cover from disk with a FileImage', () {
       final provider = artworkImageProvider(
@@ -35,6 +39,63 @@ void main() {
         (https as NetworkImage).url,
         'https://music.example.com/Items/2/Images/Primary',
       );
+    });
+  });
+
+  group('artworkImageProvider with an installed reference resolver', () {
+    test('loads an installed resolver\'s resolved URL with a NetworkImage', () {
+      installArtworkReferenceResolver((Uri ref) {
+        if (ref.scheme != 'subsonic-cover') return null;
+        return Uri.parse(
+          'https://music.example.com/rest/getCoverArt.view'
+          '?id=${ref.path}&u=alice&t=tok&s=salt',
+        );
+      });
+
+      final provider =
+          artworkImageProvider(Uri.parse('subsonic-cover:al-123'));
+      expect(provider, isA<NetworkImage>());
+      expect(
+        (provider as NetworkImage).url,
+        'https://music.example.com/rest/getCoverArt.view'
+        '?id=al-123&u=alice&t=tok&s=salt',
+      );
+    });
+
+    test('leaves a file: cover on disk even with a resolver installed', () {
+      // The resolver is only consulted for non-file references; a local cover
+      // must still load straight from disk.
+      installArtworkReferenceResolver((Uri ref) => Uri.parse('https://x/y'));
+      final provider = artworkImageProvider(Uri.parse('file:///cache/a.img'));
+      expect(provider, isA<FileImage>());
+    });
+
+    test('passes a Jellyfin http URL through untouched (resolver returns null)',
+        () {
+      // A resolver that only owns subsonic-cover references returns null for a
+      // plain http URL, which must then load unchanged.
+      installArtworkReferenceResolver(
+        (Uri ref) => ref.scheme == 'subsonic-cover' ? Uri.parse('https://x') : null,
+      );
+      final provider = artworkImageProvider(
+        Uri.parse('https://server.example/Items/1/Images/Primary'),
+      );
+      expect(provider, isA<NetworkImage>());
+      expect(
+        (provider as NetworkImage).url,
+        'https://server.example/Items/1/Images/Primary',
+      );
+    });
+
+    test('an unresolved reference (signed out) falls back to the raw reference',
+        () {
+      // No resolver installed → the reference can't be turned into a real URL.
+      // It still yields a NetworkImage (of the unloadable reference), which the
+      // caller's errorBuilder turns into the calm placeholder — never a crash.
+      final provider =
+          artworkImageProvider(Uri.parse('subsonic-cover:al-123'));
+      expect(provider, isA<NetworkImage>());
+      expect((provider as NetworkImage).url, 'subsonic-cover:al-123');
     });
   });
 }

--- a/test/shared/widgets/artwork_image_test.dart
+++ b/test/shared/widgets/artwork_image_test.dart
@@ -2,7 +2,16 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_artwork.dart';
 import 'package:linthra/shared/widgets/artwork_image.dart';
+
+const _subsonicSession = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'the-salt',
+  token: 'the-secret-token',
+);
 
 void main() {
   // The resolver is a process-global on the single artwork seam; always clear it
@@ -52,8 +61,7 @@ void main() {
         );
       });
 
-      final provider =
-          artworkImageProvider(Uri.parse('subsonic-cover:al-123'));
+      final provider = artworkImageProvider(Uri.parse('subsonic-cover:al-123'));
       expect(provider, isA<NetworkImage>());
       expect(
         (provider as NetworkImage).url,
@@ -75,7 +83,8 @@ void main() {
       // A resolver that only owns subsonic-cover references returns null for a
       // plain http URL, which must then load unchanged.
       installArtworkReferenceResolver(
-        (Uri ref) => ref.scheme == 'subsonic-cover' ? Uri.parse('https://x') : null,
+        (Uri ref) =>
+            ref.scheme == 'subsonic-cover' ? Uri.parse('https://x') : null,
       );
       final provider = artworkImageProvider(
         Uri.parse('https://server.example/Items/1/Images/Primary'),
@@ -92,10 +101,61 @@ void main() {
       // No resolver installed → the reference can't be turned into a real URL.
       // It still yields a NetworkImage (of the unloadable reference), which the
       // caller's errorBuilder turns into the calm placeholder — never a crash.
-      final provider =
-          artworkImageProvider(Uri.parse('subsonic-cover:al-123'));
+      final provider = artworkImageProvider(Uri.parse('subsonic-cover:al-123'));
       expect(provider, isA<NetworkImage>());
       expect((provider as NetworkImage).url, 'subsonic-cover:al-123');
+    });
+  });
+
+  // The regression guard: install the *exact* resolver main() installs (the
+  // real SubsonicArtwork.resolve bound to a session) and prove that adding the
+  // Subsonic cover path did not change how Jellyfin network covers or local
+  // file: covers are loaded — they are byte-for-byte what they were before.
+  group(
+      'the production Subsonic resolver leaves Jellyfin + local covers '
+      'unchanged', () {
+    setUp(() {
+      installArtworkReferenceResolver(
+        (Uri reference) => SubsonicArtwork.resolve(reference, _subsonicSession),
+      );
+    });
+
+    test('a Jellyfin token-free primary-image URL still loads unchanged', () {
+      // The Subsonic resolver returns null for a non-reference URI, so the
+      // Jellyfin http URL falls through and loads exactly as before.
+      const String jellyfin =
+          'https://music.example.com/Items/track-1/Images/Primary';
+      final provider = artworkImageProvider(Uri.parse(jellyfin));
+      expect(provider, isA<NetworkImage>());
+      expect((provider as NetworkImage).url, jellyfin);
+    });
+
+    test('a local embedded-cover file: URI still loads from disk unchanged',
+        () {
+      // file: is handled before the resolver is ever consulted, so local
+      // embedded art is untouched.
+      final provider = artworkImageProvider(
+        Uri.parse('file:///data/app/cache/linthra_local_artwork/abc.img'),
+      );
+      expect(provider, isA<FileImage>());
+      expect(
+        (provider as FileImage).file.path,
+        File('/data/app/cache/linthra_local_artwork/abc.img').path,
+      );
+    });
+
+    test(
+        'a Subsonic cover reference resolves to an authenticated getCoverArt '
+        'URL', () {
+      final provider = artworkImageProvider(SubsonicArtwork.reference('al-7'));
+      expect(provider, isA<NetworkImage>());
+      final Uri resolved = Uri.parse((provider as NetworkImage).url);
+      expect(resolved.host, 'music.example.com');
+      expect(resolved.path, '/rest/getCoverArt.view');
+      expect(resolved.queryParameters['id'], 'al-7');
+      expect(resolved.queryParameters['u'], 'alice');
+      expect(resolved.queryParameters['t'], 'the-secret-token');
+      expect(resolved.queryParameters['s'], 'the-salt');
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #169 — Navidrome/Subsonic cover art was not displayed anywhere in the app.

### Root cause
This was an unimplemented feature, not a regression. The Subsonic wire DTOs never parsed `coverArt`, and `SubsonicTrackMapper` deliberately left `Track.artworkUri` null because `getCoverArt` requires the salt+token auth query on every request and `artworkUri` is **persisted in the offline catalog** — so a ready-to-load cover URL would leak the credential into the (non-secure) catalog DB. It was a documented follow-up in `docs/providers.md`.

### Fix — resolve cover art on demand, the same way stream URLs are minted
- **Parse `coverArt`** on the song/album/artist DTOs (`subsonic_api.dart`).
- **Store a credential-free reference** `subsonic-cover:<coverArtId>` in `artworkUri` (no token, salt, username, or server URL), so the "no credential is ever persisted in the catalog" invariant still holds. The id rides as a single path segment so it round-trips exactly, even when it needs percent-encoding.
- **Add `SubsonicEndpoints.coverArt`** and **`SubsonicArtwork.resolve`**, which weave the live session's salt+token into the `getCoverArt` URL.
- **Give the shared `artworkImageProvider` seam an installable resolver**, wired in `main` to the live Subsonic session, so the reference becomes an authenticated `NetworkImage` only when an image is actually drawn.

### Why this covers the whole app
Albums and artists are *grouped from the track catalog* (`library_grouping.dart`), inheriting each track's `artworkUri`. So setting `Track.artworkUri` cascades to:
- track rows, album tiles, artist tiles
- album/artist detail headers
- now playing (background + album art), the queue sheet, and the mini-player

### Scope / safety
- **Jellyfin** http covers and **local** `file:` covers pass through the resolver untouched — only `subsonic-cover:` references are rewritten.
- **Cast** still omits artwork (a token must never reach the receiver) — unchanged.
- **No credential is persisted or logged**: the reference is credential-free; the authenticated URL exists only transiently inside the image provider, and every render site already uses an `errorBuilder`, so image load errors never surface the URL.
- No playback changes, no new permissions, no version bump.

### Known follow-up (out of scope, no regression)
The platform media session (lock screen / Android Auto) still shows no Subsonic art — it loads `MediaItem.artUri` itself and can't reach the resolver, and Subsonic offers no credential-free image URL. Caching the resolved cover to a local `file:` is noted as a follow-up in `docs/providers.md`. This is unchanged from before (it was already blank for Subsonic).

## Tests
Adds regression tests for:
- `SubsonicEndpoints.coverArt` URL generation (path, id, auth query, no credential in the path)
- `SubsonicArtwork` reference round-trip (incl. ids needing encoding), credential-free reference, and render-time resolution
- DTO `coverArt` parsing (`http_subsonic_client_test`)
- Mapper: track/album/artist `coverArt` → reference, and null when absent
- The `artworkImageProvider` resolver seam (resolves references, passes file/http through, falls back gracefully when signed out)

Full suite: **1653 tests pass**; `flutter analyze` clean; secret scan clean.

## Verification done
- `flutter analyze` — no issues
- `flutter test` — all pass
- `scripts/check_secrets.sh` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_017mMnvNPpVpSUm4qs9jrjmx)_