### PR TITLE
perf(android): adaptive high refresh rate (60/90/120/144 Hz), battery-aware

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/DisplayRefreshRate.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/DisplayRefreshRate.kt
@@ -1,0 +1,165 @@
+package io.github.thezupzup.linthra
+
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import android.os.PowerManager
+import android.view.Display
+
+/**
+ * Opts the single Flutter window into the display's *native* refresh rate
+ * (90 / 120 / 144 Hz where the panel supports it) instead of the 60 Hz many
+ * OEMs hand an app by default.
+ *
+ * ## Why this is needed
+ * A Flutter UI renders at whatever refresh rate the platform runs the app's
+ * window at. On a lot of high-refresh phones — Samsung and several others — that
+ * window defaults to 60 Hz unless the app explicitly asks for a higher
+ * [Display.Mode]. Without this, scrolling the Songs/Albums/Queue lists and the
+ * Now Playing animations are capped at 60 fps on panels that can do far better.
+ *
+ * ## What it does (and deliberately does not do)
+ * - It picks the **highest refresh rate among the modes that match the current
+ *   resolution**, so the only thing that changes is the refresh rate — a
+ *   seamless switch — never the rendered resolution. It never downgrades
+ *   resolution to chase a higher rate.
+ * - It targets whatever the device actually supports; it never hard-codes a
+ *   rate. A 90 Hz panel gets 90, a 144 Hz panel gets 144, a 60 Hz panel is left
+ *   alone.
+ * - **Battery saver is respected as the system's call, not ours.** When
+ *   [PowerManager.isPowerSaveMode] is on, the preferred-mode pin is *released*
+ *   (set back to "no preference") so Android is free to drop the refresh rate to
+ *   save power. We never force a high rate over the system's power management,
+ *   and we re-evaluate the moment battery saver toggles
+ *   ([PowerManager.ACTION_POWER_SAVE_MODE_CHANGED]).
+ *
+ * ## Lifecycle
+ * The pin lives on the window's `LayoutParams` and only matters while the
+ * activity is in the foreground, so [onResume]/[onPause] drive it: [onResume]
+ * applies the preference and starts listening for battery-saver changes;
+ * [onPause] stops listening. Re-applying on every resume also re-asserts the
+ * preference after a config change recreates the window.
+ */
+class DisplayRefreshRate(private val activity: Activity) {
+
+    /**
+     * Listens for battery-saver toggles while the activity is foregrounded so a
+     * change to power-save mode re-evaluates the refresh-rate preference
+     * immediately, rather than only on the next resume. Null while not
+     * registered.
+     */
+    private var powerSaveReceiver: BroadcastReceiver? = null
+
+    /** Apply the preferred mode and begin reacting to battery-saver changes. */
+    fun onResume() {
+        applyPreferredMode()
+        registerPowerSaveListener()
+    }
+
+    /** Stop reacting to battery-saver changes; the window pin itself persists. */
+    fun onPause() {
+        val receiver = powerSaveReceiver ?: return
+        powerSaveReceiver = null
+        // Best-effort: a receiver that is somehow already unregistered throws
+        // here, which must never crash a normal pause.
+        try {
+            activity.unregisterReceiver(receiver)
+        } catch (_: IllegalArgumentException) {
+        }
+    }
+
+    private fun registerPowerSaveListener() {
+        if (powerSaveReceiver != null) return
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                applyPreferredMode()
+            }
+        }
+        // ACTION_POWER_SAVE_MODE_CHANGED is a protected system broadcast, so a
+        // context-registered receiver for it needs no export flag even on API
+        // 34+. Registration is best-effort: if it ever fails, onResume's direct
+        // call still covers the common foreground/return cases, so the live
+        // toggle is a bonus, never a crash.
+        try {
+            activity.registerReceiver(
+                receiver,
+                IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED),
+            )
+            powerSaveReceiver = receiver
+        } catch (_: Exception) {
+        }
+    }
+
+    /**
+     * Pin the window to the highest-refresh mode at the current resolution, or —
+     * under battery saver — release the pin so the system can manage the rate.
+     * Idempotent: it only writes the window's `LayoutParams` when the preferred
+     * mode id actually changes, so a repeat call (resume, broadcast) is a no-op
+     * once the window is already where we want it.
+     *
+     * Every per-mode display API touched here (`preferredDisplayModeId`,
+     * [Display.getMode], [Display.getSupportedModes]) is API 23+, so the whole
+     * body sits behind one `SDK_INT` guard.
+     */
+    private fun applyPreferredMode() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return
+        val window = activity.window ?: return
+        val powerManager =
+            activity.getSystemService(Context.POWER_SERVICE) as? PowerManager
+
+        val targetModeId: Int = if (powerManager?.isPowerSaveMode == true) {
+            // Hand refresh-rate control back to the system so it may lower the
+            // rate to conserve power. We do not override power management.
+            0
+        } else {
+            val display = currentDisplay()
+            val active = display?.mode ?: return
+
+            // Highest refresh rate among modes that keep the *current*
+            // resolution, so the switch only raises the frame rate (seamless)
+            // and never changes what is rendered.
+            var best = active
+            for (mode in display.supportedModes) {
+                if (mode.physicalWidth == active.physicalWidth &&
+                    mode.physicalHeight == active.physicalHeight &&
+                    mode.refreshRate > best.refreshRate + REFRESH_RATE_EPSILON
+                ) {
+                    best = mode
+                }
+            }
+            // Nothing faster at this resolution: leave the preference cleared so
+            // the system keeps full control (including dropping to a lower idle
+            // rate for static content). Pinning the only/native mode would
+            // needlessly suppress that.
+            if (best.modeId != active.modeId) best.modeId else 0
+        }
+
+        val params = window.attributes
+        if (params.preferredDisplayModeId == targetModeId) return
+        params.preferredDisplayModeId = targetModeId
+        window.attributes = params
+    }
+
+    /**
+     * The display hosting this activity. [Activity.getDisplay] is the supported
+     * accessor from API 30; below that we fall back to the (deprecated, but
+     * correct for a single-display phone) default display.
+     */
+    private fun currentDisplay(): Display? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display
+        } else {
+            @Suppress("DEPRECATION")
+            activity.windowManager.defaultDisplay
+        }
+    }
+
+    private companion object {
+        // Reported refresh rates are floats (e.g. 59.96, 120.0); a small epsilon
+        // keeps "is this mode actually faster" from tripping on rounding noise.
+        const val REFRESH_RATE_EPSILON = 1f
+    }
+}

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -18,6 +18,21 @@ import io.flutter.plugin.common.MethodChannel
 // is mirrored by MethodChannelSafDocumentLister / MethodChannelSafFolderPicker
 // on the Dart side.
 class MainActivity : AudioServiceActivity() {
+    // Opts the window into the panel's native refresh rate (90/120/144 Hz where
+    // available) while foregrounded, and hands the rate back to the system under
+    // battery saver. Lazy so it binds to this activity once, on first resume.
+    private val displayRefreshRate by lazy { DisplayRefreshRate(this) }
+
+    override fun onResume() {
+        super.onResume()
+        displayRefreshRate.onResume()
+    }
+
+    override fun onPause() {
+        displayRefreshRate.onPause()
+        super.onPause()
+    }
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SAF_CHANNEL)

--- a/docs/battery.md
+++ b/docs/battery.md
@@ -78,6 +78,29 @@ tick:
 - **Queue sheet** selects only the queue identity (current + up-next + history),
   so the open sheet doesn't rebuild on position ticks while you browse it. See
   `lib/features/player/widgets/queue_sheet.dart`.
+- **The Now Playing backdrop is rasterized once per cover.** The full-screen
+  blurred artwork sits on its own `RepaintBoundary`, so the live progress bar and
+  the equalizer indicator painting above it never re-rasterize that expensive
+  blur. See `lib/features/player/widgets/now_playing_background.dart`.
+
+### Display refresh rate follows the panel — and yields under battery saver
+
+Linthra opts its window into the display's *native* refresh rate (90 / 120 /
+144 Hz where the panel supports it) so scrolling and the Now Playing animations
+are smooth on high-refresh phones, instead of the 60 Hz many OEMs hand an app by
+default. This is the one place the app touches refresh rate, and it is
+deliberately conservative about power:
+
+- **It never hard-codes a rate.** It picks the highest refresh mode that keeps
+  the *current resolution* — a seamless switch — and leaves a 60 Hz panel
+  untouched. It never lowers resolution to chase a higher rate.
+- **Battery saver is the system's call, not the app's.** When the OS is in
+  power-save mode the refresh-rate preference is *released* so Android is free to
+  drop the rate to save power; Linthra re-evaluates the moment battery saver
+  toggles. It never forces a high rate over the system's power management.
+
+See `DisplayRefreshRate` (`android/app/src/main/kotlin/.../DisplayRefreshRate.kt`),
+driven from `MainActivity`'s resume/pause.
 
 ### Network: event-driven, never polled
 

--- a/docs/manual-test-checklist.md
+++ b/docs/manual-test-checklist.md
@@ -383,6 +383,19 @@ cache's knowledge survives a restart; it never holds a URL or token.
 - ☐ Loading / error / empty states are friendly everywhere.
 - ☐ Destructive actions (delete playlist, clear cache) confirm first.
 
+### High refresh rate & scroll smoothness
+
+- ☐ On a 90/120/144 Hz phone, fling the Songs list in a large library (1000+
+  tracks) — scrolling is smooth and tracks the panel's refresh rate (not capped
+  at 60 fps). Albums and the Queue sheet scroll just as smoothly.
+- ☐ During playback, the Now Playing progress bar and the equalizer indicator
+  update with no stutter in the artwork/background around them.
+- ☐ Enable battery saver: the system is free to drop the refresh rate (Linthra
+  doesn't fight it); the app stays responsive and playback is unaffected.
+  Disable battery saver — high refresh resumes.
+- ☐ (Optional) Confirm via *Developer options ▸ Show refresh rate* that the rate
+  rises to the panel's max with Linthra in the foreground.
+
 ---
 
 ## Reporting a bug (for testers and users)

--- a/lib/features/player/widgets/now_playing_background.dart
+++ b/lib/features/player/widgets/now_playing_background.dart
@@ -22,41 +22,49 @@ class NowPlayingBackground extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final Uri? uri = artworkUri;
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        _Gradient(theme: theme),
-        if (uri != null)
-          ImageFiltered(
-            imageFilter: ui.ImageFilter.blur(sigmaX: 40, sigmaY: 40),
-            child: Image(
-              image: artworkImageProvider(uri),
-              fit: BoxFit.cover,
-              gaplessPlayback: true,
-              // A failed/decoding image leaves just the gradient showing.
-              errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-              frameBuilder: (context, child, frame, wasSync) {
-                if (wasSync || frame != null) return child;
-                return const SizedBox.shrink();
-              },
+    // The backdrop is expensive to paint (a full-screen 40px gaussian blur) but
+    // changes only when the track's artwork changes. A RepaintBoundary gives it
+    // its own retained compositing layer so the high-frequency playback updates
+    // layered above it — the ~4 Hz progress bar, the equalizer indicator — never
+    // re-rasterize the blur. That isolation matters more on 90/120/144 Hz panels,
+    // where there are simply more frames in which the cached layer pays off.
+    return RepaintBoundary(
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          _Gradient(theme: theme),
+          if (uri != null)
+            ImageFiltered(
+              imageFilter: ui.ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+              child: Image(
+                image: artworkImageProvider(uri),
+                fit: BoxFit.cover,
+                gaplessPlayback: true,
+                // A failed/decoding image leaves just the gradient showing.
+                errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                frameBuilder: (context, child, frame, wasSync) {
+                  if (wasSync || frame != null) return child;
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          // Scrim: darken toward the bottom where the controls live.
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  theme.colorScheme.surface.withValues(alpha: 0.30),
+                  theme.colorScheme.surface.withValues(alpha: 0.70),
+                  theme.colorScheme.surface.withValues(alpha: 0.92),
+                ],
+                stops: const [0.0, 0.55, 1.0],
+              ),
             ),
           ),
-        // Scrim: darken toward the bottom where the controls live.
-        DecoratedBox(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: [
-                theme.colorScheme.surface.withValues(alpha: 0.30),
-                theme.colorScheme.surface.withValues(alpha: 0.70),
-                theme.colorScheme.surface.withValues(alpha: 0.92),
-              ],
-              stops: const [0.0, 0.55, 1.0],
-            ),
-          ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary

Makes Linthra's UI adaptive to the device's refresh rate so it runs smoothly on 60/90/120/144 Hz panels, instead of the **60 Hz many OEMs (notably Samsung) hand a Flutter app by default**. This was the one genuinely missing piece — the Dart side is already well optimised for high FPS (see below).

Small, performance-focused change: **no playback-engine, provider (Plex/Jellyfin/Navidrome), or UI-design changes**, and no new dependencies (keeping the F-Droid/dependency posture intact — see `docs/dependency-license-audit.md`).

## What changed

**1. Native high refresh rate, battery-aware** — `android/.../DisplayRefreshRate.kt` (new), wired into `MainActivity` resume/pause
- Pins the window to the **highest refresh mode at the *current* resolution** via `preferredDisplayModeId` — a seamless switch that only raises the frame rate, never changes resolution.
- **Detects, never hard-codes:** a 90 Hz panel gets 90, a 144 Hz panel gets 144, a 60 Hz panel is left untouched. (Satisfies "do not force 144 Hz manually.")
- **Battery saver is the system's call, not the app's:** when `PowerManager.isPowerSaveMode` is on, the preference is *released* so Android can drop the rate to save power; it re-evaluates the instant battery saver toggles (`ACTION_POWER_SAVE_MODE_CHANGED`). We never override power management.
- Defensive throughout (best-effort receiver registration, API-23 guard) so it can never crash a resume. Note this is strictly better than just adding `flutter_displaymode`, which has **no** battery-saver awareness.

**2. Now Playing smoothness** — `now_playing_background.dart`
- Wraps the full-screen blurred artwork in a `RepaintBoundary` so the ~4 Hz progress bar and the equalizer indicator painting above it never re-rasterize the expensive gaussian blur. Pays off more at high FPS (more frames reuse the cached layer).

**3. Docs** — `docs/battery.md` (refresh-rate + battery-saver behaviour) and `docs/manual-test-checklist.md` (high-refresh / smooth-scroll QA items).

## Why the Dart side needed little

The codebase already follows Android/Flutter best practice for high FPS, so requirements #2/#3 were largely met by architecture:
- Songs list uses `ListView.builder` with fixed `itemExtentBuilder` (no per-item layout).
- Position ticks are coalesced to a steady ~4 Hz; the heavy blurred background and metadata don't rebuild on a tick (only the isolated `_LiveControls` does).
- Track rows watch a position-*independent* now-playing snapshot via `.select()`, so only the affected row rebuilds.
- The equalizer indicator stops its `AnimationController` when paused/off-screen and honours reduced-motion.

## Testing

- `flutter analyze` — clean
- `dart format --set-exit-if-changed .` — clean
- `flutter test` — **2264 passing** (incl. `player_screen` / now-playing background)
- Secret/privacy scan — clean

Native refresh-rate behaviour can't be exercised by `flutter test`; added manual-QA checklist items (smooth scroll in 1000+ track libraries, no jank during playback updates, battery-saver yields the rate, optional *Developer options ▸ Show refresh rate* spot-check).

## Out of scope (per the request)

No playback-engine changes · no provider-logic changes · no UI redesign · no forced 144 Hz · no experimental rendering engines.

https://claude.ai/code/session_01SxCdBJf8kcLkRS9SPz8g9n

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxCdBJf8kcLkRS9SPz8g9n)_