### PR TITLE
fix(subsonic): keep opaque cover refs out of the platform media session

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -162,10 +162,13 @@ actions stay hidden/disabled rather than failing:
 - **Cover art on the lock screen / Android Auto** — in-app artwork is resolved
   at render time (see the "Cover art" capability above), but the platform media
   session loads `MediaItem.artUri` itself and can't reach Linthra's resolver, so
-  it would need a credential-free image URL Subsonic doesn't offer. Caching the
-  resolved cover to a local `file:` the session can read is the follow-up; until
-  then the notification/lock screen/Android Auto show no Subsonic art (unchanged
-  from before).
+  it would need a credential-free image URL Subsonic doesn't offer. The opaque
+  `subsonic-cover:` reference is therefore deliberately kept out of
+  `MediaItem.artUri` (only `http(s)`/`file:` covers are handed to the session),
+  so the notification/lock screen/Android Auto show no Subsonic art rather than
+  a custom-scheme URI the platform can't fetch — unchanged from before. Caching
+  the resolved cover to a local `file:` the session can read (token-free) is the
+  follow-up.
 - **Per-track cast content type** — the cast receiver is sent a generic
   `audio/mpeg` hint; an exact per-track type / transcode profile is a follow-up.
 - **In-app browse/search by artist/album** — the synced catalog lists tracks;

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -304,7 +304,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       title: node.title,
       playable: false,
       displaySubtitle: node.subtitle,
-      artUri: node.artworkUri,
+      artUri: _mediaArtUri(node.artworkUri),
     );
   }
 
@@ -322,8 +322,29 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       artist: track.artistName,
       album: track.albumName,
       duration: duration > Duration.zero ? duration : null,
-      artUri: track.artworkUri,
+      artUri: _mediaArtUri(track.artworkUri),
     );
+  }
+
+  /// The artwork URI to hand the platform media session (notification, lock
+  /// screen, Android Auto), or null when there is none it can load directly.
+  ///
+  /// Unlike the in-app artwork seam ([artworkImageProvider]), `MediaItem.artUri`
+  /// is fetched by the OS/audio_service itself, so only a directly loadable,
+  /// credential-free URI belongs here: a token-free `http(s)` cover (Jellyfin)
+  /// or a local `file:` cover (a local file's embedded art). An opaque in-app
+  /// reference such as Subsonic's `subsonic-cover:<id>` — which only the widget
+  /// resolver can turn into a signed URL — is dropped to null, so the platform
+  /// is never handed a custom-scheme URI it can't fetch (which would fail/log
+  /// instead of cleanly showing no art). Caching a resolved Subsonic cover to a
+  /// `file:` for the lock screen is a separate follow-up; it must stay
+  /// token-free, since the credential must never reach the platform session.
+  static Uri? _mediaArtUri(Uri? uri) {
+    if (uri == null) return null;
+    if (uri.isScheme('http') || uri.isScheme('https') || uri.isScheme('file')) {
+      return uri;
+    }
+    return null;
   }
 
   audio.PlaybackState _playbackStateFor(PlaybackState state) {

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -70,6 +70,38 @@ void main() {
       expect(item.album, 'Album a');
     });
 
+    group('media-session artwork stays loadable (no opaque refs reach artUri)',
+        () {
+      Future<Uri?> artUriFor(Uri? artworkUri) async {
+        await controller.playTracks(<Track>[
+          Track(
+              id: 'x',
+              title: 'Song',
+              uri: 'subsonic:x',
+              artworkUri: artworkUri),
+        ]);
+        await _settle();
+        return handler.mediaItem.value?.artUri;
+      }
+
+      test('drops an opaque subsonic-cover: reference to null', () async {
+        // The OS fetches MediaItem.artUri itself and can't reach the in-app
+        // resolver, so a custom-scheme reference must not reach the session (it
+        // would fail/log on the bad URI); null cleanly shows no art, as before.
+        expect(await artUriFor(Uri.parse('subsonic-cover:al-1')), isNull);
+      });
+
+      test('passes a Jellyfin token-free http(s) cover through', () async {
+        final art = Uri.parse('https://jelly.example/Items/1/Images/Primary');
+        expect(await artUriFor(art), art);
+      });
+
+      test('passes a local file: embedded cover through', () async {
+        final art = Uri.parse('file:///cache/linthra_local_artwork/a.img');
+        expect(await artUriFor(art), art);
+      });
+    });
+
     test('queue: state is ready with pause, stop and skip controls', () async {
       await controller.playTracks([_track('a'), _track('b')]);
       await _settle();


### PR DESCRIPTION
## Summary

Follow-up to the automated review on #170 (which was merged before the comment landed, so the issue is now in `main`).

The cover-art feature sets `Track.artworkUri` to a credential-free `subsonic-cover:<id>` reference, resolved to a signed `getCoverArt` URL **only at render time** by the in-app `artworkImageProvider`. But the platform media-session path doesn't go through that resolver: `_trackMediaItem` and `_mediaItemForNode` in `lib/core/services/linthra_audio_handler.dart` handed `artworkUri` straight to `MediaItem.artUri`.

The OS/`audio_service` fetches `MediaItem.artUri` itself, so for a covered Subsonic track the lock screen / Android Auto received an **unloadable custom-scheme URI** (`subsonic-cover:…`) instead of the previous clean `null` — the platform can't fetch it and may log/fail on the bad URI.

## Fix

Guard `MediaItem.artUri` so only a directly loadable, credential-free scheme reaches the session:

- a token-free `http(s)` cover (Jellyfin) → passes through (unchanged);
- a local `file:` embedded cover → passes through (unchanged);
- an opaque `subsonic-cover:` reference (or any other non-loadable scheme) → dropped to `null`, exactly as it was before the cover-art feature.

In-app artwork is unaffected — track rows, tiles, now-playing, queue, and mini-player still resolve the reference through `artworkImageProvider` at render time. The credential is never handed to the platform session (it must stay token-free), so showing real Subsonic art on the lock screen remains the documented `file:`-cache follow-up.

## Tests

Adds a regression test in `linthra_audio_handler_test.dart` asserting the media item:
- drops a `subsonic-cover:` reference to `null`;
- passes a Jellyfin `http(s)` cover through;
- passes a local `file:` cover through.

Full suite: **1659 tests pass**; `dart format --set-exit-if-changed .` clean; `flutter analyze` clean.

Addresses the review comment on #170 (https://github.com/TheZupZup/Linthra/pull/170#discussion_r3383438420).


---
_Generated by [Claude Code](https://claude.ai/code/session_017mMnvNPpVpSUm4qs9jrjmx)_