### PR TITLE
Add Plex track mapper and music source foundation

### DIFF
--- a/lib/core/sources/plex/plex_music_source.dart
+++ b/lib/core/sources/plex/plex_music_source.dart
@@ -1,0 +1,155 @@
+import '../../models/album.dart';
+import '../../models/artist.dart';
+import '../../models/plex_session.dart';
+import '../../models/track.dart';
+import '../../services/music_source.dart';
+import '../../services/playback_diagnostics.dart';
+import 'plex_api.dart';
+import 'plex_client.dart';
+import 'plex_endpoints.dart';
+import 'plex_stream_source.dart';
+import 'plex_track_mapper.dart';
+
+/// A [MusicSource] backed by a signed-in Plex Media Server.
+///
+/// The Plex counterpart to `JellyfinMusicSource` / `SubsonicMusicSource`: it
+/// implements the same contract, so the rest of the app treats a Plex library
+/// identically to any other. Discovery (listing items) is delegated to a
+/// [PlexClient] and mapping to [PlexTrackMapper], keeping this class a thin
+/// orchestrator. Like the other sources, it persists nothing itself — the
+/// `MusicLibraryRepository` syncs these results into the offline cache the UI
+/// reads from.
+///
+/// Unlike Jellyfin/Subsonic (which sync the whole server), Plex scopes every
+/// listing to the music sections the user **selected**
+/// ([PlexSession.selectedSectionKeys]): each fetch lists one Plex metadata
+/// type (artist 8 / album 9 / track 10) per selected section and concatenates
+/// the results. No selection yet — the state every sign-in starts in until the
+/// library picker (a later PR) fills it — simply yields empty lists, never an
+/// error.
+///
+/// Playback is two-step by design (see docs/plex.md → MusicSource mapping): a
+/// track's opaque `plex:<ratingKey>` URI is resolved at play time via a
+/// `GET /library/metadata/{ratingKey}` lookup, because the playable `Part` key
+/// differs from the `ratingKey`. That live lookup doubles as the reachability/
+/// auth check Jellyfin and Subsonic get from probing their stream URL: an
+/// expired token, an offline server, or a vanished item surfaces as a typed,
+/// token-free `PlexException` before the audio engine ever touches a URL. Only
+/// then is the tokenized stream URL minted — the token never reaches a
+/// [Track], the catalog, or an error message.
+class PlexMusicSource implements MusicSource, PlexStreamSource {
+  const PlexMusicSource({required this.session, required PlexClient client})
+      : _client = client;
+
+  /// The session this source reads on behalf of (server URL, token, selected
+  /// library sections).
+  final PlexSession session;
+
+  final PlexClient _client;
+
+  /// The stable source id under which Plex tracks are stored.
+  static const String sourceId = 'plex';
+
+  @override
+  String get id => sourceId;
+
+  @override
+  String get displayName {
+    final String? name = session.serverName;
+    return (name != null && name.isNotEmpty) ? 'Plex · $name' : 'Plex';
+  }
+
+  @override
+  Future<List<Track>> fetchTracks() async {
+    final List<PlexMetadata> items =
+        await _fetchSelectedSections(PlexMetadataType.track);
+    return <Track>[
+      for (final PlexMetadata item in items) PlexTrackMapper.toTrack(item),
+    ];
+  }
+
+  @override
+  Future<List<Album>> fetchAlbums() async {
+    final List<PlexMetadata> items =
+        await _fetchSelectedSections(PlexMetadataType.album);
+    return <Album>[
+      for (final PlexMetadata item in items) PlexTrackMapper.toAlbum(item),
+    ];
+  }
+
+  @override
+  Future<List<Artist>> fetchArtists() async {
+    final List<PlexMetadata> items =
+        await _fetchSelectedSections(PlexMetadataType.artist);
+    return <Artist>[
+      for (final PlexMetadata item in items) PlexTrackMapper.toArtist(item),
+    ];
+  }
+
+  /// Every item of [itemType] across the user's selected music sections, in
+  /// selection order. An empty selection returns an empty list without
+  /// touching the server: "nothing chosen yet" is an empty library, not an
+  /// error.
+  Future<List<PlexMetadata>> _fetchSelectedSections(
+    PlexMetadataType itemType,
+  ) async {
+    final List<PlexMetadata> items = <PlexMetadata>[];
+    for (final String sectionKey in session.selectedSectionKeys) {
+      items.addAll(await _client.fetchSectionItems(
+        baseUrl: session.baseUrl,
+        token: session.token,
+        sectionKey: sectionKey,
+        itemType: itemType,
+      ));
+    }
+    return items;
+  }
+
+  /// Confirms the token is still accepted and the server reachable, via
+  /// `GET /identity`, so the player can surface a precise error before
+  /// attempting to stream. Throws a `PlexException` on failure; the token
+  /// never appears in it.
+  @override
+  Future<void> verifyReachable() async {
+    await _client.fetchIdentity(baseUrl: session.baseUrl, token: session.token);
+  }
+
+  /// Resolves a `plex:<ratingKey>` track to its direct-play stream URL on
+  /// demand: fetch `GET /library/metadata/{ratingKey}`, read the first `Part`
+  /// key, and mint `{baseUrl}{partKey}?X-Plex-Token=…` — the only moment the
+  /// token is woven into a URL, which is handed to the audio engine and never
+  /// persisted. Returns `null` when the item carries no playable part.
+  ///
+  /// Throws a token-free `PlexException` when the lookup fails (item gone,
+  /// token rejected, server unreachable).
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    final String ratingKey = _ratingKey(track);
+    final PlexMetadata item = await _client.fetchMetadata(
+      baseUrl: session.baseUrl,
+      token: session.token,
+      ratingKey: ratingKey,
+    );
+    // Log the (non-secret) resolution before minting any tokenized URL, so a
+    // track that resolves to no playable part is still diagnosable.
+    PlaybackDiagnostics.resolved(
+      source: sourceId,
+      resolver: 'PlexMusicSource',
+      itemId: ratingKey,
+    );
+    final String? partKey = item.firstPartKey;
+    if (partKey == null) return null;
+    return PlexEndpoints.streamUrl(
+      session.baseUrl,
+      partKey: partKey,
+      token: session.token,
+    );
+  }
+
+  /// The Plex `ratingKey` behind [track]: the part after the `plex:` scheme,
+  /// falling back to the track id for an unprefixed value.
+  String _ratingKey(Track track) =>
+      track.uri.startsWith(PlexTrackMapper.uriScheme)
+          ? track.uri.substring(PlexTrackMapper.uriScheme.length)
+          : track.id;
+}

--- a/lib/core/sources/plex/plex_stream_source.dart
+++ b/lib/core/sources/plex/plex_stream_source.dart
@@ -1,0 +1,25 @@
+import '../../models/track.dart';
+
+/// The narrow capability the playback resolver needs from a signed-in Plex
+/// connection: confirm the session still works, then mint a stream URL.
+///
+/// [PlexMusicSource] implements it; keeping it tiny lets the future resolver
+/// depend on just this (not the whole source or any HTTP), and lets tests fake
+/// the source directly to drive every outcome — expired token, unreachable
+/// server, a vanished item — without a real server. Mirrors
+/// `JellyfinStreamSource`; phase 1 is stream-only (no offline cache), so unlike
+/// `SubsonicStreamSource` there is no download seam to expose.
+///
+/// Security: a Plex stream URL carries the `X-Plex-Token` in its **query** (the
+/// audio engine can't set headers), so it is minted here on demand, at play
+/// time, and never stored on [track]. See docs/plex.md → Token safety rules.
+abstract interface class PlexStreamSource {
+  /// Confirms the session is still valid and the server reachable. Throws a
+  /// `PlexException` (unauthorized / not reachable / …) when it is not.
+  Future<void> verifyReachable();
+
+  /// The tokenized stream URL for [track], or `null` when one cannot be built
+  /// (the item carries no playable part). The token is woven in here, on
+  /// demand, and never stored on [track].
+  Future<Uri?> resolvePlayableUri(Track track);
+}

--- a/lib/core/sources/plex/plex_track_mapper.dart
+++ b/lib/core/sources/plex/plex_track_mapper.dart
@@ -1,0 +1,122 @@
+import '../../catalog/library_grouping.dart';
+import '../../models/album.dart';
+import '../../models/artist.dart';
+import '../../models/track.dart';
+import 'plex_api.dart';
+
+/// Converts Plex wire items into Linthra's source-agnostic domain models.
+///
+/// Kept separate from both the HTTP client (which only parses JSON) and the
+/// source (which only orchestrates), so the field-by-field mapping is pure and
+/// unit-testable — exactly like `JellyfinTrackMapper` / `SubsonicTrackMapper`.
+/// One [PlexMetadata] DTO covers all three music kinds; which method applies
+/// follows Plex's numeric metadata types ([PlexMetadataType]): **8 →
+/// [toArtist], 9 → [toAlbum], 10 → [toTrack]**, matching the `type=` filter
+/// the source lists each kind with.
+///
+/// Two deliberate choices (see docs/plex.md → Token safety rules):
+///  - A track's [Track.uri] is the opaque `plex:<ratingKey>`, NOT a playable
+///    URL. The playable URL needs the `Part` path *and* carries the
+///    `X-Plex-Token` in its query, so `PlexMusicSource.resolvePlayableUri`
+///    mints it lazily at play time; the persisted catalog never sees a Part
+///    path or the token.
+///  - [Track.artworkUri] is a credential-free `plex-thumb:<thumbPath>`
+///    reference (mirroring Subsonic's `subsonic-cover:`), never a ready-to-load
+///    URL. Plex cover art requires the token as a query param, so a loadable
+///    URL would embed the credential — and `artworkUri` is persisted in the
+///    catalog. The token (and server address) are woven in only at render time
+///    by the artwork resolver (a later PR).
+///
+/// Relationships: the domain models reference artists/albums by *name* — there
+/// is no album/artist id slot on [Track]/[Album] today (grouping is name-based,
+/// see `library_grouping.dart`) — so the parent/grandparent links Plex reports
+/// are carried via their titles: a track's `grandparentTitle` →
+/// [Track.artistName] and `parentTitle` → [Track.albumName]; an album's
+/// `parentTitle` → [Album.artistName]. When PMS omits them they stay `null`
+/// and the grouping layer folds the item into its Unknown Album/Artist buckets.
+abstract final class PlexTrackMapper {
+  /// Prefix marking a [Track.uri] as a Plex item (`plex:<ratingKey>`) rather
+  /// than a file path or another provider's item.
+  static const String uriScheme = 'plex:';
+
+  /// Scheme marking a [Uri] as a credential-free Plex cover-art reference
+  /// (`plex-thumb:<thumbPath>`). A dedicated scheme (not `plex:`, which marks
+  /// a track URI) keeps it unambiguous for the render-time resolver and any
+  /// diagnostics.
+  static const String artworkScheme = 'plex-thumb';
+
+  /// Display fallback for the rare track whose Plex `title` is missing/blank.
+  static const String _untitledTrack = 'Untitled';
+
+  /// Maps a **track** (Plex type 10) listing/metadata item.
+  ///
+  /// `PlexMetadata` doesn't parse a track index yet, so [Track.trackNumber]
+  /// stays `null` (a follow-up, like year/track-count on albums).
+  static Track toTrack(PlexMetadata item) {
+    return Track(
+      id: item.ratingKey,
+      title: _nonBlank(item.title) ?? _untitledTrack,
+      uri: '$uriScheme${item.ratingKey}',
+      artistName: _nonBlank(item.grandparentTitle),
+      albumName: _nonBlank(item.parentTitle),
+      duration: _durationFromMillis(item.duration),
+      artworkUri: _artworkReference(item.thumb),
+    );
+  }
+
+  /// Maps an **album** (Plex type 9) listing item. Year and track count aren't
+  /// parsed from Plex yet, so they keep their defaults.
+  static Album toAlbum(PlexMetadata item) {
+    return Album(
+      id: item.ratingKey,
+      title: _nonBlank(item.title) ?? kUnknownAlbum,
+      artistName: _nonBlank(item.parentTitle),
+      artworkUri: _artworkReference(item.thumb),
+    );
+  }
+
+  /// Maps an **artist** (Plex type 8) listing item.
+  static Artist toArtist(PlexMetadata item) {
+    return Artist(
+      id: item.ratingKey,
+      name: _nonBlank(item.title) ?? kUnknownArtist,
+      artworkUri: _artworkReference(item.thumb),
+    );
+  }
+
+  /// The decoded thumb path behind a `plex-thumb:` [reference], or `null` when
+  /// it isn't one — so other artwork (a Jellyfin http URL, a local `file:`
+  /// cover, a `subsonic-cover:` reference) passes through the render-time
+  /// resolver untouched.
+  static String? thumbPath(Uri reference) {
+    if (!reference.isScheme(artworkScheme)) return null;
+    final String path = reference.path;
+    return path.isEmpty ? null : path;
+  }
+
+  /// A persistable, credential-free `plex-thumb:` reference to an item's
+  /// server-absolute `thumb` path, or `null` when the item reports none (the
+  /// UI then shows its placeholder). The path rides as the [Uri] path so it
+  /// round-trips exactly through the catalog's `Uri.toString()` / `Uri.parse`
+  /// and back out via [thumbPath]. No token, no server address: both are woven
+  /// in only at render time, never persisted.
+  static Uri? _artworkReference(String? thumb) {
+    final String? path = _nonBlank(thumb);
+    if (path == null) return null;
+    return Uri(scheme: artworkScheme, path: path);
+  }
+
+  /// Plex reports durations in whole **milliseconds** (unlike Subsonic's
+  /// seconds or Jellyfin's ticks); absent or zero maps to [Duration.zero].
+  static Duration _durationFromMillis(int? millis) {
+    if (millis == null || millis <= 0) return Duration.zero;
+    return Duration(milliseconds: millis);
+  }
+
+  /// Trims [text] and treats blank as absent, so a whitespace-only Plex field
+  /// falls back the same way a missing one does.
+  static String? _nonBlank(String? text) {
+    final String? trimmed = text?.trim();
+    return (trimmed == null || trimmed.isEmpty) ? null : trimmed;
+  }
+}

--- a/test/core/sources/plex/plex_music_source_test.dart
+++ b/test/core/sources/plex/plex_music_source_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_music_source.dart';
+
+import 'fake_plex_client.dart';
+
+const String _token = 'tok-secret-123';
+
+const PlexSession _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: _token,
+  machineIdentifier: 'machine-abc',
+  serverName: 'Living Room',
+  selectedSectionKeys: <String>['3', '7'],
+);
+
+/// The same sign-in before the library picker has run: no sections selected.
+const PlexSession _noSelectionSession = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: _token,
+  machineIdentifier: 'machine-abc',
+);
+
+void main() {
+  late FakePlexClient client;
+
+  PlexMusicSource source({PlexSession session = _session}) =>
+      PlexMusicSource(session: session, client: client);
+
+  setUp(() => client = FakePlexClient());
+
+  group('identity', () {
+    test('id is the stable "plex"', () {
+      expect(source().id, 'plex');
+      expect(PlexMusicSource.sourceId, 'plex');
+    });
+
+    test('displayName names the server when known, else plain Plex', () {
+      expect(source().displayName, 'Plex · Living Room');
+      // The manual /identity flow learns no server name.
+      expect(source(session: _noSelectionSession).displayName, 'Plex');
+    });
+  });
+
+  group('fetchArtists', () {
+    test('lists Plex type 8 from every selected section, in order', () async {
+      client.itemsByType = const <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.artist: <PlexMetadata>[
+          PlexMetadata(ratingKey: '101', type: 'artist', title: 'Kavinsky'),
+        ],
+      };
+
+      final artists = await source().fetchArtists();
+
+      expect(
+          client.itemRequests,
+          <({String sectionKey, PlexMetadataType itemType})>[
+            (sectionKey: '3', itemType: PlexMetadataType.artist),
+            (sectionKey: '7', itemType: PlexMetadataType.artist),
+          ]);
+      expect(client.itemRequests.first.itemType.value, 8);
+      // One canned artist per section → the results are concatenated.
+      expect(artists, hasLength(2));
+      expect(artists.first.name, 'Kavinsky');
+      // The session's address and token went to the client (header-side).
+      expect(client.lastBaseUrl, _session.baseUrl);
+      expect(client.lastToken, _token);
+    });
+  });
+
+  group('fetchAlbums', () {
+    test('lists Plex type 9 from every selected section', () async {
+      client.itemsByType = const <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.album: <PlexMetadata>[
+          PlexMetadata(
+            ratingKey: '201',
+            type: 'album',
+            title: 'OutRun',
+            parentTitle: 'Kavinsky',
+          ),
+        ],
+      };
+
+      final albums = await source().fetchAlbums();
+
+      expect(
+        client.itemRequests.map((r) => r.sectionKey),
+        <String>['3', '7'],
+      );
+      expect(client.itemRequests.first.itemType, PlexMetadataType.album);
+      expect(client.itemRequests.first.itemType.value, 9);
+      expect(albums, hasLength(2));
+      expect(albums.first.title, 'OutRun');
+      expect(albums.first.artistName, 'Kavinsky');
+    });
+  });
+
+  group('fetchTracks', () {
+    test('lists Plex type 10 from every selected section', () async {
+      client.itemsByType = const <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.track: <PlexMetadata>[
+          PlexMetadata(
+            ratingKey: '301',
+            type: 'track',
+            title: 'Nightcall',
+            parentTitle: 'OutRun',
+            grandparentTitle: 'Kavinsky',
+            duration: 258000,
+          ),
+        ],
+      };
+
+      final tracks = await source().fetchTracks();
+
+      expect(client.itemRequests.first.itemType, PlexMetadataType.track);
+      expect(client.itemRequests.first.itemType.value, 10);
+      expect(tracks, hasLength(2));
+      expect(tracks.first.uri, 'plex:301');
+      expect(tracks.first.artistName, 'Kavinsky');
+    });
+
+    test('never lets the token reach a mapped track or its artwork', () async {
+      client.itemsByType = const <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.track: <PlexMetadata>[
+          PlexMetadata(
+            ratingKey: '301',
+            type: 'track',
+            title: 'Nightcall',
+            thumb: '/library/metadata/201/thumb/1700000000',
+          ),
+        ],
+      };
+
+      final tracks = await source().fetchTracks();
+
+      expect(tracks, isNotEmpty);
+      for (final Track t in tracks) {
+        // The opaque plex: uri carries no token, no query, no server address.
+        expect(t.uri, startsWith('plex:'));
+        expect(t.uri, isNot(contains(_token)));
+        expect(t.uri, isNot(contains('X-Plex-Token')));
+        expect(t.uri, isNot(contains('plex.example.com')));
+        // The artwork reference is equally credential-free.
+        final String artwork = t.artworkUri.toString();
+        expect(artwork, startsWith('plex-thumb:'));
+        expect(artwork, isNot(contains(_token)));
+        expect(artwork, isNot(contains('X-Plex-Token')));
+        expect(artwork, isNot(contains('plex.example.com')));
+      }
+    });
+  });
+
+  group('library selection scoping', () {
+    test('an empty selection yields empty lists without touching the server',
+        () async {
+      client.itemsByType = const <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.artist: <PlexMetadata>[
+          PlexMetadata(ratingKey: '101', type: 'artist', title: 'Kavinsky'),
+        ],
+      };
+      final s = source(session: _noSelectionSession);
+
+      expect(await s.fetchArtists(), isEmpty);
+      expect(await s.fetchAlbums(), isEmpty);
+      expect(await s.fetchTracks(), isEmpty);
+      // No selection → no section listing was even attempted.
+      expect(client.itemRequests, isEmpty);
+    });
+  });
+
+  group('resolvePlayableUri', () {
+    const Track track = Track(id: '301', title: 'Nightcall', uri: 'plex:301');
+
+    test('looks up the metadata and mints the tokenized URL only then',
+        () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(
+          ratingKey: '301',
+          type: 'track',
+          title: 'Nightcall',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[
+              PlexPart(key: '/library/parts/9001/1700000000/file.flac'),
+            ]),
+          ],
+        ),
+      };
+
+      final uri = await source().resolvePlayableUri(track);
+
+      // The play-time lookup used the ratingKey from the opaque uri.
+      expect(client.requestedRatingKeys, <String>['301']);
+      // The resolved URL streams the Part key — not the ratingKey — and the
+      // token is woven into its query only now, at play time.
+      expect(uri, isNotNull);
+      expect(uri!.path, '/library/parts/9001/1700000000/file.flac');
+      expect(uri.queryParameters['X-Plex-Token'], _token);
+      // The track itself still carries the opaque, token-free reference.
+      expect(track.uri, 'plex:301');
+    });
+
+    test('falls back to the track id for an unprefixed uri', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '77': PlexMetadata(
+          ratingKey: '77',
+          type: 'track',
+          title: 'x',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[PlexPart(key: '/library/parts/1/f')]),
+          ],
+        ),
+      };
+      const Track unprefixed = Track(id: '77', title: 'x', uri: 'not-plex');
+
+      final uri = await source().resolvePlayableUri(unprefixed);
+
+      expect(client.requestedRatingKeys, <String>['77']);
+      expect(uri, isNotNull);
+    });
+
+    test('returns null when the item carries no playable part', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(ratingKey: '301', type: 'track', title: 'x'),
+      };
+      expect(await source().resolvePlayableUri(track), isNull);
+    });
+
+    test('a vanished item surfaces as a typed, token-free PlexException', () {
+      // The fake (like the real client mapping a 404) throws notFound for an
+      // unknown ratingKey.
+      expect(
+        () => source().resolvePlayableUri(track),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notFound)
+            .having((e) => e.message, 'message', isNot(contains(_token)))
+            .having((e) => e.toString(), 'toString', isNot(contains(_token)))),
+      );
+    });
+  });
+
+  test('verifyReachable checks the server identity with the session', () async {
+    await source().verifyReachable();
+    expect(client.identityCount, 1);
+    expect(client.lastBaseUrl, _session.baseUrl);
+    expect(client.lastToken, _token);
+  });
+}

--- a/test/core/sources/plex/plex_track_mapper_test.dart
+++ b/test/core/sources/plex/plex_track_mapper_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/catalog/library_grouping.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_track_mapper.dart';
+
+void main() {
+  group('PlexTrackMapper.toTrack (Plex type 10)', () {
+    test('maps a track to a token-free plex: uri', () {
+      const item = PlexMetadata(
+        ratingKey: '301',
+        type: 'track',
+        title: 'Nightcall',
+        parentRatingKey: '201',
+        grandparentRatingKey: '101',
+        parentTitle: 'OutRun',
+        grandparentTitle: 'Kavinsky',
+        thumb: '/library/metadata/201/thumb/1700000000',
+        duration: 258000,
+      );
+
+      final track = PlexTrackMapper.toTrack(item);
+
+      expect(track.id, '301');
+      expect(track.uri, 'plex:301');
+      expect(track.title, 'Nightcall');
+      // The parent/grandparent links carry the album/artist relationship.
+      expect(track.albumName, 'OutRun');
+      expect(track.artistName, 'Kavinsky');
+      // Plex reports duration in milliseconds.
+      expect(track.duration, const Duration(minutes: 4, seconds: 18));
+      expect(
+        track.artworkUri.toString(),
+        'plex-thumb:/library/metadata/201/thumb/1700000000',
+      );
+    });
+
+    test('uses the ratingKey, never the Part path, for the uri', () {
+      // A realistic track item carries its Media/Part (the playable file
+      // path); the mapped uri must stay the opaque ratingKey reference so the
+      // catalog never names a server file path.
+      final PlexMetadata item = PlexMetadata.fromJson(<String, dynamic>{
+        'ratingKey': '301',
+        'type': 'track',
+        'title': 'Nightcall',
+        'Media': <dynamic>[
+          <String, dynamic>{
+            'Part': <dynamic>[
+              <String, dynamic>{
+                'key': '/library/parts/9001/1700000000/file.flac',
+              },
+            ],
+          },
+        ],
+      })!;
+
+      final track = PlexTrackMapper.toTrack(item);
+
+      expect(track.uri, 'plex:301');
+      expect(track.uri, isNot(contains('parts')));
+      expect(track.uri, isNot(contains('file.flac')));
+    });
+
+    test('the uri and artwork reference never embed a credential or server',
+        () {
+      const item = PlexMetadata(
+        ratingKey: '301',
+        title: 'x',
+        thumb: '/library/metadata/201/thumb/1700000000',
+      );
+
+      final track = PlexTrackMapper.toTrack(item);
+
+      // The uri is the opaque ratingKey only — no query, no token.
+      expect(track.uri, 'plex:301');
+      expect(track.uri, isNot(contains('?')));
+      expect(track.uri, isNot(contains('X-Plex-Token')));
+      expect(track.uri, isNot(contains('=')));
+      // The artwork reference is credential-free and points at no server: the
+      // token is woven in only at render time, never persisted here.
+      final String artwork = track.artworkUri.toString();
+      expect(artwork, 'plex-thumb:/library/metadata/201/thumb/1700000000');
+      expect(artwork, isNot(contains('?')));
+      expect(artwork, isNot(contains('X-Plex-Token')));
+      expect(artwork, isNot(contains('http')));
+    });
+
+    test('falls back to a safe title when Plex omits or blanks it', () {
+      const missing = PlexMetadata(ratingKey: '1');
+      const blank = PlexMetadata(ratingKey: '2', title: '   ');
+      expect(PlexTrackMapper.toTrack(missing).title, 'Untitled');
+      expect(PlexTrackMapper.toTrack(blank).title, 'Untitled');
+    });
+
+    test('leaves artist/album null when the parent titles are missing', () {
+      const item = PlexMetadata(ratingKey: '301', title: 'Nightcall');
+      final track = PlexTrackMapper.toTrack(item);
+      // Null names let the grouping layer fold the track into its Unknown
+      // Album/Artist buckets, same as a tagless local file.
+      expect(track.artistName, isNull);
+      expect(track.albumName, isNull);
+    });
+
+    test('maps absent or zero duration to zero', () {
+      const absent = PlexMetadata(ratingKey: '1', title: 't');
+      const zero = PlexMetadata(ratingKey: '2', title: 't', duration: 0);
+      expect(PlexTrackMapper.toTrack(absent).duration, Duration.zero);
+      expect(PlexTrackMapper.toTrack(zero).duration, Duration.zero);
+    });
+
+    test('leaves artworkUri null when the item reports no thumb', () {
+      const item = PlexMetadata(ratingKey: '1', title: 't');
+      // No thumb → null → the UI shows its placeholder (not a broken image).
+      expect(PlexTrackMapper.toTrack(item).artworkUri, isNull);
+    });
+  });
+
+  group('PlexTrackMapper.toAlbum (Plex type 9)', () {
+    test('maps an album, with its parentTitle as the artist name', () {
+      const item = PlexMetadata(
+        ratingKey: '201',
+        type: 'album',
+        title: 'OutRun',
+        parentRatingKey: '101',
+        parentTitle: 'Kavinsky',
+        thumb: '/library/metadata/201/thumb/1700000000',
+      );
+
+      final album = PlexTrackMapper.toAlbum(item);
+
+      expect(album.id, '201');
+      expect(album.title, 'OutRun');
+      expect(album.artistName, 'Kavinsky');
+      expect(
+        album.artworkUri.toString(),
+        'plex-thumb:/library/metadata/201/thumb/1700000000',
+      );
+    });
+
+    test('falls back to the shared Unknown Album label for a missing title',
+        () {
+      const item = PlexMetadata(ratingKey: '201', type: 'album');
+      expect(PlexTrackMapper.toAlbum(item).title, kUnknownAlbum);
+    });
+
+    test('leaves artistName and artwork null when Plex omits them', () {
+      const item = PlexMetadata(ratingKey: '201', title: 'OutRun');
+      final album = PlexTrackMapper.toAlbum(item);
+      expect(album.artistName, isNull);
+      expect(album.artworkUri, isNull);
+    });
+  });
+
+  group('PlexTrackMapper.toArtist (Plex type 8)', () {
+    test('maps artist id, name, and artwork reference', () {
+      const item = PlexMetadata(
+        ratingKey: '101',
+        type: 'artist',
+        title: 'Kavinsky',
+        thumb: '/library/metadata/101/thumb/1700000000',
+      );
+
+      final artist = PlexTrackMapper.toArtist(item);
+
+      expect(artist.id, '101');
+      expect(artist.name, 'Kavinsky');
+      expect(
+        artist.artworkUri.toString(),
+        'plex-thumb:/library/metadata/101/thumb/1700000000',
+      );
+    });
+
+    test('falls back to the shared Unknown Artist label for a missing title',
+        () {
+      const item = PlexMetadata(ratingKey: '101', type: 'artist');
+      expect(PlexTrackMapper.toArtist(item).name, kUnknownArtist);
+    });
+  });
+
+  group('plex-thumb artwork reference', () {
+    test('round-trips through the catalog persistence shape', () {
+      const item = PlexMetadata(
+        ratingKey: '1',
+        title: 't',
+        thumb: '/library/metadata/201/thumb/1700000000',
+      );
+      final Uri reference = PlexTrackMapper.toTrack(item).artworkUri!;
+
+      // The catalog persists artworkUri as a string; the reference must come
+      // back out of Uri.parse with its thumb path intact.
+      final Uri reparsed = Uri.parse(reference.toString());
+      expect(
+        PlexTrackMapper.thumbPath(reparsed),
+        '/library/metadata/201/thumb/1700000000',
+      );
+    });
+
+    test('thumbPath leaves other providers\' artwork untouched', () {
+      expect(
+        PlexTrackMapper.thumbPath(Uri.parse('https://x.example/cover.jpg')),
+        isNull,
+      );
+      expect(
+        PlexTrackMapper.thumbPath(Uri.parse('subsonic-cover:al-7')),
+        isNull,
+      );
+      expect(
+        PlexTrackMapper.thumbPath(Uri.parse('file:///covers/a.jpg')),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Plex support — PR 5: mapper + MusicSource foundation

Step 5 of the [docs/plex.md](docs/plex.md) plan for #178, building on the DTOs/endpoints (#180), client (#181), authenticator/session store (#182), and session completion (#183). Five new files, no shared-code edits.

## What's added

**`lib/core/sources/plex/plex_track_mapper.dart`** — pure Plex → domain mapping, mirroring `JellyfinTrackMapper` / `SubsonicTrackMapper`:
- Plex type **8 → `Artist`**, **9 → `Album`**, **10 → `Track`** ([`PlexMetadataType`]).
- `Track.uri` is the opaque, credential-free **`plex:<ratingKey>`** — never a Part path, never a tokenized URL.
- `Track.artworkUri` is the credential-free **`plex-thumb:<thumbPath>`** reference (mirroring `subsonic-cover:`); it carries no token and no server address, round-trips through the catalog's `Uri.toString()`/`Uri.parse`, and decodes via `PlexTrackMapper.thumbPath` for the render-time resolver (a later PR).
- Parent/grandparent links carry the relationships: a track's `grandparentTitle` → artist, `parentTitle` → album; an album's `parentTitle` → artist. Missing names stay `null` so the grouping layer folds them into its existing Unknown Album/Artist buckets (the album/artist *title* fallbacks reuse `kUnknownAlbum`/`kUnknownArtist`; a titleless track shows `Untitled`).
- Durations map from Plex's milliseconds; absent/zero → `Duration.zero`.

**`lib/core/sources/plex/plex_music_source.dart`** — `PlexMusicSource implements MusicSource, PlexStreamSource`:
- `id` → `plex`; `displayName` → `Plex · <serverName>` when known, else `Plex`.
- `fetchArtists` / `fetchAlbums` / `fetchTracks` list type 8 / 9 / 10 per **selected** section (`PlexSession.selectedSectionKeys`) and concatenate, in selection order. An empty selection (the state every sign-in starts in until the library picker ships) returns empty lists without touching the server.
- `resolvePlayableUri` does the documented two-step resolution: `GET /library/metadata/{ratingKey}` → first `Part` key → `{baseUrl}{partKey}?X-Plex-Token=…`, minted **only at play time**. The live lookup doubles as the reachability/auth check Jellyfin/Subsonic get from their stream probe — failures surface as typed, token-free `PlexException`s. An item with no playable part resolves to `null`.

**`lib/core/sources/plex/plex_stream_source.dart`** — the narrow `verifyReachable` + `resolvePlayableUri` seam for the future playback resolver, mirroring `JellyfinStreamSource` (phase 1 is stream-only, so no download seam).

## Token safety

Per docs/plex.md → Token safety rules, with tests proving each:
- no token (or server address) in any mapped `Track.uri` / `Track.artworkUri`,
- the tokenized stream URL exists only as the return value of `resolvePlayableUri`,
- a failed resolution throws the client's static, token-free `PlexException`s,
- nothing here logs; the only diagnostics call is the existing secret-free-by-construction `PlaybackDiagnostics`.

## Tests

`plex_track_mapper_test.dart` (type mapping, parent/grandparent wiring, `plex:` scheme, `plex-thumb:` reference + round-trip, missing-field fallbacks, credential-free guards) and `plex_music_source_test.dart` (id/displayName, per-section type-8/9/10 scoping, empty-selection behavior, two-step `resolvePlayableUri` incl. fallback/no-part/not-found, token-leak guards, `verifyReachable`) — driven by the existing `FakePlexClient`.

`flutter analyze`: clean · `flutter test`: **1825 passed** · `scripts/check_secrets.sh`: passed

## Out of scope (per the plan)

No provider registration (`MusicProviders` untouched — Plex stays invisible), no UI/settings/library picker, no Android Auto, offline/cache, lyrics, playlist/favorite sync, or Plex.tv PIN flow; no changes to Jellyfin/Navidrome/Subsonic/Local; no version bump.

Closes nothing on its own — part of the #178 sequence (next: registration + capability set, then library selection UI, then cover-art resolution).

https://claude.ai/code/session_01TRcK1zciA2Wmsp2ZzSpnpQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRcK1zciA2Wmsp2ZzSpnpQ)_