### PR TITLE
Remote playback cache: durable, credential-free on-disk index

### DIFF
--- a/docs/codebase-tour.md
+++ b/docs/codebase-tour.md
@@ -110,7 +110,8 @@ with `shuffled()`/`unshuffled()` transforms), and `RepeatMode`.
 
 Remote URL minting — and the credentials woven into those URLs — lives *here*,
 never in the audio layer. The remote prebuffer/cache foundation that warms those
-URLs ahead of a skip (credential-free keys, in-memory only) is described in
+URLs ahead of a skip (credential-free keys in memory, plus a durable
+credential-free on-disk index that never stores the URL) is described in
 [remote-playback-cache.md](remote-playback-cache.md). The UI entry point that
 wires all of this is `lib/features/player/player_providers.dart`. Deeper dives:
 [streaming.md](streaming.md), [background-playback.md](background-playback.md),

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -302,6 +302,13 @@ cache's knowledge survives a restart; it never holds a URL or token.
   timestamps; **no token, api_key, stream URL, or artwork URL**.
 - ☐ Play only **local** files across a restart — no `remote_cache/index.json` is
   created for them (local/`content://` tracks never touch the remote cache).
+- ☐ With two remote providers connected (e.g. Jellyfin + Plex), play a few
+  tracks from each, then **disconnect one** (Settings → that provider →
+  disconnect / sign out). The manifest keeps the *other* provider's keys and
+  drops the disconnected one's — `cat files/remote_cache/index.json` shows no
+  `jellyfin:`/`subsonic:`/`plex:` keys for the provider you just disconnected.
+- ☐ Disconnecting returns to the signed-out card immediately (the index cleanup
+  never blocks or breaks sign-out).
 
 ## 8. Favorites
 

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -268,7 +268,10 @@ Additional cast checks:
 
 The remote playback cache warms the current + next remote stream URL into memory
 so skips start faster (see [remote-playback-cache.md](remote-playback-cache.md)).
-It is **not** the offline cache — nothing is written to disk.
+It is **not** the offline cache — no audio bytes and no stream URLs are written
+to disk. A durable, credential-free **index** (`remote_cache/index.json`) does
+persist *which* tracks were prepared (opaque key + timestamps only), so the
+cache's knowledge survives a restart; it never holds a URL or token.
 
 - ☐ Play a **Jellyfin** track; let it settle, then skip to the next — the next
   track starts quickly (no fresh buffering spinner before it begins).
@@ -290,6 +293,15 @@ It is **not** the offline cache — nothing is written to disk.
   never **fails because of** prebuffering, and recovers when the network returns.
 - ☐ `adb logcat` during all of the above shows **no token / api_key / stream URL**
   from the prebuffer path (see §12).
+- ☐ Play a remote track, then fully **kill and relaunch** the app — playback
+  still works and the first remote play resolves a **fresh** URL (the index never
+  replays a stored one, because it stores none).
+- ☐ Pull the on-device manifest and confirm it is credential-free:
+  `adb exec-out run-as io.github.thezupzup.linthra cat files/remote_cache/index.json`
+  — it lists only opaque keys (`jellyfin:…` / `subsonic:…` / `plex:…`) and
+  timestamps; **no token, api_key, stream URL, or artwork URL**.
+- ☐ Play only **local** files across a restart — no `remote_cache/index.json` is
+  created for them (local/`content://` tracks never touch the remote cache).
 
 ## 8. Favorites
 

--- a/docs/remote-playback-cache.md
+++ b/docs/remote-playback-cache.md
@@ -89,6 +89,20 @@ slow or failing disk degrades to a cold index rather than throwing into the
 playback path. `RemoteStreamPrebufferer` takes the index as an *optional*
 collaborator, so the write side is byte-for-byte unchanged when none is wired.
 
+### Disconnect / sign-out cleanup
+
+When a user disconnects a provider, its prepared-track records should not linger.
+Each provider's disconnect/sign-out flow (`PlexSettingsController.disconnect`,
+`JellyfinSettingsController.clear`, `SubsonicSettingsController.clear`) calls
+`RemoteCacheIndex.removeSource(sourceId)`, which drops only that provider's
+records — `jellyfin` / `subsonic` / `plex`, keyed off `RemoteCacheKey.sourceId` —
+and persists the rest, so signing out of one server never discards another's
+records. The call is **best-effort** and runs *after* the settings UI has already
+returned to its signed-out state, so this credential-free cleanup can never throw
+into, or delay, the disconnect (the whole-index `clear` remains for a future
+"forget everything"). Records are credential-free either way, so this is privacy
+hygiene — no token is ever at stake.
+
 ## Security rules (non-negotiable)
 
 A remote stream URL carries its credential in the URL itself (Jellyfin/Subsonic

--- a/docs/remote-playback-cache.md
+++ b/docs/remote-playback-cache.md
@@ -8,9 +8,11 @@ foundation Linthra uses to prepare remote playback **earlier and more
 aggressively** — without persisting secrets and without changing how local music
 or any existing provider behaves.
 
-It is the seam the future on-disk offline/cache system will hang off; this phase
-ships the in-memory prebuffer and the credential-free key/metadata model, not a
-user-facing cache UI or downloads.
+It is the seam the future on-disk offline/cache system hangs off. This phase
+ships the in-memory prebuffer, the credential-free key/metadata model, and a
+durable, credential-free **on-disk index** of what has been prepared (so the
+cache's knowledge survives a restart) — but still no user-facing cache UI and no
+downloads: the audio *bytes* remain the offline download cache's job.
 
 ## What it does
 
@@ -37,9 +39,12 @@ know nothing about Jellyfin, Plex, or Subsonic beyond a track's URI scheme.
 | `RemoteCachePolicy` | The pure rules — what may be prebuffered, what may be stored (only a direct stream), the TTL, and whether an entry may be reused. |
 | `RemotePlaybackCache` | The in-memory store. `store` / `peek` / `consume` (consume-on-read) / `sweep` / `clear`. Persists nothing. |
 | `RemoteCacheCleanup` | The pure cleanup rule: which entries are expired and should be dropped. |
-| `RemoteStreamPrebufferer` | The **write side**: pre-resolves the current + next remote URLs through the source router and stores them. Best-effort; never throws. |
+| `RemoteStreamPrebufferer` | The **write side**: pre-resolves the current + next remote URLs through the source router, stores them, and (optionally) records each warm's credential-free key in the durable index. Best-effort; never throws. |
 | `RemoteCacheResolver` | The **read side**: a `PlayableUriResolver` that serves a fresh warmed URL once, else delegates to the router. |
 | `RemotePrebufferService` | Drives the prebufferer from the live `PlaybackState` (current + next, calm under repeat-one, off the playback path). |
+| `RemoteCacheRecord` | The **persistable, credential-free projection** of an entry: its key + timestamps, with the token-bearing stream URL cut away. There is no field that could hold a URL or token. |
+| `RemoteCacheStore` | The persistence seam — `load` / `save` a list of records. The app impl is `FileRemoteCacheStore` (a JSON manifest under `remote_cache/`); tests use an in-memory fake. |
+| `RemoteCacheIndex` | The durable index orchestrator: loads once, records each warm's credential-free key, sweeps expired records, and clears — every step best-effort and off the playback path. |
 
 ### Wiring
 
@@ -49,7 +54,40 @@ In `lib/features/player/player_providers.dart` the read side
 `remotePlaybackCacheProvider` and one `remoteSourceRouterProvider` (Jellyfin →
 Subsonic → Plex → on-device catch-all). The controller resolves through the
 offline-first resolver, which falls through to the remote cache resolver on a
-download miss. `RemotePrebufferService` is started once from `main`.
+download miss. `RemotePrebufferService` is started once from `main`, which also
+kicks a best-effort `remoteCacheIndexProvider.load()` to warm and prune the
+durable index off the first-frame path.
+
+## On-disk index (durable, credential-free)
+
+The in-memory cache forgets everything when the process ends — and holds the
+token-bearing URL only for its short TTL. The on-disk **index** is its durable
+complement: as the prebufferer warms a remote track it records that track's
+*credential-free* identity through a `RemoteCacheStore`, so the cache's
+*knowledge* survives a restart even though the (expiring, tokenized) URL
+deliberately does not.
+
+What is persisted is only a `RemoteCacheRecord` — the opaque key
+(`jellyfin:<id>` / `subsonic:<id>` / `plex:<ratingKey>`) plus two timestamps. The
+type has **no field** for a stream URL, an artwork URL, or a token, so the JSON
+manifest (`<app-support>/remote_cache/index.json`) physically cannot carry one.
+On the way back in, `RemoteCacheRecord.fromJson` re-validates every key through
+`RemoteCacheKey.forUri` and drops anything local, `content://`, or even
+*looks* tokenized — so a corrupt or hand-edited manifest can't reintroduce a
+secret either.
+
+Because no URL is stored, a restart can never replay a stale stream: the index
+remembers *that* a track was prepared (and the credential-free name its future
+on-disk bytes will use), and the resolver still mints a **fresh** URL on the next
+play. The index is the seam the future on-disk byte cache and its eviction sweep
+hang off — `RemoteCacheIndex.sweep` already drops records past a generous
+retention window, and `clear` empties both the index and the manifest.
+
+Everything here is **best-effort and non-fatal**, exactly like the prebufferer it
+rides behind: the load runs once and lazily, every store call is wrapped, and a
+slow or failing disk degrades to a cold index rather than throwing into the
+playback path. `RemoteStreamPrebufferer` takes the index as an *optional*
+collaborator, so the write side is byte-for-byte unchanged when none is wired.
 
 ## Security rules (non-negotiable)
 
@@ -57,9 +95,11 @@ A remote stream URL carries its credential in the URL itself (Jellyfin/Subsonic
 in the query, Plex's `X-Plex-Token`). The whole foundation is built so that
 credential **never** lands anywhere durable:
 
-- **Never persist a tokenized stream or artwork URL.** The cache is in-memory
-  only and serializes nothing. The token-bearing URL lives solely inside a
-  `RemoteCacheEntry.streamUri` for the life of the process.
+- **Never persist a tokenized stream or artwork URL.** The token-bearing URL
+  lives solely inside a `RemoteCacheEntry.streamUri` for the life of the process;
+  the in-memory cache serializes nothing, and the durable on-disk index persists
+  only a `RemoteCacheRecord` (the opaque key + timestamps), which has no field a
+  URL or token could ever occupy.
 - **Cache keys, filenames, and metadata are credential-free.** `RemoteCacheKey`
   is built only from the track's opaque `uri` (`jellyfin:<id>`, `subsonic:<id>`,
   `plex:<ratingKey>`). `fileSafeName` (for the future on-disk cache) sanitizes
@@ -73,9 +113,11 @@ credential **never** lands anywhere durable:
   and `artworkUri` remains `plex-thumb:<path>`; the token is woven into the
   stream URL on demand, never onto the track or into the cache key.
 
-These are enforced by tests in `test/core/services/remote_cache/` (see the
-"credential safety" groups, the tokenized-URL-refusal cases, and the
-local/`content://`-are-never-cached cases).
+These are enforced by tests in `test/core/services/remote_cache/` and
+`test/data/repositories/file_remote_cache_store_test.dart` (see the "credential
+safety" groups, the tokenized-URL-refusal cases, the local/`content://`-are-
+never-cached cases, and the assertion that the written manifest file itself
+carries no token, URL, or `api_key`).
 
 ## Failure behaviour
 

--- a/lib/core/services/remote_cache/remote_cache_index.dart
+++ b/lib/core/services/remote_cache/remote_cache_index.dart
@@ -1,0 +1,168 @@
+import 'remote_cache_entry.dart';
+import 'remote_cache_record.dart';
+import 'remote_cache_store.dart';
+
+/// The durable, **credential-free** index of the remote playback cache.
+///
+/// The in-memory [RemotePlaybackCache] forgets everything when the process ends
+/// (and holds the token-bearing stream URL only for its short TTL). This index
+/// is its on-disk complement: as the prebufferer warms a remote track it records
+/// the track's credential-free identity ([RemoteCacheRecord] — key + timestamps,
+/// never the URL) through a [RemoteCacheStore], so the cache's *knowledge*
+/// survives a restart even though the (expiring, tokenized) URL deliberately
+/// does not. This is the seam the future on-disk byte cache and its eviction
+/// sweep hang off; persisting no URL is also what guarantees a provider stream
+/// is always re-resolved fresh after a restart rather than replayed stale.
+///
+/// Everything here is **best-effort and non-fatal**, mirroring the prebufferer
+/// it rides behind: every store interaction is wrapped, so a slow or failing
+/// disk can never throw into the playback path. Reads load lazily exactly once
+/// (so a record can't race ahead of the initial load and be clobbered by it),
+/// and a record only ever carries a credential-free [RemoteCacheRecord], so no
+/// secret can reach disk, a filename, a log line, or a diagnostics string.
+class RemoteCacheIndex {
+  RemoteCacheIndex({
+    required RemoteCacheStore store,
+    Duration retention = const Duration(days: 30),
+    int maxEntries = 1024,
+    DateTime Function()? clock,
+  })  : _store = store,
+        _retention = retention,
+        _maxEntries = maxEntries,
+        _now = clock ?? DateTime.now;
+
+  final RemoteCacheStore _store;
+  final Duration _retention;
+
+  /// An upper bound on the number of records so the manifest — and every
+  /// rewrite — stays small no matter how many tracks are played over the
+  /// retention window. The oldest-recorded entries are evicted first.
+  final int _maxEntries;
+
+  final DateTime Function() _now;
+
+  /// Keyed by the credential-free [RemoteCacheRecord.value]. Never holds a URL.
+  final Map<String, RemoteCacheRecord> _records = <String, RemoteCacheRecord>{};
+
+  /// Memoizes the one-shot load so every caller (startup, the first record)
+  /// awaits the same completed load before touching [_records].
+  Future<void>? _loadFuture;
+
+  /// Loads the persisted index (merging the freshest record per key and dropping
+  /// anything already expired), then prunes and rewrites it. Idempotent: the
+  /// underlying read runs at most once for the life of the index.
+  Future<void> load() => _ensureLoaded();
+
+  /// Records [entry]'s credential-free identity into the index and persists.
+  /// Best-effort: a failure (a full disk, a denied write) is swallowed, so a
+  /// warm that can't be remembered simply isn't — playback is untouched.
+  Future<void> record(RemoteCacheEntry entry) async {
+    try {
+      await _ensureLoaded();
+      final DateTime now = _now();
+      _records[entry.key.value] = RemoteCacheRecord.fromEntry(
+        entry,
+        recordedAt: now,
+        expiresAt: now.add(_retention),
+      );
+      _enforceCap();
+      await _persist();
+    } catch (_) {
+      // Non-fatal: the index is a convenience, never required for playback.
+    }
+  }
+
+  /// Drops every record past its retention window and persists the pruned set.
+  /// The cleanup rule for the durable cache, kept on the same freshness contract
+  /// as the in-memory sweep; a sweep that removes nothing writes nothing.
+  ///
+  /// Startup [load] already prunes, so a cold start needs no separate sweep;
+  /// this is the explicit re-sweep hook for a long-running session (or a future
+  /// periodic cleanup), and it is what keeps `sweep` parallel to the in-memory
+  /// `RemotePlaybackCache.sweep`.
+  Future<void> sweep() async {
+    try {
+      await _ensureLoaded();
+      if (_pruneExpired(_now())) await _persist();
+    } catch (_) {
+      // Non-fatal.
+    }
+  }
+
+  /// Empties the index and the persisted store. The reset hook a sign-out flow
+  /// should call so a previous account's prepared-track list is not retained —
+  /// provided as a lifecycle method like the in-memory `RemotePlaybackCache.clear`
+  /// (which the sign-out flows likewise own). The records are credential-free, so
+  /// this is hygiene rather than a secret-safety requirement.
+  Future<void> clear() async {
+    _records.clear();
+    try {
+      await _store.save(const <RemoteCacheRecord>[]);
+    } catch (_) {
+      // Non-fatal.
+    }
+  }
+
+  /// A snapshot of the indexed records — credential-free, for tests/diagnostics.
+  List<RemoteCacheRecord> get records =>
+      List<RemoteCacheRecord>.of(_records.values);
+
+  /// The number of indexed records.
+  int get length => _records.length;
+
+  Future<void> _ensureLoaded() => _loadFuture ??= _load();
+
+  Future<void> _load() async {
+    try {
+      final List<RemoteCacheRecord> stored = await _store.load();
+      // _ensureLoaded memoizes this load and every writer awaits it first, so
+      // _records is empty here and a plain assign is enough (a manifest the app
+      // wrote is itself keyed by value, so it carries no duplicate keys).
+      for (final RemoteCacheRecord record in stored) {
+        _records[record.value] = record;
+      }
+      // Normalize the on-disk form only if loading actually changed it (dropped
+      // a stale record or trimmed to the cap), so a clean manifest does no
+      // redundant write.
+      final bool pruned = _pruneExpired(_now());
+      final bool capped = _enforceCap();
+      if (pruned || capped) await _persist();
+    } catch (_) {
+      // Non-fatal: an unreadable store just means a cold index.
+    }
+  }
+
+  /// Removes every record past its freshness window; returns whether any were
+  /// dropped, so callers can skip a redundant persist when nothing changed.
+  bool _pruneExpired(DateTime now) {
+    final int before = _records.length;
+    _records.removeWhere(
+      (_, RemoteCacheRecord record) => !record.isFresh(now),
+    );
+    return _records.length != before;
+  }
+
+  /// Bounds the index to [_maxEntries], evicting the oldest-recorded entries
+  /// first so the manifest stays small; returns whether any were evicted.
+  bool _enforceCap() {
+    if (_records.length <= _maxEntries) return false;
+    final List<RemoteCacheRecord> byAge = _records.values.toList()
+      ..sort((RemoteCacheRecord a, RemoteCacheRecord b) =>
+          a.recordedAt.compareTo(b.recordedAt));
+    bool evicted = false;
+    for (final RemoteCacheRecord record in byAge) {
+      if (_records.length <= _maxEntries) break;
+      _records.remove(record.value);
+      evicted = true;
+    }
+    return evicted;
+  }
+
+  Future<void> _persist() async {
+    try {
+      await _store.save(_records.values.toList(growable: false));
+    } catch (_) {
+      // Non-fatal.
+    }
+  }
+}

--- a/lib/core/services/remote_cache/remote_cache_index.dart
+++ b/lib/core/services/remote_cache/remote_cache_index.dart
@@ -89,17 +89,38 @@ class RemoteCacheIndex {
     }
   }
 
-  /// Empties the index and the persisted store. The reset hook a sign-out flow
-  /// should call so a previous account's prepared-track list is not retained —
-  /// provided as a lifecycle method like the in-memory `RemotePlaybackCache.clear`
-  /// (which the sign-out flows likewise own). The records are credential-free, so
-  /// this is hygiene rather than a secret-safety requirement.
+  /// Empties the index and the persisted store — the whole-index reset. Each
+  /// provider's disconnect/sign-out instead calls the provider-scoped
+  /// [removeSource] (so one account signing out doesn't drop another provider's
+  /// records); [clear] is the full-wipe lifecycle hook (a future "forget
+  /// everything", or tests). The records are credential-free, so this is hygiene
+  /// rather than a secret-safety requirement.
   Future<void> clear() async {
     _records.clear();
     try {
       await _store.save(const <RemoteCacheRecord>[]);
     } catch (_) {
       // Non-fatal.
+    }
+  }
+
+  /// Drops every record for [sourceId] (`jellyfin` / `subsonic` / `plex`) and
+  /// persists the result. The provider-scoped half of [clear]: when a user
+  /// disconnects one provider, its prepared-track records are removed while the
+  /// other providers' records stay — so a sign-out leaves no footprint of that
+  /// account's library without discarding the whole index. Best-effort and
+  /// non-fatal, like every path here; a sweep that removes nothing writes
+  /// nothing.
+  Future<void> removeSource(String sourceId) async {
+    try {
+      await _ensureLoaded();
+      final int before = _records.length;
+      _records.removeWhere(
+        (_, RemoteCacheRecord record) => record.sourceId == sourceId,
+      );
+      if (_records.length != before) await _persist();
+    } catch (_) {
+      // Non-fatal: a failed cleanup must never block sign-out or playback.
     }
   }
 

--- a/lib/core/services/remote_cache/remote_cache_key.dart
+++ b/lib/core/services/remote_cache/remote_cache_key.dart
@@ -35,10 +35,14 @@ class RemoteCacheKey {
   /// excluded by omission. Kept here (rather than imported from the source
   /// layer) so this services-layer seam stays free of a dependency on the
   /// provider implementations, mirroring `StreamPreloadingResolver`.
+  static const String sourceIdJellyfin = 'jellyfin';
+  static const String sourceIdSubsonic = 'subsonic';
+  static const String sourceIdPlex = 'plex';
+
   static const Set<String> remoteSchemes = <String>{
-    'jellyfin',
-    'subsonic',
-    'plex',
+    sourceIdJellyfin,
+    sourceIdSubsonic,
+    sourceIdPlex,
   };
 
   /// Substrings that must never appear in a key. A credential-free remote id is

--- a/lib/core/services/remote_cache/remote_cache_record.dart
+++ b/lib/core/services/remote_cache/remote_cache_record.dart
@@ -1,0 +1,117 @@
+import 'remote_cache_entry.dart';
+import 'remote_cache_key.dart';
+
+/// The **persistable, credential-free** projection of a remote cache entry.
+///
+/// Where a [RemoteCacheEntry] is the live, in-memory resolution — and so holds
+/// the token-bearing `streamUri` — a [RemoteCacheRecord] is what may safely
+/// outlive the process on disk: the entry's credential-free identity plus the
+/// timestamps the cleanup sweep needs. It is, deliberately, the entry with the
+/// secret cut away.
+///
+/// Security boundary (the whole reason this type exists): a record is built
+/// only from a [RemoteCacheKey] — the track's opaque, credential-free `uri`
+/// (`jellyfin:<id>`, `subsonic:<id>`, `plex:<ratingKey>`) — and two timestamps.
+/// There is no field that could carry a stream URL, an artwork URL, or a token,
+/// so the on-disk manifest physically cannot hold one. [fromEntry] takes the
+/// entry's [RemoteCacheEntry.key] and never reads its `streamUri`; [fromJson]
+/// re-validates the key through [RemoteCacheKey.forUri] and drops anything that
+/// is local, `content://`, or even *looks* tokenized, so a hand-edited or
+/// corrupt manifest can't smuggle a secret back in through this seam either.
+class RemoteCacheRecord {
+  const RemoteCacheRecord({
+    required this.key,
+    required this.recordedAt,
+    required this.expiresAt,
+  });
+
+  /// Builds a record from a live [entry], copying **only** its credential-free
+  /// [RemoteCacheEntry.key]. The token-bearing `streamUri` is never read, so it
+  /// can never reach the persisted form.
+  factory RemoteCacheRecord.fromEntry(
+    RemoteCacheEntry entry, {
+    required DateTime recordedAt,
+    required DateTime expiresAt,
+  }) =>
+      RemoteCacheRecord(
+        key: entry.key,
+        recordedAt: recordedAt,
+        expiresAt: expiresAt,
+      );
+
+  /// The credential-free identity of the recorded track. Safe to persist, log,
+  /// and (via [RemoteCacheKey.fileSafeName]) turn into a filename.
+  final RemoteCacheKey key;
+
+  /// When this track was first prepared into the cache. Kept as non-secret
+  /// metadata the future on-disk cache can order/evict by.
+  final DateTime recordedAt;
+
+  /// When the record goes stale and the cleanup sweep should drop it. Bounds how
+  /// long a credential-free record (and, later, its on-disk bytes) is retained.
+  final DateTime expiresAt;
+
+  /// The credential-free key value (the track's opaque `uri`).
+  String get value => key.value;
+
+  /// The owning provider (`jellyfin` / `subsonic` / `plex`).
+  String get sourceId => key.sourceId;
+
+  /// The filesystem-safe, secret-free name the future on-disk cache keys bytes
+  /// by — derived from the (already credential-free) [key].
+  String get fileSafeName => key.fileSafeName;
+
+  /// Whether the record is still within its retention window at [now].
+  bool isFresh(DateTime now) => now.isBefore(expiresAt);
+
+  /// The credential-free serialized form. Carries the opaque key and the two
+  /// timestamps only — never a URL or a token (there is no such field to emit).
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'key': key.value,
+        'recordedAt': recordedAt.millisecondsSinceEpoch,
+        'expiresAt': expiresAt.millisecondsSinceEpoch,
+      };
+
+  /// Rebuilds a record from [toJson] output, or returns `null` when the entry is
+  /// unusable — a missing key, or a key that is not a safe credential-free
+  /// remote id (local, `content://`, or tokenized). Re-validating through
+  /// [RemoteCacheKey.forUri] is the load-side half of the security boundary: a
+  /// tampered manifest line can never reintroduce a tokenized key, so one bad
+  /// record is simply skipped rather than trusted.
+  static RemoteCacheRecord? fromJson(Map<String, dynamic> json) {
+    final String? rawKey = json['key'] as String?;
+    if (rawKey == null || rawKey.isEmpty) return null;
+    final RemoteCacheKey? key = RemoteCacheKey.forUri(rawKey);
+    if (key == null) return null;
+    return RemoteCacheRecord(
+      key: key,
+      recordedAt: _asDate(json['recordedAt']),
+      expiresAt: _asDate(json['expiresAt']),
+    );
+  }
+
+  /// A millisecond-epoch int back to a [DateTime]; the epoch (treated as long
+  /// expired) for a missing or malformed value, so a record with no usable
+  /// timestamp is swept rather than kept forever.
+  static DateTime _asDate(Object? value) {
+    if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);
+    return DateTime.fromMillisecondsSinceEpoch(0);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is RemoteCacheRecord &&
+          other.key == key &&
+          other.recordedAt == recordedAt &&
+          other.expiresAt == expiresAt);
+
+  @override
+  int get hashCode => Object.hash(key, recordedAt, expiresAt);
+
+  /// Credential-free by construction (the key never carries a secret); safe to
+  /// log and put in diagnostics.
+  @override
+  String toString() =>
+      'remote-cache-record[$key exp=${expiresAt.toIso8601String()}]';
+}

--- a/lib/core/services/remote_cache/remote_cache_store.dart
+++ b/lib/core/services/remote_cache/remote_cache_store.dart
@@ -1,0 +1,27 @@
+import 'remote_cache_record.dart';
+
+/// Durable storage for the remote playback cache's **credential-free** index.
+///
+/// This is the persistence seam under [RemoteCacheIndex] — the on-disk half of
+/// the cache the in-memory [RemotePlaybackCache] was built as a seam for. It
+/// knows nothing about prebuffering, freshness, or providers; it only loads and
+/// saves a flat list of [RemoteCacheRecord]s.
+///
+/// Security contract: every record it round-trips is credential-free by
+/// construction (see [RemoteCacheRecord]). A store implementation must therefore
+/// never be handed — and can never obtain — a stream URL or a token; the only
+/// thing it ever writes is the opaque key + timestamps. Splitting it behind an
+/// interface keeps [RemoteCacheIndex] pure and testable (an in-memory fake) and
+/// lets the backing store swap freely (a JSON manifest on disk in the app, a
+/// fake in tests).
+abstract interface class RemoteCacheStore {
+  /// The records currently persisted. Returns an empty list (never throws) when
+  /// there is nothing stored or the backing data is unreadable, so a corrupt
+  /// manifest degrades to "cold cache" rather than breaking startup.
+  Future<List<RemoteCacheRecord>> load();
+
+  /// Replaces the persisted set with [records]. Best-effort: a failed write must
+  /// not be fatal to the caller (the [RemoteCacheIndex] swallows it), since the
+  /// index is a convenience and never on the playback path.
+  Future<void> save(List<RemoteCacheRecord> records);
+}

--- a/lib/core/services/remote_cache/remote_stream_prebufferer.dart
+++ b/lib/core/services/remote_cache/remote_stream_prebufferer.dart
@@ -1,6 +1,8 @@
 import '../../models/track.dart';
 import '../playable_uri_resolver.dart';
 import '../stream_preloader.dart';
+import 'remote_cache_entry.dart';
+import 'remote_cache_index.dart';
 import 'remote_cache_key.dart';
 import 'remote_cache_policy.dart';
 import 'remote_playback_cache.dart';
@@ -21,10 +23,12 @@ import 'remote_playback_cache.dart';
 ///  - **Best-effort, never fatal.** Every warm is wrapped; a failure is
 ///    swallowed and never rethrown, so prebuffering can never fail or stall the
 ///    current track.
-///  - **No disk, no secrets in the open.** It only ever holds a short-lived
-///    remote URL *in memory* via the cache; it never writes the offline cache,
-///    never marks a track downloaded, and never logs the resolved URL (so a
-///    token can't leak through this path).
+///  - **No secrets on disk.** It only ever holds a short-lived remote URL *in
+///    memory* via the cache; it never writes the offline cache, never marks a
+///    track downloaded, and never logs the resolved URL (so a token can't leak
+///    through this path). When an optional [RemoteCacheIndex] is wired it
+///    persists only the warmed track's *credential-free* key (never the URL),
+///    so the durable manifest cannot carry a secret either.
 ///  - **Remote-only.** Local files and `content://` documents have no cache key
 ///    (see [RemoteCacheKey]) and are skipped outright.
 ///  - **Freshness-aware & idempotent.** It sweeps stale entries and skips a
@@ -34,15 +38,23 @@ class RemoteStreamPrebufferer implements StreamPreloader {
     required PlayableUriResolver resolver,
     required RemotePlaybackCache cache,
     RemoteCachePolicy policy = const RemoteCachePolicy(),
+    RemoteCacheIndex? index,
     DateTime Function()? clock,
   })  : _resolver = resolver,
         _cache = cache,
         _policy = policy,
+        _index = index,
         _now = clock ?? DateTime.now;
 
   final PlayableUriResolver _resolver;
   final RemotePlaybackCache _cache;
   final RemoteCachePolicy _policy;
+
+  /// The optional durable, credential-free index. When wired, a successful warm
+  /// records the track's key (never its URL) so the cache's knowledge survives a
+  /// restart. Best-effort: [RemoteCacheIndex.record] never throws.
+  final RemoteCacheIndex? _index;
+
   final DateTime Function() _now;
 
   @override
@@ -77,9 +89,13 @@ class RemoteStreamPrebufferer implements StreamPreloader {
       // Only retain a fresh direct-stream URL; a local path or offline-cache hit
       // carries no benefit and must not be held here.
       if (_policy.isStorable(resolved.source)) {
-        _cache.store(
-          _policy.buildEntry(key: key, resolved: resolved, now: _now()),
-        );
+        final RemoteCacheEntry entry =
+            _policy.buildEntry(key: key, resolved: resolved, now: _now());
+        _cache.store(entry);
+        // Remember the warm in the durable, credential-free index so the cache's
+        // knowledge survives a restart. Best-effort and never throws; only the
+        // opaque key is persisted, never the token-bearing stream URL.
+        await _index?.record(entry);
       }
     } catch (_) {
       // Best-effort: a failed warm just means the track resolves normally when

--- a/lib/data/repositories/file_remote_cache_store.dart
+++ b/lib/data/repositories/file_remote_cache_store.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../../core/services/remote_cache/remote_cache_record.dart';
+import '../../core/services/remote_cache/remote_cache_store.dart';
+
+/// The app's [RemoteCacheStore]: a single JSON **manifest** of credential-free
+/// [RemoteCacheRecord]s under an app-private `remote_cache/` directory.
+///
+/// It sits beside the offline downloads' `offline_audio/` directory but is a
+/// distinct, complementary thing: this manifest is the remote playback cache's
+/// own durable index (what was prepared, and where its bytes *would* live), not
+/// the user's explicit downloads. It lives under the application *support*
+/// location (not the OS cache, which can be reclaimed at any time) and is the
+/// directory the future on-disk byte cache will write into, keyed by each
+/// record's [RemoteCacheRecord.fileSafeName].
+///
+/// The base directory is injected so tests can point it at a temp folder; the
+/// app uses `path_provider`'s application-support directory by default.
+///
+/// Security: the manifest can only ever contain a record's opaque key and its
+/// timestamps (see [RemoteCacheRecord.toJson]) — never a stream URL, an artwork
+/// URL, or a token. A malformed or hand-edited manifest degrades to an empty
+/// index ([load] never throws), and any line whose key is not a safe
+/// credential-free remote id is dropped on the way in by
+/// [RemoteCacheRecord.fromJson].
+class FileRemoteCacheStore implements RemoteCacheStore {
+  FileRemoteCacheStore({Future<Directory> Function()? directory})
+      : _directory = directory ?? _defaultDirectory;
+
+  final Future<Directory> Function() _directory;
+
+  /// The manifest file name inside the remote-cache directory.
+  static const String _manifestName = 'index.json';
+
+  static Future<Directory> _defaultDirectory() async {
+    final Directory base = await getApplicationSupportDirectory();
+    return Directory(p.join(base.path, 'remote_cache'));
+  }
+
+  @override
+  Future<List<RemoteCacheRecord>> load() async {
+    try {
+      final File file = await _manifestFile();
+      if (!await file.exists()) return const <RemoteCacheRecord>[];
+      return _decode(await file.readAsString());
+    } catch (_) {
+      // An unreadable manifest degrades to a cold index, never an error.
+      return const <RemoteCacheRecord>[];
+    }
+  }
+
+  @override
+  Future<void> save(List<RemoteCacheRecord> records) async {
+    final File file = await _manifestFile();
+    final Directory dir = file.parent;
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final String raw = jsonEncode(<Map<String, dynamic>>[
+      for (final RemoteCacheRecord record in records) record.toJson(),
+    ]);
+    // Write a sibling temp file then rename it over the manifest: a crash or
+    // kill mid-write leaves the previous good manifest intact rather than a
+    // truncated one (a torn write would otherwise discard the whole index on the
+    // next load). `load` reads only `index.json`, so a stray `.tmp` is ignored.
+    final File tmp = File('${file.path}.tmp');
+    await tmp.writeAsString(raw, flush: true);
+    await tmp.rename(file.path);
+  }
+
+  Future<File> _manifestFile() async {
+    final Directory dir = await _directory();
+    return File(p.join(dir.path, _manifestName));
+  }
+
+  /// Decodes a manifest string into records, dropping any corrupt or
+  /// non-credential-free entry rather than failing the whole load.
+  static List<RemoteCacheRecord> _decode(String raw) {
+    if (raw.isEmpty) return const <RemoteCacheRecord>[];
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return const <RemoteCacheRecord>[];
+    }
+    if (decoded is! List) return const <RemoteCacheRecord>[];
+    final List<RemoteCacheRecord> records = <RemoteCacheRecord>[];
+    for (final Object? entry in decoded) {
+      if (entry is Map<String, dynamic>) {
+        final RemoteCacheRecord? record = RemoteCacheRecord.fromJson(entry);
+        if (record != null) records.add(record);
+      }
+    }
+    return records;
+  }
+}

--- a/lib/data/repositories/remote_cache_index_provider.dart
+++ b/lib/data/repositories/remote_cache_index_provider.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/remote_cache/remote_cache_index.dart';
+import '../../core/services/remote_cache/remote_cache_store.dart';
+import 'file_remote_cache_store.dart';
+
+/// The durable, credential-free remote-cache index's on-disk store: a JSON
+/// manifest under the app-support `remote_cache/` directory. It only ever holds
+/// each warmed track's opaque key + timestamps — never a stream URL or token.
+final remoteCacheStoreProvider = Provider<RemoteCacheStore>((ref) {
+  return FileRemoteCacheStore();
+});
+
+/// The durable index that remembers (credential-free) which remote tracks the
+/// prebufferer has warmed, so the cache's knowledge survives a restart.
+///
+/// Pinned for the session and shared across the app: the write side
+/// (`remoteStreamPrebuffererProvider`) records into it, `main` loads it at
+/// startup (pruning stale records as it loads), and each provider's
+/// disconnect/sign-out flow calls [RemoteCacheIndex.removeSource] so a
+/// disconnected account's prepared-track records don't linger. Lives in the data
+/// layer (not the player feature) so both the player and the settings
+/// controllers can depend on it without a cross-feature import cycle.
+///
+/// Best-effort throughout: it never persists a URL and never throws into
+/// playback. It deliberately stores no stream URL, so a provider URL is always
+/// re-resolved fresh after a restart rather than replayed stale.
+final remoteCacheIndexProvider = Provider<RemoteCacheIndex>((ref) {
+  return RemoteCacheIndex(store: ref.watch(remoteCacheStoreProvider));
+});

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -12,7 +12,9 @@ import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/playback_reporting_service.dart';
+import '../../core/services/remote_cache/remote_cache_index.dart';
 import '../../core/services/remote_cache/remote_cache_resolver.dart';
+import '../../core/services/remote_cache/remote_cache_store.dart';
 import '../../core/services/remote_cache/remote_playback_cache.dart';
 import '../../core/services/remote_cache/remote_stream_prebufferer.dart';
 import '../../core/services/remote_prebuffer_service.dart';
@@ -27,6 +29,7 @@ import '../../core/sources/plex/plex_playback_reporter.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playback_reporter.dart';
 import '../../data/repositories/download_repository_provider.dart';
+import '../../data/repositories/file_remote_cache_store.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
@@ -46,6 +49,25 @@ import 'now_playing.dart';
 /// remote URLs in memory — never the offline cache, and never persisted.
 final remotePlaybackCacheProvider = Provider<RemotePlaybackCache>((ref) {
   return RemotePlaybackCache();
+});
+
+/// The durable, credential-free remote-cache index's on-disk store: a JSON
+/// manifest under the app-support `remote_cache/` directory. It only ever holds
+/// each warmed track's opaque key + timestamps — never a stream URL or token.
+final remoteCacheStoreProvider = Provider<RemoteCacheStore>((ref) {
+  return FileRemoteCacheStore();
+});
+
+/// The durable index that remembers (credential-free) which remote tracks the
+/// prebufferer has warmed, so the cache's knowledge survives a restart. Pinned
+/// for the session and shared by the write side ([remoteStreamPrebuffererProvider],
+/// which records into it) and `main` (which loads it at startup, pruning any
+/// stale records as it loads). Best-effort throughout: it never persists a URL
+/// and never throws into playback. It deliberately stores no stream URL, so a
+/// provider URL is always re-resolved fresh after a restart rather than replayed
+/// stale.
+final remoteCacheIndexProvider = Provider<RemoteCacheIndex>((ref) {
+  return RemoteCacheIndex(store: ref.watch(remoteCacheStoreProvider));
 });
 
 /// The source router: Jellyfin, Subsonic, Plex, then the on-device catch-all.
@@ -83,6 +105,10 @@ final remoteStreamPrebuffererProvider =
   return RemoteStreamPrebufferer(
     resolver: ref.watch(remoteSourceRouterProvider),
     cache: ref.watch(remotePlaybackCacheProvider),
+    // Persist each warm's credential-free key into the durable index so the
+    // cache's knowledge survives a restart. Best-effort and never on the
+    // playback path; only the opaque key is stored, never the stream URL.
+    index: ref.watch(remoteCacheIndexProvider),
   );
 });
 

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -12,9 +12,7 @@ import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/playback_reporting_service.dart';
-import '../../core/services/remote_cache/remote_cache_index.dart';
 import '../../core/services/remote_cache/remote_cache_resolver.dart';
-import '../../core/services/remote_cache/remote_cache_store.dart';
 import '../../core/services/remote_cache/remote_playback_cache.dart';
 import '../../core/services/remote_cache/remote_stream_prebufferer.dart';
 import '../../core/services/remote_prebuffer_service.dart';
@@ -29,8 +27,8 @@ import '../../core/sources/plex/plex_playback_reporter.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playback_reporter.dart';
 import '../../data/repositories/download_repository_provider.dart';
-import '../../data/repositories/file_remote_cache_store.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
+import '../../data/repositories/remote_cache_index_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
 import '../settings/plex/plex_settings_controller.dart';
@@ -49,25 +47,6 @@ import 'now_playing.dart';
 /// remote URLs in memory — never the offline cache, and never persisted.
 final remotePlaybackCacheProvider = Provider<RemotePlaybackCache>((ref) {
   return RemotePlaybackCache();
-});
-
-/// The durable, credential-free remote-cache index's on-disk store: a JSON
-/// manifest under the app-support `remote_cache/` directory. It only ever holds
-/// each warmed track's opaque key + timestamps — never a stream URL or token.
-final remoteCacheStoreProvider = Provider<RemoteCacheStore>((ref) {
-  return FileRemoteCacheStore();
-});
-
-/// The durable index that remembers (credential-free) which remote tracks the
-/// prebufferer has warmed, so the cache's knowledge survives a restart. Pinned
-/// for the session and shared by the write side ([remoteStreamPrebuffererProvider],
-/// which records into it) and `main` (which loads it at startup, pruning any
-/// stale records as it loads). Best-effort throughout: it never persists a URL
-/// and never throws into playback. It deliberately stores no stream URL, so a
-/// provider URL is always re-resolved fresh after a restart rather than replayed
-/// stale.
-final remoteCacheIndexProvider = Provider<RemoteCacheIndex>((ref) {
-  return RemoteCacheIndex(store: ref.watch(remoteCacheStoreProvider));
 });
 
 /// The source router: Jellyfin, Subsonic, Plex, then the on-device catch-all.

--- a/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/app_info.dart';
 import '../../../core/models/jellyfin_session.dart';
+import '../../../core/services/remote_cache/remote_cache_key.dart';
 import '../../../core/sources/jellyfin/jellyfin_api.dart';
 import '../../../core/sources/jellyfin/jellyfin_diagnostics.dart';
 import '../../../core/sources/jellyfin/jellyfin_exception.dart';
@@ -13,6 +14,7 @@ import '../../../core/sources/music_provider.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../data/repositories/jellyfin_session_store_provider.dart';
 import '../../../data/repositories/playlist_repository_provider.dart';
+import '../../../data/repositories/remote_cache_index_provider.dart';
 import '../../library/source_preference_controller.dart';
 import 'jellyfin_settings_providers.dart';
 import 'jellyfin_settings_state.dart';
@@ -196,6 +198,13 @@ class JellyfinSettingsController extends Notifier<JellyfinSettingsState> {
     state = const JellyfinSettingsState(
       statusMessage: 'Signed out. Your Jellyfin settings were cleared.',
     );
+    // Drop this account's prepared-track records from the durable remote cache
+    // index so a signed-out library leaves no footprint. Done after the visible
+    // state has already returned to the signed-out form so this best-effort,
+    // credential-free cleanup (removeSource never throws) can't delay sign-out.
+    await ref
+        .read(remoteCacheIndexProvider)
+        .removeSource(RemoteCacheKey.sourceIdJellyfin);
   }
 
   /// Reports an error without dropping an existing connection: a failed test or

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -4,12 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/models/plex_session.dart';
+import '../../../core/services/remote_cache/remote_cache_key.dart';
 import '../../../core/sources/plex/plex_api.dart';
 import '../../../core/sources/plex/plex_exception.dart';
 import '../../../core/sources/plex/plex_music_source.dart';
 import '../../../core/sources/plex/plex_pin_auth.dart';
 import '../../../core/sources/plex/plex_tv_api.dart';
 import '../../../data/repositories/plex_session_store_provider.dart';
+import '../../../data/repositories/remote_cache_index_provider.dart';
 import 'plex_settings_providers.dart';
 import 'plex_settings_state.dart';
 import 'plex_sync_controller.dart';
@@ -705,6 +707,14 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
               'removed from this device.'
           : 'Disconnected. Your Plex session was removed from this device.',
     );
+    // Drop this server's prepared-track records from the durable remote cache
+    // index so a disconnected library leaves no footprint. Done after the
+    // visible state has already returned to the disconnected card so this
+    // best-effort, credential-free cleanup (removeSource never throws) can't
+    // delay disconnect.
+    await ref
+        .read(remoteCacheIndexProvider)
+        .removeSource(RemoteCacheKey.sourceIdPlex);
   }
 
   /// Runs the catalog sync for the current selection without blocking the

--- a/lib/features/settings/subsonic/subsonic_settings_controller.dart
+++ b/lib/features/settings/subsonic/subsonic_settings_controller.dart
@@ -3,10 +3,12 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/subsonic_session.dart';
+import '../../../core/services/remote_cache/remote_cache_key.dart';
 import '../../../core/sources/music_provider.dart';
 import '../../../core/sources/subsonic/subsonic_api.dart';
 import '../../../core/sources/subsonic/subsonic_exception.dart';
 import '../../../core/sources/subsonic/subsonic_music_source.dart';
+import '../../../data/repositories/remote_cache_index_provider.dart';
 import '../../../data/repositories/subsonic_session_store_provider.dart';
 import '../../library/source_preference_controller.dart';
 import 'subsonic_settings_providers.dart';
@@ -164,6 +166,13 @@ class SubsonicSettingsController extends Notifier<SubsonicSettingsState> {
     state = const SubsonicSettingsState(
       statusMessage: 'Signed out. Your Subsonic settings were cleared.',
     );
+    // Drop this account's prepared-track records from the durable remote cache
+    // index so a signed-out library leaves no footprint. Done after the visible
+    // state has already returned to the signed-out form so this best-effort,
+    // credential-free cleanup (removeSource never throws) can't delay sign-out.
+    await ref
+        .read(remoteCacheIndexProvider)
+        .removeSource(RemoteCacheKey.sourceIdSubsonic);
   }
 
   /// Reports an error without dropping an existing connection: a failed test or

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'data/repositories/playback_source_strategy_store_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/plex_session_store_provider.dart';
 import 'data/repositories/preferred_source_store_provider.dart';
+import 'data/repositories/remote_cache_index_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
 import 'features/downloads/download_providers.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -146,6 +146,13 @@ Future<void> main() async {
   // pre-cache.
   container.read(remotePrebufferServiceProvider);
 
+  // Load the durable, credential-free remote-cache index and prune any stale
+  // records, off the first-frame path. Best-effort: the manifest holds only
+  // opaque track keys + timestamps (never a URL or token), so this can never
+  // block startup or leak a secret — and because no stream URL is persisted, a
+  // fresh one is always re-resolved after a restart rather than replayed stale.
+  unawaited(container.read(remoteCacheIndexProvider).load());
+
   // Start playback reporting: mirrors live playback onto the server that owns
   // the playing track (Plex today), so the user's own dashboard shows Linthra
   // as an active player. Best-effort and off the playback path; non-Plex

--- a/test/core/services/remote_cache/fake_remote_cache_store.dart
+++ b/test/core/services/remote_cache/fake_remote_cache_store.dart
@@ -1,0 +1,44 @@
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_store.dart';
+
+/// An in-memory [RemoteCacheStore] for the durable-index tests.
+///
+/// It stands in for the on-disk JSON manifest without touching the filesystem:
+/// it remembers the last-saved records, counts loads/saves so a test can prove
+/// the index persisted (or didn't), and can be told to throw on either call so
+/// the index's "best-effort, never fatal" contract is provable.
+class FakeRemoteCacheStore implements RemoteCacheStore {
+  FakeRemoteCacheStore({
+    List<RemoteCacheRecord> seed = const <RemoteCacheRecord>[],
+    this.failOnLoad = false,
+    this.failOnSave = false,
+  }) : _records = List<RemoteCacheRecord>.of(seed);
+
+  List<RemoteCacheRecord> _records;
+
+  /// When true, [load] throws — to prove the index degrades to a cold cache.
+  bool failOnLoad;
+
+  /// When true, [save] throws — to prove a warm/sweep is still non-fatal.
+  bool failOnSave;
+
+  int loadCount = 0;
+  int saveCount = 0;
+
+  /// The records handed to the most recent [save] (what would hit disk).
+  List<RemoteCacheRecord> get saved => List<RemoteCacheRecord>.of(_records);
+
+  @override
+  Future<List<RemoteCacheRecord>> load() async {
+    loadCount++;
+    if (failOnLoad) throw StateError('load failed');
+    return List<RemoteCacheRecord>.of(_records);
+  }
+
+  @override
+  Future<void> save(List<RemoteCacheRecord> records) async {
+    saveCount++;
+    if (failOnSave) throw StateError('save failed');
+    _records = List<RemoteCacheRecord>.of(records);
+  }
+}

--- a/test/core/services/remote_cache/fake_remote_cache_store.dart
+++ b/test/core/services/remote_cache/fake_remote_cache_store.dart
@@ -1,5 +1,32 @@
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_entry.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_key.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_store.dart';
+
+/// A credential-free record for [uri] (`jellyfin:` / `subsonic:` / `plex:`), for
+/// seeding the fake store in disconnect/sign-out tests. It is built from an entry
+/// whose stream URL carries a token — exactly the thing that must not survive
+/// into the persisted record.
+///
+/// Defaults [recordedAt] to `DateTime.now()` (not a fixed date) so the 30-day
+/// retention leaves the record *fresh* against a real-clock index — otherwise a
+/// controller test's index would prune the seed as stale before the disconnect
+/// even runs.
+RemoteCacheRecord fakeRemoteCacheRecord(String uri, {DateTime? recordedAt}) {
+  final DateTime now = recordedAt ?? DateTime.now();
+  return RemoteCacheRecord.fromEntry(
+    RemoteCacheEntry(
+      key: RemoteCacheKey.forUri(uri)!,
+      streamUri: Uri.parse('https://server.example/stream?api_key=SECRET'),
+      source: PlaybackSource.streamingDirect,
+      resolvedAt: now,
+      expiresAt: now.add(const Duration(minutes: 2)),
+    ),
+    recordedAt: now,
+    expiresAt: now.add(const Duration(days: 30)),
+  );
+}
 
 /// An in-memory [RemoteCacheStore] for the durable-index tests.
 ///

--- a/test/core/services/remote_cache/remote_cache_index_test.dart
+++ b/test/core/services/remote_cache/remote_cache_index_test.dart
@@ -1,0 +1,311 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_entry.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_key.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
+
+import 'fake_remote_cache_store.dart';
+
+RemoteCacheEntry _entry(
+  String uri, {
+  required DateTime now,
+  String token = 'SECRET',
+}) =>
+    RemoteCacheEntry(
+      key: RemoteCacheKey.forUri(uri)!,
+      streamUri: Uri.parse('https://server.example/stream?api_key=$token'),
+      source: PlaybackSource.streamingDirect,
+      resolvedAt: now,
+      expiresAt: now.add(const Duration(minutes: 2)),
+    );
+
+RemoteCacheRecord _record(
+  String uri, {
+  required DateTime recordedAt,
+  required DateTime expiresAt,
+}) =>
+    RemoteCacheRecord.fromEntry(
+      _entry(uri, now: recordedAt),
+      recordedAt: recordedAt,
+      expiresAt: expiresAt,
+    );
+
+void main() {
+  final DateTime now = DateTime(2026, 1, 1, 12, 0, 0);
+
+  group('RemoteCacheIndex.record', () {
+    test('records a warmed track and persists its credential-free key',
+        () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.record(_entry('jellyfin:a', now: now));
+
+      expect(index.length, 1);
+      expect(index.records.single.value, 'jellyfin:a');
+      expect(store.saved.single.value, 'jellyfin:a');
+    });
+
+    test('routes Jellyfin, Subsonic and Plex into one index', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.record(_entry('jellyfin:j', now: now));
+      await index.record(_entry('subsonic:s', now: now));
+      await index.record(_entry('plex:1', now: now));
+
+      expect(
+        index.records.map((RemoteCacheRecord r) => r.sourceId).toSet(),
+        <String>{'jellyfin', 'subsonic', 'plex'},
+      );
+      expect(index.length, 3);
+    });
+
+    test(
+        're-warming the same key replaces rather than duplicates (newest wins)',
+        () async {
+      DateTime clock = now;
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => clock);
+
+      await index.record(_entry('plex:1', now: clock));
+      clock = now.add(const Duration(minutes: 5));
+      await index.record(_entry('plex:1', now: clock));
+
+      expect(index.length, 1);
+      expect(index.records.single.recordedAt, clock);
+    });
+  });
+
+  group('RemoteCacheIndex.load (survives a restart)', () {
+    test('loads persisted records so the cache knowledge survives a restart',
+        () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(
+        seed: <RemoteCacheRecord>[
+          _record('jellyfin:a',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+        ],
+      );
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.load();
+
+      expect(index.length, 1);
+      expect(index.records.single.value, 'jellyfin:a');
+    });
+
+    test('prunes records already expired at load and rewrites the manifest',
+        () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(
+        seed: <RemoteCacheRecord>[
+          _record('jellyfin:old',
+              recordedAt: now.subtract(const Duration(days: 40)),
+              expiresAt: now.subtract(const Duration(days: 1))),
+          _record('jellyfin:fresh',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+        ],
+      );
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.load();
+
+      expect(index.records.map((RemoteCacheRecord r) => r.value),
+          <String>['jellyfin:fresh']);
+      expect(store.saveCount, 1); // the pruned set was written back
+      expect(store.saved.map((RemoteCacheRecord r) => r.value),
+          <String>['jellyfin:fresh']);
+    });
+
+    test('a clean manifest at load does no redundant write', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(
+        seed: <RemoteCacheRecord>[
+          _record('jellyfin:a',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+        ],
+      );
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.load();
+
+      expect(store.loadCount, 1);
+      expect(store.saveCount, 0);
+    });
+
+    test('loads at most once, even across many calls', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.load();
+      await index.load();
+      await index.record(_entry('jellyfin:a', now: now));
+
+      expect(store.loadCount, 1);
+    });
+  });
+
+  group('RemoteCacheIndex.sweep', () {
+    test('drops records that expired since they were recorded', () async {
+      DateTime clock = now;
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index = RemoteCacheIndex(
+        store: store,
+        retention: const Duration(minutes: 2),
+        clock: () => clock,
+      );
+
+      await index.record(_entry('jellyfin:a', now: clock));
+      expect(index.length, 1);
+
+      clock = now.add(const Duration(minutes: 3));
+      await index.sweep();
+
+      expect(index.length, 0);
+      expect(store.saved, isEmpty);
+    });
+
+    test('a sweep with nothing stale writes nothing', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index = RemoteCacheIndex(
+        store: store,
+        retention: const Duration(days: 30),
+        clock: () => now,
+      );
+
+      await index.record(_entry('jellyfin:a', now: now));
+      final int before = store.saveCount;
+      await index.sweep();
+
+      expect(index.length, 1);
+      expect(store.saveCount, before);
+    });
+  });
+
+  group('RemoteCacheIndex bounds the manifest', () {
+    test('evicts the oldest-recorded entries past the cap', () async {
+      DateTime clock = now;
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, maxEntries: 2, clock: () => clock);
+
+      await index.record(_entry('jellyfin:a', now: clock));
+      clock = now.add(const Duration(minutes: 1));
+      await index.record(_entry('jellyfin:b', now: clock));
+      clock = now.add(const Duration(minutes: 2));
+      await index.record(_entry('jellyfin:c', now: clock));
+
+      // 'a' (the oldest) is evicted; the two most-recent survive on disk too.
+      expect(index.records.map((RemoteCacheRecord r) => r.value).toSet(),
+          <String>{'jellyfin:b', 'jellyfin:c'});
+      expect(store.saved.map((RemoteCacheRecord r) => r.value).toSet(),
+          <String>{'jellyfin:b', 'jellyfin:c'});
+    });
+
+    test('trims an over-cap manifest on load', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(
+        seed: <RemoteCacheRecord>[
+          _record('jellyfin:a',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+          _record('jellyfin:b',
+              recordedAt: now.add(const Duration(minutes: 1)),
+              expiresAt: now.add(const Duration(days: 30))),
+          _record('jellyfin:c',
+              recordedAt: now.add(const Duration(minutes: 2)),
+              expiresAt: now.add(const Duration(days: 30))),
+        ],
+      );
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, maxEntries: 2, clock: () => now);
+
+      await index.load();
+
+      expect(index.length, 2);
+      expect(index.records.map((RemoteCacheRecord r) => r.value),
+          isNot(contains('jellyfin:a')));
+      expect(store.saveCount, 1); // the trimmed manifest was written back
+    });
+  });
+
+  group('RemoteCacheIndex.clear', () {
+    test('empties the index and the persisted store', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.record(_entry('jellyfin:a', now: now));
+      await index.clear();
+
+      expect(index.length, 0);
+      expect(store.saved, isEmpty);
+    });
+  });
+
+  group('RemoteCacheIndex is best-effort (never fatal)', () {
+    test('a failing save never throws and keeps the in-memory record',
+        () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(failOnSave: true);
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.record(_entry('jellyfin:a', now: now));
+
+      expect(index.length, 1);
+    });
+
+    test('a failing load degrades to a cold index without throwing', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(failOnLoad: true);
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.load();
+      expect(index.length, 0);
+
+      // A later warm still records (in memory), proving the index keeps working.
+      await index.record(_entry('jellyfin:a', now: now));
+      expect(index.length, 1);
+    });
+
+    test('clear never throws even if the store rejects the write', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(failOnSave: true);
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.record(_entry('jellyfin:a', now: now));
+      await index.clear();
+
+      expect(index.length, 0);
+    });
+  });
+
+  group('RemoteCacheIndex credential safety', () {
+    test('persists no token or URL for a warmed tokenized entry', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.record(_entry('plex:101', now: now, token: 'SUPER-SECRET'));
+
+      final String encoded = jsonEncode(<Map<String, dynamic>>[
+        for (final RemoteCacheRecord r in store.saved) r.toJson(),
+      ]);
+      expect(encoded, isNot(contains('SUPER-SECRET')));
+      expect(encoded.toLowerCase(), isNot(contains('token')));
+      expect(encoded.toLowerCase(), isNot(contains('api_key')));
+      expect(encoded.toLowerCase(), isNot(contains('http')));
+
+      for (final RemoteCacheRecord r in index.records) {
+        expect(r.toString(), isNot(contains('SUPER-SECRET')));
+        expect(r.fileSafeName, isNot(contains('SUPER-SECRET')));
+      }
+    });
+  });
+}

--- a/test/core/services/remote_cache/remote_cache_index_test.dart
+++ b/test/core/services/remote_cache/remote_cache_index_test.dart
@@ -249,6 +249,101 @@ void main() {
     });
   });
 
+  group('RemoteCacheIndex.removeSource (provider disconnect)', () {
+    test('drops only the given provider, keeping the others', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+      await index.record(_entry('jellyfin:a', now: now));
+      await index.record(_entry('jellyfin:b', now: now));
+      await index.record(_entry('subsonic:s', now: now));
+      await index.record(_entry('plex:1', now: now));
+
+      await index.removeSource('jellyfin');
+
+      expect(index.records.map((RemoteCacheRecord r) => r.value).toSet(),
+          <String>{'subsonic:s', 'plex:1'});
+      // The removal is persisted, not just dropped from memory.
+      expect(store.saved.map((RemoteCacheRecord r) => r.value).toSet(),
+          <String>{'subsonic:s', 'plex:1'});
+    });
+
+    test('removes each provider in isolation', () async {
+      for (final MapEntry<String, Set<String>> expected
+          in <String, Set<String>>{
+        'jellyfin': <String>{'subsonic:s', 'plex:1'},
+        'subsonic': <String>{'jellyfin:a', 'plex:1'},
+        'plex': <String>{'jellyfin:a', 'subsonic:s'},
+      }.entries) {
+        final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+        final RemoteCacheIndex index =
+            RemoteCacheIndex(store: store, clock: () => now);
+        await index.record(_entry('jellyfin:a', now: now));
+        await index.record(_entry('subsonic:s', now: now));
+        await index.record(_entry('plex:1', now: now));
+
+        await index.removeSource(expected.key);
+
+        expect(index.records.map((RemoteCacheRecord r) => r.value).toSet(),
+            expected.value);
+      }
+    });
+
+    test('loads first, so a cold index still drops persisted records',
+        () async {
+      // A fresh index (just after launch) still removes the right provider's
+      // *persisted* records when a disconnect calls removeSource.
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(
+        seed: <RemoteCacheRecord>[
+          _record('jellyfin:a',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+          _record('plex:1',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+        ],
+      );
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      await index.removeSource('plex');
+
+      expect(index.records.map((RemoteCacheRecord r) => r.value),
+          <String>['jellyfin:a']);
+      expect(store.saved.map((RemoteCacheRecord r) => r.value),
+          <String>['jellyfin:a']);
+    });
+
+    test('removing a provider with no records writes nothing', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+      await index.record(_entry('jellyfin:a', now: now));
+      final int before = store.saveCount;
+
+      await index.removeSource('plex'); // nothing of this source to remove
+
+      expect(index.length, 1);
+      expect(store.saveCount, before);
+    });
+
+    test('a failing store never throws (non-fatal)', () async {
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(
+        seed: <RemoteCacheRecord>[
+          _record('jellyfin:a',
+              recordedAt: now, expiresAt: now.add(const Duration(days: 30))),
+        ],
+        failOnSave: true,
+      );
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+
+      // Must not throw even though persisting the removal fails.
+      await index.removeSource('jellyfin');
+
+      // Removed from the in-memory view regardless.
+      expect(index.length, 0);
+    });
+  });
+
   group('RemoteCacheIndex is best-effort (never fatal)', () {
     test('a failing save never throws and keeps the in-memory record',
         () async {

--- a/test/core/services/remote_cache/remote_cache_record_test.dart
+++ b/test/core/services/remote_cache/remote_cache_record_test.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_entry.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_key.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
+
+const String _token = 'SUPER-SECRET-TOKEN';
+
+/// A live, in-memory entry whose stream URL carries a token — exactly the thing
+/// that must never reach the persisted record built from it.
+RemoteCacheEntry _entry(
+  String uri, {
+  required DateTime now,
+  String token = _token,
+}) =>
+    RemoteCacheEntry(
+      key: RemoteCacheKey.forUri(uri)!,
+      streamUri: Uri.parse('https://server.example/stream?api_key=$token'),
+      source: PlaybackSource.streamingDirect,
+      resolvedAt: now,
+      expiresAt: now.add(const Duration(minutes: 2)),
+    );
+
+void main() {
+  final DateTime now = DateTime(2026, 1, 1, 12, 0, 0);
+  final DateTime expires = now.add(const Duration(days: 30));
+
+  group('RemoteCacheRecord.fromEntry', () {
+    test('routes Jellyfin, Subsonic and Plex by their credential-free key', () {
+      for (final MapEntry<String, String> sample in <String, String>{
+        'jellyfin:abc': 'jellyfin',
+        'subsonic:def': 'subsonic',
+        'plex:101': 'plex',
+      }.entries) {
+        final RemoteCacheRecord record = RemoteCacheRecord.fromEntry(
+          _entry(sample.key, now: now),
+          recordedAt: now,
+          expiresAt: expires,
+        );
+        expect(record.value, sample.key);
+        expect(record.sourceId, sample.value);
+        expect(record.fileSafeName, startsWith('${sample.value}_'));
+      }
+    });
+
+    test('copies only the credential-free key — never the stream URL', () {
+      final RemoteCacheEntry entry = _entry('plex:101', now: now);
+      final RemoteCacheRecord record = RemoteCacheRecord.fromEntry(
+        entry,
+        recordedAt: now,
+        expiresAt: expires,
+      );
+
+      // The token lives on the entry's in-memory stream URL (allowed) ...
+      expect(entry.streamUri.toString(), contains(_token));
+      // ... but nowhere on the record or its serialized / loggable surfaces.
+      final String encoded = jsonEncode(record.toJson());
+      for (final String surface in <String>[
+        record.value,
+        record.sourceId,
+        record.fileSafeName,
+        record.toString(),
+        encoded,
+      ]) {
+        expect(surface, isNot(contains(_token)));
+        expect(surface.toLowerCase(), isNot(contains('token')));
+        expect(surface.toLowerCase(), isNot(contains('api_key')));
+        expect(surface.toLowerCase(), isNot(contains('http')));
+      }
+    });
+
+    test('the JSON has only the opaque key and timestamps — no URL field', () {
+      final Map<String, dynamic> json = RemoteCacheRecord.fromEntry(
+              _entry('jellyfin:abc', now: now),
+              recordedAt: now,
+              expiresAt: expires)
+          .toJson();
+
+      expect(json.keys.toSet(), <String>{'key', 'recordedAt', 'expiresAt'});
+      expect(json['key'], 'jellyfin:abc');
+      expect(json['recordedAt'], now.millisecondsSinceEpoch);
+      expect(json['expiresAt'], expires.millisecondsSinceEpoch);
+    });
+  });
+
+  group('RemoteCacheRecord JSON round-trip', () {
+    test('toJson then fromJson reproduces the record', () {
+      final RemoteCacheRecord original = RemoteCacheRecord.fromEntry(
+        _entry('subsonic:xyz', now: now),
+        recordedAt: now,
+        expiresAt: expires,
+      );
+
+      final RemoteCacheRecord? restored =
+          RemoteCacheRecord.fromJson(original.toJson());
+
+      expect(restored, isNotNull);
+      expect(restored, original);
+      expect(restored!.value, 'subsonic:xyz');
+      expect(restored.expiresAt, expires);
+    });
+
+    test('a restored record carries no stream URL — forcing a fresh resolve',
+        () {
+      // The persisted form has nowhere to keep a URL, so after a "restart"
+      // (load from JSON) there is nothing stale to replay: only the key remains.
+      final RemoteCacheRecord restored = RemoteCacheRecord.fromJson(
+        RemoteCacheRecord.fromEntry(_entry('plex:101', now: now),
+                recordedAt: now, expiresAt: expires)
+            .toJson(),
+      )!;
+      expect(jsonEncode(restored.toJson()), isNot(contains('server.example')));
+      expect(restored.value, 'plex:101');
+    });
+  });
+
+  group('RemoteCacheRecord.fromJson defends the credential-free boundary', () {
+    test('drops a missing or empty key', () {
+      expect(RemoteCacheRecord.fromJson(<String, dynamic>{}), isNull);
+      expect(
+        RemoteCacheRecord.fromJson(<String, dynamic>{'key': ''}),
+        isNull,
+      );
+    });
+
+    test('drops a tampered, tokenized key (cannot be reintroduced via JSON)',
+        () {
+      // A hand-edited manifest line that smuggled a token must not load.
+      expect(
+        RemoteCacheRecord.fromJson(<String, dynamic>{
+          'key': 'plex:101?X-Plex-Token=SECRET',
+          'recordedAt': now.millisecondsSinceEpoch,
+          'expiresAt': expires.millisecondsSinceEpoch,
+        }),
+        isNull,
+      );
+    });
+
+    test('drops a local or content:// key (not a remote stream)', () {
+      expect(
+        RemoteCacheRecord.fromJson(<String, dynamic>{'key': 'file:///a.mp3'}),
+        isNull,
+      );
+      expect(
+        RemoteCacheRecord.fromJson(
+          <String, dynamic>{'key': 'content://media/audio/1'},
+        ),
+        isNull,
+      );
+    });
+
+    test('tolerates missing/malformed timestamps (treated as long expired)',
+        () {
+      final RemoteCacheRecord? record = RemoteCacheRecord.fromJson(
+        <String, dynamic>{'key': 'jellyfin:abc'},
+      );
+      expect(record, isNotNull);
+      // No usable expiry -> epoch -> stale now, so the sweep drops it.
+      expect(record!.isFresh(now), isFalse);
+    });
+  });
+
+  group('RemoteCacheRecord freshness', () {
+    test('is fresh before expiry and stale after', () {
+      final RemoteCacheRecord record = RemoteCacheRecord.fromEntry(
+        _entry('jellyfin:abc', now: now),
+        recordedAt: now,
+        expiresAt: now.add(const Duration(days: 1)),
+      );
+      expect(record.isFresh(now), isTrue);
+      expect(record.isFresh(now.add(const Duration(hours: 23))), isTrue);
+      expect(record.isFresh(now.add(const Duration(days: 1))), isFalse);
+      expect(record.isFresh(now.add(const Duration(days: 2))), isFalse);
+    });
+  });
+}

--- a/test/core/services/remote_cache/remote_stream_prebufferer_test.dart
+++ b/test/core/services/remote_cache/remote_stream_prebufferer_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_source.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
 import 'package:linthra/core/services/remote_cache/remote_cache_key.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/services/remote_cache/remote_playback_cache.dart';
 import 'package:linthra/core/services/remote_cache/remote_stream_prebufferer.dart';
 
+import 'fake_remote_cache_store.dart';
 import 'fake_stream_resolver.dart';
 
 Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
@@ -231,6 +234,107 @@ void main() {
         expect(s, isNot(contains('SUPER-SECRET')));
         expect(s.toLowerCase(), isNot(contains('token')));
       }
+    });
+  });
+
+  group('durable index integration', () {
+    test('a warmed remote track is recorded in the durable index', () async {
+      final FakeStreamResolver inner = FakeStreamResolver();
+      final RemotePlaybackCache cache = RemotePlaybackCache();
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+      final RemoteStreamPrebufferer prebufferer = RemoteStreamPrebufferer(
+        resolver: inner,
+        cache: cache,
+        index: index,
+        clock: () => now,
+      );
+
+      await prebufferer.preload(_jellyfin('a'));
+
+      expect(index.records.single.value, 'jellyfin:a');
+      expect(store.saved.single.value, 'jellyfin:a');
+    });
+
+    test('records Jellyfin, Subsonic and Plex but never local/content tracks',
+        () async {
+      final FakeStreamResolver inner = FakeStreamResolver();
+      final RemotePlaybackCache cache = RemotePlaybackCache();
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+      final RemoteStreamPrebufferer prebufferer = RemoteStreamPrebufferer(
+        resolver: inner,
+        cache: cache,
+        index: index,
+        clock: () => now,
+      );
+
+      await prebufferer.prepare(
+        current: _jellyfin('j'),
+        upNext: <Track>[_subsonic('s'), _plex('1'), _local('x'), _saf('y')],
+        ahead: 4,
+      );
+
+      expect(
+        index.records.map((RemoteCacheRecord r) => r.value).toSet(),
+        <String>{'jellyfin:j', 'subsonic:s', 'plex:1'},
+      );
+    });
+
+    test('a non-stream resolution is not recorded', () async {
+      final FakeStreamResolver inner =
+          FakeStreamResolver(source: PlaybackSource.localFile);
+      final RemotePlaybackCache cache = RemotePlaybackCache();
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore();
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+      final RemoteStreamPrebufferer prebufferer = RemoteStreamPrebufferer(
+        resolver: inner,
+        cache: cache,
+        index: index,
+        clock: () => now,
+      );
+
+      await prebufferer.preload(_jellyfin('a'));
+
+      expect(index.length, 0);
+    });
+
+    test('a failing index never breaks prebuffering (non-fatal)', () async {
+      final FakeStreamResolver inner = FakeStreamResolver();
+      final RemotePlaybackCache cache = RemotePlaybackCache();
+      final FakeRemoteCacheStore store = FakeRemoteCacheStore(failOnSave: true);
+      final RemoteCacheIndex index =
+          RemoteCacheIndex(store: store, clock: () => now);
+      final RemoteStreamPrebufferer prebufferer = RemoteStreamPrebufferer(
+        resolver: inner,
+        cache: cache,
+        index: index,
+        clock: () => now,
+      );
+
+      // Must not throw despite the index's store rejecting every write ...
+      await prebufferer.preload(_jellyfin('a'));
+
+      // ... and the in-memory warm still happened.
+      expect(cache.contains(RemoteCacheKey.forUri('jellyfin:a')!, now), isTrue);
+    });
+
+    test('without an index the warm still works (back-compat)', () async {
+      // The index is optional; existing wiring passes none and is unchanged.
+      final FakeStreamResolver inner = FakeStreamResolver();
+      final RemotePlaybackCache cache = RemotePlaybackCache();
+      final RemoteStreamPrebufferer prebufferer = RemoteStreamPrebufferer(
+        resolver: inner,
+        cache: cache,
+        clock: () => now,
+      );
+
+      await prebufferer.preload(_jellyfin('a'));
+
+      expect(cache.contains(RemoteCacheKey.forUri('jellyfin:a')!, now), isTrue);
     });
   });
 }

--- a/test/data/repositories/file_remote_cache_store_test.dart
+++ b/test/data/repositories/file_remote_cache_store_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_entry.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_key.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
+import 'package:linthra/data/repositories/file_remote_cache_store.dart';
+import 'package:path/path.dart' as p;
+
+final DateTime _now = DateTime(2026, 1, 1, 12, 0, 0);
+
+RemoteCacheRecord _record(String uri, {String token = 'SECRET'}) =>
+    RemoteCacheRecord.fromEntry(
+      RemoteCacheEntry(
+        key: RemoteCacheKey.forUri(uri)!,
+        streamUri: Uri.parse('https://server.example/stream?api_key=$token'),
+        source: PlaybackSource.streamingDirect,
+        resolvedAt: _now,
+        expiresAt: _now.add(const Duration(minutes: 2)),
+      ),
+      recordedAt: _now,
+      expiresAt: _now.add(const Duration(days: 30)),
+    );
+
+void main() {
+  group('FileRemoteCacheStore', () {
+    late Directory tempDir;
+    late FileRemoteCacheStore store;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('linthra_remote_cache');
+      store = FileRemoteCacheStore(directory: () async => tempDir);
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('round-trips records through the on-disk manifest', () async {
+      await store.save(<RemoteCacheRecord>[
+        _record('jellyfin:a'),
+        _record('subsonic:b'),
+        _record('plex:1'),
+      ]);
+
+      final List<RemoteCacheRecord> loaded = await store.load();
+
+      expect(loaded.map((RemoteCacheRecord r) => r.value),
+          <String>['jellyfin:a', 'subsonic:b', 'plex:1']);
+      expect(loaded.first.expiresAt, _now.add(const Duration(days: 30)));
+    });
+
+    test('the written manifest file carries no token or URL', () async {
+      await store.save(<RemoteCacheRecord>[
+        _record('plex:101', token: 'SUPER-SECRET'),
+      ]);
+
+      final File manifest = File(p.join(tempDir.path, 'index.json'));
+      expect(await manifest.exists(), isTrue);
+      final String raw = await manifest.readAsString();
+
+      expect(raw, isNot(contains('SUPER-SECRET')));
+      expect(raw.toLowerCase(), isNot(contains('token')));
+      expect(raw.toLowerCase(), isNot(contains('api_key')));
+      expect(raw.toLowerCase(), isNot(contains('http')));
+      // It does carry the credential-free key.
+      expect(raw, contains('plex:101'));
+    });
+
+    test('creates the directory on first save', () async {
+      final Directory nested = Directory(p.join(tempDir.path, 'a', 'b', 'c'));
+      final FileRemoteCacheStore deepStore =
+          FileRemoteCacheStore(directory: () async => nested);
+
+      await deepStore.save(<RemoteCacheRecord>[_record('jellyfin:a')]);
+
+      expect(await nested.exists(), isTrue);
+      expect((await deepStore.load()).single.value, 'jellyfin:a');
+    });
+
+    test('load on a missing manifest is an empty cold cache', () async {
+      expect(await store.load(), isEmpty);
+    });
+
+    test('a corrupt manifest degrades to empty (non-fatal)', () async {
+      final File manifest = File(p.join(tempDir.path, 'index.json'));
+      await manifest.writeAsString('{ this is not json ]');
+
+      expect(await store.load(), isEmpty);
+    });
+
+    test('a non-list manifest degrades to empty', () async {
+      final File manifest = File(p.join(tempDir.path, 'index.json'));
+      await manifest.writeAsString('{"key":"jellyfin:a"}');
+
+      expect(await store.load(), isEmpty);
+    });
+
+    test('drops a manifest line whose key smuggled a token', () async {
+      // Hand-written manifest: one clean record, one with a tokenized key.
+      final File manifest = File(p.join(tempDir.path, 'index.json'));
+      await manifest.writeAsString(
+        '[{"key":"jellyfin:a","recordedAt":0,"expiresAt":33000000000000},'
+        '{"key":"plex:1?X-Plex-Token=SECRET","recordedAt":0,'
+        '"expiresAt":33000000000000}]',
+      );
+
+      final List<RemoteCacheRecord> loaded = await store.load();
+
+      expect(
+          loaded.map((RemoteCacheRecord r) => r.value), <String>['jellyfin:a']);
+    });
+
+    test('saving an empty list clears the manifest contents', () async {
+      await store.save(<RemoteCacheRecord>[_record('jellyfin:a')]);
+      await store.save(const <RemoteCacheRecord>[]);
+
+      expect(await store.load(), isEmpty);
+    });
+
+    test('save leaves the manifest in place and no temp file behind', () async {
+      await store.save(<RemoteCacheRecord>[_record('jellyfin:a')]);
+
+      expect(await File(p.join(tempDir.path, 'index.json')).exists(), isTrue);
+      expect(
+        await File(p.join(tempDir.path, 'index.json.tmp')).exists(),
+        isFalse,
+      );
+    });
+
+    test('load ignores a stray temp file left by a torn write', () async {
+      // A crash mid-write can leave an index.json.tmp behind; load reads only
+      // the committed manifest, so the previous good index survives intact.
+      await File(p.join(tempDir.path, 'index.json')).writeAsString(
+        '[{"key":"jellyfin:a","recordedAt":0,"expiresAt":33000000000000}]',
+      );
+      await File(p.join(tempDir.path, 'index.json.tmp'))
+          .writeAsString('half-written-garbage');
+
+      expect((await store.load()).single.value, 'jellyfin:a');
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_controller_test.dart
@@ -6,17 +6,22 @@ import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/favorites_repository.dart';
 import 'package:linthra/core/repositories/playlist_repository.dart';
 import 'package:linthra/core/repositories/remote_sync_result.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
 import 'package:linthra/data/repositories/favorites_repository_provider.dart';
 import 'package:linthra/data/repositories/in_memory_jellyfin_session_store.dart';
 import 'package:linthra/data/repositories/jellyfin_session_store_provider.dart';
 import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/data/repositories/remote_cache_index_provider.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_controller.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_providers.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_settings_state.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
 import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
+
+import '../../../core/services/remote_cache/fake_remote_cache_store.dart';
 
 import '../../../core/sources/jellyfin/fake_jellyfin_client.dart';
 import 'fake_jellyfin_authenticator.dart';
@@ -350,6 +355,39 @@ void main() {
       // The account's imported Jellyfin playlists are dropped so they can't
       // linger after signing out; local-only playlists are kept (repository).
       expect(playlists.clearRemoteCalls, 1);
+    });
+
+    test("sign-out drops this account's prepared remote-cache records",
+        () async {
+      final store = FakeRemoteCacheStore(seed: <RemoteCacheRecord>[
+        fakeRemoteCacheRecord('jellyfin:a'),
+        fakeRemoteCacheRecord('jellyfin:b'),
+        fakeRemoteCacheRecord('plex:1'),
+      ]);
+      final index = RemoteCacheIndex(store: store);
+      final container = ProviderContainer(overrides: <Override>[
+        jellyfinAuthenticatorProvider
+            .overrideWithValue(FakeJellyfinAuthenticator()),
+        jellyfinSessionStoreProvider.overrideWithValue(
+          InMemoryJellyfinSessionStore(initialSession: _session),
+        ),
+        jellyfinClientProvider.overrideWithValue(FakeJellyfinClient()),
+        remoteCacheIndexProvider.overrideWithValue(index),
+      ]);
+      addTearDown(container.dispose);
+      container.read(jellyfinSettingsControllerProvider);
+      await _settle();
+
+      await container.read(jellyfinSettingsControllerProvider.notifier).clear();
+
+      // Only this provider's prepared-track records are removed (memory + disk);
+      // another provider's records are left untouched.
+      expect(index.records.map((RemoteCacheRecord r) => r.value), <String>[
+        'plex:1',
+      ]);
+      expect(store.saved.map((RemoteCacheRecord r) => r.value), <String>[
+        'plex:1',
+      ]);
     });
 
     test('sign-out resets the (now stale) sync status', () async {

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -10,6 +10,8 @@ import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/repositories/plex_session_store.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
 import 'package:linthra/core/sources/plex/plex_music_source.dart';
@@ -19,12 +21,14 @@ import 'package:linthra/data/repositories/in_memory_music_library_repository.dar
 import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/data/repositories/plex_session_store_provider.dart';
+import 'package:linthra/data/repositories/remote_cache_index_provider.dart';
 import 'package:linthra/features/settings/plex/plex_settings_controller.dart';
 import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
 import 'package:linthra/features/settings/plex/plex_settings_state.dart';
 import 'package:linthra/features/settings/plex/plex_sync_controller.dart';
 import 'package:linthra/features/settings/plex/plex_sync_state.dart';
 
+import '../../../core/services/remote_cache/fake_remote_cache_store.dart';
 import '../../../core/sources/plex/fake_plex_client.dart';
 import '../../../core/sources/plex/fake_plex_tv_client.dart';
 
@@ -238,6 +242,7 @@ ProviderContainer _container({
   MusicLibraryRepository? repository,
   FakePlexTvClient? tvClient,
   ExternalLinkLauncher? launcher,
+  RemoteCacheIndex? cacheIndex,
 }) {
   final FakePlexClient plexClient =
       client ?? FakePlexClient(sections: const [_musicSection]);
@@ -248,6 +253,8 @@ ProviderContainer _container({
           .overrideWithValue(store ?? InMemoryPlexSessionStore()),
       if (repository != null)
         musicLibraryRepositoryProvider.overrideWithValue(repository),
+      if (cacheIndex != null)
+        remoteCacheIndexProvider.overrideWithValue(cacheIndex),
       // The PIN flow on fakes, with an instant wait so the poll loop runs
       // without real delays.
       plexPinAuthProvider.overrideWith(
@@ -900,6 +907,33 @@ void main() {
       expect(state.statusMessage, contains('Disconnected'));
       expect(notifier.session, isNull);
       expect(container.read(plexMusicSourceProvider), isNull);
+    });
+
+    test("drops this server's prepared remote-cache records on disconnect",
+        () async {
+      final cacheStore = FakeRemoteCacheStore(seed: <RemoteCacheRecord>[
+        fakeRemoteCacheRecord('plex:1'),
+        fakeRemoteCacheRecord('plex:2'),
+        fakeRemoteCacheRecord('jellyfin:a'),
+      ]);
+      final index = RemoteCacheIndex(store: cacheStore);
+      final container = _container(
+        store: InMemoryPlexSessionStore(initialSession: _session),
+        cacheIndex: index,
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.disconnect();
+
+      // Only Plex's prepared-track records are removed (memory + disk); another
+      // provider's records are left untouched.
+      expect(index.records.map((RemoteCacheRecord r) => r.value), <String>[
+        'jellyfin:a',
+      ]);
+      expect(cacheStore.saved.map((RemoteCacheRecord r) => r.value), <String>[
+        'jellyfin:a',
+      ]);
     });
 
     test(

--- a/test/features/settings/subsonic/subsonic_settings_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_settings_controller_test.dart
@@ -1,13 +1,17 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_index.dart';
+import 'package:linthra/core/services/remote_cache/remote_cache_record.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_exception.dart';
 import 'package:linthra/data/repositories/in_memory_subsonic_session_store.dart';
+import 'package:linthra/data/repositories/remote_cache_index_provider.dart';
 import 'package:linthra/data/repositories/subsonic_session_store_provider.dart';
 import 'package:linthra/features/settings/subsonic/subsonic_settings_controller.dart';
 import 'package:linthra/features/settings/subsonic/subsonic_settings_providers.dart';
 import 'package:linthra/features/settings/subsonic/subsonic_settings_state.dart';
 
+import '../../../core/services/remote_cache/fake_remote_cache_store.dart';
 import '../../../core/sources/subsonic/fake_subsonic_client.dart';
 
 const _session = SubsonicSession(
@@ -177,6 +181,38 @@ void main() {
         SubsonicConnectionPhase.disconnected,
       );
       expect(notifier.session, isNull);
+    });
+
+    test("sign-out drops this account's prepared remote-cache records",
+        () async {
+      final cacheStore = FakeRemoteCacheStore(seed: <RemoteCacheRecord>[
+        fakeRemoteCacheRecord('subsonic:a'),
+        fakeRemoteCacheRecord('subsonic:b'),
+        fakeRemoteCacheRecord('jellyfin:1'),
+      ]);
+      final index = RemoteCacheIndex(store: cacheStore);
+      final container = ProviderContainer(overrides: <Override>[
+        subsonicClientProvider.overrideWithValue(FakeSubsonicClient()),
+        subsonicSessionStoreProvider.overrideWithValue(
+          InMemorySubsonicSessionStore(initialSession: _session),
+        ),
+        remoteCacheIndexProvider.overrideWithValue(index),
+      ]);
+      addTearDown(container.dispose);
+      final notifier =
+          container.read(subsonicSettingsControllerProvider.notifier);
+      await notifier.ensureLoaded();
+
+      await notifier.clear();
+
+      // Only Subsonic's prepared-track records are removed (memory + disk);
+      // another provider's records are left untouched.
+      expect(index.records.map((RemoteCacheRecord r) => r.value), <String>[
+        'jellyfin:1',
+      ]);
+      expect(cacheStore.saved.map((RemoteCacheRecord r) => r.value), <String>[
+        'jellyfin:1',
+      ]);
     });
   });
 


### PR DESCRIPTION
## What & why

Builds on the remote playback cache foundation (#191) by adding **the on-disk persistence layer its in-memory store was explicitly designed as a seam for** (`RemoteCacheKey.fileSafeName` "for the future on-disk prebuffer/cache"; `RemoteCacheCleanup` "the seam where an on-disk eviction sweep will later hang off").

The in-memory `RemotePlaybackCache` holds the **token-bearing** stream URL for its short TTL and forgets everything on exit. This adds its durable complement: a **credential-free index of *which* remote tracks were prepared**, so the cache's knowledge survives a restart **without ever persisting a secret**. It is the substrate the future on-disk byte cache + eviction sweep will hang off.

This is **additive and compatible** — no offline-download UI, no cache settings UI, no downloads, no version/release changes. Jellyfin / Plex / Subsonic / local playback and the #192/#193 server-reporting paths are untouched.

## New pieces

| Class | Role |
| --- | --- |
| `RemoteCacheRecord` | The persistable projection of an entry — the opaque key + timestamps, **stream URL cut away**. No field a URL/token could occupy; `fromJson` re-validates every key through `RemoteCacheKey.forUri`. |
| `RemoteCacheStore` | The `load`/`save` seam (mirrors `DownloadStore`). |
| `RemoteCacheIndex` | Best-effort orchestrator: loads once (lazily), records each warm's credential-free key, prunes expired, **bounds the manifest to a cap** (oldest evicted), **`removeSource` on disconnect**, clears. Never throws into playback. |
| `FileRemoteCacheStore` (data) | JSON manifest under app-support `remote_cache/index.json`, **written atomically** (temp + rename) so a torn write can't discard the index. |

`RemoteStreamPrebufferer` takes the index as an **optional** collaborator and records a warm's key *after* storing the (tokenized, in-memory) entry — so the write side is byte-for-byte unchanged when none is wired. `main` loads + prunes the index off the first-frame path.

## Hardening — disconnect / sign-out cleanup (commit 2)

Per review: a provider's prepared-track records (credential-free keys like `jellyfin:<id>` / `plex:<ratingKey>`) shouldn't linger after that account disconnects.

- **`RemoteCacheIndex.removeSource(sourceId)`** — drops only that provider's records (keyed off `RemoteCacheKey.sourceId`) and persists the rest, so signing out of one server never discards another's records. Provider-scoped, the cleaner alternative to a full wipe.
- Wired into **`PlexSettingsController.disconnect`**, **`JellyfinSettingsController.clear`**, **`SubsonicSettingsController.clear`** — run *after* the settings UI has returned to its signed-out state, so the best-effort cleanup can never delay or break sign-out.
- The index providers moved to the **data layer** (`remote_cache_index_provider.dart`) so both the player and the settings controllers depend on the index without a cross-feature import cycle.
- Whole-index `clear()` stays as the future "forget everything" hook.

## Security posture (unchanged invariants, re-proven)

- **No stream/artwork URL or token is ever persisted.** `RemoteCacheRecord` has no URL field; only the opaque key + timestamps reach disk.
- **Defense in depth on load:** `fromJson` drops any key that is local, `content://`, or *looks* tokenized.
- **No tokens in keys, filenames, metadata, logs, diagnostics, or errors.** Every store call is wrapped; nothing logs a URL.
- **Stale-URL safety strengthened:** because no URL is stored, a restart can't replay a stale stream — the resolver always mints a fresh URL.
- Disconnect cleanup only ever removes/keeps **credential-free keys** — no token is at stake.
- `Track.uri` stays `plex:<ratingKey>`, `artworkUri` stays `plex-thumb:<path>`.

## Failure behaviour

Best-effort and **non-fatal** throughout: a slow/failing/corrupt disk degrades to a cold index; playback and sign-out never fail because the index failed.

## Tests (`flutter test` green: 2220 passing)

- `RemoteCacheRecord`: credential-free projection, JSON round-trip, tamper/local/content drop, freshness.
- `RemoteCacheIndex`: record / load-survives-restart / sweep / clear / cap eviction / **`removeSource` per-provider isolation, cold-index load, non-fatal** / credential safety.
- `FileRemoteCacheStore`: temp-dir round-trip, **manifest carries no token/URL/api_key**, corrupt→empty, atomic write, tampered-line drop.
- Prebufferer integration: Jellyfin/Plex/Subsonic recorded, **local & `content://` never**, failing index never breaks prebuffering.
- **Disconnect/sign-out**: a per-provider controller test for Jellyfin, Subsonic, and Plex proving the disconnected provider's records are dropped from **both memory and the persisted store** while another provider's are kept.

`flutter analyze`, `dart format --set-exit-if-changed`, and `./scripts/check_secrets.sh` all clean.

## Manual QA to run

`docs/manual-test-checklist.md` §7a: kill/relaunch keeps remote playback working and re-resolves fresh; `cat files/remote_cache/index.json` shows only opaque keys + timestamps (no token/URL); local-only playback creates no entries; **disconnecting one provider drops its keys from the manifest while keeping the other's, and returns to the signed-out card immediately**.

## Out of scope

No offline-download UI, no cache settings UI, no lyrics/playlists/favorites, no Plex.tv OAuth changes, no Android Auto work, no version bump, no release changes.

> Note: opened against `main`. This branch already contained #191–#195; this PR adds the on-disk index + disconnect-cleanup commits on top.