### PR TITLE
feat(player): refine Now Playing for a cleaner, more premium feel

### DIFF
--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -69,7 +69,10 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xs,
+      ),
       child: Row(
         children: [
           IconButton(
@@ -78,12 +81,15 @@ class _Header extends StatelessWidget {
             tooltip: 'Close',
           ),
           Expanded(
+            // A calm, tracked eyebrow rather than a heavy title, so the artwork
+            // below is unmistakably the hero of the screen.
             child: Text(
               'Now Playing',
               textAlign: TextAlign.center,
-              style: theme.textTheme.titleSmall?.copyWith(
+              style: theme.textTheme.labelLarge?.copyWith(
                 fontWeight: FontWeight.w600,
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.85),
+                letterSpacing: 1.0,
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
               ),
             ),
           ),
@@ -116,51 +122,59 @@ class _NowPlaying extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // A tighter side margin lets the artwork breathe wider and gives the
+    // transport controls more room to spread, while the generous gaps below
+    // group the screen into three calm bands: artwork · metadata · controls.
     return Padding(
       padding: const EdgeInsets.fromLTRB(
-        AppSpacing.lg,
-        AppSpacing.sm,
-        AppSpacing.lg,
         AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.lg,
       ),
       child: Column(
         children: [
           Expanded(
             child: Center(
-              child: AspectRatio(
-                aspectRatio: 1,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(AppRadii.lg),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.45),
-                        blurRadius: 32,
-                        spreadRadius: -8,
-                        offset: const Offset(0, 16),
-                      ),
-                    ],
-                  ),
-                  child: AlbumArtwork(
-                    artworkUri: track.artworkUri,
-                    borderRadius: BorderRadius.circular(AppRadii.lg),
+              child: ConstrainedBox(
+                // Cap the hero on tablets/foldables so it stays a square cover,
+                // not an oversized panel; phones use the full width.
+                constraints: const BoxConstraints(maxWidth: 480),
+                child: AspectRatio(
+                  aspectRatio: 1,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(AppRadii.lg),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.4),
+                          blurRadius: 40,
+                          spreadRadius: -12,
+                          offset: const Offset(0, 20),
+                        ),
+                      ],
+                    ),
+                    child: AlbumArtwork(
+                      artworkUri: track.artworkUri,
+                      borderRadius: BorderRadius.circular(AppRadii.lg),
+                    ),
                   ),
                 ),
               ),
             ),
           ),
-          const SizedBox(height: AppSpacing.lg),
+          const SizedBox(height: AppSpacing.xl),
           TrackMetadata(
             title: track.title,
             artistName: track.artistName,
             albumName: track.albumName,
           ),
-          const SizedBox(height: AppSpacing.md),
+          const SizedBox(height: AppSpacing.lg),
           // The only part of the screen that follows the live, high-frequency
           // playback state — kept separate so the artwork, metadata, and the
           // blurred background above never rebuild on a position tick.
           const _LiveControls(),
-          const SizedBox(height: AppSpacing.sm),
+          const SizedBox(height: AppSpacing.md),
           NowPlayingActions(track: track),
         ],
       ),
@@ -183,14 +197,14 @@ class _LiveControls extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         _SourceOrError(state: state),
-        const SizedBox(height: AppSpacing.sm),
+        const SizedBox(height: AppSpacing.md),
         PlaybackProgressBar(
           position: state.position,
           duration: state.duration,
           onSeek: (position) =>
               ref.read(playbackControllerProvider).seek(position),
         ),
-        const SizedBox(height: AppSpacing.xs),
+        const SizedBox(height: AppSpacing.sm),
         PlaybackControls(state: state),
       ],
     );
@@ -238,7 +252,9 @@ class _SourceOrError extends ConsumerWidget {
     }
     final source = state.source;
     if (source == null) {
-      return const SizedBox(height: 28);
+      // Reserve the inline chip's height so the column doesn't shift when the
+      // source resolves a beat after the track loads.
+      return const SizedBox(height: 22);
     }
     return PlaybackSourceChip(
       source: source,

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -25,32 +25,42 @@ class NowPlayingActions extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final bool isFavorite = ref.watch(isFavoriteProvider(track.id));
+    // A calm, uniform tint keeps this row reading as tertiary beneath the
+    // transport controls; favorite still lights up when active.
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.7);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         IconButton(
+          iconSize: 22,
           onPressed: () => ref
               .read(favoritesRepositoryProvider)
               .setFavorite(track, !isFavorite),
           icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
-          color: isFavorite ? theme.colorScheme.primary : null,
+          color: isFavorite ? theme.colorScheme.primary : muted,
           isSelected: isFavorite,
           tooltip: isFavorite ? 'Remove from favorites' : 'Favorite',
         ),
         IconButton(
+          iconSize: 22,
           onPressed: () => showAddToPlaylistSheet(context, <Track>[track]),
           icon: const Icon(Icons.playlist_add),
+          color: muted,
           tooltip: 'Add to playlist',
         ),
         IconButton(
+          iconSize: 22,
           onPressed: () => _openQueue(context),
           icon: const Icon(Icons.queue_music_outlined),
+          color: muted,
           tooltip: 'Queue',
         ),
         IconButton(
+          iconSize: 22,
           onPressed: () => _openLyrics(context),
           icon: const Icon(Icons.lyrics_outlined),
+          color: muted,
           tooltip: 'Lyrics',
         ),
       ],

--- a/lib/features/player/widgets/playback_controls.dart
+++ b/lib/features/player/widgets/playback_controls.dart
@@ -29,14 +29,14 @@ class PlaybackControls extends ConsumerWidget {
       children: [
         _ShuffleButton(state: state, controller: controller),
         IconButton(
-          iconSize: 36,
+          iconSize: 38,
           onPressed: state.hasPrevious ? controller.skipToPrevious : null,
           icon: const Icon(Icons.skip_previous),
           tooltip: 'Previous',
         ),
         _PlayPauseButton(state: state, controller: controller),
         IconButton(
-          iconSize: 36,
+          iconSize: 38,
           onPressed: state.hasNext ? controller.skipToNext : null,
           icon: const Icon(Icons.skip_next),
           tooltip: 'Next',
@@ -60,10 +60,15 @@ class _ShuffleButton extends StatelessWidget {
     final theme = Theme.of(context);
     final enabled = state.shuffleEnabled;
     return IconButton(
+      iconSize: 24,
       onPressed: () => controller.setShuffleEnabled(!enabled),
       icon: const Icon(Icons.shuffle),
       isSelected: enabled,
-      color: enabled ? theme.colorScheme.secondary : null,
+      // Recede when off so the transport's centre of gravity stays on the
+      // play button; warm accent when on, matching the rest of the app.
+      color: enabled
+          ? theme.colorScheme.secondary
+          : theme.colorScheme.onSurface.withValues(alpha: 0.65),
       tooltip: enabled ? 'Shuffle on' : 'Shuffle',
     );
   }
@@ -83,12 +88,15 @@ class _RepeatButton extends StatelessWidget {
     final mode = state.repeatMode;
     final active = mode != RepeatMode.off;
     return IconButton(
+      iconSize: 24,
       onPressed: () => controller.setRepeatMode(mode.next),
       icon: Icon(
         mode == RepeatMode.one ? Icons.repeat_one : Icons.repeat,
       ),
       isSelected: active,
-      color: active ? theme.colorScheme.secondary : null,
+      color: active
+          ? theme.colorScheme.secondary
+          : theme.colorScheme.onSurface.withValues(alpha: 0.65),
       tooltip: _tooltipFor(mode),
     );
   }

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -52,17 +52,22 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
     final double sliderValue = _dragMs ?? posMs.toDouble();
     final double elapsedMs = _dragMs ?? posMs.toDouble();
 
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      color: muted,
+      letterSpacing: 0.4,
+      fontFeatures: const [FontFeature.tabularFigures()],
+    );
 
     return Column(
       children: [
         SliderTheme(
           data: SliderTheme.of(context).copyWith(
-            trackHeight: 3,
-            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
+            trackHeight: 4,
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
             inactiveTrackColor:
-                theme.colorScheme.onSurface.withValues(alpha: 0.18),
+                theme.colorScheme.onSurface.withValues(alpha: 0.15),
           ),
           child: Slider(
             value: sliderValue,
@@ -71,18 +76,20 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
             onChangeEnd: canSeek ? _onChangeEnd : null,
           ),
         ),
+        // Snug under the track and aligned to its ends, so the times read as a
+        // caption for the bar rather than a separate, floating row.
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+          padding: const EdgeInsets.only(top: AppSpacing.xs),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
                 _format(Duration(milliseconds: elapsedMs.round())),
-                style: theme.textTheme.labelMedium?.copyWith(color: muted),
+                style: labelStyle,
               ),
               Text(
                 hasDuration ? _format(widget.duration) : '--:--',
-                style: theme.textTheme.labelMedium?.copyWith(color: muted),
+                style: labelStyle,
               ),
             ],
           ),

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -24,8 +24,10 @@ class TrackMetadata extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.72);
-    final fainter = theme.colorScheme.onSurface.withValues(alpha: 0.55);
+    // A deliberate three-step hierarchy: the title carries full weight, the
+    // artist is a clear secondary line, and the album recedes to a quiet tag.
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.75);
+    final fainter = theme.colorScheme.onSurface.withValues(alpha: 0.5);
     final hasArtist = artistName != null && artistName!.isNotEmpty;
     final hasAlbum = albumName != null && albumName!.isNotEmpty;
 
@@ -36,6 +38,8 @@ class TrackMetadata extends StatelessWidget {
           title,
           style: theme.textTheme.headlineSmall?.copyWith(
             fontWeight: FontWeight.w700,
+            letterSpacing: -0.2,
+            height: 1.15,
           ),
           textAlign: TextAlign.center,
           maxLines: 2,
@@ -45,7 +49,10 @@ class TrackMetadata extends StatelessWidget {
           const SizedBox(height: AppSpacing.sm),
           Text(
             artistName!,
-            style: theme.textTheme.titleMedium?.copyWith(color: muted),
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: muted,
+              fontWeight: FontWeight.w500,
+            ),
             textAlign: TextAlign.center,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
@@ -55,7 +62,10 @@ class TrackMetadata extends StatelessWidget {
           const SizedBox(height: AppSpacing.xs),
           Text(
             albumName!,
-            style: theme.textTheme.bodyMedium?.copyWith(color: fainter),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: fainter,
+              letterSpacing: 0.1,
+            ),
             textAlign: TextAlign.center,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
@@ -66,9 +76,13 @@ class TrackMetadata extends StatelessWidget {
   }
 }
 
-/// A small badge stating where the audio is *actually* coming from, e.g.
+/// A quiet inline label stating where the audio is *actually* coming from, e.g.
 /// "Playing from Navidrome", "Playing from Jellyfin", "Playing from Local music",
 /// or "Playing from Cache".
+///
+/// Rendered as a calm icon-and-caption pair (no boxed chip) so it reads as a
+/// whisper under the metadata rather than a competing badge, matching the
+/// buffering/casting indicators on the same line.
 ///
 /// Because a logical track can have several source candidates, the indicator
 /// reflects the resolved copy — the owning provider derived from [trackUri] plus
@@ -91,36 +105,26 @@ class PlaybackSourceChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md,
-        vertical: AppSpacing.xs + 2,
-      ),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withValues(alpha: 0.55),
-        borderRadius: BorderRadius.circular(AppRadii.pill),
-        border: Border.all(
-          color: theme.colorScheme.onSurface.withValues(alpha: 0.12),
-        ),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            _iconFor(source),
-            size: 14,
-            color: theme.colorScheme.primary,
-          ),
-          const SizedBox(width: AppSpacing.xs + 2),
-          Text(
+    final color = theme.colorScheme.onSurfaceVariant;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(_iconFor(source), size: 15, color: color),
+        const SizedBox(width: AppSpacing.xs + 2),
+        Flexible(
+          child: Text(
             PlaybackSourceLabel.phrase(trackUri: trackUri, source: source),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
             style: theme.textTheme.labelMedium?.copyWith(
               fontWeight: FontWeight.w600,
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.8),
+              letterSpacing: 0.2,
+              color: color,
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
## What & why

A **UI-only** polish pass over the full-screen Now Playing view. The goal was to make Linthra feel cleaner and more premium by reducing visual noise, improving spacing, and sharpening hierarchy — without touching playback logic, providers, or Plex, and **keeping every existing control**.

## Changes

- **Larger hero artwork** — tighter side margins (`md` instead of `lg`) so the cover breathes wider, a `maxWidth` cap so it stays a square cover (not an oversized panel) on tablets/foldables, and a softer, deeper shadow for premium depth.
- **Cleaner typography** — the heavy header title becomes a calm, tracked *"Now Playing"* eyebrow, and the metadata now reads as a clear **title → artist → album** step-down in size, weight, and colour.
- **Quieter source line** — the bordered *"Playing from …"* pill is now a calm inline icon + caption, matching the existing buffering/casting indicators on the same line. Less boxy noise under the title; the exact labels are unchanged.
- **Better progress bar** — a fuller rounded accent track, a finer thumb, and snug **tabular-figure** time labels tucked directly under the bar so they read as a caption rather than a floating row.
- **Stronger control hierarchy** — tertiary shuffle/repeat recede (smaller, muted when off), prev/next sit a step below the hero play button, and the favourite / add-to-playlist / queue / lyrics row reads as a quiet tertiary band, clearly separated from the transport.
- **Calmer vertical rhythm** — consistent spacing grouping the screen into three bands: **artwork · metadata · controls**.

## Controls preserved

Play/Pause · Previous · Next · Shuffle · Repeat · Queue — plus Favourite, Add to playlist, Lyrics, Cast, and Close. Nothing removed; only styling, sizing, and spacing changed.

## Scope guardrails

- ❌ No playback logic changes
- ❌ No provider changes
- ❌ No Plex work
- ✅ Material 3, Linthra violet + warm-orange branding intact
- ✅ UI-only (5 files, all Now-Playing-specific widgets)

## Verification

- `dart format --set-exit-if-changed .` → clean
- `flutter analyze` → no issues
- `flutter test` → **2237 passed** (incl. the full `test/features/player/` suite, unchanged)
- Rendered the screen at phone size to confirm the new spacing, hierarchy, and larger artwork.

https://claude.ai/code/session_01LzKj6RR7m6U4emtdwKoWML

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzKj6RR7m6U4emtdwKoWML)_