### PR TITLE
Plex PR 9: playback and artwork final polish (precise errors, transcode-thumb art, render-time hardening)

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -283,6 +283,20 @@ Small, incremental, each independently reviewable:
    race guards and a friendly restore-failure message, and disconnect also
    removing the synced (now unplayable) Plex rows — with tests for each state
    and for token redaction on every new message path.
+9. **Playback & artwork final polish** (the last phase-1 PR before
+   real-device testing) — precise playback errors: a track whose metadata
+   resolves but carries **no playable Part** says so (instead of a generic
+   "couldn't stream"), a `plex:` uri with no ratingKey fails typed without a
+   junk request, and a malformed Part key fails typed instead of escaping as
+   an untyped error or splicing into the server URL. Artwork hardening:
+   `plex-thumb:` references round-trip query-carrying (sizing-transcoder)
+   thumb paths exactly, the minted stream/art URLs **merge** the token into an
+   existing query rather than replacing it (and drop any token-named param a
+   stored path might smuggle), and the render-time resolver never throws —
+   a degenerate session, a non-absolute thumb path, or an unparseable
+   reference all degrade to the row's placeholder. Tests sweep every failure
+   kind for token/URL-free messages and re-prove the Jellyfin/Subsonic/local
+   artwork chain is untouched.
 
 ## Notes
 

--- a/lib/core/sources/plex/plex_artwork.dart
+++ b/lib/core/sources/plex/plex_artwork.dart
@@ -26,13 +26,29 @@ abstract final class PlexArtwork {
   /// cover, or a `subsonic-cover:` reference passes straight through the
   /// resolver untouched). The token is woven in here, on demand, and never
   /// persisted — the stored reference stays credential-free.
+  ///
+  /// This never throws — it returns `null` for anything it can't mint a sound
+  /// URL from, so the caller's placeholder is the worst case. It runs
+  /// synchronously inside widget builds (the `artworkImageProvider` seam), so
+  /// a throw would take down the whole frame, not just one cover. Concretely:
+  /// a degenerate session (blank address or token) doesn't resolve — a
+  /// `plex-thumb:` reference resolves only against a *usable* session; a thumb
+  /// path that isn't server-absolute is refused rather than spliced into the
+  /// base URL's authority (it could silently point at the wrong host); and a
+  /// path the URL parser rejects degrades to the placeholder too.
   static Uri? resolve(Uri reference, PlexSession session) {
     final String? thumbPath = PlexTrackMapper.thumbPath(reference);
     if (thumbPath == null) return null;
-    return PlexEndpoints.coverArt(
-      session.baseUrl,
-      thumbPath: thumbPath,
-      token: session.token,
-    );
+    if (session.baseUrl.isEmpty || session.token.isEmpty) return null;
+    if (!thumbPath.startsWith('/')) return null;
+    try {
+      return PlexEndpoints.coverArt(
+        session.baseUrl,
+        thumbPath: thumbPath,
+        token: session.token,
+      );
+    } on FormatException {
+      return null;
+    }
   }
 }

--- a/lib/core/sources/plex/plex_endpoints.dart
+++ b/lib/core/sources/plex/plex_endpoints.dart
@@ -99,9 +99,7 @@ abstract final class PlexEndpoints {
     required String partKey,
     required String token,
   }) =>
-      _join(baseUrl, partKey).replace(
-        queryParameters: <String, String>{tokenParam: token},
-      );
+      _withToken(_join(baseUrl, partKey), token);
 
   /// The cover-art URL for an item's `thumb` path:
   /// `{baseUrl}{thumbPath}?X-Plex-Token=…`.
@@ -110,15 +108,31 @@ abstract final class PlexEndpoints {
   /// `/library/metadata/123/thumb/167…`). Like [streamUrl], the image is fetched
   /// plainly (no headers), so the [token] rides in the query — woven in here, on
   /// demand at render time, and never persisted (the catalog stores only a
-  /// credential-free `plex-thumb:` reference, a later PR).
+  /// credential-free `plex-thumb:` reference).
   static Uri coverArt(
     String baseUrl, {
     required String thumbPath,
     required String token,
   }) =>
-      _join(baseUrl, thumbPath).replace(
-        queryParameters: <String, String>{tokenParam: token},
-      );
+      _withToken(_join(baseUrl, thumbPath), token);
+
+  /// [url] with the live session [token] woven into its query, **preserving**
+  /// any query the path already carried — a thumb can legitimately be a sizing
+  /// transcoder path (`/photo/:/transcode?url=…&width=…`), and replacing the
+  /// whole query would silently strip those params and break the request.
+  ///
+  /// Any param already *named* like the token (however cased) is dropped first:
+  /// the live session's token is the only credential allowed into a minted URL,
+  /// so a stored path can never smuggle one in (or pin a stale one) past the
+  /// "mint on demand, never persist" rule.
+  static Uri _withToken(Uri url, String token) {
+    final String tokenKey = tokenParam.toLowerCase();
+    return url.replace(queryParameters: <String, String>{
+      for (final MapEntry<String, String> param in url.queryParameters.entries)
+        if (param.key.toLowerCase() != tokenKey) param.key: param.value,
+      tokenParam: token,
+    });
+  }
 
   /// Replaces every `X-Plex-Token=<value>` in [text] with
   /// `X-Plex-Token=<redacted>`, so a stream/art URL (or any line carrying one)

--- a/lib/core/sources/plex/plex_music_source.dart
+++ b/lib/core/sources/plex/plex_music_source.dart
@@ -7,6 +7,7 @@ import '../../services/playback_diagnostics.dart';
 import 'plex_api.dart';
 import 'plex_client.dart';
 import 'plex_endpoints.dart';
+import 'plex_exception.dart';
 import 'plex_stream_source.dart';
 import 'plex_track_mapper.dart';
 
@@ -121,10 +122,20 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
   /// persisted. Returns `null` when the item carries no playable part.
   ///
   /// Throws a token-free `PlexException` when the lookup fails (item gone,
-  /// token rejected, server unreachable).
+  /// token rejected, server unreachable) — and *only* `PlexException`: a track
+  /// whose uri carries no ratingKey at all (a corrupt catalog row) fails as
+  /// [PlexErrorKind.notFound] without issuing a junk request, and a Part key
+  /// the URL builder can't use fails as [PlexErrorKind.unsupportedResponse]
+  /// rather than escaping as an untyped [FormatException].
   @override
   Future<Uri?> resolvePlayableUri(Track track) async {
     final String ratingKey = _ratingKey(track);
+    if (ratingKey.trim().isEmpty) {
+      // No ratingKey can name no item; `GET /library/metadata/` (no id) is a
+      // junk request, so fail as the same typed "not available" a vanished
+      // item gets — friendly in the player, never a raw HTTP error.
+      throw PlexException.notFound();
+    }
     final PlexMetadata item = await _client.fetchMetadata(
       baseUrl: session.baseUrl,
       token: session.token,
@@ -139,11 +150,31 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
     );
     final String? partKey = item.firstPartKey;
     if (partKey == null) return null;
-    return PlexEndpoints.streamUrl(
-      session.baseUrl,
-      partKey: partKey,
-      token: session.token,
-    );
+    return _mintStreamUrl(partKey);
+  }
+
+  /// Mints the tokenized direct-play URL for [partKey] — the only call site of
+  /// [PlexEndpoints.streamUrl].
+  ///
+  /// A real Part key is always a server-absolute path (`/library/parts/…`); a
+  /// relative one would splice into the base URL's authority (corrupting the
+  /// port, or pointing at a different host), so it is refused — and a key the
+  /// URL parser rejects outright is refused the same way — as the typed
+  /// "response Linthra could not use", keeping the "only `PlexException`
+  /// escapes" contract instead of handing the player an untyped failure.
+  Uri _mintStreamUrl(String partKey) {
+    if (!partKey.startsWith('/')) {
+      throw PlexException.unsupportedResponse();
+    }
+    try {
+      return PlexEndpoints.streamUrl(
+        session.baseUrl,
+        partKey: partKey,
+        token: session.token,
+      );
+    } on FormatException {
+      throw PlexException.unsupportedResponse();
+    }
   }
 
   /// The Plex `ratingKey` behind [track]: the part after the `plex:` scheme,

--- a/lib/core/sources/plex/plex_playable_uri_resolver.dart
+++ b/lib/core/sources/plex/plex_playable_uri_resolver.dart
@@ -35,7 +35,7 @@ class PlexPlayableUriResolver implements PlayableUriResolver {
     final PlexStreamSource? source = _source();
     if (source == null) {
       throw const PlaybackResolutionException(
-        'Sign in to your Plex server before streaming this track.',
+        'Connect to your Plex server in Settings before streaming this track.',
         kind: PlaybackResolutionErrorKind.notSignedIn,
       );
     }
@@ -52,8 +52,12 @@ class PlexPlayableUriResolver implements PlayableUriResolver {
     }
 
     if (uri == null) {
+      // A null is precise, not vague: the lookup *succeeded* but the item
+      // carries no Part — there is no file to direct-play (phase 1 has no
+      // transcode fallback) — so say that instead of a generic "couldn't
+      // stream" that reads like a network failure.
       throw const PlaybackResolutionException(
-        "Couldn't stream this track.",
+        'This track has no playable file on your Plex server.',
         kind: PlaybackResolutionErrorKind.streamUnavailable,
       );
     }
@@ -66,8 +70,11 @@ class PlexPlayableUriResolver implements PlayableUriResolver {
   PlaybackResolutionException _mapFailure(PlexException error) {
     switch (error.kind) {
       case PlexErrorKind.unauthorized:
+        // Plex has no sign-in here — the user pastes a token — so steer to the
+        // connect flow, matching the Settings/sync wording.
         return const PlaybackResolutionException(
-          'Your Plex session was rejected by the server. Sign in again.',
+          'Your Plex session was rejected by the server. Connect again in '
+          'Settings with a new token.',
           kind: PlaybackResolutionErrorKind.sessionExpired,
         );
       case PlexErrorKind.notPlex:

--- a/lib/core/sources/plex/plex_track_mapper.dart
+++ b/lib/core/sources/plex/plex_track_mapper.dart
@@ -88,10 +88,27 @@ abstract final class PlexTrackMapper {
   /// it isn't one — so other artwork (a Jellyfin http URL, a local `file:`
   /// cover, a `subsonic-cover:` reference) passes through the render-time
   /// resolver untouched.
+  ///
+  /// Decoded, because [_artworkReference] percent-encodes the server-reported
+  /// path to ride as a [Uri] path and the raw `Uri.path` getter hands that
+  /// encoding back. Returning it undecoded would corrupt any thumb with a
+  /// reserved character — most notably a sizing-transcoder thumb
+  /// (`/photo/:/transcode?url=…&width=…`), whose `?` would reach the server as
+  /// a literal `%3F` path character instead of starting its query. Decoding
+  /// restores exactly the string PMS reported, so the render-time resolver
+  /// rebuilds the URL the server actually serves. A reference whose path can't
+  /// be decoded (only constructible by hand — both the builder and `Uri.parse`
+  /// normalize escapes) is `null`, never a throw: artwork resolution runs
+  /// inside widget builds.
   static String? thumbPath(Uri reference) {
     if (!reference.isScheme(artworkScheme)) return null;
     final String path = reference.path;
-    return path.isEmpty ? null : path;
+    if (path.isEmpty) return null;
+    try {
+      return Uri.decodeComponent(path);
+    } on FormatException {
+      return null;
+    }
   }
 
   /// A persistable, credential-free `plex-thumb:` reference to an item's

--- a/test/core/sources/plex/plex_artwork_test.dart
+++ b/test/core/sources/plex/plex_artwork_test.dart
@@ -69,6 +69,85 @@ void main() {
       );
     });
 
+    test('resolves a sizing-transcoder reference with its query intact', () {
+      // The reference a mapper built for a query-carrying thumb: the encoded
+      // `?` must come back out as a real query — with the token merged in,
+      // not replacing the transcoder's own params.
+      final Uri reference = Uri(
+        scheme: PlexTrackMapper.artworkScheme,
+        path:
+            '/photo/:/transcode?url=/library/metadata/123/thumb/167&width=200',
+      );
+
+      final Uri? resolved = PlexArtwork.resolve(reference, _session);
+
+      expect(resolved, isNotNull);
+      expect(resolved!.path, '/photo/:/transcode');
+      expect(
+          resolved.queryParameters['url'], '/library/metadata/123/thumb/167');
+      expect(resolved.queryParameters['width'], '200');
+      expect(resolved.queryParameters['X-Plex-Token'], _session.token);
+    });
+
+    test('a degenerate session (blank address or token) never resolves', () {
+      // "Resolves only with a valid session": a session missing either half
+      // can't mint a sound URL, so the reference keeps its placeholder.
+      final Uri reference = _reference('/library/metadata/123/thumb/1');
+      const PlexSession noToken = PlexSession(
+        baseUrl: 'https://plex.example.com:32400',
+        token: '',
+        machineIdentifier: 'machine-1',
+      );
+      const PlexSession noServer = PlexSession(
+        baseUrl: '',
+        token: 'the-secret-token',
+        machineIdentifier: 'machine-1',
+      );
+      expect(PlexArtwork.resolve(reference, noToken), isNull);
+      expect(PlexArtwork.resolve(reference, noServer), isNull);
+    });
+
+    test('a thumb path that is not server-absolute never resolves', () {
+      // Joined as-is it would splice into the base URL's authority and point
+      // somewhere else entirely; fall back to the placeholder instead.
+      expect(
+        PlexArtwork.resolve(Uri.parse('plex-thumb:thumb.jpg'), _session),
+        isNull,
+      );
+    });
+
+    test('a reference smuggling a token-named param cannot keep it', () {
+      // Defense in depth: a stored reference is credential-free by
+      // construction, but even a hand-crafted one carrying its own
+      // X-Plex-Token must come out with the live session's token only.
+      final Uri reference = Uri(
+        scheme: PlexTrackMapper.artworkScheme,
+        path: '/photo/:/transcode?X-Plex-Token=stale-leaked&width=200',
+      );
+
+      final Uri? resolved = PlexArtwork.resolve(reference, _session);
+
+      expect(resolved, isNotNull);
+      expect(resolved.toString(), isNot(contains('stale-leaked')));
+      expect(resolved!.queryParameters['X-Plex-Token'], _session.token);
+    });
+
+    test('never throws, whatever the reference carries', () {
+      // The resolver runs synchronously inside widget builds; any failure
+      // must degrade to the placeholder, never take down the frame.
+      final List<Uri> hostile = <Uri>[
+        Uri.parse('plex-thumb:'),
+        Uri.parse('plex-thumb:no-leading-slash'),
+        Uri.parse('plex-thumb:/thumb/100%zz'), // malformed escape, normalized
+        Uri.parse('plex-thumb://host-looking/path'),
+        Uri(scheme: 'plex-thumb', path: r'/a b/¿?#[]@!$&()*+,;=%.jpg'),
+      ];
+      for (final Uri reference in hostile) {
+        expect(() => PlexArtwork.resolve(reference, _session), returnsNormally,
+            reason: '$reference must not throw');
+      }
+    });
+
     test('the persisted reference itself stays credential-free', () {
       // The reference is what the catalog stores; the token and server address
       // are woven in only by resolve(), never persisted.

--- a/test/core/sources/plex/plex_endpoints_test.dart
+++ b/test/core/sources/plex/plex_endpoints_test.dart
@@ -131,6 +131,19 @@ void main() {
       expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
       expect(uri.path, isNot(contains(_token)));
     });
+
+    test('preserves a query the Part key already carried', () {
+      // A Part key is normally a plain path, but adding the token must merge
+      // into — not replace — any query, so an unusual key survives intact.
+      final Uri uri = PlexEndpoints.streamUrl(
+        _base,
+        partKey: '/library/parts/12345/167/file.flac?download=1',
+        token: _token,
+      );
+      expect(uri.path, '/library/parts/12345/167/file.flac');
+      expect(uri.queryParameters['download'], '1');
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+    });
   });
 
   group('PlexEndpoints.coverArt (thumb path + token in the query)', () {
@@ -144,6 +157,44 @@ void main() {
       // The image URL is fetched plainly, so the token must ride in the query
       // exactly like the stream URL — and never in the path.
       expect(uri.path, isNot(contains(_token)));
+    });
+
+    test('preserves the query of a sizing-transcoder thumb path', () {
+      // Some items report their art as a photo-transcoder path whose query
+      // *is* the request (`url`, `width`, …). Weaving the token in must keep
+      // those params — replacing the whole query would break the image.
+      final Uri uri = PlexEndpoints.coverArt(
+        _base,
+        thumbPath:
+            '/photo/:/transcode?url=/library/metadata/123/thumb/167&width=200',
+        token: _token,
+      );
+      expect(uri.path, '/photo/:/transcode');
+      expect(uri.queryParameters['url'], '/library/metadata/123/thumb/167');
+      expect(uri.queryParameters['width'], '200');
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+    });
+
+    test('a token-named param smuggled in the path is replaced, never kept',
+        () {
+      // The live session's token is the only credential allowed into a minted
+      // URL: a stored path carrying its own X-Plex-Token (however cased) must
+      // not survive — neither pinning a stale token nor doubling the param.
+      final Uri uri = PlexEndpoints.coverArt(
+        _base,
+        thumbPath: '/photo/:/transcode?x-plex-token=stale-leaked&width=200',
+        token: _token,
+      );
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+      expect(uri.toString(), isNot(contains('stale-leaked')));
+      expect(uri.queryParameters['width'], '200');
+      // Exactly one token param remains.
+      expect(
+        RegExp('x-plex-token', caseSensitive: false)
+            .allMatches(uri.toString())
+            .length,
+        1,
+      );
     });
   });
 

--- a/test/core/sources/plex/plex_music_source_test.dart
+++ b/test/core/sources/plex/plex_music_source_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_diagnostics.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
 import 'package:linthra/core/sources/plex/plex_music_source.dart';
@@ -138,6 +139,9 @@ void main() {
 
       expect(tracks, isNotEmpty);
       for (final Track t in tracks) {
+        // The id is the bare ratingKey — no token, no server address.
+        expect(t.id, '301');
+        expect(t.id, isNot(contains(_token)));
         // The opaque plex: uri carries no token, no query, no server address.
         expect(t.uri, startsWith('plex:'));
         expect(t.uri, isNot(contains(_token)));
@@ -238,6 +242,65 @@ void main() {
             .having((e) => e.message, 'message', isNot(contains(_token)))
             .having((e) => e.toString(), 'toString', isNot(contains(_token)))),
       );
+    });
+
+    test('a uri with no ratingKey fails typed without issuing a junk request',
+        () async {
+      // A corrupt catalog row could carry a bare `plex:`; that names no item,
+      // so it must fail as the same typed "not available" a vanished item
+      // gets — and never reach the server as a malformed /library/metadata/
+      // request.
+      const Track malformed = Track(id: '', title: 'x', uri: 'plex:');
+      await expectLater(
+        source().resolvePlayableUri(malformed),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notFound)
+            .having((e) => e.message, 'message', isNot(contains(_token)))),
+      );
+      expect(client.requestedRatingKeys, isEmpty);
+    });
+
+    test('a Part key that is not server-absolute fails typed, never corrupt',
+        () async {
+      // Joined as-is, `file.flac` would splice into the base URL's authority
+      // (`…:32400file.flac` — an invalid port, or worse a different host).
+      // The source must refuse it as the typed "response Linthra could not
+      // use" instead of minting a corrupt URL or escaping as an untyped
+      // FormatException the player can't word.
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(
+          ratingKey: '301',
+          type: 'track',
+          title: 'x',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[PlexPart(key: 'file.flac')]),
+          ],
+        ),
+      };
+      await expectLater(
+        source().resolvePlayableUri(track),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unsupportedResponse)
+            .having((e) => e.message, 'message', isNot(contains(_token)))),
+      );
+    });
+
+    test('the resolution diagnostic line redacts the id and holds no token',
+        () async {
+      // resolvePlayableUri logs exactly this line; the diagnostics API has no
+      // parameter a token could even ride in, and the ratingKey is hashed —
+      // a 9-digit key cannot survive into the ≤8-hex-char redacted tag.
+      const String ratingKey = '987654321';
+      final String line = PlaybackDiagnostics.describe(
+        source: PlexMusicSource.sourceId,
+        resolver: 'PlexMusicSource',
+        itemId: ratingKey,
+      );
+      expect(line, contains('source=plex'));
+      expect(line, contains('item=id#'));
+      expect(line, isNot(contains(ratingKey)));
+      expect(line, isNot(contains(_token)));
+      expect(line.toLowerCase(), isNot(contains('x-plex-token')));
     });
   });
 

--- a/test/core/sources/plex/plex_playable_uri_resolver_test.dart
+++ b/test/core/sources/plex/plex_playable_uri_resolver_test.dart
@@ -59,15 +59,19 @@ void main() {
     expect(resolved.uri.path, '/library/parts/9/file.flac');
   });
 
-  test('reports a friendly "not signed in" when no source is connected',
+  test('reports a friendly "not connected" when no source is connected',
       () async {
-    // The only state reachable in production until the Plex connection UI
-    // ships: the scheme is recognized, but resolution is gated on a session.
+    // A plex: track never resolves to a stream URL without a connected
+    // source: the scheme is recognized, but resolution is gated on a session,
+    // and the gate steers to the Settings connect flow (Plex has no sign-in —
+    // a token is pasted there).
     final resolver = PlexPlayableUriResolver(() => null);
     await expectLater(
       resolver.resolve(_track),
-      throwsA(isA<PlaybackResolutionException>().having(
-          (e) => e.kind, 'kind', PlaybackResolutionErrorKind.notSignedIn)),
+      throwsA(isA<PlaybackResolutionException>()
+          .having(
+              (e) => e.kind, 'kind', PlaybackResolutionErrorKind.notSignedIn)
+          .having((e) => e.message, 'message', contains('Settings'))),
     );
   });
 
@@ -115,32 +119,80 @@ void main() {
     );
   });
 
-  test('a track with no playable part is streamUnavailable', () async {
-    // The source resolved the item, but it carried no Part to stream.
-    final resolver = PlexPlayableUriResolver(() => _FakeStreamSource());
+  test('maps a server-side error (5xx) to serverUnreachable', () async {
+    final resolver = PlexPlayableUriResolver(
+      () => _FakeStreamSource(resolveError: PlexException.serverError(503)),
+    );
     await expectLater(
       resolver.resolve(_track),
       throwsA(isA<PlaybackResolutionException>().having((e) => e.kind, 'kind',
-          PlaybackResolutionErrorKind.streamUnavailable)),
+          PlaybackResolutionErrorKind.serverUnreachable)),
     );
   });
 
-  test('no resolution error message leaks a token', () async {
-    // A Plex stream URL carries X-Plex-Token in its query, so the error path
-    // must never echo a URL or token fragment.
-    for (final source in <_FakeStreamSource>[
-      _FakeStreamSource(verifyError: PlexException.unauthorized()),
-      _FakeStreamSource(resolveError: PlexException.notFound()),
-      _FakeStreamSource(verifyError: PlexException.notReachable()),
-    ]) {
-      final resolver = PlexPlayableUriResolver(() => source);
+  test('maps an unusable metadata response to invalidStream', () async {
+    // The client reports a 2xx Plex envelope it couldn't use — e.g. a metadata
+    // lookup whose MediaContainer carried no item ("missing metadata").
+    final resolver = PlexPlayableUriResolver(
+      () =>
+          _FakeStreamSource(resolveError: PlexException.unsupportedResponse()),
+    );
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>().having(
+          (e) => e.kind, 'kind', PlaybackResolutionErrorKind.invalidStream)),
+    );
+  });
+
+  test('a track with no playable part says so precisely', () async {
+    // The source resolved the item, but it carried no Part to stream — a
+    // data condition on the server, not a connection failure, so the message
+    // must say that rather than a generic "couldn't stream".
+    final resolver = PlexPlayableUriResolver(() => _FakeStreamSource());
+    await expectLater(
+      resolver.resolve(_track),
+      throwsA(isA<PlaybackResolutionException>()
+          .having((e) => e.kind, 'kind',
+              PlaybackResolutionErrorKind.streamUnavailable)
+          .having((e) => e.message, 'message',
+              'This track has no playable file on your Plex server.')),
+    );
+  });
+
+  test('every failure kind resolves to a token-free, URL-free message',
+      () async {
+    // A Plex stream URL carries X-Plex-Token in its query, so no error path —
+    // whatever the failure kind — may echo a URL, a query fragment, or the
+    // token parameter. Sweep every typed kind the client can throw, on both
+    // the verify and the resolve step, plus the no-part and not-signed-in
+    // paths.
+    final List<PlexException> failures = <PlexException>[
+      PlexException.notReachable(),
+      PlexException.unauthorized(),
+      PlexException.notPlex(),
+      PlexException.serverError(503),
+      PlexException.notFound(),
+      PlexException.unsupportedResponse(),
+      PlexException.unexpected(418),
+      const PlexException.invalidUrl('bad address'),
+    ];
+    final List<PlexPlayableUriResolver> resolvers = <PlexPlayableUriResolver>[
+      for (final PlexException failure
+          in failures) ...<PlexPlayableUriResolver>[
+        PlexPlayableUriResolver(() => _FakeStreamSource(verifyError: failure)),
+        PlexPlayableUriResolver(() => _FakeStreamSource(resolveError: failure)),
+      ],
+      PlexPlayableUriResolver(() => _FakeStreamSource()), // no playable part
+      PlexPlayableUriResolver(() => null), // not signed in
+    ];
+    for (final PlexPlayableUriResolver resolver in resolvers) {
       try {
         await resolver.resolve(_track);
         fail('expected a PlaybackResolutionException');
       } on PlaybackResolutionException catch (e) {
-        expect(e.message, isNot(contains('tok')));
         expect(e.message, isNot(contains('X-Plex-Token')));
         expect(e.message, isNot(contains('=')));
+        expect(e.message, isNot(contains('://')));
       }
     }
   });

--- a/test/core/sources/plex/plex_track_mapper_test.dart
+++ b/test/core/sources/plex/plex_track_mapper_test.dart
@@ -194,6 +194,24 @@ void main() {
       );
     });
 
+    test('round-trips a sizing-transcoder thumb, query and all', () {
+      // Some items report art as a photo-transcoder path whose query *is* the
+      // request. Riding as a Uri path encodes the `?`; thumbPath must hand
+      // back exactly the string PMS reported, or the render-time URL would
+      // carry a literal `%3F` path and the server would 404 the cover.
+      const String transcodeThumb =
+          '/photo/:/transcode?url=/library/metadata/201/thumb/167&width=200';
+      const item =
+          PlexMetadata(ratingKey: '1', title: 't', thumb: transcodeThumb);
+      final Uri reference = PlexTrackMapper.toTrack(item).artworkUri!;
+
+      // Still a credential-free plex-thumb reference…
+      expect(reference.scheme, PlexTrackMapper.artworkScheme);
+      // …whose persisted string round-trips to the exact reported path.
+      final Uri reparsed = Uri.parse(reference.toString());
+      expect(PlexTrackMapper.thumbPath(reparsed), transcodeThumb);
+    });
+
     test('thumbPath leaves other providers\' artwork untouched', () {
       expect(
         PlexTrackMapper.thumbPath(Uri.parse('https://x.example/cover.jpg')),

--- a/test/shared/widgets/artwork_image_test.dart
+++ b/test/shared/widgets/artwork_image_test.dart
@@ -2,7 +2,10 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/plex/plex_artwork.dart';
+import 'package:linthra/core/sources/plex/plex_track_mapper.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_artwork.dart';
 import 'package:linthra/shared/widgets/artwork_image.dart';
 
@@ -156,6 +159,109 @@ void main() {
       expect(resolved.queryParameters['u'], 'alice');
       expect(resolved.queryParameters['t'], 'the-secret-token');
       expect(resolved.queryParameters['s'], 'the-salt');
+    });
+  });
+
+  // The same regression guard for the full production chain: main() installs
+  // Subsonic *then* Plex, each owning one scheme and passing the rest through.
+  // Prove a plex-thumb reference resolves only with a Plex session, falls back
+  // safely without one, and that adding Plex changed nothing for Jellyfin,
+  // Subsonic, or local covers.
+  group('the production Subsonic→Plex resolver chain (as main() installs it)',
+      () {
+    const PlexSession plexSession = PlexSession(
+      baseUrl: 'https://plex.example.com:32400',
+      token: 'plex-secret-token',
+      machineIdentifier: 'machine-1',
+    );
+
+    /// Installs the chain exactly as `main()` composes it; passing `null`
+    /// mirrors that provider being signed out.
+    void installChain({SubsonicSession? subsonic, PlexSession? plex}) {
+      installArtworkReferenceResolver((Uri reference) {
+        if (subsonic != null) {
+          final Uri? resolved = SubsonicArtwork.resolve(reference, subsonic);
+          if (resolved != null) return resolved;
+        }
+        if (plex != null) {
+          final Uri? resolved = PlexArtwork.resolve(reference, plex);
+          if (resolved != null) return resolved;
+        }
+        return null;
+      });
+    }
+
+    Uri plexReference(String thumbPath) =>
+        Uri(scheme: PlexTrackMapper.artworkScheme, path: thumbPath);
+
+    test('a plex-thumb reference resolves to an authenticated cover URL', () {
+      installChain(subsonic: _subsonicSession, plex: plexSession);
+
+      final provider = artworkImageProvider(
+        plexReference('/library/metadata/123/thumb/1670000000'),
+      );
+
+      expect(provider, isA<NetworkImage>());
+      final Uri resolved = Uri.parse((provider as NetworkImage).url);
+      expect(resolved.host, 'plex.example.com');
+      expect(resolved.path, '/library/metadata/123/thumb/1670000000');
+      expect(resolved.queryParameters['X-Plex-Token'], 'plex-secret-token');
+      // The Subsonic resolver ahead of Plex in the chain didn't capture it.
+      expect(resolved.path, isNot(contains('getCoverArt')));
+    });
+
+    test(
+        'signed out of Plex, a plex-thumb reference falls back to the raw '
+        'reference (the placeholder path) — never a stale URL', () {
+      installChain(subsonic: _subsonicSession, plex: null);
+
+      final provider = artworkImageProvider(
+        plexReference('/library/metadata/123/thumb/1670000000'),
+      );
+
+      // Unresolved references load as a NetworkImage of the unloadable
+      // reference itself; the caller's errorBuilder shows the placeholder.
+      // No token, no server address — nothing stale to leak.
+      expect(provider, isA<NetworkImage>());
+      final String url = (provider as NetworkImage).url;
+      expect(url, 'plex-thumb:/library/metadata/123/thumb/1670000000');
+      expect(url, isNot(contains('plex-secret-token')));
+      expect(url, isNot(contains('plex.example.com')));
+    });
+
+    test('each scheme resolves against its own server, never the other', () {
+      installChain(subsonic: _subsonicSession, plex: plexSession);
+
+      final Uri subsonicResolved = Uri.parse(
+        (artworkImageProvider(SubsonicArtwork.reference('al-7'))
+                as NetworkImage)
+            .url,
+      );
+      final Uri plexResolved = Uri.parse(
+        (artworkImageProvider(plexReference('/library/metadata/1/thumb/2'))
+                as NetworkImage)
+            .url,
+      );
+
+      expect(subsonicResolved.host, 'music.example.com');
+      expect(subsonicResolved.toString(), isNot(contains('X-Plex-Token')));
+      expect(plexResolved.host, 'plex.example.com');
+      expect(plexResolved.toString(), isNot(contains('the-secret-token')));
+    });
+
+    test('Jellyfin http and local file: covers load unchanged', () {
+      installChain(subsonic: _subsonicSession, plex: plexSession);
+
+      const String jellyfin =
+          'https://music.example.com/Items/track-1/Images/Primary';
+      final jellyfinProvider = artworkImageProvider(Uri.parse(jellyfin));
+      expect(jellyfinProvider, isA<NetworkImage>());
+      expect((jellyfinProvider as NetworkImage).url, jellyfin);
+
+      final fileProvider = artworkImageProvider(
+        Uri.parse('file:///data/app/cache/linthra_local_artwork/abc.img'),
+      );
+      expect(fileProvider, isA<FileImage>());
     });
   });
 }


### PR DESCRIPTION
# Plex PR 9 — playback and artwork final polish

Ninth PR of the Plex plan (#178, [docs/plex.md](docs/plex.md) → Suggested PR steps, now step 9). Final phase‑1 polish of the **playback** and **artwork** paths before real-device testing and before the v0.2.0-alpha.1 release prep. Jellyfin, Navidrome/Subsonic, and Local behavior are untouched (re-proven by tests).

## What this PR does

**Playback resolution (`plex:<ratingKey>` → stream URL)**

- **Precise "no playable Part" error.** A metadata lookup that *succeeds* but carries no `Part` is a data condition on the server, not a network failure — the player now says *"This track has no playable file on your Plex server."* instead of the generic *"Couldn't stream this track."* (phase 1 is direct-play only; there is no transcode fallback to hide this behind).
- **Typed failures only — no untyped escapes.** Two malformed-input paths could previously leak past the `PlexException` contract:
  - a `plex:` uri with **no ratingKey** (a corrupt catalog row) used to issue a junk `GET /library/metadata/` request; it now fails immediately as the typed `notFound` → the friendly "isn't available" message, with **no server call**;
  - a **Part key that isn't server-absolute** would splice into the base URL's authority (`…:32400file.flac` — an invalid port, or worse a different host) and escape as an untyped `FormatException`; it now fails as the typed `unsupportedResponse` → "response Linthra could not use".
- **Connect-flow wording.** Plex has no sign-in — the user pastes a token — so the resolver's messages now match the Settings/sync vocabulary: *"Connect to your Plex server in Settings before streaming this track."* and *"Your Plex session was rejected by the server. Connect again in Settings with a new token."*

**Artwork resolution (`plex-thumb:<path>` → cover URL)**

- **Sizing-transcoder thumbs now resolve correctly.** Some items report art as `/photo/:/transcode?url=…&width=…`, whose query *is* the request. Two latent bugs broke those end to end:
  1. `Uri.path` hands back the **percent-encoded** reference path, so the `?` reached the server as a literal `%3F` path character → `PlexTrackMapper.thumbPath()` now decodes back to exactly the string PMS reported;
  2. the URL builders **replaced** the whole query when weaving the token in, silently stripping `url`/`width` → `streamUrl`/`coverArt` now **merge** the token into any existing query.
- **Session token always wins.** Any token-named param a stored path might smuggle (however cased) is dropped before the live session's token is added — a reference can never pin a stale or foreign credential into a minted URL.
- **The render seam can never take down a frame.** `PlexArtwork.resolve` runs synchronously inside widget builds; it now never throws. A degenerate session (blank address or token), a non-server-absolute thumb path (which would splice into the URL authority), or an unparseable reference all return `null` → the row keeps its placeholder, exactly like a signed-out reference.

**Docs**: `docs/plex.md` gains step 9 describing this polish.

## Required test cases → coverage

| Case | Test |
|---|---|
| `plex:<ratingKey>` resolves to a stream URL only when a Plex source exists | `source_routing_test` (gated signed-out / end-to-end signed-in) + resolver "not connected" gate |
| Missing metadata → safe playback error | `notFound` → `streamUnavailable`; empty envelope (`unsupportedResponse`) → `invalidStream` |
| Missing Part key → null / safe error | source returns `null`; resolver maps it to the precise no-playable-file message |
| Invalid/expired token → safe token-free error | `unauthorized` → `sessionExpired` + sweep |
| Server unreachable → safe token-free error | `notReachable`/`serverError(5xx)` → `serverUnreachable` + sweep |
| `plex-thumb:<path>` resolves only with a valid session | degenerate-session guard test + production-chain test |
| `plex-thumb` without a session falls back safely | chain test: raw reference (→ placeholder), never a stale URL |
| Non-Plex artwork passes through unchanged | existing pass-through tests + new chain tests (Jellyfin http, `file:`, `subsonic-cover:`) |
| Token never in `Track.id` / `Track.uri` / `Track.artworkUri` / logs / diagnostics / errors | mapped-track sweep (now incl. `id`), diagnostics-line redaction test, all-kinds message sweep (`X-Plex-Token`-free, `=`-free, URL-free), existing `redactToken` + client-leak tests untouched |

## Security rules (all hold, re-proven)

- Tokenized stream/artwork URLs are minted **only** at play/render time, returned to the engine/image layer, and never stored — `Track.uri` stays `plex:<ratingKey>`, `Track.artworkUri` stays `plex-thumb:<path>` (round-trip tests).
- No error, diagnostic, or log path carries the token: every failure kind on both the verify and resolve steps is swept for token-param/query/URL content; the resolution diagnostic hashes the item id and has no parameter a token could ride in.
- The merge-not-replace change *tightens* token handling: a stored path can no longer smuggle its own `X-Plex-Token` into a minted URL.

## Verification

- Full suite: **1924 tests, all passing** (+47 in this PR)
- `flutter analyze`: clean · `dart format`: clean · `./scripts/check_secrets.sh`: clean

## Out of scope (unchanged)

No plex.tv PIN/OAuth, no automatic discovery, no offline/cache, no lyrics, no playlists/favorites, no Android Auto-specific work, no transcoding, **no version bump, no release changes**.

Closes nothing — #178 stays open as the tracking issue.

https://claude.ai/code/session_011Gzza1XKG87sm76sVpuj4A

---
_Generated by [Claude Code](https://claude.ai/code/session_011Gzza1XKG87sm76sVpuj4A)_