### PR TITLE
feat(reporting): Jellyfin and Subsonic/Navidrome playback reporting

### DIFF
--- a/docs/jellyfin-compatibility.md
+++ b/docs/jellyfin-compatibility.md
@@ -94,6 +94,9 @@ between call sites and the full surface is auditable here.
 | Cover art | `GET /Items/{itemId}/Images/Primary` | **Token-free**; safe to cache/persist. |
 | Direct stream | `GET /Audio/{itemId}/stream?static=true&api_key=…&UserId=…&DeviceId=…` | `static=true` serves the original file (no transcode). Token in query. |
 | Download | `GET /Items/{itemId}/Download?api_key=…` | Original file for the offline cache. Token in query. |
+| Report playback start | `POST /Sessions/Playing` | Body `{ItemId, PositionTicks, …}`; shows Linthra on the dashboard. Best-effort. |
+| Report playback progress | `POST /Sessions/Playing/Progress` | Throttled heartbeat; `IsPaused` carries pause/resume. Best-effort. |
+| Report playback stop | `POST /Sessions/Playing/Stopped` | Settles the server's session/play state. Best-effort. |
 
 **Authentication header.** Authenticated JSON calls send the standard Jellyfin
 `Authorization: MediaBrowser Client="Linthra", Device="Linthra", DeviceId="…",

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -137,6 +137,32 @@ check in §4 #14b):
   is **negligible** — confirming the position flush stopped on pause and nothing
   polls while idle. This is the key "no unnecessary polling/wake-ups" check.
 
+## 3b. Server playback reporting (Now Playing on your server)
+
+While a remote track plays, Linthra reports its playback to the server that
+owns it — Plex timelines, Jellyfin play sessions, Subsonic/Navidrome
+now-playing + scrobble. Reporting is best-effort: it must never affect
+playback.
+
+- ☐ Play a **Plex** track: the PMS dashboard shows Linthra under Now Playing;
+  pause/resume update the entry; stop/skip clears it (unchanged from before).
+- ☐ Play a **Jellyfin** track: the server dashboard shows Linthra as an active
+  session with the playing item; pause shows paused; position advances on the
+  ~10 s heartbeat; stop/skip clears the session.
+- ☐ Play a **Navidrome (or other Subsonic)** track: the server's activity /
+  `getNowPlaying` shows Linthra as the client; letting the track run past
+  half (or 4 minutes) bumps its play count when it ends; skipping early does
+  **not** count a play.
+- ☐ Play a **local** track: no server traffic, nothing appears on any
+  dashboard.
+- ☐ Pause / resume / skip / stop across providers (including a queue mixing
+  providers): each server only ever shows its own track, and the outgoing
+  track's session closes on a cross-provider skip.
+- ☐ Reporting failure is invisible: play a remote track, then cut the server
+  off (stop the server or drop the tunnel) — playback of the already-started
+  stream continues, pause/skip/stop still work, and no error surfaces. No log
+  line contains a token (`adb logcat | grep -i linthra` spot-check).
+
 ## 4. Cast / Chromecast
 
 Run the end-to-end pass in this order (a streamed track is required — local

--- a/docs/plex.md
+++ b/docs/plex.md
@@ -220,8 +220,9 @@ the entry.
   + `onTrackChanged`, with a `NoOpServerPlaybackReporter` for providers
   without reporting.
 - **`RoutingServerPlaybackReporter`** — selects the reporter whose `handles`
-  claims the track's uri; `plex:` routes to Plex, everything else reports
-  nowhere, so local/Jellyfin/Subsonic playback can never trigger a Plex call.
+  claims the track's uri; `plex:` routes to Plex, `jellyfin:` to the Jellyfin
+  reporter, `subsonic:` to the Subsonic one, and local files report nowhere,
+  so one provider's playback can never trigger another provider's call.
   `onTrackChanged` is forwarded to the owners of *both* sides, so a Plex
   session closes even when the next track belongs to another provider.
 - **`PlaybackReportingService`** (`core/services/playback_reporting_service.dart`)

--- a/lib/core/services/playback_reporting_service.dart
+++ b/lib/core/services/playback_reporting_service.dart
@@ -23,7 +23,8 @@ enum _ReportedPhase {
 
 /// Watches live playback and reports its lifecycle to the
 /// [ServerPlaybackReporter] — the bridge that makes the user's own media
-/// server (Plex today) show Linthra as an active player.
+/// server (Plex, Jellyfin, Subsonic/Navidrome) show Linthra as an active
+/// player.
 ///
 /// It listens to the unified [PlaybackState] stream and derives the few events
 /// a server can use from the raw emissions:

--- a/lib/core/services/routing_server_playback_reporter.dart
+++ b/lib/core/services/routing_server_playback_reporter.dart
@@ -5,9 +5,9 @@ import 'server_playback_reporter.dart';
 /// track's uri — the reporting counterpart of `RoutingPlayableUriResolver`.
 ///
 /// A track no reporter handles is silently dropped: not reporting *is* the
-/// correct behaviour for providers without reporting support (local files,
-/// Jellyfin, Subsonic today), so non-Plex playback can never trigger a Plex
-/// report — the only reporter that sees a track is the one that claimed it.
+/// correct behaviour for providers without reporting support (local files
+/// today), and the only reporter that sees a track is the one that claimed it
+/// — so one provider's playback can never trigger another provider's report.
 ///
 /// [onTrackChanged] is the one event that can span two providers (a Plex track
 /// followed by a Jellyfin one): it is forwarded to the reporter owning each

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -171,6 +171,51 @@ class HttpJellyfinClient implements JellyfinClient {
   }
 
   @override
+  Future<void> reportPlayback(
+    JellyfinSession session, {
+    required String itemId,
+    required JellyfinPlaybackEvent event,
+    required Duration position,
+  }) async {
+    final Uri uri = switch (event) {
+      JellyfinPlaybackEvent.started =>
+        JellyfinEndpoints.playbackStarted(session.baseUrl),
+      JellyfinPlaybackEvent.progress ||
+      JellyfinPlaybackEvent.paused ||
+      JellyfinPlaybackEvent.resumed =>
+        JellyfinEndpoints.playbackProgress(session.baseUrl),
+      JellyfinPlaybackEvent.stopped =>
+        JellyfinEndpoints.playbackStopped(session.baseUrl),
+    };
+    // PositionTicks is Jellyfin's 100-nanosecond unit (10 ticks per
+    // microsecond) — the same unit the item listings report RunTimeTicks in.
+    final Map<String, Object> body = <String, Object>{
+      'ItemId': itemId,
+      'PositionTicks': position.inMicroseconds * 10,
+    };
+    if (event != JellyfinPlaybackEvent.stopped) {
+      // `static=true` streams (and offline copies) play the original file
+      // bytes, so DirectPlay is the honest label for the dashboard.
+      body['CanSeek'] = true;
+      body['IsPaused'] = event == JellyfinPlaybackEvent.paused;
+      body['PlayMethod'] = 'DirectPlay';
+    }
+    final http.Response response = await _send(
+      () => _client.post(
+        uri,
+        headers: <String, String>{
+          ..._authHeaders(session),
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode(body),
+      ),
+    );
+    // The body is deliberately not parsed: Jellyfin answers these with
+    // `204 No Content` — a 2xx alone means the report landed.
+    _checkStatus(response);
+  }
+
+  @override
   Future<Set<String>> fetchFavoriteIds(JellyfinSession session) async {
     final Uri uri = JellyfinEndpoints.favoriteAudioItems(
       session.baseUrl,

--- a/lib/core/sources/jellyfin/jellyfin_api.dart
+++ b/lib/core/sources/jellyfin/jellyfin_api.dart
@@ -14,6 +14,15 @@ import 'jellyfin_server_capabilities.dart';
 /// query string.
 enum JellyfinItemKind { audio, album, artist }
 
+/// A playback lifecycle event reported to Jellyfin's play-session endpoints.
+///
+/// The client maps each value to the right endpoint and body: [started] posts
+/// to `/Sessions/Playing`, [stopped] to `/Sessions/Playing/Stopped`, and the
+/// middle three to `/Sessions/Playing/Progress` (with `IsPaused` telling the
+/// server whether the player is paused). The reporter only ever picks an
+/// event; how Jellyfin spells it on the wire stays inside the client.
+enum JellyfinPlaybackEvent { started, progress, paused, resumed, stopped }
+
 /// What a tiny pre-flight request to a minted stream URL observed.
 ///
 /// The playback source probes the stream URL before handing it to the audio

--- a/lib/core/sources/jellyfin/jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/jellyfin_client.dart
@@ -62,6 +62,23 @@ abstract interface class JellyfinClient {
   /// for transport or auth failures.
   Future<Lyrics?> fetchLyrics(JellyfinSession session, String itemId);
 
+  /// Reports a playback lifecycle [event] for the audio item [itemId] at
+  /// [position] to the server's play-session endpoints, so Jellyfin's
+  /// dashboard shows this client as an active player and the item's play
+  /// state stays in sync.
+  ///
+  /// The server keys the session on the client/device identity in the
+  /// `Authorization` header — the same one used at sign-in — so a
+  /// pause/resume updates one player entry instead of spawning new ones.
+  /// Throws a [JellyfinException] on failure; the *caller* (the playback
+  /// reporter) treats every failure as best-effort and swallows it.
+  Future<void> reportPlayback(
+    JellyfinSession session, {
+    required String itemId,
+    required JellyfinPlaybackEvent event,
+    required Duration position,
+  });
+
   /// The audio item ids the signed-in user has marked as favourites.
   Future<Set<String>> fetchFavoriteIds(JellyfinSession session);
 

--- a/lib/core/sources/jellyfin/jellyfin_endpoints.dart
+++ b/lib/core/sources/jellyfin/jellyfin_endpoints.dart
@@ -26,6 +26,9 @@ abstract final class JellyfinEndpoints {
   static const String _itemsPath = '/Items';
   static const String _artistsPath = '/Artists';
   static const String _playlistsPath = '/Playlists';
+  static const String _playingPath = '/Sessions/Playing';
+  static const String _playingProgressPath = '/Sessions/Playing/Progress';
+  static const String _playingStoppedPath = '/Sessions/Playing/Stopped';
 
   // --- Query-parameter keys, named once so a typo can't split a request. ---
 
@@ -198,6 +201,22 @@ abstract final class JellyfinEndpoints {
   /// 401/403 is mapped to a friendly "couldn't delete" rather than retried.
   static Uri deleteItem(String baseUrl, {required String itemId}) =>
       _join(baseUrl, '$_itemsPath/$itemId');
+
+  /// `POST /Sessions/Playing` — report that playback of an item started. The
+  /// item and position ride in the JSON body; the session this player shows up
+  /// as on the server's dashboard is keyed off the `Authorization` header's
+  /// client/device identity, so the URL itself carries nothing.
+  static Uri playbackStarted(String baseUrl) => _join(baseUrl, _playingPath);
+
+  /// `POST /Sessions/Playing/Progress` — report position (and the
+  /// paused/playing flag) for the item already reported via [playbackStarted].
+  static Uri playbackProgress(String baseUrl) =>
+      _join(baseUrl, _playingProgressPath);
+
+  /// `POST /Sessions/Playing/Stopped` — report that playback of an item ended,
+  /// settling the server's session and play state for it.
+  static Uri playbackStopped(String baseUrl) =>
+      _join(baseUrl, _playingStoppedPath);
 
   /// `GET /Audio/<itemId>/Lyrics` — time-synced or plain lyrics (a 404 just
   /// means the server has none).

--- a/lib/core/sources/jellyfin/jellyfin_playback_reporter.dart
+++ b/lib/core/sources/jellyfin/jellyfin_playback_reporter.dart
@@ -1,0 +1,157 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/jellyfin_session.dart';
+import '../../models/track.dart';
+import '../../services/server_playback_reporter.dart';
+import 'jellyfin_api.dart';
+import 'jellyfin_client.dart';
+import 'jellyfin_exception.dart';
+import 'jellyfin_track_mapper.dart';
+
+/// Reports playback of `jellyfin:<itemId>` tracks back to the Jellyfin
+/// server's play-session endpoints, so Linthra shows up as an active player on
+/// the server's dashboard — playing, paused, progressing, and cleared again
+/// when playback stops or moves on — and the item's play state stays in sync.
+///
+/// Every Jellyfin-specific reporting detail lives here: the lifecycle →
+/// [JellyfinPlaybackEvent] mapping and the `itemId` extraction from the opaque
+/// track uri. The playback layer only ever sees the provider-neutral
+/// [ServerPlaybackReporter]; how Jellyfin spells an event on the wire
+/// (endpoints, ticks, `IsPaused`) stays inside the [JellyfinClient].
+///
+/// The session and client are read through getters at event time — exactly
+/// like `JellyfinPlayableUriResolver` reads its source — so signing in/out
+/// (and the device identity persisted at sign-in, which is what the server
+/// keys the player session on) is always the live one without rebuilding
+/// anything. With no session every event is a silent no-op.
+///
+/// Best-effort by contract: every failure (typed or not) is swallowed, so a
+/// down server or rejected token can never disturb playback — at most it
+/// leaves a debug breadcrumb carrying only the error *kind* (an enum name).
+/// Token safety follows the established Jellyfin rules: the token is handed to
+/// the [JellyfinClient] (which sends it in the `Authorization` header) and
+/// never reaches a URL this class sees, a log, or an error; nothing here is
+/// persisted.
+class JellyfinPlaybackReporter implements ServerPlaybackReporter {
+  JellyfinPlaybackReporter({
+    required JellyfinSession? Function() session,
+    required JellyfinClient Function() client,
+  })  : _session = session,
+        _client = client;
+
+  /// Supplies the live signed-in session, or `null` when not connected.
+  final JellyfinSession? Function() _session;
+
+  /// Supplies the live client (whose auth header names this install).
+  final JellyfinClient Function() _client;
+
+  /// The last position actually reported for the current track, so
+  /// [onTrackChanged] can close the outgoing track's session at an honest
+  /// position (that event carries no position of its own).
+  String? _lastReportedUri;
+  Duration _lastReportedPosition = Duration.zero;
+
+  @override
+  bool handles(Track track) =>
+      track.uri.startsWith(JellyfinTrackMapper.uriScheme);
+
+  @override
+  Future<void> onPlaybackStarted(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, JellyfinPlaybackEvent.started, position);
+
+  @override
+  Future<void> onPlaybackProgress(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, JellyfinPlaybackEvent.progress, position);
+
+  @override
+  Future<void> onPlaybackPaused(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, JellyfinPlaybackEvent.paused, position);
+
+  @override
+  Future<void> onPlaybackResumed(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, JellyfinPlaybackEvent.resumed, position);
+
+  @override
+  Future<void> onPlaybackStopped(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _report(track, JellyfinPlaybackEvent.stopped, position);
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {
+    // Only the outgoing track is this reporter's business here: a Jellyfin
+    // track that stops playing must release its session whatever plays next
+    // (another Jellyfin track, another provider's, or nothing). The incoming
+    // track announces itself via onPlaybackStarted once it actually plays.
+    if (previousTrack == null || !handles(previousTrack)) return;
+    final bool remembered = previousTrack.uri == _lastReportedUri;
+    await _report(
+      previousTrack,
+      JellyfinPlaybackEvent.stopped,
+      remembered ? _lastReportedPosition : Duration.zero,
+    );
+  }
+
+  /// Sends one play-session report, best-effort. A non-Jellyfin track, a
+  /// missing session, or a blank itemId is a silent no-op; a failed request is
+  /// swallowed (with a kind-only debug breadcrumb) — playback never notices.
+  Future<void> _report(
+    Track track,
+    JellyfinPlaybackEvent event,
+    Duration position,
+  ) async {
+    if (!handles(track)) return;
+    final JellyfinSession? session = _session();
+    if (session == null) return;
+    final String itemId =
+        track.uri.substring(JellyfinTrackMapper.uriScheme.length).trim();
+    if (itemId.isEmpty) return;
+
+    if (event == JellyfinPlaybackEvent.stopped) {
+      if (track.uri == _lastReportedUri) _lastReportedUri = null;
+    } else {
+      _lastReportedUri = track.uri;
+      _lastReportedPosition = position;
+    }
+
+    try {
+      await _client().reportPlayback(
+        session,
+        itemId: itemId,
+        event: event,
+        position: position,
+      );
+    } on JellyfinException catch (error) {
+      // Best-effort by contract. The breadcrumb carries only the error kind
+      // and the reported event — never the message, a URL, or the token.
+      _log('playback ${event.name} failed: ${error.kind.name}');
+    } catch (_) {
+      _log('playback ${event.name} failed: unexpected');
+    }
+  }
+
+  static void _log(String message) {
+    if (!kDebugMode) return;
+    developer.log(message, name: 'linthra.jellyfin');
+  }
+}

--- a/lib/core/sources/subsonic/http_subsonic_client.dart
+++ b/lib/core/sources/subsonic/http_subsonic_client.dart
@@ -205,6 +205,24 @@ class HttpSubsonicClient implements SubsonicClient {
     );
   }
 
+  @override
+  Future<void> scrobble(
+    SubsonicSession session,
+    String songId, {
+    required bool submission,
+  }) async {
+    final Uri uri = SubsonicEndpoints.scrobble(
+      session.baseUrl,
+      username: session.username,
+      credentials: _credentials(session),
+      songId: songId,
+      submission: submission,
+    );
+    // Only the envelope's ok/failed status matters; a server that rejects or
+    // doesn't support scrobbling throws the usual typed, secret-free error.
+    await _get(uri);
+  }
+
   SubsonicCredentials _credentials(SubsonicSession session) =>
       SubsonicCredentials(salt: session.salt, token: session.token);
 

--- a/lib/core/sources/subsonic/subsonic_client.dart
+++ b/lib/core/sources/subsonic/subsonic_client.dart
@@ -67,4 +67,20 @@ abstract interface class SubsonicClient {
   /// only a transport failure throws (a non-2xx status is returned for the
   /// caller to classify).
   Future<SubsonicStreamProbe> probeStream(Uri url);
+
+  /// Registers playback of the song [songId] with the server's `scrobble`
+  /// endpoint: `submission: false` marks it as "now playing" (so Navidrome's
+  /// activity panel shows this client), `submission: true` records a completed
+  /// play (play count / last played / configured scrobble forwarding).
+  ///
+  /// Throws a [SubsonicException] on failure — including a server that
+  /// doesn't support scrobbling, which answers with a Subsonic error
+  /// envelope; the *caller* (the playback reporter) treats every failure as
+  /// best-effort and swallows it. The credential is woven into the request
+  /// URL on demand and never logged or placed in a thrown error.
+  Future<void> scrobble(
+    SubsonicSession session,
+    String songId, {
+    required bool submission,
+  });
 }

--- a/lib/core/sources/subsonic/subsonic_endpoints.dart
+++ b/lib/core/sources/subsonic/subsonic_endpoints.dart
@@ -103,6 +103,26 @@ abstract final class SubsonicEndpoints {
       _build(baseUrl, 'getLyrics', username, credentials,
           extra: <String, String>{'artist': artist, 'title': title});
 
+  /// `GET /rest/scrobble.view?id=…&submission=…` — registers playback of a
+  /// song. With `submission=false` the server marks it as "now playing"
+  /// (Navidrome's activity panel and `getNowPlaying`); with `submission=true`
+  /// it records a completed play (play count, last played, and any scrobble
+  /// forwarding the server is configured for). In the Subsonic API since
+  /// 1.5.0, so Navidrome and generic servers alike answer it; one that
+  /// doesn't returns a Subsonic error envelope the client maps to a typed
+  /// exception (which the playback reporter swallows).
+  static Uri scrobble(
+    String baseUrl, {
+    required String username,
+    required SubsonicCredentials credentials,
+    required String songId,
+    required bool submission,
+  }) =>
+      _build(baseUrl, 'scrobble', username, credentials, extra: {
+        idParam: songId,
+        'submission': '$submission',
+      });
+
   /// The audio stream URL for a song: `/rest/stream.view?id=…` plus auth.
   ///
   /// The server serves a playable stream (transcoding to a broadly compatible

--- a/lib/core/sources/subsonic/subsonic_playback_reporter.dart
+++ b/lib/core/sources/subsonic/subsonic_playback_reporter.dart
@@ -1,0 +1,210 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/subsonic_session.dart';
+import '../../models/track.dart';
+import '../../services/server_playback_reporter.dart';
+import 'subsonic_client.dart';
+import 'subsonic_exception.dart';
+import 'subsonic_track_mapper.dart';
+
+/// Reports playback of `subsonic:<id>` tracks back to the server through the
+/// Subsonic `scrobble` endpoint — the one playback-reporting concept the
+/// Subsonic API has — so Navidrome (and any Subsonic-compatible server) shows
+/// Linthra under "now playing" and counts completed plays.
+///
+/// The lifecycle is mapped onto what the protocol can express:
+///  - **start / resume** → `scrobble(submission=false)`: registers the song as
+///    now playing (resume re-announces, so the entry stays fresh after a long
+///    pause). There is no pause or stop wire concept, so paused/stopped state
+///    is never sent — entries age out on the server.
+///  - **progress / pause** → no request; only the position is remembered, so a
+///    later settle can judge how much actually played.
+///  - **stop / track change** → `scrobble(submission=true)` when the play
+///    *counts*: at least half the track, or at least [submissionFloor] of it,
+///    was played — the classic scrobbling rule, applied client-side because
+///    the server records whatever a client submits. A skipped-early track
+///    submits nothing.
+///
+/// Every Subsonic-specific reporting detail lives here: the lifecycle →
+/// scrobble mapping, the played-enough rule, and the id extraction from the
+/// opaque track uri. The playback layer only ever sees the provider-neutral
+/// [ServerPlaybackReporter].
+///
+/// The session and client are read through getters at event time — exactly
+/// like `SubsonicPlayableUriResolver` reads its source — so signing in/out is
+/// always picked up live without rebuilding anything. With no session every
+/// event is a silent no-op.
+///
+/// Best-effort by contract: every failure (typed or not — including a server
+/// without scrobble support, which answers with an error envelope) is
+/// swallowed, so reporting can never disturb playback — at most it leaves a
+/// debug breadcrumb carrying only the error *kind* (an enum name). Credential
+/// safety follows the established Subsonic rules: the salt+token are woven
+/// into the request URL inside the client, on demand, and never reach this
+/// class, a log, or an error; nothing here is persisted.
+class SubsonicPlaybackReporter implements ServerPlaybackReporter {
+  SubsonicPlaybackReporter({
+    required SubsonicSession? Function() session,
+    required SubsonicClient Function() client,
+  })  : _session = session,
+        _client = client;
+
+  /// Supplies the live signed-in session, or `null` when not connected.
+  final SubsonicSession? Function() _session;
+
+  /// Supplies the live client.
+  final SubsonicClient Function() _client;
+
+  /// A play always counts once this much of it ran, even when that is less
+  /// than half (the long-track half of the half-or-four-minutes rule).
+  static const Duration submissionFloor = Duration(minutes: 4);
+
+  /// The track currently announced as now playing, with the last position and
+  /// duration observed for it — what a settle (stop or track change) judges
+  /// the play by. One play submits at most once: settling clears it.
+  String? _nowPlayingUri;
+  Duration _lastPosition = Duration.zero;
+  Duration _lastDuration = Duration.zero;
+
+  @override
+  bool handles(Track track) =>
+      track.uri.startsWith(SubsonicTrackMapper.uriScheme);
+
+  @override
+  Future<void> onPlaybackStarted(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    final String songId = _songId(track);
+    if (songId.isEmpty) return;
+    _remember(track, position, duration);
+    await _scrobble(songId, submission: false);
+  }
+
+  @override
+  Future<void> onPlaybackProgress(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    // No progress concept on the wire; just keep the settle judgement honest.
+    if (_songId(track).isEmpty) return;
+    _remember(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackPaused(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    // No pause concept on the wire either.
+    if (_songId(track).isEmpty) return;
+    _remember(track, position, duration);
+  }
+
+  @override
+  Future<void> onPlaybackResumed(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    final String songId = _songId(track);
+    if (songId.isEmpty) return;
+    _remember(track, position, duration);
+    // Re-announce so the server's now-playing entry is fresh after a pause.
+    await _scrobble(songId, submission: false);
+  }
+
+  @override
+  Future<void> onPlaybackStopped(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) =>
+      _settle(track, position, duration);
+
+  @override
+  Future<void> onTrackChanged(Track? previousTrack, Track? nextTrack) async {
+    // Only the outgoing track is this reporter's business here: its play must
+    // be settled whatever comes next (another Subsonic track, another
+    // provider's, or nothing). The incoming track announces itself via
+    // onPlaybackStarted once it actually plays. This event carries no
+    // position, so the settle uses the last one observed.
+    if (previousTrack == null || !handles(previousTrack)) return;
+    if (previousTrack.uri != _nowPlayingUri) return;
+    await _settle(previousTrack, _lastPosition, _lastDuration);
+  }
+
+  /// Closes the play of [track]: submits a scrobble when enough of it ran to
+  /// count, nothing otherwise, and forgets the play either way so it can never
+  /// submit twice (a stop followed by the queue moving on settles once).
+  Future<void> _settle(
+    Track track,
+    Duration position,
+    Duration duration,
+  ) async {
+    final String songId = _songId(track);
+    if (songId.isEmpty) return;
+    if (track.uri != _nowPlayingUri) return;
+    _nowPlayingUri = null;
+    if (!playedEnoughToSubmit(position, duration)) return;
+    await _scrobble(songId, submission: true);
+  }
+
+  /// Whether a play that ended at [position] counts as a completed play:
+  /// at least half of a known [duration], or at least [submissionFloor]
+  /// regardless. A play whose position was never observed counts nothing.
+  @visibleForTesting
+  static bool playedEnoughToSubmit(Duration position, Duration duration) {
+    if (position <= Duration.zero) return false;
+    if (position >= submissionFloor) return true;
+    return duration > Duration.zero && position * 2 >= duration;
+  }
+
+  /// The song id from the opaque `subsonic:<id>` uri, or `''` when the track
+  /// isn't this provider's (or the uri is corrupt) — the caller's cue to
+  /// silently do nothing.
+  String _songId(Track track) {
+    if (!handles(track)) return '';
+    return track.uri.substring(SubsonicTrackMapper.uriScheme.length).trim();
+  }
+
+  void _remember(Track track, Duration position, Duration duration) {
+    if (track.uri != _nowPlayingUri) {
+      // A fresh play: drop the previous play's leftovers so they can never
+      // bleed into this track's settle judgement.
+      _nowPlayingUri = track.uri;
+      _lastPosition = Duration.zero;
+      _lastDuration = Duration.zero;
+    }
+    if (position > Duration.zero) _lastPosition = position;
+    if (duration > Duration.zero) _lastDuration = duration;
+  }
+
+  /// Sends one scrobble call, best-effort. Signed out is a silent no-op; a
+  /// failed request is swallowed (with a kind-only debug breadcrumb) —
+  /// playback never notices.
+  Future<void> _scrobble(String songId, {required bool submission}) async {
+    final SubsonicSession? session = _session();
+    if (session == null) return;
+    final String what = submission ? 'scrobble' : 'now-playing';
+    try {
+      await _client().scrobble(session, songId, submission: submission);
+    } on SubsonicException catch (error) {
+      // Best-effort by contract. The breadcrumb carries only the error kind —
+      // never the message, a URL, or the credential.
+      _log('$what failed: ${error.kind.name}');
+    } catch (_) {
+      _log('$what failed: unexpected');
+    }
+  }
+
+  static void _log(String message) {
+    if (!kDebugMode) return;
+    developer.log(message, name: 'linthra.subsonic');
+  }
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -21,15 +21,19 @@ import '../../core/services/routing_server_playback_reporter.dart';
 import '../../core/services/server_playback_reporter.dart';
 import '../../core/services/smart_precache_service.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
+import '../../core/sources/jellyfin/jellyfin_playback_reporter.dart';
 import '../../core/sources/plex/plex_playable_uri_resolver.dart';
 import '../../core/sources/plex/plex_playback_reporter.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
+import '../../core/sources/subsonic/subsonic_playback_reporter.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/jellyfin/jellyfin_settings_providers.dart';
 import '../settings/plex/plex_settings_controller.dart';
 import '../settings/plex/plex_settings_providers.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
+import '../settings/subsonic/subsonic_settings_providers.dart';
 import 'cast/cast_providers.dart';
 import 'now_playing.dart';
 
@@ -212,27 +216,39 @@ final remotePrebufferServiceProvider = Provider<RemotePrebufferService>((ref) {
 });
 
 /// The reporter playback lifecycle events route through: Plex for
-/// `plex:<ratingKey>` tracks, nothing for everyone else (local / Jellyfin /
-/// Subsonic playback is reported to no server, exactly as before).
+/// `plex:<ratingKey>` tracks (PMS timelines), Jellyfin for `jellyfin:<itemId>`
+/// tracks (play-session reports), Subsonic for `subsonic:<id>` tracks
+/// (now-playing + scrobble), and nothing for local files — a track only ever
+/// reaches the reporter that claims its uri, so one provider's playback can
+/// never trigger another provider's call.
 ///
-/// The Plex reporter reads its session and client through lazy getters — the
+/// Each reporter reads its session and client through lazy getters — the
 /// same shape the source router above uses — so signing in/out, and the
-/// client identity persisted at sign-in (which PMS keys the player session
-/// on), are picked up live without rebuilding the reporter or the
-/// session-pinned reporting service that holds it.
+/// client/device identity persisted at sign-in (which the server keys the
+/// player session on), are picked up live without rebuilding the reporter or
+/// the session-pinned reporting service that holds it.
 final serverPlaybackReporterProvider = Provider<ServerPlaybackReporter>((ref) {
   return RoutingServerPlaybackReporter(<ServerPlaybackReporter>[
     PlexPlaybackReporter(
       session: () => ref.read(plexMusicSourceProvider)?.session,
       client: () => ref.read(plexClientProvider),
     ),
+    JellyfinPlaybackReporter(
+      session: () => ref.read(jellyfinMusicSourceProvider)?.session,
+      client: () => ref.read(jellyfinClientProvider),
+    ),
+    SubsonicPlaybackReporter(
+      session: () => ref.read(subsonicMusicSourceProvider)?.session,
+      client: () => ref.read(subsonicClientProvider),
+    ),
   ]);
 });
 
 /// Playback reporting: mirrors live playback onto the server that owns the
-/// playing track (Plex today), so the user's own dashboard shows Linthra as an
-/// active player — started/paused/resumed/stopped immediately, progress on a
-/// throttled heartbeat.
+/// playing track (Plex, Jellyfin, or Subsonic/Navidrome), so the user's own
+/// dashboard shows Linthra as an active player — started/paused/resumed/
+/// stopped immediately, progress on a throttled heartbeat (each provider
+/// reporter maps those onto what its protocol supports).
 ///
 /// Pinned for the session like smart pre-cache and remote prebuffer: it reads
 /// the controller's state stream and the reporter once with [Ref.read], does

--- a/test/core/services/routing_server_playback_reporter_test.dart
+++ b/test/core/services/routing_server_playback_reporter_test.dart
@@ -52,6 +52,7 @@ class _SchemeReporter implements ServerPlaybackReporter {
 
 Track _plex(String id) => Track(id: id, title: id, uri: 'plex:$id');
 Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+Track _subsonic(String id) => Track(id: id, title: id, uri: 'subsonic:$id');
 Track _local(String id) =>
     Track(id: id, title: id, uri: 'file:///music/$id.flac');
 
@@ -104,6 +105,61 @@ void main() {
         router.onPlaybackStarted(_local('l'), Duration.zero, Duration.zero),
         completes,
       );
+    });
+
+    group('with the production line-up (Plex, Jellyfin, Subsonic)', () {
+      late _SchemeReporter jellyfin;
+      late _SchemeReporter subsonic;
+      late RoutingServerPlaybackReporter producers;
+
+      setUp(() {
+        jellyfin = _SchemeReporter('jellyfin:');
+        subsonic = _SchemeReporter('subsonic:');
+        producers = RoutingServerPlaybackReporter(
+            <ServerPlaybackReporter>[plex, jellyfin, subsonic]);
+      });
+
+      Future<void> playThrough(Track track) async {
+        const Duration p = Duration(seconds: 30);
+        const Duration d = Duration(minutes: 3);
+        await producers.onPlaybackStarted(track, p, d);
+        await producers.onPlaybackProgress(track, p, d);
+        await producers.onPlaybackPaused(track, p, d);
+        await producers.onPlaybackResumed(track, p, d);
+        await producers.onPlaybackStopped(track, p, d);
+      }
+
+      test('each provider reporter sees only its own tracks', () async {
+        await playThrough(_plex('p'));
+        await playThrough(_jellyfin('j'));
+        await playThrough(_subsonic('s'));
+
+        expect(plex.events.every((e) => e.endsWith(':p')), isTrue);
+        expect(plex.events, hasLength(5));
+        expect(jellyfin.events.every((e) => e.endsWith(':j')), isTrue);
+        expect(jellyfin.events, hasLength(5));
+        expect(subsonic.events.every((e) => e.endsWith(':s')), isTrue);
+        expect(subsonic.events, hasLength(5));
+      });
+
+      test('local playback never triggers any server reporter', () async {
+        await playThrough(_local('l'));
+        await producers.onTrackChanged(_local('l'), _local('m'));
+
+        expect(plex.events, isEmpty);
+        expect(jellyfin.events, isEmpty);
+        expect(subsonic.events, isEmpty);
+      });
+
+      test(
+          'a cross-provider queue move reaches exactly the two owners '
+          '(Jellyfin closes, Subsonic told; Plex never hears of it)', () async {
+        await producers.onTrackChanged(_jellyfin('j'), _subsonic('s'));
+
+        expect(jellyfin.events, <String>['changed:j->s']);
+        expect(subsonic.events, <String>['changed:j->s']);
+        expect(plex.events, isEmpty);
+      });
     });
 
     test('the first reporter claiming a track wins', () async {

--- a/test/core/sources/jellyfin/fake_jellyfin_client.dart
+++ b/test/core/sources/jellyfin/fake_jellyfin_client.dart
@@ -52,6 +52,29 @@ class FakeJellyfinClient implements JellyfinClient {
   JellyfinException? lyricsError;
   String? lastLyricsItemId;
 
+  /// When set, every [reportPlayback] call throws it (after being recorded),
+  /// so reporters can prove failures are swallowed. Set [playbackReportError]
+  /// for a typed failure or [playbackReportUnexpectedError] for an untyped one.
+  JellyfinException? playbackReportError;
+  Object? playbackReportUnexpectedError;
+
+  /// Every playback report received, in order, so tests can assert the exact
+  /// event/position sequence a playback scenario produced.
+  final List<
+      ({
+        String itemId,
+        JellyfinPlaybackEvent event,
+        Duration position,
+      })> playbackReports = <({
+    String itemId,
+    JellyfinPlaybackEvent event,
+    Duration position,
+  })>[];
+
+  /// The session the last [reportPlayback] call carried, so a test can prove
+  /// the live (current) session was used.
+  JellyfinSession? lastReportSession;
+
   /// Canned favourite ids for [fetchFavoriteIds] (also updated by [setFavorite]
   /// so a round-trip reads back consistently).
   Set<String> favoriteIds = <String>{};
@@ -253,6 +276,21 @@ class FakeJellyfinClient implements JellyfinClient {
       throw error;
     }
     return lyrics;
+  }
+
+  @override
+  Future<void> reportPlayback(
+    JellyfinSession session, {
+    required String itemId,
+    required JellyfinPlaybackEvent event,
+    required Duration position,
+  }) async {
+    lastReportSession = session;
+    playbackReports.add((itemId: itemId, event: event, position: position));
+    final JellyfinException? error = playbackReportError;
+    if (error != null) throw error;
+    final Object? unexpected = playbackReportUnexpectedError;
+    if (unexpected != null) throw unexpected;
   }
 
   @override

--- a/test/core/sources/jellyfin/http_jellyfin_client_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_test.dart
@@ -451,4 +451,163 @@ void main() {
       expect(requests[1].url.path, '/Users/user-1/FavoriteItems/item-7');
     });
   });
+
+  group('reportPlayback', () {
+    test('started POSTs the start body to /Sessions/Playing', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response('', 204);
+      }));
+
+      await client.reportPlayback(
+        _session,
+        itemId: 'item-7',
+        event: JellyfinPlaybackEvent.started,
+        position: const Duration(seconds: 1),
+      );
+
+      expect(captured!.method, 'POST');
+      expect(captured!.url.path, '/Sessions/Playing');
+      expect(captured!.headers['Content-Type'], startsWith('application/json'));
+      final Map<String, dynamic> body =
+          jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body['ItemId'], 'item-7');
+      // 10,000,000 ticks (100-ns units) is exactly one second.
+      expect(body['PositionTicks'], 10000000);
+      expect(body['IsPaused'], isFalse);
+      expect(body['CanSeek'], isTrue);
+      expect(body['PlayMethod'], 'DirectPlay');
+    });
+
+    test('progress and resume report the Progress endpoint, not paused',
+        () async {
+      final List<http.Request> requests = <http.Request>[];
+      final client = _client(MockClient((http.Request request) async {
+        requests.add(request);
+        return http.Response('', 204);
+      }));
+
+      for (final JellyfinPlaybackEvent event in <JellyfinPlaybackEvent>[
+        JellyfinPlaybackEvent.progress,
+        JellyfinPlaybackEvent.resumed,
+      ]) {
+        await client.reportPlayback(
+          _session,
+          itemId: 'item-7',
+          event: event,
+          position: const Duration(seconds: 30),
+        );
+      }
+
+      for (final http.Request request in requests) {
+        expect(request.url.path, '/Sessions/Playing/Progress');
+        final Map<String, dynamic> body =
+            jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['IsPaused'], isFalse);
+      }
+    });
+
+    test('paused reports the Progress endpoint with IsPaused', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response('', 204);
+      }));
+
+      await client.reportPlayback(
+        _session,
+        itemId: 'item-7',
+        event: JellyfinPlaybackEvent.paused,
+        position: const Duration(seconds: 30),
+      );
+
+      expect(captured!.url.path, '/Sessions/Playing/Progress');
+      final Map<String, dynamic> body =
+          jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body['IsPaused'], isTrue);
+    });
+
+    test(
+        'stopped POSTs only the item and position to '
+        '/Sessions/Playing/Stopped', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response('', 204);
+      }));
+
+      await client.reportPlayback(
+        _session,
+        itemId: 'item-7',
+        event: JellyfinPlaybackEvent.stopped,
+        position: const Duration(minutes: 3),
+      );
+
+      expect(captured!.url.path, '/Sessions/Playing/Stopped');
+      final Map<String, dynamic> body =
+          jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(body['ItemId'], 'item-7');
+      expect(
+        body['PositionTicks'],
+        const Duration(minutes: 3).inMicroseconds * 10,
+      );
+      expect(body.containsKey('IsPaused'), isFalse);
+      expect(body.containsKey('PlayMethod'), isFalse);
+    });
+
+    test('the token rides in the Authorization header, never the URL',
+        () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return http.Response('', 204);
+      }));
+
+      await client.reportPlayback(
+        _session,
+        itemId: 'item-7',
+        event: JellyfinPlaybackEvent.started,
+        position: Duration.zero,
+      );
+
+      expect(captured!.headers['Authorization'], contains('Token="tok-abc"'));
+      expect(captured!.url.toString(), isNot(contains('tok-abc')));
+      expect(captured!.url.hasQuery, isFalse);
+    });
+
+    test('maps a 401 to unauthorized (token-free)', () async {
+      final client =
+          _client(MockClient((_) async => http.Response('denied', 401)));
+
+      await expectLater(
+        client.reportPlayback(
+          _session,
+          itemId: 'item-7',
+          event: JellyfinPlaybackEvent.started,
+          position: Duration.zero,
+        ),
+        throwsA(isA<JellyfinException>()
+            .having((e) => e.kind, 'kind', JellyfinErrorKind.unauthorized)
+            .having((e) => e.message, 'message', isNot(contains('tok-abc')))),
+      );
+    });
+
+    test('maps a transport failure to notReachable', () async {
+      final client = _client(
+        MockClient((_) async => throw http.ClientException('refused')),
+      );
+
+      await expectLater(
+        client.reportPlayback(
+          _session,
+          itemId: 'item-7',
+          event: JellyfinPlaybackEvent.progress,
+          position: Duration.zero,
+        ),
+        throwsA(isA<JellyfinException>()
+            .having((e) => e.kind, 'kind', JellyfinErrorKind.notReachable)),
+      );
+    });
+  });
 }

--- a/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
@@ -96,6 +96,30 @@ void main() {
     });
   });
 
+  group('JellyfinEndpoints playback reporting', () {
+    test('start/progress/stop target the play-session endpoints', () {
+      expect(
+          JellyfinEndpoints.playbackStarted(_base).path, '/Sessions/Playing');
+      expect(JellyfinEndpoints.playbackProgress(_base).path,
+          '/Sessions/Playing/Progress');
+      expect(JellyfinEndpoints.playbackStopped(_base).path,
+          '/Sessions/Playing/Stopped');
+    });
+
+    test('the reporting URLs are token-free (item and auth ride elsewhere)',
+        () {
+      // The item/position go in the JSON body and the token in the
+      // Authorization header, so these URLs carry nothing at all.
+      for (final Uri uri in <Uri>[
+        JellyfinEndpoints.playbackStarted(_base),
+        JellyfinEndpoints.playbackProgress(_base),
+        JellyfinEndpoints.playbackStopped(_base),
+      ]) {
+        expect(uri.hasQuery, isFalse);
+      }
+    });
+  });
+
   group('JellyfinEndpoints.audioStream', () {
     final Uri uri = JellyfinEndpoints.audioStream(
       _base,

--- a/test/core/sources/jellyfin/jellyfin_playback_reporter_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_playback_reporter_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_playback_reporter.dart';
+
+import 'fake_jellyfin_client.dart';
+
+const String _token = 'super-secret-jellyfin-token';
+
+const JellyfinSession _session = JellyfinSession(
+  baseUrl: 'https://jellyfin.example.com',
+  userId: 'user-1',
+  accessToken: _token,
+  deviceId: 'device-1',
+);
+
+Track _jellyfinTrack(String itemId) => Track(
+      id: 'jf-$itemId',
+      title: 'Song $itemId',
+      uri: 'jellyfin:$itemId',
+      duration: const Duration(minutes: 3),
+    );
+
+const Track _plexTrack = Track(id: 'plex-1', title: 'Elsewhere', uri: 'plex:1');
+const Track _localTrack =
+    Track(id: 'local-1', title: 'On disk', uri: 'file:///music/song.flac');
+
+const Duration _position = Duration(seconds: 42);
+const Duration _duration = Duration(minutes: 3);
+
+void main() {
+  group('JellyfinPlaybackReporter', () {
+    late FakeJellyfinClient client;
+    JellyfinSession? session = _session;
+
+    setUp(() {
+      client = FakeJellyfinClient();
+      session = _session;
+    });
+
+    JellyfinPlaybackReporter build() => JellyfinPlaybackReporter(
+          session: () => session,
+          client: () => client,
+        );
+
+    test('handles only jellyfin: tracks', () {
+      final reporter = build();
+      expect(reporter.handles(_jellyfinTrack('42')), isTrue);
+      expect(reporter.handles(_plexTrack), isFalse);
+      expect(reporter.handles(_localTrack), isFalse);
+    });
+
+    test('started reports a start event with the itemId and position',
+        () async {
+      await build()
+          .onPlaybackStarted(_jellyfinTrack('item-1'), _position, _duration);
+
+      expect(client.playbackReports, hasLength(1));
+      final report = client.playbackReports.single;
+      expect(report.itemId, 'item-1');
+      expect(report.event, JellyfinPlaybackEvent.started);
+      expect(report.position, _position);
+      expect(client.lastReportSession, _session);
+    });
+
+    test('progress, pause, resume, and stop map to their events', () async {
+      final reporter = build();
+      final Track track = _jellyfinTrack('7');
+
+      await reporter.onPlaybackProgress(track, _position, _duration);
+      await reporter.onPlaybackPaused(track, _position, _duration);
+      await reporter.onPlaybackResumed(track, _position, _duration);
+      await reporter.onPlaybackStopped(track, _position, _duration);
+
+      expect(
+        client.playbackReports.map((r) => r.event),
+        <JellyfinPlaybackEvent>[
+          JellyfinPlaybackEvent.progress,
+          JellyfinPlaybackEvent.paused,
+          JellyfinPlaybackEvent.resumed,
+          JellyfinPlaybackEvent.stopped,
+        ],
+      );
+    });
+
+    test(
+        'a track change closes the outgoing Jellyfin track at its last '
+        'position', () async {
+      final reporter = build();
+      final Track previous = _jellyfinTrack('1');
+
+      await reporter.onPlaybackStarted(previous, Duration.zero, _duration);
+      await reporter.onPlaybackProgress(
+          previous, const Duration(seconds: 65), _duration);
+      await reporter.onTrackChanged(previous, _jellyfinTrack('2'));
+
+      final report = client.playbackReports.last;
+      expect(report.itemId, '1');
+      expect(report.event, JellyfinPlaybackEvent.stopped);
+      expect(report.position, const Duration(seconds: 65));
+    });
+
+    test('a track change with no remembered position stops at zero', () async {
+      await build().onTrackChanged(_jellyfinTrack('1'), null);
+
+      final report = client.playbackReports.single;
+      expect(report.event, JellyfinPlaybackEvent.stopped);
+      expect(report.position, Duration.zero);
+    });
+
+    test('a track change from another provider reports nothing', () async {
+      final reporter = build();
+
+      await reporter.onTrackChanged(_plexTrack, _jellyfinTrack('2'));
+      await reporter.onTrackChanged(null, _jellyfinTrack('2'));
+
+      expect(client.playbackReports, isEmpty);
+    });
+
+    group('never reports for what it cannot own', () {
+      test('a non-Jellyfin track is a silent no-op on every event', () async {
+        final reporter = build();
+
+        for (final Track track in <Track>[_plexTrack, _localTrack]) {
+          await reporter.onPlaybackStarted(track, _position, _duration);
+          await reporter.onPlaybackProgress(track, _position, _duration);
+          await reporter.onPlaybackPaused(track, _position, _duration);
+          await reporter.onPlaybackResumed(track, _position, _duration);
+          await reporter.onPlaybackStopped(track, _position, _duration);
+        }
+
+        expect(client.playbackReports, isEmpty);
+      });
+
+      test('a jellyfin: uri with a blank itemId is a silent no-op', () async {
+        const Track corrupt = Track(id: 'x', title: 'x', uri: 'jellyfin: ');
+
+        await build().onPlaybackStarted(corrupt, _position, _duration);
+
+        expect(client.playbackReports, isEmpty);
+      });
+
+      test('signed out (no session) is a silent no-op', () async {
+        session = null;
+
+        await build()
+            .onPlaybackStarted(_jellyfinTrack('1'), _position, _duration);
+
+        expect(client.playbackReports, isEmpty);
+      });
+    });
+
+    test(
+        'reads the live session at event time (sign-out mid-play stops '
+        'reporting; reconnect picks the new server up)', () async {
+      final reporter = build();
+      final Track track = _jellyfinTrack('1');
+
+      await reporter.onPlaybackStarted(track, _position, _duration);
+      session = null;
+      await reporter.onPlaybackProgress(track, _position, _duration);
+      session = _session.copyWith(baseUrl: 'https://other.example.com');
+      await reporter.onPlaybackPaused(track, _position, _duration);
+
+      expect(client.playbackReports, hasLength(2));
+      expect(client.lastReportSession?.baseUrl, 'https://other.example.com');
+    });
+
+    group('reporting is best-effort and never throws', () {
+      test('a typed Jellyfin failure is swallowed', () async {
+        client.playbackReportError = JellyfinException.notReachable();
+
+        await expectLater(
+          build().onPlaybackStarted(_jellyfinTrack('1'), _position, _duration),
+          completes,
+        );
+        // The attempt was made; the failure stayed inside the reporter.
+        expect(client.playbackReports, hasLength(1));
+      });
+
+      test('every lifecycle event swallows a failing server', () async {
+        client.playbackReportError = JellyfinException.unauthorized();
+        final reporter = build();
+        final Track track = _jellyfinTrack('1');
+
+        await expectLater(
+            reporter.onPlaybackStarted(track, _position, _duration), completes);
+        await expectLater(
+            reporter.onPlaybackProgress(track, _position, _duration),
+            completes);
+        await expectLater(
+            reporter.onPlaybackPaused(track, _position, _duration), completes);
+        await expectLater(
+            reporter.onPlaybackResumed(track, _position, _duration), completes);
+        await expectLater(
+            reporter.onPlaybackStopped(track, _position, _duration), completes);
+        await expectLater(reporter.onTrackChanged(track, null), completes);
+      });
+
+      test('an untyped failure is swallowed too', () async {
+        client.playbackReportUnexpectedError = StateError('boom $_token');
+
+        await expectLater(
+          build().onPlaybackStarted(_jellyfinTrack('1'), _position, _duration),
+          completes,
+        );
+      });
+    });
+
+    test(
+        'token safety: the token goes only to the client seam, and no '
+        'failure path can surface it', () async {
+      // Force every failure kind through the reporter with the real token in
+      // play; nothing may escape (the reporter never throws), so there is no
+      // error object, message, or return value a token could ride out on.
+      for (final JellyfinException error in <JellyfinException>[
+        JellyfinException.unauthorized(),
+        JellyfinException.notReachable(),
+        JellyfinException.serverError(500),
+        JellyfinException.notJellyfin(),
+      ]) {
+        client = FakeJellyfinClient()..playbackReportError = error;
+        Object? escaped;
+        try {
+          await build()
+              .onPlaybackStarted(_jellyfinTrack('1'), _position, _duration);
+        } catch (e) {
+          escaped = e;
+        }
+        expect(escaped, isNull,
+            reason: 'reporting must never throw (${error.kind})');
+        // The token was used solely inside the session handed to the client.
+        expect(client.lastReportSession?.accessToken, _token);
+      }
+    });
+
+    test('reported values stay credential-free (itemId is not a URL or token)',
+        () async {
+      await build()
+          .onPlaybackStarted(_jellyfinTrack('item-9'), _position, _duration);
+
+      final report = client.playbackReports.single;
+      expect(report.itemId, isNot(contains(_token)));
+      expect(report.itemId, isNot(contains('http')));
+    });
+  });
+}

--- a/test/core/sources/subsonic/fake_subsonic_client.dart
+++ b/test/core/sources/subsonic/fake_subsonic_client.dart
@@ -37,6 +37,21 @@ class FakeSubsonicClient implements SubsonicClient {
   Lyrics? lyrics;
   SubsonicException? lyricsError;
 
+  /// When set, every [scrobble] call throws it (after being recorded), so
+  /// reporters can prove failures are swallowed. Set [scrobbleError] for a
+  /// typed failure or [scrobbleUnexpectedError] for an untyped one.
+  SubsonicException? scrobbleError;
+  Object? scrobbleUnexpectedError;
+
+  /// Every scrobble call received, in order, so tests can assert the exact
+  /// now-playing/submission sequence a playback scenario produced.
+  final List<({String songId, bool submission})> scrobbles =
+      <({String songId, bool submission})>[];
+
+  /// The session the last [scrobble] call carried, so a test can prove the
+  /// live (current) session was used.
+  SubsonicSession? lastScrobbleSession;
+
   // Recorded inputs.
   String? lastBaseUrl;
   String? lastUsername;
@@ -121,5 +136,19 @@ class FakeSubsonicClient implements SubsonicClient {
     if (error != null) throw error;
     return streamProbe ??
         const SubsonicStreamProbe(statusCode: 200, contentType: 'audio/mpeg');
+  }
+
+  @override
+  Future<void> scrobble(
+    SubsonicSession session,
+    String songId, {
+    required bool submission,
+  }) async {
+    lastScrobbleSession = session;
+    scrobbles.add((songId: songId, submission: submission));
+    final SubsonicException? error = scrobbleError;
+    if (error != null) throw error;
+    final Object? unexpected = scrobbleUnexpectedError;
+    if (unexpected != null) throw unexpected;
   }
 }

--- a/test/core/sources/subsonic/http_subsonic_client_test.dart
+++ b/test/core/sources/subsonic/http_subsonic_client_test.dart
@@ -497,4 +497,67 @@ void main() {
       );
     });
   });
+
+  group('scrobble', () {
+    test('targets /rest/scrobble.view with the id, flag, and auth query',
+        () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _ok(const <String, dynamic>{});
+      }));
+
+      await client.scrobble(_session, 's-7', submission: false);
+
+      expect(captured!.url.path, '/rest/scrobble.view');
+      final q = captured!.url.queryParameters;
+      expect(q['id'], 's-7');
+      expect(q['submission'], 'false');
+      expect(q['u'], 'alice');
+      expect(q['t'], 'tok1');
+      expect(q['s'], 'salt1');
+    });
+
+    test('a submission sends submission=true', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _ok(const <String, dynamic>{});
+      }));
+
+      await client.scrobble(_session, 's-7', submission: true);
+
+      expect(captured!.url.queryParameters['submission'], 'true');
+    });
+
+    test('an error envelope throws the typed kind (e.g. an old server)',
+        () async {
+      // A server that rejects/doesn't support scrobbling answers inside a 200;
+      // the typed exception is what the playback reporter swallows.
+      final client = _client(
+        MockClient((_) async => _failed(30, 'Incompatible version')),
+      );
+
+      await expectLater(
+        () => client.scrobble(_session, 's-7', submission: true),
+        throwsA(isA<SubsonicException>().having(
+            (e) => e.kind, 'kind', SubsonicErrorKind.unsupportedResponse)),
+      );
+    });
+
+    test('a transport failure throws notReachable, never the URL credential',
+        () async {
+      final client = _client(MockClient((_) async => throw http.ClientException(
+            'Connection failed: $_base/rest/scrobble.view?t=tok1&s=salt1',
+          )));
+
+      await expectLater(
+        () => client.scrobble(_session, 's-7', submission: false),
+        throwsA(isA<SubsonicException>()
+            .having((e) => e.kind, 'kind', SubsonicErrorKind.notReachable)
+            .having((e) => e.message, 'message', isNot(contains('tok1')))
+            .having((e) => e.message, 'message', isNot(contains('salt1')))),
+      );
+    });
+  });
 }

--- a/test/core/sources/subsonic/subsonic_endpoints_test.dart
+++ b/test/core/sources/subsonic/subsonic_endpoints_test.dart
@@ -70,6 +70,31 @@ void main() {
       expect(download.queryParameters['id'], 's-7');
     });
 
+    test('scrobble carries the song id and the submission flag', () {
+      final Uri nowPlaying = SubsonicEndpoints.scrobble(
+        _base,
+        username: _user,
+        credentials: _creds,
+        songId: 's-7',
+        submission: false,
+      );
+      final Uri submission = SubsonicEndpoints.scrobble(
+        _base,
+        username: _user,
+        credentials: _creds,
+        songId: 's-7',
+        submission: true,
+      );
+      expect(nowPlaying.path, '/rest/scrobble.view');
+      expect(nowPlaying.queryParameters['id'], 's-7');
+      expect(nowPlaying.queryParameters['submission'], 'false');
+      expect(submission.queryParameters['submission'], 'true');
+      // The standard auth query rides along like on every endpoint.
+      expect(nowPlaying.queryParameters['u'], _user);
+      expect(nowPlaying.queryParameters['t'], _creds.token);
+      expect(nowPlaying.queryParameters['s'], _creds.salt);
+    });
+
     test('coverArt targets /rest/getCoverArt.view and carries the cover id',
         () {
       final Uri uri = SubsonicEndpoints.coverArt(

--- a/test/core/sources/subsonic/subsonic_playback_reporter_test.dart
+++ b/test/core/sources/subsonic/subsonic_playback_reporter_test.dart
@@ -1,0 +1,419 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_playback_reporter.dart';
+
+import 'fake_subsonic_client.dart';
+
+const String _token = 'super-secret-subsonic-token';
+
+const SubsonicSession _session = SubsonicSession(
+  baseUrl: 'https://navidrome.example.com',
+  username: 'alice',
+  salt: 'salty',
+  token: _token,
+);
+
+Track _subsonicTrack(String id,
+        {Duration duration = const Duration(minutes: 3)}) =>
+    Track(
+      id: 'sub-$id',
+      title: 'Song $id',
+      uri: 'subsonic:$id',
+      duration: duration,
+    );
+
+const Track _plexTrack = Track(id: 'plex-1', title: 'Elsewhere', uri: 'plex:1');
+const Track _localTrack =
+    Track(id: 'local-1', title: 'On disk', uri: 'file:///music/song.flac');
+
+const Duration _duration = Duration(minutes: 3);
+
+/// Past half of [_duration], so a settle at this position submits a play.
+const Duration _playedEnough = Duration(minutes: 2);
+
+/// Well short of half of [_duration] (and of the four-minute floor), so a
+/// settle at this position submits nothing.
+const Duration _playedLittle = Duration(seconds: 20);
+
+void main() {
+  group('SubsonicPlaybackReporter', () {
+    late FakeSubsonicClient client;
+    SubsonicSession? session = _session;
+
+    setUp(() {
+      client = FakeSubsonicClient();
+      session = _session;
+    });
+
+    SubsonicPlaybackReporter build() => SubsonicPlaybackReporter(
+          session: () => session,
+          client: () => client,
+        );
+
+    test('handles only subsonic: tracks', () {
+      final reporter = build();
+      expect(reporter.handles(_subsonicTrack('42')), isTrue);
+      expect(reporter.handles(_plexTrack), isFalse);
+      expect(reporter.handles(_localTrack), isFalse);
+    });
+
+    test('started announces now playing (submission=false)', () async {
+      await build().onPlaybackStarted(
+          _subsonicTrack('song-1'), Duration.zero, _duration);
+
+      expect(client.scrobbles, hasLength(1));
+      final scrobble = client.scrobbles.single;
+      expect(scrobble.songId, 'song-1');
+      expect(scrobble.submission, isFalse);
+      expect(client.lastScrobbleSession, _session);
+    });
+
+    test('progress and pause send nothing (no wire concept for them)',
+        () async {
+      final reporter = build();
+      final Track track = _subsonicTrack('7');
+
+      await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+      await reporter.onPlaybackProgress(track, _playedLittle, _duration);
+      await reporter.onPlaybackPaused(track, _playedEnough, _duration);
+
+      // Only the start's now-playing went out.
+      expect(client.scrobbles, hasLength(1));
+      expect(client.scrobbles.single.submission, isFalse);
+    });
+
+    test('resume re-announces now playing', () async {
+      final reporter = build();
+      final Track track = _subsonicTrack('7');
+
+      await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+      await reporter.onPlaybackPaused(track, _playedLittle, _duration);
+      await reporter.onPlaybackResumed(track, _playedLittle, _duration);
+
+      expect(client.scrobbles, hasLength(2));
+      expect(client.scrobbles.every((s) => !s.submission), isTrue);
+      expect(client.scrobbles.every((s) => s.songId == '7'), isTrue);
+    });
+
+    group('a stop submits the play only when enough of it ran', () {
+      test('stopping past half the track submits (submission=true)', () async {
+        final reporter = build();
+        final Track track = _subsonicTrack('s');
+
+        await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+        await reporter.onPlaybackStopped(track, _playedEnough, _duration);
+
+        expect(client.scrobbles, hasLength(2));
+        final submission = client.scrobbles.last;
+        expect(submission.songId, 's');
+        expect(submission.submission, isTrue);
+      });
+
+      test('stopping early submits nothing (a skip is not a play)', () async {
+        final reporter = build();
+        final Track track = _subsonicTrack('s');
+
+        await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+        await reporter.onPlaybackStopped(track, _playedLittle, _duration);
+
+        expect(client.scrobbles, hasLength(1));
+        expect(client.scrobbles.single.submission, isFalse);
+      });
+
+      test('four minutes of a long track submit even when short of half',
+          () async {
+        const Duration long = Duration(minutes: 10);
+        final reporter = build();
+        final Track track = _subsonicTrack('long', duration: long);
+
+        await reporter.onPlaybackStarted(track, Duration.zero, long);
+        await reporter.onPlaybackStopped(
+            track, const Duration(minutes: 4), long);
+
+        expect(client.scrobbles.last.submission, isTrue);
+      });
+
+      test('an unknown duration submits only past the four-minute floor',
+          () async {
+        final reporter = build();
+        final Track track = _subsonicTrack('nodur', duration: Duration.zero);
+
+        await reporter.onPlaybackStarted(track, Duration.zero, Duration.zero);
+        await reporter.onPlaybackStopped(
+            track, const Duration(minutes: 3), Duration.zero);
+
+        expect(client.scrobbles, hasLength(1),
+            reason: 'three minutes of an unknown-length track is not a play');
+
+        await reporter.onPlaybackStarted(track, Duration.zero, Duration.zero);
+        await reporter.onPlaybackStopped(
+            track, const Duration(minutes: 4), Duration.zero);
+
+        expect(client.scrobbles.last.submission, isTrue);
+      });
+    });
+
+    test('a track change settles the outgoing track at its last position',
+        () async {
+      final reporter = build();
+      final Track previous = _subsonicTrack('1');
+
+      await reporter.onPlaybackStarted(previous, Duration.zero, _duration);
+      await reporter.onPlaybackProgress(previous, _playedEnough, _duration);
+      await reporter.onTrackChanged(previous, _subsonicTrack('2'));
+
+      final submission = client.scrobbles.last;
+      expect(submission.songId, '1');
+      expect(submission.submission, isTrue);
+    });
+
+    test('a track change after an early skip submits nothing', () async {
+      final reporter = build();
+      final Track previous = _subsonicTrack('1');
+
+      await reporter.onPlaybackStarted(previous, Duration.zero, _duration);
+      await reporter.onPlaybackProgress(previous, _playedLittle, _duration);
+      await reporter.onTrackChanged(previous, _subsonicTrack('2'));
+
+      expect(client.scrobbles, hasLength(1));
+      expect(client.scrobbles.single.submission, isFalse);
+    });
+
+    test('a stop followed by the queue moving on settles once, not twice',
+        () async {
+      final reporter = build();
+      final Track track = _subsonicTrack('1');
+
+      await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+      await reporter.onPlaybackStopped(track, _playedEnough, _duration);
+      await reporter.onTrackChanged(track, _subsonicTrack('2'));
+
+      expect(
+        client.scrobbles.where((s) => s.submission),
+        hasLength(1),
+        reason: 'one play must submit at most one scrobble',
+      );
+    });
+
+    test('replaying the same track submits again (each play counts)', () async {
+      final reporter = build();
+      final Track track = _subsonicTrack('loop');
+
+      await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+      await reporter.onPlaybackStopped(track, _duration, _duration);
+      await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+      await reporter.onPlaybackStopped(track, _duration, _duration);
+
+      expect(client.scrobbles.where((s) => s.submission), hasLength(2));
+    });
+
+    test(
+        'a fresh play never inherits the previous track\'s position '
+        '(early skip after a long play stays unsubmitted)', () async {
+      final reporter = build();
+      final Track first = _subsonicTrack('1');
+      final Track second = _subsonicTrack('2');
+
+      await reporter.onPlaybackStarted(first, Duration.zero, _duration);
+      await reporter.onPlaybackProgress(first, _playedEnough, _duration);
+      await reporter.onTrackChanged(first, second);
+      await reporter.onPlaybackStarted(second, Duration.zero, _duration);
+      await reporter.onTrackChanged(second, null);
+
+      // First track: now-playing + submission. Second: now-playing only —
+      // its play never moved past zero, whatever the first track did.
+      expect(
+        client.scrobbles.map((s) => '${s.songId}:${s.submission}'),
+        <String>['1:false', '1:true', '2:false'],
+      );
+    });
+
+    test('a track change from another provider reports nothing', () async {
+      final reporter = build();
+
+      await reporter.onTrackChanged(_plexTrack, _subsonicTrack('2'));
+      await reporter.onTrackChanged(null, _subsonicTrack('2'));
+      await reporter.onTrackChanged(_localTrack, null);
+
+      expect(client.scrobbles, isEmpty);
+    });
+
+    group('never reports for what it cannot own', () {
+      test('a non-Subsonic track is a silent no-op on every event', () async {
+        final reporter = build();
+
+        for (final Track track in <Track>[_plexTrack, _localTrack]) {
+          await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+          await reporter.onPlaybackProgress(track, _playedEnough, _duration);
+          await reporter.onPlaybackPaused(track, _playedEnough, _duration);
+          await reporter.onPlaybackResumed(track, _playedEnough, _duration);
+          await reporter.onPlaybackStopped(track, _duration, _duration);
+        }
+
+        expect(client.scrobbles, isEmpty);
+      });
+
+      test('a subsonic: uri with a blank id is a silent no-op', () async {
+        const Track corrupt = Track(id: 'x', title: 'x', uri: 'subsonic: ');
+
+        await build().onPlaybackStarted(corrupt, Duration.zero, _duration);
+
+        expect(client.scrobbles, isEmpty);
+      });
+
+      test('signed out (no session) is a silent no-op', () async {
+        session = null;
+
+        await build()
+            .onPlaybackStarted(_subsonicTrack('1'), Duration.zero, _duration);
+
+        expect(client.scrobbles, isEmpty);
+      });
+    });
+
+    test(
+        'reads the live session at event time (sign-out mid-play stops '
+        'reporting; reconnect picks the new server up)', () async {
+      final reporter = build();
+      final Track track = _subsonicTrack('1');
+
+      await reporter.onPlaybackStarted(track, Duration.zero, _duration);
+      session = null;
+      await reporter.onPlaybackResumed(track, _playedLittle, _duration);
+      session = _session.copyWith(baseUrl: 'https://other.example.com');
+      await reporter.onPlaybackResumed(track, _playedLittle, _duration);
+
+      expect(client.scrobbles, hasLength(2));
+      expect(client.lastScrobbleSession?.baseUrl, 'https://other.example.com');
+    });
+
+    group('reporting is best-effort and never throws', () {
+      test('a typed Subsonic failure is swallowed', () async {
+        client.scrobbleError = SubsonicException.notReachable();
+
+        await expectLater(
+          build()
+              .onPlaybackStarted(_subsonicTrack('1'), Duration.zero, _duration),
+          completes,
+        );
+        // The attempt was made; the failure stayed inside the reporter.
+        expect(client.scrobbles, hasLength(1));
+      });
+
+      test('a server without scrobble support is swallowed on every event',
+          () async {
+        // A server that doesn't implement scrobble answers with a Subsonic
+        // error envelope, which the client maps to a typed exception.
+        client.scrobbleError = SubsonicException.unsupportedResponse();
+        final reporter = build();
+        final Track track = _subsonicTrack('1');
+
+        await expectLater(
+            reporter.onPlaybackStarted(track, Duration.zero, _duration),
+            completes);
+        await expectLater(
+            reporter.onPlaybackResumed(track, _playedEnough, _duration),
+            completes);
+        await expectLater(
+            reporter.onPlaybackStopped(track, _duration, _duration), completes);
+        await expectLater(reporter.onTrackChanged(track, null), completes);
+      });
+
+      test('an untyped failure is swallowed too', () async {
+        client.scrobbleUnexpectedError = StateError('boom $_token');
+
+        await expectLater(
+          build()
+              .onPlaybackStarted(_subsonicTrack('1'), Duration.zero, _duration),
+          completes,
+        );
+      });
+    });
+
+    test(
+        'credential safety: the credential goes only to the client seam, and '
+        'no failure path can surface it', () async {
+      // Force every failure kind through the reporter with the real token in
+      // play; nothing may escape (the reporter never throws), so there is no
+      // error object, message, or return value a credential could ride out on.
+      for (final SubsonicException error in <SubsonicException>[
+        SubsonicException.unauthorized(),
+        SubsonicException.notReachable(),
+        SubsonicException.serverError(500),
+        SubsonicException.unsupportedResponse(),
+      ]) {
+        client = FakeSubsonicClient()..scrobbleError = error;
+        Object? escaped;
+        try {
+          await build()
+              .onPlaybackStarted(_subsonicTrack('1'), Duration.zero, _duration);
+        } catch (e) {
+          escaped = e;
+        }
+        expect(escaped, isNull,
+            reason: 'reporting must never throw (${error.kind})');
+        // The credential was used solely inside the session handed to the
+        // client.
+        expect(client.lastScrobbleSession?.token, _token);
+      }
+    });
+
+    test('scrobbled values stay credential-free (songId is not a URL or token)',
+        () async {
+      await build().onPlaybackStarted(
+          _subsonicTrack('song-9'), Duration.zero, _duration);
+
+      final scrobble = client.scrobbles.single;
+      expect(scrobble.songId, isNot(contains(_token)));
+      expect(scrobble.songId, isNot(contains('http')));
+    });
+
+    group('playedEnoughToSubmit', () {
+      const Duration threeMinutes = Duration(minutes: 3);
+
+      test('half the track counts', () {
+        expect(
+          SubsonicPlaybackReporter.playedEnoughToSubmit(
+              const Duration(seconds: 90), threeMinutes),
+          isTrue,
+        );
+      });
+
+      test('just under half does not count', () {
+        expect(
+          SubsonicPlaybackReporter.playedEnoughToSubmit(
+              const Duration(seconds: 89), threeMinutes),
+          isFalse,
+        );
+      });
+
+      test('the four-minute floor counts regardless of duration', () {
+        expect(
+          SubsonicPlaybackReporter.playedEnoughToSubmit(
+              const Duration(minutes: 4), const Duration(minutes: 60)),
+          isTrue,
+        );
+        expect(
+          SubsonicPlaybackReporter.playedEnoughToSubmit(
+              const Duration(minutes: 4), Duration.zero),
+          isTrue,
+        );
+      });
+
+      test('zero position never counts', () {
+        expect(
+          SubsonicPlaybackReporter.playedEnoughToSubmit(
+              Duration.zero, threeMinutes),
+          isFalse,
+        );
+        expect(
+          SubsonicPlaybackReporter.playedEnoughToSubmit(
+              Duration.zero, Duration.zero),
+          isFalse,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Jellyfin and Subsonic/Navidrome playback reporting

Extends the provider-neutral `ServerPlaybackReporter` system (#192) so Linthra is recognized as an active player by **Jellyfin** and **Subsonic/Navidrome**, not only Plex. The playback layer is untouched: the existing `PlaybackReportingService` and `RoutingServerPlaybackReporter` keep deriving/routing lifecycle events; two new per-provider reporters claim their own uri schemes.

## Jellyfin (`jellyfin:<itemId>` tracks)

- New `JellyfinClient.reportPlayback` posts to the play-session endpoints — `POST /Sessions/Playing`, `/Sessions/Playing/Progress` (with `IsPaused` for pause/resume), `/Sessions/Playing/Stopped` — with `ItemId` + `PositionTicks` (100-ns ticks) in the JSON body.
- The server keys the session on the same `MediaBrowser Client="Linthra", DeviceId=…` Authorization header used everywhere, so the dashboard shows **Linthra** and pause/resume update one player entry.
- `JellyfinPlaybackReporter` mirrors the Plex reporter: started/progress/paused/resumed/stopped map 1:1; a queue move closes the outgoing track at its last reported position.

## Subsonic/Navidrome (`subsonic:<id>` tracks)

- New `SubsonicClient.scrobble` calls `GET /rest/scrobble.view?id=…&submission=…` (Subsonic API ≥ 1.5.0, so Navidrome and generic servers alike).
- `SubsonicPlaybackReporter` maps the lifecycle onto what the protocol can express:
  - **start / resume** → `submission=false` (now playing; resume re-announces so the entry stays fresh),
  - **progress / pause** → no request (no wire concept); the position is remembered,
  - **stop / queue move** → `submission=true` only when the play *counts*: at least half the track, or at least 4 minutes — the classic scrobbling rule, applied client-side. A skipped-early track submits nothing, and one play submits at most once.
- A server without scrobble support answers with an error envelope → the usual typed, secret-free exception, swallowed by the reporter.

## Shared contract (unchanged invariants)

- **Best-effort, never fatal**: every failure (typed or not) is swallowed inside the reporter with a kind-only debug breadcrumb; the reporting service already dispatches off the playback path.
- **Routing isolation**: a track only ever reaches the reporter that claims its scheme; local files report nowhere.
- **Live session reads**: reporters read session + client through lazy getters, so sign-in/out is picked up mid-play; signed out = silent no-op.
- **Secret safety**: the Jellyfin token rides only in the `Authorization` header (the reporting URLs carry nothing — no query at all); Subsonic credentials are woven into the URL inside the client per call and discarded, exactly like stream URLs. Nothing about reporting is persisted, and no token/credential can reach a log, error, or diagnostic on any path.

## Tests (2090 passing, `flutter analyze` clean)

- Each provider reporter reports **only for its own tracks**; non-owned tracks and blank ids are silent no-ops (per-reporter + routing-level tests with the production Plex/Jellyfin/Subsonic line-up).
- **Local playback triggers no server reporter** (routing test).
- **Reporting errors never stop playback**: every lifecycle event swallows every failure kind on both new reporters (plus the existing service-level throwing-reporter test).
- Wire mapping: endpoint selection per event, `PositionTicks` conversion, `IsPaused`, stopped body shape, scrobble `id`/`submission` + auth query, Subsonic error-envelope mapping.
- Token safety: Jellyfin reporting URLs are token-free, errors are token-free, and forced failures with real tokens in play can't surface them.

## Docs

- `docs/jellyfin-compatibility.md`: the three new endpoints added to the audited table.
- `docs/plex.md`: routing description updated (each provider now claims its scheme).
- `docs/manual-test-checklist.md`: new §3b with the manual QA pass below.

## Manual QA

- [ ] Play a Plex track → PMS Now Playing still works (start/pause/progress/stop).
- [ ] Play a Jellyfin track → server dashboard shows a Linthra session; pause shows paused; stop/skip clears it.
- [ ] Play a Navidrome/Subsonic track → now-playing shows Linthra; play count bumps after half/4 min; early skip doesn't count.
- [ ] Play a local track → no server reporting anywhere.
- [ ] Pause/resume/skip/stop across providers, including a mixed-provider queue.
- [ ] Kill the server mid-play → playback continues, controls work, no error, no token in logs.

## Out of scope

No lyrics, no offline/cache UI, no Plex.tv OAuth, no new provider UI, no version bump, no release changes.

https://claude.ai/code/session_01MrRLZuBosnDenfyEyLETUw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrRLZuBosnDenfyEyLETUw)_