### PR TITLE
Plex PR 8: real-device hardening and phase 1 polish (sync, safe states, restore/disconnect)

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -273,6 +273,16 @@ Small, incremental, each independently reviewable:
    `plex_settings_section/controller/state`, Riverpod providers + tests.
 7. **Cover art** — `plex-thumb:` reference resolver at render time; update the
    [providers.md](providers.md) provider matrix to add the Plex row.
+8. **Real-device hardening & phase-1 polish** — the catalog sync
+   (`plex_sync_controller`: a *Sync Plex library* action plus an automatic,
+   coalesced sync after every committed library-selection change; the sync
+   **replaces** the catalog's Plex slice even when empty, so the catalog
+   always mirrors the selection), explicit loading/empty/error + retry states
+   in the library picker, selection pruning when a section vanishes
+   server-side, same-server reconnects keeping the selection, startup-restore
+   race guards and a friendly restore-failure message, and disconnect also
+   removing the synced (now unplayable) Plex rows — with tests for each state
+   and for token redaction on every new message path.
 
 ## Notes
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -197,14 +197,24 @@ server URL + Plex token, Linthra verifies them against `/identity`, persists
 the session encrypted at rest, and — unlike Jellyfin/Subsonic, which sync the
 whole server — asks the user to **pick which music libraries** to include
 (the selection is saved with the session and scopes every fetch; connected
-with nothing selected simply means an empty library). Disconnecting removes
-only the Plex session.
+with nothing selected simply means an empty library).
+
+**Syncing follows the selection.** Choosing a library kicks a background
+catalog sync automatically (rapid checkbox changes coalesce into one re-run),
+and a *Sync Plex library* button reruns it on demand; the synced tracks then
+appear in the Library like any other source's. Because the selection scopes
+the Plex library, a sync **replaces** the catalog's Plex slice even when the
+result is empty — deselecting a library really removes its tracks. A library
+deleted on the server is pruned from the selection on the next refresh.
+**Disconnecting** removes the Plex session *and* the synced Plex rows (without
+a session — and with no offline cache in phase 1 — they could never play
+again); reconnecting to the **same** server keeps the library selection, while
+a different server starts clean.
 
 Underneath, the full plumbing is wired: the stream-only capability set,
 recognition of `plex:<ratingKey>` track URIs in the playback router (two-step
 play resolution, minting the tokenized stream URL only at play time), and
-render-time resolution of credential-free `plex-thumb:` cover references. The
-remaining step is the catalog sync that lists Plex music in the Library.
+render-time resolution of credential-free `plex-thumb:` cover references.
 Phase 1 is stream-only (direct play); offline cache, favorites, playlists,
 lyrics, cast, and the plex.tv PIN sign-in are declared unsupported /
 follow-ups — and Plex follows the same token-safety rules as every other

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/plex_session.dart';
@@ -7,10 +9,13 @@ import '../../../core/sources/plex/plex_music_source.dart';
 import '../../../data/repositories/plex_session_store_provider.dart';
 import 'plex_settings_providers.dart';
 import 'plex_settings_state.dart';
+import 'plex_sync_controller.dart';
 
 /// Drives the Plex settings card: loads any saved session, tests a connection,
 /// connects (verify + persist), discovers the server's music libraries, saves
-/// the user's library selection, and disconnects.
+/// the user's library selection (kicking a background catalog sync so the
+/// Library screen follows it), and disconnects (also dropping the synced
+/// Plex rows, which are unplayable without a session).
 ///
 /// The single coordinator between the separated concerns — the authenticator
 /// (verify a URL + token against `/identity`), the session store (encrypted
@@ -32,6 +37,13 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   /// connection, so [loadSectionsIfNeeded] stays a no-op on rebuilds (and a
   /// server with zero music libraries isn't re-polled on every Settings open).
   bool _sectionsLoadAttempted = false;
+
+  /// Set once a user action (connect/disconnect) has taken ownership of the
+  /// session while the startup restore was still reading storage. The restore
+  /// then discards its stale result instead of overwriting a fresh connect or
+  /// resurrecting a just-cleared session — secure-storage reads can be slow on
+  /// real devices, so this race is reachable.
+  bool _restoreSuperseded = false;
 
   /// The live signed-in session, or `null` when not connected. Used to build a
   /// [PlexMusicSource]; callers must not log it ([PlexSession.toString]
@@ -55,8 +67,21 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     try {
       saved = await ref.read(plexSessionStoreProvider).read();
     } catch (_) {
-      // A storage hiccup must not break startup; stay disconnected. (A
-      // missing/corrupt record already reads back as null inside the store.)
+      // A storage hiccup must not break startup; stay disconnected but say
+      // so (statically, token-free), so a user who *was* connected isn't left
+      // wondering where their server went. (A missing/corrupt record already
+      // reads back as null inside the store and stays silent.)
+      if (!_restoreSuperseded && _session == null) {
+        state = const PlexSettingsState(
+          errorMessage: "Couldn't restore your saved Plex connection from "
+              'this device. If you use Plex, connect again below.',
+        );
+      }
+      return;
+    }
+    // A connect/disconnect that landed while this read was in flight owns the
+    // session now; applying the stale result would overwrite it.
+    if (_restoreSuperseded || _session != null) {
       return;
     }
     if (saved == null) {
@@ -115,10 +140,19 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   /// connected, and fetches the server's music libraries for the picker.
   /// Returns whether the connection succeeded (a failure to *list libraries*
   /// afterwards does not fail the connect — it surfaces as a retryable error).
+  ///
+  /// Reconnecting to the **same** server (recognised by its
+  /// `machineIdentifier`, e.g. after rotating the token) keeps the existing
+  /// library selection and refreshes the synced catalog against it — wiping
+  /// the selection would silently empty the user's Plex library on the next
+  /// sync. A different server starts with a clean (empty) selection, and any
+  /// rows the previous server synced are dropped quietly: their ratingKeys
+  /// belong to another machine and could never play.
   Future<bool> connect({
     required String url,
     required String token,
   }) async {
+    final PlexSession? previous = _session;
     state = PlexSettingsState(
       phase: PlexConnectionPhase.connecting,
       baseUrl: url,
@@ -134,10 +168,16 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       return false;
     }
 
+    final bool sameServer = previous != null &&
+        previous.machineIdentifier == newSession.machineIdentifier;
     // Persist the client identifier the verify above announced, so every
-    // later launch presents the same install to the server.
+    // later launch presents the same install to the server — and carry the
+    // library selection (and known server name) over a same-server reconnect.
     final PlexSession stamped = newSession.copyWith(
       clientIdentifier: ref.read(plexClientIdentityProvider).clientIdentifier,
+      serverName: sameServer ? previous.serverName : null,
+      selectedSectionKeys:
+          sameServer ? previous.selectedSectionKeys : const <String>[],
     );
     try {
       await ref.read(plexSessionStoreProvider).write(stamped);
@@ -153,19 +193,33 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
 
     _session = stamped;
     _sectionsLoadAttempted = false;
+    _restoreSuperseded = true;
     ref
         .read(plexPersistedClientIdentifierProvider.notifier)
         .publish(stamped.clientIdentifier);
+    // A fresh connection gets a fresh sync status — the old "Synced N tracks"
+    // line described the previous session.
+    ref.invalidate(plexSyncControllerProvider);
     state = PlexSettingsState(
       phase: PlexConnectionPhase.connected,
       baseUrl: stamped.baseUrl,
       serverName: stamped.serverName,
       serverVersion: stamped.serverVersion,
+      selectedSectionKeys: stamped.selectedSectionKeys,
       statusMessage: _connectedMessage(stamped),
     );
     // Fetch the music libraries for the picker right away. Best-effort: a
     // listing failure keeps the connection and surfaces a retryable error.
     await refreshSections();
+    if (stamped.selectedSectionKeys.isNotEmpty) {
+      // Same-server reconnect with a kept selection: bring the catalog back
+      // in step without blocking the connect.
+      unawaited(_syncInBackground());
+    } else {
+      // First connect or a different server: drop any rows a previous server
+      // synced. The catalog refills once the user selects libraries.
+      unawaited(_clearCatalogQuietly());
+    }
     return true;
   }
 
@@ -204,7 +258,12 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
           if (directory.isMusic)
             PlexLibrarySection(key: directory.key, title: directory.title),
       ];
-      state = state.copyWith(sections: music, isLoadingSections: false);
+      state = state.copyWith(
+        sections: music,
+        isLoadingSections: false,
+        sectionsLoaded: true,
+      );
+      await _pruneVanishedSelection(music);
     } on PlexException catch (error) {
       state = state.copyWith(
         isLoadingSections: false,
@@ -212,6 +271,42 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
         errorKind: error.kind,
       );
     }
+  }
+
+  /// Drops selected section keys that no longer exist on the server (the
+  /// music library was deleted or re-created server-side), so the selection
+  /// can't hold an invisible entry the picker shows no checkbox for — one
+  /// that would 404 every sync with no way to deselect it.
+  ///
+  /// Only runs against a **successful** sections fetch: a transient listing
+  /// failure must never shrink the selection. Quiet best-effort: if the
+  /// pruned selection can't be persisted the stale keys simply remain until
+  /// the next refresh, and no sync is kicked here — the next sync (manual or
+  /// selection-driven) drops the vanished section's tracks.
+  Future<void> _pruneVanishedSelection(List<PlexLibrarySection> music) async {
+    final PlexSession? current = _session;
+    if (current == null || current.selectedSectionKeys.isEmpty) {
+      return;
+    }
+    final Set<String> available = <String>{
+      for (final PlexLibrarySection section in music) section.key,
+    };
+    final List<String> kept = <String>[
+      for (final String key in current.selectedSectionKeys)
+        if (available.contains(key)) key,
+    ];
+    if (kept.length == current.selectedSectionKeys.length) {
+      return;
+    }
+    final PlexSession updated =
+        current.copyWith(selectedSectionKeys: List<String>.unmodifiable(kept));
+    try {
+      await ref.read(plexSessionStoreProvider).write(updated);
+    } catch (_) {
+      return;
+    }
+    _session = updated;
+    state = state.copyWith(selectedSectionKeys: updated.selectedSectionKeys);
   }
 
   /// Includes or excludes one music library [sectionKey] and persists the
@@ -254,11 +349,17 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       errorMessage: null,
       errorKind: null,
     );
+    // Keep the catalog in step with the new selection without blocking the
+    // checkbox tap; the sync controller coalesces rapid toggles into one
+    // re-run and reports progress through its own state.
+    unawaited(_syncInBackground());
   }
 
-  /// Disconnects Plex: removes the saved session (the only thing Plex
-  /// persists) and resets to the signed-out state. Other providers' data is
-  /// untouched — this clears the Plex store and nothing else.
+  /// Disconnects Plex: removes the saved session, resets to the signed-out
+  /// state, resets the sync status, and removes the synced Plex tracks from
+  /// the local catalog — without a session (and with no offline cache in
+  /// phase 1) they are permanently unplayable rows. Other providers' data is
+  /// untouched: only the Plex store and the catalog's `plex` slice change.
   Future<void> disconnect() async {
     try {
       await ref.read(plexSessionStoreProvider).clear();
@@ -273,11 +374,48 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     }
     _session = null;
     _sectionsLoadAttempted = false;
+    _restoreSuperseded = true;
     ref.read(plexPersistedClientIdentifierProvider.notifier).publish(null);
-    state = const PlexSettingsState(
-      statusMessage: 'Disconnected. Your Plex session was removed from this '
-          'device.',
+    // The old "Synced N tracks" status described the session that just ended.
+    ref.invalidate(plexSyncControllerProvider);
+    bool catalogCleared = true;
+    try {
+      await ref.read(plexSyncControllerProvider.notifier).removeSyncedCatalog();
+    } catch (_) {
+      // Best-effort: the session is already gone (the part that matters for
+      // the token); stale rows are replaced by the next successful sync.
+      catalogCleared = false;
+    }
+    state = PlexSettingsState(
+      statusMessage: catalogCleared
+          ? 'Disconnected. Your Plex session and synced Plex tracks were '
+              'removed from this device.'
+          : 'Disconnected. Your Plex session was removed from this device.',
     );
+  }
+
+  /// Runs the catalog sync for the current selection without blocking the
+  /// caller. Failures are swallowed here on purpose: the sync controller
+  /// reports its own progress and errors through `PlexSyncState`, and a
+  /// backgrounded kick must never surface a raw error past this seam.
+  Future<void> _syncInBackground() async {
+    try {
+      await ref
+          .read(plexSyncControllerProvider.notifier)
+          .syncAfterSelectionChange();
+    } catch (_) {
+      // Reported through PlexSyncState; nothing to add here.
+    }
+  }
+
+  /// Removes the synced Plex rows from the catalog without reporting through
+  /// any state — used when a connect made them stale (different server).
+  Future<void> _clearCatalogQuietly() async {
+    try {
+      await ref.read(plexSyncControllerProvider.notifier).removeSyncedCatalog();
+    } catch (_) {
+      // Best-effort: stale rows are replaced by the next successful sync.
+    }
   }
 
   /// Reports a failure without dropping an existing connection: a failed test
@@ -293,6 +431,7 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
         serverName: current.serverName,
         serverVersion: current.serverVersion,
         sections: state.sections,
+        sectionsLoaded: state.sectionsLoaded,
         selectedSectionKeys: current.selectedSectionKeys,
         statusMessage: _connectedMessage(current),
         errorMessage: error.message,

--- a/lib/features/settings/plex/plex_settings_section.dart
+++ b/lib/features/settings/plex/plex_settings_section.dart
@@ -5,6 +5,8 @@ import '../../../app/dimens.dart';
 import '../../../core/sources/music_provider.dart';
 import 'plex_settings_controller.dart';
 import 'plex_settings_state.dart';
+import 'plex_sync_controller.dart';
+import 'plex_sync_state.dart';
 
 /// The Plex connection card on the Settings screen (phase 1, experimental).
 ///
@@ -87,6 +89,10 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
     await ref.read(plexSettingsControllerProvider.notifier).refreshSections();
   }
 
+  Future<void> _sync() async {
+    await ref.read(plexSyncControllerProvider.notifier).sync();
+  }
+
   void _toggleSection(String key, bool included) {
     ref
         .read(plexSettingsControllerProvider.notifier)
@@ -96,6 +102,7 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
   @override
   Widget build(BuildContext context) {
     final PlexSettingsState state = ref.watch(plexSettingsControllerProvider);
+    final PlexSyncState syncState = ref.watch(plexSyncControllerProvider);
     final ThemeData theme = Theme.of(context);
 
     // After a restart restored the session, the picker still needs the
@@ -141,12 +148,19 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
             if (state.isConnected)
               _ConnectedView(
                 state: state,
+                syncState: syncState,
                 onRefreshSections: (state.isBusy || state.isLoadingSections)
                     ? null
                     : _refreshSections,
                 onToggleSection:
                     state.isLoadingSections ? null : _toggleSection,
-                onDisconnect: state.isBusy ? null : _disconnect,
+                onSync: (state.isBusy ||
+                        state.isLoadingSections ||
+                        syncState.isSyncing)
+                    ? null
+                    : _sync,
+                onDisconnect:
+                    (state.isBusy || syncState.isSyncing) ? null : _disconnect,
               )
             else
               _buildForm(state),
@@ -186,6 +200,9 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
           enabled: !busy,
           obscureText: _obscureToken,
           autocorrect: false,
+          // Keep the token out of the keyboard's suggestion/learning store
+          // even while it is momentarily revealed via the eye toggle.
+          enableSuggestions: false,
           textInputAction: TextInputAction.done,
           onSubmitted: (_canSubmit && !busy) ? (_) => _connect() : null,
           decoration: InputDecoration(
@@ -292,20 +309,25 @@ class _CapabilityChips extends StatelessWidget {
   }
 }
 
-/// The connected view: which server, the music-library picker, and disconnect.
+/// The connected view: which server, the music-library picker (with explicit
+/// loading / failed / empty states), the sync action, and disconnect.
 ///
 /// Shows only server metadata — never the token.
 class _ConnectedView extends StatelessWidget {
   const _ConnectedView({
     required this.state,
+    required this.syncState,
     required this.onRefreshSections,
     required this.onToggleSection,
+    required this.onSync,
     required this.onDisconnect,
   });
 
   final PlexSettingsState state;
+  final PlexSyncState syncState;
   final VoidCallback? onRefreshSections;
   final void Function(String key, bool included)? onToggleSection;
+  final VoidCallback? onSync;
   final VoidCallback? onDisconnect;
 
   @override
@@ -361,22 +383,38 @@ class _ConnectedView extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.xs),
         if (state.isLoadingSections)
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: AppSpacing.md),
-            child: Center(
-              child: SizedBox.square(
-                dimension: 24,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              ),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Text(
+                  'Loading music libraries…',
+                  style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                ),
+              ],
             ),
           )
+        else if (!state.sectionsLoaded)
+          // The list was never fetched successfully for this connection (the
+          // specific reason, e.g. "couldn't reach", is in the error line
+          // below) — offer a retry instead of a misleading "no libraries".
+          _PickerNotice(
+            message: "Your music libraries haven't loaded yet.",
+            actionLabel: 'Try again',
+            onAction: onRefreshSections,
+          )
         else if (state.sections.isEmpty)
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-            child: Text(
-              'No music libraries found on this server.',
-              style: theme.textTheme.bodySmall?.copyWith(color: muted),
-            ),
+          _PickerNotice(
+            message: 'No music libraries found on this server. Create a '
+                'music library in Plex, then refresh.',
+            actionLabel: 'Refresh',
+            onAction: onRefreshSections,
           )
         else ...[
           for (final PlexLibrarySection section in state.sections)
@@ -402,12 +440,69 @@ class _ConnectedView extends StatelessWidget {
             ),
         ],
         const SizedBox(height: AppSpacing.md),
+        FilledButton.tonalIcon(
+          onPressed: onSync,
+          icon: syncState.isSyncing
+              ? const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.sync_outlined),
+          label: Text(syncState.isSyncing ? 'Syncing…' : 'Sync Plex library'),
+        ),
+        if (syncState.message != null && !syncState.isSyncing) ...[
+          const SizedBox(height: AppSpacing.sm),
+          _StatusLine(message: syncState.message!, isError: syncState.isError),
+        ],
+        const SizedBox(height: AppSpacing.sm),
         OutlinedButton.icon(
           onPressed: onDisconnect,
           icon: const Icon(Icons.logout_outlined),
           label: const Text('Disconnect Plex'),
         ),
       ],
+    );
+  }
+}
+
+/// A short notice inside the library-picker area with one inline action
+/// (retry a failed load, or refresh an empty list).
+class _PickerNotice extends StatelessWidget {
+  const _PickerNotice({
+    required this.message,
+    required this.actionLabel,
+    required this.onAction,
+  });
+
+  final String message;
+  final String actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            message,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: onAction,
+              icon: const Icon(Icons.refresh_outlined, size: 18),
+              label: Text(actionLabel),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/settings/plex/plex_settings_state.dart
+++ b/lib/features/settings/plex/plex_settings_state.dart
@@ -64,6 +64,7 @@ class PlexSettingsState {
     this.serverVersion,
     this.sections = const <PlexLibrarySection>[],
     this.isLoadingSections = false,
+    this.sectionsLoaded = false,
     this.selectedSectionKeys = const <String>[],
     this.statusMessage,
     this.errorMessage,
@@ -91,6 +92,13 @@ class PlexSettingsState {
 
   /// True while the library sections are being (re)fetched.
   final bool isLoadingSections;
+
+  /// True once the music libraries have been fetched successfully at least
+  /// once for the current connection. Lets the UI tell "this server has no
+  /// music libraries" (loaded, [sections] empty) apart from "they couldn't be
+  /// loaded yet" (not loaded — offer a retry instead of a misleading empty
+  /// message). Reset on connect/restore/disconnect.
+  final bool sectionsLoaded;
 
   /// `key`s of the music libraries the user selected. Empty means connected
   /// but nothing chosen yet — the source then serves an empty library, never
@@ -136,6 +144,7 @@ class PlexSettingsState {
     String? serverVersion,
     List<PlexLibrarySection>? sections,
     bool? isLoadingSections,
+    bool? sectionsLoaded,
     List<String>? selectedSectionKeys,
     Object? statusMessage = _unset,
     Object? errorMessage = _unset,
@@ -148,6 +157,7 @@ class PlexSettingsState {
       serverVersion: serverVersion ?? this.serverVersion,
       sections: sections ?? this.sections,
       isLoadingSections: isLoadingSections ?? this.isLoadingSections,
+      sectionsLoaded: sectionsLoaded ?? this.sectionsLoaded,
       selectedSectionKeys: selectedSectionKeys ?? this.selectedSectionKeys,
       statusMessage: identical(statusMessage, _unset)
           ? this.statusMessage

--- a/lib/features/settings/plex/plex_sync_controller.dart
+++ b/lib/features/settings/plex/plex_sync_controller.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/album.dart';
+import '../../../core/models/artist.dart';
+import '../../../core/models/track.dart';
+import '../../../core/sources/plex/plex_exception.dart';
+import '../../../core/sources/plex/plex_music_source.dart';
+import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../library/library_controller.dart';
+import 'plex_settings_controller.dart';
+import 'plex_sync_state.dart';
+
+/// Drives the "Sync Plex library" action.
+///
+/// Reads the signed-in [PlexMusicSource] (via [plexMusicSourceProvider]) to
+/// fetch the catalog, then hands the results to the `MusicLibraryRepository`
+/// under the stable `plex` source id — the same upsert path local scanning,
+/// Jellyfin, and Subsonic use. The Library screen reads from that repository,
+/// so a refresh after the upsert makes the synced tracks appear.
+///
+/// Unlike Jellyfin/Subsonic (which sync the whole server), the Plex library is
+/// **scoped by the user's selected music sections**, so the catalog must
+/// mirror the selection: a sync against an empty result (or an empty
+/// selection) **replaces** the stored Plex rows rather than skipping the
+/// write, so deselecting a library actually removes its tracks on the next
+/// sync instead of leaving stale, unplayable rows behind.
+///
+/// The settings controller kicks [syncAfterSelectionChange] after every
+/// committed selection change, so picking a library populates the Library
+/// screen on its own — mirroring how Jellyfin auto-syncs a fresh connection.
+/// Rapid checkbox toggles coalesce: changes that land while a sync is running
+/// mark it dirty and the finished sync re-runs once against the newest
+/// selection, instead of queueing one full library walk per tap.
+///
+/// Security: the source mints any authenticated stream URL lazily at play
+/// time, so nothing persisted here carries a credential. This controller
+/// never logs the session, and surfaces only friendly, secret-free messages
+/// through [PlexSyncState].
+class PlexSyncController extends Notifier<PlexSyncState> {
+  /// Guards against overlapping syncs (an auto-sync racing a manual tap). Set
+  /// synchronously before any await so a second concurrent call simply bails,
+  /// satisfying "never run two syncs at once" without cancelling the first.
+  bool _syncing = false;
+
+  /// Set when a selection change lands while a sync is already running, so
+  /// the in-flight sync re-runs once when it finishes — the catalog must end
+  /// on the newest selection, not the one the first walk started with.
+  bool _selectionChangedDuringSync = false;
+
+  @override
+  PlexSyncState build() => const PlexSyncState();
+
+  /// The manual "Sync Plex library" action. Pulls artists/albums/tracks from
+  /// the selected sections and replaces the Plex slice of the local catalog.
+  /// Reflects loading/success/error through [state]; never throws.
+  Future<void> sync() => _runSync();
+
+  /// Keeps the catalog in step after a library-selection change. Coalesces:
+  /// if a sync is already running it only marks it dirty (one re-run at the
+  /// end), so toggling several checkboxes doesn't stack full library walks.
+  Future<void> syncAfterSelectionChange() {
+    if (_syncing) {
+      _selectionChangedDuringSync = true;
+      return Future<void>.value();
+    }
+    return _runSync();
+  }
+
+  /// Removes every synced Plex row from the local catalog and refreshes the
+  /// Library screen. Used on disconnect (the rows are unplayable without a
+  /// session — phase 1 has no offline cache) and when connecting to a
+  /// different server (the old rows' ratingKeys belong to another machine).
+  ///
+  /// Quiet by design: it reports nothing through [state] — the caller owns
+  /// the user-facing message — but throws on a storage failure so the caller
+  /// can phrase that message honestly.
+  Future<void> removeSyncedCatalog() =>
+      _replacePlexCatalog(tracks: const <Track>[]);
+
+  Future<void> _runSync() async {
+    if (_syncing) return;
+    _syncing = true;
+    try {
+      do {
+        _selectionChangedDuringSync = false;
+        await _syncOnce();
+      } while (_selectionChangedDuringSync);
+    } finally {
+      _syncing = false;
+    }
+  }
+
+  Future<void> _syncOnce() async {
+    final PlexMusicSource? source = ref.read(plexMusicSourceProvider);
+    if (source == null) {
+      state = const PlexSyncState.error(
+        'Connect to your Plex server in Settings before syncing.',
+      );
+      return;
+    }
+
+    if (source.session.selectedSectionKeys.isEmpty) {
+      // No selection means an empty Plex library by definition, so prune any
+      // rows a previous selection synced — without touching the server.
+      try {
+        await _replacePlexCatalog(tracks: const <Track>[]);
+      } catch (_) {
+        state = const PlexSyncState.error(_savingFailedMessage);
+        return;
+      }
+      state = const PlexSyncState.success(
+        trackCount: 0,
+        message: 'No music libraries are selected — choose at least one '
+            'above to sync its music.',
+      );
+      return;
+    }
+
+    state = const PlexSyncState.syncing();
+    try {
+      final List<Track> tracks = await source.fetchTracks();
+      final List<Album> albums = await source.fetchAlbums();
+      final List<Artist> artists = await source.fetchArtists();
+
+      // Replace even when empty: the result *is* the selected libraries'
+      // honest content, and skipping the write would leave rows from a
+      // previously wider selection lingering as unplayable entries.
+      await _replacePlexCatalog(
+          tracks: tracks, albums: albums, artists: artists);
+
+      state = tracks.isEmpty
+          ? const PlexSyncState.success(
+              trackCount: 0,
+              message: 'Your selected libraries have no tracks yet — '
+                  'nothing to sync.',
+            )
+          : PlexSyncState.success(
+              trackCount: tracks.length,
+              message: _successMessage(tracks.length),
+            );
+    } on PlexException catch (error) {
+      state = PlexSyncState.error(_friendlyMessage(error));
+    } catch (_) {
+      state = const PlexSyncState.error(_savingFailedMessage);
+    }
+  }
+
+  /// Replaces the Plex slice of the catalog and refreshes the Library screen
+  /// so the change is visible immediately. Other sources' rows are untouched
+  /// (the repository replaces per `sourceId`).
+  Future<void> _replacePlexCatalog({
+    required List<Track> tracks,
+    List<Album> albums = const <Album>[],
+    List<Artist> artists = const <Artist>[],
+  }) async {
+    await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+          sourceId: PlexMusicSource.sourceId,
+          tracks: tracks,
+          albums: albums,
+          artists: artists,
+        );
+    await ref.read(libraryControllerProvider.notifier).refresh();
+  }
+
+  static const String _savingFailedMessage =
+      'Something went wrong saving your Plex library. Please try again.';
+
+  String _successMessage(int trackCount) {
+    final String tracks = trackCount == 1 ? '1 track' : '$trackCount tracks';
+    return 'Synced $tracks from your Plex libraries.';
+  }
+
+  /// Turns a typed Plex failure into a friendly, actionable line. Branches on
+  /// [PlexErrorKind] rather than message text, and never carries the token —
+  /// every string here is static.
+  String _friendlyMessage(PlexException error) {
+    switch (error.kind) {
+      case PlexErrorKind.notReachable:
+        return "Couldn't reach your Plex server. Check your connection and "
+            'that the server is online.';
+      case PlexErrorKind.unauthorized:
+        return 'Your Plex session was rejected by the server. Disconnect and '
+            'connect again with a new token.';
+      case PlexErrorKind.notPlex:
+        return "That server didn't respond like a Plex Media Server. "
+            'Double-check the server address in Settings.';
+      case PlexErrorKind.serverError:
+        return 'Your Plex server reported an error. Try again in a moment.';
+      case PlexErrorKind.notFound:
+        return "A selected library wasn't found on your Plex server. Refresh "
+            'your music libraries in Settings, then sync again.';
+      // The factory messages for these already carry specific, actionable,
+      // token-free wording (which port Plex listens on, the unsupported-
+      // version hint, …), so surface them as-is.
+      case PlexErrorKind.invalidUrl:
+      case PlexErrorKind.unsupportedResponse:
+      case PlexErrorKind.unexpected:
+        return error.message;
+    }
+  }
+}
+
+final plexSyncControllerProvider =
+    NotifierProvider<PlexSyncController, PlexSyncState>(
+  PlexSyncController.new,
+);

--- a/lib/features/settings/plex/plex_sync_state.dart
+++ b/lib/features/settings/plex/plex_sync_state.dart
@@ -1,0 +1,45 @@
+/// Where a Plex library sync is in its lifecycle.
+enum PlexSyncStatus { idle, syncing, success, error }
+
+/// Immutable snapshot the Plex settings UI renders the sync action from.
+///
+/// Like every other state object in the app, this holds only display-safe
+/// values: a status, a friendly [message], and how many tracks landed. It
+/// never carries the Plex token or a tokenized stream/art URL — every message
+/// is static or built from a token-free `PlexException`.
+class PlexSyncState {
+  const PlexSyncState({
+    this.status = PlexSyncStatus.idle,
+    this.message,
+    this.trackCount = 0,
+  });
+
+  const PlexSyncState.syncing()
+      : this(
+          status: PlexSyncStatus.syncing,
+          message: 'Syncing your Plex libraries…',
+        );
+
+  const PlexSyncState.success({
+    required int trackCount,
+    required String message,
+  }) : this(
+          status: PlexSyncStatus.success,
+          trackCount: trackCount,
+          message: message,
+        );
+
+  const PlexSyncState.error(String message)
+      : this(status: PlexSyncStatus.error, message: message);
+
+  final PlexSyncStatus status;
+
+  /// A friendly status or error line for the UI; never contains a secret.
+  final String? message;
+
+  /// How many tracks the last successful sync stored.
+  final int trackCount;
+
+  bool get isSyncing => status == PlexSyncStatus.syncing;
+  bool get isError => status == PlexSyncStatus.error;
+}

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -1,15 +1,25 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/repositories/plex_session_store.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
 import 'package:linthra/core/sources/plex/plex_music_source.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/data/repositories/plex_session_store_provider.dart';
 import 'package:linthra/features/settings/plex/plex_settings_controller.dart';
 import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
 import 'package:linthra/features/settings/plex/plex_settings_state.dart';
+import 'package:linthra/features/settings/plex/plex_sync_controller.dart';
+import 'package:linthra/features/settings/plex/plex_sync_state.dart';
 
 import '../../../core/sources/plex/fake_plex_client.dart';
 
@@ -68,11 +78,80 @@ class _FlakyPlexSessionStore implements PlexSessionStore {
   }
 }
 
+/// A [PlexSessionStore] whose read blocks until released, simulating a slow
+/// secure-storage read on a real device so user actions can race the startup
+/// restore. The read returns what was persisted when it *started* (a stale
+/// snapshot), exactly like a disk read would.
+class _GatedReadStore implements PlexSessionStore {
+  _GatedReadStore(this._session);
+
+  PlexSession? _session;
+  final Completer<void> readGate = Completer<void>();
+
+  @override
+  Future<PlexSession?> read() async {
+    final PlexSession? snapshot = _session;
+    await readGate.future;
+    return snapshot;
+  }
+
+  @override
+  Future<void> write(PlexSession session) async {
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    _session = null;
+  }
+}
+
+/// Records catalog upserts so the disconnect/connect cleanup paths can be
+/// asserted (and made to fail).
+class _RecordingRepository implements MusicLibraryRepository {
+  _RecordingRepository({this.upsertError});
+
+  final Object? upsertError;
+
+  String? upsertedSourceId;
+  List<Track> upsertedTracks = const <Track>[];
+  int upsertCount = 0;
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    upsertCount++;
+    if (upsertError != null) throw upsertError!;
+    upsertedSourceId = sourceId;
+    upsertedTracks = tracks;
+  }
+
+  @override
+  Future<List<Track>> getAllTracks() async => upsertedTracks;
+
+  @override
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
+
+  @override
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
+
+  @override
+  Future<Track?> getTrackById(String id) async => null;
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {}
+}
+
 Future<void> _settle() => Future<void>.delayed(Duration.zero);
 
 ProviderContainer _container({
   FakePlexClient? client,
   PlexSessionStore? store,
+  MusicLibraryRepository? repository,
 }) {
   final container = ProviderContainer(
     overrides: <Override>[
@@ -81,6 +160,8 @@ ProviderContainer _container({
       ),
       plexSessionStoreProvider
           .overrideWithValue(store ?? InMemoryPlexSessionStore()),
+      if (repository != null)
+        musicLibraryRepositoryProvider.overrideWithValue(repository),
     ],
   );
   addTearDown(container.dispose);
@@ -132,10 +213,12 @@ void main() {
           .read(plexSettingsControllerProvider.notifier)
           .ensureLoaded();
 
-      expect(
-        container.read(plexSettingsControllerProvider).phase,
-        PlexConnectionPhase.disconnected,
-      );
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.disconnected);
+      // A user who *was* connected shouldn't wonder where the server went:
+      // the failure to even read the saved session is said out loud
+      // (statically — no token, no raw storage error).
+      expect(state.errorMessage, contains("Couldn't restore"));
       expect(container.read(plexMusicSourceProvider), isNull);
     });
 
@@ -152,6 +235,55 @@ void main() {
         container.read(plexClientIdentityProvider).clientIdentifier,
         'install-1',
       );
+    });
+
+    test('a connect that wins the slow-startup-restore race is kept', () async {
+      // Secure-storage reads can be slow on real devices: the user connects
+      // to a NEW server while the old session is still being read.
+      final store = _GatedReadStore(_session);
+      final container = _container(
+        client: FakePlexClient(
+          identity:
+              const PlexServerIdentity(machineIdentifier: 'other-machine'),
+          sections: const [_musicSection],
+        ),
+        store: store,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      final ok = await notifier.connect(
+        url: 'https://new.example.com',
+        token: 'new-token',
+      );
+      expect(ok, isTrue);
+
+      // The stale read lands afterwards — and is discarded.
+      store.readGate.complete();
+      await _settle();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.baseUrl, 'https://new.example.com');
+      expect(notifier.session!.machineIdentifier, 'other-machine');
+      expect(notifier.session!.token, 'new-token');
+    });
+
+    test('a disconnect during the startup restore is not resurrected',
+        () async {
+      final store = _GatedReadStore(_session);
+      final container = _container(store: store);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      await notifier.disconnect();
+
+      // The pre-disconnect snapshot lands afterwards — and is discarded:
+      // signing out must stay signed out.
+      store.readGate.complete();
+      await _settle();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.disconnected);
+      expect(notifier.session, isNull);
+      expect(container.read(plexMusicSourceProvider), isNull);
     });
   });
 
@@ -333,6 +465,94 @@ void main() {
       expect(state.errorMessage, isNull);
       expect(state.sections, hasLength(1));
     });
+
+    test(
+        'reconnecting to the same server keeps the library selection and '
+        'refreshes the catalog against it', () async {
+      final store = InMemoryPlexSessionStore(
+        // machineIdentifier matches the fake's default identity → same server.
+        initialSession: _session.copyWith(
+          machineIdentifier: 'fake-machine-id',
+          selectedSectionKeys: const <String>['5'],
+        ),
+      );
+      final repo = _RecordingRepository();
+      final container = _container(
+        client: FakePlexClient(
+          sections: const [_musicSection],
+          itemsByType: const <PlexMetadataType, List<PlexMetadata>>{
+            PlexMetadataType.track: <PlexMetadata>[
+              PlexMetadata(ratingKey: '101', type: 'track', title: 'Aurora'),
+            ],
+          },
+        ),
+        store: store,
+        repository: repo,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      // The user re-pastes a rotated token for the same server.
+      final ok = await notifier.connect(
+        url: 'https://plex.example.com:32400',
+        token: 'rotated-token',
+      );
+      await _settle();
+
+      expect(ok, isTrue);
+      // The selection survived the reconnect — in state and at rest…
+      expect(
+        container.read(plexSettingsControllerProvider).selectedSectionKeys,
+        <String>['5'],
+      );
+      final saved = await store.read();
+      expect(saved!.selectedSectionKeys, <String>['5']);
+      expect(saved.token, 'rotated-token');
+      // …and the kept selection was re-synced in the background.
+      expect(repo.upsertedSourceId, 'plex');
+      expect(repo.upsertedTracks.map((Track t) => t.uri), ['plex:101']);
+    });
+
+    test(
+        'connecting to a different server starts with a clean selection and '
+        'drops the old server\'s rows', () async {
+      final store = InMemoryPlexSessionStore(
+        // A previous session for another machine, with a selection.
+        initialSession: _session, // machineIdentifier: machine-abc
+      );
+      final repo = _RecordingRepository();
+      final container = _container(
+        client: FakePlexClient(
+          // The new server identifies as a different machine.
+          identity: const PlexServerIdentity(
+            machineIdentifier: 'other-machine',
+          ),
+          sections: const [_musicSection],
+        ),
+        store: store,
+        repository: repo,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      final ok = await notifier.connect(
+        url: 'https://new.example.com:32400',
+        token: 'other-token',
+      );
+      await _settle();
+
+      expect(ok, isTrue);
+      // The old server's selection doesn't leak onto the new one…
+      expect(
+        container.read(plexSettingsControllerProvider).selectedSectionKeys,
+        isEmpty,
+      );
+      expect((await store.read())!.selectedSectionKeys, isEmpty);
+      // …and the old server's synced rows (unplayable ratingKeys from another
+      // machine) were cleared quietly.
+      expect(repo.upsertedSourceId, 'plex');
+      expect(repo.upsertedTracks, isEmpty);
+    });
   });
 
   group('sections', () {
@@ -392,6 +612,103 @@ void main() {
       await notifier.refreshSections();
 
       expect(container.read(plexSettingsControllerProvider).sections, isEmpty);
+    });
+
+    test(
+        'sectionsLoaded distinguishes a failed listing from a server with '
+        'no music libraries', () async {
+      final client = FakePlexClient(
+        sectionsError: PlexException.serverError(503),
+      );
+      final container = _container(
+        client: client,
+        store: InMemoryPlexSessionStore(initialSession: _session),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.refreshSections();
+      var state = container.read(plexSettingsControllerProvider);
+      expect(state.sectionsLoaded, isFalse);
+      expect(state.errorMessage, isNotNull);
+
+      // Once a listing succeeds — even an empty one — the state says
+      // "loaded", so the UI can show "no music libraries" honestly.
+      client.sectionsError = null;
+      client.sections = const <PlexDirectory>[_movieSection];
+      await notifier.refreshSections();
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.sectionsLoaded, isTrue);
+      expect(state.sections, isEmpty);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('prunes selected libraries the server no longer has', () async {
+      final store = InMemoryPlexSessionStore(
+        initialSession:
+            _session.copyWith(selectedSectionKeys: const <String>['5', '9']),
+      );
+      // Section 9 was deleted server-side; only 5 remains.
+      final container = _container(
+        client: FakePlexClient(sections: const [_musicSection]),
+        store: store,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.refreshSections();
+
+      // The vanished key is dropped from the state, the live session, and
+      // the persisted record — it had no checkbox left to deselect it with.
+      expect(
+        container.read(plexSettingsControllerProvider).selectedSectionKeys,
+        <String>['5'],
+      );
+      expect(notifier.session!.selectedSectionKeys, <String>['5']);
+      expect((await store.read())!.selectedSectionKeys, <String>['5']);
+    });
+
+    test('a failed listing never shrinks the selection', () async {
+      final container = _container(
+        client: FakePlexClient(sectionsError: PlexException.notReachable()),
+        store: InMemoryPlexSessionStore(
+          initialSession:
+              _session.copyWith(selectedSectionKeys: const <String>['5', '9']),
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.refreshSections();
+
+      expect(
+        container.read(plexSettingsControllerProvider).selectedSectionKeys,
+        <String>['5', '9'],
+      );
+      expect(notifier.session!.selectedSectionKeys, <String>['5', '9']);
+    });
+
+    test('a failed prune persist quietly keeps the old selection', () async {
+      final store = _FlakyPlexSessionStore(
+        initialSession:
+            _session.copyWith(selectedSectionKeys: const <String>['5', '9']),
+      );
+      final container = _container(
+        client: FakePlexClient(sections: const [_musicSection]),
+        store: store,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      store.writeError = StateError('keystore busy');
+      await notifier.refreshSections();
+
+      // Not persistable → not applied (state and store stay consistent); the
+      // stale key remains until a later refresh can prune it, and no error is
+      // raised for this background cleanup.
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.selectedSectionKeys, <String>['5', '9']);
+      expect(state.errorMessage, isNull);
     });
   });
 
@@ -485,6 +802,81 @@ void main() {
       expect(state.statusMessage, contains('Disconnected'));
       expect(notifier.session, isNull);
       expect(container.read(plexMusicSourceProvider), isNull);
+    });
+
+    test(
+        'drops the synced Plex rows but leaves other sources untouched, and '
+        'resets the sync status', () async {
+      final repository = InMemoryMusicLibraryRepository();
+      // The catalog holds rows from several sources, as on a real device.
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: const <Track>[
+          Track(id: 'j1', title: 'Jelly song', uri: 'jellyfin:j1'),
+        ],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      final container = _container(
+        client: FakePlexClient(
+          sections: const [_musicSection],
+          itemsByType: const <PlexMetadataType, List<PlexMetadata>>{
+            PlexMetadataType.track: <PlexMetadata>[
+              PlexMetadata(ratingKey: '101', type: 'track', title: 'Aurora'),
+            ],
+          },
+        ),
+        store: InMemoryPlexSessionStore(initialSession: _session),
+        repository: repository,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+      await container.read(plexSyncControllerProvider.notifier).sync();
+      expect((await repository.getAllTracks()), hasLength(2));
+      expect(
+        container.read(plexSyncControllerProvider).status,
+        PlexSyncStatus.success,
+      );
+
+      await notifier.disconnect();
+
+      // Without a session (and with no offline cache in phase 1) the Plex
+      // rows are permanently unplayable — they're removed; Jellyfin stays.
+      final tracks = await repository.getAllTracks();
+      expect(tracks.map((Track t) => t.uri), <String>['jellyfin:j1']);
+      expect(
+        container.read(plexSettingsControllerProvider).statusMessage,
+        contains('synced Plex tracks were removed'),
+      );
+      // The old "Synced N tracks" status described the ended session.
+      expect(
+        container.read(plexSyncControllerProvider).status,
+        PlexSyncStatus.idle,
+      );
+    });
+
+    test('a failed catalog cleanup still disconnects, with an honest message',
+        () async {
+      final container = _container(
+        store: InMemoryPlexSessionStore(initialSession: _session),
+        repository: _RecordingRepository(upsertError: StateError('db locked')),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.disconnect();
+
+      final state = container.read(plexSettingsControllerProvider);
+      // The part that matters for the token — the session — is gone…
+      expect(state.phase, PlexConnectionPhase.disconnected);
+      expect(notifier.session, isNull);
+      // …and the message doesn't claim the rows were removed when they
+      // weren't.
+      expect(state.statusMessage, contains('Disconnected'));
+      expect(
+        state.statusMessage,
+        isNot(contains('synced Plex tracks were removed')),
+      );
     });
 
     test('a failed clear stays connected and reports it', () async {

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -26,6 +28,23 @@ const PlexSession _restoredSession = PlexSession(
   clientIdentifier: 'install-1',
   selectedSectionKeys: <String>['5'],
 );
+
+/// A [FakePlexClient] whose sections listing blocks until [gate] completes,
+/// so the picker's loading state can be observed deterministically.
+class _GatedSectionsClient extends FakePlexClient {
+  _GatedSectionsClient({super.sections});
+
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<List<PlexDirectory>> fetchSections({
+    required String baseUrl,
+    required String token,
+  }) async {
+    await gate.future;
+    return super.fetchSections(baseUrl: baseUrl, token: token);
+  }
+}
 
 Future<void> _pump(
   WidgetTester tester, {
@@ -184,6 +203,101 @@ void main() {
         in tester.widgetList<TextField>(find.byType(TextField))) {
       expect(field.controller!.text, isEmpty);
     }
+  });
+
+  testWidgets('shows a labelled loading state while libraries are fetched',
+      (tester) async {
+    final client =
+        _GatedSectionsClient(sections: const [_movieSection, _musicSection]);
+    await _pump(
+      tester,
+      client: client,
+      store: InMemoryPlexSessionStore(initialSession: _restoredSession),
+    );
+    // Let the restore land and the post-frame section load start (held at
+    // the gate) — explicit pumps, since the spinner animates forever.
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Loading music libraries…'), findsOneWidget);
+    expect(find.textContaining('No music libraries found'), findsNothing);
+
+    client.gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Loading music libraries…'), findsNothing);
+    expect(find.byType(CheckboxListTile), findsOneWidget);
+  });
+
+  testWidgets('a failed library listing offers Try again and recovers',
+      (tester) async {
+    final client = FakePlexClient(
+      sectionsError: PlexException.serverError(503),
+      sections: const [_movieSection, _musicSection],
+    );
+    await _pump(
+      tester,
+      client: client,
+      store: InMemoryPlexSessionStore(initialSession: _restoredSession),
+    );
+    await tester.pumpAndSettle();
+
+    // A failed load must NOT claim the server has no music libraries; it
+    // offers a retry, with the specific reason in the error line below.
+    expect(
+        find.text("Your music libraries haven't loaded yet."), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+    expect(find.textContaining('No music libraries found'), findsNothing);
+    expect(find.textContaining('HTTP 503'), findsOneWidget);
+
+    client.sectionsError = null;
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CheckboxListTile), findsOneWidget);
+    expect(find.textContaining('HTTP 503'), findsNothing);
+  });
+
+  testWidgets('a server without music libraries says so, with a refresh',
+      (tester) async {
+    await _pump(
+      tester,
+      client: FakePlexClient(sections: const [_movieSection]),
+      store: InMemoryPlexSessionStore(initialSession: _restoredSession),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('No music libraries found on this server'),
+        findsOneWidget);
+    expect(find.text('Refresh'), findsOneWidget);
+    expect(find.byType(CheckboxListTile), findsNothing);
+  });
+
+  testWidgets(
+      'selecting a library syncs it automatically and the manual sync '
+      'button stays available', (tester) async {
+    final client = FakePlexClient(
+      sections: const [_movieSection, _musicSection],
+      itemsByType: const <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.track: <PlexMetadata>[
+          PlexMetadata(ratingKey: '101', type: 'track', title: 'Aurora'),
+        ],
+      },
+    );
+    await _pump(tester, client: client);
+    await _connect(tester);
+
+    expect(find.text('Sync Plex library'), findsOneWidget);
+
+    await tester.tap(find.byType(CheckboxListTile));
+    await tester.pumpAndSettle();
+
+    // The background sync kicked by the selection landed and reported.
+    expect(find.textContaining('Synced 1 track'), findsOneWidget);
+
+    // The manual action reruns it on demand.
+    await tester.tap(find.text('Sync Plex library'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Synced 1 track'), findsOneWidget);
   });
 
   testWidgets('a rejected token shows a friendly, token-free error',

--- a/test/features/settings/plex/plex_sync_controller_test.dart
+++ b/test/features/settings/plex/plex_sync_controller_test.dart
@@ -1,0 +1,448 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/album.dart';
+import 'package:linthra/core/models/artist.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/plex_session_store_provider.dart';
+import 'package:linthra/features/settings/plex/plex_settings_controller.dart';
+import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
+import 'package:linthra/features/settings/plex/plex_sync_controller.dart';
+import 'package:linthra/features/settings/plex/plex_sync_state.dart';
+
+import '../../../core/sources/plex/fake_plex_client.dart';
+
+const String _token = 'super-secret-plex-token';
+
+/// `machineIdentifier` matches [FakePlexClient]'s default identity, so a
+/// re-connect in these tests counts as the same server.
+const PlexSession _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: _token,
+  machineIdentifier: 'fake-machine-id',
+  clientIdentifier: 'install-1',
+  selectedSectionKeys: <String>['5'],
+);
+
+const PlexDirectory _musicSection =
+    PlexDirectory(key: '5', title: 'Music', type: 'artist');
+
+const PlexMetadata _trackItem = PlexMetadata(
+  ratingKey: '101',
+  type: 'track',
+  title: 'Aurora',
+  grandparentTitle: 'The Band',
+  parentTitle: 'First Light',
+  duration: 215000,
+  thumb: '/library/metadata/101/thumb/1',
+);
+const PlexMetadata _secondTrackItem =
+    PlexMetadata(ratingKey: '102', type: 'track', title: 'Dusk');
+const PlexMetadata _albumItem = PlexMetadata(
+  ratingKey: '201',
+  type: 'album',
+  title: 'First Light',
+  parentTitle: 'The Band',
+);
+const PlexMetadata _artistItem =
+    PlexMetadata(ratingKey: '301', type: 'artist', title: 'The Band');
+
+const Map<PlexMetadataType, List<PlexMetadata>> _libraryItems =
+    <PlexMetadataType, List<PlexMetadata>>{
+  PlexMetadataType.track: <PlexMetadata>[_trackItem, _secondTrackItem],
+  PlexMetadataType.album: <PlexMetadata>[_albumItem],
+  PlexMetadataType.artist: <PlexMetadata>[_artistItem],
+};
+
+/// Records every upsert so tests can assert exactly what reached the catalog
+/// (and can be made to throw, proving storage failures surface friendly).
+class _RecordingRepository implements MusicLibraryRepository {
+  _RecordingRepository({this.upsertError});
+
+  final Object? upsertError;
+
+  String? upsertedSourceId;
+  List<Track> upsertedTracks = const <Track>[];
+  List<Album> upsertedAlbums = const <Album>[];
+  List<Artist> upsertedArtists = const <Artist>[];
+  int upsertCount = 0;
+
+  @override
+  Future<void> upsertCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+    required List<Album> albums,
+    required List<Artist> artists,
+  }) async {
+    upsertCount++;
+    if (upsertError != null) throw upsertError!;
+    upsertedSourceId = sourceId;
+    upsertedTracks = tracks;
+    upsertedAlbums = albums;
+    upsertedArtists = artists;
+  }
+
+  @override
+  Future<List<Track>> getAllTracks() async => upsertedTracks;
+
+  @override
+  Future<List<Album>> getAllAlbums() async => upsertedAlbums;
+
+  @override
+  Future<List<Artist>> getAllArtists() async => upsertedArtists;
+
+  @override
+  Future<Track?> getTrackById(String id) async => null;
+
+  @override
+  Future<void> removeTracks(List<String> trackIds) async {}
+}
+
+/// A [FakePlexClient] whose item listings block until [gate] completes, so a
+/// test can hold a sync mid-flight and race it against selection changes.
+class _GatedPlexClient extends FakePlexClient {
+  _GatedPlexClient({super.sections, super.itemsByType});
+
+  Completer<void> gate = Completer<void>();
+
+  @override
+  Future<List<PlexMetadata>> fetchSectionItems({
+    required String baseUrl,
+    required String token,
+    required String sectionKey,
+    required PlexMetadataType itemType,
+  }) async {
+    await gate.future;
+    return super.fetchSectionItems(
+      baseUrl: baseUrl,
+      token: token,
+      sectionKey: sectionKey,
+      itemType: itemType,
+    );
+  }
+}
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+ProviderContainer _container({
+  FakePlexClient? client,
+  PlexSession? session,
+  MusicLibraryRepository? repository,
+}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      plexClientProvider.overrideWithValue(
+        client ??
+            FakePlexClient(
+              sections: const [_musicSection],
+              itemsByType: _libraryItems,
+            ),
+      ),
+      plexSessionStoreProvider.overrideWithValue(
+        InMemoryPlexSessionStore(initialSession: session),
+      ),
+      musicLibraryRepositoryProvider
+          .overrideWithValue(repository ?? _RecordingRepository()),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('sync', () {
+    test('reports a friendly error when not connected, touching nothing',
+        () async {
+      final repo = _RecordingRepository();
+      final container = _container(repository: repo);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.isError, isTrue);
+      expect(state.message, contains('Connect to your Plex server'));
+      expect(repo.upsertCount, 0);
+    });
+
+    test('pulls the selected libraries into the catalog under the plex id',
+        () async {
+      final client = FakePlexClient(
+        sections: const [_musicSection],
+        itemsByType: _libraryItems,
+      );
+      final repo = _RecordingRepository();
+      final container =
+          _container(client: client, session: _session, repository: repo);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      expect(repo.upsertedSourceId, 'plex');
+      expect(
+        repo.upsertedTracks.map((Track t) => t.uri),
+        <String>['plex:101', 'plex:102'],
+      );
+      // What reaches the (persisted) catalog stays credential-free: opaque
+      // plex: URIs and plex-thumb: references — never a tokenized URL.
+      for (final Track track in repo.upsertedTracks) {
+        expect(track.uri, isNot(contains(_token)));
+        expect(track.uri, isNot(contains('X-Plex-Token')));
+        final Uri? artwork = track.artworkUri;
+        if (artwork != null) {
+          expect(artwork.scheme, 'plex-thumb');
+          expect(artwork.toString(), isNot(contains(_token)));
+        }
+      }
+      expect(repo.upsertedAlbums, hasLength(1));
+      expect(repo.upsertedArtists, hasLength(1));
+      // Each kind was listed once, scoped to the selected section.
+      expect(
+        client.itemRequests.map((r) => r.sectionKey).toSet(),
+        <String>{'5'},
+      );
+      expect(client.itemRequests, hasLength(3));
+
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.status, PlexSyncStatus.success);
+      expect(state.trackCount, 2);
+      expect(state.message, contains('Synced 2 tracks'));
+    });
+
+    test(
+        'selected libraries with no tracks report honestly and still '
+        'replace the catalog', () async {
+      final repo = _RecordingRepository();
+      final container = _container(
+        client: FakePlexClient(sections: const [_musicSection]),
+        session: _session,
+        repository: repo,
+      );
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      // The empty result is written (a previously wider selection's rows
+      // must not linger), and the message says what happened.
+      expect(repo.upsertCount, 1);
+      expect(repo.upsertedTracks, isEmpty);
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.status, PlexSyncStatus.success);
+      expect(state.trackCount, 0);
+      expect(state.message, contains('no tracks yet'));
+    });
+
+    test('an empty selection clears previously synced Plex rows', () async {
+      final repo = _RecordingRepository();
+      final container = _container(
+        session: _session.copyWith(selectedSectionKeys: const <String>[]),
+        repository: repo,
+      );
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      expect(repo.upsertCount, 1);
+      expect(repo.upsertedSourceId, 'plex');
+      expect(repo.upsertedTracks, isEmpty);
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.status, PlexSyncStatus.success);
+      expect(state.message, contains('No music libraries are selected'));
+    });
+  });
+
+  group('failures', () {
+    test('maps each failure kind to a friendly, token-free message', () async {
+      final cases = <PlexException, String>{
+        PlexException.notReachable(): "Couldn't reach your Plex server",
+        PlexException.unauthorized(): 'rejected by the server',
+        PlexException.notPlex(): "didn't respond like a Plex Media Server",
+        PlexException.serverError(503): 'reported an error',
+        PlexException.notFound(): "A selected library wasn't found",
+        PlexException.unsupportedResponse(): 'could not use',
+      };
+      for (final MapEntry<PlexException, String> entry in cases.entries) {
+        final repo = _RecordingRepository();
+        final container = _container(
+          client: FakePlexClient(itemsError: entry.key),
+          session: _session,
+          repository: repo,
+        );
+        await container
+            .read(plexSettingsControllerProvider.notifier)
+            .ensureLoaded();
+
+        await container.read(plexSyncControllerProvider.notifier).sync();
+
+        final state = container.read(plexSyncControllerProvider);
+        expect(state.isError, isTrue, reason: '${entry.key.kind}');
+        expect(state.message, contains(entry.value),
+            reason: '${entry.key.kind}');
+        expect(state.message, isNot(contains(_token)),
+            reason: '${entry.key.kind}');
+        // A failed listing never half-writes the catalog.
+        expect(repo.upsertCount, 0, reason: '${entry.key.kind}');
+      }
+    });
+
+    test('a storage failure surfaces a friendly message', () async {
+      final container = _container(
+        session: _session,
+        repository: _RecordingRepository(upsertError: StateError('disk full')),
+      );
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.isError, isTrue);
+      expect(state.message, contains('Something went wrong'));
+      expect(state.message, isNot(contains(_token)));
+    });
+  });
+
+  group('coalescing', () {
+    test(
+        'a selection change during a sync re-runs once against the newest '
+        'selection; a manual tap mid-sync is a no-op', () async {
+      final client = _GatedPlexClient(
+        sections: const [
+          _musicSection,
+          PlexDirectory(key: '9', title: 'Vinyl rips', type: 'artist'),
+        ],
+        itemsByType: _libraryItems,
+      );
+      final repo = _RecordingRepository();
+      final container =
+          _container(client: client, session: _session, repository: repo);
+      final settings = container.read(plexSettingsControllerProvider.notifier);
+      await settings.ensureLoaded();
+      final sync = container.read(plexSyncControllerProvider.notifier);
+
+      final Future<void> first = sync.sync();
+      await _settle();
+      expect(container.read(plexSyncControllerProvider).isSyncing, isTrue);
+
+      // While the walk is held at the gate, the user widens the selection
+      // (the settings controller kicks syncAfterSelectionChange itself) and
+      // also mashes the sync button — neither may stack extra walks.
+      await settings.setSelectedSections(const <String>['5', '9']);
+      await sync.sync();
+
+      client.gate.complete();
+      await first;
+      await _settle();
+
+      // Exactly two passes: the original walk plus one coalesced re-run.
+      expect(repo.upsertCount, 2);
+      // The re-run walked the NEW selection (both sections, three kinds).
+      expect(client.itemRequests, hasLength(3 + 6));
+      expect(
+        client.itemRequests.skip(3).map((r) => r.sectionKey).toSet(),
+        <String>{'5', '9'},
+      );
+      expect(
+        container.read(plexSyncControllerProvider).status,
+        PlexSyncStatus.success,
+      );
+    });
+  });
+
+  group('selection-driven sync', () {
+    test('toggling a library kicks a background sync that fills the catalog',
+        () async {
+      final repo = _RecordingRepository();
+      final container = _container(repository: repo);
+      final settings = container.read(plexSettingsControllerProvider.notifier);
+      await settings.ensureLoaded();
+      await settings.connect(url: 'plex.example.com', token: _token);
+      await _settle();
+
+      await settings.toggleSection('5', included: true);
+      await _settle();
+
+      expect(repo.upsertedSourceId, 'plex');
+      expect(
+        repo.upsertedTracks.map((Track t) => t.uri),
+        <String>['plex:101', 'plex:102'],
+      );
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.status, PlexSyncStatus.success);
+      expect(state.trackCount, 2);
+    });
+
+    test('deselecting the last library prunes its tracks from the catalog',
+        () async {
+      final repo = _RecordingRepository();
+      final container = _container(session: _session, repository: repo);
+      final settings = container.read(plexSettingsControllerProvider.notifier);
+      await settings.ensureLoaded();
+      await container.read(plexSyncControllerProvider.notifier).sync();
+      expect(repo.upsertedTracks, isNotEmpty);
+
+      await settings.toggleSection('5', included: false);
+      await _settle();
+
+      expect(repo.upsertedTracks, isEmpty);
+      expect(
+        container.read(plexSyncControllerProvider).message,
+        contains('No music libraries are selected'),
+      );
+    });
+  });
+
+  group('token safety', () {
+    test('no sync outcome ever carries the token in its message', () async {
+      final outcomes = <PlexSyncState>[];
+
+      // Success.
+      var container = _container(session: _session);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+      await container.read(plexSyncControllerProvider.notifier).sync();
+      outcomes.add(container.read(plexSyncControllerProvider));
+
+      // Every typed failure.
+      for (final PlexException error in <PlexException>[
+        PlexException.unauthorized(),
+        PlexException.notReachable(),
+        PlexException.notPlex(),
+        PlexException.serverError(500),
+        PlexException.notFound(),
+      ]) {
+        container = _container(
+          client: FakePlexClient(itemsError: error),
+          session: _session,
+        );
+        await container
+            .read(plexSettingsControllerProvider.notifier)
+            .ensureLoaded();
+        await container.read(plexSyncControllerProvider.notifier).sync();
+        outcomes.add(container.read(plexSyncControllerProvider));
+      }
+
+      for (final PlexSyncState state in outcomes) {
+        expect(state.message, isNotNull);
+        expect(state.message, isNot(contains(_token)));
+      }
+    });
+  });
+}


### PR DESCRIPTION
# Plex PR 8 — real-device hardening and phase 1 polish

Eighth PR of the Plex plan (#178, [docs/plex.md](docs/plex.md) → Suggested PR steps, step 8). Stabilizes the manual connection flow so Plex phase 1 is reliable on a real device **before any version bump or alpha release**. Jellyfin, Navidrome/Subsonic, and Local behavior are untouched.

## What was missing / fragile

The biggest gap after PRs 2–7: **there was no Plex catalog sync at all.** A user could connect and pick libraries, but no track ever reached the Library screen ([docs/providers.md](docs/providers.md) called this out as "the remaining step"). On top of that, the library picker claimed *"No music libraries found"* when the listing merely **failed**, disconnect left state behind, a same-server reconnect silently wiped the library selection, and a slow secure-storage read at startup could race a fast connect/disconnect.

## What this PR does

**Sync after library selection** (new `plex_sync_controller.dart` / `plex_sync_state.dart`)
- Selecting a library kicks a **background sync automatically** — the Library fills without hunting for a button. Rapid checkbox toggles **coalesce**: changes landing mid-sync mark it dirty and it re-runs exactly once against the newest selection.
- A manual **Sync Plex library** button reruns it on demand (mirrors the Subsonic sync UI).
- Because the selection *scopes* the Plex library, a sync **replaces** the catalog's `plex` slice even when the result is empty — deselecting a library really removes its tracks; other sources' rows are never touched.
- Every failure kind maps to a friendly, static, token-free message (unreachable, rejected token, not-a-Plex-server, server error, vanished library, storage failure).

**Safe loading / empty / error states in the picker** (`sectionsLoaded` on the state)
- Loading → labelled spinner ("Loading music libraries…").
- Listing failed → *"Your music libraries haven't loaded yet."* + **Try again** (the specific reason shows below) — no longer masquerades as an empty server.
- Genuinely no music libraries → honest empty state + **Refresh**.

**Session restore on startup**
- A failed secure-storage read now surfaces a friendly, static message instead of failing silently.
- A restore that loses the race against a fast **connect** no longer overwrites the new session; one racing a fast **disconnect** no longer resurrects the cleared session.

**Selected-library persistence**
- Reconnecting to the **same server** (`machineIdentifier` match, e.g. rotated token) keeps the selection and re-syncs it; a **different server** starts clean and quietly drops the old server's rows.
- A library deleted server-side is **pruned** from the selection on the next *successful* refresh (a failed listing never shrinks it), so a phantom selection can't 404 every sync with no checkbox left to clear it.

**Disconnect**
- Also resets the "Synced N tracks" status and removes the synced Plex rows — with no session and no offline cache in phase 1 they are permanently unplayable. The success message only claims rows were removed when they actually were; a cleanup failure still completes the disconnect (the token-bearing session is gone either way).

**Small polish**: token field sets `enableSuggestions: false`; disconnect/sync/refresh disable consistently while busy.

## Required states → how each is handled

| State | Behavior |
|---|---|
| No Plex session | Connect form; `plex:` resolution → friendly "sign in" (unchanged); sync → "Connect to your Plex server in Settings before syncing." |
| Connected, no libraries selected | Picker hint; source serves empty library; sync prunes stale rows + "No music libraries are selected…" |
| Selected libraries, no tracks | Sync succeeds with 0, says "Your selected libraries have no tracks yet", still replaces the slice |
| Invalid server URL | Rejected before any network call with the specific reason (existing, retested) |
| Server unreachable | Typed `notReachable` → friendly line in connect/test/sync/play paths |
| Expired/invalid token | Typed `unauthorized` → "rejected… connect again with a new token" |
| Non-JSON/XML response | Typed `notPlex` (existing client behavior, retested) |
| Server has no music libraries | Honest empty state + Refresh (now distinct from a failed load) |
| Saved session missing/corrupt | Reads back as signed-out (existing); unreadable storage now says "Couldn't restore…" |
| Disconnect with old Plex state loaded | Session cleared, sync status reset, plex rows removed, artwork refs fall back to placeholders, other sources untouched |

## Security rules (all re-proven by tests)

- Token never shown after saving, never logged, never in diagnostics, never in any exception/state message — every new message path is asserted token-free.
- No tokenized stream/artwork URL is ever stored: the sync test asserts catalog rows keep `Track.uri = plex:<ratingKey>` and `Track.artworkUri = plex-thumb:<path>` with no `X-Plex-Token` anywhere.
- `PlexSession.toString()` redaction still covered (existing tests untouched and passing).

## Tests

- New `plex_sync_controller_test.dart` (10): scoping, empty-selection pruning, per-kind friendly errors, storage failure, coalescing/no-op-mid-sync, selection-driven auto-sync, token safety incl. catalog-row schemes.
- `plex_settings_controller_test.dart` 23 → 33: restore failure message, both restore races, `sectionsLoaded`, pruning (success/failure/persist-failure), same/different-server reconnects, disconnect catalog cleanup + honest fallback + sync-status reset.
- `plex_settings_section_test.dart` 8 → 12: loading label, Try again recovery, no-music-libraries state, auto-sync + manual sync UI.
- Full suite: **1906 tests, all passing**; `flutter analyze` clean; secrets scan clean.

## Manual QA checklist (real device)

- [ ] Connect with valid local Plex URL
- [ ] Reject invalid URL safely
- [ ] Reject invalid token safely
- [ ] Reject unreachable server safely
- [ ] List only music libraries
- [ ] Select one library
- [ ] Select multiple libraries
- [ ] Restart app and confirm session persists
- [ ] Restart app and confirm selected libraries persist
- [ ] Sync Plex tracks
- [ ] Play a Plex track
- [ ] Pause/resume Plex playback
- [ ] Background/app switch playback
- [ ] Disconnect Plex
- [ ] Confirm Jellyfin still works
- [ ] Confirm Navidrome/Subsonic still works
- [ ] Confirm Local music still works

## Out of scope (unchanged)

No plex.tv PIN/OAuth, no automatic discovery, no offline/cache, no lyrics, no playlists/favorites, no Android Auto artwork, no transcoding, **no version bump, no release changes**.

Closes nothing — #178 stays open as the tracking issue.

https://claude.ai/code/session_01UKYKw3icRoLR7eRB8A3oja

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKYKw3icRoLR7eRB8A3oja)_