### PR TITLE
docs(site): add OpenAPK to hero download links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -69,6 +69,7 @@
 
         <div class="cta-row cta-row-soon" aria-label="More ways to get Linthra">
           <a class="chip chip-link" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
+          <a class="chip chip-link" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
           <span class="chip" aria-disabled="true">Google&nbsp;Play <em>testing soon</em></span>
           <a class="chip chip-link" href="privacy.html">Privacy&nbsp;Policy</a>
         </div>


### PR DESCRIPTION
## What & why

PR #201 added OpenAPK to the **"Get Linthra"** section and the footer, but the **hero** CTA still only listed GitHub, AndroidFreeware, F-Droid, Google Play, and Privacy Policy. This makes the hero consistent with the rest of the page by surfacing OpenAPK there too.

## Change

Add a single OpenAPK link to the hero's "More ways to get Linthra" row, right beside the existing F-Droid link:

```html
<a class="chip chip-link" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
```

It reuses the existing `chip chip-link` style (identical to the F-Droid chip), so the two live alternate stores (F-Droid, OpenAPK) now sit together ahead of the not-yet-available Google Play, with Privacy Policy last.

## Scope / guarantees

- **Docs-only:** one line added to `docs/index.html` (`1 file changed, 1 insertion(+)`).
- Keeps GitHub, AndroidFreeware, F-Droid, Google Play, and Privacy Policy.
- No redesign; reuses an existing component — no new CSS, no new assets.
- No color, screenshot, or asset changes.
- No app code changes; no `versionCode`/`versionName` changes; no release.

OpenAPK URL: `https://www.openapk.net/linthra/io.github.thezupzup.linthra/`

https://claude.ai/code/session_01CBfGSS76z9Cc66vA1CEm8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBfGSS76z9Cc66vA1CEm8Y)_