### PR TITLE
Add plex.tv PIN sign-in flow as primary authentication method

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -27,8 +27,10 @@ Phase 1 is a **read-only** Plex provider, mirroring how Subsonic shipped
 streaming first and deferred the rest:
 
 - Connect to a Plex Media Server.
-- **Token-based authentication**, starting with a **manual server URL + manual
-  token** (the plex.tv PIN/OAuth flow is a documented follow-up).
+- **Token-based authentication** — the plex.tv **PIN sign-in** ("Connect with
+  Plex", shipped after the phase-1 polish) as the primary flow, with the
+  original **manual server URL + manual token** kept as the advanced
+  fallback.
 - Discover and let the user **select** which music libraries (sections) to use.
 - List artists, albums, and tracks.
 - **Stream** tracks — **direct play only** (no server-side transcoding).
@@ -93,24 +95,40 @@ Jellyfin's device id + `Authorization` client header.
 
 ### Two ways to obtain a token
 
-- **Manual token + server URL — phase 1 first cut (recommended).** The user
-  pastes their `X-Plex-Token` and server URL; Linthra verifies it against
-  `/identity`. Closest to the existing Jellyfin/Subsonic "URL + credential,
-  verify against the server" flow, with no browser handoff.
-- **PIN / OAuth via plex.tv — later (nicer UX, more moving parts).**
-  `POST https://plex.tv/api/v2/pins?strong=true` → `{id, code}`; the user opens
-  `https://app.plex.tv/auth#?clientID=…&code=…`; Linthra polls
-  `GET https://plex.tv/api/v2/pins/{id}` until `authToken` is populated.
-  Optionally `GET https://plex.tv/api/v2/resources?includeHttps=1` then returns
-  the user's servers, **each with its own per-server `accessToken`** and
-  connection URIs.
+- **PIN sign-in via plex.tv — the primary flow (shipped).** "Connect with
+  Plex" in Settings: `POST https://plex.tv/api/v2/pins?strong=true` →
+  `{id, code}`; the browser opens
+  `https://app.plex.tv/auth#?clientID=…&code=…&context[device][product]=…`
+  (parameters in the **fragment**, bound to the same
+  `X-Plex-Client-Identifier` that minted the PIN); Linthra polls
+  `GET https://plex.tv/api/v2/pins/{id}` every 2s until `authToken` is
+  populated (tolerating transient failures while the user is away in the
+  browser; a 404 means the PIN lapsed). With the account token,
+  `GET https://plex.tv/api/v2/resources?includeHttps=1&includeRelay=1`
+  returns the user's servers, **each with its own per-server `accessToken`**
+  and connection URIs. One server connects directly; several show a picker
+  (owned servers first); none shows a clean empty state. The picked server's
+  connections are probed in order (relay last) against `GET /identity`, and
+  only then is a session persisted. The account token lives **only in
+  memory** for the duration of the flow and is released the moment the flow
+  ends — connected, cancelled, or failed.
+  Implementation: `plex_tv_endpoints.dart` / `plex_tv_api.dart` /
+  `plex_tv_client.dart` / `http_plex_tv_client.dart` / `plex_pin_auth.dart`.
+- **Manual token + server URL — the advanced fallback (kept).** The user
+  pastes their `X-Plex-Token` and server URL under "Manual setup (advanced)";
+  Linthra verifies it against `/identity`. Closest to the existing
+  Jellyfin/Subsonic "URL + credential, verify against the server" flow, with
+  no browser handoff — useful for dev setups and tokens scoped by hand.
 
 ### Token scope (key safety decision)
 
 Prefer the **per-server `accessToken`** from the resources endpoint over the
 **account token**: the account token grants access to the whole Plex account,
 not just one server — a far bigger blast radius if it ever leaks. The design
-defaults to the **narrowest token that works**.
+defaults to the **narrowest token that works**. The shipped PIN flow follows
+this: `PlexPinAuth.connectToServer` persists the picked server's
+`accessToken` and falls back to the account token only when plex.tv didn't
+provide one; the account token itself is never persisted anywhere.
 
 ## Token safety rules
 
@@ -122,8 +140,14 @@ extra concern (the token rides in **query params** for stream/art URLs).
   via `flutter_secure_storage`, in a `secure_plex_session_store.dart` under a
   single versioned key (e.g. `plex_session_v1`), with an
   `InMemoryPlexSessionStore` for tests.
-- **Never persist a password.** If the PIN flow is used later, only the
-  resulting token is kept.
+- **Never persist a password.** The PIN flow never sees one (the user signs
+  in to plex.tv in their own browser); only the resulting token is kept. The
+  **account** token granted by the PIN exists only in controller memory while
+  the flow runs (poll → server pick) and is released when the flow ends.
+- **plex.tv calls keep the token in the header.** The pins/resources URLs are
+  token-free; the only token-bearing wire DTO (`PlexResource.accessToken`)
+  redacts it in `toString`, and the settings state exposes display-safe
+  `PlexServerChoice`s instead of resources.
 - **No token in `Track.uri` or `Track.artworkUri`** (or the DB). Keep the
   opaque, credential-free `plex:<ratingKey>` and `plex-thumb:<…>` references;
   mint credentialed URLs **only** at play/render time and discard them.
@@ -261,15 +285,17 @@ token-free, and the reporter swallows every failure kind.
   than Jellyfin's `api_key` param or Subsonic's salt+token. → Centralize URL
   redaction.
 - **Auth-flow complexity.** Plex's modern path is a plex.tv PIN/browser handoff,
-  unlike a single username/password POST. → Phase 1 starts with manual token
-  paste.
+  unlike a single username/password POST. → Phase 1 started with manual token
+  paste; the PIN flow has since shipped on top of it (manual stays as the
+  advanced fallback).
 - **Two-step play resolution.** `ratingKey` ≠ Part `key`, so playback needs an
   extra metadata round trip. Jellyfin/Subsonic build the stream URL straight
   from the id.
 - **Connectivity / `.plex.direct` TLS & relay.** Plex servers are often reached
   via plex.tv-discovered connections (relay, `*.plex.direct` certs) rather than
-  a plain typed URL. → Phase 1: typed URL + token; document relay/discovery as a
-  follow-up.
+  a plain typed URL. → The PIN flow now probes the plex.tv-advertised
+  connections in order (relay kept as the last resort, since it is
+  bandwidth-capped); the manual flow still takes a typed URL.
 - **Direct-play codec fit.** Without the transcoder, a Part may be a codec the
   device can't decode. → Phase 1 is direct-play only; transcoding is a later
   capability.
@@ -280,11 +306,16 @@ token-free, and the reporter swallows every failure kind.
 
 ```
 lib/core/sources/plex/
-  plex_api.dart            # DTOs (MediaContainer / Metadata / Part)
-  plex_endpoints.dart      # pure URL builders
-  plex_client.dart         # interface (HTTP behind this seam)
+  plex_api.dart            # PMS DTOs (MediaContainer / Metadata / Part)
+  plex_endpoints.dart      # pure PMS URL builders
+  plex_client.dart         # PMS interface (HTTP behind this seam)
   http_plex_client.dart    # package:http impl, JSON via Accept header
-  plex_authenticator.dart  # token verify (+ optional PIN flow)
+  plex_authenticator.dart  # manual token verify (advanced fallback)
+  plex_tv_api.dart         # plex.tv DTOs (PlexPin / PlexResource)
+  plex_tv_endpoints.dart   # pure plex.tv URL builders (pins/resources/auth)
+  plex_tv_client.dart      # plex.tv interface
+  http_plex_tv_client.dart # package:http impl for plex.tv
+  plex_pin_auth.dart       # the PIN sign-in flow (begin/poll/servers/connect)
   plex_track_mapper.dart   # type 8/9/10 -> Artist/Album/Track, plex: scheme
   plex_music_source.dart   # implements MusicSource (+ PlexStreamSource)
   plex_stream_source.dart  # narrow stream seam
@@ -308,13 +339,24 @@ overrides.
   missing-field fallbacks.
 - `http_plex_client_test.dart` — JSON parsing via `Accept: application/json`,
   error → `PlexException` mapping, **token never in exception/log**, paging.
-- `plex_authenticator_test.dart` — token-paste verify against `/identity`;
-  (if PIN flow) pin create/poll; per-server vs account token selection.
-- `fake_plex_client.dart` — reusable canned-response/error fake.
+- `plex_authenticator_test.dart` — token-paste verify against `/identity`.
+- `plex_tv_endpoints_test.dart` — pins/resources/auth-app builders (fragment
+  shape, encoding, token-free URLs).
+- `plex_tv_api_test.dart` — PIN/resource parsing, `providesServer`,
+  **`PlexResource.toString` redacts the accessToken**.
+- `http_plex_tv_client_test.dart` — pin create/poll/expiry, resources array,
+  token in header only, every failure token-free.
+- `plex_pin_auth_test.dart` — poll pacing/cancel/expiry/transient tolerance,
+  server filtering (owned first), per-server vs account token selection,
+  connection probe order (relay last; unauthorized aborts), session building.
+- `fake_plex_client.dart` / `fake_plex_tv_client.dart` — reusable
+  canned-response/error fakes.
 - `plex_music_source_test.dart` — fetch + `resolvePlayableUri` (part-key
   lookup), library-selection scoping.
 - `plex_settings_controller_test.dart` — connect/select-libraries/sign-out,
-  state holds **no** token, password/token cleared after use.
+  state holds **no** token, password/token cleared after use; the sign-in
+  flow's linking/picker/cancel/error states, server selection, and a
+  full-flow token sweep over every state field.
 - Capability-matrix test — Plex declares stream-only in phase 1.
 - A guard test that `MusicProviders.forTrackUri` still routes existing
   `jellyfin:` / `subsonic:` / local URIs unchanged (no regression).
@@ -365,6 +407,16 @@ Small, incremental, each independently reviewable:
    reference all degrade to the row's placeholder. Tests sweep every failure
    kind for token/URL-free messages and re-prove the Jellyfin/Subsonic/local
    artwork chain is untouched.
+10. **plex.tv PIN sign-in ("Connect with Plex")** — the browser/PIN flow as
+    the primary connection path (this section's [Authentication](#authentication)
+    describes it): mint a strong PIN, open `app.plex.tv/auth` in the browser,
+    poll for approval (cancellable, transient-failure tolerant), list the
+    account's servers with per-server tokens, pick one (auto when there is
+    exactly one; clean empty state when there are none), probe its
+    plex.tv-advertised connections (relay last), and persist the
+    server-scoped session. Manual URL + token stays available under
+    "Manual setup (advanced)", and a rejected/expired session offers
+    "Reconnect with Plex" right at the error.
 
 ## Notes
 

--- a/lib/app/external_link_launcher_provider.dart
+++ b/lib/app/external_link_launcher_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/services/external_link_launcher.dart';
+
+/// The browser seam the app launches external pages through — the "Report a
+/// bug" flow's prefilled GitHub issue and the Plex "Connect with Plex"
+/// sign-in page. One shared provider (declared here at the app level, like
+/// `notificationPermissionProvider`) so every feature opens the browser
+/// through the same seam and a test override covers them all.
+///
+/// Production wires the `url_launcher`-backed launcher; tests override it
+/// with a fake so no real browser is opened. Every launch is an explicit
+/// user action; nothing opens on its own.
+final externalLinkLauncherProvider = Provider<ExternalLinkLauncher>(
+  (ref) => const UrlLauncherExternalLinkLauncher(),
+);

--- a/lib/core/models/plex_session.dart
+++ b/lib/core/models/plex_session.dart
@@ -44,8 +44,8 @@ class PlexSession {
   final String machineIdentifier;
 
   /// The server's friendly name, when known. `GET /identity` doesn't report
-  /// one, so the manual flow leaves this `null`; the plex.tv discovery flow (a
-  /// follow-up) provides it. Not secret, display only.
+  /// one, so the manual flow leaves this `null`; the plex.tv sign-in flow
+  /// fills it from the picked server resource. Not secret, display only.
   final String? serverName;
 
   /// The server's reported version (from `/identity`), when known. Carried so the

--- a/lib/core/sources/plex/http_plex_tv_client.dart
+++ b/lib/core/sources/plex/http_plex_tv_client.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'plex_client.dart';
+import 'plex_exception.dart';
+import 'plex_tv_api.dart';
+import 'plex_tv_client.dart';
+import 'plex_tv_endpoints.dart';
+
+/// The real [PlexTvClient], backed by `package:http`.
+///
+/// The only file in the app that talks to plex.tv over HTTP (the sibling of
+/// `HttpPlexClient`, which owns the user's own server): it sets
+/// `Accept: application/json`, the [PlexClientIdentity] headers — plex.tv
+/// binds a PIN to the `X-Plex-Client-Identifier` that minted it, so the same
+/// identity must sign every call — and, only where a call needs one, the
+/// account token as the `X-Plex-Token` **header**. Every URL it requests is
+/// token-free and safe to log.
+///
+/// Every failure becomes a [PlexException] built from a static, plex.tv-worded
+/// factory; no token is ever written into an exception, a log, or any other
+/// output. See docs/plex.md → Token safety rules.
+class HttpPlexTvClient implements PlexTvClient {
+  HttpPlexTvClient({
+    required PlexClientIdentity identity,
+    http.Client? httpClient,
+  })  : _identity = identity,
+        _client = httpClient ?? http.Client();
+
+  final PlexClientIdentity _identity;
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(seconds: 20);
+
+  @override
+  Future<PlexPin> createPin() async {
+    final http.Response response = await _send(
+      () => _client.post(PlexTvEndpoints.pins(), headers: _headers()),
+    );
+    _checkStatus(response);
+    final PlexPin? pin = PlexPin.fromJson(_decodeObject(response));
+    if (pin == null) {
+      // A 2xx body without an id/code: nothing Linthra could poll.
+      throw PlexException.plexTvUnexpected();
+    }
+    return pin;
+  }
+
+  @override
+  Future<String?> checkPin(int pinId) async {
+    final http.Response response = await _send(
+      () => _client.get(PlexTvEndpoints.pin(pinId), headers: _headers()),
+    );
+    if (response.statusCode == 404) {
+      // plex.tv discarded the PIN before it was approved — definitive, so the
+      // poll loop stops instead of spinning on a dead id.
+      throw PlexException.signInExpired();
+    }
+    _checkStatus(response);
+    final Object? token = _decodeObject(response)['authToken'];
+    if (token is String && token.isNotEmpty) {
+      return token;
+    }
+    return null;
+  }
+
+  @override
+  Future<List<PlexResource>> fetchResources({required String token}) async {
+    final http.Response response = await _send(
+      () => _client.get(
+        PlexTvEndpoints.resources(),
+        headers: _headers(token: token),
+      ),
+    );
+    _checkStatus(response);
+    final Object? decoded = _decode(response);
+    if (decoded is! List) {
+      // /api/v2/resources answers a bare JSON array; anything else isn't a
+      // response Linthra can use.
+      throw PlexException.plexTvUnexpected();
+    }
+    return <PlexResource>[
+      for (final Object? entry in decoded)
+        if (entry is Map<String, dynamic>)
+          if (PlexResource.fromJson(entry) case final PlexResource resource)
+            resource,
+    ];
+  }
+
+  /// The headers every plex.tv call sends: `Accept: application/json`, the
+  /// stable client-identity headers, and — only when a call needs one — the
+  /// account [token] as the `X-Plex-Token` **header** (never a query param,
+  /// so the URLs stay token-free and loggable).
+  Map<String, String> _headers({String? token}) => <String, String>{
+        'Accept': 'application/json',
+        if (token != null) 'X-Plex-Token': token,
+        ..._identity.toHeaders(),
+      };
+
+  /// Runs a request with a timeout, turning any transport-level failure into
+  /// the single friendly [PlexException.plexTvUnreachable].
+  ///
+  /// Security: the low-level error text is **never** echoed into the thrown
+  /// message — only the static, token-free factory is used.
+  Future<http.Response> _send(Future<http.Response> Function() request) async {
+    try {
+      return await request().timeout(_timeout);
+    } on TimeoutException {
+      throw PlexException.plexTvUnreachable();
+    } on http.ClientException {
+      throw PlexException.plexTvUnreachable();
+    } on Exception {
+      // SocketException / HandshakeException and friends: all "can't reach".
+      throw PlexException.plexTvUnreachable();
+    }
+  }
+
+  /// Maps an HTTP status to a [PlexException]. 2xx passes; everything else
+  /// throws before the body is parsed, so error handling never depends on —
+  /// or echoes — response content. (A PIN-poll 404 is handled by the caller,
+  /// which knows it means "expired", before this runs.)
+  void _checkStatus(http.Response response) {
+    final int code = response.statusCode;
+    if (code >= 200 && code < 300) return;
+    if (code == 401 || code == 403) {
+      throw PlexException.signInRejected();
+    }
+    if (code >= 500) {
+      throw PlexException.plexTvError(code);
+    }
+    throw PlexException.plexTvUnexpected(code);
+  }
+
+  /// Decodes a JSON object body, or throws [PlexException.plexTvUnexpected]
+  /// when the body isn't a JSON object.
+  Map<String, dynamic> _decodeObject(http.Response response) {
+    final Object? decoded = _decode(response);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    throw PlexException.plexTvUnexpected();
+  }
+
+  /// Decodes a JSON body of any shape (the resources endpoint answers a bare
+  /// array), or throws [PlexException.plexTvUnexpected] for non-JSON.
+  Object? _decode(http.Response response) {
+    try {
+      // Decode the raw bytes as UTF-8 rather than `response.body` (which
+      // falls back to latin1 without a charset and would mangle non-ASCII
+      // server names).
+      final String text = utf8.decode(response.bodyBytes, allowMalformed: true);
+      return jsonDecode(text);
+    } on FormatException {
+      // Not JSON at all — e.g. plex.tv's default XML or an HTML error page.
+      throw PlexException.plexTvUnexpected();
+    }
+  }
+}

--- a/lib/core/sources/plex/plex_authenticator.dart
+++ b/lib/core/sources/plex/plex_authenticator.dart
@@ -6,13 +6,13 @@ import 'plex_server_url.dart';
 
 /// Turns a manually typed server URL + token into a usable [PlexSession].
 ///
-/// The "authentication" concern for phase 1's manual flow, kept separate from
-/// session storage (the `PlexSessionStore`) and from library fetching (the
-/// future `PlexMusicSource`): it normalizes the URL and asks the [PlexClient] to
-/// confirm the address is a reachable Plex Media Server that accepts the token,
-/// via `GET /identity`. It does not persist anything — the controller decides
-/// whether/where to store the session — so this stays a pure coordinator that's
-/// trivial to test with a fake client.
+/// The "authentication" concern for the **manual / advanced** flow, kept
+/// separate from session storage (the `PlexSessionStore`) and from library
+/// fetching (the `PlexMusicSource`): it normalizes the URL and asks the
+/// [PlexClient] to confirm the address is a reachable Plex Media Server that
+/// accepts the token, via `GET /identity`. It does not persist anything — the
+/// controller decides whether/where to store the session — so this stays a
+/// pure coordinator that's trivial to test with a fake client.
 ///
 /// Token safety: the token is only trimmed, handed to the client (which sends it
 /// as the `X-Plex-Token` **header** — never a logged URL), and copied into the
@@ -22,8 +22,9 @@ import 'plex_server_url.dart';
 /// server-scoped one) plus the server metadata; it never holds a stream/art URL.
 /// See docs/plex.md → Authentication / Token safety rules.
 ///
-/// The plex.tv PIN/OAuth flow is a documented follow-up; phase 1 is manual token
-/// paste only.
+/// The primary "Connect with Plex" path is the plex.tv PIN sign-in
+/// (`PlexPinAuth`); this manual flow stays as the advanced fallback for users
+/// who already have a token (and for dev setups).
 class PlexAuthenticator {
   PlexAuthenticator(this._client);
 

--- a/lib/core/sources/plex/plex_exception.dart
+++ b/lib/core/sources/plex/plex_exception.dart
@@ -114,6 +114,63 @@ class PlexException implements Exception {
         statusCode: statusCode,
       );
 
+  // --- plex.tv (account sign-in) failures. Same rules as above: static,
+  // token-free messages only — but worded for plex.tv, not the user's own
+  // server, so a sign-in hiccup doesn't tell them to go check a server
+  // address that was never involved.
+
+  factory PlexException.plexTvUnreachable() => const PlexException(
+        "Couldn't reach plex.tv to sign you in. Check that you're online, "
+        'then try again.',
+        kind: PlexErrorKind.notReachable,
+      );
+
+  factory PlexException.plexTvError(int statusCode) => PlexException(
+        'plex.tv reported an error (HTTP $statusCode). Try again in a moment.',
+        kind: PlexErrorKind.serverError,
+        statusCode: statusCode,
+      );
+
+  factory PlexException.plexTvUnexpected([int? statusCode]) => PlexException(
+        'plex.tv returned a response Linthra could not use'
+        '${statusCode != null ? ' (HTTP $statusCode)' : ''}. '
+        'Try again in a moment.',
+        kind: PlexErrorKind.unexpected,
+        statusCode: statusCode,
+      );
+
+  /// The browser sign-in wasn't approved in time (the plex.tv PIN lapsed or
+  /// was discarded server-side). Definitive — polling the same PIN again can
+  /// never succeed — so the flow restarts from "Connect with Plex".
+  factory PlexException.signInExpired() => const PlexException(
+        'Your Plex sign-in expired before it finished. '
+        'Tap "Connect with Plex" to try again.',
+        kind: PlexErrorKind.unauthorized,
+      );
+
+  factory PlexException.signInRejected() => const PlexException(
+        "plex.tv didn't accept the sign-in request. Try connecting again.",
+        kind: PlexErrorKind.unauthorized,
+        statusCode: 401,
+      );
+
+  /// No advertised connection address of the chosen server answered. Worded
+  /// for the picker flow ("its addresses" come from plex.tv, the user never
+  /// typed one).
+  factory PlexException.serverUnreachable() => const PlexException(
+        "Couldn't reach your Plex server at any of its addresses. Make sure "
+        "it's online and reachable from this device, then try again.",
+        kind: PlexErrorKind.notReachable,
+      );
+
+  /// The device has no browser to hand the plex.tv sign-in page to (or it
+  /// refused the launch). Thrown by the settings flow, not the HTTP layer.
+  factory PlexException.browserUnavailable() => const PlexException(
+        "Couldn't open the Plex sign-in page in a browser on this device. "
+        'Try again, or use manual setup below.',
+        kind: PlexErrorKind.unexpected,
+      );
+
   /// A user-facing explanation safe to show in the UI — never carries the token.
   final String message;
 

--- a/lib/core/sources/plex/plex_pin_auth.dart
+++ b/lib/core/sources/plex/plex_pin_auth.dart
@@ -167,8 +167,13 @@ class PlexPinAuth {
   /// bandwidth-capped — only worth it when nothing direct answers). A
   /// rejected token ([PlexErrorKind.unauthorized]) aborts immediately — the
   /// same token would be rejected on every address — while unreachable or
-  /// non-Plex answers just move on to the next address. When nothing answers,
-  /// throws [PlexException.serverUnreachable].
+  /// non-Plex answers just move on to the next address. An address that
+  /// answers as a **different** server (its `machineIdentifier` doesn't match
+  /// the picked [server]'s `clientIdentifier`) is skipped too: a stale or
+  /// reused advertised address can reach another Plex server that — under the
+  /// account-token fallback — accepts the same account-wide token, and
+  /// persisting it would silently bind the user to the wrong server. When
+  /// nothing matching answers, throws [PlexException.serverUnreachable].
   Future<PlexSession> connectToServer({
     required PlexResource server,
     required String accountToken,
@@ -201,6 +206,15 @@ class PlexPinAuth {
         );
       } on PlexException catch (error) {
         if (error.kind == PlexErrorKind.unauthorized) rethrow;
+        continue;
+      }
+      // Confirm this address actually reached the server the user picked. A
+      // PMS reports its `machineIdentifier` as the resource's
+      // `clientIdentifier`, so a mismatch means a stale/reused address landed
+      // on some other server (reachable here only because the account-token
+      // fallback is accepted account-wide) — skip it rather than persist the
+      // wrong server under the picked one's name.
+      if (identity.machineIdentifier != server.clientIdentifier) {
         continue;
       }
       return PlexSession(

--- a/lib/core/sources/plex/plex_pin_auth.dart
+++ b/lib/core/sources/plex/plex_pin_auth.dart
@@ -1,0 +1,216 @@
+import '../../models/plex_session.dart';
+import 'plex_api.dart';
+import 'plex_client.dart';
+import 'plex_exception.dart';
+import 'plex_server_url.dart';
+import 'plex_tv_api.dart';
+import 'plex_tv_client.dart';
+import 'plex_tv_endpoints.dart';
+
+/// One started browser sign-in: the PIN to poll and the page the browser was
+/// (or can again be) handed.
+///
+/// Holds no token — the PIN [code] inside [authUrl] is the public half of the
+/// handshake (approving it requires the user's own plex.tv browser session),
+/// and the granted token only ever travels through
+/// [PlexPinAuth.waitForAuthToken]'s return value.
+class PlexPinLink {
+  const PlexPinLink({required this.pinId, required this.authUrl});
+
+  /// The plex.tv PIN id this flow polls.
+  final int pinId;
+
+  /// The `app.plex.tv/auth` page to open in the user's browser.
+  final Uri authUrl;
+
+  @override
+  String toString() => 'PlexPinLink(pinId: $pinId)';
+}
+
+/// The seam the poll loop waits through, injectable so tests can run the loop
+/// without real delays. Production uses `Future.delayed`.
+typedef PlexPinAuthWait = Future<void> Function(Duration duration);
+
+/// The plex.tv PIN sign-in flow, end to end: mint a PIN and the browser URL
+/// ([begin]), poll until the user approves it ([waitForAuthToken]), list the
+/// account's Plex Media Servers ([fetchServers]), and turn the picked server
+/// into a verified, persistable [PlexSession] ([connectToServer]).
+///
+/// Every plex.tv-specific auth detail lives here, behind plain methods, so the
+/// settings controller only orchestrates UI state — mirroring how the manual
+/// flow keeps its details in [PlexAuthenticator] (which remains the advanced /
+/// fallback path).
+///
+/// Token safety: the account token returned by [waitForAuthToken] exists to be
+/// handed straight back into [fetchServers]/[connectToServer]; it is never
+/// stored on this class, never logged, and never reaches an exception (every
+/// failure is a static, token-free [PlexException]). [connectToServer] prefers
+/// each server's **server-scoped** `accessToken` over the account token — the
+/// narrowest credential that works — and only the resulting session (whose
+/// `toString` redacts its token) carries a secret out of this class. See
+/// docs/plex.md → Token safety rules.
+class PlexPinAuth {
+  PlexPinAuth({
+    required PlexTvClient tvClient,
+    required PlexClient serverClient,
+    required PlexClientIdentity identity,
+    PlexPinAuthWait wait = Future.delayed,
+  })  : _tvClient = tvClient,
+        _serverClient = serverClient,
+        _identity = identity,
+        _wait = wait;
+
+  final PlexTvClient _tvClient;
+  final PlexClient _serverClient;
+  final PlexClientIdentity _identity;
+  final PlexPinAuthWait _wait;
+
+  /// How often the granted-token poll asks plex.tv about the PIN. Plex's own
+  /// guidance is ~1s; 2s is plenty responsive for a flow that involves a
+  /// browser round-trip, and halves the request load.
+  static const Duration pollInterval = Duration(seconds: 2);
+
+  /// How long the poll keeps trying before giving up as expired. Slightly
+  /// inside plex.tv's own ~30-minute PIN lifetime, and generous enough for a
+  /// password manager + 2FA round-trip in the browser.
+  static const Duration pollTimeout = Duration(minutes: 15);
+
+  /// How many *consecutive* failed polls (plex.tv unreachable, 5xx, …) are
+  /// tolerated before the flow gives up. Polling happens while the user is
+  /// away in the browser, where a connectivity blip is normal — a single
+  /// failed request must not kill the sign-in — but a plex.tv that hasn't
+  /// answered for ~30s isn't coming back within the user's patience.
+  static const int maxConsecutivePollFailures = 15;
+
+  /// Mints a PIN and builds the browser page for it. The `clientID` woven
+  /// into the URL is the same `X-Plex-Client-Identifier` the client sends on
+  /// every request — plex.tv binds the PIN to it.
+  Future<PlexPinLink> begin() async {
+    final PlexPin pin = await _tvClient.createPin();
+    return PlexPinLink(
+      pinId: pin.id,
+      authUrl: PlexTvEndpoints.authApp(
+        clientIdentifier: _identity.clientIdentifier,
+        code: pin.code,
+        product: _identity.product,
+      ),
+    );
+  }
+
+  /// Polls the PIN until the user approves the sign-in in the browser,
+  /// returning the granted **account** token — or `null` when [isCancelled]
+  /// reports the caller no longer wants the result (the user cancelled, or a
+  /// newer attempt superseded this one).
+  ///
+  /// Transient failures (plex.tv unreachable, a 5xx) are tolerated and the
+  /// poll continues — the app may be backgrounded behind the browser while
+  /// connectivity flaps — but [maxConsecutivePollFailures] in a row rethrows
+  /// the last failure, and a PIN plex.tv no longer knows (404) or a poll that
+  /// outlives [pollTimeout] throws [PlexException.signInExpired].
+  Future<String?> waitForAuthToken(
+    int pinId, {
+    bool Function()? isCancelled,
+  }) async {
+    final int maxAttempts =
+        pollTimeout.inMilliseconds ~/ pollInterval.inMilliseconds;
+    int consecutiveFailures = 0;
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
+      if (isCancelled?.call() ?? false) return null;
+      try {
+        final String? token = await _tvClient.checkPin(pinId);
+        consecutiveFailures = 0;
+        if (token != null && token.isNotEmpty) {
+          return token;
+        }
+      } on PlexException catch (error) {
+        // A 401/403/404 from the PIN endpoint is definitive (the PIN lapsed
+        // or was refused); anything else is treated as transient.
+        if (error.kind == PlexErrorKind.unauthorized) rethrow;
+        consecutiveFailures++;
+        if (consecutiveFailures >= maxConsecutivePollFailures) rethrow;
+      }
+      if (isCancelled?.call() ?? false) return null;
+      await _wait(pollInterval);
+    }
+    throw PlexException.signInExpired();
+  }
+
+  /// Lists the account's Plex Media Servers (resources that provide
+  /// `server`), owned servers first so the picker leads with the user's own.
+  Future<List<PlexResource>> fetchServers({
+    required String accountToken,
+  }) async {
+    final List<PlexResource> resources =
+        await _tvClient.fetchResources(token: accountToken);
+    final List<PlexResource> servers = <PlexResource>[
+      for (final PlexResource resource in resources)
+        if (resource.providesServer) resource,
+    ];
+    return <PlexResource>[
+      for (final PlexResource server in servers)
+        if (server.owned) server,
+      for (final PlexResource server in servers)
+        if (!server.owned) server,
+    ];
+  }
+
+  /// Verifies the picked [server] is reachable and returns a session for it.
+  ///
+  /// Token choice: the server's own **server-scoped** `accessToken` when
+  /// plex.tv provided one, falling back to the account token only when it
+  /// didn't — the narrowest blast radius that works (docs/plex.md → Token
+  /// scope). The session starts with no selected library sections; the
+  /// existing library picker fills them.
+  ///
+  /// Connections are probed one at a time in plex.tv's order, except that
+  /// relay addresses go last (they work from anywhere but are
+  /// bandwidth-capped — only worth it when nothing direct answers). A
+  /// rejected token ([PlexErrorKind.unauthorized]) aborts immediately — the
+  /// same token would be rejected on every address — while unreachable or
+  /// non-Plex answers just move on to the next address. When nothing answers,
+  /// throws [PlexException.serverUnreachable].
+  Future<PlexSession> connectToServer({
+    required PlexResource server,
+    required String accountToken,
+  }) async {
+    final String? accessToken = server.accessToken;
+    final String token = (accessToken != null && accessToken.isNotEmpty)
+        ? accessToken
+        : accountToken;
+
+    final List<PlexResourceConnection> ordered = <PlexResourceConnection>[
+      for (final PlexResourceConnection c in server.connections)
+        if (!c.relay) c,
+      for (final PlexResourceConnection c in server.connections)
+        if (c.relay) c,
+    ];
+
+    for (final PlexResourceConnection connection in ordered) {
+      final String baseUrl;
+      try {
+        baseUrl = PlexServerUrl.normalize(connection.uri);
+      } on PlexException {
+        // A malformed advertised address can't be probed; try the next one.
+        continue;
+      }
+      final PlexServerIdentity identity;
+      try {
+        identity = await _serverClient.fetchIdentity(
+          baseUrl: baseUrl,
+          token: token,
+        );
+      } on PlexException catch (error) {
+        if (error.kind == PlexErrorKind.unauthorized) rethrow;
+        continue;
+      }
+      return PlexSession(
+        baseUrl: baseUrl,
+        token: token,
+        machineIdentifier: identity.machineIdentifier,
+        serverName: server.name.isNotEmpty ? server.name : null,
+        serverVersion: identity.version ?? server.productVersion,
+      );
+    }
+    throw PlexException.serverUnreachable();
+  }
+}

--- a/lib/core/sources/plex/plex_pin_auth.dart
+++ b/lib/core/sources/plex/plex_pin_auth.dart
@@ -164,16 +164,22 @@ class PlexPinAuth {
   ///
   /// Connections are probed one at a time in plex.tv's order, except that
   /// relay addresses go last (they work from anywhere but are
-  /// bandwidth-capped — only worth it when nothing direct answers). A
-  /// rejected token ([PlexErrorKind.unauthorized]) aborts immediately — the
-  /// same token would be rejected on every address — while unreachable or
-  /// non-Plex answers just move on to the next address. An address that
-  /// answers as a **different** server (its `machineIdentifier` doesn't match
-  /// the picked [server]'s `clientIdentifier`) is skipped too: a stale or
-  /// reused advertised address can reach another Plex server that — under the
-  /// account-token fallback — accepts the same account-wide token, and
-  /// persisting it would silently bind the user to the wrong server. When
-  /// nothing matching answers, throws [PlexException.serverUnreachable].
+  /// bandwidth-capped — only worth it when nothing direct answers).
+  /// Unreachable or non-Plex answers move on to the next address. An address
+  /// that answers as a **different** server (its `machineIdentifier` doesn't
+  /// match the picked [server]'s `clientIdentifier`) is skipped too: a stale
+  /// or reused advertised address can reach another Plex server that — under
+  /// the account-token fallback — accepts the same account-wide token, and
+  /// persisting it would silently bind the user to the wrong server.
+  ///
+  /// A rejected token (HTTP 401/403) on a single address does **not** abort
+  /// the probe either: that same stale/reused address can land on a different
+  /// server that rejects this server-scoped token, while a later advertised
+  /// address still reaches the picked one. Every address is tried; if none
+  /// matches, a token rejection seen on any of them is reported in preference
+  /// to a generic unreachable error (it's the more actionable failure —
+  /// reconnect to re-grant the token), otherwise
+  /// [PlexException.serverUnreachable].
   Future<PlexSession> connectToServer({
     required PlexResource server,
     required String accountToken,
@@ -190,6 +196,11 @@ class PlexPinAuth {
         if (c.relay) c,
     ];
 
+    // Remembered across the whole probe: a 401/403 from any single address is
+    // not fatal on its own (it may come from a stale address on a different
+    // server), but if nothing matches it's the failure worth surfacing.
+    PlexException? rejected;
+
     for (final PlexResourceConnection connection in ordered) {
       final String baseUrl;
       try {
@@ -205,7 +216,13 @@ class PlexPinAuth {
           token: token,
         );
       } on PlexException catch (error) {
-        if (error.kind == PlexErrorKind.unauthorized) rethrow;
+        // Don't let one address's rejection abort the rest: a stale/reused
+        // address can reach a *different* server that rejects this
+        // server-scoped token, while a later address still reaches the picked
+        // one. Remember it and keep probing.
+        if (error.kind == PlexErrorKind.unauthorized) {
+          rejected = error;
+        }
         continue;
       }
       // Confirm this address actually reached the server the user picked. A
@@ -224,6 +241,11 @@ class PlexPinAuth {
         serverName: server.name.isNotEmpty ? server.name : null,
         serverVersion: identity.version ?? server.productVersion,
       );
+    }
+    // Nothing reached the picked server. A token rejection on any address is
+    // the more actionable outcome (reconnect/re-grant) than "unreachable".
+    if (rejected != null) {
+      throw rejected;
     }
     throw PlexException.serverUnreachable();
   }

--- a/lib/core/sources/plex/plex_tv_api.dart
+++ b/lib/core/sources/plex/plex_tv_api.dart
@@ -1,0 +1,219 @@
+/// Wire models for the plex.tv account API (the PIN sign-in flow).
+///
+/// These mirror the JSON shapes `https://plex.tv/api/v2` returns when asked for
+/// JSON (`Accept: application/json`) and live behind the `PlexTvClient`;
+/// nothing outside the Plex source should touch them. They are deliberately
+/// separate from `plex_api.dart`: that file models the user's own Plex Media
+/// Server, this one models Plex's account service — two different hosts with
+/// two different envelopes (plex.tv answers bare objects/arrays, a PMS wraps
+/// everything in `MediaContainer`).
+///
+/// **Secrets.** A [PlexPin] holds **no** token by design — the granted
+/// `authToken` is read off the poll response by the client and handed straight
+/// to the caller, never parked on a DTO. A [PlexResource] must carry its
+/// per-server `accessToken` (that token is the very thing the flow is after),
+/// so its [PlexResource.toString] redacts it, exactly like `PlexSession`. See
+/// docs/plex.md → Token safety rules.
+///
+/// Only the fields Linthra uses are kept; the rest of each payload is ignored.
+library;
+
+/// One sign-in PIN minted by `POST https://plex.tv/api/v2/pins?strong=true`.
+///
+/// The [id] is what Linthra polls (`GET /api/v2/pins/{id}`) and the [code] is
+/// what the plex.tv auth page consumes (woven into the `app.plex.tv/auth` URL
+/// the browser opens). Neither is the auth token: the code is the *public*
+/// half of the handshake — approving it requires the user's signed-in plex.tv
+/// session in the browser — and the granted token is returned only by the
+/// poll, bound to the `X-Plex-Client-Identifier` that created the PIN.
+class PlexPin {
+  const PlexPin({required this.id, required this.code, this.expiresInSeconds});
+
+  /// The PIN's id, used to poll its status. Not a credential.
+  final int id;
+
+  /// The single-use code the browser auth page consumes. Short-lived and
+  /// useless without the user approving it from their own plex.tv session.
+  final String code;
+
+  /// Seconds until plex.tv discards an unapproved PIN, when reported. The
+  /// poll loop keeps its own (shorter) cap, so this is informational.
+  final int? expiresInSeconds;
+
+  /// Parses a `POST /api/v2/pins` body, or returns `null` when the [id] or
+  /// [code] is missing (so the caller reports "unusable response" instead of
+  /// polling a half-built PIN).
+  static PlexPin? fromJson(Map<String, dynamic> json) {
+    final int? id = _asInt(json['id']);
+    final String? code = _asString(json['code']);
+    if (id == null || code == null || code.isEmpty) return null;
+    return PlexPin(
+      id: id,
+      code: code,
+      expiresInSeconds: _asInt(json['expiresIn']),
+    );
+  }
+
+  @override
+  String toString() =>
+      'PlexPin(id: $id, expiresInSeconds: $expiresInSeconds, code: <omitted>)';
+}
+
+/// One device on the user's Plex account, from
+/// `GET https://plex.tv/api/v2/resources` — Linthra keeps the ones that
+/// [providesServer] (the user's Plex Media Servers).
+///
+/// Carries the **server-scoped** [accessToken] (the narrowest credential that
+/// works — see docs/plex.md → Token scope) plus the [connections] the server
+/// can be reached on. [toString] redacts the token.
+class PlexResource {
+  const PlexResource({
+    required this.name,
+    required this.clientIdentifier,
+    this.provides = '',
+    this.accessToken,
+    this.owned = true,
+    this.productVersion,
+    this.connections = const <PlexResourceConnection>[],
+  });
+
+  /// The server's friendly name (what the picker shows). Not secret.
+  final String name;
+
+  /// The device's stable identifier. For a Plex Media Server this is its
+  /// `machineIdentifier` — the same value `GET /identity` reports. Not secret.
+  final String clientIdentifier;
+
+  /// Comma-separated capabilities (`"server"`, `"client,player"`, …).
+  final String provides;
+
+  /// The **server-scoped** token plex.tv minted for this user on this server —
+  /// the credential Linthra prefers over the account token. Secret: never log,
+  /// never put in a URL outside the documented stream/art builders.
+  final String? accessToken;
+
+  /// Whether the account owns this server (vs. one shared with it).
+  final bool owned;
+
+  /// The server's reported version, when present. Display only.
+  final String? productVersion;
+
+  /// The addresses this server may be reachable on, in plex.tv's order.
+  final List<PlexResourceConnection> connections;
+
+  /// Whether this resource is a Plex Media Server (it `provides` "server").
+  bool get providesServer =>
+      provides.split(',').map((String p) => p.trim()).contains('server');
+
+  /// Parses one resource, or returns `null` when it lacks the identity fields
+  /// a picker entry needs, so a single malformed entry can't break the
+  /// listing. Malformed connections are skipped the same way.
+  static PlexResource? fromJson(Map<String, dynamic> json) {
+    final String? name = _asString(json['name']);
+    final String? clientIdentifier = _asString(json['clientIdentifier']);
+    if (clientIdentifier == null || clientIdentifier.isEmpty) return null;
+
+    final Object? rawConnections = json['connections'];
+    final List<PlexResourceConnection> connections = rawConnections is List
+        ? <PlexResourceConnection>[
+            for (final Object? entry in rawConnections)
+              if (entry is Map<String, dynamic>)
+                if (PlexResourceConnection.fromJson(entry)
+                    case final PlexResourceConnection c)
+                  c,
+          ]
+        : const <PlexResourceConnection>[];
+
+    return PlexResource(
+      name: name ?? '',
+      clientIdentifier: clientIdentifier,
+      provides: _asString(json['provides']) ?? '',
+      accessToken: _asString(json['accessToken']),
+      owned: _asBool(json['owned'], fallback: true),
+      productVersion: _asString(json['productVersion']),
+      connections: connections,
+    );
+  }
+
+  /// Redacts the access token so a resource can be safely interpolated into
+  /// logs or error messages without leaking the secret.
+  @override
+  String toString() => 'PlexResource(name: $name, '
+      'clientIdentifier: $clientIdentifier, '
+      'provides: $provides, '
+      'owned: $owned, '
+      'productVersion: $productVersion, '
+      'connections: $connections, '
+      'accessToken: ${accessToken == null ? 'null' : '<redacted>'})';
+}
+
+/// One address a [PlexResource] may be reachable on.
+///
+/// The [uri] is what Linthra probes (e.g. a `*.plex.direct` HTTPS address or a
+/// LAN address); [local]/[relay] describe what kind of path it is so the probe
+/// can keep the slow plex.tv relay as the last resort. No field is a secret.
+class PlexResourceConnection {
+  const PlexResourceConnection({
+    required this.uri,
+    this.local = false,
+    this.relay = false,
+    this.protocol,
+  });
+
+  /// The full base address to try (scheme + host + port). Token-free.
+  final String uri;
+
+  /// Whether plex.tv classified this address as on the server's LAN.
+  final bool local;
+
+  /// Whether this address goes through the plex.tv relay (reachable from
+  /// anywhere but bandwidth-limited — a last resort for streaming).
+  final bool relay;
+
+  /// `http` / `https`, when reported.
+  final String? protocol;
+
+  /// Parses one connection, or returns `null` without a usable [uri].
+  static PlexResourceConnection? fromJson(Map<String, dynamic> json) {
+    final String? uri = _asString(json['uri']);
+    if (uri == null || uri.isEmpty) return null;
+    return PlexResourceConnection(
+      uri: uri,
+      local: _asBool(json['local']),
+      relay: _asBool(json['relay']),
+      protocol: _asString(json['protocol']),
+    );
+  }
+
+  @override
+  String toString() => 'PlexResourceConnection(uri: $uri, local: $local, '
+      'relay: $relay, protocol: $protocol)';
+}
+
+/// Reads a field that plex.tv may report as either a JSON string or a number,
+/// returning a `String?` either way (mirrors `plex_api.dart`).
+String? _asString(Object? value) {
+  if (value is String) return value;
+  if (value is num) return value.toString();
+  return null;
+}
+
+/// Reads an int that may arrive as a number or numeric string.
+int? _asInt(Object? value) {
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value);
+  return null;
+}
+
+/// Reads a boolean that may arrive as a real bool (api/v2 JSON), a 0/1 number,
+/// or a `"0"`/`"1"`/`"true"`/`"false"` string (older envelopes) — so a quirky
+/// serializer can't flip a connection's `relay`/`local` classification.
+bool _asBool(Object? value, {bool fallback = false}) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    if (value == '1' || value.toLowerCase() == 'true') return true;
+    if (value == '0' || value.toLowerCase() == 'false') return false;
+  }
+  return fallback;
+}

--- a/lib/core/sources/plex/plex_tv_client.dart
+++ b/lib/core/sources/plex/plex_tv_client.dart
@@ -1,0 +1,46 @@
+import 'plex_tv_api.dart';
+
+/// The single seam through which Linthra talks HTTP to **plex.tv** (the
+/// account service behind the PIN sign-in flow).
+///
+/// The sibling of `PlexClient`, which talks to the user's own Plex Media
+/// Server: the rest of the app (the PIN auth coordinator, the settings
+/// controller) depends only on this interface — never on `http`, URLs,
+/// headers, or JSON — so the whole sign-in flow is testable with a fake client
+/// and canned responses.
+///
+/// Implementations send the `X-Plex-*` client-identity headers on every call
+/// (plex.tv binds a PIN to the `X-Plex-Client-Identifier` that minted it) and
+/// the account token — where one is needed at all — as the `X-Plex-Token`
+/// **header**, never in a URL. Every failure becomes a `PlexException` whose
+/// message is static and token-free; no token (account or server-scoped) may
+/// ever reach an exception, a log, or any other output. See docs/plex.md →
+/// Token safety rules.
+abstract interface class PlexTvClient {
+  /// Mints a new sign-in PIN via `POST /api/v2/pins?strong=true`. No token is
+  /// sent — this is the very first step of obtaining one.
+  ///
+  /// Throws `PlexException` (`notReachable` when plex.tv can't be reached,
+  /// `unexpected` for an unusable body).
+  Future<PlexPin> createPin();
+
+  /// Polls one PIN via `GET /api/v2/pins/{id}`: returns the granted account
+  /// auth token once the user approved the sign-in in the browser, or `null`
+  /// while the approval is still pending.
+  ///
+  /// The returned token is a secret — the caller must hand it on (to fetch
+  /// resources / build a session) and never log or persist it as-is.
+  ///
+  /// Throws `PlexException.signInExpired` when plex.tv no longer knows the
+  /// PIN (HTTP 404 — it lapsed before approval; polling it again can never
+  /// succeed), and the usual token-free failures otherwise.
+  Future<String?> checkPin(int pinId);
+
+  /// Lists the account's devices via `GET /api/v2/resources` (HTTPS and relay
+  /// addresses included). The caller keeps the ones that provide `server`.
+  ///
+  /// [token] is the account token granted by [checkPin]; it rides in the
+  /// `X-Plex-Token` header. Each returned server carries its own
+  /// server-scoped `accessToken` — the credential Linthra actually keeps.
+  Future<List<PlexResource>> fetchResources({required String token});
+}

--- a/lib/core/sources/plex/plex_tv_endpoints.dart
+++ b/lib/core/sources/plex/plex_tv_endpoints.dart
@@ -1,0 +1,68 @@
+/// Every plex.tv (account service) URL Linthra builds, in one place.
+///
+/// The sibling of `plex_endpoints.dart`, which owns the user's own Plex Media
+/// Server paths: this file owns the **plex.tv** side of the PIN sign-in flow —
+/// minting a PIN, polling it, listing the account's servers, and the
+/// `app.plex.tv` page the browser opens. Keeping them separate keeps the
+/// "which host is this request for" question answerable at a glance.
+///
+/// All builders are pure and **token-free**: the account token rides in the
+/// `X-Plex-Token` *request header* (set by `HttpPlexTvClient`), never in a URL
+/// built here, so every one of these URLs is safe to log. The auth-app URL
+/// carries the PIN [authApp]`code` — the *public* half of the handshake, not a
+/// credential (approving it requires the user's own plex.tv browser session).
+/// See docs/plex.md → Authentication.
+abstract final class PlexTvEndpoints {
+  /// The plex.tv API origin. The PIN and resources endpoints live here.
+  static const String plexTvBaseUrl = 'https://plex.tv';
+
+  /// The hosted sign-in page origin the browser is handed.
+  static const String authAppBaseUrl = 'https://app.plex.tv/auth';
+
+  static const String _pinsPath = '/api/v2/pins';
+  static const String _resourcesPath = '/api/v2/resources';
+
+  /// `POST https://plex.tv/api/v2/pins?strong=true` — mints a new sign-in PIN.
+  ///
+  /// `strong=true` asks for the long, link-style code the `app.plex.tv/auth`
+  /// page consumes directly (the short 4-character codes are for TVs, where
+  /// the user types them at plex.tv/link — Linthra opens the browser instead,
+  /// so the user never sees or types a code).
+  static Uri pins() => Uri.parse('$plexTvBaseUrl$_pinsPath?strong=true');
+
+  /// `GET https://plex.tv/api/v2/pins/{id}` — polls one PIN until the user
+  /// approves it in the browser and the response carries an `authToken`.
+  static Uri pin(int id) => Uri.parse('$plexTvBaseUrl$_pinsPath/$id');
+
+  /// `GET https://plex.tv/api/v2/resources?includeHttps=1&includeRelay=1` —
+  /// lists the account's devices, each Plex Media Server with its
+  /// **server-scoped** `accessToken` and the connection addresses it can be
+  /// reached on. `includeHttps` asks for the `*.plex.direct` HTTPS addresses;
+  /// `includeRelay` includes the plex.tv relay as a last-resort path.
+  static Uri resources() =>
+      Uri.parse('$plexTvBaseUrl$_resourcesPath?includeHttps=1&includeRelay=1');
+
+  /// The `https://app.plex.tv/auth#?…` page the browser opens so the user can
+  /// approve the sign-in with their own Plex account.
+  ///
+  /// The parameters ride in the **fragment** (after `#`) — that is the shape
+  /// the hosted page expects (it reads them client-side; a fragment is never
+  /// sent to a server in a request line, so they also can't land in an access
+  /// log). `clientID` must be the same `X-Plex-Client-Identifier` that minted
+  /// the PIN — plex.tv binds the PIN to it — and `context[device][product]`
+  /// names the app on the approval screen. Values are percent-encoded
+  /// (`Uri.encodeComponent`, so a space is `%20`, matching how the page's own
+  /// client parses the fragment).
+  static Uri authApp({
+    required String clientIdentifier,
+    required String code,
+    required String product,
+  }) {
+    final String params = <String>[
+      'clientID=${Uri.encodeComponent(clientIdentifier)}',
+      'code=${Uri.encodeComponent(code)}',
+      'context%5Bdevice%5D%5Bproduct%5D=${Uri.encodeComponent(product)}',
+    ].join('&');
+    return Uri.parse('$authAppBaseUrl#?$params');
+  }
+}

--- a/lib/features/settings/bug_report/bug_report_providers.dart
+++ b/lib/features/settings/bug_report/bug_report_providers.dart
@@ -2,8 +2,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/diagnostics/app_diagnostics.dart';
 import '../../../core/diagnostics/safe_event_log.dart';
-import '../../../core/services/external_link_launcher.dart';
 import '../diagnostics/diagnostics_collector.dart';
+
+// The browser seam used to live here; it moved to the app level once Plex's
+// "Connect with Plex" flow needed the same launcher. Re-exported so existing
+// imports (and test overrides) keep working unchanged.
+export '../../../app/external_link_launcher_provider.dart'
+    show externalLinkLauncherProvider;
 
 /// The secret-free inputs the bug-report screen renders from: the diagnostics
 /// snapshot and the recent safe app events.
@@ -38,10 +43,3 @@ final bugReportDiagnosticsProvider =
     recentEventLines: SafeEventLog.instance.lines,
   );
 });
-
-/// The browser seam the "Open GitHub issue" action launches through. Production
-/// wires the `url_launcher`-backed launcher; tests override it with a fake so
-/// no real browser is opened.
-final externalLinkLauncherProvider = Provider<ExternalLinkLauncher>(
-  (ref) => const UrlLauncherExternalLinkLauncher(),
-);

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -406,14 +406,18 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     try {
       await ref.read(plexSessionStoreProvider).write(stamped);
     } catch (_) {
-      // Without persistence the connection would silently vanish on restart;
-      // fail honestly instead. Nothing sensitive is kept in memory either —
-      // including the sign-in flow's tokens.
+      // The new connection couldn't be persisted; without that it would
+      // silently vanish on restart, so don't adopt it. The sign-in flow's
+      // in-memory tokens are released here. A previous session, if any, is
+      // untouched — the failed write didn't replace it at rest, and [_session]
+      // still holds it — so restore its connected view with the error rather
+      // than dropping to a disconnected card while [plexMusicSourceProvider]
+      // keeps serving it ([_setFailure] rebuilds from the live [_session], or
+      // shows a plain signed-out error when there is none).
       _resetLinkFlow();
-      state = const PlexSettingsState(
-        errorMessage: "Couldn't save your Plex session on this device. "
-            'Try again.',
-      );
+      _setFailure(const PlexException(
+        "Couldn't save your Plex session on this device. Try again.",
+      ));
       return false;
     }
 

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -134,19 +134,26 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       return;
     }
     _session = saved;
-    // Re-announce the identifier this install presented when it connected, so
-    // the server keeps seeing the same client across restarts.
-    ref
-        .read(plexPersistedClientIdentifierProvider.notifier)
-        .publish(saved.clientIdentifier);
     if (_linkFlowOwnsCard) {
       // A "Connect with Plex" flow started while this slow read was still in
       // flight and owns the card now — including its `connecting` probe, which
       // [PlexSettingsState.isLinkFlowActive] wouldn't catch. The restored
       // session stays live behind it (a cancel rebuilds the connected view
-      // from it); only the visible state must not be clobbered.
+      // from it), but two things must NOT happen now: the visible state must
+      // not be clobbered, and — critically — the restored client identifier
+      // must NOT be published. Publishing it would swap the
+      // `X-Plex-Client-Identifier` mid-flow (the running PIN is bound to the
+      // id `begin()` minted with), so the browser approval could be rejected
+      // or expire. The flow publishes the right id when it connects
+      // ([_completeConnect]); a cancel publishes the restored one
+      // ([_restoreIdleState]).
       return;
     }
+    // Re-announce the identifier this install presented when it connected, so
+    // the server keeps seeing the same client across restarts.
+    ref
+        .read(plexPersistedClientIdentifierProvider.notifier)
+        .publish(saved.clientIdentifier);
     state = PlexSettingsState(
       phase: PlexConnectionPhase.connected,
       baseUrl: saved.baseUrl,
@@ -490,6 +497,13 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   void _restoreIdleState() {
     final PlexSession? current = _session;
     if (current != null) {
+      // Now that the flow has yielded the card, announce the session's client
+      // identifier. A mid-flow restore deliberately deferred this (publishing
+      // it would have swapped the in-flight PIN's identity); it's a harmless
+      // no-op for a session whose id was already published at startup.
+      ref
+          .read(plexPersistedClientIdentifierProvider.notifier)
+          .publish(current.clientIdentifier);
       state = PlexSettingsState(
         phase: PlexConnectionPhase.connected,
         baseUrl: current.baseUrl,

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -65,6 +65,17 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   /// re-launch the same PIN's page after the user closed the browser tab.
   PlexPinLink? _activeLink;
 
+  /// True from the moment a "Connect with Plex" flow starts until it connects,
+  /// is cancelled, or is superseded — i.e. while the flow owns the card.
+  ///
+  /// Broader than the phase-based [PlexSettingsState.isLinkFlowActive]: it
+  /// stays true through the flow's `connecting` **probe** too, which shares
+  /// the `connecting` phase with the manual form and so can't be told apart by
+  /// phase alone. The startup restore consults this (not the phase) so a slow
+  /// secure-storage read landing mid-flow — on success **or** failure — can't
+  /// clobber the visible sign-in with a restored session or a restore error.
+  bool _linkFlowOwnsCard = false;
+
   /// Whether the music libraries were already fetched once for the current
   /// connection, so [loadSectionsIfNeeded] stays a no-op on rebuilds (and a
   /// server with zero music libraries isn't re-polled on every Settings open).
@@ -102,8 +113,11 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       // A storage hiccup must not break startup; stay disconnected but say
       // so (statically, token-free), so a user who *was* connected isn't left
       // wondering where their server went. (A missing/corrupt record already
-      // reads back as null inside the store and stays silent.)
-      if (!_restoreSuperseded && _session == null) {
+      // reads back as null inside the store and stays silent.) But if a
+      // "Connect with Plex" flow has since taken over the card, leave it
+      // alone — replacing it with a disconnected restore error would strip
+      // the user's Cancel/reopen controls while the poll keeps running.
+      if (!_restoreSuperseded && _session == null && !_linkFlowOwnsCard) {
         state = const PlexSettingsState(
           errorMessage: "Couldn't restore your saved Plex connection from "
               'this device. If you use Plex, connect again below.',
@@ -125,11 +139,12 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     ref
         .read(plexPersistedClientIdentifierProvider.notifier)
         .publish(saved.clientIdentifier);
-    if (state.isLinkFlowActive) {
+    if (_linkFlowOwnsCard) {
       // A "Connect with Plex" flow started while this slow read was still in
-      // flight and owns the card now. The restored session stays live behind
-      // it (a cancel rebuilds the connected view from it); only the visible
-      // state must not be clobbered.
+      // flight and owns the card now — including its `connecting` probe, which
+      // [PlexSettingsState.isLinkFlowActive] wouldn't catch. The restored
+      // session stays live behind it (a cancel rebuilds the connected view
+      // from it); only the visible state must not be clobbered.
       return;
     }
     state = PlexSettingsState(
@@ -213,6 +228,9 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   Future<void> connectWithPlex() async {
     if (state.isBusy || state.isLinkFlowActive) return;
     final int attempt = ++_linkAttempt;
+    // The flow now owns the card; the startup restore must not clobber it
+    // (on success or failure) until it connects, cancels, or is superseded.
+    _linkFlowOwnsCard = true;
 
     // Immediate feedback while the PIN is minted; keep the current card
     // context (server fields, sections, selection) so a cancel or failure
@@ -464,6 +482,7 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     _accountToken = null;
     _flowServers = const <PlexResource>[];
     _activeLink = null;
+    _linkFlowOwnsCard = false;
   }
 
   /// Restores the card to its resting state: the connected view rebuilt from

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -2,36 +2,68 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/models/plex_session.dart';
 import '../../../core/sources/plex/plex_api.dart';
 import '../../../core/sources/plex/plex_exception.dart';
 import '../../../core/sources/plex/plex_music_source.dart';
+import '../../../core/sources/plex/plex_pin_auth.dart';
+import '../../../core/sources/plex/plex_tv_api.dart';
 import '../../../data/repositories/plex_session_store_provider.dart';
 import 'plex_settings_providers.dart';
 import 'plex_settings_state.dart';
 import 'plex_sync_controller.dart';
 
-/// Drives the Plex settings card: loads any saved session, tests a connection,
-/// connects (verify + persist), discovers the server's music libraries, saves
-/// the user's library selection (kicking a background catalog sync so the
-/// Library screen follows it), and disconnects (also dropping the synced
-/// Plex rows, which are unplayable without a session).
+/// Drives the Plex settings card: loads any saved session, runs the
+/// "Connect with Plex" browser sign-in (PIN → server picker → session), tests
+/// or connects a manually typed URL + token (the advanced fallback),
+/// discovers the server's music libraries, saves the user's library selection
+/// (kicking a background catalog sync so the Library screen follows it), and
+/// disconnects (also dropping the synced Plex rows, which are unplayable
+/// without a session).
 ///
-/// The single coordinator between the separated concerns — the authenticator
-/// (verify a URL + token against `/identity`), the session store (encrypted
-/// persistence), the client (library-section discovery), and the source
-/// (library access) — so the UI only ever talks to this controller and its
-/// [PlexSettingsState], never to HTTP or storage.
+/// The single coordinator between the separated concerns — the PIN auth flow
+/// ([PlexPinAuth]), the manual authenticator (verify a URL + token against
+/// `/identity`), the session store (encrypted persistence), the client
+/// (library-section discovery), and the source (library access) — so the UI
+/// only ever talks to this controller and its [PlexSettingsState], never to
+/// HTTP or storage.
 ///
 /// Token safety: the live [session] (with its token) is kept privately for
 /// building the source; it is never exposed through the public [state], never
 /// logged, and the token handed to [connect]/[testConnection] is forwarded
-/// once to the authenticator and never retained here. Every error message
-/// surfaced through the state comes from a static, token-free [PlexException]
-/// factory. See docs/plex.md → Token safety rules.
+/// once to the authenticator and never retained here. The sign-in flow's
+/// account token and token-bearing server resources live only in private
+/// fields for the duration of the flow ([state] gets display-safe
+/// [PlexServerChoice]s instead) and are released the moment the flow ends —
+/// connected, cancelled, or failed. Every error message surfaced through the
+/// state comes from a static, token-free [PlexException] factory. See
+/// docs/plex.md → Token safety rules.
 class PlexSettingsController extends Notifier<PlexSettingsState> {
   PlexSession? _session;
   late final Future<void> _initialLoad;
+
+  /// Monotonic id of the current "Connect with Plex" attempt. Every await in
+  /// the flow re-checks it afterwards, so a cancel / disconnect / newer
+  /// attempt makes the superseded continuation drop its result instead of
+  /// clobbering fresh state — the polling loop can outlive several user
+  /// actions while the user is away in the browser.
+  int _linkAttempt = 0;
+
+  /// The account token granted by the sign-in, held **only** between the PIN
+  /// approval and the server pick (it's what authorizes the resources call
+  /// and the fallback when a server has no scoped token). Never exposed
+  /// through [state], never logged, nulled by [_resetLinkFlow].
+  String? _accountToken;
+
+  /// The token-bearing server resources behind the display-safe
+  /// [PlexSettingsState.servers] choices. Private for the same reason as
+  /// [_accountToken]; cleared with it.
+  List<PlexResource> _flowServers = const <PlexResource>[];
+
+  /// The active sign-in link, kept so "Open the sign-in page again" can
+  /// re-launch the same PIN's page after the user closed the browser tab.
+  PlexPinLink? _activeLink;
 
   /// Whether the music libraries were already fetched once for the current
   /// connection, so [loadSectionsIfNeeded] stays a no-op on rebuilds (and a
@@ -93,6 +125,13 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     ref
         .read(plexPersistedClientIdentifierProvider.notifier)
         .publish(saved.clientIdentifier);
+    if (state.isLinkFlowActive) {
+      // A "Connect with Plex" flow started while this slow read was still in
+      // flight and owns the card now. The restored session stays live behind
+      // it (a cancel rebuilds the connected view from it); only the visible
+      // state must not be clobbered.
+      return;
+    }
     state = PlexSettingsState(
       phase: PlexConnectionPhase.connected,
       baseUrl: saved.baseUrl,
@@ -135,24 +174,17 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     }
   }
 
-  /// Connects with [url] + [token]: verifies them against `/identity`,
-  /// persists the resulting session (token encrypted at rest), flips to
-  /// connected, and fetches the server's music libraries for the picker.
-  /// Returns whether the connection succeeded (a failure to *list libraries*
-  /// afterwards does not fail the connect — it surfaces as a retryable error).
-  ///
-  /// Reconnecting to the **same** server (recognised by its
-  /// `machineIdentifier`, e.g. after rotating the token) keeps the existing
-  /// library selection and refreshes the synced catalog against it — wiping
-  /// the selection would silently empty the user's Plex library on the next
-  /// sync. A different server starts with a clean (empty) selection, and any
-  /// rows the previous server synced are dropped quietly: their ratingKeys
-  /// belong to another machine and could never play.
+  /// Connects with a manually typed [url] + [token] (the advanced fallback
+  /// flow): verifies them against `/identity`, then persists and finishes
+  /// like every connect ([_completeConnect]). Returns whether the connection
+  /// succeeded (a failure to *list libraries* afterwards does not fail the
+  /// connect — it surfaces as a retryable error).
   Future<bool> connect({
     required String url,
     required String token,
   }) async {
-    final PlexSession? previous = _session;
+    // A manual connect supersedes any sign-in flow still polling.
+    _resetLinkFlow();
     state = PlexSettingsState(
       phase: PlexConnectionPhase.connecting,
       baseUrl: url,
@@ -167,15 +199,207 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       _setFailure(error, url: url);
       return false;
     }
+    return _completeConnect(newSession);
+  }
 
+  /// Starts the "Connect with Plex" browser sign-in: mints a plex.tv PIN,
+  /// opens the hosted approval page in the browser, polls until the user
+  /// approves it, then fetches the account's Plex Media Servers — connecting
+  /// straight away when there is exactly one, otherwise showing the server
+  /// picker ([selectServer] finishes it). Safe to call while connected: the
+  /// existing session stays live (and is restored on cancel/failure) until a
+  /// new one actually lands, which is what makes this the "reconnect" action
+  /// for an expired token too.
+  Future<void> connectWithPlex() async {
+    if (state.isBusy || state.isLinkFlowActive) return;
+    final int attempt = ++_linkAttempt;
+
+    // Immediate feedback while the PIN is minted; keep the current card
+    // context (server fields, sections, selection) so a cancel or failure
+    // can restore the connected view exactly as it was.
+    state = state.copyWith(
+      phase: PlexConnectionPhase.linking,
+      servers: const <PlexServerChoice>[],
+      statusMessage: 'Contacting plex.tv…',
+      errorMessage: null,
+      errorKind: null,
+    );
+
+    final PlexPinLink link;
+    try {
+      link = await ref.read(plexPinAuthProvider).begin();
+    } on PlexException catch (error) {
+      if (_linkAttempt != attempt) return;
+      _resetLinkFlow();
+      _setFailure(error);
+      return;
+    }
+    if (_linkAttempt != attempt) return;
+    _activeLink = link;
+
+    final bool opened =
+        await ref.read(externalLinkLauncherProvider).open(link.authUrl);
+    if (_linkAttempt != attempt) return;
+    if (!opened) {
+      _resetLinkFlow();
+      _setFailure(PlexException.browserUnavailable());
+      return;
+    }
+    state = state.copyWith(
+      statusMessage: 'Approve Linthra on the Plex sign-in page that just '
+          'opened, then come back here.',
+    );
+
+    final String? accountToken;
+    try {
+      accountToken = await ref.read(plexPinAuthProvider).waitForAuthToken(
+            link.pinId,
+            isCancelled: () => _linkAttempt != attempt,
+          );
+    } on PlexException catch (error) {
+      if (_linkAttempt != attempt) return;
+      _resetLinkFlow();
+      _setFailure(error);
+      return;
+    }
+    // Cancelled (null) or superseded: someone else owns the card now.
+    if (_linkAttempt != attempt || accountToken == null) return;
+
+    state = state.copyWith(
+      phase: PlexConnectionPhase.loadingServers,
+      statusMessage: 'Signed in. Finding your Plex Media Servers…',
+    );
+
+    final List<PlexResource> servers;
+    try {
+      servers = await ref
+          .read(plexPinAuthProvider)
+          .fetchServers(accountToken: accountToken);
+    } on PlexException catch (error) {
+      if (_linkAttempt != attempt) return;
+      _resetLinkFlow();
+      _setFailure(error);
+      return;
+    }
+    if (_linkAttempt != attempt) return;
+
+    // The flow now holds secrets (account token, per-server tokens) — only
+    // until a server is connected, the flow is cancelled, or it fails.
+    _accountToken = accountToken;
+    _flowServers = servers;
+
+    if (servers.length == 1) {
+      // One server: nothing to choose, connect to it directly.
+      await _connectToFlowServer(servers.single, attempt);
+      return;
+    }
+    // Several servers (the user picks) — or none (the picker's empty state).
+    state = state.copyWith(
+      phase: PlexConnectionPhase.pickingServer,
+      servers: _choicesFor(servers),
+      statusMessage: null,
+    );
+  }
+
+  /// Connects to the picked server from the server picker. Returns whether
+  /// the connection succeeded; a failure returns to the picker with a
+  /// friendly error so another server (or the same one) can be tried.
+  Future<bool> selectServer(String clientIdentifier) async {
+    if (state.phase != PlexConnectionPhase.pickingServer) return false;
+    for (final PlexResource server in _flowServers) {
+      if (server.clientIdentifier == clientIdentifier) {
+        return _connectToFlowServer(server, _linkAttempt);
+      }
+    }
+    return false;
+  }
+
+  /// Abandons the "Connect with Plex" flow at any of its stages, releasing
+  /// the in-memory account token and restoring the card to where it was
+  /// (the still-live connected session, or the signed-out form).
+  void cancelPlexLink() {
+    if (!state.isLinkFlowActive) return;
+    _resetLinkFlow();
+    _restoreIdleState();
+  }
+
+  /// Re-opens the sign-in page for the active link — for when the user
+  /// closed the browser tab before approving. The PIN (and its poll) keep
+  /// running; this only re-hands the same page to the browser.
+  Future<void> reopenPlexSignIn() async {
+    final PlexPinLink? link = _activeLink;
+    if (link == null || state.phase != PlexConnectionPhase.linking) return;
+    final bool opened =
+        await ref.read(externalLinkLauncherProvider).open(link.authUrl);
+    if (!opened && state.phase == PlexConnectionPhase.linking) {
+      final PlexException error = PlexException.browserUnavailable();
+      state = state.copyWith(
+        errorMessage: error.message,
+        errorKind: error.kind,
+      );
+    }
+  }
+
+  /// Probes and persists one of the sign-in flow's servers, preferring its
+  /// server-scoped token (see [PlexPinAuth.connectToServer]).
+  Future<bool> _connectToFlowServer(PlexResource server, int attempt) async {
+    final String? accountToken = _accountToken;
+    if (accountToken == null) return false;
+    state = state.copyWith(
+      phase: PlexConnectionPhase.connecting,
+      servers: _choicesFor(_flowServers),
+      statusMessage: 'Connecting to '
+          '${server.name.isNotEmpty ? server.name : 'your Plex server'}…',
+      errorMessage: null,
+      errorKind: null,
+    );
+    final PlexSession newSession;
+    try {
+      newSession = await ref.read(plexPinAuthProvider).connectToServer(
+            server: server,
+            accountToken: accountToken,
+          );
+    } on PlexException catch (error) {
+      if (_linkAttempt != attempt) return false;
+      // Back to the picker: with several servers another can be tried, and
+      // with one the retry (tap it again) or Cancel is right there.
+      state = state.copyWith(
+        phase: PlexConnectionPhase.pickingServer,
+        statusMessage: null,
+        errorMessage: error.message,
+        errorKind: error.kind,
+      );
+      return false;
+    }
+    if (_linkAttempt != attempt) return false;
+    return _completeConnect(newSession);
+  }
+
+  /// The shared tail of every successful verify — manual form and sign-in
+  /// flow alike: stamps the announced client identifier, persists the session
+  /// (token encrypted at rest), flips to connected, fetches the music
+  /// libraries for the picker, and brings the synced catalog in step.
+  ///
+  /// Reconnecting to the **same** server (recognised by its
+  /// `machineIdentifier`, e.g. after rotating or re-granting the token) keeps
+  /// the existing library selection and refreshes the synced catalog against
+  /// it — wiping the selection would silently empty the user's Plex library
+  /// on the next sync. A different server starts with a clean (empty)
+  /// selection, and any rows the previous server synced are dropped quietly:
+  /// their ratingKeys belong to another machine and could never play.
+  Future<bool> _completeConnect(PlexSession newSession) async {
+    final PlexSession? previous = _session;
     final bool sameServer = previous != null &&
         previous.machineIdentifier == newSession.machineIdentifier;
     // Persist the client identifier the verify above announced, so every
     // later launch presents the same install to the server — and carry the
-    // library selection (and known server name) over a same-server reconnect.
+    // library selection (and any already-known server name) over a
+    // same-server reconnect. A fresh name from the sign-in flow wins over a
+    // remembered one (the server may have been renamed).
     final PlexSession stamped = newSession.copyWith(
       clientIdentifier: ref.read(plexClientIdentityProvider).clientIdentifier,
-      serverName: sameServer ? previous.serverName : null,
+      serverName:
+          newSession.serverName ?? (sameServer ? previous.serverName : null),
       selectedSectionKeys:
           sameServer ? previous.selectedSectionKeys : const <String>[],
     );
@@ -183,7 +407,9 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       await ref.read(plexSessionStoreProvider).write(stamped);
     } catch (_) {
       // Without persistence the connection would silently vanish on restart;
-      // fail honestly instead. Nothing sensitive is kept in memory either.
+      // fail honestly instead. Nothing sensitive is kept in memory either —
+      // including the sign-in flow's tokens.
+      _resetLinkFlow();
       state = const PlexSettingsState(
         errorMessage: "Couldn't save your Plex session on this device. "
             'Try again.',
@@ -194,6 +420,9 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     _session = stamped;
     _sectionsLoadAttempted = false;
     _restoreSuperseded = true;
+    // The flow is complete: release the account token and the token-bearing
+    // resources. Only the (encrypted) session keeps a credential now.
+    _resetLinkFlow();
     ref
         .read(plexPersistedClientIdentifierProvider.notifier)
         .publish(stamped.clientIdentifier);
@@ -221,6 +450,50 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       unawaited(_clearCatalogQuietly());
     }
     return true;
+  }
+
+  /// Invalidates any in-flight sign-in attempt (its continuations see a newer
+  /// [_linkAttempt] and drop their results) and releases the flow's
+  /// in-memory secrets.
+  void _resetLinkFlow() {
+    _linkAttempt++;
+    _accountToken = null;
+    _flowServers = const <PlexResource>[];
+    _activeLink = null;
+  }
+
+  /// Restores the card to its resting state: the connected view rebuilt from
+  /// the still-live session, or the pristine signed-out state.
+  void _restoreIdleState() {
+    final PlexSession? current = _session;
+    if (current != null) {
+      state = PlexSettingsState(
+        phase: PlexConnectionPhase.connected,
+        baseUrl: current.baseUrl,
+        serverName: current.serverName,
+        serverVersion: current.serverVersion,
+        sections: state.sections,
+        sectionsLoaded: state.sectionsLoaded,
+        selectedSectionKeys: current.selectedSectionKeys,
+        statusMessage: _connectedMessage(current),
+      );
+      return;
+    }
+    state = const PlexSettingsState();
+  }
+
+  /// The display-safe picker projections of the flow's server resources —
+  /// the only shape of them that may reach [state].
+  List<PlexServerChoice> _choicesFor(List<PlexResource> servers) {
+    return List<PlexServerChoice>.unmodifiable(<PlexServerChoice>[
+      for (final PlexResource server in servers)
+        PlexServerChoice(
+          clientIdentifier: server.clientIdentifier,
+          name: server.name.isNotEmpty ? server.name : 'Plex Media Server',
+          productVersion: server.productVersion,
+          owned: server.owned,
+        ),
+    ]);
   }
 
   /// Fetches the music libraries once for the current connection if they
@@ -360,7 +633,10 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   /// the local catalog — without a session (and with no offline cache in
   /// phase 1) they are permanently unplayable rows. Other providers' data is
   /// untouched: only the Plex store and the catalog's `plex` slice change.
+  /// Any sign-in flow still in flight is abandoned (and its in-memory tokens
+  /// released) along the way.
   Future<void> disconnect() async {
+    _resetLinkFlow();
     try {
       await ref.read(plexSessionStoreProvider).clear();
     } catch (_) {

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -738,6 +738,16 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   void _setFailure(PlexException error, {String? url}) {
     final PlexSession? current = _session;
     if (current != null) {
+      // Announce the session's client identifier before showing it as the
+      // active connection. A mid-flow restore deferred publishing it (a
+      // publish would have swapped the in-flight PIN's identity); if that
+      // flow now fails back to this session, this is where it's restored —
+      // otherwise later Plex requests would run under the temporary PIN/launch
+      // id instead of the session's persisted one. Idempotent (a no-op when
+      // the id was already published at startup or connect).
+      ref
+          .read(plexPersistedClientIdentifierProvider.notifier)
+          .publish(current.clientIdentifier);
       state = PlexSettingsState(
         phase: PlexConnectionPhase.connected,
         baseUrl: current.baseUrl,

--- a/lib/features/settings/plex/plex_settings_providers.dart
+++ b/lib/features/settings/plex/plex_settings_providers.dart
@@ -5,8 +5,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/app_info.dart';
 import '../../../core/sources/plex/http_plex_client.dart';
+import '../../../core/sources/plex/http_plex_tv_client.dart';
 import '../../../core/sources/plex/plex_authenticator.dart';
 import '../../../core/sources/plex/plex_client.dart';
+import '../../../core/sources/plex/plex_pin_auth.dart';
+import '../../../core/sources/plex/plex_tv_client.dart';
 
 /// A fallback `X-Plex-Client-Identifier`, generated once per app launch.
 ///
@@ -100,7 +103,34 @@ final plexClientProvider = Provider<PlexClient>((ref) {
 ///
 /// The settings controller depends on this rather than on the client directly,
 /// keeping authentication (produce a session) separate from the controller's
-/// orchestration (when to test, connect, persist, clear).
+/// orchestration (when to test, connect, persist, clear). This is the
+/// **manual / advanced** path; the primary "Connect with Plex" flow lives
+/// behind [plexPinAuthProvider].
 final plexAuthenticatorProvider = Provider<PlexAuthenticator>((ref) {
   return PlexAuthenticator(ref.watch(plexClientProvider));
+});
+
+/// The HTTP seam for all **plex.tv** (account service) networking.
+///
+/// Defaults to the real [HttpPlexTvClient]; tests override it with a fake
+/// returning canned PIN/resource responses, so the whole "Connect with Plex"
+/// flow runs without plex.tv. Watches the same client identity as the PMS
+/// client: plex.tv binds a PIN to the `X-Plex-Client-Identifier` that minted
+/// it, so both hosts must see the same identity.
+final plexTvClientProvider = Provider<PlexTvClient>((ref) {
+  return HttpPlexTvClient(identity: ref.watch(plexClientIdentityProvider));
+});
+
+/// Coordinates the plex.tv PIN sign-in flow (mint PIN → browser → poll →
+/// servers → verified session) on top of [plexTvClientProvider] and
+/// [plexClientProvider].
+///
+/// Tests override this with a [PlexPinAuth] built on fakes and an instant
+/// `wait`, so the poll loop runs without real delays.
+final plexPinAuthProvider = Provider<PlexPinAuth>((ref) {
+  return PlexPinAuth(
+    tvClient: ref.watch(plexTvClientProvider),
+    serverClient: ref.watch(plexClientProvider),
+    identity: ref.watch(plexClientIdentityProvider),
+  );
 });

--- a/lib/features/settings/plex/plex_settings_section.dart
+++ b/lib/features/settings/plex/plex_settings_section.dart
@@ -3,21 +3,29 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
 import '../../../core/sources/music_provider.dart';
+import '../../../core/sources/plex/plex_exception.dart';
 import 'plex_settings_controller.dart';
 import 'plex_settings_state.dart';
 import 'plex_sync_controller.dart';
 import 'plex_sync_state.dart';
 
-/// The Plex connection card on the Settings screen (phase 1, experimental).
+/// The Plex connection card on the Settings screen (experimental).
 ///
-/// Owns the text fields (server URL / token) but nothing else: every action is
-/// forwarded to [PlexSettingsController], and everything rendered comes from
-/// [PlexSettingsState]. The widget never touches HTTP or storage directly.
+/// The primary path is **Connect with Plex**: a plex.tv sign-in in the
+/// browser, a server picker when the account has several servers, then the
+/// music-library picker — no token hunting. Manually pasting a server URL +
+/// `X-Plex-Token` remains available under "Manual setup (advanced)".
 ///
-/// Token safety: the pasted token is obscured while typed, forwarded once to
-/// the controller, and cleared from the field the moment the connection is
-/// saved — after that it is never shown again anywhere (the connected view
-/// renders only server metadata, and the state holds no token).
+/// The widget owns only its text fields and the advanced-section toggle:
+/// every action is forwarded to [PlexSettingsController], and everything
+/// rendered comes from [PlexSettingsState]. It never touches HTTP or storage.
+///
+/// Token safety: nothing token-shaped is ever rendered. The sign-in flow's
+/// tokens never reach this widget (the state exposes display-safe
+/// [PlexServerChoice]s only), and a manually pasted token is obscured while
+/// typed, forwarded once to the controller, and cleared from the field the
+/// moment the connection is saved — after that it is never shown again
+/// anywhere (the connected view renders only server metadata).
 ///
 /// Unlike Jellyfin/Subsonic (which sync the whole server), the connected view
 /// hosts the **library picker**: Plex asks the user to choose which music
@@ -34,6 +42,7 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
   final TextEditingController _urlController = TextEditingController();
   final TextEditingController _tokenController = TextEditingController();
   bool _obscureToken = true;
+  bool _showManualSetup = false;
 
   @override
   void initState() {
@@ -51,11 +60,29 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
     super.dispose();
   }
 
-  /// Both fields are required: Plex verifies `/identity` with the token, so a
-  /// successful test confirms connecting will work.
+  /// Both manual fields are required: Plex verifies `/identity` with the
+  /// token, so a successful test confirms connecting will work.
   bool get _canSubmit =>
       _urlController.text.trim().isNotEmpty &&
       _tokenController.text.trim().isNotEmpty;
+
+  Future<void> _connectWithPlex() async {
+    await ref.read(plexSettingsControllerProvider.notifier).connectWithPlex();
+  }
+
+  Future<void> _reopenSignIn() async {
+    await ref.read(plexSettingsControllerProvider.notifier).reopenPlexSignIn();
+  }
+
+  void _cancelLink() {
+    ref.read(plexSettingsControllerProvider.notifier).cancelPlexLink();
+  }
+
+  Future<void> _selectServer(String clientIdentifier) async {
+    await ref
+        .read(plexSettingsControllerProvider.notifier)
+        .selectServer(clientIdentifier);
+  }
 
   Future<void> _test() async {
     FocusScope.of(context).unfocus();
@@ -83,6 +110,9 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
     await ref.read(plexSettingsControllerProvider.notifier).disconnect();
     _urlController.clear();
     _tokenController.clear();
+    if (mounted) {
+      setState(() => _showManualSetup = false);
+    }
   }
 
   Future<void> _refreshSections() async {
@@ -117,6 +147,12 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
       });
     }
 
+    // The sign-in-flow views present the status line themselves (next to
+    // their spinner), so the shared line at the card foot would duplicate it.
+    final bool statusShownByFlowView = state.isLinkFlowActive ||
+        (state.phase == PlexConnectionPhase.connecting &&
+            state.servers.isNotEmpty);
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.md),
@@ -135,9 +171,9 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
             ),
             const SizedBox(height: AppSpacing.xs),
             Text(
-              'Stream from your own Plex Media Server. Paste the server '
-              'address and a Plex token — the token is stored encrypted on '
-              'this device and never shown again.',
+              'Stream from your own Plex Media Server. Connect with your '
+              'Plex account, pick your server, and choose which music '
+              'libraries to play.',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
               ),
@@ -145,29 +181,23 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
             const SizedBox(height: AppSpacing.sm),
             const _CapabilityChips(),
             const SizedBox(height: AppSpacing.md),
-            if (state.isConnected)
-              _ConnectedView(
-                state: state,
-                syncState: syncState,
-                onRefreshSections: (state.isBusy || state.isLoadingSections)
-                    ? null
-                    : _refreshSections,
-                onToggleSection:
-                    state.isLoadingSections ? null : _toggleSection,
-                onSync: (state.isBusy ||
-                        state.isLoadingSections ||
-                        syncState.isSyncing)
-                    ? null
-                    : _sync,
-                onDisconnect:
-                    (state.isBusy || syncState.isSyncing) ? null : _disconnect,
-              )
-            else
-              _buildForm(state),
+            ..._buildBody(state, syncState),
             if (state.errorMessage != null) ...[
               const SizedBox(height: AppSpacing.md),
               _StatusLine(message: state.errorMessage!, isError: true),
-            ] else if (state.statusMessage != null) ...[
+              // A rejected/expired session is fixed by signing in again, not
+              // by hunting for a new token — offer that right at the error.
+              if (state.isConnected &&
+                  state.errorKind == PlexErrorKind.unauthorized) ...[
+                const SizedBox(height: AppSpacing.sm),
+                FilledButton.icon(
+                  onPressed: state.isBusy ? null : _connectWithPlex,
+                  icon: const Icon(Icons.link_outlined),
+                  label: const Text('Reconnect with Plex'),
+                ),
+              ],
+            ] else if (state.statusMessage != null &&
+                !statusShownByFlowView) ...[
               const SizedBox(height: AppSpacing.md),
               _StatusLine(message: state.statusMessage!, isError: false),
             ],
@@ -177,7 +207,117 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
     );
   }
 
-  Widget _buildForm(PlexSettingsState state) {
+  /// The phase-dependent middle of the card.
+  List<Widget> _buildBody(PlexSettingsState state, PlexSyncState syncState) {
+    switch (state.phase) {
+      case PlexConnectionPhase.connected:
+        return [
+          _ConnectedView(
+            state: state,
+            syncState: syncState,
+            onRefreshSections: (state.isBusy || state.isLoadingSections)
+                ? null
+                : _refreshSections,
+            onToggleSection: state.isLoadingSections ? null : _toggleSection,
+            onSync:
+                (state.isBusy || state.isLoadingSections || syncState.isSyncing)
+                    ? null
+                    : _sync,
+            onDisconnect:
+                (state.isBusy || syncState.isSyncing) ? null : _disconnect,
+          ),
+        ];
+      case PlexConnectionPhase.linking:
+        return [
+          _LinkingView(
+            statusMessage: state.statusMessage,
+            onReopen: _reopenSignIn,
+            onCancel: _cancelLink,
+          ),
+        ];
+      case PlexConnectionPhase.loadingServers:
+        return [
+          _FlowBusyView(
+            message: state.statusMessage ?? 'Finding your Plex Media Servers…',
+            onCancel: _cancelLink,
+          ),
+        ];
+      case PlexConnectionPhase.pickingServer:
+        return [
+          _ServerPickerView(
+            servers: state.servers,
+            onSelect: _selectServer,
+            onCancel: _cancelLink,
+          ),
+        ];
+      case PlexConnectionPhase.connecting when state.servers.isNotEmpty:
+        // Connecting to a picked server (the manual form shows its own
+        // in-button spinner for a form connect instead).
+        return [
+          _FlowBusyView(
+            message: state.statusMessage ?? 'Connecting to your Plex server…',
+            onCancel: null,
+          ),
+        ];
+      case PlexConnectionPhase.disconnected:
+      case PlexConnectionPhase.testing:
+      case PlexConnectionPhase.tested:
+      case PlexConnectionPhase.connecting:
+        return _buildDisconnected(state);
+    }
+  }
+
+  /// The signed-out view: the primary "Connect with Plex" action, with the
+  /// manual URL + token form tucked behind an Advanced toggle.
+  List<Widget> _buildDisconnected(PlexSettingsState state) {
+    final ThemeData theme = Theme.of(context);
+    final bool busy = state.isBusy;
+    return [
+      FilledButton.icon(
+        onPressed: busy ? null : _connectWithPlex,
+        icon: const Icon(Icons.link_outlined),
+        label: const Text('Connect with Plex'),
+      ),
+      const SizedBox(height: AppSpacing.xs),
+      Text(
+        'Sign in with your Plex account in the browser — no token needed. '
+        'Linthra never sees your password and stores only the access '
+        'token Plex grants, encrypted on this device.',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+        ),
+      ),
+      const SizedBox(height: AppSpacing.sm),
+      Align(
+        alignment: Alignment.centerLeft,
+        child: TextButton.icon(
+          onPressed: () => setState(() => _showManualSetup = !_showManualSetup),
+          icon: Icon(
+            _showManualSetup
+                ? Icons.expand_less_outlined
+                : Icons.expand_more_outlined,
+            size: 18,
+          ),
+          label: const Text('Manual setup (advanced)'),
+        ),
+      ),
+      if (_showManualSetup) ...[
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          'Already have an X-Plex-Token? Paste the server address and the '
+          'token — it is stored encrypted on this device and never shown '
+          'again.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        _buildManualForm(state),
+      ],
+    ];
+  }
+
+  Widget _buildManualForm(PlexSettingsState state) {
     final bool busy = state.isBusy;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -248,9 +388,9 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
   }
 }
 
-/// Marks the whole card as a phase-1 work-in-progress, so nobody mistakes
-/// Plex for a finished provider while caching/favorites/lyrics/cast are still
-/// follow-ups (docs/plex.md → Out of scope).
+/// Marks the whole card as a work-in-progress, so nobody mistakes Plex for a
+/// finished provider while caching/favorites/lyrics/cast are still follow-ups
+/// (docs/plex.md → Out of scope).
 class _ExperimentalBadge extends StatelessWidget {
   const _ExperimentalBadge();
 
@@ -276,8 +416,7 @@ class _ExperimentalBadge extends StatelessWidget {
 
 /// Capability-based action chips: one per ability the Plex provider actually
 /// supports, so unimplemented actions (offline, favorites, lyrics, cast)
-/// simply don't appear rather than being offered and failing. Phase 1 shows
-/// only Streaming.
+/// simply don't appear rather than being offered and failing.
 class _CapabilityChips extends StatelessWidget {
   const _CapabilityChips();
 
@@ -306,6 +445,186 @@ class _CapabilityChips extends StatelessWidget {
           ),
       ],
     );
+  }
+}
+
+/// The "waiting for the browser sign-in" view: the poll runs while the user
+/// approves Linthra on plex.tv; they can re-open the page or cancel — the
+/// flow never traps them.
+class _LinkingView extends StatelessWidget {
+  const _LinkingView({
+    required this.statusMessage,
+    required this.onReopen,
+    required this.onCancel,
+  });
+
+  final String? statusMessage;
+  final VoidCallback? onReopen;
+  final VoidCallback? onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            const SizedBox.square(
+              dimension: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text('Waiting for your Plex sign-in…',
+                  style: theme.textTheme.titleSmall),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          statusMessage ??
+              'Approve Linthra on the Plex sign-in page in your browser, '
+                  'then come back here.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton.icon(
+            onPressed: onReopen,
+            icon: const Icon(Icons.open_in_new_outlined, size: 18),
+            label: const Text('Open the sign-in page again'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        OutlinedButton(
+          onPressed: onCancel,
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}
+
+/// A short busy step of the sign-in flow (finding servers / connecting to
+/// the picked one), optionally cancellable.
+class _FlowBusyView extends StatelessWidget {
+  const _FlowBusyView({required this.message, required this.onCancel});
+
+  final String message;
+  final VoidCallback? onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            const SizedBox.square(
+              dimension: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text(message, style: theme.textTheme.bodySmall),
+            ),
+          ],
+        ),
+        if (onCancel != null) ...[
+          const SizedBox(height: AppSpacing.md),
+          OutlinedButton(
+            onPressed: onCancel,
+            child: const Text('Cancel'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// The server picker: one entry per Plex Media Server on the signed-in
+/// account (owned ones first), with a clean empty state when the account has
+/// none. Shows names and versions only — never tokens.
+class _ServerPickerView extends StatelessWidget {
+  const _ServerPickerView({
+    required this.servers,
+    required this.onSelect,
+    required this.onCancel,
+  });
+
+  final List<PlexServerChoice> servers;
+  final void Function(String clientIdentifier)? onSelect;
+  final VoidCallback? onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    if (servers.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text('No Plex Media Server found', style: theme.textTheme.titleSmall),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            "You're signed in, but this Plex account has no Plex Media "
+            'Server linked to it yet. Set up your server (or ask its owner '
+            'to share it with you), then connect again.',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          OutlinedButton(
+            onPressed: onCancel,
+            child: const Text('Back'),
+          ),
+        ],
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Choose your Plex server', style: theme.textTheme.titleSmall),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          'Your account can reach more than one server — pick the one with '
+          'your music.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        for (final PlexServerChoice server in servers)
+          ListTile(
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            leading: const Icon(Icons.dns_outlined),
+            title: Text(server.name),
+            subtitle: Text(_subtitleFor(server)),
+            trailing: const Icon(Icons.chevron_right_outlined),
+            onTap: onSelect == null
+                ? null
+                : () => onSelect!(server.clientIdentifier),
+          ),
+        const SizedBox(height: AppSpacing.sm),
+        OutlinedButton(
+          onPressed: onCancel,
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+
+  String _subtitleFor(PlexServerChoice server) {
+    final List<String> parts = <String>[
+      if (server.productVersion != null && server.productVersion!.isNotEmpty)
+        'Plex Media Server ${server.productVersion}'
+      else
+        'Plex Media Server',
+      if (!server.owned) 'Shared with you',
+    ];
+    return parts.join(' · ');
   }
 }
 

--- a/lib/features/settings/plex/plex_settings_state.dart
+++ b/lib/features/settings/plex/plex_settings_state.dart
@@ -14,11 +14,25 @@ enum PlexConnectionPhase {
   /// nothing is persisted yet.
   tested,
 
-  /// Connect (verify + persist) is running.
+  /// Connect (verify + persist) is running — for the manual flow right after
+  /// the form submits, for the sign-in flow right after a server is picked.
   connecting,
 
   /// Connected — a session exists.
   connected,
+
+  /// "Connect with Plex" handed the sign-in page to the browser and the app
+  /// is polling plex.tv for the user's approval. Can run for minutes (the
+  /// user is away in the browser); cancellable.
+  linking,
+
+  /// The sign-in was approved; the account's Plex Media Servers are being
+  /// fetched from plex.tv.
+  loadingServers,
+
+  /// The servers are known and the user is choosing one ([PlexSettingsState.
+  /// servers] holds the choices — possibly none, the empty state).
+  pickingServer,
 }
 
 /// One Plex music library the user can include — the display-safe projection of
@@ -46,6 +60,51 @@ class PlexLibrarySection {
   String toString() => 'PlexLibrarySection(key: $key, title: $title)';
 }
 
+/// One Plex Media Server the user can pick after signing in — the
+/// display-safe projection of a `PlexResource`, so the server picker UI (and
+/// this state) never touches the token-bearing wire DTO. **No field is a
+/// secret**: the per-server access token stays inside the controller's
+/// private flow state and the (encrypted) session.
+@immutable
+class PlexServerChoice {
+  const PlexServerChoice({
+    required this.clientIdentifier,
+    required this.name,
+    this.productVersion,
+    this.owned = true,
+  });
+
+  /// The server's stable identifier (its `machineIdentifier`), used to tell
+  /// the controller which server was picked. Not a credential.
+  final String clientIdentifier;
+
+  /// The server's friendly name.
+  final String name;
+
+  /// The server's reported version, when known. Display only.
+  final String? productVersion;
+
+  /// Whether the signed-in account owns this server (vs. shared with it).
+  final bool owned;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PlexServerChoice &&
+          other.clientIdentifier == clientIdentifier &&
+          other.name == name &&
+          other.productVersion == productVersion &&
+          other.owned == owned);
+
+  @override
+  int get hashCode =>
+      Object.hash(clientIdentifier, name, productVersion, owned);
+
+  @override
+  String toString() => 'PlexServerChoice(clientIdentifier: $clientIdentifier, '
+      'name: $name, productVersion: $productVersion, owned: $owned)';
+}
+
 /// Immutable snapshot the Plex settings UI renders from.
 ///
 /// The screen reads this and never reaches into HTTP, the authenticator, or the
@@ -66,6 +125,7 @@ class PlexSettingsState {
     this.isLoadingSections = false,
     this.sectionsLoaded = false,
     this.selectedSectionKeys = const <String>[],
+    this.servers = const <PlexServerChoice>[],
     this.statusMessage,
     this.errorMessage,
     this.errorKind,
@@ -77,9 +137,9 @@ class PlexSettingsState {
   /// the token; Plex API URLs keep the token in a header).
   final String? baseUrl;
 
-  /// The server's friendly name, when known. The manual `/identity` flow
-  /// doesn't report one, so this stays `null` until the plex.tv discovery
-  /// flow (a follow-up) provides it.
+  /// The server's friendly name, when known. The plex.tv sign-in flow fills
+  /// it from the picked server resource; the manual `/identity` flow doesn't
+  /// report one, so it stays `null` there.
   final String? serverName;
 
   /// The server's reported version, when known. Display only.
@@ -105,6 +165,12 @@ class PlexSettingsState {
   /// an error.
   final List<String> selectedSectionKeys;
 
+  /// The signed-in account's Plex Media Servers, for the server picker
+  /// ([PlexConnectionPhase.pickingServer] — where an empty list is the "no
+  /// servers on this account" empty state, not an error). Display-safe
+  /// projections only; the token-bearing resources stay in the controller.
+  final List<PlexServerChoice> servers;
+
   /// A friendly, non-error status line (e.g. "Connected to Plex…").
   final String? statusMessage;
 
@@ -118,10 +184,21 @@ class PlexSettingsState {
   bool get isConnected => phase == PlexConnectionPhase.connected;
 
   /// True while a network action is in flight, so the UI can disable inputs
-  /// and show a spinner.
+  /// and show a spinner. [PlexConnectionPhase.linking] is deliberately *not*
+  /// busy: it waits on the user (possibly for minutes) and must keep its
+  /// Cancel action live.
   bool get isBusy =>
       phase == PlexConnectionPhase.testing ||
-      phase == PlexConnectionPhase.connecting;
+      phase == PlexConnectionPhase.connecting ||
+      phase == PlexConnectionPhase.loadingServers;
+
+  /// True while the "Connect with Plex" sign-in flow owns the card (waiting
+  /// on the browser, loading servers, or picking one) — the phases a Cancel
+  /// returns from.
+  bool get isLinkFlowActive =>
+      phase == PlexConnectionPhase.linking ||
+      phase == PlexConnectionPhase.loadingServers ||
+      phase == PlexConnectionPhase.pickingServer;
 
   /// The "Plex" / "Plex · name" label the section header shows once connected.
   String get displayName {
@@ -146,6 +223,7 @@ class PlexSettingsState {
     bool? isLoadingSections,
     bool? sectionsLoaded,
     List<String>? selectedSectionKeys,
+    List<PlexServerChoice>? servers,
     Object? statusMessage = _unset,
     Object? errorMessage = _unset,
     Object? errorKind = _unset,
@@ -159,6 +237,7 @@ class PlexSettingsState {
       isLoadingSections: isLoadingSections ?? this.isLoadingSections,
       sectionsLoaded: sectionsLoaded ?? this.sectionsLoaded,
       selectedSectionKeys: selectedSectionKeys ?? this.selectedSectionKeys,
+      servers: servers ?? this.servers,
       statusMessage: identical(statusMessage, _unset)
           ? this.statusMessage
           : statusMessage as String?,

--- a/test/core/sources/plex/fake_plex_tv_client.dart
+++ b/test/core/sources/plex/fake_plex_tv_client.dart
@@ -1,0 +1,68 @@
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_tv_api.dart';
+import 'package:linthra/core/sources/plex/plex_tv_client.dart';
+
+/// A configurable [PlexTvClient] that returns canned responses (or throws) and
+/// records what it was asked, so the PIN auth flow and the settings controller
+/// can be tested without plex.tv or HTTP.
+///
+/// Mirrors `FakePlexClient`: no mocking library, just settable fields and
+/// recorded inputs. [checkPin] is scripted per call through [checkPinScript],
+/// so a test can spell out an exact poll sequence (pending → transient failure
+/// → granted) and the timeout/expiry paths.
+class FakePlexTvClient implements PlexTvClient {
+  FakePlexTvClient({
+    this.pin =
+        const PlexPin(id: 7, code: 'fake-pin-code', expiresInSeconds: 1800),
+    this.createPinError,
+    List<Object?>? checkPinScript,
+    this.resources = const <PlexResource>[],
+    this.resourcesError,
+  }) : checkPinScript = checkPinScript ?? <Object?>[];
+
+  /// Canned PIN for [createPin].
+  PlexPin pin;
+  PlexException? createPinError;
+
+  /// One entry consumed per [checkPin] call: a `String` is returned as the
+  /// granted token, `null` means still pending, and a [PlexException] is
+  /// thrown. An exhausted script keeps answering "pending" — the state a
+  /// timeout test needs.
+  final List<Object?> checkPinScript;
+
+  /// Canned devices for [fetchResources].
+  List<PlexResource> resources;
+  PlexException? resourcesError;
+
+  // Recorded inputs.
+  int createPinCount = 0;
+  int checkPinCount = 0;
+  int? lastCheckedPinId;
+  String? lastResourcesToken;
+
+  @override
+  Future<PlexPin> createPin() async {
+    createPinCount++;
+    final PlexException? error = createPinError;
+    if (error != null) throw error;
+    return pin;
+  }
+
+  @override
+  Future<String?> checkPin(int pinId) async {
+    checkPinCount++;
+    lastCheckedPinId = pinId;
+    if (checkPinScript.isEmpty) return null;
+    final Object? next = checkPinScript.removeAt(0);
+    if (next is PlexException) throw next;
+    return next as String?;
+  }
+
+  @override
+  Future<List<PlexResource>> fetchResources({required String token}) async {
+    lastResourcesToken = token;
+    final PlexException? error = resourcesError;
+    if (error != null) throw error;
+    return resources;
+  }
+}

--- a/test/core/sources/plex/http_plex_tv_client_test.dart
+++ b/test/core/sources/plex/http_plex_tv_client_test.dart
@@ -1,0 +1,258 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/sources/plex/http_plex_tv_client.dart';
+import 'package:linthra/core/sources/plex/plex_client.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_tv_api.dart';
+
+const String _accountToken = 'super-secret-account-token';
+
+const PlexClientIdentity _identity = PlexClientIdentity(
+  clientIdentifier: 'install-uuid-1',
+  product: 'Linthra',
+  version: '0.1.5',
+  platform: 'Android',
+  device: 'Pixel',
+);
+
+HttpPlexTvClient _client(MockClient mock) =>
+    HttpPlexTvClient(identity: _identity, httpClient: mock);
+
+/// A JSON 200 response with the usual content type.
+http.Response _json(Object body, {int status = 200}) => http.Response(
+      jsonEncode(body),
+      status,
+      headers: const <String, String>{'content-type': 'application/json'},
+    );
+
+void main() {
+  group('createPin', () {
+    test('POSTs /api/v2/pins?strong=true and parses the pin', () async {
+      http.Request? captured;
+      final HttpPlexTvClient client = _client(MockClient((r) async {
+        captured = r;
+        return _json(const <String, dynamic>{
+          'id': 123456,
+          'code': 'abcDEF123',
+          'expiresIn': 1800,
+          'authToken': null,
+        });
+      }));
+
+      final PlexPin pin = await client.createPin();
+
+      expect(pin.id, 123456);
+      expect(pin.code, 'abcDEF123');
+      expect(captured!.method, 'POST');
+      expect(captured!.url.host, 'plex.tv');
+      expect(captured!.url.path, '/api/v2/pins');
+      expect(captured!.url.queryParameters['strong'], 'true');
+    });
+
+    test('sends Accept JSON and the identity headers — and no token', () async {
+      http.Request? captured;
+      final HttpPlexTvClient client = _client(MockClient((r) async {
+        captured = r;
+        return _json(const <String, dynamic>{'id': 1, 'code': 'c'});
+      }));
+
+      await client.createPin();
+
+      final Map<String, String> headers = captured!.headers;
+      // `package:http` lower-cases header names.
+      expect(headers['accept'], 'application/json');
+      expect(headers['x-plex-client-identifier'], 'install-uuid-1');
+      expect(headers['x-plex-product'], 'Linthra');
+      // Minting a PIN is the first step of *obtaining* a token: none exists.
+      expect(headers.containsKey('x-plex-token'), isFalse);
+    });
+
+    test('treats a body without id/code as unusable', () async {
+      final HttpPlexTvClient client = _client(
+        MockClient(
+            (_) async => _json(const <String, dynamic>{'trusted': false})),
+      );
+
+      await expectLater(
+        client.createPin(),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unexpected)),
+      );
+    });
+
+    test('maps a transport failure to a friendly plex.tv message', () async {
+      final HttpPlexTvClient client = _client(
+        MockClient((_) async => throw http.ClientException('refused')),
+      );
+
+      await expectLater(
+        client.createPin(),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notReachable)
+            .having((e) => e.message, 'message', contains('plex.tv'))),
+      );
+    });
+  });
+
+  group('checkPin', () {
+    test('returns null while approval is pending', () async {
+      final HttpPlexTvClient client = _client(MockClient((_) async => _json(
+            const <String, dynamic>{'id': 1, 'code': 'c', 'authToken': null},
+          )));
+
+      expect(await client.checkPin(1), isNull);
+    });
+
+    test('returns the granted token once approved', () async {
+      http.Request? captured;
+      final HttpPlexTvClient client = _client(MockClient((r) async {
+        captured = r;
+        return _json(const <String, dynamic>{
+          'id': 1,
+          'code': 'c',
+          'authToken': _accountToken,
+        });
+      }));
+
+      expect(await client.checkPin(1), _accountToken);
+      expect(captured!.method, 'GET');
+      expect(captured!.url.path, '/api/v2/pins/1');
+    });
+
+    test('treats an empty authToken as still pending', () async {
+      final HttpPlexTvClient client = _client(MockClient((_) async => _json(
+            const <String, dynamic>{'id': 1, 'code': 'c', 'authToken': ''},
+          )));
+
+      expect(await client.checkPin(1), isNull);
+    });
+
+    test('maps a 404 to "sign-in expired" — definitive, not retryable',
+        () async {
+      final HttpPlexTvClient client =
+          _client(MockClient((_) async => http.Response('', 404)));
+
+      await expectLater(
+        client.checkPin(1),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)
+            .having((e) => e.message, 'message', contains('expired'))),
+      );
+    });
+  });
+
+  group('fetchResources', () {
+    test('GETs /api/v2/resources with the token in the header only', () async {
+      http.Request? captured;
+      final HttpPlexTvClient client = _client(MockClient((r) async {
+        captured = r;
+        return _json(const <Object?>[]);
+      }));
+
+      await client.fetchResources(token: _accountToken);
+
+      expect(captured!.url.path, '/api/v2/resources');
+      expect(captured!.url.queryParameters['includeHttps'], '1');
+      expect(captured!.url.queryParameters['includeRelay'], '1');
+      // The token rides in the header — the URL stays token-free.
+      expect(captured!.headers['x-plex-token'], _accountToken);
+      expect(captured!.url.toString(), isNot(contains(_accountToken)));
+    });
+
+    test('parses the bare JSON array of devices, skipping malformed ones',
+        () async {
+      final HttpPlexTvClient client = _client(MockClient((_) async => _json(
+            const <Object?>[
+              <String, dynamic>{
+                'name': 'Office Server',
+                'clientIdentifier': 'machine-abc',
+                'provides': 'server',
+                'accessToken': 'scoped-token',
+                'connections': <Object?>[
+                  <String, dynamic>{
+                    'uri': 'https://x.plex.direct:32400',
+                    'local': false,
+                    'relay': false,
+                  },
+                ],
+              },
+              <String, dynamic>{'name': 'no identifier'},
+              'garbage',
+            ],
+          )));
+
+      final List<PlexResource> resources =
+          await client.fetchResources(token: _accountToken);
+
+      expect(resources, hasLength(1));
+      expect(resources.single.name, 'Office Server');
+      expect(resources.single.accessToken, 'scoped-token');
+      expect(resources.single.connections.single.uri,
+          'https://x.plex.direct:32400');
+    });
+
+    test('treats a non-array body as unusable', () async {
+      final HttpPlexTvClient client = _client(
+        MockClient((_) async => _json(const <String, dynamic>{'error': 'x'})),
+      );
+
+      await expectLater(
+        client.fetchResources(token: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unexpected)),
+      );
+    });
+
+    test('maps 401 to a sign-in rejection', () async {
+      final HttpPlexTvClient client =
+          _client(MockClient((_) async => http.Response('', 401)));
+
+      await expectLater(
+        client.fetchResources(token: 'revoked'),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+    });
+  });
+
+  group('token safety', () {
+    test('every failure path throws a token-free message', () async {
+      final List<MockClient> failures = <MockClient>[
+        MockClient((_) async => http.Response('', 401)),
+        MockClient((_) async => http.Response('', 404)),
+        MockClient((_) async => http.Response('', 500)),
+        MockClient((_) async => http.Response('<html>nope</html>', 200)),
+        MockClient((_) async => _json(const <String, dynamic>{})),
+        MockClient((_) async => throw http.ClientException('boom')),
+      ];
+
+      for (final MockClient mock in failures) {
+        final HttpPlexTvClient client = _client(mock);
+        try {
+          await client.fetchResources(token: _accountToken);
+          fail('expected a PlexException');
+        } on PlexException catch (error) {
+          expect(error.message, isNot(contains(_accountToken)));
+          expect(error.toString(), isNot(contains(_accountToken)));
+        }
+      }
+    });
+
+    test('non-JSON pin bodies fail without echoing content', () async {
+      final HttpPlexTvClient client = _client(
+        MockClient((_) async =>
+            http.Response('<pin secret="leaky-body-content"/>', 200)),
+      );
+
+      try {
+        await client.createPin();
+        fail('expected a PlexException');
+      } on PlexException catch (error) {
+        expect(error.message, isNot(contains('leaky-body-content')));
+      }
+    });
+  });
+}

--- a/test/core/sources/plex/plex_pin_auth_test.dart
+++ b/test/core/sources/plex/plex_pin_auth_test.dart
@@ -1,0 +1,411 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_client.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_pin_auth.dart';
+import 'package:linthra/core/sources/plex/plex_tv_api.dart';
+
+import 'fake_plex_client.dart';
+import 'fake_plex_tv_client.dart';
+
+const String _accountToken = 'super-secret-account-token';
+const String _serverToken = 'super-secret-server-token';
+
+const PlexClientIdentity _identity = PlexClientIdentity(
+  clientIdentifier: 'install-uuid-1',
+  product: 'Linthra',
+  version: '0.1.5',
+  platform: 'Android',
+  device: 'Pixel',
+);
+
+const PlexResourceConnection _directConnection = PlexResourceConnection(
+  uri: 'https://10-0-0-5.abc.plex.direct:32400',
+  local: true,
+);
+const PlexResourceConnection _remoteConnection = PlexResourceConnection(
+  uri: 'https://93-184-216-34.abc.plex.direct:32400',
+);
+const PlexResourceConnection _relayConnection = PlexResourceConnection(
+  uri: 'https://relay.plex.direct:8443',
+  relay: true,
+);
+
+const PlexResource _server = PlexResource(
+  name: 'Office Server',
+  clientIdentifier: 'machine-abc',
+  provides: 'server',
+  accessToken: _serverToken,
+  productVersion: '1.41.0',
+  connections: <PlexResourceConnection>[_directConnection, _remoteConnection],
+);
+
+PlexPinAuth _auth({
+  FakePlexTvClient? tvClient,
+  FakePlexClient? serverClient,
+  List<Duration>? waits,
+}) {
+  return PlexPinAuth(
+    tvClient: tvClient ?? FakePlexTvClient(),
+    serverClient: serverClient ?? FakePlexClient(),
+    identity: _identity,
+    wait: (Duration duration) async => waits?.add(duration),
+  );
+}
+
+void main() {
+  group('begin', () {
+    test('mints a pin and builds the browser page for it', () async {
+      final tvClient = FakePlexTvClient(
+        pin: const PlexPin(id: 99, code: 'the-code'),
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      final PlexPinLink link = await auth.begin();
+
+      expect(link.pinId, 99);
+      // The page is bound to the same client identifier the client's headers
+      // announce — plex.tv ties the PIN to it.
+      expect(
+        link.authUrl.toString(),
+        'https://app.plex.tv/auth#?clientID=install-uuid-1&code=the-code'
+        '&context%5Bdevice%5D%5Bproduct%5D=Linthra',
+      );
+    });
+
+    test('toString of the link never includes the code', () async {
+      final PlexPinAuth auth = _auth(
+        tvClient: FakePlexTvClient(
+          pin: const PlexPin(id: 5, code: 'secretish-code'),
+        ),
+      );
+
+      final PlexPinLink link = await auth.begin();
+
+      expect(link.toString(), isNot(contains('secretish-code')));
+    });
+  });
+
+  group('waitForAuthToken', () {
+    test('polls until the token is granted, pacing with the interval',
+        () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[null, null, _accountToken],
+      );
+      final waits = <Duration>[];
+      final PlexPinAuth auth = _auth(tvClient: tvClient, waits: waits);
+
+      final String? token = await auth.waitForAuthToken(7);
+
+      expect(token, _accountToken);
+      expect(tvClient.checkPinCount, 3);
+      expect(tvClient.lastCheckedPinId, 7);
+      // Two pending polls → two waits, none after the grant.
+      expect(waits, hasLength(2));
+      expect(waits.toSet().single, PlexPinAuth.pollInterval);
+    });
+
+    test('returns null promptly once cancelled', () async {
+      int polls = 0;
+      final tvClient = FakePlexTvClient();
+      final PlexPinAuth auth = PlexPinAuth(
+        tvClient: tvClient,
+        serverClient: FakePlexClient(),
+        identity: _identity,
+        wait: (_) async => polls++,
+      );
+
+      final String? token = await auth.waitForAuthToken(
+        7,
+        // Cancel after the second pending answer.
+        isCancelled: () => tvClient.checkPinCount >= 2,
+      );
+
+      expect(token, isNull);
+      expect(tvClient.checkPinCount, 2);
+    });
+
+    test('an expired pin (404) propagates as sign-in expired', () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[null, PlexException.signInExpired()],
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      await expectLater(
+        auth.waitForAuthToken(7),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+    });
+
+    test('tolerates transient failures while the user is away in the browser',
+        () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[
+          null,
+          PlexException.plexTvUnreachable(),
+          PlexException.plexTvError(503),
+          null,
+          _accountToken,
+        ],
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      expect(await auth.waitForAuthToken(7), _accountToken);
+    });
+
+    test('gives up after too many consecutive failures', () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[
+          for (int i = 0; i < PlexPinAuth.maxConsecutivePollFailures; i++)
+            PlexException.plexTvUnreachable(),
+        ],
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      await expectLater(
+        auth.waitForAuthToken(7),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notReachable)),
+      );
+      expect(
+        tvClient.checkPinCount,
+        PlexPinAuth.maxConsecutivePollFailures,
+      );
+    });
+
+    test('a poll that never gets approved expires at the timeout', () async {
+      // An empty script answers "pending" forever; the instant wait lets the
+      // loop burn through the whole timeout's worth of attempts.
+      final tvClient = FakePlexTvClient();
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      await expectLater(
+        auth.waitForAuthToken(7),
+        throwsA(isA<PlexException>()
+            .having((e) => e.message, 'message', contains('expired'))),
+      );
+    });
+  });
+
+  group('fetchServers', () {
+    test('keeps only resources that provide server, owned first', () async {
+      const PlexResource shared = PlexResource(
+        name: 'Shared box',
+        clientIdentifier: 'machine-shared',
+        provides: 'server',
+        owned: false,
+      );
+      const PlexResource player = PlexResource(
+        name: 'Some player',
+        clientIdentifier: 'machine-player',
+        provides: 'client,player',
+      );
+      final tvClient = FakePlexTvClient(
+        resources: const <PlexResource>[shared, player, _server],
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      final List<PlexResource> servers =
+          await auth.fetchServers(accountToken: _accountToken);
+
+      expect(servers.map((r) => r.clientIdentifier),
+          <String>['machine-abc', 'machine-shared']);
+      expect(tvClient.lastResourcesToken, _accountToken);
+    });
+  });
+
+  group('connectToServer', () {
+    test('prefers the server-scoped token and probes the first connection',
+        () async {
+      final serverClient = FakePlexClient(
+        identity: const PlexServerIdentity(
+          machineIdentifier: 'machine-abc',
+          version: '1.41.0.9999',
+        ),
+      );
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      final PlexSession session = await auth.connectToServer(
+        server: _server,
+        accountToken: _accountToken,
+      );
+
+      // The narrowest credential that works: the per-server accessToken, not
+      // the account-wide token.
+      expect(session.token, _serverToken);
+      expect(serverClient.lastToken, _serverToken);
+      expect(session.baseUrl, 'https://10-0-0-5.abc.plex.direct:32400');
+      expect(session.machineIdentifier, 'machine-abc');
+      expect(session.serverName, 'Office Server');
+      expect(session.serverVersion, '1.41.0.9999');
+      // The library picker starts empty — selection is the user's next step.
+      expect(session.selectedSectionKeys, isEmpty);
+    });
+
+    test('falls back to the account token when no scoped token exists',
+        () async {
+      const PlexResource unscoped = PlexResource(
+        name: 'S',
+        clientIdentifier: 'machine-abc',
+        provides: 'server',
+        connections: <PlexResourceConnection>[_directConnection],
+      );
+      final serverClient = FakePlexClient();
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      final PlexSession session = await auth.connectToServer(
+        server: unscoped,
+        accountToken: _accountToken,
+      );
+
+      expect(session.token, _accountToken);
+    });
+
+    test('keeps the relay as the last resort', () async {
+      final probed = <String>[];
+      final serverClient = _ProbeRecordingClient(
+        probed,
+        failFor: <String>{
+          // Both direct addresses are unreachable; only the relay answers.
+          'https://10-0-0-5.abc.plex.direct:32400',
+          'https://93-184-216-34.abc.plex.direct:32400',
+        },
+      );
+      const PlexResource server = PlexResource(
+        name: 'S',
+        clientIdentifier: 'machine-abc',
+        provides: 'server',
+        accessToken: _serverToken,
+        // plex.tv put the relay first; the probe order must still demote it.
+        connections: <PlexResourceConnection>[
+          _relayConnection,
+          _directConnection,
+          _remoteConnection,
+        ],
+      );
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      final PlexSession session = await auth.connectToServer(
+        server: server,
+        accountToken: _accountToken,
+      );
+
+      expect(probed, <String>[
+        'https://10-0-0-5.abc.plex.direct:32400',
+        'https://93-184-216-34.abc.plex.direct:32400',
+        'https://relay.plex.direct:8443',
+      ]);
+      expect(session.baseUrl, 'https://relay.plex.direct:8443');
+    });
+
+    test('a rejected token aborts immediately instead of probing on', () async {
+      final probed = <String>[];
+      final serverClient = _ProbeRecordingClient(
+        probed,
+        errorFor: <String, PlexException>{
+          'https://10-0-0-5.abc.plex.direct:32400':
+              PlexException.unauthorized(),
+        },
+      );
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      await expectLater(
+        auth.connectToServer(server: _server, accountToken: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+      // The same token would be rejected on every address — one probe only.
+      expect(probed, hasLength(1));
+    });
+
+    test('reports unreachable when no address answers', () async {
+      final serverClient =
+          FakePlexClient(identityError: PlexException.notReachable());
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      await expectLater(
+        auth.connectToServer(server: _server, accountToken: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notReachable)
+            .having((e) => e.message, 'message', contains('addresses'))),
+      );
+    });
+
+    test('reports unreachable for a server with no usable address', () async {
+      const PlexResource server = PlexResource(
+        name: 'S',
+        clientIdentifier: 'machine-abc',
+        provides: 'server',
+        connections: <PlexResourceConnection>[
+          PlexResourceConnection(uri: 'ftp://not-a-web-address'),
+        ],
+      );
+      final PlexPinAuth auth = _auth();
+
+      await expectLater(
+        auth.connectToServer(server: server, accountToken: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notReachable)),
+      );
+    });
+
+    test('the produced session keeps redacting its token', () async {
+      final PlexPinAuth auth = _auth();
+
+      final PlexSession session = await auth.connectToServer(
+        server: _server,
+        accountToken: _accountToken,
+      );
+
+      final String text = session.toString();
+      expect(text, isNot(contains(_serverToken)));
+      expect(text, isNot(contains(_accountToken)));
+      expect(text, contains('<redacted>'));
+    });
+
+    test('failure messages never carry either token', () async {
+      final serverClient =
+          FakePlexClient(identityError: PlexException.notReachable());
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      try {
+        await auth.connectToServer(
+          server: _server,
+          accountToken: _accountToken,
+        );
+        fail('expected a PlexException');
+      } on PlexException catch (error) {
+        expect(error.message, isNot(contains(_serverToken)));
+        expect(error.message, isNot(contains(_accountToken)));
+      }
+    });
+  });
+}
+
+/// A [FakePlexClient] that records the probed base URLs and can fail
+/// specific ones, so the connection-order logic can be asserted.
+class _ProbeRecordingClient extends FakePlexClient {
+  _ProbeRecordingClient(
+    this.probed, {
+    this.failFor = const <String>{},
+    this.errorFor = const <String, PlexException>{},
+  });
+
+  final List<String> probed;
+  final Set<String> failFor;
+  final Map<String, PlexException> errorFor;
+
+  @override
+  Future<PlexServerIdentity> fetchIdentity({
+    required String baseUrl,
+    required String token,
+  }) async {
+    probed.add(baseUrl);
+    final PlexException? specific = errorFor[baseUrl];
+    if (specific != null) throw specific;
+    if (failFor.contains(baseUrl)) throw PlexException.notReachable();
+    return const PlexServerIdentity(machineIdentifier: 'machine-abc');
+  }
+}

--- a/test/core/sources/plex/plex_pin_auth_test.dart
+++ b/test/core/sources/plex/plex_pin_auth_test.dart
@@ -48,7 +48,12 @@ PlexPinAuth _auth({
 }) {
   return PlexPinAuth(
     tvClient: tvClient ?? FakePlexTvClient(),
-    serverClient: serverClient ?? FakePlexClient(),
+    // The default server answers as `_server`'s machine, so a probe matches
+    // the picked resource's clientIdentifier (the identity guard).
+    serverClient: serverClient ??
+        FakePlexClient(
+          identity: const PlexServerIdentity(machineIdentifier: 'machine-abc'),
+        ),
     identity: _identity,
     wait: (Duration duration) async => waits?.add(duration),
   );
@@ -252,7 +257,9 @@ void main() {
         provides: 'server',
         connections: <PlexResourceConnection>[_directConnection],
       );
-      final serverClient = FakePlexClient();
+      final serverClient = FakePlexClient(
+        identity: const PlexServerIdentity(machineIdentifier: 'machine-abc'),
+      );
       final PlexPinAuth auth = _auth(serverClient: serverClient);
 
       final PlexSession session = await auth.connectToServer(
@@ -261,6 +268,53 @@ void main() {
       );
 
       expect(session.token, _accountToken);
+    });
+
+    test('skips an address that answers as a different server', () async {
+      // The first advertised address is stale and now reaches a DIFFERENT
+      // server that still accepts the account-wide token; the second reaches
+      // the real one. Only the server the user picked is persisted.
+      final probed = <String>[];
+      final serverClient = _IdentityByUrlClient(
+        probed,
+        identityFor: const <String, PlexServerIdentity>{
+          'https://10-0-0-5.abc.plex.direct:32400':
+              PlexServerIdentity(machineIdentifier: 'someone-elses-server'),
+          'https://93-184-216-34.abc.plex.direct:32400':
+              PlexServerIdentity(machineIdentifier: 'machine-abc'),
+        },
+      );
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      final PlexSession session = await auth.connectToServer(
+        server: _server,
+        accountToken: _accountToken,
+      );
+
+      // Both addresses were probed; the matching one won.
+      expect(probed, <String>[
+        'https://10-0-0-5.abc.plex.direct:32400',
+        'https://93-184-216-34.abc.plex.direct:32400',
+      ]);
+      expect(session.machineIdentifier, 'machine-abc');
+      expect(session.baseUrl, 'https://93-184-216-34.abc.plex.direct:32400');
+    });
+
+    test('reports unreachable when no address reaches the picked server',
+        () async {
+      // Every advertised address answers as a different server — none is the
+      // one the user picked, so nothing is persisted.
+      final serverClient = FakePlexClient(
+        identity:
+            const PlexServerIdentity(machineIdentifier: 'not-the-picked-one'),
+      );
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
+      await expectLater(
+        auth.connectToServer(server: _server, accountToken: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notReachable)),
+      );
     });
 
     test('keeps the relay as the last resort', () async {
@@ -407,5 +461,26 @@ class _ProbeRecordingClient extends FakePlexClient {
     if (specific != null) throw specific;
     if (failFor.contains(baseUrl)) throw PlexException.notReachable();
     return const PlexServerIdentity(machineIdentifier: 'machine-abc');
+  }
+}
+
+/// A [FakePlexClient] that records probed base URLs and returns a per-URL
+/// identity, so the "address answers as a different server" guard can be
+/// exercised. An unmapped URL is treated as unreachable.
+class _IdentityByUrlClient extends FakePlexClient {
+  _IdentityByUrlClient(this.probed, {required this.identityFor});
+
+  final List<String> probed;
+  final Map<String, PlexServerIdentity> identityFor;
+
+  @override
+  Future<PlexServerIdentity> fetchIdentity({
+    required String baseUrl,
+    required String token,
+  }) async {
+    probed.add(baseUrl);
+    final PlexServerIdentity? id = identityFor[baseUrl];
+    if (id == null) throw PlexException.notReachable();
+    return id;
   }
 }

--- a/test/core/sources/plex/plex_pin_auth_test.dart
+++ b/test/core/sources/plex/plex_pin_auth_test.dart
@@ -354,7 +354,12 @@ void main() {
       expect(session.baseUrl, 'https://relay.plex.direct:8443');
     });
 
-    test('a rejected token aborts immediately instead of probing on', () async {
+    test(
+        'an auth failure on one address does not abort: a later address still '
+        'reaches the picked server', () async {
+      // The first advertised address is stale and lands on a different server
+      // that rejects this server-scoped token (401); the second reaches the
+      // picked server. The probe must not give up on the first rejection.
       final probed = <String>[];
       final serverClient = _ProbeRecordingClient(
         probed,
@@ -365,13 +370,42 @@ void main() {
       );
       final PlexPinAuth auth = _auth(serverClient: serverClient);
 
+      final PlexSession session = await auth.connectToServer(
+        server: _server,
+        accountToken: _accountToken,
+      );
+
+      expect(probed, <String>[
+        'https://10-0-0-5.abc.plex.direct:32400',
+        'https://93-184-216-34.abc.plex.direct:32400',
+      ]);
+      expect(session.baseUrl, 'https://93-184-216-34.abc.plex.direct:32400');
+      expect(session.machineIdentifier, 'machine-abc');
+    });
+
+    test('reports the token rejection only after every address is exhausted',
+        () async {
+      // Every advertised address rejects the token; only then is it surfaced
+      // (as the more actionable failure than a generic "unreachable").
+      final probed = <String>[];
+      final serverClient = _ProbeRecordingClient(
+        probed,
+        errorFor: <String, PlexException>{
+          'https://10-0-0-5.abc.plex.direct:32400':
+              PlexException.unauthorized(),
+          'https://93-184-216-34.abc.plex.direct:32400':
+              PlexException.unauthorized(),
+        },
+      );
+      final PlexPinAuth auth = _auth(serverClient: serverClient);
+
       await expectLater(
         auth.connectToServer(server: _server, accountToken: _accountToken),
         throwsA(isA<PlexException>()
             .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
       );
-      // The same token would be rejected on every address — one probe only.
-      expect(probed, hasLength(1));
+      // Both addresses were tried before reporting the rejection.
+      expect(probed, hasLength(2));
     });
 
     test('reports unreachable when no address answers', () async {

--- a/test/core/sources/plex/plex_tv_api_test.dart
+++ b/test/core/sources/plex/plex_tv_api_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/plex/plex_tv_api.dart';
+
+const String _accessToken = 'super-secret-server-token';
+
+void main() {
+  group('PlexPin', () {
+    test('parses id, code, and expiry', () {
+      final PlexPin? pin = PlexPin.fromJson(const <String, dynamic>{
+        'id': 123456,
+        'code': 'abcDEF123',
+        'expiresIn': 1800,
+        'authToken': null,
+      });
+
+      expect(pin, isNotNull);
+      expect(pin!.id, 123456);
+      expect(pin.code, 'abcDEF123');
+      expect(pin.expiresInSeconds, 1800);
+    });
+
+    test('tolerates string-typed numbers', () {
+      final PlexPin? pin = PlexPin.fromJson(const <String, dynamic>{
+        'id': '42',
+        'code': 'c0de',
+        'expiresIn': '900',
+      });
+
+      expect(pin!.id, 42);
+      expect(pin.expiresInSeconds, 900);
+    });
+
+    test('returns null without an id or code', () {
+      expect(PlexPin.fromJson(const <String, dynamic>{'code': 'x'}), isNull);
+      expect(PlexPin.fromJson(const <String, dynamic>{'id': 1}), isNull);
+      expect(
+        PlexPin.fromJson(const <String, dynamic>{'id': 1, 'code': ''}),
+        isNull,
+      );
+    });
+
+    test('toString omits the code', () {
+      const PlexPin pin = PlexPin(id: 9, code: 'should-not-print');
+      expect(pin.toString(), isNot(contains('should-not-print')));
+      expect(pin.toString(), contains('9'));
+    });
+  });
+
+  group('PlexResource', () {
+    test('parses a server resource with its connections', () {
+      final PlexResource? resource =
+          PlexResource.fromJson(const <String, dynamic>{
+        'name': 'Office Server',
+        'clientIdentifier': 'machine-abc',
+        'provides': 'server',
+        'accessToken': _accessToken,
+        'owned': true,
+        'productVersion': '1.41.0.8994',
+        'connections': <Object?>[
+          <String, dynamic>{
+            'protocol': 'https',
+            'address': '192.168.1.10',
+            'port': 32400,
+            'uri': 'https://192-168-1-10.abc.plex.direct:32400',
+            'local': true,
+            'relay': false,
+          },
+          <String, dynamic>{
+            'protocol': 'https',
+            'uri': 'https://relay.plex.direct:8443',
+            'local': false,
+            'relay': true,
+          },
+        ],
+      });
+
+      expect(resource, isNotNull);
+      expect(resource!.name, 'Office Server');
+      expect(resource.clientIdentifier, 'machine-abc');
+      expect(resource.providesServer, isTrue);
+      expect(resource.accessToken, _accessToken);
+      expect(resource.owned, isTrue);
+      expect(resource.productVersion, '1.41.0.8994');
+      expect(resource.connections, hasLength(2));
+      expect(resource.connections.first.uri,
+          'https://192-168-1-10.abc.plex.direct:32400');
+      expect(resource.connections.first.local, isTrue);
+      expect(resource.connections.first.relay, isFalse);
+      expect(resource.connections.last.relay, isTrue);
+    });
+
+    test('providesServer matches inside a comma-separated list only', () {
+      PlexResource resource({required String provides}) =>
+          PlexResource(name: 'X', clientIdentifier: 'id', provides: provides);
+
+      expect(resource(provides: 'server').providesServer, isTrue);
+      expect(resource(provides: 'client,server').providesServer, isTrue);
+      expect(resource(provides: 'client, server').providesServer, isTrue);
+      expect(resource(provides: 'client,player').providesServer, isFalse);
+      // A *player* that merely contains the word must not match.
+      expect(resource(provides: 'serverless').providesServer, isFalse);
+      expect(resource(provides: '').providesServer, isFalse);
+    });
+
+    test('tolerates 0/1 and string booleans from older envelopes', () {
+      final PlexResource? resource =
+          PlexResource.fromJson(const <String, dynamic>{
+        'name': 'S',
+        'clientIdentifier': 'id',
+        'provides': 'server',
+        'owned': '0',
+        'connections': <Object?>[
+          <String, dynamic>{
+            'uri': 'http://10.0.0.2:32400',
+            'local': 1,
+            'relay': '0'
+          },
+        ],
+      });
+
+      expect(resource!.owned, isFalse);
+      expect(resource.connections.single.local, isTrue);
+      expect(resource.connections.single.relay, isFalse);
+    });
+
+    test('skips malformed connections and tolerates a missing token', () {
+      final PlexResource? resource =
+          PlexResource.fromJson(const <String, dynamic>{
+        'name': 'S',
+        'clientIdentifier': 'id',
+        'provides': 'server',
+        'connections': <Object?>[
+          <String, dynamic>{'local': true}, // no uri — unusable
+          'garbage',
+          <String, dynamic>{'uri': 'http://10.0.0.2:32400'},
+        ],
+      });
+
+      expect(resource!.accessToken, isNull);
+      expect(resource.connections, hasLength(1));
+      expect(resource.connections.single.uri, 'http://10.0.0.2:32400');
+    });
+
+    test('returns null without a clientIdentifier', () {
+      expect(
+        PlexResource.fromJson(const <String, dynamic>{'name': 'S'}),
+        isNull,
+      );
+    });
+
+    test('toString redacts the access token', () {
+      const PlexResource resource = PlexResource(
+        name: 'Office Server',
+        clientIdentifier: 'machine-abc',
+        provides: 'server',
+        accessToken: _accessToken,
+        connections: <PlexResourceConnection>[
+          PlexResourceConnection(uri: 'https://x.plex.direct:32400'),
+        ],
+      );
+
+      final String text = resource.toString();
+      expect(text, isNot(contains(_accessToken)));
+      expect(text, contains('<redacted>'));
+      // Display-safe fields still print, so debugging stays useful.
+      expect(text, contains('Office Server'));
+      expect(text, contains('machine-abc'));
+    });
+
+    test('toString says null when there is no token to redact', () {
+      const PlexResource resource =
+          PlexResource(name: 'S', clientIdentifier: 'id');
+      expect(resource.toString(), contains('accessToken: null'));
+    });
+  });
+}

--- a/test/core/sources/plex/plex_tv_endpoints_test.dart
+++ b/test/core/sources/plex/plex_tv_endpoints_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/plex/plex_tv_endpoints.dart';
+
+void main() {
+  group('pins', () {
+    test('mints at /api/v2/pins with strong=true', () {
+      final Uri url = PlexTvEndpoints.pins();
+      expect(url.toString(), 'https://plex.tv/api/v2/pins?strong=true');
+    });
+
+    test('polls one pin by id', () {
+      final Uri url = PlexTvEndpoints.pin(123456);
+      expect(url.toString(), 'https://plex.tv/api/v2/pins/123456');
+    });
+  });
+
+  group('resources', () {
+    test('asks for https and relay addresses', () {
+      final Uri url = PlexTvEndpoints.resources();
+      expect(
+        url.toString(),
+        'https://plex.tv/api/v2/resources?includeHttps=1&includeRelay=1',
+      );
+    });
+  });
+
+  group('authApp', () {
+    test('builds the hosted sign-in page with params in the fragment', () {
+      final Uri url = PlexTvEndpoints.authApp(
+        clientIdentifier: 'install-uuid-1',
+        code: 'abc123DEF',
+        product: 'Linthra',
+      );
+
+      // The exact canonical shape the hosted page parses: everything after
+      // `#?`, with the context key percent-encoded.
+      expect(
+        url.toString(),
+        'https://app.plex.tv/auth#?clientID=install-uuid-1&code=abc123DEF'
+        '&context%5Bdevice%5D%5Bproduct%5D=Linthra',
+      );
+      // Fragment, not query: the params are read client-side by the page and
+      // are never sent to a server in a request line.
+      expect(url.query, isEmpty);
+      expect(url.fragment, startsWith('?clientID='));
+    });
+
+    test('percent-encodes reserved characters in values', () {
+      final Uri url = PlexTvEndpoints.authApp(
+        clientIdentifier: 'id with space',
+        code: 'co&de=+x',
+        product: 'My Player',
+      );
+
+      final String text = url.toString();
+      expect(text, contains('clientID=id%20with%20space'));
+      expect(text, contains('code=co%26de%3D%2Bx'));
+      expect(text, contains('context%5Bdevice%5D%5Bproduct%5D=My%20Player'));
+    });
+
+    test('never carries a token parameter', () {
+      final Uri url = PlexTvEndpoints.authApp(
+        clientIdentifier: 'cid',
+        code: 'code',
+        product: 'Linthra',
+      );
+      expect(url.toString().toLowerCase(), isNot(contains('x-plex-token')));
+    });
+  });
+}

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -1613,6 +1613,56 @@ void main() {
     });
 
     test(
+        'a slow restore landing mid-flow does not swap the in-flight PIN '
+        'client identity', () async {
+      // The restore would bring back a session whose clientIdentifier differs
+      // from the launch id the PIN flow minted its PIN with.
+      final store = _GatedReadStore(
+        _session.copyWith(
+          machineIdentifier: 'old-machine',
+          clientIdentifier: 'restored-install-id',
+        ),
+      );
+      final tvClient =
+          _GatedPinTvClient(checkPinScript: <Object?>[_accountToken])
+            ..resources = const <PlexResource>[_officeResource];
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      final launchId =
+          container.read(plexClientIdentityProvider).clientIdentifier;
+      expect(launchId, isNot('restored-install-id'));
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+
+      // The slow restore completes mid-flow. It must NOT publish the restored
+      // client id — the in-flight PIN is bound to the launch id, so swapping
+      // the X-Plex-Client-Identifier would break the approval.
+      store.readGate.complete();
+      await _settle();
+      expect(
+        container.read(plexClientIdentityProvider).clientIdentifier,
+        launchId,
+      );
+
+      // The flow proceeds and connects under the identity it began with.
+      tvClient.gate.complete();
+      await flow;
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(notifier.session!.clientIdentifier, launchId);
+      expect(
+        container.read(plexClientIdentityProvider).clientIdentifier,
+        launchId,
+      );
+    });
+
+    test(
         'no token — account, server-scoped, or shared — ever reaches the '
         'state through the whole flow', () async {
       final container = _container(

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -140,17 +140,20 @@ class _FlakyPlexSessionStore implements PlexSessionStore {
 /// A [PlexSessionStore] whose read blocks until released, simulating a slow
 /// secure-storage read on a real device so user actions can race the startup
 /// restore. The read returns what was persisted when it *started* (a stale
-/// snapshot), exactly like a disk read would.
+/// snapshot), exactly like a disk read would — or throws [readErrorAfterGate]
+/// when set, to simulate a read that fails only after the race window opened.
 class _GatedReadStore implements PlexSessionStore {
-  _GatedReadStore(this._session);
+  _GatedReadStore(this._session, {this.readErrorAfterGate});
 
   PlexSession? _session;
+  final Object? readErrorAfterGate;
   final Completer<void> readGate = Completer<void>();
 
   @override
   Future<PlexSession?> read() async {
     final PlexSession? snapshot = _session;
     await readGate.future;
+    if (readErrorAfterGate != null) throw readErrorAfterGate!;
     return snapshot;
   }
 
@@ -162,6 +165,28 @@ class _GatedReadStore implements PlexSessionStore {
   @override
   Future<void> clear() async {
     _session = null;
+  }
+}
+
+/// A [FakePlexClient] whose `fetchIdentity` blocks until [identityGate]
+/// completes, so a test can hold the PIN flow in its `connecting` server-probe
+/// while another event (a slow startup restore) lands.
+class _GatedIdentityClient extends FakePlexClient {
+  _GatedIdentityClient({
+    required this.identityGate,
+    super.identity,
+    super.sections,
+  });
+
+  final Completer<void> identityGate;
+
+  @override
+  Future<PlexServerIdentity> fetchIdentity({
+    required String baseUrl,
+    required String token,
+  }) async {
+    await identityGate.future;
+    return super.fetchIdentity(baseUrl: baseUrl, token: token);
   }
 }
 
@@ -1496,6 +1521,95 @@ void main() {
 
       tvClient.gate.complete();
       await flow;
+    });
+
+    test(
+        'a restore read failure landing mid-flow does not clobber the sign-in '
+        'with a disconnected error', () async {
+      // The slow startup read ultimately FAILS, while the user has already
+      // started "Connect with Plex".
+      final store = _GatedReadStore(null,
+          readErrorAfterGate: StateError('keystore gone'));
+      final tvClient = _GatedPinTvClient();
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+
+      // The failed restore must not replace the linking card with a
+      // disconnected restore error (which would strip Cancel/reopen).
+      store.readGate.complete();
+      await _settle();
+      final mid = container.read(plexSettingsControllerProvider);
+      expect(mid.phase, PlexConnectionPhase.linking);
+      expect(mid.errorMessage, isNull);
+
+      // The flow's controls still work.
+      notifier.cancelPlexLink();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.disconnected,
+      );
+
+      tvClient.gate.complete();
+      await flow;
+    });
+
+    test(
+        'a slow restore completing while the picked server is probed does not '
+        'clobber the sign-in', () async {
+      final identityGate = Completer<void>();
+      final client = _GatedIdentityClient(
+        identityGate: identityGate,
+        identity:
+            const PlexServerIdentity(machineIdentifier: 'fake-machine-id'),
+        sections: const [_musicSection],
+      );
+      // The restore would bring back an OLD, different session.
+      final store = _GatedReadStore(
+        _session.copyWith(machineIdentifier: 'old-machine'),
+      );
+      final container = _container(
+        client: client,
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[_officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      final Future<void> flow = notifier.connectWithPlex();
+      // Advance to the connecting probe (single server auto-connects), held at
+      // the gated fetchIdentity.
+      await _settle();
+      await _settle();
+      var state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connecting);
+      // A PIN-flow connecting (servers known) — not the manual form, which
+      // `isLinkFlowActive` alone couldn't tell apart.
+      expect(state.servers, isNotEmpty);
+
+      // The slow restore completes mid-probe — it must not clobber the
+      // in-progress sign-in with the old restored session.
+      store.readGate.complete();
+      await _settle();
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connecting);
+      expect(state.baseUrl, isNull); // not the restored old base URL
+
+      // Releasing the probe completes the flow against the picked server.
+      identityGate.complete();
+      await flow;
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.serverName, 'Office Server');
+      expect(notifier.session!.machineIdentifier, 'fake-machine-id');
     });
 
     test(

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -1142,6 +1142,9 @@ void main() {
 
     test('a failed server connect returns to the picker, retryable', () async {
       final client = FakePlexClient(
+        // Once reachable, the probe answers as the picked Attic server so the
+        // identity guard accepts it.
+        identity: const PlexServerIdentity(machineIdentifier: 'machine-attic'),
         identityError: PlexException.notReachable(),
         sections: const [_musicSection],
       );
@@ -1379,6 +1382,48 @@ void main() {
       expect(saved!.selectedSectionKeys, <String>['5']);
       // The token was rotated to the freshly granted server-scoped one.
       expect(saved.token, _serverScopedToken);
+    });
+
+    test(
+        'a save failure during a PIN reconnect keeps the existing connection '
+        'live instead of showing a disconnected card', () async {
+      // A live session exists; the user reconnects through the PIN flow but
+      // the store write fails.
+      final store = _FlakyPlexSessionStore(
+        initialSession: _session.copyWith(
+          machineIdentifier: 'fake-machine-id',
+          selectedSectionKeys: const <String>['5'],
+        ),
+      );
+      final container = _container(
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[_officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+      expect(container.read(plexMusicSourceProvider), isNotNull);
+
+      store.writeError = StateError('keystore busy');
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      // Still shown as connected to the existing server, with the save error…
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.errorMessage, contains("Couldn't save your Plex session"));
+      expect(state.baseUrl, _session.baseUrl);
+      expect(state.selectedSectionKeys, <String>['5']);
+      // …and the old session is still live and consistent with the UI — the
+      // music source keeps serving it rather than vanishing under a
+      // "disconnected" card.
+      expect(notifier.session, isNotNull);
+      final source = container.read(plexMusicSourceProvider);
+      expect(source, isNotNull);
+      expect(source!.session.baseUrl, _session.baseUrl);
+      // The in-memory flow tokens were still released.
+      expect(await notifier.selectServer('fake-machine-id'), isFalse);
     });
 
     test('a second connectWithPlex while one is waiting is ignored', () async {

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -1613,6 +1613,65 @@ void main() {
     });
 
     test(
+        'a slow restore completing while a server PICKED from the multi-server '
+        'list is being probed does not clobber the sign-in', () async {
+      // The reviewer's exact scenario: a multi-server account, the user picks
+      // a server from the list, and the slow startup restore finishes while
+      // that picked server is being probed/connected.
+      final identityGate = Completer<void>();
+      final client = _GatedIdentityClient(
+        identityGate: identityGate,
+        identity: const PlexServerIdentity(machineIdentifier: 'machine-attic'),
+        sections: const [_musicSection],
+      );
+      // The restore would bring back an OLD, different session.
+      final store = _GatedReadStore(
+        _session.copyWith(machineIdentifier: 'old-machine'),
+      );
+      final container = _container(
+        client: client,
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          // Two servers → the picker, no auto-connect.
+          resources: const <PlexResource>[_officeResource, _atticResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      // The whole sign-in runs to the picker (fetchIdentity isn't called until
+      // a server is picked), so connectWithPlex can be awaited fully.
+      await notifier.connectWithPlex();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.pickingServer,
+      );
+
+      // The user picks Attic; its probe is held at the gated fetchIdentity.
+      final Future<bool> picked = notifier.selectServer('machine-attic');
+      await _settle();
+      var state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connecting);
+      expect(state.servers, isNotEmpty);
+
+      // The slow startup restore finishes mid-probe — it must not overwrite
+      // the visible connecting state with the old restored session.
+      store.readGate.complete();
+      await _settle();
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connecting);
+      expect(state.baseUrl, isNull); // not the restored old base URL
+
+      // Releasing the probe completes the connection to the picked server.
+      identityGate.complete();
+      expect(await picked, isTrue);
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.serverName, 'Attic NAS');
+      expect(notifier.session!.machineIdentifier, 'machine-attic');
+    });
+
+    test(
         'a slow restore landing mid-flow does not swap the in-flight PIN '
         'client identity', () async {
       // The restore would bring back a session whose clientIdentifier differs

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -1722,6 +1722,57 @@ void main() {
     });
 
     test(
+        'a flow failure after a deferred-publish restore announces the '
+        'restored session identity', () async {
+      // The slow restore brings back a session whose client id was deferred
+      // (the flow owned the card); the flow then FAILS and falls back to that
+      // session — its persisted client id must be announced, not left on the
+      // temporary launch/PIN id.
+      final store = _GatedReadStore(
+        _session.copyWith(clientIdentifier: 'restored-install-id'),
+      );
+      // The PIN expires on the first poll, so the flow fails via _setFailure.
+      final tvClient = _GatedPinTvClient(
+        checkPinScript: <Object?>[PlexException.signInExpired()],
+      );
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      final launchId =
+          container.read(plexClientIdentityProvider).clientIdentifier;
+      expect(launchId, isNot('restored-install-id'));
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+
+      // The restore lands mid-flow: identity stays on the launch id (deferred).
+      store.readGate.complete();
+      await _settle();
+      expect(
+        container.read(plexClientIdentityProvider).clientIdentifier,
+        launchId,
+      );
+
+      // The PIN expires → the flow fails and falls back to the restored
+      // session as connected. That fallback must publish the restored id.
+      tvClient.gate.complete();
+      await flow;
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.errorMessage, contains('expired'));
+      expect(state.baseUrl, _session.baseUrl);
+      expect(
+        container.read(plexClientIdentityProvider).clientIdentifier,
+        'restored-install-id',
+      );
+      expect(notifier.session!.clientIdentifier, 'restored-install-id');
+    });
+
+    test(
         'no token — account, server-scoped, or shared — ever reaches the '
         'state through the whole flow', () async {
       final container = _container(

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -2,15 +2,19 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/external_link_launcher_provider.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/repositories/plex_session_store.dart';
+import 'package:linthra/core/services/external_link_launcher.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
 import 'package:linthra/core/sources/plex/plex_music_source.dart';
+import 'package:linthra/core/sources/plex/plex_pin_auth.dart';
+import 'package:linthra/core/sources/plex/plex_tv_api.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
@@ -22,8 +26,11 @@ import 'package:linthra/features/settings/plex/plex_sync_controller.dart';
 import 'package:linthra/features/settings/plex/plex_sync_state.dart';
 
 import '../../../core/sources/plex/fake_plex_client.dart';
+import '../../../core/sources/plex/fake_plex_tv_client.dart';
 
 const String _token = 'super-secret-plex-token';
+const String _accountToken = 'super-secret-account-token';
+const String _serverScopedToken = 'super-secret-server-scoped-token';
 
 const PlexSession _session = PlexSession(
   baseUrl: 'https://plex.example.com:32400',
@@ -40,6 +47,58 @@ const PlexDirectory _secondMusicSection =
     PlexDirectory(key: '9', title: 'Vinyl rips', type: 'artist');
 const PlexDirectory _movieSection =
     PlexDirectory(key: '1', title: 'Movies', type: 'movie');
+
+const PlexResource _officeResource = PlexResource(
+  name: 'Office Server',
+  clientIdentifier: 'fake-machine-id',
+  provides: 'server',
+  accessToken: _serverScopedToken,
+  productVersion: '1.41.0',
+  connections: <PlexResourceConnection>[
+    PlexResourceConnection(uri: 'https://office.abc.plex.direct:32400'),
+  ],
+);
+
+const PlexResource _atticResource = PlexResource(
+  name: 'Attic NAS',
+  clientIdentifier: 'machine-attic',
+  provides: 'server',
+  accessToken: 'super-secret-attic-token',
+  owned: false,
+  connections: <PlexResourceConnection>[
+    PlexResourceConnection(uri: 'https://attic.abc.plex.direct:32400'),
+  ],
+);
+
+/// An [ExternalLinkLauncher] that records what it was asked to open and
+/// never touches a real browser.
+class _RecordingLauncher implements ExternalLinkLauncher {
+  _RecordingLauncher({this.result = true});
+
+  bool result;
+  final List<Uri> opened = <Uri>[];
+
+  @override
+  Future<bool> open(Uri url) async {
+    opened.add(url);
+    return result;
+  }
+}
+
+/// A [FakePlexTvClient] whose PIN polls block until [gate] completes, so a
+/// test can hold the controller in the `linking` phase and exercise
+/// cancellation deterministically.
+class _GatedPinTvClient extends FakePlexTvClient {
+  _GatedPinTvClient({super.checkPinScript});
+
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<String?> checkPin(int pinId) async {
+    await gate.future;
+    return super.checkPin(pinId);
+  }
+}
 
 /// A [PlexSessionStore] whose operations can be made to throw, to prove a
 /// storage failure never crashes or wedges the controller.
@@ -152,16 +211,30 @@ ProviderContainer _container({
   FakePlexClient? client,
   PlexSessionStore? store,
   MusicLibraryRepository? repository,
+  FakePlexTvClient? tvClient,
+  ExternalLinkLauncher? launcher,
 }) {
+  final FakePlexClient plexClient =
+      client ?? FakePlexClient(sections: const [_musicSection]);
   final container = ProviderContainer(
     overrides: <Override>[
-      plexClientProvider.overrideWithValue(
-        client ?? FakePlexClient(sections: const [_musicSection]),
-      ),
+      plexClientProvider.overrideWithValue(plexClient),
       plexSessionStoreProvider
           .overrideWithValue(store ?? InMemoryPlexSessionStore()),
       if (repository != null)
         musicLibraryRepositoryProvider.overrideWithValue(repository),
+      // The PIN flow on fakes, with an instant wait so the poll loop runs
+      // without real delays.
+      plexPinAuthProvider.overrideWith(
+        (ref) => PlexPinAuth(
+          tvClient: tvClient ?? FakePlexTvClient(),
+          serverClient: plexClient,
+          identity: ref.watch(plexClientIdentityProvider),
+          wait: (_) async {},
+        ),
+      ),
+      externalLinkLauncherProvider
+          .overrideWithValue(launcher ?? _RecordingLauncher()),
     ],
   );
   addTearDown(container.dispose);
@@ -952,6 +1025,480 @@ void main() {
 
       final String text = notifier.session.toString();
       expect(text, isNot(contains(_token)));
+      expect(text, contains('<redacted>'));
+    });
+  });
+
+  group('connect with Plex (sign-in flow)', () {
+    test(
+        'a single-server account connects end to end: pin → browser → poll → '
+        'server-scoped session', () async {
+      final store = InMemoryPlexSessionStore();
+      final launcher = _RecordingLauncher();
+      final tvClient = FakePlexTvClient(
+        pin: const PlexPin(id: 7, code: 'pin-code'),
+        checkPinScript: <Object?>[null, _accountToken],
+        resources: const <PlexResource>[_officeResource],
+      );
+      final container = _container(
+        client: FakePlexClient(sections: const [_movieSection, _musicSection]),
+        store: store,
+        tvClient: tvClient,
+        launcher: launcher,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      // The plex.tv flow knows the server's name — unlike the manual flow.
+      expect(state.serverName, 'Office Server');
+      expect(state.displayName, 'Plex · Office Server');
+      expect(state.baseUrl, 'https://office.abc.plex.direct:32400');
+      // The music libraries were fetched for the picker right away.
+      expect(state.sections, const <PlexLibrarySection>[
+        PlexLibrarySection(key: '5', title: 'Music'),
+      ]);
+
+      // The browser was handed the hosted sign-in page for this pin.
+      final Uri opened = launcher.opened.single;
+      expect(opened.host, 'app.plex.tv');
+      expect(opened.fragment, contains('code=pin-code'));
+      expect(tvClient.lastCheckedPinId, 7);
+      // The account token authorized the resources lookup once…
+      expect(tvClient.lastResourcesToken, _accountToken);
+
+      // …but what's persisted is the narrower server-scoped token.
+      final saved = await store.read();
+      expect(saved!.token, _serverScopedToken);
+      expect(saved.serverName, 'Office Server');
+      expect(saved.selectedSectionKeys, isEmpty);
+      expect(container.read(plexMusicSourceProvider), isNotNull);
+    });
+
+    test('a multi-server account gets the picker, owned servers first',
+        () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          // plex.tv reports the shared server first; the picker leads with
+          // the owned one anyway.
+          resources: const <PlexResource>[_atticResource, _officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.pickingServer);
+      expect(state.servers, const <PlexServerChoice>[
+        PlexServerChoice(
+          clientIdentifier: 'fake-machine-id',
+          name: 'Office Server',
+          productVersion: '1.41.0',
+        ),
+        PlexServerChoice(
+          clientIdentifier: 'machine-attic',
+          name: 'Attic NAS',
+          owned: false,
+        ),
+      ]);
+      // Nothing connected or persisted until a server is picked.
+      expect(notifier.session, isNull);
+    });
+
+    test('picking a server connects to it with its own scoped token', () async {
+      final store = InMemoryPlexSessionStore();
+      final client = FakePlexClient(
+        identity: const PlexServerIdentity(machineIdentifier: 'machine-attic'),
+        sections: const [_musicSection],
+      );
+      final container = _container(
+        client: client,
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[_officeResource, _atticResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      final bool ok = await notifier.selectServer('machine-attic');
+
+      expect(ok, isTrue);
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.serverName, 'Attic NAS');
+      expect((await store.read())!.token, 'super-secret-attic-token');
+      // The picked server was probed on its own advertised address.
+      expect(client.lastBaseUrl, 'https://attic.abc.plex.direct:32400');
+    });
+
+    test('a failed server connect returns to the picker, retryable', () async {
+      final client = FakePlexClient(
+        identityError: PlexException.notReachable(),
+        sections: const [_musicSection],
+      );
+      final container = _container(
+        client: client,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[_officeResource, _atticResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      final bool failed = await notifier.selectServer('machine-attic');
+
+      expect(failed, isFalse);
+      var state = container.read(plexSettingsControllerProvider);
+      // Back on the picker with both servers still offered and a friendly,
+      // token-free reason.
+      expect(state.phase, PlexConnectionPhase.pickingServer);
+      expect(state.servers, hasLength(2));
+      expect(state.errorMessage, contains('addresses'));
+      expect(state.errorKind, PlexErrorKind.notReachable);
+
+      // The server comes back online; the retry succeeds.
+      client.identityError = null;
+      final bool ok = await notifier.selectServer('machine-attic');
+      expect(ok, isTrue);
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('selecting an unknown server id is a no-op', () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[_officeResource, _atticResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      expect(await notifier.selectServer('machine-unknown'), isFalse);
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.pickingServer,
+      );
+    });
+
+    test(
+        'cancelling while waiting for the browser restores the signed-out '
+        'state and discards the poll', () async {
+      final store = InMemoryPlexSessionStore();
+      final tvClient = _GatedPinTvClient(
+        checkPinScript: <Object?>[_accountToken],
+      );
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+
+      notifier.cancelPlexLink();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.disconnected,
+      );
+      // No stale error or status from the abandoned attempt.
+      expect(
+        container.read(plexSettingsControllerProvider).errorMessage,
+        isNull,
+      );
+
+      // The poll answers afterwards — and its granted token is discarded.
+      tvClient.gate.complete();
+      await flow;
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.disconnected,
+      );
+      expect(await store.read(), isNull);
+      expect(notifier.session, isNull);
+      // The abandoned flow released its resources: nothing left to select.
+      expect(await notifier.selectServer('fake-machine-id'), isFalse);
+    });
+
+    test('cancelling a reconnect restores the existing connection untouched',
+        () async {
+      final store = InMemoryPlexSessionStore(initialSession: _session);
+      final tvClient = _GatedPinTvClient();
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+      // The live session stays usable behind the flow.
+      expect(notifier.session, isNotNull);
+      expect(container.read(plexMusicSourceProvider), isNotNull);
+
+      notifier.cancelPlexLink();
+      tvClient.gate.complete();
+      await flow;
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.baseUrl, _session.baseUrl);
+      expect(state.selectedSectionKeys, _session.selectedSectionKeys);
+      expect((await store.read()), _session);
+    });
+
+    test('an expired pin surfaces a friendly error and persists nothing',
+        () async {
+      final store = InMemoryPlexSessionStore();
+      final container = _container(
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[null, PlexException.signInExpired()],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.disconnected);
+      expect(state.errorMessage, contains('expired'));
+      expect(state.errorKind, PlexErrorKind.unauthorized);
+      expect(await store.read(), isNull);
+    });
+
+    test('an unopenable browser aborts the flow before any polling', () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+      );
+      final container = _container(
+        tvClient: tvClient,
+        launcher: _RecordingLauncher(result: false),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.disconnected);
+      expect(state.errorMessage, contains("Couldn't open"));
+      expect(tvClient.checkPinCount, 0);
+    });
+
+    test('a failed servers lookup surfaces a friendly plex.tv error', () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resourcesError: PlexException.plexTvError(503),
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.disconnected);
+      expect(state.errorMessage, contains('plex.tv'));
+      expect(state.errorKind, PlexErrorKind.serverError);
+    });
+
+    test('an account with no servers gets the picker\'s clean empty state',
+        () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.pickingServer);
+      expect(state.servers, isEmpty);
+      expect(state.errorMessage, isNull);
+
+      // Backing out lands on the pristine signed-out card.
+      notifier.cancelPlexLink();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.disconnected,
+      );
+    });
+
+    test(
+        'reconnecting through the flow to the same server keeps the '
+        'library selection', () async {
+      // The saved session points at the same machine the flow's server
+      // resource identifies as (the fake client reports fake-machine-id).
+      final store = InMemoryPlexSessionStore(
+        initialSession: _session.copyWith(
+          machineIdentifier: 'fake-machine-id',
+          selectedSectionKeys: const <String>['5'],
+        ),
+      );
+      final container = _container(
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          resources: const <PlexResource>[_officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.selectedSectionKeys, <String>['5']);
+      final saved = await store.read();
+      expect(saved!.selectedSectionKeys, <String>['5']);
+      // The token was rotated to the freshly granted server-scoped one.
+      expect(saved.token, _serverScopedToken);
+    });
+
+    test('a second connectWithPlex while one is waiting is ignored', () async {
+      final tvClient = _GatedPinTvClient();
+      final container = _container(tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      final Future<void> first = notifier.connectWithPlex();
+      await _settle();
+      await notifier.connectWithPlex();
+
+      expect(tvClient.createPinCount, 1);
+
+      notifier.cancelPlexLink();
+      tvClient.gate.complete();
+      await first;
+    });
+
+    test('reopenPlexSignIn re-launches the same sign-in page', () async {
+      final launcher = _RecordingLauncher();
+      final tvClient = _GatedPinTvClient();
+      final container = _container(tvClient: tvClient, launcher: launcher);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      await notifier.reopenPlexSignIn();
+
+      expect(launcher.opened, hasLength(2));
+      expect(launcher.opened[0], launcher.opened[1]);
+
+      notifier.cancelPlexLink();
+      tvClient.gate.complete();
+      await flow;
+    });
+
+    test(
+        'a slow startup restore landing mid-flow keeps the flow on screen '
+        'and the session live behind it', () async {
+      final store = _GatedReadStore(_session);
+      final tvClient = _GatedPinTvClient();
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+
+      final Future<void> flow = notifier.connectWithPlex();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+
+      // The restore lands while the user is away in the browser: the card
+      // must not flip out from under the flow…
+      store.readGate.complete();
+      await _settle();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.linking,
+      );
+
+      // …but the restored session is live, so cancelling shows it connected.
+      notifier.cancelPlexLink();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.connected,
+      );
+      expect(notifier.session, isNotNull);
+
+      tvClient.gate.complete();
+      await flow;
+    });
+
+    test(
+        'no token — account, server-scoped, or shared — ever reaches the '
+        'state through the whole flow', () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[null, _accountToken],
+          resources: const <PlexResource>[_officeResource, _atticResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      const List<String> secrets = <String>[
+        _accountToken,
+        _serverScopedToken,
+        'super-secret-attic-token',
+      ];
+      void expectStateTokenFree() {
+        final state = container.read(plexSettingsControllerProvider);
+        final List<String> texts = <String>[
+          state.baseUrl ?? '',
+          state.serverName ?? '',
+          state.serverVersion ?? '',
+          state.statusMessage ?? '',
+          state.errorMessage ?? '',
+          for (final PlexServerChoice server in state.servers)
+            server.toString(),
+        ];
+        for (final String text in texts) {
+          for (final String secret in secrets) {
+            expect(text, isNot(contains(secret)));
+          }
+        }
+      }
+
+      await notifier.connectWithPlex();
+      expectStateTokenFree();
+
+      await notifier.selectServer('fake-machine-id');
+      expectStateTokenFree();
+
+      // And the live session still redacts its token when printed.
+      final String text = notifier.session.toString();
+      for (final String secret in secrets) {
+        expect(text, isNot(contains(secret)));
+      }
       expect(text, contains('<redacted>'));
     });
   });

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -3,17 +3,23 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/external_link_launcher_provider.dart';
 import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/services/external_link_launcher.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_pin_auth.dart';
+import 'package:linthra/core/sources/plex/plex_tv_api.dart';
 import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
 import 'package:linthra/data/repositories/plex_session_store_provider.dart';
 import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
 import 'package:linthra/features/settings/plex/plex_settings_section.dart';
 
 import '../../../core/sources/plex/fake_plex_client.dart';
+import '../../../core/sources/plex/fake_plex_tv_client.dart';
 
 const String _token = 'super-secret-plex-token';
+const String _accountToken = 'super-secret-account-token';
 
 const PlexDirectory _musicSection =
     PlexDirectory(key: '5', title: 'Music', type: 'artist');
@@ -27,6 +33,28 @@ const PlexSession _restoredSession = PlexSession(
   serverVersion: '1.40.1',
   clientIdentifier: 'install-1',
   selectedSectionKeys: <String>['5'],
+);
+
+const PlexResource _officeResource = PlexResource(
+  name: 'Office Server',
+  clientIdentifier: 'fake-machine-id',
+  provides: 'server',
+  accessToken: 'super-secret-server-scoped-token',
+  productVersion: '1.41.0',
+  connections: <PlexResourceConnection>[
+    PlexResourceConnection(uri: 'https://office.abc.plex.direct:32400'),
+  ],
+);
+
+const PlexResource _atticResource = PlexResource(
+  name: 'Attic NAS',
+  clientIdentifier: 'machine-attic',
+  provides: 'server',
+  accessToken: 'super-secret-attic-token',
+  owned: false,
+  connections: <PlexResourceConnection>[
+    PlexResourceConnection(uri: 'https://attic.abc.plex.direct:32400'),
+  ],
 );
 
 /// A [FakePlexClient] whose sections listing blocks until [gate] completes,
@@ -46,20 +74,57 @@ class _GatedSectionsClient extends FakePlexClient {
   }
 }
 
+/// A [FakePlexTvClient] whose PIN polls block until [gate] completes, so the
+/// "waiting for the browser" view can be observed deterministically.
+class _GatedPinTvClient extends FakePlexTvClient {
+  _GatedPinTvClient();
+
+  final Completer<void> gate = Completer<void>();
+
+  @override
+  Future<String?> checkPin(int pinId) async {
+    await gate.future;
+    return super.checkPin(pinId);
+  }
+}
+
+/// An [ExternalLinkLauncher] that records launches instead of opening a
+/// real browser.
+class _RecordingLauncher implements ExternalLinkLauncher {
+  final List<Uri> opened = <Uri>[];
+
+  @override
+  Future<bool> open(Uri url) async {
+    opened.add(url);
+    return true;
+  }
+}
+
 Future<void> _pump(
   WidgetTester tester, {
   FakePlexClient? client,
   InMemoryPlexSessionStore? store,
+  FakePlexTvClient? tvClient,
+  ExternalLinkLauncher? launcher,
 }) async {
+  final FakePlexClient plexClient =
+      client ?? FakePlexClient(sections: const [_movieSection, _musicSection]);
   await tester.pumpWidget(
     ProviderScope(
       overrides: <Override>[
-        plexClientProvider.overrideWithValue(
-          client ??
-              FakePlexClient(sections: const [_movieSection, _musicSection]),
-        ),
+        plexClientProvider.overrideWithValue(plexClient),
         plexSessionStoreProvider
             .overrideWithValue(store ?? InMemoryPlexSessionStore()),
+        plexPinAuthProvider.overrideWith(
+          (ref) => PlexPinAuth(
+            tvClient: tvClient ?? FakePlexTvClient(),
+            serverClient: plexClient,
+            identity: ref.watch(plexClientIdentityProvider),
+            wait: (_) async {},
+          ),
+        ),
+        externalLinkLauncherProvider
+            .overrideWithValue(launcher ?? _RecordingLauncher()),
       ],
       child: const MaterialApp(
         home: Scaffold(
@@ -71,7 +136,15 @@ Future<void> _pump(
   await tester.pump();
 }
 
+/// Opens the advanced manual form (hidden by default behind the primary
+/// "Connect with Plex" action).
+Future<void> _openManualSetup(WidgetTester tester) async {
+  await tester.tap(find.text('Manual setup (advanced)'));
+  await tester.pump();
+}
+
 Future<void> _connect(WidgetTester tester) async {
+  await _openManualSetup(tester);
   await tester.enterText(
       find.byType(TextField).at(0), 'https://plex.example.com:32400');
   await tester.enterText(find.byType(TextField).at(1), _token);
@@ -81,16 +154,30 @@ Future<void> _connect(WidgetTester tester) async {
 }
 
 void main() {
-  testWidgets('renders the connection form marked Experimental',
-      (tester) async {
+  testWidgets(
+      'leads with Connect with Plex and keeps the manual form behind '
+      'Advanced', (tester) async {
     await _pump(tester);
 
     expect(find.text('Plex'), findsOneWidget);
     expect(find.text('Experimental'), findsOneWidget);
+    expect(find.text('Connect with Plex'), findsOneWidget);
+    expect(find.text('Manual setup (advanced)'), findsOneWidget);
+    // No token hunting up front: the manual fields are hidden by default.
+    expect(find.text('Server URL'), findsNothing);
+    expect(find.text('Plex token'), findsNothing);
+
+    await _openManualSetup(tester);
+
     expect(find.text('Server URL'), findsOneWidget);
     expect(find.text('Plex token'), findsOneWidget);
     expect(find.text('Test connection'), findsOneWidget);
     expect(find.text('Connect'), findsOneWidget);
+
+    // The toggle collapses it again.
+    await tester.tap(find.text('Manual setup (advanced)'));
+    await tester.pump();
+    expect(find.text('Server URL'), findsNothing);
   });
 
   testWidgets('shows capability chips only for implemented features',
@@ -105,9 +192,10 @@ void main() {
     expect(find.text('Lyrics'), findsNothing);
   });
 
-  testWidgets('Connect is disabled until both fields are filled',
+  testWidgets('Connect is disabled until both manual fields are filled',
       (tester) async {
     await _pump(tester);
+    await _openManualSetup(tester);
 
     FilledButton connect() => tester.widget<FilledButton>(
           find.widgetWithText(FilledButton, 'Connect'),
@@ -187,7 +275,7 @@ void main() {
     expect(find.text(_token), findsNothing);
   });
 
-  testWidgets('disconnect returns to an empty form', (tester) async {
+  testWidgets('disconnect returns to the signed-out card', (tester) async {
     final store = InMemoryPlexSessionStore(initialSession: _restoredSession);
     await _pump(tester, store: store);
     await tester.pumpAndSettle();
@@ -196,9 +284,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(await store.read(), isNull);
-    expect(find.text('Plex token'), findsOneWidget);
+    expect(find.text('Connect with Plex'), findsOneWidget);
     expect(find.textContaining('Disconnected'), findsOneWidget);
-    // Both fields come back empty — nothing of the old session lingers.
+    // The manual form folds back behind Advanced…
+    expect(find.text('Plex token'), findsNothing);
+
+    // …and comes back empty — nothing of the old session lingers.
+    await _openManualSetup(tester);
     for (final TextField field
         in tester.widgetList<TextField>(find.byType(TextField))) {
       expect(field.controller!.text, isEmpty);
@@ -308,6 +400,7 @@ void main() {
         identityError: PlexException.unauthorized(),
       ),
     );
+    await _openManualSetup(tester);
 
     await tester.enterText(find.byType(TextField).at(0), 'plex.example.com');
     await tester.enterText(find.byType(TextField).at(1), 'wrong-token');
@@ -324,5 +417,157 @@ void main() {
     }
     // Still on the form, ready to retry.
     expect(find.text('Connect'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Connect with Plex opens the browser and shows the waiting view, '
+      'and Cancel backs out of it', (tester) async {
+    final launcher = _RecordingLauncher();
+    final tvClient = _GatedPinTvClient();
+    await _pump(tester, tvClient: tvClient, launcher: launcher);
+
+    await tester.tap(find.text('Connect with Plex'));
+    // Explicit pumps — the waiting spinner animates forever.
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Waiting for your Plex sign-in…'), findsOneWidget);
+    expect(find.text('Open the sign-in page again'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+    // The browser was handed the hosted plex.tv page.
+    expect(launcher.opened.single.host, 'app.plex.tv');
+    expect(launcher.opened.single.fragment, contains('code=fake-pin-code'));
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+
+    expect(find.text('Connect with Plex'), findsOneWidget);
+    expect(find.text('Waiting for your Plex sign-in…'), findsNothing);
+
+    // Release the gated poll so the abandoned flow finishes quietly.
+    tvClient.gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Connect with Plex'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a single-server account connects straight through to the library '
+      'picker, never showing a token', (tester) async {
+    final store = InMemoryPlexSessionStore();
+    await _pump(
+      tester,
+      store: store,
+      tvClient: FakePlexTvClient(
+        checkPinScript: <Object?>[null, _accountToken],
+        resources: const <PlexResource>[_officeResource],
+      ),
+    );
+
+    await tester.tap(find.text('Connect with Plex'));
+    await tester.pumpAndSettle();
+
+    // Connected, named after the picked server (card header + connected
+    // view), with the library picker up.
+    expect(find.text('Plex · Office Server'), findsNWidgets(2));
+    expect(find.text('Music libraries'), findsOneWidget);
+    expect(find.text('Music'), findsOneWidget);
+    expect(find.text('Disconnect Plex'), findsOneWidget);
+
+    // The server-scoped token was persisted (encrypted in production)…
+    expect((await store.read())!.token, 'super-secret-server-scoped-token');
+    // …and no token of any kind was ever rendered.
+    for (final Text text in tester.widgetList<Text>(find.byType(Text))) {
+      expect(text.data ?? '', isNot(contains('super-secret')));
+      expect(text.data ?? '', isNot(contains(_accountToken)));
+    }
+  });
+
+  testWidgets('a multi-server account picks from the server list',
+      (tester) async {
+    final store = InMemoryPlexSessionStore();
+    await _pump(
+      tester,
+      client: FakePlexClient(
+        identity: const PlexServerIdentity(machineIdentifier: 'machine-attic'),
+        sections: const [_musicSection],
+      ),
+      store: store,
+      tvClient: FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        resources: const <PlexResource>[_officeResource, _atticResource],
+      ),
+    );
+
+    await tester.tap(find.text('Connect with Plex'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Choose your Plex server'), findsOneWidget);
+    expect(find.text('Office Server'), findsOneWidget);
+    expect(find.text('Attic NAS'), findsOneWidget);
+    // The shared server says so; versions show when known.
+    expect(find.textContaining('Shared with you'), findsOneWidget);
+    expect(find.textContaining('1.41.0'), findsOneWidget);
+
+    await tester.tap(find.text('Attic NAS'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Plex · Attic NAS'), findsNWidgets(2));
+    expect((await store.read())!.token, 'super-secret-attic-token');
+  });
+
+  testWidgets('an account with no servers shows a clean empty state',
+      (tester) async {
+    await _pump(
+      tester,
+      tvClient: FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        resources: const <PlexResource>[],
+      ),
+    );
+
+    await tester.tap(find.text('Connect with Plex'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No Plex Media Server found'), findsOneWidget);
+    expect(find.textContaining('no Plex Media Server linked'), findsOneWidget);
+
+    await tester.tap(find.text('Back'));
+    await tester.pump();
+    expect(find.text('Connect with Plex'), findsOneWidget);
+  });
+
+  testWidgets('an expired sign-in shows a friendly error on the card',
+      (tester) async {
+    await _pump(
+      tester,
+      tvClient: FakePlexTvClient(
+        checkPinScript: <Object?>[PlexException.signInExpired()],
+      ),
+    );
+
+    await tester.tap(find.text('Connect with Plex'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('sign-in expired'), findsOneWidget);
+    // Back on the signed-out card, ready to retry.
+    expect(find.text('Connect with Plex'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a rejected session offers Reconnect with Plex on the connected card',
+      (tester) async {
+    // The saved token stopped working: the server rejects the library
+    // listing with a 401.
+    await _pump(
+      tester,
+      client: FakePlexClient(sectionsError: PlexException.unauthorized()),
+      store: InMemoryPlexSessionStore(initialSession: _restoredSession),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('was not accepted'), findsOneWidget);
+    expect(find.text('Reconnect with Plex'), findsOneWidget);
+    // Still connected behind the error — disconnecting stays possible too.
+    expect(find.text('Disconnect Plex'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

Implements the plex.tv PIN-based OAuth sign-in flow as the primary authentication method for Plex, replacing the manual server URL + token entry as the default path. The manual flow is retained as an advanced fallback option.

## Key Changes

- **New PIN auth flow** (`plex_pin_auth.dart`): Orchestrates the complete sign-in journey — minting a PIN, launching the browser to `app.plex.tv/auth`, polling for user approval, fetching the account's servers, and converting the picked server into a verified session.

- **plex.tv API client** (`http_plex_tv_client.dart`, `plex_tv_client.dart`): New HTTP seam for communicating with plex.tv's account service (`/api/v2/pins`, `/api/v2/resources`), separate from the user's own Plex Media Server client.

- **Wire models** (`plex_tv_api.dart`): DTOs for PIN and server resource responses from plex.tv, with token redaction in `toString()` methods following the existing safety rules.

- **External link launcher** (`external_link_launcher_provider.dart`, `external_link_launcher.dart`): New provider abstraction for opening the browser, enabling testability and reuse across the app.

- **Settings controller expansion** (`plex_settings_controller.dart`): Added `connectWithPlex()`, `reopenPlexSignIn()`, `cancelPlexLink()`, and `selectServer()` methods to drive the new flow. Private fields track the account token, server resources, and link attempt ID to prevent race conditions during polling.

- **Settings state** (`plex_settings_state.dart`): New phases (`linking`, `loadingServers`, `pickingServer`) and `PlexServerChoice` DTO for the sign-in flow's UI states.

- **UI updates** (`plex_settings_section.dart`): Restructured to show "Connect with Plex" as the primary button, with the manual setup fields hidden behind a toggle. Added server picker and link-in-progress views.

- **Comprehensive test coverage**: New test files for the PIN auth flow (`plex_pin_auth_test.dart`), plex.tv HTTP client (`http_plex_tv_client_test.dart`), wire models (`plex_tv_api_test.dart`), and endpoints (`plex_tv_endpoints_test.dart`). Extended controller and section tests to cover the new flow paths, including cancellation, multi-server accounts, and error handling.

- **Fake clients**: Added `FakePlexTvClient` and gated variants for deterministic testing of the polling loop and UI states.

## Notable Implementation Details

- **Token safety**: Account tokens and server-scoped tokens are held only in private controller fields during the flow, never exposed through public state, never logged, and released immediately when the flow ends. The state exposes only display-safe `PlexServerChoice` objects.

- **Race condition prevention**: A monotonic `_linkAttempt` ID ensures that polling continuations from a cancelled or superseded flow drop their results instead of clobbering fresh state.

- **Server selection**: Prefers each server's server-scoped `accessToken` over the account token (narrowest credential principle), with a fallback to the account token if needed.

- **Deterministic testing**: Gated fake clients allow tests to hold the controller in intermediate phases (linking, loading servers) and exercise cancellation and UI state transitions without real delays.

- **Backward compatibility**: The manual flow remains fully functional and accessible via the advanced toggle, preserving the existing token-based authentication path.

https://claude.ai/code/session_01XdckPtiaapEFJQgEquqHTt