### PR TITLE
Complete PlexSession per design: serverName + selected section keys

### DIFF
--- a/lib/core/models/plex_session.dart
+++ b/lib/core/models/plex_session.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 /// An authenticated Plex session: everything needed to make further authorized
 /// requests to one Plex Media Server, kept in one immutable value so it can be
 /// persisted as a unit and passed to the source.
@@ -21,7 +23,9 @@ class PlexSession {
     required this.baseUrl,
     required this.token,
     required this.machineIdentifier,
+    this.serverName,
     this.serverVersion,
+    this.selectedSectionKeys = const <String>[],
   });
 
   /// Clean base URL of the server (no trailing slash), e.g.
@@ -38,21 +42,36 @@ class PlexSession {
   /// recognise the same server again. Not a secret.
   final String machineIdentifier;
 
+  /// The server's friendly name, when known. `GET /identity` doesn't report
+  /// one, so the manual flow leaves this `null`; the plex.tv discovery flow (a
+  /// follow-up) provides it. Not secret, display only.
+  final String? serverName;
+
   /// The server's reported version (from `/identity`), when known. Carried so the
   /// diagnostics report can show it after a restart. Not secret, display only.
   final String? serverVersion;
+
+  /// `key`s of the music library sections the user chose to include. Starts
+  /// empty at sign-in — the library picker (a later PR) fills it — and scopes
+  /// the future artist/album/track fetches (see docs/plex.md → MusicSource
+  /// mapping). Section keys are not secret.
+  final List<String> selectedSectionKeys;
 
   PlexSession copyWith({
     String? baseUrl,
     String? token,
     String? machineIdentifier,
+    String? serverName,
     String? serverVersion,
+    List<String>? selectedSectionKeys,
   }) {
     return PlexSession(
       baseUrl: baseUrl ?? this.baseUrl,
       token: token ?? this.token,
       machineIdentifier: machineIdentifier ?? this.machineIdentifier,
+      serverName: serverName ?? this.serverName,
       serverVersion: serverVersion ?? this.serverVersion,
+      selectedSectionKeys: selectedSectionKeys ?? this.selectedSectionKeys,
     );
   }
 
@@ -63,7 +82,10 @@ class PlexSession {
         'baseUrl': baseUrl,
         'token': token,
         'machineIdentifier': machineIdentifier,
+        if (serverName != null) 'serverName': serverName,
         if (serverVersion != null) 'serverVersion': serverVersion,
+        if (selectedSectionKeys.isNotEmpty)
+          'selectedSectionKeys': selectedSectionKeys,
       };
 
   /// Rebuilds a session from [toJson] output, or returns `null` if any required
@@ -76,11 +98,19 @@ class PlexSession {
     if (baseUrl == null || baseUrl.isEmpty) return null;
     if (token == null || token.isEmpty) return null;
     if (machineIdentifier == null || machineIdentifier.isEmpty) return null;
+    // Records persisted before section selection existed simply lack the key;
+    // they load with an empty selection rather than failing.
+    final Object? rawKeys = json['selectedSectionKeys'];
+    final List<String> selectedSectionKeys = rawKeys is List
+        ? rawKeys.whereType<String>().toList(growable: false)
+        : const <String>[];
     return PlexSession(
       baseUrl: baseUrl,
       token: token,
       machineIdentifier: machineIdentifier,
+      serverName: json['serverName'] as String?,
       serverVersion: json['serverVersion'] as String?,
+      selectedSectionKeys: selectedSectionKeys,
     );
   }
 
@@ -91,14 +121,18 @@ class PlexSession {
           other.baseUrl == baseUrl &&
           other.token == token &&
           other.machineIdentifier == machineIdentifier &&
-          other.serverVersion == serverVersion);
+          other.serverName == serverName &&
+          other.serverVersion == serverVersion &&
+          listEquals(other.selectedSectionKeys, selectedSectionKeys));
 
   @override
   int get hashCode => Object.hash(
         baseUrl,
         token,
         machineIdentifier,
+        serverName,
         serverVersion,
+        Object.hashAll(selectedSectionKeys),
       );
 
   /// Redacts the token so the session can be safely interpolated into logs or
@@ -106,5 +140,7 @@ class PlexSession {
   @override
   String toString() => 'PlexSession(baseUrl: $baseUrl, '
       'machineIdentifier: $machineIdentifier, '
-      'serverVersion: $serverVersion, token: <redacted>)';
+      'serverName: $serverName, '
+      'serverVersion: $serverVersion, '
+      'selectedSectionKeys: $selectedSectionKeys, token: <redacted>)';
 }

--- a/lib/core/sources/plex/plex_authenticator.dart
+++ b/lib/core/sources/plex/plex_authenticator.dart
@@ -47,6 +47,9 @@ class PlexAuthenticator {
 
   /// Verifies the server and returns a session that stores **only** the token
   /// (prefer a server-scoped one) plus the server metadata needed to reach it.
+  /// The session starts with **no** selected library sections (the library
+  /// picker fills [PlexSession.selectedSectionKeys] later) and no server name
+  /// (`/identity` doesn't report one).
   ///
   /// Throws [PlexException] for a bad URL, a missing token, an unreachable/
   /// non-Plex server, or a rejected token.

--- a/test/core/sources/plex/plex_authenticator_test.dart
+++ b/test/core/sources/plex/plex_authenticator_test.dart
@@ -68,6 +68,10 @@ void main() {
       expect(session.machineIdentifier, 'machine-abc');
       expect(session.serverVersion, '1.40.1');
       expect(client.lastToken, 'tok-123');
+      // The manual flow has no friendly name (/identity doesn't report one)
+      // and no libraries picked yet — the picker PR fills the selection.
+      expect(session.serverName, isNull);
+      expect(session.selectedSectionKeys, isEmpty);
     });
 
     test('surfaces a rejected token as unauthorized (invalid token)', () async {

--- a/test/data/repositories/plex_session_store_test.dart
+++ b/test/data/repositories/plex_session_store_test.dart
@@ -6,7 +6,9 @@ const _session = PlexSession(
   baseUrl: 'https://plex.example.com:32400',
   token: 'tok-123',
   machineIdentifier: 'machine-abc',
+  serverName: 'Living Room PMS',
   serverVersion: '1.40.1',
+  selectedSectionKeys: <String>['5', '12'],
 );
 
 void main() {
@@ -40,17 +42,37 @@ void main() {
       expect(restored, _session);
       // The encrypted store must be able to persist and restore the token.
       expect(restored!.token, 'tok-123');
+      expect(restored.serverName, 'Living Room PMS');
+      expect(restored.selectedSectionKeys, <String>['5', '12']);
     });
 
-    test('omits the optional serverVersion when null', () {
+    test('omits the optional fields when absent', () {
       const minimal = PlexSession(
         baseUrl: 'https://plex.example.com',
         token: 'tok',
         machineIdentifier: 'm',
       );
       final json = minimal.toJson();
+      expect(json.containsKey('serverName'), isFalse);
       expect(json.containsKey('serverVersion'), isFalse);
+      expect(json.containsKey('selectedSectionKeys'), isFalse);
       expect(PlexSession.fromJson(json), minimal);
+    });
+
+    test('loads a record persisted before section selection existed', () {
+      // The shape SecurePlexSessionStore wrote under plex_session_v1 before
+      // serverName/selectedSectionKeys were added.
+      const legacy = <String, dynamic>{
+        'baseUrl': 'https://plex.example.com:32400',
+        'token': 'tok-123',
+        'machineIdentifier': 'machine-abc',
+        'serverVersion': '1.40.1',
+      };
+      final restored = PlexSession.fromJson(legacy);
+      expect(restored, isNotNull);
+      expect(restored!.token, 'tok-123');
+      expect(restored.serverName, isNull);
+      expect(restored.selectedSectionKeys, isEmpty);
     });
 
     test('returns null when a required field is missing or blank', () {
@@ -75,6 +97,31 @@ void main() {
     });
   });
 
+  group('PlexSession value semantics', () {
+    test('equality covers the selected section keys', () {
+      expect(_session, _session.copyWith());
+      expect(
+        _session,
+        isNot(_session.copyWith(selectedSectionKeys: <String>['5'])),
+      );
+    });
+
+    test('copyWith replaces the selection (the library picker path)', () {
+      const fresh = PlexSession(
+        baseUrl: 'https://plex.example.com',
+        token: 'tok',
+        machineIdentifier: 'm',
+      );
+      expect(fresh.selectedSectionKeys, isEmpty);
+
+      final picked = fresh.copyWith(selectedSectionKeys: <String>['3']);
+      expect(picked.selectedSectionKeys, <String>['3']);
+      // The token and server identity ride along untouched.
+      expect(picked.token, 'tok');
+      expect(picked.machineIdentifier, 'm');
+    });
+  });
+
   group('token redaction', () {
     test('toString redacts the token, keeps metadata visible', () {
       final text = _session.toString();
@@ -83,6 +130,7 @@ void main() {
       // Server metadata stays visible for diagnostics.
       expect(text, contains('machine-abc'));
       expect(text, contains('plex.example.com'));
+      expect(text, contains('Living Room PMS'));
     });
 
     test('the token lives only in the persisted JSON, not in toString', () {


### PR DESCRIPTION
## What

A small completion of **PR 4** of the Plex sequence in #178. PR #182 already landed the manual-token authenticator, `PlexSession`, and the secure + in-memory session stores — but the session model was missing two fields the PR-4 spec and [`docs/plex.md`](docs/plex.md) call for:

| Field | Why |
| --- | --- |
| `serverName` (`String?`, display only) | "Server name if available". `GET /identity` doesn't report a friendly name, so the manual flow leaves it `null`; the plex.tv discovery follow-up fills it. |
| `selectedSectionKeys` (`List<String>`, defaults to empty) | Per the design, "the selected section keys live in the Plex session" and scope the future artist/album/track fetches. Sign-in starts with an **empty** selection; the library-picker PR fills it via `copyWith`. |

The client identifier deliberately stays out of the session: it already lives at the client layer (`PlexClientIdentity`), is per-install rather than per-server, and isn't a secret — the wiring PR can decide where its persistence lives.

## Changes

- `lib/core/models/plex_session.dart` — the two new fields, threaded through `copyWith` / `toJson` / `fromJson` / equality (`listEquals` / `Object.hashAll`, matching the other list-carrying models) / `toString`.
- `lib/core/sources/plex/plex_authenticator.dart` — doc-only: `signIn` documents that a fresh session has no selection and no server name.
- Tests:
  - Round-trip preserves the new fields; both are omitted from JSON when absent.
  - **Backward compat:** a record persisted under `plex_session_v1` *before* these fields existed loads with a `null` name and an empty selection (not "signed out").
  - Equality covers section-key contents; `copyWith` replaces the selection while the token and server identity ride along untouched.
  - `toString()` still **redacts the token** while showing the (non-secret) new metadata; fresh sign-in asserts empty selection / null name.

## Security

Unchanged from #182: the token is persisted only via the encrypted store, never in URIs/logs/errors/diagnostics, and `toString()` redacts it — the redaction tests still pass with the new fields in place. The new fields are non-secret metadata.

## Out of scope

No UI, no provider registration, no playback changes, no `MusicSource` impl, no PIN/OAuth, no discovery, no library picker, no changes to Jellyfin/Navidrome/Subsonic/Local, no version or release changes.

## Verification

`flutter test test/data/repositories/plex_session_store_test.dart test/core/sources/plex/` → **all 84 pass** (Flutter 3.44.2); `dart analyze` clean on every touched file.

Refs #178

https://claude.ai/code/session_01CShYcei4NcbW8y7tx4LJ2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01CShYcei4NcbW8y7tx4LJ2R)_