### PR TITLE
docs(site): add sitemap.xml and robots.txt for SEO indexing

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://linthra.ca/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://linthra.ca/</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://linthra.ca/privacy.html</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

Small, docs-only change to improve SEO indexing for **linthra.ca**. Adds two static files to the GitHub Pages source (`docs/`):

- **`docs/robots.txt`** — allows crawling and points crawlers to the sitemap.
- **`docs/sitemap.xml`** — a standard [XML sitemap](https://www.sitemaps.org/protocol.html) listing the homepage and privacy page.

Because `docs/` is the Pages root (with `CNAME` → `linthra.ca`), these are served at:
- `https://linthra.ca/robots.txt`
- `https://linthra.ca/sitemap.xml`

## Contents

`robots.txt`:
```
User-agent: *
Allow: /
Sitemap: https://linthra.ca/sitemap.xml
```

`sitemap.xml` URLs:
- `https://linthra.ca/`
- `https://linthra.ca/privacy.html`

`lastmod` dates reflect the last commit dates of `index.html` / `privacy.html`. The XML was validated as well-formed.

## Constraints honored

- ✅ No analytics
- ✅ No trackers
- ✅ No JavaScript
- ✅ No app code changes — only two new static files under `docs/`

https://claude.ai/code/session_01ShYdmPbpNFXuvuVqVyUQQK

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShYdmPbpNFXuvuVqVyUQQK)_