### PR TITLE
Add HTTP Plex client foundation + fake test client

### DIFF
--- a/lib/core/sources/plex/http_plex_client.dart
+++ b/lib/core/sources/plex/http_plex_client.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'plex_api.dart';
+import 'plex_client.dart';
+import 'plex_endpoints.dart';
+import 'plex_exception.dart';
+
+/// The real [PlexClient], backed by `package:http`.
+///
+/// The only file in the app that talks to a Plex Media Server over HTTP: it sets
+/// the `Accept: application/json` header (Plex defaults to XML — see
+/// docs/plex.md → Risks), the `X-Plex-Token` header, the [PlexClientIdentity]
+/// headers, and parses the JSON `MediaContainer` envelope. The token-bearing
+/// stream/art URLs are built elsewhere ([PlexEndpoints]); the API calls here
+/// keep the token in a header, so the URLs they build are token-free and safe to
+/// log.
+///
+/// Every failure becomes a [PlexException]; the token is never written into an
+/// exception, a log, or any other output, so a leaked error string can't expose
+/// it. Transport errors are classified from the low-level failure but only the
+/// static, secret-free factory messages are ever thrown.
+class HttpPlexClient implements PlexClient {
+  HttpPlexClient({
+    required PlexClientIdentity identity,
+    http.Client? httpClient,
+    int pageSize = _defaultPageSize,
+  })  : assert(pageSize > 0, 'pageSize must be positive'),
+        _identity = identity,
+        _pageSize = pageSize,
+        _client = httpClient ?? http.Client();
+
+  final PlexClientIdentity _identity;
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(seconds: 20);
+
+  /// A page is requested this large; large libraries are walked page by page.
+  /// Overridable via the constructor (mainly so tests can exercise the paged
+  /// walk without 200-item fixtures).
+  static const int _defaultPageSize = 200;
+  final int _pageSize;
+
+  /// A generous page-count cap stops a runaway loop if a server ever ignores the
+  /// `X-Plex-Container-Start` offset.
+  static const int _maxPages = 1000;
+
+  @override
+  Future<PlexServerIdentity> fetchIdentity({
+    required String baseUrl,
+    required String token,
+  }) async {
+    final Map<String, dynamic> json =
+        await _getJson(PlexEndpoints.identity(baseUrl), token);
+    final PlexServerIdentity? identity = PlexServerIdentity.fromJson(json);
+    if (identity == null) {
+      // A 200 body with no `machineIdentifier`: something answered, but it isn't
+      // a recognisable Plex server.
+      throw PlexException.notPlex();
+    }
+    return identity;
+  }
+
+  @override
+  Future<List<PlexDirectory>> fetchSections({
+    required String baseUrl,
+    required String token,
+  }) async {
+    final PlexMediaContainer container =
+        await _getContainer(PlexEndpoints.librarySections(baseUrl), token);
+    return container.directories;
+  }
+
+  @override
+  Future<List<PlexMetadata>> fetchSectionItems({
+    required String baseUrl,
+    required String token,
+    required String sectionKey,
+    required PlexMetadataType itemType,
+  }) async {
+    final List<PlexMetadata> items = <PlexMetadata>[];
+    // Walk pages until the server reports the whole set is fetched, hands back a
+    // short (final) page, or returns nothing. `MediaContainer.totalSize` is the
+    // authoritative total; `size` is how many this page actually returned.
+    int start = 0;
+    for (int page = 0; page < _maxPages; page++) {
+      final Uri uri = PlexEndpoints.sectionItems(
+        baseUrl,
+        sectionKey: sectionKey,
+        itemType: itemType,
+        start: start,
+        size: _pageSize,
+      );
+      final PlexMediaContainer container = await _getContainer(uri, token);
+      items.addAll(container.metadata);
+
+      final int returned = container.size ?? container.metadata.length;
+      if (returned <= 0) break;
+      start += returned;
+      final int? total = container.totalSize;
+      if (total != null && start >= total) break;
+      if (returned < _pageSize) break;
+    }
+    return items;
+  }
+
+  @override
+  Future<PlexMetadata> fetchMetadata({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+  }) async {
+    final PlexMediaContainer container = await _getContainer(
+      PlexEndpoints.metadata(baseUrl, ratingKey: ratingKey),
+      token,
+    );
+    if (container.metadata.isEmpty) {
+      // A 200 Plex envelope that carried no item — a shape we can't use.
+      throw PlexException.unsupportedResponse();
+    }
+    return container.metadata.first;
+  }
+
+  /// GETs [uri] with the auth + identity headers, checks the status, and decodes
+  /// a JSON `MediaContainer` envelope — throwing [PlexException.notPlex] when the
+  /// body isn't a Plex `MediaContainer` (missing envelope, or non-JSON/XML).
+  Future<PlexMediaContainer> _getContainer(Uri uri, String token) async {
+    final PlexMediaContainer? container =
+        PlexMediaContainer.fromJson(await _getJson(uri, token));
+    if (container == null) {
+      throw PlexException.notPlex();
+    }
+    return container;
+  }
+
+  /// GETs [uri] with the standard headers, maps the status to a [PlexException],
+  /// and decodes a JSON object body.
+  ///
+  /// The [token] rides in the `X-Plex-Token` **header**, so it never reaches
+  /// [uri] (which stays token-free and loggable). The identity headers and
+  /// `Accept: application/json` are added so the PMS answers with JSON.
+  Future<Map<String, dynamic>> _getJson(Uri uri, String token) async {
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _headers(token)),
+    );
+    _checkStatus(response);
+    return _decodeObject(response);
+  }
+
+  /// The headers every API call sends: `Accept: application/json` (Plex defaults
+  /// to XML), the `X-Plex-Token` **header** (never a query param, so the URL is
+  /// safe to log), and the stable [PlexClientIdentity] headers.
+  Map<String, String> _headers(String token) => <String, String>{
+        'Accept': 'application/json',
+        PlexEndpoints.tokenParam: token,
+        ..._identity.toHeaders(),
+      };
+
+  /// Runs a request with a timeout, turning any transport-level failure (DNS,
+  /// refused connection, TLS handshake, timeout) into a single friendly
+  /// [PlexException.notReachable].
+  ///
+  /// Security: the low-level error text could in principle contain a URL, so it
+  /// is **never** echoed into the thrown message — only the static, token-free
+  /// factory is used.
+  Future<http.Response> _send(Future<http.Response> Function() request) async {
+    try {
+      return await request().timeout(_timeout);
+    } on TimeoutException {
+      throw PlexException.notReachable();
+    } on http.ClientException {
+      throw PlexException.notReachable();
+    } on Exception {
+      // SocketException / HandshakeException and friends: all "can't reach it".
+      throw PlexException.notReachable();
+    }
+  }
+
+  /// Maps an HTTP status to a [PlexException]. 2xx passes; everything else throws
+  /// before the body is parsed, so error handling never depends on — or echoes —
+  /// response content.
+  void _checkStatus(http.Response response) {
+    final int code = response.statusCode;
+    if (code >= 200 && code < 300) return;
+    if (code == 401 || code == 403) {
+      throw PlexException.unauthorized();
+    }
+    if (code == 404) {
+      throw PlexException.notFound();
+    }
+    if (code >= 500) {
+      throw PlexException.serverError(code);
+    }
+    // Other 4xx (wrong path, proxy 4xx, …) usually mean the address isn't really
+    // a Plex API root.
+    throw PlexException.notPlex();
+  }
+
+  /// Decodes a JSON object body, or throws [PlexException.notPlex] when the body
+  /// isn't JSON (Plex's default XML, an HTML error page, …) or isn't an object.
+  Map<String, dynamic> _decodeObject(http.Response response) {
+    Object? decoded;
+    try {
+      // Decode the raw bytes as UTF-8 rather than `response.body` (which falls
+      // back to latin1 without a charset and would mangle non-ASCII titles and
+      // artist names).
+      final String text = utf8.decode(response.bodyBytes, allowMalformed: true);
+      decoded = jsonDecode(text);
+    } on FormatException {
+      // Not JSON at all — e.g. Plex's default XML, or an HTML proxy error page.
+      throw PlexException.notPlex();
+    }
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    throw PlexException.notPlex();
+  }
+}

--- a/lib/core/sources/plex/plex_client.dart
+++ b/lib/core/sources/plex/plex_client.dart
@@ -1,0 +1,120 @@
+import 'plex_api.dart';
+import 'plex_exception.dart';
+
+/// The stable client-identity a Plex client announces on every request.
+///
+/// Plex expects each client install to identify itself with a set of
+/// `X-Plex-*` headers alongside the auth token: a stable per-install
+/// [clientIdentifier] (a UUID) plus human-readable [product] / [version] /
+/// [platform] / [device] strings. This is analogous to Jellyfin's device id +
+/// `Authorization` client header. None of these are secret — they carry **no**
+/// token and are safe to log — but they are required for a PMS to accept the
+/// request, so they live in one typed place the client merges into its headers.
+class PlexClientIdentity {
+  const PlexClientIdentity({
+    required this.clientIdentifier,
+    required this.product,
+    required this.version,
+    required this.platform,
+    required this.device,
+  });
+
+  // --- Header names: written once so a typo can't split a request. ---
+  static const String clientIdentifierHeader = 'X-Plex-Client-Identifier';
+  static const String productHeader = 'X-Plex-Product';
+  static const String versionHeader = 'X-Plex-Version';
+  static const String platformHeader = 'X-Plex-Platform';
+  static const String deviceHeader = 'X-Plex-Device';
+
+  /// A stable per-install UUID identifying this client to the server. Not a
+  /// secret; it never grants access on its own.
+  final String clientIdentifier;
+
+  /// The product name reported to Plex (e.g. `Linthra`).
+  final String product;
+
+  /// The client/app version string.
+  final String version;
+
+  /// The platform the client runs on (e.g. `Android`).
+  final String platform;
+
+  /// A human-readable device name/model.
+  final String device;
+
+  /// The five `X-Plex-*` identity headers as a map, ready to merge with the
+  /// `Accept` and `X-Plex-Token` headers the client adds per request. Carries no
+  /// token, so the result is safe to log.
+  Map<String, String> toHeaders() => <String, String>{
+        clientIdentifierHeader: clientIdentifier,
+        productHeader: product,
+        versionHeader: version,
+        platformHeader: platform,
+        deviceHeader: device,
+      };
+}
+
+/// The single seam through which Linthra talks HTTP to a Plex Media Server.
+///
+/// Every request to Plex goes through this interface, so the rest of the app
+/// (the future authenticator, source, settings) depends only on it — never on
+/// `http`, URLs, headers, or JSON. That keeps networking swappable and, just as
+/// importantly, lets tests drive the whole feature with a fake client and canned
+/// responses (no real server).
+///
+/// Each call takes the server [baseUrl] and the `X-Plex-Token` explicitly (a
+/// `PlexSession` that bundles them is a later PR). Implementations send the
+/// token as the `X-Plex-Token` **header** — never in these API URLs, which stay
+/// token-free and safe to log — alongside the [PlexClientIdentity] headers and
+/// `Accept: application/json`.
+///
+/// Implementations throw a [PlexException] (with a friendly message and a
+/// [PlexErrorKind]) for every failure, and must **never** put the token into an
+/// exception, a log, or any other output (header **or** query param). See
+/// docs/plex.md → Token safety rules.
+abstract interface class PlexClient {
+  /// Fetches server identity from `GET /identity`, confirming the address is a
+  /// reachable Plex Media Server (and recording its `machineIdentifier` /
+  /// version). Backs the "Test connection" / token-verify flow.
+  ///
+  /// Throws [PlexException] ([PlexErrorKind.notPlex] when the body isn't a Plex
+  /// `MediaContainer`, [PlexErrorKind.unauthorized] when the token is rejected,
+  /// [PlexErrorKind.notReachable] when offline).
+  Future<PlexServerIdentity> fetchIdentity({
+    required String baseUrl,
+    required String token,
+  });
+
+  /// Lists the server's library sections from `GET /library/sections`.
+  ///
+  /// Returns **all** sections (movies, shows, music, …); selecting the music
+  /// ones ([PlexDirectory.isMusic]) is the caller's job, since the user picks
+  /// which music libraries to include.
+  Future<List<PlexDirectory>> fetchSections({
+    required String baseUrl,
+    required String token,
+  });
+
+  /// Lists every item of one music [itemType] (artist 8 / album 9 / track 10)
+  /// in the section [sectionKey], walking **all pages** internally via
+  /// `X-Plex-Container-Start` / `X-Plex-Container-Size` so the caller gets the
+  /// complete set in one call.
+  Future<List<PlexMetadata>> fetchSectionItems({
+    required String baseUrl,
+    required String token,
+    required String sectionKey,
+    required PlexMetadataType itemType,
+  });
+
+  /// Fetches a single item from `GET /library/metadata/{ratingKey}`, including
+  /// its `Media`/`Part` entries — the play-time lookup that turns an opaque
+  /// `plex:<ratingKey>` into a playable [PlexPart.key].
+  ///
+  /// Throws [PlexException] ([PlexErrorKind.notFound] when the `ratingKey` no
+  /// longer exists).
+  Future<PlexMetadata> fetchMetadata({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+  });
+}

--- a/lib/core/sources/plex/plex_exception.dart
+++ b/lib/core/sources/plex/plex_exception.dart
@@ -1,0 +1,128 @@
+/// The category of a [PlexException].
+///
+/// Lets the UI react to the *kind* of failure (re-prompt for the token on
+/// [unauthorized], suggest checking the address on [notReachable]/[notPlex])
+/// without fragile matching on message text. Mirrors [JellyfinException] /
+/// [SubsonicException].
+enum PlexErrorKind {
+  /// The address the user typed isn't a usable http(s) URL.
+  invalidUrl,
+
+  /// The server couldn't be reached at all (DNS, connection refused, TLS
+  /// handshake, or timeout). Often a wrong address or an offline tunnel.
+  notReachable,
+
+  /// The server answered but rejected the token (HTTP 401/403). A Plex server
+  /// returns these when the `X-Plex-Token` is missing, wrong, or not scoped to
+  /// the requested library.
+  unauthorized,
+
+  /// Something answered, but it isn't a Plex Media Server we can use: a non-JSON
+  /// body (Plex defaults to **XML** and only returns JSON for
+  /// `Accept: application/json` — an older server or proxy may still send XML or
+  /// an HTML error page), or a 2xx JSON body with **no `MediaContainer`**
+  /// envelope (so it isn't a recognisable Plex response).
+  notPlex,
+
+  /// The Plex server reported a server-side error (HTTP 5xx).
+  serverError,
+
+  /// The requested item isn't available (HTTP 404) — e.g. a `ratingKey` that no
+  /// longer exists, or a library the token can't reach.
+  notFound,
+
+  /// The server answered with a 2xx Plex envelope Linthra can't use — a shape an
+  /// older/newer server returned that this version doesn't understand (e.g. a
+  /// metadata lookup whose `MediaContainer` carried no item).
+  unsupportedResponse,
+
+  /// Any other unexpected failure.
+  unexpected,
+}
+
+/// The single typed error the Plex layer throws.
+///
+/// Callers get a friendly, user-facing [message] plus a [kind] to branch on,
+/// instead of a raw HTTP/socket failure — exactly like [JellyfinException] and
+/// [SubsonicException].
+///
+/// **Security invariant — the token must NEVER reach a message.** A Plex
+/// `X-Plex-Token` rides in an `X-Plex-Token` *header* for API calls and in a
+/// *query param* for stream/art URLs, so a single leaked URL or error string
+/// would expose the whole token. The factories below intentionally carry only a
+/// status code and a generic, safe explanation — never the request URL, a
+/// header, or a response body. See docs/plex.md → Token safety rules.
+class PlexException implements Exception {
+  const PlexException(
+    this.message, {
+    this.kind = PlexErrorKind.unexpected,
+    this.statusCode,
+  });
+
+  /// The typed address-format failure. The caller supplies a specific reason
+  /// (what was wrong with the input) since only it knows the context.
+  const PlexException.invalidUrl(this.message)
+      : kind = PlexErrorKind.invalidUrl,
+        statusCode = null;
+
+  factory PlexException.notReachable() => const PlexException(
+        "Couldn't reach your Plex server. Check the address and that you're "
+        'online. If your server is behind a reverse proxy or tunnel, make sure '
+        'it is running.',
+        kind: PlexErrorKind.notReachable,
+      );
+
+  factory PlexException.unauthorized() => const PlexException(
+        'Your Plex token was not accepted by the server. Check that the token '
+        'is correct and still valid.',
+        kind: PlexErrorKind.unauthorized,
+        statusCode: 401,
+      );
+
+  factory PlexException.notPlex() => const PlexException(
+        "That address responded, but it doesn't look like a Plex Media Server. "
+        'Double-check the URL — point it at the server root (Plex normally '
+        'listens on port 32400).',
+        kind: PlexErrorKind.notPlex,
+      );
+
+  factory PlexException.serverError(int statusCode) => PlexException(
+        'Your Plex server reported an error (HTTP $statusCode). '
+        'Try again in a moment.',
+        kind: PlexErrorKind.serverError,
+        statusCode: statusCode,
+      );
+
+  factory PlexException.notFound() => const PlexException(
+        "This item isn't available from your Plex server right now. "
+        'It may have been moved or removed.',
+        kind: PlexErrorKind.notFound,
+        statusCode: 404,
+      );
+
+  factory PlexException.unsupportedResponse([int? statusCode]) => PlexException(
+        'Your Plex server returned a response Linthra could not use'
+        '${statusCode != null ? ' (HTTP $statusCode)' : ''}. '
+        'It may be running an unsupported version.',
+        kind: PlexErrorKind.unsupportedResponse,
+        statusCode: statusCode,
+      );
+
+  factory PlexException.unexpected(int statusCode) => PlexException(
+        'Unexpected response from your Plex server (HTTP $statusCode).',
+        kind: PlexErrorKind.unexpected,
+        statusCode: statusCode,
+      );
+
+  /// A user-facing explanation safe to show in the UI — never carries the token.
+  final String message;
+
+  /// What broadly went wrong, for the UI to branch on.
+  final PlexErrorKind kind;
+
+  /// The HTTP status code, when the failure came from a response.
+  final int? statusCode;
+
+  @override
+  String toString() => message;
+}

--- a/test/core/sources/plex/fake_plex_client.dart
+++ b/test/core/sources/plex/fake_plex_client.dart
@@ -1,0 +1,107 @@
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_client.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+
+/// A configurable [PlexClient] that returns canned responses (or throws) and
+/// records what it was asked, so the future authenticator / source / controllers
+/// can be tested without a real server or HTTP.
+///
+/// Mirrors `FakeJellyfinClient` / `FakeSubsonicClient`: no mocking library, just
+/// settable fields and recorded inputs.
+class FakePlexClient implements PlexClient {
+  FakePlexClient({
+    this.identity,
+    this.identityError,
+    this.sections = const <PlexDirectory>[],
+    this.sectionsError,
+    this.itemsByType = const <PlexMetadataType, List<PlexMetadata>>{},
+    this.itemsError,
+    this.metadataByRatingKey = const <String, PlexMetadata>{},
+    this.metadataError,
+  });
+
+  /// Canned identity for [fetchIdentity]; defaults to a healthy server.
+  PlexServerIdentity? identity;
+  PlexException? identityError;
+
+  /// Canned sections for [fetchSections].
+  List<PlexDirectory> sections;
+  PlexException? sectionsError;
+
+  /// Canned items per music type for [fetchSectionItems].
+  Map<PlexMetadataType, List<PlexMetadata>> itemsByType;
+  PlexException? itemsError;
+
+  /// Canned single items per `ratingKey` for [fetchMetadata]; a missing key
+  /// throws [PlexException.notFound] (the real client maps a 404 the same way).
+  Map<String, PlexMetadata> metadataByRatingKey;
+  PlexException? metadataError;
+
+  // Recorded inputs.
+  String? lastBaseUrl;
+  String? lastToken;
+  final List<({String sectionKey, PlexMetadataType itemType})> itemRequests =
+      <({String sectionKey, PlexMetadataType itemType})>[];
+  final List<String> requestedRatingKeys = <String>[];
+  int identityCount = 0;
+
+  @override
+  Future<PlexServerIdentity> fetchIdentity({
+    required String baseUrl,
+    required String token,
+  }) async {
+    identityCount++;
+    lastBaseUrl = baseUrl;
+    lastToken = token;
+    final PlexException? error = identityError;
+    if (error != null) throw error;
+    return identity ??
+        const PlexServerIdentity(
+          machineIdentifier: 'fake-machine-id',
+          version: '1.40.0',
+        );
+  }
+
+  @override
+  Future<List<PlexDirectory>> fetchSections({
+    required String baseUrl,
+    required String token,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastToken = token;
+    final PlexException? error = sectionsError;
+    if (error != null) throw error;
+    return sections;
+  }
+
+  @override
+  Future<List<PlexMetadata>> fetchSectionItems({
+    required String baseUrl,
+    required String token,
+    required String sectionKey,
+    required PlexMetadataType itemType,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastToken = token;
+    itemRequests.add((sectionKey: sectionKey, itemType: itemType));
+    final PlexException? error = itemsError;
+    if (error != null) throw error;
+    return itemsByType[itemType] ?? const <PlexMetadata>[];
+  }
+
+  @override
+  Future<PlexMetadata> fetchMetadata({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastToken = token;
+    requestedRatingKeys.add(ratingKey);
+    final PlexException? error = metadataError;
+    if (error != null) throw error;
+    final PlexMetadata? item = metadataByRatingKey[ratingKey];
+    if (item == null) throw PlexException.notFound();
+    return item;
+  }
+}

--- a/test/core/sources/plex/http_plex_client_test.dart
+++ b/test/core/sources/plex/http_plex_client_test.dart
@@ -211,7 +211,10 @@ void main() {
       final HttpPlexClient client = _client(MockClient((http.Request r) async {
         captured = r;
         return _json(<String, dynamic>{
-          'MediaContainer': <String, dynamic>{'size': 0, 'Metadata': <dynamic>[]},
+          'MediaContainer': <String, dynamic>{
+            'size': 0,
+            'Metadata': <dynamic>[]
+          },
         });
       }));
 
@@ -230,7 +233,10 @@ void main() {
       final HttpPlexClient client = _client(MockClient((http.Request r) async {
         captured = r;
         return _json(<String, dynamic>{
-          'MediaContainer': <String, dynamic>{'size': 0, 'Metadata': <dynamic>[]},
+          'MediaContainer': <String, dynamic>{
+            'size': 0,
+            'Metadata': <dynamic>[]
+          },
         });
       }));
 
@@ -291,7 +297,8 @@ void main() {
         itemType: PlexMetadataType.track,
       );
 
-      expect(tracks.map((PlexMetadata t) => t.ratingKey), <String>['1', '2', '3']);
+      expect(
+          tracks.map((PlexMetadata t) => t.ratingKey), <String>['1', '2', '3']);
       // Two pages: started at 0 then 2, each asking for the page size.
       expect(requestedStarts, <String>['0', '2']);
       expect(requestedSizes, <String>['2', '2']);
@@ -330,7 +337,10 @@ void main() {
           _client(pageSize: 2, MockClient((http.Request r) async {
         calls++;
         return _json(<String, dynamic>{
-          'MediaContainer': <String, dynamic>{'size': 0, 'Metadata': <dynamic>[]},
+          'MediaContainer': <String, dynamic>{
+            'size': 0,
+            'Metadata': <dynamic>[]
+          },
         });
       }));
 
@@ -441,8 +451,8 @@ void main() {
       await expectLater(
         client.fetchSections(baseUrl: _base, token: _token),
         throwsA(isA<PlexException>()
-            .having((PlexException e) => e.kind, 'kind',
-                PlexErrorKind.serverError)
+            .having(
+                (PlexException e) => e.kind, 'kind', PlexErrorKind.serverError)
             .having((PlexException e) => e.statusCode, 'statusCode', 503)),
       );
     });

--- a/test/core/sources/plex/http_plex_client_test.dart
+++ b/test/core/sources/plex/http_plex_client_test.dart
@@ -1,0 +1,546 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/sources/plex/http_plex_client.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_client.dart';
+import 'package:linthra/core/sources/plex/plex_endpoints.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+
+const String _base = 'https://plex.example.com:32400';
+const String _token = 'super-secret-plex-token';
+
+const PlexClientIdentity _identity = PlexClientIdentity(
+  clientIdentifier: 'install-uuid-1',
+  product: 'Linthra',
+  version: '0.1.5',
+  platform: 'Android',
+  device: 'Pixel',
+);
+
+HttpPlexClient _client(MockClient mock, {int pageSize = 200}) =>
+    HttpPlexClient(identity: _identity, httpClient: mock, pageSize: pageSize);
+
+/// A JSON 200 response with the usual content type.
+http.Response _json(Map<String, dynamic> body) => http.Response(
+      jsonEncode(body),
+      200,
+      headers: const <String, String>{'content-type': 'application/json'},
+    );
+
+void main() {
+  group('fetchIdentity', () {
+    test('parses identity and calls /identity', () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'machineIdentifier': 'abc123def',
+            'version': '1.40.2.8395',
+          },
+        });
+      }));
+
+      final PlexServerIdentity identity =
+          await client.fetchIdentity(baseUrl: _base, token: _token);
+
+      expect(identity.machineIdentifier, 'abc123def');
+      expect(identity.version, '1.40.2.8395');
+      expect(captured!.method, 'GET');
+      expect(captured!.url.path, '/identity');
+    });
+
+    test('sends Accept JSON, the token header, and the identity headers',
+        () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{'machineIdentifier': 'm'},
+        });
+      }));
+
+      await client.fetchIdentity(baseUrl: _base, token: _token);
+
+      final Map<String, String> headers = captured!.headers;
+      // `package:http` lower-cases header names.
+      expect(headers['accept'], 'application/json');
+      expect(headers['x-plex-token'], _token);
+      expect(headers['x-plex-client-identifier'], 'install-uuid-1');
+      expect(headers['x-plex-product'], 'Linthra');
+      expect(headers['x-plex-version'], '0.1.5');
+      expect(headers['x-plex-platform'], 'Android');
+      expect(headers['x-plex-device'], 'Pixel');
+    });
+
+    test('treats a body without machineIdentifier as "not a Plex server"',
+        () async {
+      final HttpPlexClient client = _client(MockClient((_) async => _json(
+            <String, dynamic>{
+              'MediaContainer': <String, dynamic>{'version': '1.40'},
+            },
+          )));
+
+      await expectLater(
+        client.fetchIdentity(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notPlex,
+        )),
+      );
+    });
+
+    test('treats an XML/non-JSON body as "not a Plex server"', () async {
+      // Plex defaults to XML; without a JSON Accept an old server may still
+      // answer XML. The client asks for JSON, so any non-JSON body is a failure.
+      final HttpPlexClient client = _client(MockClient(
+        (_) async => http.Response(
+          '<MediaContainer machineIdentifier="abc"/>',
+          200,
+          headers: const <String, String>{'content-type': 'application/xml'},
+        ),
+      ));
+
+      await expectLater(
+        client.fetchIdentity(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notPlex,
+        )),
+      );
+    });
+
+    test('decodes a UTF-8 body without a charset header', () async {
+      final HttpPlexClient client = _client(MockClient((_) async {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<String, dynamic>{
+            'MediaContainer': <String, dynamic>{
+              'machineIdentifier': 'm',
+              'version': 'Café 1.0',
+            },
+          })),
+          200,
+        );
+      }));
+
+      final PlexServerIdentity identity =
+          await client.fetchIdentity(baseUrl: _base, token: _token);
+      expect(identity.version, 'Café 1.0');
+    });
+  });
+
+  group('fetchSections', () {
+    test('returns every section (music + non-music) from /library/sections',
+        () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'Directory': <dynamic>[
+              <String, dynamic>{'key': '3', 'title': 'Music', 'type': 'artist'},
+              <String, dynamic>{'key': '1', 'title': 'Movies', 'type': 'movie'},
+            ],
+          },
+        });
+      }));
+
+      final List<PlexDirectory> sections =
+          await client.fetchSections(baseUrl: _base, token: _token);
+
+      expect(captured!.url.path, '/library/sections');
+      expect(sections, hasLength(2));
+      expect(sections.first.isMusic, isTrue);
+      expect(sections[1].isMusic, isFalse);
+    });
+
+    test('throws notPlex when the body has no MediaContainer', () async {
+      final HttpPlexClient client =
+          _client(MockClient((_) async => _json(<String, dynamic>{})));
+
+      await expectLater(
+        client.fetchSections(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notPlex,
+        )),
+      );
+    });
+  });
+
+  group('fetchSectionItems — music types 8 / 9 / 10', () {
+    test('artists request type=8 on the section listing path', () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'size': 1,
+            'Metadata': <dynamic>[
+              <String, dynamic>{
+                'ratingKey': '50',
+                'type': 'artist',
+                'title': 'Boards of Canada',
+              },
+            ],
+          },
+        });
+      }));
+
+      final List<PlexMetadata> artists = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.artist,
+      );
+
+      expect(captured!.url.path, '/library/sections/3/all');
+      expect(captured!.url.queryParameters[PlexEndpoints.typeParam], '8');
+      expect(artists.single.ratingKey, '50');
+      expect(artists.single.metadataType, PlexMetadataType.artist);
+    });
+
+    test('albums request type=9', () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{'size': 0, 'Metadata': <dynamic>[]},
+        });
+      }));
+
+      await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.album,
+      );
+
+      expect(captured!.url.queryParameters[PlexEndpoints.typeParam], '9');
+    });
+
+    test('tracks request type=10', () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{'size': 0, 'Metadata': <dynamic>[]},
+        });
+      }));
+
+      await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+
+      expect(captured!.url.queryParameters[PlexEndpoints.typeParam], '10');
+    });
+  });
+
+  group('fetchSectionItems — pagination', () {
+    test('walks every page via X-Plex-Container-Start until totalSize is met',
+        () async {
+      final List<String?> requestedStarts = <String?>[];
+      final List<String?> requestedSizes = <String?>[];
+      // pageSize 2: page 0 returns items 1+2, page 1 returns item 3 (last).
+      final HttpPlexClient client =
+          _client(pageSize: 2, MockClient((http.Request r) async {
+        requestedStarts
+            .add(r.url.queryParameters[PlexEndpoints.containerStartParam]);
+        requestedSizes
+            .add(r.url.queryParameters[PlexEndpoints.containerSizeParam]);
+        final int start = int.parse(
+            r.url.queryParameters[PlexEndpoints.containerStartParam]!);
+        if (start == 0) {
+          return _json(<String, dynamic>{
+            'MediaContainer': <String, dynamic>{
+              'size': 2,
+              'totalSize': 3,
+              'offset': 0,
+              'Metadata': <dynamic>[
+                <String, dynamic>{'ratingKey': '1', 'type': 'track'},
+                <String, dynamic>{'ratingKey': '2', 'type': 'track'},
+              ],
+            },
+          });
+        }
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'size': 1,
+            'totalSize': 3,
+            'offset': 2,
+            'Metadata': <dynamic>[
+              <String, dynamic>{'ratingKey': '3', 'type': 'track'},
+            ],
+          },
+        });
+      }));
+
+      final List<PlexMetadata> tracks = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+
+      expect(tracks.map((PlexMetadata t) => t.ratingKey), <String>['1', '2', '3']);
+      // Two pages: started at 0 then 2, each asking for the page size.
+      expect(requestedStarts, <String>['0', '2']);
+      expect(requestedSizes, <String>['2', '2']);
+    });
+
+    test('stops after a single short page (no totalSize)', () async {
+      int calls = 0;
+      final HttpPlexClient client =
+          _client(pageSize: 200, MockClient((http.Request r) async {
+        calls++;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'size': 2,
+            'Metadata': <dynamic>[
+              <String, dynamic>{'ratingKey': '1', 'type': 'album'},
+              <String, dynamic>{'ratingKey': '2', 'type': 'album'},
+            ],
+          },
+        });
+      }));
+
+      final List<PlexMetadata> albums = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.album,
+      );
+
+      expect(albums, hasLength(2));
+      expect(calls, 1, reason: 'a short page is the last page');
+    });
+
+    test('stops on an empty first page', () async {
+      int calls = 0;
+      final HttpPlexClient client =
+          _client(pageSize: 2, MockClient((http.Request r) async {
+        calls++;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{'size': 0, 'Metadata': <dynamic>[]},
+        });
+      }));
+
+      final List<PlexMetadata> tracks = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+
+      expect(tracks, isEmpty);
+      expect(calls, 1);
+    });
+  });
+
+  group('fetchMetadata', () {
+    test('parses a single item with its Part for the play-time lookup',
+        () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'Metadata': <dynamic>[
+              <String, dynamic>{
+                'ratingKey': '123',
+                'type': 'track',
+                'title': 'Roygbiv',
+                'Media': <dynamic>[
+                  <String, dynamic>{
+                    'Part': <dynamic>[
+                      <String, dynamic>{
+                        'key': '/library/parts/12345/167/file.flac',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        });
+      }));
+
+      final PlexMetadata item = await client.fetchMetadata(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(captured!.url.path, '/library/metadata/123');
+      expect(item.ratingKey, '123');
+      expect(item.firstPartKey, '/library/parts/12345/167/file.flac');
+    });
+
+    test('maps a 404 to notFound', () async {
+      final HttpPlexClient client =
+          _client(MockClient((_) async => http.Response('nope', 404)));
+
+      await expectLater(
+        client.fetchMetadata(baseUrl: _base, token: _token, ratingKey: '999'),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notFound,
+        )),
+      );
+    });
+
+    test('throws unsupportedResponse when the container carries no item',
+        () async {
+      final HttpPlexClient client = _client(MockClient((_) async => _json(
+            <String, dynamic>{
+              'MediaContainer': <String, dynamic>{'Metadata': <dynamic>[]},
+            },
+          )));
+
+      await expectLater(
+        client.fetchMetadata(baseUrl: _base, token: _token, ratingKey: '1'),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.unsupportedResponse,
+        )),
+      );
+    });
+  });
+
+  group('error mapping', () {
+    test('401/403 → unauthorized', () async {
+      for (final int code in <int>[401, 403]) {
+        final HttpPlexClient client =
+            _client(MockClient((_) async => http.Response('no', code)));
+        await expectLater(
+          client.fetchIdentity(baseUrl: _base, token: _token),
+          throwsA(isA<PlexException>().having(
+            (PlexException e) => e.kind,
+            'kind',
+            PlexErrorKind.unauthorized,
+          )),
+        );
+      }
+    });
+
+    test('5xx → serverError carrying the status code', () async {
+      final HttpPlexClient client =
+          _client(MockClient((_) async => http.Response('boom', 503)));
+
+      await expectLater(
+        client.fetchSections(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>()
+            .having((PlexException e) => e.kind, 'kind',
+                PlexErrorKind.serverError)
+            .having((PlexException e) => e.statusCode, 'statusCode', 503)),
+      );
+    });
+
+    test('a non-Plex 4xx → notPlex', () async {
+      final HttpPlexClient client =
+          _client(MockClient((_) async => http.Response('nope', 400)));
+
+      await expectLater(
+        client.fetchSections(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notPlex,
+        )),
+      );
+    });
+
+    test('an HTML/non-JSON 200 body → notPlex', () async {
+      final HttpPlexClient client = _client(
+        MockClient((_) async => http.Response('<html>proxy error</html>', 200)),
+      );
+
+      await expectLater(
+        client.fetchSections(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notPlex,
+        )),
+      );
+    });
+
+    test('a transport failure → notReachable', () async {
+      final HttpPlexClient client = _client(
+        MockClient((_) async => throw http.ClientException('connection lost')),
+      );
+
+      await expectLater(
+        client.fetchIdentity(baseUrl: _base, token: _token),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notReachable,
+        )),
+      );
+    });
+  });
+
+  group('token redaction / no leakage', () {
+    test('the token rides in the X-Plex-Token header, never in the API URL',
+        () async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{'machineIdentifier': 'm'},
+        });
+      }));
+
+      await client.fetchIdentity(baseUrl: _base, token: _token);
+
+      // The token is sent as a header...
+      expect(captured!.headers['x-plex-token'], _token);
+      // ...and the URL (the thing that ends up in logs) is token-free.
+      final String url = captured!.url.toString();
+      expect(url, isNot(contains(_token)));
+      expect(url.toLowerCase(), isNot(contains('x-plex-token')));
+      // And even a hand-built "GET <url>" log line stays clean once redacted.
+      expect(PlexEndpoints.redactToken('GET $url'), isNot(contains(_token)));
+    });
+
+    test('the token never appears in a thrown exception', () async {
+      // Drive every error path with the real token supplied and assert none of
+      // the friendly messages leak it.
+      final List<MockClient> mocks = <MockClient>[
+        MockClient((_) async => http.Response('no', 401)), // unauthorized
+        MockClient((_) async => http.Response('boom', 500)), // serverError
+        MockClient((_) async => http.Response('<html>', 200)), // notPlex
+        MockClient((_) async => http.Response('no', 404)), // notFound
+        MockClient((_) async => throw http.ClientException('x $_token')),
+      ];
+
+      for (final MockClient mock in mocks) {
+        final HttpPlexClient client = _client(mock);
+        try {
+          await client.fetchMetadata(
+            baseUrl: _base,
+            token: _token,
+            ratingKey: '1',
+          );
+          fail('expected a PlexException');
+        } on PlexException catch (e) {
+          expect(e.message, isNot(contains(_token)));
+          expect(e.message.toLowerCase(), isNot(contains('x-plex-token')));
+          expect(e.toString(), isNot(contains(_token)));
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Phase 1 Plex provider, **PR 3** of the sequence in #178 (after #179 design doc and #180 DTOs/endpoints): the HTTP client seam that sits above the DTOs/endpoints from #180. Uses #178, `docs/plex.md`, and the existing Plex DTOs/endpoints as the source of truth.

## Scope (kept small and focused)

**In:**
- `lib/core/sources/plex/plex_client.dart` — the `PlexClient` interface plus `PlexClientIdentity` (the stable `X-Plex-*` identity headers each request carries).
- `lib/core/sources/plex/http_plex_client.dart` — `package:http` implementation.
- `lib/core/sources/plex/plex_exception.dart` — `PlexException` / `PlexErrorKind`, mirroring the Jellyfin/Subsonic error model.
- `test/core/sources/plex/fake_plex_client.dart` — hand-written `FakePlexClient` for future source/authenticator tests (matches the existing `Fake*` style).
- `test/core/sources/plex/http_plex_client_test.dart` — client tests.

**Out (deliberately, per the task):** no UI, no provider registration, no playback changes, no secure storage, no auth flow, no `MusicSource` impl, no version/release changes, and **no changes** to Jellyfin, Navidrome/Subsonic, or Local music.

## Client responsibilities

- Sends `Accept: application/json` (Plex defaults to XML).
- Sends `X-Plex-Token` as a **header** for API calls — never in the API URL, so URLs stay safe to log.
- Sends the Plex identity headers: `X-Plex-Client-Identifier`, `X-Plex-Product`, `X-Plex-Version`, `X-Plex-Platform`, `X-Plex-Device`.
- Fetches server identity from `/identity`, library sections from `/library/sections`, artists/albums/tracks via `type` 8/9/10, and a single item via `/library/metadata/{ratingKey}`.
- Walks **all pages** via `X-Plex-Container-Start` / `X-Plex-Container-Size` (page size overridable for tests).
- Parses JSON with the #180 DTOs; returns clear `PlexException`s for non-JSON/XML bodies, bad status codes, malformed responses, and a missing `MediaContainer`.

## Security

- The token never reaches an API URL, an exception message, or any diagnostic — it rides only in the `X-Plex-Token` header here.
- Exception messages are static and token-free.
- Tests prove redaction/no-leakage: the token is sent as a header (URL is token-free and stays clean through `PlexEndpoints.redactToken`), and it never appears in any thrown exception across every error path.

## Tests

`flutter test test/core/sources/plex/` → **all 61 pass** (23 new client tests covering identity, sections, music items, the metadata lookup, multi-page pagination, error mapping, and token redaction; plus the existing DTO/endpoint suites). `flutter analyze` on the new files is clean.

https://claude.ai/code/session_01SspKMRmNw4A5koJFuxr3yd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SspKMRmNw4A5koJFuxr3yd)_