### PR TITLE
Add a sleep timer to the Now Playing screen

### DIFF
--- a/lib/features/player/sleep_timer_controller.dart
+++ b/lib/features/player/sleep_timer_controller.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'player_providers.dart';
+
+/// Immutable snapshot of the sleep timer, rendered by the sleep-timer sheet and
+/// the Now Playing action button.
+///
+/// Inactive by default. When [isActive] both [total] (the chosen delay) and
+/// [remaining] (the live countdown) are non-null; the controller emits a fresh
+/// state once a second so the UI shows a ticking countdown without owning a
+/// timer of its own.
+@immutable
+class SleepTimerState {
+  const SleepTimerState({this.total, this.remaining});
+
+  /// No timer running.
+  static const SleepTimerState inactive = SleepTimerState();
+
+  /// The chosen delay, or null when no timer is running.
+  final Duration? total;
+
+  /// How long until playback pauses, or null when no timer is running.
+  final Duration? remaining;
+
+  /// Whether a countdown is currently running.
+  bool get isActive => total != null && remaining != null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SleepTimerState &&
+          other.total == total &&
+          other.remaining == remaining);
+
+  @override
+  int get hashCode => Object.hash(total, remaining);
+}
+
+/// Owns the Sleep Timer: a single countdown that pauses playback when it
+/// reaches zero, so the listener can fall asleep to music and have it stop on
+/// its own.
+///
+/// It drives playback only through the unified [PlaybackController] — pausing
+/// (never stopping) on expiry, so the queue and position survive and playback
+/// can be resumed where it left off. It never touches a music source, the
+/// offline cache, casting, or the sync logic. The countdown is exposed as plain
+/// [SleepTimerState] the UI renders from; the ticking [Timer] is an internal
+/// detail, injectable so tests can drive expiry deterministically without real
+/// time passing.
+class SleepTimerController extends Notifier<SleepTimerState> {
+  SleepTimerController({
+    Timer Function(Duration, void Function(Timer))? createPeriodic,
+    Duration tick = const Duration(seconds: 1),
+  })  : _createPeriodic = createPeriodic ?? Timer.periodic,
+        _tick = tick;
+
+  final Timer Function(Duration, void Function(Timer)) _createPeriodic;
+  final Duration _tick;
+  Timer? _timer;
+
+  @override
+  SleepTimerState build() {
+    // The countdown must never outlive the provider scope, so always release
+    // the timer on dispose.
+    ref.onDispose(_clearTimer);
+    return SleepTimerState.inactive;
+  }
+
+  /// Starts (or replaces) the countdown for [duration], after which playback
+  /// pauses. A non-positive [duration] is ignored.
+  void start(Duration duration) {
+    if (duration <= Duration.zero) return;
+    _clearTimer();
+    state = SleepTimerState(total: duration, remaining: duration);
+    _timer = _createPeriodic(_tick, _onTick);
+  }
+
+  /// Cancels the active countdown, leaving playback untouched. A no-op when no
+  /// timer is running.
+  void cancel() {
+    if (!state.isActive) return;
+    _clearTimer();
+    state = SleepTimerState.inactive;
+  }
+
+  void _onTick(Timer timer) {
+    // Defensive: a stray tick after the timer was cleared must change nothing.
+    if (!state.isActive) return;
+    final Duration remaining = state.remaining! - _tick;
+    if (remaining <= Duration.zero) {
+      // Reached zero: stop ticking and clear the state first, then pause
+      // playback through the unified controller. Pause (not stop) so resuming
+      // later picks up the same track, queue, and position.
+      _clearTimer();
+      state = SleepTimerState.inactive;
+      unawaited(ref.read(playbackControllerProvider).pause());
+      return;
+    }
+    state = SleepTimerState(total: state.total, remaining: remaining);
+  }
+
+  void _clearTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}
+
+final sleepTimerControllerProvider =
+    NotifierProvider<SleepTimerController, SleepTimerState>(
+  SleepTimerController.new,
+);

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -6,16 +6,20 @@ import '../../../core/models/track.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../favorites_providers.dart';
+import '../sleep_timer_controller.dart';
 import 'lyrics_view.dart';
 import 'queue_sheet.dart';
+import 'sleep_timer_sheet.dart';
 
-/// Bottom action row on the now-playing screen: favorite · queue · lyrics.
+/// Bottom action row on the now-playing screen: favorite · playlist · queue ·
+/// lyrics · sleep timer.
 ///
-/// All three are live: favorite toggles a heart synced through the
+/// They're live: favorite toggles a heart synced through the
 /// [FavoritesRepository] (to Jellyfin for remote tracks, on-device for local
-/// ones), queue opens the up-next list, and lyrics fetches the track's lyrics
-/// from the source — falling back to an honest "no lyrics" state when there are
-/// none (or for a local track / when signed out).
+/// ones), queue opens the up-next list, lyrics fetches the track's lyrics from
+/// the source — falling back to an honest "no lyrics" state when there are none
+/// (or for a local track / when signed out) — and the sleep timer (a moon that
+/// lights up while a countdown is running) opens the delay picker.
 class NowPlayingActions extends ConsumerWidget {
   const NowPlayingActions({super.key, required this.track});
 
@@ -25,8 +29,12 @@ class NowPlayingActions extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final bool isFavorite = ref.watch(isFavoriteProvider(track.id));
+    final bool sleepTimerActive = ref.watch(
+      sleepTimerControllerProvider.select((s) => s.isActive),
+    );
     // A calm, uniform tint keeps this row reading as tertiary beneath the
-    // transport controls; favorite still lights up when active.
+    // transport controls; favorite and the sleep timer still light up when
+    // active.
     final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.7);
 
     return Row(
@@ -62,6 +70,16 @@ class NowPlayingActions extends ConsumerWidget {
           icon: const Icon(Icons.lyrics_outlined),
           color: muted,
           tooltip: 'Lyrics',
+        ),
+        IconButton(
+          iconSize: 22,
+          onPressed: () => showSleepTimerSheet(context),
+          icon: Icon(
+            sleepTimerActive ? Icons.bedtime : Icons.bedtime_outlined,
+          ),
+          color: sleepTimerActive ? theme.colorScheme.primary : muted,
+          isSelected: sleepTimerActive,
+          tooltip: sleepTimerActive ? 'Sleep timer (on)' : 'Sleep timer',
         ),
       ],
     );

--- a/lib/features/player/widgets/sleep_timer_sheet.dart
+++ b/lib/features/player/widgets/sleep_timer_sheet.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../sleep_timer_controller.dart';
+
+/// Opens the Sleep Timer as a compact Material 3 bottom sheet.
+///
+/// It reads the live [SleepTimerState], so it shows the running countdown (and a
+/// Cancel action) when a timer is active, or the delay presets when it isn't.
+Future<void> showSleepTimerSheet(BuildContext context) {
+  return showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    builder: (_) => const SleepTimerSheet(),
+  );
+}
+
+/// Formats [remaining] as a calm `M:SS` countdown (or `H:MM:SS` past an hour),
+/// clamping a negative value to zero so the display never shows `-0:01`.
+String formatSleepRemaining(Duration remaining) {
+  final int totalSeconds = remaining.isNegative ? 0 : remaining.inSeconds;
+  final int hours = totalSeconds ~/ 3600;
+  final int minutes = (totalSeconds % 3600) ~/ 60;
+  final int seconds = totalSeconds % 60;
+  final String mm = minutes.toString().padLeft(2, '0');
+  final String ss = seconds.toString().padLeft(2, '0');
+  return hours > 0 ? '$hours:$mm:$ss' : '$minutes:$ss';
+}
+
+/// The Sleep Timer panel.
+///
+/// Minimal by design: a header, then either the live countdown with a Cancel
+/// button (timer running) or the delay presets plus a Custom option (idle).
+/// Every action goes through the [SleepTimerController] — the single owner of
+/// the countdown — so the panel never touches playback directly.
+class SleepTimerSheet extends ConsumerWidget {
+  const SleepTimerSheet({super.key});
+
+  /// The quick-pick delays, in minutes.
+  static const List<int> presetMinutes = <int>[5, 10, 15, 20];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final SleepTimerState timer = ref.watch(sleepTimerControllerProvider);
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          0,
+          AppSpacing.lg,
+          AppSpacing.lg,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(Icons.bedtime_outlined, color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Sleep timer', style: theme.textTheme.titleMedium),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.md),
+            if (timer.isActive)
+              _ActiveTimer(remaining: timer.remaining!)
+            else
+              const _TimerOptions(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The idle view: a short prompt and the delay presets (plus Custom).
+class _TimerOptions extends ConsumerWidget {
+  const _TimerOptions();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(
+          'Pause playback after',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Wrap(
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.sm,
+          children: <Widget>[
+            for (final int minutes in SleepTimerSheet.presetMinutes)
+              ActionChip(
+                label: Text('$minutes min'),
+                onPressed: () => ref
+                    .read(sleepTimerControllerProvider.notifier)
+                    .start(Duration(minutes: minutes)),
+              ),
+            ActionChip(
+              avatar: const Icon(Icons.edit_outlined, size: 18),
+              label: const Text('Custom'),
+              onPressed: () => _pickCustom(context, ref),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> _pickCustom(BuildContext context, WidgetRef ref) async {
+    final int? minutes = await showCustomSleepMinutesDialog(context);
+    if (minutes == null) return;
+    ref
+        .read(sleepTimerControllerProvider.notifier)
+        .start(Duration(minutes: minutes));
+  }
+}
+
+/// The running view: the live countdown and a single Cancel action.
+class _ActiveTimer extends ConsumerWidget {
+  const _ActiveTimer({required this.remaining});
+
+  final Duration remaining;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(
+          'Pausing playback in',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          formatSleepRemaining(remaining),
+          textAlign: TextAlign.center,
+          style: theme.textTheme.displaySmall?.copyWith(
+            color: theme.colorScheme.primary,
+            // Tabular figures so the seconds digit doesn't jitter the layout as
+            // it counts down.
+            fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        FilledButton.tonalIcon(
+          onPressed: () =>
+              ref.read(sleepTimerControllerProvider.notifier).cancel(),
+          icon: const Icon(Icons.close),
+          label: const Text('Cancel timer'),
+        ),
+      ],
+    );
+  }
+}
+
+/// Prompts for a custom delay in whole minutes, returning it (or null if the
+/// listener dismissed the dialog). Kept simple: a single validated number field.
+Future<int?> showCustomSleepMinutesDialog(BuildContext context) {
+  return showDialog<int>(
+    context: context,
+    builder: (_) => const _CustomMinutesDialog(),
+  );
+}
+
+class _CustomMinutesDialog extends StatefulWidget {
+  const _CustomMinutesDialog();
+
+  @override
+  State<_CustomMinutesDialog> createState() => _CustomMinutesDialogState();
+}
+
+class _CustomMinutesDialogState extends State<_CustomMinutesDialog> {
+  final TextEditingController _controller = TextEditingController();
+  String? _error;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final int? minutes = int.tryParse(_controller.text.trim());
+    if (minutes == null || minutes <= 0) {
+      setState(() => _error = 'Enter a whole number of minutes.');
+      return;
+    }
+    Navigator.of(context).pop(minutes);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Custom sleep timer'),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        keyboardType: TextInputType.number,
+        inputFormatters: <TextInputFormatter>[
+          FilteringTextInputFormatter.digitsOnly,
+        ],
+        decoration: InputDecoration(
+          labelText: 'Minutes',
+          suffixText: 'min',
+          errorText: _error,
+        ),
+        onSubmitted: (_) => _submit(),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: const Text('Start'),
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/player/sleep_timer_controller_test.dart
+++ b/test/features/player/sleep_timer_controller_test.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/sleep_timer_controller.dart';
+
+import 'fake_playback_controller.dart';
+
+/// A hand-driven [Timer] so a test advances the sleep-timer countdown tick by
+/// tick, with no real time passing. Stands in for `Timer.periodic`.
+class _FakePeriodicTimer implements Timer {
+  _FakePeriodicTimer(this._onTick);
+
+  final void Function(Timer) _onTick;
+  bool _active = true;
+  int _tick = 0;
+
+  /// Fires one tick, as `Timer.periodic` would, while still active.
+  void fire() {
+    if (!_active) return;
+    _tick++;
+    _onTick(this);
+  }
+
+  @override
+  void cancel() => _active = false;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  int get tick => _tick;
+}
+
+void main() {
+  group('SleepTimerController', () {
+    late FakePlaybackController playback;
+    late ProviderContainer container;
+    _FakePeriodicTimer? created;
+
+    // Builds the controller under test with a hand-driven periodic timer,
+    // recording the created timer into [created] so the test can fire its ticks.
+    SleepTimerController createController() {
+      return SleepTimerController(
+        createPeriodic: (Duration _, void Function(Timer) onTick) {
+          final timer = _FakePeriodicTimer(onTick);
+          created = timer;
+          return timer;
+        },
+      );
+    }
+
+    setUp(() {
+      playback = FakePlaybackController(
+        initial: const PlaybackState(status: PlaybackStatus.playing),
+      );
+      created = null;
+      container = ProviderContainer(
+        overrides: <Override>[
+          playbackControllerProvider.overrideWithValue(playback),
+          sleepTimerControllerProvider.overrideWith(createController),
+        ],
+      );
+      addTearDown(container.dispose);
+    });
+
+    SleepTimerController controller() =>
+        container.read(sleepTimerControllerProvider.notifier);
+    SleepTimerState read() => container.read(sleepTimerControllerProvider);
+
+    test('starts inactive', () {
+      expect(read(), SleepTimerState.inactive);
+      expect(read().isActive, isFalse);
+      expect(created, isNull);
+    });
+
+    test('start arms the countdown with the full duration', () {
+      controller().start(const Duration(minutes: 5));
+
+      expect(read().isActive, isTrue);
+      expect(read().total, const Duration(minutes: 5));
+      expect(read().remaining, const Duration(minutes: 5));
+      expect(created, isNotNull);
+      expect(created!.isActive, isTrue);
+      expect(playback.pauseCount, 0);
+    });
+
+    test('each tick decrements the remaining time', () {
+      controller().start(const Duration(minutes: 1));
+
+      created!.fire();
+      expect(read().remaining, const Duration(seconds: 59));
+      created!.fire();
+      expect(read().remaining, const Duration(seconds: 58));
+      // The total is unchanged while counting down.
+      expect(read().total, const Duration(minutes: 1));
+      expect(playback.pauseCount, 0);
+    });
+
+    test('expiry pauses playback and clears the timer', () {
+      controller().start(const Duration(seconds: 3));
+
+      created!.fire(); // 3s -> 2s
+      created!.fire(); // 2s -> 1s
+      expect(read().isActive, isTrue);
+      expect(playback.pauseCount, 0);
+
+      created!.fire(); // 1s -> 0s => expiry
+      expect(read(), SleepTimerState.inactive);
+      expect(read().isActive, isFalse);
+      expect(playback.pauseCount, 1);
+      // The periodic timer is cancelled, so it never ticks again.
+      expect(created!.isActive, isFalse);
+    });
+
+    test('cancel stops the countdown without pausing playback', () {
+      controller().start(const Duration(minutes: 10));
+      final _FakePeriodicTimer armed = created!;
+
+      controller().cancel();
+
+      expect(read().isActive, isFalse);
+      expect(armed.isActive, isFalse);
+      expect(playback.pauseCount, 0);
+    });
+
+    test('cancel is a no-op when no timer is running', () {
+      controller().cancel();
+
+      expect(read().isActive, isFalse);
+      expect(playback.pauseCount, 0);
+    });
+
+    test('start replaces an existing countdown', () {
+      controller().start(const Duration(minutes: 5));
+      final _FakePeriodicTimer first = created!;
+
+      controller().start(const Duration(minutes: 20));
+
+      // The previous timer is cancelled and a fresh one armed for the new delay.
+      expect(first.isActive, isFalse);
+      expect(identical(created, first), isFalse);
+      expect(created!.isActive, isTrue);
+      expect(read().total, const Duration(minutes: 20));
+      expect(read().remaining, const Duration(minutes: 20));
+    });
+
+    test('start ignores a non-positive duration', () {
+      controller().start(Duration.zero);
+
+      expect(read().isActive, isFalse);
+      expect(created, isNull);
+
+      controller().start(const Duration(seconds: -5));
+      expect(read().isActive, isFalse);
+      expect(created, isNull);
+    });
+
+    test('a stray tick after cancel changes nothing', () {
+      controller().start(const Duration(minutes: 1));
+      final _FakePeriodicTimer armed = created!;
+      controller().cancel();
+
+      // Even if a tick somehow fires after cancellation, it must not resurrect
+      // the countdown or pause playback. (fire() respects cancel, so force it.)
+      armed._active = true;
+      armed.fire();
+
+      expect(read().isActive, isFalse);
+      expect(playback.pauseCount, 0);
+    });
+  });
+}

--- a/test/features/player/sleep_timer_sheet_test.dart
+++ b/test/features/player/sleep_timer_sheet_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/sleep_timer_controller.dart';
+import 'package:linthra/features/player/widgets/now_playing_actions.dart';
+import 'package:linthra/features/player/widgets/sleep_timer_sheet.dart';
+
+/// An inert [Timer] that never fires, so arming the countdown in a widget test
+/// schedules no real timers (which would otherwise leave the test pending).
+class _InertTimer implements Timer {
+  bool _active = true;
+
+  @override
+  void cancel() => _active = false;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  int get tick => 0;
+}
+
+Timer _noopPeriodic(Duration _, void Function(Timer) __) => _InertTimer();
+
+/// Pumps the sheet with a controller whose countdown never ticks, so a test can
+/// arm a timer and assert the running view without real time passing.
+Future<void> _pumpSheet(WidgetTester tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        sleepTimerControllerProvider.overrideWith(
+          () => SleepTimerController(createPeriodic: _noopPeriodic),
+        ),
+      ],
+      child: const MaterialApp(home: Scaffold(body: SleepTimerSheet())),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SleepTimerSheet', () {
+    testWidgets('shows the delay presets when idle', (tester) async {
+      await _pumpSheet(tester);
+
+      expect(find.text('5 min'), findsOneWidget);
+      expect(find.text('10 min'), findsOneWidget);
+      expect(find.text('15 min'), findsOneWidget);
+      expect(find.text('20 min'), findsOneWidget);
+      expect(find.text('Custom'), findsOneWidget);
+      expect(find.text('Cancel timer'), findsNothing);
+    });
+
+    testWidgets('tapping a preset arms the timer and shows the countdown',
+        (tester) async {
+      await _pumpSheet(tester);
+
+      await tester.tap(find.text('15 min'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('15:00'), findsOneWidget);
+      expect(find.text('Cancel timer'), findsOneWidget);
+      // The presets give way to the running view.
+      expect(find.text('5 min'), findsNothing);
+    });
+
+    testWidgets('Cancel timer returns to the presets', (tester) async {
+      await _pumpSheet(tester);
+
+      await tester.tap(find.text('20 min'));
+      await tester.pumpAndSettle();
+      expect(find.text('20:00'), findsOneWidget);
+
+      await tester.tap(find.text('Cancel timer'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Cancel timer'), findsNothing);
+      expect(find.text('5 min'), findsOneWidget);
+    });
+
+    testWidgets('the Custom option arms a custom delay', (tester) async {
+      await _pumpSheet(tester);
+
+      await tester.tap(find.text('Custom'));
+      await tester.pumpAndSettle();
+      expect(find.text('Custom sleep timer'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), '45');
+      await tester.tap(find.text('Start'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('45:00'), findsOneWidget);
+    });
+
+    testWidgets('an empty or zero custom value shows a validation error',
+        (tester) async {
+      await _pumpSheet(tester);
+
+      await tester.tap(find.text('Custom'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '0');
+      await tester.tap(find.text('Start'));
+      await tester.pumpAndSettle();
+
+      // The dialog stays open with an error; no countdown was armed.
+      expect(find.text('Enter a whole number of minutes.'), findsOneWidget);
+      expect(find.text('Custom sleep timer'), findsOneWidget);
+    });
+  });
+
+  group('NowPlayingActions sleep timer', () {
+    testWidgets('includes a Sleep timer action that opens the sheet',
+        (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: NowPlayingActions(
+                track: Track(id: '1', title: 'Song One', uri: 'jellyfin:1'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Sleep timer'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Sleep timer'));
+      await tester.pumpAndSettle();
+
+      // The sheet is open: the prompt and presets are visible.
+      expect(find.text('Pause playback after'), findsOneWidget);
+      expect(find.text('5 min'), findsOneWidget);
+    });
+  });
+
+  group('formatSleepRemaining', () {
+    test('formats minutes and seconds as M:SS', () {
+      expect(
+        formatSleepRemaining(const Duration(minutes: 4, seconds: 5)),
+        '4:05',
+      );
+    });
+
+    test('formats H:MM:SS past an hour', () {
+      expect(
+        formatSleepRemaining(const Duration(hours: 1, minutes: 2, seconds: 3)),
+        '1:02:03',
+      );
+    });
+
+    test('clamps a negative remaining to zero', () {
+      expect(formatSleepRemaining(const Duration(seconds: -1)), '0:00');
+    });
+  });
+}


### PR DESCRIPTION
## Sleep timer

Lets the listener stop playback automatically after a chosen delay.

### What's new
- A **sleep timer action** on the Now Playing actions row (a moon icon that
  lights up while a timer is running).
- A minimal **Material 3 bottom sheet**:
  - presets: **5 / 10 / 15 / 20 minutes**
  - a **Custom minutes** option (a single validated number field)
  - while running: a **live countdown** with a **Cancel timer** button
- When the countdown reaches zero, playback is **paused** (not stopped), so the
  queue and position survive and the listener can resume where they left off.

### Design
- `SleepTimerController` (a Riverpod `Notifier<SleepTimerState>`) owns a single
  countdown and drives playback only through the unified `PlaybackController`.
  The ticking `Timer` is injectable, so expiry is exercised deterministically in
  tests without any real time passing.
- The sheet and the action button render from `SleepTimerState`; the timer keeps
  running app-wide, so leaving Now Playing doesn't cancel it.

### Scope (intentionally small)
- **No changes** to provider, Plex, or sync logic — only a new feature provider
  + UI, plus the one new button wired into `NowPlayingActions`.
- The optional **"end of current track"** option is left out for now: a correct
  implementation needs deeper playback-boundary coupling than fits a small,
  reviewable PR. Easy to add as a follow-up.

### Tests
- `sleep_timer_controller_test.dart` — start, cancel, expiry (pauses playback
  exactly once and clears the timer), restart, the non-positive-duration guard,
  and a stray-tick-after-cancel guard.
- `sleep_timer_sheet_test.dart` — presets shown when idle, arming switches to the
  live countdown, cancel returns to the presets, the custom dialog (valid and
  invalid input), the Now Playing action opening the sheet, and the
  `formatSleepRemaining` formatter.

> Note: the Flutter SDK isn't available in this environment, so I couldn't run
> `dart format` / `flutter analyze` / `flutter test` here. The code was written
> to match the repo's existing formatting and lint conventions; CI will confirm.

https://claude.ai/code/session_011iUUgHMsFoj8u7UHwRR91U

---
_Generated by [Claude Code](https://claude.ai/code/session_011iUUgHMsFoj8u7UHwRR91U)_