### PR TITLE
perf(plex): persist sync signature to skip unchanged-library rebuilds

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -206,6 +206,44 @@ The `MusicSource` contract is small (`id`, `displayName`,
 Cast is a natural later add (the stream URL is network-reachable) but stays off
 in phase 1 to keep the credential-in-URL surface small.
 
+## Local cache & re-sync
+
+Like every source, Plex **syncs into the local SQLite catalog** the UI reads
+from (`MusicLibraryRepository`); the browse screens never hit the server, so the
+library is instant and survives restarts without re-fetching. A sync writes
+**tracks** only — albums and artists are derived from them at display time
+(`core/catalog/library_grouping.dart`), so they're cached implicitly with no
+extra library walks.
+
+Re-syncing an **unchanged** library is cheap, even across launches. After each
+successful sync the controller stores a credential-free **content signature** —
+the selected sections plus a one-way hash of every track's identity/display
+fields — through `PlexSyncCacheStore` (plain `shared_preferences`, scoped by the
+server's `machineIdentifier`). On the next sync — a manual *Sync* tap, a
+same-server reconnect, or the auto-sync after a selection change — a scan that
+produces the same signature **skips the catalog rebuild and the Library
+refresh** instead of rewriting rows that didn't change. Previously that
+signature lived only in memory, so the first sync after a restart always rebuilt.
+
+**Invalidation is conservative on purpose.** The signature is computed *after*
+the scan, so a sync still lists the library every time and can never miss a real
+change — the fast path only avoids redundant *writes*, never the fetch. Any
+change to the selection, or to a track's id / title / artist / album / duration /
+track number / artwork, changes the signature and forces a rebuild. Disconnecting
+or connecting to a *different* server clears the stored signature (and the
+`machineIdentifier` scope means another server's fingerprint never matches), so a
+freshly-emptied catalog is never mistaken for "already in sync".
+
+**Artwork.** Covers stay credential-free `plex-thumb:` references in the catalog
+(see *Artwork references* above), resolved to a tokened URL only at render time.
+The platform media session (lock screen / Android Auto) additionally caches the
+fetched cover bytes on disk through `MediaArtworkCache`, keyed by the reference
+hash, so a cover fetched once is reused across launches without re-downloading.
+
+> **Security.** Nothing cached here carries a credential: the catalog stores
+> opaque `plex:` / `plex-thumb:` references, and the durable signature is a
+> one-way hash plus the non-secret server id — never a token, URL, or title.
+
 ## Playback reporting / Now Playing (shipped after phase 1)
 
 Phase 1 above is read-only. The one deliberate exception added since:

--- a/lib/core/repositories/plex_sync_cache_store.dart
+++ b/lib/core/repositories/plex_sync_cache_store.dart
@@ -1,0 +1,41 @@
+/// Remembers the content signature of the **last successful Plex sync**, so a
+/// re-sync of an *unchanged* Plex library — after an app restart, a manual
+/// "Sync" tap, or a same-server reconnect — can skip rebuilding the on-device
+/// catalog and reloading the Library screen.
+///
+/// The signature is the same credential-free fingerprint `PlexSyncController`
+/// already computes (selected sections + each track's identity/display fields,
+/// folded into a one-way hash). Keeping it only in memory meant every launch
+/// treated the library as "possibly changed" and rebuilt the catalog from
+/// scratch on the next sync; persisting it lets the "nothing changed" fast path
+/// survive a restart, which is what makes a re-sync of an unchanged library
+/// cheap.
+///
+/// Scoped by the server's `machineIdentifier`: [readSignature] only returns a
+/// signature stored for the **same** server, so reconnecting to a *different*
+/// Plex server never matches a stale fingerprint (the catalog is rebuilt, as it
+/// must be — another server's `ratingKey`s are different items). Kept behind
+/// this seam so the backing store swaps freely (in-memory for tests, key/value
+/// in the app), mirroring [JellyfinAutoSyncStore].
+///
+/// Privacy: the stored value is non-secret by construction — section keys, a
+/// track count, and a one-way content hash, plus the (non-secret)
+/// `machineIdentifier`. It carries no token, server URL, authenticated URL,
+/// track title, or file path, so plain (unencrypted) key/value storage is the
+/// right weight, exactly as the Jellyfin auto-sync fingerprint uses.
+abstract interface class PlexSyncCacheStore {
+  /// The persisted signature of the last successful sync for the server with
+  /// [machineIdentifier], or `null` when none is stored (or the stored record
+  /// belongs to a different server). A corrupt/absent record reads as `null`
+  /// rather than throwing, so a storage hiccup only costs one extra rebuild.
+  Future<String?> readSignature(String machineIdentifier);
+
+  /// Records [signature] as the last successful sync for the server with
+  /// [machineIdentifier], replacing any previous record (for this or another
+  /// server).
+  Future<void> writeSignature(String machineIdentifier, String signature);
+
+  /// Forgets the recorded signature (e.g. on disconnect, or when connecting to a
+  /// different server cleared the Plex catalog slice). Never throws.
+  Future<void> clear();
+}

--- a/lib/data/repositories/in_memory_plex_sync_cache_store.dart
+++ b/lib/data/repositories/in_memory_plex_sync_cache_store.dart
@@ -1,0 +1,36 @@
+import '../../core/repositories/plex_sync_cache_store.dart';
+
+/// A non-persistent [PlexSyncCacheStore] for development and tests.
+///
+/// Holds the last server + signature in memory, so they're forgotten when the
+/// instance is dropped. This is the default binding (mirroring the other
+/// repositories); the running app swaps in
+/// [SharedPreferencesPlexSyncCacheStore] so the "nothing changed" fast path
+/// survives restarts.
+class InMemoryPlexSyncCacheStore implements PlexSyncCacheStore {
+  InMemoryPlexSyncCacheStore({String? machineIdentifier, String? signature})
+      : _machineIdentifier = machineIdentifier,
+        _signature = signature;
+
+  String? _machineIdentifier;
+  String? _signature;
+
+  @override
+  Future<String?> readSignature(String machineIdentifier) async =>
+      _machineIdentifier == machineIdentifier ? _signature : null;
+
+  @override
+  Future<void> writeSignature(
+    String machineIdentifier,
+    String signature,
+  ) async {
+    _machineIdentifier = machineIdentifier;
+    _signature = signature;
+  }
+
+  @override
+  Future<void> clear() async {
+    _machineIdentifier = null;
+    _signature = null;
+  }
+}

--- a/lib/data/repositories/plex_sync_cache_store_provider.dart
+++ b/lib/data/repositories/plex_sync_cache_store_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/plex_sync_cache_store.dart';
+import 'in_memory_plex_sync_cache_store.dart';
+import 'shared_preferences_plex_sync_cache_store.dart';
+
+/// The single [PlexSyncCacheStore] the Plex sync controller reads/writes the
+/// last-synced content signature through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins (no `shared_preferences`). The running app overrides this
+/// with [sharedPreferencesPlexSyncCacheStoreOverride] so the "nothing changed"
+/// fast path survives restarts.
+final plexSyncCacheStoreProvider = Provider<PlexSyncCacheStore>((ref) {
+  return InMemoryPlexSyncCacheStore();
+});
+
+/// Production binding: persists the last-synced Plex signature via
+/// `shared_preferences`, so a re-sync of an unchanged library after a restart
+/// skips rebuilding the catalog. Applied in `main`. Non-secret by construction
+/// (see [PlexSyncCacheStore]), so plain key/value storage is appropriate.
+final sharedPreferencesPlexSyncCacheStoreOverride =
+    plexSyncCacheStoreProvider.overrideWithValue(
+  const SharedPreferencesPlexSyncCacheStore(),
+);

--- a/lib/data/repositories/shared_preferences_plex_sync_cache_store.dart
+++ b/lib/data/repositories/shared_preferences_plex_sync_cache_store.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/plex_sync_cache_store.dart';
+
+/// A [PlexSyncCacheStore] backed by `shared_preferences`.
+///
+/// Persists a tiny JSON record — `{ machineIdentifier, signature }` — under one
+/// key. The server's `machineIdentifier` is stored alongside the signature so
+/// [readSignature] can refuse a fingerprint that belongs to a *different* Plex
+/// server (reconnecting elsewhere must rebuild the catalog, not skip it).
+///
+/// Privacy: both fields are non-secret — the `machineIdentifier` is the server's
+/// public id, and the signature is a one-way content hash over section keys +
+/// track count + per-track display fields (never a token, URL, title, or path).
+/// Plain `shared_preferences` (not encrypted storage) is the right weight here
+/// precisely because there is no secret, exactly like the Jellyfin auto-sync
+/// fingerprint. A corrupt or absent value reads as "no record" rather than
+/// throwing, so a storage hiccup can never break a sync — at worst it costs one
+/// redundant rebuild.
+class SharedPreferencesPlexSyncCacheStore implements PlexSyncCacheStore {
+  const SharedPreferencesPlexSyncCacheStore();
+
+  static const String _key = 'plex_sync_cache_v1';
+  static const String _machineField = 'machineIdentifier';
+  static const String _signatureField = 'signature';
+
+  @override
+  Future<String?> readSignature(String machineIdentifier) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(_key);
+    if (raw == null || raw.isEmpty) return null;
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+    // Only return a signature stored for this exact server; a record from a
+    // different machine must not match (its catalog rows are different items).
+    if (decoded[_machineField] != machineIdentifier) return null;
+    final Object? signature = decoded[_signatureField];
+    return signature is String && signature.isNotEmpty ? signature : null;
+  }
+
+  @override
+  Future<void> writeSignature(
+    String machineIdentifier,
+    String signature,
+  ) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _key,
+      jsonEncode(<String, String>{
+        _machineField: machineIdentifier,
+        _signatureField: signature,
+      }),
+    );
+  }
+
+  @override
+  Future<void> clear() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}

--- a/lib/features/settings/plex/plex_sync_controller.dart
+++ b/lib/features/settings/plex/plex_sync_controller.dart
@@ -10,6 +10,7 @@ import '../../../core/repositories/music_library_repository.dart';
 import '../../../core/sources/plex/plex_exception.dart';
 import '../../../core/sources/plex/plex_music_source.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
+import '../../../data/repositories/plex_sync_cache_store_provider.dart';
 import '../../library/library_controller.dart';
 import 'plex_settings_controller.dart';
 import 'plex_sync_state.dart';
@@ -29,12 +30,15 @@ import 'plex_sync_state.dart';
 ///    catalog the Library screen reads — but in chunks of [_writeBatchSize] via
 ///    [IncrementalCatalogWriter] when available, refreshing after the first
 ///    chunk so the library fills progressively instead of after one big write.
-///  - **Unchanged libraries are skipped.** A content signature of the last
-///    successful sync is kept; a re-sync (a re-tapped *Sync* button, or a
-///    selection toggle that settles back to an already-synced set) that finds
-///    the same content skips the whole database rebuild + refresh. The durable
-///    catalog itself already lives in SQLite, so the app never re-scans Plex on
-///    launch just to show the library; this only avoids redundant *re*-syncs.
+///  - **Unchanged libraries are skipped — across restarts.** A content
+///    signature of the last successful sync is kept, and persisted (see
+///    [PlexSyncCacheStore]); a re-sync (a re-tapped *Sync* button, a same-server
+///    reconnect, or a selection toggle that settles back to an already-synced
+///    set) that finds the same content skips the whole database rebuild +
+///    refresh — even on the first sync after a restart, which the old in-memory
+///    signature could not. The durable catalog itself already lives in SQLite,
+///    so the app never re-scans Plex on launch just to show the library; this
+///    avoids redundant *re*-syncs rebuilding it.
 ///
 /// Playback is untouched: a scan only writes the catalog, never the player. A
 /// `plex:` track resolves its stream URL lazily at play time, so music keeps
@@ -54,9 +58,10 @@ import 'plex_sync_state.dart';
 ///
 /// Security: the source mints any authenticated stream URL lazily at play time,
 /// so nothing persisted here carries a credential, and the content signature is
-/// built from credential-free catalog fields only. This controller never logs
-/// the session, and surfaces only friendly, secret-free messages through
-/// [PlexSyncState].
+/// built from credential-free catalog fields only — so the durable
+/// [PlexSyncCacheStore] record (a one-way content hash plus the non-secret
+/// server id) holds no secret either. This controller never logs the session,
+/// and surfaces only friendly, secret-free messages through [PlexSyncState].
 class PlexSyncController extends Notifier<PlexSyncState> {
   /// Guards against overlapping syncs (an auto-sync racing a manual tap). Set
   /// synchronously before any await so a second concurrent call simply bails,
@@ -71,9 +76,18 @@ class PlexSyncController extends Notifier<PlexSyncState> {
   /// Content signature of the last successful sync (selection + the scanned
   /// tracks). When a fresh scan produces the same signature, the database
   /// rebuild and the library refresh are skipped — the expensive part of a
-  /// re-sync of an unchanged library. Session-scoped: the durable copy of the
-  /// library is the SQLite catalog, which already survives restarts.
+  /// re-sync of an unchanged library. Seeded once per controller from the
+  /// durable [PlexSyncCacheStore] (see [_signatureLoaded]) and persisted back
+  /// after each successful rebuild, so the "nothing changed" fast path survives
+  /// a restart — not just the SQLite catalog it guards, which already did.
   String? _lastSyncedSignature;
+
+  /// Whether [_lastSyncedSignature] has been seeded from the durable
+  /// [PlexSyncCacheStore] yet. The first sync of a fresh controller (e.g. just
+  /// after a restart restored the session) loads the persisted signature once,
+  /// so an unchanged library is recognised across launches; later syncs reuse
+  /// the in-memory value the previous write left behind.
+  bool _signatureLoaded = false;
 
   /// How many tracks are written per batch. 100 keeps each main-isolate
   /// serialization step small while bounding the number of progress refreshes.
@@ -105,12 +119,19 @@ class PlexSyncController extends Notifier<PlexSyncState> {
   ///
   /// Quiet by design: it reports nothing through [state] — the caller owns the
   /// user-facing message — but throws on a storage failure so the caller can
-  /// phrase that message honestly. Resets the content signature so the next
-  /// sync rebuilds rather than mistaking the freshly-emptied slice for "already
-  /// in sync" with a future server's identical content.
+  /// phrase that message honestly. Resets the content signature — the in-memory
+  /// value and the durable [PlexSyncCacheStore] record — so the next sync
+  /// rebuilds rather than mistaking the freshly-emptied slice for "already in
+  /// sync" with a future server's identical content.
   Future<void> removeSyncedCatalog() async {
     await _writeCatalogInBatches(const <Track>[]);
     _lastSyncedSignature = _signatureFor(const <String>[], const <Track>[]);
+    // The durable signature described the rows just cleared; forget it (and
+    // mark it loaded) so the next sync rebuilds rather than skipping against a
+    // stale fingerprint. Best-effort and last, so a write failure above still
+    // propagates to the caller unchanged.
+    _signatureLoaded = true;
+    await _clearPersistedSignature();
   }
 
   Future<void> _runSync() async {
@@ -137,6 +158,11 @@ class PlexSyncController extends Notifier<PlexSyncState> {
 
     final List<String> sectionKeys = source.session.selectedSectionKeys;
     try {
+      // 0. Seed the "nothing changed" signature from the durable cache once, so
+      //    an unchanged library is recognised even on the first sync after a
+      //    restart restored the session (not just within a single run).
+      await _ensureSignatureLoaded(source.session.machineIdentifier);
+
       // 1. Read the library from the server. An empty selection is an empty
       //    library by definition, so it touches no network — and still flows
       //    through the same write path so a previously wider selection's rows
@@ -164,6 +190,10 @@ class PlexSyncController extends Notifier<PlexSyncState> {
       state = PlexSyncState.syncing(trackCount: tracks.length);
       await _writeCatalogInBatches(tracks);
       _lastSyncedSignature = signature;
+      // Remember this outcome so a re-sync of an unchanged library on the next
+      // launch can skip the rebuild above. Best-effort: a cache write failure
+      // only costs one redundant rebuild, never the sync itself.
+      await _persistSignature(source.session.machineIdentifier, signature);
 
       state = PlexSyncState.done(
         trackCount: tracks.length,
@@ -173,6 +203,52 @@ class PlexSyncController extends Notifier<PlexSyncState> {
       state = PlexSyncState.error(_friendlyMessage(error));
     } catch (_) {
       state = const PlexSyncState.error(_savingFailedMessage);
+    }
+  }
+
+  /// Seeds [_lastSyncedSignature] from the durable [PlexSyncCacheStore] the
+  /// first time this controller syncs, scoped to the current server's
+  /// [machineIdentifier]. Idempotent (runs once per controller) and best-effort:
+  /// a missing record — or a read hiccup — leaves the signature null, so the
+  /// sync simply rebuilds, the safe default. Only seeds when nothing is set yet,
+  /// so an in-session value from an earlier write always wins over the durable
+  /// one.
+  Future<void> _ensureSignatureLoaded(String machineIdentifier) async {
+    if (_signatureLoaded) return;
+    _signatureLoaded = true;
+    if (_lastSyncedSignature != null) return;
+    try {
+      _lastSyncedSignature = await ref
+          .read(plexSyncCacheStoreProvider)
+          .readSignature(machineIdentifier);
+    } catch (_) {
+      // A cache read hiccup just means the next sync rebuilds; never fatal.
+    }
+  }
+
+  /// Persists [signature] as the last successful sync for [machineIdentifier].
+  /// Best-effort: a write failure must not fail a sync whose catalog write has
+  /// already succeeded — it only costs a redundant rebuild on the next launch.
+  Future<void> _persistSignature(
+    String machineIdentifier,
+    String signature,
+  ) async {
+    try {
+      await ref
+          .read(plexSyncCacheStoreProvider)
+          .writeSignature(machineIdentifier, signature);
+    } catch (_) {
+      // Best-effort: swallow so the sync still reports success.
+    }
+  }
+
+  /// Forgets the durable signature. Best-effort: a failure only costs a
+  /// redundant rebuild on the next sync.
+  Future<void> _clearPersistedSignature() async {
+    try {
+      await ref.read(plexSyncCacheStoreProvider).clear();
+    } catch (_) {
+      // Best-effort: swallow (see [_persistSignature]).
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,7 @@ import 'data/repositories/playback_preferences_provider.dart';
 import 'data/repositories/playback_source_strategy_store_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/plex_session_store_provider.dart';
+import 'data/repositories/plex_sync_cache_store_provider.dart';
 import 'data/repositories/preferred_source_store_provider.dart';
 import 'data/repositories/remote_cache_index_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
@@ -90,6 +91,11 @@ Future<void> main() async {
       sharedPreferencesJellyfinAutoSyncStoreOverride,
       secureSubsonicSessionStoreOverride,
       securePlexSessionStoreOverride,
+      // Persist the content signature of the last Plex sync, so a re-sync of an
+      // unchanged library after a restart skips rebuilding the catalog and
+      // reloading the Library screen (the catalog itself already lives in
+      // SQLite). Non-secret (a one-way hash, scoped by server id).
+      sharedPreferencesPlexSyncCacheStoreOverride,
       sharedPreferencesFavoritesStoreOverride,
       jellyfinFavoritesOverride,
       sharedPreferencesPlaylistStoreOverride,

--- a/test/data/repositories/plex_sync_cache_store_test.dart
+++ b/test/data/repositories/plex_sync_cache_store_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/plex_sync_cache_store.dart';
+import 'package:linthra/data/repositories/in_memory_plex_sync_cache_store.dart';
+import 'package:linthra/data/repositories/shared_preferences_plex_sync_cache_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues(<String, Object>{}));
+
+  // Both bindings must satisfy the same contract, so they share one test body.
+  final Map<String, PlexSyncCacheStore Function()> impls =
+      <String, PlexSyncCacheStore Function()>{
+    'InMemoryPlexSyncCacheStore': InMemoryPlexSyncCacheStore.new,
+    'SharedPreferencesPlexSyncCacheStore':
+        SharedPreferencesPlexSyncCacheStore.new,
+  };
+
+  for (final MapEntry<String, PlexSyncCacheStore Function()> entry
+      in impls.entries) {
+    group(entry.key, () {
+      test('reads null when nothing is stored', () async {
+        expect(await entry.value().readSignature('machine-1'), isNull);
+      });
+
+      test('round-trips a signature for the same server', () async {
+        final PlexSyncCacheStore store = entry.value();
+        await store.writeSignature('machine-1', 'sig-abc');
+        expect(await store.readSignature('machine-1'), 'sig-abc');
+      });
+
+      test('returns null for a different server (never a stale fingerprint)',
+          () async {
+        final PlexSyncCacheStore store = entry.value();
+        await store.writeSignature('machine-1', 'sig-abc');
+        expect(await store.readSignature('machine-2'), isNull);
+      });
+
+      test('a later write replaces the previous record', () async {
+        final PlexSyncCacheStore store = entry.value();
+        await store.writeSignature('machine-1', 'sig-old');
+        await store.writeSignature('machine-1', 'sig-new');
+        expect(await store.readSignature('machine-1'), 'sig-new');
+      });
+
+      test('reconnecting to a different server replaces the record', () async {
+        final PlexSyncCacheStore store = entry.value();
+        await store.writeSignature('machine-1', 'sig-1');
+        await store.writeSignature('machine-2', 'sig-2');
+        expect(await store.readSignature('machine-1'), isNull);
+        expect(await store.readSignature('machine-2'), 'sig-2');
+      });
+
+      test('clear forgets the stored signature', () async {
+        final PlexSyncCacheStore store = entry.value();
+        await store.writeSignature('machine-1', 'sig-abc');
+        await store.clear();
+        expect(await store.readSignature('machine-1'), isNull);
+      });
+    });
+  }
+
+  group('SharedPreferencesPlexSyncCacheStore (persistence specifics)', () {
+    test('a written signature survives a fresh store instance', () async {
+      await const SharedPreferencesPlexSyncCacheStore()
+          .writeSignature('machine-1', 'sig-abc');
+
+      // A brand-new instance (e.g. after a restart) still reads it back.
+      expect(
+        await const SharedPreferencesPlexSyncCacheStore()
+            .readSignature('machine-1'),
+        'sig-abc',
+      );
+    });
+
+    test('a corrupt value reads as no record rather than throwing', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'plex_sync_cache_v1': 'not-json',
+      });
+      expect(
+        await const SharedPreferencesPlexSyncCacheStore()
+            .readSignature('machine-1'),
+        isNull,
+      );
+    });
+
+    test('stores no secret — only the server id and signature it was given',
+        () async {
+      await const SharedPreferencesPlexSyncCacheStore()
+          .writeSignature('machine-1', '5|2|123456');
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final String raw = prefs.getString('plex_sync_cache_v1')!;
+      // The persisted blob is exactly the (non-secret) machine id + signature.
+      expect(raw, contains('machine-1'));
+      expect(raw, contains('5|2|123456'));
+    });
+  });
+}

--- a/test/features/settings/plex/plex_sync_controller_test.dart
+++ b/test/features/settings/plex/plex_sync_controller_test.dart
@@ -8,11 +8,14 @@ import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/incremental_catalog_writer.dart';
 import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/repositories/plex_sync_cache_store.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
 import 'package:linthra/data/repositories/in_memory_plex_session_store.dart';
+import 'package:linthra/data/repositories/in_memory_plex_sync_cache_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/data/repositories/plex_session_store_provider.dart';
+import 'package:linthra/data/repositories/plex_sync_cache_store_provider.dart';
 import 'package:linthra/features/settings/plex/plex_settings_controller.dart';
 import 'package:linthra/features/settings/plex/plex_settings_providers.dart';
 import 'package:linthra/features/settings/plex/plex_sync_controller.dart';
@@ -197,6 +200,7 @@ ProviderContainer _container({
   FakePlexClient? client,
   PlexSession? session,
   MusicLibraryRepository? repository,
+  PlexSyncCacheStore? cacheStore,
 }) {
   final container = ProviderContainer(
     overrides: <Override>[
@@ -212,6 +216,10 @@ ProviderContainer _container({
       ),
       musicLibraryRepositoryProvider
           .overrideWithValue(repository ?? _RecordingRepository()),
+      // A caller passes a shared cache store to model the durable signature
+      // surviving a "restart" (a fresh container built over the same store).
+      plexSyncCacheStoreProvider
+          .overrideWithValue(cacheStore ?? InMemoryPlexSyncCacheStore()),
     ],
   );
   addTearDown(container.dispose);
@@ -473,6 +481,143 @@ void main() {
       final state = container.read(plexSyncControllerProvider);
       expect(state.isDone, isTrue);
       expect(state.message, contains('Synced 3 tracks'));
+    });
+  });
+
+  group('durable signature (across restarts)', () {
+    test(
+        'a persisted signature skips the rebuild on the first sync after a '
+        'restart', () async {
+      final repo = _RecordingRepository();
+      final cache = InMemoryPlexSyncCacheStore();
+
+      // First launch: a sync fills the catalog and persists the signature.
+      final first =
+          _container(session: _session, repository: repo, cacheStore: cache);
+      await first.read(plexSettingsControllerProvider.notifier).ensureLoaded();
+      await first.read(plexSyncControllerProvider.notifier).sync();
+      expect(repo.beginCount, 1);
+      expect(repo.stored, hasLength(2));
+
+      // Second launch: fresh controllers, but the SAME durable cache and the
+      // SAME (SQLite-like) catalog, and the server is unchanged.
+      final second =
+          _container(session: _session, repository: repo, cacheStore: cache);
+      await second.read(plexSettingsControllerProvider.notifier).ensureLoaded();
+      await second.read(plexSyncControllerProvider.notifier).sync();
+
+      // The catalog was not rebuilt again — the persisted signature recognised
+      // the unchanged library across the "restart", which the old in-memory-only
+      // signature could not.
+      expect(repo.beginCount, 1);
+      expect(repo.appendCount, 0);
+      final state = second.read(plexSyncControllerProvider);
+      expect(state.isDone, isTrue);
+      expect(state.message, contains('already up to date'));
+    });
+
+    test('a library changed while the app was closed still rebuilds', () async {
+      final client = FakePlexClient(
+        sections: const [_musicSection],
+        itemsByType: <PlexMetadataType, List<PlexMetadata>>{
+          PlexMetadataType.track: const <PlexMetadata>[
+            _trackItem,
+            _secondTrackItem,
+          ],
+        },
+      );
+      final repo = _RecordingRepository();
+      final cache = InMemoryPlexSyncCacheStore();
+
+      final first = _container(
+          client: client,
+          session: _session,
+          repository: repo,
+          cacheStore: cache);
+      await first.read(plexSettingsControllerProvider.notifier).ensureLoaded();
+      await first.read(plexSyncControllerProvider.notifier).sync();
+      expect(repo.beginCount, 1);
+
+      // The server gains a track between launches.
+      client.itemsByType = <PlexMetadataType, List<PlexMetadata>>{
+        PlexMetadataType.track: const <PlexMetadata>[
+          _trackItem,
+          _secondTrackItem,
+          PlexMetadata(ratingKey: '103', type: 'track', title: 'Twilight'),
+        ],
+      };
+
+      final second = _container(
+          client: client,
+          session: _session,
+          repository: repo,
+          cacheStore: cache);
+      await second.read(plexSettingsControllerProvider.notifier).ensureLoaded();
+      await second.read(plexSyncControllerProvider.notifier).sync();
+
+      expect(repo.beginCount, 2);
+      expect(repo.stored, hasLength(3));
+      expect(
+        second.read(plexSyncControllerProvider).message,
+        contains('Synced 3 tracks'),
+      );
+    });
+
+    test('a signature stored for a different server is ignored', () async {
+      final repo = _RecordingRepository();
+      // The cache holds a fingerprint for some OTHER Plex server.
+      final cache = InMemoryPlexSyncCacheStore(
+        machineIdentifier: 'a-different-machine-id',
+        signature: 'stale-signature',
+      );
+
+      final container =
+          _container(session: _session, repository: repo, cacheStore: cache);
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      // The stale fingerprint never matched this server, so the catalog rebuilt
+      // rather than skipping into another server's items.
+      expect(repo.beginCount, 1);
+      expect(repo.stored, hasLength(2));
+      expect(
+        container.read(plexSyncControllerProvider).message,
+        contains('Synced 2 tracks'),
+      );
+    });
+
+    test(
+        'removeSyncedCatalog clears the durable signature so a later sync '
+        'rebuilds rather than skipping into an empty catalog', () async {
+      final repo = _RecordingRepository();
+      final cache = InMemoryPlexSyncCacheStore();
+
+      final first =
+          _container(session: _session, repository: repo, cacheStore: cache);
+      await first.read(plexSettingsControllerProvider.notifier).ensureLoaded();
+      final firstSync = first.read(plexSyncControllerProvider.notifier);
+      await firstSync.sync();
+      expect(repo.stored, hasLength(2));
+
+      // Disconnect-style cleanup empties the catalog; it must also forget the
+      // fingerprint, or a reconnect would skip against it and stay empty.
+      await firstSync.removeSyncedCatalog();
+      expect(await cache.readSignature(_session.machineIdentifier), isNull);
+      expect(repo.stored, isEmpty);
+
+      // Next launch re-syncs the same (unchanged) server: with no durable
+      // signature it rebuilds, repopulating the catalog instead of skipping.
+      final second =
+          _container(session: _session, repository: repo, cacheStore: cache);
+      await second.read(plexSettingsControllerProvider.notifier).ensureLoaded();
+      await second.read(plexSyncControllerProvider.notifier).sync();
+      expect(repo.stored, hasLength(2));
+      expect(
+        second.read(plexSyncControllerProvider).message,
+        contains('Synced 2 tracks'),
+      );
     });
   });
 


### PR DESCRIPTION
## What & why

A small, incremental caching improvement for the **Plex** provider: avoid re-doing work for an **unchanged** library after an app restart.

Today, the Plex catalog already persists in **SQLite** (`MusicLibraryRepository`), so *browsing* never re-fetches on launch — that part is already cache-first. The gap was the **"nothing changed" content signature**: `PlexSyncController` computes a credential-free fingerprint of the last sync and uses it to skip the catalog rebuild + Library refresh when a re-sync finds the same content — but that signature lived **only in memory**. So the first sync after a restart (a manual **Sync**, a same-server reconnect, or the auto-sync after a library-selection change) always rebuilt the whole Plex slice and reloaded the Library, even when nothing had changed.

This PR makes that "nothing changed" fast path **durable across restarts**.

## How

- New `PlexSyncCacheStore` seam (mirrors the existing `JellyfinAutoSyncStore` pattern):
  - `core/repositories/plex_sync_cache_store.dart` — interface
  - `data/repositories/in_memory_plex_sync_cache_store.dart` — default (tests/dev)
  - `data/repositories/shared_preferences_plex_sync_cache_store.dart` — production binding
  - `data/repositories/plex_sync_cache_store_provider.dart` — provider + override (wired in `main.dart`)
- `PlexSyncController` now **seeds** the signature from the store on its first sync, **persists** it after each successful rebuild, and **clears** it when the Plex catalog slice is emptied (`removeSyncedCatalog`).
- The record is **scoped by the server's `machineIdentifier`**, so reconnecting to a *different* Plex server never matches a stale fingerprint.

## Invalidation (conservative by design)

- The signature is still computed **after** the scan, so a sync always lists the library and **can never miss a real change** — only redundant *writes* are skipped, never the network fetch.
- Any change to the selection, or to a track's id/title/artist/album/duration/track-number/artwork, changes the signature → full rebuild.
- Disconnect / different-server connect **clears** the stored signature, so a freshly emptied catalog is never mistaken for "already in sync".

## Scope / non-goals

- **Plex-only.** Jellyfin/Navidrome caching behavior is untouched (entirely new, Plex-scoped code).
- **No UI changes.** **No playback-engine changes** — a `plex:` track still resolves its stream URL lazily at play time, so music keeps playing during a sync/cache load.
- No new user-facing features.

## Security

Nothing cached here carries a credential: the catalog stores opaque `plex:` / `plex-thumb:` references, and the durable signature is a **one-way content hash** plus the **non-secret** `machineIdentifier` — never a token, URL, or title. Plain (unencrypted) `shared_preferences` is appropriate, exactly like the existing Jellyfin auto-sync fingerprint. (Album artwork is already cached on disk across launches for the media session via `MediaArtworkCache`, keyed by the credential-free reference; see the new *Local cache & re-sync* note in `docs/plex.md`.)

## Testing

- `flutter analyze` clean; `dart format` clean.
- Full suite green (**2321 tests**).
- New tests:
  - `plex_sync_cache_store_test.dart` — contract over both impls (round-trip, machine-id scoping, replace, clear) + persistence/corrupt-value/no-secret specifics.
  - `plex_sync_controller_test.dart` — skip-rebuild on the first sync after a "restart" (fresh container over the same durable store), changed-library still rebuilds, different-server fingerprint ignored, and `removeSyncedCatalog` clears the record so a later sync rebuilds rather than skipping into an empty catalog.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SeU3XZZ13yRFwLRfyBZ5ts)_