### PR TITLE
feat(plex): map track number, album year & track count; wire source priority

### DIFF
--- a/lib/core/catalog/source_priority.dart
+++ b/lib/core/catalog/source_priority.dart
@@ -20,6 +20,7 @@ class SourcePriority {
   static const List<String> defaultOrder = <String>[
     'jellyfin',
     'subsonic',
+    'plex',
     'local',
   ];
 

--- a/lib/core/sources/plex/plex_api.dart
+++ b/lib/core/sources/plex/plex_api.dart
@@ -252,6 +252,9 @@ class PlexMetadata {
     this.grandparentTitle,
     this.thumb,
     this.duration,
+    this.index,
+    this.year,
+    this.leafCount,
     this.media = const <PlexMedia>[],
   });
 
@@ -287,6 +290,20 @@ class PlexMetadata {
   /// Duration in **milliseconds**, when reported (PMS reports track length in
   /// ms, unlike Subsonic's whole seconds or Jellyfin's 100-ns ticks).
   final int? duration;
+
+  /// A track's **track number** within its album (PMS `index`), when reported;
+  /// `null` for an artist/album or a track PMS doesn't number. Plex reports the
+  /// **disc** number separately as `parentIndex`, which Linthra's [Track] model
+  /// has no field for, so it is intentionally not parsed (a disc field would be
+  /// a shared-model + schema change neither Jellyfin nor Subsonic carry).
+  final int? index;
+
+  /// An album's release **year** (PMS `year`), when reported; `null` otherwise.
+  final int? year;
+
+  /// An album's **track count** (PMS `leafCount` — the number of tracks under
+  /// it), when reported; `null` otherwise.
+  final int? leafCount;
 
   /// The item's `Media` entries (present on tracks; an album/artist listing
   /// omits them). Each holds the [PlexPart]s whose [PlexPart.key] is the actual
@@ -337,6 +354,9 @@ class PlexMetadata {
       grandparentTitle: _asString(json['grandparentTitle']),
       thumb: _asString(json['thumb']),
       duration: (json['duration'] as num?)?.toInt(),
+      index: (json['index'] as num?)?.toInt(),
+      year: (json['year'] as num?)?.toInt(),
+      leafCount: (json['leafCount'] as num?)?.toInt(),
       media: media,
     );
   }

--- a/lib/core/sources/plex/plex_track_mapper.dart
+++ b/lib/core/sources/plex/plex_track_mapper.dart
@@ -48,10 +48,12 @@ abstract final class PlexTrackMapper {
   /// Display fallback for the rare track whose Plex `title` is missing/blank.
   static const String _untitledTrack = 'Untitled';
 
-  /// Maps a **track** (Plex type 10) listing/metadata item.
-  ///
-  /// `PlexMetadata` doesn't parse a track index yet, so [Track.trackNumber]
-  /// stays `null` (a follow-up, like year/track-count on albums).
+  /// Maps a **track** (Plex type 10) listing/metadata item, carrying its
+  /// **track number** ([Track.trackNumber]) from PMS's `index` so albums play
+  /// and display in order — mirroring Jellyfin's `indexNumber` and Subsonic's
+  /// `track`. Plex's separate **disc** number (`parentIndex`) is intentionally
+  /// not mapped: the shared [Track] model has no disc field (see
+  /// [PlexMetadata.index]).
   static Track toTrack(PlexMetadata item) {
     return Track(
       id: item.ratingKey,
@@ -60,17 +62,22 @@ abstract final class PlexTrackMapper {
       artistName: _nonBlank(item.grandparentTitle),
       albumName: _nonBlank(item.parentTitle),
       duration: _durationFromMillis(item.duration),
+      trackNumber: _positiveOrNull(item.index),
       artworkUri: _artworkReference(item.thumb),
     );
   }
 
-  /// Maps an **album** (Plex type 9) listing item. Year and track count aren't
-  /// parsed from Plex yet, so they keep their defaults.
+  /// Maps an **album** (Plex type 9) listing item, including its release
+  /// [Album.year] (PMS `year`) and [Album.trackCount] (PMS `leafCount`) when
+  /// reported — mirroring Jellyfin (`productionYear` / `childCount`) and
+  /// Subsonic (`year` / `songCount`).
   static Album toAlbum(PlexMetadata item) {
     return Album(
       id: item.ratingKey,
       title: _nonBlank(item.title) ?? kUnknownAlbum,
       artistName: _nonBlank(item.parentTitle),
+      year: _positiveOrNull(item.year),
+      trackCount: item.leafCount ?? 0,
       artworkUri: _artworkReference(item.thumb),
     );
   }
@@ -139,6 +146,16 @@ abstract final class PlexTrackMapper {
   static Duration _durationFromMillis(int? millis) {
     if (millis == null || millis <= 0) return Duration.zero;
     return Duration(milliseconds: millis);
+  }
+
+  /// A positive [value], or `null` when it is absent or non-positive. PMS omits
+  /// a track index / album year it doesn't know, but a stray `0` (or negative)
+  /// is meaningless as a track number or a year, so it folds to `null` the same
+  /// way a missing field does — just as [_durationFromMillis] folds a
+  /// non-positive duration to zero.
+  static int? _positiveOrNull(int? value) {
+    if (value == null || value <= 0) return null;
+    return value;
   }
 
   /// Trims [text] and treats blank as absent, so a whitespace-only Plex field

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/models/plex_session.dart';
 import '../../../core/services/remote_cache/remote_cache_key.dart';
+import '../../../core/sources/music_provider.dart';
 import '../../../core/sources/plex/plex_api.dart';
 import '../../../core/sources/plex/plex_exception.dart';
 import '../../../core/sources/plex/plex_music_source.dart';
@@ -12,6 +13,7 @@ import '../../../core/sources/plex/plex_pin_auth.dart';
 import '../../../core/sources/plex/plex_tv_api.dart';
 import '../../../data/repositories/plex_session_store_provider.dart';
 import '../../../data/repositories/remote_cache_index_provider.dart';
+import '../../library/source_preference_controller.dart';
 import 'plex_settings_providers.dart';
 import 'plex_settings_state.dart';
 import 'plex_sync_controller.dart';
@@ -449,6 +451,16 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     }
 
     _session = stamped;
+    // The just-connected server becomes the active/default provider for picking
+    // among duplicate sources, so a song that also lives on another server now
+    // prefers Plex. Persisted and best-effort — mirrors Jellyfin/Subsonic
+    // sign-in (an explicit "Default source" choice still wins, see
+    // SourcePreferenceController).
+    unawaited(
+      ref
+          .read(librarySourcePriorityProvider.notifier)
+          .markPreferred(MusicProviders.plex.sourceId),
+    );
     _sectionsLoadAttempted = false;
     _restoreSuperseded = true;
     // The flow is complete: release the account token and the token-bearing

--- a/lib/features/settings/source/default_provider_section.dart
+++ b/lib/features/settings/source/default_provider_section.dart
@@ -45,6 +45,11 @@ class DefaultProviderSettingsSection extends ConsumerWidget {
         subtitle: null,
       ),
       (
+        id: MusicProviders.plex.sourceId,
+        title: MusicProviders.plex.displayName,
+        subtitle: null,
+      ),
+      (
         id: MusicProviders.local.sourceId,
         title: MusicProviders.local.displayName,
         subtitle: 'Prefer a copy on this device when one exists.',

--- a/test/core/catalog/source_priority_test.dart
+++ b/test/core/catalog/source_priority_test.dart
@@ -16,14 +16,30 @@ void main() {
     });
 
     test('falls back to the default order for unlisted sources', () {
-      // Nothing preferred: jellyfin < subsonic < local by the fixed default.
+      // Nothing preferred: jellyfin < subsonic < plex < local by the fixed
+      // default (remote servers before local).
       expect(
         SourcePriority.fallback.rankOf('jellyfin'),
         lessThan(SourcePriority.fallback.rankOf('subsonic')),
       );
       expect(
         SourcePriority.fallback.rankOf('subsonic'),
+        lessThan(SourcePriority.fallback.rankOf('plex')),
+      );
+      expect(
+        SourcePriority.fallback.rankOf('plex'),
         lessThan(SourcePriority.fallback.rankOf('local')),
+      );
+    });
+
+    test('plex is a known source, ranked ahead of an unknown one', () {
+      // Plex now has a deterministic, non-trailing rank rather than sharing the
+      // unknown-source tail, so a Plex copy is preferred over a truly unknown
+      // provider when both hold the same song.
+      const priority = SourcePriority(<String>['jellyfin']);
+      expect(
+        priority.rankOf('plex'),
+        lessThan(priority.rankOf('webdav')),
       );
     });
 

--- a/test/core/sources/plex/plex_api_test.dart
+++ b/test/core/sources/plex/plex_api_test.dart
@@ -125,18 +125,23 @@ void main() {
       expect(artist.grandparentRatingKey, isNull);
     });
 
-    test('parses an album (type 9) with its parent artist link', () {
+    test('parses an album (type 9) with its parent link, year, and track count',
+        () {
       final PlexMetadata album = _single(<String, dynamic>{
         'ratingKey': '100',
         'type': 'album',
         'title': 'Music Has the Right to Children',
         'parentRatingKey': '50',
         'parentTitle': 'Boards of Canada',
+        'year': 1998,
+        'leafCount': 12,
       });
       expect(album.metadataType, PlexMetadataType.album);
       expect(album.parentRatingKey, '50');
       expect(album.parentTitle, 'Boards of Canada');
       expect(album.grandparentRatingKey, isNull);
+      expect(album.year, 1998);
+      expect(album.leafCount, 12);
     });
 
     test('parses a track (type 10) with parent + grandparent links and Part',
@@ -151,6 +156,7 @@ void main() {
         'grandparentTitle': 'Boards of Canada',
         'thumb': '/library/metadata/123/thumb/9',
         'duration': 215000,
+        'index': 4,
         'Media': <dynamic>[
           <String, dynamic>{
             'container': 'flac',
@@ -171,6 +177,8 @@ void main() {
       expect(track.parentTitle, 'Music Has the Right to Children');
       expect(track.grandparentTitle, 'Boards of Canada');
       expect(track.duration, 215000);
+      // The track number (PMS `index`) is parsed for in-order album playback.
+      expect(track.index, 4);
 
       expect(track.media, hasLength(1));
       expect(track.media.single.container, 'flac');
@@ -193,6 +201,17 @@ void main() {
       expect(track.duration, isNull);
       expect(track.media, isEmpty);
       expect(track.firstPartKey, isNull);
+    });
+
+    test('leaves index / year / leafCount null when PMS omits them', () {
+      final PlexMetadata item = _single(<String, dynamic>{
+        'ratingKey': '125',
+        'type': 'track',
+        'title': 'Unnumbered',
+      });
+      expect(item.index, isNull);
+      expect(item.year, isNull);
+      expect(item.leafCount, isNull);
     });
 
     test('skips an item missing its ratingKey, keeps the valid ones', () {

--- a/test/core/sources/plex/plex_track_mapper_test.dart
+++ b/test/core/sources/plex/plex_track_mapper_test.dart
@@ -107,6 +107,21 @@ void main() {
       expect(PlexTrackMapper.toTrack(zero).duration, Duration.zero);
     });
 
+    test('carries the track number from the Plex index', () {
+      const item = PlexMetadata(ratingKey: '301', title: 'Nightcall', index: 7);
+      expect(PlexTrackMapper.toTrack(item).trackNumber, 7);
+    });
+
+    test('leaves trackNumber null for an absent or non-positive index', () {
+      const absent = PlexMetadata(ratingKey: '1', title: 't');
+      const zero = PlexMetadata(ratingKey: '2', title: 't', index: 0);
+      // PMS omits the index it doesn't know; a stray 0 is meaningless as a
+      // track number, so both fold to null (the grouping layer keeps the
+      // server's listing order rather than forcing a bogus "track 0").
+      expect(PlexTrackMapper.toTrack(absent).trackNumber, isNull);
+      expect(PlexTrackMapper.toTrack(zero).trackNumber, isNull);
+    });
+
     test('leaves artworkUri null when the item reports no thumb', () {
       const item = PlexMetadata(ratingKey: '1', title: 't');
       // No thumb → null → the UI shows its placeholder (not a broken image).
@@ -147,6 +162,35 @@ void main() {
       final album = PlexTrackMapper.toAlbum(item);
       expect(album.artistName, isNull);
       expect(album.artworkUri, isNull);
+    });
+
+    test('carries the release year and track count when reported', () {
+      const item = PlexMetadata(
+        ratingKey: '201',
+        type: 'album',
+        title: 'OutRun',
+        year: 2013,
+        leafCount: 13,
+      );
+      final album = PlexTrackMapper.toAlbum(item);
+      expect(album.year, 2013);
+      expect(album.trackCount, 13);
+    });
+
+    test('defaults year to null and track count to 0 when PMS omits them', () {
+      const item = PlexMetadata(ratingKey: '201', title: 'OutRun');
+      final album = PlexTrackMapper.toAlbum(item);
+      // A missing year stays null (Unknown); a missing count is 0, mirroring
+      // Jellyfin's `childCount ?? 0`.
+      expect(album.year, isNull);
+      expect(album.trackCount, 0);
+    });
+
+    test('folds a non-positive year to null', () {
+      const item = PlexMetadata(ratingKey: '201', title: 'OutRun', year: 0);
+      // PMS occasionally reports year 0 for an unknown date; that is not a real
+      // year, so it folds to null like an omitted field.
+      expect(PlexTrackMapper.toAlbum(item).year, isNull);
     });
   });
 

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -17,11 +17,16 @@ import 'package:linthra/core/sources/plex/plex_exception.dart';
 import 'package:linthra/core/sources/plex/plex_music_source.dart';
 import 'package:linthra/core/sources/plex/plex_pin_auth.dart';
 import 'package:linthra/core/sources/plex/plex_tv_api.dart';
+import 'package:linthra/data/repositories/default_provider_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_default_provider_store.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
+import 'package:linthra/data/repositories/in_memory_preferred_source_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/data/repositories/plex_session_store_provider.dart';
+import 'package:linthra/data/repositories/preferred_source_store_provider.dart';
 import 'package:linthra/data/repositories/remote_cache_index_provider.dart';
+import 'package:linthra/features/library/source_preference_controller.dart';
 import 'package:linthra/features/settings/plex/plex_settings_controller.dart';
 import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
 import 'package:linthra/features/settings/plex/plex_settings_state.dart';
@@ -267,6 +272,13 @@ ProviderContainer _container({
       ),
       externalLinkLauncherProvider
           .overrideWithValue(launcher ?? _RecordingLauncher()),
+      // Keep the source-priority graph fully in-memory so a connect's
+      // best-effort markPreferred(plex) is deterministic and never reaches real
+      // device storage.
+      preferredSourceStoreProvider
+          .overrideWithValue(InMemoryPreferredSourceStore()),
+      defaultProviderStoreProvider
+          .overrideWithValue(InMemoryDefaultProviderStore()),
     ],
   );
   addTearDown(container.dispose);
@@ -507,6 +519,28 @@ void main() {
       final PlexMusicSource? source = container.read(plexMusicSourceProvider);
       expect(source, isNotNull);
       expect(source!.session, saved);
+    });
+
+    test('promotes Plex as the active source for duplicate resolution',
+        () async {
+      final container = _container();
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      final ok = await notifier.connect(
+        url: 'https://plex.example.com:32400',
+        token: _token,
+      );
+      await _settle();
+
+      expect(ok, isTrue);
+      // The just-connected server is promoted to the front of the automatic
+      // source preference, so a song that also lives on another server now
+      // prefers this Plex copy — mirroring Jellyfin/Subsonic sign-in.
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder.first,
+        'plex',
+      );
     });
 
     test('does not persist anything on a rejected token', () async {

--- a/test/features/settings/source/default_provider_section_test.dart
+++ b/test/features/settings/source/default_provider_section_test.dart
@@ -40,6 +40,7 @@ void main() {
       expect(find.text('Automatic'), findsOneWidget);
       expect(find.text('Jellyfin'), findsOneWidget);
       expect(find.text('Navidrome / Subsonic'), findsOneWidget);
+      expect(find.text('Plex'), findsOneWidget);
       expect(find.text('Local music'), findsOneWidget);
     });
 
@@ -60,6 +61,21 @@ void main() {
       expect(
         container.read(librarySourcePriorityProvider).preferredOrder.first,
         'jellyfin',
+      );
+    });
+
+    testWidgets('choosing Plex persists it and pins it to the head',
+        (tester) async {
+      final container = await pump(tester);
+
+      await tester.tap(find.text('Plex'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(defaultProviderControllerProvider), 'plex');
+      expect(await store.read(), 'plex');
+      expect(
+        container.read(librarySourcePriorityProvider).preferredOrder.first,
+        'plex',
       );
     });
 


### PR DESCRIPTION
## What this improves

A focused stability pass that makes the existing **read-only** Plex provider feel
more complete by mapping Plex metadata fields Linthra already has models for, and
by letting Plex participate in cross-provider source selection like Jellyfin/Subsonic.
No new features, no new architecture.

### Metadata mapping
- `PlexMetadata` now parses three fields it previously dropped: `index` (track
  number), `year`, and `leafCount` (album track count).
- `PlexTrackMapper` fills the **existing** shared model fields:
  - `Track.trackNumber` ← Plex `index` — so albums play and display **in order**
    instead of in the server's listing order (the most visible gap).
  - `Album.year` ← Plex `year`.
  - `Album.trackCount` ← Plex `leafCount`.
- Mirrors the existing `JellyfinTrackMapper` (`indexNumber` / `productionYear` /
  `childCount`) and `SubsonicTrackMapper` (`track` / `year` / `songCount`)
  patterns. A non-positive `index`/`year` folds to `null` (PMS sometimes emits
  `0` for "unknown"), consistent with the mapper's existing duration guard; a
  missing count defaults to `0` like Jellyfin's `childCount ?? 0`.

### Source priority / provider selection
- `'plex'` is added to `SourcePriority.defaultOrder`, giving it a deterministic,
  non-trailing rank instead of sharing the unknown-source tail.
- Connecting a Plex server now promotes it to the front of the automatic source
  preference (`markPreferred`), mirroring Jellyfin/Subsonic sign-in.
- Plex is selectable in the **Default source** settings card.
- Net effect: when the same song exists on Plex and another server, the Plex
  copy is preferred/falls back correctly rather than always losing.

## Intentionally left for follow-up PRs
- **Disc number** — the shared `Track` model has **no disc field**, and neither
  Jellyfin nor Subsonic map one; adding it is a shared-model + DB-schema change
  that's out of scope for this small PR. (The rationale is documented inline on
  `PlexMetadata.index`.)
- The larger deferred capabilities remain untouched and unsupported as before:
  **offline cache, lyrics, cast, and the Android Auto media-session artwork
  pipeline.**

## Scope / safety
- Behavior stays **read-only** — no writes, no playback-logic changes, no DB
  schema change, no UI redesign (one radio option added to an existing card).
- Existing providers (Jellyfin, Subsonic, Local) are untouched apart from Plex
  joining the shared source-priority order.

## Tests
- `plex_api_test` — parses `index` / `year` / `leafCount`; null when omitted.
- `plex_track_mapper_test` — track number from `index`, album year + track count,
  and the non-positive → null / missing → 0 guards.
- `source_priority_test` — `jellyfin < subsonic < plex < local`; Plex outranks an
  unknown provider.
- `plex_settings_controller_test` — connecting promotes Plex to the front of the
  preference (with the source-priority stores kept in-memory in the harness).
- `default_provider_section_test` — Plex option shown and pinnable.

> Note: no Flutter SDK was available in the build environment, so the suite was
> not run locally — relying on CI to execute it.

https://claude.ai/code/session_01LZi7Sy2S56rtpswX9VRsXE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZi7Sy2S56rtpswX9VRsXE)_