### PR TITLE
Register Plex provider internally: capabilities, plex: routing, plex-thumb: artwork resolver (hidden from UI)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,10 +22,10 @@ source actually supports:
 | `canLyrics`            | Lyrics can be fetched for the source's tracks.                |
 | `canCast`              | A track's playback URL is network-reachable, so it can cast.  |
 
-A track carries an opaque `scheme:` URI (`subsonic:<id>`, `jellyfin:<id>`, or a
-file path) and **never** an authenticated URL — stream/download URLs are minted
-on demand at play/download time and discarded, so no secret reaches the
-persisted catalog.
+A track carries an opaque `scheme:` URI (`subsonic:<id>`, `jellyfin:<id>`,
+`plex:<ratingKey>`, or a file path) and **never** an authenticated URL —
+stream/download URLs are minted on demand at play/download time and discarded,
+so no secret reaches the persisted catalog.
 
 ## Provider matrix
 
@@ -34,10 +34,12 @@ persisted catalog.
 | Local music           | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   ✅   |  —   |
 | Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
 | Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  ✅  |
+| Plex                  | `plex`     |   🚧   |  🔜   |    🔜     |    🔜     |   🔜   |  🔜  |
 
-✅ implemented · 🔜 planned follow-up · — not applicable. "local" favourites/
-playlists stay on-device; "synced" ones mirror with the server (server is the
-source of truth on refresh).
+✅ implemented · 🚧 in development, not yet visible in Settings · 🔜 planned
+follow-up · — not applicable. "local" favourites/playlists stay on-device;
+"synced" ones mirror with the server (server is the source of truth on
+refresh).
 
 ## One library across providers
 
@@ -184,6 +186,22 @@ actions stay hidden/disabled rather than failing:
   `audio/mpeg` hint; an exact per-track type / transcode profile is a follow-up.
 - **In-app browse/search by artist/album** — the synced catalog lists tracks;
   richer browsing is shared work across all providers.
+
+## Plex (in development)
+
+A **read-only** [Plex Media Server](https://www.plex.tv/) provider is being
+built in small PRs behind the same `MusicSource` seam — see [plex.md](plex.md)
+for the full design and issue #178 for the plan. The internal plumbing exists
+(the stream-only capability set, recognition of `plex:<ratingKey>` track URIs
+in the playback router, and render-time resolution of credential-free
+`plex-thumb:` cover references), but **Plex is not yet visible in Settings**:
+the connection (server URL + token) and library-picker screens haven't
+shipped, so no Plex session can exist and nothing Plex-related appears in the
+app. Phase 1 will be stream-only (direct play); offline cache, favorites,
+playlists, lyrics, and cast are declared unsupported in the capability model
+until later — and Plex follows the same token-safety rules as every other
+provider (token encrypted at rest, never logged, never woven into a persisted
+URI or cache filename).
 
 ## Future provider possibilities
 

--- a/lib/core/catalog/source_capability.dart
+++ b/lib/core/catalog/source_capability.dart
@@ -9,6 +9,7 @@ import 'track_identity.dart';
 enum SourceProviderType {
   jellyfin('Jellyfin'),
   subsonic('Navidrome / Subsonic'),
+  plex('Plex'),
   local('Local music'),
   unknown('Unknown source');
 
@@ -55,9 +56,10 @@ enum SourceDelivery {
 ///
 /// ## Safety
 ///
-/// Only a non-identifying [sourceId] (`jellyfin` / `subsonic` / `local`) plus
-/// enums and plain numbers are stored. The track's URI, file path, server host,
-/// username, and tokens are **never** held or printed — [toString] is safe to log.
+/// Only a non-identifying [sourceId] (`jellyfin` / `subsonic` / `plex` /
+/// `local`) plus enums and plain numbers are stored. The track's URI, file
+/// path, server host, username, and tokens are **never** held or printed —
+/// [toString] is safe to log.
 class PlaybackSourceCapability {
   const PlaybackSourceCapability({
     required this.sourceId,
@@ -180,6 +182,9 @@ class PlaybackSourceCapability {
     if (sourceId == MusicProviders.subsonic.sourceId) {
       return SourceProviderType.subsonic;
     }
+    if (sourceId == MusicProviders.plex.sourceId) {
+      return SourceProviderType.plex;
+    }
     if (sourceId == MusicProviders.local.sourceId) {
       return SourceProviderType.local;
     }
@@ -192,6 +197,7 @@ class PlaybackSourceCapability {
         return SourceDelivery.localFile;
       case SourceProviderType.jellyfin:
       case SourceProviderType.subsonic:
+      case SourceProviderType.plex:
         return SourceDelivery.remoteStream;
       case SourceProviderType.unknown:
         return SourceDelivery.unknown;

--- a/lib/core/services/playback_source_label.dart
+++ b/lib/core/services/playback_source_label.dart
@@ -11,11 +11,12 @@ import '../sources/music_provider.dart';
 /// vs a live stream vs an on-device file).
 ///
 /// Security: only fixed, non-identifying display names are ever returned —
-/// "Navidrome", "Jellyfin", "Local music", "Cache", or "Unknown source". A
-/// server URL, IP, username, token, or file path is never exposed.
+/// "Navidrome", "Jellyfin", "Plex", "Local music", "Cache", or "Unknown
+/// source". A server URL, IP, username, token, or file path is never exposed.
 abstract final class PlaybackSourceLabel {
   static const String navidrome = 'Navidrome';
   static const String jellyfin = 'Jellyfin';
+  static const String plex = 'Plex';
   static const String local = 'Local music';
   static const String cache = 'Cache';
   static const String unknown = 'Unknown source';
@@ -46,6 +47,8 @@ abstract final class PlaybackSourceLabel {
         return jellyfin;
       case 'subsonic':
         return navidrome;
+      case 'plex':
+        return plex;
       case 'local':
         // An on-device file should resolve as localFile, not streamingDirect;
         // reaching here means an unexpected pairing, so stay vague but safe.

--- a/lib/core/services/stream_preloading_resolver.dart
+++ b/lib/core/services/stream_preloading_resolver.dart
@@ -37,8 +37,14 @@ class StreamPreloadingResolver implements PlayableUriResolver, StreamPreloader {
       <String, _PreloadedResolution>{};
 
   /// Remote stream schemes worth preloading; local files and `content://`
-  /// documents open instantly and need no warming.
-  static const Set<String> _remoteSchemes = <String>{'jellyfin', 'subsonic'};
+  /// documents open instantly and need no warming. Plex benefits the most: its
+  /// play resolution is two-step (a metadata lookup before the URL is minted),
+  /// so warming hides that extra round trip on a skip.
+  static const Set<String> _remoteSchemes = <String>{
+    'jellyfin',
+    'subsonic',
+    'plex',
+  };
 
   @override
   bool handles(Track track) => _inner.handles(track);

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'jellyfin/jellyfin_track_mapper.dart';
+import 'plex/plex_track_mapper.dart';
 import 'subsonic/subsonic_track_mapper.dart';
 
 /// What a music provider can do, so the UI can show only the actions a given
@@ -142,9 +143,9 @@ class MusicProviderCapabilities {
 }
 
 /// The identity + capabilities of one music provider (local files, Jellyfin,
-/// Subsonic/Navidrome). The [serverUrlLabel] is the field label a settings
-/// section shows for the server address, or null for the on-device source which
-/// has no server.
+/// Subsonic/Navidrome, Plex). The [serverUrlLabel] is the field label a
+/// settings section shows for the server address, or null for the on-device
+/// source which has no server.
 @immutable
 class MusicProvider {
   const MusicProvider({
@@ -256,11 +257,50 @@ abstract final class MusicProviders {
     ),
   );
 
+  /// Plex (phase 1, in development — see docs/plex.md and issue #178).
+  /// Registered so `plex:<ratingKey>` URIs are recognized internally, but
+  /// deliberately **not** surfaced anywhere in Settings/UI yet: the connection
+  /// and library-picker screens are later PRs, so no Plex session — and
+  /// therefore no `plex:` track — can exist in a normal install.
+  ///
+  /// Stream-only by design: caching, favorites, lyrics, playlists, and cast are
+  /// declared unsupported so their actions stay hidden/disabled rather than
+  /// failing — exactly how Subsonic shipped streaming first. Cast stays off in
+  /// phase 1 to keep the credential-in-URL surface small (a Plex stream URL
+  /// carries the token as a query param).
+  static const MusicProvider plex = MusicProvider(
+    sourceId: 'plex',
+    displayName: 'Plex',
+    serverUrlLabel: 'Server URL',
+    capabilities: MusicProviderCapabilities(
+      canStream: true,
+      // Offline caching is a documented follow-up (docs/plex.md → Out of
+      // scope), so there is no app-managed copy to remove either.
+      canCache: false,
+      canFavoriteTracks: false,
+      canReadFavoriteState: false,
+      canSyncFavorites: false,
+      canLyrics: false,
+      canCast: false,
+      canRemoveFromLibrary: true,
+      canRemoveOfflineCopy: false,
+      canDeleteLocalFile: false,
+      // Phase 1 is read-only: Linthra never writes to a Plex server.
+      canDeleteRemoteItem: false,
+      canListPlaylists: false,
+      canCreatePlaylist: false,
+      canEditPlaylist: false,
+      canDeletePlaylist: false,
+      canSyncPlaylists: false,
+    ),
+  );
+
   /// The provider that owns [trackUri], by its `scheme:` prefix. Anything not a
   /// known remote scheme is an on-device ([local]) track.
   static MusicProvider forTrackUri(String trackUri) {
     if (trackUri.startsWith(JellyfinTrackMapper.uriScheme)) return jellyfin;
     if (trackUri.startsWith(SubsonicTrackMapper.uriScheme)) return subsonic;
+    if (trackUri.startsWith(PlexTrackMapper.uriScheme)) return plex;
     return local;
   }
 

--- a/lib/core/sources/plex/plex_artwork.dart
+++ b/lib/core/sources/plex/plex_artwork.dart
@@ -1,0 +1,40 @@
+import '../../models/plex_session.dart';
+import 'plex_endpoints.dart';
+import 'plex_track_mapper.dart';
+
+/// Render-time resolution of a credential-free `plex-thumb:` cover reference
+/// into an authenticated Plex cover-art URL.
+///
+/// Why a reference instead of a ready-to-load URL: Plex cover art requires the
+/// `X-Plex-Token` as a query param on *every* request (the image layer can't
+/// set headers), so a loadable cover URL would embed the credential — and
+/// `Track.artworkUri` is persisted in the offline catalog. To keep the same
+/// "the credential never reaches the catalog" invariant the stream URLs
+/// follow, `PlexTrackMapper` stores only an opaque `plex-thumb:<thumbPath>`
+/// reference (no token, no server URL), and [resolve] weaves the live
+/// session's token in on demand at render time — exactly how
+/// `SubsonicArtwork.resolve` mints `getCoverArt` URLs.
+///
+/// The reference is provider-scoped, not server-scoped: there is a single
+/// signed-in Plex session at a time, so resolution reads whichever session is
+/// current. A reference left over after sign-out simply fails to resolve (the
+/// UI shows its placeholder) rather than loading a stale cover. Until the Plex
+/// connection UI ships, no session can exist, so every `plex-thumb:` reference
+/// stays unresolved and invisible.
+abstract final class PlexArtwork {
+  /// Resolves a credential-free cover [reference] into a loadable,
+  /// authenticated cover-art URL for [session], or `null` when [reference]
+  /// isn't a Plex cover reference (so a Jellyfin http URL, a local `file:`
+  /// cover, or a `subsonic-cover:` reference passes straight through the
+  /// resolver untouched). The token is woven in here, on demand, and never
+  /// persisted — the stored reference stays credential-free.
+  static Uri? resolve(Uri reference, PlexSession session) {
+    final String? thumbPath = PlexTrackMapper.thumbPath(reference);
+    if (thumbPath == null) return null;
+    return PlexEndpoints.coverArt(
+      session.baseUrl,
+      thumbPath: thumbPath,
+      token: session.token,
+    );
+  }
+}

--- a/lib/core/sources/plex/plex_playable_uri_resolver.dart
+++ b/lib/core/sources/plex/plex_playable_uri_resolver.dart
@@ -1,0 +1,105 @@
+import '../../models/playback_source.dart';
+import '../../models/track.dart';
+import '../../services/playable_uri_resolver.dart';
+import 'plex_exception.dart';
+import 'plex_stream_source.dart';
+import 'plex_track_mapper.dart';
+
+/// Resolves Plex tracks to authenticated streaming URLs at play time.
+///
+/// The `X-Plex-Token` is woven into the URL here, on demand by the
+/// [PlexStreamSource], and never stored on the track or in the catalog — a
+/// Plex stream URL carries the token in its **query**, so persisting one would
+/// persist the credential (see docs/plex.md → Token safety rules). Before
+/// minting, this verifies the session is still valid and the server reachable,
+/// so the player can show a precise, friendly error instead of an opaque
+/// audio-engine failure. The minted URL is returned to the controller and
+/// handed to the engine — never logged, never placed in [Track].
+///
+/// The current signed-in source is read through a getter so signing in or out
+/// is reflected without rebuilding the controller; with no Plex session (the
+/// only possible state until the connection UI ships) every `plex:` track
+/// resolves to a friendly "not signed in" — recognized, but unavailable. The
+/// resolver depends only on the narrow [PlexStreamSource], never on Riverpod
+/// or HTTP.
+class PlexPlayableUriResolver implements PlayableUriResolver {
+  const PlexPlayableUriResolver(this._source);
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final PlexStreamSource? Function() _source;
+
+  @override
+  bool handles(Track track) => track.uri.startsWith(PlexTrackMapper.uriScheme);
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    final PlexStreamSource? source = _source();
+    if (source == null) {
+      throw const PlaybackResolutionException(
+        'Sign in to your Plex server before streaming this track.',
+        kind: PlaybackResolutionErrorKind.notSignedIn,
+      );
+    }
+
+    // Confirm the session still works, then mint the stream URL — both can
+    // throw a typed [PlexException], which becomes a precise, secret-free
+    // message rather than the engine's opaque "couldn't play".
+    final Uri? uri;
+    try {
+      await source.verifyReachable();
+      uri = await source.resolvePlayableUri(track);
+    } on PlexException catch (error) {
+      throw _mapFailure(error);
+    }
+
+    if (uri == null) {
+      throw const PlaybackResolutionException(
+        "Couldn't stream this track.",
+        kind: PlaybackResolutionErrorKind.streamUnavailable,
+      );
+    }
+    return ResolvedPlayable(uri, PlaybackSource.streamingDirect);
+  }
+
+  /// Maps a Plex failure to a friendly, secret-free playback error. Branches
+  /// on [PlexErrorKind] so wording can change without breaking it, and so a
+  /// new kind is a compile error here rather than a silent generic message.
+  PlaybackResolutionException _mapFailure(PlexException error) {
+    switch (error.kind) {
+      case PlexErrorKind.unauthorized:
+        return const PlaybackResolutionException(
+          'Your Plex session was rejected by the server. Sign in again.',
+          kind: PlaybackResolutionErrorKind.sessionExpired,
+        );
+      case PlexErrorKind.notPlex:
+        return const PlaybackResolutionException(
+          'Your server returned a web page instead of audio. Check your '
+          'reverse proxy / server address.',
+          kind: PlaybackResolutionErrorKind.serverReturnedWebPage,
+        );
+      case PlexErrorKind.notFound:
+        return const PlaybackResolutionException(
+          "This track isn't available from your Plex server right now.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        );
+      case PlexErrorKind.unsupportedResponse:
+        return const PlaybackResolutionException(
+          'Your Plex server returned a response Linthra could not use. '
+          'It may be running an unsupported version.',
+          kind: PlaybackResolutionErrorKind.invalidStream,
+        );
+      case PlexErrorKind.notReachable:
+      case PlexErrorKind.serverError:
+        return const PlaybackResolutionException(
+          "Couldn't reach your Plex server.",
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
+      case PlexErrorKind.invalidUrl:
+      case PlexErrorKind.unexpected:
+        return const PlaybackResolutionException(
+          "Couldn't stream this track.",
+          kind: PlaybackResolutionErrorKind.streamUnavailable,
+        );
+    }
+  }
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -16,10 +16,12 @@ import '../../core/services/smart_precache_service.dart';
 import '../../core/services/stream_preload_service.dart';
 import '../../core/services/stream_preloading_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
+import '../../core/sources/plex/plex_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/plex/plex_providers.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'cast/cast_providers.dart';
 import 'now_playing.dart';
@@ -39,6 +41,10 @@ final streamPreloadingResolverProvider =
     RoutingPlayableUriResolver(<PlayableUriResolver>[
       JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
       SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
+      // Plex is wired but has no connection UI yet: its source provider is
+      // always null in production, so a plex: track resolves to a friendly
+      // "not signed in" rather than falling through as unplayable.
+      PlexPlayableUriResolver(() => ref.read(plexMusicSourceProvider)),
       const LocalPlayableUriResolver(),
     ]),
   );

--- a/lib/features/settings/plex/plex_providers.dart
+++ b/lib/features/settings/plex/plex_providers.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/sources/plex/plex_music_source.dart';
+
+/// Internal Plex wiring — deliberately invisible to users.
+///
+/// This is the "register the provider" step of the Plex plan (issue #178 /
+/// docs/plex.md): the playback router and the render-time artwork seam read
+/// this provider, so `plex:<ratingKey>` track URIs and `plex-thumb:` artwork
+/// references are recognized end to end. There is **no** Plex entry in
+/// Settings, no sign-in screen, and no library picker yet, so in production
+/// nothing can ever supply a session: this stays `null`, every `plex:` track
+/// fails resolution with a friendly "not signed in", and every `plex-thumb:`
+/// reference falls back to the artwork placeholder. Plex stays completely
+/// invisible until the connection UI ships.
+///
+/// The settings controller PR will replace this default with the real session
+/// lifecycle (manual-token sign-in, persisted via the encrypted
+/// `PlexSessionStore`, library-section selection), exactly like
+/// `jellyfinMusicSourceProvider` / `subsonicMusicSourceProvider` derive from
+/// their controllers. Everything downstream is already wired through this
+/// seam, so that PR only has to make it return a real source. Tests override
+/// it (with a `PlexMusicSource` built on a `FakePlexClient`) to exercise the
+/// signed-in paths today.
+final plexMusicSourceProvider = Provider<PlexMusicSource?>((ref) => null);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app/linthra_app.dart';
+import 'core/models/plex_session.dart';
 import 'core/models/subsonic_session.dart';
 import 'core/services/linthra_audio_handler.dart';
+import 'core/sources/plex/plex_artwork.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
 import 'data/repositories/default_provider_store_provider.dart';
 import 'data/repositories/download_repository_provider.dart';
@@ -30,6 +32,7 @@ import 'features/player/media_artwork_providers.dart';
 import 'features/player/player_providers.dart';
 import 'features/settings/jellyfin/jellyfin_settings_controller.dart';
 import 'features/settings/playback/normalize_volume_controller.dart';
+import 'features/settings/plex/plex_providers.dart';
 import 'features/settings/subsonic/subsonic_settings_controller.dart';
 import 'shared/widgets/artwork_image.dart';
 
@@ -178,20 +181,32 @@ Future<void> main() async {
     // Ignore: the user can still connect in Settings.
   }
 
-  // Teach the shared artwork seam how to turn a credential-free Subsonic cover
-  // reference (subsonic-cover:<id>, the only artwork the catalog persists) into
-  // an authenticated getCoverArt URL, weaving the live session's salt+token in
-  // at render time — exactly how stream URLs are minted on demand, so the
-  // credential never reaches the catalog. Reads the session live, so signing
-  // in/out is picked up without a rebuild; returns null when signed out (the
-  // row keeps its placeholder) and for any non-Subsonic reference (Jellyfin and
-  // local covers load directly). Secret-free: only the resolved NetworkImage URL
-  // is built, never logged.
+  // Teach the shared artwork seam how to turn a credential-free cover
+  // reference (subsonic-cover:<id> or plex-thumb:<path>, the only artwork the
+  // catalog persists for those providers) into an authenticated cover URL,
+  // weaving the live session's credential in at render time — exactly how
+  // stream URLs are minted on demand, so the credential never reaches the
+  // catalog. Each resolver owns one scheme and returns null for the rest, so
+  // they chain safely. Sessions are read live, so signing in/out is picked up
+  // without a rebuild; a signed-out provider's reference stays unresolved (the
+  // row keeps its placeholder) and anything else (Jellyfin and local covers)
+  // loads directly. Plex has no connection UI yet, so its session is always
+  // null today and plex-thumb: references simply keep their placeholder.
+  // Secret-free: only the resolved NetworkImage URL is built, never logged.
   installArtworkReferenceResolver((Uri reference) {
-    final SubsonicSession? session =
+    final SubsonicSession? subsonicSession =
         container.read(subsonicSettingsControllerProvider.notifier).session;
-    if (session == null) return null;
-    return SubsonicArtwork.resolve(reference, session);
+    if (subsonicSession != null) {
+      final Uri? resolved = SubsonicArtwork.resolve(reference, subsonicSession);
+      if (resolved != null) return resolved;
+    }
+    final PlexSession? plexSession =
+        container.read(plexMusicSourceProvider)?.session;
+    if (plexSession != null) {
+      final Uri? resolved = PlexArtwork.resolve(reference, plexSession);
+      if (resolved != null) return resolved;
+    }
+    return null;
   });
 
   // With the session loaded, pull the user's Jellyfin favourites so the heart

--- a/test/core/catalog/source_capability_test.dart
+++ b/test/core/catalog/source_capability_test.dart
@@ -27,6 +27,15 @@ void main() {
       expect(cap.isRemoteStream, isTrue);
     });
 
+    test('a Plex candidate gets provider type plex and streams remotely', () {
+      final cap = PlaybackSourceCapability.fromTrack(_track('p', 'plex:101'));
+      expect(cap.providerType, SourceProviderType.plex);
+      expect(cap.providerType.displayName, 'Plex');
+      expect(cap.sourceId, 'plex');
+      expect(cap.isRemoteStream, isTrue);
+      expect(cap.isLocalFile, isFalse);
+    });
+
     test('a local-file candidate is marked local', () {
       final cap =
           PlaybackSourceCapability.fromTrack(_track('l', '/music/one.mp3'));

--- a/test/core/services/playback_source_label_test.dart
+++ b/test/core/services/playback_source_label_test.dart
@@ -34,6 +34,18 @@ void main() {
       );
     });
 
+    test('a direct Plex stream names Plex — and only the fixed name', () {
+      // Like every label: a fixed, non-identifying string — never a server
+      // URL, host, or token.
+      expect(
+        PlaybackSourceLabel.of(
+          trackUri: 'plex:101',
+          source: PlaybackSource.streamingDirect,
+        ),
+        'Plex',
+      );
+    });
+
     test('a cached copy reads as Cache regardless of the owning server', () {
       expect(
         PlaybackSourceLabel.of(

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -43,11 +43,35 @@ void main() {
       expect(caps.canListPlaylists, isFalse);
     });
 
+    test('plex: stream-only in phase 1 (docs/plex.md capability matrix)', () {
+      final caps = MusicProviders.plex.capabilities;
+      expect(caps.canStream, isTrue);
+      // Everything else is declared unsupported so its actions stay hidden/
+      // disabled rather than failing — exactly how Subsonic deferred features.
+      expect(caps.canCache, isFalse);
+      expect(caps.canFavoriteTracks, isFalse);
+      expect(caps.canReadFavoriteState, isFalse);
+      expect(caps.canSyncFavorites, isFalse);
+      expect(caps.canLyrics, isFalse);
+      // Cast stays off in phase 1 to keep the credential-in-URL surface small.
+      expect(caps.canCast, isFalse);
+      expect(caps.canListPlaylists, isFalse);
+      expect(caps.canCreatePlaylist, isFalse);
+      expect(caps.canEditPlaylist, isFalse);
+      expect(caps.canDeletePlaylist, isFalse);
+      expect(caps.canSyncPlaylists, isFalse);
+      // No cache means no app-managed offline copy to remove.
+      expect(caps.canRemoveOfflineCopy, isFalse);
+    });
+
     test('identity fields', () {
       expect(MusicProviders.subsonic.sourceId, 'subsonic');
       expect(MusicProviders.subsonic.displayName, 'Navidrome / Subsonic');
       expect(MusicProviders.subsonic.serverUrlLabel, 'Server URL');
       expect(MusicProviders.local.serverUrlLabel, isNull);
+      expect(MusicProviders.plex.sourceId, 'plex');
+      expect(MusicProviders.plex.displayName, 'Plex');
+      expect(MusicProviders.plex.serverUrlLabel, 'Server URL');
     });
 
     test('remove/delete capabilities are safe by default', () {
@@ -55,6 +79,7 @@ void main() {
       expect(MusicProviders.local.capabilities.canRemoveFromLibrary, isTrue);
       expect(MusicProviders.jellyfin.capabilities.canRemoveFromLibrary, isTrue);
       expect(MusicProviders.subsonic.capabilities.canRemoveFromLibrary, isTrue);
+      expect(MusicProviders.plex.capabilities.canRemoveFromLibrary, isTrue);
 
       // On-device tracks have no app-managed offline copy to remove; remote
       // providers do.
@@ -62,11 +87,13 @@ void main() {
       expect(MusicProviders.jellyfin.capabilities.canRemoveOfflineCopy, isTrue);
 
       // Destructive file/server deletes are not enabled in this release for any
-      // provider, so those actions stay hidden everywhere.
+      // provider, so those actions stay hidden everywhere. Plex is additionally
+      // read-only by design (phase 1 never writes to the server).
       for (final caps in <MusicProviderCapabilities>[
         MusicProviders.local.capabilities,
         MusicProviders.jellyfin.capabilities,
         MusicProviders.subsonic.capabilities,
+        MusicProviders.plex.capabilities,
       ]) {
         expect(caps.canDeleteLocalFile, isFalse);
         expect(caps.canDeleteRemoteItem, isFalse);
@@ -162,9 +189,32 @@ void main() {
           same(MusicProviders.subsonic));
       expect(MusicProviders.forTrackUri('jellyfin:abc'),
           same(MusicProviders.jellyfin));
+      expect(MusicProviders.forTrackUri('plex:101'), same(MusicProviders.plex));
       expect(MusicProviders.forTrackUri('/music/song.mp3'),
           same(MusicProviders.local));
       expect(MusicProviders.forTrackUri('content://media/x'),
+          same(MusicProviders.local));
+    });
+
+    test('registering plex did not change how existing URIs route', () {
+      // The no-regression guard docs/plex.md calls for: the only shared-code
+      // edit Plex makes is its own forTrackUri branch, so every URI shape the
+      // existing providers produce must keep resolving exactly as before.
+      expect(MusicProviders.forTrackUri('jellyfin:item-42'),
+          same(MusicProviders.jellyfin));
+      expect(MusicProviders.forTrackUri('subsonic:mf-7'),
+          same(MusicProviders.subsonic));
+      expect(MusicProviders.forTrackUri('/storage/emulated/0/Music/a.flac'),
+          same(MusicProviders.local));
+      expect(MusicProviders.forTrackUri('content://com.android.docs/tree/x'),
+          same(MusicProviders.local));
+      expect(MusicProviders.forTrackUri('file:///music/song.ogg'),
+          same(MusicProviders.local));
+      // Near-misses of the plex: scheme stay on-device rather than routing to
+      // Plex; the artwork scheme is not a track scheme.
+      expect(
+          MusicProviders.forTrackUri('plexamp:1'), same(MusicProviders.local));
+      expect(MusicProviders.forTrackUri('plex-thumb:/library/x'),
           same(MusicProviders.local));
     });
 
@@ -172,6 +222,10 @@ void main() {
       expect(
         MusicProviders.capabilitiesForTrackUri('subsonic:1'),
         MusicProviders.subsonic.capabilities,
+      );
+      expect(
+        MusicProviders.capabilitiesForTrackUri('plex:1'),
+        MusicProviders.plex.capabilities,
       );
     });
   });

--- a/test/core/sources/plex/plex_artwork_test.dart
+++ b/test/core/sources/plex/plex_artwork_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/sources/plex/plex_artwork.dart';
+import 'package:linthra/core/sources/plex/plex_track_mapper.dart';
+
+const _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'the-secret-token',
+  machineIdentifier: 'machine-1',
+);
+
+/// The credential-free reference the mapper persists for a thumb path, built
+/// the same way `PlexTrackMapper` builds `Track.artworkUri`.
+Uri _reference(String thumbPath) =>
+    Uri(scheme: PlexTrackMapper.artworkScheme, path: thumbPath);
+
+void main() {
+  group('PlexArtwork.resolve', () {
+    test('weaves the session token into a cover-art URL at render time', () {
+      final Uri? resolved = PlexArtwork.resolve(
+        _reference('/library/metadata/123/thumb/1670000000'),
+        _session,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.host, 'plex.example.com');
+      expect(resolved.port, 32400);
+      expect(resolved.path, '/library/metadata/123/thumb/1670000000');
+      expect(resolved.queryParameters['X-Plex-Token'], 'the-secret-token');
+    });
+
+    test('keeps the token in the query only, never in the path', () {
+      final Uri resolved = PlexArtwork.resolve(
+        _reference('/library/metadata/123/thumb/1'),
+        _session,
+      )!;
+      expect(resolved.path, isNot(contains('the-secret-token')));
+    });
+
+    test('returns null for a non-Plex reference so other covers pass through',
+        () {
+      // A Jellyfin already-loadable http URL must not be rewritten.
+      expect(
+        PlexArtwork.resolve(
+          Uri.parse('https://server.example/Items/1/Images/Primary'),
+          _session,
+        ),
+        isNull,
+      );
+      // A local file cover is not a Plex reference.
+      expect(
+        PlexArtwork.resolve(Uri.parse('file:///cache/art/abc.img'), _session),
+        isNull,
+      );
+      // A Subsonic cover reference belongs to the Subsonic resolver.
+      expect(
+        PlexArtwork.resolve(Uri.parse('subsonic-cover:al-123'), _session),
+        isNull,
+      );
+      // The plex: *track* scheme is deliberately distinct from the artwork
+      // reference scheme and must not resolve as a cover.
+      expect(PlexArtwork.resolve(Uri.parse('plex:101'), _session), isNull);
+    });
+
+    test('returns null for an empty reference', () {
+      expect(
+        PlexArtwork.resolve(Uri.parse('plex-thumb:'), _session),
+        isNull,
+      );
+    });
+
+    test('the persisted reference itself stays credential-free', () {
+      // The reference is what the catalog stores; the token and server address
+      // are woven in only by resolve(), never persisted.
+      final String reference =
+          _reference('/library/metadata/123/thumb/1').toString();
+      expect(reference, isNot(contains(_session.token)));
+      expect(reference, isNot(contains(_session.baseUrl)));
+      expect(reference, isNot(contains('plex.example.com')));
+      expect(reference, isNot(contains('http')));
+    });
+  });
+}

--- a/test/core/sources/plex/plex_playable_uri_resolver_test.dart
+++ b/test/core/sources/plex/plex_playable_uri_resolver_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/plex/plex_stream_source.dart';
+
+/// A configurable [PlexStreamSource] for resolver tests.
+class _FakeStreamSource implements PlexStreamSource {
+  _FakeStreamSource({this.uri, this.verifyError, this.resolveError});
+
+  Uri? uri;
+  PlexException? verifyError;
+  PlexException? resolveError;
+
+  @override
+  Future<void> verifyReachable() async {
+    if (verifyError != null) throw verifyError!;
+  }
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    if (resolveError != null) throw resolveError!;
+    return uri;
+  }
+}
+
+const _track = Track(id: '101', title: 'One', uri: 'plex:101');
+
+void main() {
+  test('handles only plex: tracks', () {
+    final resolver = PlexPlayableUriResolver(() => _FakeStreamSource());
+    expect(resolver.handles(_track), isTrue);
+    expect(
+      resolver.handles(const Track(id: 'j', title: 'x', uri: 'jellyfin:j')),
+      isFalse,
+    );
+    expect(
+      resolver.handles(const Track(id: 's', title: 'x', uri: 'subsonic:s')),
+      isFalse,
+    );
+    expect(
+      resolver.handles(const Track(id: 'l', title: 'x', uri: '/music/a.mp3')),
+      isFalse,
+    );
+  });
+
+  test('resolves to a streaming-direct playable', () async {
+    final source = _FakeStreamSource(
+      uri: Uri.parse(
+          'https://plex.example.com/library/parts/9/file.flac?X-Plex-Token=tok'),
+    );
+    final resolver = PlexPlayableUriResolver(() => source);
+
+    final resolved = await resolver.resolve(_track);
+
+    expect(resolved.source, PlaybackSource.streamingDirect);
+    expect(resolved.uri.path, '/library/parts/9/file.flac');
+  });
+
+  test('reports a friendly "not signed in" when no source is connected',
+      () async {
+    // The only state reachable in production until the Plex connection UI
+    // ships: the scheme is recognized, but resolution is gated on a session.
+    final resolver = PlexPlayableUriResolver(() => null);
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having(
+          (e) => e.kind, 'kind', PlaybackResolutionErrorKind.notSignedIn)),
+    );
+  });
+
+  test('maps an unauthorized failure to sessionExpired', () async {
+    final resolver = PlexPlayableUriResolver(
+      () => _FakeStreamSource(verifyError: PlexException.unauthorized()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having(
+          (e) => e.kind, 'kind', PlaybackResolutionErrorKind.sessionExpired)),
+    );
+  });
+
+  test('maps an HTML/proxy page to serverReturnedWebPage', () async {
+    final resolver = PlexPlayableUriResolver(
+      () => _FakeStreamSource(resolveError: PlexException.notPlex()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having((e) => e.kind, 'kind',
+          PlaybackResolutionErrorKind.serverReturnedWebPage)),
+    );
+  });
+
+  test('maps a vanished item (404) to streamUnavailable', () async {
+    final resolver = PlexPlayableUriResolver(
+      () => _FakeStreamSource(resolveError: PlexException.notFound()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having((e) => e.kind, 'kind',
+          PlaybackResolutionErrorKind.streamUnavailable)),
+    );
+  });
+
+  test('maps an offline server to serverUnreachable', () async {
+    final resolver = PlexPlayableUriResolver(
+      () => _FakeStreamSource(verifyError: PlexException.notReachable()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having((e) => e.kind, 'kind',
+          PlaybackResolutionErrorKind.serverUnreachable)),
+    );
+  });
+
+  test('a track with no playable part is streamUnavailable', () async {
+    // The source resolved the item, but it carried no Part to stream.
+    final resolver = PlexPlayableUriResolver(() => _FakeStreamSource());
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having((e) => e.kind, 'kind',
+          PlaybackResolutionErrorKind.streamUnavailable)),
+    );
+  });
+
+  test('no resolution error message leaks a token', () async {
+    // A Plex stream URL carries X-Plex-Token in its query, so the error path
+    // must never echo a URL or token fragment.
+    for (final source in <_FakeStreamSource>[
+      _FakeStreamSource(verifyError: PlexException.unauthorized()),
+      _FakeStreamSource(resolveError: PlexException.notFound()),
+      _FakeStreamSource(verifyError: PlexException.notReachable()),
+    ]) {
+      final resolver = PlexPlayableUriResolver(() => source);
+      try {
+        await resolver.resolve(_track);
+        fail('expected a PlaybackResolutionException');
+      } on PlaybackResolutionException catch (e) {
+        expect(e.message, isNot(contains('tok')));
+        expect(e.message, isNot(contains('X-Plex-Token')));
+        expect(e.message, isNot(contains('=')));
+      }
+    }
+  });
+}

--- a/test/features/player/source_routing_test.dart
+++ b/test/features/player/source_routing_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/local_playable_uri_resolver.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/routing_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_music_source.dart';
+import 'package:linthra/core/sources/plex/plex_playable_uri_resolver.dart';
+import 'package:linthra/core/sources/plex/plex_stream_source.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_playable_uri_resolver.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/settings/plex/plex_providers.dart';
+
+import '../../core/sources/plex/fake_plex_client.dart';
+
+/// A signed-in Plex stream source minting a canned URL, for routing tests that
+/// don't need the full client round trip.
+class _FakePlexStreamSource implements PlexStreamSource {
+  _FakePlexStreamSource(this._uri);
+
+  final Uri _uri;
+  int resolveCount = 0;
+
+  @override
+  Future<void> verifyReachable() async {}
+
+  @override
+  Future<Uri?> resolvePlayableUri(Track track) async {
+    resolveCount++;
+    return _uri;
+  }
+}
+
+const _jellyfinTrack = Track(id: 'j1', title: 'J', uri: 'jellyfin:j1');
+const _subsonicTrack = Track(id: 's1', title: 'S', uri: 'subsonic:s1');
+const _plexTrack = Track(id: '101', title: 'P', uri: 'plex:101');
+const _localTrack = Track(id: 'l1', title: 'L', uri: '/music/one.mp3');
+const _safTrack = Track(
+  id: 'c1',
+  title: 'C',
+  uri: 'content://media/external/audio/media/42',
+);
+
+/// The exact source-router composition `streamPreloadingResolverProvider`
+/// builds: Jellyfin, Subsonic, Plex, then the on-device catch-all.
+RoutingPlayableUriResolver _router({
+  PlexStreamSource? Function()? plex,
+}) {
+  return RoutingPlayableUriResolver(<PlayableUriResolver>[
+    JellyfinPlayableUriResolver(() => null),
+    SubsonicPlayableUriResolver(() => null),
+    PlexPlayableUriResolver(plex ?? () => null),
+    const LocalPlayableUriResolver(),
+  ]);
+}
+
+Matcher _failsAs(PlaybackResolutionErrorKind kind) => throwsA(
+    isA<PlaybackResolutionException>().having((e) => e.kind, 'kind', kind));
+
+void main() {
+  group('source routing with Plex registered — no regression', () {
+    test('a local path still plays from its on-device file', () async {
+      final resolved = await _router().resolve(_localTrack);
+      expect(resolved.uri.scheme, 'file');
+      expect(resolved.uri.toFilePath(), '/music/one.mp3');
+      expect(resolved.source, PlaybackSource.localFile);
+    });
+
+    test('a content:// (SAF) document still plays as a local track', () async {
+      final resolved = await _router().resolve(_safTrack);
+      expect(resolved.uri, Uri.parse(_safTrack.uri));
+      expect(resolved.source, PlaybackSource.localFile);
+    });
+
+    test(
+        'jellyfin: and subsonic: still reach their own resolvers '
+        '(a precise "not signed in", never an unrecognized-track fallthrough)',
+        () async {
+      // streamUnavailable is what the router throws for a URI *no* resolver
+      // claims, so notSignedIn proves each scheme is still owned by its own
+      // provider's resolver after Plex was added to the list.
+      await expectLater(
+        _router().resolve(_jellyfinTrack),
+        _failsAs(PlaybackResolutionErrorKind.notSignedIn),
+      );
+      await expectLater(
+        _router().resolve(_subsonicTrack),
+        _failsAs(PlaybackResolutionErrorKind.notSignedIn),
+      );
+    });
+
+    test('a connected Plex source never captures other providers\' tracks',
+        () async {
+      final plex = _FakePlexStreamSource(
+        Uri.parse(
+            'https://plex.example.com/library/parts/9/f.flac?X-Plex-Token=t'),
+      );
+      final router = _router(plex: () => plex);
+
+      await expectLater(
+        router.resolve(_jellyfinTrack),
+        _failsAs(PlaybackResolutionErrorKind.notSignedIn),
+      );
+      await expectLater(
+        router.resolve(_subsonicTrack),
+        _failsAs(PlaybackResolutionErrorKind.notSignedIn),
+      );
+      final local = await router.resolve(_localTrack);
+      expect(local.source, PlaybackSource.localFile);
+      expect(plex.resolveCount, 0);
+    });
+  });
+
+  group('plex: routes only when a Plex session/source is available', () {
+    test('signed out (the only production state today): a friendly gate',
+        () async {
+      // Recognized — the Plex resolver claims the scheme — but unavailable,
+      // because no source is connected. Without registration this would be the
+      // router's streamUnavailable instead.
+      await expectLater(
+        _router().resolve(_plexTrack),
+        _failsAs(PlaybackResolutionErrorKind.notSignedIn),
+      );
+    });
+
+    test('with a connected source the same track streams directly', () async {
+      final plex = _FakePlexStreamSource(
+        Uri.parse(
+            'https://plex.example.com/library/parts/9/f.flac?X-Plex-Token=t'),
+      );
+      final resolved = await _router(plex: () => plex).resolve(_plexTrack);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(resolved.uri.path, '/library/parts/9/f.flac');
+      expect(plex.resolveCount, 1);
+    });
+  });
+
+  group('the real Riverpod wiring (streamPreloadingResolverProvider)', () {
+    test('by default the Plex source is null, so a plex: track is gated',
+        () async {
+      // No overrides: exactly what a production install runs today. The
+      // jellyfin/subsonic session stores default to in-memory (empty), and
+      // plexMusicSourceProvider is null by construction.
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final resolver = container.read(streamPreloadingResolverProvider);
+
+      await expectLater(
+        resolver.resolve(_plexTrack),
+        _failsAs(PlaybackResolutionErrorKind.notSignedIn),
+      );
+      // And the existing local path is untouched by the wiring.
+      final local = await resolver.resolve(_localTrack);
+      expect(local.source, PlaybackSource.localFile);
+    });
+
+    test(
+        'overriding plexMusicSourceProvider (as the future settings PR will) '
+        'streams a plex: track end to end, minting the tokenized URL on demand',
+        () async {
+      const session = PlexSession(
+        baseUrl: 'https://plex.example.com:32400',
+        token: 'secret-token',
+        machineIdentifier: 'machine-1',
+        selectedSectionKeys: <String>['5'],
+      );
+      final client = FakePlexClient(
+        metadataByRatingKey: <String, PlexMetadata>{
+          '101': const PlexMetadata(
+            ratingKey: '101',
+            type: 'track',
+            title: 'One',
+            media: <PlexMedia>[
+              PlexMedia(parts: <PlexPart>[
+                PlexPart(key: '/library/parts/9/1670000000/file.flac'),
+              ]),
+            ],
+          ),
+        },
+      );
+      final container = ProviderContainer(overrides: [
+        plexMusicSourceProvider.overrideWithValue(
+          PlexMusicSource(session: session, client: client),
+        ),
+      ]);
+      addTearDown(container.dispose);
+      final resolver = container.read(streamPreloadingResolverProvider);
+
+      final resolved = await resolver.resolve(_plexTrack);
+
+      // The two-step resolution ran (metadata lookup → Part key → stream URL)
+      // and the token was woven in only now, in the query — never in the
+      // track's opaque uri.
+      expect(client.requestedRatingKeys, <String>['101']);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(resolved.uri.path, '/library/parts/9/1670000000/file.flac');
+      expect(resolved.uri.queryParameters['X-Plex-Token'], 'secret-token');
+      expect(_plexTrack.uri, 'plex:101');
+      expect(_plexTrack.uri, isNot(contains('secret-token')));
+    });
+  });
+}


### PR DESCRIPTION
# Plex support — PR 6: internal provider registration (no UI)

Part of #178, following [docs/plex.md](docs/plex.md). Wires the existing Plex foundation (DTOs, client, session/auth, mapper, `PlexMusicSource` — #180–#184) into Linthra's provider architecture **without making Plex visible or usable**: there is still no Settings entry, no sign-in screen, and no library picker, so no Plex session can exist in a normal install and nothing Plex-related appears in the app.

## What this adds

**Capability metadata & identity constants**
- `MusicProviders.plex` with the phase-1 **stream-only** capability set from the design doc (cache/favorites/lyrics/playlists/cast declared unsupported so their actions stay hidden rather than failing; cast stays off to keep the credential-in-URL surface small).
- `SourceProviderType.plex` (inherent delivery: remote stream) in the playback-source capability metadata, and the fixed, non-identifying `"Plex"` name in `PlaybackSourceLabel`.

**`plex:<ratingKey>` track URIs recognized internally**
- The `plex:` branch in `MusicProviders.forTrackUri` — per the design doc, the only shared-code edit the plan calls for (plus the docs row).
- New `PlexPlayableUriResolver` (mirrors the Jellyfin/Subsonic resolvers: verify-then-mint, typed `PlexException` → friendly secret-free playback errors), composed into the production source router in `player_providers.dart`.
- `plex` added to the stream-preloader's remote-scheme set — Plex's two-step play resolution benefits most from warming.
- New `plexMusicSourceProvider`, **always `null` in production** until the connection UI ships: a `plex:` track resolves to a friendly "not signed in" instead of an unrecognized-track fallthrough. The future settings PR only has to make this seam return a real source.

**`plex-thumb:` artwork references recognized internally**
- New `PlexArtwork.resolve` (mirrors `SubsonicArtwork.resolve`): weaves the session token into a cover URL **only at render time**, returns `null` for any non-Plex reference.
- Chained into the existing app-level artwork-reference seam (`installArtworkReferenceResolver` in `main.dart`) after Subsonic; each resolver owns one scheme, so the chain is order-independent. With no Plex session (today: always), references simply keep their placeholder.

**Docs**
- `docs/providers.md`: Plex row in the provider matrix marked 🚧 "in development, not yet visible in Settings", plus a short section linking the design doc.

## Tests

- `plex_playable_uri_resolver_test.dart` — handles only `plex:`; **"not signed in" when no source is connected**; `PlexErrorKind` → playback-error mapping; no token/URL fragment in any error message.
- `plex_artwork_test.dart` — token woven into the query only at render time; Jellyfin/local/Subsonic/`plex:` URIs pass through untouched; the persisted reference stays credential-free.
- `source_routing_test.dart` — the production router composition: **local, `content://`, `jellyfin:`, and `subsonic:` routing unchanged**; a connected Plex source never captures other providers' tracks; `plex:` resolves **only when a source is available**, both with the hand-built router and through the real `streamPreloadingResolverProvider` (default = gated; overridden with a `FakePlexClient`-backed source = end-to-end tokenized stream URL, opaque `Track.uri` untouched).
- `music_provider_test.dart` — Plex capability matrix; the no-regression `forTrackUri` guard from the design doc (existing schemes unchanged; `plexamp:`/`plex-thumb:` near-misses stay local).
- `source_capability_test.dart`, `playback_source_label_test.dart` — Plex identity metadata.

`flutter analyze` clean · `dart format` clean · **full suite: 1851 tests pass** · `scripts/check_secrets.sh` passes.

## Security invariants (unchanged and tested)

- No tokenized stream or artwork URL is ever stored — `Track.uri` stays `plex:<ratingKey>`, `Track.artworkUri` stays `plex-thumb:<path>`; credentialed URLs are minted at play/render time and discarded.
- No token in logs, diagnostics, error messages, or cache filenames; resolver error messages are asserted token-free.

## Out of scope (later PRs per the plan)

Settings/connection UI · library picker · login screen · plex.tv PIN/OAuth · offline cache · lyrics · playlists/favorites · Android Auto artwork · version/release changes.

https://claude.ai/code/session_013JMRbbz3CsdCQGj2BCrx3v

---
_Generated by [Claude Code](https://claude.ai/code/session_013JMRbbz3CsdCQGj2BCrx3v)_