### PR TITLE
Plex PR 9 follow-up: preserve PMS's own percent-encoding through plex-thumb references

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -290,9 +290,11 @@ Small, incremental, each independently reviewable:
    junk request, and a malformed Part key fails typed instead of escaping as
    an untyped error or splicing into the server URL. Artwork hardening:
    `plex-thumb:` references round-trip query-carrying (sizing-transcoder)
-   thumb paths exactly, the minted stream/art URLs **merge** the token into an
-   existing query rather than replacing it (and drop any token-named param a
-   stored path might smuggle), and the render-time resolver never throws —
+   thumb paths byte-for-byte — including a `url=` value PMS itself
+   percent-encoded — the minted stream/art URLs **merge** the token into an
+   existing query rather than replacing it, splicing the existing pairs
+   through raw (and dropping any token-named param a stored path might
+   smuggle, however encoded), and the render-time resolver never throws —
    a degenerate session, a non-absolute thumb path, or an unparseable
    reference all degrade to the row's placeholder. Tests sweep every failure
    kind for token/URL-free messages and re-prove the Jellyfin/Subsonic/local

--- a/lib/core/sources/plex/plex_endpoints.dart
+++ b/lib/core/sources/plex/plex_endpoints.dart
@@ -121,17 +121,46 @@ abstract final class PlexEndpoints {
   /// transcoder path (`/photo/:/transcode?url=…&width=…`), and replacing the
   /// whole query would silently strip those params and break the request.
   ///
-  /// Any param already *named* like the token (however cased) is dropped first:
-  /// the live session's token is the only credential allowed into a minted URL,
-  /// so a stored path can never smuggle one in (or pin a stale one) past the
-  /// "mint on demand, never persist" rule.
+  /// The existing pairs are spliced through **raw** (from `Uri.query`), never
+  /// decoded and re-encoded: a transcoder's `url=` value is itself
+  /// percent-encoded, and a decode/re-encode cycle would normalize its bytes
+  /// (e.g. `%20` ↔ `+`), handing the server a query it never wrote. Splitting
+  /// on `&` is sound on the raw form — an encoded value's own `&` is still
+  /// `%26` there.
+  ///
+  /// Any pair already *naming* the token (however cased or percent-encoded) is
+  /// dropped first: the live session's token is the only credential allowed
+  /// into a minted URL, so a stored path can never smuggle one in (or pin a
+  /// stale one) past the "mint on demand, never persist" rule.
   static Uri _withToken(Uri url, String token) {
-    final String tokenKey = tokenParam.toLowerCase();
-    return url.replace(queryParameters: <String, String>{
-      for (final MapEntry<String, String> param in url.queryParameters.entries)
-        if (param.key.toLowerCase() != tokenKey) param.key: param.value,
-      tokenParam: token,
-    });
+    final StringBuffer query = StringBuffer();
+    for (final String pair in url.query.split('&')) {
+      if (pair.isEmpty || _namesToken(pair)) continue;
+      if (query.isNotEmpty) query.write('&');
+      query.write(pair);
+    }
+    if (query.isNotEmpty) query.write('&');
+    query.write('$tokenParam=${Uri.encodeQueryComponent(token)}');
+    return url.replace(query: query.toString());
+  }
+
+  /// Whether a raw `key=value` query [pair] names the token parameter, however
+  /// the key is cased or percent-encoded — so a smuggled credential can't dodge
+  /// [_withToken]'s filter by encoding a letter of its name. A key that fails
+  /// to decode (not producible by a parsed [Uri], which normalizes invalid
+  /// escapes) is kept as an ordinary pair: it can't *be* the token name.
+  static bool _namesToken(String pair) {
+    final int equals = pair.indexOf('=');
+    final String rawKey = equals < 0 ? pair : pair.substring(0, equals);
+    try {
+      return Uri.decodeQueryComponent(rawKey).toLowerCase() ==
+          tokenParam.toLowerCase();
+    } on ArgumentError {
+      // decodeQueryComponent rejects an invalid escape with an ArgumentError.
+      return false;
+    } on FormatException {
+      return false;
+    }
   }
 
   /// Replaces every `X-Plex-Token=<value>` in [text] with

--- a/lib/core/sources/plex/plex_track_mapper.dart
+++ b/lib/core/sources/plex/plex_track_mapper.dart
@@ -117,10 +117,21 @@ abstract final class PlexTrackMapper {
   /// round-trips exactly through the catalog's `Uri.toString()` / `Uri.parse`
   /// and back out via [thumbPath]. No token, no server address: both are woven
   /// in only at render time, never persisted.
+  ///
+  /// Literal `%` is escaped *before* the [Uri] constructor encodes the rest,
+  /// because the constructor preserves any valid pre-existing escape triplet:
+  /// fed a transcoder thumb whose `url=` value PMS already percent-encoded
+  /// (`…?url=http%3A%2F%2F…%26b%3D2&width=…`), it would keep the server's
+  /// `%3A`/`%26` as-is while adding its own `%3F` for the `?` — two encoding
+  /// levels collapsed into one, which [thumbPath]'s single decode could not
+  /// tell apart (it would strip the server's level too, promoting the inner
+  /// `&b=2` to a top-level param and corrupting the cover request). With `%`
+  /// pre-escaped, exactly one encoding level ever exists, so the single
+  /// decode restores the reported string byte-for-byte for every input.
   static Uri? _artworkReference(String? thumb) {
     final String? path = _nonBlank(thumb);
     if (path == null) return null;
-    return Uri(scheme: artworkScheme, path: path);
+    return Uri(scheme: artworkScheme, path: path.replaceAll('%', '%25'));
   }
 
   /// Plex reports durations in whole **milliseconds** (unlike Subsonic's

--- a/test/core/sources/plex/plex_artwork_test.dart
+++ b/test/core/sources/plex/plex_artwork_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_artwork.dart';
 import 'package:linthra/core/sources/plex/plex_track_mapper.dart';
 
@@ -10,9 +11,12 @@ const _session = PlexSession(
 );
 
 /// The credential-free reference the mapper persists for a thumb path, built
-/// the same way `PlexTrackMapper` builds `Track.artworkUri`.
-Uri _reference(String thumbPath) =>
-    Uri(scheme: PlexTrackMapper.artworkScheme, path: thumbPath);
+/// the same way `PlexTrackMapper` builds `Track.artworkUri` (literal `%`
+/// pre-escaped so the stored form carries exactly one encoding level).
+Uri _reference(String thumbPath) => Uri(
+      scheme: PlexTrackMapper.artworkScheme,
+      path: thumbPath.replaceAll('%', '%25'),
+    );
 
 void main() {
   group('PlexArtwork.resolve', () {
@@ -73,10 +77,8 @@ void main() {
       // The reference a mapper built for a query-carrying thumb: the encoded
       // `?` must come back out as a real query — with the token merged in,
       // not replacing the transcoder's own params.
-      final Uri reference = Uri(
-        scheme: PlexTrackMapper.artworkScheme,
-        path:
-            '/photo/:/transcode?url=/library/metadata/123/thumb/167&width=200',
+      final Uri reference = _reference(
+        '/photo/:/transcode?url=/library/metadata/123/thumb/167&width=200',
       );
 
       final Uri? resolved = PlexArtwork.resolve(reference, _session);
@@ -85,6 +87,32 @@ void main() {
       expect(resolved!.path, '/photo/:/transcode');
       expect(
           resolved.queryParameters['url'], '/library/metadata/123/thumb/167');
+      expect(resolved.queryParameters['width'], '200');
+      expect(resolved.queryParameters['X-Plex-Token'], _session.token);
+    });
+
+    test(
+        'resolves a transcoder reference whose url value PMS pre-encoded, '
+        'end to end', () {
+      // Built by the real mapper from the wire thumb, persisted, re-parsed,
+      // and resolved — the inner encoding must reach the final URL untouched:
+      // no decode/re-encode may promote the url value's `&b=2` to a top-level
+      // param or truncate the inner URL the transcoder fetches.
+      const String nestedThumb = '/photo/:/transcode'
+          '?url=http%3A%2F%2Fhost%2Fcover%3Fa%3D1%26b%3D2&width=200';
+      const PlexMetadata item =
+          PlexMetadata(ratingKey: '7', title: 't', thumb: nestedThumb);
+      final Uri persisted =
+          Uri.parse(PlexTrackMapper.toTrack(item).artworkUri!.toString());
+
+      final Uri? resolved = PlexArtwork.resolve(persisted, _session);
+
+      expect(resolved, isNotNull);
+      expect(resolved!.path, '/photo/:/transcode');
+      expect(resolved.query,
+          contains('url=http%3A%2F%2Fhost%2Fcover%3Fa%3D1%26b%3D2'));
+      expect(resolved.queryParameters.containsKey('b'), isFalse);
+      expect(resolved.queryParameters['url'], 'http://host/cover?a=1&b=2');
       expect(resolved.queryParameters['width'], '200');
       expect(resolved.queryParameters['X-Plex-Token'], _session.token);
     });

--- a/test/core/sources/plex/plex_endpoints_test.dart
+++ b/test/core/sources/plex/plex_endpoints_test.dart
@@ -175,26 +175,68 @@ void main() {
       expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
     });
 
+    test('splices an encoded transcoder url value through byte-for-byte', () {
+      // A transcoder's `url=` value is itself percent-encoded; weaving the
+      // token in must not decode and re-encode it (the inner `%26` would
+      // become a real `&`, promoting `b=2` to a top-level param and handing
+      // the transcoder a truncated url).
+      final Uri uri = PlexEndpoints.coverArt(
+        _base,
+        thumbPath: '/photo/:/transcode'
+            '?url=http%3A%2F%2Fhost%2Fcover%3Fa%3D1%26b%3D2&width=200',
+        token: _token,
+      );
+      // The raw query still carries the value exactly as the server wrote it.
+      expect(
+          uri.query, contains('url=http%3A%2F%2Fhost%2Fcover%3Fa%3D1%26b%3D2'));
+      expect(uri.queryParameters.containsKey('b'), isFalse);
+      // The server decodes the full inner URL back out, query intact.
+      expect(uri.queryParameters['url'], 'http://host/cover?a=1&b=2');
+      expect(uri.queryParameters['width'], '200');
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+    });
+
+    test('never rewrites the encoding of untouched query pairs', () {
+      // `%20` and `+` both read as a space, but they are different bytes; the
+      // weave must pass pairs through raw, not normalize one to the other.
+      final Uri uri = PlexEndpoints.coverArt(
+        _base,
+        thumbPath: '/photo/:/transcode?url=a%20b&width=200',
+        token: _token,
+      );
+      expect(uri.query, contains('url=a%20b'));
+      expect(uri.query, isNot(contains('url=a+b')));
+    });
+
     test('a token-named param smuggled in the path is replaced, never kept',
         () {
       // The live session's token is the only credential allowed into a minted
-      // URL: a stored path carrying its own X-Plex-Token (however cased) must
-      // not survive — neither pinning a stale token nor doubling the param.
-      final Uri uri = PlexEndpoints.coverArt(
-        _base,
-        thumbPath: '/photo/:/transcode?x-plex-token=stale-leaked&width=200',
-        token: _token,
-      );
-      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
-      expect(uri.toString(), isNot(contains('stale-leaked')));
-      expect(uri.queryParameters['width'], '200');
-      // Exactly one token param remains.
-      expect(
-        RegExp('x-plex-token', caseSensitive: false)
-            .allMatches(uri.toString())
-            .length,
-        1,
-      );
+      // URL: a stored path carrying its own X-Plex-Token (however cased or
+      // with its name percent-encoded) must not survive — neither pinning a
+      // stale token nor doubling the param.
+      for (final String smuggled in <String>[
+        '/photo/:/transcode?x-plex-token=stale-leaked&width=200',
+        '/photo/:/transcode?X%2DPlex%2DToken=stale-leaked&width=200',
+      ]) {
+        final Uri uri = PlexEndpoints.coverArt(
+          _base,
+          thumbPath: smuggled,
+          token: _token,
+        );
+        expect(uri.queryParameters[PlexEndpoints.tokenParam], _token,
+            reason: '$smuggled must carry the live token');
+        expect(uri.toString(), isNot(contains('stale-leaked')),
+            reason: '$smuggled must not keep the smuggled value');
+        expect(uri.queryParameters['width'], '200');
+        // Exactly one token param remains.
+        expect(
+          RegExp('x-plex-token', caseSensitive: false)
+              .allMatches(Uri.decodeFull(uri.toString()))
+              .length,
+          1,
+          reason: '$smuggled must yield exactly one token param',
+        );
+      }
     });
   });
 

--- a/test/core/sources/plex/plex_track_mapper_test.dart
+++ b/test/core/sources/plex/plex_track_mapper_test.dart
@@ -212,6 +212,22 @@ void main() {
       expect(PlexTrackMapper.thumbPath(reparsed), transcodeThumb);
     });
 
+    test('round-trips a transcoder thumb whose url value PMS pre-encoded', () {
+      // The trap: the Uri constructor *preserves* valid escape triplets, so a
+      // thumb whose `url=` value is itself percent-encoded would store with
+      // the server's `%3A`/`%26` and the builder's `%3F` collapsed into one
+      // encoding level — and a single decode would strip the server's level
+      // too, promoting the inner `&b=2` to a top-level param. The builder
+      // pre-escapes `%` so the decode restores the exact reported bytes.
+      const String nestedThumb = '/photo/:/transcode'
+          '?url=http%3A%2F%2Fhost%2Fcover%3Fa%3D1%26b%3D2&width=200';
+      const item = PlexMetadata(ratingKey: '1', title: 't', thumb: nestedThumb);
+      final Uri reference = PlexTrackMapper.toTrack(item).artworkUri!;
+
+      final Uri reparsed = Uri.parse(reference.toString());
+      expect(PlexTrackMapper.thumbPath(reparsed), nestedThumb);
+    });
+
     test('thumbPath leaves other providers\' artwork untouched', () {
       expect(
         PlexTrackMapper.thumbPath(Uri.parse('https://x.example/cover.jpg')),


### PR DESCRIPTION
# Plex PR 9 follow-up — byte-exact `plex-thumb:` round trip

Follow-up to #188 (merged), fixing a correctness issue [flagged in review](https://github.com/TheZupZup/Linthra/pull/188#discussion_r3400969199) minutes *after* the merge — the fix commit was pushed to the PR branch but didn't make the squash. Same scope, same rules as #188: Plex phase 1 polish only (#178, docs/plex.md step 9), no version bump, no changes to Jellyfin/Subsonic/Local.

## The bug (review finding — confirmed by probe before fixing)

A transcoder thumb whose `url=` value PMS itself percent-encodes, e.g.

```
/photo/:/transcode?url=http%3A%2F%2Fhost%2Fcover%3Fa%3D1%26b%3D2&width=200
```

was corrupted by the reference round trip. Dart's `Uri` path constructor **preserves valid pre-existing escape triplets** (it does not escape their `%`), so the stored `plex-thumb:` reference collapsed the server's encoding level (`%3A`/`%26` inside the `url` value) and the builder's own (`%3F` for the `?`) into one — and `thumbPath()`'s single decode then stripped both: the inner `&b=2` was promoted to a top-level query param and the transcoder received a truncated `url`, breaking those covers.

## The fix

- **`PlexTrackMapper._artworkReference` pre-escapes literal `%`** (`%` → `%25`) before the constructor encodes the rest, so the stored reference always carries exactly **one** encoding level — the single decode in `thumbPath()` then restores the reported thumb **byte-for-byte for every input** (including invalid-escape oddities like `100%zz`, which previously relied on parse normalization). Plain `/library/metadata/…/thumb/…` paths contain no `%`, so the common-case stored format is **byte-identical to before** — no migration; a rare pre-fix `%`-carrying row self-heals on the next catalog sync (the sync replaces the Plex slice).
- **`PlexEndpoints._withToken` now splices existing query pairs through raw** (from `Uri.query`) instead of decoding and re-encoding via `queryParameters`, so untouched pairs keep their exact bytes (no `%20` ↔ `+` normalization, no nested-value rewriting). Splitting on `&` is sound on the raw form — an encoded value's own `&` is still `%26` there.
- **Token-smuggle filter unchanged in strength, stronger in coverage**: pair *names* are still decoded for the check, so a percent-encoded `X%2DPlex%2DToken=` key can't dodge the "live session's token is the only credential in a minted URL" rule (new test).

## Tests (+4, all pinning the review's exact example)

- Mapper: nested-encoded transcoder thumb round-trips through the catalog persistence shape exactly.
- Endpoints: the encoded `url=` value is spliced through byte-for-byte (`b` never becomes a top-level param; the server-side decode yields the full inner URL); untouched pair encoding is never rewritten (`%20` stays `%20`); an encoded-name smuggled token is stripped, exactly one token param remains.
- Artwork: the mapper-built nested reference resolves end to end with the inner encoding intact.

Full suite: **1928 tests, all passing** · `flutter analyze` clean · `dart format` clean · `./scripts/check_secrets.sh` clean.

#178 stays open as the tracking issue.

https://claude.ai/code/session_011Gzza1XKG87sm76sVpuj4A

---
_Generated by [Claude Code](https://claude.ai/code/session_011Gzza1XKG87sm76sVpuj4A)_