### PR TITLE
chore(release): prepare v0.1.4

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/104999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/104999.txt
@@ -1,0 +1,15 @@
+Linthra 0.1.4 — Navidrome/Subsonic cover art hotfix.
+
+Fixed:
+- Navidrome/Subsonic cover art now displays across the app.
+- Navidrome/Subsonic cover art now displays in Android Auto / media
+  session, using a privacy-safe local artwork path.
+- Android Auto artwork is handled without exposing tokens, salts,
+  passwords, usernames, server URLs, or authenticated cover URLs.
+
+Notes:
+- Jellyfin artwork still works.
+- Local embedded artwork still works.
+- Cast behavior is unchanged.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.3';
+  static const String _devVersionName = '0.1.4';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.3+103999
+version: 0.1.4+104999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Release prep: Linthra v0.1.4 — Navidrome/Subsonic cover art hotfix

Prepares the **`v0.1.4`** release. Precondition satisfied: **PR #172 is merged into `main`** (`main` is at the #172 merge commit `1403fc8`), so this branch already carries both cover-art fixes from #170 and #172.

This is a focused, **version-only** bump — no source/UI/behavior changes ride along.

### Version bump → `0.1.4+104999`

The three files a Linthra release bump touches (`docs/release-process.md` §3), mirroring the v0.1.3 bump (#168):

| File | Change |
| --- | --- |
| `pubspec.yaml` | `version: 0.1.3+103999` → `0.1.4+104999` |
| `lib/core/app_info.dart` | `_devVersionName` `0.1.3` → `0.1.4` (in-app version mirror) |
| `fastlane/metadata/android/en-US/changelogs/104999.txt` | new (F-Droid "What's New") |

`104999` is the canonical encoding of `0.1.4` from `tool/version_from_tag.dart` (`MINOR*100000 + PATCH*1000 + 999`); confirmed by `./scripts/release_preflight.sh v0.1.4`.

### What ships in v0.1.4

- ✅ In-app Navidrome/Subsonic cover art fix (#170)
- ✅ Android Auto / media-session Navidrome/Subsonic artwork fix (#172)
- ✅ Privacy-safe `content://` FileProvider artwork path
- ✅ No credential leaks — no tokens, salts, passwords, usernames, server URLs, or authenticated cover URLs exposed
- ✅ No playback behavior changes beyond the artwork / media-session fix

### Release notes (for the GitHub Release, to be written at publish time)

> **Linthra v0.1.4 — Navidrome/Subsonic cover art hotfix**
>
> **Fixed:**
> - Navidrome/Subsonic cover art now displays across the app.
> - Navidrome/Subsonic cover art now displays in Android Auto / media session using a privacy-safe local artwork path.
> - Android Auto artwork is handled without exposing tokens, salts, passwords, usernames, server URLs, or authenticated cover URLs.
>
> **Notes:**
> - Jellyfin artwork still works.
> - Local embedded artwork still works.
> - Cast behavior is unchanged.
> - No ads, no tracking, no analytics, no telemetry.

### Verification

Ran the full CI-equivalent suite locally against Flutter `3.27.4` / Dart `3.6.2` (the pinned `.flutter-version`):

| Check | Result |
| --- | --- |
| `flutter pub get --enforce-lockfile` | ✅ in sync |
| `dart format --set-exit-if-changed .` | ✅ 527 files, 0 changed |
| `flutter analyze` | ✅ No issues found |
| `flutter test` (full suite) | ✅ **1705 passed** |
| Release guardrails (`app_info_version`, `release_changelog`, `fdroid_release_guardrails`, `version_from_tag`) | ✅ 39 passed |
| `./scripts/check_secrets.sh` (secret & privacy scan) | ✅ passed |
| `./scripts/release_preflight.sh v0.1.4` | ✅ matches `pubspec.yaml 0.1.4+104999` |
| Android APK build | ⚠️ see note below — verified by CI on this PR |

> **Android APK build note.** A local Android build isn't possible in this remote environment: the network policy blocks `dl.google.com` and `maven.google.com` (`403 host_not_allowed`), so the Android SDK and the Android Gradle Plugin / androidx dependencies can't be fetched, and no SDK is pre-installed. The **`Android Debug APK` CI workflow (`android-debug-apk.yml`) builds and verifies the debug APK on this PR**, which is the standard path for PR APK verification.

### Out of scope (intentionally)

- ❌ No git tag created — tagging `v0.1.4` stays manual, **after** this PR merges.
- ❌ No GitHub Release published.
- ❌ No `fdroiddata` edits, and no in-repo F-Droid recipe (`metadata/io.github.thezupzup.linthra.yml`) change — `AutoUpdateMode: Version` auto-detects the version from `pubspec.yaml`, so the recipe is intentionally left untouched (consistent with the v0.1.1–v0.1.3 bumps).

### After merge

`./scripts/release_preflight.sh v0.1.4` prints the next safe steps:
```
git tag -a v0.1.4 -m "Linthra 0.1.4"
git push origin v0.1.4
```
…then create the GitHub Release with the notes above.

https://claude.ai/code/session_01RkewPhTEnb17q67hFd1pgQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkewPhTEnb17q67hFd1pgQ)_