### PR TITLE
feat(subsonic): media-session cover art via content:// FileProvider (v0.1.4, pending car test)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -116,6 +116,31 @@
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />
 
+        <!-- FileProvider for Navidrome/Subsonic media-session cover art.
+
+             The platform media session (lock screen / Android Auto) loads
+             MediaItem.artUri in its OWN process, which can't read an app-private
+             file: path — so the cover Linthra fetched and cached is exposed to it
+             as a content:// URI served here instead. exported="false" +
+             grantUriPermissions: nothing is world-readable; the platform reads it
+             via the session, and audio_service decodes it in-process. It serves
+             ONLY the private cover cache (res/xml/media_artwork_paths.xml), whose
+             filenames are SHA-256 hashes of a credential-free reference — never a
+             username, token, salt, server URL, or auth query. No storage
+             permission is added. The authority is fixed (matches
+             kMediaArtworkAuthority in
+             lib/core/services/media_artwork_content_uri.dart) so it is identical
+             in debug and release. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="io.github.thezupzup.linthra.mediaartwork"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/media_artwork_paths" />
+        </provider>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -121,18 +121,20 @@
              The platform media session (lock screen / Android Auto) loads
              MediaItem.artUri in its OWN process, which can't read an app-private
              file: path — so the cover Linthra fetched and cached is exposed to it
-             as a content:// URI served here instead. exported="false" +
-             grantUriPermissions: nothing is world-readable; the platform reads it
-             via the session, and audio_service decodes it in-process. It serves
-             ONLY the private cover cache (res/xml/media_artwork_paths.xml), whose
-             filenames are SHA-256 hashes of a credential-free reference — never a
-             username, token, salt, server URL, or auth query. No storage
-             permission is added. The authority is fixed (matches
-             kMediaArtworkAuthority in
+             as a content:// URI served here instead. The MediaArtworkFileProvider
+             subclass grants the media consumers (Android Auto / SystemUI /
+             Bluetooth) read access to each cover URI when Linthra opens it, so
+             those processes can actually read it; exported="false" +
+             grantUriPermissions keeps nothing world-readable — only those
+             explicit per-URI read grants apply. It serves ONLY the private cover
+             cache (res/xml/media_artwork_paths.xml), whose filenames are SHA-256
+             hashes of a credential-free reference — never a username, token,
+             salt, server URL, or auth query. No storage permission is added. The
+             authority is fixed (matches kMediaArtworkAuthority in
              lib/core/services/media_artwork_content_uri.dart) so it is identical
              in debug and release. -->
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".MediaArtworkFileProvider"
             android:authorities="io.github.thezupzup.linthra.mediaartwork"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MediaArtworkFileProvider.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MediaArtworkFileProvider.kt
@@ -29,8 +29,10 @@ import java.io.FileNotFoundException
  * artwork, which are not served here.
  */
 class MediaArtworkFileProvider : FileProvider() {
+    // FileProvider.openFile returns a nullable ParcelFileDescriptor?, so the
+    // override must match (Kotlin rejects narrowing it to non-null).
     @Throws(FileNotFoundException::class)
-    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
         grantReadToMediaConsumers(uri)
         return super.openFile(uri, mode)
     }

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MediaArtworkFileProvider.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MediaArtworkFileProvider.kt
@@ -1,0 +1,67 @@
+package io.github.thezupzup.linthra
+
+import android.content.Intent
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import androidx.core.content.FileProvider
+import java.io.FileNotFoundException
+
+/**
+ * FileProvider for Navidrome/Subsonic media-session cover art that also grants
+ * the platform media consumers temporary **read** access to each cover URI.
+ *
+ * Why this exists: the platform media session loads `MediaItem.artUri` in the
+ * consumer's *own* process (Android Auto's, SystemUI's for the lock screen,
+ * Bluetooth AVRCP), not Linthra's. The provider is `exported="false"`, so those
+ * processes get a permission denial and the cover never shows — even though
+ * `audio_service` already decoded the same URI in *Linthra's* process to embed
+ * the bitmap. So when Linthra opens a cover here (which `audio_service` does at
+ * metadata-publish time, just before the metadata — carrying the very same URI —
+ * is delivered to those consumers), we grant each consumer read access to that
+ * exact URI. By the time the consumer reads it, the grant is already in place.
+ *
+ * Privacy/security: the grant is **read-only** and only ever for these cover
+ * URIs, which are credential-free album art with SHA-256 filenames — no
+ * username, password, token, salt, server URL, or auth query is ever exposed.
+ * The provider stays `exported="false"`; nothing is world-readable. Granting is
+ * best-effort and never touches playback. It runs *only* when a cover from this
+ * provider is opened, so it never runs for Jellyfin (`http`) or local (`file`)
+ * artwork, which are not served here.
+ */
+class MediaArtworkFileProvider : FileProvider() {
+    @Throws(FileNotFoundException::class)
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor {
+        grantReadToMediaConsumers(uri)
+        return super.openFile(uri, mode)
+    }
+
+    private fun grantReadToMediaConsumers(uri: Uri) {
+        val ctx = context ?: return
+        for (consumer in MEDIA_CONSUMER_PACKAGES) {
+            try {
+                ctx.grantUriPermission(
+                    consumer,
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            } catch (_: Exception) {
+                // Best-effort: a consumer that isn't installed (or a grant that
+                // fails) just means that surface can't read this one cover. It
+                // never affects playback and never leaks anything.
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * The platform components that render MediaSession album art in their own
+         * process and therefore need read access to the cover `content://` URI.
+         * Kept to the well-known media hosts; an un-installed one is skipped.
+         */
+        val MEDIA_CONSUMER_PACKAGES = listOf(
+            "com.google.android.projection.gearhead", // Android Auto (phone)
+            "com.android.systemui", // lock screen / notification shade
+            "com.android.bluetooth", // Bluetooth AVRCP metadata
+        )
+    }
+}

--- a/android/app/src/main/res/xml/media_artwork_paths.xml
+++ b/android/app/src/main/res/xml/media_artwork_paths.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Paths the media-artwork FileProvider (see AndroidManifest.xml) may serve.
+
+     Exactly one entry, and only the private media-session cover cache:
+     `media_session_artwork/` under the app cache dir
+     (path_provider's getTemporaryDirectory() == Context.getCacheDir()), which
+     `MediaArtworkCache` writes to. The served content:// URIs are
+     `content://<authority>/media_artwork/<sha256>.img` — the filename is a hash
+     of a credential-free `subsonic-cover:` reference, never a credential, server
+     URL, or auth query. Nothing else (no documents, no other cache, no storage)
+     is exposed. -->
+<paths>
+    <cache-path
+        name="media_artwork"
+        path="media_session_artwork/" />
+</paths>

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -382,8 +382,12 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   1. fetches a **server-downscaled** cover itself and caches the bytes to a
      private file, keyed by a hash of the credential-free `subsonic-cover:`
      reference (never the URL);
-  2. **pre-warms** the now-playing + next few covers off the playback path, so a
-     cover is cached before its track reaches the now-playing card;
+  2. **pre-warms** the now-playing + next few covers off the playback path
+     (now-playing first, retrying a transient miss on the next queue change), so a
+     cover is cached before its track reaches the now-playing card; if it lands
+     *after* the card was published art-less, a `coverReady` event re-publishes
+     the now-playing item at once (gated by the change check, so it never
+     double-pushes or loops) instead of waiting for the next playback tick;
   3. hands the session a credential-free **`content://` URI** for the cover via a
      `FileProvider` (`MediaArtworkFileProvider`, authority
      `…linthra.mediaartwork`, serving only the hashed-filename cover cache —

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -375,25 +375,32 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   wraps).
 - The car experience is **basic browsing**, not a custom/polished car UI (no
   tabs, content-style hints, lyrics, or now-playing artwork tuning).
-- Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL),
-  local embedded covers (extracted during the scan into a private `file:`), and
-  Subsonic/Navidrome. Subsonic's `getCoverArt` carries the salt+token, so it
-  can't be handed to the session as a URL; instead Linthra fetches a
-  **server-downscaled** cover itself and caches the bytes to a private `file:`
-  (keyed by a hash of the credential-free `subsonic-cover:` reference, never the
-  URL), then sets `MediaItem.artUri` to that local file — which `audio_service`
-  loads in-process and embeds in the session metadata. To beat a head unit that
-  snapshots the now-playing art at the track change (a cover fetched only *at*
-  the change arrives too late), the now-playing + next few covers are
-  **pre-warmed** off the playback path, so the cached file is attached
-  synchronously when the track flips. Downscaling keeps the decode cheap (a
-  full-size cover could stutter or OOM). A failed/slow fetch just leaves the card
-  art-less and never blocks playback. **On-device status:** the in-app cover fix
-  ships; the Subsonic media-session cover is **pending verification on a real
-  head unit** before it's considered done (head units vary in whether they
-  refresh art mid-track). The car **browse-tree** thumbnail for a private-`file:`
-  cover (a local embedded cover, or a Subsonic cover not warmed for the
-  now-playing card) may not be readable by the car's own process, so a Jellyfin
-  server cover remains the most reliable browse thumbnail; this is a known
-  limitation, not a regression.
+- Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL)
+  and local embedded covers (extracted during the scan into a private `file:`).
+  Subsonic/Navidrome media-session art is a **work in progress (parked
+  follow-up — not in `v0.1.4`)**: `getCoverArt` carries the salt+token, so it
+  can't be handed to the session as a URL; Linthra fetches a **server-downscaled**
+  cover itself and caches the bytes to a private file (keyed by a hash of the
+  credential-free `subsonic-cover:` reference, never the URL), and pre-warms the
+  now-playing + next few covers off the playback path so a cover is ready before
+  its track reaches the now-playing card.
+  - **On-device status (two real head-unit tests):** the **playback regression**
+    from the first attempt is **fixed** (downscaling + pre-warming + a purely
+    synchronous handler). But a private `file:` `artUri` still **does not** show
+    the cover on a real Android Auto head unit. Root cause: Android Auto loads
+    album art from the art **URI in its own process** (the Binder-friendly path
+    Google recommends over a large embedded bitmap), and an app-private `file:`
+    is not readable from that process — Jellyfin's `http` cover works precisely
+    because Android Auto can fetch it.
+  - **Follow-up direction:** serve the cached cover as a credential-free
+    **`content://` URI via a `FileProvider`** (an opaque hashed filename, no
+    credential — exactly the privacy properties of the `file:` cache) and set
+    that as `artUri`. Android Auto can read a granted `content://`, and
+    `audio_service` also decodes it in-process; optionally pair it with
+    `androidArtDownscaleSize` so any embedded bitmap stays small enough to cross
+    to the car. The credential must never reach `artUri` or the metadata.
+  - The car **browse-tree** thumbnail for a private-`file:` cover (a local
+    embedded cover) may not be readable by the car's own process, so a Jellyfin
+    server cover remains the most reliable browse thumbnail; this is a known
+    limitation, not a regression.
 - No MPRIS (Linux desktop media keys) yet.

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -385,20 +385,30 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   2. **pre-warms** the now-playing + next few covers off the playback path, so a
      cover is cached before its track reaches the now-playing card;
   3. hands the session a credential-free **`content://` URI** for the cover via a
-     `FileProvider` (`androidx.core.content.FileProvider`, authority
+     `FileProvider` (`MediaArtworkFileProvider`, authority
      `…linthra.mediaartwork`, serving only the hashed-filename cover cache —
-     `res/xml/media_artwork_paths.xml`). This is the key fix: the session loads
-     `MediaItem.artUri` in its **own process**, which can read a `content://` URI
-     (and `audio_service` also decodes it in-process) but **not** an app-private
-     `file:` path. The embedded album-art bitmap is also downscaled
-     (`artDownscaleWidth/Height`) so it survives delivery to the car.
-  - **Why this path:** an earlier attempt set `artUri` to a private `file:`. Two
-    real head-unit tests showed it fixed playback smoothness (downscale +
-    pre-warm + a synchronous handler) but the cover stayed blank, because Android
-    Auto loads the art URI in its own process and can't read an app-private
-    `file:` — Jellyfin's `http` cover works precisely because Android Auto can
-    fetch it. The `content://` FileProvider URI gives Android Auto a readable
-    cover without ever exposing a credential.
+     `res/xml/media_artwork_paths.xml`). The session loads `MediaItem.artUri` in
+     its **own process**, which can read a `content://` URI (and `audio_service`
+     also decodes it in-process) but **not** an app-private `file:` path. The
+     embedded album-art bitmap is also downscaled (`artDownscaleWidth/Height`) so
+     it survives delivery to the car.
+  4. **grants the media consumers read access** to each cover URI. The provider
+     is `exported="false"`, so Android Auto / SystemUI (lock screen) / Bluetooth
+     would otherwise get a permission denial reading the URI from their own
+     processes. `MediaArtworkFileProvider` overrides `openFile` to
+     `grantUriPermission(<consumer>, uri, FLAG_GRANT_READ_URI_PERMISSION)` for
+     those well-known media hosts whenever Linthra itself opens a cover — which
+     `audio_service` does at metadata-publish time, just before the same URI is
+     delivered to the consumers, so the **read** grant is already in place when
+     they read it. Read-only, per-URI, best-effort, and never write.
+  - **Why this path:** earlier attempts set `artUri` to a private `file:`, then a
+    `content://` with no grant. Real head-unit tests showed the `file:`/no-grant
+    paths fixed playback smoothness (downscale + pre-warm + a synchronous handler)
+    but the cover stayed blank, because Android Auto loads the art URI in its own
+    process and can't read an app-private `file:` (nor an *ungranted*
+    `content://`) — Jellyfin's `http` cover works precisely because Android Auto
+    can fetch it. The granted `content://` gives Android Auto a readable cover
+    without ever exposing a credential. **Still pending real-car confirmation.**
   - **Privacy:** the `content://` path is `…/media_artwork/<sha256>.img` — no
     username, password, token, salt, server URL, or auth query, anywhere in the
     URI, the filename, the metadata, logs, or the DB. A failed/slow fetch leaves

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -378,14 +378,22 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 - Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL),
   local embedded covers (extracted during the scan into a private `file:`), and
   Subsonic/Navidrome. Subsonic's `getCoverArt` carries the salt+token, so it
-  can't be handed to the session as a URL; instead Linthra fetches the
-  now-playing cover itself and caches the bytes to a private `file:` (keyed by a
-  hash of the credential-free `subsonic-cover:` reference, never the URL), then
-  sets `MediaItem.artUri` to that local file — which `audio_service` loads
-  in-process for the media session. A failed/slow fetch just leaves the card
-  art-less and never blocks playback. The car **browse-tree** thumbnail for a
-  private-`file:` cover (a local embedded cover, or a Subsonic cover that hasn't
-  been fetched for the now-playing card) may not be readable by the car's own
-  process, so a Jellyfin server cover remains the most reliable browse
-  thumbnail; this is a known limitation, not a regression.
+  can't be handed to the session as a URL; instead Linthra fetches a
+  **server-downscaled** cover itself and caches the bytes to a private `file:`
+  (keyed by a hash of the credential-free `subsonic-cover:` reference, never the
+  URL), then sets `MediaItem.artUri` to that local file — which `audio_service`
+  loads in-process and embeds in the session metadata. To beat a head unit that
+  snapshots the now-playing art at the track change (a cover fetched only *at*
+  the change arrives too late), the now-playing + next few covers are
+  **pre-warmed** off the playback path, so the cached file is attached
+  synchronously when the track flips. Downscaling keeps the decode cheap (a
+  full-size cover could stutter or OOM). A failed/slow fetch just leaves the card
+  art-less and never blocks playback. **On-device status:** the in-app cover fix
+  ships; the Subsonic media-session cover is **pending verification on a real
+  head unit** before it's considered done (head units vary in whether they
+  refresh art mid-track). The car **browse-tree** thumbnail for a private-`file:`
+  cover (a local embedded cover, or a Subsonic cover not warmed for the
+  now-playing card) may not be readable by the car's own process, so a Jellyfin
+  server cover remains the most reliable browse thumbnail; this is a known
+  limitation, not a regression.
 - No MPRIS (Linux desktop media keys) yet.

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -375,30 +375,34 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   wraps).
 - The car experience is **basic browsing**, not a custom/polished car UI (no
   tabs, content-style hints, lyrics, or now-playing artwork tuning).
-- Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL)
-  and local embedded covers (extracted during the scan into a private `file:`).
-  Subsonic/Navidrome media-session art is a **work in progress (parked
-  follow-up — not in `v0.1.4`)**: `getCoverArt` carries the salt+token, so it
-  can't be handed to the session as a URL; Linthra fetches a **server-downscaled**
-  cover itself and caches the bytes to a private file (keyed by a hash of the
-  credential-free `subsonic-cover:` reference, never the URL), and pre-warms the
-  now-playing + next few covers off the playback path so a cover is ready before
-  its track reaches the now-playing card.
-  - **On-device status (two real head-unit tests):** the **playback regression**
-    from the first attempt is **fixed** (downscaling + pre-warming + a purely
-    synchronous handler). But a private `file:` `artUri` still **does not** show
-    the cover on a real Android Auto head unit. Root cause: Android Auto loads
-    album art from the art **URI in its own process** (the Binder-friendly path
-    Google recommends over a large embedded bitmap), and an app-private `file:`
-    is not readable from that process — Jellyfin's `http` cover works precisely
-    because Android Auto can fetch it.
-  - **Follow-up direction:** serve the cached cover as a credential-free
-    **`content://` URI via a `FileProvider`** (an opaque hashed filename, no
-    credential — exactly the privacy properties of the `file:` cache) and set
-    that as `artUri`. Android Auto can read a granted `content://`, and
-    `audio_service` also decodes it in-process; optionally pair it with
-    `androidArtDownscaleSize` so any embedded bitmap stays small enough to cross
-    to the car. The credential must never reach `artUri` or the metadata.
+- Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL),
+  local embedded covers (extracted during the scan into a private `file:`), and
+  Subsonic/Navidrome. `getCoverArt` carries the salt+token, so it can't be handed
+  to the session as a URL; Linthra instead:
+  1. fetches a **server-downscaled** cover itself and caches the bytes to a
+     private file, keyed by a hash of the credential-free `subsonic-cover:`
+     reference (never the URL);
+  2. **pre-warms** the now-playing + next few covers off the playback path, so a
+     cover is cached before its track reaches the now-playing card;
+  3. hands the session a credential-free **`content://` URI** for the cover via a
+     `FileProvider` (`androidx.core.content.FileProvider`, authority
+     `…linthra.mediaartwork`, serving only the hashed-filename cover cache —
+     `res/xml/media_artwork_paths.xml`). This is the key fix: the session loads
+     `MediaItem.artUri` in its **own process**, which can read a `content://` URI
+     (and `audio_service` also decodes it in-process) but **not** an app-private
+     `file:` path. The embedded album-art bitmap is also downscaled
+     (`artDownscaleWidth/Height`) so it survives delivery to the car.
+  - **Why this path:** an earlier attempt set `artUri` to a private `file:`. Two
+    real head-unit tests showed it fixed playback smoothness (downscale +
+    pre-warm + a synchronous handler) but the cover stayed blank, because Android
+    Auto loads the art URI in its own process and can't read an app-private
+    `file:` — Jellyfin's `http` cover works precisely because Android Auto can
+    fetch it. The `content://` FileProvider URI gives Android Auto a readable
+    cover without ever exposing a credential.
+  - **Privacy:** the `content://` path is `…/media_artwork/<sha256>.img` — no
+    username, password, token, salt, server URL, or auth query, anywhere in the
+    URI, the filename, the metadata, logs, or the DB. A failed/slow fetch leaves
+    the card art-less and never blocks playback.
   - The car **browse-tree** thumbnail for a private-`file:` cover (a local
     embedded cover) may not be readable by the car's own process, so a Jellyfin
     server cover remains the most reliable browse thumbnail; this is a known

--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -25,7 +25,7 @@ troubleshoot.
 | Now-playing **queue / Up Next** on the head unit | ✅ (mirrors the app's queue) |
 | Tap a row in the car's Up Next list (skip-to-queue-item) | ✅ |
 | Shuffle / repeat from the car | ✅ |
-| Now-playing metadata (title / artist / album / artwork) | ✅ (artwork depends on `Track.artworkUri`) |
+| Now-playing metadata (title / artist / album / artwork) | ✅ (Jellyfin / local / Subsonic covers; the Subsonic cover is fetched + cached to a private file so no credential reaches `artUri`) |
 | Offline / downloaded section | ✅ (user downloads only — smart pre-cache is not listed) |
 | Cast-safe (no duplicate local playback while casting) | ✅ |
 | Search from Android Auto | ❌ (not implemented — [follow-up](#known-limitations)) |
@@ -174,15 +174,23 @@ Android Auto media items are deliberately **secret-free**:
   file/SAF path), not a stream URL. The **authenticated stream URL is minted
   lazily at play time** by the resolver inside the playback engine, and is never
   stored on a track or handed to the media browser.
-- `MediaItem.artUri` (cover art) is the **token-free** image endpoint for
-  Jellyfin, and `null` for Subsonic/local — so no credential rides along in
-  artwork either.
+- `MediaItem.artUri` (cover art) is only ever a **credential-free, platform-
+  loadable** URI: the **token-free** image endpoint for Jellyfin, a **private
+  `file:`** for a local embedded cover or a fetched-and-cached Subsonic cover,
+  or `null`. The authenticated Subsonic `getCoverArt` URL (which embeds the
+  salt+token) is **never** put in `artUri`: Linthra fetches that cover itself
+  and hands the session only the resulting private `file:` (see
+  [the now-playing artwork note](#known-limitations)), so no credential rides
+  along in artwork.
 - The diagnostic log (see below) prints only the **category** of a media id
   (e.g. `library`, `album`, `artist`, `playlist`, `favorite`, `offline`) and
   small counts — never a raw id, title, URI, or token.
-- Album/artist grouping ids and the cover-art URL never carry a token: art is
-  the **token-free** `Track.artworkUri` (the public image endpoint, or null),
-  the same source the now-playing card already uses.
+- Album/artist grouping ids and the cover-art URL never carry a token: browse
+  art is the **token-free** `Track.artworkUri` (a public image endpoint, a
+  private `file:`, or null). A credential-free reference (e.g. Subsonic's
+  `subsonic-cover:<id>`) that hasn't been fetched to a local file is **dropped to
+  null** for browse rows rather than handed over unloadable — only the
+  now-playing cover is fetched and cached locally.
 
 ## Diagnostics / logging
 
@@ -367,11 +375,17 @@ mode → **Add unknown sources** enabled for a sideloaded build.
   wraps).
 - The car experience is **basic browsing**, not a custom/polished car UI (no
   tabs, content-style hints, lyrics, or now-playing artwork tuning).
-- Lock-screen / now-playing artwork depends on `Track.artworkUri`, which now
-  includes a local file's embedded cover (extracted during the scan) as well as
-  server covers — `audio_service` loads it in-process for the media session. The
-  car **browse-tree** thumbnail for a local file is a private-cache `file://`
-  URI the car's own process may not be able to read, so a server cover remains
-  the most reliable browse thumbnail; this is a known limitation, not a
-  regression (local rows had no art before).
+- Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL),
+  local embedded covers (extracted during the scan into a private `file:`), and
+  Subsonic/Navidrome. Subsonic's `getCoverArt` carries the salt+token, so it
+  can't be handed to the session as a URL; instead Linthra fetches the
+  now-playing cover itself and caches the bytes to a private `file:` (keyed by a
+  hash of the credential-free `subsonic-cover:` reference, never the URL), then
+  sets `MediaItem.artUri` to that local file — which `audio_service` loads
+  in-process for the media session. A failed/slow fetch just leaves the card
+  art-less and never blocks playback. The car **browse-tree** thumbnail for a
+  private-`file:` cover (a local embedded cover, or a Subsonic cover that hasn't
+  been fetched for the now-playing card) may not be readable by the car's own
+  process, so a Jellyfin server cover remains the most reliable browse
+  thumbnail; this is a known limitation, not a regression.
 - No MPRIS (Linux desktop media keys) yet.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -102,20 +102,21 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
 - **Cover art**: album/artist/track artwork shows across the app. The catalog
   stores only a credential-free `subsonic-cover:<coverArtId>` reference; the
   authenticated `getCoverArt` URL is resolved on demand at render time (the
-  salt+token are woven in then, never persisted), exactly like stream URLs. This
-  in-app cover art is the part that **ships**.
-  - **Media-session cover (lock screen / Android Auto) is a parked follow-up,
-    not in `v0.1.4`.** The platform session loads `MediaItem.artUri` itself —
-    somewhere the render-time resolver can't reach, and where a credentialed URL
-    must never go — so Linthra fetches a **server-downscaled** cover itself,
-    caches it to a private file keyed by a hash of the credential-free reference,
-    and pre-warms the now-playing + next covers off the playback path. The
-    credential is used once and never stored, logged, or put in the filename.
-    Real head-unit testing showed this **fixes the playback smoothness** but a
-    private `file:` `artUri` still doesn't show the cover on Android Auto (it
-    loads the URI in its own process, where an app-private `file:` isn't
-    readable). The follow-up is a credential-free **`content://` (FileProvider)**
-    URI Android Auto can read — see `docs/android-auto.md`.
+  salt+token are woven in then, never persisted), exactly like stream URLs.
+  - **Media session (lock screen / Android Auto).** The platform session loads
+    `MediaItem.artUri` in its **own process** — where the render-time resolver
+    can't reach and a credentialed URL must never go — so Linthra fetches a
+    **server-downscaled** cover itself, caches it to a private file keyed by a
+    hash of the credential-free reference, and pre-warms the now-playing + next
+    covers off the playback path. The handler then hands the session a
+    credential-free **`content://` URI** (a `FileProvider`, authority
+    `…linthra.mediaartwork`, serving only that hashed-filename cover cache —
+    `res/xml/media_artwork_paths.xml`), which the session/Android Auto can read
+    and `audio_service` also decodes in-process; the embedded album-art bitmap is
+    downscaled (`artDownscale*`) so it survives delivery to the car. The
+    credential is used once and never stored, logged, exposed, or put in the URI
+    / filename. A failed/slow fetch leaves the card art-less and never blocks
+    playback. See `docs/android-auto.md`.
   - Cast still omits Subsonic artwork (a credentialed URL must not reach the
     receiver).
 - **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -109,14 +109,17 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
     **server-downscaled** cover itself, caches it to a private file keyed by a
     hash of the credential-free reference, and pre-warms the now-playing + next
     covers off the playback path. The handler then hands the session a
-    credential-free **`content://` URI** (a `FileProvider`, authority
+    credential-free **`content://` URI** (`MediaArtworkFileProvider`, authority
     `…linthra.mediaartwork`, serving only that hashed-filename cover cache —
-    `res/xml/media_artwork_paths.xml`), which the session/Android Auto can read
-    and `audio_service` also decodes in-process; the embedded album-art bitmap is
-    downscaled (`artDownscale*`) so it survives delivery to the car. The
-    credential is used once and never stored, logged, exposed, or put in the URI
-    / filename. A failed/slow fetch leaves the card art-less and never blocks
-    playback. See `docs/android-auto.md`.
+    `res/xml/media_artwork_paths.xml`). The provider is `exported="false"` and
+    grants the media hosts (Android Auto / SystemUI / Bluetooth) **read-only**
+    access to each cover URI when Linthra opens it — so their own processes can
+    read it — and `audio_service` also decodes it in-process; the embedded
+    album-art bitmap is downscaled (`artDownscale*`) so it survives delivery to
+    the car. The credential is used once and never stored, logged, exposed, or
+    put in the URI / filename. A failed/slow fetch leaves the card art-less and
+    never blocks playback. Pending real-car confirmation; see
+    `docs/android-auto.md`.
   - Cast still omits Subsonic artwork (a credentialed URL must not reach the
     receiver).
 - **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -99,19 +99,23 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
 - **Offline cache**: a Subsonic track can be downloaded for offline use (the
   original file via `download.view`).
 - **Cast**: a Subsonic track casts to a Chromecast as a live stream.
-- **Cover art**: album/artist/track artwork shows across the app, and the
-  now-playing cover shows on the lock screen / Android Auto. The catalog stores
-  only a credential-free `subsonic-cover:<coverArtId>` reference; the
+- **Cover art**: album/artist/track artwork shows across the app. The catalog
+  stores only a credential-free `subsonic-cover:<coverArtId>` reference; the
   authenticated `getCoverArt` URL is resolved on demand at render time (the
   salt+token are woven in then, never persisted), exactly like stream URLs.
-  Because the platform media session loads `MediaItem.artUri` itself — somewhere
-  the render-time resolver can't reach, and where a credentialed URL must never
-  go — Linthra instead fetches the now-playing cover itself, caches the bytes to
-  a private `file:` keyed by a hash of the credential-free reference, and hands
-  the session only that local file. The credential is used once to fetch and
-  never stored, logged, or put in the cache filename; a failed fetch just leaves
-  the session art-less (playback is unaffected). Cast still omits Subsonic
-  artwork (a credentialed URL must not reach the receiver).
+  For the **media session** (lock screen / Android Auto now-playing card), which
+  loads `MediaItem.artUri` itself — somewhere the render-time resolver can't
+  reach, and where a credentialed URL must never go — Linthra instead fetches a
+  **server-downscaled** cover itself and caches the bytes to a private `file:`,
+  keyed by a hash of the credential-free reference, then hands the session only
+  that local file. To beat a head unit's metadata snapshot at the track change,
+  the now-playing + next few covers are **pre-warmed** off the playback path, so
+  the handler can attach the cached file synchronously. The credential is used
+  once to fetch and never stored, logged, or put in the cache filename; a failed
+  or slow fetch just leaves the session art-less (playback is unaffected). Cast
+  still omits Subsonic artwork (a credentialed URL must not reach the receiver).
+  Media-session artwork on a real head unit is **pending on-device verification**
+  (see `docs/android-auto.md`).
 - **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic
   `getLyricsBySongId` extension (how Navidrome exposes embedded/sidecar lyrics),
   with a fallback to the legacy `getLyrics` (plain text, matched by artist +

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -102,20 +102,22 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
 - **Cover art**: album/artist/track artwork shows across the app. The catalog
   stores only a credential-free `subsonic-cover:<coverArtId>` reference; the
   authenticated `getCoverArt` URL is resolved on demand at render time (the
-  salt+token are woven in then, never persisted), exactly like stream URLs.
-  For the **media session** (lock screen / Android Auto now-playing card), which
-  loads `MediaItem.artUri` itself — somewhere the render-time resolver can't
-  reach, and where a credentialed URL must never go — Linthra instead fetches a
-  **server-downscaled** cover itself and caches the bytes to a private `file:`,
-  keyed by a hash of the credential-free reference, then hands the session only
-  that local file. To beat a head unit's metadata snapshot at the track change,
-  the now-playing + next few covers are **pre-warmed** off the playback path, so
-  the handler can attach the cached file synchronously. The credential is used
-  once to fetch and never stored, logged, or put in the cache filename; a failed
-  or slow fetch just leaves the session art-less (playback is unaffected). Cast
-  still omits Subsonic artwork (a credentialed URL must not reach the receiver).
-  Media-session artwork on a real head unit is **pending on-device verification**
-  (see `docs/android-auto.md`).
+  salt+token are woven in then, never persisted), exactly like stream URLs. This
+  in-app cover art is the part that **ships**.
+  - **Media-session cover (lock screen / Android Auto) is a parked follow-up,
+    not in `v0.1.4`.** The platform session loads `MediaItem.artUri` itself —
+    somewhere the render-time resolver can't reach, and where a credentialed URL
+    must never go — so Linthra fetches a **server-downscaled** cover itself,
+    caches it to a private file keyed by a hash of the credential-free reference,
+    and pre-warms the now-playing + next covers off the playback path. The
+    credential is used once and never stored, logged, or put in the filename.
+    Real head-unit testing showed this **fixes the playback smoothness** but a
+    private `file:` `artUri` still doesn't show the cover on Android Auto (it
+    loads the URI in its own process, where an app-private `file:` isn't
+    readable). The follow-up is a credential-free **`content://` (FileProvider)**
+    URI Android Auto can read — see `docs/android-auto.md`.
+  - Cast still omits Subsonic artwork (a credentialed URL must not reach the
+    receiver).
 - **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic
   `getLyricsBySongId` extension (how Navidrome exposes embedded/sidecar lyrics),
   with a fallback to the legacy `getLyrics` (plain text, matched by artist +

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -99,10 +99,19 @@ Linthra speaks the **Subsonic-compatible REST API**, so it works with
 - **Offline cache**: a Subsonic track can be downloaded for offline use (the
   original file via `download.view`).
 - **Cast**: a Subsonic track casts to a Chromecast as a live stream.
-- **Cover art**: album/artist/track artwork shows across the app. The catalog
-  stores only a credential-free `subsonic-cover:<coverArtId>` reference; the
+- **Cover art**: album/artist/track artwork shows across the app, and the
+  now-playing cover shows on the lock screen / Android Auto. The catalog stores
+  only a credential-free `subsonic-cover:<coverArtId>` reference; the
   authenticated `getCoverArt` URL is resolved on demand at render time (the
   salt+token are woven in then, never persisted), exactly like stream URLs.
+  Because the platform media session loads `MediaItem.artUri` itself — somewhere
+  the render-time resolver can't reach, and where a credentialed URL must never
+  go — Linthra instead fetches the now-playing cover itself, caches the bytes to
+  a private `file:` keyed by a hash of the credential-free reference, and hands
+  the session only that local file. The credential is used once to fetch and
+  never stored, logged, or put in the cache filename; a failed fetch just leaves
+  the session art-less (playback is unaffected). Cast still omits Subsonic
+  artwork (a credentialed URL must not reach the receiver).
 - **Lyrics**: synced or plain lyrics are fetched on demand via the OpenSubsonic
   `getLyricsBySongId` extension (how Navidrome exposes embedded/sidecar lyrics),
   with a fallback to the legacy `getLyrics` (plain text, matched by artist +
@@ -142,8 +151,10 @@ Concretely, Linthra:
 - never stores an authenticated cover-art URL in `Track.artworkUri` or the
   database (it stores the credential-free `subsonic-cover:<id>` reference, and
   weaves the salt+token in only when an image is actually rendered);
-- never puts a credential in a cache filename or cache metadata (the cache file
-  extension comes from the response content type, not the URL);
+- never puts a credential in a cache filename or cache metadata (the offline
+  audio cache file extension comes from the response content type, not the URL;
+  the media-session artwork cache filename is a hash of the credential-free
+  `subsonic-cover:` reference — never the server URL or auth query);
 - never surfaces a credential or credentialed URL in a UI error message;
 - resolves stream/download URLs **only at play/download time**, and cover-art
   URLs **only at render time**.
@@ -159,13 +170,6 @@ actions stay hidden/disabled rather than failing:
   `getLyricsBySongId` path returns synced lyrics today; the legacy `getLyrics`
   fallback is treated as plain text, so any LRC-style timestamps embedded in its
   value aren't time-synced yet. That refinement is a follow-up.
-- **Cover art on the lock screen / Android Auto** — in-app artwork is resolved
-  at render time (see the "Cover art" capability above), but the platform media
-  session loads `MediaItem.artUri` itself and can't reach Linthra's resolver, so
-  it would need a credential-free image URL Subsonic doesn't offer. Caching the
-  resolved cover to a local `file:` the session can read is the follow-up; until
-  then the notification/lock screen/Android Auto show no Subsonic art (unchanged
-  from before).
 - **Per-track cast content type** — the cast receiver is sent a generic
   `audio/mpeg` hint; an exact per-track type / transcode profile is a follow-up.
 - **In-app browse/search by artist/album** — the synced catalog lists tracks;

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -533,6 +533,18 @@ Future<LinthraAudioHandler?> connectMediaSession(
         // a mid-stream re-buffer (see [_isSessionPlaying]).
         androidNotificationOngoing: true,
         androidStopForegroundOnPause: true,
+        // Downscale the album-art bitmap `audio_service` embeds in the session
+        // metadata. The metadata (with the bitmap) is delivered to the platform
+        // session and to Android Auto across a process boundary; a full-size
+        // cover can exceed the cross-process limit and be dropped — leaving
+        // Android Auto, which then can only fall back to the art URI it loads in
+        // its own process, with no art. A small bitmap crosses reliably, so the
+        // now-playing cover actually shows. This applies to all sources (it only
+        // changes the bitmap *size*, not whether art shows) and is the artwork
+        // change that — with the content:// cover URI — makes Subsonic covers
+        // appear on the car; it does not touch audio playback.
+        artDownscaleWidth: 256,
+        artDownscaleHeight: 256,
       ),
     );
     _log('media session attached (Android Auto browser ready)');

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -72,6 +72,11 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     MediaArtworkSource? artwork,
   }) : _artwork = artwork {
     _subscription = _controller.stateStream.listen(_broadcast);
+    // Refresh the now-playing item the instant the current track's cover finishes
+    // warming, so a card published without art picks it up at once instead of
+    // waiting for the next playback tick. Off the playback path; [_onCoverReady]
+    // gates the actual push so it never double-pushes or loops.
+    _coverReadySub = artwork?.coverReady.listen(_onCoverReady);
     // Seed the session from the latest known state so a freshly attached
     // notification/Android Auto isn't blank before the first stream event.
     _broadcast(_controller.state);
@@ -80,13 +85,16 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   final PlaybackController _controller;
   final MediaBrowserTree _tree;
   late final StreamSubscription<PlaybackState> _subscription;
+  StreamSubscription<Uri>? _coverReadySub;
 
-  /// Synchronous lookup of an already-fetched, safe local `file:` cover for a
+  /// Synchronous lookup of an already-fetched, safe `content://` cover for a
   /// credential-free reference (e.g. Subsonic). `null` when none is wired (tests
   /// / unsupported platform), in which case such references carry no
   /// media-session artwork. Covers are warmed ahead of time, off the playback
-  /// path, by `MediaArtworkPrewarmService`, so this stays a pure synchronous read
-  /// — the handler never fetches or re-broadcasts on the playback path.
+  /// path, by `MediaArtworkPrewarmService`; the handler reads this synchronously
+  /// while building a `MediaItem` and never fetches. Its `coverReady` stream lets
+  /// the handler re-publish a now-art-less item once a cover lands (also off the
+  /// playback path).
   final MediaArtworkSource? _artwork;
 
   // The last media item / playback state actually pushed to the platform
@@ -255,6 +263,19 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     if (artworkUri == null) return null;
     if (isPlatformLoadableArtwork(artworkUri)) return artworkUri;
     return _artwork?.cached(artworkUri);
+  }
+
+  /// A cover ([reference]) just finished warming. If it belongs to the track
+  /// playing now, re-publish so its art appears immediately rather than at the
+  /// next playback tick. Off the playback path (driven by the cache, not the
+  /// engine), and safe: [_broadcast]'s [_sameItem] check pushes only when the
+  /// item actually changed, so an already-shown cover (or a cover for some other
+  /// track) is a no-op — no double-push, no loop (a re-broadcast never emits
+  /// `coverReady`).
+  void _onCoverReady(Uri reference) {
+    if (_controller.state.currentTrack?.artworkUri == reference) {
+      _broadcast(_controller.state);
+    }
   }
 
   /// The non-secret *scheme* of an artwork [uri], for the diagnostic trace —
@@ -494,7 +515,10 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   }
 
   /// Stops mirroring controller state. Call before disposing the controller.
-  Future<void> dispose() => _subscription.cancel();
+  Future<void> dispose() async {
+    await _coverReadySub?.cancel();
+    await _subscription.cancel();
+  }
 }
 
 /// Registers [controller] with the platform media session so playback appears

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -214,6 +214,12 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     if (!_seeded || !_sameItem(item, _lastItem)) {
       _lastItem = item;
       mediaItem.add(item);
+      // Secret-free artwork trace: the *scheme* of what reached MediaItem.artUri
+      // (never the URI). `content` = a safe FileProvider cover was attached;
+      // `none` = no cover (not warmed / failed); `http`/`file` = Jellyfin/local;
+      // `other` = a bug (an unresolved reference leaked). Lets a car test +
+      // `adb logcat | grep Linthra` show whether the cover is actually being set.
+      _log('now-playing: art=${_artScheme(item?.artUri)}');
     }
     // Publish the play queue so the car / head-unit "Up Next" list mirrors the
     // controller's queue and a tapped row (skipToQueueItem) lands on the right
@@ -236,18 +242,31 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   /// The media-session-safe artwork URI for [artworkUri].
   ///
-  /// A platform-loadable cover (a private `file:`, a token-free `http`/`https`
-  /// image such as Jellyfin's primary image, or an app-provided `content:` URI)
-  /// is handed to the session unchanged. A credential-free *reference* (e.g.
+  /// A platform-loadable cover (a token-free `http`/`https` image such as
+  /// Jellyfin's primary image, a local `file:`, or an app-provided `content:`
+  /// URI) is handed to the session unchanged. A credential-free *reference* (e.g.
   /// Subsonic's `subsonic-cover:<id>`) is replaced by its already-fetched, cached
-  /// private `file:` copy when one exists, or `null` otherwise — so an unloadable
-  /// reference, and crucially never a credentialed URL, reaches `MediaItem
-  /// .artUri`. Covers are fetched+cached ahead of time off the playback path by
+  /// `content://` copy (a FileProvider URI the session's process can read) when
+  /// one exists, or `null` otherwise — so an unloadable reference, and crucially
+  /// never a credentialed URL, reaches `MediaItem.artUri`. Covers are
+  /// fetched+cached ahead of time off the playback path by
   /// `MediaArtworkPrewarmService`; this read is purely synchronous.
   Uri? _sessionArtUri(Uri? artworkUri) {
     if (artworkUri == null) return null;
     if (isPlatformLoadableArtwork(artworkUri)) return artworkUri;
     return _artwork?.cached(artworkUri);
+  }
+
+  /// The non-secret *scheme* of an artwork [uri], for the diagnostic trace —
+  /// never the URI itself (a `content:`/`file:`/`http` URI is credential-free,
+  /// but logging only the scheme keeps the trace trivially safe). `none` for
+  /// null; `other` flags the bug where a reference leaked into `artUri`.
+  static String _artScheme(Uri? uri) {
+    if (uri == null) return 'none';
+    if (uri.isScheme('content')) return 'content';
+    if (uri.isScheme('http') || uri.isScheme('https')) return 'http';
+    if (uri.isScheme('file')) return 'file';
+    return 'other';
   }
 
   /// Whether two media items would show the same thing in the session, so a

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -24,6 +24,20 @@ const String _logName = 'Linthra.AndroidAuto';
 
 void _log(String message) => developer.log(message, name: _logName);
 
+/// Resolves a credential-free artwork *reference* (e.g. Subsonic's
+/// `subsonic-cover:<id>`) into a safe, local media-session artwork URI (a
+/// private `file:` the session loads in-process), fetching and caching the image
+/// on demand. Returns `null` — never throws — when no safe artwork can be
+/// produced (signed out, a failed download), so the session simply shows none.
+///
+/// The platform media session loads `MediaItem.artUri` itself, somewhere Linthra
+/// can't add the Subsonic salt+token, so a credentialed `getCoverArt` URL must
+/// never be placed there. This seam lets the handler instead attach only a safe
+/// local file the session can read. Wired in `main` (backed by
+/// `MediaArtworkCache`); `null` in tests / on platforms without it, where
+/// Subsonic media-session art is simply absent (the prior behaviour, unchanged).
+typedef MediaArtworkResolver = Future<Uri?> Function(Uri reference);
+
 /// The non-secret category an [id] belongs to, for safe diagnostics. Returns a
 /// fixed label set — never the id itself — so a track id, playlist id, URI, or
 /// token can never reach the log.
@@ -65,7 +79,11 @@ String _categoryOf(String id) {
 /// stays the single source of truth and owns `just_audio`; the UI never touches
 /// this class.
 class LinthraAudioHandler extends audio.BaseAudioHandler {
-  LinthraAudioHandler(this._controller, this._tree) {
+  LinthraAudioHandler(
+    this._controller,
+    this._tree, {
+    MediaArtworkResolver? artwork,
+  }) : _resolveArtwork = artwork {
     _subscription = _controller.stateStream.listen(_broadcast);
     // Seed the session from the latest known state so a freshly attached
     // notification/Android Auto isn't blank before the first stream event.
@@ -75,6 +93,22 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   final PlaybackController _controller;
   final MediaBrowserTree _tree;
   late final StreamSubscription<PlaybackState> _subscription;
+
+  /// Fetches a safe local `file:` for a credential-free artwork reference (e.g.
+  /// Subsonic), or `null` when none is wired (tests / unsupported platform), in
+  /// which case such references simply carry no media-session artwork.
+  final MediaArtworkResolver? _resolveArtwork;
+
+  /// Media-session artwork already fetched to a safe local `file:` URI, keyed by
+  /// the original credential-free reference. Lets [_sessionArtUri] attach it
+  /// synchronously while building a `MediaItem`, without a credentialed URL or an
+  /// unloadable reference ever reaching `artUri`.
+  final Map<Uri, Uri> _resolvedArt = <Uri, Uri>{};
+
+  /// References a fetch has already been started for, so a cover is fetched at
+  /// most once at a time; a failed fetch is dropped from the set so it can retry
+  /// on a later track change.
+  final Set<Uri> _artworkRequested = <Uri>{};
 
   // The last media item / playback state actually pushed to the platform
   // session. Position ticks arrive several times a second; re-pushing identical
@@ -193,6 +227,11 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   void _broadcast(PlaybackState state) {
     final Track? track = state.currentTrack;
+    // Kick off media-session artwork resolution for the now-playing track when
+    // its cover is a credential-free reference (e.g. Subsonic) the platform
+    // can't load itself. Off the playback path: a fetch failure never blocks
+    // this broadcast, and the item is simply art-less until (if) it succeeds.
+    if (track != null) _ensureArtwork(track);
     final audio.MediaItem? item = track == null
         ? null
         : _trackMediaItem(track, id: track.id, live: state.duration);
@@ -220,6 +259,74 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     }
     _seeded = true;
   }
+
+  /// Starts media-session artwork resolution for [track] when its cover is a
+  /// credential-free *reference* (e.g. Subsonic's `subsonic-cover:<id>`) the
+  /// platform can't load itself. A platform-loadable cover (Jellyfin http, a
+  /// local file) needs no fetch and is left untouched. On success the fetched
+  /// private `file:` is cached and the session re-broadcast so the now-playing
+  /// item picks it up; on failure the item stays art-less and playback is
+  /// unaffected. At most one fetch per reference is in flight.
+  void _ensureArtwork(Track track) {
+    final MediaArtworkResolver? resolve = _resolveArtwork;
+    final Uri? reference = track.artworkUri;
+    if (resolve == null || reference == null) return;
+    if (_isPlatformLoadable(reference)) return;
+    if (_resolvedArt.containsKey(reference)) return;
+    if (!_artworkRequested.add(reference)) return;
+    unawaited(_fetchArtwork(resolve, reference));
+  }
+
+  Future<void> _fetchArtwork(
+    MediaArtworkResolver resolve,
+    Uri reference,
+  ) async {
+    Uri? local;
+    try {
+      local = await resolve(reference);
+    } catch (_) {
+      // The resolver contract is "never throw"; guard anyway so a stray failure
+      // can't break the broadcast listener.
+      local = null;
+    }
+    if (local == null) {
+      // Unavailable (signed out / fetch failed): allow a retry on a later track
+      // change and leave the now-playing item art-less rather than unsafe.
+      _artworkRequested.remove(reference);
+      return;
+    }
+    _resolvedArt[reference] = local;
+    // Re-publish only if this cover still belongs to the current track, so a
+    // late fetch can't stamp art onto a track the user has already skipped past.
+    if (_controller.state.currentTrack?.artworkUri == reference) {
+      _broadcast(_controller.state);
+    }
+  }
+
+  /// The media-session-safe artwork URI for [artworkUri].
+  ///
+  /// A platform-loadable cover (a private `file:`, a token-free `http`/`https`
+  /// image such as Jellyfin's primary image, or an app-provided `content:` URI)
+  /// is handed to the session unchanged. A credential-free *reference* (e.g.
+  /// Subsonic's `subsonic-cover:<id>`) is replaced by its already-fetched private
+  /// `file:` copy when one exists, or `null` while it's still being fetched (or
+  /// couldn't be) — so an unloadable reference, and crucially never a
+  /// credentialed URL, reaches `MediaItem.artUri`.
+  Uri? _sessionArtUri(Uri? artworkUri) {
+    if (artworkUri == null) return null;
+    if (_isPlatformLoadable(artworkUri)) return artworkUri;
+    return _resolvedArt[artworkUri];
+  }
+
+  /// Whether [uri] is a scheme the platform media session can load on its own —
+  /// a private `file:`, a remote `http`/`https` image, or an app-provided
+  /// `content:` URI. Any other scheme is an app-internal artwork reference that
+  /// must first be resolved to a local file (see [_sessionArtUri]).
+  static bool _isPlatformLoadable(Uri uri) =>
+      uri.isScheme('file') ||
+      uri.isScheme('http') ||
+      uri.isScheme('https') ||
+      uri.isScheme('content');
 
   /// Whether two media items would show the same thing in the session, so a
   /// re-push can be skipped. Compares the fields the platform renders; all of
@@ -299,12 +406,14 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     }
     // A browsable container (album/artist) may carry token-free cover art so the
     // car shows artwork on the row; categories and placeholders leave it null.
+    // A credential-free reference (e.g. Subsonic) that isn't already cached
+    // locally is dropped to null rather than handed over unloadable.
     return audio.MediaItem(
       id: node.id,
       title: node.title,
       playable: false,
       displaySubtitle: node.subtitle,
-      artUri: node.artworkUri,
+      artUri: _sessionArtUri(node.artworkUri),
     );
   }
 
@@ -322,7 +431,9 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       artist: track.artistName,
       album: track.albumName,
       duration: duration > Duration.zero ? duration : null,
-      artUri: track.artworkUri,
+      // Only a platform-loadable cover (or a locally-cached reference) — never a
+      // credentialed URL or an unloadable reference — reaches the session.
+      artUri: _sessionArtUri(track.artworkUri),
     );
   }
 
@@ -455,6 +566,12 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 /// answerable from the persisted catalog/playlists/favourites/downloads — it
 /// does not wait on the Flutter UI.
 ///
+/// When [artwork] is supplied it lets the now-playing media item show a
+/// credential-free source's cover (e.g. Subsonic) on the lock screen / Android
+/// Auto: the handler hands it the credential-free reference and gets back a safe
+/// local `file:` to use as `artUri`, never a credentialed URL. It is best-effort
+/// and entirely off the playback path.
+///
 /// Best-effort by design: returns `null` when `audio_service` can't initialise
 /// (a platform without the native setup, or a test environment). Playback still
 /// works through the controller in that case, so a missing media session never
@@ -467,6 +584,7 @@ Future<LinthraAudioHandler?> connectMediaSession(
   PlaylistRepository? playlists,
   FavoritesRepository? favorites,
   DownloadRepository? downloads,
+  MediaArtworkResolver? artwork,
 }) async {
   try {
     final handler = await audio.AudioService.init(
@@ -478,6 +596,7 @@ Future<LinthraAudioHandler?> connectMediaSession(
           favorites: favorites,
           downloads: downloads,
         ),
+        artwork: artwork,
       ),
       config: const audio.AudioServiceConfig(
         androidNotificationChannelId: 'com.linthra.audio',

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -10,6 +10,7 @@ import '../repositories/download_repository.dart';
 import '../repositories/favorites_repository.dart';
 import '../repositories/music_library_repository.dart';
 import '../repositories/playlist_repository.dart';
+import 'media_artwork_source.dart';
 import 'media_browser_tree.dart';
 import 'playback_controller.dart';
 
@@ -23,20 +24,6 @@ import 'playback_controller.dart';
 const String _logName = 'Linthra.AndroidAuto';
 
 void _log(String message) => developer.log(message, name: _logName);
-
-/// Resolves a credential-free artwork *reference* (e.g. Subsonic's
-/// `subsonic-cover:<id>`) into a safe, local media-session artwork URI (a
-/// private `file:` the session loads in-process), fetching and caching the image
-/// on demand. Returns `null` — never throws — when no safe artwork can be
-/// produced (signed out, a failed download), so the session simply shows none.
-///
-/// The platform media session loads `MediaItem.artUri` itself, somewhere Linthra
-/// can't add the Subsonic salt+token, so a credentialed `getCoverArt` URL must
-/// never be placed there. This seam lets the handler instead attach only a safe
-/// local file the session can read. Wired in `main` (backed by
-/// `MediaArtworkCache`); `null` in tests / on platforms without it, where
-/// Subsonic media-session art is simply absent (the prior behaviour, unchanged).
-typedef MediaArtworkResolver = Future<Uri?> Function(Uri reference);
 
 /// The non-secret category an [id] belongs to, for safe diagnostics. Returns a
 /// fixed label set — never the id itself — so a track id, playlist id, URI, or
@@ -82,8 +69,8 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   LinthraAudioHandler(
     this._controller,
     this._tree, {
-    MediaArtworkResolver? artwork,
-  }) : _resolveArtwork = artwork {
+    MediaArtworkSource? artwork,
+  }) : _artwork = artwork {
     _subscription = _controller.stateStream.listen(_broadcast);
     // Seed the session from the latest known state so a freshly attached
     // notification/Android Auto isn't blank before the first stream event.
@@ -94,21 +81,13 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   final MediaBrowserTree _tree;
   late final StreamSubscription<PlaybackState> _subscription;
 
-  /// Fetches a safe local `file:` for a credential-free artwork reference (e.g.
-  /// Subsonic), or `null` when none is wired (tests / unsupported platform), in
-  /// which case such references simply carry no media-session artwork.
-  final MediaArtworkResolver? _resolveArtwork;
-
-  /// Media-session artwork already fetched to a safe local `file:` URI, keyed by
-  /// the original credential-free reference. Lets [_sessionArtUri] attach it
-  /// synchronously while building a `MediaItem`, without a credentialed URL or an
-  /// unloadable reference ever reaching `artUri`.
-  final Map<Uri, Uri> _resolvedArt = <Uri, Uri>{};
-
-  /// References a fetch has already been started for, so a cover is fetched at
-  /// most once at a time; a failed fetch is dropped from the set so it can retry
-  /// on a later track change.
-  final Set<Uri> _artworkRequested = <Uri>{};
+  /// Synchronous lookup of an already-fetched, safe local `file:` cover for a
+  /// credential-free reference (e.g. Subsonic). `null` when none is wired (tests
+  /// / unsupported platform), in which case such references carry no
+  /// media-session artwork. Covers are warmed ahead of time, off the playback
+  /// path, by `MediaArtworkPrewarmService`, so this stays a pure synchronous read
+  /// — the handler never fetches or re-broadcasts on the playback path.
+  final MediaArtworkSource? _artwork;
 
   // The last media item / playback state actually pushed to the platform
   // session. Position ticks arrive several times a second; re-pushing identical
@@ -227,11 +206,6 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 
   void _broadcast(PlaybackState state) {
     final Track? track = state.currentTrack;
-    // Kick off media-session artwork resolution for the now-playing track when
-    // its cover is a credential-free reference (e.g. Subsonic) the platform
-    // can't load itself. Off the playback path: a fetch failure never blocks
-    // this broadcast, and the item is simply art-less until (if) it succeeds.
-    if (track != null) _ensureArtwork(track);
     final audio.MediaItem? item = track == null
         ? null
         : _trackMediaItem(track, id: track.id, live: state.duration);
@@ -260,73 +234,21 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     _seeded = true;
   }
 
-  /// Starts media-session artwork resolution for [track] when its cover is a
-  /// credential-free *reference* (e.g. Subsonic's `subsonic-cover:<id>`) the
-  /// platform can't load itself. A platform-loadable cover (Jellyfin http, a
-  /// local file) needs no fetch and is left untouched. On success the fetched
-  /// private `file:` is cached and the session re-broadcast so the now-playing
-  /// item picks it up; on failure the item stays art-less and playback is
-  /// unaffected. At most one fetch per reference is in flight.
-  void _ensureArtwork(Track track) {
-    final MediaArtworkResolver? resolve = _resolveArtwork;
-    final Uri? reference = track.artworkUri;
-    if (resolve == null || reference == null) return;
-    if (_isPlatformLoadable(reference)) return;
-    if (_resolvedArt.containsKey(reference)) return;
-    if (!_artworkRequested.add(reference)) return;
-    unawaited(_fetchArtwork(resolve, reference));
-  }
-
-  Future<void> _fetchArtwork(
-    MediaArtworkResolver resolve,
-    Uri reference,
-  ) async {
-    Uri? local;
-    try {
-      local = await resolve(reference);
-    } catch (_) {
-      // The resolver contract is "never throw"; guard anyway so a stray failure
-      // can't break the broadcast listener.
-      local = null;
-    }
-    if (local == null) {
-      // Unavailable (signed out / fetch failed): allow a retry on a later track
-      // change and leave the now-playing item art-less rather than unsafe.
-      _artworkRequested.remove(reference);
-      return;
-    }
-    _resolvedArt[reference] = local;
-    // Re-publish only if this cover still belongs to the current track, so a
-    // late fetch can't stamp art onto a track the user has already skipped past.
-    if (_controller.state.currentTrack?.artworkUri == reference) {
-      _broadcast(_controller.state);
-    }
-  }
-
   /// The media-session-safe artwork URI for [artworkUri].
   ///
   /// A platform-loadable cover (a private `file:`, a token-free `http`/`https`
   /// image such as Jellyfin's primary image, or an app-provided `content:` URI)
   /// is handed to the session unchanged. A credential-free *reference* (e.g.
-  /// Subsonic's `subsonic-cover:<id>`) is replaced by its already-fetched private
-  /// `file:` copy when one exists, or `null` while it's still being fetched (or
-  /// couldn't be) — so an unloadable reference, and crucially never a
-  /// credentialed URL, reaches `MediaItem.artUri`.
+  /// Subsonic's `subsonic-cover:<id>`) is replaced by its already-fetched, cached
+  /// private `file:` copy when one exists, or `null` otherwise — so an unloadable
+  /// reference, and crucially never a credentialed URL, reaches `MediaItem
+  /// .artUri`. Covers are fetched+cached ahead of time off the playback path by
+  /// `MediaArtworkPrewarmService`; this read is purely synchronous.
   Uri? _sessionArtUri(Uri? artworkUri) {
     if (artworkUri == null) return null;
-    if (_isPlatformLoadable(artworkUri)) return artworkUri;
-    return _resolvedArt[artworkUri];
+    if (isPlatformLoadableArtwork(artworkUri)) return artworkUri;
+    return _artwork?.cached(artworkUri);
   }
-
-  /// Whether [uri] is a scheme the platform media session can load on its own —
-  /// a private `file:`, a remote `http`/`https` image, or an app-provided
-  /// `content:` URI. Any other scheme is an app-internal artwork reference that
-  /// must first be resolved to a local file (see [_sessionArtUri]).
-  static bool _isPlatformLoadable(Uri uri) =>
-      uri.isScheme('file') ||
-      uri.isScheme('http') ||
-      uri.isScheme('https') ||
-      uri.isScheme('content');
 
   /// Whether two media items would show the same thing in the session, so a
   /// re-push can be skipped. Compares the fields the platform renders; all of
@@ -566,11 +488,12 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
 /// answerable from the persisted catalog/playlists/favourites/downloads — it
 /// does not wait on the Flutter UI.
 ///
-/// When [artwork] is supplied it lets the now-playing media item show a
+/// When [artwork] is supplied the now-playing media item can show a
 /// credential-free source's cover (e.g. Subsonic) on the lock screen / Android
-/// Auto: the handler hands it the credential-free reference and gets back a safe
-/// local `file:` to use as `artUri`, never a credentialed URL. It is best-effort
-/// and entirely off the playback path.
+/// Auto: the handler reads an already-cached safe local `file:` for the cover's
+/// reference (warmed ahead of time, off the playback path, by
+/// `MediaArtworkPrewarmService`) and uses it as `artUri`, never a credentialed
+/// URL. The read is synchronous, so artwork never touches the playback path.
 ///
 /// Best-effort by design: returns `null` when `audio_service` can't initialise
 /// (a platform without the native setup, or a test environment). Playback still
@@ -584,7 +507,7 @@ Future<LinthraAudioHandler?> connectMediaSession(
   PlaylistRepository? playlists,
   FavoritesRepository? favorites,
   DownloadRepository? downloads,
-  MediaArtworkResolver? artwork,
+  MediaArtworkSource? artwork,
 }) async {
   try {
     final handler = await audio.AudioService.init(

--- a/lib/core/services/media_artwork_cache.dart
+++ b/lib/core/services/media_artwork_cache.dart
@@ -7,6 +7,8 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'media_artwork_source.dart';
+
 /// Turns a credential-free artwork *reference* (e.g. Subsonic's
 /// `subsonic-cover:<id>`) into a **safe, local** media-session artwork URI: a
 /// `file:` in app-private storage the platform media session (lock screen /
@@ -29,7 +31,7 @@ import 'package:path_provider/path_provider.dart';
 /// - any failure (signed out, network error, a non-image body, a write error)
 ///   yields `null` so the caller falls back to *no* artwork — it never throws and
 ///   never blocks playback.
-class MediaArtworkCache {
+class MediaArtworkCache implements MediaArtworkSource {
   MediaArtworkCache({
     required Uri? Function(Uri reference) resolveUrl,
     Future<List<int>?> Function(Uri url)? fetch,
@@ -62,6 +64,13 @@ class MediaArtworkCache {
   final Map<String, Completer<Uri?>> _inFlight = <String, Completer<Uri?>>{};
 
   static const Duration _timeout = Duration(seconds: 20);
+
+  /// The safe local `file:` URI for [reference] if it has already been fetched
+  /// and cached this session, else `null`. Synchronous and side-effect-free, so
+  /// the media handler can attach it while building a `MediaItem` without
+  /// awaiting — covers are warmed ahead of time by `MediaArtworkPrewarmService`.
+  @override
+  Uri? cached(Uri reference) => _memo[_cacheKey(reference)];
 
   /// Resolves [reference] to a safe local `file:` artwork URI, fetching and
   /// caching the image on a miss. Returns `null` (never throws) when the artwork

--- a/lib/core/services/media_artwork_cache.dart
+++ b/lib/core/services/media_artwork_cache.dart
@@ -41,9 +41,14 @@ class MediaArtworkCache implements MediaArtworkSource {
     required Uri? Function(Uri reference) resolveUrl,
     Future<List<int>?> Function(Uri url)? fetch,
     Future<Directory> Function()? directory,
+    http.Client? httpClient,
   })  : _resolveUrl = resolveUrl,
-        _fetch = fetch ?? _httpFetch,
-        _directory = directory ?? _defaultDirectory;
+        _directory = directory ?? _defaultDirectory,
+        _httpClient = httpClient ?? http.Client() {
+    // Default to the shared-client fetcher (an instance method, so it can reuse
+    // [_httpClient]); tests inject their own [fetch].
+    _fetch = fetch ?? _defaultHttpFetch;
+  }
 
   /// Turns a credential-free [reference] into the authenticated fetch URL for the
   /// live session, or `null` when it isn't a reference this cache can resolve
@@ -51,9 +56,15 @@ class MediaArtworkCache implements MediaArtworkSource {
   /// credential and is used only inside [resolve].
   final Uri? Function(Uri reference) _resolveUrl;
 
+  /// The HTTP client used by the default fetcher. Reused across cover fetches so
+  /// the sequential pre-warm benefits from keep-alive (one TLS handshake per
+  /// idle period instead of one per cover), trimming the per-cover latency.
+  /// Closed in [dispose]. Unused when a custom [fetch] is injected (tests).
+  final http.Client _httpClient;
+
   /// Fetches the raw image bytes for an (authenticated) `url`, or `null` on any
   /// failure / a non-image response. Must never log the URL.
-  final Future<List<int>?> Function(Uri url) _fetch;
+  late final Future<List<int>?> Function(Uri url) _fetch;
 
   /// The private directory cached artwork files live in.
   final Future<Directory> Function() _directory;
@@ -158,10 +169,13 @@ class MediaArtworkCache implements MediaArtworkSource {
     if (!_coverReady.isClosed) _coverReady.add(reference);
   }
 
-  /// Releases the cover-ready stream. The in-memory memo and on-disk cache are
-  /// left intact (the cache is process-lived); call when the owning container is
-  /// torn down.
-  Future<void> dispose() => _coverReady.close();
+  /// Releases the cover-ready stream and the shared HTTP client. The in-memory
+  /// memo and on-disk cache are left intact (the cache is process-lived); call
+  /// when the owning container is torn down.
+  Future<void> dispose() async {
+    _httpClient.close();
+    await _coverReady.close();
+  }
 
   /// A credential-free, filename-safe cache key: the SHA-256 of the
   /// *credential-free* reference string (e.g. `subsonic-cover:al-123`). The
@@ -176,14 +190,14 @@ class MediaArtworkCache implements MediaArtworkSource {
     return Directory(p.join(base.path, 'media_session_artwork'));
   }
 
-  /// The default fetcher: a plain GET that returns the body bytes only for a 2xx
-  /// image response. Any transport error, non-2xx status, or non-image body
-  /// (e.g. a Subsonic error envelope) yields `null`. The URL — which carries the
-  /// credential — is never logged, even on error.
-  static Future<List<int>?> _httpFetch(Uri url) async {
-    final http.Client client = http.Client();
+  /// The default fetcher: a plain GET (over the reused [_httpClient]) that returns
+  /// the body bytes only for a 2xx image response. Any transport error, non-2xx
+  /// status, or non-image body (e.g. a Subsonic error envelope) yields `null`.
+  /// The URL — which carries the credential — is never logged, even on error.
+  Future<List<int>?> _defaultHttpFetch(Uri url) async {
     try {
-      final http.Response response = await client.get(url).timeout(_timeout);
+      final http.Response response =
+          await _httpClient.get(url).timeout(_timeout);
       if (response.statusCode < 200 || response.statusCode >= 300) return null;
       final String contentType =
           (response.headers['content-type'] ?? '').toLowerCase();
@@ -193,8 +207,6 @@ class MediaArtworkCache implements MediaArtworkSource {
     } catch (_) {
       // Swallow every failure (and never log the credentialed URL).
       return null;
-    } finally {
-      client.close();
     }
   }
 }

--- a/lib/core/services/media_artwork_cache.dart
+++ b/lib/core/services/media_artwork_cache.dart
@@ -7,25 +7,30 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
+import 'media_artwork_content_uri.dart';
 import 'media_artwork_source.dart';
 
 /// Turns a credential-free artwork *reference* (e.g. Subsonic's
 /// `subsonic-cover:<id>`) into a **safe, local** media-session artwork URI: a
-/// `file:` in app-private storage the platform media session (lock screen /
-/// Android Auto now-playing card) can load in-process.
+/// `content://` URI (served by the app's FileProvider) over a private cached
+/// cover the platform media session (lock screen / Android Auto now-playing card)
+/// can read.
 ///
 /// Why a separate cache from the in-app render seam (`artworkImageProvider`):
 /// the in-app UI can hand Flutter a credential-bearing `getCoverArt`
 /// `NetworkImage` and load it itself, but the platform media session loads
 /// `MediaItem.artUri` in a place Linthra can't authenticate — so an authenticated
 /// URL must never be put there. Instead Linthra fetches the cover *itself* (with
-/// the live session's salt+token, used once and discarded) and writes the bytes
-/// to a private file, then hands the session only that `file:` URI.
+/// the live session's salt+token, used once and discarded), writes the bytes to a
+/// private file, and hands the session a `content://` URI for it (see
+/// [mediaArtworkContentUri]). `content://` rather than `file:` because the
+/// session loads the URI in its **own process** (e.g. Android Auto), which can't
+/// read an app-private `file:` path.
 ///
 /// Privacy / security invariants:
-/// - the cache *key* — and therefore the file name — is a hash of the
-///   credential-free reference, never the username, salt, token, server URL, or
-///   the authenticated `getCoverArt` URL;
+/// - the cache *key* — and therefore the file name and the `content://` path —
+///   is a hash of the credential-free reference, never the username, salt, token,
+///   server URL, or the authenticated `getCoverArt` URL;
 /// - the authenticated URL exists only as a local inside [resolve], is used once
 ///   to fetch, and is never returned, persisted, or logged;
 /// - any failure (signed out, network error, a non-image body, a write error)
@@ -65,14 +70,14 @@ class MediaArtworkCache implements MediaArtworkSource {
 
   static const Duration _timeout = Duration(seconds: 20);
 
-  /// The safe local `file:` URI for [reference] if it has already been fetched
+  /// The safe `content://` URI for [reference] if it has already been fetched
   /// and cached this session, else `null`. Synchronous and side-effect-free, so
   /// the media handler can attach it while building a `MediaItem` without
   /// awaiting — covers are warmed ahead of time by `MediaArtworkPrewarmService`.
   @override
   Uri? cached(Uri reference) => _memo[_cacheKey(reference)];
 
-  /// Resolves [reference] to a safe local `file:` artwork URI, fetching and
+  /// Resolves [reference] to a safe `content://` artwork URI, fetching and
   /// caching the image on a miss. Returns `null` (never throws) when the artwork
   /// can't be produced safely — the caller then shows no artwork.
   Future<Uri?> resolve(Uri reference) {
@@ -106,7 +111,7 @@ class MediaArtworkCache implements MediaArtworkSource {
     // Disk hit from an earlier run: reuse it without re-fetching (and without
     // ever touching the credential again).
     if (await file.exists() && await file.length() > 0) {
-      final Uri uri = file.uri;
+      final Uri uri = mediaArtworkContentUri(file);
       _memo[key] = uri;
       return uri;
     }
@@ -131,7 +136,7 @@ class MediaArtworkCache implements MediaArtworkSource {
       // A write failure must not leak or throw: fall back to no artwork.
       return null;
     }
-    final Uri uri = file.uri;
+    final Uri uri = mediaArtworkContentUri(file);
     _memo[key] = uri;
     return uri;
   }

--- a/lib/core/services/media_artwork_cache.dart
+++ b/lib/core/services/media_artwork_cache.dart
@@ -68,6 +68,14 @@ class MediaArtworkCache implements MediaArtworkSource {
   /// be retried on a later request.
   final Map<String, Completer<Uri?>> _inFlight = <String, Completer<Uri?>>{};
 
+  /// Broadcasts a reference the moment its cover first caches, so a now-playing
+  /// item published without art can be refreshed immediately (see the handler),
+  /// rather than waiting for the next playback tick.
+  final StreamController<Uri> _coverReady = StreamController<Uri>.broadcast();
+
+  @override
+  Stream<Uri> get coverReady => _coverReady.stream;
+
   static const Duration _timeout = Duration(seconds: 20);
 
   /// The safe `content://` URI for [reference] if it has already been fetched
@@ -113,6 +121,7 @@ class MediaArtworkCache implements MediaArtworkSource {
     if (await file.exists() && await file.length() > 0) {
       final Uri uri = mediaArtworkContentUri(file);
       _memo[key] = uri;
+      _announceReady(reference);
       return uri;
     }
 
@@ -138,8 +147,21 @@ class MediaArtworkCache implements MediaArtworkSource {
     }
     final Uri uri = mediaArtworkContentUri(file);
     _memo[key] = uri;
+    _announceReady(reference);
     return uri;
   }
+
+  /// Notifies listeners (the media handler) that [reference]'s cover just became
+  /// cached, so a now-playing item can pick it up immediately. Guards against a
+  /// closed controller (after [dispose]) so a late warm can't throw.
+  void _announceReady(Uri reference) {
+    if (!_coverReady.isClosed) _coverReady.add(reference);
+  }
+
+  /// Releases the cover-ready stream. The in-memory memo and on-disk cache are
+  /// left intact (the cache is process-lived); call when the owning container is
+  /// torn down.
+  Future<void> dispose() => _coverReady.close();
 
   /// A credential-free, filename-safe cache key: the SHA-256 of the
   /// *credential-free* reference string (e.g. `subsonic-cover:al-123`). The

--- a/lib/core/services/media_artwork_cache.dart
+++ b/lib/core/services/media_artwork_cache.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Turns a credential-free artwork *reference* (e.g. Subsonic's
+/// `subsonic-cover:<id>`) into a **safe, local** media-session artwork URI: a
+/// `file:` in app-private storage the platform media session (lock screen /
+/// Android Auto now-playing card) can load in-process.
+///
+/// Why a separate cache from the in-app render seam (`artworkImageProvider`):
+/// the in-app UI can hand Flutter a credential-bearing `getCoverArt`
+/// `NetworkImage` and load it itself, but the platform media session loads
+/// `MediaItem.artUri` in a place Linthra can't authenticate — so an authenticated
+/// URL must never be put there. Instead Linthra fetches the cover *itself* (with
+/// the live session's salt+token, used once and discarded) and writes the bytes
+/// to a private file, then hands the session only that `file:` URI.
+///
+/// Privacy / security invariants:
+/// - the cache *key* — and therefore the file name — is a hash of the
+///   credential-free reference, never the username, salt, token, server URL, or
+///   the authenticated `getCoverArt` URL;
+/// - the authenticated URL exists only as a local inside [resolve], is used once
+///   to fetch, and is never returned, persisted, or logged;
+/// - any failure (signed out, network error, a non-image body, a write error)
+///   yields `null` so the caller falls back to *no* artwork — it never throws and
+///   never blocks playback.
+class MediaArtworkCache {
+  MediaArtworkCache({
+    required Uri? Function(Uri reference) resolveUrl,
+    Future<List<int>?> Function(Uri url)? fetch,
+    Future<Directory> Function()? directory,
+  })  : _resolveUrl = resolveUrl,
+        _fetch = fetch ?? _httpFetch,
+        _directory = directory ?? _defaultDirectory;
+
+  /// Turns a credential-free [reference] into the authenticated fetch URL for the
+  /// live session, or `null` when it isn't a reference this cache can resolve
+  /// (e.g. signed out, or a Jellyfin/local URL). The returned URL carries the
+  /// credential and is used only inside [resolve].
+  final Uri? Function(Uri reference) _resolveUrl;
+
+  /// Fetches the raw image bytes for an (authenticated) `url`, or `null` on any
+  /// failure / a non-image response. Must never log the URL.
+  final Future<List<int>?> Function(Uri url) _fetch;
+
+  /// The private directory cached artwork files live in.
+  final Future<Directory> Function() _directory;
+
+  /// Successful resolutions: cache key -> local `file:` URI. Skips a repeat
+  /// disk/network round-trip for a cover already fetched this session.
+  final Map<String, Uri> _memo = <String, Uri>{};
+
+  /// In-flight resolutions, so concurrent requests for the same reference share
+  /// one fetch instead of racing to write the same file. The completer is
+  /// removed when the fetch settles (success or failure), so a failed cover can
+  /// be retried on a later request.
+  final Map<String, Completer<Uri?>> _inFlight = <String, Completer<Uri?>>{};
+
+  static const Duration _timeout = Duration(seconds: 20);
+
+  /// Resolves [reference] to a safe local `file:` artwork URI, fetching and
+  /// caching the image on a miss. Returns `null` (never throws) when the artwork
+  /// can't be produced safely — the caller then shows no artwork.
+  Future<Uri?> resolve(Uri reference) {
+    final String key = _cacheKey(reference);
+    final Uri? memoized = _memo[key];
+    if (memoized != null) return Future<Uri?>.value(memoized);
+    final Completer<Uri?>? pending = _inFlight[key];
+    if (pending != null) return pending.future;
+
+    final Completer<Uri?> completer = Completer<Uri?>();
+    _inFlight[key] = completer;
+    unawaited(_resolveUncached(reference, key).then<void>(
+      (Uri? result) {
+        _inFlight.remove(key);
+        completer.complete(result);
+      },
+      onError: (Object _, StackTrace __) {
+        // _resolveUncached is written not to throw; guard anyway so a stray
+        // failure resolves to "no artwork" rather than an unhandled error.
+        _inFlight.remove(key);
+        completer.complete(null);
+      },
+    ));
+    return completer.future;
+  }
+
+  Future<Uri?> _resolveUncached(Uri reference, String key) async {
+    final Directory dir = await _directory();
+    final File file = File(p.join(dir.path, '$key.img'));
+
+    // Disk hit from an earlier run: reuse it without re-fetching (and without
+    // ever touching the credential again).
+    if (await file.exists() && await file.length() > 0) {
+      final Uri uri = file.uri;
+      _memo[key] = uri;
+      return uri;
+    }
+
+    // Mint the authenticated URL on demand, fetch, and discard it. A null URL
+    // means "not a resolvable reference / signed out" -> no artwork.
+    final Uri? url = _resolveUrl(reference);
+    if (url == null) return null;
+    final List<int>? bytes = await _fetch(url);
+    if (bytes == null || bytes.isEmpty) return null;
+
+    try {
+      if (!await dir.exists()) {
+        await dir.create(recursive: true);
+      }
+      // Write to a temp sibling then rename, so a crash mid-write can't leave a
+      // truncated image that would render broken until evicted.
+      final File tmp = File('${file.path}.tmp');
+      await tmp.writeAsBytes(bytes, flush: true);
+      await tmp.rename(file.path);
+    } catch (_) {
+      // A write failure must not leak or throw: fall back to no artwork.
+      return null;
+    }
+    final Uri uri = file.uri;
+    _memo[key] = uri;
+    return uri;
+  }
+
+  /// A credential-free, filename-safe cache key: the SHA-256 of the
+  /// *credential-free* reference string (e.g. `subsonic-cover:al-123`). The
+  /// reference carries no username, salt, token, server URL, or auth query, so
+  /// neither does the key — and hashing also keeps an odd id from escaping the
+  /// cache directory.
+  static String _cacheKey(Uri reference) =>
+      sha256.convert(utf8.encode(reference.toString())).toString();
+
+  static Future<Directory> _defaultDirectory() async {
+    final Directory base = await getTemporaryDirectory();
+    return Directory(p.join(base.path, 'media_session_artwork'));
+  }
+
+  /// The default fetcher: a plain GET that returns the body bytes only for a 2xx
+  /// image response. Any transport error, non-2xx status, or non-image body
+  /// (e.g. a Subsonic error envelope) yields `null`. The URL — which carries the
+  /// credential — is never logged, even on error.
+  static Future<List<int>?> _httpFetch(Uri url) async {
+    final http.Client client = http.Client();
+    try {
+      final http.Response response = await client.get(url).timeout(_timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) return null;
+      final String contentType =
+          (response.headers['content-type'] ?? '').toLowerCase();
+      if (!contentType.startsWith('image/')) return null;
+      final List<int> bytes = response.bodyBytes;
+      return bytes.isEmpty ? null : bytes;
+    } catch (_) {
+      // Swallow every failure (and never log the credentialed URL).
+      return null;
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/lib/core/services/media_artwork_content_uri.dart
+++ b/lib/core/services/media_artwork_content_uri.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// The FileProvider authority that serves Linthra's cached media-session cover
+/// art. Must match `android:authorities` on the `<provider>` in
+/// `android/app/src/main/AndroidManifest.xml` (and is fixed — independent of the
+/// build's `applicationId` — so the authority is the same in debug and release).
+const String kMediaArtworkAuthority =
+    'io.github.thezupzup.linthra.mediaartwork';
+
+/// The `<paths>` name (`res/xml/media_artwork_paths.xml`) the cover cache dir is
+/// exposed under. The first path segment of every served `content://` URI.
+const String kMediaArtworkPathName = 'media_artwork';
+
+/// The credential-free `content://` URI Linthra's FileProvider serves [file] at.
+///
+/// Why `content://` and not the `file:` path: the platform media session loads
+/// `MediaItem.artUri` **in its own process** (e.g. Android Auto), which can't
+/// read an app-private `file:` path. A FileProvider `content://` URI can be read
+/// by the platform/Android Auto, and `audio_service` also decodes it in-process
+/// for the session's embedded album-art bitmap.
+///
+/// Privacy: the path is only the provider name plus the file's **hashed**
+/// basename (a SHA-256 of the credential-free `subsonic-cover:` reference) — it
+/// carries no username, password, token, salt, server URL, or auth query. The
+/// matching `<cache-path>` maps the private cover-cache dir, so nothing else is
+/// exposed.
+Uri mediaArtworkContentUri(File file) => Uri(
+      scheme: 'content',
+      host: kMediaArtworkAuthority,
+      pathSegments: <String>[kMediaArtworkPathName, p.basename(file.path)],
+    );

--- a/lib/core/services/media_artwork_prewarm_service.dart
+++ b/lib/core/services/media_artwork_prewarm_service.dart
@@ -25,9 +25,11 @@ const String _logName = 'Linthra.MediaArtwork';
 /// covers (Jellyfin http, a local `file:`) need no warming and are skipped.
 ///
 /// Best-effort by design, mirroring the stream preloader: warms run
-/// sequentially, one at a time, off the playback path; each reference is warmed
-/// at most once per session; and the cache swallows every failure (returning
-/// null), so a slow or failing fetch can never stall or restart playback.
+/// sequentially, one at a time, off the playback path; the now-playing cover is
+/// warmed first; a reference that succeeds is warmed once, while a transient
+/// failure is allowed to retry on a later queue change; and the cache swallows
+/// every failure (returning null), so a slow or failing fetch can never stall or
+/// restart playback.
 class MediaArtworkPrewarmService {
   MediaArtworkPrewarmService({
     required Stream<PlaybackState> playbackStates,
@@ -63,24 +65,28 @@ class MediaArtworkPrewarmService {
     // position tick (which re-emits the same key).
     if (key == _lastKey) return;
     _lastKey = key;
-    for (final Track track in _tracksToWarm(state)) {
-      final Uri? art = track.artworkUri;
-      if (art == null) continue;
-      // Jellyfin http / local file covers load directly: nothing to fetch.
-      if (isPlatformLoadableArtwork(art)) continue;
-      // Each reference is warmed at most once per session.
-      if (!_requested.add(art)) continue;
-      _queue.add(art);
+    // Prioritise the now-playing cover (front of the queue) so it warms before
+    // the look-ahead — its delay is the one visible on the now-playing card.
+    _enqueue(state.currentTrack?.artworkUri, front: true);
+    for (final Track track in state.upNext.take(_lookahead)) {
+      _enqueue(track.artworkUri, front: false);
     }
     unawaited(_drain());
   }
 
-  /// The now-playing track followed by the look-ahead of up-next tracks — the
-  /// covers worth having cached before they reach the now-playing card.
-  Iterable<Track> _tracksToWarm(PlaybackState state) sync* {
-    final Track? current = state.currentTrack;
-    if (current != null) yield current;
-    yield* state.upNext.take(_lookahead);
+  /// Queues [art] to be warmed if it's a fetchable reference not already
+  /// warmed/warming. The now-playing cover goes to the [front] so it fetches
+  /// ahead of the look-ahead covers; Jellyfin (`http`) / local (`file`) covers
+  /// load directly and are skipped.
+  void _enqueue(Uri? art, {required bool front}) {
+    if (art == null) return;
+    if (isPlatformLoadableArtwork(art)) return;
+    if (!_requested.add(art)) return;
+    if (front) {
+      _queue.insert(0, art);
+    } else {
+      _queue.add(art);
+    }
   }
 
   /// A fingerprint of the now-playing + look-ahead track ids, so warming reacts
@@ -104,13 +110,21 @@ class MediaArtworkPrewarmService {
         // break the drain (and so can never touch playback).
         try {
           final Uri? local = await _warm(reference);
+          if (local == null) {
+            // A transient miss (signed out / fetch failed): drop it from the
+            // warmed set so a later queue change can retry, rather than leaving
+            // that track coverless for the whole session.
+            _requested.remove(reference);
+          }
           // Secret-free trace: did this cover cache to a safe local URI? `ok`
           // means a later now-playing item can carry it; `miss` means signed
           // out / fetch failed. No URL, credential, or id is logged.
           developer.log('warm: ${local == null ? 'miss' : 'ok'}',
               name: _logName);
         } catch (_) {
-          // Swallow: a failed/throwing warm just means no cover for that track.
+          // Swallow + allow a later retry: a failed/throwing warm just means no
+          // cover for that track right now.
+          _requested.remove(reference);
           developer.log('warm: error', name: _logName);
         }
       }

--- a/lib/core/services/media_artwork_prewarm_service.dart
+++ b/lib/core/services/media_artwork_prewarm_service.dart
@@ -1,8 +1,14 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import '../models/playback_state.dart';
 import '../models/track.dart';
 import 'media_artwork_source.dart';
+
+/// Secret-free diagnostic tag for the media-session artwork warm path. View with
+/// `adb logcat | grep Linthra.MediaArtwork`. Logs only structural outcomes
+/// (a warm produced a local cover, or didn't) — never a URL, credential, or id.
+const String _logName = 'Linthra.MediaArtwork';
 
 /// Warms the now-playing track's and the next few up-next tracks' media-session
 /// cover art into the local cache, off the playback path, so each cover is
@@ -14,9 +20,9 @@ import 'media_artwork_source.dart';
 /// Subsonic's `subsonic-cover:<id>`) must be fetched to a local file first, which
 /// is too slow to do at the moment the track flips — so a cover fetched only
 /// then arrives after the snapshot and never shows. Warming the look-ahead means
-/// the handler can attach the already-cached `file:` synchronously when the track
-/// becomes current, beating the snapshot. Platform-loadable covers (Jellyfin
-/// http, a local `file:`) need no warming and are skipped.
+/// the handler can attach the already-cached `content://` cover synchronously
+/// when the track becomes current, beating the snapshot. Platform-loadable
+/// covers (Jellyfin http, a local `file:`) need no warming and are skipped.
 ///
 /// Best-effort by design, mirroring the stream preloader: warms run
 /// sequentially, one at a time, off the playback path; each reference is warmed
@@ -97,9 +103,15 @@ class MediaArtworkPrewarmService {
         // defensive — a warm must never surface as an uncaught async error or
         // break the drain (and so can never touch playback).
         try {
-          await _warm(reference);
+          final Uri? local = await _warm(reference);
+          // Secret-free trace: did this cover cache to a safe local URI? `ok`
+          // means a later now-playing item can carry it; `miss` means signed
+          // out / fetch failed. No URL, credential, or id is logged.
+          developer.log('warm: ${local == null ? 'miss' : 'ok'}',
+              name: _logName);
         } catch (_) {
           // Swallow: a failed/throwing warm just means no cover for that track.
+          developer.log('warm: error', name: _logName);
         }
       }
     } finally {

--- a/lib/core/services/media_artwork_prewarm_service.dart
+++ b/lib/core/services/media_artwork_prewarm_service.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import 'media_artwork_source.dart';
+
+/// Warms the now-playing track's and the next few up-next tracks' media-session
+/// cover art into the local cache, off the playback path, so each cover is
+/// cached *before* its track reaches the now-playing card.
+///
+/// Why ahead of time: the platform media session loads `MediaItem.artUri`
+/// itself, and many car head units snapshot the now-playing art at the track
+/// change and don't refresh it. A credential-free cover *reference* (e.g.
+/// Subsonic's `subsonic-cover:<id>`) must be fetched to a local file first, which
+/// is too slow to do at the moment the track flips — so a cover fetched only
+/// then arrives after the snapshot and never shows. Warming the look-ahead means
+/// the handler can attach the already-cached `file:` synchronously when the track
+/// becomes current, beating the snapshot. Platform-loadable covers (Jellyfin
+/// http, a local `file:`) need no warming and are skipped.
+///
+/// Best-effort by design, mirroring the stream preloader: warms run
+/// sequentially, one at a time, off the playback path; each reference is warmed
+/// at most once per session; and the cache swallows every failure (returning
+/// null), so a slow or failing fetch can never stall or restart playback.
+class MediaArtworkPrewarmService {
+  MediaArtworkPrewarmService({
+    required Stream<PlaybackState> playbackStates,
+    required Future<Uri?> Function(Uri reference) warm,
+    int lookahead = _defaultLookahead,
+  })  : _warm = warm,
+        _lookahead = lookahead {
+    _subscription = playbackStates.listen(_onState);
+  }
+
+  /// Fetches+caches the cover for a credential-free [reference], returning the
+  /// local URI or null; the result is ignored here (the cache memoizes it for
+  /// the handler's synchronous `cached` lookup). Never throws.
+  final Future<Uri?> Function(Uri reference) _warm;
+
+  /// How many up-next tracks (beyond the current one) to warm ahead.
+  final int _lookahead;
+
+  late final StreamSubscription<PlaybackState> _subscription;
+
+  static const int _defaultLookahead = 3;
+
+  /// References already warmed (or warming) this session, so a re-emitted state
+  /// (a position tick, a pause) never re-warms a cover.
+  final Set<Uri> _requested = <Uri>{};
+  final List<Uri> _queue = <Uri>[];
+  bool _running = false;
+  String? _lastKey;
+
+  void _onState(PlaybackState state) {
+    final String key = _keyFor(state);
+    // Only react when the now-playing + look-ahead set changes — not on every
+    // position tick (which re-emits the same key).
+    if (key == _lastKey) return;
+    _lastKey = key;
+    for (final Track track in _tracksToWarm(state)) {
+      final Uri? art = track.artworkUri;
+      if (art == null) continue;
+      // Jellyfin http / local file covers load directly: nothing to fetch.
+      if (isPlatformLoadableArtwork(art)) continue;
+      // Each reference is warmed at most once per session.
+      if (!_requested.add(art)) continue;
+      _queue.add(art);
+    }
+    unawaited(_drain());
+  }
+
+  /// The now-playing track followed by the look-ahead of up-next tracks — the
+  /// covers worth having cached before they reach the now-playing card.
+  Iterable<Track> _tracksToWarm(PlaybackState state) sync* {
+    final Track? current = state.currentTrack;
+    if (current != null) yield current;
+    yield* state.upNext.take(_lookahead);
+  }
+
+  /// A fingerprint of the now-playing + look-ahead track ids, so warming reacts
+  /// to queue/track changes but not to position/status ticks (same key).
+  String _keyFor(PlaybackState state) {
+    final String current = state.currentTrack?.id ?? '-';
+    final String ahead =
+        state.upNext.take(_lookahead).map((Track t) => t.id).join(',');
+    return '$current|$ahead';
+  }
+
+  Future<void> _drain() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (_queue.isNotEmpty) {
+        final Uri reference = _queue.removeAt(0);
+        // Sequential + best-effort: the cache fetches a server-downscaled cover,
+        // caches it, and returns null on any failure. The try/catch is purely
+        // defensive — a warm must never surface as an uncaught async error or
+        // break the drain (and so can never touch playback).
+        try {
+          await _warm(reference);
+        } catch (_) {
+          // Swallow: a failed/throwing warm just means no cover for that track.
+        }
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  Future<void> dispose() => _subscription.cancel();
+}

--- a/lib/core/services/media_artwork_source.dart
+++ b/lib/core/services/media_artwork_source.dart
@@ -1,0 +1,26 @@
+/// A synchronous source of already-fetched, safe **local** media-session
+/// artwork — the seam the media handler reads while building a `MediaItem`,
+/// without ever awaiting or triggering a fetch on the playback path.
+///
+/// Backed by `MediaArtworkCache`, whose covers are warmed ahead of time by
+/// `MediaArtworkPrewarmService` so a track's cover is usually cached *before* it
+/// reaches the now-playing card — beating the head unit's metadata snapshot at
+/// the track change (a plain late-arriving cover is ignored by many head units).
+abstract interface class MediaArtworkSource {
+  /// The safe local `file:` URI for [reference] if it has already been fetched
+  /// and cached, else `null`. Synchronous and side-effect-free — it never starts
+  /// a fetch, so reading it while building a `MediaItem` can't block playback or
+  /// put a credential in `artUri`.
+  Uri? cached(Uri reference);
+}
+
+/// Whether [uri] is a cover the platform media session can load by itself — a
+/// private `file:`, a remote token-free `http`/`https` image (e.g. Jellyfin), or
+/// an app `content:` URI. Any other scheme is an app-internal *reference* (e.g.
+/// Subsonic's `subsonic-cover:<id>`) that must first be fetched to a local file
+/// (see `MediaArtworkCache`) before it can be shown on the media session.
+bool isPlatformLoadableArtwork(Uri uri) =>
+    uri.isScheme('file') ||
+    uri.isScheme('http') ||
+    uri.isScheme('https') ||
+    uri.isScheme('content');

--- a/lib/core/services/media_artwork_source.dart
+++ b/lib/core/services/media_artwork_source.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 /// A synchronous source of already-fetched, safe **local** media-session
 /// artwork — the seam the media handler reads while building a `MediaItem`,
 /// without ever awaiting or triggering a fetch on the playback path.
@@ -7,11 +9,18 @@
 /// reaches the now-playing card — beating the head unit's metadata snapshot at
 /// the track change (a plain late-arriving cover is ignored by many head units).
 abstract interface class MediaArtworkSource {
-  /// The safe local `file:` URI for [reference] if it has already been fetched
+  /// The safe `content://` URI for [reference] if it has already been fetched
   /// and cached, else `null`. Synchronous and side-effect-free — it never starts
   /// a fetch, so reading it while building a `MediaItem` can't block playback or
   /// put a credential in `artUri`.
   Uri? cached(Uri reference);
+
+  /// Emits a [reference] the moment its cover first becomes cached (so [cached]
+  /// would now return a URI for it). Lets a now-playing item that was published
+  /// without art be refreshed at once — instead of waiting for the next playback
+  /// tick — when its cover finishes warming. Broadcast; emits at most once per
+  /// reference.
+  Stream<Uri> get coverReady;
 }
 
 /// Whether [uri] is a cover the platform media session can load by itself — a

--- a/lib/core/sources/subsonic/subsonic_artwork.dart
+++ b/lib/core/sources/subsonic/subsonic_artwork.dart
@@ -47,7 +47,11 @@ abstract final class SubsonicArtwork {
   /// `getCoverArt` URL for [session], or `null` when [reference] isn't a
   /// Subsonic cover reference. The salt+token are woven in here, on demand, and
   /// never persisted — the stored reference stays credential-free.
-  static Uri? resolve(Uri reference, SubsonicSession session) {
+  ///
+  /// [size] (px) is forwarded to `getCoverArt` to ask the server for a scaled
+  /// cover: it is left unset for the in-app full-size render, and set for the
+  /// platform media-session cache, which wants a small, fast-to-decode image.
+  static Uri? resolve(Uri reference, SubsonicSession session, {int? size}) {
     final String? id = coverArtId(reference);
     if (id == null) return null;
     return SubsonicEndpoints.coverArt(
@@ -56,6 +60,7 @@ abstract final class SubsonicArtwork {
       credentials:
           SubsonicCredentials(salt: session.salt, token: session.token),
       coverArtId: id,
+      size: size,
     );
   }
 }

--- a/lib/core/sources/subsonic/subsonic_endpoints.dart
+++ b/lib/core/sources/subsonic/subsonic_endpoints.dart
@@ -138,16 +138,23 @@ abstract final class SubsonicEndpoints {
   /// credential in its query — it is therefore woven in here, on demand at
   /// render time, and never persisted on a track or in the catalog (the catalog
   /// stores only a credential-free `subsonic-cover:` reference; see
-  /// `SubsonicArtwork`). No `size` is requested, so the server serves the
-  /// original art — matching how Jellyfin's primary image is loaded full-size.
+  /// `SubsonicArtwork`).
+  ///
+  /// [size] asks the server to scale the cover to that many pixels (Subsonic's
+  /// `getCoverArt` `size` parameter). It is omitted for the in-app full-size
+  /// render (matching how Jellyfin's primary image loads full-size), and set for
+  /// the platform media session, which wants a small, fast-to-decode cover.
   static Uri coverArt(
     String baseUrl, {
     required String username,
     required SubsonicCredentials credentials,
     required String coverArtId,
+    int? size,
   }) =>
-      _build(baseUrl, 'getCoverArt', username, credentials,
-          extra: {idParam: coverArtId});
+      _build(baseUrl, 'getCoverArt', username, credentials, extra: {
+        idParam: coverArtId,
+        if (size != null) 'size': '$size',
+      });
 
   /// Builds `/rest/<method>.view` with the standard auth + format query and any
   /// method-specific [extra] parameters. The single place the salt+token are

--- a/lib/features/player/media_artwork_providers.dart
+++ b/lib/features/player/media_artwork_providers.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/subsonic_session.dart';
+import '../../core/services/media_artwork_cache.dart';
+import '../../core/services/media_artwork_prewarm_service.dart';
+import '../../core/sources/subsonic/subsonic_artwork.dart';
+import '../settings/subsonic/subsonic_settings_controller.dart';
+import 'player_providers.dart';
+
+/// The pixel size Linthra requests Subsonic cover art at for the **media
+/// session** (lock screen / Android Auto now-playing card). Small enough to
+/// download quickly and let the platform decode it without jank or OOM, but
+/// crisp on those surfaces. The in-app full-size render (PR #170) is unaffected.
+const int kMediaSessionArtworkSize = 512;
+
+/// The privacy-safe media-session artwork cache for Subsonic/Navidrome.
+///
+/// The platform media session loads `MediaItem.artUri` itself, somewhere Linthra
+/// can't add the salt+token, so the credentialed `getCoverArt` URL must never go
+/// there. The cache instead fetches a **server-downscaled** cover itself
+/// (weaving the live session's salt+token in on demand, used once and never
+/// stored or logged), writes the bytes to a private file keyed by a hash of the
+/// credential-free `subsonic-cover:` reference, and exposes it as a safe local
+/// `file:`. Jellyfin (token-free http) and local (`file:`) covers are already
+/// platform-loadable and never reach this cache. Reads the session live, so
+/// sign-in/out is picked up; signed out, or on any fetch failure, it yields no
+/// artwork and playback is unaffected.
+final mediaArtworkCacheProvider = Provider<MediaArtworkCache>((ref) {
+  return MediaArtworkCache(
+    resolveUrl: (Uri reference) {
+      final SubsonicSession? session =
+          ref.read(subsonicSettingsControllerProvider.notifier).session;
+      if (session == null) return null;
+      return SubsonicArtwork.resolve(
+        reference,
+        session,
+        size: kMediaSessionArtworkSize,
+      );
+    },
+  );
+});
+
+/// Warms the now-playing + look-ahead covers into [mediaArtworkCacheProvider]
+/// off the playback path, so a cover is cached before its track reaches the
+/// now-playing card (beating the head unit's metadata snapshot). Side-effect
+/// only — like the stream preloader, instantiating it wires the listener; the
+/// UI reads no value from it.
+final mediaArtworkPrewarmServiceProvider =
+    Provider<MediaArtworkPrewarmService>((ref) {
+  final service = MediaArtworkPrewarmService(
+    playbackStates: ref.read(playbackControllerProvider).stateStream,
+    warm: ref.read(mediaArtworkCacheProvider).resolve,
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});

--- a/lib/features/player/media_artwork_providers.dart
+++ b/lib/features/player/media_artwork_providers.dart
@@ -26,7 +26,7 @@ const int kMediaSessionArtworkSize = 512;
 /// sign-in/out is picked up; signed out, or on any fetch failure, it yields no
 /// artwork and playback is unaffected.
 final mediaArtworkCacheProvider = Provider<MediaArtworkCache>((ref) {
-  return MediaArtworkCache(
+  final cache = MediaArtworkCache(
     resolveUrl: (Uri reference) {
       final SubsonicSession? session =
           ref.read(subsonicSettingsControllerProvider.notifier).session;
@@ -38,6 +38,8 @@ final mediaArtworkCacheProvider = Provider<MediaArtworkCache>((ref) {
       );
     },
   );
+  ref.onDispose(cache.dispose);
+  return cache;
 });
 
 /// Warms the now-playing + look-ahead covers into [mediaArtworkCacheProvider]

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app/linthra_app.dart';
 import 'core/models/subsonic_session.dart';
 import 'core/services/linthra_audio_handler.dart';
+import 'core/services/media_artwork_cache.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
 import 'data/repositories/default_provider_store_provider.dart';
 import 'data/repositories/download_repository_provider.dart';
@@ -98,6 +99,27 @@ Future<void> main() async {
     ],
   );
 
+  // A privacy-safe media-session artwork cache for Subsonic/Navidrome: the
+  // platform media session loads MediaItem.artUri itself, somewhere Linthra
+  // can't add the salt+token, so the credentialed getCoverArt URL must never go
+  // there. Instead the cache fetches the cover itself — weaving the live
+  // session's salt+token into the getCoverArt URL on demand, used once to fetch
+  // and never stored or logged — and writes the bytes to a private file, keyed
+  // by a hash of the credential-free `subsonic-cover:<id>` reference (no
+  // credential in the filename). The handler then sets artUri to only that local
+  // file:// URI. Reads the session live, so sign-in/out is picked up; returns
+  // null when signed out or on any fetch failure (the session then shows no art,
+  // and playback is unaffected). Jellyfin (token-free http) and local (file:)
+  // covers never reach this cache — they're already platform-loadable.
+  final mediaArtworkCache = MediaArtworkCache(
+    resolveUrl: (Uri reference) {
+      final SubsonicSession? session =
+          container.read(subsonicSettingsControllerProvider.notifier).session;
+      if (session == null) return null;
+      return SubsonicArtwork.resolve(reference, session);
+    },
+  );
+
   // Attaching the session is best-effort: on a platform without the native
   // audio_service setup it returns null and basic playback still works. The
   // handler mirrors the controller and outlives this scope with the container.
@@ -111,6 +133,7 @@ Future<void> main() async {
     playlists: container.read(playlistRepositoryProvider),
     favorites: container.read(favoritesRepositoryProvider),
     downloads: container.read(downloadRepositoryProvider),
+    artwork: mediaArtworkCache.resolve,
   );
 
   // Start smart pre-cache: as playback advances it warms the next queued tracks

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app/linthra_app.dart';
 import 'core/models/subsonic_session.dart';
 import 'core/services/linthra_audio_handler.dart';
-import 'core/services/media_artwork_cache.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
 import 'data/repositories/default_provider_store_provider.dart';
 import 'data/repositories/download_repository_provider.dart';
@@ -27,6 +26,7 @@ import 'features/library/playback_candidates_provider.dart';
 import 'features/player/cast/cast_providers.dart';
 import 'features/player/favorites_providers.dart';
 import 'features/player/lyrics_providers.dart';
+import 'features/player/media_artwork_providers.dart';
 import 'features/player/player_providers.dart';
 import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
 import 'features/settings/playback/normalize_volume_controller.dart';
@@ -99,27 +99,6 @@ Future<void> main() async {
     ],
   );
 
-  // A privacy-safe media-session artwork cache for Subsonic/Navidrome: the
-  // platform media session loads MediaItem.artUri itself, somewhere Linthra
-  // can't add the salt+token, so the credentialed getCoverArt URL must never go
-  // there. Instead the cache fetches the cover itself — weaving the live
-  // session's salt+token into the getCoverArt URL on demand, used once to fetch
-  // and never stored or logged — and writes the bytes to a private file, keyed
-  // by a hash of the credential-free `subsonic-cover:<id>` reference (no
-  // credential in the filename). The handler then sets artUri to only that local
-  // file:// URI. Reads the session live, so sign-in/out is picked up; returns
-  // null when signed out or on any fetch failure (the session then shows no art,
-  // and playback is unaffected). Jellyfin (token-free http) and local (file:)
-  // covers never reach this cache — they're already platform-loadable.
-  final mediaArtworkCache = MediaArtworkCache(
-    resolveUrl: (Uri reference) {
-      final SubsonicSession? session =
-          container.read(subsonicSettingsControllerProvider.notifier).session;
-      if (session == null) return null;
-      return SubsonicArtwork.resolve(reference, session);
-    },
-  );
-
   // Attaching the session is best-effort: on a platform without the native
   // audio_service setup it returns null and basic playback still works. The
   // handler mirrors the controller and outlives this scope with the container.
@@ -127,14 +106,27 @@ Future<void> main() async {
   // browse Playlists/Favorites/Offline (when the user has any) alongside
   // Songs/Albums/Artists/Queue — all read straight from the persisted stores, so
   // the car tree is answerable even before any phone screen is opened.
+  //
+  // The media-session artwork cache lets the now-playing card show a
+  // credential-free source's cover (Subsonic) as a safe local file: — the
+  // handler reads it synchronously, never a credentialed getCoverArt URL. The
+  // covers are fetched (server-downscaled) and cached ahead of time, off the
+  // playback path, by the prewarm service started below.
   await connectMediaSession(
     container.read(playbackControllerProvider),
     container.read(musicLibraryRepositoryProvider),
     playlists: container.read(playlistRepositoryProvider),
     favorites: container.read(favoritesRepositoryProvider),
     downloads: container.read(downloadRepositoryProvider),
-    artwork: mediaArtworkCache.resolve,
+    artwork: container.read(mediaArtworkCacheProvider),
   );
+
+  // Warm the now-playing + look-ahead Subsonic covers into the media-session
+  // artwork cache as playback advances, so each cover is cached before its track
+  // reaches the now-playing card (beating a head unit's metadata snapshot).
+  // Off the playback path and best-effort, like the stream preloader below;
+  // instantiating it wires the listener.
+  container.read(mediaArtworkPrewarmServiceProvider);
 
   // Start smart pre-cache: as playback advances it warms the next queued tracks
   // into the offline cache (under the same limit, honouring "Allow mobile data"

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -921,7 +921,12 @@ void main() {
         artworkUri: Uri.parse('subsonic-cover:al-9'),
       );
       final reference = Uri.parse('subsonic-cover:al-9');
-      final localArt = Uri.parse('file:///cache/media_session_artwork/abc.img');
+      // What the cache hands back: a credential-free FileProvider content:// URI
+      // over the cached cover, which the platform session can read.
+      final localArt = Uri.parse(
+        'content://io.github.thezupzup.linthra.mediaartwork/media_artwork/'
+        'abc.img',
+      );
 
       LinthraAudioHandler handlerWith(
         FakePlaybackController c,
@@ -969,7 +974,7 @@ void main() {
         await _settle();
 
         final String art = h.mediaItem.value?.artUri?.toString() ?? '';
-        expect(art, startsWith('file:'));
+        expect(art, startsWith('content:'));
         expect(art, isNot(contains('subsonic-cover')));
         expect(art.toLowerCase(), isNot(contains('getcoverart')));
         expect(art.toLowerCase(), isNot(contains('token')));

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:audio_service/audio_service.dart' as audio;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
@@ -20,15 +22,25 @@ class _RecordingArtworkSource implements MediaArtworkSource {
 
   final Map<Uri, Uri> _cache;
   final List<Uri> queries = <Uri>[];
+  final StreamController<Uri> _coverReady = StreamController<Uri>.broadcast();
 
-  /// Simulates the prewarm service finishing a fetch for [reference].
-  void warm(Uri reference, Uri local) => _cache[reference] = local;
+  /// Simulates the prewarm service finishing a fetch for [reference]: the cover
+  /// becomes cached and the ready event fires (as the real cache does).
+  void warm(Uri reference, Uri local) {
+    _cache[reference] = local;
+    _coverReady.add(reference);
+  }
 
   @override
   Uri? cached(Uri reference) {
     queries.add(reference);
     return _cache[reference];
   }
+
+  @override
+  Stream<Uri> get coverReady => _coverReady.stream;
+
+  Future<void> close() => _coverReady.close();
 }
 
 Track _track(String id) {
@@ -941,6 +953,7 @@ void main() {
         addTearDown(() async {
           await h.dispose();
           await c.dispose();
+          if (artwork is _RecordingArtworkSource) await artwork.close();
         });
         return h;
       }
@@ -1002,11 +1015,11 @@ void main() {
       });
 
       test(
-          'a cover warmed mid-track appears on the next broadcast, no '
-          'handler re-broadcast', () async {
-        // The cold first-track case: the cover finishes warming after play
-        // starts, and the controller's next natural state tick carries it — the
-        // handler never re-broadcasts on the playback path itself.
+          'a cover warmed mid-track appears immediately via coverReady, no '
+          'position tick needed', () async {
+        // The cold first-track case: the cover finishes warming after the card
+        // is published art-less. The coverReady event re-publishes the item at
+        // once — no waiting for the next playback tick (the residual delay fix).
         final source = _RecordingArtworkSource(); // empty at first
         final c = FakePlaybackController();
         final h = handlerWith(c, <Track>[subsonic], artwork: source);
@@ -1015,14 +1028,63 @@ void main() {
         await _settle();
         expect(h.mediaItem.value?.artUri, isNull);
 
-        // The prewarm completes out of band: the cover is now cached.
+        // The prewarm completes out of band → cover cached + coverReady fires.
+        // No position tick is emitted; the cover must still appear.
         source.warm(reference, localArt);
-        // A position tick (the controller's natural update) rebuilds the item,
-        // which now picks up the cached cover.
-        c.emit(c.state.copyWith(position: const Duration(seconds: 5)));
         await _settle();
 
         expect(h.mediaItem.value?.artUri, localArt);
+      });
+
+      test('coverReady for the current track re-publishes only once (no loop)',
+          () async {
+        // The re-publish must be a single, gated push: one item with art, never
+        // a tight loop of re-broadcasts.
+        final source = _RecordingArtworkSource();
+        final c = FakePlaybackController();
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
+
+        final List<audio.MediaItem?> pushes = <audio.MediaItem?>[];
+        final sub = h.mediaItem.listen(pushes.add);
+        addTearDown(sub.cancel);
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+        final int beforeWarm = pushes.length;
+
+        source.warm(reference, localArt); // cover cached + coverReady
+        await _settle();
+
+        // Exactly one extra push — the item that gained the art.
+        expect(pushes.length, beforeWarm + 1);
+        expect(pushes.last?.artUri, localArt);
+
+        // A duplicate coverReady for an already-shown cover is a no-op (the
+        // _sameItem guard), so no further push.
+        source.warm(reference, localArt);
+        await _settle();
+        expect(pushes.length, beforeWarm + 1);
+      });
+
+      test(
+          'coverReady for a non-current cover leaves the now-playing item alone',
+          () async {
+        // Warming an up-next cover must not disturb the current now-playing item.
+        final source = _RecordingArtworkSource();
+        final c = FakePlaybackController();
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+
+        // A different reference (some up-next cover) becomes ready.
+        source.warm(Uri.parse('subsonic-cover:other'),
+            Uri.parse('content://x/media_artwork/other.img'));
+        await _settle();
+
+        // The now-playing item is unchanged (still art-less for sub-1).
+        expect(h.mediaItem.value?.id, 'sub-1');
+        expect(h.mediaItem.value?.artUri, isNull);
       });
 
       test('without an artwork source, a reference never leaks into artUri',

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -4,11 +4,32 @@ import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/linthra_audio_handler.dart';
+import 'package:linthra/core/services/media_artwork_source.dart';
 import 'package:linthra/core/services/media_browser_tree.dart';
 
 import '../../features/library/fake_music_library_repository.dart';
 import '../../features/player/fake_playback_controller.dart';
 import 'fake_browse_repositories.dart';
+
+/// A synchronous [MediaArtworkSource] that returns the covers it's been warmed
+/// with and records every lookup, so tests can prove the handler reads the cache
+/// by the credential-free reference (and not at all for platform-loadable art).
+class _RecordingArtworkSource implements MediaArtworkSource {
+  _RecordingArtworkSource([Map<Uri, Uri>? cache])
+      : _cache = cache ?? <Uri, Uri>{};
+
+  final Map<Uri, Uri> _cache;
+  final List<Uri> queries = <Uri>[];
+
+  /// Simulates the prewarm service finishing a fetch for [reference].
+  void warm(Uri reference, Uri local) => _cache[reference] = local;
+
+  @override
+  Uri? cached(Uri reference) {
+    queries.add(reference);
+    return _cache[reference];
+  }
+}
 
 Track _track(String id) {
   return Track(
@@ -885,9 +906,12 @@ void main() {
     group('Subsonic media-session artwork (privacy-safe local cache)', () {
       // A Subsonic track persists a *credential-free* reference in artworkUri
       // (subsonic-cover:<id>). The platform media session loads artUri itself —
-      // somewhere Linthra can't add the salt+token — so the session must show a
-      // *local* cover (fetched and cached by Linthra), never the reference and
-      // never the authenticated getCoverArt URL.
+      // somewhere Linthra can't add the salt+token — so the handler attaches a
+      // *pre-warmed local* cover (a file: the MediaArtworkPrewarmService cached
+      // ahead of time), never the reference and never the getCoverArt URL. The
+      // read is synchronous, so a warmed cover is present on the very first push
+      // (beating a head unit's metadata snapshot) and nothing fetches on the
+      // playback path.
       final subsonic = Track(
         id: 'sub-1',
         title: 'Sub Song',
@@ -896,12 +920,13 @@ void main() {
         albumName: 'Sub Album',
         artworkUri: Uri.parse('subsonic-cover:al-9'),
       );
+      final reference = Uri.parse('subsonic-cover:al-9');
       final localArt = Uri.parse('file:///cache/media_session_artwork/abc.img');
 
       LinthraAudioHandler handlerWith(
         FakePlaybackController c,
         List<Track> tracks, {
-        MediaArtworkResolver? artwork,
+        MediaArtworkSource? artwork,
       }) {
         final h = LinthraAudioHandler(
           c,
@@ -915,37 +940,32 @@ void main() {
         return h;
       }
 
-      test('resolves a cover reference to a safe local file artUri', () async {
+      test(
+          'shows a pre-warmed cover as a safe local file artUri on the first '
+          'push', () async {
+        final source = _RecordingArtworkSource(<Uri, Uri>{reference: localArt});
         final c = FakePlaybackController();
-        final h = handlerWith(
-          c,
-          <Track>[subsonic],
-          artwork: (Uri ref) async =>
-              ref.isScheme('subsonic-cover') ? localArt : null,
-        );
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
 
         await c.playTracks(<Track>[subsonic]);
-        await _settle(); // initial push: cover not fetched yet
-        await _settle(); // fetch settles, re-broadcast with the local art
+        await _settle(); // a single broadcast — the read is synchronous
 
         // The now-playing item — what the lock screen / Android Auto card shows
-        // — carries the safe local cover, never the reference or a credential.
+        // — carries the safe local cover, present immediately (snapshot-safe).
         expect(h.mediaItem.value?.id, 'sub-1');
         expect(h.mediaItem.value?.artUri, localArt);
+        // It was looked up by the credential-free reference, nothing else.
+        expect(source.queries, contains(reference));
       });
 
       test(
           'the now-playing artUri is a safe file:, never the reference or a '
           'credential', () async {
+        final source = _RecordingArtworkSource(<Uri, Uri>{reference: localArt});
         final c = FakePlaybackController();
-        final h = handlerWith(
-          c,
-          <Track>[subsonic],
-          artwork: (Uri ref) async => localArt,
-        );
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
 
         await c.playTracks(<Track>[subsonic]);
-        await _settle();
         await _settle();
 
         final String art = h.mediaItem.value?.artUri?.toString() ?? '';
@@ -958,17 +978,15 @@ void main() {
         expect(art.toLowerCase(), isNot(contains('s=')));
       });
 
-      test('a failed resolution leaves artUri null without affecting playback',
+      test('an un-warmed cover leaves artUri null without affecting playback',
           () async {
+        // The cover isn't cached yet (or couldn't be): artUri is null, never the
+        // reference, and the rest of the now-playing metadata is intact.
+        final source = _RecordingArtworkSource(); // empty cache
         final c = FakePlaybackController();
-        final h = handlerWith(
-          c,
-          <Track>[subsonic],
-          artwork: (Uri ref) async => null, // signed out / download failed
-        );
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
 
         await c.playTracks(<Track>[subsonic]);
-        await _settle();
         await _settle();
 
         final item = h.mediaItem.value;
@@ -978,12 +996,36 @@ void main() {
         expect(item.artUri, isNull); // no artwork, and crucially no leak
       });
 
-      test('without a resolver, a cover reference never leaks into artUri',
+      test(
+          'a cover warmed mid-track appears on the next broadcast, no '
+          'handler re-broadcast', () async {
+        // The cold first-track case: the cover finishes warming after play
+        // starts, and the controller's next natural state tick carries it — the
+        // handler never re-broadcasts on the playback path itself.
+        final source = _RecordingArtworkSource(); // empty at first
+        final c = FakePlaybackController();
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+        expect(h.mediaItem.value?.artUri, isNull);
+
+        // The prewarm completes out of band: the cover is now cached.
+        source.warm(reference, localArt);
+        // A position tick (the controller's natural update) rebuilds the item,
+        // which now picks up the cached cover.
+        c.emit(c.state.copyWith(position: const Duration(seconds: 5)));
+        await _settle();
+
+        expect(h.mediaItem.value?.artUri, localArt);
+      });
+
+      test('without an artwork source, a reference never leaks into artUri',
           () async {
-        // The default (tests / a platform without the cache): the unloadable
+        // The default (a platform without the cache): the unloadable
         // subsonic-cover: reference must be dropped, not handed to the session.
         final c = FakePlaybackController();
-        final h = handlerWith(c, <Track>[subsonic]);
+        final h = handlerWith(c, <Track>[subsonic]); // no artwork source
 
         await c.playTracks(<Track>[subsonic]);
         await _settle();
@@ -995,16 +1037,14 @@ void main() {
             item.artUri?.toString() ?? '', isNot(contains('subsonic-cover')));
       });
 
-      test('browse-tree containers drop an unresolved cover reference',
+      test('browse-tree containers drop an un-warmed cover reference',
           () async {
-        // The car browse tree never fetches covers, so a Subsonic album/artist
-        // container's reference must be dropped (null), never leaked unloadable.
+        // Browse covers aren't pre-warmed, so a Subsonic album/artist
+        // container's reference is dropped (null), never leaked as an unloadable
+        // URI.
+        final source = _RecordingArtworkSource(); // nothing cached
         final c = FakePlaybackController();
-        final h = handlerWith(
-          c,
-          <Track>[subsonic],
-          artwork: (Uri ref) async => localArt, // must not be consulted here
-        );
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
 
         final albums = await h.getChildren(MediaId.albums);
         expect(albums, isNotEmpty);
@@ -1017,12 +1057,10 @@ void main() {
         }
       });
 
-      test('Jellyfin http art and local file art still pass through unchanged',
+      test('Jellyfin http art and local file art pass through unchanged',
           () async {
-        // Regression: wiring the reference resolver must not change how a
-        // platform-loadable cover (Jellyfin token-free http, a local file:) is
-        // forwarded — and the resolver must not even be consulted for them.
-        bool resolverCalled = false;
+        // A platform-loadable cover (Jellyfin token-free http, a local file:) is
+        // forwarded unchanged, and the artwork source is never even consulted.
         final jf = Track(
           id: 'jf',
           title: 'JF',
@@ -1036,18 +1074,11 @@ void main() {
           uri: '/music/loc.mp3',
           artworkUri: Uri.parse('file:///cache/linthra_local_artwork/loc.img'),
         );
+        final source = _RecordingArtworkSource();
         final c = FakePlaybackController();
-        final h = handlerWith(
-          c,
-          <Track>[jf, loc],
-          artwork: (Uri ref) async {
-            resolverCalled = true;
-            return Uri.parse('file:///should/not/be/used.img');
-          },
-        );
+        final h = handlerWith(c, <Track>[jf, loc], artwork: source);
 
         await c.playTracks(<Track>[jf, loc]);
-        await _settle();
         await _settle();
 
         // Jellyfin token-free http art is used as-is.
@@ -1061,34 +1092,8 @@ void main() {
           locRow.artUri,
           Uri.parse('file:///cache/linthra_local_artwork/loc.img'),
         );
-        // The reference resolver is never consulted for platform-loadable art.
-        expect(resolverCalled, isFalse);
-      });
-
-      test('fetches the cover at most once despite re-broadcasts', () async {
-        int calls = 0;
-        final c = FakePlaybackController();
-        final h = handlerWith(
-          c,
-          <Track>[subsonic],
-          artwork: (Uri ref) async {
-            calls++;
-            return localArt;
-          },
-        );
-
-        await c.playTracks(<Track>[subsonic]);
-        await _settle();
-        await _settle();
-        // A seek (a large position jump) forces a playback re-push; a small tick
-        // does not. Neither must re-fetch the already-resolved cover.
-        c.emit(c.state.copyWith(position: const Duration(seconds: 30)));
-        await _settle();
-        c.emit(c.state.copyWith(position: const Duration(seconds: 31)));
-        await _settle();
-
-        expect(calls, 1);
-        expect(h.mediaItem.value?.artUri, localArt);
+        // The source is not consulted for platform-loadable covers.
+        expect(source.queries, isEmpty);
       });
     });
   });

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -1087,8 +1087,9 @@ void main() {
         await _settle();
 
         // Jellyfin token-free http art is used as-is.
+        final nowPlayingArt = h.mediaItem.value?.artUri;
         expect(
-          h.mediaItem.value?.artUri,
+          nowPlayingArt,
           Uri.parse('https://music.example.com/Items/jf/Images/Primary'),
         );
         // The local file: art rides on its queue row unchanged.
@@ -1097,7 +1098,12 @@ void main() {
           locRow.artUri,
           Uri.parse('file:///cache/linthra_local_artwork/loc.img'),
         );
-        // The source is not consulted for platform-loadable covers.
+        // Neither becomes a content:// URI, so they are never served by the
+        // media-artwork FileProvider and its read-grant logic never runs for
+        // Jellyfin/local covers — only Subsonic references go through the cache.
+        expect(nowPlayingArt?.isScheme('content'), isFalse);
+        expect(locRow.artUri?.isScheme('content'), isFalse);
+        // The cover source is not consulted at all for platform-loadable covers.
         expect(source.queries, isEmpty);
       });
     });

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -849,5 +849,215 @@ void main() {
         }
       });
     });
+
+    group('Subsonic media-session artwork (privacy-safe local cache)', () {
+      // A Subsonic track persists a *credential-free* reference in artworkUri
+      // (subsonic-cover:<id>). The platform media session loads artUri itself —
+      // somewhere Linthra can't add the salt+token — so the session must show a
+      // *local* cover (fetched and cached by Linthra), never the reference and
+      // never the authenticated getCoverArt URL.
+      final subsonic = Track(
+        id: 'sub-1',
+        title: 'Sub Song',
+        uri: 'subsonic:sub-1',
+        artistName: 'Sub Artist',
+        albumName: 'Sub Album',
+        artworkUri: Uri.parse('subsonic-cover:al-9'),
+      );
+      final localArt = Uri.parse('file:///cache/media_session_artwork/abc.img');
+
+      LinthraAudioHandler handlerWith(
+        FakePlaybackController c,
+        List<Track> tracks, {
+        MediaArtworkResolver? artwork,
+      }) {
+        final h = LinthraAudioHandler(
+          c,
+          MediaBrowserTree(FakeMusicLibraryRepository(tracks: tracks)),
+          artwork: artwork,
+        );
+        addTearDown(() async {
+          await h.dispose();
+          await c.dispose();
+        });
+        return h;
+      }
+
+      test('resolves a cover reference to a safe local file artUri', () async {
+        final c = FakePlaybackController();
+        final h = handlerWith(
+          c,
+          <Track>[subsonic],
+          artwork: (Uri ref) async =>
+              ref.isScheme('subsonic-cover') ? localArt : null,
+        );
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle(); // initial push: cover not fetched yet
+        await _settle(); // fetch settles, re-broadcast with the local art
+
+        // The now-playing item — what the lock screen / Android Auto card shows
+        // — carries the safe local cover, never the reference or a credential.
+        expect(h.mediaItem.value?.id, 'sub-1');
+        expect(h.mediaItem.value?.artUri, localArt);
+      });
+
+      test(
+          'the now-playing artUri is a safe file:, never the reference or a '
+          'credential', () async {
+        final c = FakePlaybackController();
+        final h = handlerWith(
+          c,
+          <Track>[subsonic],
+          artwork: (Uri ref) async => localArt,
+        );
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+        await _settle();
+
+        final String art = h.mediaItem.value?.artUri?.toString() ?? '';
+        expect(art, startsWith('file:'));
+        expect(art, isNot(contains('subsonic-cover')));
+        expect(art.toLowerCase(), isNot(contains('getcoverart')));
+        expect(art.toLowerCase(), isNot(contains('token')));
+        expect(art.toLowerCase(), isNot(contains('u=')));
+        expect(art.toLowerCase(), isNot(contains('t=')));
+        expect(art.toLowerCase(), isNot(contains('s=')));
+      });
+
+      test('a failed resolution leaves artUri null without affecting playback',
+          () async {
+        final c = FakePlaybackController();
+        final h = handlerWith(
+          c,
+          <Track>[subsonic],
+          artwork: (Uri ref) async => null, // signed out / download failed
+        );
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+        await _settle();
+
+        final item = h.mediaItem.value;
+        expect(item, isNotNull);
+        expect(item!.id, 'sub-1'); // metadata intact, playback unaffected
+        expect(item.title, 'Sub Song');
+        expect(item.artUri, isNull); // no artwork, and crucially no leak
+      });
+
+      test('without a resolver, a cover reference never leaks into artUri',
+          () async {
+        // The default (tests / a platform without the cache): the unloadable
+        // subsonic-cover: reference must be dropped, not handed to the session.
+        final c = FakePlaybackController();
+        final h = handlerWith(c, <Track>[subsonic]);
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+
+        final item = h.mediaItem.value;
+        expect(item, isNotNull);
+        expect(item!.artUri, isNull);
+        expect(
+            item.artUri?.toString() ?? '', isNot(contains('subsonic-cover')));
+      });
+
+      test('browse-tree containers drop an unresolved cover reference',
+          () async {
+        // The car browse tree never fetches covers, so a Subsonic album/artist
+        // container's reference must be dropped (null), never leaked unloadable.
+        final c = FakePlaybackController();
+        final h = handlerWith(
+          c,
+          <Track>[subsonic],
+          artwork: (Uri ref) async => localArt, // must not be consulted here
+        );
+
+        final albums = await h.getChildren(MediaId.albums);
+        expect(albums, isNotEmpty);
+        for (final item in albums) {
+          expect(item.artUri, isNull);
+          expect(
+            item.artUri?.toString() ?? '',
+            isNot(contains('subsonic-cover')),
+          );
+        }
+      });
+
+      test('Jellyfin http art and local file art still pass through unchanged',
+          () async {
+        // Regression: wiring the reference resolver must not change how a
+        // platform-loadable cover (Jellyfin token-free http, a local file:) is
+        // forwarded — and the resolver must not even be consulted for them.
+        bool resolverCalled = false;
+        final jf = Track(
+          id: 'jf',
+          title: 'JF',
+          uri: 'jellyfin:jf',
+          artworkUri:
+              Uri.parse('https://music.example.com/Items/jf/Images/Primary'),
+        );
+        final loc = Track(
+          id: 'loc',
+          title: 'Loc',
+          uri: '/music/loc.mp3',
+          artworkUri: Uri.parse('file:///cache/linthra_local_artwork/loc.img'),
+        );
+        final c = FakePlaybackController();
+        final h = handlerWith(
+          c,
+          <Track>[jf, loc],
+          artwork: (Uri ref) async {
+            resolverCalled = true;
+            return Uri.parse('file:///should/not/be/used.img');
+          },
+        );
+
+        await c.playTracks(<Track>[jf, loc]);
+        await _settle();
+        await _settle();
+
+        // Jellyfin token-free http art is used as-is.
+        expect(
+          h.mediaItem.value?.artUri,
+          Uri.parse('https://music.example.com/Items/jf/Images/Primary'),
+        );
+        // The local file: art rides on its queue row unchanged.
+        final locRow = h.queue.value.firstWhere((i) => i.id == 'loc');
+        expect(
+          locRow.artUri,
+          Uri.parse('file:///cache/linthra_local_artwork/loc.img'),
+        );
+        // The reference resolver is never consulted for platform-loadable art.
+        expect(resolverCalled, isFalse);
+      });
+
+      test('fetches the cover at most once despite re-broadcasts', () async {
+        int calls = 0;
+        final c = FakePlaybackController();
+        final h = handlerWith(
+          c,
+          <Track>[subsonic],
+          artwork: (Uri ref) async {
+            calls++;
+            return localArt;
+          },
+        );
+
+        await c.playTracks(<Track>[subsonic]);
+        await _settle();
+        await _settle();
+        // A seek (a large position jump) forces a playback re-push; a small tick
+        // does not. Neither must re-fetch the already-resolved cover.
+        c.emit(c.state.copyWith(position: const Duration(seconds: 30)));
+        await _settle();
+        c.emit(c.state.copyWith(position: const Duration(seconds: 31)));
+        await _settle();
+
+        expect(calls, 1);
+        expect(h.mediaItem.value?.artUri, localArt);
+      });
+    });
   });
 }

--- a/test/core/services/media_artwork_cache_test.dart
+++ b/test/core/services/media_artwork_cache_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/services/media_artwork_cache.dart';
+import 'package:linthra/core/services/media_artwork_content_uri.dart';
 import 'package:path/path.dart' as p;
 
 /// A credential-free Subsonic cover reference (what the catalog persists).
@@ -39,8 +40,13 @@ void main() {
     return cacheDir.listSync(recursive: true).whereType<File>().toList();
   }
 
+  /// The on-disk cache file a returned `content://` URI points at (its last path
+  /// segment is the hashed filename, written under [cacheDir]).
+  File fileFor(Uri contentUri) =>
+      File(p.join(cacheDir.path, contentUri.pathSegments.last));
+
   group('MediaArtworkCache.resolve', () {
-    test('fetches the cover and returns a local file: URI holding the bytes',
+    test('fetches the cover and returns a content:// URI over the cached bytes',
         () async {
       Uri? fetchedUrl;
       final cache = MediaArtworkCache(
@@ -56,15 +62,20 @@ void main() {
       final Uri? result = await cache.resolve(_reference);
 
       expect(result, isNotNull);
-      expect(result!.isScheme('file'), isTrue);
-      final File file = File(result.toFilePath());
+      // A FileProvider content:// URI the platform session can read — not a
+      // file: path (which Android Auto's process couldn't read).
+      expect(result!.isScheme('content'), isTrue);
+      expect(result.host, kMediaArtworkAuthority);
+      expect(result.pathSegments.first, kMediaArtworkPathName);
+      // The bytes are on disk under the private cache dir.
+      final File file = fileFor(result);
       expect(await file.exists(), isTrue);
       expect(await file.readAsBytes(), _imageBytes);
       // The authenticated URL was used once, only to fetch.
       expect(fetchedUrl, _authUrl);
     });
 
-    test('the cache filename carries no credential, server URL, or auth query',
+    test('the content URI carries no credential, server URL, or auth query',
         () async {
       final cache = MediaArtworkCache(
         resolveUrl: (Uri reference) => _authUrl,
@@ -73,7 +84,8 @@ void main() {
       );
 
       final Uri? result = await cache.resolve(_reference);
-      final String name = p.basename(result!.toFilePath()).toLowerCase();
+      final String uri = result!.toString().toLowerCase();
+      final String name = result.pathSegments.last;
 
       for (final String secret in <String>[
         'alice',
@@ -88,13 +100,13 @@ void main() {
         'http',
         'view',
       ]) {
-        expect(name, isNot(contains(secret.toLowerCase())),
-            reason: 'cache filename leaked "$secret"');
+        expect(uri, isNot(contains(secret.toLowerCase())),
+            reason: 'content URI leaked "$secret"');
       }
-      // It is exactly the SHA-256 of the *credential-free* reference + `.img`.
+      // The filename is exactly the SHA-256 of the *credential-free* reference.
       final String expected =
           '${sha256.convert(utf8.encode(_reference.toString()))}.img';
-      expect(p.basename(result.toFilePath()), expected);
+      expect(name, expected);
     });
 
     test('never persists the authenticated URL in the cached bytes or path',
@@ -107,8 +119,8 @@ void main() {
 
       final Uri? result = await cache.resolve(_reference);
 
-      // The returned URI and the file path are credential-free.
-      final String full = '${result!}\n${result.toFilePath()}'.toLowerCase();
+      // The returned content URI and the on-disk file path are credential-free.
+      final String full = '${result!}\n${fileFor(result).path}'.toLowerCase();
       expect(full, isNot(contains('the-secret-token')));
       expect(full, isNot(contains('the-salt')));
       expect(full, isNot(contains('getcoverart')));
@@ -225,8 +237,10 @@ void main() {
       );
 
       final Uri? result = await cache.resolve(_reference);
-      expect(result, seeded.uri);
-      // Served straight from disk: no fetch, and the credential was never read.
+      // Reused straight from disk as the content:// URI over the seeded file.
+      expect(result, mediaArtworkContentUri(seeded));
+      expect(result!.isScheme('content'), isTrue);
+      // No fetch, and the credential was never read.
       expect(fetchCalls, 0);
     });
 
@@ -264,7 +278,7 @@ void main() {
       // Now the warmed cover is available synchronously for the media handler.
       expect(cache.cached(_reference), isNotNull);
       expect(cache.cached(_reference), resolved);
-      expect(cache.cached(_reference)!.isScheme('file'), isTrue);
+      expect(cache.cached(_reference)!.isScheme('content'), isTrue);
     });
 
     test('stays null for a reference whose fetch failed', () async {

--- a/test/core/services/media_artwork_cache_test.dart
+++ b/test/core/services/media_artwork_cache_test.dart
@@ -303,4 +303,69 @@ void main() {
       expect(cache.cached(Uri.parse('subsonic-cover:other')), isNull);
     });
   });
+
+  group('MediaArtworkCache.coverReady', () {
+    test('emits the reference the moment a cover first caches', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+      final List<Uri> ready = <Uri>[];
+      final sub = cache.coverReady.listen(ready.add);
+      addTearDown(sub.cancel);
+
+      await cache.resolve(_reference);
+      await pumpEventQueue();
+
+      // Lets a now-playing item refresh immediately instead of on the next tick.
+      expect(ready, <Uri>[_reference]);
+    });
+
+    test('does not emit when the fetch fails (no cover to show)', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => null, // failed download
+        directory: directory,
+      );
+      final List<Uri> ready = <Uri>[];
+      final sub = cache.coverReady.listen(ready.add);
+      addTearDown(sub.cancel);
+
+      await cache.resolve(_reference);
+      await pumpEventQueue();
+
+      expect(ready, isEmpty);
+    });
+
+    test('emits once even across repeat resolves (a memo hit never re-emits)',
+        () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+      final List<Uri> ready = <Uri>[];
+      final sub = cache.coverReady.listen(ready.add);
+      addTearDown(sub.cancel);
+
+      await cache.resolve(_reference);
+      await cache.resolve(_reference); // served from the memo — no re-emit
+      await pumpEventQueue();
+
+      expect(ready, <Uri>[_reference]);
+    });
+
+    test('a late emit after dispose does not throw', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+      await cache.dispose();
+      // resolve still works (writes the file) and must not throw on the closed
+      // ready controller.
+      expect(await cache.resolve(_reference), isNotNull);
+    });
+  });
 }

--- a/test/core/services/media_artwork_cache_test.dart
+++ b/test/core/services/media_artwork_cache_test.dart
@@ -1,0 +1,250 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/media_artwork_cache.dart';
+import 'package:path/path.dart' as p;
+
+/// A credential-free Subsonic cover reference (what the catalog persists).
+final Uri _reference = Uri.parse('subsonic-cover:al-123');
+
+/// The authenticated getCoverArt URL the live session would mint — it carries
+/// the username, salt, and token, and must never end up in a filename or be
+/// returned/persisted by the cache.
+final Uri _authUrl = Uri.parse(
+  'https://music.example.com/rest/getCoverArt.view'
+  '?id=al-123&u=alice&t=the-secret-token&s=the-salt&v=1.16.1&c=Linthra&f=json',
+);
+
+const List<int> _imageBytes = <int>[0x89, 0x50, 0x4E, 0x47, 1, 2, 3, 4];
+
+void main() {
+  late Directory tempRoot;
+  late Directory cacheDir;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('media_artwork_cache');
+    cacheDir = Directory(p.join(tempRoot.path, 'media_session_artwork'));
+  });
+
+  tearDown(() async {
+    if (await tempRoot.exists()) await tempRoot.delete(recursive: true);
+  });
+
+  Future<Directory> directory() async => cacheDir;
+
+  List<File> cachedFiles() {
+    if (!cacheDir.existsSync()) return <File>[];
+    return cacheDir.listSync(recursive: true).whereType<File>().toList();
+  }
+
+  group('MediaArtworkCache.resolve', () {
+    test('fetches the cover and returns a local file: URI holding the bytes',
+        () async {
+      Uri? fetchedUrl;
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) =>
+            reference == _reference ? _authUrl : null,
+        fetch: (Uri url) async {
+          fetchedUrl = url;
+          return _imageBytes;
+        },
+        directory: directory,
+      );
+
+      final Uri? result = await cache.resolve(_reference);
+
+      expect(result, isNotNull);
+      expect(result!.isScheme('file'), isTrue);
+      final File file = File(result.toFilePath());
+      expect(await file.exists(), isTrue);
+      expect(await file.readAsBytes(), _imageBytes);
+      // The authenticated URL was used once, only to fetch.
+      expect(fetchedUrl, _authUrl);
+    });
+
+    test('the cache filename carries no credential, server URL, or auth query',
+        () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+
+      final Uri? result = await cache.resolve(_reference);
+      final String name = p.basename(result!.toFilePath()).toLowerCase();
+
+      for (final String secret in <String>[
+        'alice',
+        'the-secret-token',
+        'the-salt',
+        'music.example.com',
+        'getcoverart',
+        'rest',
+        'u=',
+        't=',
+        's=',
+        'http',
+        'view',
+      ]) {
+        expect(name, isNot(contains(secret.toLowerCase())),
+            reason: 'cache filename leaked "$secret"');
+      }
+      // It is exactly the SHA-256 of the *credential-free* reference + `.img`.
+      final String expected =
+          '${sha256.convert(utf8.encode(_reference.toString()))}.img';
+      expect(p.basename(result.toFilePath()), expected);
+    });
+
+    test('never persists the authenticated URL in the cached bytes or path',
+        () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+
+      final Uri? result = await cache.resolve(_reference);
+
+      // The returned URI and the file path are credential-free.
+      final String full = '${result!}\n${result.toFilePath()}'.toLowerCase();
+      expect(full, isNot(contains('the-secret-token')));
+      expect(full, isNot(contains('the-salt')));
+      expect(full, isNot(contains('getcoverart')));
+    });
+
+    test('a signed-out reference (null URL) yields null without fetching',
+        () async {
+      int fetchCalls = 0;
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => null, // signed out / not resolvable
+        fetch: (Uri url) async {
+          fetchCalls++;
+          return _imageBytes;
+        },
+        directory: directory,
+      );
+
+      expect(await cache.resolve(_reference), isNull);
+      expect(fetchCalls, 0);
+      expect(cachedFiles(), isEmpty);
+    });
+
+    test('a failed download yields null and writes no file', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => null, // transport error / non-image body
+        directory: directory,
+      );
+
+      expect(await cache.resolve(_reference), isNull);
+      expect(cachedFiles(), isEmpty);
+    });
+
+    test('an empty body yields null', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => const <int>[],
+        directory: directory,
+      );
+
+      expect(await cache.resolve(_reference), isNull);
+      expect(cachedFiles(), isEmpty);
+    });
+
+    test('a fetch that throws resolves to null (never blocks the caller)',
+        () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => throw const SocketException('offline'),
+        directory: directory,
+      );
+
+      expect(await cache.resolve(_reference), isNull);
+    });
+
+    test('a second resolve reuses the cached file without re-fetching',
+        () async {
+      int fetchCalls = 0;
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async {
+          fetchCalls++;
+          return _imageBytes;
+        },
+        directory: directory,
+      );
+
+      final Uri? first = await cache.resolve(_reference);
+      final Uri? second = await cache.resolve(_reference);
+
+      expect(second, first);
+      expect(fetchCalls, 1);
+    });
+
+    test('concurrent resolves share a single fetch', () async {
+      int fetchCalls = 0;
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async {
+          fetchCalls++;
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return _imageBytes;
+        },
+        directory: directory,
+      );
+
+      final List<Uri?> results = await Future.wait(<Future<Uri?>>[
+        cache.resolve(_reference),
+        cache.resolve(_reference),
+      ]);
+
+      expect(results[0], isNotNull);
+      expect(results[0], results[1]);
+      expect(fetchCalls, 1);
+    });
+
+    test('a pre-existing cache file is reused on a cold cache (disk hit)',
+        () async {
+      // Pre-write the file as if a previous run had cached it.
+      final String key =
+          sha256.convert(utf8.encode(_reference.toString())).toString();
+      await cacheDir.create(recursive: true);
+      final File seeded = File(p.join(cacheDir.path, '$key.img'));
+      await seeded.writeAsBytes(_imageBytes, flush: true);
+
+      int fetchCalls = 0;
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async {
+          fetchCalls++;
+          return _imageBytes;
+        },
+        directory: directory,
+      );
+
+      final Uri? result = await cache.resolve(_reference);
+      expect(result, seeded.uri);
+      // Served straight from disk: no fetch, and the credential was never read.
+      expect(fetchCalls, 0);
+    });
+
+    test('a failed download can be retried (no negative caching)', () async {
+      int attempt = 0;
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async {
+          attempt++;
+          return attempt == 1 ? null : _imageBytes; // first fails, then works
+        },
+        directory: directory,
+      );
+
+      expect(await cache.resolve(_reference), isNull);
+      final Uri? retried = await cache.resolve(_reference);
+      expect(retried, isNotNull);
+      expect(attempt, 2);
+    });
+  });
+}

--- a/test/core/services/media_artwork_cache_test.dart
+++ b/test/core/services/media_artwork_cache_test.dart
@@ -247,4 +247,46 @@ void main() {
       expect(attempt, 2);
     });
   });
+
+  group('MediaArtworkCache.cached', () {
+    test('is null before a reference is resolved, then the cached file after',
+        () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+
+      // Synchronous, side-effect-free: nothing fetched yet.
+      expect(cache.cached(_reference), isNull);
+
+      final Uri? resolved = await cache.resolve(_reference);
+      // Now the warmed cover is available synchronously for the media handler.
+      expect(cache.cached(_reference), isNotNull);
+      expect(cache.cached(_reference), resolved);
+      expect(cache.cached(_reference)!.isScheme('file'), isTrue);
+    });
+
+    test('stays null for a reference whose fetch failed', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => null, // failed download
+        directory: directory,
+      );
+
+      await cache.resolve(_reference);
+      expect(cache.cached(_reference), isNull);
+    });
+
+    test('is null for a different reference than the one resolved', () async {
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+      );
+
+      await cache.resolve(_reference);
+      expect(cache.cached(Uri.parse('subsonic-cover:other')), isNull);
+    });
+  });
 }

--- a/test/core/services/media_artwork_cache_test.dart
+++ b/test/core/services/media_artwork_cache_test.dart
@@ -3,9 +3,24 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:linthra/core/services/media_artwork_cache.dart';
 import 'package:linthra/core/services/media_artwork_content_uri.dart';
 import 'package:path/path.dart' as p;
+
+/// A stand-in HTTP client that records whether it was closed, so a test can
+/// prove the cache releases its shared client on dispose. `send` is never
+/// exercised here (the tests inject `fetch`).
+class _RecordingHttpClient extends http.BaseClient {
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+
+  @override
+  void close() => closed = true;
+}
 
 /// A credential-free Subsonic cover reference (what the catalog persists).
 final Uri _reference = Uri.parse('subsonic-cover:al-123');
@@ -366,6 +381,25 @@ void main() {
       // resolve still works (writes the file) and must not throw on the closed
       // ready controller.
       expect(await cache.resolve(_reference), isNotNull);
+    });
+  });
+
+  group('MediaArtworkCache shared HTTP client', () {
+    test('is reused across fetches and closed on dispose', () async {
+      // The shared client lets the sequential pre-warm reuse the connection
+      // (keep-alive) instead of a fresh TLS handshake per cover; dispose releases
+      // it so no connection is leaked.
+      final client = _RecordingHttpClient();
+      final cache = MediaArtworkCache(
+        resolveUrl: (Uri reference) => _authUrl,
+        fetch: (Uri url) async => _imageBytes,
+        directory: directory,
+        httpClient: client,
+      );
+
+      expect(client.closed, isFalse);
+      await cache.dispose();
+      expect(client.closed, isTrue);
     });
   });
 }

--- a/test/core/services/media_artwork_content_uri_test.dart
+++ b/test/core/services/media_artwork_content_uri_test.dart
@@ -57,4 +57,57 @@ void main() {
       expect(kMediaArtworkPathName, 'media_artwork');
     });
   });
+
+  // The Dart content:// URI is hand-built to match the native FileProvider, so
+  // the manifest provider + the granting subclass must stay in lockstep with the
+  // Dart constants. A drift would make audio_service / Android Auto unable to
+  // resolve or read the cover, silently breaking the feature — these guard it.
+  group('the native FileProvider + grant match the Dart side', () {
+    late String manifest;
+
+    setUpAll(() {
+      manifest =
+          File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+    });
+
+    test('the manifest provider uses the matching authority', () {
+      expect(
+          manifest, contains('android:authorities="$kMediaArtworkAuthority"'));
+    });
+
+    test('the manifest binds the granting subclass, not the plain FileProvider',
+        () {
+      // The plain androidx FileProvider would leave the content:// URI unreadable
+      // from Android Auto's / SystemUI's process; the subclass grants them read
+      // access, which is the whole point.
+      expect(manifest, contains('android:name=".MediaArtworkFileProvider"'));
+      expect(
+        manifest,
+        isNot(contains('android:name="androidx.core.content.FileProvider"')),
+      );
+    });
+
+    test('the provider stays non-exported with uri-permission grants enabled',
+        () {
+      // exported="false" keeps it non-public; grantUriPermissions="true" is what
+      // lets the explicit per-URI read grants to the media hosts take effect.
+      expect(manifest, contains('android:exported="false"'));
+      expect(manifest, contains('android:grantUriPermissions="true"'));
+    });
+
+    test('the granting subclass grants READ-ONLY and never write', () {
+      final File provider = File(
+        'android/app/src/main/kotlin/io/github/thezupzup/linthra/'
+        'MediaArtworkFileProvider.kt',
+      );
+      expect(provider.existsSync(), isTrue,
+          reason: 'MediaArtworkFileProvider.kt must exist for the grant');
+      final String src = provider.readAsStringSync();
+      expect(src, contains('package io.github.thezupzup.linthra'));
+      expect(src, contains(': FileProvider()'));
+      // Read access only — never write — and only ever for these cover URIs.
+      expect(src, contains('FLAG_GRANT_READ_URI_PERMISSION'));
+      expect(src, isNot(contains('FLAG_GRANT_WRITE_URI_PERMISSION')));
+    });
+  });
 }

--- a/test/core/services/media_artwork_content_uri_test.dart
+++ b/test/core/services/media_artwork_content_uri_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/media_artwork_content_uri.dart';
+
+void main() {
+  group('mediaArtworkContentUri', () {
+    test('maps a cached file to a content:// URI under the FileProvider', () {
+      final file = File('/data/user/0/io.github.thezupzup.linthra/cache/'
+          'media_session_artwork/abc123.img');
+
+      final Uri uri = mediaArtworkContentUri(file);
+
+      expect(uri.scheme, 'content');
+      expect(uri.host, kMediaArtworkAuthority);
+      // <provider-name>/<filename> — the platform reads this through the session.
+      expect(uri.pathSegments, <String>[kMediaArtworkPathName, 'abc123.img']);
+      expect(
+        uri.toString(),
+        'content://io.github.thezupzup.linthra.mediaartwork/'
+        'media_artwork/abc123.img',
+      );
+    });
+
+    test('carries only the hashed filename — no directory, credential, or URL',
+        () {
+      // Even if the file lives under a path with sensitive-looking segments,
+      // only the basename (a hash) reaches the URI.
+      final file = File('/cache/media_session_artwork/'
+          'deadbeefcafe0123456789.img');
+
+      final Uri uri = mediaArtworkContentUri(file);
+      final String text = uri.toString().toLowerCase();
+
+      // The directory is dropped; only provider name + hashed basename remain.
+      expect(uri.pathSegments.last, 'deadbeefcafe0123456789.img');
+      for (final String secret in <String>[
+        'getcoverart',
+        'token',
+        'salt',
+        'u=',
+        't=',
+        's=',
+        'http',
+        'password',
+      ]) {
+        expect(text, isNot(contains(secret)),
+            reason: 'content URI leaked "$secret"');
+      }
+    });
+
+    test('the authority is fixed (debug == release, matches the manifest)', () {
+      // A hard-coded authority — independent of applicationId/build flavor — so
+      // it always matches android:authorities in AndroidManifest.xml.
+      expect(
+          kMediaArtworkAuthority, 'io.github.thezupzup.linthra.mediaartwork');
+      expect(kMediaArtworkPathName, 'media_artwork');
+    });
+  });
+}

--- a/test/core/services/media_artwork_prewarm_service_test.dart
+++ b/test/core/services/media_artwork_prewarm_service_test.dart
@@ -174,6 +174,71 @@ void main() {
     await _settle();
     expect(warmed, isEmpty);
   });
+
+  test('warms a newly now-playing cover ahead of an earlier look-ahead',
+      () async {
+    // Priority: when the track changes while a previous batch's look-ahead is
+    // still pending, the new now-playing cover jumps ahead of it.
+    final gate = Completer<void>();
+    final order = <String>[];
+    final service = MediaArtworkPrewarmService(
+      playbackStates: states.stream,
+      lookahead: 3,
+      warm: (Uri reference) async {
+        final String id = reference.pathSegments.first;
+        order.add(id);
+        if (id == 'al-a') await gate.future; // hold the first warm in-flight
+        return Uri.parse('content://x/$id.img');
+      },
+    );
+    addTearDown(service.dispose);
+
+    // Batch 1: a (now-playing) starts warming and blocks; b is queued behind it.
+    states.add(_playing(
+      current: _subsonic('a', 'al-a'),
+      upNext: <Track>[_subsonic('b', 'al-b')],
+    ));
+    await _settle();
+    // Batch 2: skip to x — its cover must jump ahead of the still-pending b.
+    states.add(_playing(current: _subsonic('x', 'al-x')));
+    await _settle();
+    gate.complete(); // let the held first warm finish; the drain proceeds
+    await _settle();
+    await _settle();
+
+    // a was already in-flight; x (the new now-playing) warmed before b.
+    expect(order, <String>['al-a', 'al-x', 'al-b']);
+  });
+
+  test('retries a failed warm on a later queue change', () async {
+    int attemptsForA = 0;
+    final service = MediaArtworkPrewarmService(
+      playbackStates: states.stream,
+      lookahead: 1,
+      warm: (Uri reference) async {
+        if (reference == Uri.parse('subsonic-cover:al-a')) {
+          attemptsForA++;
+          // First attempt fails (transient), later attempts succeed.
+          return attemptsForA == 1 ? null : Uri.parse('content://x/a.img');
+        }
+        return Uri.parse('content://x/${reference.pathSegments.first}.img');
+      },
+    );
+    addTearDown(service.dispose);
+
+    states.add(_playing(current: _subsonic('a', 'al-a')));
+    await _settle();
+    expect(attemptsForA, 1); // failed and was dropped from the warmed set
+
+    // A queue change re-evaluates; al-a (still now-playing) retries rather than
+    // staying coverless for the session.
+    states.add(_playing(
+      current: _subsonic('a', 'al-a'),
+      upNext: <Track>[_subsonic('b', 'al-b')],
+    ));
+    await _settle();
+    expect(attemptsForA, 2); // retried
+  });
 }
 
 /// A throwable stand-in so the failure test doesn't depend on dart:io.

--- a/test/core/services/media_artwork_prewarm_service_test.dart
+++ b/test/core/services/media_artwork_prewarm_service_test.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/media_artwork_prewarm_service.dart';
+
+Track _subsonic(String id, String coverId) => Track(
+      id: id,
+      title: 'Song $id',
+      uri: 'subsonic:$id',
+      artworkUri: Uri.parse('subsonic-cover:$coverId'),
+    );
+
+PlaybackState _playing(
+        {Track? current, List<Track> upNext = const <Track>[]}) =>
+    PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: current,
+      upNext: upNext,
+    );
+
+/// Lets a state pushed onto the controller stream reach the service's listener
+/// and its sequential drain run before assertions.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  late StreamController<PlaybackState> states;
+  late List<Uri> warmed;
+
+  setUp(() {
+    states = StreamController<PlaybackState>.broadcast();
+    warmed = <Uri>[];
+  });
+
+  tearDown(() => states.close());
+
+  MediaArtworkPrewarmService serviceWith({
+    int lookahead = 3,
+    Future<Uri?> Function(Uri reference)? warm,
+  }) {
+    final service = MediaArtworkPrewarmService(
+      playbackStates: states.stream,
+      lookahead: lookahead,
+      warm: warm ??
+          (Uri reference) async {
+            warmed.add(reference);
+            return Uri.parse('file:///cache/${reference.pathSegments.first}');
+          },
+    );
+    addTearDown(service.dispose);
+    return service;
+  }
+
+  test('warms the now-playing cover and the look-ahead up-next covers',
+      () async {
+    serviceWith(lookahead: 2);
+
+    states.add(_playing(
+      current: _subsonic('a', 'al-a'),
+      upNext: <Track>[
+        _subsonic('b', 'al-b'),
+        _subsonic('c', 'al-c'),
+        _subsonic('d', 'al-d'), // beyond the look-ahead of 2
+      ],
+    ));
+    await _settle();
+
+    expect(warmed, <Uri>[
+      Uri.parse('subsonic-cover:al-a'),
+      Uri.parse('subsonic-cover:al-b'),
+      Uri.parse('subsonic-cover:al-c'),
+    ]);
+  });
+
+  test('skips platform-loadable covers (Jellyfin http, local file) and nulls',
+      () async {
+    serviceWith();
+
+    states.add(_playing(
+      current: Track(
+        id: 'jf',
+        title: 'JF',
+        uri: 'jellyfin:jf',
+        artworkUri: Uri.parse('https://music.example.com/Items/jf/Images/1'),
+      ),
+      upNext: <Track>[
+        Track(
+          id: 'loc',
+          title: 'Loc',
+          uri: '/loc.mp3',
+          artworkUri: Uri.parse('file:///cache/loc.img'),
+        ),
+        const Track(id: 'none', title: 'None', uri: 'subsonic:none'), // no art
+        _subsonic('sub', 'al-sub'),
+      ],
+    ));
+    await _settle();
+
+    // Only the credential-free reference is warmed; http/file/no-art are skipped.
+    expect(warmed, <Uri>[Uri.parse('subsonic-cover:al-sub')]);
+  });
+
+  test('warms each reference at most once across position ticks', () async {
+    serviceWith();
+
+    final Track current = _subsonic('a', 'al-a');
+    final List<Track> up = <Track>[_subsonic('b', 'al-b')];
+    states.add(_playing(current: current, upNext: up));
+    await _settle();
+    // Pure position/status ticks (same tracks) must not re-warm.
+    states.add(_playing(current: current, upNext: up));
+    states.add(_playing(current: current, upNext: up));
+    await _settle();
+
+    expect(warmed, <Uri>[
+      Uri.parse('subsonic-cover:al-a'),
+      Uri.parse('subsonic-cover:al-b'),
+    ]);
+  });
+
+  test('warms a newly-surfaced cover when the queue advances', () async {
+    serviceWith(lookahead: 1);
+
+    states.add(_playing(
+      current: _subsonic('a', 'al-a'),
+      upNext: <Track>[_subsonic('b', 'al-b')],
+    ));
+    await _settle();
+    // Advance: b is now current, c surfaces as the next up-next.
+    states.add(_playing(
+      current: _subsonic('b', 'al-b'),
+      upNext: <Track>[_subsonic('c', 'al-c')],
+    ));
+    await _settle();
+
+    // a + b from the first state, then only the new c (b isn't re-warmed).
+    expect(warmed, <Uri>[
+      Uri.parse('subsonic-cover:al-a'),
+      Uri.parse('subsonic-cover:al-b'),
+      Uri.parse('subsonic-cover:al-c'),
+    ]);
+  });
+
+  test('a warm that fails or throws never breaks the service', () async {
+    int attempts = 0;
+    serviceWith(
+      warm: (Uri reference) async {
+        attempts++;
+        if (attempts == 1) return null; // a failed fetch
+        if (attempts == 2) throw const SocketExceptionStub(); // a thrown error
+        warmed.add(reference);
+        return Uri.parse('file:///ok');
+      },
+    );
+
+    states.add(_playing(
+      current: _subsonic('a', 'al-a'),
+      upNext: <Track>[_subsonic('b', 'al-b'), _subsonic('c', 'al-c')],
+    ));
+    // Must not throw out of the listener / drain.
+    await _settle();
+    await _settle();
+
+    // The first two outcomes (null, throw) are swallowed; the drain continues to
+    // the third reference.
+    expect(attempts, 3);
+    expect(warmed, <Uri>[Uri.parse('subsonic-cover:al-c')]);
+  });
+
+  test('does nothing when there is no current track', () async {
+    serviceWith();
+    states.add(_playing()); // idle: no current, no up-next
+    await _settle();
+    expect(warmed, isEmpty);
+  });
+}
+
+/// A throwable stand-in so the failure test doesn't depend on dart:io.
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+}

--- a/test/core/sources/subsonic/subsonic_artwork_test.dart
+++ b/test/core/sources/subsonic/subsonic_artwork_test.dart
@@ -94,6 +94,25 @@ void main() {
       expect(resolved.path, isNot(contains('the-salt')));
     });
 
+    test('forwards a size so the media session gets a server-scaled cover', () {
+      final Uri resolved = SubsonicArtwork.resolve(
+        SubsonicArtwork.reference('al-1'),
+        _session,
+        size: 512,
+      )!;
+      expect(resolved.queryParameters['id'], 'al-1');
+      expect(resolved.queryParameters['size'], '512');
+      // Still credential-free in the path, exactly like the full-size resolve.
+      expect(resolved.path, isNot(contains('the-secret-token')));
+      expect(resolved.path, isNot(contains('the-salt')));
+    });
+
+    test('omits size by default (the in-app render stays full-size)', () {
+      final Uri resolved =
+          SubsonicArtwork.resolve(SubsonicArtwork.reference('al-1'), _session)!;
+      expect(resolved.queryParameters.containsKey('size'), isFalse);
+    });
+
     test('returns null for a non-reference uri so other covers pass through',
         () {
       // Jellyfin's already-loadable http URL must not be rewritten.

--- a/test/core/sources/subsonic/subsonic_endpoints_test.dart
+++ b/test/core/sources/subsonic/subsonic_endpoints_test.dart
@@ -106,6 +106,21 @@ void main() {
       expect(uri.path, isNot(contains(_creds.salt)));
     });
 
+    test('coverArt requests a server-scaled cover when size is given', () {
+      final Uri uri = SubsonicEndpoints.coverArt(
+        _base,
+        username: _user,
+        credentials: _creds,
+        coverArtId: 'al-123',
+        size: 512,
+      );
+      // The media session wants a small, fast-to-decode cover; the server scales
+      // it via getCoverArt's size parameter (the path stays credential-free).
+      expect(uri.queryParameters['id'], 'al-123');
+      expect(uri.queryParameters['size'], '512');
+      expect(uri.path, '/rest/getCoverArt.view');
+    });
+
     test('getLyricsBySongId targets its endpoint and carries the song id', () {
       final Uri uri = SubsonicEndpoints.getLyricsBySongId(
         _base,


### PR DESCRIPTION
## What & why

PR #170 made Subsonic/Navidrome cover art show **inside the app** by storing a credential-free `subsonic-cover:<id>` reference and resolving the authenticated `getCoverArt` URL only at render time. But the **platform media session** (lock screen / Android Auto now-playing card) loads `MediaItem.artUri` itself — in a place that render-time resolver can't reach, and where a credentialed URL must never go — so Subsonic art was still absent there.

This adds now-playing media-session artwork for Subsonic/Navidrome **without weakening the privacy model**: Linthra fetches the cover itself and hands the session only a safe local `file:`.

## How

- **New `MediaArtworkCache`** (`lib/core/services/media_artwork_cache.dart`): turns a credential-free reference into a private cached image. It mints the authenticated `getCoverArt` URL on demand (live session salt+token), fetches the bytes itself, and writes them to an app-private file under the OS cache dir. The cache key — and therefore the filename — is a **SHA-256 of the credential-free reference**, never the username, salt, token, server URL, or auth query. The authenticated URL is used once to fetch and **never returned, persisted, or logged**; only `image/*` 2xx bodies are kept. Any failure yields `null` (never throws).
- **`LinthraAudioHandler`** gains a `MediaArtworkResolver` seam. `MediaItem.artUri` is now computed through `_sessionArtUri`: a platform-loadable cover (Jellyfin token-free http, a local `file:`) passes through unchanged; a credential-free reference becomes its cached local `file:` **or null** — so an unloadable reference, and crucially **never** a credentialed URL, reaches the session. The now-playing track kicks off at most one fetch per cover, **off the playback path**, and re-broadcasts on success; a failure leaves the card art-less and never blocks playback.
- **`main`** wires the cache to the live Subsonic session.

## Privacy / security invariants held

- ✅ Never put username/password/salt/token/API key or the authenticated `getCoverArt` URL into `MediaItem.artUri`.
- ✅ Never persist authenticated cover URLs in the catalog DB (`Track.artworkUri` stays `subsonic-cover:<id>`).
- ✅ Never log authenticated cover URLs (fetch swallows errors silently; the Android Auto trace is unchanged and category-only).
- ✅ No credential in cache filenames, media metadata, diagnostics, or DB fields.
- ✅ Cast unchanged — Subsonic cast still omits artwork; Jellyfin cast still sends its token-free URL.
- ✅ Safe artwork can't be generated → fall back to **no artwork**, never a leak.

## Scope

- No change to audio playback behavior.
- Jellyfin artwork and local embedded artwork pass through **unchanged**.
- The in-app PR #170 resolver (`artworkImageProvider` / `installArtworkReferenceResolver`) is **untouched**.
- No new storage permissions (app-private OS cache dir; `file:` loaded in-process by `audio_service`).
- No version bump, tags, or fdroiddata edits.

## Tests

New `media_artwork_cache_test.dart` + an extended `linthra_audio_handler_test.dart` cover:

- a `subsonic-cover:<id>` reference becomes a safe local `file:` holding the fetched bytes;
- the cache filename / returned URI carry no credential, server URL, or auth query (asserted explicitly);
- signed-out / failed / empty / throwing fetches fall back to `null` without writing a file or blocking playback;
- disk reuse and concurrent-fetch dedup;
- the now-playing item shows the local cover while the reference and credential never reach `artUri`;
- without a resolver, a `subsonic-cover:` reference is dropped (never leaked) from `artUri`;
- Jellyfin http art and local file art still pass through unchanged, and the resolver isn't even consulted for them;
- browse-tree containers drop an unresolved reference.

Full suite: **1674 passing**, `flutter analyze` clean, `dart format` clean, secret-scan clean.

Targeted to be safe for the `v0.1.4` hotfix.

https://claude.ai/code/session_01BLf35327oj8ArATZeJkZkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLf35327oj8ArATZeJkZkH)_