### PR TITLE
test(reporting): pin that content:// local documents report to no server

### DIFF
--- a/test/core/services/routing_server_playback_reporter_test.dart
+++ b/test/core/services/routing_server_playback_reporter_test.dart
@@ -56,6 +56,16 @@ Track _subsonic(String id) => Track(id: id, title: id, uri: 'subsonic:$id');
 Track _local(String id) =>
     Track(id: id, title: id, uri: 'file:///music/$id.flac');
 
+/// An Android SAF-picked local document: its [Track.uri] is the raw
+/// `content://` document URI (LocalTrackMapper.fromSafDocument), which names no
+/// provider scheme — so, like a `file://` local track, it must reach no server
+/// reporter (a private on-device file is never announced to any server).
+Track _localDocument(String id) => Track(
+      id: id,
+      title: id,
+      uri: 'content://com.android.externalstorage.documents/document/$id',
+    );
+
 void main() {
   group('RoutingServerPlaybackReporter', () {
     late _SchemeReporter plex;
@@ -87,7 +97,11 @@ void main() {
     });
 
     test('non-Plex tracks never reach the Plex reporter', () async {
-      for (final Track track in <Track>[_jellyfin('j'), _local('l')]) {
+      for (final Track track in <Track>[
+        _jellyfin('j'),
+        _local('l'),
+        _localDocument('d'),
+      ]) {
         await router.onPlaybackStarted(track, Duration.zero, Duration.zero);
         await router.onPlaybackProgress(track, Duration.zero, Duration.zero);
         await router.onPlaybackPaused(track, Duration.zero, Duration.zero);
@@ -145,6 +159,20 @@ void main() {
       test('local playback never triggers any server reporter', () async {
         await playThrough(_local('l'));
         await producers.onTrackChanged(_local('l'), _local('m'));
+
+        expect(plex.events, isEmpty);
+        expect(jellyfin.events, isEmpty);
+        expect(subsonic.events, isEmpty);
+      });
+
+      test('a content:// local document never triggers any server reporter',
+          () async {
+        // SAF documents are private on-device files whose uri is a raw
+        // content:// path naming no provider; playing one (and moving off it)
+        // must announce nothing to Plex, Jellyfin, or Subsonic.
+        await playThrough(_localDocument('d'));
+        await producers.onTrackChanged(
+            _localDocument('d'), _localDocument('e'));
 
         expect(plex.events, isEmpty);
         expect(jellyfin.events, isEmpty);

--- a/test/core/sources/plex/plex_playback_reporter_test.dart
+++ b/test/core/sources/plex/plex_playback_reporter_test.dart
@@ -25,6 +25,15 @@ Track _plexTrack(String ratingKey) => Track(
 const Track _jellyfinTrack =
     Track(id: 'jf-1', title: 'Elsewhere', uri: 'jellyfin:item-1');
 
+/// An Android SAF-picked local document: its uri is the raw content:// path
+/// (not this provider's), so a private on-device file is never reported to
+/// Plex on any event.
+const Track _localDocumentTrack = Track(
+  id: 'doc-1',
+  title: 'Home Recording',
+  uri: 'content://com.android.externalstorage.documents/document/home',
+);
+
 const Duration _position = Duration(seconds: 42);
 const Duration _duration = Duration(minutes: 3);
 
@@ -134,6 +143,25 @@ void main() {
         await reporter.onPlaybackPaused(_jellyfinTrack, _position, _duration);
         await reporter.onPlaybackResumed(_jellyfinTrack, _position, _duration);
         await reporter.onPlaybackStopped(_jellyfinTrack, _position, _duration);
+
+        expect(client.timelineReports, isEmpty);
+      });
+
+      test('a content:// local document is a silent no-op on every event',
+          () async {
+        final reporter = build();
+
+        await reporter.onPlaybackStarted(
+            _localDocumentTrack, _position, _duration);
+        await reporter.onPlaybackProgress(
+            _localDocumentTrack, _position, _duration);
+        await reporter.onPlaybackPaused(
+            _localDocumentTrack, _position, _duration);
+        await reporter.onPlaybackResumed(
+            _localDocumentTrack, _position, _duration);
+        await reporter.onPlaybackStopped(
+            _localDocumentTrack, _position, _duration);
+        await reporter.onTrackChanged(_localDocumentTrack, null);
 
         expect(client.timelineReports, isEmpty);
       });


### PR DESCRIPTION
## Context

This started as a request to build the server playback reporting foundation (Plex first). On review, that foundation is **already implemented, wired, activated, and tested** on `main`:

- **#192** — `ServerPlaybackReporter` / `NoOpServerPlaybackReporter`, `RoutingServerPlaybackReporter`, `PlaybackReportingService`, `PlexPlaybackReporter` (+ `PlexClient.reportTimeline` / `PlexEndpoints.timeline`), wired in `player_providers.dart` and activated in `main.dart`.
- **#193** — the Jellyfin and Subsonic/Navidrome reporters on the same seam.

So rather than rebuild it, this PR is a focused **hardening** from that review. The review found the layer correct and token-safe (token rides only in the `X-Plex-Token` header, timeline URLs are token-free, failures are swallowed with kind-only debug breadcrumbs, nothing is persisted). It surfaced **one real gap**.

## The gap

The reporting routing layer guarantees that local playback reaches no server reporter — but its exclusion tests only covered `file://` tracks. Android SAF‑picked documents carry a raw **`content://`** uri (`LocalTrackMapper.fromSafDocument`), which is the primary local scheme on Android and is called out **separately from `file://`** as a must‑not‑report case. The remote‑cache layer (#191) already pins `content://` exclusion; the reporting layer did not.

The production code already handles this correctly — a scheme‑prefixed `handles()` (`plex:` / `jellyfin:` / `subsonic:`) can never match `content://`, so the router drops it and every provider reporter no‑ops it. This PR only adds the regression guards so that privacy guarantee can’t silently regress.

## Changes (tests only — no production code)

- `routing_server_playback_reporter_test.dart`
  - new `content://` local-document helper;
  - the full production line-up (Plex + Jellyfin + Subsonic) is told **nothing** when a `content://` document plays through its whole lifecycle and a track change;
  - a `content://` document is added to the existing “non-Plex tracks never reach the Plex reporter” case.
- `plex_playback_reporter_test.dart`
  - a `content://` local document is a silent no-op on every event (started/progress/paused/resumed/stopped + track change).

## Verification

- `./scripts/check_secrets.sh` passes (no tokens/secrets in the diff).
- Lines kept within the formatter’s 80-col width; additions follow the existing test style.
- Flutter/Dart isn’t installed in this environment, so `flutter test` / `flutter analyze` were **not** run here — please let CI confirm. The new tests assert only the existing, already-correct routing/no-op behavior.

Draft pending CI.

https://claude.ai/code/session_014Upz1WBjW1nkQ8f8h2TVA6

---
_Generated by [Claude Code](https://claude.ai/code/session_014Upz1WBjW1nkQ8f8h2TVA6)_