### PR TITLE
feat(shared): add reusable unified sync status component

### DIFF
--- a/lib/shared/widgets/sync_status_view.dart
+++ b/lib/shared/widgets/sync_status_view.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/material.dart';
+
+import '../../app/dimens.dart';
+
+/// Where a music source's library sync is in its lifecycle, unified across every
+/// provider so the UI can present one consistent status regardless of which
+/// backend produced it.
+///
+/// Each provider (Navidrome/Subsonic, Jellyfin, …) tracks its own sync in its
+/// own controller; this small, display-only vocabulary is what they map into so
+/// [SyncStatusView] can render them all identically.
+enum SyncState {
+  /// A sync is running right now.
+  syncing,
+
+  /// The last sync finished successfully.
+  synced,
+
+  /// The last sync attempt failed.
+  failed,
+
+  /// This source has never been synced (a fresh connection).
+  neverSynced,
+
+  /// The device is offline, so a sync can't run.
+  offline,
+}
+
+/// An immutable, display-safe snapshot of a source's sync status.
+///
+/// It carries only what the UI shows — the [state], when the last *successful*
+/// sync landed ([lastSyncedAt]), and a friendly [lastError] for a failure. Like
+/// the per-provider state objects it unifies, it never holds a token, password,
+/// or streaming URL.
+@immutable
+class SyncStatusData {
+  const SyncStatusData({
+    required this.state,
+    this.lastSyncedAt,
+    this.lastError,
+  });
+
+  /// A source that has never been synced (no time, no error).
+  const SyncStatusData.neverSynced() : this(state: SyncState.neverSynced);
+
+  /// A sync in progress; [lastSyncedAt] is the previous success, if any.
+  const SyncStatusData.syncing({DateTime? lastSyncedAt})
+      : this(state: SyncState.syncing, lastSyncedAt: lastSyncedAt);
+
+  /// A sync that completed successfully at [lastSyncedAt].
+  const SyncStatusData.synced(DateTime lastSyncedAt)
+      : this(state: SyncState.synced, lastSyncedAt: lastSyncedAt);
+
+  /// A failed sync, optionally with a friendly [error] and the previous success
+  /// time ([lastSyncedAt]) so the UI can still say when it last worked.
+  const SyncStatusData.failed({String? error, DateTime? lastSyncedAt})
+      : this(
+          state: SyncState.failed,
+          lastError: error,
+          lastSyncedAt: lastSyncedAt,
+        );
+
+  /// Offline, with the previous success time ([lastSyncedAt]) if known.
+  const SyncStatusData.offline({DateTime? lastSyncedAt})
+      : this(state: SyncState.offline, lastSyncedAt: lastSyncedAt);
+
+  final SyncState state;
+
+  /// When the last *successful* sync completed, or null if it never has.
+  final DateTime? lastSyncedAt;
+
+  /// A friendly, secret-free reason the last sync failed — shown only when
+  /// [state] is [SyncState.failed] and one is available.
+  final String? lastError;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SyncStatusData &&
+      other.state == state &&
+      other.lastSyncedAt == lastSyncedAt &&
+      other.lastError == lastError;
+
+  @override
+  int get hashCode => Object.hash(state, lastSyncedAt, lastError);
+}
+
+/// Formats how long ago [time] was, in the short, friendly style the sync
+/// status uses ("just now", "2 minutes ago", "yesterday", "3 days ago").
+///
+/// [now] is injectable so the relative phrasing is deterministic in tests; it
+/// defaults to the wall clock. A [time] in the (near) future — clock skew, or a
+/// just-stamped value — clamps to "just now" rather than reading as negative.
+String syncTimeAgo(DateTime time, {DateTime? now}) {
+  final DateTime reference = now ?? DateTime.now();
+  final Duration diff = reference.difference(time);
+
+  if (diff.inSeconds < 45) return 'just now';
+  if (diff.inMinutes < 60) {
+    final int minutes = diff.inMinutes < 1 ? 1 : diff.inMinutes;
+    return minutes == 1 ? '1 minute ago' : '$minutes minutes ago';
+  }
+  if (diff.inHours < 24) {
+    final int hours = diff.inHours;
+    return hours == 1 ? '1 hour ago' : '$hours hours ago';
+  }
+  if (diff.inDays == 1) return 'yesterday';
+  if (diff.inDays < 7) return '${diff.inDays} days ago';
+  if (diff.inDays < 30) {
+    final int weeks = (diff.inDays / 7).floor();
+    return weeks == 1 ? '1 week ago' : '$weeks weeks ago';
+  }
+  if (diff.inDays < 365) {
+    final int months = (diff.inDays / 30).floor();
+    return months == 1 ? '1 month ago' : '$months months ago';
+  }
+  final int years = (diff.inDays / 365).floor();
+  return years == 1 ? '1 year ago' : '$years years ago';
+}
+
+/// A reusable, Material 3 sync-status block that makes a source's sync state
+/// obvious at a glance — identically for every provider.
+///
+/// It renders, straight from a [SyncStatusData]:
+///   * a status line — "Syncing…", "Synced 2 minutes ago", "Last sync failed",
+///     "Never synced", or "Offline" — with a matching icon and colour;
+///   * the last *successful* sync time (in the line for [SyncState.synced], or
+///     as a quiet "Last synced …" sub-line once a later attempt fails / goes
+///     offline);
+///   * the last error, when a failure carries one; and
+///   * an [onSync] button (a spinner labelled "Syncing…" while a sync runs).
+///
+/// Drop it into any provider's settings card; the provider only has to map its
+/// own sync state into a [SyncStatusData]. For example:
+///
+/// ```dart
+/// SyncStatusView(
+///   status: SyncStatusData.synced(lastSyncedAt),
+///   syncLabel: 'Sync library',
+///   onSync: controller.sync,
+/// )
+/// ```
+class SyncStatusView extends StatelessWidget {
+  const SyncStatusView({
+    required this.status,
+    this.onSync,
+    this.syncLabel = 'Sync now',
+    this.now,
+    super.key,
+  });
+
+  /// The status to render.
+  final SyncStatusData status;
+
+  /// Invoked when the sync button is tapped. When null, no button is shown; the
+  /// button is always disabled while a sync is already running.
+  final VoidCallback? onSync;
+
+  /// The idle sync button label (e.g. "Sync library"). While a sync runs the
+  /// button always reads "Syncing…".
+  final String syncLabel;
+
+  /// Injectable clock for the relative "… ago" phrasing; defaults to the wall
+  /// clock. Exists so widget tests can render a deterministic time.
+  final DateTime? now;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool syncing = status.state == SyncState.syncing;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _statusLine(theme),
+        if (onSync != null) ...[
+          const SizedBox(height: AppSpacing.md),
+          FilledButton.tonalIcon(
+            onPressed: syncing ? null : onSync,
+            icon: syncing
+                ? const SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.sync_outlined),
+            label: Text(syncing ? 'Syncing…' : syncLabel),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _statusLine(ThemeData theme) {
+    final Color color = _color(theme);
+    final String? subline = _subline();
+    final bool showError = status.state == SyncState.failed &&
+        status.lastError != null &&
+        status.lastError!.isNotEmpty;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // The icon/spinner only mirrors the text line, so keep it out of the
+        // semantics tree — the headline and sub-lines already read the state.
+        ExcludeSemantics(child: _leading(theme, color)),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                _headline(),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              if (subline != null) ...[
+                const SizedBox(height: 2),
+                Text(
+                  subline,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+              if (showError) ...[
+                const SizedBox(height: 2),
+                Text(
+                  status.lastError!,
+                  style: theme.textTheme.bodySmall?.copyWith(color: color),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _leading(ThemeData theme, Color color) {
+    if (status.state == SyncState.syncing) {
+      return const SizedBox.square(
+        dimension: 20,
+        child: Padding(
+          padding: EdgeInsets.all(1),
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return Icon(_icon(), size: 20, color: color);
+  }
+
+  String _headline() {
+    switch (status.state) {
+      case SyncState.syncing:
+        return 'Syncing…';
+      case SyncState.synced:
+        final DateTime? at = status.lastSyncedAt;
+        return at == null ? 'Synced' : 'Synced ${syncTimeAgo(at, now: now)}';
+      case SyncState.failed:
+        return 'Last sync failed';
+      case SyncState.neverSynced:
+        return 'Never synced';
+      case SyncState.offline:
+        return 'Offline';
+    }
+  }
+
+  /// A quiet "Last synced …" line for states whose headline isn't already the
+  /// time but that have synced successfully before (a later failure, or going
+  /// offline). [SyncState.synced] shows the time in its headline instead.
+  String? _subline() {
+    final DateTime? at = status.lastSyncedAt;
+    if (at == null) return null;
+    if (status.state == SyncState.failed || status.state == SyncState.offline) {
+      return 'Last synced ${syncTimeAgo(at, now: now)}';
+    }
+    return null;
+  }
+
+  IconData _icon() {
+    switch (status.state) {
+      // A spinner stands in for syncing (see [_leading]); this keeps the switch
+      // exhaustive and is otherwise unused.
+      case SyncState.syncing:
+        return Icons.sync_outlined;
+      case SyncState.synced:
+        return Icons.cloud_done_outlined;
+      case SyncState.failed:
+        return Icons.error_outline;
+      case SyncState.neverSynced:
+        return Icons.cloud_outlined;
+      case SyncState.offline:
+        return Icons.cloud_off_outlined;
+    }
+  }
+
+  Color _color(ThemeData theme) {
+    switch (status.state) {
+      case SyncState.syncing:
+      case SyncState.synced:
+        return theme.colorScheme.primary;
+      case SyncState.failed:
+        return theme.colorScheme.error;
+      case SyncState.neverSynced:
+      case SyncState.offline:
+        return theme.colorScheme.onSurfaceVariant;
+    }
+  }
+}

--- a/test/shared/widgets/sync_status_view_test.dart
+++ b/test/shared/widgets/sync_status_view_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/sync_status_view.dart';
+
+void main() {
+  group('syncTimeAgo', () {
+    final DateTime now = DateTime(2026, 6, 15, 12);
+
+    test('reads "just now" under three-quarters of a minute', () {
+      expect(syncTimeAgo(now, now: now), 'just now');
+      expect(
+        syncTimeAgo(now.subtract(const Duration(seconds: 44)), now: now),
+        'just now',
+      );
+    });
+
+    test('rounds the first minute up to "1 minute ago"', () {
+      expect(
+        syncTimeAgo(now.subtract(const Duration(seconds: 45)), now: now),
+        '1 minute ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(seconds: 90)), now: now),
+        '1 minute ago',
+      );
+    });
+
+    test('pluralises minutes and hours', () {
+      expect(
+        syncTimeAgo(now.subtract(const Duration(minutes: 2)), now: now),
+        '2 minutes ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(minutes: 59)), now: now),
+        '59 minutes ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(hours: 1)), now: now),
+        '1 hour ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(hours: 5)), now: now),
+        '5 hours ago',
+      );
+    });
+
+    test('says "yesterday" for a day, then counts days/weeks/months/years', () {
+      expect(
+        syncTimeAgo(now.subtract(const Duration(hours: 24)), now: now),
+        'yesterday',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(days: 3)), now: now),
+        '3 days ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(days: 14)), now: now),
+        '2 weeks ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(days: 60)), now: now),
+        '2 months ago',
+      );
+      expect(
+        syncTimeAgo(now.subtract(const Duration(days: 400)), now: now),
+        '1 year ago',
+      );
+    });
+
+    test('clamps a future timestamp to "just now"', () {
+      expect(
+        syncTimeAgo(now.add(const Duration(minutes: 5)), now: now),
+        'just now',
+      );
+    });
+  });
+
+  group('SyncStatusView', () {
+    final DateTime now = DateTime(2026, 6, 15, 12);
+
+    Future<void> pump(
+      WidgetTester tester, {
+      required SyncStatusData status,
+      VoidCallback? onSync,
+      String syncLabel = 'Sync now',
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SyncStatusView(
+              status: status,
+              onSync: onSync,
+              syncLabel: syncLabel,
+              now: now,
+            ),
+          ),
+        ),
+      );
+    }
+
+    FilledButton? syncButton(WidgetTester tester) {
+      // FilledButton.tonalIcon builds a private FilledButton subclass, so match
+      // on the supertype rather than an exact runtimeType.
+      final Finder finder = find.byWidgetPredicate((w) => w is FilledButton);
+      if (finder.evaluate().isEmpty) return null;
+      return tester.widget<FilledButton>(finder);
+    }
+
+    testWidgets('shows "Never synced" with an enabled, labelled button',
+        (tester) async {
+      await pump(
+        tester,
+        status: const SyncStatusData.neverSynced(),
+        onSync: () {},
+        syncLabel: 'Sync library',
+      );
+
+      expect(find.text('Never synced'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Sync library'), findsNothing);
+      expect(find.text('Sync library'), findsOneWidget);
+      expect(syncButton(tester)?.onPressed, isNotNull);
+    });
+
+    testWidgets('shows the last successful sync time when synced',
+        (tester) async {
+      await pump(
+        tester,
+        status: SyncStatusData.synced(now.subtract(const Duration(minutes: 2))),
+        onSync: () {},
+      );
+
+      expect(find.text('Synced 2 minutes ago'), findsOneWidget);
+    });
+
+    testWidgets('disables the button and reads "Syncing…" while a sync runs',
+        (tester) async {
+      await pump(
+        tester,
+        status: const SyncStatusData.syncing(),
+        onSync: () {},
+      );
+
+      // "Syncing…" appears both as the status headline and the button label.
+      expect(find.text('Syncing…'), findsNWidgets(2));
+      expect(syncButton(tester)?.onPressed, isNull);
+    });
+
+    testWidgets('shows the error and the previous sync time on failure',
+        (tester) async {
+      await pump(
+        tester,
+        status: SyncStatusData.failed(
+          error: "Couldn't reach your server.",
+          lastSyncedAt: now.subtract(const Duration(hours: 3)),
+        ),
+        onSync: () {},
+      );
+
+      expect(find.text('Last sync failed'), findsOneWidget);
+      expect(find.text("Couldn't reach your server."), findsOneWidget);
+      expect(find.text('Last synced 3 hours ago'), findsOneWidget);
+      // The button stays enabled so the user can retry.
+      expect(syncButton(tester)?.onPressed, isNotNull);
+    });
+
+    testWidgets('shows "Offline" with the last good sync time', (tester) async {
+      await pump(
+        tester,
+        status: SyncStatusData.offline(
+          lastSyncedAt: now.subtract(const Duration(days: 1)),
+        ),
+        onSync: () {},
+      );
+
+      expect(find.text('Offline'), findsOneWidget);
+      expect(find.text('Last synced yesterday'), findsOneWidget);
+    });
+
+    testWidgets('omits the button entirely when onSync is null',
+        (tester) async {
+      await pump(tester, status: const SyncStatusData.neverSynced());
+
+      expect(syncButton(tester), isNull);
+      expect(find.text('Sync now'), findsNothing);
+    });
+
+    testWidgets('invokes onSync when the button is tapped', (tester) async {
+      int taps = 0;
+      await pump(
+        tester,
+        status: const SyncStatusData.neverSynced(),
+        onSync: () => taps++,
+        syncLabel: 'Sync library',
+      );
+
+      await tester.tap(find.text('Sync library'));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Sync state is presented differently by every music source today — Subsonic, Jellyfin, and Plex each hand-roll their own sync button + status line (and a copy-pasted `_StatusLine` / `_ButtonLabel`). This adds one **reusable Material 3 component** so sync state reads the same everywhere.

This PR is the **shared foundation only** — no provider logic, backend, or Plex changes — so each provider can adopt it incrementally in small follow-ups.

## What's included

`lib/shared/widgets/sync_status_view.dart`:

- **`SyncState`** — a unified, display-only vocabulary: `syncing`, `synced`, `failed`, `neverSynced`, `offline`.
- **`SyncStatusData`** — an immutable, display-safe snapshot (state + last successful sync time + last error). Like the per-provider state objects it unifies, it never holds a token, password, or streaming URL.
- **`SyncStatusView`** — the widget. It renders:
  - a status line for all five states, each with a matching icon and colour;
  - the **last successful sync time** — in the line when synced (`Synced 2 minutes ago`), or as a quiet `Last synced …` sub-line once a later attempt fails / goes offline;
  - the **last error**, when a failure carries one;
  - a **sync button** (a spinner labelled `Syncing…` while a sync runs; stays enabled after a failure so the user can retry; omitted entirely when no `onSync` is given).
- **`syncTimeAgo`** — a small relative-time helper (`just now`, `2 minutes ago`, `yesterday`, `3 days ago`). Takes an injectable clock so phrasing is deterministic in tests.

### Example states

```
Syncing…
Synced 2 minutes ago
Last sync failed
Never synced
Offline
```

### Usage

```dart
SyncStatusView(
  status: SyncStatusData.synced(lastSyncedAt),
  syncLabel: 'Sync library',
  onSync: controller.sync,
)
```

## Scope notes (per the requirements)

- ✅ Reusable widget/component
- ✅ Material 3 (uses the theme's `colorScheme` tokens + `FilledButton.tonalIcon`)
- ✅ No backend architecture changes
- ✅ No provider logic changes — providers aren't rewired here. Showing real `Synced X ago` times needs a `lastSyncedAt` timestamp the controllers don't track yet; adding that is provider-logic work, deliberately left for follow-up adoption PRs (one per provider).
- ✅ No Plex work
- ✅ Small, reviewable (one widget + one test file)

## Testing

`test/shared/widgets/sync_status_view_test.dart` covers every state's rendering, the button's enabled/disabled/tap behaviour, the "button omitted" case, and the `syncTimeAgo` boundaries.

Verified locally with the CI toolchain (Flutter 3.27.4):
- `flutter analyze` — no issues
- `dart format --set-exit-if-changed .` — clean
- `flutter test` — all 2237 tests pass (12 new)

https://claude.ai/code/session_019fzhRrG4trk1kWx1BZAj24

---
_Generated by [Claude Code](https://claude.ai/code/session_019fzhRrG4trk1kWx1BZAj24)_