### PR TITLE
chore(release): prepare v0.1.5

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/105999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/105999.txt
@@ -1,0 +1,15 @@
+Linthra 0.1.5 — Playback stability hotfix.
+
+Fixed:
+- Fixed a playback stability issue where music could resume by itself
+  after screen wake, app switching, or audio-focus changes.
+- Fixed cases where playback could pause unexpectedly during transient
+  audio-focus changes.
+- Improved pause/play reliability across the app, lock screen, Android
+  Auto, Bluetooth, and background playback.
+
+Notes:
+- No new features in this release.
+- Navidrome/Subsonic cover art improvements from 0.1.4 remain included.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.4';
+  static const String _devVersionName = '0.1.5';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.4+104999
+version: 0.1.5+105999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Release prep: Linthra v0.1.5 — playback stability hotfix

A focused, version-only bump that cuts `v0.1.5` on top of the playback-stability fix already merged via #175. **No new features**; no behavior change beyond what #175 already landed on `main`.

### What changed (3 files — version-only, per `docs/release-process.md`)
| File | Change |
| --- | --- |
| `pubspec.yaml` | `version: 0.1.4+104999` → `0.1.5+105999` |
| `lib/core/app_info.dart` | `_devVersionName` `0.1.4` → `0.1.5` (in-app version mirror) |
| `fastlane/metadata/android/en-US/changelogs/105999.txt` | new user-facing changelog |

`105999` is the canonical encoding of `0.1.5` from `tool/version_from_tag.dart` (`MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + 999` for a stable release). Confirmed: `dart run tool/version_from_tag.dart v0.1.5` → `LINTHRA_VERSION_CODE=105999`.

### What v0.1.5 ships (already on `main` via #175)
- Playback no longer starts/resumes by itself after screen wake, app switching, battery saver / Doze changes, or audio-focus regain.
- Playback no longer pauses unexpectedly and stays paused after transient focus events.
- Pause/play behavior is stable; background playback stays stable with the screen off; Android Auto / media-session controls stay stable.
- Navidrome/Subsonic cover art improvements from `v0.1.4` remain included.

### Release notes (for the eventual GitHub Release — published later, not here)
> **Linthra v0.1.5 — Playback stability hotfix**
>
> **Fixed:**
> - Fixed a playback stability issue where music could resume by itself after screen wake, app switching, or audio-focus changes.
> - Fixed cases where playback could pause unexpectedly during transient audio-focus changes.
> - Improved pause/play reliability across the app, lock screen, Android Auto, Bluetooth, and background playback.
>
> **Notes:**
> - No new features in this release.
> - Navidrome/Subsonic cover art improvements from `v0.1.4` remain included.
> - No ads, no tracking, no analytics, no telemetry.

### Verification (local, Flutter 3.27.4 / Dart 3.6.2)
- ✅ `flutter pub get --enforce-lockfile` — lockfile in sync
- ✅ `dart format --set-exit-if-changed .` — clean (0 changed)
- ✅ `flutter analyze` — No issues found
- ✅ `flutter test` — **1715 passed** (includes the version-drift / canonical-`versionCode` guard in `test/core/app_info_version_test.dart` and the changelog-presence guard in `test/tooling/release_changelog_test.dart`)
- ✅ `scripts/check_secrets.sh` — secret/privacy scan passed
- ⏳ **Android debug APK** — not buildable in this environment (no Android SDK; the Android maven repos are network-blocked here, as noted in #175). The **Android Debug APK** CI workflow builds and verifies it on this PR.

### Scope / explicitly deferred (per request)
- ❌ No `fdroiddata` edits (in-repo `metadata/` F-Droid recipe untouched, matching the v0.1.1–v0.1.4 prep PRs; F-Droid auto-detects the new tag via `AutoUpdateMode: Version`).
- ❌ No git tag created.
- ❌ No GitHub Release published.
- Release-prep only — no code/feature changes.

After CI is green and you merge this into `main`, the remaining manual steps are to tag `v0.1.5` from `main` and publish the GitHub Release.

https://claude.ai/code/session_01FjYvJym5VFuM3yZbwjuzru

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjYvJym5VFuM3yZbwjuzru)_