### PR TITLE
feat(remote): receive remote playback commands — Jellyfin + neutral seam (Plex designed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Offline cache & downloads | [docs/offline-cache.md](./docs/offline-cache.md) |
 | Battery usage | [docs/battery.md](./docs/battery.md) |
 | Cast / Chromecast | [docs/cast.md](./docs/cast.md) |
+| Remote control (drive Linthra from another app) | [docs/remote-control.md](./docs/remote-control.md) |
 | Android Auto | [docs/android-auto.md](./docs/android-auto.md) |
 | Reporting a bug | [docs/reporting-bugs.md](./docs/reporting-bugs.md) |
 | Playlists & safe removal | [docs/playlists-and-delete.md](./docs/playlists-and-delete.md) |

--- a/docs/plex-remote-control.md
+++ b/docs/plex-remote-control.md
@@ -1,0 +1,365 @@
+# Plex remote control (Companion) — design
+
+> **Status: design only.** This page captures the investigation and the agreed
+> design for **receiving Plex remote-playback commands** (play / pause / skip
+> next / skip previous / stop) so it can be built in small, reviewable PRs.
+> **No remote-control code ships with this document.** It does **not** register a
+> companion server, open a socket, advertise the player, or change playback; it
+> does **not** touch Jellyfin, Navidrome/Subsonic, or Local music, and it keeps
+> Plex **read-only from the library's perspective** (no playlist or favorites
+> editing). It is the design counterpart to
+> [docs/plex.md → Playback reporting / Now Playing](plex.md#playback-reporting--now-playing-shipped-after-phase-1),
+> which shipped one-way timeline reporting; this is its symmetric follow-up.
+
+## The symptom
+
+Linthra appears correctly in a Plex Media Server's **Now Playing dashboard**
+while a `plex:` track plays — it is listed as an active player, playing,
+paused, and progressing. But when the user reaches for the **remote / speaker
+controls** in another Plex app (or the server's web dashboard) to pause, play,
+skip next, or skip previous *that* player, **Linthra does not react.** The
+controls appear to do nothing.
+
+## What is missing today (root cause)
+
+Linthra's Plex playback integration is **one-way**. It *pushes* its state to
+the server and never *receives* anything back:
+
+- `PlexPlaybackReporter` (`lib/core/sources/plex/plex_playback_reporter.dart`)
+  sends `GET /:/timeline?...&state=playing|paused|stopped&time=…` reports via
+  `HttpPlexClient.reportTimeline`. That report is what makes the session appear
+  in the Now Playing dashboard.
+- The report is a plain outbound HTTP **GET**. There is **no** listening socket,
+  **no** discovery broadcast, and **no** command channel anywhere in the app. A
+  repo-wide search for `HttpServer`, `RawDatagramSocket`, `ServerSocket`,
+  `protocolCapabilities`, GDM, or `/player/…` finds **nothing** in the Plex code
+  (the only socket code is the unrelated Chromecast transport under
+  `lib/core/services/cast/`).
+
+A timeline report **announces a session**; it does **not** open the channel a
+controller uses to drive that session. Those are two different halves of the
+Plex protocol, and Linthra only implements the first.
+
+## How Plex remote control actually works (Plex Companion)
+
+Plex remote control is the **Plex Companion** protocol. It is **not** officially
+documented by Plex; the description below is reconstructed from
+[python-plexapi's `PlexClient`](https://python-plexapi.readthedocs.io/en/latest/modules/client.html),
+its [`gdm` module](https://python-plexapi.readthedocs.io/en/latest/modules/gdm.html),
+the [Music Assistant "Plex Connect" remote-control plugin](https://github.com/music-assistant/server/pull/2608)
+(a recent, real implementation of exactly this), and the community forum threads
+on the [`X-Plex-Target-Client-Identifier` header](https://forums.plex.tv/t/player-playback-play-500-internal-server-error-x-plex-target-client-identifier-not-found/236236).
+**Every detail here must be re-verified against a real PMS + Plexamp during
+implementation** (see [Open questions](#open-questions)).
+
+The crucial fact: **a controllable player runs an HTTP server and is
+discoverable.** Control commands are *delivered to the player*, not polled by
+it. Concretely, a player must do four things Linthra does none of today:
+
+### 1. Be discoverable — GDM (and/or a reachable registered connection)
+
+Plex discovers players on the LAN with **GDM** ("Good Day Mate"), a small
+UDP datagram protocol:
+
+- **Server** discovery uses multicast group `239.0.0.250`, port **32414**.
+- **Client/player** discovery uses broadcast `255.255.255.255`, port **32412**
+  (with `32413`/`32414` seen in variants).
+
+A controllable player listens for the GDM "hello"/discovery datagram and replies
+with a small descriptor (its name, `Content-Type: plex/media-player`, the
+`Resource-Identifier` = its client identifier, `protocolCapabilities`, and the
+**port** its HTTP server listens on). For control *across networks* (controller
+and player on different LANs) GDM does not apply; the player must instead be a
+plex.tv-registered device whose connection the controller (or the PMS, see
+[proxy-through-server](#4-be-reachable-directly-or-proxied-through-the-pms))
+can actually reach — which a phone behind carrier NAT usually is not.
+
+### 2. Serve a capability descriptor — `GET /resources`
+
+The controller fetches `GET /resources` from the player and reads a
+`<MediaContainer><Player .../></MediaContainer>` carrying `machineIdentifier`,
+`product`, `protocolCapabilities`, etc. The **`protocolCapabilities`** attribute
+is a comma-separated list — `timeline,playback,navigation,playqueues,mirror` —
+and **a client only receives the commands it declares.** Declaring `playback`
+is what makes play/pause/skip reach the player at all.
+
+### 3. Serve the command + timeline endpoints — `/player/…`
+
+The controller sends each transport command as an HTTP request **to the
+player's** HTTP server, under `/player/playback/…`:
+
+| Command | Player endpoint | Params |
+| --- | --- | --- |
+| Play | `GET /player/playback/play` | |
+| Pause | `GET /player/playback/pause` | |
+| Stop | `GET /player/playback/stop` | |
+| Skip next | `GET /player/playback/skipNext` | |
+| Skip previous | `GET /player/playback/skipPrevious` | |
+| Seek | `GET /player/playback/seekTo` | `offset` (ms) |
+| Skip to item | `GET /player/playback/skipTo` | `key` (ratingKey) |
+| Step fwd/back | `GET /player/playback/stepForward` / `stepBack` | |
+| Volume / shuffle / repeat | `GET /player/playback/setParameters` | `volume` (0–100), `shuffle`, `repeat` |
+
+Every command carries:
+
+- **`commandID`** — a monotonically increasing integer **per controller**. The
+  player must track the highest seen per controller and echo it in the timeline
+  it returns, so the controller can order and de-duplicate.
+- **`type`** — the media type (`music` for Linthra).
+- header **`X-Plex-Target-Client-Identifier`** — set to *this player's*
+  identifier; the player should reject a command not addressed to it (a missing
+  one is a known `500` on the server side).
+- header **`X-Plex-Client-Identifier`** — the *controller's* identifier.
+
+To keep the controller's UI in sync, the player also serves the **timeline
+subscription** pair:
+
+- `GET /player/timeline/subscribe?protocol=http&port=<n>&commandID=<n>` — the
+  controller asks the player to **push** `POST /:/timeline` updates to it (at
+  the given host:port) whenever state changes.
+- `GET /player/timeline/unsubscribe` — stop pushing.
+- `GET /player/timeline/poll?wait=1&commandID=<n>` — the **pull** alternative:
+  a controller that can't accept pushes fetches one timeline snapshot from the
+  player. (Note: this `poll` is *served by the player* — it is **not** an
+  outbound "poll the server for commands" call. There is no such call in the
+  protocol.)
+
+### 4. Be reachable directly, or proxied through the PMS
+
+A controller can address the player **directly** (its discovered IP:port) or
+ask the **PMS to proxy** the command (`proxyThroughServer`: the controller does
+`server.query('/player/…')` with the `X-Plex-Target-Client-Identifier` header
+and the PMS forwards it to the registered player). Either path still requires
+the player to be **reachable by an HTTP listener** — directly on the LAN, or via
+a connection the PMS holds open. There is no path where a NAT'd, listener-less
+mobile app receives commands purely by making outbound requests.
+
+## Why "it shows up but won't react" — the two halves
+
+| Half of the protocol | Direction | Linthra today |
+| --- | --- | --- |
+| Timeline **report** (`GET /:/timeline`) | app → server (push) | ✅ shipped — this is why it appears in Now Playing |
+| Companion **command channel** (GDM + `/resources` + `/player/playback/*`) | controller → app (inbound) | ❌ absent — nothing listens, nothing is advertised |
+
+The dashboard lists the session from the report; the remote control needs the
+second half, which does not exist. So the controls have **nowhere to send the
+command**, and nothing happens.
+
+## Can this ship safely in one small PR?
+
+**No.** Receiving commands is not a tweak to the existing one-way reporter; it
+is a **new, always-on, inbound network surface on a mobile device**, with its
+own discovery, HTTP server, capability handshake, per-controller `commandID`
+bookkeeping, and subscription lifecycle — plus Android foreground-service,
+battery, and security implications. Shipping any *partial* slice on its own
+would be worse than today:
+
+- Advertising `protocolCapabilities=…,playback` **before** commands are wired
+  would make the server offer controls that silently do nothing — i.e. it would
+  *deepen* the exact bug being reported.
+- A GDM responder or an HTTP server with no command handling advertises a player
+  that can't be driven.
+
+So there is **no safe, independently-useful one-PR version**. This matches how
+the Plex provider itself was introduced — a design doc first (this file), then a
+sequence of small PRs (see [docs/plex.md → Suggested PR steps](plex.md#suggested-pr-steps)).
+The breakdown below keeps each PR reviewable and never ships a misleading
+half-state.
+
+## Proposed architecture (provider-neutral seam)
+
+Mirror the **reporting** seam that already exists, in reverse. Reporting has a
+neutral `ServerPlaybackReporter` contract, a `RoutingServerPlaybackReporter`
+that dispatches by uri scheme, and a Plex-specific `PlexPlaybackReporter` behind
+it (`lib/core/services/server_playback_reporter.dart`,
+`routing_server_playback_reporter.dart`,
+`lib/core/sources/plex/plex_playback_reporter.dart`). Receiving commands gets
+the symmetric shape:
+
+- **`RemoteControlReceiver`** (new, `core/services/remote_control_receiver.dart`)
+  — the neutral contract: `start()` / `stop()` a control channel and a stream of
+  neutral **`RemoteCommand`**s (`play`, `pause`, `playPause`, `stop`, `next`,
+  `previous`, `seekTo(position)`). A `NoOpRemoteControlReceiver` for providers
+  without remote control (everything except Plex today). Commands are **neutral**
+  — no Plex types leak out — exactly like `ServerPlaybackReporter` hands
+  reporters only a catalog `Track`.
+- **`RemoteControlService`** (new) — subscribes to the active receiver's command
+  stream and applies each command to the existing **`PlaybackController`**
+  (`play()`, `pause()`, `stop()`, `seek()`, `skipToNext()`, `skipToPrevious()`).
+  That interface is already the single transport seam the UI and cast both use,
+  so commands flow through the *same* path as a user tap — no parallel control
+  logic. The service also feeds the receiver the live `PlaybackState` so the
+  companion timeline it returns to controllers matches reality, reusing the
+  `PlaybackReportingService`'s derived lifecycle rather than re-deriving it.
+- **`PlexCompanionServer`** (new, `core/sources/plex/plex_companion_server.dart`)
+  — all Plex-specific detail behind the neutral interface: the GDM responder,
+  the `dart:io` `HttpServer`, the `/resources` descriptor, parsing
+  `/player/playback/*` → `RemoteCommand`, the per-controller `commandID` table,
+  and the `/player/timeline/{subscribe,poll,unsubscribe}` lifecycle. It reads
+  the live `PlexSession` lazily (signed out → silent no-op), exactly like
+  `PlexPlaybackReporter` and the playable-uri resolver. It uses the **same
+  `X-Plex-Client-Identifier`** persisted on the session, so the server keys the
+  controllable player to the same entry it already shows in Now Playing.
+
+### What the commands are *allowed* to do (hard invariants)
+
+- **Library stays read-only.** `RemoteCommand` covers transport only — play,
+  pause, stop, next, previous, seek (and optionally volume). It can **never**
+  create/edit/delete a playlist, change favorites, rate, scrobble-write, or
+  mutate any library item. The neutral enum simply has no such cases, so the
+  invariant is enforced by construction, not by discipline.
+- **`skipTo` by `key` is read-only navigation within the current queue**, not a
+  library write; phase 1 may decline it (respond but no-op) until queue-jump
+  semantics are designed.
+- **Non-Plex providers are untouched.** Only `PlexCompanionServer` exists; the
+  router starts a receiver only for a live Plex session, so a Jellyfin/Subsonic/
+  Local-only user has *no* listening socket and *no* behavior change.
+
+### Token / security safety (same non-negotiables, plus inbound concerns)
+
+The reporting path's rules carry over, and an **inbound server** adds new ones:
+
+- **The companion server never exposes the `X-Plex-Token`.** The token rides
+  only in the outbound timeline-push header (as today); it is never placed in a
+  served response body, a `/resources` document, a log, or an error. `/resources`
+  and timelines are token-free by construction.
+- **Commands are authenticated.** A command is honored only when its
+  `X-Plex-Target-Client-Identifier` matches this install's identifier; phase 1
+  binds the server to the **loopback/LAN** interface and does not register a
+  public connection, so the surface is the local network only. Whether to
+  additionally verify the controller against the signed-in account is an
+  [open question](#open-questions).
+- **The listener exists only while signed in to Plex and only while it adds
+  value** (see battery, below). Signing out tears it down.
+- **No new persisted state.** Subscriptions and `commandID` tables are in-memory
+  and die with the session. Nothing about remote control is written to disk.
+
+## Battery & network risk (and how the design contains it)
+
+Linthra's battery stance is explicitly **"event-driven, never polled — no
+background polling, heartbeats, or keep-alives"** (see [docs/battery.md](battery.md)).
+An always-listening companion server is the single biggest tension with that
+stance, so the design contains it deliberately:
+
+- **Risk — a persistent listening socket + GDM responder.** An idle bound
+  `HttpServer` is cheap (no busy loop), but holding it open implies the process
+  stays alive and reachable. **Mitigation:** bind the server **only while a Plex
+  track is the active session** (started ↔ stopped, reusing the reporter's
+  lifecycle), not for the whole app lifetime. No Plex playback → no socket.
+- **Risk — GDM is multicast/broadcast UDP.** Responding to every discovery probe
+  on a busy network is wake-ups. **Mitigation:** only listen while controllable
+  (as above); ignore malformed/non-Plex datagrams cheaply; never *initiate*
+  periodic broadcasts (respond-only), so there is no timer.
+- **Risk — timeline *push* on subscribe could become a per-tick spam.**
+  **Mitigation:** reuse the existing throttle (`PlaybackReportingService` already
+  collapses ticks to lifecycle + one progress per 10s); push on **state change**,
+  not on every position tick.
+- **Risk — Android background limits.** A bound socket while the screen is off
+  needs the playback foreground service to already be up. **Mitigation:** the
+  server only runs *during Plex playback*, when the `audio_service` foreground
+  service (and its wake locks) is already promoted — so remote control adds **no
+  new** wake lock or foreground-service window beyond what playback already
+  holds. It must **never** keep the process alive after playback ends.
+- **Risk — `poll?wait=N` long-poll holds a request open.** **Mitigation:** cap
+  the wait, cap concurrent subscribers, and drop idle subscriptions.
+
+Net: with the "only while a Plex track is playing, respond-only, reuse the
+existing throttle" rules, remote control adds no new *timer* and no new
+foreground-service window — it rides the one playback already owns.
+
+## Recommended PR breakdown
+
+Small, incremental, each independently reviewable, and **none ships a state
+where the server offers controls that don't work**:
+
+1. **Design doc** — this `docs/plex-remote-control.md`. **No code.** ← *this PR*
+2. **Neutral command seam (no I/O, no advertisement).** `RemoteCommand` enum +
+   `RemoteControlReceiver` / `NoOpRemoteControlReceiver` contract +
+   `RemoteControlService` that maps commands → `PlaybackController`. Fully
+   unit-tested with a `FakeRemoteControlReceiver`; **nothing binds a socket and
+   nothing is advertised**, so the app's behavior is unchanged.
+3. **Pure Companion protocol units.** A `/player/playback/*` request →
+   `RemoteCommand` parser, a `/resources` descriptor builder, a per-controller
+   `commandID` tracker, and a GDM datagram parse/format helper — **pure
+   functions, no sockets**, exhaustively unit-tested (incl. token-free output
+   and rejecting commands not addressed to this client).
+4. **`PlexCompanionServer` — HTTP server, wired but feature-flagged off.** Bind
+   a `dart:io` `HttpServer`, serve `/resources` + `/player/playback/*` +
+   `/player/timeline/*`, emit neutral commands. Behind an **off-by-default**
+   setting so it can be tested on a real device without changing default
+   behavior. Tests drive the server with a fake controller over loopback.
+5. **GDM discovery responder.** Respond to discovery probes so controllers find
+   the player on the LAN, advertising `protocolCapabilities` incl. `playback`.
+   Still feature-flagged.
+6. **Lifecycle wiring + enable.** Start the receiver only while a Plex track is
+   the active session (reuse the reporter lifecycle), tear it down on stop /
+   sign-out / app exit; verify the foreground-service interaction; then flip the
+   flag on (or expose a Settings toggle). This is the PR that makes the controls
+   work end-to-end. Tests cover start/stop on session boundaries and a clean
+   teardown on sign-out.
+7. **(Optional, later) Remote reachability.** Register a connection with plex.tv
+   / proxy-through-server so control works across networks, *if* it proves
+   feasible and safe behind NAT — likely its own design note.
+
+Stop after step 1 (this PR) and confirm the design before building 2+. Steps
+2–3 are safe to land early (pure, untested-surface-free); the behavior change
+only arrives at step 6.
+
+## Tests to add (per the repo's `Fake*` + Riverpod-override style)
+
+Mirrors the Jellyfin/Subsonic/Plex test layout; no mocking library.
+
+- `remote_command_test.dart` — neutral command mapping → `PlaybackController`
+  calls (play/pause/stop/next/previous/seek), with a `FakePlaybackController`.
+- `remote_control_service_test.dart` — a command stream drives exactly the right
+  controller calls, in order; a no-op receiver causes nothing.
+- `plex_companion_endpoints_test.dart` — `/player/playback/*` → `RemoteCommand`
+  parsing, `type`/`commandID` handling, rejecting a command whose
+  `X-Plex-Target-Client-Identifier` isn't ours, and `seekTo` offset parsing.
+- `plex_resources_descriptor_test.dart` — the `/resources` document declares
+  `playback` capability and is **token-free**.
+- `plex_command_id_test.dart` — per-controller monotonic tracking + echo.
+- `plex_gdm_test.dart` — discovery datagram parse/format, ignore non-Plex.
+- `plex_companion_server_test.dart` — drive a loopback `HttpServer` with a fake
+  controller: a command turns into a `PlaybackController` call; a foreign target
+  identifier is refused; no response body ever carries the token.
+- A **guard test** that with no Plex session (or a non-Plex-only setup) **no
+  socket is bound and nothing is advertised** — the no-behavior-change invariant.
+- A **library-read-only guard**: the `RemoteCommand` surface has no
+  library-mutating case, and no command path calls any catalog/playlist/favorites
+  write.
+
+## Open questions
+
+Decide these before/while building, ideally against a real PMS + Plexamp:
+
+- **Exact GDM ports & datagram shape**, and the precise `/resources` /
+  `Player` descriptor a current PMS/Plexamp expects — the protocol is
+  reverse-engineered, so validate empirically.
+- **Direct-LAN only vs proxy-through-server**: is LAN control enough for phase 1
+  (almost certainly yes), deferring cross-network control to a later note?
+- **Controller authentication**: is matching `X-Plex-Target-Client-Identifier`
+  + LAN-binding sufficient, or should commands be checked against the signed-in
+  account/token?
+- **Default on or behind a Settings toggle?** Given the inbound-socket surface,
+  a default-off toggle (with a clear "let Plex apps control this player"
+  explanation) is the conservative first ship.
+- **`stop` semantics**: map Companion `stop` to `PlaybackController.stop()` —
+  safe and already supported — vs treating it as pause. Stop is in scope and
+  safe; confirm it shouldn't instead tear down the queue.
+
+## Notes
+
+- This design must **not** change existing providers. The only shared-code
+  additions are the new neutral `RemoteControlReceiver`/`RemoteControlService`
+  seam (used by Plex alone today) and wiring that starts a receiver **only** for
+  a live Plex session.
+- Reuse, don't reinvent: `PlaybackController` is the existing transport seam,
+  `PlaybackReportingService` already derives the playback lifecycle and throttle,
+  `dart:io` provides `HttpServer`/`RawDatagramSocket`, and the `Fake*`-client +
+  Riverpod-override test style is already in place.
+- Credentials follow the same non-negotiables as every other provider: the token
+  is never logged, never served in a response, and never woven into a persisted
+  value.
+</content>
+</invoke>

--- a/docs/plex-remote-control.md
+++ b/docs/plex-remote-control.md
@@ -1,15 +1,23 @@
 # Plex remote control (Companion) — design
 
-> **Status: design only.** This page captures the investigation and the agreed
-> design for **receiving Plex remote-playback commands** (play / pause / skip
-> next / skip previous / stop) so it can be built in small, reviewable PRs.
-> **No remote-control code ships with this document.** It does **not** register a
-> companion server, open a socket, advertise the player, or change playback; it
-> does **not** touch Jellyfin, Navidrome/Subsonic, or Local music, and it keeps
-> Plex **read-only from the library's perspective** (no playlist or favorites
-> editing). It is the design counterpart to
+> **Status: design only (Plex half).** This page captures the investigation and
+> the agreed design for **receiving Plex remote-playback commands** (play /
+> pause / skip next / skip previous / stop) so it can be built in small,
+> reviewable PRs. **No Plex remote-control code ships with this document.** It
+> does **not** register a companion server, open a socket, advertise the player,
+> or change playback, and it keeps Plex **read-only from the library's
+> perspective** (no playlist or favorites editing). It is the design counterpart
+> to
 > [docs/plex.md → Playback reporting / Now Playing](plex.md#playback-reporting--now-playing-shipped-after-phase-1),
 > which shipped one-way timeline reporting; this is its symmetric follow-up.
+>
+> **Update:** the provider-neutral remote-control seam this design proposes has
+> since shipped, and **Jellyfin** remote control is implemented on it (Jellyfin
+> uses an outbound control WebSocket, a different and more NAT-friendly protocol
+> than Plex's inbound Companion server). See
+> [docs/remote-control.md](remote-control.md) for the cross-provider overview
+> and status. This page remains the design for the **Plex Companion** half,
+> which is not yet built.
 
 ## The symptom
 

--- a/docs/plex.md
+++ b/docs/plex.md
@@ -215,6 +215,13 @@ benign, ephemeral write (PMS updates its session list; nothing in the library
 is modified) and is **best-effort by contract** — a failed report is silently
 dropped and can never stall, stop, or alter playback.
 
+> **Note — this is reporting only, not remote control.** Timeline reporting is
+> a one-way *push*; it lists the session but does not open the channel a Plex
+> controller uses to drive it, so Linthra appears in the dashboard but does not
+> yet react to remote play/pause/skip commands. Receiving those commands is the
+> separate **Plex Companion** protocol, designed in
+> [docs/plex-remote-control.md](plex-remote-control.md).
+
 ### How Plex sees a player
 
 A client reports its playback to `GET /:/timeline` (verified against

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -221,6 +221,12 @@ follow-ups — and Plex follows the same token-safety rules as every other
 provider (token encrypted at rest, never logged, never shown again after
 saving, never woven into a persisted URI or cache filename).
 
+Linthra also reports a playback **timeline**, so it appears as an active player
+in the server's Now Playing dashboard. That report is one-way, though, so the
+player does not yet *react* to remote play/pause/skip commands from other Plex
+apps — receiving those is the separate **Plex Companion** protocol, designed in
+[plex-remote-control.md](plex-remote-control.md).
+
 ## Future provider possibilities
 
 The `MusicSource` seam is designed so more **self-hosted / user-owned** backends

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -1,0 +1,96 @@
+# Remote playback control
+
+Linthra reports its playback to the server that owns the playing track, so it
+appears as an active player in that server's dashboard (see
+[providers.md](providers.md) and [plex.md](plex.md)). This page covers the
+*other* direction — **receiving** remote play / pause / skip / seek commands so
+another app (or a speaker remote) can drive Linthra.
+
+Crucially, "remote control" is **not one mechanism**: each provider does it
+completely differently, and two of them cannot do it at all. The neutral seam
+below lets each provider that *can* be controlled plug in without the rest of
+the app knowing how.
+
+## Per-provider status
+
+| Provider | Mechanism | Status |
+| --- | --- | :--- |
+| **Jellyfin** | Outbound **control WebSocket** (`/socket`) — server pushes `Playstate` commands; client registers `SupportsMediaControl`. NAT-friendly. | ✅ Implemented |
+| **Plex** | Inbound **Companion** protocol — GDM discovery + a local HTTP server serving `/player/playback/*`. Needs an inbound socket on-device. | 🔜 Designed — see [plex-remote-control.md](plex-remote-control.md) |
+| **Navidrome / Subsonic** | — | ❌ Not possible: the Subsonic API has **no** way for a server to push playback commands to a streaming client. Its only remote-control feature is Jukebox mode (a client commanding *server-side* playback — the inverse). |
+| **Local files** | — | ➖ Not applicable: there is no server. External control of local playback is the **system media session** (lock screen, Bluetooth, Android Auto), which Linthra already provides via `audio_service`. |
+
+## The neutral seam
+
+Remote control mirrors the **reporting** seam in reverse. Where
+`ServerPlaybackReporter` pushes lifecycle events *out*, a `RemoteControlReceiver`
+brings commands *in*; both keep every provider's protocol behind the interface.
+
+- **`RemoteCommand`** (`core/services/remote_command.dart`) — a closed,
+  **transport-only** command set: play, pause, playPause, stop, next, previous,
+  seek. It has **no** library-mutating case (no playlist, favorite, rating, or
+  catalog write), so remote control can never reach past transport into the
+  library *by construction*.
+- **`RemoteControlReceiver`** (`core/services/remote_control_receiver.dart`) —
+  the per-provider seam: owns a transport, surfaces neutral commands on
+  `commands`, and is `start()`/`stop()`-able so the transport runs only while
+  useful. `NoOpRemoteControlReceiver` covers providers with no remote control.
+- **`RemoteControlService`** (`core/services/remote_control_service.dart`) —
+  applies each command to the existing **`PlaybackController`**, strictly in
+  arrival order, one at a time, swallowing failures. A remote pause therefore
+  takes the *exact same path* as an on-screen tap — through cast routing, the
+  media session, and server reporting — with no parallel control logic.
+- **`RemoteControlActivator`** (`core/services/remote_control_activator.dart`) —
+  starts/stops the receiver in step with playback, so the transport is open only
+  while a controllable track plays (see Battery).
+
+### Jellyfin specifics
+
+`JellyfinRemoteControlReceiver` (`core/sources/jellyfin/`) connects the server's
+`/socket`, registers session capabilities via `POST /Sessions/Capabilities/Full`
+(declaring audio + media control), and maps pushed `Playstate` messages
+(`Unpause`/`Play`/`Pause`/`PlayPause`/`Stop`/`NextTrack`/`PreviousTrack`/`Seek`)
+to neutral commands. It answers `ForceKeepAlive` with periodic `KeepAlive`s and
+reconnects after a drop. The WebSocket itself sits behind a tiny
+`JellyfinControlSocket` seam (with a `dart:io WebSocket` adapter — **no new
+package**, so the committed lockfile is untouched), so the connect/keepalive/
+reconnect logic is unit-tested with a fake.
+
+## Battery & network
+
+Linthra's stance is *event-driven, never polled — no background keep-alives*
+(see [battery.md](battery.md)). A control socket is in tension with that, so it
+is contained:
+
+- **The socket is open only while a controllable track is playing/paused.**
+  `RemoteControlActivator` watches playback and `stop()`s the receiver the
+  moment playback stops or moves to a non-Jellyfin track — there is no
+  persistent signed-in-but-idle socket.
+- **Keepalives are server-driven**, answered at half the server's requested
+  interval; Linthra never initiates its own heartbeat timer outside an open,
+  in-use session.
+- **Reconnects use a fixed delay** and stop the instant the activator does.
+
+Follow-ups (not done here): exponential reconnect backoff and foreground-gating;
+and the Plex Companion path, whose inbound socket has its own battery profile
+(see [plex-remote-control.md](plex-remote-control.md) → Battery).
+
+## Security
+
+- The command set is transport-only, so an authenticated controller can never
+  reach the library. Commands run through `PlaybackController` exactly like a
+  user tap.
+- Jellyfin's token rides in the WebSocket URL's `api_key` query (like the audio
+  stream URL) and the capability POST's `Authorization` header; the URL is
+  treated as a secret and never logged.
+- Nothing about remote control is persisted.
+
+## Tests
+
+`test/core/services/remote_control_service_test.dart`,
+`remote_control_activator_test.dart`,
+`test/core/sources/jellyfin/jellyfin_remote_command_test.dart`, and
+`jellyfin_remote_control_receiver_test.dart` cover command mapping, the
+controller bridge, playback-gated activation, capability registration,
+keepalive, the signed-out no-op, and stop/disconnect — all with fakes, no real
+sockets or servers.

--- a/lib/core/services/remote_command.dart
+++ b/lib/core/services/remote_command.dart
@@ -1,0 +1,101 @@
+/// A provider-neutral remote playback command: one transport action a remote
+/// controller has asked Linthra to perform on whatever is playing now.
+///
+/// Remote controllers speak very different wire protocols — Plex's Companion
+/// `/player/playback/*` requests, a Jellyfin control WebSocket's
+/// `PlaystateCommand` messages — but they all reduce to the same small set of
+/// transport intents. Each provider's `RemoteControlReceiver` maps its protocol
+/// onto these neutral commands, and `RemoteControlService` maps these onto the
+/// existing `PlaybackController`, so a remote command takes exactly the same
+/// path as the user tapping the matching on-screen control.
+///
+/// The set is deliberately closed to **transport only**: there is no command
+/// that reads, creates, edits, or deletes anything in the library — no
+/// playlist, favorite, rating, or catalog mutation — so by construction remote
+/// control can never reach past play/pause/skip/seek into the user's library.
+sealed class RemoteCommand {
+  const RemoteCommand();
+}
+
+/// Begin, or resume, playback of the current track.
+final class RemotePlay extends RemoteCommand {
+  const RemotePlay();
+
+  @override
+  bool operator ==(Object other) => other is RemotePlay;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Pause playback, keeping the current track and position.
+final class RemotePause extends RemoteCommand {
+  const RemotePause();
+
+  @override
+  bool operator ==(Object other) => other is RemotePause;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Toggle between playing and paused — what most controllers send for a single
+/// play/pause button. [RemoteControlService] consults the live playback state
+/// to decide which way to flip.
+final class RemotePlayPause extends RemoteCommand {
+  const RemotePlayPause();
+
+  @override
+  bool operator ==(Object other) => other is RemotePlayPause;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Stop playback.
+final class RemoteStop extends RemoteCommand {
+  const RemoteStop();
+
+  @override
+  bool operator ==(Object other) => other is RemoteStop;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Skip to the next track in the queue.
+final class RemoteNext extends RemoteCommand {
+  const RemoteNext();
+
+  @override
+  bool operator ==(Object other) => other is RemoteNext;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Skip to the previous track in the queue.
+final class RemotePrevious extends RemoteCommand {
+  const RemotePrevious();
+
+  @override
+  bool operator ==(Object other) => other is RemotePrevious;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// Seek the current track to [position].
+final class RemoteSeek extends RemoteCommand {
+  const RemoteSeek(this.position);
+
+  /// The absolute position to seek to from the start of the track.
+  final Duration position;
+
+  @override
+  bool operator ==(Object other) =>
+      other is RemoteSeek && other.position == position;
+
+  @override
+  int get hashCode => position.hashCode;
+}

--- a/lib/core/services/remote_control_activator.dart
+++ b/lib/core/services/remote_control_activator.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import 'remote_control_receiver.dart';
+
+/// Starts and stops a [RemoteControlReceiver] in step with playback, so a
+/// provider's remote-control transport (e.g. the Jellyfin control WebSocket) is
+/// connected only while it is actually useful — never as a persistent
+/// background keep-alive.
+///
+/// It watches the unified playback state and, whenever [isControllable] turns
+/// true, [RemoteControlReceiver.start]s the receiver; when it turns false, it
+/// [RemoteControlReceiver.stop]s it. With nothing controllable playing there is
+/// no open socket, keeping remote control battery-friendly and consistent with
+/// Linthra's "event-driven, never polled" stance. The receiver's command stream
+/// stays alive across start/stop, so the [RemoteControlService] consuming it is
+/// unaffected.
+class RemoteControlActivator {
+  RemoteControlActivator({
+    required RemoteControlReceiver receiver,
+    required Stream<PlaybackState> playbackStates,
+    required bool Function(PlaybackState state) isControllable,
+  })  : _receiver = receiver,
+        _isControllable = isControllable {
+    _subscription = playbackStates.listen(_onState);
+  }
+
+  final RemoteControlReceiver _receiver;
+  final bool Function(PlaybackState state) _isControllable;
+  late final StreamSubscription<PlaybackState> _subscription;
+
+  bool _active = false;
+
+  void _onState(PlaybackState state) {
+    final bool want = _isControllable(state);
+    if (want == _active) return;
+    _active = want;
+    if (want) {
+      unawaited(_receiver.start());
+    } else {
+      unawaited(_receiver.stop());
+    }
+  }
+
+  /// Stops watching and disconnects the receiver. The receiver itself is owned
+  /// (and finally disposed) by its provider.
+  Future<void> dispose() async {
+    await _subscription.cancel();
+    await _receiver.stop();
+  }
+}

--- a/lib/core/services/remote_control_receiver.dart
+++ b/lib/core/services/remote_control_receiver.dart
@@ -17,11 +17,23 @@ import 'remote_command.dart';
 ///    [RemoteCommand]s, so remote control can never reach into the library.
 abstract interface class RemoteControlReceiver {
   /// The neutral commands this provider's controller(s) have asked for. A
-  /// broadcast stream: nothing is buffered for late listeners, so a command
-  /// that arrives before [RemoteControlService] subscribes is simply dropped.
+  /// broadcast stream that stays open across [start]/[stop], so the
+  /// [RemoteControlService] consuming it subscribes once for the session.
+  /// Nothing is buffered for late listeners.
   Stream<RemoteCommand> get commands;
 
-  /// Releases the transport (closes sockets/subscriptions). Idempotent.
+  /// Connects the transport and begins receiving commands. Idempotent, and a
+  /// safe no-op when signed out (the receiver simply has nothing to connect
+  /// to). Reconnects after a drop are the receiver's own concern.
+  Future<void> start();
+
+  /// Disconnects the transport **without** ending [commands], so a later
+  /// [start] resumes. Idempotent. Used to keep the transport open only while it
+  /// is useful (see `RemoteControlActivator`) rather than as a background
+  /// keep-alive.
+  Future<void> stop();
+
+  /// Releases everything and ends [commands]. Idempotent. Call on shutdown.
   Future<void> dispose();
 }
 
@@ -33,6 +45,12 @@ class NoOpRemoteControlReceiver implements RemoteControlReceiver {
 
   @override
   Stream<RemoteCommand> get commands => const Stream<RemoteCommand>.empty();
+
+  @override
+  Future<void> start() async {}
+
+  @override
+  Future<void> stop() async {}
 
   @override
   Future<void> dispose() async {}

--- a/lib/core/services/remote_control_receiver.dart
+++ b/lib/core/services/remote_control_receiver.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import 'remote_command.dart';
+
+/// A source of [RemoteCommand]s for one provider: it owns its own transport (a
+/// control WebSocket to a Jellyfin server, a local Companion HTTP server + GDM
+/// responder for Plex, …) and surfaces the neutral commands it receives on
+/// [commands]. The provider-specific protocol, auth, and connection lifecycle
+/// stay behind this seam — the mirror image of how `ServerPlaybackReporter`
+/// hides the *reporting* side.
+///
+/// Contract for implementations:
+///  - **Best-effort, never fatal.** A transport failure must never throw out of
+///    [commands] or disturb playback; reconnects are the receiver's own
+///    business.
+///  - **Transport only.** A receiver may only ever emit the closed set of
+///    [RemoteCommand]s, so remote control can never reach into the library.
+abstract interface class RemoteControlReceiver {
+  /// The neutral commands this provider's controller(s) have asked for. A
+  /// broadcast stream: nothing is buffered for late listeners, so a command
+  /// that arrives before [RemoteControlService] subscribes is simply dropped.
+  Stream<RemoteCommand> get commands;
+
+  /// Releases the transport (closes sockets/subscriptions). Idempotent.
+  Future<void> dispose();
+}
+
+/// The receiver for setups with no remote control (no signed-in controllable
+/// provider): an inert, empty command stream. Lets the wiring always hold a
+/// receiver instead of special-casing "nothing to receive".
+class NoOpRemoteControlReceiver implements RemoteControlReceiver {
+  const NoOpRemoteControlReceiver();
+
+  @override
+  Stream<RemoteCommand> get commands => const Stream<RemoteCommand>.empty();
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/lib/core/services/remote_control_service.dart
+++ b/lib/core/services/remote_control_service.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'playback_controller.dart';
+import 'remote_command.dart';
+import 'remote_control_receiver.dart';
+
+/// Applies [RemoteCommand]s from a [RemoteControlReceiver] to the app's
+/// [PlaybackController] — the bridge that lets a Plex or Jellyfin remote
+/// actually drive playback.
+///
+/// It listens to the receiver's neutral command stream and calls the *same*
+/// [PlaybackController] transport methods the on-screen controls use, so a
+/// remote pause and an in-app pause are indistinguishable downstream (both flow
+/// through cast routing, the media session, and server reporting). A
+/// [RemotePlayPause] toggle consults the controller's live
+/// [PlaybackController.state] to decide play vs. pause.
+///
+/// Like the reporting service, it is best-effort and off the critical path:
+/// commands are applied strictly in arrival order, one at a time (so a slow
+/// seek can't let a later pause overtake it), and any failure applying a single
+/// command is swallowed so it can never stall the stream or disturb playback.
+class RemoteControlService {
+  RemoteControlService({
+    required RemoteControlReceiver receiver,
+    required PlaybackController controller,
+  }) : _controller = controller {
+    _subscription = receiver.commands.listen(_enqueue);
+  }
+
+  final PlaybackController _controller;
+  late final StreamSubscription<RemoteCommand> _subscription;
+
+  final List<RemoteCommand> _pending = <RemoteCommand>[];
+  bool _draining = false;
+
+  void _enqueue(RemoteCommand command) {
+    _pending.add(command);
+    unawaited(_drain());
+  }
+
+  /// Applies pending commands strictly in order, one at a time. A failure on
+  /// one command is swallowed so the next still runs and playback is never
+  /// disturbed.
+  Future<void> _drain() async {
+    if (_draining) return;
+    _draining = true;
+    try {
+      while (_pending.isNotEmpty) {
+        final RemoteCommand command = _pending.removeAt(0);
+        try {
+          await _apply(command);
+        } catch (_) {
+          // Best-effort by contract; the next command still goes out.
+        }
+      }
+    } finally {
+      _draining = false;
+    }
+  }
+
+  Future<void> _apply(RemoteCommand command) async {
+    switch (command) {
+      case RemotePlay():
+        await _controller.play();
+      case RemotePause():
+        await _controller.pause();
+      case RemotePlayPause():
+        if (_controller.state.isPlaying) {
+          await _controller.pause();
+        } else {
+          await _controller.play();
+        }
+      case RemoteStop():
+        await _controller.stop();
+      case RemoteNext():
+        await _controller.skipToNext();
+      case RemotePrevious():
+        await _controller.skipToPrevious();
+      case RemoteSeek(:final position):
+        await _controller.seek(position);
+    }
+  }
+
+  /// Stops applying commands. Call when the controllable session ends; the
+  /// receiver owns its own transport and is disposed separately.
+  Future<void> dispose() async {
+    await _subscription.cancel();
+  }
+}

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -216,6 +216,34 @@ class HttpJellyfinClient implements JellyfinClient {
   }
 
   @override
+  Future<void> registerRemoteControlCapabilities(
+    JellyfinSession session,
+  ) async {
+    final Uri uri = JellyfinEndpoints.capabilitiesFull(session.baseUrl);
+    final http.Response response = await _send(
+      () => _client.post(
+        uri,
+        headers: <String, String>{
+          ..._authHeaders(session),
+          'Content-Type': 'application/json',
+        },
+        // Declare audio playback + media control so the server lists this
+        // session as controllable and pushes Playstate commands to it. No
+        // GeneralCommands are claimed (Linthra has no volume transport), and
+        // no persistent identifier is offered.
+        body: jsonEncode(<String, Object>{
+          'PlayableMediaTypes': <String>['Audio'],
+          'SupportedCommands': <String>[],
+          'SupportsMediaControl': true,
+          'SupportsPersistentIdentifier': false,
+        }),
+      ),
+    );
+    // Jellyfin answers `204 No Content`; a 2xx alone means it landed.
+    _checkStatus(response);
+  }
+
+  @override
   Future<Set<String>> fetchFavoriteIds(JellyfinSession session) async {
     final Uri uri = JellyfinEndpoints.favoriteAudioItems(
       session.baseUrl,

--- a/lib/core/sources/jellyfin/jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/jellyfin_client.dart
@@ -79,6 +79,16 @@ abstract interface class JellyfinClient {
     required Duration position,
   });
 
+  /// Registers this client's session capabilities via
+  /// `POST /Sessions/Capabilities/Full`, declaring audio playback and media
+  /// control so other Jellyfin apps list it as a controllable player and the
+  /// server delivers transport (Playstate) commands over the control socket.
+  ///
+  /// Throws a [JellyfinException] on failure; the caller (the remote-control
+  /// receiver) treats it as best-effort, so a registration hiccup never stops
+  /// it from listening for commands.
+  Future<void> registerRemoteControlCapabilities(JellyfinSession session);
+
   /// The audio item ids the signed-in user has marked as favourites.
   Future<Set<String>> fetchFavoriteIds(JellyfinSession session);
 

--- a/lib/core/sources/jellyfin/jellyfin_control_socket.dart
+++ b/lib/core/sources/jellyfin/jellyfin_control_socket.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:io';
+
+/// A live control connection to a Jellyfin server's session WebSocket.
+///
+/// Abstracted behind this seam so the receiver's logic — parse, emit, keepalive,
+/// reconnect — is unit-testable with a fake, while the real implementation is a
+/// thin `dart:io` [WebSocket] (no extra package, so the committed lockfile is
+/// untouched).
+abstract interface class JellyfinControlSocket {
+  /// Text frames from the server, each a raw JSON envelope the receiver decodes
+  /// and maps. The stream completes (or errors) when the socket closes.
+  Stream<String> get messages;
+
+  /// Sends a text frame to the server (e.g. a `KeepAlive` reply).
+  void send(String message);
+
+  /// Closes the connection. Idempotent.
+  Future<void> close();
+}
+
+/// Opens a [JellyfinControlSocket] to [url]. Injected into the receiver so tests
+/// supply a fake; production passes [connectJellyfinControlSocket].
+typedef JellyfinControlSocketConnector = Future<JellyfinControlSocket> Function(
+  Uri url,
+);
+
+/// Production connector: a `dart:io` [WebSocket]. The [url] carries the access
+/// token in its `api_key` query, so it must never be logged here.
+Future<JellyfinControlSocket> connectJellyfinControlSocket(Uri url) async {
+  final WebSocket socket = await WebSocket.connect(url.toString());
+  return _WebSocketJellyfinControlSocket(socket);
+}
+
+class _WebSocketJellyfinControlSocket implements JellyfinControlSocket {
+  _WebSocketJellyfinControlSocket(this._socket);
+
+  final WebSocket _socket;
+
+  @override
+  Stream<String> get messages =>
+      _socket.where((Object? event) => event is String).cast<String>();
+
+  @override
+  void send(String message) => _socket.add(message);
+
+  @override
+  Future<void> close() => _socket.close();
+}

--- a/lib/core/sources/jellyfin/jellyfin_endpoints.dart
+++ b/lib/core/sources/jellyfin/jellyfin_endpoints.dart
@@ -29,6 +29,8 @@ abstract final class JellyfinEndpoints {
   static const String _playingPath = '/Sessions/Playing';
   static const String _playingProgressPath = '/Sessions/Playing/Progress';
   static const String _playingStoppedPath = '/Sessions/Playing/Stopped';
+  static const String _capabilitiesFullPath = '/Sessions/Capabilities/Full';
+  static const String _socketPath = '/socket';
 
   // --- Query-parameter keys, named once so a typo can't split a request. ---
 
@@ -217,6 +219,37 @@ abstract final class JellyfinEndpoints {
   /// settling the server's session and play state for it.
   static Uri playbackStopped(String baseUrl) =>
       _join(baseUrl, _playingStoppedPath);
+
+  /// `POST /Sessions/Capabilities/Full` — declares this client's session
+  /// capabilities, so other Jellyfin apps list it as a controllable player.
+  /// Linthra posts `SupportsMediaControl: true` here to receive the transport
+  /// (Playstate) commands over the control socket; the token rides in the
+  /// `Authorization` header, so this URL is token-free.
+  static Uri capabilitiesFull(String baseUrl) =>
+      _join(baseUrl, _capabilitiesFullPath);
+
+  /// The session control WebSocket: `{ws|wss}://<host>/socket?api_key=…&deviceId=…`.
+  ///
+  /// Built from [baseUrl] by switching the scheme to `ws`/`wss`. The server
+  /// pushes remote-control (Playstate/GeneralCommand) messages down this socket
+  /// once the session is registered. Auth rides in the [accessToken] `api_key`
+  /// query — exactly like the audio stream URL ([audioStream]) — so the receiver
+  /// must treat this Uri as a secret and never log it.
+  static Uri controlSocket(
+    String baseUrl, {
+    required String accessToken,
+    required String deviceId,
+  }) {
+    final Uri http = Uri.parse('$baseUrl$_socketPath');
+    final String wsScheme = http.scheme == 'https' ? 'wss' : 'ws';
+    return http.replace(
+      scheme: wsScheme,
+      queryParameters: <String, String>{
+        apiKeyParam: accessToken,
+        'deviceId': deviceId,
+      },
+    );
+  }
 
   /// `GET /Audio/<itemId>/Lyrics` — time-synced or plain lyrics (a 404 just
   /// means the server has none).

--- a/lib/core/sources/jellyfin/jellyfin_remote_command.dart
+++ b/lib/core/sources/jellyfin/jellyfin_remote_command.dart
@@ -1,0 +1,75 @@
+import '../../services/remote_command.dart';
+
+/// Maps a Jellyfin control-WebSocket message to a neutral [RemoteCommand], or
+/// `null` when the message is not a transport command Linthra acts on.
+///
+/// Jellyfin pushes remote-control intents over the session WebSocket as JSON
+/// envelopes `{ "MessageType": "...", "Data": {...} }`. The transport commands
+/// arrive as `MessageType: "Playstate"` with a `Data.Command` naming the action
+/// (and, for a seek, `Data.SeekPositionTicks`). Everything else — other message
+/// types, the volume/`GeneralCommand`s Linthra has no transport for, unknown or
+/// unsupported commands — maps to `null` and is ignored, so the socket can
+/// carry anything without surprising playback.
+///
+/// Pure and side-effect-free: it only translates, so it is exhaustively
+/// unit-testable and carries no transport, auth, or I/O concerns. The match is
+/// case-insensitive on both the message type and the command name, so a casing
+/// difference between server versions can't silently drop a command.
+abstract final class JellyfinRemoteCommand {
+  /// The `MessageType` that carries a playstate transport command.
+  static const String playstateMessageType = 'Playstate';
+
+  /// Jellyfin records position in ticks of 100 ns, so there are 10 ticks per
+  /// microsecond (10,000,000 per second) — the same unit `PositionTicks` and
+  /// `RunTimeTicks` use elsewhere. A seek's `SeekPositionTicks` is converted to
+  /// a [Duration] through this.
+  static const int _ticksPerMicrosecond = 10;
+
+  /// Translates one decoded WebSocket [message] into a neutral command, or
+  /// returns `null` when it is not a transport command Linthra applies.
+  static RemoteCommand? fromMessage(Map<String, dynamic> message) {
+    final Object? type = message['MessageType'];
+    if (type is! String) return null;
+    if (type.toLowerCase() != playstateMessageType.toLowerCase()) return null;
+
+    final Object? data = message['Data'];
+    if (data is! Map<String, dynamic>) return null;
+
+    final Object? command = data['Command'];
+    if (command is! String) return null;
+
+    switch (command.toLowerCase()) {
+      case 'play':
+      case 'unpause':
+        return const RemotePlay();
+      case 'pause':
+        return const RemotePause();
+      case 'playpause':
+        return const RemotePlayPause();
+      case 'stop':
+        return const RemoteStop();
+      case 'nexttrack':
+        return const RemoteNext();
+      case 'previoustrack':
+        return const RemotePrevious();
+      case 'seek':
+        final Duration? position = _seekPosition(data);
+        return position == null ? null : RemoteSeek(position);
+      default:
+        // Rewind / FastForward and anything else Linthra doesn't model.
+        return null;
+    }
+  }
+
+  static Duration? _seekPosition(Map<String, dynamic> data) {
+    final Object? ticks = data['SeekPositionTicks'];
+    int? value;
+    if (ticks is int) {
+      value = ticks;
+    } else if (ticks is double) {
+      value = ticks.toInt();
+    }
+    if (value == null || value < 0) return null;
+    return Duration(microseconds: value ~/ _ticksPerMicrosecond);
+  }
+}

--- a/lib/core/sources/jellyfin/jellyfin_remote_control_receiver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_remote_control_receiver.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+import 'dart:convert';
+
+import '../../models/jellyfin_session.dart';
+import '../../services/remote_command.dart';
+import '../../services/remote_control_receiver.dart';
+import 'jellyfin_client.dart';
+import 'jellyfin_control_socket.dart';
+import 'jellyfin_endpoints.dart';
+import 'jellyfin_remote_command.dart';
+
+/// Receives remote playback commands from a Jellyfin server over its session
+/// control WebSocket, surfaced as neutral [RemoteCommand]s.
+///
+/// Jellyfin remote control is **outbound**: this client connects out to the
+/// server's `/socket`, registers its session capabilities (audio + media
+/// control), and the server then pushes `Playstate` commands down that socket
+/// when another Jellyfin app drives this player. Being outbound, it works
+/// behind NAT with no inbound server — unlike Plex's Companion protocol.
+///
+/// Resilience & best-effort: [start] connects (and reconnects after a drop,
+/// with a fixed delay) while a session is signed in; the server's
+/// `ForceKeepAlive` is answered with periodic `KeepAlive`s. A transport failure
+/// only schedules a reconnect — it never throws out of [commands] or disturbs
+/// playback. [stop] disconnects without ending the command stream (a later
+/// [start] resumes); [dispose] closes everything.
+///
+/// Token safety: the access token rides in the WebSocket URL's `api_key` query
+/// (like the audio stream URL) and the capability POST's `Authorization`
+/// header; the URL is never logged, and nothing here is persisted.
+class JellyfinRemoteControlReceiver implements RemoteControlReceiver {
+  JellyfinRemoteControlReceiver({
+    required JellyfinSession? Function() session,
+    required JellyfinClient Function() client,
+    JellyfinControlSocketConnector connect = connectJellyfinControlSocket,
+    Duration retryDelay = const Duration(seconds: 15),
+  })  : _session = session,
+        _client = client,
+        _connect = connect,
+        _retryDelay = retryDelay;
+
+  final JellyfinSession? Function() _session;
+  final JellyfinClient Function() _client;
+  final JellyfinControlSocketConnector _connect;
+  final Duration _retryDelay;
+
+  final StreamController<RemoteCommand> _commands =
+      StreamController<RemoteCommand>.broadcast();
+
+  JellyfinControlSocket? _socket;
+  StreamSubscription<String>? _messages;
+  Timer? _keepAlive;
+  Timer? _retry;
+  bool _running = false;
+  bool _disposed = false;
+
+  @override
+  Stream<RemoteCommand> get commands => _commands.stream;
+
+  @override
+  Future<void> start() async {
+    if (_disposed || _running) return;
+    _running = true;
+    await _open();
+  }
+
+  @override
+  Future<void> stop() async {
+    if (!_running) return;
+    _running = false;
+    _retry?.cancel();
+    _retry = null;
+    await _teardownSocket();
+  }
+
+  @override
+  Future<void> dispose() async {
+    _disposed = true;
+    _running = false;
+    _retry?.cancel();
+    _retry = null;
+    await _teardownSocket();
+    await _commands.close();
+  }
+
+  Future<void> _open() async {
+    if (_disposed || !_running) return;
+    final JellyfinSession? session = _session();
+    if (session == null) {
+      // Signed out: nothing to connect to. A later start (after sign-in) tries
+      // again; don't busy-retry here.
+      return;
+    }
+
+    // Best-effort capability registration so other Jellyfin apps list this
+    // player as controllable. A failure here must not stop us listening.
+    try {
+      await _client().registerRemoteControlCapabilities(session);
+    } catch (_) {
+      // ignore — still try to receive commands.
+    }
+    if (_disposed || !_running) return;
+
+    try {
+      final Uri url = JellyfinEndpoints.controlSocket(
+        session.baseUrl,
+        accessToken: session.accessToken,
+        deviceId: session.deviceId,
+      );
+      final JellyfinControlSocket socket = await _connect(url);
+      if (_disposed || !_running) {
+        await socket.close();
+        return;
+      }
+      _socket = socket;
+      _messages = socket.messages.listen(
+        _onMessage,
+        onError: (Object _) => _scheduleReconnect(),
+        onDone: _scheduleReconnect,
+        cancelOnError: true,
+      );
+    } catch (_) {
+      _scheduleReconnect();
+    }
+  }
+
+  void _onMessage(String raw) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return;
+    }
+    if (decoded is! Map<String, dynamic>) return;
+
+    final Object? type = decoded['MessageType'];
+    if (type is String && type.toLowerCase() == 'forcekeepalive') {
+      _sendKeepAlive();
+      _scheduleKeepAlive(decoded['Data']);
+      return;
+    }
+
+    final RemoteCommand? command = JellyfinRemoteCommand.fromMessage(decoded);
+    if (command != null && !_commands.isClosed) {
+      _commands.add(command);
+    }
+  }
+
+  void _scheduleKeepAlive(Object? data) {
+    _keepAlive?.cancel();
+    // ForceKeepAlive carries the server's timeout (seconds); reply at half that
+    // to stay inside the window. Fall back to 60s, clamped to a sane range.
+    final int timeout = data is int && data > 1 ? data : 60;
+    int every = timeout ~/ 2;
+    if (every < 5) every = 5;
+    if (every > 60) every = 60;
+    _keepAlive = Timer.periodic(
+      Duration(seconds: every),
+      (_) => _sendKeepAlive(),
+    );
+  }
+
+  void _sendKeepAlive() {
+    final JellyfinControlSocket? socket = _socket;
+    if (socket == null) return;
+    try {
+      socket.send(jsonEncode(<String, Object?>{
+        'MessageType': 'KeepAlive',
+        'Data': '',
+      }));
+    } catch (_) {
+      // A dead socket surfaces via onError/onDone, which reconnects.
+    }
+  }
+
+  void _scheduleReconnect() {
+    if (_disposed || !_running) return;
+    unawaited(_teardownSocket());
+    _retry?.cancel();
+    _retry = Timer(_retryDelay, () => unawaited(_open()));
+  }
+
+  Future<void> _teardownSocket() async {
+    _keepAlive?.cancel();
+    _keepAlive = null;
+    final StreamSubscription<String>? messages = _messages;
+    _messages = null;
+    final JellyfinControlSocket? socket = _socket;
+    _socket = null;
+    await messages?.cancel();
+    await socket?.close();
+  }
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -15,6 +15,9 @@ import '../../core/services/playback_reporting_service.dart';
 import '../../core/services/remote_cache/remote_cache_resolver.dart';
 import '../../core/services/remote_cache/remote_playback_cache.dart';
 import '../../core/services/remote_cache/remote_stream_prebufferer.dart';
+import '../../core/services/remote_control_activator.dart';
+import '../../core/services/remote_control_receiver.dart';
+import '../../core/services/remote_control_service.dart';
 import '../../core/services/remote_prebuffer_service.dart';
 import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/services/routing_server_playback_reporter.dart';
@@ -22,6 +25,8 @@ import '../../core/services/server_playback_reporter.dart';
 import '../../core/services/smart_precache_service.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playback_reporter.dart';
+import '../../core/sources/jellyfin/jellyfin_remote_control_receiver.dart';
+import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
 import '../../core/sources/plex/plex_playable_uri_resolver.dart';
 import '../../core/sources/plex/plex_playback_reporter.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
@@ -268,6 +273,61 @@ final playbackReportingServiceProvider =
   );
   ref.onDispose(service.dispose);
   return service;
+});
+
+/// The remote-control receiver — the inverse of the playback reporter. A
+/// Jellyfin control-socket receiver today; reads the live Jellyfin
+/// session/client lazily, so sign-in/out is picked up without rebuilding.
+/// Pinned for the session: its transport is opened/closed by
+/// [remoteControlActivatorProvider] in step with playback, and finally disposed
+/// with the scope.
+final remoteControlReceiverProvider = Provider<RemoteControlReceiver>((ref) {
+  final receiver = JellyfinRemoteControlReceiver(
+    session: () => ref.read(jellyfinMusicSourceProvider)?.session,
+    client: () => ref.read(jellyfinClientProvider),
+  );
+  ref.onDispose(receiver.dispose);
+  return receiver;
+});
+
+/// Applies remote commands to the active [PlaybackController], so a Jellyfin
+/// remote's play/pause/skip/seek drives playback exactly like an on-screen tap
+/// — flowing through cast routing, the media session, and reporting alike.
+/// Side-effect-only; `main` instantiates it once after startup.
+final remoteControlServiceProvider = Provider<RemoteControlService>((ref) {
+  final service = RemoteControlService(
+    receiver: ref.read(remoteControlReceiverProvider),
+    controller: ref.read(playbackControllerProvider),
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// Whether [state] is a Jellyfin track actively playing or paused — the window
+/// in which Linthra connects the control socket to accept remote commands.
+/// Keeping the socket to exactly this window (rather than the whole signed-in
+/// session) is what keeps remote control off the "no background keep-alives"
+/// budget.
+bool _isJellyfinControllable(PlaybackState state) {
+  final track = state.currentTrack;
+  if (track == null) return false;
+  if (!track.uri.startsWith(JellyfinTrackMapper.uriScheme)) return false;
+  final status = state.status;
+  return status == PlaybackStatus.playing || status == PlaybackStatus.paused;
+}
+
+/// Connects the remote-control transport only while a controllable Jellyfin
+/// track is the active playback session, so there is no persistent background
+/// socket (keeping Linthra's "event-driven, never polled" stance). Reads the
+/// controller's state stream once; side-effect-only, instantiated by `main`.
+final remoteControlActivatorProvider = Provider<RemoteControlActivator>((ref) {
+  final activator = RemoteControlActivator(
+    receiver: ref.read(remoteControlReceiverProvider),
+    playbackStates: ref.read(playbackControllerProvider).stateStream,
+    isControllable: _isJellyfinControllable,
+  );
+  ref.onDispose(activator.dispose);
+  return activator;
 });
 
 /// Production binding: lets the cache eviction policy see the currently playing

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -160,6 +160,16 @@ Future<void> main() async {
   // playback reports nothing. Side-effect-only, like the services above.
   container.read(playbackReportingServiceProvider);
 
+  // Start remote control: while a controllable (Jellyfin) track plays, accept
+  // the play/pause/skip/seek commands the server pushes over its control socket
+  // and apply them to the active player — so other Jellyfin apps and speaker
+  // remotes can drive Linthra. The activator opens the socket only during such
+  // playback (no persistent background socket); the service applies the
+  // commands through the same PlaybackController an on-screen tap uses.
+  // Side-effect-only, like the services above.
+  container.read(remoteControlServiceProvider);
+  container.read(remoteControlActivatorProvider);
+
   // Mirror the user's "Normalize volume" choice onto the local audio engine,
   // seeding the persisted value now and pushing every later toggle. The engine
   // applies the clip-safe ReplayGain attenuation; with the choice off (the

--- a/test/core/services/remote_control_activator_test.dart
+++ b/test/core/services/remote_control_activator_test.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/services/remote_command.dart';
+import 'package:linthra/core/services/remote_control_activator.dart';
+import 'package:linthra/core/services/remote_control_receiver.dart';
+
+/// A [RemoteControlReceiver] that just counts start/stop, so the activator's
+/// gating can be asserted without any real transport.
+class _RecordingReceiver implements RemoteControlReceiver {
+  int starts = 0;
+  int stops = 0;
+  final StreamController<RemoteCommand> _commands =
+      StreamController<RemoteCommand>.broadcast();
+
+  @override
+  Stream<RemoteCommand> get commands => _commands.stream;
+
+  @override
+  Future<void> start() async {
+    starts++;
+  }
+
+  @override
+  Future<void> stop() async {
+    stops++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _commands.close();
+  }
+}
+
+void main() {
+  late StreamController<PlaybackState> states;
+  late _RecordingReceiver receiver;
+  late RemoteControlActivator activator;
+
+  setUp(() {
+    states = StreamController<PlaybackState>.broadcast();
+    receiver = _RecordingReceiver();
+    activator = RemoteControlActivator(
+      receiver: receiver,
+      playbackStates: states.stream,
+      isControllable: (PlaybackState state) =>
+          state.status == PlaybackStatus.playing,
+    );
+  });
+
+  tearDown(() async {
+    await activator.dispose();
+    await receiver.dispose();
+    await states.close();
+  });
+
+  Future<void> push(PlaybackStatus status) async {
+    states.add(PlaybackState.idle.copyWith(status: status));
+    await pumpEventQueue();
+  }
+
+  test('starts the receiver when a state becomes controllable', () async {
+    await push(PlaybackStatus.playing);
+    expect(receiver.starts, 1);
+    expect(receiver.stops, 0);
+  });
+
+  test('stops the receiver when it stops being controllable', () async {
+    await push(PlaybackStatus.playing);
+    await push(PlaybackStatus.paused);
+    expect(receiver.starts, 1);
+    expect(receiver.stops, 1);
+  });
+
+  test('does not restart while it stays controllable', () async {
+    await push(PlaybackStatus.playing);
+    await push(PlaybackStatus.playing);
+    expect(receiver.starts, 1);
+  });
+
+  test('does nothing for a non-controllable state', () async {
+    await push(PlaybackStatus.idle);
+    expect(receiver.starts, 0);
+    expect(receiver.stops, 0);
+  });
+}

--- a/test/core/services/remote_control_service_test.dart
+++ b/test/core/services/remote_control_service_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/services/remote_command.dart';
+import 'package:linthra/core/services/remote_control_receiver.dart';
+import 'package:linthra/core/services/remote_control_service.dart';
+
+import '../../features/player/fake_playback_controller.dart';
+
+/// A [RemoteControlReceiver] driven directly by a test [StreamController], so a
+/// test can push neutral commands without any real transport.
+class _StreamReceiver implements RemoteControlReceiver {
+  _StreamReceiver(this._commands);
+
+  final StreamController<RemoteCommand> _commands;
+
+  @override
+  Stream<RemoteCommand> get commands => _commands.stream;
+
+  @override
+  Future<void> dispose() async {}
+}
+
+void main() {
+  late StreamController<RemoteCommand> commands;
+  late FakePlaybackController controller;
+  late RemoteControlService service;
+
+  setUp(() {
+    commands = StreamController<RemoteCommand>.broadcast();
+    controller = FakePlaybackController();
+    service = RemoteControlService(
+      receiver: _StreamReceiver(commands),
+      controller: controller,
+    );
+  });
+
+  tearDown(() async {
+    await service.dispose();
+    await controller.dispose();
+    await commands.close();
+  });
+
+  Future<void> send(RemoteCommand command) async {
+    commands.add(command);
+    await pumpEventQueue();
+  }
+
+  test('play command starts the controller', () async {
+    await send(const RemotePlay());
+    expect(controller.playCount, 1);
+    expect(controller.pauseCount, 0);
+  });
+
+  test('pause command pauses the controller', () async {
+    await send(const RemotePause());
+    expect(controller.pauseCount, 1);
+  });
+
+  test('stop command stops the controller', () async {
+    await send(const RemoteStop());
+    expect(controller.stopCount, 1);
+  });
+
+  test('next command skips to the next track', () async {
+    await send(const RemoteNext());
+    expect(controller.skipCount, 1);
+  });
+
+  test('previous command steps to the previous track', () async {
+    await send(const RemotePrevious());
+    expect(controller.previousCount, 1);
+  });
+
+  test('seek command seeks to the requested position', () async {
+    await send(const RemoteSeek(Duration(seconds: 42)));
+    expect(controller.seeks, <Duration>[const Duration(seconds: 42)]);
+  });
+
+  test('play/pause toggles to pause while playing', () async {
+    controller.emit(
+      PlaybackState.idle.copyWith(status: PlaybackStatus.playing),
+    );
+    await send(const RemotePlayPause());
+    expect(controller.pauseCount, 1);
+    expect(controller.playCount, 0);
+  });
+
+  test('play/pause toggles to play while not playing', () async {
+    // The default fake state is idle (not playing).
+    await send(const RemotePlayPause());
+    expect(controller.playCount, 1);
+    expect(controller.pauseCount, 0);
+  });
+
+  test('a burst of commands all apply', () async {
+    commands.add(const RemotePlay());
+    commands.add(const RemoteSeek(Duration(seconds: 5)));
+    commands.add(const RemotePause());
+    await pumpEventQueue();
+    expect(controller.playCount, 1);
+    expect(controller.seeks, <Duration>[const Duration(seconds: 5)]);
+    expect(controller.pauseCount, 1);
+  });
+
+  test('no command is applied after dispose', () async {
+    await service.dispose();
+    commands.add(const RemotePlay());
+    await pumpEventQueue();
+    expect(controller.playCount, 0);
+  });
+
+  test('a no-op receiver drives nothing', () async {
+    final RemoteControlService idle = RemoteControlService(
+      receiver: const NoOpRemoteControlReceiver(),
+      controller: controller,
+    );
+    await pumpEventQueue();
+    expect(controller.playCount, 0);
+    expect(controller.pauseCount, 0);
+    await idle.dispose();
+  });
+}

--- a/test/core/services/remote_control_service_test.dart
+++ b/test/core/services/remote_control_service_test.dart
@@ -19,6 +19,12 @@ class _StreamReceiver implements RemoteControlReceiver {
   Stream<RemoteCommand> get commands => _commands.stream;
 
   @override
+  Future<void> start() async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
   Future<void> dispose() async {}
 }
 

--- a/test/core/sources/jellyfin/fake_jellyfin_client.dart
+++ b/test/core/sources/jellyfin/fake_jellyfin_client.dart
@@ -293,6 +293,25 @@ class FakeJellyfinClient implements JellyfinClient {
     if (unexpected != null) throw unexpected;
   }
 
+  /// How many times [registerRemoteControlCapabilities] was called, and the
+  /// last session it carried, so the receiver wiring can prove it registered.
+  int capabilitiesRegistered = 0;
+  JellyfinSession? lastCapabilitiesSession;
+
+  /// When set, [registerRemoteControlCapabilities] throws it (after recording),
+  /// so the receiver can prove registration failures are swallowed.
+  JellyfinException? capabilitiesError;
+
+  @override
+  Future<void> registerRemoteControlCapabilities(
+    JellyfinSession session,
+  ) async {
+    capabilitiesRegistered++;
+    lastCapabilitiesSession = session;
+    final JellyfinException? error = capabilitiesError;
+    if (error != null) throw error;
+  }
+
   @override
   Future<Set<String>> fetchFavoriteIds(JellyfinSession session) async {
     final JellyfinException? error = favoritesError;

--- a/test/core/sources/jellyfin/jellyfin_remote_command_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_remote_command_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/remote_command.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_endpoints.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_remote_command.dart';
+
+Map<String, dynamic> playstate(String command, {int? seekTicks}) {
+  return <String, dynamic>{
+    'MessageType': 'Playstate',
+    'Data': <String, dynamic>{
+      'Command': command,
+      if (seekTicks != null) 'SeekPositionTicks': seekTicks,
+    },
+  };
+}
+
+void main() {
+  group('JellyfinRemoteCommand.fromMessage', () {
+    test('maps the transport commands to neutral commands', () {
+      expect(JellyfinRemoteCommand.fromMessage(playstate('Unpause')),
+          const RemotePlay());
+      expect(JellyfinRemoteCommand.fromMessage(playstate('Play')),
+          const RemotePlay());
+      expect(JellyfinRemoteCommand.fromMessage(playstate('Pause')),
+          const RemotePause());
+      expect(JellyfinRemoteCommand.fromMessage(playstate('PlayPause')),
+          const RemotePlayPause());
+      expect(JellyfinRemoteCommand.fromMessage(playstate('Stop')),
+          const RemoteStop());
+      expect(JellyfinRemoteCommand.fromMessage(playstate('NextTrack')),
+          const RemoteNext());
+      expect(JellyfinRemoteCommand.fromMessage(playstate('PreviousTrack')),
+          const RemotePrevious());
+    });
+
+    test('maps Seek ticks to a Duration (10M ticks == 1 second)', () {
+      expect(
+        JellyfinRemoteCommand.fromMessage(
+          playstate('Seek', seekTicks: 50000000),
+        ),
+        const RemoteSeek(Duration(seconds: 5)),
+      );
+    });
+
+    test('matches the message type and command case-insensitively', () {
+      final Map<String, dynamic> message = <String, dynamic>{
+        'MessageType': 'playstate',
+        'Data': <String, dynamic>{'Command': 'pAuSe'},
+      };
+      expect(JellyfinRemoteCommand.fromMessage(message), const RemotePause());
+    });
+
+    test('ignores a Seek with no/invalid position', () {
+      expect(JellyfinRemoteCommand.fromMessage(playstate('Seek')), isNull);
+      expect(
+        JellyfinRemoteCommand.fromMessage(playstate('Seek', seekTicks: -1)),
+        isNull,
+      );
+    });
+
+    test('ignores unsupported commands and other message types', () {
+      expect(JellyfinRemoteCommand.fromMessage(playstate('Rewind')), isNull);
+      expect(
+        JellyfinRemoteCommand.fromMessage(playstate('FastForward')),
+        isNull,
+      );
+      expect(
+        JellyfinRemoteCommand.fromMessage(<String, dynamic>{
+          'MessageType': 'GeneralCommand',
+          'Data': <String, dynamic>{'Name': 'SetVolume'},
+        }),
+        isNull,
+      );
+    });
+
+    test('ignores malformed envelopes', () {
+      expect(JellyfinRemoteCommand.fromMessage(<String, dynamic>{}), isNull);
+      expect(
+        JellyfinRemoteCommand.fromMessage(<String, dynamic>{
+          'MessageType': 'Playstate',
+          'Data': 'not-a-map',
+        }),
+        isNull,
+      );
+      expect(
+        JellyfinRemoteCommand.fromMessage(<String, dynamic>{
+          'MessageType': 'Playstate',
+          'Data': <String, dynamic>{'NoCommand': true},
+        }),
+        isNull,
+      );
+    });
+  });
+
+  group('JellyfinEndpoints control endpoints', () {
+    test('controlSocket builds a wss URL with api_key and deviceId', () {
+      final Uri uri = JellyfinEndpoints.controlSocket(
+        'https://music.example.com',
+        accessToken: 'tok',
+        deviceId: 'dev-1',
+      );
+      expect(uri.scheme, 'wss');
+      expect(uri.host, 'music.example.com');
+      expect(uri.path, '/socket');
+      expect(uri.queryParameters['api_key'], 'tok');
+      expect(uri.queryParameters['deviceId'], 'dev-1');
+    });
+
+    test('controlSocket uses ws for an http base and keeps the port', () {
+      final Uri uri = JellyfinEndpoints.controlSocket(
+        'http://10.0.0.5:8096',
+        accessToken: 'tok',
+        deviceId: 'dev-1',
+      );
+      expect(uri.scheme, 'ws');
+      expect(uri.host, '10.0.0.5');
+      expect(uri.port, 8096);
+    });
+
+    test('capabilitiesFull targets the Full capabilities endpoint', () {
+      expect(
+        JellyfinEndpoints.capabilitiesFull('https://music.example.com')
+            .toString(),
+        'https://music.example.com/Sessions/Capabilities/Full',
+      );
+    });
+  });
+}

--- a/test/core/sources/jellyfin/jellyfin_remote_control_receiver_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_remote_control_receiver_test.dart
@@ -38,17 +38,19 @@ const JellyfinSession _session = JellyfinSession(
   deviceId: 'dev-1',
 );
 
-String _playstate(String command) => jsonEncode(<String, dynamic>{
-      'MessageType': 'Playstate',
-      'Data': <String, dynamic>{'Command': command},
-    });
+String _playstate(String command) {
+  return jsonEncode(<String, dynamic>{
+    'MessageType': 'Playstate',
+    'Data': <String, dynamic>{'Command': command},
+  });
+}
 
 void main() {
   test('registers capabilities and connects on start', () async {
     final FakeJellyfinClient client = FakeJellyfinClient();
     final _FakeSocket socket = _FakeSocket();
     Uri? connectedTo;
-    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+    final receiver = JellyfinRemoteControlReceiver(
       session: () => _session,
       client: () => client,
       connect: (Uri url) async {
@@ -71,14 +73,13 @@ void main() {
   test('emits a neutral command for a Playstate message', () async {
     final FakeJellyfinClient client = FakeJellyfinClient();
     final _FakeSocket socket = _FakeSocket();
-    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+    final receiver = JellyfinRemoteControlReceiver(
       session: () => _session,
       client: () => client,
       connect: (Uri _) async => socket,
     );
     final List<RemoteCommand> received = <RemoteCommand>[];
-    final StreamSubscription<RemoteCommand> sub =
-        receiver.commands.listen(received.add);
+    final sub = receiver.commands.listen(received.add);
 
     await receiver.start();
     await pumpEventQueue();
@@ -94,7 +95,7 @@ void main() {
   test('answers ForceKeepAlive with a KeepAlive frame', () async {
     final FakeJellyfinClient client = FakeJellyfinClient();
     final _FakeSocket socket = _FakeSocket();
-    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+    final receiver = JellyfinRemoteControlReceiver(
       session: () => _session,
       client: () => client,
       connect: (Uri _) async => socket,
@@ -117,7 +118,7 @@ void main() {
   test('does not connect when signed out', () async {
     final FakeJellyfinClient client = FakeJellyfinClient();
     int connectCalls = 0;
-    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+    final receiver = JellyfinRemoteControlReceiver(
       session: () => null,
       client: () => client,
       connect: (Uri _) async {
@@ -138,7 +139,7 @@ void main() {
   test('stop disconnects the socket', () async {
     final FakeJellyfinClient client = FakeJellyfinClient();
     final _FakeSocket socket = _FakeSocket();
-    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+    final receiver = JellyfinRemoteControlReceiver(
       session: () => _session,
       client: () => client,
       connect: (Uri _) async => socket,

--- a/test/core/sources/jellyfin/jellyfin_remote_control_receiver_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_remote_control_receiver_test.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/services/remote_command.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_control_socket.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_remote_control_receiver.dart';
+
+import 'fake_jellyfin_client.dart';
+
+/// An in-memory [JellyfinControlSocket]: a test pushes server frames via [emit]
+/// and reads back whatever the receiver [send]s.
+class _FakeSocket implements JellyfinControlSocket {
+  final StreamController<String> _incoming = StreamController<String>();
+  final List<String> sent = <String>[];
+  bool closed = false;
+
+  @override
+  Stream<String> get messages => _incoming.stream;
+
+  @override
+  void send(String message) => sent.add(message);
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    if (!_incoming.isClosed) await _incoming.close();
+  }
+
+  void emit(String raw) => _incoming.add(raw);
+}
+
+const JellyfinSession _session = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'user-1',
+  accessToken: 'tok',
+  deviceId: 'dev-1',
+);
+
+String _playstate(String command) => jsonEncode(<String, dynamic>{
+      'MessageType': 'Playstate',
+      'Data': <String, dynamic>{'Command': command},
+    });
+
+void main() {
+  test('registers capabilities and connects on start', () async {
+    final FakeJellyfinClient client = FakeJellyfinClient();
+    final _FakeSocket socket = _FakeSocket();
+    Uri? connectedTo;
+    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+      session: () => _session,
+      client: () => client,
+      connect: (Uri url) async {
+        connectedTo = url;
+        return socket;
+      },
+    );
+
+    await receiver.start();
+    await pumpEventQueue();
+
+    expect(client.capabilitiesRegistered, 1);
+    expect(connectedTo, isNotNull);
+    expect(connectedTo!.scheme, 'wss');
+    expect(connectedTo!.path, '/socket');
+
+    await receiver.dispose();
+  });
+
+  test('emits a neutral command for a Playstate message', () async {
+    final FakeJellyfinClient client = FakeJellyfinClient();
+    final _FakeSocket socket = _FakeSocket();
+    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+      session: () => _session,
+      client: () => client,
+      connect: (Uri _) async => socket,
+    );
+    final List<RemoteCommand> received = <RemoteCommand>[];
+    final StreamSubscription<RemoteCommand> sub =
+        receiver.commands.listen(received.add);
+
+    await receiver.start();
+    await pumpEventQueue();
+    socket.emit(_playstate('Pause'));
+    await pumpEventQueue();
+
+    expect(received, <RemoteCommand>[const RemotePause()]);
+
+    await sub.cancel();
+    await receiver.dispose();
+  });
+
+  test('answers ForceKeepAlive with a KeepAlive frame', () async {
+    final FakeJellyfinClient client = FakeJellyfinClient();
+    final _FakeSocket socket = _FakeSocket();
+    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+      session: () => _session,
+      client: () => client,
+      connect: (Uri _) async => socket,
+    );
+
+    await receiver.start();
+    await pumpEventQueue();
+    socket.emit(jsonEncode(<String, dynamic>{
+      'MessageType': 'ForceKeepAlive',
+      'Data': 30,
+    }));
+    await pumpEventQueue();
+
+    expect(socket.sent, isNotEmpty);
+    expect(socket.sent.first, contains('KeepAlive'));
+
+    await receiver.dispose();
+  });
+
+  test('does not connect when signed out', () async {
+    final FakeJellyfinClient client = FakeJellyfinClient();
+    int connectCalls = 0;
+    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+      session: () => null,
+      client: () => client,
+      connect: (Uri _) async {
+        connectCalls++;
+        return _FakeSocket();
+      },
+    );
+
+    await receiver.start();
+    await pumpEventQueue();
+
+    expect(connectCalls, 0);
+    expect(client.capabilitiesRegistered, 0);
+
+    await receiver.dispose();
+  });
+
+  test('stop disconnects the socket', () async {
+    final FakeJellyfinClient client = FakeJellyfinClient();
+    final _FakeSocket socket = _FakeSocket();
+    final JellyfinRemoteControlReceiver receiver = JellyfinRemoteControlReceiver(
+      session: () => _session,
+      client: () => client,
+      connect: (Uri _) async => socket,
+    );
+
+    await receiver.start();
+    await pumpEventQueue();
+    await receiver.stop();
+
+    expect(socket.closed, isTrue);
+
+    await receiver.dispose();
+  });
+}


### PR DESCRIPTION
## What & why

Linthra appeared as a playing client on a server's dashboard but did not react
to remote play / pause / skip / seek from another app or a speaker remote,
because its integration only *pushed* timeline state — it never *received*
commands. This adds that missing half.

"Remote control" is a different mechanism per provider, so the work is split
into a provider-neutral seam plus per-provider receivers.

## Implemented (CI green)

- **Provider-neutral seam** — `RemoteCommand` (a closed, **transport-only**
  command set: play/pause/playPause/stop/next/previous/seek — no
  library-mutating case, so remote control can't reach past transport by
  construction), `RemoteControlReceiver` (per-provider transport, start/stop/
  dispose), and `RemoteControlService` (applies commands to the existing
  `PlaybackController`, in order, swallowing failures — so a remote pause takes
  the exact same path as an on-screen tap).
- **Jellyfin remote control** — `JellyfinRemoteControlReceiver` connects the
  server's `/socket`, registers `SupportsMediaControl` via
  `POST /Sessions/Capabilities/Full`, and maps pushed `Playstate` commands to
  neutral commands (Unpause/Play→play, Pause, PlayPause, Stop, NextTrack,
  PreviousTrack, Seek via `SeekPositionTicks`). Answers `ForceKeepAlive`,
  reconnects after a drop. The WebSocket sits behind a tiny testable seam (a
  `dart:io WebSocket` adapter — **no new dependency**, lockfile untouched).
  Outbound, so it works behind NAT.
- **Battery-gated** — `RemoteControlActivator` opens the control socket **only
  while a controllable `jellyfin:` track is playing/paused**, never as a
  persistent background keep-alive (keeps the repo's "event-driven, never
  polled" stance).

Wired in `player_providers` + `main`; non-Jellyfin playback is unchanged (the
activator only opens the socket for `jellyfin:` tracks). Unit-tested with fake
sockets/clients (command mapping, the controller bridge, playback-gated
activation, capability registration, keepalive, signed-out no-op, stop).

## Not built (by design / not possible)

- **Plex** — needs the inbound **Companion** protocol (GDM + a local HTTP
  server), a larger, real-device-validation-dependent change. Designed in
  [`docs/plex-remote-control.md`](../blob/claude/upbeat-feynman-ezjcv5/docs/plex-remote-control.md); not implemented here.
- **Navidrome / Subsonic** — **not possible**: the Subsonic API has no
  mechanism to push playback commands to a streaming client (only Jukebox mode,
  the inverse).
- **Local files** — **n/a**: no server; external control is the system media
  session (lock screen / Bluetooth / Android Auto), which already works.

See [`docs/remote-control.md`](../blob/claude/upbeat-feynman-ezjcv5/docs/remote-control.md) for the cross-provider overview.

## Tests / CI

New unit tests for every pure/logic piece; Flutter checks (format, analyze,
test), the secret scan, and the debug APK build are all green. The `dart:io`
WebSocket adapter is the one thin piece tests can't exercise; it wants a
real-device smoke test.

https://claude.ai/code/session_01Tf43JtrQZzFQQ9wqi1a1KX