### PR TITLE
Add Plex DTOs and endpoint builders (provider foundation)

### DIFF
--- a/lib/core/sources/plex/plex_api.dart
+++ b/lib/core/sources/plex/plex_api.dart
@@ -1,0 +1,397 @@
+/// Wire models for the Plex Media Server HTTP API.
+///
+/// These mirror the JSON shapes a Plex Media Server (PMS) returns when asked for
+/// JSON (`Accept: application/json`) and live behind the future `PlexClient`;
+/// nothing outside the Plex source should touch them. Mapping them to Linthra's
+/// [Track]/[Album]/[Artist] is the future `PlexTrackMapper`'s job, keeping HTTP
+/// parsing and domain mapping separate — exactly as `JellyfinApi` /
+/// `SubsonicApi` do.
+///
+/// **JSON-only (phase 1, intentional).** PMS defaults to XML and only returns
+/// JSON when the client sends `Accept: application/json`. These parsers read
+/// **JSON only**; XML is deliberately unsupported in phase 1 (the future client
+/// sets the `Accept` header and maps a non-JSON body to a clear error). See
+/// docs/plex.md → Risks.
+///
+/// **No credentials here.** None of these DTOs carry, parse, or hold an
+/// `X-Plex-Token`. A Plex item's stable identity is its per-server `ratingKey`,
+/// and a track's playable bytes live behind a [PlexPart.key] *path* — neither is
+/// a credential, and the token is woven into a URL only at play/render time by
+/// the URL builders in `plex_endpoints.dart`, never stored on a DTO. See
+/// docs/plex.md → Token safety rules.
+///
+/// Only the fields Linthra maps today are kept; the rest of each (large) Plex
+/// payload is ignored.
+library;
+
+/// Plex's numeric metadata `type` for the three music kinds Linthra lists.
+///
+/// PMS identifies music items by a numeric type both in the listing query
+/// (`/library/sections/{key}/all?type=8`) and, as a string, on each item
+/// (`"type": "artist"`). This enum is the one place that mapping lives, so the
+/// endpoint builder and the (future) track mapper agree on 8 = artist,
+/// 9 = album, 10 = track.
+enum PlexMetadataType {
+  artist(8, 'artist'),
+  album(9, 'album'),
+  track(10, 'track');
+
+  const PlexMetadataType(this.value, this.typeName);
+
+  /// The numeric `type` PMS expects in the listing query string.
+  final int value;
+
+  /// The string `type` PMS reports on each metadata item.
+  final String typeName;
+
+  /// The type for a metadata item's string `type` field (e.g. `"album"`), or
+  /// `null` for anything that isn't one of the three music kinds.
+  static PlexMetadataType? fromTypeName(String? name) {
+    if (name == null) return null;
+    for (final PlexMetadataType type in values) {
+      if (type.typeName == name) return type;
+    }
+    return null;
+  }
+}
+
+/// Server identity from `GET /identity` — enough to confirm the address is a
+/// Plex Media Server and to record its version for display and diagnostics.
+///
+/// Mirrors `JellyfinServerInfo` / `SubsonicServerInfo`: a successful parse means
+/// "this really is a Plex server", so the future authenticator can report "not
+/// a Plex server" instead of surfacing a half-empty object. The identity fields
+/// live inside the `MediaContainer` envelope PMS wraps every response in.
+class PlexServerIdentity {
+  const PlexServerIdentity({required this.machineIdentifier, this.version});
+
+  /// The stable per-server id PMS reports as `machineIdentifier`. Used to
+  /// recognise the same server again; not a secret.
+  final String machineIdentifier;
+
+  /// The PMS version string, when reported (display/diagnostics only — never
+  /// used to branch request behavior).
+  final String? version;
+
+  /// Parses the `/identity` body, or returns `null` when it lacks the
+  /// `machineIdentifier` a real PMS always sends (so the caller can report "not
+  /// a Plex server").
+  static PlexServerIdentity? fromJson(Map<String, dynamic> json) {
+    final Object? container = json['MediaContainer'];
+    if (container is! Map<String, dynamic>) return null;
+    final String? id = _asString(container['machineIdentifier']);
+    if (id == null || id.isEmpty) return null;
+    return PlexServerIdentity(
+      machineIdentifier: id,
+      version: _asString(container['version']),
+    );
+  }
+}
+
+/// The `MediaContainer` envelope every Plex listing endpoint wraps its payload
+/// in (`/library/sections`, `/library/sections/{key}/all`, `/library/metadata`).
+///
+/// Carries the paging counters Linthra needs to walk a large library
+/// ([totalSize] / [size] / [offset]) plus the two payload arrays: [directories]
+/// (library sections) and [metadata] (artists/albums/tracks). A given response
+/// uses one array or the other; the unused one is empty.
+class PlexMediaContainer {
+  const PlexMediaContainer({
+    this.size,
+    this.totalSize,
+    this.offset,
+    this.directories = const <PlexDirectory>[],
+    this.metadata = const <PlexMetadata>[],
+  });
+
+  /// The number of items in *this* response page (PMS `size`).
+  final int? size;
+
+  /// The total number of items across all pages (PMS `totalSize`). PMS may omit
+  /// it when the whole set fits in one response; [total] then falls back to
+  /// [size]. This is the counter the paged walk compares against.
+  final int? totalSize;
+
+  /// The zero-based index of the first item in this page (PMS `offset`),
+  /// echoing the requested `X-Plex-Container-Start`.
+  final int? offset;
+
+  /// Library sections from `GET /library/sections` (the `Directory` array).
+  final List<PlexDirectory> directories;
+
+  /// Music items from `GET /library/sections/{key}/all` or
+  /// `GET /library/metadata/{ratingKey}` (the `Metadata` array).
+  final List<PlexMetadata> metadata;
+
+  /// The total item count for pagination: [totalSize] when PMS reports it, else
+  /// [size] (a single-page response omits `totalSize`), else `null`.
+  int? get total => totalSize ?? size;
+
+  /// Parses the top-level body, or returns `null` when it isn't a
+  /// `MediaContainer` envelope (so the client can report "not a Plex server"
+  /// rather than surfacing a half-empty object). Malformed individual entries
+  /// are skipped, so one bad item can't break a whole listing.
+  static PlexMediaContainer? fromJson(Map<String, dynamic> json) {
+    final Object? raw = json['MediaContainer'];
+    if (raw is! Map<String, dynamic>) return null;
+
+    final Object? rawDirectories = raw['Directory'];
+    final List<PlexDirectory> directories = rawDirectories is List
+        ? <PlexDirectory>[
+            for (final Object? entry in rawDirectories)
+              if (entry is Map<String, dynamic>)
+                if (PlexDirectory.fromJson(entry) case final PlexDirectory d) d,
+          ]
+        : const <PlexDirectory>[];
+
+    final Object? rawMetadata = raw['Metadata'];
+    final List<PlexMetadata> metadata = rawMetadata is List
+        ? <PlexMetadata>[
+            for (final Object? entry in rawMetadata)
+              if (entry is Map<String, dynamic>)
+                if (PlexMetadata.fromJson(entry) case final PlexMetadata m) m,
+          ]
+        : const <PlexMetadata>[];
+
+    return PlexMediaContainer(
+      size: (raw['size'] as num?)?.toInt(),
+      totalSize: (raw['totalSize'] as num?)?.toInt(),
+      offset: (raw['offset'] as num?)?.toInt(),
+      directories: directories,
+      metadata: metadata,
+    );
+  }
+}
+
+/// A library section (`Directory`) from `GET /library/sections`.
+///
+/// Linthra keeps the music sections — those whose `type` is `"artist"` (PMS
+/// labels a music library by its top-level item type) — and lets the user pick
+/// which to include. The [key] is the section id used in the listing path
+/// (`/library/sections/{key}/all`); it is **not** a credential.
+class PlexDirectory {
+  const PlexDirectory({
+    required this.key,
+    required this.title,
+    this.type,
+    this.uuid,
+  });
+
+  /// The section id used to build its listing path. A short server-local
+  /// identifier (e.g. `"3"`), not a secret.
+  final String key;
+
+  final String title;
+
+  /// The section's content type (`"artist"` for a music library, `"movie"`,
+  /// `"show"`, …), when reported.
+  final String? type;
+
+  /// The section's stable UUID, when reported.
+  final String? uuid;
+
+  /// Whether this is a music library (PMS types a music section as `artist`).
+  bool get isMusic => type == 'artist';
+
+  /// Parses one section, or returns `null` when it lacks a key/title so a single
+  /// malformed entry can't break the sections listing.
+  static PlexDirectory? fromJson(Map<String, dynamic> json) {
+    final String? key = _asString(json['key']);
+    final String? title = _asString(json['title']);
+    if (key == null || key.isEmpty || title == null) return null;
+    return PlexDirectory(
+      key: key,
+      title: title,
+      type: _asString(json['type']),
+      uuid: _asString(json['uuid']),
+    );
+  }
+}
+
+/// A single music item (artist, album, or track) from a `Metadata` array.
+///
+/// One DTO covers all three kinds; [type] (and [metadataType]) says which.
+/// Album and track items carry their parent/grandparent links so the mapper can
+/// fill artist/album names without a second request:
+///  - an **album** (`type` 9) has [parentRatingKey] → its artist;
+///  - a **track** (`type` 10) has [parentRatingKey] → its album and
+///    [grandparentRatingKey] → its artist.
+///
+/// The stable per-server [ratingKey] is the item's identity (and the basis for
+/// the opaque `plex:<ratingKey>` track URI a later PR mints) — it is **not** the
+/// playable [PlexPart.key] and carries no credential.
+class PlexMetadata {
+  const PlexMetadata({
+    required this.ratingKey,
+    this.type,
+    this.title,
+    this.parentRatingKey,
+    this.grandparentRatingKey,
+    this.parentTitle,
+    this.grandparentTitle,
+    this.thumb,
+    this.duration,
+    this.media = const <PlexMedia>[],
+  });
+
+  /// The stable per-server id PMS assigns this item. Identity only — never a
+  /// file path and never a credential.
+  final String ratingKey;
+
+  /// The item's string `type` (`"artist"`, `"album"`, `"track"`), when present.
+  final String? type;
+
+  final String? title;
+
+  /// For an album: its artist's `ratingKey`. For a track: its album's. `null`
+  /// for an artist (or when PMS omits it).
+  final String? parentRatingKey;
+
+  /// For a track: its artist's `ratingKey`. `null` for albums/artists.
+  final String? grandparentRatingKey;
+
+  /// The parent's title (an album's artist name, a track's album name), when
+  /// reported — a free fallback so the mapper needn't refetch the parent.
+  final String? parentTitle;
+
+  /// The grandparent's title (a track's artist name), when reported.
+  final String? grandparentTitle;
+
+  /// The item's cover-art *path* (e.g. `/library/metadata/123/thumb/167…`), when
+  /// present. A path, not a URL: the token is woven in only at render time by
+  /// [PlexEndpoints.coverArt], and the catalog stores a credential-free
+  /// `plex-thumb:` reference (a later PR), never this turned into a tokened URL.
+  final String? thumb;
+
+  /// Duration in **milliseconds**, when reported (PMS reports track length in
+  /// ms, unlike Subsonic's whole seconds or Jellyfin's 100-ns ticks).
+  final int? duration;
+
+  /// The item's `Media` entries (present on tracks; an album/artist listing
+  /// omits them). Each holds the [PlexPart]s whose [PlexPart.key] is the actual
+  /// stream path resolved at play time.
+  final List<PlexMedia> media;
+
+  /// The strongly-typed music kind for [type], or `null` when this item isn't
+  /// one of artist/album/track.
+  PlexMetadataType? get metadataType => PlexMetadataType.fromTypeName(type);
+
+  /// The stream path of the first available [PlexPart], or `null` when the item
+  /// carries no media (e.g. an album/artist listing entry).
+  ///
+  /// This is the `Media[0].Part[0].key` the documented two-step play resolution
+  /// reads after a `GET /library/metadata/{ratingKey}` — a *path*, fed to
+  /// [PlexEndpoints.streamUrl] with the token at play time, never persisted.
+  String? get firstPartKey {
+    for (final PlexMedia m in media) {
+      for (final PlexPart part in m.parts) {
+        return part.key;
+      }
+    }
+    return null;
+  }
+
+  /// Parses one item, or returns `null` when it lacks a [ratingKey] (its stable
+  /// identity) so a single malformed entry can't break a whole listing. A
+  /// missing title is tolerated (kept `null`); the mapper supplies a fallback.
+  static PlexMetadata? fromJson(Map<String, dynamic> json) {
+    final String? ratingKey = _asString(json['ratingKey']);
+    if (ratingKey == null || ratingKey.isEmpty) return null;
+
+    final Object? rawMedia = json['Media'];
+    final List<PlexMedia> media = rawMedia is List
+        ? <PlexMedia>[
+            for (final Object? entry in rawMedia)
+              if (entry is Map<String, dynamic>) PlexMedia.fromJson(entry),
+          ]
+        : const <PlexMedia>[];
+
+    return PlexMetadata(
+      ratingKey: ratingKey,
+      type: _asString(json['type']),
+      title: _asString(json['title']),
+      parentRatingKey: _asString(json['parentRatingKey']),
+      grandparentRatingKey: _asString(json['grandparentRatingKey']),
+      parentTitle: _asString(json['parentTitle']),
+      grandparentTitle: _asString(json['grandparentTitle']),
+      thumb: _asString(json['thumb']),
+      duration: (json['duration'] as num?)?.toInt(),
+      media: media,
+    );
+  }
+}
+
+/// A `Media` entry on a track — a single playable rendition, holding the
+/// [PlexPart]s that carry the actual file paths.
+///
+/// Phase 1 is direct-play only, so Linthra reads the first part's path and hands
+/// it (with the token) to the audio engine; the transcoder is out of scope.
+class PlexMedia {
+  const PlexMedia({this.container, this.parts = const <PlexPart>[]});
+
+  /// The rendition's container format (e.g. `"flac"`), when reported. Display /
+  /// codec-fit only.
+  final String? container;
+
+  final List<PlexPart> parts;
+
+  /// Parses one `Media` entry. Malformed parts are skipped; a media with no
+  /// usable part yields an empty [parts] (the caller treats it as not playable).
+  static PlexMedia fromJson(Map<String, dynamic> json) {
+    final Object? rawParts = json['Part'];
+    final List<PlexPart> parts = rawParts is List
+        ? <PlexPart>[
+            for (final Object? entry in rawParts)
+              if (entry is Map<String, dynamic>)
+                if (PlexPart.fromJson(entry) case final PlexPart p) p,
+          ]
+        : const <PlexPart>[];
+    return PlexMedia(
+      container: _asString(json['container']),
+      parts: parts,
+    );
+  }
+}
+
+/// A `Part` of a [PlexMedia] — one physical file, whose [key] is the path the
+/// stream URL is built from.
+///
+/// The Part [key] (e.g. `/library/parts/12345/…/file.flac`) is **not** the
+/// item's `ratingKey`, which is exactly why a track's playable URL needs a
+/// `GET /library/metadata/{ratingKey}` lookup at play time. The key is a path,
+/// not a credential; the token is added only by [PlexEndpoints.streamUrl] when
+/// the URL is minted, and that tokened URL is never persisted.
+class PlexPart {
+  const PlexPart({required this.key, this.container, this.duration});
+
+  /// The stream path for this file. A server path, not a credential.
+  final String key;
+
+  /// The file's container format (e.g. `"flac"`), when reported.
+  final String? container;
+
+  /// Duration in milliseconds, when reported.
+  final int? duration;
+
+  /// Parses one part, or returns `null` when it lacks a [key] (without which it
+  /// can't be streamed) so a malformed part is skipped rather than half-built.
+  static PlexPart? fromJson(Map<String, dynamic> json) {
+    final String? key = _asString(json['key']);
+    if (key == null || key.isEmpty) return null;
+    return PlexPart(
+      key: key,
+      container: _asString(json['container']),
+      duration: (json['duration'] as num?)?.toInt(),
+    );
+  }
+}
+
+/// Reads a field that PMS may report as either a JSON string or a number
+/// (`ratingKey`, `key`, and friends are usually strings but some servers/fields
+/// emit bare numbers), returning a `String?` either way. Returns `null` for any
+/// other type so a malformed value is treated as "absent".
+String? _asString(Object? value) {
+  if (value is String) return value;
+  if (value is num) return value.toString();
+  return null;
+}

--- a/lib/core/sources/plex/plex_endpoints.dart
+++ b/lib/core/sources/plex/plex_endpoints.dart
@@ -1,0 +1,139 @@
+import 'plex_api.dart';
+
+/// Every Plex Media Server REST path and URL Linthra builds, in one place.
+///
+/// Centralizing the endpoints means:
+///  - the (future) HTTP client, music source, and track mapper never embed raw
+///    path strings, so a path can't quietly drift between two call sites;
+///  - the exact set of endpoints Linthra depends on is auditable from this one
+///    file (kept in sync with docs/plex.md);
+///  - the token-bearing stream and cover-art URLs are built by the same pure,
+///    tested helpers, so the "weave the token into the query, on demand, never
+///    store it" rule — and the matching redaction — live in a single spot.
+///
+/// All builders are pure: they take a clean base URL (no trailing slash) plus
+/// the ids/params they need and return a [Uri]. Nothing here performs I/O,
+/// holds state, or logs.
+///
+/// **Where the token rides (Plex's key difference).** API calls
+/// ([identity], [librarySections], [sectionItems], [metadata]) carry the
+/// `X-Plex-Token` in a *request header*, set by the client — so those builders
+/// take **no token** and emit token-free URLs safe to log. Only the
+/// stream/cover-art URLs ([streamUrl], [coverArt]) are handed to the audio/image
+/// layers, which can't set headers, so they must carry the token as a **query
+/// param** — a bigger leak surface. Those two builders are the *only* place a
+/// token enters a Plex URL, and [redactToken] is the matching guard for any code
+/// that logs one. See docs/plex.md → Token safety rules.
+abstract final class PlexEndpoints {
+  // --- Path templates: the only place these strings are written. ---
+  static const String _identityPath = '/identity';
+  static const String _sectionsPath = '/library/sections';
+  static const String _metadataPath = '/library/metadata';
+
+  // --- Query-parameter keys, named once so a typo can't split a request. ---
+
+  /// The Plex auth token. Carried in the query of **stream/cover-art** URLs only
+  /// (the audio/image layers can't set a header); API calls send it as the
+  /// `X-Plex-Token` *header* instead, so it never reaches a logged API URL.
+  static const String tokenParam = 'X-Plex-Token';
+
+  /// The numeric metadata `type` selector for a section listing (8/9/10).
+  static const String typeParam = 'type';
+
+  /// Pagination: the zero-based index of the first item to return.
+  static const String containerStartParam = 'X-Plex-Container-Start';
+
+  /// Pagination: the maximum number of items to return in one page.
+  static const String containerSizeParam = 'X-Plex-Container-Size';
+
+  /// `GET /identity` — server identity / reachability (`machineIdentifier`,
+  /// version). Token-free path; the client adds the `X-Plex-Token` header.
+  /// Mirrors Jellyfin `/System/Info/Public` and Subsonic `ping`.
+  static Uri identity(String baseUrl) => _join(baseUrl, _identityPath);
+
+  /// `GET /library/sections` — the library sections (`Directory` entries).
+  /// Linthra keeps the music ones ([PlexDirectory.isMusic]).
+  static Uri librarySections(String baseUrl) => _join(baseUrl, _sectionsPath);
+
+  /// `GET /library/sections/{key}/all?type=…` — one page of a music section's
+  /// items of the given [itemType] (artist 8 / album 9 / track 10).
+  ///
+  /// Pagination is opt-in: pass [start] and/or [size] to add the
+  /// `X-Plex-Container-Start` / `X-Plex-Container-Size` query params and walk a
+  /// large library page by page (reusing the paged-walk shape Subsonic uses);
+  /// omit them to let PMS return its default first page. The token is **not**
+  /// added here — it rides in the client's request header.
+  static Uri sectionItems(
+    String baseUrl, {
+    required String sectionKey,
+    required PlexMetadataType itemType,
+    int? start,
+    int? size,
+  }) {
+    final Map<String, String> query = <String, String>{
+      typeParam: '${itemType.value}',
+      if (start != null) containerStartParam: '$start',
+      if (size != null) containerSizeParam: '$size',
+    };
+    return _join(baseUrl, '$_sectionsPath/$sectionKey/all')
+        .replace(queryParameters: query);
+  }
+
+  /// `GET /library/metadata/{ratingKey}` — a single item with its `Media`/`Part`
+  /// entries. The play-time lookup that turns an opaque `plex:<ratingKey>` into a
+  /// playable [PlexPart.key], because the Part key differs from the `ratingKey`.
+  /// Token-free path; the client adds the `X-Plex-Token` header.
+  static Uri metadata(String baseUrl, {required String ratingKey}) =>
+      _join(baseUrl, '$_metadataPath/$ratingKey');
+
+  /// The direct-play stream URL for a track: `{baseUrl}{partKey}?X-Plex-Token=…`.
+  ///
+  /// [partKey] is the `Media[0].Part[0].key` *path* read from a metadata lookup
+  /// (e.g. `/library/parts/12345/…/file.flac`) — already server-absolute, so it
+  /// is appended to [baseUrl] as-is. Phase 1 is direct-play only (no
+  /// transcoder). Unlike the API calls, this URL is fetched by the audio engine,
+  /// which can't set headers, so the [token] is woven into the **query** here,
+  /// on demand, and never stored on a [Track] or in the catalog.
+  static Uri streamUrl(
+    String baseUrl, {
+    required String partKey,
+    required String token,
+  }) =>
+      _join(baseUrl, partKey).replace(
+        queryParameters: <String, String>{tokenParam: token},
+      );
+
+  /// The cover-art URL for an item's `thumb` path:
+  /// `{baseUrl}{thumbPath}?X-Plex-Token=…`.
+  ///
+  /// [thumbPath] is the server-absolute `thumb` path an item reports (e.g.
+  /// `/library/metadata/123/thumb/167…`). Like [streamUrl], the image is fetched
+  /// plainly (no headers), so the [token] rides in the query — woven in here, on
+  /// demand at render time, and never persisted (the catalog stores only a
+  /// credential-free `plex-thumb:` reference, a later PR).
+  static Uri coverArt(
+    String baseUrl, {
+    required String thumbPath,
+    required String token,
+  }) =>
+      _join(baseUrl, thumbPath).replace(
+        queryParameters: <String, String>{tokenParam: token},
+      );
+
+  /// Replaces every `X-Plex-Token=<value>` in [text] with
+  /// `X-Plex-Token=<redacted>`, so a stream/art URL (or any line carrying one)
+  /// can be logged or surfaced without leaking the token.
+  ///
+  /// Because the token rides in stream/art **query params**, a single
+  /// unguarded URL log line would expose the whole token — so anything that logs
+  /// a Plex URL must pass it through here first. Pure and case-insensitive on
+  /// the parameter name; the value runs up to the next `&`, `#`, whitespace, or
+  /// end of string.
+  static String redactToken(String text) =>
+      text.replaceAll(_tokenPattern, '$tokenParam=<redacted>');
+
+  static final RegExp _tokenPattern =
+      RegExp('$tokenParam=[^&#\\s]*', caseSensitive: false);
+
+  static Uri _join(String baseUrl, String path) => Uri.parse('$baseUrl$path');
+}

--- a/test/core/sources/plex/plex_api_test.dart
+++ b/test/core/sources/plex/plex_api_test.dart
@@ -1,0 +1,303 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+
+void main() {
+  group('PlexMetadataType', () {
+    test('maps the three music kinds to PMS numeric types', () {
+      expect(PlexMetadataType.artist.value, 8);
+      expect(PlexMetadataType.album.value, 9);
+      expect(PlexMetadataType.track.value, 10);
+    });
+
+    test('resolves a type from its string name', () {
+      expect(PlexMetadataType.fromTypeName('artist'), PlexMetadataType.artist);
+      expect(PlexMetadataType.fromTypeName('album'), PlexMetadataType.album);
+      expect(PlexMetadataType.fromTypeName('track'), PlexMetadataType.track);
+    });
+
+    test('returns null for a non-music or missing type', () {
+      expect(PlexMetadataType.fromTypeName('movie'), isNull);
+      expect(PlexMetadataType.fromTypeName(null), isNull);
+    });
+  });
+
+  group('PlexServerIdentity.fromJson', () {
+    test('parses machineIdentifier and version from /identity', () {
+      final PlexServerIdentity? identity =
+          PlexServerIdentity.fromJson(<String, dynamic>{
+        'MediaContainer': <String, dynamic>{
+          'machineIdentifier': 'abc123def',
+          'version': '1.40.2.8395',
+        },
+      });
+
+      expect(identity, isNotNull);
+      expect(identity!.machineIdentifier, 'abc123def');
+      expect(identity.version, '1.40.2.8395');
+    });
+
+    test('tolerates a missing version', () {
+      final PlexServerIdentity? identity =
+          PlexServerIdentity.fromJson(<String, dynamic>{
+        'MediaContainer': <String, dynamic>{'machineIdentifier': 'abc123def'},
+      });
+      expect(identity, isNotNull);
+      expect(identity!.version, isNull);
+    });
+
+    test('returns null when the body is not a Plex MediaContainer', () {
+      expect(PlexServerIdentity.fromJson(<String, dynamic>{}), isNull);
+      expect(
+        PlexServerIdentity.fromJson(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{'version': '1.40'},
+        }),
+        isNull,
+        reason: 'no machineIdentifier means this is not a recognisable PMS',
+      );
+    });
+  });
+
+  group('PlexMediaContainer.fromJson — library sections (Directory)', () {
+    test('parses sections and flags music libraries', () {
+      final PlexMediaContainer? container =
+          PlexMediaContainer.fromJson(<String, dynamic>{
+        'MediaContainer': <String, dynamic>{
+          'size': 2,
+          'Directory': <dynamic>[
+            <String, dynamic>{
+              'key': '3',
+              'title': 'Music',
+              'type': 'artist',
+              'uuid': 'uuid-music',
+            },
+            <String, dynamic>{
+              'key': '1',
+              'title': 'Movies',
+              'type': 'movie',
+            },
+          ],
+        },
+      });
+
+      expect(container, isNotNull);
+      expect(container!.directories, hasLength(2));
+
+      final PlexDirectory music = container.directories.first;
+      expect(music.key, '3');
+      expect(music.title, 'Music');
+      expect(music.type, 'artist');
+      expect(music.uuid, 'uuid-music');
+      expect(music.isMusic, isTrue);
+
+      expect(container.directories[1].isMusic, isFalse);
+    });
+
+    test('skips a section missing its key or title', () {
+      final PlexMediaContainer? container =
+          PlexMediaContainer.fromJson(<String, dynamic>{
+        'MediaContainer': <String, dynamic>{
+          'Directory': <dynamic>[
+            <String, dynamic>{'title': 'No key'},
+            <String, dynamic>{'key': '5'},
+            <String, dynamic>{'key': '3', 'title': 'Music', 'type': 'artist'},
+          ],
+        },
+      });
+      expect(container!.directories, hasLength(1));
+      expect(container.directories.single.key, '3');
+    });
+  });
+
+  group('PlexMediaContainer.fromJson — metadata items', () {
+    test('parses an artist (type 8)', () {
+      final PlexMetadata artist = _single(<String, dynamic>{
+        'ratingKey': '50',
+        'type': 'artist',
+        'title': 'Boards of Canada',
+        'thumb': '/library/metadata/50/thumb/1',
+      });
+      expect(artist.ratingKey, '50');
+      expect(artist.metadataType, PlexMetadataType.artist);
+      expect(artist.title, 'Boards of Canada');
+      expect(artist.thumb, '/library/metadata/50/thumb/1');
+      // An artist has no parent links.
+      expect(artist.parentRatingKey, isNull);
+      expect(artist.grandparentRatingKey, isNull);
+    });
+
+    test('parses an album (type 9) with its parent artist link', () {
+      final PlexMetadata album = _single(<String, dynamic>{
+        'ratingKey': '100',
+        'type': 'album',
+        'title': 'Music Has the Right to Children',
+        'parentRatingKey': '50',
+        'parentTitle': 'Boards of Canada',
+      });
+      expect(album.metadataType, PlexMetadataType.album);
+      expect(album.parentRatingKey, '50');
+      expect(album.parentTitle, 'Boards of Canada');
+      expect(album.grandparentRatingKey, isNull);
+    });
+
+    test('parses a track (type 10) with parent + grandparent links and Part',
+        () {
+      final PlexMetadata track = _single(<String, dynamic>{
+        'ratingKey': '123',
+        'type': 'track',
+        'title': 'Roygbiv',
+        'parentRatingKey': '100',
+        'grandparentRatingKey': '50',
+        'parentTitle': 'Music Has the Right to Children',
+        'grandparentTitle': 'Boards of Canada',
+        'thumb': '/library/metadata/123/thumb/9',
+        'duration': 215000,
+        'Media': <dynamic>[
+          <String, dynamic>{
+            'container': 'flac',
+            'Part': <dynamic>[
+              <String, dynamic>{
+                'key': '/library/parts/12345/167/file.flac',
+                'container': 'flac',
+                'duration': 215000,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(track.metadataType, PlexMetadataType.track);
+      expect(track.parentRatingKey, '100');
+      expect(track.grandparentRatingKey, '50');
+      expect(track.parentTitle, 'Music Has the Right to Children');
+      expect(track.grandparentTitle, 'Boards of Canada');
+      expect(track.duration, 215000);
+
+      expect(track.media, hasLength(1));
+      expect(track.media.single.container, 'flac');
+      expect(track.media.single.parts, hasLength(1));
+
+      final PlexPart part = track.media.single.parts.single;
+      expect(part.key, '/library/parts/12345/167/file.flac');
+      expect(part.container, 'flac');
+
+      // The two-step play resolution reads Media[0].Part[0].key.
+      expect(track.firstPartKey, '/library/parts/12345/167/file.flac');
+    });
+
+    test('tolerates a track without duration or media', () {
+      final PlexMetadata track = _single(<String, dynamic>{
+        'ratingKey': '124',
+        'type': 'track',
+        'title': 'No media here',
+      });
+      expect(track.duration, isNull);
+      expect(track.media, isEmpty);
+      expect(track.firstPartKey, isNull);
+    });
+
+    test('skips an item missing its ratingKey, keeps the valid ones', () {
+      final PlexMediaContainer? container =
+          PlexMediaContainer.fromJson(<String, dynamic>{
+        'MediaContainer': <String, dynamic>{
+          'Metadata': <dynamic>[
+            <String, dynamic>{'type': 'track', 'title': 'Orphan'},
+            <String, dynamic>{'ratingKey': '7', 'type': 'track', 'title': 'OK'},
+          ],
+        },
+      });
+      expect(container!.metadata, hasLength(1));
+      expect(container.metadata.single.ratingKey, '7');
+    });
+
+    test('tolerates a missing title (mapper supplies the fallback)', () {
+      final PlexMetadata item = _single(<String, dynamic>{
+        'ratingKey': '9',
+        'type': 'track',
+      });
+      expect(item.ratingKey, '9');
+      expect(item.title, isNull);
+    });
+
+    test('accepts ratingKey reported as a bare number', () {
+      // Some PMS fields/servers emit numeric ids rather than strings.
+      final PlexMetadata item = _single(<String, dynamic>{
+        'ratingKey': 42,
+        'type': 'album',
+        'title': 'Numbered',
+      });
+      expect(item.ratingKey, '42');
+    });
+  });
+
+  group('PlexMediaContainer.fromJson — pagination', () {
+    test('reads totalSize / size / offset for the paged walk', () {
+      final PlexMediaContainer container = _container(<String, dynamic>{
+        'size': 50,
+        'totalSize': 1234,
+        'offset': 500,
+        'Metadata': <dynamic>[],
+      });
+      expect(container.size, 50);
+      expect(container.totalSize, 1234);
+      expect(container.offset, 500);
+      expect(container.total, 1234);
+    });
+
+    test('total falls back to size when totalSize is absent (single page)', () {
+      final PlexMediaContainer container = _container(<String, dynamic>{
+        'size': 12,
+        'Metadata': <dynamic>[],
+      });
+      expect(container.totalSize, isNull);
+      expect(container.total, 12);
+    });
+
+    test('returns null when the body is not a MediaContainer', () {
+      expect(PlexMediaContainer.fromJson(<String, dynamic>{}), isNull);
+    });
+  });
+
+  group('no token leakage', () {
+    test('DTOs carry only credential-free paths/ids, never a token', () {
+      // ratingKey is identity; the Part key is a server path. Neither is the
+      // X-Plex-Token, which only the URL builders weave in at play/render time.
+      final PlexMetadata track = _single(<String, dynamic>{
+        'ratingKey': '123',
+        'type': 'track',
+        'title': 'Roygbiv',
+        'thumb': '/library/metadata/123/thumb/9',
+        'Media': <dynamic>[
+          <String, dynamic>{
+            'Part': <dynamic>[
+              <String, dynamic>{'key': '/library/parts/12345/167/file.flac'},
+            ],
+          },
+        ],
+      });
+
+      final String dump = <Object?>[
+        track.ratingKey,
+        track.thumb,
+        track.firstPartKey,
+      ].join(' ');
+      expect(dump.toLowerCase(), isNot(contains('x-plex-token')));
+      expect(dump.toLowerCase(), isNot(contains('token')));
+    });
+  });
+}
+
+/// Parses [meta] as the sole item of a one-element `Metadata` array.
+PlexMetadata _single(Map<String, dynamic> meta) {
+  final PlexMediaContainer container = _container(<String, dynamic>{
+    'Metadata': <dynamic>[meta],
+  });
+  return container.metadata.single;
+}
+
+/// Wraps [body] in the `MediaContainer` envelope and parses it.
+PlexMediaContainer _container(Map<String, dynamic> body) {
+  final PlexMediaContainer? container =
+      PlexMediaContainer.fromJson(<String, dynamic>{'MediaContainer': body});
+  expect(container, isNotNull);
+  return container!;
+}

--- a/test/core/sources/plex/plex_endpoints_test.dart
+++ b/test/core/sources/plex/plex_endpoints_test.dart
@@ -83,7 +83,8 @@ void main() {
       expect(uri.queryParameters[PlexEndpoints.typeParam], '10');
     });
 
-    test('the named pagination keys are exactly the PMS header/query names', () {
+    test('the named pagination keys are exactly the PMS header/query names',
+        () {
       expect(PlexEndpoints.containerStartParam, 'X-Plex-Container-Start');
       expect(PlexEndpoints.containerSizeParam, 'X-Plex-Container-Size');
     });
@@ -104,8 +105,8 @@ void main() {
         PlexEndpoints.metadata(_base, ratingKey: '1234'),
       ];
       for (final Uri uri in apiUrls) {
-        expect(uri.queryParameters.containsKey(PlexEndpoints.tokenParam),
-            isFalse,
+        expect(
+            uri.queryParameters.containsKey(PlexEndpoints.tokenParam), isFalse,
             reason: '$uri must not carry the token in its query');
         expect(uri.toString().toLowerCase(), isNot(contains('x-plex-token')),
             reason: '$uri must be safe to log');

--- a/test/core/sources/plex/plex_endpoints_test.dart
+++ b/test/core/sources/plex/plex_endpoints_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_endpoints.dart';
+
+const String _base = 'https://plex.example.com:32400';
+const String _token = 'super-secret-plex-token';
+
+void main() {
+  group('PlexEndpoints builds the API paths internally', () {
+    test('identity targets /identity', () {
+      expect(PlexEndpoints.identity(_base).path, '/identity');
+    });
+
+    test('librarySections targets /library/sections', () {
+      expect(PlexEndpoints.librarySections(_base).path, '/library/sections');
+    });
+
+    test('metadata carries the ratingKey in the path', () {
+      final Uri uri = PlexEndpoints.metadata(_base, ratingKey: '1234');
+      expect(uri.path, '/library/metadata/1234');
+    });
+
+    test('preserves a reverse-proxy subpath ahead of the API path', () {
+      final Uri uri = PlexEndpoints.identity('https://example.com/plex');
+      expect(uri.path, '/plex/identity');
+    });
+  });
+
+  group('PlexEndpoints.sectionItems selects the music type', () {
+    test('artists request type=8 on /library/sections/{key}/all', () {
+      final Uri uri = PlexEndpoints.sectionItems(
+        _base,
+        sectionKey: '3',
+        itemType: PlexMetadataType.artist,
+      );
+      expect(uri.path, '/library/sections/3/all');
+      expect(uri.queryParameters[PlexEndpoints.typeParam], '8');
+    });
+
+    test('albums request type=9', () {
+      final Uri uri = PlexEndpoints.sectionItems(
+        _base,
+        sectionKey: '3',
+        itemType: PlexMetadataType.album,
+      );
+      expect(uri.path, '/library/sections/3/all');
+      expect(uri.queryParameters[PlexEndpoints.typeParam], '9');
+    });
+
+    test('tracks request type=10', () {
+      final Uri uri = PlexEndpoints.sectionItems(
+        _base,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+      expect(uri.path, '/library/sections/3/all');
+      expect(uri.queryParameters[PlexEndpoints.typeParam], '10');
+    });
+
+    test('omits the pagination params when no start/size is given', () {
+      final Uri uri = PlexEndpoints.sectionItems(
+        _base,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+      expect(uri.queryParameters.containsKey(PlexEndpoints.containerStartParam),
+          isFalse);
+      expect(uri.queryParameters.containsKey(PlexEndpoints.containerSizeParam),
+          isFalse);
+    });
+
+    test('adds X-Plex-Container-Start / -Size to page a large library', () {
+      final Uri uri = PlexEndpoints.sectionItems(
+        _base,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+        start: 500,
+        size: 100,
+      );
+      expect(uri.queryParameters[PlexEndpoints.containerStartParam], '500');
+      expect(uri.queryParameters[PlexEndpoints.containerSizeParam], '100');
+      // The type selector survives alongside the paging params.
+      expect(uri.queryParameters[PlexEndpoints.typeParam], '10');
+    });
+
+    test('the named pagination keys are exactly the PMS header/query names', () {
+      expect(PlexEndpoints.containerStartParam, 'X-Plex-Container-Start');
+      expect(PlexEndpoints.containerSizeParam, 'X-Plex-Container-Size');
+    });
+  });
+
+  group('PlexEndpoints API calls carry NO token (it rides in a header)', () {
+    test('identity / sections / items / metadata URLs are token-free', () {
+      final List<Uri> apiUrls = <Uri>[
+        PlexEndpoints.identity(_base),
+        PlexEndpoints.librarySections(_base),
+        PlexEndpoints.sectionItems(
+          _base,
+          sectionKey: '3',
+          itemType: PlexMetadataType.album,
+          start: 0,
+          size: 50,
+        ),
+        PlexEndpoints.metadata(_base, ratingKey: '1234'),
+      ];
+      for (final Uri uri in apiUrls) {
+        expect(uri.queryParameters.containsKey(PlexEndpoints.tokenParam),
+            isFalse,
+            reason: '$uri must not carry the token in its query');
+        expect(uri.toString().toLowerCase(), isNot(contains('x-plex-token')),
+            reason: '$uri must be safe to log');
+      }
+    });
+  });
+
+  group('PlexEndpoints.streamUrl (Part key + token in the query)', () {
+    const String partKey = '/library/parts/12345/167/file.flac';
+
+    test('appends the server-absolute Part key to the base URL', () {
+      final Uri uri =
+          PlexEndpoints.streamUrl(_base, partKey: partKey, token: _token);
+      expect(uri.path, '/library/parts/12345/167/file.flac');
+      expect(uri.host, 'plex.example.com');
+      expect(uri.port, 32400);
+    });
+
+    test('weaves the token into the query — never the path', () {
+      final Uri uri =
+          PlexEndpoints.streamUrl(_base, partKey: partKey, token: _token);
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+      expect(uri.path, isNot(contains(_token)));
+    });
+  });
+
+  group('PlexEndpoints.coverArt (thumb path + token in the query)', () {
+    const String thumb = '/library/metadata/123/thumb/1670000000';
+
+    test('appends the thumb path and weaves the token into the query', () {
+      final Uri uri =
+          PlexEndpoints.coverArt(_base, thumbPath: thumb, token: _token);
+      expect(uri.path, '/library/metadata/123/thumb/1670000000');
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+      // The image URL is fetched plainly, so the token must ride in the query
+      // exactly like the stream URL — and never in the path.
+      expect(uri.path, isNot(contains(_token)));
+    });
+  });
+
+  group('PlexEndpoints.redactToken guards URL/log lines', () {
+    test('redacts the token in a stream URL', () {
+      final String url =
+          PlexEndpoints.streamUrl(_base, partKey: '/p/1', token: _token)
+              .toString();
+      final String redacted = PlexEndpoints.redactToken(url);
+      expect(redacted, isNot(contains(_token)));
+      expect(redacted, contains('X-Plex-Token=<redacted>'));
+    });
+
+    test('redacts the token mid-query without eating later params', () {
+      const String line =
+          'GET /p/1?X-Plex-Token=$_token&X-Plex-Container-Size=50 200';
+      final String redacted = PlexEndpoints.redactToken(line);
+      expect(redacted, isNot(contains(_token)));
+      expect(redacted, contains('X-Plex-Token=<redacted>'));
+      // The value stops at the '&' so the following param survives intact.
+      expect(redacted, contains('X-Plex-Container-Size=50'));
+    });
+
+    test('redacts a token that appears before a fragment', () {
+      const String line = 'https://h/p?X-Plex-Token=$_token#frag';
+      final String redacted = PlexEndpoints.redactToken(line);
+      expect(redacted, isNot(contains(_token)));
+      expect(redacted, contains('#frag'));
+    });
+
+    test('matches the parameter name case-insensitively', () {
+      const String line = 'https://h/p?x-plex-token=$_token';
+      expect(PlexEndpoints.redactToken(line), isNot(contains(_token)));
+    });
+
+    test('leaves a token-free line untouched', () {
+      const String line = 'GET /library/sections 200';
+      expect(PlexEndpoints.redactToken(line), line);
+    });
+  });
+}


### PR DESCRIPTION
## What

First code foundation for the future **read-only Plex music provider** — PR 2 from the sequence in [issue #178](https://github.com/TheZupZup/Linthra/issues/178) / [`docs/plex.md`](docs/plex.md). Pure JSON parsing + pure URL builders, fully unit-tested.

Deliberately **out of scope** for this PR (kept small and reviewable): no UI, no provider registration, no playback changes, no secure storage, no auth flow, no version/release changes, and **no changes to Jellyfin, Navidrome/Subsonic, or Local**.

## Files

| File | Purpose |
| --- | --- |
| `lib/core/sources/plex/plex_api.dart` | JSON wire models (DTOs) |
| `lib/core/sources/plex/plex_endpoints.dart` | Pure URL builders |
| `test/core/sources/plex/plex_api_test.dart` | DTO parsing tests |
| `test/core/sources/plex/plex_endpoints_test.dart` | URL builder + redaction tests |

These mirror the existing `jellyfin_api.dart`/`jellyfin_endpoints.dart` and `subsonic_*` layout and conventions.

## DTOs (`plex_api.dart`)

- `PlexMediaContainer` — the envelope every listing wraps in, with `size` / `totalSize` / `offset` and a `total` getter (falls back to `size` for single-page responses) for the paged walk.
- `PlexDirectory` — library sections (`key`, `title`, `type`, `uuid`) with an `isMusic` flag (`type == "artist"`).
- `PlexMetadata` — artists/albums/tracks in one DTO: `ratingKey`, `parentRatingKey`, `grandparentRatingKey`, parent/grandparent titles, `thumb`, optional `duration` (ms), and `Media`/`Part` entries. `firstPartKey` exposes `Media[0].Part[0].key` for the documented two-step play resolution.
- `PlexMedia` / `PlexPart` — the rendition + file path.
- `PlexServerIdentity` — `machineIdentifier` + version from `GET /identity`.
- `PlexMetadataType` — the one place 8→artist / 9→album / 10→track lives.
- **JSON-only is intentional for phase 1** (documented in the file header); PMS XML is deliberately unsupported here — the future client sets `Accept: application/json` and maps a non-JSON body to a clear error.

## Endpoints (`plex_endpoints.dart`)

Pure `Uri` builders for: `GET /identity`, `GET /library/sections`, `GET /library/sections/{key}/all?type=8|9|10`, `GET /library/metadata/{ratingKey}`, the direct-play **stream URL** from a Part key, and the **cover-art URL** from a `thumb` path. Pagination via `X-Plex-Container-Start` / `X-Plex-Container-Size`.

## Token safety

- **API-call URLs carry no token** — it rides in the request header (set by the future client), so `/identity`, `/library/sections`, `/library/sections/{key}/all`, and `/library/metadata` URLs are safe to log. Tests assert this.
- Only the **stream/cover-art** URLs weave the token into the **query** (the audio/image layers can't set headers); tests assert the token never lands in a path.
- `PlexEndpoints.redactToken(...)` centrally redacts `X-Plex-Token=…` in any URL/log line (case-insensitive, value-bounded), with tests.
- DTOs hold only credential-free ids/paths (`ratingKey`, Part `key`, `thumb`) — never a token.

## Verification

- `dart analyze` clean on both production files.
- All DTO parsing and endpoint/redaction logic exercised and passing via a standalone harness (the in-repo tests run under `flutter test` in CI).

Refs #178

https://claude.ai/code/session_01A9XTt81arR8NTAvRZrsz1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9XTt81arR8NTAvRZrsz1Y)_