### PR TITLE
fix(android): leave release build unsigned when no signing material (F-Droid)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -11,9 +11,10 @@ plugins {
 //     LINTHRA_KEYSTORE_BASE64 secret and sets LINTHRA_KEYSTORE_PATH, or
 //   * a git-ignored android/key.properties file — for local release builds.
 // Environment variables take precedence over key.properties. If no complete
-// signing config is found, release builds fall back to the debug key so that
-// `flutter run --release` keeps working. Debug-signed artifacts are NOT real
-// releases and must not be distributed as such. See docs/release-signing.md.
+// signing config is found, the release build is left UNSIGNED — F-Droid
+// expects an unsigned release APK so it can sign the artifact with its own
+// key. A build that is not release-signed must not be distributed as a real
+// release. See docs/release-signing.md.
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file("key.properties")
 if (keystorePropertiesFile.exists()) {
@@ -40,7 +41,7 @@ def hasReleaseSigning = releaseStoreFilePath != null && !releaseStoreFilePath.is
 if (hasReleaseSigning) {
     logger.lifecycle("Linthra: release build will be signed with the configured release keystore.")
 } else {
-    logger.lifecycle("Linthra: no release signing config found; release build falls back to the DEBUG key (not a real release).")
+    logger.lifecycle("Linthra: no release signing config found; release build will be UNSIGNED (e.g. for F-Droid, which signs it itself).")
 }
 
 android {
@@ -100,10 +101,13 @@ android {
     buildTypes {
         release {
             // Use the real release signing config when complete signing material
-            // is available (env vars or key.properties); otherwise fall back to
-            // the debug key so `flutter run --release` still works. Debug-signed
-            // release builds are clearly labeled by CI and must not be shipped.
-            signingConfig = hasReleaseSigning ? signingConfigs.release : signingConfigs.debug
+            // is available (env vars or key.properties). Otherwise leave the
+            // release build UNSIGNED: F-Droid expects an unsigned release APK so
+            // it can sign the artifact with its own key. (A build that is not
+            // release-signed must never be distributed as a real release.)
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.release
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

F-Droid maintainers reported that Linthra's Gradle build outputs a **debug-signed** APK when no release keystore is provided. F-Droid builds from source and signs APKs with its **own** key, so it expects an **unsigned** release APK.

The cause is the debug-signing fallback in `android/app/build.gradle`:

```gradle
signingConfig = hasReleaseSigning ? signingConfigs.release : signingConfigs.debug
```

When F-Droid builds without any release signing material, this falls back to `signingConfigs.debug`, producing a debug-signed APK instead of an unsigned one.

## Fix

Remove the debug fallback. Set `signingConfig` **only** when complete release signing material is present; otherwise leave the release build type's `signingConfig` unset so AGP emits an unsigned release APK:

```gradle
release {
    if (hasReleaseSigning) {
        signingConfig = signingConfigs.release
    }
}
```

The `signingConfigs { ... }` block already defines `release` only when `hasReleaseSigning` is true, so referencing `signingConfigs.release` solely inside the matching guard is safe. The `release` build type has no default signing config in AGP, so an unset config yields an unsigned APK.

## Behavior

- ✅ **F-Droid** (no signing material) → **unsigned** release APK that F-Droid signs itself.
- ✅ **GitHub CI / local** with proper secrets or `key.properties` → still **release-signed**.
- ✅ `versionCode` / `versionName` unchanged.
- ✅ No app runtime behavior change.
- ✅ Only `android/app/build.gradle` touched.

Also updated the header comment, the build-time `logger.lifecycle` line, and the comment above the `release` build type so they no longer claim release builds fall back to the debug key.

## Note for reviewers (not changed here)

`docs/release-signing.md` §1 still states the old behavior ("Otherwise the build falls back to the **debug** key"). I left it untouched to keep this PR scoped to the build file as requested; it may warrant a quick follow-up to stay consistent with the code.

https://claude.ai/code/session_01QNQRHuDEooGyeXZ1C3QPTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNQRHuDEooGyeXZ1C3QPTi)_