### PR TITLE
feat(plex): show track lyrics (synced or static) when the server has them

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -45,7 +45,6 @@ favorites/etc:
 
 - Offline downloads / caching.
 - Cache management.
-- Lyrics.
 - Playlist sync.
 - Favorites sync.
 - Android Auto-specific artwork changes.
@@ -192,7 +191,7 @@ The `MusicSource` contract is small (`id`, `displayName`,
 
 ### Capabilities (phase 1)
 
-`MusicProviderCapabilities` for Plex declares **stream-only**:
+`MusicProviderCapabilities` for Plex declares **stream + lyrics**:
 
 | Capability | Phase 1 |
 | --- | :---: |
@@ -200,11 +199,35 @@ The `MusicSource` contract is small (`id`, `displayName`,
 | `canCache` | ❌ |
 | `canFavoriteTracks` / `canReadFavoriteState` / `canSyncFavorites` | ❌ |
 | `canListPlaylists` / `canSyncPlaylists` (and create/edit/delete) | ❌ |
-| `canLyrics` | ❌ |
+| `canLyrics` | ✅ |
 | `canCast` | ❌ |
 
 Cast is a natural later add (the stream URL is network-reachable) but stays off
 in phase 1 to keep the credential-in-URL surface small.
+
+### Lyrics
+
+Lyrics are fetched **on demand, off the playback path** by
+`PlexLyricsProvider` (registered for `plex:` tracks in the shared
+`LyricsResolver`, exactly like the Jellyfin/Subsonic/Local providers — no
+provider-architecture change). `PlexClient.fetchLyrics` does the two-step
+lookup:
+
+1. `GET /library/metadata/{ratingKey}` — the track's full metadata carries its
+   `Media → Part → Stream` list; a **lyric stream is Plex's `streamType=4`**,
+   whose `key` (e.g. `/library/streams/12345`) and `format` (`lrc`/`txt`) name
+   the content.
+2. `GET {key}` — the stream body, parsed into the shared `Lyrics` model. Plex
+   serves either its **structured JSON** (`MediaContainer.Lyrics[].Line[].Span[]`
+   with millisecond `startOffset`s, for agent / LyricFind lyrics) or the **raw
+   `.lrc`/`.txt` bytes** of a local sidecar — both handled, with `.lrc`-style
+   timed content rendering synced and plain content static, via the same
+   `LyricsTextParser` the local reader uses.
+
+A track with no lyric stream (or missing content) resolves to `null` → the
+calm "No lyrics available" state; a transport/auth failure throws a token-free
+`PlexException` → "couldn't load". Like every API call the token rides in the
+`X-Plex-Token` **header**, so both lyric URLs are token-free and safe to log.
 
 ## Playback reporting / Now Playing (shipped after phase 1)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -34,7 +34,7 @@ so no secret reaches the persisted catalog.
 | Local music           | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   ✅   |  —   |
 | Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
 | Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  ✅  |
-| Plex                  | `plex`     |   🚧   |  🔜   |    🔜     |    🔜     |   🔜   |  🔜  |
+| Plex                  | `plex`     |   🚧   |  🔜   |    🔜     |    🔜     |   ✅   |  🔜  |
 
 ✅ implemented · 🚧 in development (Plex is connectable in Settings, marked
 **Experimental**) · 🔜 planned follow-up · — not applicable. "local"

--- a/lib/core/services/plex_lyrics_provider.dart
+++ b/lib/core/services/plex_lyrics_provider.dart
@@ -1,0 +1,52 @@
+import '../models/lyrics.dart';
+import '../models/plex_session.dart';
+import '../models/track.dart';
+import '../sources/music_provider.dart';
+import '../sources/plex/plex_client.dart';
+import '../sources/plex/plex_track_mapper.dart';
+import 'lyrics_provider.dart';
+
+/// The [LyricsProvider] backed by a signed-in Plex Media Server.
+///
+/// The [LyricsResolver] only routes Plex-owned tracks here; the scheme check
+/// below is the parse guard for extracting the `ratingKey` from a
+/// `plex:<ratingKey>` URI, and doubles as a safety net if the class is ever used
+/// outside the resolver. A non-Plex track, or being signed out, returns `null`
+/// so the UI shows "no lyrics". The session (server URL + token) is read lazily
+/// through [_session] so connecting/disconnecting is picked up without a
+/// rebuild, mirroring [JellyfinLyricsProvider] / [SubsonicLyricsProvider] and
+/// the streaming path.
+///
+/// Fetching is two steps off the playback path — locate the track's lyric
+/// stream, then fetch and parse it — owned by the [PlexClient] along with the
+/// token-safety rules: it returns `null` for "no lyrics" and throws a token-free
+/// `PlexException` only for a real transport/auth failure, which the resolver
+/// surfaces as the calm "couldn't load" state.
+class PlexLyricsProvider implements LyricsProvider {
+  PlexLyricsProvider({
+    required PlexClient client,
+    required PlexSession? Function() session,
+  })  : _client = client,
+        _session = session;
+
+  final PlexClient _client;
+  final PlexSession? Function() _session;
+
+  @override
+  String get sourceId => MusicProviders.plex.sourceId;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async {
+    if (!track.uri.startsWith(PlexTrackMapper.uriScheme)) return null;
+    final PlexSession? session = _session();
+    if (session == null) return null;
+    final String ratingKey =
+        track.uri.substring(PlexTrackMapper.uriScheme.length);
+    if (ratingKey.isEmpty) return null;
+    return _client.fetchLyrics(
+      baseUrl: session.baseUrl,
+      token: session.token,
+      ratingKey: ratingKey,
+    );
+  }
+}

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -264,11 +264,12 @@ abstract final class MusicProviders {
   /// (badged Experimental) lets the user connect with a manual server URL +
   /// token and pick which music libraries to include.
   ///
-  /// Stream-only by design: caching, favorites, lyrics, playlists, and cast are
-  /// declared unsupported so their actions stay hidden/disabled rather than
-  /// failing — exactly how Subsonic shipped streaming first. Cast stays off in
-  /// phase 1 to keep the credential-in-URL surface small (a Plex stream URL
-  /// carries the token as a query param).
+  /// Stream + lyrics: caching, favorites, playlists, and cast stay declared
+  /// unsupported so their actions stay hidden/disabled rather than failing —
+  /// exactly how Subsonic shipped streaming first. Lyrics are fetched on demand
+  /// from the track's Plex lyric stream (synced `.lrc` or plain), the one read
+  /// beyond streaming. Cast stays off in phase 1 to keep the credential-in-URL
+  /// surface small (a Plex stream URL carries the token as a query param).
   static const MusicProvider plex = MusicProvider(
     sourceId: 'plex',
     displayName: 'Plex',
@@ -281,7 +282,9 @@ abstract final class MusicProviders {
       canFavoriteTracks: false,
       canReadFavoriteState: false,
       canSyncFavorites: false,
-      canLyrics: false,
+      // Lyrics are fetched on demand from the track's Plex lyric stream (synced
+      // `.lrc` or plain text), parsed into the shared Lyrics model.
+      canLyrics: true,
       canCast: false,
       canRemoveFromLibrary: true,
       canRemoveOfflineCopy: false,

--- a/lib/core/sources/plex/http_plex_client.dart
+++ b/lib/core/sources/plex/http_plex_client.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
+import '../../models/lyrics.dart';
+import '../../services/lyrics_text_parser.dart';
 import 'plex_api.dart';
 import 'plex_client.dart';
 import 'plex_endpoints.dart';
@@ -75,6 +77,10 @@ class HttpPlexClient implements PlexClient {
   /// A generous page-count cap stops a runaway loop if a server ever ignores the
   /// `X-Plex-Container-Start` offset.
   static const int _maxPages = 1000;
+
+  /// Plex's numeric `streamType` for a lyric `Stream` (2 = audio, 3 = subtitle,
+  /// 4 = lyrics). The one stream kind [fetchLyrics] looks for on a track's Part.
+  static const int _lyricStreamType = 4;
 
   @override
   Future<PlexServerIdentity> fetchIdentity({
@@ -150,6 +156,33 @@ class HttpPlexClient implements PlexClient {
       throw PlexException.unsupportedResponse();
     }
     return container.metadata.first;
+  }
+
+  @override
+  Future<Lyrics?> fetchLyrics({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+  }) async {
+    // Step 1: the track's full single-item metadata carries its
+    // Media → Part → Stream list (streams ride in this response by default);
+    // a lyric stream is Plex's streamType=4, whose `key` points at the content.
+    final Map<String, dynamic> metadata = await _getJson(
+      PlexEndpoints.metadata(baseUrl, ratingKey: ratingKey),
+      token,
+    );
+    final ({String key, String? format})? stream = _findLyricStream(metadata);
+    // No lyric stream on the track → no lyrics (a normal outcome, not an error).
+    if (stream == null) return null;
+
+    // Step 2: fetch the stream's content and parse it. A 404 means the content
+    // has gone missing — treated as "no lyrics" too, never a hard failure.
+    final String? body = await _getLyricBody(
+      PlexEndpoints.lyricStream(baseUrl, streamKey: stream.key),
+      token,
+    );
+    if (body == null) return null;
+    return _parseLyricBody(body, stream.format);
   }
 
   @override
@@ -241,6 +274,169 @@ class HttpPlexClient implements PlexClient {
     );
     _checkStatus(response);
     return _decodeObject(response);
+  }
+
+  /// GETs a lyric stream's content, returning its body text — or `null` on a 404
+  /// (the content is gone: "no lyrics", not a failure). Other non-2xx statuses
+  /// throw the usual [PlexException]. Bytes are decoded as UTF-8 so non-ASCII
+  /// lyrics aren't mangled.
+  Future<String?> _getLyricBody(Uri uri, String token) async {
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: _headers(token)),
+    );
+    if (response.statusCode == 404) return null;
+    _checkStatus(response);
+    return utf8.decode(response.bodyBytes, allowMalformed: true);
+  }
+
+  /// Locates the first lyric stream (Plex `streamType=4`) in a track's metadata
+  /// JSON, returning its server-absolute `key` (the path the content is fetched
+  /// from) and reported `format` (e.g. `lrc`/`txt`), or `null` when the track
+  /// carries none. Walks Metadata → Media → Part → Stream defensively: any
+  /// missing or odd level is skipped, never thrown. A relative `key` is refused
+  /// (it would splice into the base URL's authority), the same guard the stream
+  /// URL builder applies.
+  static ({String key, String? format})? _findLyricStream(
+    Map<String, dynamic> json,
+  ) {
+    final Object? container = json['MediaContainer'];
+    if (container is! Map<String, dynamic>) return null;
+    final Object? metadata = container['Metadata'];
+    if (metadata is! List) return null;
+    for (final Object? item in metadata) {
+      if (item is! Map<String, dynamic>) continue;
+      final Object? media = item['Media'];
+      if (media is! List) continue;
+      for (final Object? rendition in media) {
+        if (rendition is! Map<String, dynamic>) continue;
+        final Object? parts = rendition['Part'];
+        if (parts is! List) continue;
+        for (final Object? part in parts) {
+          if (part is! Map<String, dynamic>) continue;
+          final Object? streams = part['Stream'];
+          if (streams is! List) continue;
+          for (final Object? stream in streams) {
+            if (stream is! Map<String, dynamic>) continue;
+            if (_asInt(stream['streamType']) != _lyricStreamType) continue;
+            final String? key = _nonEmpty(stream['key']);
+            if (key == null || !key.startsWith('/')) continue;
+            return (key: key, format: _nonEmpty(stream['format']));
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Turns a lyric stream body into [Lyrics]. Plex serves either its structured
+  /// JSON document (agent / LyricFind lyrics) or the raw `.lrc`/`.txt` file bytes
+  /// (a local sidecar). A JSON object body is read structurally; anything else
+  /// is the raw text, parsed by the shared [LyricsTextParser] — so a Plex `.lrc`
+  /// renders synced and a `.txt` static, exactly like a local sidecar. Returns
+  /// `null` when nothing usable remains; total — malformed input never throws.
+  static Lyrics? _parseLyricBody(String body, String? format) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(body);
+    } on FormatException {
+      decoded = null; // Raw .lrc/.txt text (a local sidecar), not JSON.
+    }
+    if (decoded is Map<String, dynamic>) {
+      return _parseStructuredLyrics(decoded);
+    }
+    return (format?.toLowerCase() == 'txt')
+        ? LyricsTextParser.parsePlain(body)
+        : LyricsTextParser.parseLrc(body);
+  }
+
+  /// Parses Plex's structured lyric JSON: `MediaContainer.Lyrics[].Line[]`, each
+  /// line's text the concatenation of its `Span[].text` and its timestamp the
+  /// line's (or first span's) `startOffset` in **milliseconds**. Timed lines win
+  /// (synced, ordered by time, mirroring the `.lrc` parser); a document with no
+  /// offsets degrades to plain lines. `null` when no usable line remains.
+  static Lyrics? _parseStructuredLyrics(Map<String, dynamic> json) {
+    final Object? container = json['MediaContainer'];
+    if (container is! Map<String, dynamic>) return null;
+    final Object? documents = container['Lyrics'];
+    if (documents is! List) return null;
+    final List<LyricLine> timed = <LyricLine>[];
+    final List<String> plain = <String>[];
+    for (final Object? document in documents) {
+      if (document is! Map<String, dynamic>) continue;
+      final Object? lines = document['Line'];
+      if (lines is! List) continue;
+      for (final Object? line in lines) {
+        if (line is! Map<String, dynamic>) continue;
+        final String text = _structuredLineText(line);
+        final int? offsetMs = _structuredLineOffsetMs(line);
+        if (offsetMs != null && offsetMs >= 0) {
+          timed.add(
+            LyricLine(text: text, start: Duration(milliseconds: offsetMs)),
+          );
+        } else {
+          plain.add(text);
+        }
+      }
+    }
+    if (timed.isNotEmpty) {
+      // Order by time so the model's active-line search (ascending order) holds.
+      timed.sort((LyricLine a, LyricLine b) => a.start!.compareTo(b.start!));
+      return Lyrics(lines: timed);
+    }
+    if (plain.isEmpty) return null;
+    // Reuse the plain parser's blank-trim + empty→null handling.
+    return LyricsTextParser.parsePlain(plain.join('\n'));
+  }
+
+  /// The text of one structured lyric line: its `Span[].text` joined in order,
+  /// falling back to a line-level `text` when a server reports no spans.
+  static String _structuredLineText(Map<String, dynamic> line) {
+    final Object? spans = line['Span'];
+    if (spans is List) {
+      final StringBuffer buffer = StringBuffer();
+      for (final Object? span in spans) {
+        if (span is Map<String, dynamic> && span['text'] is String) {
+          buffer.write(span['text'] as String);
+        }
+      }
+      if (buffer.isNotEmpty) return buffer.toString();
+    }
+    final Object? text = line['text'];
+    return text is String ? text : '';
+  }
+
+  /// The millisecond start offset of a structured lyric line: the line's own
+  /// `startOffset`, or the first span's when the line carries none; `null` for
+  /// an untimed line.
+  static int? _structuredLineOffsetMs(Map<String, dynamic> line) {
+    final int? lineOffset = _asInt(line['startOffset']);
+    if (lineOffset != null) return lineOffset;
+    final Object? spans = line['Span'];
+    if (spans is List) {
+      for (final Object? span in spans) {
+        if (span is Map<String, dynamic>) {
+          final int? spanOffset = _asInt(span['startOffset']);
+          if (spanOffset != null) return spanOffset;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Reads a JSON value PMS may emit as a number or a numeric string (e.g.
+  /// `streamType`, `startOffset`) as an `int`, or `null` for anything else.
+  static int? _asInt(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
+
+  /// A trimmed, non-empty [String] for a JSON string [value], or `null`.
+  static String? _nonEmpty(Object? value) {
+    if (value is! String) return null;
+    final String trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
   }
 
   /// The headers every API call sends: `Accept: application/json` (Plex defaults

--- a/lib/core/sources/plex/plex_client.dart
+++ b/lib/core/sources/plex/plex_client.dart
@@ -1,3 +1,4 @@
+import '../../models/lyrics.dart';
 import 'plex_api.dart';
 import 'plex_exception.dart';
 
@@ -121,6 +122,25 @@ abstract interface class PlexClient {
   /// Throws [PlexException] ([PlexErrorKind.notFound] when the `ratingKey` no
   /// longer exists).
   Future<PlexMetadata> fetchMetadata({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+  });
+
+  /// Fetches the lyrics for the track identified by [ratingKey], or `null` when
+  /// the server has none — a normal outcome, never an error.
+  ///
+  /// Two steps, on demand and off the playback path: a
+  /// `GET /library/metadata/{ratingKey}` lookup locates the track's lyric
+  /// `Stream` (Plex's `streamType=4`) and its `key`, then that key is fetched
+  /// and parsed into the shared [Lyrics] model — timed `.lrc`-style content
+  /// renders synced, plain content static. A track with no lyric stream (or one
+  /// whose content has gone missing) resolves to `null`.
+  ///
+  /// Throws a token-free [PlexException] for a transport/auth failure (offline
+  /// server, rejected token) so the lyrics panel can tell "couldn't load" apart
+  /// from "no lyrics"; the token never appears in the thrown message.
+  Future<Lyrics?> fetchLyrics({
     required String baseUrl,
     required String token,
     required String ratingKey,

--- a/lib/core/sources/plex/plex_endpoints.dart
+++ b/lib/core/sources/plex/plex_endpoints.dart
@@ -111,6 +111,16 @@ abstract final class PlexEndpoints {
   static Uri metadata(String baseUrl, {required String ratingKey}) =>
       _join(baseUrl, '$_metadataPath/$ratingKey');
 
+  /// `GET {streamKey}` — fetches a track's lyric-stream content, where
+  /// [streamKey] is the server-absolute `key` of a `streamType=4` (lyric)
+  /// `Stream` read from a `GET /library/metadata/{ratingKey}` lookup (e.g.
+  /// `/library/streams/12345`). The path is already server-absolute, so it is
+  /// appended to [baseUrl] as-is. Like every API call (and unlike the stream/art
+  /// URLs), the token is **not** woven in here — it rides in the client's
+  /// `X-Plex-Token` header — so a lyric-stream URL is token-free and safe to log.
+  static Uri lyricStream(String baseUrl, {required String streamKey}) =>
+      _join(baseUrl, streamKey);
+
   /// `GET /:/timeline?ratingKey=…&key=…&state=…&time=…` — reports playback of
   /// one item back to PMS, which is what makes the client appear in (and
   /// update / leave) the server's Now Playing dashboard.

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -9,14 +9,15 @@ import '../../core/services/local_lyrics_provider.dart';
 import '../../core/services/lyrics_provider.dart';
 import '../../core/services/lyrics_resolver.dart';
 import '../../core/services/lyrics_service.dart';
-import '../../core/services/no_lyrics_provider.dart';
+import '../../core/services/plex_lyrics_provider.dart';
 import '../../core/services/subsonic_lyrics_provider.dart';
 import '../../core/sources/local/io_local_lyrics_reader.dart';
 import '../../core/sources/local/local_lyrics_reader.dart';
 import '../../core/sources/local/method_channel_saf_lyrics_reader.dart';
-import '../../core/sources/music_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
+import '../settings/plex/plex_settings_controller.dart';
+import '../settings/plex/plex_settings_providers.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_providers.dart';
 import 'player_providers.dart';
@@ -79,12 +80,11 @@ final localLyricsReaderProvider = Provider<LocalLyricsReader>((ref) {
 
 /// Production binding: a [LyricsResolver] that routes each track, by the
 /// source that owns its URI, to that source's [LyricsProvider] — a signed-in
-/// Jellyfin or Subsonic/Navidrome server, the sidecar file next to a local
-/// track, or the explicit "no lyrics yet" placeholder for Plex (kept on the
-/// calm empty state until a real Plex lyrics path lands). The live clients +
-/// sessions are read lazily so signing in/out is picked up without a rebuild;
-/// the local reader is platform-bound via [localLyricsReaderProvider]. Applied
-/// in `main`; tests keep the empty-resolver default.
+/// Jellyfin, Subsonic/Navidrome, or Plex server, or the sidecar file next to a
+/// local track. The live clients + sessions are read lazily so signing in/out
+/// (connecting/disconnecting) is picked up without a rebuild; the local reader
+/// is platform-bound via [localLyricsReaderProvider]. Applied in `main`; tests
+/// keep the empty-resolver default.
 final lyricsServiceOverride = lyricsServiceProvider.overrideWith((ref) {
   return LyricsResolver(<LyricsProvider>[
     JellyfinLyricsProvider(
@@ -97,7 +97,10 @@ final lyricsServiceOverride = lyricsServiceProvider.overrideWith((ref) {
       session: () =>
           ref.read(subsonicSettingsControllerProvider.notifier).session,
     ),
+    PlexLyricsProvider(
+      client: ref.read(plexClientProvider),
+      session: () => ref.read(plexSettingsControllerProvider.notifier).session,
+    ),
     LocalLyricsProvider(ref.read(localLyricsReaderProvider)),
-    NoLyricsProvider(MusicProviders.plex.sourceId),
   ]);
 });

--- a/test/core/services/lyrics_resolver_test.dart
+++ b/test/core/services/lyrics_resolver_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/subsonic_session.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/jellyfin_lyrics_provider.dart';
@@ -8,11 +9,13 @@ import 'package:linthra/core/services/local_lyrics_provider.dart';
 import 'package:linthra/core/services/lyrics_provider.dart';
 import 'package:linthra/core/services/lyrics_resolver.dart';
 import 'package:linthra/core/services/no_lyrics_provider.dart';
+import 'package:linthra/core/services/plex_lyrics_provider.dart';
 import 'package:linthra/core/services/subsonic_lyrics_provider.dart';
 import 'package:linthra/core/sources/local/local_lyrics_reader.dart';
 import 'package:linthra/core/sources/music_provider.dart';
 
 import '../sources/jellyfin/fake_jellyfin_client.dart';
+import '../sources/plex/fake_plex_client.dart';
 import '../sources/subsonic/fake_subsonic_client.dart';
 
 /// A [LyricsProvider] that returns canned lyrics (or throws), and records
@@ -236,15 +239,22 @@ void main() {
       salt: 'salt1',
       token: 'tok1',
     );
+    const plexSession = PlexSession(
+      baseUrl: 'https://plex.example.com:32400',
+      token: 'plex-tok',
+      machineIdentifier: 'm-1',
+    );
 
     late FakeJellyfinClient jellyfin;
     late FakeSubsonicClient subsonic;
+    late FakePlexClient plex;
     late _FakeLocalLyricsReader reader;
     late LyricsResolver resolver;
 
     setUp(() {
       jellyfin = FakeJellyfinClient();
       subsonic = FakeSubsonicClient();
+      plex = FakePlexClient();
       reader = _FakeLocalLyricsReader(lrc: '[00:01.00]local line\n');
       resolver = LyricsResolver(<LyricsProvider>[
         JellyfinLyricsProvider(
@@ -255,8 +265,11 @@ void main() {
           client: subsonic,
           session: () => subsonicSession,
         ),
+        PlexLyricsProvider(
+          client: plex,
+          session: () => plexSession,
+        ),
         LocalLyricsProvider(reader),
-        NoLyricsProvider(MusicProviders.plex.sourceId),
       ]);
     });
 
@@ -297,14 +310,17 @@ void main() {
       expect(subsonic.lastLyricsSongId, isNull);
     });
 
-    test('a Plex track stays on "no lyrics" without touching any backend',
-        () async {
+    test('a Plex track resolves via Plex, untouched by local', () async {
+      plex.lyrics = const Lyrics(lines: <LyricLine>[LyricLine(text: 'plx')]);
+
       final Lyrics? lyrics = await resolver.lyricsFor(_plexTrack);
 
-      expect(lyrics, isNull);
+      expect(lyrics?.lines.single.text, 'plx');
+      expect(plex.requestedLyricsRatingKeys, <String>['101']);
+      // The local reader and the other servers were never consulted.
+      expect(reader.requestedExtensions, isEmpty);
       expect(jellyfin.lastLyricsItemId, isNull);
       expect(subsonic.lastLyricsSongId, isNull);
-      expect(reader.requestedExtensions, isEmpty);
     });
   });
 }

--- a/test/core/services/plex_lyrics_provider_test.dart
+++ b/test/core/services/plex_lyrics_provider_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/plex_lyrics_provider.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+
+import '../sources/plex/fake_plex_client.dart';
+
+const _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'plex-token',
+  machineIdentifier: 'machine-1',
+);
+
+void main() {
+  group('PlexLyricsProvider', () {
+    late FakePlexClient client;
+
+    setUp(() => client = FakePlexClient());
+
+    PlexLyricsProvider build({PlexSession? session}) =>
+        PlexLyricsProvider(client: client, session: () => session);
+
+    test('declares the plex source id the resolver routes by', () {
+      expect(build(session: _session).sourceId, 'plex');
+    });
+
+    test('fetches lyrics for a Plex track by its ratingKey', () async {
+      client.lyrics = const Lyrics(
+        lines: <LyricLine>[LyricLine(text: 'la la')],
+      );
+      final provider = build(session: _session);
+
+      final lyrics = await provider.lyricsFor(
+        const Track(id: '42', title: 'Song', uri: 'plex:42'),
+      );
+
+      expect(client.requestedLyricsRatingKeys, <String>['42']);
+      expect(client.lastBaseUrl, 'https://plex.example.com:32400');
+      expect(client.lastToken, 'plex-token');
+      expect(lyrics?.lines.single.text, 'la la');
+    });
+
+    test('returns "no lyrics" (null) when the server has none', () async {
+      client.lyrics = null; // The default; a track with no lyric stream.
+      final provider = build(session: _session);
+
+      final lyrics = await provider.lyricsFor(
+        const Track(id: '42', title: 'Song', uri: 'plex:42'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.requestedLyricsRatingKeys, <String>['42']);
+    });
+
+    test('a fetch failure propagates so the UI can show "couldn\'t load"',
+        () async {
+      client.lyricsError = PlexException.notReachable();
+      final provider = build(session: _session);
+
+      await expectLater(
+        provider.lyricsFor(
+          const Track(id: '42', title: 'Song', uri: 'plex:42'),
+        ),
+        throwsA(isA<PlexException>()),
+      );
+    });
+
+    test('returns null for a non-Plex track without hitting the server',
+        () async {
+      final provider = build(session: _session);
+
+      final lyrics = await provider.lyricsFor(
+        const Track(id: '1', title: 'Local', uri: 'file:///1.mp3'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.requestedLyricsRatingKeys, isEmpty);
+    });
+
+    test('returns null when signed out (no session), no server call', () async {
+      final provider = build(session: null);
+
+      final lyrics = await provider.lyricsFor(
+        const Track(id: '42', title: 'Song', uri: 'plex:42'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.requestedLyricsRatingKeys, isEmpty);
+    });
+
+    test('returns null for a plex: uri carrying no ratingKey, no server call',
+        () async {
+      final provider = build(session: _session);
+
+      final lyrics = await provider.lyricsFor(
+        const Track(id: '', title: 'Broken', uri: 'plex:'),
+      );
+
+      expect(lyrics, isNull);
+      expect(client.requestedLyricsRatingKeys, isEmpty);
+    });
+  });
+}

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -46,16 +46,19 @@ void main() {
       expect(caps.canListPlaylists, isFalse);
     });
 
-    test('plex: stream-only in phase 1 (docs/plex.md capability matrix)', () {
+    test('plex: stream + lyrics in phase 1 (docs/plex.md capability matrix)',
+        () {
       final caps = MusicProviders.plex.capabilities;
       expect(caps.canStream, isTrue);
+      // Lyrics are fetched on demand from the track's Plex lyric stream (synced
+      // `.lrc` or plain), so they read ✅ — the one capability beyond streaming.
+      expect(caps.canLyrics, isTrue);
       // Everything else is declared unsupported so its actions stay hidden/
       // disabled rather than failing — exactly how Subsonic deferred features.
       expect(caps.canCache, isFalse);
       expect(caps.canFavoriteTracks, isFalse);
       expect(caps.canReadFavoriteState, isFalse);
       expect(caps.canSyncFavorites, isFalse);
-      expect(caps.canLyrics, isFalse);
       // Cast stays off in phase 1 to keep the credential-in-URL surface small.
       expect(caps.canCast, isFalse);
       expect(caps.canListPlaylists, isFalse);

--- a/test/core/sources/plex/fake_plex_client.dart
+++ b/test/core/sources/plex/fake_plex_client.dart
@@ -1,3 +1,4 @@
+import 'package:linthra/core/models/lyrics.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_client.dart';
 import 'package:linthra/core/sources/plex/plex_exception.dart';
@@ -37,6 +38,11 @@ class FakePlexClient implements PlexClient {
   Map<String, PlexMetadata> metadataByRatingKey;
   PlexException? metadataError;
 
+  /// Canned lyrics for [fetchLyrics]; `null` (the default) means "no lyrics".
+  /// Set [lyricsError] to make the call throw instead (a transport/auth fault).
+  Lyrics? lyrics;
+  PlexException? lyricsError;
+
   /// When set, every [reportTimeline] call throws it (after being recorded),
   /// so reporters can prove failures are swallowed. Set [timelineError] for a
   /// typed failure or [timelineUnexpectedError] for an untyped one.
@@ -49,6 +55,7 @@ class FakePlexClient implements PlexClient {
   final List<({String sectionKey, PlexMetadataType itemType})> itemRequests =
       <({String sectionKey, PlexMetadataType itemType})>[];
   final List<String> requestedRatingKeys = <String>[];
+  final List<String> requestedLyricsRatingKeys = <String>[];
   int identityCount = 0;
 
   /// Every timeline report received, in order, so tests can assert the exact
@@ -124,6 +131,20 @@ class FakePlexClient implements PlexClient {
     final PlexMetadata? item = metadataByRatingKey[ratingKey];
     if (item == null) throw PlexException.notFound();
     return item;
+  }
+
+  @override
+  Future<Lyrics?> fetchLyrics({
+    required String baseUrl,
+    required String token,
+    required String ratingKey,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastToken = token;
+    requestedLyricsRatingKeys.add(ratingKey);
+    final PlexException? error = lyricsError;
+    if (error != null) throw error;
+    return lyrics;
   }
 
   @override

--- a/test/core/sources/plex/http_plex_client_test.dart
+++ b/test/core/sources/plex/http_plex_client_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:linthra/core/models/lyrics.dart';
 import 'package:linthra/core/sources/plex/http_plex_client.dart';
 import 'package:linthra/core/sources/plex/plex_api.dart';
 import 'package:linthra/core/sources/plex/plex_client.dart';
@@ -428,6 +429,221 @@ void main() {
           PlexErrorKind.unsupportedResponse,
         )),
       );
+    });
+  });
+
+  group('fetchLyrics', () {
+    // A 200 text/plain response — Plex serves a local `.lrc`/`.txt` sidecar's
+    // bytes raw (no JSON envelope).
+    http.Response text(String body) => http.Response(
+          body,
+          200,
+          headers: const <String, String>{'content-type': 'text/plain'},
+        );
+
+    // Track metadata whose single Part carries the given Stream list.
+    Map<String, dynamic> metadataWith(List<Map<String, dynamic>> streams) =>
+        <String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'Metadata': <dynamic>[
+              <String, dynamic>{
+                'ratingKey': '123',
+                'type': 'track',
+                'Media': <dynamic>[
+                  <String, dynamic>{
+                    'Part': <dynamic>[
+                      <String, dynamic>{
+                        'key': '/library/parts/1/file.flac',
+                        'Stream': streams,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        };
+
+    const Map<String, dynamic> lyricStream = <String, dynamic>{
+      'streamType': 4,
+      'key': '/library/streams/99',
+      'format': 'lrc',
+    };
+
+    // A client serving [metadata] for the metadata path and [stream] for the
+    // /library/streams/ path, recording every request it receives.
+    ({HttpPlexClient client, List<http.Request> requests}) routed({
+      required Map<String, dynamic> metadata,
+      http.Response Function()? stream,
+    }) {
+      final List<http.Request> requests = <http.Request>[];
+      final HttpPlexClient client = _client(MockClient((http.Request r) async {
+        requests.add(r);
+        if (r.url.path.startsWith('/library/streams/')) {
+          return (stream ?? () => text('')).call();
+        }
+        return _json(metadata);
+      }));
+      return (client: client, requests: requests);
+    }
+
+    test('synced .lrc: locates the streamType=4 stream and parses timed lines',
+        () async {
+      final routed_ = routed(
+        metadata: metadataWith(<Map<String, dynamic>>[
+          // An audio stream (streamType 2) is skipped; the lyric one is found.
+          <String, dynamic>{'streamType': 2, 'key': '/library/streams/1'},
+          lyricStream,
+        ]),
+        stream: () => text('[00:01.00]hello\n[00:02.00]world\n'),
+      );
+
+      final Lyrics? lyrics = await routed_.client.fetchLyrics(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isTrue);
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text),
+        <String>['hello', 'world'],
+      );
+      expect(lyrics.lines.first.start, const Duration(seconds: 1));
+      // Two requests: the metadata lookup then the lyric stream key.
+      expect(routed_.requests.map((http.Request r) => r.url.path), <String>[
+        '/library/metadata/123',
+        '/library/streams/99',
+      ]);
+    });
+
+    test('structured JSON: parses Line/Span startOffset (ms) into timed lines',
+        () async {
+      final routed_ = routed(
+        metadata: metadataWith(<Map<String, dynamic>>[lyricStream]),
+        stream: () => _json(<String, dynamic>{
+          'MediaContainer': <String, dynamic>{
+            'Lyrics': <dynamic>[
+              <String, dynamic>{
+                'format': 'lrc',
+                'Line': <dynamic>[
+                  <String, dynamic>{
+                    'Span': <dynamic>[
+                      <String, dynamic>{'text': 'first', 'startOffset': 1000},
+                    ],
+                  },
+                  <String, dynamic>{
+                    'startOffset': 2500,
+                    'Span': <dynamic>[
+                      <String, dynamic>{'text': 'sec'},
+                      <String, dynamic>{'text': 'ond'},
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+
+      final Lyrics? lyrics = await routed_.client.fetchLyrics(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isTrue);
+      // A line's text is its spans joined; its time the line- or first-span
+      // startOffset.
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text),
+        <String>['first', 'second'],
+      );
+      expect(lyrics.lines[0].start, const Duration(milliseconds: 1000));
+      expect(lyrics.lines[1].start, const Duration(milliseconds: 2500));
+    });
+
+    test('plain .txt lyrics render static (untimed)', () async {
+      final routed_ = routed(
+        metadata: metadataWith(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'streamType': 4,
+            'key': '/library/streams/99',
+            'format': 'txt',
+          },
+        ]),
+        stream: () => text('line a\nline b\n'),
+      );
+
+      final Lyrics? lyrics = await routed_.client.fetchLyrics(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(lyrics, isNotNull);
+      expect(lyrics!.isSynced, isFalse);
+      expect(
+        lyrics.lines.map((LyricLine l) => l.text),
+        <String>['line a', 'line b'],
+      );
+    });
+
+    test('a track with no lyric stream resolves to null, no second request',
+        () async {
+      final routed_ = routed(
+        metadata: metadataWith(<Map<String, dynamic>>[
+          <String, dynamic>{'streamType': 2, 'key': '/library/streams/1'},
+        ]),
+      );
+
+      final Lyrics? lyrics = await routed_.client.fetchLyrics(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(lyrics, isNull);
+      expect(routed_.requests, hasLength(1)); // metadata only
+      expect(routed_.requests.single.url.path, '/library/metadata/123');
+    });
+
+    test('a 404 on the lyric content is "no lyrics", not a failure', () async {
+      final routed_ = routed(
+        metadata: metadataWith(<Map<String, dynamic>>[lyricStream]),
+        stream: () => http.Response('', 404),
+      );
+
+      final Lyrics? lyrics = await routed_.client.fetchLyrics(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(lyrics, isNull);
+    });
+
+    test('the token rides in the header on both requests, never the URL',
+        () async {
+      final routed_ = routed(
+        metadata: metadataWith(<Map<String, dynamic>>[lyricStream]),
+        stream: () => text('[00:01.00]hi\n'),
+      );
+
+      await routed_.client.fetchLyrics(
+        baseUrl: _base,
+        token: _token,
+        ratingKey: '123',
+      );
+
+      expect(routed_.requests, hasLength(2));
+      for (final http.Request r in routed_.requests) {
+        expect(r.headers['x-plex-token'], _token);
+        // No token (indeed nothing) smuggled into the query string.
+        expect(r.url.query, isEmpty);
+      }
     });
   });
 

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -184,12 +184,12 @@ void main() {
       (tester) async {
     await _pump(tester);
 
-    // Phase 1 is stream-only → only Streaming appears.
+    // Phase 1 implements streaming + lyrics → both chips appear; the rest don't.
     expect(find.text('Streaming'), findsOneWidget);
+    expect(find.text('Lyrics'), findsOneWidget);
     expect(find.text('Offline'), findsNothing);
     expect(find.text('Cast'), findsNothing);
     expect(find.text('Favorites'), findsNothing);
-    expect(find.text('Lyrics'), findsNothing);
   });
 
   testWidgets('Connect is disabled until both manual fields are filled',


### PR DESCRIPTION
## What

Display lyrics for Plex tracks when the server has them — synced (timed) or
static — falling back to the calm "No lyrics" state when it doesn't.

Today a `plex:` track is wired to a `NoLyricsProvider` placeholder, so the Now
Playing lyrics panel always shows "No lyrics available" for Plex. This replaces
that placeholder with a real `PlexLyricsProvider`.

## How

- **`PlexClient.fetchLyrics`** (interface + HTTP impl + fake) does a two-step,
  on-demand lookup, off the playback path:
  1. `GET /library/metadata/{ratingKey}` — locate the track's lyric `Stream`
     (Plex's `streamType=4`) and its `key`/`format` in `Media → Part → Stream`
     (streams ride in the single-item metadata response by default).
  2. `GET {key}` — fetch the content and parse it into the shared `Lyrics`
     model. Plex serves either its **structured JSON**
     (`MediaContainer.Lyrics[].Line[].Span[]` with millisecond `startOffset`s,
     for agent / LyricFind lyrics) or the **raw `.lrc`/`.txt` bytes** of a local
     sidecar — both handled, with timed content rendering synced and plain
     content static (reusing the existing `LyricsTextParser`).
- **`PlexLyricsProvider`** registered in the shared `LyricsResolver` next to the
  Jellyfin / Subsonic / Local providers — the resolver routes a track to its
  owning source, so this is a drop-in, **no provider-architecture change**.
- **`MusicProviders.plex` `canLyrics` → `true`**, so the Settings card shows the
  Lyrics capability chip; docs matrices updated to match.

## Safety

- The token rides in the `X-Plex-Token` **header** on both requests, so the
  lyric URLs are token-free and safe to log (same rule as every Plex API call).
- "No lyrics" (no stream / missing content / 404) is `null`, never an error; a
  real transport/auth failure throws a token-free `PlexException` so the panel
  can show "couldn't load" instead.

## Constraints honoured

- Small, Plex-scoped PR — no refactor of the provider architecture.
- No caching work. No playback-engine change. No other provider touched.
- **No UI changes**: the existing Now Playing lyrics view already renders
  loading / empty / plain / synced for any provider.

## Tests

- New `PlexLyricsProvider` test (routing, no-session, non-Plex, propagated
  failure, empty ratingKey).
- New `HttpPlexClient.fetchLyrics` cases: synced `.lrc`, structured JSON
  Line/Span offsets, plain `.txt`, no-lyric-stream → null (no second request),
  404 content → null, token-in-header-never-URL.
- Updated the resolver "shipped providers" group to mirror the real Plex
  provider, plus the capability + Settings-chip expectations.
- `dart format`, `flutter analyze`, and the full `flutter test` suite (2315
  tests) all pass locally.

https://claude.ai/code/session_011DKUJJ5FV4hkiZEHK77jGb

---
_Generated by [Claude Code](https://claude.ai/code/session_011DKUJJ5FV4hkiZEHK77jGb)_