### PR TITLE
feat(plex): playback reporting — Linthra appears in Plex Now Playing

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -182,6 +182,71 @@ The `MusicSource` contract is small (`id`, `displayName`,
 Cast is a natural later add (the stream URL is network-reachable) but stays off
 in phase 1 to keep the credential-in-URL surface small.
 
+## Playback reporting / Now Playing (shipped after phase 1)
+
+Phase 1 above is read-only. The one deliberate exception added since:
+**timeline reporting**, so a Plex Media Server shows Linthra as an active
+player in its Now Playing dashboard while a `plex:` track plays. It is a
+benign, ephemeral write (PMS updates its session list; nothing in the library
+is modified) and is **best-effort by contract** — a failed report is silently
+dropped and can never stall, stop, or alter playback.
+
+### How Plex sees a player
+
+A client reports its playback to `GET /:/timeline` (verified against
+python-plexapi's `updateTimeline` and the community API docs):
+
+| Param | Value |
+| --- | --- |
+| `ratingKey` | the playing item's id (from the opaque `plex:<ratingKey>` uri) |
+| `key` | `/library/metadata/{ratingKey}` |
+| `identifier` | `com.plexapp.plugins.library` (fixed protocol constant) |
+| `state` | `playing` / `paused` / `stopped` (`buffering` exists; unused) |
+| `time` | playback position, **milliseconds** |
+| `duration` | item length, **milliseconds** — omitted when unknown |
+
+The token rides in the `X-Plex-Token` **header** (like every API call), so a
+timeline URL is token-free and safe to log. The `X-Plex-*` identity headers
+name the player: `X-Plex-Product` / `X-Plex-Device` / `X-Plex-Device-Name`
+are `Linthra`, and `X-Plex-Client-Identifier` is the stable per-install id
+persisted with the session — PMS keys the session on it, so pause/resume
+update one player entry instead of spawning new ones. `state=stopped` clears
+the entry.
+
+### Architecture (provider-neutral seam)
+
+- **`ServerPlaybackReporter`** (`core/services/server_playback_reporter.dart`)
+  — the neutral contract: `onPlaybackStarted/Progress/Paused/Resumed/Stopped`
+  + `onTrackChanged`, with a `NoOpServerPlaybackReporter` for providers
+  without reporting.
+- **`RoutingServerPlaybackReporter`** — selects the reporter whose `handles`
+  claims the track's uri; `plex:` routes to Plex, everything else reports
+  nowhere, so local/Jellyfin/Subsonic playback can never trigger a Plex call.
+  `onTrackChanged` is forwarded to the owners of *both* sides, so a Plex
+  session closes even when the next track belongs to another provider.
+- **`PlaybackReportingService`** (`core/services/playback_reporting_service.dart`)
+  — listens to the unified `PlaybackState` stream and derives the lifecycle:
+  first play → started, pause/resume → immediate, idle/completed/error →
+  stopped, queue move → track change. Progress is **throttled** (one report
+  per 10s of steady play) so position ticks never spam the server; reports
+  dispatch strictly in order, off the playback path, with every failure
+  swallowed. `loading`/`buffering` are not transitions (no pause/resume flap
+  on a re-buffer; a track that never starts is never reported).
+- **`PlexPlaybackReporter`** (`core/sources/plex/plex_playback_reporter.dart`)
+  — every Plex-specific detail (state mapping, ratingKey extraction, ms
+  units) stays here, behind the neutral interface. It reads the live session
+  and client lazily — signed out means silent no-op — exactly like the
+  playable-uri resolver.
+
+### Token safety (same non-negotiables)
+
+The timeline path adds **no** new token surface: the token goes only to the
+`PlexClient` (header), never into the URL, a log, an error, or diagnostics;
+the reporter never throws, so no failure can carry anything out; timeline
+URLs are minted per report and discarded — nothing about reporting is ever
+persisted. Tests prove the URL builder is token-free, the HTTP errors are
+token-free, and the reporter swallows every failure kind.
+
 ## Risks vs Jellyfin and Navidrome
 
 - **XML-first API.** PMS defaults to XML; we rely on `Accept: application/json`,

--- a/lib/core/services/playback_reporting_service.dart
+++ b/lib/core/services/playback_reporting_service.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import 'server_playback_reporter.dart';
+
+/// What the service last told reporters about the current track, so raw state
+/// emissions (several a second while playing) collapse into the few lifecycle
+/// transitions a server cares about.
+enum _ReportedPhase {
+  /// Nothing reported yet for this track (it may still be loading).
+  none,
+
+  /// Last report said the track is playing.
+  playing,
+
+  /// Last report said the track is paused.
+  paused,
+
+  /// Last report said playback stopped; a later play reports a fresh start.
+  stopped,
+}
+
+/// Watches live playback and reports its lifecycle to the
+/// [ServerPlaybackReporter] — the bridge that makes the user's own media
+/// server (Plex today) show Linthra as an active player.
+///
+/// It listens to the unified [PlaybackState] stream and derives the few events
+/// a server can use from the raw emissions:
+///  - the first `playing` for a track → [ServerPlaybackReporter.onPlaybackStarted];
+///  - `playing` → `paused` → [ServerPlaybackReporter.onPlaybackPaused];
+///  - `paused` → `playing` → [ServerPlaybackReporter.onPlaybackResumed];
+///  - steady playing → throttled [ServerPlaybackReporter.onPlaybackProgress]
+///    (at most one per [progressInterval], so position ticks — up to several a
+///    second — can never spam the server);
+///  - idle / completed / error → [ServerPlaybackReporter.onPlaybackStopped];
+///  - a queue move → [ServerPlaybackReporter.onTrackChanged] (so the outgoing
+///    track's session is closed even when the next track belongs to another
+///    provider — or fails to load).
+///
+/// `loading` and `buffering` are deliberately *not* transitions: a mid-stream
+/// re-buffer keeps the session "playing" rather than flapping pause/resume,
+/// and a track that never gets past loading is never reported as started.
+///
+/// What it deliberately does NOT do:
+///  - **Never blocks or breaks playback.** Events are dispatched off the
+///    playback path, strictly one at a time (so a slow report can't reorder a
+///    pause behind a later progress), and every failure is swallowed —
+///    reporting is best-effort by contract.
+///  - **No provider knowledge, no secrets.** It hands reporters only the
+///    catalog [Track] and positions; which server (if any) is told — and how
+///    credentials are woven in — is entirely the reporter's business.
+class PlaybackReportingService {
+  PlaybackReportingService({
+    required Stream<PlaybackState> playbackStates,
+    required ServerPlaybackReporter reporter,
+    this.progressInterval = const Duration(seconds: 10),
+    DateTime Function() now = DateTime.now,
+  })  : _reporter = reporter,
+        _now = now {
+    _subscription = playbackStates.listen(_onState);
+  }
+
+  final ServerPlaybackReporter _reporter;
+
+  /// Minimum spacing between two progress reports for one steadily playing
+  /// track. State *changes* (start/pause/resume/stop) always report
+  /// immediately; only the periodic progress heartbeat is throttled.
+  final Duration progressInterval;
+
+  final DateTime Function() _now;
+  late final StreamSubscription<PlaybackState> _subscription;
+
+  Track? _track;
+  _ReportedPhase _phase = _ReportedPhase.none;
+  DateTime? _lastProgressAt;
+
+  /// The last real position/duration observed for [_track]. Kept because a
+  /// stop or error emits a *fresh* state whose position is zero — reporting
+  /// that would tell the server the user stopped at 0:00 regardless of where
+  /// they actually were.
+  Duration _lastPosition = Duration.zero;
+  Duration _lastDuration = Duration.zero;
+
+  /// Pending reporter calls, dispatched strictly in order, one at a time.
+  final List<Future<void> Function()> _pending = <Future<void> Function()>[];
+  bool _draining = false;
+
+  void _onState(PlaybackState state) {
+    final Track? track = state.currentTrack;
+    final Track? previous = _track;
+
+    if (track?.id != previous?.id) {
+      // The queue moved (skip, natural advance, or cleared to nothing). Tell
+      // reporters even when the new track never starts, so the outgoing
+      // track's session is always closed.
+      if (previous != null && _isActive) {
+        final Track? next = track;
+        _enqueue(() => _reporter.onTrackChanged(previous, next));
+      }
+      _track = track;
+      _phase = _ReportedPhase.none;
+      _lastPosition = Duration.zero;
+      _lastDuration = Duration.zero;
+    }
+
+    final Track? current = _track;
+    if (current == null) return;
+
+    // Prefer the engine's live values; fall back to the catalog's duration
+    // (and the last observed position for the zeroed stop/error states).
+    final Duration duration =
+        state.duration > Duration.zero ? state.duration : current.duration;
+    if (state.position > Duration.zero) _lastPosition = state.position;
+    if (duration > Duration.zero) _lastDuration = duration;
+
+    switch (state.status) {
+      case PlaybackStatus.playing:
+        final Duration position = state.position;
+        switch (_phase) {
+          case _ReportedPhase.none:
+          case _ReportedPhase.stopped:
+            _phase = _ReportedPhase.playing;
+            _lastProgressAt = _now();
+            _enqueue(
+                () => _reporter.onPlaybackStarted(current, position, duration));
+          case _ReportedPhase.paused:
+            _phase = _ReportedPhase.playing;
+            _lastProgressAt = _now();
+            _enqueue(
+                () => _reporter.onPlaybackResumed(current, position, duration));
+          case _ReportedPhase.playing:
+            final DateTime now = _now();
+            final DateTime? last = _lastProgressAt;
+            if (last == null || now.difference(last) >= progressInterval) {
+              _lastProgressAt = now;
+              _enqueue(() =>
+                  _reporter.onPlaybackProgress(current, position, duration));
+            }
+        }
+      case PlaybackStatus.paused:
+        if (_phase == _ReportedPhase.playing) {
+          final Duration position = state.position;
+          _phase = _ReportedPhase.paused;
+          _enqueue(
+              () => _reporter.onPlaybackPaused(current, position, duration));
+        }
+      case PlaybackStatus.idle:
+      case PlaybackStatus.completed:
+      case PlaybackStatus.error:
+        if (_isActive) {
+          // stop() and an error emit a fresh, zero-position state; report the
+          // last position actually observed so the server settles honestly.
+          final Duration position = _lastPosition;
+          final Duration lastDuration = _lastDuration;
+          _phase = _ReportedPhase.stopped;
+          _enqueue(() =>
+              _reporter.onPlaybackStopped(current, position, lastDuration));
+        }
+      case PlaybackStatus.loading:
+      case PlaybackStatus.buffering:
+        // Indeterminate: keep the last reported phase. A re-buffer stays
+        // "playing"; a fresh load reports nothing until it actually plays.
+        break;
+    }
+  }
+
+  /// Whether the server currently believes this track has an open session.
+  bool get _isActive =>
+      _phase == _ReportedPhase.playing || _phase == _ReportedPhase.paused;
+
+  void _enqueue(Future<void> Function() report) {
+    _pending.add(report);
+    unawaited(_drain());
+  }
+
+  /// Dispatches pending reports strictly in order, one at a time, so a slow
+  /// network call can never deliver a pause after a later progress. Failures
+  /// are swallowed: reporting must never disturb playback or later reports.
+  Future<void> _drain() async {
+    if (_draining) return;
+    _draining = true;
+    try {
+      while (_pending.isNotEmpty) {
+        final Future<void> Function() report = _pending.removeAt(0);
+        try {
+          await report();
+        } catch (_) {
+          // Best-effort by contract; the next report still goes out.
+        }
+      }
+    } finally {
+      _draining = false;
+    }
+  }
+
+  /// Stops listening. If a session was open, a final best-effort stop is
+  /// reported so the server doesn't keep showing a phantom player.
+  Future<void> dispose() async {
+    await _subscription.cancel();
+    final Track? track = _track;
+    if (track != null && _isActive) {
+      final Duration position = _lastPosition;
+      final Duration duration = _lastDuration;
+      _phase = _ReportedPhase.stopped;
+      _enqueue(() => _reporter.onPlaybackStopped(track, position, duration));
+    }
+  }
+}

--- a/lib/core/services/routing_server_playback_reporter.dart
+++ b/lib/core/services/routing_server_playback_reporter.dart
@@ -1,0 +1,89 @@
+import '../models/track.dart';
+import 'server_playback_reporter.dart';
+
+/// Routes each playback report to the first reporter that [handles] the
+/// track's uri — the reporting counterpart of `RoutingPlayableUriResolver`.
+///
+/// A track no reporter handles is silently dropped: not reporting *is* the
+/// correct behaviour for providers without reporting support (local files,
+/// Jellyfin, Subsonic today), so non-Plex playback can never trigger a Plex
+/// report — the only reporter that sees a track is the one that claimed it.
+///
+/// [onTrackChanged] is the one event that can span two providers (a Plex track
+/// followed by a Jellyfin one): it is forwarded to the reporter owning each
+/// side — once when both sides route to the same reporter — so the outgoing
+/// provider can close its session no matter what plays next.
+class RoutingServerPlaybackReporter implements ServerPlaybackReporter {
+  const RoutingServerPlaybackReporter(this._reporters);
+
+  /// Candidate reporters, most specific first.
+  final List<ServerPlaybackReporter> _reporters;
+
+  @override
+  bool handles(Track track) => true;
+
+  ServerPlaybackReporter? _reporterFor(Track? track) {
+    if (track == null) return null;
+    for (final ServerPlaybackReporter reporter in _reporters) {
+      if (reporter.handles(track)) return reporter;
+    }
+    return null;
+  }
+
+  @override
+  Future<void> onPlaybackStarted(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    await _reporterFor(track)?.onPlaybackStarted(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackProgress(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    await _reporterFor(track)?.onPlaybackProgress(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackPaused(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    await _reporterFor(track)?.onPlaybackPaused(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackResumed(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    await _reporterFor(track)?.onPlaybackResumed(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackStopped(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    await _reporterFor(track)?.onPlaybackStopped(track, position, duration);
+  }
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {
+    final ServerPlaybackReporter? previous = _reporterFor(previousTrack);
+    final ServerPlaybackReporter? next = _reporterFor(nextTrack);
+    if (previous != null) {
+      await previous.onTrackChanged(previousTrack, nextTrack);
+    }
+    if (next != null && !identical(next, previous)) {
+      await next.onTrackChanged(previousTrack, nextTrack);
+    }
+  }
+}

--- a/lib/core/services/server_playback_reporter.dart
+++ b/lib/core/services/server_playback_reporter.dart
@@ -1,0 +1,88 @@
+import '../models/track.dart';
+
+/// Reports playback lifecycle events for a [Track] back to the server that
+/// owns it, so the user's own media server can show the app as an active
+/// player (e.g. Plex's Now Playing dashboard) and keep its play state in sync.
+///
+/// This is the provider-neutral seam: the playback layer emits the events and
+/// never knows *how* (or whether) a provider reports them — a routing
+/// implementation selects the reporter that [handles] the track, and providers
+/// without reporting support fall through to [NoOpServerPlaybackReporter].
+///
+/// Contract for implementations:
+///  - **Best-effort, never fatal.** Reporting must never throw out of these
+///    methods and must never stall, stop, or alter playback. A failed report is
+///    silently dropped (at most a secret-free debug breadcrumb).
+///  - **Secret-free.** No credential — token, password, authenticated URL —
+///    may reach a log, an error, or any other output on any reporting path.
+///  - **Stateless inputs.** Events carry only the catalog [Track] (opaque,
+///    credential-free uri) plus the playback [position] and [duration]; an
+///    implementation minting a server call weaves credentials in on demand and
+///    discards them, exactly like stream-URL resolution.
+abstract interface class ServerPlaybackReporter {
+  /// Whether this reporter knows how to report playback of [track] (decided
+  /// from its opaque uri scheme, like `PlayableUriResolver.handles`).
+  bool handles(Track track);
+
+  /// A track started playing (a fresh start — not a resume after pause).
+  Future<void> onPlaybackStarted(
+      Track track, Duration position, Duration duration);
+
+  /// Periodic progress while playing. Callers throttle this to a calm cadence;
+  /// implementations may assume it is *not* called for every position tick.
+  Future<void> onPlaybackProgress(
+      Track track, Duration position, Duration duration);
+
+  /// Playback was paused at [position].
+  Future<void> onPlaybackPaused(
+      Track track, Duration position, Duration duration);
+
+  /// Playback resumed from a pause at [position].
+  Future<void> onPlaybackResumed(
+      Track track, Duration position, Duration duration);
+
+  /// Playback stopped (user stop, queue ran out, or a playback error ended
+  /// it). The server should clear/settle its active session for [track].
+  Future<void> onPlaybackStopped(
+      Track track, Duration position, Duration duration);
+
+  /// The queue moved from [previousTrack] to [nextTrack] (either may be null
+  /// at the edges of a queue). Reporters owning [previousTrack] should close
+  /// its session; [nextTrack]'s own start is reported separately via
+  /// [onPlaybackStarted] once it is actually playing.
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack);
+}
+
+/// The reporter for providers without server-side playback reporting (local
+/// files today, and any remote provider until its reporting path lands):
+/// accepts every track and reports nothing, so the playback layer never has to
+/// special-case "this source doesn't report".
+class NoOpServerPlaybackReporter implements ServerPlaybackReporter {
+  const NoOpServerPlaybackReporter();
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<void> onPlaybackStarted(
+      Track track, Duration position, Duration duration) async {}
+
+  @override
+  Future<void> onPlaybackProgress(
+      Track track, Duration position, Duration duration) async {}
+
+  @override
+  Future<void> onPlaybackPaused(
+      Track track, Duration position, Duration duration) async {}
+
+  @override
+  Future<void> onPlaybackResumed(
+      Track track, Duration position, Duration duration) async {}
+
+  @override
+  Future<void> onPlaybackStopped(
+      Track track, Duration position, Duration duration) async {}
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {}
+}

--- a/lib/core/sources/plex/http_plex_client.dart
+++ b/lib/core/sources/plex/http_plex_client.dart
@@ -123,6 +123,32 @@ class HttpPlexClient implements PlexClient {
     return container.metadata.first;
   }
 
+  @override
+  Future<void> reportTimeline({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+    required PlexTimelineState state,
+    required Duration time,
+    Duration? duration,
+  }) async {
+    final Uri uri = PlexEndpoints.timeline(
+      baseUrl,
+      ratingKey: ratingKey,
+      state: state,
+      timeMs: time.inMilliseconds,
+      durationMs: duration?.inMilliseconds,
+    );
+    // Same transport + status mapping as every API call (token in the header,
+    // never the URL), but the body is deliberately not parsed: PMS answers a
+    // timeline report with a small (often empty, sometimes XML) body that
+    // carries nothing Linthra needs — a 2xx alone means the report landed.
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _headers(token)),
+    );
+    _checkStatus(response);
+  }
+
   /// GETs [uri] with the auth + identity headers, checks the status, and decodes
   /// a JSON `MediaContainer` envelope — throwing [PlexException.notPlex] when the
   /// body isn't a Plex `MediaContainer` (missing envelope, or non-JSON/XML).

--- a/lib/core/sources/plex/plex_api.dart
+++ b/lib/core/sources/plex/plex_api.dart
@@ -55,6 +55,27 @@ enum PlexMetadataType {
   }
 }
 
+/// The playback state a client reports to PMS on the `/:/timeline` endpoint.
+///
+/// Mirrors [PlexMetadataType]: a request-side wire value named once, so the
+/// endpoint builder, client, and reporter agree on the exact strings PMS
+/// expects. PMS keys its Now Playing sessions off these reports: `playing` /
+/// `paused` show (and update) the session, `stopped` clears it, and
+/// `buffering` is accepted for an engine stall. (PMS also accepts `error`,
+/// which Linthra deliberately never sends — a playback failure ends the
+/// session, so it reports `stopped`.)
+enum PlexTimelineState {
+  playing('playing'),
+  paused('paused'),
+  stopped('stopped'),
+  buffering('buffering');
+
+  const PlexTimelineState(this.value);
+
+  /// The literal `state` query value PMS expects.
+  final String value;
+}
+
 /// Server identity from `GET /identity` — enough to confirm the address is a
 /// Plex Media Server and to record its version for display and diagnostics.
 ///

--- a/lib/core/sources/plex/plex_client.dart
+++ b/lib/core/sources/plex/plex_client.dart
@@ -26,6 +26,13 @@ class PlexClientIdentity {
   static const String platformHeader = 'X-Plex-Platform';
   static const String deviceHeader = 'X-Plex-Device';
 
+  /// The friendly player name a PMS displays for this client — most visibly
+  /// as the player title in the Now Playing dashboard once Linthra reports a
+  /// playback timeline. Sent with the same value as [device] (Linthra has no
+  /// separate per-device nickname), so the dashboard names the player
+  /// "Linthra" instead of an unknown/blank device.
+  static const String deviceNameHeader = 'X-Plex-Device-Name';
+
   /// A stable per-install UUID identifying this client to the server. Not a
   /// secret; it never grants access on its own.
   final String clientIdentifier;
@@ -42,7 +49,7 @@ class PlexClientIdentity {
   /// A human-readable device name/model.
   final String device;
 
-  /// The five `X-Plex-*` identity headers as a map, ready to merge with the
+  /// The `X-Plex-*` identity headers as a map, ready to merge with the
   /// `Accept` and `X-Plex-Token` headers the client adds per request. Carries no
   /// token, so the result is safe to log.
   Map<String, String> toHeaders() => <String, String>{
@@ -51,6 +58,7 @@ class PlexClientIdentity {
         versionHeader: version,
         platformHeader: platform,
         deviceHeader: device,
+        deviceNameHeader: device,
       };
 }
 
@@ -116,5 +124,23 @@ abstract interface class PlexClient {
     required String baseUrl,
     required String token,
     required String ratingKey,
+  });
+
+  /// Reports playback of one item to `GET /:/timeline`, which is what makes
+  /// this client appear in — and update or leave — the server's Now Playing
+  /// dashboard. [time] is the playback position; [duration] the item length
+  /// (omitted when unknown); both are sent in milliseconds.
+  ///
+  /// The response body is ignored: a 2xx means the report landed. Failures
+  /// throw the usual token-free [PlexException]; the *caller* (the playback
+  /// reporter) treats every failure as best-effort and swallows it, so a
+  /// reporting hiccup can never disturb playback.
+  Future<void> reportTimeline({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+    required PlexTimelineState state,
+    required Duration time,
+    Duration? duration,
   });
 }

--- a/lib/core/sources/plex/plex_endpoints.dart
+++ b/lib/core/sources/plex/plex_endpoints.dart
@@ -29,6 +29,7 @@ abstract final class PlexEndpoints {
   static const String _identityPath = '/identity';
   static const String _sectionsPath = '/library/sections';
   static const String _metadataPath = '/library/metadata';
+  static const String _timelinePath = '/:/timeline';
 
   // --- Query-parameter keys, named once so a typo can't split a request. ---
 
@@ -45,6 +46,30 @@ abstract final class PlexEndpoints {
 
   /// Pagination: the maximum number of items to return in one page.
   static const String containerSizeParam = 'X-Plex-Container-Size';
+
+  // --- Timeline (playback reporting) query keys; see [timeline]. ---
+
+  /// The reported item's stable per-server id.
+  static const String ratingKeyParam = 'ratingKey';
+
+  /// The reported item's metadata path (`/library/metadata/{ratingKey}`).
+  static const String keyParam = 'key';
+
+  /// The playback state being reported (a [PlexTimelineState] value).
+  static const String stateParam = 'state';
+
+  /// The playback position, in **milliseconds**.
+  static const String timeParam = 'time';
+
+  /// The item duration, in **milliseconds**.
+  static const String durationParam = 'duration';
+
+  /// The metadata-provider identifier PMS expects on a timeline report. Every
+  /// library item PMS serves belongs to this built-in provider, so the value
+  /// is a fixed protocol constant (the same one the official clients and
+  /// python-plexapi send), not anything per-user or secret.
+  static const String identifierParam = 'identifier';
+  static const String libraryIdentifier = 'com.plexapp.plugins.library';
 
   /// `GET /identity` — server identity / reachability (`machineIdentifier`,
   /// version). Token-free path; the client adds the `X-Plex-Token` header.
@@ -85,6 +110,37 @@ abstract final class PlexEndpoints {
   /// Token-free path; the client adds the `X-Plex-Token` header.
   static Uri metadata(String baseUrl, {required String ratingKey}) =>
       _join(baseUrl, '$_metadataPath/$ratingKey');
+
+  /// `GET /:/timeline?ratingKey=…&key=…&state=…&time=…` — reports playback of
+  /// one item back to PMS, which is what makes the client appear in (and
+  /// update / leave) the server's Now Playing dashboard.
+  ///
+  /// [timeMs] is the playback position and [durationMs] the item length, both
+  /// in **milliseconds** (the unit PMS uses everywhere; omit [durationMs] when
+  /// unknown rather than reporting a fake zero). The `key` is derived from the
+  /// [ratingKey] (`/library/metadata/{ratingKey}`), and `identifier` is the
+  /// fixed library-provider constant — neither is a credential. Like every
+  /// API call (and unlike the stream/art URLs), the token is **not** woven in
+  /// here: it rides in the client's `X-Plex-Token` header, so a timeline URL
+  /// is token-free, safe to log, and never worth persisting.
+  static Uri timeline(
+    String baseUrl, {
+    required String ratingKey,
+    required PlexTimelineState state,
+    required int timeMs,
+    int? durationMs,
+  }) {
+    return _join(baseUrl, _timelinePath).replace(
+      queryParameters: <String, String>{
+        ratingKeyParam: ratingKey,
+        keyParam: '$_metadataPath/$ratingKey',
+        identifierParam: libraryIdentifier,
+        stateParam: state.value,
+        timeParam: '$timeMs',
+        if (durationMs != null) durationParam: '$durationMs',
+      },
+    );
+  }
 
   /// The direct-play stream URL for a track: `{baseUrl}{partKey}?X-Plex-Token=…`.
   ///

--- a/lib/core/sources/plex/plex_playback_reporter.dart
+++ b/lib/core/sources/plex/plex_playback_reporter.dart
@@ -1,0 +1,160 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/plex_session.dart';
+import '../../models/track.dart';
+import '../../services/server_playback_reporter.dart';
+import 'plex_api.dart';
+import 'plex_client.dart';
+import 'plex_exception.dart';
+import 'plex_track_mapper.dart';
+
+/// Reports playback of `plex:<ratingKey>` tracks back to the Plex Media
+/// Server's `/:/timeline` endpoint, so Linthra shows up as an active player in
+/// the server's Now Playing dashboard — playing, paused, progressing, and
+/// cleared again when playback stops or moves on.
+///
+/// Every Plex-specific reporting detail lives here: the lifecycle → timeline
+/// `state` mapping, the `ratingKey` extraction from the opaque track uri, and
+/// the millisecond units PMS expects. The playback layer only ever sees the
+/// provider-neutral [ServerPlaybackReporter].
+///
+/// The session and client are read through getters at event time — exactly
+/// like `PlexPlayableUriResolver` reads its source — so signing in/out (and
+/// the client identity persisted at sign-in, which is what PMS keys the
+/// player session on) is always the live one without rebuilding anything.
+/// With no session every event is a silent no-op.
+///
+/// Best-effort by contract: every failure (typed or not) is swallowed, so a
+/// down server or rejected token can never disturb playback — at most it
+/// leaves a debug breadcrumb carrying only the error *kind* (an enum name).
+/// Token safety follows the established Plex rules: the token is handed to
+/// the [PlexClient] (which sends it as a header) and never reaches a URL this
+/// class sees, a log, or an error; nothing here is persisted.
+class PlexPlaybackReporter implements ServerPlaybackReporter {
+  PlexPlaybackReporter({
+    required PlexSession? Function() session,
+    required PlexClient Function() client,
+  })  : _session = session,
+        _client = client;
+
+  /// Supplies the live signed-in session, or `null` when not connected.
+  final PlexSession? Function() _session;
+
+  /// Supplies the live client (whose identity headers name this install).
+  final PlexClient Function() _client;
+
+  /// The last position/duration actually reported for the current track, so
+  /// [onTrackChanged] can close the outgoing track's session at an honest
+  /// position (that event carries no position of its own).
+  String? _lastReportedUri;
+  Duration _lastReportedPosition = Duration.zero;
+  Duration? _lastReportedDuration;
+
+  @override
+  bool handles(Track track) => track.uri.startsWith(PlexTrackMapper.uriScheme);
+
+  @override
+  Future<void> onPlaybackStarted(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, PlexTimelineState.playing, position, duration);
+
+  @override
+  Future<void> onPlaybackProgress(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, PlexTimelineState.playing, position, duration);
+
+  @override
+  Future<void> onPlaybackPaused(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, PlexTimelineState.paused, position, duration);
+
+  @override
+  Future<void> onPlaybackResumed(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, PlexTimelineState.playing, position, duration);
+
+  @override
+  Future<void> onPlaybackStopped(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, PlexTimelineState.stopped, position, duration);
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {
+    // Only the outgoing track is this reporter's business here: a Plex track
+    // that stops playing must release its Now Playing session whatever plays
+    // next (another Plex track, another provider's, or nothing). The incoming
+    // track announces itself via onPlaybackStarted once it actually plays.
+    if (previousTrack == null || !handles(previousTrack)) return;
+    final bool remembered = previousTrack.uri == _lastReportedUri;
+    await _report(
+      previousTrack,
+      PlexTimelineState.stopped,
+      remembered ? _lastReportedPosition : Duration.zero,
+      remembered ? (_lastReportedDuration ?? Duration.zero) : Duration.zero,
+    );
+  }
+
+  /// Sends one timeline report, best-effort. A non-Plex track, a missing
+  /// session, or a blank ratingKey is a silent no-op; a failed request is
+  /// swallowed (with a kind-only debug breadcrumb) — playback never notices.
+  Future<void> _report(
+    Track track,
+    PlexTimelineState state,
+    Duration position,
+    Duration duration,
+  ) async {
+    if (!handles(track)) return;
+    final PlexSession? session = _session();
+    if (session == null) return;
+    final String ratingKey =
+        track.uri.substring(PlexTrackMapper.uriScheme.length).trim();
+    if (ratingKey.isEmpty) return;
+
+    if (state == PlexTimelineState.stopped) {
+      if (track.uri == _lastReportedUri) _lastReportedUri = null;
+    } else {
+      _lastReportedUri = track.uri;
+      _lastReportedPosition = position;
+      _lastReportedDuration = duration > Duration.zero ? duration : null;
+    }
+
+    try {
+      await _client().reportTimeline(
+        baseUrl: session.baseUrl,
+        token: session.token,
+        ratingKey: ratingKey,
+        state: state,
+        time: position,
+        duration: duration > Duration.zero ? duration : null,
+      );
+    } on PlexException catch (error) {
+      // Best-effort by contract. The breadcrumb carries only the error kind
+      // and the reported state — never the message, a URL, or the token.
+      _log('timeline ${state.value} failed: ${error.kind.name}');
+    } catch (_) {
+      _log('timeline ${state.value} failed: unexpected');
+    }
+  }
+
+  static void _log(String message) {
+    if (!kDebugMode) return;
+    developer.log(message, name: 'linthra.plex');
+  }
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -11,19 +11,24 @@ import '../../core/services/offline_first_playable_uri_resolver.dart';
 import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
+import '../../core/services/playback_reporting_service.dart';
 import '../../core/services/remote_cache/remote_cache_resolver.dart';
 import '../../core/services/remote_cache/remote_playback_cache.dart';
 import '../../core/services/remote_cache/remote_stream_prebufferer.dart';
 import '../../core/services/remote_prebuffer_service.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
+import '../../core/services/routing_server_playback_reporter.dart';
+import '../../core/services/server_playback_reporter.dart';
 import '../../core/services/smart_precache_service.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../core/sources/plex/plex_playable_uri_resolver.dart';
+import '../../core/sources/plex/plex_playback_reporter.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/plex/plex_settings_controller.dart';
+import '../settings/plex/plex_settings_providers.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'cast/cast_providers.dart';
 import 'now_playing.dart';
@@ -201,6 +206,44 @@ final remotePrebufferServiceProvider = Provider<RemotePrebufferService>((ref) {
   final service = RemotePrebufferService(
     playbackStates: ref.read(playbackControllerProvider).stateStream,
     prebufferer: ref.read(remoteStreamPrebuffererProvider),
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// The reporter playback lifecycle events route through: Plex for
+/// `plex:<ratingKey>` tracks, nothing for everyone else (local / Jellyfin /
+/// Subsonic playback is reported to no server, exactly as before).
+///
+/// The Plex reporter reads its session and client through lazy getters — the
+/// same shape the source router above uses — so signing in/out, and the
+/// client identity persisted at sign-in (which PMS keys the player session
+/// on), are picked up live without rebuilding the reporter or the
+/// session-pinned reporting service that holds it.
+final serverPlaybackReporterProvider = Provider<ServerPlaybackReporter>((ref) {
+  return RoutingServerPlaybackReporter(<ServerPlaybackReporter>[
+    PlexPlaybackReporter(
+      session: () => ref.read(plexMusicSourceProvider)?.session,
+      client: () => ref.read(plexClientProvider),
+    ),
+  ]);
+});
+
+/// Playback reporting: mirrors live playback onto the server that owns the
+/// playing track (Plex today), so the user's own dashboard shows Linthra as an
+/// active player — started/paused/resumed/stopped immediately, progress on a
+/// throttled heartbeat.
+///
+/// Pinned for the session like smart pre-cache and remote prebuffer: it reads
+/// the controller's state stream and the reporter once with [Ref.read], does
+/// its work as a side effect of listening (best-effort, off the playback
+/// path, failures swallowed), and `main` instantiates it once after startup;
+/// nothing in the UI reads its value.
+final playbackReportingServiceProvider =
+    Provider<PlaybackReportingService>((ref) {
+  final service = PlaybackReportingService(
+    playbackStates: ref.read(playbackControllerProvider).stateStream,
+    reporter: ref.read(serverPlaybackReporterProvider),
   );
   ref.onDispose(service.dispose);
   return service;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -146,6 +146,12 @@ Future<void> main() async {
   // pre-cache.
   container.read(remotePrebufferServiceProvider);
 
+  // Start playback reporting: mirrors live playback onto the server that owns
+  // the playing track (Plex today), so the user's own dashboard shows Linthra
+  // as an active player. Best-effort and off the playback path; non-Plex
+  // playback reports nothing. Side-effect-only, like the services above.
+  container.read(playbackReportingServiceProvider);
+
   // Mirror the user's "Normalize volume" choice onto the local audio engine,
   // seeding the persisted value now and pushing every later toggle. The engine
   // applies the clip-safe ReplayGain attenuation; with the choice off (the

--- a/test/core/services/playback_reporting_service_test.dart
+++ b/test/core/services/playback_reporting_service_test.dart
@@ -1,0 +1,489 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_reporting_service.dart';
+import 'package:linthra/core/services/server_playback_reporter.dart';
+
+/// Records every reporter call as a compact `event:track@pos/dur` line, so a
+/// test can assert the exact lifecycle sequence a playback scenario produced.
+class _RecordingReporter implements ServerPlaybackReporter {
+  final List<String> events = <String>[];
+
+  String _line(
+          String event, Track track, Duration position, Duration duration) =>
+      '$event:${track.id}@${position.inMilliseconds}/${duration.inMilliseconds}';
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<void> onPlaybackStarted(
+      Track track, Duration position, Duration duration) async {
+    events.add(_line('started', track, position, duration));
+  }
+
+  @override
+  Future<void> onPlaybackProgress(
+      Track track, Duration position, Duration duration) async {
+    events.add(_line('progress', track, position, duration));
+  }
+
+  @override
+  Future<void> onPlaybackPaused(
+      Track track, Duration position, Duration duration) async {
+    events.add(_line('paused', track, position, duration));
+  }
+
+  @override
+  Future<void> onPlaybackResumed(
+      Track track, Duration position, Duration duration) async {
+    events.add(_line('resumed', track, position, duration));
+  }
+
+  @override
+  Future<void> onPlaybackStopped(
+      Track track, Duration position, Duration duration) async {
+    events.add(_line('stopped', track, position, duration));
+  }
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {
+    events.add('changed:${previousTrack?.id}->${nextTrack?.id}');
+  }
+}
+
+/// A reporter that throws from every call (after recording it), proving a
+/// failing reporter can never break the service or later events.
+class _ThrowingReporter extends _RecordingReporter {
+  @override
+  Future<void> onPlaybackStarted(
+      Track track, Duration position, Duration duration) async {
+    await super.onPlaybackStarted(track, position, duration);
+    throw StateError('report failed');
+  }
+
+  @override
+  Future<void> onPlaybackPaused(
+      Track track, Duration position, Duration duration) async {
+    await super.onPlaybackPaused(track, position, duration);
+    throw StateError('report failed');
+  }
+}
+
+/// A reporter whose calls block on [gate] until a test opens it, recording
+/// when each call *starts*, so dispatch order under a slow network can be
+/// asserted (a pause must never overtake an in-flight progress).
+class _GatedReporter extends _RecordingReporter {
+  final Completer<void> gate = Completer<void>();
+  final List<String> startedCalls = <String>[];
+
+  @override
+  Future<void> onPlaybackStarted(
+      Track track, Duration position, Duration duration) async {
+    startedCalls.add('started');
+    await gate.future;
+    await super.onPlaybackStarted(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackPaused(
+      Track track, Duration position, Duration duration) async {
+    startedCalls.add('paused');
+    await gate.future;
+    await super.onPlaybackPaused(track, position, duration);
+  }
+}
+
+Track _track(String id, {Duration duration = Duration.zero}) =>
+    Track(id: id, title: id, uri: 'plex:$id', duration: duration);
+
+PlaybackState _state(
+  PlaybackStatus status,
+  Track? track, {
+  Duration position = Duration.zero,
+  Duration duration = Duration.zero,
+}) =>
+    PlaybackState(
+      status: status,
+      currentTrack: track,
+      position: position,
+      duration: duration,
+    );
+
+/// Drains the microtask chain the listener + dispatch queue run on.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group('PlaybackReportingService', () {
+    late StreamController<PlaybackState> states;
+    late _RecordingReporter reporter;
+    late DateTime clock;
+
+    setUp(() {
+      states = StreamController<PlaybackState>.broadcast();
+      reporter = _RecordingReporter();
+      clock = DateTime(2026, 1, 1);
+    });
+
+    PlaybackReportingService build({
+      Duration progressInterval = const Duration(seconds: 10),
+    }) =>
+        PlaybackReportingService(
+          playbackStates: states.stream,
+          reporter: reporter,
+          progressInterval: progressInterval,
+          now: () => clock,
+        );
+
+    test('reports started once when a loading track first plays', () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.loading, a));
+      states.add(_state(PlaybackStatus.playing, a,
+          duration: const Duration(minutes: 3)));
+      await _settle();
+
+      expect(reporter.events, <String>['started:a@0/180000']);
+      await service.dispose();
+    });
+
+    test('a track that never gets past loading reports nothing', () async {
+      final service = build();
+
+      states.add(_state(PlaybackStatus.loading, _track('a')));
+      states.add(_state(PlaybackStatus.error, _track('a')));
+      await _settle();
+
+      expect(reporter.events, isEmpty);
+      await service.dispose();
+    });
+
+    test('throttles progress: position ticks inside the interval are dropped',
+        () async {
+      final service = build();
+      final Track a = _track('a');
+      const Duration d = Duration(minutes: 3);
+
+      // Settle between emissions so each is observed at its own clock time,
+      // the way live position ticks arrive.
+      states.add(_state(PlaybackStatus.playing, a, duration: d));
+      await _settle();
+      // Three ticks within the 10s window: all dropped.
+      for (int seconds = 1; seconds <= 3; seconds++) {
+        clock = clock.add(const Duration(seconds: 1));
+        states.add(_state(PlaybackStatus.playing, a,
+            position: Duration(seconds: seconds), duration: d));
+        await _settle();
+      }
+      // Cross the window: exactly one progress goes out.
+      clock = clock.add(const Duration(seconds: 7));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 10), duration: d));
+      await _settle();
+      // And the very next tick is throttled again.
+      clock = clock.add(const Duration(seconds: 1));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 11), duration: d));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/180000',
+        'progress:a@10000/180000',
+      ]);
+      await service.dispose();
+    });
+
+    test('reports paused and resumed immediately, with positions', () async {
+      final service = build();
+      final Track a = _track('a');
+      const Duration d = Duration(minutes: 3);
+
+      states.add(_state(PlaybackStatus.playing, a, duration: d));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 42), duration: d));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 42), duration: d));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/180000',
+        'paused:a@42000/180000',
+        'resumed:a@42000/180000',
+      ]);
+      await service.dispose();
+    });
+
+    test('repeated paused states report only one pause', () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 5)));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 5)));
+      await _settle();
+
+      expect(reporter.events, <String>['started:a@0/0', 'paused:a@5000/0']);
+      await service.dispose();
+    });
+
+    test('a pause without a prior start reports nothing', () async {
+      final service = build();
+
+      // The suspended-engine (cast handoff) shape: a paused state for a track
+      // that was never reported as playing.
+      states.add(_state(PlaybackStatus.paused, _track('a')));
+      await _settle();
+
+      expect(reporter.events, isEmpty);
+      await service.dispose();
+    });
+
+    test('stop reports stopped at the last observed position, not zero',
+        () async {
+      final service = build();
+      final Track a = _track('a');
+      const Duration d = Duration(minutes: 3);
+
+      states.add(_state(PlaybackStatus.playing, a, duration: d));
+      await _settle();
+      clock = clock.add(const Duration(seconds: 30));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 30), duration: d));
+      // stop() emits a fresh state whose position/duration are zeroed.
+      states.add(_state(PlaybackStatus.idle, a));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/180000',
+        'progress:a@30000/180000',
+        'stopped:a@30000/180000',
+      ]);
+      await service.dispose();
+    });
+
+    test('the queue running out (completed) reports stopped', () async {
+      final service = build();
+      final Track a = _track('a');
+      const Duration d = Duration(minutes: 3);
+
+      states.add(_state(PlaybackStatus.playing, a, duration: d));
+      states.add(_state(PlaybackStatus.completed, a, position: d, duration: d));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/180000',
+        'stopped:a@180000/180000',
+      ]);
+      await service.dispose();
+    });
+
+    test('a playback error reports stopped (the session must not linger)',
+        () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 1)));
+      await _settle();
+      clock = clock.add(const Duration(seconds: 20));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 20)));
+      states.add(_state(PlaybackStatus.error, a));
+      await _settle();
+
+      expect(reporter.events.last, 'stopped:a@20000/0');
+      await service.dispose();
+    });
+
+    test('stopping while paused still reports stopped', () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 9)));
+      states.add(_state(PlaybackStatus.idle, a));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/0',
+        'paused:a@9000/0',
+        'stopped:a@9000/0',
+      ]);
+      await service.dispose();
+    });
+
+    test('playing again after a stop reports a fresh start', () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.idle, a));
+      states.add(_state(PlaybackStatus.playing, a));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/0',
+        'stopped:a@0/0',
+        'started:a@0/0',
+      ]);
+      await service.dispose();
+    });
+
+    test('a track change reports onTrackChanged, then the new start', () async {
+      final service = build();
+      final Track a = _track('a');
+      final Track b = _track('b');
+
+      states.add(_state(PlaybackStatus.playing, a,
+          duration: const Duration(minutes: 3)));
+      // The controller's natural advance: a loading state for the next track.
+      states.add(_state(PlaybackStatus.loading, b));
+      states.add(_state(PlaybackStatus.playing, b,
+          duration: const Duration(minutes: 2)));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/180000',
+        'changed:a->b',
+        'started:b@0/120000',
+      ]);
+      await service.dispose();
+    });
+
+    test('a skip while paused still closes the outgoing track', () async {
+      final service = build();
+      final Track a = _track('a');
+      final Track b = _track('b');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 30)));
+      states.add(_state(PlaybackStatus.loading, b));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:a@0/0',
+        'paused:a@30000/0',
+        'changed:a->b',
+      ]);
+      await service.dispose();
+    });
+
+    test('a track change from one that never started reports nothing for it',
+        () async {
+      final service = build();
+
+      states.add(_state(PlaybackStatus.loading, _track('a')));
+      states.add(_state(PlaybackStatus.loading, _track('b')));
+      states.add(_state(PlaybackStatus.playing, _track('b')));
+      await _settle();
+
+      // No session was ever open for `a`, so there is nothing to close.
+      expect(reporter.events, <String>['started:b@0/0']);
+      await service.dispose();
+    });
+
+    test('buffering mid-play is not a pause/resume flap', () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.buffering, a,
+          position: const Duration(seconds: 5)));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 5)));
+      await _settle();
+
+      expect(reporter.events, <String>['started:a@0/0']);
+      await service.dispose();
+    });
+
+    test('falls back to the catalog duration when the engine reports none',
+        () async {
+      final service = build();
+      final Track a = _track('a', duration: const Duration(minutes: 4));
+
+      states.add(_state(PlaybackStatus.playing, a));
+      await _settle();
+
+      expect(reporter.events, <String>['started:a@0/240000']);
+      await service.dispose();
+    });
+
+    test('a throwing reporter never breaks later events', () async {
+      reporter = _ThrowingReporter();
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 3)));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 3)));
+      await _settle();
+
+      // Every event was still attempted, in order, despite each throw.
+      expect(reporter.events, <String>[
+        'started:a@0/0',
+        'paused:a@3000/0',
+        'resumed:a@3000/0',
+      ]);
+      await service.dispose();
+    });
+
+    test('dispatches strictly in order even when a report is slow', () async {
+      final gated = _GatedReporter();
+      reporter = gated;
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a));
+      states.add(_state(PlaybackStatus.paused, a,
+          position: const Duration(seconds: 2)));
+      await _settle();
+
+      // The slow started call is in flight; the pause must wait behind it.
+      expect(gated.startedCalls, <String>['started']);
+      gated.gate.complete();
+      await _settle();
+
+      expect(gated.startedCalls, <String>['started', 'paused']);
+      expect(reporter.events, <String>['started:a@0/0', 'paused:a@2000/0']);
+      await service.dispose();
+    });
+
+    test('dispose closes an open session with a final stop', () async {
+      final service = build();
+      final Track a = _track('a');
+
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 1)));
+      await _settle();
+      clock = clock.add(const Duration(seconds: 15));
+      states.add(_state(PlaybackStatus.playing, a,
+          position: const Duration(seconds: 15)));
+      await _settle();
+      await service.dispose();
+      await _settle();
+
+      expect(reporter.events.last, 'stopped:a@15000/0');
+    });
+
+    test('dispose with nothing playing reports nothing', () async {
+      final service = build();
+
+      states.add(_state(PlaybackStatus.idle, null));
+      await _settle();
+      await service.dispose();
+      await _settle();
+
+      expect(reporter.events, isEmpty);
+    });
+  });
+}

--- a/test/core/services/routing_server_playback_reporter_test.dart
+++ b/test/core/services/routing_server_playback_reporter_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/routing_server_playback_reporter.dart';
+import 'package:linthra/core/services/server_playback_reporter.dart';
+
+/// Records every call routed to it, claiming only tracks whose uri starts
+/// with [scheme] — the shape of a real provider reporter (Plex claims `plex:`).
+class _SchemeReporter implements ServerPlaybackReporter {
+  _SchemeReporter(this.scheme);
+
+  final String scheme;
+  final List<String> events = <String>[];
+
+  @override
+  bool handles(Track track) => track.uri.startsWith(scheme);
+
+  @override
+  Future<void> onPlaybackStarted(
+      Track track, Duration position, Duration duration) async {
+    events.add('started:${track.id}');
+  }
+
+  @override
+  Future<void> onPlaybackProgress(
+      Track track, Duration position, Duration duration) async {
+    events.add('progress:${track.id}');
+  }
+
+  @override
+  Future<void> onPlaybackPaused(
+      Track track, Duration position, Duration duration) async {
+    events.add('paused:${track.id}');
+  }
+
+  @override
+  Future<void> onPlaybackResumed(
+      Track track, Duration position, Duration duration) async {
+    events.add('resumed:${track.id}');
+  }
+
+  @override
+  Future<void> onPlaybackStopped(
+      Track track, Duration position, Duration duration) async {
+    events.add('stopped:${track.id}');
+  }
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {
+    events.add('changed:${previousTrack?.id}->${nextTrack?.id}');
+  }
+}
+
+Track _plex(String id) => Track(id: id, title: id, uri: 'plex:$id');
+Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+Track _local(String id) =>
+    Track(id: id, title: id, uri: 'file:///music/$id.flac');
+
+void main() {
+  group('RoutingServerPlaybackReporter', () {
+    late _SchemeReporter plex;
+    late RoutingServerPlaybackReporter router;
+
+    setUp(() {
+      plex = _SchemeReporter('plex:');
+      router = RoutingServerPlaybackReporter(<ServerPlaybackReporter>[plex]);
+    });
+
+    test('routes every event of a plex: track to the Plex reporter', () async {
+      final Track track = _plex('a');
+      const Duration p = Duration(seconds: 3);
+      const Duration d = Duration(minutes: 3);
+
+      await router.onPlaybackStarted(track, p, d);
+      await router.onPlaybackProgress(track, p, d);
+      await router.onPlaybackPaused(track, p, d);
+      await router.onPlaybackResumed(track, p, d);
+      await router.onPlaybackStopped(track, p, d);
+
+      expect(plex.events, <String>[
+        'started:a',
+        'progress:a',
+        'paused:a',
+        'resumed:a',
+        'stopped:a',
+      ]);
+    });
+
+    test('non-Plex tracks never reach the Plex reporter', () async {
+      for (final Track track in <Track>[_jellyfin('j'), _local('l')]) {
+        await router.onPlaybackStarted(track, Duration.zero, Duration.zero);
+        await router.onPlaybackProgress(track, Duration.zero, Duration.zero);
+        await router.onPlaybackPaused(track, Duration.zero, Duration.zero);
+        await router.onPlaybackResumed(track, Duration.zero, Duration.zero);
+        await router.onPlaybackStopped(track, Duration.zero, Duration.zero);
+        await router.onTrackChanged(track, track);
+      }
+
+      expect(plex.events, isEmpty);
+    });
+
+    test('an unclaimed track is silently dropped (no reporter, no error)',
+        () async {
+      await expectLater(
+        router.onPlaybackStarted(_local('l'), Duration.zero, Duration.zero),
+        completes,
+      );
+    });
+
+    test('the first reporter claiming a track wins', () async {
+      final _SchemeReporter first = _SchemeReporter('plex:');
+      final _SchemeReporter second = _SchemeReporter('plex:');
+      final RoutingServerPlaybackReporter routed =
+          RoutingServerPlaybackReporter(
+              <ServerPlaybackReporter>[first, second]);
+
+      await routed.onPlaybackStarted(_plex('a'), Duration.zero, Duration.zero);
+
+      expect(first.events, <String>['started:a']);
+      expect(second.events, isEmpty);
+    });
+
+    group('onTrackChanged across providers', () {
+      late _SchemeReporter jellyfin;
+      late RoutingServerPlaybackReporter mixed;
+
+      setUp(() {
+        jellyfin = _SchemeReporter('jellyfin:');
+        mixed = RoutingServerPlaybackReporter(
+            <ServerPlaybackReporter>[plex, jellyfin]);
+      });
+
+      test('a plex → local change reaches the Plex reporter (to close it)',
+          () async {
+        await mixed.onTrackChanged(_plex('a'), _local('l'));
+
+        expect(plex.events, <String>['changed:a->l']);
+        expect(jellyfin.events, isEmpty);
+      });
+
+      test('a local → plex change reaches the Plex reporter once', () async {
+        await mixed.onTrackChanged(_local('l'), _plex('a'));
+
+        expect(plex.events, <String>['changed:l->a']);
+      });
+
+      test('a plex → plex change is forwarded once, not twice', () async {
+        await mixed.onTrackChanged(_plex('a'), _plex('b'));
+
+        expect(plex.events, <String>['changed:a->b']);
+      });
+
+      test('a cross-provider change reaches both owners', () async {
+        await mixed.onTrackChanged(_plex('a'), _jellyfin('j'));
+
+        expect(plex.events, <String>['changed:a->j']);
+        expect(jellyfin.events, <String>['changed:a->j']);
+      });
+
+      test('a change to nothing (queue ended) still reaches the owner',
+          () async {
+        await mixed.onTrackChanged(_plex('a'), null);
+
+        expect(plex.events, <String>['changed:a->null']);
+      });
+    });
+
+    test('NoOpServerPlaybackReporter claims everything and does nothing', () {
+      const NoOpServerPlaybackReporter noOp = NoOpServerPlaybackReporter();
+      expect(noOp.handles(_plex('a')), isTrue);
+      expect(noOp.handles(_local('l')), isTrue);
+      // The methods complete without effect (nothing observable to assert
+      // beyond completion — that is the point).
+      expect(
+        noOp.onPlaybackStarted(_local('l'), Duration.zero, Duration.zero),
+        completes,
+      );
+    });
+  });
+}

--- a/test/core/sources/plex/fake_plex_client.dart
+++ b/test/core/sources/plex/fake_plex_client.dart
@@ -37,6 +37,12 @@ class FakePlexClient implements PlexClient {
   Map<String, PlexMetadata> metadataByRatingKey;
   PlexException? metadataError;
 
+  /// When set, every [reportTimeline] call throws it (after being recorded),
+  /// so reporters can prove failures are swallowed. Set [timelineError] for a
+  /// typed failure or [timelineUnexpectedError] for an untyped one.
+  PlexException? timelineError;
+  Object? timelineUnexpectedError;
+
   // Recorded inputs.
   String? lastBaseUrl;
   String? lastToken;
@@ -44,6 +50,21 @@ class FakePlexClient implements PlexClient {
       <({String sectionKey, PlexMetadataType itemType})>[];
   final List<String> requestedRatingKeys = <String>[];
   int identityCount = 0;
+
+  /// Every timeline report received, in order, so tests can assert the exact
+  /// state/position/duration sequence a playback scenario produced.
+  final List<
+      ({
+        String ratingKey,
+        PlexTimelineState state,
+        Duration time,
+        Duration? duration,
+      })> timelineReports = <({
+    String ratingKey,
+    PlexTimelineState state,
+    Duration time,
+    Duration? duration,
+  })>[];
 
   @override
   Future<PlexServerIdentity> fetchIdentity({
@@ -103,5 +124,28 @@ class FakePlexClient implements PlexClient {
     final PlexMetadata? item = metadataByRatingKey[ratingKey];
     if (item == null) throw PlexException.notFound();
     return item;
+  }
+
+  @override
+  Future<void> reportTimeline({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+    required PlexTimelineState state,
+    required Duration time,
+    Duration? duration,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastToken = token;
+    timelineReports.add((
+      ratingKey: ratingKey,
+      state: state,
+      time: time,
+      duration: duration,
+    ));
+    final PlexException? error = timelineError;
+    if (error != null) throw error;
+    final Object? unexpected = timelineUnexpectedError;
+    if (unexpected != null) throw unexpected;
   }
 }

--- a/test/core/sources/plex/http_plex_client_test.dart
+++ b/test/core/sources/plex/http_plex_client_test.dart
@@ -74,6 +74,8 @@ void main() {
       expect(headers['x-plex-version'], '0.1.5');
       expect(headers['x-plex-platform'], 'Android');
       expect(headers['x-plex-device'], 'Pixel');
+      // The friendly player name a PMS dashboard displays for this client.
+      expect(headers['x-plex-device-name'], 'Pixel');
     });
 
     test('treats a body without machineIdentifier as "not a Plex server"',
@@ -425,6 +427,122 @@ void main() {
           PlexErrorKind.unsupportedResponse,
         )),
       );
+    });
+  });
+
+  group('reportTimeline', () {
+    Future<http.Request> report(
+      http.Response response, {
+      Duration? duration = const Duration(minutes: 3),
+    }) async {
+      http.Request? captured;
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        captured = r;
+        return response;
+      }));
+      await client.reportTimeline(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '4242',
+        state: PlexTimelineState.paused,
+        time: const Duration(seconds: 65),
+        duration: duration,
+      );
+      return captured!;
+    }
+
+    test('GETs /:/timeline with the report params, in milliseconds', () async {
+      final http.Request request = await report(http.Response('', 200));
+
+      expect(request.method, 'GET');
+      expect(request.url.path, '/:/timeline');
+      expect(request.url.queryParameters[PlexEndpoints.ratingKeyParam], '4242');
+      expect(request.url.queryParameters[PlexEndpoints.keyParam],
+          '/library/metadata/4242');
+      expect(request.url.queryParameters[PlexEndpoints.stateParam], 'paused');
+      expect(request.url.queryParameters[PlexEndpoints.timeParam], '65000');
+      expect(
+          request.url.queryParameters[PlexEndpoints.durationParam], '180000');
+    });
+
+    test('the token rides in the header; the timeline URL is token-free',
+        () async {
+      final http.Request request = await report(http.Response('', 200));
+
+      expect(request.headers['x-plex-token'], _token);
+      // The identity headers (incl. the device name PMS displays) come too.
+      expect(request.headers['x-plex-client-identifier'], 'install-uuid-1');
+      expect(request.headers['x-plex-device-name'], 'Pixel');
+      final String url = request.url.toString();
+      expect(url, isNot(contains(_token)));
+      expect(url.toLowerCase(), isNot(contains('x-plex-token')));
+    });
+
+    test('omits duration when unknown', () async {
+      final http.Request request =
+          await report(http.Response('', 200), duration: null);
+
+      expect(
+        request.url.queryParameters.containsKey(PlexEndpoints.durationParam),
+        isFalse,
+      );
+    });
+
+    test('tolerates any 2xx body — empty, XML, or JSON — without parsing',
+        () async {
+      for (final http.Response response in <http.Response>[
+        http.Response('', 200),
+        http.Response('<MediaContainer size="0"/>', 200),
+        _json(<String, dynamic>{'MediaContainer': <String, dynamic>{}}),
+      ]) {
+        await expectLater(report(response), completes);
+      }
+    });
+
+    test('maps failures to the usual token-free PlexException', () async {
+      final Map<int, PlexErrorKind> cases = <int, PlexErrorKind>{
+        401: PlexErrorKind.unauthorized,
+        404: PlexErrorKind.notFound,
+        500: PlexErrorKind.serverError,
+      };
+      for (final MapEntry<int, PlexErrorKind> entry in cases.entries) {
+        final HttpPlexClient client =
+            _client(MockClient((_) async => http.Response('no', entry.key)));
+        try {
+          await client.reportTimeline(
+            baseUrl: _base,
+            token: _token,
+            ratingKey: '1',
+            state: PlexTimelineState.playing,
+            time: Duration.zero,
+          );
+          fail('expected a PlexException for HTTP ${entry.key}');
+        } on PlexException catch (e) {
+          expect(e.kind, entry.value);
+          expect(e.message, isNot(contains(_token)));
+          expect(e.toString(), isNot(contains(_token)));
+        }
+      }
+    });
+
+    test('a transport failure becomes notReachable, token-free', () async {
+      final HttpPlexClient client = _client(
+          MockClient((_) async => throw http.ClientException('x $_token')));
+
+      try {
+        await client.reportTimeline(
+          baseUrl: _base,
+          token: _token,
+          ratingKey: '1',
+          state: PlexTimelineState.stopped,
+          time: Duration.zero,
+        );
+        fail('expected a PlexException');
+      } on PlexException catch (e) {
+        expect(e.kind, PlexErrorKind.notReachable);
+        expect(e.message, isNot(contains(_token)));
+        expect(e.toString(), isNot(contains(_token)));
+      }
     });
   });
 

--- a/test/core/sources/plex/plex_endpoints_test.dart
+++ b/test/core/sources/plex/plex_endpoints_test.dart
@@ -114,6 +114,74 @@ void main() {
     });
   });
 
+  group('PlexEndpoints.timeline (playback reporting)', () {
+    Uri timeline({String? base, PlexTimelineState? state, int? durationMs}) =>
+        PlexEndpoints.timeline(
+          base ?? _base,
+          ratingKey: '4242',
+          state: state ?? PlexTimelineState.playing,
+          timeMs: 65000,
+          durationMs: durationMs,
+        );
+
+    test('targets /:/timeline with the documented report params', () {
+      final Uri uri = timeline(durationMs: 180000);
+      expect(uri.path, '/:/timeline');
+      expect(uri.queryParameters[PlexEndpoints.ratingKeyParam], '4242');
+      expect(uri.queryParameters[PlexEndpoints.keyParam],
+          '/library/metadata/4242');
+      expect(uri.queryParameters[PlexEndpoints.identifierParam],
+          PlexEndpoints.libraryIdentifier);
+      expect(uri.queryParameters[PlexEndpoints.stateParam], 'playing');
+      // Position and duration ride in milliseconds — PMS's unit everywhere.
+      expect(uri.queryParameters[PlexEndpoints.timeParam], '65000');
+      expect(uri.queryParameters[PlexEndpoints.durationParam], '180000');
+    });
+
+    test('each timeline state maps to the literal PMS value', () {
+      expect(
+          timeline(state: PlexTimelineState.playing)
+              .queryParameters[PlexEndpoints.stateParam],
+          'playing');
+      expect(
+          timeline(state: PlexTimelineState.paused)
+              .queryParameters[PlexEndpoints.stateParam],
+          'paused');
+      expect(
+          timeline(state: PlexTimelineState.stopped)
+              .queryParameters[PlexEndpoints.stateParam],
+          'stopped');
+      expect(
+          timeline(state: PlexTimelineState.buffering)
+              .queryParameters[PlexEndpoints.stateParam],
+          'buffering');
+    });
+
+    test('omits duration when unknown rather than reporting a fake zero', () {
+      final Uri uri = timeline();
+      expect(uri.queryParameters.containsKey(PlexEndpoints.durationParam),
+          isFalse);
+    });
+
+    test('preserves a reverse-proxy subpath ahead of the timeline path', () {
+      final Uri uri = timeline(base: 'https://example.com/plex');
+      expect(uri.path, '/plex/:/timeline');
+    });
+
+    test(
+        'is token-free: the builder takes no token and the URL never carries '
+        'one (it rides in the request header)', () {
+      final Uri uri = timeline(durationMs: 180000);
+      expect(
+          uri.queryParameters.containsKey(PlexEndpoints.tokenParam), isFalse);
+      expect(uri.toString().toLowerCase(), isNot(contains('x-plex-token')));
+      expect(uri.toString(), isNot(contains(_token)));
+      // Belt and braces: even passed through the redactor it is unchanged,
+      // so a logged timeline URL can never need redaction.
+      expect(PlexEndpoints.redactToken(uri.toString()), uri.toString());
+    });
+  });
+
   group('PlexEndpoints.streamUrl (Part key + token in the query)', () {
     const String partKey = '/library/parts/12345/167/file.flac';
 

--- a/test/core/sources/plex/plex_playback_reporter_test.dart
+++ b/test/core/sources/plex/plex_playback_reporter_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_playback_reporter.dart';
+
+import 'fake_plex_client.dart';
+
+const String _token = 'super-secret-plex-token';
+
+const PlexSession _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: _token,
+  machineIdentifier: 'machine-1',
+);
+
+Track _plexTrack(String ratingKey) => Track(
+      id: 'plex-$ratingKey',
+      title: 'Song $ratingKey',
+      uri: 'plex:$ratingKey',
+      duration: const Duration(minutes: 3),
+    );
+
+const Track _jellyfinTrack =
+    Track(id: 'jf-1', title: 'Elsewhere', uri: 'jellyfin:item-1');
+
+const Duration _position = Duration(seconds: 42);
+const Duration _duration = Duration(minutes: 3);
+
+void main() {
+  group('PlexPlaybackReporter', () {
+    late FakePlexClient client;
+    PlexSession? session = _session;
+
+    setUp(() {
+      client = FakePlexClient();
+      session = _session;
+    });
+
+    PlexPlaybackReporter build() => PlexPlaybackReporter(
+          session: () => session,
+          client: () => client,
+        );
+
+    test('handles only plex: tracks', () {
+      final reporter = build();
+      expect(reporter.handles(_plexTrack('42')), isTrue);
+      expect(reporter.handles(_jellyfinTrack), isFalse);
+    });
+
+    test('started reports a playing timeline with the ratingKey', () async {
+      await build().onPlaybackStarted(_plexTrack('4242'), _position, _duration);
+
+      expect(client.timelineReports, hasLength(1));
+      final report = client.timelineReports.single;
+      expect(report.ratingKey, '4242');
+      expect(report.state, PlexTimelineState.playing);
+      expect(report.time, _position);
+      expect(report.duration, _duration);
+      expect(client.lastBaseUrl, _session.baseUrl);
+      expect(client.lastToken, _token);
+    });
+
+    test('progress and resume report playing; pause paused; stop stopped',
+        () async {
+      final reporter = build();
+      final Track track = _plexTrack('7');
+
+      await reporter.onPlaybackProgress(track, _position, _duration);
+      await reporter.onPlaybackPaused(track, _position, _duration);
+      await reporter.onPlaybackResumed(track, _position, _duration);
+      await reporter.onPlaybackStopped(track, _position, _duration);
+
+      expect(
+        client.timelineReports.map((r) => r.state),
+        <PlexTimelineState>[
+          PlexTimelineState.playing,
+          PlexTimelineState.paused,
+          PlexTimelineState.playing,
+          PlexTimelineState.stopped,
+        ],
+      );
+    });
+
+    test('an unknown duration is omitted, never reported as zero', () async {
+      await build()
+          .onPlaybackStarted(_plexTrack('9'), _position, Duration.zero);
+
+      expect(client.timelineReports.single.duration, isNull);
+    });
+
+    test('a track change closes the outgoing Plex track at its last position',
+        () async {
+      final reporter = build();
+      final Track previous = _plexTrack('1');
+
+      await reporter.onPlaybackStarted(previous, Duration.zero, _duration);
+      await reporter.onPlaybackProgress(
+          previous, const Duration(seconds: 65), _duration);
+      await reporter.onTrackChanged(previous, _plexTrack('2'));
+
+      final report = client.timelineReports.last;
+      expect(report.ratingKey, '1');
+      expect(report.state, PlexTimelineState.stopped);
+      expect(report.time, const Duration(seconds: 65));
+      expect(report.duration, _duration);
+    });
+
+    test('a track change with no remembered position stops at zero', () async {
+      await build().onTrackChanged(_plexTrack('1'), null);
+
+      final report = client.timelineReports.single;
+      expect(report.state, PlexTimelineState.stopped);
+      expect(report.time, Duration.zero);
+      expect(report.duration, isNull);
+    });
+
+    test('a track change from a non-Plex track reports nothing', () async {
+      final reporter = build();
+
+      await reporter.onTrackChanged(_jellyfinTrack, _plexTrack('2'));
+      await reporter.onTrackChanged(null, _plexTrack('2'));
+
+      expect(client.timelineReports, isEmpty);
+    });
+
+    group('never reports for what it cannot own', () {
+      test('a non-Plex track is a silent no-op on every event', () async {
+        final reporter = build();
+
+        await reporter.onPlaybackStarted(_jellyfinTrack, _position, _duration);
+        await reporter.onPlaybackProgress(_jellyfinTrack, _position, _duration);
+        await reporter.onPlaybackPaused(_jellyfinTrack, _position, _duration);
+        await reporter.onPlaybackResumed(_jellyfinTrack, _position, _duration);
+        await reporter.onPlaybackStopped(_jellyfinTrack, _position, _duration);
+
+        expect(client.timelineReports, isEmpty);
+      });
+
+      test('a plex: uri with a blank ratingKey is a silent no-op', () async {
+        const Track corrupt = Track(id: 'x', title: 'x', uri: 'plex: ');
+
+        await build().onPlaybackStarted(corrupt, _position, _duration);
+
+        expect(client.timelineReports, isEmpty);
+      });
+
+      test('signed out (no session) is a silent no-op', () async {
+        session = null;
+
+        await build().onPlaybackStarted(_plexTrack('1'), _position, _duration);
+
+        expect(client.timelineReports, isEmpty);
+      });
+    });
+
+    test(
+        'reads the live session at event time (sign-out mid-play stops '
+        'reporting; reconnect picks the new server up)', () async {
+      final reporter = build();
+      final Track track = _plexTrack('1');
+
+      await reporter.onPlaybackStarted(track, _position, _duration);
+      session = null;
+      await reporter.onPlaybackProgress(track, _position, _duration);
+      session = _session.copyWith(baseUrl: 'https://other.example.com:32400');
+      await reporter.onPlaybackPaused(track, _position, _duration);
+
+      expect(client.timelineReports, hasLength(2));
+      expect(client.lastBaseUrl, 'https://other.example.com:32400');
+    });
+
+    group('reporting is best-effort and never throws', () {
+      test('a typed Plex failure is swallowed', () async {
+        client.timelineError = PlexException.notReachable();
+
+        await expectLater(
+          build().onPlaybackStarted(_plexTrack('1'), _position, _duration),
+          completes,
+        );
+        // The attempt was made; the failure stayed inside the reporter.
+        expect(client.timelineReports, hasLength(1));
+      });
+
+      test('every lifecycle event swallows a failing server', () async {
+        client.timelineError = PlexException.unauthorized();
+        final reporter = build();
+        final Track track = _plexTrack('1');
+
+        await expectLater(
+            reporter.onPlaybackStarted(track, _position, _duration), completes);
+        await expectLater(
+            reporter.onPlaybackProgress(track, _position, _duration),
+            completes);
+        await expectLater(
+            reporter.onPlaybackPaused(track, _position, _duration), completes);
+        await expectLater(
+            reporter.onPlaybackResumed(track, _position, _duration), completes);
+        await expectLater(
+            reporter.onPlaybackStopped(track, _position, _duration), completes);
+        await expectLater(reporter.onTrackChanged(track, null), completes);
+      });
+
+      test('an untyped failure is swallowed too', () async {
+        client.timelineUnexpectedError = StateError('boom $_token');
+
+        await expectLater(
+          build().onPlaybackStarted(_plexTrack('1'), _position, _duration),
+          completes,
+        );
+      });
+    });
+
+    test(
+        'token safety: the token goes only to the client seam, and no '
+        'failure path can surface it', () async {
+      // Force every failure kind through the reporter with the real token in
+      // play; nothing may escape (the reporter never throws), so there is no
+      // error object, message, or return value a token could ride out on.
+      for (final PlexException error in <PlexException>[
+        PlexException.unauthorized(),
+        PlexException.notReachable(),
+        PlexException.serverError(500),
+        PlexException.notFound(),
+      ]) {
+        client = FakePlexClient()..timelineError = error;
+        Object? escaped;
+        try {
+          await build()
+              .onPlaybackStarted(_plexTrack('1'), _position, _duration);
+        } catch (e) {
+          escaped = e;
+        }
+        expect(escaped, isNull,
+            reason: 'reporting must never throw (${error.kind})');
+        // The token was used solely as the client-call credential.
+        expect(client.lastToken, _token);
+      }
+    });
+
+    test(
+        'reported values stay credential-free (ratingKey is not a URL or '
+        'token)', () async {
+      await build().onPlaybackStarted(_plexTrack('4242'), _position, _duration);
+
+      final report = client.timelineReports.single;
+      expect(report.ratingKey, isNot(contains(_token)));
+      expect(report.ratingKey, isNot(contains('http')));
+    });
+  });
+}


### PR DESCRIPTION
# Plex playback reporting / Now Playing integration

Linthra can stream `plex:<ratingKey>` tracks, but Plex never showed it as an active player because playback was never reported back to the server. This PR makes Linthra appear in the Plex Web dashboard's **Now Playing** while a Plex track plays — playing, paused, progressing, and cleared again when playback stops or moves to another track.

## API verification

The reporting path was verified against [python-plexapi's `updateTimeline`](https://github.com/pkkid/python-plexapi/blob/master/plexapi/base.py) and the community API docs ([plexapi.dev](https://plexapi.dev/api-reference/timeline/report-media-timeline), [Arcanemagus' Plex Web API overview](https://github.com/Arcanemagus/plex-api/wiki/Plex-Web-API-Overview)):

`GET /:/timeline` with `ratingKey`, `key=/library/metadata/{ratingKey}`, `identifier=com.plexapp.plugins.library`, `state` (`playing`/`paused`/`stopped`/`buffering`), and `time`/`duration` in **milliseconds**, authenticated via the `X-Plex-Token` **header** plus the `X-Plex-*` client identity headers. PMS keys the Now Playing session on `X-Plex-Client-Identifier` and labels the player from `X-Plex-Device-Name`/`X-Plex-Product`.

## Architecture

- **`ServerPlaybackReporter`** (`core/services/server_playback_reporter.dart`) — provider-neutral lifecycle contract: `onPlaybackStarted/Progress/Paused/Resumed/Stopped` + `onTrackChanged`, with a `NoOpServerPlaybackReporter` for providers without reporting support.
- **`RoutingServerPlaybackReporter`** — selects the reporter whose `handles` claims the track's uri. Only `plex:` tracks ever reach the Plex reporter; local/Jellyfin/Subsonic playback reports nothing, exactly as before. `onTrackChanged` reaches the owners of *both* sides (deduped), so a Plex session closes even when the next track belongs to another provider.
- **`PlaybackReportingService`** — listens to the unified `PlaybackState` stream and derives the lifecycle: first `playing` → started, pause/resume → immediate, idle/completed/error → stopped (at the last *observed* position, since `stop()` emits a zeroed state), queue move → track change. `loading`/`buffering` are deliberately not transitions, so a mid-stream re-buffer never flaps pause/resume and a track that never starts is never reported. **Progress is throttled** to one report per 10 s of steady play. Reports dispatch strictly in order, one at a time, off the playback path, with every failure swallowed.
- **`PlexPlaybackReporter`** (`core/sources/plex/plex_playback_reporter.dart`) — all Plex-specific details (state mapping, `ratingKey` extraction, ms units) stay here. Reads the live session/client lazily (the `PlexPlayableUriResolver` shape): signed out → silent no-op. `PlexClient.reportTimeline` + `PlexEndpoints.timeline` carry the wire details; the 2xx body is deliberately not parsed.
- Wired in `player_providers.dart` + `main.dart` exactly like smart pre-cache / remote prebuffer (session-pinned, side-effect-only).

## Identity shown to Plex

`X-Plex-Product` / `X-Plex-Device` were already `Linthra`; the identity headers now also send `X-Plex-Device-Name` so the dashboard names the player "Linthra" instead of a blank device. The stable per-install `X-Plex-Client-Identifier` persisted with the session is reused, so pause/resume update one player entry instead of spawning new sessions.

## Token safety

- The token rides only in the `X-Plex-Token` header; the timeline URL is token-free and safe to log (asserted in tests).
- Reporting failures are token-free `PlexException`s (asserted per error kind), and the reporter **never throws at all** — there is no error path a token could ride out on (asserted).
- Timeline URLs are minted per report and discarded; nothing about reporting is persisted.
- Debug breadcrumbs carry only the error *kind* (enum name), never a message, URL, or token.

## Tests (all 2031 pass; format + analyze clean)

- `playback_reporting_service_test.dart` — start / throttled progress / pause / resume / stop (honest final position) / track change / error→stopped / no flap on buffering / duration fallback / strict ordering under a slow report / throwing reporter never breaks later events / dispose closes an open session.
- `routing_server_playback_reporter_test.dart` — plex routing, **non-Plex tracks never reach the Plex reporter**, cross-provider track changes, first-match wins, no-op fallback.
- `plex_playback_reporter_test.dart` — state mapping, ratingKey/ms payloads, signed-out & corrupt-uri no-ops, live session reads, **never throws on any failure kind**, token only ever reaches the client seam.
- `plex_endpoints_test.dart` / `http_plex_client_test.dart` — timeline URL shape & token-free guarantee, header placement (incl. `X-Plex-Device-Name`), tolerant of empty/XML 2xx bodies, token-free error mapping.

## Manual QA (needs a real PMS — not possible in this environment)

- [ ] Start a Plex track in Linthra → Plex Web dashboard shows **Linthra** as an active player
- [ ] Pause in Linthra → dashboard shows paused
- [ ] Resume → dashboard back to playing
- [ ] Skip to another Plex track → dashboard updates to the new track
- [ ] Stop playback → dashboard clears the session
- [ ] Play Jellyfin / Subsonic / Local tracks → unchanged, no Plex traffic

## Out of scope (unchanged)

No Jellyfin reporting, no Subsonic/Navidrome scrobbling, no lyrics, no offline/cache UI, no Plex.tv OAuth, no version bump, no release changes.

https://claude.ai/code/session_01LZMMZfvJVkAU3gmEBF4XVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZMMZfvJVkAU3gmEBF4XVY)_