### PR TITLE
fix(player): stop self-resuming playback on audio-focus regain (v0.1.5 hotfix)

### DIFF
--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -25,6 +25,24 @@ import 'stream_interruption.dart';
 /// or authenticated stream URL.
 typedef TrackCompletionCallback = void Function(Track track);
 
+/// What the on-device engine should do in response to an audio-focus change.
+/// The outcome of [JustAudioPlaybackController.audioFocusAction], kept separate
+/// so the standard-contract decision is pure and unit-testable.
+enum AudioFocusAction {
+  /// A transient loss (a call, a notification/lock sound): pause, and resume on
+  /// the matching regain if we were playing.
+  pauseTransient,
+
+  /// A permanent loss (another media app took focus): pause and stay paused.
+  pausePermanent,
+
+  /// Focus regained — resume only if a transient loss had armed it.
+  resume,
+
+  /// Nothing to do (a duckable transient we keep playing through, or its end).
+  ignore,
+}
+
 /// [PlaybackController] backed by `just_audio`.
 ///
 /// This is the only file in the app that knows `just_audio` exists. It adapts
@@ -129,6 +147,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   StreamSubscription<AudioInterruptionEvent>? _interruptionSub;
   StreamSubscription<void>? _becomingNoisySub;
 
+  /// Whether a focus *regain* should resume playback. Armed only when a
+  /// **transient** focus loss (a call, a notification/lock sound) paused us
+  /// while we were actively playing; cleared on a permanent loss, a
+  /// becoming-noisy pause, and once consumed. So another media app taking focus,
+  /// a plain screen-on, or a track the user had paused never auto-resumes, while
+  /// a brief transient interruption to background playback recovers.
+  bool _resumeAfterTransientLoss = false;
+
   PlaybackState _state = PlaybackState.idle;
   PlaybackQueue _queue = PlaybackQueue.empty;
 
@@ -199,13 +225,15 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   }
 
   /// Takes over audio-focus handling from just_audio (disabled via
-  /// `handleInterruptions: false`) so playback never auto-resumes itself.
+  /// `handleInterruptions: false`) so playback follows the standard Android
+  /// audio-focus contract deliberately, rather than just_audio's
+  /// resume-after-any-loss behaviour.
   ///
   /// Best-effort and platform-gated: only the engine we created manages focus,
   /// and only on a real Android/iOS device — a test host or desktop has no
   /// audio_session platform, so it stays inert (and unit tests never touch the
-  /// platform channel). The pause-or-not decision is the pure
-  /// [shouldPauseForInterruption]; the loud-output guard is [_onBecomingNoisy].
+  /// platform channel). The classification is the pure [audioFocusAction]; the
+  /// loud-output guard is [_onBecomingNoisy].
   void _wireAudioFocus() {
     if (!_manageAudioFocus) return;
     if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) return;
@@ -226,55 +254,93 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     }
   }
 
-  /// Reacts to an audio-focus [event] for the on-device engine.
+  /// Reacts to an audio-focus [event] for the on-device engine, following the
+  /// standard Android contract — *not* just_audio's resume-after-any-loss.
+  ///
+  /// The crucial distinction (encoded by audio_session in the event type):
+  ///  - a **transient** loss (a call, a notification or lock sound briefly
+  ///    grabbing focus) pauses and, when focus returns, *resumes* — but only if
+  ///    we were actually playing. A momentary screen-off interruption to
+  ///    background playback recovers instead of becoming a stuck pause.
+  ///  - a **permanent** loss (another media app took focus for good) pauses and
+  ///    **stays** paused; returning to Linthra must not auto-resume.
+  ///  - a plain screen-on / app-return / exit-Doze emits *no* focus loss at all
+  ///    (focus is independent of screen state), and a bare regain with nothing
+  ///    to resume is ignored — so the screen turning on never starts playback.
   ///
   /// While suspended a cast receiver owns the audio and the engine is parked, so
-  /// a local focus change is ignored. Otherwise a real focus loss pauses and a
-  /// focus *regain* does nothing — see [shouldPauseForInterruption]. Each
-  /// outcome leaves a secret-free breadcrumb so a "music started by itself on
-  /// screen wake / leaving battery saver" report shows the regain was ignored.
+  /// a local focus change is ignored. Each branch leaves a secret-free
+  /// breadcrumb so a field report can tell exactly which event paused/resumed.
   void _onAudioInterruption(AudioInterruptionEvent event) {
     if (_suspended) return;
-    if (shouldPauseForInterruption(event)) {
-      StabilityDiagnostics.audioFocus('loss:paused');
-      unawaited(pause());
-    } else {
-      // A focus regain (interruption ended) or a transient duck: we never
-      // resume here. This is the exact point just_audio used to call play().
-      StabilityDiagnostics.audioFocus(
-        event.begin ? 'duck:ignored' : 'regain:ignored',
-      );
+    switch (audioFocusAction(event)) {
+      case AudioFocusAction.pauseTransient:
+        // Resume afterwards only if this interrupted active playback; never
+        // arm a resume for something the user had already paused.
+        _resumeAfterTransientLoss = _state.isPlaying || _state.isBusy;
+        StabilityDiagnostics.audioFocus(_resumeAfterTransientLoss
+            ? 'loss-transient:paused'
+            : 'loss-transient:already-paused');
+        unawaited(pause());
+      case AudioFocusAction.pausePermanent:
+        _resumeAfterTransientLoss = false;
+        StabilityDiagnostics.audioFocus('loss-permanent:paused');
+        unawaited(pause());
+      case AudioFocusAction.resume:
+        if (_resumeAfterTransientLoss) {
+          _resumeAfterTransientLoss = false;
+          StabilityDiagnostics.audioFocus('regain:resumed');
+          unawaited(play());
+        } else {
+          // Focus came back but the loss was permanent (or we weren't playing):
+          // the screen-wake / app-return / exit-Doze case — never auto-resume.
+          StabilityDiagnostics.audioFocus('regain:ignored');
+        }
+      case AudioFocusAction.ignore:
+        // A duckable transient (we keep playing at full volume) or its unduck.
+        StabilityDiagnostics.audioFocus(
+            event.begin ? 'duck:ignored' : 'unduck:ignored');
     }
   }
 
-  /// Whether an audio-focus [event] should pause the on-device engine.
+  /// Classifies an audio-focus [event] into the action the engine should take,
+  /// per the standard Android contract. Pure and unit-tested, so the
+  /// "screen-on never resumes / a permanent loss stays paused / a transient loss
+  /// recovers" rules can be exercised without any platform.
   ///
-  /// The whole point of owning focus ourselves: playback must NEVER resume by
-  /// itself. So this pauses on a genuine focus *loss* (another app took focus, a
-  /// call, an alarm) and returns `false` for every focus *regain*
-  /// (`event.begin == false`) — only an explicit user / media-session play
-  /// resumes. A transient duck (a brief system sound) is left to ride at full
-  /// volume rather than pausing; just_audio is no longer adjusting it, and a
-  /// momentary overlap is preferable to a surprise pause/!resume.
+  /// audio_session maps Android's focus changes onto the event type:
+  ///  - begin + `pause`   ← `AUDIOFOCUS_LOSS_TRANSIENT` (a transient loss)
+  ///  - begin + `unknown` ← `AUDIOFOCUS_LOSS` (a permanent loss; focus abandoned)
+  ///  - begin + `duck`    ← `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK`
+  ///  - end   + any       ← `AUDIOFOCUS_GAIN` (focus regained)
   @visibleForTesting
-  static bool shouldPauseForInterruption(AudioInterruptionEvent event) {
-    // Focus regained / interruption ended: do nothing. This is the exact point
-    // just_audio's built-in handler called play() — the auto-resume we remove.
-    if (!event.begin) return false;
+  static AudioFocusAction audioFocusAction(AudioInterruptionEvent event) {
+    if (event.begin) {
+      switch (event.type) {
+        case AudioInterruptionType.pause:
+          return AudioFocusAction.pauseTransient;
+        case AudioInterruptionType.unknown:
+          return AudioFocusAction.pausePermanent;
+        case AudioInterruptionType.duck:
+          return AudioFocusAction.ignore;
+      }
+    }
+    // Interruption ended / focus regained.
     switch (event.type) {
-      case AudioInterruptionType.duck:
-        return false;
       case AudioInterruptionType.pause:
       case AudioInterruptionType.unknown:
-        return true;
+        return AudioFocusAction.resume;
+      case AudioInterruptionType.duck:
+        return AudioFocusAction.ignore;
     }
   }
 
   /// Headphones unplugged / the output became the phone speaker: pause so audio
-  /// doesn't suddenly blast out loud. Never auto-resumes when they're plugged
-  /// back in — consistent with the no-surprise-resume rule.
+  /// doesn't suddenly blast out loud, and clear any armed transient-resume so it
+  /// never auto-resumes when they're plugged back in.
   void _onBecomingNoisy() {
     if (_suspended) return;
+    _resumeAfterTransientLoss = false;
     StabilityDiagnostics.audioFocus('noisy:paused');
     unawaited(pause());
   }

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'dart:math';
 
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter/foundation.dart';
 import 'package:just_audio/just_audio.dart';
 
@@ -47,14 +49,32 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         _resolver = resolver,
         _candidates = candidates,
         _random = random ?? Random(),
-        _onTrackCompleted = onTrackCompleted {
+        _onTrackCompleted = onTrackCompleted,
+        // Own audio focus only for the engine we created. An injected player
+        // (tests, or a future custom engine) keeps whatever interruption
+        // handling its owner configured, so unit tests never touch the
+        // audio_session platform.
+        _manageAudioFocus = player == null {
     _wire();
   }
 
   /// The default engine, tuned for resilient remote streaming. An injected
   /// [player] (tests, or a future custom engine) bypasses this.
-  static AudioPlayer _defaultPlayer() =>
-      AudioPlayer(audioLoadConfiguration: _streamBuffering);
+  ///
+  /// `handleInterruptions: false` deliberately turns *off* just_audio's built-in
+  /// audio-focus handling. That handler pauses on a focus loss but then calls
+  /// `play()` again on focus *regain* — so after a transient interruption (a
+  /// notification, another app briefly taking focus, or the focus churn some
+  /// OEMs emit on screen on/off and around battery-saver/Doze) the engine
+  /// resumes on its own, underneath the controller and media session. That is
+  /// the "music starts/resumes by itself when the screen turns on / when I
+  /// switch apps" regression. [_wireAudioFocus] takes over: it pauses on a real
+  /// focus loss and *never* auto-resumes — only an explicit user / media-session
+  /// play resumes.
+  static AudioPlayer _defaultPlayer() => AudioPlayer(
+        audioLoadConfiguration: _streamBuffering,
+        handleInterruptions: false,
+      );
 
   /// Buffering tuned for remote streams so a brief network hiccup is absorbed
   /// instead of stalling playback: a generous look-ahead (up to ~2 minutes), a
@@ -99,6 +119,15 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       StreamController<PlaybackState>.broadcast();
   final List<StreamSubscription<void>> _subscriptions =
       <StreamSubscription<void>>[];
+
+  /// Whether this controller owns audio-focus handling for its engine (true only
+  /// for the default engine it created; an injected player is left to its owner).
+  final bool _manageAudioFocus;
+
+  /// The audio-session subscriptions, kept so [dispose] can cancel them. Null
+  /// until [_wireAudioFocus] attaches (real Android/iOS device only).
+  StreamSubscription<AudioInterruptionEvent>? _interruptionSub;
+  StreamSubscription<void>? _becomingNoisySub;
 
   PlaybackState _state = PlaybackState.idle;
   PlaybackQueue _queue = PlaybackQueue.empty;
@@ -166,6 +195,76 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _subscriptions.add(
       _player.playbackEventStream.listen((_) {}, onError: _onEngineError),
     );
+    _wireAudioFocus();
+  }
+
+  /// Takes over audio-focus handling from just_audio (disabled via
+  /// `handleInterruptions: false`) so playback never auto-resumes itself.
+  ///
+  /// Best-effort and platform-gated: only the engine we created manages focus,
+  /// and only on a real Android/iOS device — a test host or desktop has no
+  /// audio_session platform, so it stays inert (and unit tests never touch the
+  /// platform channel). The pause-or-not decision is the pure
+  /// [shouldPauseForInterruption]; the loud-output guard is [_onBecomingNoisy].
+  void _wireAudioFocus() {
+    if (!_manageAudioFocus) return;
+    if (kIsWeb || !(Platform.isAndroid || Platform.isIOS)) return;
+    unawaited(_attachAudioSession());
+  }
+
+  Future<void> _attachAudioSession() async {
+    try {
+      final AudioSession session = await AudioSession.instance;
+      await session.configure(const AudioSessionConfiguration.music());
+      _interruptionSub =
+          session.interruptionEventStream.listen(_onAudioInterruption);
+      _becomingNoisySub =
+          session.becomingNoisyEventStream.listen((_) => _onBecomingNoisy());
+    } catch (_) {
+      // No audio_session platform here: skip focus management entirely. Playback
+      // still works; we simply don't pause on a focus loss on this host.
+    }
+  }
+
+  /// Reacts to an audio-focus [event] for the on-device engine.
+  ///
+  /// While suspended a cast receiver owns the audio and the engine is parked, so
+  /// a local focus change is ignored. Otherwise a real focus loss pauses and a
+  /// focus *regain* does nothing — see [shouldPauseForInterruption].
+  void _onAudioInterruption(AudioInterruptionEvent event) {
+    if (_suspended) return;
+    if (shouldPauseForInterruption(event)) unawaited(pause());
+  }
+
+  /// Whether an audio-focus [event] should pause the on-device engine.
+  ///
+  /// The whole point of owning focus ourselves: playback must NEVER resume by
+  /// itself. So this pauses on a genuine focus *loss* (another app took focus, a
+  /// call, an alarm) and returns `false` for every focus *regain*
+  /// (`event.begin == false`) — only an explicit user / media-session play
+  /// resumes. A transient duck (a brief system sound) is left to ride at full
+  /// volume rather than pausing; just_audio is no longer adjusting it, and a
+  /// momentary overlap is preferable to a surprise pause/!resume.
+  @visibleForTesting
+  static bool shouldPauseForInterruption(AudioInterruptionEvent event) {
+    // Focus regained / interruption ended: do nothing. This is the exact point
+    // just_audio's built-in handler called play() — the auto-resume we remove.
+    if (!event.begin) return false;
+    switch (event.type) {
+      case AudioInterruptionType.duck:
+        return false;
+      case AudioInterruptionType.pause:
+      case AudioInterruptionType.unknown:
+        return true;
+    }
+  }
+
+  /// Headphones unplugged / the output became the phone speaker: pause so audio
+  /// doesn't suddenly blast out loud. Never auto-resumes when they're plugged
+  /// back in — consistent with the no-surprise-resume rule.
+  void _onBecomingNoisy() {
+    if (_suspended) return;
+    unawaited(pause());
   }
 
   /// Maps one raw engine [PlayerState] onto the unified [PlaybackState] and
@@ -732,6 +831,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   @override
   Future<void> dispose() async {
     _resetPositionFlush();
+    await _interruptionSub?.cancel();
+    await _becomingNoisySub?.cancel();
     for (final subscription in _subscriptions) {
       await subscription.cancel();
     }

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -230,10 +230,21 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   ///
   /// While suspended a cast receiver owns the audio and the engine is parked, so
   /// a local focus change is ignored. Otherwise a real focus loss pauses and a
-  /// focus *regain* does nothing — see [shouldPauseForInterruption].
+  /// focus *regain* does nothing — see [shouldPauseForInterruption]. Each
+  /// outcome leaves a secret-free breadcrumb so a "music started by itself on
+  /// screen wake / leaving battery saver" report shows the regain was ignored.
   void _onAudioInterruption(AudioInterruptionEvent event) {
     if (_suspended) return;
-    if (shouldPauseForInterruption(event)) unawaited(pause());
+    if (shouldPauseForInterruption(event)) {
+      StabilityDiagnostics.audioFocus('loss:paused');
+      unawaited(pause());
+    } else {
+      // A focus regain (interruption ended) or a transient duck: we never
+      // resume here. This is the exact point just_audio used to call play().
+      StabilityDiagnostics.audioFocus(
+        event.begin ? 'duck:ignored' : 'regain:ignored',
+      );
+    }
   }
 
   /// Whether an audio-focus [event] should pause the on-device engine.
@@ -264,6 +275,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// back in — consistent with the no-surprise-resume rule.
   void _onBecomingNoisy() {
     if (_suspended) return;
+    StabilityDiagnostics.audioFocus('noisy:paused');
     unawaited(pause());
   }
 

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -134,7 +134,15 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   }
 
   @override
-  Future<void> pause() => _controller.pause();
+  Future<void> pause() {
+    // A pause that arrived through the platform media session: the notification
+    // / lock-screen pause, or Android Auto / Bluetooth / a headset sending
+    // PAUSE. Breadcrumb it (secret-free) so a screen-off "it paused by itself"
+    // report can tell a real session PAUSE apart from an audio-focus-loss or
+    // becoming-noisy pause (both logged under `audio focus:` by the engine).
+    StabilityDiagnostics.pauseCommand('media-session');
+    return _controller.pause();
+  }
 
   @override
   Future<void> stop() async {

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -13,6 +13,7 @@ import '../repositories/playlist_repository.dart';
 import 'media_artwork_source.dart';
 import 'media_browser_tree.dart';
 import 'playback_controller.dart';
+import 'stability_diagnostics.dart';
 
 /// Logger name for the Android Auto / media-browser path. Filter device logs
 /// with `adb logcat | grep $_logName` to see whether the session attached and
@@ -122,7 +123,15 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   static const Duration _positionResyncThreshold = Duration(seconds: 1);
 
   @override
-  Future<void> play() => _controller.play();
+  Future<void> play() {
+    // A play that arrived through the platform media session: the user tapped
+    // the notification / lock-screen play, or Android Auto / Bluetooth / a
+    // headset sent PLAY. Breadcrumb it (secret-free) so every legitimate resume
+    // is accounted for and distinguishable from an unwanted self-resume — which,
+    // with the engine's audio-focus auto-resume disabled, no longer happens.
+    StabilityDiagnostics.playCommand('media-session');
+    return _controller.play();
+  }
 
   @override
   Future<void> pause() => _controller.pause();
@@ -274,6 +283,11 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
   /// `coverReady`).
   void _onCoverReady(Uri reference) {
     if (_controller.state.currentTrack?.artworkUri == reference) {
+      // A cover finished warming: refresh the now-playing card so the art shows.
+      // Breadcrumb it (secret-free) so a "cover art refresh restarted my music"
+      // report shows the rebroadcast is off the playback path — [_broadcast]
+      // mirrors the controller's *current* state and issues no transport command.
+      StabilityDiagnostics.mediaItemRebroadcast('artwork');
       _broadcast(_controller.state);
     }
   }

--- a/lib/core/services/stability_diagnostics.dart
+++ b/lib/core/services/stability_diagnostics.dart
@@ -148,4 +148,20 @@ abstract final class StabilityDiagnostics {
   }
 
   static String describePlayCommand(String source) => 'play command: $source';
+
+  /// A pause command that arrived through the platform media session — a user
+  /// tapping the notification / lock-screen pause, or Android Auto / Bluetooth /
+  /// a headset sending PAUSE. (Android routes all of these through the one media
+  /// session, so the specific transport isn't distinguishable here; the label is
+  /// `media-session`.) Recorded so a screen-off "it paused by itself" report can
+  /// tell a real session PAUSE apart from an audio-focus-loss pause
+  /// (`audio focus: loss-*`), a becoming-noisy pause (`audio focus: noisy:*`), or
+  /// an in-app user pause (which goes through the controller, not the session, so
+  /// it carries no `pause command` breadcrumb).
+  static void pauseCommand(String source) {
+    SafeEventLog.instance.record('pause', source);
+    _log(describePauseCommand(source));
+  }
+
+  static String describePauseCommand(String source) => 'pause command: $source';
 }

--- a/lib/core/services/stability_diagnostics.dart
+++ b/lib/core/services/stability_diagnostics.dart
@@ -44,6 +44,17 @@ abstract final class StabilityDiagnostics {
   /// one occurs. Never the raw error (which can carry a tokenized URL).
   static String? lastInterruptionKind;
 
+  /// The last audio-focus event seen for the on-device engine and how it was
+  /// handled (`loss:paused`, `regain:ignored`, `duck:ignored`, `noisy:paused`),
+  /// retained for diagnostics. Null until one occurs.
+  ///
+  /// This is the breadcrumb that proves playback is *not* auto-resumed when
+  /// audio focus comes back — the screen-wake / exit-Doze / exit-battery-saver /
+  /// return-from-another-app path that used to surprise-start music. A regain is
+  /// always recorded as `regain:ignored`, never a play. A fixed structural label
+  /// — never a track, URL, or token.
+  static String? lastAudioFocusEvent;
+
   /// An app lifecycle transition (`resumed`, `paused`, `inactive`, …) — the
   /// boundary most freezes/ANRs cluster around (background/foreground).
   static void lifecycle(String state) {
@@ -96,4 +107,45 @@ abstract final class StabilityDiagnostics {
   }
 
   static String describePlaybackError(String kind) => 'playback error: $kind';
+
+  /// An audio-focus event for the on-device engine and how it was handled.
+  /// [event] is a fixed structural label — `loss:paused` (a real focus loss, so
+  /// we paused), `regain:ignored` (focus came back; we did NOT resume),
+  /// `duck:ignored`, or `noisy:paused` (headphones unplugged). Retained in
+  /// [lastAudioFocusEvent] and recorded so a "music started by itself on screen
+  /// wake / when leaving battery saver" report shows the focus regain was
+  /// ignored rather than treated as a play. Never a track, URL, or token.
+  static void audioFocus(String event) {
+    lastAudioFocusEvent = event;
+    SafeEventLog.instance.record('audio-focus', event);
+    _log(describeAudioFocus(event));
+  }
+
+  static String describeAudioFocus(String event) => 'audio focus: $event';
+
+  /// A media-session now-playing item re-broadcast that did NOT originate from
+  /// playback — e.g. a cover finished warming so the card was refreshed to show
+  /// the art. Recorded so a "cover art / metadata refresh restarted my music"
+  /// report can show the rebroadcast happened off the playback path (it issues
+  /// no transport command). [cause] is a fixed label such as `artwork` — never a
+  /// URL, id, or title.
+  static void mediaItemRebroadcast(String cause) {
+    SafeEventLog.instance.record('rebroadcast', cause);
+    _log(describeMediaItemRebroadcast(cause));
+  }
+
+  static String describeMediaItemRebroadcast(String cause) =>
+      'media item rebroadcast: $cause';
+
+  /// A play command that arrived through the platform media session — a user
+  /// tapping the notification / lock-screen play, or Android Auto / Bluetooth /
+  /// a headset sending PLAY. Recorded so every legitimate resume is accounted
+  /// for and distinguishable from an unwanted self-resume (which no longer
+  /// happens). [source] is a fixed label such as `media-session`.
+  static void playCommand(String source) {
+    SafeEventLog.instance.record('play', source);
+    _log(describePlayCommand(source));
+  }
+
+  static String describePlayCommand(String source) => 'play command: $source';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -58,7 +58,7 @@ packages:
     source: hosted
     version: "0.1.4"
   audio_session:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: audio_session
       sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,14 @@ dependencies:
   # forwards session commands to PlaybackController and mirrors its state out.
   # The UI never depends on audio_service directly.
   audio_service: ^0.18.15
+  # Audio-focus / interruption handling for the on-device engine. just_audio's
+  # built-in handler auto-resumes playback on focus regain (the screen-wake /
+  # app-switch "music starts by itself" bug), so JustAudioPlaybackController
+  # disables it and owns focus deliberately through this seam: it pauses on a
+  # real focus loss and never auto-resumes. Already a transitive dependency of
+  # just_audio/audio_service; declared here because the services layer imports
+  # it directly. The UI never depends on audio_session.
+  audio_session: ^0.1.25
   # Native folder chooser for selecting a music folder to scan. Used only by
   # FilePickerFolderPickerService; the UI depends on the FolderPickerService
   # interface, never on file_picker directly.

--- a/test/app/playback_lifecycle_test.dart
+++ b/test/app/playback_lifecycle_test.dart
@@ -57,13 +57,12 @@ Future<void> _foreground(WidgetTester tester) async {
 Future<FakePlaybackController> _pumpApp(
   WidgetTester tester, {
   NotificationPermission? permission,
+  PlaybackState initial = const PlaybackState(
+    status: PlaybackStatus.playing,
+    currentTrack: _playingTrack,
+  ),
 }) async {
-  final controller = FakePlaybackController(
-    initial: const PlaybackState(
-      status: PlaybackStatus.playing,
-      currentTrack: _playingTrack,
-    ),
-  );
+  final controller = FakePlaybackController(initial: initial);
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
@@ -104,6 +103,72 @@ void main() {
     expect(controller.playCount, 0);
     expect(controller.pauseCount, 0);
     expect(controller.stopCount, 0);
+  });
+
+  testWidgets('screen wake / lifecycle resumed never auto-resumes playback',
+      (tester) async {
+    // The regression: turning the screen back on (a lifecycle resumed) must not
+    // start or resume playback by itself. Start from a paused state and drive a
+    // full lock → unlock cycle.
+    final controller = await _pumpApp(
+      tester,
+      initial: const PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: _playingTrack,
+      ),
+    );
+
+    await _background(tester);
+    await _foreground(tester);
+    // A bare resumed (screen on without a prior full background cycle) too.
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    // Nothing started playing on resume; the paused state is untouched.
+    expect(controller.playCount, 0);
+    expect(controller.playedTracks, isEmpty);
+    expect(controller.state.status, PlaybackStatus.paused);
+  });
+
+  testWidgets(
+      'a paused track stays paused across a background/foreground cycle',
+      (tester) async {
+    final controller = await _pumpApp(
+      tester,
+      initial: const PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: _playingTrack,
+      ),
+    );
+
+    await _background(tester);
+    // Background playback continues only if it was already playing: here it was
+    // paused, so nothing resumes while backgrounded.
+    expect(controller.playCount, 0);
+
+    await _foreground(tester);
+
+    // Still paused, never auto-resumed, never re-loaded.
+    expect(controller.state.status, PlaybackStatus.paused);
+    expect(controller.playCount, 0);
+    expect(controller.playedTracks, isEmpty);
+    expect(controller.pauseCount, 0);
+    expect(controller.stopCount, 0);
+  });
+
+  testWidgets(
+      'backgrounding while playing leaves playback running (continues only if '
+      'already playing)', (tester) async {
+    final controller = await _pumpApp(tester); // playing by default
+
+    await _background(tester);
+
+    // Already playing: the foreground service keeps it alive — no pause/stop,
+    // and equally no spurious re-trigger of play().
+    expect(controller.state.status, PlaybackStatus.playing);
+    expect(controller.pauseCount, 0);
+    expect(controller.stopCount, 0);
+    expect(controller.playCount, 0);
   });
 
   testWidgets('a background transition records the playback state for reports',

--- a/test/core/services/just_audio_playback_controller_test.dart
+++ b/test/core/services/just_audio_playback_controller_test.dart
@@ -182,39 +182,53 @@ void main() {
     });
   });
 
-  group('audio focus never forces an unexpected resume', () {
-    // The "music starts/resumes by itself when the screen turns on, or when I
-    // switch apps" regression. just_audio's built-in interruption handler
-    // (handleInterruptions: true) pauses on a focus loss but then calls play()
-    // again on focus *regain* — so a transient interruption (a notification,
-    // another app briefly taking focus, the focus churn some OEMs emit on screen
-    // on/off and around battery-saver/Doze) resumes playback underneath the
-    // controller. The controller disables that handler and owns focus itself:
-    // it pauses on a real loss and NEVER auto-resumes. shouldPauseForInterruption
-    // is the pure decision behind that, exercised here without any platform.
-    bool shouldPause(bool begin, AudioInterruptionType type) =>
-        JustAudioPlaybackController.shouldPauseForInterruption(
+  group('audio focus follows the standard contract (no surprise pause/resume)',
+      () {
+    // Two field reports, one fix. just_audio's built-in handler
+    // (handleInterruptions: true) pauses on any focus loss and then resumes on
+    // any regain — so (a) returning from another media app surprise-resumed, and
+    // (b) a transient lock/notification sound that briefly took focus would, if
+    // we simply never resumed, leave background playback stuck paused. The
+    // controller disables that handler and classifies focus changes per the
+    // standard Android contract via the pure audioFocusAction, exercised here
+    // without any platform: a permanent loss stays paused, a transient loss
+    // recovers, and a bare regain (screen-on / app-return / exit-Doze) does
+    // nothing.
+    AudioFocusAction action(bool begin, AudioInterruptionType type) =>
+        JustAudioPlaybackController.audioFocusAction(
             AudioInterruptionEvent(begin, type));
 
-    test('a focus loss (interruption begins) pauses', () {
-      // Another app / a call grabbed focus: pause so we don't talk over it.
-      expect(shouldPause(true, AudioInterruptionType.pause), isTrue);
-      expect(shouldPause(true, AudioInterruptionType.unknown), isTrue);
+    test('a transient focus loss pauses (and can later resume)', () {
+      // AUDIOFOCUS_LOSS_TRANSIENT (a call, a notification/lock sound) maps to a
+      // begin + pause event.
+      expect(action(true, AudioInterruptionType.pause),
+          AudioFocusAction.pauseTransient);
     });
 
-    test('a focus regain (interruption ends) never resumes', () {
-      // This is the exact point just_audio used to call play(). For every event
-      // type, returning to the foreground / regaining focus must NOT resume —
-      // only an explicit user / media-session play does.
-      expect(shouldPause(false, AudioInterruptionType.pause), isFalse);
-      expect(shouldPause(false, AudioInterruptionType.unknown), isFalse);
-      expect(shouldPause(false, AudioInterruptionType.duck), isFalse);
+    test('a permanent focus loss pauses and stays paused', () {
+      // AUDIOFOCUS_LOSS (another media app took focus for good) maps to a
+      // begin + unknown event: pause and never resume on return.
+      expect(action(true, AudioInterruptionType.unknown),
+          AudioFocusAction.pausePermanent);
     });
 
-    test('a transient duck does not pause (and so cannot trigger a resume)',
+    test('a duckable transient is ignored (we keep playing, never pause)', () {
+      expect(action(true, AudioInterruptionType.duck), AudioFocusAction.ignore);
+    });
+
+    test('a focus regain only ever maps to resume (gated at the call site)',
         () {
-      // A brief duck is left to ride; we neither pause nor (therefore) resume.
-      expect(shouldPause(true, AudioInterruptionType.duck), isFalse);
+      // The regain itself classifies as resume, but the controller honours it
+      // only when a *transient* loss armed it. A regain after a permanent loss
+      // or with nothing playing is a no-op — the screen-on / app-return /
+      // exit-Doze case.
+      expect(
+          action(false, AudioInterruptionType.pause), AudioFocusAction.resume);
+      expect(action(false, AudioInterruptionType.unknown),
+          AudioFocusAction.resume);
+      // An unduck end is ignored.
+      expect(
+          action(false, AudioInterruptionType.duck), AudioFocusAction.ignore);
     });
   });
 }

--- a/test/core/services/just_audio_playback_controller_test.dart
+++ b/test/core/services/just_audio_playback_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:audio_session/audio_session.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:linthra/core/models/playback_state.dart';
@@ -178,6 +179,42 @@ void main() {
       // like the transient reload idle).
       controller.handleEngineState(PlayerState(false, ProcessingState.ready));
       expect(controller.state.status, PlaybackStatus.paused);
+    });
+  });
+
+  group('audio focus never forces an unexpected resume', () {
+    // The "music starts/resumes by itself when the screen turns on, or when I
+    // switch apps" regression. just_audio's built-in interruption handler
+    // (handleInterruptions: true) pauses on a focus loss but then calls play()
+    // again on focus *regain* — so a transient interruption (a notification,
+    // another app briefly taking focus, the focus churn some OEMs emit on screen
+    // on/off and around battery-saver/Doze) resumes playback underneath the
+    // controller. The controller disables that handler and owns focus itself:
+    // it pauses on a real loss and NEVER auto-resumes. shouldPauseForInterruption
+    // is the pure decision behind that, exercised here without any platform.
+    bool shouldPause(bool begin, AudioInterruptionType type) =>
+        JustAudioPlaybackController.shouldPauseForInterruption(
+            AudioInterruptionEvent(begin, type));
+
+    test('a focus loss (interruption begins) pauses', () {
+      // Another app / a call grabbed focus: pause so we don't talk over it.
+      expect(shouldPause(true, AudioInterruptionType.pause), isTrue);
+      expect(shouldPause(true, AudioInterruptionType.unknown), isTrue);
+    });
+
+    test('a focus regain (interruption ends) never resumes', () {
+      // This is the exact point just_audio used to call play(). For every event
+      // type, returning to the foreground / regaining focus must NOT resume —
+      // only an explicit user / media-session play does.
+      expect(shouldPause(false, AudioInterruptionType.pause), isFalse);
+      expect(shouldPause(false, AudioInterruptionType.unknown), isFalse);
+      expect(shouldPause(false, AudioInterruptionType.duck), isFalse);
+    });
+
+    test('a transient duck does not pause (and so cannot trigger a resume)',
+        () {
+      // A brief duck is left to ride; we neither pause nor (therefore) resume.
+      expect(shouldPause(true, AudioInterruptionType.duck), isFalse);
     });
   });
 }

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -1066,6 +1066,37 @@ void main() {
         expect(pushes.length, beforeWarm + 1);
       });
 
+      test('a cover warm / MediaItem rebroadcast never calls play', () async {
+        // #172 artwork must stay strictly off the playback path: when a cover
+        // finishes warming, the handler re-publishes the now-playing MediaItem
+        // so the art appears — but it must NOT touch transport. A rebroadcast
+        // that resumed/started playback would be the "cover art restarted my
+        // music" bug.
+        final source = _RecordingArtworkSource();
+        final c = FakePlaybackController();
+        final h = handlerWith(c, <Track>[subsonic], artwork: source);
+
+        // The user paused; the now-playing item is published, art-less.
+        await c.playTracks(<Track>[subsonic]);
+        c.emit(c.state.copyWith(status: PlaybackStatus.paused));
+        await _settle();
+        final int playsBefore = c.playedTracks.length;
+        final int playCountBefore = c.playCount;
+
+        // The cover warms out of band → coverReady fires → the item is
+        // re-broadcast with its art. No transport command may result.
+        source.warm(reference, localArt);
+        await _settle();
+
+        // The art landed (the rebroadcast did its job) …
+        expect(h.mediaItem.value?.artUri, localArt);
+        // … but playback was never started/resumed by it, and stays paused.
+        expect(c.playCount, playCountBefore);
+        expect(c.playedTracks.length, playsBefore);
+        expect(c.pauseCount, 0);
+        expect(h.playbackState.value.playing, isFalse);
+      });
+
       test(
           'coverReady for a non-current cover leaves the now-playing item alone',
           () async {

--- a/test/core/services/stability_diagnostics_test.dart
+++ b/test/core/services/stability_diagnostics_test.dart
@@ -18,6 +18,18 @@ void main() {
         StabilityDiagnostics.describePlaybackError('sessionExpired'),
         'playback error: sessionExpired',
       );
+      expect(
+        StabilityDiagnostics.describeAudioFocus('regain:ignored'),
+        'audio focus: regain:ignored',
+      );
+      expect(
+        StabilityDiagnostics.describeMediaItemRebroadcast('artwork'),
+        'media item rebroadcast: artwork',
+      );
+      expect(
+        StabilityDiagnostics.describePlayCommand('media-session'),
+        'play command: media-session',
+      );
     });
 
     test('a breadcrumb carries only its label — no room to leak a secret', () {
@@ -105,6 +117,27 @@ void main() {
     test('playbackError retains the last interruption kind', () {
       StabilityDiagnostics.playbackError('connectionLost');
       expect(StabilityDiagnostics.lastInterruptionKind, 'connectionLost');
+    });
+
+    test('audioFocus retains and records the event', () {
+      // The key breadcrumb: a focus regain is recorded as ignored, never a play.
+      StabilityDiagnostics.audioFocus('loss:paused');
+      StabilityDiagnostics.audioFocus('regain:ignored');
+      expect(StabilityDiagnostics.lastAudioFocusEvent, 'regain:ignored');
+      expect(SafeEventLog.instance.lines, <String>[
+        'audio-focus: loss:paused',
+        'audio-focus: regain:ignored',
+      ]);
+    });
+
+    test('mediaItemRebroadcast and playCommand record off-playback breadcrumbs',
+        () {
+      StabilityDiagnostics.mediaItemRebroadcast('artwork');
+      StabilityDiagnostics.playCommand('media-session');
+      expect(SafeEventLog.instance.lines, <String>[
+        'rebroadcast: artwork',
+        'play: media-session',
+      ]);
     });
   });
 }

--- a/test/core/services/stability_diagnostics_test.dart
+++ b/test/core/services/stability_diagnostics_test.dart
@@ -30,6 +30,10 @@ void main() {
         StabilityDiagnostics.describePlayCommand('media-session'),
         'play command: media-session',
       );
+      expect(
+        StabilityDiagnostics.describePauseCommand('media-session'),
+        'pause command: media-session',
+      );
     });
 
     test('a breadcrumb carries only its label — no room to leak a secret', () {
@@ -120,23 +124,25 @@ void main() {
     });
 
     test('audioFocus retains and records the event', () {
-      // The key breadcrumb: a focus regain is recorded as ignored, never a play.
-      StabilityDiagnostics.audioFocus('loss:paused');
+      // A permanent loss pauses; the following regain is recorded as ignored,
+      // never a play (the "screen-on / return from another app" case).
+      StabilityDiagnostics.audioFocus('loss-permanent:paused');
       StabilityDiagnostics.audioFocus('regain:ignored');
       expect(StabilityDiagnostics.lastAudioFocusEvent, 'regain:ignored');
       expect(SafeEventLog.instance.lines, <String>[
-        'audio-focus: loss:paused',
+        'audio-focus: loss-permanent:paused',
         'audio-focus: regain:ignored',
       ]);
     });
 
-    test('mediaItemRebroadcast and playCommand record off-playback breadcrumbs',
-        () {
+    test('rebroadcast, play and pause commands record source breadcrumbs', () {
       StabilityDiagnostics.mediaItemRebroadcast('artwork');
       StabilityDiagnostics.playCommand('media-session');
+      StabilityDiagnostics.pauseCommand('media-session');
       expect(SafeEventLog.instance.lines, <String>[
         'rebroadcast: artwork',
         'play: media-session',
+        'pause: media-session',
       ]);
     });
   });


### PR DESCRIPTION
## Symptoms (two directions, one root cause)

1. **Self-resume:** on screen wake / returning from another app / leaving battery-saver or Doze, playback started or resumed by itself.
2. **Self-pause:** with the screen off, playback could pause and **stay** paused, and the state looked wrong on screen-on.

Both come from how audio focus was handled. The on-device engine (`JustAudioPlaybackController`) used `just_audio`'s default `handleInterruptions: true`, whose handler **pauses on any focus loss and resumes on any regain**:

- After a **permanent** loss (another media app took focus for good), it still armed a resume, so returning to Linthra surprise-resumed → symptom #1.
- (My first cut over-corrected by *never* resuming, which then turned a **transient** loss while the screen is off — a notification or lock sound briefly grabbing focus — into a stuck pause → symptom #2.)

Battery saver / Doze / background restrictions feed the same path: entering them takes focus away; leaving them (or waking the screen) hands it back, and that regain was being mishandled.

## Fix — follow the standard Android audio-focus contract

Disable just_audio's handler (`handleInterruptions: false`) and classify focus changes deliberately, using the transient-vs-permanent distinction `audio_session` already encodes in the event type:

| Android focus change | event | action |
|---|---|---|
| `AUDIOFOCUS_LOSS_TRANSIENT` (call, notification, lock sound) | begin + `pause` | **pause; resume on regain — only if we were playing** |
| `AUDIOFOCUS_LOSS` (another media app, permanent) | begin + `unknown` | **pause and stay paused** |
| `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` | begin + `duck` | keep playing (no pause) |
| `AUDIOFOCUS_GAIN` | end | resume **only** if a transient loss armed it; else ignore |
| becoming-noisy (headphones unplugged) | — | pause; never auto-resume |

The decision is the pure, unit-tested `audioFocusAction`; the call site arms a one-shot resume only for a transient loss that interrupted **active** playback, and clears it on a permanent loss and on becoming-noisy. Focus is owned only for the engine the controller created (Android/iOS only); an injected test player is untouched, so unit tests never hit the platform.

This meets every hard requirement directly:

- A plain **screen-on / app-return / exit-Doze emits no focus loss at all** (focus is independent of screen state); a bare regain with nothing armed is ignored → **the screen turning on never starts playback**.
- A **user-paused** track has nothing armed → **stays paused** across screen off/on.
- **Already playing in the background** stays playing on screen-off (no spurious pause); a brief transient interruption **recovers** instead of sticking.
- **Returning from another media app** (permanent loss) **stays paused** — no surprise resume.
- A **real** focus loss still pauses (acceptable per the requirements).

**Artwork (#172) is *not* a cause** — the cover-ready rebroadcast re-publishes the now-playing `MediaItem` but issues no transport command (pinned by a test + breadcrumb).

## Secret-free diagnostics — distinguish every pause/resume source

`StabilityDiagnostics` breadcrumbs (fixed labels; into the in-memory `SafeEventLog` for bug reports, and `adb logcat | grep linthra.stability` in debug). On a screen-off "it paused/started by itself" report these tell you *exactly* what happened:

- **`audio focus: …`** — `loss-transient:paused`, `loss-permanent:paused`, `loss-transient:already-paused`, `regain:resumed`, `regain:ignored`, `duck:ignored`, `unduck:ignored`, `noisy:paused`.
- **`pause command: media-session`** — a PAUSE from the session / Android Auto / Bluetooth / headset / lock screen. (Android routes them all through one media session, so the specific transport isn't distinguishable at the Dart layer.)
- **`play command: media-session`** — a play from the same surfaces.
- **`media item rebroadcast: artwork`** — a cover refresh, proving it's off the playback path.
- Existing **`lifecycle: …`** and **`background playback: …`** breadcrumbs remain.

So you can attribute any pause: `audio focus: loss-*` (focus), `audio focus: noisy:*` (headphones), `pause command: media-session` (AA/BT/headset/lock), or **none of these** = an in-app user pause (it goes through the controller, not the session). The lifecycle handler issues **no** pause — confirmed by existing tests — so a lifecycle change won't show a pause breadcrumb.

**Battery-optimization *detection*** (`isIgnoringBatteryOptimizations` / Doze) was deliberately **not** added — it needs a platform channel and a new plugin/permission (a feature, not a hotfix). The lifecycle + focus breadcrumbs already make a Doze/battery-saver transition visible.

## Tests

- **audio focus** — transient loss → `pauseTransient`; permanent loss → `pausePermanent`; duck → ignore; regain classifies as resume but is gated to transient-only at the call site.
- **lifecycle / screen wake** — `resumed` never auto-resumes; a paused track stays paused across background→foreground; backgrounding while playing keeps it running.
- **artwork** — a cover warm / `MediaItem` rebroadcast never calls `play` and leaves a paused track paused.
- **diagnostics** — every new `describe*` label is secret-free and recorded.
- Existing Android Auto / media-session and `onAppResumed` (cast-only refresh) tests unchanged and passing.

## Verification (local)

`flutter test` (full suite) ✅ · `flutter analyze` no issues ✅ · `dart format --set-exit-if-changed .` clean ✅ · `flutter pub get --enforce-lockfile` clean ✅ · `scripts/check_secrets.sh` passed ✅.

## Android debug APK

Couldn't be built **inside the agent's environment** (network policy blocks `dl.google.com` / `maven.google.com` → 403). It **is** built by CI — the **Android Debug APK** workflow runs on this PR and uploads the **`linthra-debug-apk`** artifact. Local fallback: `./scripts/setup_flutter.sh && export PATH="$PWD/.tool/flutter/bin:$PATH" && flutter pub get && flutter build apk --debug`.

## Scope

No new features. No F-Droid metadata changes. No tags. No broad playback rewrite. No version bump yet — code-only hotfix until confirmed stable on a real device; the **v0.1.5** version bump can follow in its own version-only PR.

## Recommended on-device check (watch `adb logcat | grep linthra.stability`)

1. Play, lock, wait, unlock → stays playing; no `pause command`, no unexpected `audio focus` line.
2. Pause, lock, unlock → stays paused; `regain:ignored` at most, never `regain:resumed`.
3. Play, open another music app, return → stays paused (`loss-permanent:paused` then `regain:ignored`).
4. Play, trigger a short notification/system sound with screen off → recovers (`loss-transient:paused` → `regain:resumed`).
5. Battery saver / Doze idle then wake → no self-start.
6. Unplug headphones → `noisy:paused`; replug → stays paused.
7. In-app / lock-screen / Android Auto / Bluetooth play & pause still work.

https://claude.ai/code/session_01KLxpRcDqmcdoNEwJf1SjM6