### PR TITLE
Add Plex manual-token authenticator + secure session store (provider foundation)

### DIFF
--- a/lib/core/models/plex_session.dart
+++ b/lib/core/models/plex_session.dart
@@ -1,0 +1,110 @@
+/// An authenticated Plex session: everything needed to make further authorized
+/// requests to one Plex Media Server, kept in one immutable value so it can be
+/// persisted as a unit and passed to the source.
+///
+/// Security — the token is the whole credential. Plex's `X-Plex-Token` rides in
+/// an `X-Plex-Token` *header* for API calls and in a *query param* for stream/art
+/// URLs, so a single leak exposes everything the token can reach. Linthra stores
+/// **only** the token — preferring a **server-scoped** token over an account-wide
+/// one, the narrowest blast radius if it ever leaks — plus the small amount of
+/// server metadata needed to talk to that one server. The token is persisted only
+/// through the `PlexSessionStore` (the production binding is encrypted on-device)
+/// and must never be logged or shown in the UI. [toString] deliberately redacts
+/// it so an accidental interpolation can't leak it into logs or error text.
+///
+/// No password is involved (phase 1 pastes a token directly), and an
+/// authenticated stream/art URL is **never** part of a session — those are minted
+/// on demand at play/render time and discarded. See docs/plex.md → Token safety
+/// rules.
+class PlexSession {
+  const PlexSession({
+    required this.baseUrl,
+    required this.token,
+    required this.machineIdentifier,
+    this.serverVersion,
+  });
+
+  /// Clean base URL of the server (no trailing slash), e.g.
+  /// `https://plex.example.com:32400`. API paths and the (token-bearing)
+  /// stream/art URLs are built from this.
+  final String baseUrl;
+
+  /// Secret, server-scoped `X-Plex-Token`. Sent as the `X-Plex-Token` header on
+  /// API calls and woven into stream/art query params only at play/render time.
+  /// Never log this.
+  final String token;
+
+  /// The server's stable `machineIdentifier` (from `GET /identity`), used to
+  /// recognise the same server again. Not a secret.
+  final String machineIdentifier;
+
+  /// The server's reported version (from `/identity`), when known. Carried so the
+  /// diagnostics report can show it after a restart. Not secret, display only.
+  final String? serverVersion;
+
+  PlexSession copyWith({
+    String? baseUrl,
+    String? token,
+    String? machineIdentifier,
+    String? serverVersion,
+  }) {
+    return PlexSession(
+      baseUrl: baseUrl ?? this.baseUrl,
+      token: token ?? this.token,
+      machineIdentifier: machineIdentifier ?? this.machineIdentifier,
+      serverVersion: serverVersion ?? this.serverVersion,
+    );
+  }
+
+  /// Serializes for the session store. The token is included because the only
+  /// caller is the (encrypted) store; do not route this through any plaintext
+  /// sink.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'baseUrl': baseUrl,
+        'token': token,
+        'machineIdentifier': machineIdentifier,
+        if (serverVersion != null) 'serverVersion': serverVersion,
+      };
+
+  /// Rebuilds a session from [toJson] output, or returns `null` if any required
+  /// field is missing/blank (e.g. a partially written or corrupted record), so
+  /// the app treats it as "not signed in" rather than crashing.
+  static PlexSession? fromJson(Map<String, dynamic> json) {
+    final String? baseUrl = json['baseUrl'] as String?;
+    final String? token = json['token'] as String?;
+    final String? machineIdentifier = json['machineIdentifier'] as String?;
+    if (baseUrl == null || baseUrl.isEmpty) return null;
+    if (token == null || token.isEmpty) return null;
+    if (machineIdentifier == null || machineIdentifier.isEmpty) return null;
+    return PlexSession(
+      baseUrl: baseUrl,
+      token: token,
+      machineIdentifier: machineIdentifier,
+      serverVersion: json['serverVersion'] as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PlexSession &&
+          other.baseUrl == baseUrl &&
+          other.token == token &&
+          other.machineIdentifier == machineIdentifier &&
+          other.serverVersion == serverVersion);
+
+  @override
+  int get hashCode => Object.hash(
+        baseUrl,
+        token,
+        machineIdentifier,
+        serverVersion,
+      );
+
+  /// Redacts the token so the session can be safely interpolated into logs or
+  /// error messages without leaking the secret.
+  @override
+  String toString() => 'PlexSession(baseUrl: $baseUrl, '
+      'machineIdentifier: $machineIdentifier, '
+      'serverVersion: $serverVersion, token: <redacted>)';
+}

--- a/lib/core/repositories/plex_session_store.dart
+++ b/lib/core/repositories/plex_session_store.dart
@@ -1,0 +1,23 @@
+import '../models/plex_session.dart';
+
+/// Persists the single Plex [PlexSession] across app restarts.
+///
+/// Deliberately separate from authentication (which *produces* a session) and
+/// from library fetching (which *uses* one): this contract owns only the storage
+/// of the signed-in session, so the secret, server-scoped token has exactly one
+/// persistence path that can be made secure in isolation.
+///
+/// The production binding encrypts on-device; tests and dev use an in-memory
+/// implementation. No password is ever given to this store (phase 1 pastes a
+/// token directly) — only the session (token + server metadata) is.
+abstract interface class PlexSessionStore {
+  /// The persisted session, or `null` if the user isn't signed in (or the
+  /// stored record was missing/corrupt).
+  Future<PlexSession?> read();
+
+  /// Persists [session], replacing any previous one.
+  Future<void> write(PlexSession session);
+
+  /// Forgets the signed-in session (sign out).
+  Future<void> clear();
+}

--- a/lib/core/sources/plex/plex_authenticator.dart
+++ b/lib/core/sources/plex/plex_authenticator.dart
@@ -1,0 +1,84 @@
+import '../../models/plex_session.dart';
+import 'plex_api.dart';
+import 'plex_client.dart';
+import 'plex_exception.dart';
+import 'plex_server_url.dart';
+
+/// Turns a manually typed server URL + token into a usable [PlexSession].
+///
+/// The "authentication" concern for phase 1's manual flow, kept separate from
+/// session storage (the `PlexSessionStore`) and from library fetching (the
+/// future `PlexMusicSource`): it normalizes the URL and asks the [PlexClient] to
+/// confirm the address is a reachable Plex Media Server that accepts the token,
+/// via `GET /identity`. It does not persist anything — the controller decides
+/// whether/where to store the session — so this stays a pure coordinator that's
+/// trivial to test with a fake client.
+///
+/// Token safety: the token is only trimmed, handed to the client (which sends it
+/// as the `X-Plex-Token` **header** — never a logged URL), and copied into the
+/// returned session (whose [PlexSession.toString] redacts it). It is never
+/// logged, and the client's [PlexException]s are static and token-free, so a
+/// failure on any path can't leak it. The session stores only the token (prefer a
+/// server-scoped one) plus the server metadata; it never holds a stream/art URL.
+/// See docs/plex.md → Authentication / Token safety rules.
+///
+/// The plex.tv PIN/OAuth flow is a documented follow-up; phase 1 is manual token
+/// paste only.
+class PlexAuthenticator {
+  PlexAuthenticator(this._client);
+
+  final PlexClient _client;
+
+  /// Validates [rawUrl] + [token] and confirms they reach a Plex Media Server
+  /// that accepts them, returning its identity. Throws [PlexException] on a bad
+  /// URL, a missing token, an unreachable/non-Plex server, or a rejected token.
+  ///
+  /// Backs a future "Test connection" button. Like Subsonic's credentialed ping
+  /// (and unlike Jellyfin's anonymous probe), the token is sent on the check, so
+  /// a success also confirms sign-in will work.
+  Future<PlexServerIdentity> testConnection({
+    required String rawUrl,
+    required String token,
+  }) async {
+    final String baseUrl = PlexServerUrl.normalize(rawUrl);
+    final String trimmedToken = _requireToken(token);
+    return _client.fetchIdentity(baseUrl: baseUrl, token: trimmedToken);
+  }
+
+  /// Verifies the server and returns a session that stores **only** the token
+  /// (prefer a server-scoped one) plus the server metadata needed to reach it.
+  ///
+  /// Throws [PlexException] for a bad URL, a missing token, an unreachable/
+  /// non-Plex server, or a rejected token.
+  Future<PlexSession> signIn({
+    required String rawUrl,
+    required String token,
+  }) async {
+    final String baseUrl = PlexServerUrl.normalize(rawUrl);
+    final String trimmedToken = _requireToken(token);
+
+    final PlexServerIdentity identity =
+        await _client.fetchIdentity(baseUrl: baseUrl, token: trimmedToken);
+
+    return PlexSession(
+      baseUrl: baseUrl,
+      token: trimmedToken,
+      machineIdentifier: identity.machineIdentifier,
+      serverVersion: identity.version,
+    );
+  }
+
+  /// Trims a pasted token and rejects an empty one before any network call. A
+  /// real `X-Plex-Token` carries no surrounding whitespace, so trimming only
+  /// removes copy-paste slips; the value is otherwise untouched.
+  String _requireToken(String token) {
+    final String trimmed = token.trim();
+    if (trimmed.isEmpty) {
+      throw const PlexException(
+        'Enter your Plex token.',
+        kind: PlexErrorKind.unauthorized,
+      );
+    }
+    return trimmed;
+  }
+}

--- a/lib/core/sources/plex/plex_server_url.dart
+++ b/lib/core/sources/plex/plex_server_url.dart
@@ -1,0 +1,85 @@
+import 'plex_exception.dart';
+
+/// Validates and normalizes the server address the user types into the Plex
+/// settings (phase 1 authenticates against a manually typed server URL + token).
+///
+/// Intentionally pure string logic with no HTTP: it is the one place that decides
+/// what a "valid Plex address" looks like, so the connection test and sign-in
+/// agree, and so the rules stay unit-testable without a network. Plex Media
+/// Server normally listens on port 32400 and a self-hosted server is often
+/// reached over a reverse proxy, so the choices mirror that:
+///  - A bare host (`plex.example.com`) defaults to **https**, because a remote
+///    server is reached over TLS and users rarely type the scheme. A LAN server
+///    is typed with its scheme and port (`http://192.168.1.10:32400`).
+///  - An explicit port is preserved, since a LAN server is reached by host:port.
+///  - A subpath is preserved (`example.com/plex`), since a reverse proxy may
+///    mount PMS under one; the API paths append to whatever base survives here.
+///  - A trailing slash, query, and fragment are stripped so the result is a
+///    clean base to append to (the endpoint builders concatenate paths directly).
+abstract final class PlexServerUrl {
+  /// Returns a clean base URL (no trailing slash) for [input], or throws a
+  /// [PlexException] of kind [PlexErrorKind.invalidUrl] with a friendly reason
+  /// when the address can't be used.
+  static String normalize(String input) {
+    final String trimmed = input.trim();
+    if (trimmed.isEmpty) {
+      throw const PlexException.invalidUrl(
+        'Enter your Plex server address, e.g. http://192.168.1.10:32400',
+      );
+    }
+
+    // No scheme typed → assume https (the common remote default).
+    final String withScheme =
+        trimmed.contains('://') ? trimmed : 'https://$trimmed';
+
+    final Uri? uri = Uri.tryParse(withScheme);
+    if (uri == null) {
+      throw const PlexException.invalidUrl(
+        "That doesn't look like a valid web address.",
+      );
+    }
+
+    final String scheme = uri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      throw const PlexException.invalidUrl(
+        'The address must start with https:// (or http:// on a local network).',
+      );
+    }
+
+    if (uri.host.isEmpty) {
+      throw const PlexException.invalidUrl(
+        'The address is missing a server name, e.g. 192.168.1.10:32400',
+      );
+    }
+
+    final StringBuffer base = StringBuffer()
+      ..write(scheme)
+      ..write('://')
+      ..write(uri.host);
+    if (uri.hasPort) {
+      base
+        ..write(':')
+        ..write(uri.port);
+    }
+    base.write(_trimTrailingSlashes(uri.path));
+    return base.toString();
+  }
+
+  /// Like [normalize] but returns `null` instead of throwing, for callers that
+  /// only need a yes/no (e.g. enabling a button) and don't want the reason.
+  static String? tryNormalize(String input) {
+    try {
+      return normalize(input);
+    } on PlexException {
+      return null;
+    }
+  }
+
+  static String _trimTrailingSlashes(String path) {
+    int end = path.length;
+    while (end > 0 && path[end - 1] == '/') {
+      end--;
+    }
+    return path.substring(0, end);
+  }
+}

--- a/lib/data/repositories/in_memory_plex_session_store.dart
+++ b/lib/data/repositories/in_memory_plex_session_store.dart
@@ -1,0 +1,28 @@
+import '../../core/models/plex_session.dart';
+import '../../core/repositories/plex_session_store.dart';
+
+/// A non-persistent [PlexSessionStore] for development and tests.
+///
+/// Holds the session in a single field, so it's forgotten when the instance is
+/// dropped. This is the default binding (mirroring the other repositories); the
+/// running app swaps in [SecurePlexSessionStore] so the server-scoped token
+/// survives restarts in encrypted storage.
+class InMemoryPlexSessionStore implements PlexSessionStore {
+  InMemoryPlexSessionStore({PlexSession? initialSession})
+      : _session = initialSession;
+
+  PlexSession? _session;
+
+  @override
+  Future<PlexSession?> read() async => _session;
+
+  @override
+  Future<void> write(PlexSession session) async {
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    _session = null;
+  }
+}

--- a/lib/data/repositories/secure_plex_session_store.dart
+++ b/lib/data/repositories/secure_plex_session_store.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../../core/models/plex_session.dart';
+import '../../core/repositories/plex_session_store.dart';
+
+/// A [PlexSessionStore] backed by `flutter_secure_storage`.
+///
+/// The session is serialized to JSON and written to platform-encrypted storage
+/// (Android Keystore-backed) under a single key, so the server-scoped token is
+/// never at rest in plaintext (unlike `shared_preferences`). This is the
+/// production binding; it's intentionally never touched by tests, which use the
+/// in-memory store so they stay free of platform channels.
+///
+/// A malformed/partial record reads back as `null` (treated as "signed out")
+/// rather than throwing, so a storage glitch can't wedge the app at launch.
+class SecurePlexSessionStore implements PlexSessionStore {
+  const SecurePlexSessionStore({
+    FlutterSecureStorage storage = const FlutterSecureStorage(),
+  }) : _storage = storage;
+
+  final FlutterSecureStorage _storage;
+
+  static const String _key = 'plex_session_v1';
+
+  @override
+  Future<PlexSession?> read() async {
+    final String? raw = await _storage.read(key: _key);
+    if (raw == null || raw.isEmpty) {
+      return null;
+    }
+    try {
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return PlexSession.fromJson(decoded);
+      }
+      return null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> write(PlexSession session) async {
+    await _storage.write(key: _key, value: jsonEncode(session.toJson()));
+  }
+
+  @override
+  Future<void> clear() async {
+    await _storage.delete(key: _key);
+  }
+}

--- a/test/core/sources/plex/plex_authenticator_test.dart
+++ b/test/core/sources/plex/plex_authenticator_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_authenticator.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+
+import 'fake_plex_client.dart';
+
+void main() {
+  late FakePlexClient client;
+
+  PlexAuthenticator auth() => PlexAuthenticator(client);
+
+  setUp(() => client = FakePlexClient());
+
+  group('PlexAuthenticator.testConnection', () {
+    test('normalizes the URL, sends the token as given, returns identity',
+        () async {
+      client.identity = const PlexServerIdentity(
+        machineIdentifier: 'machine-abc',
+        version: '1.40.1',
+      );
+
+      final identity = await auth().testConnection(
+        rawUrl: 'plex.example.com',
+        token: '  tok-123  ',
+      );
+
+      expect(identity.machineIdentifier, 'machine-abc');
+      // Bare host got the https scheme; the pasted token was trimmed first.
+      expect(client.lastBaseUrl, 'https://plex.example.com');
+      expect(client.lastToken, 'tok-123');
+    });
+
+    test('rejects an empty token before any network call', () async {
+      await expectLater(
+        auth().testConnection(rawUrl: 'plex.example.com', token: '   '),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+      expect(client.lastToken, isNull); // never reached the client
+    });
+
+    test('throws an invalidUrl before touching the client', () async {
+      await expectLater(
+        auth().testConnection(rawUrl: '   ', token: 'tok'),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.invalidUrl)),
+      );
+      expect(client.lastBaseUrl, isNull);
+    });
+  });
+
+  group('PlexAuthenticator.signIn', () {
+    test('produces a session storing the token + server metadata', () async {
+      client.identity = const PlexServerIdentity(
+        machineIdentifier: 'machine-abc',
+        version: '1.40.1',
+      );
+
+      final session = await auth().signIn(
+        rawUrl: 'https://plex.example.com:32400/',
+        token: 'tok-123',
+      );
+
+      // Trailing slash stripped; explicit port preserved.
+      expect(session.baseUrl, 'https://plex.example.com:32400');
+      expect(session.token, 'tok-123');
+      expect(session.machineIdentifier, 'machine-abc');
+      expect(session.serverVersion, '1.40.1');
+      expect(client.lastToken, 'tok-123');
+    });
+
+    test('surfaces a rejected token as unauthorized (invalid token)', () async {
+      client.identityError = PlexException.unauthorized();
+      await expectLater(
+        auth().signIn(rawUrl: 'plex.example.com', token: 'bad-token'),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+    });
+
+    test('surfaces an unreachable server', () async {
+      client.identityError = PlexException.notReachable();
+      await expectLater(
+        auth().signIn(rawUrl: 'plex.example.com', token: 'tok'),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notReachable)),
+      );
+    });
+
+    test('surfaces an address that is not a Plex server', () async {
+      client.identityError = PlexException.notPlex();
+      await expectLater(
+        auth().signIn(rawUrl: 'plex.example.com', token: 'tok'),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notPlex)),
+      );
+    });
+
+    test('propagates a malformed/unsupported response unchanged', () async {
+      // A Plex-shaped body Linthra can't use (an unexpected shape from an older/
+      // newer server) reaches the UI as-is; the authenticator is a transparent
+      // propagator and transforms no error kinds.
+      client.identityError = PlexException.unsupportedResponse();
+      await expectLater(
+        auth().signIn(rawUrl: 'plex.example.com', token: 'tok'),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unsupportedResponse)),
+      );
+    });
+
+    test('rejects an empty token without calling the client', () async {
+      await expectLater(
+        auth().signIn(rawUrl: 'plex.example.com', token: ''),
+        throwsA(isA<PlexException>()),
+      );
+      expect(client.lastToken, isNull);
+    });
+  });
+
+  group('token safety', () {
+    test('the returned session redacts the token in toString', () async {
+      final session = await auth().signIn(
+        rawUrl: 'plex.example.com',
+        token: 'super-secret-token',
+      );
+
+      // Stored for use by the client...
+      expect(session.token, 'super-secret-token');
+      // ...but never present in the string form.
+      expect(session.toString(), isNot(contains('super-secret-token')));
+      expect(session.toString(), contains('<redacted>'));
+    });
+
+    test('a thrown error never carries the token', () async {
+      client.identityError = PlexException.unauthorized();
+
+      try {
+        await auth().signIn(
+          rawUrl: 'plex.example.com',
+          token: 'super-secret-token',
+        );
+        fail('expected a PlexException');
+      } on PlexException catch (e) {
+        expect(e.message, isNot(contains('super-secret-token')));
+        expect(e.toString(), isNot(contains('super-secret-token')));
+      }
+    });
+  });
+}

--- a/test/data/repositories/plex_session_store_test.dart
+++ b/test/data/repositories/plex_session_store_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
+
+const _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'tok-123',
+  machineIdentifier: 'machine-abc',
+  serverVersion: '1.40.1',
+);
+
+void main() {
+  group('InMemoryPlexSessionStore', () {
+    test('starts empty by default', () async {
+      final store = InMemoryPlexSessionStore();
+      expect(await store.read(), isNull);
+    });
+
+    test('exposes an initial session', () async {
+      final store = InMemoryPlexSessionStore(initialSession: _session);
+      expect(await store.read(), _session);
+    });
+
+    test('write then read returns the session', () async {
+      final store = InMemoryPlexSessionStore();
+      await store.write(_session);
+      expect(await store.read(), _session);
+    });
+
+    test('clear forgets the session (sign out)', () async {
+      final store = InMemoryPlexSessionStore(initialSession: _session);
+      await store.clear();
+      expect(await store.read(), isNull);
+    });
+  });
+
+  group('PlexSession serialization', () {
+    test('round-trips through toJson/fromJson with the token preserved', () {
+      final restored = PlexSession.fromJson(_session.toJson());
+      expect(restored, _session);
+      // The encrypted store must be able to persist and restore the token.
+      expect(restored!.token, 'tok-123');
+    });
+
+    test('omits the optional serverVersion when null', () {
+      const minimal = PlexSession(
+        baseUrl: 'https://plex.example.com',
+        token: 'tok',
+        machineIdentifier: 'm',
+      );
+      final json = minimal.toJson();
+      expect(json.containsKey('serverVersion'), isFalse);
+      expect(PlexSession.fromJson(json), minimal);
+    });
+
+    test('returns null when a required field is missing or blank', () {
+      const noBaseUrl = <String, dynamic>{
+        'token': 'tok',
+        'machineIdentifier': 'm',
+      };
+      const blankToken = <String, dynamic>{
+        'baseUrl': 'https://plex.example.com',
+        'token': '',
+        'machineIdentifier': 'm',
+      };
+      const noMachineId = <String, dynamic>{
+        'baseUrl': 'https://plex.example.com',
+        'token': 'tok',
+      };
+
+      // A partially written / corrupted record reads back as "signed out".
+      expect(PlexSession.fromJson(noBaseUrl), isNull);
+      expect(PlexSession.fromJson(blankToken), isNull);
+      expect(PlexSession.fromJson(noMachineId), isNull);
+    });
+  });
+
+  group('token redaction', () {
+    test('toString redacts the token, keeps metadata visible', () {
+      final text = _session.toString();
+      expect(text, isNot(contains('tok-123')));
+      expect(text, contains('<redacted>'));
+      // Server metadata stays visible for diagnostics.
+      expect(text, contains('machine-abc'));
+      expect(text, contains('plex.example.com'));
+    });
+
+    test('the token lives only in the persisted JSON, not in toString', () {
+      // toJson is the store-only sink that carries the token...
+      expect(_session.toJson()['token'], 'tok-123');
+      // ...and the human/log-facing string form never does.
+      expect(_session.toString(), isNot(contains('tok-123')));
+    });
+  });
+}


### PR DESCRIPTION
## What

Phase 1 Plex provider, **PR 4** of the sequence in [#178](https://github.com/TheZupZup/Linthra/issues/178) (after #179 design doc, #180 DTOs/endpoints, #181 HTTP client): the **manual server URL + manual token** authentication foundation. Uses #178, [`docs/plex.md`](docs/plex.md), and the merged Plex client/DTOs/endpoints as the source of truth.

A manual token + server URL is the phase‑1 first cut the design recommends (the plex.tv PIN/OAuth flow stays a documented follow‑up). **No Plex is wired into the app yet** — no provider registration, no UI, no playback.

## Scope

**In:**
| File | Purpose |
| --- | --- |
| `lib/core/models/plex_session.dart` | Immutable session holding **only** the server‑scoped token + server metadata (`baseUrl`, `machineIdentifier`, `version`); `toString()` redacts the token. |
| `lib/core/repositories/plex_session_store.dart` | Store interface (`read`/`write`/`clear`), mirroring the Jellyfin/Subsonic seam. |
| `lib/data/repositories/secure_plex_session_store.dart` | `flutter_secure_storage` binding — encrypted at rest under a single `plex_session_v1` key. |
| `lib/data/repositories/in_memory_plex_session_store.dart` | Non‑persistent test/dev binding. |
| `lib/core/sources/plex/plex_server_url.dart` | Pure URL normalizer; consumes the already‑present `PlexException.invalidUrl`. |
| `lib/core/sources/plex/plex_authenticator.dart` | Verifies a manual URL + token against `GET /identity` via the #181 HTTP client and returns a session (`testConnection` + `signIn`); a pure coordinator that persists nothing. |
| `test/core/sources/plex/plex_authenticator_test.dart` | Authenticator tests. |
| `test/data/repositories/plex_session_store_test.dart` | Session + store tests. |

**Out (deliberately, per the task):** no UI, no provider registration, no playback changes, no `MusicSource` impl, no plex.tv PIN/OAuth, no library selection, no cache/offline/lyrics/playlists/favorites, **no changes to Jellyfin, Navidrome/Subsonic, or Local**, and no version/release changes.

## How auth works

`PlexAuthenticator` normalizes the typed URL (`PlexServerUrl`), trims the pasted token, and asks the `PlexClient` from #181 to confirm the address is a reachable Plex Media Server that accepts the token via `GET /identity`. `signIn` then returns a `PlexSession` storing only the token + `machineIdentifier` + version. Like Subsonic's credentialed ping (and unlike Jellyfin's anonymous probe), the token is sent on the check, so success also confirms sign‑in will work. It persists nothing — the (future) controller decides whether/where to store the session.

## Security

- Stores **only** the token (preferring a **server‑scoped** token — narrowest blast radius) plus the metadata needed to reach the server, **encrypted at rest** via `flutter_secure_storage`.
- The token never lands in a URL, log, diagnostic, cache filename, or exception message — the client's `PlexException`s are static and token‑free, and `PlexSession.toString()` **redacts** the token (`toJson` is the store‑only sink that carries it).
- No authenticated stream/art URL is ever part of a session.
- Tests prove the redaction and that **no path leaks the token** (the returned session redacts it in `toString`; a thrown error never carries it).

## Tests

- **Authenticator:** successful auth (URL normalized, token sent, session carries token + machine id + version), invalid token → `unauthorized`, unreachable server → `notReachable`, not‑a‑Plex → `notPlex`, malformed/unsupported response propagated unchanged, empty‑token / bad‑URL guards before any network call, and token redaction / no‑leak.
- **Session + stores:** in‑memory `write`/`read`/`clear` (sign‑out), `toJson`↔`fromJson` round‑trip with the token preserved, `fromJson` returns `null` on missing/blank required fields, and `toString` redacts the token while keeping non‑secret metadata visible.

Hand‑written `FakePlexClient` (no mocking library), matching the existing `Fake*` style.

Refs #178

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lf1phrV8wQ6Yvhxuyo1z4g)_