### PR TITLE
docs(site): improve copywriting and add OpenAPK + direct AndroidFreeware links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
             <svg class="btn-ico" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .5A11.5 11.5 0 0 0 8.36 22.93c.57.1.78-.25.78-.55v-2c-3.2.7-3.88-1.36-3.88-1.36-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.66.79.55A11.5 11.5 0 0 0 12 .5Z"/></svg>
             View on GitHub
           </a>
-          <a class="btn btn-secondary" href="https://www.androidfreeware.net/" rel="noopener">
+          <a class="btn btn-secondary" href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">
             <svg class="btn-ico" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M5 20a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zm2.3-13.9L6 4.2a.5.5 0 0 1 .84-.55l1.36 1.96a7.97 7.97 0 0 1 7.6 0l1.36-1.96A.5.5 0 0 1 18 4.2l-1.3 1.9A8 8 0 0 1 21 13H3a8 8 0 0 1 4.3-6.9M8.5 11a1 1 0 1 0 0-2 1 1 0 0 0 0 2m7 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>
             AndroidFreeware
           </a>
@@ -215,7 +215,7 @@
         <h2 id="get-title" class="section-title">Get Linthra</h2>
         <p class="section-lead">
           Linthra is early alpha but usable for testing today. Install it from
-          F-Droid, grab an APK from GitHub Releases, or get it on AndroidFreeware.
+          F-Droid, grab an APK from GitHub Releases, or get it on AndroidFreeware or OpenAPK.
           <a href="https://github.com/ImranR98/Obtainium" rel="noopener">Obtainium</a>
           can install straight from GitHub Releases and keep it updated.
         </p>
@@ -226,7 +226,8 @@
         <div class="cta-row center">
           <!-- Direct universal signed APK from the latest GitHub Release; bump the version on each release. -->
           <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases/download/v0.1.5/linthra-v0.1.5-release-signed.apk" rel="noopener">Download APK (v0.1.5)</a>
-          <a class="btn btn-secondary" href="https://www.androidfreeware.net/" rel="noopener">AndroidFreeware</a>
+          <a class="btn btn-secondary" href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware</a>
+          <a class="btn btn-secondary" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
         </div>
         <div class="store-grid">
           <span class="store-item" aria-disabled="true">
@@ -267,7 +268,8 @@
       <nav class="footer-links" aria-label="Footer">
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub repository</a>
         <a href="#get">Download</a>
-        <a href="https://www.androidfreeware.net/" rel="noopener">AndroidFreeware</a>
+        <a href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware</a>
+        <a href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="https://github.com/TheZupZup/Linthra/blob/main/LICENSE" rel="noopener">License (MPL-2.0)</a>
       </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Linthra — Open-source music player for local &amp; self-hosted music</title>
+  <title>Linthra · Open-source music player for local &amp; self-hosted music</title>
   <meta name="description" content="Linthra is an open-source Android music player for local libraries and self-hosted music servers like Jellyfin and Navidrome/Subsonic. No ads, no tracking, no account." />
   <meta name="theme-color" content="#111018" />
   <meta name="color-scheme" content="dark" />
@@ -14,11 +14,11 @@
 
   <!-- Open Graph / social -->
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Linthra — Open-source music player for local &amp; self-hosted music" />
+  <meta property="og:title" content="Linthra · Open-source music player for local &amp; self-hosted music" />
   <meta property="og:description" content="An open-source Android music player for local libraries and self-hosted music servers like Jellyfin and Navidrome/Subsonic. No ads, no tracking, no account." />
   <meta property="og:image" content="assets/feature-graphic.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Linthra — Open-source music player for local &amp; self-hosted music" />
+  <meta name="twitter:title" content="Linthra · Open-source music player for local &amp; self-hosted music" />
   <meta name="twitter:description" content="An open-source Android music player for local libraries and self-hosted music servers. No ads, no tracking, no account." />
   <meta name="twitter:image" content="assets/feature-graphic.png" />
 
@@ -49,11 +49,11 @@
         <img class="hero-logo" src="assets/linthra-icon.svg" alt="Linthra logo" width="104" height="104" />
         <p class="eyebrow">Open source · Android · Built in Canada 🇨🇦</p>
         <h1 class="hero-title">Linthra</h1>
-        <p class="tagline">Open-source music player for local and self-hosted music.</p>
+        <p class="tagline">Built for local and self-hosted music.</p>
         <p class="hero-desc">
-          Linthra is an Android music player for the music you actually own — local
-          files on your device and your own self-hosted music servers like Jellyfin
-          and Navidrome / Subsonic. No ads, no tracking, no account, nothing phoning home.
+          Linthra plays the music you keep yourself: local files on your phone, or
+          your own Jellyfin and Navidrome / Subsonic server. It streams straight from
+          the source, with no ads and no account to sign up for.
         </p>
 
         <div class="cta-row">
@@ -75,9 +75,9 @@
 
         <p class="alpha-note">
           <span class="badge-alpha">Early alpha</span>
-          Usable for testing today — install from
+          but usable for testing today. Install from
           <a href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
-          or sideload from
+          or sideload the APK from
           <a href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">GitHub Releases</a>.
           Not on Google Play yet.
         </p>
@@ -89,11 +89,11 @@
       <div class="container narrow">
         <h2 id="about-title" class="section-title">Your music, your server</h2>
         <p class="section-lead">
-          Point Linthra at a folder of local files or your own Jellyfin /
+          Point Linthra at a folder of local files, or at your own Jellyfin /
           Navidrome / Subsonic server, and it plays from there. Streaming is the
-          default — nothing downloads unless you ask. Browsing stays fast because
-          the app reads from a local catalog rather than the network, and nothing
-          phones home: no telemetry, no ads, no account.
+          default, so nothing downloads until you ask for it. Browsing stays quick
+          because the app reads from a catalog it keeps on the device, instead of
+          hitting the network on every tap.
         </p>
       </div>
     </section>
@@ -108,21 +108,21 @@
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M9 18V6l10-2v12M9 18a3 3 0 1 1-3-3 3 3 0 0 1 3 3m10-2a3 3 0 1 1-3-3 3 3 0 0 1 3 3"/></svg>
             </span>
             <h3>Local music playback</h3>
-            <p>Pick a folder (Storage Access Framework — no broad storage permission), scan it, and browse Songs, Albums &amp; Artists with search.</p>
+            <p>Pick a folder, scan it, and browse Songs, Albums &amp; Artists with search. It uses the Storage Access Framework, so it never asks for broad storage access.</p>
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 5a8 4 0 0 0 16 0a8 4 0 0 0-16 0v14a8 4 0 0 0 16 0V5M4 12a8 4 0 0 0 16 0"/></svg>
             </span>
             <h3>Jellyfin support</h3>
-            <p>Connect your own Jellyfin server: test, sign in, sync, stream, cache and cast — including over HTTPS. Playlists &amp; favourites sync where supported.</p>
+            <p>Connect your own Jellyfin server, sign in, and sync the library, then stream, cache and cast from it. Works over HTTPS. Playlists &amp; favourites sync where the server supports it.</p>
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M3 6h18v5H3zM3 13h18v5H3M7 8.5h.01M7 15.5h.01"/></svg>
             </span>
             <h3>Subsonic / Navidrome</h3>
-            <p>Subsonic-compatible streaming, caching and casting from your own Navidrome or Subsonic server. Bring your own server and account.</p>
+            <p>Stream, cache and cast from your own Navidrome server, or any Subsonic-compatible one. You bring the server and the account.</p>
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
@@ -136,7 +136,7 @@
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M12 3v12m0 0 4-4m-4 4-4-4M5 17v2a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-2"/></svg>
             </span>
             <h3>Offline cache</h3>
-            <p>Download the tracks you want for offline play, with a size limit and a “Keep offline” pin. Wi-Fi only by default — downloads are always user-initiated.</p>
+            <p>Download the tracks you want for offline play, with a size limit and a “Keep offline” pin. It only downloads when you ask, and stays on Wi-Fi unless you allow mobile data.</p>
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
@@ -157,7 +157,7 @@
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M8 9l-4 3 4 3m8-6 4 3-4 3m-3-9-2 12"/></svg>
             </span>
             <h3>Open source</h3>
-            <p>Built with Flutter and licensed under MPL-2.0 — anyone can read, build and contribute. Bug reports are built on-device and never auto-sent.</p>
+            <p>Built with Flutter and licensed under MPL-2.0, so anyone can read the code, build it, and send a patch. Bug reports are assembled on your device and never sent automatically.</p>
           </li>
           <li class="card card-soon">
             <span class="card-badge">In development</span>
@@ -165,11 +165,11 @@
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 7h16v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1zM4 7l2-3h12l2 3M10 12h4"/></svg>
             </span>
             <h3>Plex support</h3>
-            <p>Read-only support for your own Plex Media Server is being designed and built in small, reviewable steps. Not shipped yet — it’s coming.</p>
+            <p>Read-only support for your own Plex Media Server is in progress, built in small steps that are easy to review. It hasn’t shipped yet.</p>
           </li>
         </ul>
         <p class="muted-note">
-          Linthra is an unofficial community client — it is not affiliated with
+          Linthra is an unofficial, independent client. It isn’t affiliated with
           Jellyfin, Navidrome, Subsonic or Plex.
         </p>
       </div>
@@ -231,7 +231,7 @@
         <div class="store-grid">
           <span class="store-item" aria-disabled="true">
             <strong>Google Play</strong>
-            <span>Testing track — coming soon</span>
+            <span>Testing track, coming soon</span>
           </span>
         </div>
         <p class="muted-note">
@@ -248,7 +248,7 @@
         <h2 id="privacy-title" class="section-title">Privacy first</h2>
         <p class="section-lead">
           No ads. No trackers. No analytics or telemetry SDK. No account, and no
-          Linthra server — the app talks only to the music sources <strong>you</strong>
+          Linthra server. The app talks only to the music sources <strong>you</strong>
           configure and to your own local files.
         </p>
         <p class="center">

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Privacy Policy — Linthra</title>
+  <title>Privacy Policy · Linthra</title>
   <meta name="description" content="Linthra's privacy policy. Linthra has no ads, no trackers, no analytics, and does not sell user data. Your music and server connections stay on your device and under your control." />
   <meta name="theme-color" content="#111018" />
   <meta name="color-scheme" content="dark" />

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -195,7 +195,8 @@
       <nav class="footer-links" aria-label="Footer">
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub repository</a>
         <a href="index.html#get">Download</a>
-        <a href="https://www.androidfreeware.net/" rel="noopener">AndroidFreeware</a>
+        <a href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware</a>
+        <a href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
         <a href="privacy.html">Privacy Policy</a>
         <a href="https://github.com/TheZupZup/Linthra/blob/main/LICENSE" rel="noopener">License (MPL-2.0)</a>
       </nav>


### PR DESCRIPTION
Docs-only pass over the website (`docs/index.html`, `docs/privacy.html`). No layout, design, colour, asset, or screenshot changes.

## 1. Copywriting

Reword the site to read more like an independent open-source project and less like generated SaaS marketing.

- **Hero** — new tagline (`Built for local and self-hosted music.`) and a rewritten description.
- **Early-alpha note** and **About lead** — reworded.
- **Feature cards** — clearer wording for Local music, Jellyfin, Subsonic/Navidrome, Offline cache, Open source, and the unaffiliated-client disclaimer.
- **Plex** — kept clearly marked **In development** ("It hasn't shipped yet").
- **Em dashes** reduced across both pages (the two inside the Screenshots section left as-is). Page/social titles use a middot instead.
- Kept by request: the **"Privacy first"** heading and the **"Privacy-friendly"** feature title.

## 2. Download sources

- **AndroidFreeware** links now point at the dedicated page (`/download-linthra-apk.html`) instead of the site root — in the hero, the download section, and both footers.
- **OpenAPK** added as a download/discovery source: a button in the download section, a link in both footers, and a mention in the download intro.

Unchanged: F-Droid, GitHub Releases, the direct APK download (v0.1.5), and the Google Play testing notice.

https://claude.ai/code/session_01TS5Eor6Ge6DDWoLwmkrmwC