### PR TITLE
docs(site): add website pages for linthra.ca — privacy page + downloads

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+linthra.ca

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@
     <section class="hero" id="top">
       <div class="container hero-inner">
         <img class="hero-logo" src="assets/linthra-icon.svg" alt="Linthra logo" width="104" height="104" />
-        <p class="eyebrow">Open source · Android · Self-hosted</p>
+        <p class="eyebrow">Open source · Android · Built in Canada 🇨🇦</p>
         <h1 class="hero-title">Linthra</h1>
         <p class="tagline">Open-source music player for local and self-hosted music.</p>
         <p class="hero-desc">
@@ -67,17 +67,19 @@
           </a>
         </div>
 
-        <div class="cta-row cta-row-soon" aria-label="Coming soon">
+        <div class="cta-row cta-row-soon" aria-label="More ways to get Linthra">
+          <a class="chip chip-link" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
           <span class="chip" aria-disabled="true">Google&nbsp;Play <em>testing soon</em></span>
-          <span class="chip" aria-disabled="true">F-Droid <em>coming soon</em></span>
-          <a class="chip chip-link" href="https://github.com/TheZupZup/Linthra/blob/main/PRIVACY.md" rel="noopener">Privacy&nbsp;Policy</a>
+          <a class="chip chip-link" href="privacy.html">Privacy&nbsp;Policy</a>
         </div>
 
         <p class="alpha-note">
           <span class="badge-alpha">Early alpha</span>
-          Usable for testing today and sideloadable from
+          Usable for testing today — install from
+          <a href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
+          or sideload from
           <a href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">GitHub Releases</a>.
-          Not on Google Play or F-Droid yet.
+          Not on Google Play yet.
         </p>
       </div>
     </section>
@@ -212,13 +214,18 @@
       <div class="container narrow">
         <h2 id="get-title" class="section-title">Get Linthra</h2>
         <p class="section-lead">
-          Linthra is early alpha. It’s distributed for testing as a sideloadable
-          APK from GitHub Releases — it isn’t on Google Play or F-Droid yet.
+          Linthra is early alpha but usable for testing today. Install it from
+          F-Droid, grab an APK from GitHub Releases, or get it on AndroidFreeware.
           <a href="https://github.com/ImranR98/Obtainium" rel="noopener">Obtainium</a>
-          can install it straight from GitHub Releases and keep it updated.
+          can install straight from GitHub Releases and keep it updated.
         </p>
         <div class="cta-row center">
-          <a class="btn btn-primary" href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">Download from GitHub Releases</a>
+          <a class="btn btn-primary" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">Get it on F-Droid</a>
+          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">GitHub Releases</a>
+        </div>
+        <div class="cta-row center">
+          <!-- Direct universal signed APK from the latest GitHub Release; bump the version on each release. -->
+          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases/download/v0.1.5/linthra-v0.1.5-release-signed.apk" rel="noopener">Download APK (v0.1.5)</a>
           <a class="btn btn-secondary" href="https://www.androidfreeware.net/" rel="noopener">AndroidFreeware</a>
         </div>
         <div class="store-grid">
@@ -226,11 +233,12 @@
             <strong>Google Play</strong>
             <span>Testing track — coming soon</span>
           </span>
-          <span class="store-item" aria-disabled="true">
-            <strong>F-Droid</strong>
-            <span>Preparation underway — coming soon</span>
-          </span>
         </div>
+        <p class="muted-note">
+          Looking for older builds? See
+          <a href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">previous versions &amp; changelog</a>
+          on GitHub.
+        </p>
       </div>
     </section>
 
@@ -244,7 +252,7 @@
           configure and to your own local files.
         </p>
         <p class="center">
-          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/blob/main/PRIVACY.md" rel="noopener">Read the Privacy Policy</a>
+          <a class="btn btn-secondary" href="privacy.html">Read the Privacy Policy</a>
         </p>
       </div>
     </section>
@@ -258,10 +266,12 @@
       </div>
       <nav class="footer-links" aria-label="Footer">
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub repository</a>
-        <a href="https://github.com/TheZupZup/Linthra/blob/main/PRIVACY.md" rel="noopener">Privacy Policy</a>
+        <a href="#get">Download</a>
+        <a href="https://www.androidfreeware.net/" rel="noopener">AndroidFreeware</a>
+        <a href="privacy.html">Privacy Policy</a>
         <a href="https://github.com/TheZupZup/Linthra/blob/main/LICENSE" rel="noopener">License (MPL-2.0)</a>
       </nav>
-      <p class="footer-credit">Built by <a href="https://github.com/TheZupZup" rel="noopener">TheZupZup</a></p>
+      <p class="footer-credit">Built by <a href="https://github.com/TheZupZup" rel="noopener">TheZupZup</a> in Canada. 🇨🇦</p>
     </div>
   </footer>
 </body>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy — Linthra</title>
+  <meta name="description" content="Linthra's privacy policy. Linthra has no ads, no trackers, no analytics, and does not sell user data. Your music and server connections stay on your device and under your control." />
+  <meta name="theme-color" content="#111018" />
+  <meta name="color-scheme" content="dark" />
+
+  <link rel="icon" type="image/svg+xml" href="assets/linthra-icon.svg" />
+  <link rel="apple-touch-icon" href="assets/icon-512.png" />
+
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="brand" href="index.html" aria-label="Linthra home">
+        <img class="brand-mark" src="assets/linthra-icon.svg" alt="" width="32" height="32" />
+        <span class="brand-name">Linthra</span>
+      </a>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#features">Features</a>
+        <a href="index.html#screenshots">Screenshots</a>
+        <a href="index.html#get">Get it</a>
+        <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="section legal">
+      <div class="container narrow">
+        <h1 class="section-title legal-title">Privacy Policy</h1>
+        <p class="legal-updated">Last updated: 2026-06-14</p>
+
+        <div class="legal-body">
+          <p>
+            Linthra is an open-source Android music player focused on local music
+            and user-controlled self-hosted music libraries.
+          </p>
+          <p>
+            This policy explains what information Linthra handles, where it is
+            stored, and how it is used.
+          </p>
+          <p>
+            In short: <strong>Linthra has no ads, no trackers, no analytics, and
+            does not sell user data.</strong>
+          </p>
+
+          <div class="legal-callout">
+            <ul role="list">
+              <li>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5-9 2.5 2.5 5-5"/></svg>
+                Linthra does not sell user data.
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5-9 2.5 2.5 5-5"/></svg>
+                Linthra does not include ads.
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5-9 2.5 2.5 5-5"/></svg>
+                Linthra does not use third-party advertising trackers.
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5-9 2.5 2.5 5-5"/></svg>
+                Linthra does not operate a cloud account system for users.
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5-9 2.5 2.5 5-5"/></svg>
+                Linthra does not send personal data to TheZupZup or to a Linthra-owned server.
+              </li>
+              <li>
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm-3.5-9 2.5 2.5 5-5"/></svg>
+                Server connections such as Jellyfin, Plex, and Subsonic/Navidrome are optional and are configured by the user.
+              </li>
+            </ul>
+          </div>
+
+          <h2>Data handled by the app</h2>
+          <p>
+            Depending on how the user chooses to use Linthra, the app may handle
+            the following data on the user's device:
+          </p>
+          <ul>
+            <li>Local music file information, such as song titles, album names, artists, duration, and artwork references.</li>
+            <li>Playback state, queue information, favorites, playlists, and play history.</li>
+            <li>Self-hosted server settings, such as server URL, selected library, and connection state.</li>
+            <li>Authentication tokens or session details for user-configured music services such as Jellyfin, Plex, or Subsonic/Navidrome.</li>
+            <li>Diagnostic information generated locally when the user chooses to report a problem.</li>
+          </ul>
+
+          <h2>Local music</h2>
+          <p>
+            When the user grants access to local music files or folders, Linthra
+            reads those files to build and display the music library. Local files
+            remain on the user's device unless the user explicitly uses a feature
+            that connects to their own server or exports information.
+          </p>
+
+          <h2>Self-hosted and third-party music servers</h2>
+          <p>
+            Linthra can connect to user-configured music services, including
+            Jellyfin, Plex, and Subsonic/Navidrome-compatible servers.
+          </p>
+          <p>
+            When the user connects one of these services, Linthra may send
+            requests to that server to browse libraries, stream music, display
+            artwork, and report playback state where supported by the server.
+          </p>
+          <p>
+            These connections are between the user's device and the server or
+            service configured by the user. Linthra does not operate those
+            servers. The privacy practices of those services are governed by the
+            user's server configuration and the policies of the service provider.
+          </p>
+
+          <h2>Authentication and tokens</h2>
+          <p>
+            Authentication tokens and session information are stored locally on
+            the user's device. Linthra uses them only to connect to the music
+            servers configured by the user.
+          </p>
+          <p>
+            Linthra is designed to avoid storing tokenized stream URLs in
+            long-term storage, logs, diagnostics, or cache metadata.
+          </p>
+
+          <h2>Data sharing</h2>
+          <p>
+            Linthra does not sell or share user data with advertisers or data
+            brokers.
+          </p>
+          <p>
+            Linthra may communicate with user-configured music servers only when
+            needed for app functionality, such as signing in, browsing a library,
+            streaming tracks, fetching artwork, syncing metadata, or reporting
+            playback state.
+          </p>
+
+          <h2>Data storage and deletion</h2>
+          <p>
+            Most Linthra data is stored locally on the user's device. The user can
+            remove app data by using Android system settings to clear Linthra's
+            storage or uninstall the app.
+          </p>
+          <p>
+            When a user disconnects a music service inside Linthra, the related
+            local session information is removed or made inactive according to the
+            app's current implementation.
+          </p>
+
+          <h2>Network security</h2>
+          <p>
+            Linthra supports connections to user-provided server URLs. Users are
+            encouraged to use HTTPS whenever possible. If a user configures a
+            server using an unencrypted HTTP connection, data sent to that server
+            may not be encrypted in transit.
+          </p>
+
+          <h2>Children</h2>
+          <p>
+            Linthra is not designed specifically for children. The app is intended
+            for users who manage their own music library or self-hosted music
+            services.
+          </p>
+
+          <h2>Open source</h2>
+          <p>
+            Linthra is open-source. Its source code is available at:
+            <a href="https://github.com/TheZupZup/Linthra" rel="noopener">https://github.com/TheZupZup/Linthra</a>
+          </p>
+
+          <h2>Contact</h2>
+          <p>
+            For privacy questions or support, contact:
+            <a href="mailto:thezupzup@gmail.com">thezupzup@gmail.com</a>
+          </p>
+
+          <a class="legal-back" href="index.html">&larr; Back to home</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <img class="brand-mark" src="assets/linthra-icon.svg" alt="" width="28" height="28" />
+        <span>Linthra</span>
+      </div>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub repository</a>
+        <a href="index.html#get">Download</a>
+        <a href="https://www.androidfreeware.net/" rel="noopener">AndroidFreeware</a>
+        <a href="privacy.html">Privacy Policy</a>
+        <a href="https://github.com/TheZupZup/Linthra/blob/main/LICENSE" rel="noopener">License (MPL-2.0)</a>
+      </nav>
+      <p class="footer-credit">Built by <a href="https://github.com/TheZupZup" rel="noopener">TheZupZup</a> in Canada. &#127464;&#127462;</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -452,3 +452,70 @@ h1, h2, h3 { line-height: 1.2; margin: 0; }
 .footer-links a { color: var(--muted); font-size: 0.92rem; }
 .footer-links a:hover { color: var(--text); }
 .footer-credit { margin: 0; color: var(--muted); font-size: 0.92rem; }
+
+/* ---------- Legal / privacy page ---------- */
+.legal { padding: 56px 0 72px; }
+.legal-title { text-align: center; }
+.legal-updated {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 10px 0 0;
+}
+.legal-body {
+  margin-top: 34px;
+  color: #D4CFE4;
+  font-size: 1rem;
+}
+.legal-body h2 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 34px 0 12px;
+}
+.legal-body p { margin: 0 0 14px; }
+.legal-body ul { margin: 0 0 16px; padding-left: 1.25em; }
+.legal-body li { margin: 7px 0; }
+.legal-body a { color: var(--purple-bright); }
+
+/* Privacy highlight callout */
+.legal-callout {
+  margin: 28px 0 6px;
+  padding: 22px;
+  border-radius: var(--radius);
+  background:
+    radial-gradient(90% 130% at 0% 0%, rgba(124, 92, 255, 0.12), transparent 70%),
+    var(--surface);
+  border: 1px solid var(--border-strong);
+}
+.legal-callout ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+.legal-callout li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin: 0;
+  color: var(--text);
+  font-weight: 500;
+}
+.legal-callout svg {
+  width: 20px;
+  height: 20px;
+  margin-top: 2px;
+  flex: none;
+  color: var(--purple-bright);
+}
+.legal-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 32px;
+  font-weight: 600;
+}


### PR DESCRIPTION
## What this adds

Completes the static GitHub Pages site (`docs/`) so it can be served standalone at **linthra.ca**, building on the landing page already on `main` (#199).

**1 commit · 4 files · docs-only · +301 / −17**, based on current `main` (`4115e61`):

- **`docs/CNAME`** — `linthra.ca`, the GitHub Pages custom domain.
- **`docs/privacy.html`** *(new)* — a styled privacy page that mirrors `PRIVACY.md`, with a callout making clear Linthra has **no ads, no trackers, no analytics, and does not sell user data**. The homepage privacy links now point here.
- **`docs/index.html`** — expanded **download section** + footer/Canada polish (below).
- **`docs/styles.css`** — a small `.legal` / `.legal-callout` block for the privacy page (same dark theme + brand tokens).

## Download section

| Channel | State | Link |
|---|---|---|
| **F-Droid** | ✅ available (live listing) | `f-droid.org/packages/io.github.thezupzup.linthra/` |
| **GitHub Releases** | ✅ | `/releases/latest` |
| **Latest APK** | ✅ direct universal signed APK | `…/releases/download/v0.1.5/linthra-v0.1.5-release-signed.apk` |
| **AndroidFreeware** | ✅ | `androidfreeware.net` |
| **Previous versions / changelog** | ✅ | `/releases` |
| **Google Play (testing)** | ⏳ coming soon | no public testing URL yet |

The hero's stale "not on F-Droid yet" note and "F-Droid coming soon" chip were corrected to reflect the live F-Droid listing.

## Checklist

- [x] Plain HTML + CSS only — **no JS**, no framework, no backend, no analytics/trackers/ads
- [x] Mobile-friendly, responsive, dark theme; brand colors `#7C5CFF` / `#FF9F43` / `#111018`
- [x] Tagline + **"Built in Canada"**; footer **"Built by TheZupZup in Canada."**
- [x] Download section: **F-Droid (available)**, GitHub Releases, latest APK, AndroidFreeware, previous-versions/changelog, Google Play (coming soon)
- [x] Features incl. **Plex shown only as "In development"**
- [x] Screenshots reuse the existing Play Store captures in `docs/assets/screenshots/`
- [x] `docs/privacy.html` from `PRIVACY.md`; no ads/trackers/analytics, no data selling
- [x] **No app / version / Plex / release changes — only `docs/` is touched**
- [x] Single website commit on top of current `main` (`4115e61`) — clean diff

## Notes for the reviewer

- **F-Droid** is presented as an available install (the listing is live, accepted at `alpha.40`), per `docs/fdroid-submission.md` and the README badge — not "coming soon".
- **Google Play** stays "coming soon": only internal/closed testing is planned and there's no public opt-in URL to link, so no button is fabricated.
- The **latest-APK** link is version-pinned (`v0.1.5`) because the site is static (no JS) and release assets embed the version. Bump it per release, or switch that button to the `/releases/latest` page if you'd prefer it never go stale.

https://claude.ai/code/session_01PhA57J2zM35KNRnjwsJfoi