### PR TITLE
fix(plex): show album artwork in Android Auto & lock screen

### DIFF
--- a/docs/android-auto.md
+++ b/docs/android-auto.md
@@ -25,7 +25,7 @@ troubleshoot.
 | Now-playing **queue / Up Next** on the head unit | ✅ (mirrors the app's queue) |
 | Tap a row in the car's Up Next list (skip-to-queue-item) | ✅ |
 | Shuffle / repeat from the car | ✅ |
-| Now-playing metadata (title / artist / album / artwork) | ✅ (Jellyfin / local / Subsonic covers; the Subsonic cover is fetched + cached to a private file so no credential reaches `artUri`) |
+| Now-playing metadata (title / artist / album / artwork) | ✅ (Jellyfin / local / Subsonic / Plex covers; the Subsonic & Plex covers are fetched + cached to a private file so no credential reaches `artUri`) |
 | Offline / downloaded section | ✅ (user downloads only — smart pre-cache is not listed) |
 | Cast-safe (no duplicate local playback while casting) | ✅ |
 | Search from Android Auto | ❌ (not implemented — [follow-up](#known-limitations)) |
@@ -176,10 +176,11 @@ Android Auto media items are deliberately **secret-free**:
   stored on a track or handed to the media browser.
 - `MediaItem.artUri` (cover art) is only ever a **credential-free, platform-
   loadable** URI: the **token-free** image endpoint for Jellyfin, a **private
-  `file:`** for a local embedded cover or a fetched-and-cached Subsonic cover,
-  or `null`. The authenticated Subsonic `getCoverArt` URL (which embeds the
-  salt+token) is **never** put in `artUri`: Linthra fetches that cover itself
-  and hands the session only the resulting private `file:` (see
+  `content://`** for a local embedded cover or a fetched-and-cached
+  Subsonic/Plex cover, or `null`. An authenticated cover URL that embeds a
+  credential (Subsonic's salt+token `getCoverArt`, or Plex's `X-Plex-Token`
+  cover-art URL) is **never** put in `artUri`: Linthra fetches that cover itself
+  and hands the session only the resulting private `content://` (see
   [the now-playing artwork note](#known-limitations)), so no credential rides
   along in artwork.
 - The diagnostic log (see below) prints only the **category** of a media id
@@ -376,12 +377,14 @@ mode → **Add unknown sources** enabled for a sideloaded build.
 - The car experience is **basic browsing**, not a custom/polished car UI (no
   tabs, content-style hints, lyrics, or now-playing artwork tuning).
 - Lock-screen / now-playing artwork covers Jellyfin (its token-free image URL),
-  local embedded covers (extracted during the scan into a private `file:`), and
-  Subsonic/Navidrome. `getCoverArt` carries the salt+token, so it can't be handed
-  to the session as a URL; Linthra instead:
-  1. fetches a **server-downscaled** cover itself and caches the bytes to a
-     private file, keyed by a hash of the credential-free `subsonic-cover:`
-     reference (never the URL);
+  local embedded covers (extracted during the scan into a private `file:`),
+  Subsonic/Navidrome, and Plex. A credentialed cover URL (Subsonic's salt+token
+  `getCoverArt`, or Plex's `X-Plex-Token` cover-art URL) can't be handed to the
+  session as a URL; Linthra instead:
+  1. fetches the cover itself (Subsonic **server-downscaled** via its `size`
+     param; Plex as the stored thumb) and caches the bytes to a private file,
+     keyed by a hash of the credential-free reference (`subsonic-cover:` /
+     `plex-thumb:`) — never the URL;
   2. **pre-warms** the now-playing + next few covers off the playback path
      (now-playing first, retrying a transient miss on the next queue change), so a
      cover is cached before its track reaches the now-playing card; if it lands

--- a/lib/features/player/media_artwork_providers.dart
+++ b/lib/features/player/media_artwork_providers.dart
@@ -1,9 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/models/plex_session.dart';
 import '../../core/models/subsonic_session.dart';
 import '../../core/services/media_artwork_cache.dart';
 import '../../core/services/media_artwork_prewarm_service.dart';
+import '../../core/sources/plex/plex_artwork.dart';
 import '../../core/sources/subsonic/subsonic_artwork.dart';
+import '../settings/plex/plex_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 import 'player_providers.dart';
 
@@ -13,30 +16,61 @@ import 'player_providers.dart';
 /// crisp on those surfaces. The in-app full-size render (PR #170) is unaffected.
 const int kMediaSessionArtworkSize = 512;
 
-/// The privacy-safe media-session artwork cache for Subsonic/Navidrome.
+/// Resolves a credential-free media-session cover [reference] into an
+/// authenticated, ready-to-fetch cover URL for whichever provider owns its
+/// scheme, weaving the live session's credential in on demand. Returns `null`
+/// for a reference no signed-in provider owns — signed out, or an already
+/// platform-loadable Jellyfin/local cover the cache never sees — and the caller
+/// then shows no media-session artwork.
+///
+/// Each provider's resolver owns one reference scheme and returns `null` for the
+/// rest, so they chain safely: a `subsonic-cover:` goes to Subsonic, a
+/// `plex-thumb:` to Plex. Mirrors `main.dart`'s in-app
+/// `installArtworkReferenceResolver`, but asks Subsonic for a media-session-
+/// sized cover ([kMediaSessionArtworkSize]) — small and fast to decode on the
+/// lock screen / Android Auto card. The credential is woven in here and used
+/// once by the cache to fetch; it is never persisted (the catalog stores only
+/// the credential-free reference) or logged.
+Uri? resolveMediaSessionArtworkUrl(
+  Uri reference, {
+  SubsonicSession? subsonic,
+  PlexSession? plex,
+}) {
+  if (subsonic != null) {
+    final Uri? resolved = SubsonicArtwork.resolve(
+      reference,
+      subsonic,
+      size: kMediaSessionArtworkSize,
+    );
+    if (resolved != null) return resolved;
+  }
+  if (plex != null) {
+    final Uri? resolved = PlexArtwork.resolve(reference, plex);
+    if (resolved != null) return resolved;
+  }
+  return null;
+}
+
+/// The privacy-safe media-session artwork cache for Subsonic/Navidrome and Plex.
 ///
 /// The platform media session loads `MediaItem.artUri` itself, somewhere Linthra
-/// can't add the salt+token, so the credentialed `getCoverArt` URL must never go
-/// there. The cache instead fetches a **server-downscaled** cover itself
-/// (weaving the live session's salt+token in on demand, used once and never
-/// stored or logged), writes the bytes to a private file keyed by a hash of the
-/// credential-free `subsonic-cover:` reference, and exposes it as a safe local
-/// `file:`. Jellyfin (token-free http) and local (`file:`) covers are already
-/// platform-loadable and never reach this cache. Reads the session live, so
-/// sign-in/out is picked up; signed out, or on any fetch failure, it yields no
-/// artwork and playback is unaffected.
+/// can't add the credential, so a credentialed cover URL (Subsonic's salt+token
+/// `getCoverArt`, or Plex's `X-Plex-Token` cover-art URL) must never go there.
+/// The cache instead fetches the cover itself (weaving the live session's
+/// credential in on demand via [resolveMediaSessionArtworkUrl], used once and
+/// never stored or logged), writes the bytes to a private file keyed by a hash
+/// of the credential-free reference (`subsonic-cover:` / `plex-thumb:`), and
+/// exposes it as a safe local `content://`. Jellyfin (token-free http) and local
+/// (`file:`) covers are already platform-loadable and never reach this cache.
+/// Reads the sessions live, so sign-in/out is picked up; signed out, or on any
+/// fetch failure, it yields no artwork and playback is unaffected.
 final mediaArtworkCacheProvider = Provider<MediaArtworkCache>((ref) {
   final cache = MediaArtworkCache(
-    resolveUrl: (Uri reference) {
-      final SubsonicSession? session =
-          ref.read(subsonicSettingsControllerProvider.notifier).session;
-      if (session == null) return null;
-      return SubsonicArtwork.resolve(
-        reference,
-        session,
-        size: kMediaSessionArtworkSize,
-      );
-    },
+    resolveUrl: (Uri reference) => resolveMediaSessionArtworkUrl(
+      reference,
+      subsonic: ref.read(subsonicSettingsControllerProvider.notifier).session,
+      plex: ref.read(plexSettingsControllerProvider.notifier).session,
+    ),
   );
   ref.onDispose(cache.dispose);
   return cache;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -120,10 +120,10 @@ Future<void> main() async {
   // the car tree is answerable even before any phone screen is opened.
   //
   // The media-session artwork cache lets the now-playing card show a
-  // credential-free source's cover (Subsonic) as a safe local file: — the
-  // handler reads it synchronously, never a credentialed getCoverArt URL. The
-  // covers are fetched (server-downscaled) and cached ahead of time, off the
-  // playback path, by the prewarm service started below.
+  // credential-free source's cover (Subsonic or Plex) as a safe local
+  // content:// — the handler reads it synchronously, never a credentialed
+  // getCoverArt / X-Plex-Token cover URL. The covers are fetched and cached
+  // ahead of time, off the playback path, by the prewarm service started below.
   await connectMediaSession(
     container.read(playbackControllerProvider),
     container.read(musicLibraryRepositoryProvider),
@@ -133,11 +133,11 @@ Future<void> main() async {
     artwork: container.read(mediaArtworkCacheProvider),
   );
 
-  // Warm the now-playing + look-ahead Subsonic covers into the media-session
-  // artwork cache as playback advances, so each cover is cached before its track
-  // reaches the now-playing card (beating a head unit's metadata snapshot).
-  // Off the playback path and best-effort, like the stream preloader below;
-  // instantiating it wires the listener.
+  // Warm the now-playing + look-ahead Subsonic/Plex covers into the media-
+  // session artwork cache as playback advances, so each cover is cached before
+  // its track reaches the now-playing card (beating a head unit's metadata
+  // snapshot). Off the playback path and best-effort, like the stream preloader
+  // below; instantiating it wires the listener.
   container.read(mediaArtworkPrewarmServiceProvider);
 
   // Start smart pre-cache: as playback advances it warms the next queued tracks

--- a/test/features/player/media_artwork_providers_test.dart
+++ b/test/features/player/media_artwork_providers_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/plex/plex_track_mapper.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_artwork.dart';
+import 'package:linthra/features/player/media_artwork_providers.dart';
+
+const _subsonic = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'the-salt',
+  token: 'subsonic-secret-token',
+);
+
+const _plex = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'plex-secret-token',
+  machineIdentifier: 'machine-1',
+);
+
+/// A credential-free Plex cover reference built exactly as `PlexTrackMapper`
+/// builds `Track.artworkUri` (literal `%` pre-escaped), so the test exercises
+/// the same value the catalog persists for a Plex track.
+Uri _plexThumb(String thumbPath) => Uri(
+      scheme: PlexTrackMapper.artworkScheme,
+      path: thumbPath.replaceAll('%', '%25'),
+    );
+
+void main() {
+  group('resolveMediaSessionArtworkUrl', () {
+    // The regression this fixes: a Plex track's plex-thumb: cover reaching the
+    // media session (lock screen / Android Auto). Before the fix the resolver
+    // only knew Subsonic, so a Plex reference resolved to null, was never
+    // fetched/cached, and the now-playing card showed no art.
+    test('resolves a Plex plex-thumb: reference with the live Plex session', () {
+      final Uri? resolved = resolveMediaSessionArtworkUrl(
+        _plexThumb('/library/metadata/123/thumb/1670000000'),
+        plex: _plex,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.host, 'plex.example.com');
+      expect(resolved.port, 32400);
+      expect(resolved.path, '/library/metadata/123/thumb/1670000000');
+      // The token rides in the query (the image layer can't set headers) — and
+      // it is the live session's token, woven in on demand.
+      expect(resolved.queryParameters['X-Plex-Token'], 'plex-secret-token');
+    });
+
+    test('a Plex reference resolves even when a Subsonic session is also present',
+        () {
+      // Proves the providers chain: Subsonic returns null for a plex-thumb:
+      // reference (it isn't a subsonic-cover:), so resolution falls through to
+      // Plex rather than stopping at the first provider. This is exactly the
+      // path that was missing before the fix.
+      final Uri? resolved = resolveMediaSessionArtworkUrl(
+        _plexThumb('/library/metadata/123/thumb/1'),
+        subsonic: _subsonic,
+        plex: _plex,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.host, 'plex.example.com');
+      expect(resolved.queryParameters['X-Plex-Token'], 'plex-secret-token');
+    });
+
+    test('a Plex reference does not resolve when signed out of Plex', () {
+      expect(
+        resolveMediaSessionArtworkUrl(
+          _plexThumb('/library/metadata/123/thumb/1'),
+        ),
+        isNull,
+      );
+    });
+
+    test('resolves a Subsonic reference at the media-session size', () {
+      final Uri? resolved = resolveMediaSessionArtworkUrl(
+        SubsonicArtwork.reference('al-123'),
+        subsonic: _subsonic,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.path, contains('getCoverArt'));
+      expect(resolved.queryParameters['id'], 'al-123');
+      // The media-session path asks the server for a small, fast-to-decode
+      // cover (unlike the in-app full-size render), so the card stays crisp
+      // without crossing the process boundary as a huge bitmap.
+      expect(resolved.queryParameters['size'], '$kMediaSessionArtworkSize');
+      expect(resolved.queryParameters['t'], 'subsonic-secret-token');
+    });
+
+    test('a Subsonic reference resolves to Subsonic even with a Plex session',
+        () {
+      // Subsonic owns its scheme and is tried first, so the Plex session is not
+      // consulted for a subsonic-cover: reference.
+      final Uri? resolved = resolveMediaSessionArtworkUrl(
+        SubsonicArtwork.reference('al-123'),
+        subsonic: _subsonic,
+        plex: _plex,
+      );
+
+      expect(resolved, isNotNull);
+      expect(resolved!.host, 'music.example.com');
+      expect(resolved.toString(), isNot(contains('plex-secret-token')));
+    });
+
+    test('an already-loadable Jellyfin/local cover is left for direct loading',
+        () {
+      // A token-free http(s) image and a local file: cover are platform-
+      // loadable and never reach this cache, so neither provider claims them.
+      for (final Uri loadable in <Uri>[
+        Uri.parse('https://server.example/Items/1/Images/Primary'),
+        Uri.parse('file:///cache/art/abc.img'),
+      ]) {
+        expect(
+          resolveMediaSessionArtworkUrl(
+            loadable,
+            subsonic: _subsonic,
+            plex: _plex,
+          ),
+          isNull,
+          reason: '$loadable must not be rewritten by a reference resolver',
+        );
+      }
+    });
+
+    test('no signed-in providers means no media-session artwork', () {
+      expect(
+        resolveMediaSessionArtworkUrl(_plexThumb('/library/metadata/1/thumb/1')),
+        isNull,
+      );
+      expect(
+        resolveMediaSessionArtworkUrl(SubsonicArtwork.reference('al-1')),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/features/player/media_artwork_providers_test.dart
+++ b/test/features/player/media_artwork_providers_test.dart
@@ -32,7 +32,8 @@ void main() {
     // media session (lock screen / Android Auto). Before the fix the resolver
     // only knew Subsonic, so a Plex reference resolved to null, was never
     // fetched/cached, and the now-playing card showed no art.
-    test('resolves a Plex plex-thumb: reference with the live Plex session', () {
+    test('resolves a Plex plex-thumb: reference with the live Plex session',
+        () {
       final Uri? resolved = resolveMediaSessionArtworkUrl(
         _plexThumb('/library/metadata/123/thumb/1670000000'),
         plex: _plex,
@@ -47,7 +48,8 @@ void main() {
       expect(resolved.queryParameters['X-Plex-Token'], 'plex-secret-token');
     });
 
-    test('a Plex reference resolves even when a Subsonic session is also present',
+    test(
+        'a Plex reference resolves even when a Subsonic session is also present',
         () {
       // Proves the providers chain: Subsonic returns null for a plex-thumb:
       // reference (it isn't a subsonic-cover:), so resolution falls through to
@@ -126,7 +128,8 @@ void main() {
 
     test('no signed-in providers means no media-session artwork', () {
       expect(
-        resolveMediaSessionArtworkUrl(_plexThumb('/library/metadata/1/thumb/1')),
+        resolveMediaSessionArtworkUrl(
+            _plexThumb('/library/metadata/1/thumb/1')),
         isNull,
       );
       expect(


### PR DESCRIPTION
## Problem

When playing **Plex** tracks, album artwork did not appear in:
- Android Auto
- Android lock-screen media controls (and Bluetooth media displays)

…even though the same cover showed fine **in-app**, and Subsonic/Navidrome/Jellyfin covers showed fine on those same system surfaces.

## Root cause

Artwork for the platform media session flows through `MediaArtworkCache`: a credential-free cover *reference* is fetched off the playback path, cached on disk as a `content://` FileProvider URI, and attached to `MediaItem.artUri` — which `audio_service` then converts to the session's album-art bitmap natively.

The cache's resolver (`mediaArtworkCacheProvider.resolveUrl`) only knew how to turn a Subsonic `subsonic-cover:` reference into an authenticated cover URL. A Plex **`plex-thumb:`** reference resolved to `null`, so:

1. the prewarm service never fetched it,
2. the cache never held it (`cached()` returned `null`),
3. the handler attached **no** `artUri` for Plex tracks.

→ blank now-playing artwork for Plex on every system surface.

(In-app artwork worked because the in-app render seam — `installArtworkReferenceResolver` in `main.dart` — resolves `plex-thumb:` separately, so the bug was scoped to the media-session path only.)

Notably, `docs/plex.md` already *described* Plex covers being cached through `MediaArtworkCache` — the design was intended; only the provider wiring was missing.

## Fix

Wire the existing, already-tested `PlexArtwork.resolve` into the cache's resolver chain (Subsonic, then Plex), mirroring the in-app resolver. Plex covers now flow through the **same proven pipeline** Subsonic uses — the one that already makes Subsonic covers appear on the car.

- Extract `resolveMediaSessionArtworkUrl` as a small, pure, testable helper (Subsonic → Plex chaining; each provider owns one reference scheme).
- Point `mediaArtworkCacheProvider` at it, reading both sessions live.
- Add a regression test for the chaining (incl. the "Plex resolves even when a Subsonic session is also present" case that was the missing path).
- Update the Android Auto / Plex docs to reflect Plex covers.

## How this maps to the requirements

1. **MediaSession metadata includes artwork (album-art / display-icon / art keys)** — handled by `audio_service` natively once `artUri` is a loadable `content://`; unchanged, now exercised for Plex.
2. **Convert the Plex artwork URL into a Bitmap** — `MediaArtworkCache` fetches the authenticated Plex cover-art URL into bytes; `audio_service` decodes the `content://` into the session bitmap (downscaled to 256px for reliable cross-process delivery to Android Auto).
3. **Cache locally to avoid re-downloading on every track change** — `MediaArtworkCache` memoizes + writes a private file keyed by a hash of the credential-free reference; reused across launches.
4. **Update MediaSession on every track change (not only on playback start)** — already handled by the handler's `_broadcast` (re-pushes on track change) + `coverReady` re-publish; the fix simply makes `artUri` non-null for Plex.
5. **Compatibility with Android Auto / lock screen / Bluetooth** — identical `content://` + downscaled-bitmap path already proven for Subsonic.

## Constraints honored

- No playback-engine changes.
- No Jellyfin / Navidrome provider changes.
- Scoped to the Plex provider + Android MediaSession integration.
- No UI redesign.
- Token safety preserved: the Plex `X-Plex-Token` is woven in on demand only to fetch, used once, and never persisted (the catalog keeps the credential-free `plex-thumb:` reference); the cached `content://` path carries no credential.

## Testing

- Added `test/features/player/media_artwork_providers_test.dart` covering Plex resolution, Subsonic→Plex chaining, the media-session size for Subsonic, signed-out cases, and pass-through of already-loadable Jellyfin/local covers.
- ⚠️ This environment has no Flutter/Dart toolchain, so `flutter test` / `flutter analyze` were not run locally — relying on CI. Manual on-device verification (a Plex track shows its cover on the lock screen & in Android Auto) is still recommended, consistent with the existing "pending real-car confirmation" note in `docs/android-auto.md`.

## Possible follow-up (out of scope here)

Plex covers are fetched at the stored thumb resolution (the in-app path does the same), then downscaled by `audio_service` for the session bitmap. A future enhancement could request a Plex `/photo/:/transcode`-sized cover (as Subsonic does via its `size` param) to trim the one-time per-cover download.

https://claude.ai/code/session_01Eajbnp4E4qQCWsRC16E371

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eajbnp4E4qQCWsRC16E371)_