### PR TITLE
fix(plex): make library scanning async, incremental, and non-blocking

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -417,6 +417,29 @@ Small, incremental, each independently reviewable:
     server-scoped session. Manual URL + token stays available under
     "Manual setup (advanced)", and a rejected/expired session offers
     "Reconnect with Plex" right at the error.
+11. **Scan performance & reliability** — make a large-library sync (≈1000+
+    tracks) non-blocking and incremental, fixing the UI freeze / "app not
+    responding" reports. Four changes, all Plex-scoped:
+    - **Off-isolate decode.** A library page's `jsonDecode` + `MediaContainer`
+      parse — the heaviest synchronous step — runs on a background isolate
+      (`HttpPlexClient` decodes bodies over a size threshold via `compute`);
+      small replies stay inline.
+    - **Tracks only.** The sync reads just tracks; albums/artists are derived
+      from tracks by the library screen (`library_browse_providers.dart`) and
+      were never persisted, so listing them was two extra full library walks of
+      wasted work.
+    - **Batched, progressive writes.** Results are written in chunks via a new
+      optional `IncrementalCatalogWriter` capability (implemented by the
+      Drift/in-memory/recording repositories), refreshing after the first chunk
+      so the library fills as it goes instead of after one monolithic write.
+    - **Skip unchanged.** A credential-free content signature of the last
+      successful sync lets a re-sync that finds the same library skip the
+      database rebuild entirely (the durable catalog already lives in SQLite, so
+      launch never re-scans — this only avoids redundant re-syncs).
+
+    Playback is untouched — a `plex:` track resolves its stream URL lazily at
+    play time, so music keeps playing during a scan — and the sync status gains
+    explicit `scanning` / `syncing` (writing) / `done` phases.
 
 ## Notes
 

--- a/lib/core/repositories/incremental_catalog_writer.dart
+++ b/lib/core/repositories/incremental_catalog_writer.dart
@@ -1,0 +1,42 @@
+import '../models/track.dart';
+
+/// Optional capability a [MusicLibraryRepository] may also implement so a large
+/// remote sync can build a source's catalog slice **incrementally**, across
+/// several batches, instead of one monolithic write.
+///
+/// A whole-library `upsertCatalog` of a big remote library (≈1000+ tracks)
+/// serializes every row to the database isolate in one burst and only becomes
+/// visible once the entire payload lands — so nothing appears until the very
+/// end. Writing in chunks instead lets the library be read (and shown) as it
+/// fills, and keeps each main-isolate serialization step small enough to stay
+/// responsive.
+///
+/// Kept as a *separate* capability rather than widening [MusicLibraryRepository]
+/// so the many repositories and test fakes that only ever do whole-catalog
+/// upserts stay source-compatible. A caller that wants progressive writes checks
+/// `repo is IncrementalCatalogWriter` and falls back to
+/// [MusicLibraryRepository.upsertCatalog] when the capability is absent.
+///
+/// The end state of `beginCatalogReplacement(tracks: a)` followed by
+/// `appendToCatalog(tracks: b)` matches a single `upsertCatalog(tracks: a + b)`
+/// for the same `sourceId`; only the timing differs (the slice is readable, and
+/// already partly populated, between batches).
+abstract interface class IncrementalCatalogWriter {
+  /// Starts a fresh incremental sync for [sourceId]: removes the source's
+  /// existing rows and writes the first [tracks] batch in **one** transaction,
+  /// so a reader never observes the old slice with the first batch missing.
+  /// Other sources' rows are untouched. An empty [tracks] simply clears the
+  /// slice (the "deselected everything" case).
+  Future<void> beginCatalogReplacement({
+    required String sourceId,
+    required List<Track> tracks,
+  });
+
+  /// Appends one more [tracks] batch to the slice started by
+  /// [beginCatalogReplacement] for the same [sourceId]. Other sources' rows are
+  /// untouched. An empty [tracks] is a no-op.
+  Future<void> appendToCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+  });
+}

--- a/lib/core/sources/plex/http_plex_client.dart
+++ b/lib/core/sources/plex/http_plex_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'plex_api.dart';
@@ -18,6 +19,14 @@ import 'plex_exception.dart';
 /// keep the token in a header, so the URLs they build are token-free and safe to
 /// log.
 ///
+/// Large `MediaContainer` listings are decoded **off the UI isolate**: a library
+/// scan's `jsonDecode` + envelope parse of a big page is the heaviest
+/// synchronous step in the whole flow, and running it inline froze the UI (and
+/// triggered "app not responding") on 1000+-track libraries. Bodies at or above
+/// [_backgroundParseThreshold] are parsed via `compute` on a background isolate;
+/// small bodies (identity, a single item, a short page) stay inline to avoid the
+/// isolate-spawn overhead.
+///
 /// Every failure becomes a [PlexException]; the token is never written into an
 /// exception, a log, or any other output, so a leaked error string can't expose
 /// it. Transport errors are classified from the low-level failure but only the
@@ -27,9 +36,16 @@ class HttpPlexClient implements PlexClient {
     required PlexClientIdentity identity,
     http.Client? httpClient,
     int pageSize = _defaultPageSize,
+    int backgroundParseThreshold = _defaultBackgroundParseThreshold,
+    @visibleForTesting
+    Future<PlexMediaContainer?> Function(Uint8List bytes)? backgroundParser,
   })  : assert(pageSize > 0, 'pageSize must be positive'),
+        assert(backgroundParseThreshold >= 0,
+            'backgroundParseThreshold must not be negative'),
         _identity = identity,
         _pageSize = pageSize,
+        _backgroundParseThreshold = backgroundParseThreshold,
+        _backgroundParser = backgroundParser ?? _computeParseContainer,
         _client = httpClient ?? http.Client();
 
   final PlexClientIdentity _identity;
@@ -42,6 +58,19 @@ class HttpPlexClient implements PlexClient {
   /// walk without 200-item fixtures).
   static const int _defaultPageSize = 200;
   final int _pageSize;
+
+  /// A `MediaContainer` body at least this many bytes is decoded on a background
+  /// isolate; smaller ones are decoded inline. 64 KiB comfortably clears tiny
+  /// replies (identity, a single item) while catching full library pages, whose
+  /// synchronous decode is what stalled the UI. Overridable for tests.
+  static const int _defaultBackgroundParseThreshold = 64 * 1024;
+  final int _backgroundParseThreshold;
+
+  /// Decodes a large `MediaContainer` body into a [PlexMediaContainer]
+  /// (`null` on a non-Plex/non-JSON body). Defaults to a `compute` call so the
+  /// heavy parse runs off the UI isolate; injectable so a test can prove the
+  /// large-body path is taken without spawning a real isolate.
+  final Future<PlexMediaContainer?> Function(Uint8List bytes) _backgroundParser;
 
   /// A generous page-count cap stops a runaway loop if a server ever ignores the
   /// `X-Plex-Container-Start` offset.
@@ -152,14 +181,52 @@ class HttpPlexClient implements PlexClient {
   /// GETs [uri] with the auth + identity headers, checks the status, and decodes
   /// a JSON `MediaContainer` envelope — throwing [PlexException.notPlex] when the
   /// body isn't a Plex `MediaContainer` (missing envelope, or non-JSON/XML).
+  ///
+  /// The decode + envelope parse runs on a background isolate for bodies at or
+  /// above [_backgroundParseThreshold] (a full library page) and inline for
+  /// small ones, so a big scan never blocks the UI on `jsonDecode`. The status
+  /// is checked here (a cheap int compare) so error handling never depends on —
+  /// or ships off-isolate — the response body.
   Future<PlexMediaContainer> _getContainer(Uri uri, String token) async {
-    final PlexMediaContainer? container =
-        PlexMediaContainer.fromJson(await _getJson(uri, token));
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _headers(token)),
+    );
+    _checkStatus(response);
+    final Uint8List bytes = response.bodyBytes;
+    final PlexMediaContainer? container = bytes.length >= _backgroundParseThreshold
+        ? await _backgroundParser(bytes)
+        : _parseContainerBytes(bytes);
     if (container == null) {
       throw PlexException.notPlex();
     }
     return container;
   }
+
+  /// Decodes a `MediaContainer` JSON body into a [PlexMediaContainer], or
+  /// returns `null` when the body isn't JSON or isn't a Plex `MediaContainer`
+  /// envelope (Plex's default XML, an HTML proxy error page, a JSON array, …) —
+  /// the caller turns `null` into [PlexException.notPlex], matching the inline
+  /// path's old behavior exactly.
+  ///
+  /// Static and `this`-free so it can run on a background isolate via `compute`.
+  /// Decodes the raw bytes as UTF-8 (not `response.body`, which falls back to
+  /// latin1 without a charset and would mangle non-ASCII titles/artist names).
+  static PlexMediaContainer? _parseContainerBytes(Uint8List bytes) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(bytes, allowMalformed: true));
+    } on FormatException {
+      // Not JSON at all — e.g. Plex's default XML, or an HTML proxy error page.
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+    return PlexMediaContainer.fromJson(decoded);
+  }
+
+  /// The default [_backgroundParser]: runs [_parseContainerBytes] on a one-shot
+  /// background isolate. A top-level/static tear-off, as `compute` requires.
+  static Future<PlexMediaContainer?> _computeParseContainer(Uint8List bytes) =>
+      compute(_parseContainerBytes, bytes);
 
   /// GETs [uri] with the standard headers, maps the status to a [PlexException],
   /// and decodes a JSON object body.

--- a/lib/core/sources/plex/http_plex_client.dart
+++ b/lib/core/sources/plex/http_plex_client.dart
@@ -193,9 +193,10 @@ class HttpPlexClient implements PlexClient {
     );
     _checkStatus(response);
     final Uint8List bytes = response.bodyBytes;
-    final PlexMediaContainer? container = bytes.length >= _backgroundParseThreshold
-        ? await _backgroundParser(bytes)
-        : _parseContainerBytes(bytes);
+    final PlexMediaContainer? container =
+        bytes.length >= _backgroundParseThreshold
+            ? await _backgroundParser(bytes)
+            : _parseContainerBytes(bytes);
     if (container == null) {
       throw PlexException.notPlex();
     }

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -3,6 +3,7 @@ import 'package:drift/drift.dart';
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/incremental_catalog_writer.dart';
 import '../../core/repositories/music_library_repository.dart';
 import '../database/linthra_database.dart';
 import '../mappers/track_mapper.dart';
@@ -13,7 +14,11 @@ import '../mappers/track_mapper.dart';
 ///
 /// Albums and artists are not persisted yet — [getAllAlbums] and
 /// [getAllArtists] return empty lists. Only tracks are stored at v1.
-class DriftMusicLibraryRepository implements MusicLibraryRepository {
+///
+/// Also implements [IncrementalCatalogWriter] so a large remote sync (Plex) can
+/// fill a source's slice batch by batch instead of one monolithic write.
+class DriftMusicLibraryRepository
+    implements MusicLibraryRepository, IncrementalCatalogWriter {
   DriftMusicLibraryRepository(this._db);
 
   final LinthraDatabase _db;
@@ -50,14 +55,45 @@ class DriftMusicLibraryRepository implements MusicLibraryRepository {
     required List<Artist> artists,
   }) async {
     await _db.transaction(() async {
-      await (_db.delete(_db.tracks)..where((t) => t.sourceId.equals(sourceId)))
-          .go();
-      await _db.batch((Batch batch) {
-        batch.insertAll(
-          _db.tracks,
-          tracks.map((Track t) => trackToCompanion(t, sourceId)).toList(),
-        );
-      });
+      await _deleteSource(sourceId);
+      await _insertTracks(sourceId, tracks);
+    });
+  }
+
+  /// Starts an incremental replacement: clears [sourceId]'s slice and writes the
+  /// first batch in one transaction, so a reader never sees the old rows gone
+  /// with no new ones in their place.
+  @override
+  Future<void> beginCatalogReplacement({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    await _db.transaction(() async {
+      await _deleteSource(sourceId);
+      await _insertTracks(sourceId, tracks);
+    });
+  }
+
+  /// Appends one more batch to a slice already begun by
+  /// [beginCatalogReplacement]. An empty batch is a no-op.
+  @override
+  Future<void> appendToCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    await _insertTracks(sourceId, tracks);
+  }
+
+  Future<void> _deleteSource(String sourceId) =>
+      (_db.delete(_db.tracks)..where((t) => t.sourceId.equals(sourceId))).go();
+
+  Future<void> _insertTracks(String sourceId, List<Track> tracks) async {
+    if (tracks.isEmpty) return;
+    await _db.batch((Batch batch) {
+      batch.insertAll(
+        _db.tracks,
+        tracks.map((Track t) => trackToCompanion(t, sourceId)).toList(),
+      );
     });
   }
 

--- a/lib/data/repositories/in_memory_music_library_repository.dart
+++ b/lib/data/repositories/in_memory_music_library_repository.dart
@@ -1,6 +1,7 @@
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/incremental_catalog_writer.dart';
 import '../../core/repositories/music_library_repository.dart';
 
 /// An in-memory [MusicLibraryRepository] for development and tests.
@@ -14,7 +15,8 @@ import '../../core/repositories/music_library_repository.dart';
 /// the catalog for that one source, leaving every other source untouched.
 /// The `getAll*` methods flatten across sources, preserving the order that
 /// sources were first seen and the item order within each source.
-class InMemoryMusicLibraryRepository implements MusicLibraryRepository {
+class InMemoryMusicLibraryRepository
+    implements MusicLibraryRepository, IncrementalCatalogWriter {
   // Per-source catalogs. Keyed by sourceId so a re-scan of one source can
   // replace just its slice without disturbing the others. `upsertCatalog` is
   // the only writer, which keeps the three maps in sync.
@@ -73,6 +75,28 @@ class InMemoryMusicLibraryRepository implements MusicLibraryRepository {
     _tracksBySource[sourceId] = List<Track>.of(tracks);
     _albumsBySource[sourceId] = List<Album>.of(albums);
     _artistsBySource[sourceId] = List<Artist>.of(artists);
+  }
+
+  @override
+  Future<void> beginCatalogReplacement({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    // Mirror upsertCatalog's "replace this source" semantics, but only for the
+    // tracks an incremental sync streams; the album/artist slices are derived
+    // from tracks by readers, so they're dropped to stay consistent.
+    _tracksBySource[sourceId] = List<Track>.of(tracks);
+    _albumsBySource.remove(sourceId);
+    _artistsBySource.remove(sourceId);
+  }
+
+  @override
+  Future<void> appendToCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    if (tracks.isEmpty) return;
+    (_tracksBySource[sourceId] ??= <Track>[]).addAll(tracks);
   }
 
   @override

--- a/lib/data/repositories/recording_music_library_repository.dart
+++ b/lib/data/repositories/recording_music_library_repository.dart
@@ -1,6 +1,7 @@
 import '../../core/models/album.dart';
 import '../../core/models/artist.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/incremental_catalog_writer.dart';
 import '../../core/repositories/library_added_store.dart';
 import '../../core/repositories/music_library_repository.dart';
 
@@ -18,7 +19,14 @@ import '../../core/repositories/music_library_repository.dart';
 ///
 /// Reads (`getAllTracks`, etc.) pass straight through. The stored map holds only
 /// non-secret track ids and timestamps; it never carries a uri or token.
-class RecordingMusicLibraryRepository implements MusicLibraryRepository {
+///
+/// Incremental writes ([beginCatalogReplacement] / [appendToCatalog]) stamp each
+/// streamed batch the same way [upsertCatalog] does, so a progressively-synced
+/// library still feeds "Recently added" correctly; they delegate to the wrapped
+/// repository's [IncrementalCatalogWriter] when it has one (the production Drift
+/// repository does) and otherwise fall back to a whole-slice write.
+class RecordingMusicLibraryRepository
+    implements MusicLibraryRepository, IncrementalCatalogWriter {
   RecordingMusicLibraryRepository({
     required MusicLibraryRepository delegate,
     required LibraryAddedStore addedStore,
@@ -56,6 +64,47 @@ class RecordingMusicLibraryRepository implements MusicLibraryRepository {
       albums: albums,
       artists: artists,
     );
+    await _stampFirstSeen(tracks);
+  }
+
+  @override
+  Future<void> beginCatalogReplacement({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    final MusicLibraryRepository delegate = _delegate;
+    if (delegate is IncrementalCatalogWriter) {
+      await (delegate as IncrementalCatalogWriter)
+          .beginCatalogReplacement(sourceId: sourceId, tracks: tracks);
+    } else {
+      await delegate.upsertCatalog(
+        sourceId: sourceId,
+        tracks: tracks,
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+    }
+    await _stampFirstSeen(tracks);
+  }
+
+  @override
+  Future<void> appendToCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    final MusicLibraryRepository delegate = _delegate;
+    if (delegate is IncrementalCatalogWriter) {
+      await (delegate as IncrementalCatalogWriter)
+          .appendToCatalog(sourceId: sourceId, tracks: tracks);
+    }
+    await _stampFirstSeen(tracks);
+  }
+
+  /// Records `now` as the first-seen time for any track id not seen before,
+  /// preserving earlier timestamps so a routine re-sync never resets "recently
+  /// added". Shared by the whole-catalog and incremental write paths.
+  Future<void> _stampFirstSeen(List<Track> tracks) async {
+    if (tracks.isEmpty) return;
     final Map<String, DateTime> addedAt = await _addedStore.load();
     final DateTime now = _now();
     bool changed = false;

--- a/lib/features/settings/plex/plex_settings_section.dart
+++ b/lib/features/settings/plex/plex_settings_section.dart
@@ -767,7 +767,13 @@ class _ConnectedView extends StatelessWidget {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               : const Icon(Icons.sync_outlined),
-          label: Text(syncState.isSyncing ? 'Syncing…' : 'Sync Plex library'),
+          label: Text(
+            syncState.isScanning
+                ? 'Scanning…'
+                : syncState.isWriting
+                    ? 'Saving…'
+                    : 'Sync Plex library',
+          ),
         ),
         if (syncState.message != null && !syncState.isSyncing) ...[
           const SizedBox(height: AppSpacing.sm),

--- a/lib/features/settings/plex/plex_sync_controller.dart
+++ b/lib/features/settings/plex/plex_sync_controller.dart
@@ -1,8 +1,12 @@
+import 'dart:math' as math;
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/album.dart';
 import '../../../core/models/artist.dart';
 import '../../../core/models/track.dart';
+import '../../../core/repositories/incremental_catalog_writer.dart';
+import '../../../core/repositories/music_library_repository.dart';
 import '../../../core/sources/plex/plex_exception.dart';
 import '../../../core/sources/plex/plex_music_source.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
@@ -10,32 +14,49 @@ import '../../library/library_controller.dart';
 import 'plex_settings_controller.dart';
 import 'plex_sync_state.dart';
 
-/// Drives the "Sync Plex library" action.
+/// Drives the "Sync Plex library" action — built to stay smooth on large
+/// libraries (1000+ tracks), where the old one-shot sync froze the UI.
 ///
-/// Reads the signed-in [PlexMusicSource] (via [plexMusicSourceProvider]) to
-/// fetch the catalog, then hands the results to the `MusicLibraryRepository`
-/// under the stable `plex` source id — the same upsert path local scanning,
-/// Jellyfin, and Subsonic use. The Library screen reads from that repository,
-/// so a refresh after the upsert makes the synced tracks appear.
+/// Three things keep a scan off the UI thread and incremental:
+///  - **Scanning is off-isolate.** Reading the catalog goes through
+///    [PlexMusicSource]/[PlexClient], which decodes big library pages on a
+///    background isolate (the heaviest synchronous step). Only **tracks** are
+///    read: albums/artists are derived from tracks by the library screen
+///    (`library_browse_providers.dart`) and are *not* persisted, so fetching
+///    them was three full library walks of wasted work.
+///  - **Writing is batched.** Results are stored through the
+///    `MusicLibraryRepository` under the stable `plex` source id — the same
+///    catalog the Library screen reads — but in chunks of [_writeBatchSize] via
+///    [IncrementalCatalogWriter] when available, refreshing after the first
+///    chunk so the library fills progressively instead of after one big write.
+///  - **Unchanged libraries are skipped.** A content signature of the last
+///    successful sync is kept; a re-sync (a re-tapped *Sync* button, or a
+///    selection toggle that settles back to an already-synced set) that finds
+///    the same content skips the whole database rebuild + refresh. The durable
+///    catalog itself already lives in SQLite, so the app never re-scans Plex on
+///    launch just to show the library; this only avoids redundant *re*-syncs.
+///
+/// Playback is untouched: a scan only writes the catalog, never the player. A
+/// `plex:` track resolves its stream URL lazily at play time, so music keeps
+/// playing — and new tracks stay playable — throughout a sync.
 ///
 /// Unlike Jellyfin/Subsonic (which sync the whole server), the Plex library is
-/// **scoped by the user's selected music sections**, so the catalog must
-/// mirror the selection: a sync against an empty result (or an empty
-/// selection) **replaces** the stored Plex rows rather than skipping the
-/// write, so deselecting a library actually removes its tracks on the next
-/// sync instead of leaving stale, unplayable rows behind.
+/// **scoped by the user's selected music sections**, so the catalog mirrors the
+/// selection: a sync against an empty selection (or an empty result) **replaces**
+/// the stored Plex rows, so deselecting a library removes its tracks. Re-running
+/// against unchanged content is the only case that skips the write.
 ///
 /// The settings controller kicks [syncAfterSelectionChange] after every
-/// committed selection change, so picking a library populates the Library
-/// screen on its own — mirroring how Jellyfin auto-syncs a fresh connection.
-/// Rapid checkbox toggles coalesce: changes that land while a sync is running
-/// mark it dirty and the finished sync re-runs once against the newest
-/// selection, instead of queueing one full library walk per tap.
+/// committed selection change, so picking a library populates the Library screen
+/// on its own. Rapid checkbox toggles coalesce: changes that land while a sync
+/// is running mark it dirty and the finished sync re-runs once against the
+/// newest selection, instead of queueing one full library walk per tap.
 ///
-/// Security: the source mints any authenticated stream URL lazily at play
-/// time, so nothing persisted here carries a credential. This controller
-/// never logs the session, and surfaces only friendly, secret-free messages
-/// through [PlexSyncState].
+/// Security: the source mints any authenticated stream URL lazily at play time,
+/// so nothing persisted here carries a credential, and the content signature is
+/// built from credential-free catalog fields only. This controller never logs
+/// the session, and surfaces only friendly, secret-free messages through
+/// [PlexSyncState].
 class PlexSyncController extends Notifier<PlexSyncState> {
   /// Guards against overlapping syncs (an auto-sync racing a manual tap). Set
   /// synchronously before any await so a second concurrent call simply bails,
@@ -47,12 +68,23 @@ class PlexSyncController extends Notifier<PlexSyncState> {
   /// on the newest selection, not the one the first walk started with.
   bool _selectionChangedDuringSync = false;
 
+  /// Content signature of the last successful sync (selection + the scanned
+  /// tracks). When a fresh scan produces the same signature, the database
+  /// rebuild and the library refresh are skipped — the expensive part of a
+  /// re-sync of an unchanged library. Session-scoped: the durable copy of the
+  /// library is the SQLite catalog, which already survives restarts.
+  String? _lastSyncedSignature;
+
+  /// How many tracks are written per batch. 100 keeps each main-isolate
+  /// serialization step small while bounding the number of progress refreshes.
+  static const int _writeBatchSize = 100;
+
   @override
   PlexSyncState build() => const PlexSyncState();
 
-  /// The manual "Sync Plex library" action. Pulls artists/albums/tracks from
-  /// the selected sections and replaces the Plex slice of the local catalog.
-  /// Reflects loading/success/error through [state]; never throws.
+  /// The manual "Sync Plex library" action. Scans the selected sections and
+  /// replaces the Plex slice of the local catalog. Reflects scanning / writing /
+  /// done / error through [state]; never throws.
   Future<void> sync() => _runSync();
 
   /// Keeps the catalog in step after a library-selection change. Coalesces:
@@ -71,11 +103,15 @@ class PlexSyncController extends Notifier<PlexSyncState> {
   /// session — phase 1 has no offline cache) and when connecting to a
   /// different server (the old rows' ratingKeys belong to another machine).
   ///
-  /// Quiet by design: it reports nothing through [state] — the caller owns
-  /// the user-facing message — but throws on a storage failure so the caller
-  /// can phrase that message honestly.
-  Future<void> removeSyncedCatalog() =>
-      _replacePlexCatalog(tracks: const <Track>[]);
+  /// Quiet by design: it reports nothing through [state] — the caller owns the
+  /// user-facing message — but throws on a storage failure so the caller can
+  /// phrase that message honestly. Resets the content signature so the next
+  /// sync rebuilds rather than mistaking the freshly-emptied slice for "already
+  /// in sync" with a future server's identical content.
+  Future<void> removeSyncedCatalog() async {
+    await _writeCatalogInBatches(const <Track>[]);
+    _lastSyncedSignature = _signatureFor(const <String>[], const <Track>[]);
+  }
 
   Future<void> _runSync() async {
     if (_syncing) return;
@@ -99,45 +135,40 @@ class PlexSyncController extends Notifier<PlexSyncState> {
       return;
     }
 
-    if (source.session.selectedSectionKeys.isEmpty) {
-      // No selection means an empty Plex library by definition, so prune any
-      // rows a previous selection synced — without touching the server.
-      try {
-        await _replacePlexCatalog(tracks: const <Track>[]);
-      } catch (_) {
-        state = const PlexSyncState.error(_savingFailedMessage);
+    final List<String> sectionKeys = source.session.selectedSectionKeys;
+    try {
+      // 1. Read the library from the server. An empty selection is an empty
+      //    library by definition, so it touches no network — and still flows
+      //    through the same write path so a previously wider selection's rows
+      //    are pruned. The scan itself decodes off the UI isolate.
+      final List<Track> tracks;
+      if (sectionKeys.isEmpty) {
+        tracks = const <Track>[];
+      } else {
+        state = const PlexSyncState.scanning();
+        tracks = await source.fetchTracks();
+      }
+
+      // 2. Skip the whole rebuild when nothing changed since the last sync.
+      final String signature = _signatureFor(sectionKeys, tracks);
+      if (signature == _lastSyncedSignature) {
+        state = PlexSyncState.done(
+          trackCount: tracks.length,
+          message: _doneMessage(sectionKeys, tracks.length, upToDate: true),
+        );
         return;
       }
-      state = const PlexSyncState.success(
-        trackCount: 0,
-        message: 'No music libraries are selected — choose at least one '
-            'above to sync its music.',
+
+      // 3. Write progressively so the library fills as the sync goes, instead
+      //    of staying blank until one monolithic write finishes.
+      state = PlexSyncState.syncing(trackCount: tracks.length);
+      await _writeCatalogInBatches(tracks);
+      _lastSyncedSignature = signature;
+
+      state = PlexSyncState.done(
+        trackCount: tracks.length,
+        message: _doneMessage(sectionKeys, tracks.length, upToDate: false),
       );
-      return;
-    }
-
-    state = const PlexSyncState.syncing();
-    try {
-      final List<Track> tracks = await source.fetchTracks();
-      final List<Album> albums = await source.fetchAlbums();
-      final List<Artist> artists = await source.fetchArtists();
-
-      // Replace even when empty: the result *is* the selected libraries'
-      // honest content, and skipping the write would leave rows from a
-      // previously wider selection lingering as unplayable entries.
-      await _replacePlexCatalog(
-          tracks: tracks, albums: albums, artists: artists);
-
-      state = tracks.isEmpty
-          ? const PlexSyncState.success(
-              trackCount: 0,
-              message: 'Your selected libraries have no tracks yet — '
-                  'nothing to sync.',
-            )
-          : PlexSyncState.success(
-              trackCount: tracks.length,
-              message: _successMessage(tracks.length),
-            );
     } on PlexException catch (error) {
       state = PlexSyncState.error(_friendlyMessage(error));
     } catch (_) {
@@ -145,29 +176,125 @@ class PlexSyncController extends Notifier<PlexSyncState> {
     }
   }
 
-  /// Replaces the Plex slice of the catalog and refreshes the Library screen
-  /// so the change is visible immediately. Other sources' rows are untouched
-  /// (the repository replaces per `sourceId`).
-  Future<void> _replacePlexCatalog({
-    required List<Track> tracks,
-    List<Album> albums = const <Album>[],
-    List<Artist> artists = const <Artist>[],
-  }) async {
-    await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
+  /// Replaces the Plex slice of the catalog with [tracks] in chunks, refreshing
+  /// the Library screen after the first chunk so it isn't blank while the rest
+  /// streams in. Falls back to a single whole-slice write when the repository
+  /// has no [IncrementalCatalogWriter] capability (some test fakes). Other
+  /// sources' rows are untouched (the write is scoped by `sourceId`).
+  Future<void> _writeCatalogInBatches(List<Track> tracks) async {
+    final MusicLibraryRepository repository =
+        ref.read(musicLibraryRepositoryProvider);
+
+    if (repository is! IncrementalCatalogWriter) {
+      await repository.upsertCatalog(
+        sourceId: PlexMusicSource.sourceId,
+        tracks: tracks,
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await _refreshLibrary();
+      return;
+    }
+
+    final IncrementalCatalogWriter writer =
+        repository as IncrementalCatalogWriter;
+    final List<List<Track>> batches = _chunk(tracks, _writeBatchSize);
+
+    if (batches.isEmpty) {
+      // No tracks — still clear the slice (deselected, or an empty library).
+      await writer.beginCatalogReplacement(
+        sourceId: PlexMusicSource.sourceId,
+        tracks: const <Track>[],
+      );
+      await _refreshLibrary();
+      return;
+    }
+
+    for (int i = 0; i < batches.length; i++) {
+      if (i == 0) {
+        await writer.beginCatalogReplacement(
           sourceId: PlexMusicSource.sourceId,
-          tracks: tracks,
-          albums: albums,
-          artists: artists,
+          tracks: batches[i],
         );
-    await ref.read(libraryControllerProvider.notifier).refresh();
+        // First chunk visible immediately.
+        await _refreshLibrary();
+      } else {
+        await writer.appendToCatalog(
+          sourceId: PlexMusicSource.sourceId,
+          tracks: batches[i],
+        );
+      }
+    }
+
+    // One final refresh once every chunk has landed (a single-chunk sync
+    // already refreshed above).
+    if (batches.length > 1) {
+      await _refreshLibrary();
+    }
+  }
+
+  Future<void> _refreshLibrary() =>
+      ref.read(libraryControllerProvider.notifier).refresh();
+
+  /// Splits [tracks] into runs of at most [size]. An empty list yields no
+  /// batches (the caller still clears the slice explicitly).
+  List<List<Track>> _chunk(List<Track> tracks, int size) {
+    if (tracks.isEmpty) return const <List<Track>>[];
+    final List<List<Track>> batches = <List<Track>>[];
+    for (int i = 0; i < tracks.length; i += size) {
+      batches.add(tracks.sublist(i, math.min(i + size, tracks.length)));
+    }
+    return batches;
+  }
+
+  /// A stable, credential-free fingerprint of a sync's outcome: the selected
+  /// sections plus the scanned tracks' identity and display fields. Two scans
+  /// with the same signature describe the same library, so the second can skip
+  /// the rebuild. Order-independent over tracks (a server reordering its listing
+  /// is not a real change); the selection and track count are folded in so a
+  /// changed selection or a different count always re-syncs.
+  String _signatureFor(List<String> sectionKeys, List<Track> tracks) {
+    final List<String> sortedSections = List<String>.of(sectionKeys)..sort();
+    final Iterable<int> trackHashes = tracks.map(
+      (Track t) => Object.hash(
+        t.id,
+        t.title,
+        t.artistName,
+        t.albumName,
+        t.duration.inMilliseconds,
+        t.trackNumber,
+        t.artworkUri?.toString(),
+      ),
+    );
+    final int content = Object.hashAllUnordered(trackHashes);
+    return '${sortedSections.join(',')}|${tracks.length}|$content';
   }
 
   static const String _savingFailedMessage =
       'Something went wrong saving your Plex library. Please try again.';
 
-  String _successMessage(int trackCount) {
-    final String tracks = trackCount == 1 ? '1 track' : '$trackCount tracks';
-    return 'Synced $tracks from your Plex libraries.';
+  String _tracksLabel(int trackCount) =>
+      trackCount == 1 ? '1 track' : '$trackCount tracks';
+
+  /// The friendly line for a finished sync, branching on selection/result, and
+  /// noting when nothing changed.
+  String _doneMessage(
+    List<String> sectionKeys,
+    int trackCount, {
+    required bool upToDate,
+  }) {
+    if (sectionKeys.isEmpty) {
+      return 'No music libraries are selected — choose at least one '
+          'above to sync its music.';
+    }
+    if (trackCount == 0) {
+      return 'Your selected libraries have no tracks yet — nothing to sync.';
+    }
+    if (upToDate) {
+      return 'Your Plex library is already up to date '
+          '(${_tracksLabel(trackCount)}).';
+    }
+    return 'Synced ${_tracksLabel(trackCount)} from your Plex libraries.';
   }
 
   /// Turns a typed Plex failure into a friendly, actionable line. Branches on

--- a/lib/features/settings/plex/plex_sync_state.dart
+++ b/lib/features/settings/plex/plex_sync_state.dart
@@ -1,12 +1,21 @@
 /// Where a Plex library sync is in its lifecycle.
-enum PlexSyncStatus { idle, syncing, success, error }
+///
+/// Split into two active phases so the UI can say which is happening:
+///  - [scanning] — reading the catalog from the Plex server (the network walk
+///    plus the off-isolate decode);
+///  - [syncing] — writing the scanned tracks into the local database, batch by
+///    batch, so the library fills progressively.
+///
+/// [done] is the resting "finished successfully" state (a completed sync or a
+/// no-op when nothing changed); [idle] is the never-run-yet state.
+enum PlexSyncStatus { idle, scanning, syncing, done, error }
 
 /// Immutable snapshot the Plex settings UI renders the sync action from.
 ///
 /// Like every other state object in the app, this holds only display-safe
-/// values: a status, a friendly [message], and how many tracks landed. It
-/// never carries the Plex token or a tokenized stream/art URL — every message
-/// is static or built from a token-free `PlexException`.
+/// values: a status, a friendly [message], and how many tracks the library
+/// holds. It never carries the Plex token or a tokenized stream/art URL — every
+/// message is static or built from a token-free `PlexException`.
 class PlexSyncState {
   const PlexSyncState({
     this.status = PlexSyncStatus.idle,
@@ -14,17 +23,28 @@ class PlexSyncState {
     this.trackCount = 0,
   });
 
-  const PlexSyncState.syncing()
+  /// Reading the library from the server (and decoding it off the UI isolate).
+  const PlexSyncState.scanning()
       : this(
-          status: PlexSyncStatus.syncing,
-          message: 'Syncing your Plex libraries…',
+          status: PlexSyncStatus.scanning,
+          message: 'Scanning your Plex libraries…',
         );
 
-  const PlexSyncState.success({
+  /// Writing the scanned tracks into the local database. [trackCount] is the
+  /// total being written, so the UI can show progress if it wants to.
+  const PlexSyncState.syncing({int trackCount = 0})
+      : this(
+          status: PlexSyncStatus.syncing,
+          trackCount: trackCount,
+          message: 'Saving your Plex libraries…',
+        );
+
+  /// Finished successfully — a completed sync or an up-to-date no-op.
+  const PlexSyncState.done({
     required int trackCount,
     required String message,
   }) : this(
-          status: PlexSyncStatus.success,
+          status: PlexSyncStatus.done,
           trackCount: trackCount,
           message: message,
         );
@@ -37,9 +57,20 @@ class PlexSyncState {
   /// A friendly status or error line for the UI; never contains a secret.
   final String? message;
 
-  /// How many tracks the last successful sync stored.
+  /// How many tracks the last successful sync stored (or is storing).
   final int trackCount;
 
-  bool get isSyncing => status == PlexSyncStatus.syncing;
+  /// Reading from the server.
+  bool get isScanning => status == PlexSyncStatus.scanning;
+
+  /// Writing to the local database.
+  bool get isWriting => status == PlexSyncStatus.syncing;
+
+  /// Any active phase — scanning **or** writing. Kept named `isSyncing` because
+  /// the UI uses it as the single "a sync is in progress" flag (spinner shown,
+  /// actions disabled) across both phases.
+  bool get isSyncing => isScanning || isWriting;
+
   bool get isError => status == PlexSyncStatus.error;
+  bool get isDone => status == PlexSyncStatus.done;
 }

--- a/lib/features/settings/source/provider_summary_cards.dart
+++ b/lib/features/settings/source/provider_summary_cards.dart
@@ -503,8 +503,10 @@ class PlexProviderCard extends ConsumerWidget {
     } else if (state.errorMessage != null) {
       detail = state.errorMessage;
       detailIsError = true;
-    } else if (sync.isSyncing) {
-      detail = 'Syncing your libraries…';
+    } else if (sync.isScanning) {
+      detail = 'Scanning your libraries…';
+    } else if (sync.isWriting) {
+      detail = 'Saving your libraries…';
     } else if (sync.isError) {
       detail = sync.message;
       detailIsError = true;

--- a/test/core/sources/plex/http_plex_client_test.dart
+++ b/test/core/sources/plex/http_plex_client_test.dart
@@ -709,7 +709,8 @@ void main() {
       expect(parserCalls, 1, reason: 'a large page is parsed off the seam');
     });
 
-    test('small bodies stay inline (the background seam is not used)', () async {
+    test('small bodies stay inline (the background seam is not used)',
+        () async {
       int parserCalls = 0;
       final HttpPlexClient client = HttpPlexClient(
         identity: _identity,

--- a/test/core/sources/plex/http_plex_client_test.dart
+++ b/test/core/sources/plex/http_plex_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -669,6 +670,134 @@ void main() {
           expect(e.toString(), isNot(contains(_token)));
         }
       }
+    });
+  });
+
+  group('off-isolate parsing of large library pages', () {
+    PlexMediaContainer? decodeInline(Uint8List bytes) =>
+        PlexMediaContainer.fromJson(
+            jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>);
+
+    test('routes a large page through the background parser seam', () async {
+      int parserCalls = 0;
+      final HttpPlexClient client = HttpPlexClient(
+        identity: _identity,
+        // Force the background path for any non-empty body.
+        backgroundParseThreshold: 0,
+        backgroundParser: (Uint8List bytes) async {
+          parserCalls++;
+          return decodeInline(bytes);
+        },
+        httpClient: MockClient((_) async => _json(<String, dynamic>{
+              'MediaContainer': <String, dynamic>{
+                'size': 1,
+                'Metadata': <dynamic>[
+                  <String, dynamic>{'ratingKey': '1', 'type': 'track'},
+                ],
+              },
+            })),
+      );
+
+      final List<PlexMetadata> tracks = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+
+      expect(tracks.map((PlexMetadata t) => t.ratingKey), <String>['1']);
+      expect(parserCalls, 1, reason: 'a large page is parsed off the seam');
+    });
+
+    test('small bodies stay inline (the background seam is not used)', () async {
+      int parserCalls = 0;
+      final HttpPlexClient client = HttpPlexClient(
+        identity: _identity,
+        // Default 64 KiB threshold — a tiny reply stays inline.
+        backgroundParser: (Uint8List bytes) async {
+          parserCalls++;
+          return decodeInline(bytes);
+        },
+        httpClient: MockClient((_) async => _json(<String, dynamic>{
+              'MediaContainer': <String, dynamic>{
+                'size': 1,
+                'Metadata': <dynamic>[
+                  <String, dynamic>{'ratingKey': '1', 'type': 'track'},
+                ],
+              },
+            })),
+      );
+
+      final List<PlexMetadata> tracks = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+
+      expect(tracks.map((PlexMetadata t) => t.ratingKey), <String>['1']);
+      expect(parserCalls, 0, reason: 'small bodies are decoded inline');
+    });
+
+    test('decodes a large page correctly via the real compute isolate',
+        () async {
+      // No injected parser: exercises the production `compute` seam end to end.
+      final HttpPlexClient client = HttpPlexClient(
+        identity: _identity,
+        backgroundParseThreshold: 0,
+        httpClient: MockClient((_) async => _json(<String, dynamic>{
+              'MediaContainer': <String, dynamic>{
+                'size': 2,
+                'totalSize': 2,
+                'Metadata': <dynamic>[
+                  <String, dynamic>{
+                    'ratingKey': '1',
+                    'type': 'track',
+                    'title': 'Aurøra', // non-ASCII survives the UTF-8 decode
+                  },
+                  <String, dynamic>{'ratingKey': '2', 'type': 'track'},
+                ],
+              },
+            })),
+      );
+
+      final List<PlexMetadata> tracks = await client.fetchSectionItems(
+        baseUrl: _base,
+        token: _token,
+        sectionKey: '3',
+        itemType: PlexMetadataType.track,
+      );
+
+      expect(tracks.map((PlexMetadata t) => t.ratingKey), <String>['1', '2']);
+      expect(tracks.first.title, 'Aurøra');
+    });
+
+    test('a large non-JSON body still maps to notPlex off-isolate', () async {
+      final HttpPlexClient client = HttpPlexClient(
+        identity: _identity,
+        backgroundParseThreshold: 0,
+        httpClient: MockClient(
+          (_) async => http.Response(
+            '<MediaContainer machineIdentifier="abc"/>',
+            200,
+            headers: const <String, String>{'content-type': 'application/xml'},
+          ),
+        ),
+      );
+
+      await expectLater(
+        client.fetchSectionItems(
+          baseUrl: _base,
+          token: _token,
+          sectionKey: '3',
+          itemType: PlexMetadataType.track,
+        ),
+        throwsA(isA<PlexException>().having(
+          (PlexException e) => e.kind,
+          'kind',
+          PlexErrorKind.notPlex,
+        )),
+      );
     });
   });
 }

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -1001,7 +1001,7 @@ void main() {
       expect((await repository.getAllTracks()), hasLength(2));
       expect(
         container.read(plexSyncControllerProvider).status,
-        PlexSyncStatus.success,
+        PlexSyncStatus.done,
       );
 
       await notifier.disconnect();

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -386,10 +386,12 @@ void main() {
     // The background sync kicked by the selection landed and reported.
     expect(find.textContaining('Synced 1 track'), findsOneWidget);
 
-    // The manual action reruns it on demand.
+    // The manual action reruns it on demand; with nothing changed since the
+    // selection-driven sync, it reports the library is already current rather
+    // than rebuilding it.
     await tester.tap(find.text('Sync Plex library'));
     await tester.pumpAndSettle();
-    expect(find.textContaining('Synced 1 track'), findsOneWidget);
+    expect(find.textContaining('already up to date'), findsOneWidget);
   });
 
   testWidgets('a rejected token shows a friendly, token-free error',

--- a/test/features/settings/plex/plex_sync_controller_test.dart
+++ b/test/features/settings/plex/plex_sync_controller_test.dart
@@ -388,9 +388,10 @@ void main() {
           .ensureLoaded();
 
       bool finished = false;
-      final Future<void> running =
-          container.read(plexSyncControllerProvider.notifier).sync()
-            ..then((_) => finished = true).ignore();
+      final Future<void> running = container
+          .read(plexSyncControllerProvider.notifier)
+          .sync()
+        ..then((_) => finished = true).ignore();
 
       // Advance until the sync is parked on the gated second batch.
       for (int i = 0; i < 50 && repo.appendCount == 0; i++) {

--- a/test/features/settings/plex/plex_sync_controller_test.dart
+++ b/test/features/settings/plex/plex_sync_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/incremental_catalog_writer.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
@@ -45,6 +46,10 @@ const PlexMetadata _trackItem = PlexMetadata(
 );
 const PlexMetadata _secondTrackItem =
     PlexMetadata(ratingKey: '102', type: 'track', title: 'Dusk');
+
+// Albums/artists are intentionally still present in the fixture but never
+// requested: the sync reads tracks only (the library derives groupings from
+// tracks), so listing albums/artists would be wasted library walks.
 const PlexMetadata _albumItem = PlexMetadata(
   ratingKey: '201',
   type: 'album',
@@ -61,18 +66,68 @@ const Map<PlexMetadataType, List<PlexMetadata>> _libraryItems =
   PlexMetadataType.artist: <PlexMetadata>[_artistItem],
 };
 
-/// Records every upsert so tests can assert exactly what reached the catalog
-/// (and can be made to throw, proving storage failures surface friendly).
-class _RecordingRepository implements MusicLibraryRepository {
-  _RecordingRepository({this.upsertError});
+/// `count` track items, for exercising the batched (chunked) write path.
+List<PlexMetadata> _trackItems(int count) => <PlexMetadata>[
+      for (int i = 0; i < count; i++)
+        PlexMetadata(ratingKey: 'r$i', type: 'track', title: 'Track $i'),
+    ];
 
-  final Object? upsertError;
+/// Records every catalog write so tests can assert exactly what reached the
+/// catalog and in how many batches. Implements the incremental capability so
+/// the controller exercises its progressive path (a whole-slice `upsertCatalog`
+/// is kept only for interface completeness and is not used by the controller).
+class _RecordingRepository
+    implements MusicLibraryRepository, IncrementalCatalogWriter {
+  _RecordingRepository({this.beginError, this.appendGate});
 
-  String? upsertedSourceId;
-  List<Track> upsertedTracks = const <Track>[];
-  List<Album> upsertedAlbums = const <Album>[];
-  List<Artist> upsertedArtists = const <Artist>[];
+  /// When set, the first (begin) write throws it, so a storage failure can be
+  /// proven to surface friendly and never half-write.
+  final Object? beginError;
+
+  /// When set, [appendToCatalog] awaits it before applying its batch, so a test
+  /// can hold a sync mid-write and observe the already-stored batches.
+  final Future<void>? appendGate;
+
+  String? lastSourceId;
+
+  /// The catalog accumulated across the current begin/append run.
+  final List<Track> stored = <Track>[];
+
+  /// Each batch handed to begin/append, in order.
+  final List<List<Track>> batches = <List<Track>>[];
+
+  int beginCount = 0;
+  int appendCount = 0;
   int upsertCount = 0;
+
+  int get writeCount => beginCount + appendCount + upsertCount;
+
+  @override
+  Future<void> beginCatalogReplacement({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    beginCount++;
+    if (beginError != null) throw beginError!;
+    lastSourceId = sourceId;
+    stored
+      ..clear()
+      ..addAll(tracks);
+    batches.add(List<Track>.of(tracks));
+  }
+
+  @override
+  Future<void> appendToCatalog({
+    required String sourceId,
+    required List<Track> tracks,
+  }) async {
+    appendCount++;
+    final Future<void>? gate = appendGate;
+    if (gate != null) await gate;
+    lastSourceId = sourceId;
+    stored.addAll(tracks);
+    batches.add(List<Track>.of(tracks));
+  }
 
   @override
   Future<void> upsertCatalog({
@@ -82,21 +137,22 @@ class _RecordingRepository implements MusicLibraryRepository {
     required List<Artist> artists,
   }) async {
     upsertCount++;
-    if (upsertError != null) throw upsertError!;
-    upsertedSourceId = sourceId;
-    upsertedTracks = tracks;
-    upsertedAlbums = albums;
-    upsertedArtists = artists;
+    if (beginError != null) throw beginError!;
+    lastSourceId = sourceId;
+    stored
+      ..clear()
+      ..addAll(tracks);
+    batches.add(List<Track>.of(tracks));
   }
 
   @override
-  Future<List<Track>> getAllTracks() async => upsertedTracks;
+  Future<List<Track>> getAllTracks() async => List<Track>.of(stored);
 
   @override
-  Future<List<Album>> getAllAlbums() async => upsertedAlbums;
+  Future<List<Album>> getAllAlbums() async => const <Album>[];
 
   @override
-  Future<List<Artist>> getAllArtists() async => upsertedArtists;
+  Future<List<Artist>> getAllArtists() async => const <Artist>[];
 
   @override
   Future<Track?> getTrackById(String id) async => null;
@@ -106,9 +162,15 @@ class _RecordingRepository implements MusicLibraryRepository {
 }
 
 /// A [FakePlexClient] whose item listings block until [gate] completes, so a
-/// test can hold a sync mid-flight and race it against selection changes.
+/// test can hold a sync mid-scan and race it against selection changes (and
+/// prove playback still resolves while a scan is in flight — `fetchMetadata`,
+/// the play-time lookup, is deliberately *not* gated).
 class _GatedPlexClient extends FakePlexClient {
-  _GatedPlexClient({super.sections, super.itemsByType});
+  _GatedPlexClient({
+    super.sections,
+    super.itemsByType,
+    super.metadataByRatingKey,
+  });
 
   Completer<void> gate = Completer<void>();
 
@@ -171,11 +233,12 @@ void main() {
       final state = container.read(plexSyncControllerProvider);
       expect(state.isError, isTrue);
       expect(state.message, contains('Connect to your Plex server'));
-      expect(repo.upsertCount, 0);
+      expect(repo.writeCount, 0);
     });
 
-    test('pulls the selected libraries into the catalog under the plex id',
-        () async {
+    test(
+        'pulls the selected libraries (tracks only) into the catalog under the '
+        'plex id', () async {
       final client = FakePlexClient(
         sections: const [_musicSection],
         itemsByType: _libraryItems,
@@ -189,14 +252,14 @@ void main() {
 
       await container.read(plexSyncControllerProvider.notifier).sync();
 
-      expect(repo.upsertedSourceId, 'plex');
+      expect(repo.lastSourceId, 'plex');
       expect(
-        repo.upsertedTracks.map((Track t) => t.uri),
+        repo.stored.map((Track t) => t.uri),
         <String>['plex:101', 'plex:102'],
       );
       // What reaches the (persisted) catalog stays credential-free: opaque
       // plex: URIs and plex-thumb: references — never a tokenized URL.
-      for (final Track track in repo.upsertedTracks) {
+      for (final Track track in repo.stored) {
         expect(track.uri, isNot(contains(_token)));
         expect(track.uri, isNot(contains('X-Plex-Token')));
         final Uri? artwork = track.artworkUri;
@@ -205,17 +268,20 @@ void main() {
           expect(artwork.toString(), isNot(contains(_token)));
         }
       }
-      expect(repo.upsertedAlbums, hasLength(1));
-      expect(repo.upsertedArtists, hasLength(1));
-      // Each kind was listed once, scoped to the selected section.
+      // Only the track kind is listed (no album/artist walks), scoped to the
+      // selected section.
+      expect(
+        client.itemRequests.map((r) => r.itemType).toSet(),
+        <PlexMetadataType>{PlexMetadataType.track},
+      );
       expect(
         client.itemRequests.map((r) => r.sectionKey).toSet(),
         <String>{'5'},
       );
-      expect(client.itemRequests, hasLength(3));
+      expect(client.itemRequests, hasLength(1));
 
       final state = container.read(plexSyncControllerProvider);
-      expect(state.status, PlexSyncStatus.success);
+      expect(state.status, PlexSyncStatus.done);
       expect(state.trackCount, 2);
       expect(state.message, contains('Synced 2 tracks'));
     });
@@ -235,12 +301,12 @@ void main() {
 
       await container.read(plexSyncControllerProvider.notifier).sync();
 
-      // The empty result is written (a previously wider selection's rows
-      // must not linger), and the message says what happened.
-      expect(repo.upsertCount, 1);
-      expect(repo.upsertedTracks, isEmpty);
+      // The empty result is written (a previously wider selection's rows must
+      // not linger), and the message says what happened.
+      expect(repo.beginCount, 1);
+      expect(repo.stored, isEmpty);
       final state = container.read(plexSyncControllerProvider);
-      expect(state.status, PlexSyncStatus.success);
+      expect(state.status, PlexSyncStatus.done);
       expect(state.trackCount, 0);
       expect(state.message, contains('no tracks yet'));
     });
@@ -257,12 +323,207 @@ void main() {
 
       await container.read(plexSyncControllerProvider.notifier).sync();
 
-      expect(repo.upsertCount, 1);
-      expect(repo.upsertedSourceId, 'plex');
-      expect(repo.upsertedTracks, isEmpty);
+      expect(repo.beginCount, 1);
+      expect(repo.lastSourceId, 'plex');
+      expect(repo.stored, isEmpty);
+      // An empty selection needs no server walk.
+      final client = container.read(plexClientProvider) as FakePlexClient;
+      expect(client.itemRequests, isEmpty);
       final state = container.read(plexSyncControllerProvider);
-      expect(state.status, PlexSyncStatus.success);
+      expect(state.status, PlexSyncStatus.done);
       expect(state.message, contains('No music libraries are selected'));
+    });
+  });
+
+  group('incremental writes', () {
+    test('a large library is written progressively in capped batches',
+        () async {
+      final repo = _RecordingRepository();
+      final container = _container(
+        client: FakePlexClient(
+          sections: const [_musicSection],
+          itemsByType: <PlexMetadataType, List<PlexMetadata>>{
+            PlexMetadataType.track: _trackItems(250),
+          },
+        ),
+        session: _session,
+        repository: repo,
+      );
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      // 250 tracks → one begin (100) + two appends (100, 50).
+      expect(repo.beginCount, 1);
+      expect(repo.appendCount, 2);
+      expect(repo.batches.map((b) => b.length), <int>[100, 100, 50]);
+      // No batch exceeds the chunk size, and the whole library landed in order.
+      expect(repo.batches.every((b) => b.length <= 100), isTrue);
+      expect(repo.stored, hasLength(250));
+      expect(
+        repo.stored.map((Track t) => t.id),
+        _trackItems(250).map((PlexMetadata m) => m.ratingKey),
+      );
+      expect(container.read(plexSyncControllerProvider).trackCount, 250);
+    });
+
+    test('the first batch is in the catalog before the sync finishes',
+        () async {
+      final gate = Completer<void>();
+      final repo = _RecordingRepository(appendGate: gate.future);
+      final container = _container(
+        client: FakePlexClient(
+          sections: const [_musicSection],
+          itemsByType: <PlexMetadataType, List<PlexMetadata>>{
+            PlexMetadataType.track: _trackItems(150),
+          },
+        ),
+        session: _session,
+        repository: repo,
+      );
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      bool finished = false;
+      final Future<void> running =
+          container.read(plexSyncControllerProvider.notifier).sync()
+            ..then((_) => finished = true).ignore();
+
+      // Advance until the sync is parked on the gated second batch.
+      for (int i = 0; i < 50 && repo.appendCount == 0; i++) {
+        await _settle();
+      }
+
+      // The first 100 tracks are already stored (the library could show them)
+      // while the sync is still writing the rest.
+      expect(repo.appendCount, 1);
+      expect(repo.stored, hasLength(100));
+      expect(finished, isFalse);
+      expect(container.read(plexSyncControllerProvider).isWriting, isTrue);
+
+      gate.complete();
+      await running;
+
+      expect(repo.stored, hasLength(150));
+      expect(container.read(plexSyncControllerProvider).isDone, isTrue);
+    });
+
+    test('an unchanged library skips the rebuild on a re-sync', () async {
+      final repo = _RecordingRepository();
+      final container = _container(session: _session, repository: repo);
+      final sync = container.read(plexSyncControllerProvider.notifier);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await sync.sync();
+      expect(repo.beginCount, 1);
+      expect(repo.stored, hasLength(2));
+
+      await sync.sync();
+
+      // Nothing changed, so the database was not rebuilt a second time.
+      expect(repo.beginCount, 1);
+      expect(repo.appendCount, 0);
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.isDone, isTrue);
+      expect(state.trackCount, 2);
+      expect(state.message, contains('already up to date'));
+    });
+
+    test('a changed library is rebuilt rather than skipped', () async {
+      final client = FakePlexClient(
+        sections: const [_musicSection],
+        itemsByType: <PlexMetadataType, List<PlexMetadata>>{
+          PlexMetadataType.track: const <PlexMetadata>[
+            _trackItem,
+            _secondTrackItem,
+          ],
+        },
+      );
+      final repo = _RecordingRepository();
+      final container =
+          _container(client: client, session: _session, repository: repo);
+      final sync = container.read(plexSyncControllerProvider.notifier);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await sync.sync();
+      expect(repo.beginCount, 1);
+      expect(repo.stored, hasLength(2));
+
+      // The server gains a track between syncs.
+      client.itemsByType = <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.track: const <PlexMetadata>[
+          _trackItem,
+          _secondTrackItem,
+          PlexMetadata(ratingKey: '103', type: 'track', title: 'Twilight'),
+        ],
+      };
+
+      await sync.sync();
+
+      expect(repo.beginCount, 2);
+      expect(repo.stored, hasLength(3));
+      final state = container.read(plexSyncControllerProvider);
+      expect(state.isDone, isTrue);
+      expect(state.message, contains('Synced 3 tracks'));
+    });
+  });
+
+  group('playback during a scan', () {
+    test('a track still resolves to a stream URL while a scan is in flight',
+        () async {
+      final client = _GatedPlexClient(
+        sections: const [_musicSection],
+        itemsByType: _libraryItems,
+        metadataByRatingKey: const <String, PlexMetadata>{
+          '500': PlexMetadata(
+            ratingKey: '500',
+            type: 'track',
+            title: 'Now Playing',
+            media: <PlexMedia>[
+              PlexMedia(
+                parts: <PlexPart>[PlexPart(key: '/library/parts/1/file.flac')],
+              ),
+            ],
+          ),
+        },
+      );
+      final container =
+          _container(client: client, session: _session, repository: null);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      // Start a sync; it parks at the gated section walk (scanning).
+      final Future<void> scanning =
+          container.read(plexSyncControllerProvider.notifier).sync();
+      for (int i = 0;
+          i < 50 && !container.read(plexSyncControllerProvider).isScanning;
+          i++) {
+        await _settle();
+      }
+      expect(container.read(plexSyncControllerProvider).isScanning, isTrue);
+
+      // Playback resolution (the play-time metadata lookup) is not blocked by
+      // the in-flight scan and returns a playable URL.
+      final source = container.read(plexMusicSourceProvider)!;
+      final Uri? uri = await source.resolvePlayableUri(
+        const Track(id: '500', title: 'Now Playing', uri: 'plex:500'),
+      );
+      expect(uri, isNotNull);
+      expect(uri.toString(), contains('/library/parts/1/file.flac'));
+      // The scan is still running — playback didn't have to wait for it.
+      expect(container.read(plexSyncControllerProvider).isScanning, isTrue);
+
+      client.gate.complete();
+      await scanning;
+      expect(container.read(plexSyncControllerProvider).isDone, isTrue);
     });
   });
 
@@ -295,15 +556,15 @@ void main() {
             reason: '${entry.key.kind}');
         expect(state.message, isNot(contains(_token)),
             reason: '${entry.key.kind}');
-        // A failed listing never half-writes the catalog.
-        expect(repo.upsertCount, 0, reason: '${entry.key.kind}');
+        // A failed scan never half-writes the catalog.
+        expect(repo.writeCount, 0, reason: '${entry.key.kind}');
       }
     });
 
     test('a storage failure surfaces a friendly message', () async {
       final container = _container(
         session: _session,
-        repository: _RecordingRepository(upsertError: StateError('disk full')),
+        repository: _RecordingRepository(beginError: StateError('disk full')),
       );
       await container
           .read(plexSettingsControllerProvider.notifier)
@@ -340,9 +601,9 @@ void main() {
       await _settle();
       expect(container.read(plexSyncControllerProvider).isSyncing, isTrue);
 
-      // While the walk is held at the gate, the user widens the selection
-      // (the settings controller kicks syncAfterSelectionChange itself) and
-      // also mashes the sync button — neither may stack extra walks.
+      // While the walk is held at the gate, the user widens the selection (the
+      // settings controller kicks syncAfterSelectionChange itself) and also
+      // mashes the sync button — neither may stack extra walks.
       await settings.setSelectedSections(const <String>['5', '9']);
       await sync.sync();
 
@@ -350,17 +611,21 @@ void main() {
       await first;
       await _settle();
 
-      // Exactly two passes: the original walk plus one coalesced re-run.
-      expect(repo.upsertCount, 2);
-      // The re-run walked the NEW selection (both sections, three kinds).
-      expect(client.itemRequests, hasLength(3 + 6));
+      // Exactly two write passes: the original plus one coalesced re-run.
+      expect(repo.beginCount, 2);
+      // Track-only walks: 1 section first, then both sections on the re-run.
+      expect(client.itemRequests, hasLength(1 + 2));
       expect(
-        client.itemRequests.skip(3).map((r) => r.sectionKey).toSet(),
+        client.itemRequests.skip(1).map((r) => r.sectionKey).toSet(),
         <String>{'5', '9'},
       );
       expect(
+        client.itemRequests.map((r) => r.itemType).toSet(),
+        <PlexMetadataType>{PlexMetadataType.track},
+      );
+      expect(
         container.read(plexSyncControllerProvider).status,
-        PlexSyncStatus.success,
+        PlexSyncStatus.done,
       );
     });
   });
@@ -378,13 +643,13 @@ void main() {
       await settings.toggleSection('5', included: true);
       await _settle();
 
-      expect(repo.upsertedSourceId, 'plex');
+      expect(repo.lastSourceId, 'plex');
       expect(
-        repo.upsertedTracks.map((Track t) => t.uri),
+        repo.stored.map((Track t) => t.uri),
         <String>['plex:101', 'plex:102'],
       );
       final state = container.read(plexSyncControllerProvider);
-      expect(state.status, PlexSyncStatus.success);
+      expect(state.status, PlexSyncStatus.done);
       expect(state.trackCount, 2);
     });
 
@@ -395,12 +660,12 @@ void main() {
       final settings = container.read(plexSettingsControllerProvider.notifier);
       await settings.ensureLoaded();
       await container.read(plexSyncControllerProvider.notifier).sync();
-      expect(repo.upsertedTracks, isNotEmpty);
+      expect(repo.stored, isNotEmpty);
 
       await settings.toggleSection('5', included: false);
       await _settle();
 
-      expect(repo.upsertedTracks, isEmpty);
+      expect(repo.stored, isEmpty);
       expect(
         container.read(plexSyncControllerProvider).message,
         contains('No music libraries are selected'),


### PR DESCRIPTION
## What & why

Users reported that scanning a large Plex library (~1000+ tracks) froze the UI and sometimes triggered an ANR-like *"app not responding"*, with no progressive feedback.

### Root cause (investigation)

The scan is triggered by `PlexSyncController` (manual **Sync Plex library**, an auto-sync after a library-selection change, and a same-server reconnect). On the UI isolate it did three things that stall on a big library:

1. **Synchronous JSON decode on the UI isolate.** `HttpPlexClient` ran `jsonDecode` + `MediaContainer` parse for *every* page inline — the single heaviest synchronous step of a scan.
2. **Three full library walks.** It fetched **tracks + albums + artists**, even though albums/artists are derived from tracks (`library_browse_providers.dart`) and are *never persisted* (`getAllAlbums`/`getAllArtists` are unused) — two of the three walks were wasted work.
3. **One monolithic write + full rebuild every time.** The whole Plex slice was deleted and re-inserted on every sync, so the library stayed blank until the end and a re-sync of an unchanged library rebuilt everything.

(The Drift database itself already runs on a background isolate, so the fix is on the fetch/parse/write-orchestration side — all Plex-scoped.)

## The fix

| Requirement | Change |
|---|---|
| **Fully async / off the UI thread** | `HttpPlexClient` decodes large `MediaContainer` pages on a background isolate via `compute()` (size-thresholded; small replies stay inline). |
| **Incremental scanning** | Tracks are written in **chunks of 100** through a new optional `IncrementalCatalogWriter` capability, refreshing the library after the first chunk so it fills progressively. Albums/artists walks dropped (unused). |
| **Caching layer** | A credential-free **content signature** of the last successful sync lets a re-sync of an unchanged library **skip the database rebuild**. The durable metadata cache is the existing SQLite catalog (launch never re-scans). |
| **Lightweight sync state** | `PlexSyncStatus` is now `idle / scanning / syncing / done / error`, surfaced as minimal **Scanning… / Saving…** labels (no UI redesign). |
| **Playback unaffected** | A scan only writes the catalog; a `plex:` track resolves its stream URL lazily at play time, so music keeps playing throughout. |

## Scope / non-goals

- **No Jellyfin/Navidrome logic touched.** `IncrementalCatalogWriter` is a *separate, optional* capability — those providers keep using `upsertCatalog` unchanged, and their tests/fakes are untouched.
- No UI redesign, no playback-engine changes, no new Plex features, no remote control.

## Tests

- `http_plex_client_test.dart`: large pages route through the background parse seam; small bodies stay inline; the real `compute` path decodes correctly (incl. non-ASCII); a large non-JSON body still maps to `notPlex`.
- `plex_sync_controller_test.dart`: progressive batched writes (250 tracks → 100/100/50); **first batch lands before the sync finishes**; unchanged library skips the rebuild; a changed library is rebuilt; **a track still resolves while a scan is in flight** (playback not blocked); plus the existing error-mapping / coalescing / token-safety guards updated for the new flow.

Full suite: **2273 tests pass**, `flutter analyze` clean (Flutter 3.27.4).

Design notes added to `docs/plex.md` (step 11).

https://claude.ai/code/session_01PQyB2Lc4ZAhSxsofBV6VRW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQyB2Lc4ZAhSxsofBV6VRW)_