### PR TITLE
feat(plex): pick a Plex Home user after sign-in, before any sync

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -119,6 +119,43 @@ Jellyfin's device id + `Authorization` client header.
   Jellyfin/Subsonic "URL + credential, verify against the server" flow, with
   no browser handoff — useful for dev setups and tokens scoped by hand.
 
+### Plex Home user selection (whose library to sync)
+
+A Plex account can host a **Plex Home** — several profiles (the owner plus
+managed users like a partner or a kids profile) sharing one account. After the
+PIN grants the account token, Linthra lists the Home users
+(`GET https://plex.tv/api/v2/home/users`) and, when there is more than one,
+shows a **user picker** *before* the server step and any sync. Picking a profile
+is what keeps onboarding fast and scoped — only that profile's library is
+synced:
+
+- **Owner/admin** — already who the account token belongs to, so no switch is
+  made; the flow continues with the account token.
+- **A managed profile** — Linthra switches into it
+  (`POST https://plex.tv/api/v2/home/users/{uuid}/switch`, plus the profile's
+  PIN when it is protected) to mint that profile's **own** token, then lists
+  servers and builds the session with it. A restricted profile's token only
+  sees the libraries the owner shared, so the synced catalog mirrors exactly
+  what that person may play.
+
+The picker is an **enhancement, never a gate**: an account without Plex Home
+(one user), or a plex.tv hiccup while listing profiles, simply skips it and
+connects as the owner — identical to the pre-picker behaviour. As before,
+nothing syncs automatically on connect (a fresh sign-in starts with an empty
+selection and clears the Plex catalog slice rather than kicking a full library
+walk); the existing library picker + *Sync* path is unchanged.
+
+Implementation: the listing/switch live in `plex_tv_endpoints.dart` /
+`plex_tv_api.dart` (`PlexHomeUser`) / `plex_tv_client.dart` /
+`http_plex_tv_client.dart`; the flow seam (`fetchHomeUsers` / `switchToUser`)
+in `plex_pin_auth.dart`; and the new UI states (`loadingUsers` / `pickingUser`,
+`PlexUserChoice`) in the settings controller/section. Token safety is the same
+as the rest of the flow: the per-profile token is minted by the switch, lives
+only in the controller's in-memory flow state until the session is persisted
+(encrypted), and never reaches `state`, a log, or an exception. The switch URL
+carries the **profile PIN** (a short, low-entropy local PIN — *not* the
+`X-Plex-Token`) as a query param; the account token always rides in the header.
+
 ### Token scope (key safety decision)
 
 Prefer the **per-server `accessToken`** from the resources endpoint over the

--- a/lib/core/sources/plex/http_plex_tv_client.dart
+++ b/lib/core/sources/plex/http_plex_tv_client.dart
@@ -89,6 +89,51 @@ class HttpPlexTvClient implements PlexTvClient {
     ];
   }
 
+  @override
+  Future<List<PlexHomeUser>> fetchHomeUsers({required String token}) async {
+    final http.Response response = await _send(
+      () => _client.get(
+        PlexTvEndpoints.homeUsers(),
+        headers: _headers(token: token),
+      ),
+    );
+    _checkStatus(response);
+    final Object? decoded = _decode(response);
+    // api/v2 answers an object with a `users` array; tolerate a bare array too
+    // so an older/alternate envelope still parses.
+    final Object? rawUsers =
+        decoded is Map<String, dynamic> ? decoded['users'] : decoded;
+    if (rawUsers is! List) {
+      throw PlexException.plexTvUnexpected();
+    }
+    return <PlexHomeUser>[
+      for (final Object? entry in rawUsers)
+        if (entry is Map<String, dynamic>)
+          if (PlexHomeUser.fromJson(entry) case final PlexHomeUser user) user,
+    ];
+  }
+
+  @override
+  Future<String> switchHomeUser({
+    required String uuid,
+    required String token,
+    String? pin,
+  }) async {
+    final http.Response response = await _send(
+      () => _client.post(
+        PlexTvEndpoints.switchHomeUser(uuid: uuid, pin: pin),
+        headers: _headers(token: token),
+      ),
+    );
+    _checkStatus(response);
+    final Object? authToken = _decodeObject(response)['authToken'];
+    if (authToken is String && authToken.isNotEmpty) {
+      return authToken;
+    }
+    // A 2xx switch with no token is unusable — there's nothing to connect with.
+    throw PlexException.plexTvUnexpected();
+  }
+
   /// The headers every plex.tv call sends: `Accept: application/json`, the
   /// stable client-identity headers, and — only when a call needs one — the
   /// account [token] as the `X-Plex-Token` **header** (never a query param,

--- a/lib/core/sources/plex/plex_pin_auth.dart
+++ b/lib/core/sources/plex/plex_pin_auth.dart
@@ -154,6 +154,37 @@ class PlexPinAuth {
     ];
   }
 
+  /// Lists the account's Plex Home users (profiles) so the caller can offer a
+  /// "whose library?" picker before any sync runs. A thin pass-through to the
+  /// tv client — the account [accountToken] rides in the header; the listing
+  /// carries no per-user token. An account without Plex Home simply reports one
+  /// user (the owner), which the caller treats as "nothing to pick".
+  Future<List<PlexHomeUser>> fetchHomeUsers({
+    required String accountToken,
+  }) {
+    return _tvClient.fetchHomeUsers(token: accountToken);
+  }
+
+  /// Switches into the Plex Home user [uuid], returning that profile's own
+  /// account token — the credential the rest of the flow then uses, so the
+  /// fetched servers and the persisted session are scoped to what the profile
+  /// may see. [pin] is required for a protected profile.
+  ///
+  /// The owner/admin already holds [accountToken], so the caller skips this for
+  /// them. Token safety mirrors [waitForAuthToken]: the returned token is the
+  /// only secret that leaves here, never logged and never put in an exception.
+  Future<String> switchToUser({
+    required String uuid,
+    required String accountToken,
+    String? pin,
+  }) {
+    return _tvClient.switchHomeUser(
+      uuid: uuid,
+      token: accountToken,
+      pin: pin,
+    );
+  }
+
   /// Verifies the picked [server] is reachable and returns a session for it.
   ///
   /// Token choice: the server's own **server-scoped** `accessToken` when

--- a/lib/core/sources/plex/plex_tv_api.dart
+++ b/lib/core/sources/plex/plex_tv_api.dart
@@ -190,6 +190,70 @@ class PlexResourceConnection {
       'relay: $relay, protocol: $protocol)';
 }
 
+/// One Plex Home user (profile) on the signed-in account, from
+/// `GET https://plex.tv/api/v2/home/users`.
+///
+/// Plex Home lets several people share one account — the owner plus managed
+/// profiles (a partner, a kids profile). Linthra lists them right after sign-in
+/// so the person can pick **whose** library to use on this device before any
+/// sync runs; the picked profile's own token (minted by the separate switch
+/// call) then scopes every later fetch, so a restricted profile only ever syncs
+/// the libraries it is allowed to see.
+///
+/// Carries **no** secret: the listing has no per-user token (that is granted by
+/// the switch call), only the display fields and the [uuid] the switch
+/// addresses. [protected] means switching into the profile needs its PIN.
+class PlexHomeUser {
+  const PlexHomeUser({
+    required this.uuid,
+    this.id,
+    this.title = '',
+    this.admin = false,
+    this.restricted = false,
+    this.protected = false,
+  });
+
+  /// The profile's stable UUID — what the switch endpoint addresses. Not a
+  /// credential.
+  final String uuid;
+
+  /// The profile's numeric id, when reported. Not a credential.
+  final int? id;
+
+  /// The profile's display name (e.g. "Dad", "Kids"). Not a credential.
+  final String title;
+
+  /// Whether this profile is the account owner/admin. They already hold the
+  /// account token, so switching into them needs no extra call.
+  final bool admin;
+
+  /// Whether this is a restricted (managed) profile — its token sees only the
+  /// libraries the owner shared with it.
+  final bool restricted;
+
+  /// Whether switching into this profile requires its PIN.
+  final bool protected;
+
+  /// Parses one user, or returns `null` when it lacks the [uuid] the switch
+  /// call needs, so a single malformed entry can't break the whole listing.
+  static PlexHomeUser? fromJson(Map<String, dynamic> json) {
+    final String? uuid = _asString(json['uuid']);
+    if (uuid == null || uuid.isEmpty) return null;
+    return PlexHomeUser(
+      uuid: uuid,
+      id: _asInt(json['id']),
+      title: _asString(json['title']) ?? _asString(json['username']) ?? '',
+      admin: _asBool(json['admin']),
+      restricted: _asBool(json['restricted']),
+      protected: _asBool(json['protected']),
+    );
+  }
+
+  @override
+  String toString() => 'PlexHomeUser(uuid: $uuid, id: $id, title: $title, '
+      'admin: $admin, restricted: $restricted, protected: $protected)';
+}
+
 /// Reads a field that plex.tv may report as either a JSON string or a number,
 /// returning a `String?` either way (mirrors `plex_api.dart`).
 String? _asString(Object? value) {

--- a/lib/core/sources/plex/plex_tv_client.dart
+++ b/lib/core/sources/plex/plex_tv_client.dart
@@ -43,4 +43,29 @@ abstract interface class PlexTvClient {
   /// `X-Plex-Token` header. Each returned server carries its own
   /// server-scoped `accessToken` — the credential Linthra actually keeps.
   Future<List<PlexResource>> fetchResources({required String token});
+
+  /// Lists the account's Plex Home users (profiles) via
+  /// `GET /api/v2/home/users`, so the caller can let the user pick whose
+  /// library to use before syncing. [token] is the account token granted by
+  /// [checkPin]; it rides in the `X-Plex-Token` header.
+  ///
+  /// The listing carries **no** per-user token (that is minted by
+  /// [switchHomeUser]); a single user means there is nothing to pick.
+  Future<List<PlexHomeUser>> fetchHomeUsers({required String token});
+
+  /// Switches into the Plex Home user [uuid] via
+  /// `POST /api/v2/home/users/{uuid}/switch`, returning that profile's own
+  /// auth token — the credential that scopes every later fetch to what the
+  /// profile may see.
+  ///
+  /// [token] is the account (owner) token, in the `X-Plex-Token` header. A
+  /// protected profile needs its [pin]. The returned token is a secret — the
+  /// caller hands it on (to fetch resources / build a session) and never logs
+  /// or persists it as-is. Throws `PlexException.signInRejected` (401/403) when
+  /// the PIN is missing or wrong, and the usual token-free failures otherwise.
+  Future<String> switchHomeUser({
+    required String uuid,
+    required String token,
+    String? pin,
+  });
 }

--- a/lib/core/sources/plex/plex_tv_endpoints.dart
+++ b/lib/core/sources/plex/plex_tv_endpoints.dart
@@ -21,6 +21,7 @@ abstract final class PlexTvEndpoints {
 
   static const String _pinsPath = '/api/v2/pins';
   static const String _resourcesPath = '/api/v2/resources';
+  static const String _homeUsersPath = '/api/v2/home/users';
 
   /// `POST https://plex.tv/api/v2/pins?strong=true` — mints a new sign-in PIN.
   ///
@@ -41,6 +42,25 @@ abstract final class PlexTvEndpoints {
   /// `includeRelay` includes the plex.tv relay as a last-resort path.
   static Uri resources() =>
       Uri.parse('$plexTvBaseUrl$_resourcesPath?includeHttps=1&includeRelay=1');
+
+  /// `GET https://plex.tv/api/v2/home/users` — lists the account's Plex Home
+  /// users (profiles). The account token rides in the `X-Plex-Token`
+  /// **header**, so this URL stays token-free and loggable.
+  static Uri homeUsers() => Uri.parse('$plexTvBaseUrl$_homeUsersPath');
+
+  /// `POST https://plex.tv/api/v2/home/users/{uuid}/switch` — switches into a
+  /// Plex Home user, returning that profile's own auth token.
+  ///
+  /// A protected profile needs its [pin] (a short, low-entropy profile PIN —
+  /// **not** the account `X-Plex-Token`); it rides as a query param because
+  /// that is the shape the endpoint expects. The account token still rides in
+  /// the `X-Plex-Token` header, so the URL never carries it.
+  static Uri switchHomeUser({required String uuid, String? pin}) {
+    final String base =
+        '$plexTvBaseUrl$_homeUsersPath/${Uri.encodeComponent(uuid)}/switch';
+    if (pin == null || pin.isEmpty) return Uri.parse(base);
+    return Uri.parse('$base?pin=${Uri.encodeComponent(pin)}');
+  }
 
   /// The `https://app.plex.tv/auth#?…` page the browser opens so the user can
   /// approve the sign-in with their own Plex account.

--- a/lib/features/settings/plex/plex_settings_controller.dart
+++ b/lib/features/settings/plex/plex_settings_controller.dart
@@ -65,6 +65,13 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
   /// [_accountToken]; cleared with it.
   List<PlexResource> _flowServers = const <PlexResource>[];
 
+  /// The account's Plex Home users behind the display-safe
+  /// [PlexSettingsState.users] choices, kept between fetching them and the
+  /// user's pick so [selectUser] can look up the picked profile (its `admin`
+  /// flag decides whether a switch is needed). Holds no token; cleared by
+  /// [_resetLinkFlow] with the rest of the flow state.
+  List<PlexHomeUser> _homeUsers = const <PlexHomeUser>[];
+
   /// The active sign-in link, kept so "Open the sign-in page again" can
   /// re-launch the same PIN's page after the user closed the browser tab.
   PlexPinLink? _activeLink;
@@ -230,12 +237,15 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
 
   /// Starts the "Connect with Plex" browser sign-in: mints a plex.tv PIN,
   /// opens the hosted approval page in the browser, polls until the user
-  /// approves it, then fetches the account's Plex Media Servers — connecting
-  /// straight away when there is exactly one, otherwise showing the server
-  /// picker ([selectServer] finishes it). Safe to call while connected: the
-  /// existing session stays live (and is restored on cancel/failure) until a
-  /// new one actually lands, which is what makes this the "reconnect" action
-  /// for an expired token too.
+  /// approves it, then fetches the account's Plex Home users (profiles) and —
+  /// when there is more than one — shows the user picker ([selectUser] finishes
+  /// it) so only the chosen profile's library is synced. A single-profile
+  /// account skips straight to the server step: fetch the account's Plex Media
+  /// Servers, connecting straight away when there is exactly one, otherwise
+  /// showing the server picker ([selectServer] finishes it). Safe to call while
+  /// connected: the existing session stays live (and is restored on
+  /// cancel/failure) until a new one actually lands, which is what makes this
+  /// the "reconnect" action for an expired token too.
   Future<void> connectWithPlex() async {
     if (state.isBusy || state.isLinkFlowActive) return;
     final int attempt = ++_linkAttempt;
@@ -294,11 +304,54 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     // Cancelled (null) or superseded: someone else owns the card now.
     if (_linkAttempt != attempt || accountToken == null) return;
 
+    // The flow now holds the account token — only until a server is connected,
+    // the flow is cancelled, or it fails.
+    _accountToken = accountToken;
+
+    // Before any sync, fetch the account's Plex Home users so the person can
+    // pick whose library to use. Best-effort by contract: an account without
+    // Plex Home (or a plex.tv hiccup) just skips the picker and connects as the
+    // owner, exactly as before this step existed — listing profiles must never
+    // gate the sign-in.
+    state = state.copyWith(
+      phase: PlexConnectionPhase.loadingUsers,
+      statusMessage: 'Signed in. Finding your Plex users…',
+    );
+    List<PlexHomeUser> users;
+    try {
+      users = await ref
+          .read(plexPinAuthProvider)
+          .fetchHomeUsers(accountToken: accountToken);
+    } on PlexException {
+      users = const <PlexHomeUser>[];
+    }
+    if (_linkAttempt != attempt) return;
+
+    if (users.length <= 1) {
+      // Zero or one profile: nothing to choose — connect as the owner with the
+      // account token.
+      await _continueToServers(accountToken, attempt);
+      return;
+    }
+    // Several profiles: let the user pick whose library to use first.
+    _homeUsers = users;
+    state = state.copyWith(
+      phase: PlexConnectionPhase.pickingUser,
+      users: _userChoicesFor(users),
+      statusMessage: null,
+    );
+  }
+
+  /// The shared "find and pick a server" tail of the sign-in flow, run with
+  /// whichever token scopes this connection: the account (owner) token for a
+  /// single-profile account, or the picked Home profile's token after a switch.
+  /// One server connects directly; several show the picker; none shows the
+  /// picker's clean empty state.
+  Future<void> _continueToServers(String accountToken, int attempt) async {
     state = state.copyWith(
       phase: PlexConnectionPhase.loadingServers,
-      statusMessage: 'Signed in. Finding your Plex Media Servers…',
+      statusMessage: 'Finding your Plex Media Servers…',
     );
-
     final List<PlexResource> servers;
     try {
       servers = await ref
@@ -312,8 +365,9 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     }
     if (_linkAttempt != attempt) return;
 
-    // The flow now holds secrets (account token, per-server tokens) — only
-    // until a server is connected, the flow is cancelled, or it fails.
+    // The flow now holds the connection-scoping token plus the per-server
+    // tokens — only until a server is connected, the flow is cancelled, or it
+    // fails.
     _accountToken = accountToken;
     _flowServers = servers;
 
@@ -341,6 +395,74 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       }
     }
     return false;
+  }
+
+  /// Connects as the picked Plex Home user from the user picker. Switches into
+  /// that profile to mint its own token — so the fetched servers and the
+  /// eventual sync only ever see what that profile may — then continues to the
+  /// server step. The owner/admin already holds the account token, so picking
+  /// them needs no switch. A protected profile needs its [pin]; a failed switch
+  /// returns to the user picker with a friendly, token-free reason so another
+  /// profile (or the same one with the right PIN) can be tried.
+  ///
+  /// Returns whether the switch step proceeded (the connection then completes
+  /// through the server step); an unknown id, or a pick outside the picker, is
+  /// a no-op that returns `false`.
+  Future<bool> selectUser(String uuid, {String? pin}) async {
+    if (state.phase != PlexConnectionPhase.pickingUser) return false;
+    final String? accountToken = _accountToken;
+    if (accountToken == null) return false;
+    PlexHomeUser? picked;
+    for (final PlexHomeUser user in _homeUsers) {
+      if (user.uuid == uuid) {
+        picked = user;
+        break;
+      }
+    }
+    if (picked == null) return false;
+    final int attempt = _linkAttempt;
+
+    final String who =
+        picked.title.isNotEmpty ? picked.title : 'your Plex user';
+    state = state.copyWith(
+      phase: PlexConnectionPhase.loadingServers,
+      statusMessage: 'Switching to $who…',
+      errorMessage: null,
+      errorKind: null,
+    );
+
+    final String userToken;
+    if (picked.admin) {
+      // The owner's profile is exactly who the account token belongs to — no
+      // switch call (or PIN) needed.
+      userToken = accountToken;
+    } else {
+      try {
+        userToken = await ref.read(plexPinAuthProvider).switchToUser(
+              uuid: uuid,
+              accountToken: accountToken,
+              pin: pin,
+            );
+      } on PlexException catch (error) {
+        if (_linkAttempt != attempt) return false;
+        // Back to the user picker so another profile — or the right PIN — can
+        // be tried. A protected profile's rejection is almost always the PIN.
+        final bool pinIssue =
+            picked.protected && error.kind == PlexErrorKind.unauthorized;
+        state = state.copyWith(
+          phase: PlexConnectionPhase.pickingUser,
+          statusMessage: null,
+          errorMessage: pinIssue
+              ? "That PIN wasn't accepted. Check it and try again."
+              : error.message,
+          errorKind: error.kind,
+        );
+        return false;
+      }
+    }
+    if (_linkAttempt != attempt) return false;
+    await _continueToServers(userToken, attempt);
+    return true;
   }
 
   /// Abandons the "Connect with Plex" flow at any of its stages, releasing
@@ -502,6 +624,7 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
     _linkAttempt++;
     _accountToken = null;
     _flowServers = const <PlexResource>[];
+    _homeUsers = const <PlexHomeUser>[];
     _activeLink = null;
     _linkFlowOwnsCard = false;
   }
@@ -531,6 +654,21 @@ class PlexSettingsController extends Notifier<PlexSettingsState> {
       return;
     }
     state = const PlexSettingsState();
+  }
+
+  /// The display-safe picker projections of the flow's Home users — the only
+  /// shape of them that may reach [state].
+  List<PlexUserChoice> _userChoicesFor(List<PlexHomeUser> users) {
+    return List<PlexUserChoice>.unmodifiable(<PlexUserChoice>[
+      for (final PlexHomeUser user in users)
+        PlexUserChoice(
+          uuid: user.uuid,
+          title: user.title.isNotEmpty ? user.title : 'Plex user',
+          admin: user.admin,
+          restricted: user.restricted,
+          protected: user.protected,
+        ),
+    ]);
   }
 
   /// The display-safe picker projections of the flow's server resources —

--- a/lib/features/settings/plex/plex_settings_section.dart
+++ b/lib/features/settings/plex/plex_settings_section.dart
@@ -84,6 +84,12 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
         .selectServer(clientIdentifier);
   }
 
+  Future<void> _selectUser(String uuid, {String? pin}) async {
+    await ref
+        .read(plexSettingsControllerProvider.notifier)
+        .selectUser(uuid, pin: pin);
+  }
+
   Future<void> _test() async {
     FocusScope.of(context).unfocus();
     await ref.read(plexSettingsControllerProvider.notifier).testConnection(
@@ -232,6 +238,21 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
           _LinkingView(
             statusMessage: state.statusMessage,
             onReopen: _reopenSignIn,
+            onCancel: _cancelLink,
+          ),
+        ];
+      case PlexConnectionPhase.loadingUsers:
+        return [
+          _FlowBusyView(
+            message: state.statusMessage ?? 'Finding your Plex users…',
+            onCancel: _cancelLink,
+          ),
+        ];
+      case PlexConnectionPhase.pickingUser:
+        return [
+          _UserPickerView(
+            users: state.users,
+            onSelect: _selectUser,
             onCancel: _cancelLink,
           ),
         ];
@@ -541,6 +562,185 @@ class _FlowBusyView extends StatelessWidget {
             child: const Text('Cancel'),
           ),
         ],
+      ],
+    );
+  }
+}
+
+/// The user picker: one entry per Plex Home user (profile) on the signed-in
+/// account, so the person chooses whose library to use before any sync — the
+/// step that keeps onboarding fast. A protected profile reveals an inline PIN
+/// entry on tap; an unprotected one is picked straight away. Shows display
+/// names only — never tokens (the listing has none anyway).
+class _UserPickerView extends StatefulWidget {
+  const _UserPickerView({
+    required this.users,
+    required this.onSelect,
+    required this.onCancel,
+  });
+
+  final List<PlexUserChoice> users;
+  final void Function(String uuid, {String? pin})? onSelect;
+  final VoidCallback? onCancel;
+
+  @override
+  State<_UserPickerView> createState() => _UserPickerViewState();
+}
+
+class _UserPickerViewState extends State<_UserPickerView> {
+  final TextEditingController _pinController = TextEditingController();
+
+  /// The uuid of the protected profile currently being asked for its PIN, or
+  /// `null` while the plain profile list is shown.
+  String? _pinForUuid;
+
+  @override
+  void dispose() {
+    _pinController.dispose();
+    super.dispose();
+  }
+
+  void _tap(PlexUserChoice user) {
+    if (user.protected) {
+      _pinController.clear();
+      setState(() => _pinForUuid = user.uuid);
+    } else {
+      widget.onSelect?.call(user.uuid);
+    }
+  }
+
+  void _submitPin(String uuid) {
+    final String pin = _pinController.text.trim();
+    widget.onSelect?.call(uuid, pin: pin.isEmpty ? null : pin);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    final String? pinUuid = _pinForUuid;
+    if (pinUuid != null) {
+      final PlexUserChoice user = widget.users.firstWhere(
+        (PlexUserChoice u) => u.uuid == pinUuid,
+        orElse: () => PlexUserChoice(uuid: pinUuid, title: 'Plex user'),
+      );
+      return _PinEntry(
+        title: user.title,
+        controller: _pinController,
+        onSubmit: widget.onSelect == null ? null : () => _submitPin(pinUuid),
+        onBack: () => setState(() => _pinForUuid = null),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Choose your Plex user', style: theme.textTheme.titleSmall),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          'Pick the profile to use on this device — only its library is '
+          'synced, so onboarding stays fast.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        for (final PlexUserChoice user in widget.users)
+          ListTile(
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+            leading: Icon(
+              user.admin ? Icons.person_outline : Icons.people_outline,
+            ),
+            title: Text(user.title),
+            subtitle: Text(_subtitleFor(user)),
+            trailing: Icon(
+              user.protected
+                  ? Icons.lock_outline
+                  : Icons.chevron_right_outlined,
+            ),
+            onTap: widget.onSelect == null ? null : () => _tap(user),
+          ),
+        const SizedBox(height: AppSpacing.sm),
+        OutlinedButton(
+          onPressed: widget.onCancel,
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+
+  String _subtitleFor(PlexUserChoice user) {
+    final List<String> parts = <String>[
+      if (user.admin) 'Account owner' else 'Managed profile',
+      if (user.protected) 'PIN protected',
+    ];
+    return parts.join(' · ');
+  }
+}
+
+/// The inline PIN entry shown when a protected Plex Home profile is picked —
+/// part of the same card, never a dialog, matching the rest of the flow.
+class _PinEntry extends StatelessWidget {
+  const _PinEntry({
+    required this.title,
+    required this.controller,
+    required this.onSubmit,
+    required this.onBack,
+  });
+
+  final String title;
+  final TextEditingController controller;
+  final VoidCallback? onSubmit;
+  final VoidCallback? onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Enter the PIN for $title', style: theme.textTheme.titleSmall),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          'This Plex profile is protected — enter its PIN to switch into it.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        TextField(
+          controller: controller,
+          autofocus: true,
+          obscureText: true,
+          keyboardType: TextInputType.number,
+          autocorrect: false,
+          // A profile PIN is not the account token, but keep it out of the
+          // keyboard's learning store anyway.
+          enableSuggestions: false,
+          textInputAction: TextInputAction.done,
+          onSubmitted: onSubmit == null ? null : (_) => onSubmit!(),
+          decoration: const InputDecoration(
+            labelText: 'Profile PIN',
+            prefixIcon: Icon(Icons.lock_outline),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: onBack,
+                child: const Text('Back'),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: FilledButton(
+                onPressed: onSubmit,
+                child: const Text('Continue'),
+              ),
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/lib/features/settings/plex/plex_settings_state.dart
+++ b/lib/features/settings/plex/plex_settings_state.dart
@@ -26,6 +26,16 @@ enum PlexConnectionPhase {
   /// user is away in the browser); cancellable.
   linking,
 
+  /// The sign-in was approved; the account's Plex Home users (profiles) are
+  /// being fetched from plex.tv, before the server step.
+  loadingUsers,
+
+  /// The Home users are known and the user is choosing which profile to use
+  /// ([PlexSettingsState.users] holds the choices). Only reached when the
+  /// account has more than one profile; a single-user account skips straight
+  /// to the server step.
+  pickingUser,
+
   /// The sign-in was approved; the account's Plex Media Servers are being
   /// fetched from plex.tv.
   loadingServers,
@@ -105,6 +115,55 @@ class PlexServerChoice {
       'name: $name, productVersion: $productVersion, owned: $owned)';
 }
 
+/// One Plex Home user (profile) the user can pick after signing in — the
+/// display-safe projection of a `PlexHomeUser`, so the user picker UI (and this
+/// state) never touches the wire DTO. **No field is a secret**: the listing has
+/// no per-user token, and the one minted by switching into the profile stays in
+/// the controller's private flow state and the (encrypted) session.
+@immutable
+class PlexUserChoice {
+  const PlexUserChoice({
+    required this.uuid,
+    required this.title,
+    this.admin = false,
+    this.restricted = false,
+    this.protected = false,
+  });
+
+  /// The profile's stable UUID, used to tell the controller which profile was
+  /// picked. Not a credential.
+  final String uuid;
+
+  /// The profile's display name.
+  final String title;
+
+  /// Whether this profile is the account owner/admin.
+  final bool admin;
+
+  /// Whether this is a restricted (managed) profile.
+  final bool restricted;
+
+  /// Whether switching into this profile requires its PIN.
+  final bool protected;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PlexUserChoice &&
+          other.uuid == uuid &&
+          other.title == title &&
+          other.admin == admin &&
+          other.restricted == restricted &&
+          other.protected == protected);
+
+  @override
+  int get hashCode => Object.hash(uuid, title, admin, restricted, protected);
+
+  @override
+  String toString() => 'PlexUserChoice(uuid: $uuid, title: $title, '
+      'admin: $admin, restricted: $restricted, protected: $protected)';
+}
+
 /// Immutable snapshot the Plex settings UI renders from.
 ///
 /// The screen reads this and never reaches into HTTP, the authenticator, or the
@@ -126,6 +185,7 @@ class PlexSettingsState {
     this.sectionsLoaded = false,
     this.selectedSectionKeys = const <String>[],
     this.servers = const <PlexServerChoice>[],
+    this.users = const <PlexUserChoice>[],
     this.statusMessage,
     this.errorMessage,
     this.errorKind,
@@ -171,6 +231,12 @@ class PlexSettingsState {
   /// projections only; the token-bearing resources stay in the controller.
   final List<PlexServerChoice> servers;
 
+  /// The account's Plex Home users (profiles), for the user picker
+  /// ([PlexConnectionPhase.pickingUser]). Display-safe projections only; the
+  /// per-profile token minted by switching stays in the controller. Empty
+  /// outside the picker.
+  final List<PlexUserChoice> users;
+
   /// A friendly, non-error status line (e.g. "Connected to Plex…").
   final String? statusMessage;
 
@@ -190,13 +256,16 @@ class PlexSettingsState {
   bool get isBusy =>
       phase == PlexConnectionPhase.testing ||
       phase == PlexConnectionPhase.connecting ||
+      phase == PlexConnectionPhase.loadingUsers ||
       phase == PlexConnectionPhase.loadingServers;
 
   /// True while the "Connect with Plex" sign-in flow owns the card (waiting
-  /// on the browser, loading servers, or picking one) — the phases a Cancel
-  /// returns from.
+  /// on the browser, loading users/servers, or picking one) — the phases a
+  /// Cancel returns from.
   bool get isLinkFlowActive =>
       phase == PlexConnectionPhase.linking ||
+      phase == PlexConnectionPhase.loadingUsers ||
+      phase == PlexConnectionPhase.pickingUser ||
       phase == PlexConnectionPhase.loadingServers ||
       phase == PlexConnectionPhase.pickingServer;
 
@@ -224,6 +293,7 @@ class PlexSettingsState {
     bool? sectionsLoaded,
     List<String>? selectedSectionKeys,
     List<PlexServerChoice>? servers,
+    List<PlexUserChoice>? users,
     Object? statusMessage = _unset,
     Object? errorMessage = _unset,
     Object? errorKind = _unset,
@@ -238,6 +308,7 @@ class PlexSettingsState {
       sectionsLoaded: sectionsLoaded ?? this.sectionsLoaded,
       selectedSectionKeys: selectedSectionKeys ?? this.selectedSectionKeys,
       servers: servers ?? this.servers,
+      users: users ?? this.users,
       statusMessage: identical(statusMessage, _unset)
           ? this.statusMessage
           : statusMessage as String?,

--- a/test/core/sources/plex/fake_plex_tv_client.dart
+++ b/test/core/sources/plex/fake_plex_tv_client.dart
@@ -18,7 +18,12 @@ class FakePlexTvClient implements PlexTvClient {
     List<Object?>? checkPinScript,
     this.resources = const <PlexResource>[],
     this.resourcesError,
-  }) : checkPinScript = checkPinScript ?? <Object?>[];
+    this.homeUsers = const <PlexHomeUser>[],
+    this.homeUsersError,
+    Map<String, String>? switchTokens,
+    this.switchError,
+  })  : checkPinScript = checkPinScript ?? <Object?>[],
+        switchTokens = switchTokens ?? <String, String>{};
 
   /// Canned PIN for [createPin].
   PlexPin pin;
@@ -34,11 +39,25 @@ class FakePlexTvClient implements PlexTvClient {
   List<PlexResource> resources;
   PlexException? resourcesError;
 
+  /// Canned Plex Home users for [fetchHomeUsers].
+  List<PlexHomeUser> homeUsers;
+  PlexException? homeUsersError;
+
+  /// Per-uuid tokens returned by [switchHomeUser]; an unmapped uuid falls back
+  /// to a deterministic `switched-token-<uuid>`.
+  Map<String, String> switchTokens;
+  PlexException? switchError;
+
   // Recorded inputs.
   int createPinCount = 0;
   int checkPinCount = 0;
   int? lastCheckedPinId;
   String? lastResourcesToken;
+  String? lastHomeUsersToken;
+  int switchCount = 0;
+  String? lastSwitchedUuid;
+  String? lastSwitchToken;
+  String? lastSwitchPin;
 
   @override
   Future<PlexPin> createPin() async {
@@ -64,5 +83,28 @@ class FakePlexTvClient implements PlexTvClient {
     final PlexException? error = resourcesError;
     if (error != null) throw error;
     return resources;
+  }
+
+  @override
+  Future<List<PlexHomeUser>> fetchHomeUsers({required String token}) async {
+    lastHomeUsersToken = token;
+    final PlexException? error = homeUsersError;
+    if (error != null) throw error;
+    return homeUsers;
+  }
+
+  @override
+  Future<String> switchHomeUser({
+    required String uuid,
+    required String token,
+    String? pin,
+  }) async {
+    switchCount++;
+    lastSwitchedUuid = uuid;
+    lastSwitchToken = token;
+    lastSwitchPin = pin;
+    final PlexException? error = switchError;
+    if (error != null) throw error;
+    return switchTokens[uuid] ?? 'switched-token-$uuid';
   }
 }

--- a/test/core/sources/plex/http_plex_tv_client_test.dart
+++ b/test/core/sources/plex/http_plex_tv_client_test.dart
@@ -218,6 +218,126 @@ void main() {
     });
   });
 
+  group('fetchHomeUsers', () {
+    test('GETs /api/v2/home/users with the token in the header only', () async {
+      http.Request? captured;
+      final HttpPlexTvClient client = _client(MockClient((r) async {
+        captured = r;
+        return _json(const <String, dynamic>{'users': <Object?>[]});
+      }));
+
+      await client.fetchHomeUsers(token: _accountToken);
+
+      expect(captured!.method, 'GET');
+      expect(captured!.url.path, '/api/v2/home/users');
+      expect(captured!.headers['x-plex-token'], _accountToken);
+      expect(captured!.url.toString(), isNot(contains(_accountToken)));
+    });
+
+    test('parses the users array, skipping malformed entries', () async {
+      final HttpPlexTvClient client = _client(MockClient((_) async => _json(
+            const <String, dynamic>{
+              'users': <Object?>[
+                <String, dynamic>{
+                  'id': 1,
+                  'uuid': 'uuid-owner',
+                  'title': 'Dad',
+                  'admin': true,
+                  'protected': true,
+                },
+                <String, dynamic>{'title': 'no uuid'}, // unusable
+                'garbage',
+              ],
+            },
+          )));
+
+      final List<PlexHomeUser> users =
+          await client.fetchHomeUsers(token: _accountToken);
+
+      expect(users, hasLength(1));
+      expect(users.single.uuid, 'uuid-owner');
+      expect(users.single.title, 'Dad');
+      expect(users.single.admin, isTrue);
+      expect(users.single.protected, isTrue);
+    });
+
+    test('tolerates a bare array envelope', () async {
+      final HttpPlexTvClient client = _client(MockClient((_) async => _json(
+            const <Object?>[
+              <String, dynamic>{'uuid': 'u1', 'title': 'A'},
+            ],
+          )));
+
+      final List<PlexHomeUser> users =
+          await client.fetchHomeUsers(token: _accountToken);
+      expect(users.single.uuid, 'u1');
+    });
+
+    test('treats a non-list users field as unusable', () async {
+      final HttpPlexTvClient client = _client(
+        MockClient(
+            (_) async => _json(const <String, dynamic>{'users': 'nope'})),
+      );
+
+      await expectLater(
+        client.fetchHomeUsers(token: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unexpected)),
+      );
+    });
+  });
+
+  group('switchHomeUser', () {
+    test('POSTs the switch and returns the granted token', () async {
+      http.Request? captured;
+      final HttpPlexTvClient client = _client(MockClient((r) async {
+        captured = r;
+        return _json(const <String, dynamic>{
+          'uuid': 'uuid-kid',
+          'authToken': 'kid-scoped-token',
+        });
+      }));
+
+      final String token = await client.switchHomeUser(
+        uuid: 'uuid-kid',
+        token: _accountToken,
+        pin: '1234',
+      );
+
+      expect(token, 'kid-scoped-token');
+      expect(captured!.method, 'POST');
+      expect(captured!.url.path, '/api/v2/home/users/uuid-kid/switch');
+      expect(captured!.url.queryParameters['pin'], '1234');
+      // The account (owner) token authorizes the switch via the header.
+      expect(captured!.headers['x-plex-token'], _accountToken);
+    });
+
+    test('a 401 (wrong/missing pin) maps to an unauthorized rejection',
+        () async {
+      final HttpPlexTvClient client =
+          _client(MockClient((_) async => http.Response('', 401)));
+
+      await expectLater(
+        client.switchHomeUser(uuid: 'uuid-kid', token: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+    });
+
+    test('a 2xx switch with no token is unusable', () async {
+      final HttpPlexTvClient client = _client(
+        MockClient(
+            (_) async => _json(const <String, dynamic>{'uuid': 'uuid-kid'})),
+      );
+
+      await expectLater(
+        client.switchHomeUser(uuid: 'uuid-kid', token: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unexpected)),
+      );
+    });
+  });
+
   group('token safety', () {
     test('every failure path throws a token-free message', () async {
       final List<MockClient> failures = <MockClient>[
@@ -233,6 +353,25 @@ void main() {
         final HttpPlexTvClient client = _client(mock);
         try {
           await client.fetchResources(token: _accountToken);
+          fail('expected a PlexException');
+        } on PlexException catch (error) {
+          expect(error.message, isNot(contains(_accountToken)));
+          expect(error.toString(), isNot(contains(_accountToken)));
+        }
+      }
+    });
+
+    test('a failed home-user switch never echoes the account token', () async {
+      final List<MockClient> failures = <MockClient>[
+        MockClient((_) async => http.Response('', 401)),
+        MockClient((_) async => http.Response('', 500)),
+        MockClient((_) async => throw http.ClientException('boom')),
+      ];
+
+      for (final MockClient mock in failures) {
+        final HttpPlexTvClient client = _client(mock);
+        try {
+          await client.switchHomeUser(uuid: 'u', token: _accountToken);
           fail('expected a PlexException');
         } on PlexException catch (error) {
           expect(error.message, isNot(contains(_accountToken)));

--- a/test/core/sources/plex/plex_pin_auth_test.dart
+++ b/test/core/sources/plex/plex_pin_auth_test.dart
@@ -221,6 +221,78 @@ void main() {
     });
   });
 
+  group('fetchHomeUsers', () {
+    test('lists the account profiles with the account token', () async {
+      const PlexHomeUser owner = PlexHomeUser(
+        uuid: 'uuid-owner',
+        title: 'Dad',
+        admin: true,
+      );
+      const PlexHomeUser kid = PlexHomeUser(
+        uuid: 'uuid-kid',
+        title: 'Kids',
+        restricted: true,
+      );
+      final tvClient = FakePlexTvClient(
+        homeUsers: const <PlexHomeUser>[owner, kid],
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      final List<PlexHomeUser> users =
+          await auth.fetchHomeUsers(accountToken: _accountToken);
+
+      expect(users.map((u) => u.uuid), <String>['uuid-owner', 'uuid-kid']);
+      expect(tvClient.lastHomeUsersToken, _accountToken);
+    });
+
+    test('propagates a plex.tv failure for the caller to handle', () async {
+      final tvClient = FakePlexTvClient(
+        homeUsersError: PlexException.plexTvError(503),
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      await expectLater(
+        auth.fetchHomeUsers(accountToken: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.serverError)),
+      );
+    });
+  });
+
+  group('switchToUser', () {
+    test('switches into a profile, forwarding the pin and account token',
+        () async {
+      final tvClient = FakePlexTvClient(
+        switchTokens: <String, String>{'uuid-kid': 'kid-scoped-token'},
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      final String token = await auth.switchToUser(
+        uuid: 'uuid-kid',
+        accountToken: _accountToken,
+        pin: '4242',
+      );
+
+      expect(token, 'kid-scoped-token');
+      expect(tvClient.lastSwitchedUuid, 'uuid-kid');
+      expect(tvClient.lastSwitchToken, _accountToken);
+      expect(tvClient.lastSwitchPin, '4242');
+    });
+
+    test('propagates a rejected switch (wrong pin)', () async {
+      final tvClient = FakePlexTvClient(
+        switchError: PlexException.signInRejected(),
+      );
+      final PlexPinAuth auth = _auth(tvClient: tvClient);
+
+      await expectLater(
+        auth.switchToUser(uuid: 'uuid-kid', accountToken: _accountToken),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unauthorized)),
+      );
+    });
+  });
+
   group('connectToServer', () {
     test('prefers the server-scoped token and probes the first connection',
         () async {

--- a/test/core/sources/plex/plex_tv_api_test.dart
+++ b/test/core/sources/plex/plex_tv_api_test.dart
@@ -173,4 +173,75 @@ void main() {
       expect(resource.toString(), contains('accessToken: null'));
     });
   });
+
+  group('PlexHomeUser', () {
+    test('parses the owner and a managed profile', () {
+      final PlexHomeUser? owner = PlexHomeUser.fromJson(const <String, dynamic>{
+        'id': 12345,
+        'uuid': 'uuid-owner',
+        'title': 'Dad',
+        'admin': true,
+        'restricted': false,
+        'protected': true,
+      });
+      expect(owner, isNotNull);
+      expect(owner!.uuid, 'uuid-owner');
+      expect(owner.id, 12345);
+      expect(owner.title, 'Dad');
+      expect(owner.admin, isTrue);
+      expect(owner.restricted, isFalse);
+      expect(owner.protected, isTrue);
+
+      final PlexHomeUser? kid = PlexHomeUser.fromJson(const <String, dynamic>{
+        'uuid': 'uuid-kid',
+        'title': 'Kids',
+        'admin': false,
+        'restricted': true,
+        'protected': false,
+      });
+      expect(kid!.admin, isFalse);
+      expect(kid.restricted, isTrue);
+      expect(kid.protected, isFalse);
+    });
+
+    test('falls back to username, then empty, for a missing title', () {
+      expect(
+        PlexHomeUser.fromJson(const <String, dynamic>{
+          'uuid': 'u',
+          'username': 'guest42',
+        })!
+            .title,
+        'guest42',
+      );
+      expect(
+        PlexHomeUser.fromJson(const <String, dynamic>{'uuid': 'u'})!.title,
+        '',
+      );
+    });
+
+    test('tolerates 0/1 and string booleans from older envelopes', () {
+      final PlexHomeUser? user = PlexHomeUser.fromJson(const <String, dynamic>{
+        'uuid': 'u',
+        'id': '99',
+        'admin': '1',
+        'restricted': 0,
+        'protected': 'true',
+      });
+      expect(user!.id, 99);
+      expect(user.admin, isTrue);
+      expect(user.restricted, isFalse);
+      expect(user.protected, isTrue);
+    });
+
+    test('returns null without a uuid (nothing to switch into)', () {
+      expect(
+        PlexHomeUser.fromJson(const <String, dynamic>{'title': 'No uuid'}),
+        isNull,
+      );
+      expect(
+        PlexHomeUser.fromJson(const <String, dynamic>{'uuid': ''}),
+        isNull,
+      );
+    });
+  });
 }

--- a/test/core/sources/plex/plex_tv_endpoints_test.dart
+++ b/test/core/sources/plex/plex_tv_endpoints_test.dart
@@ -24,6 +24,53 @@ void main() {
     });
   });
 
+  group('homeUsers', () {
+    test('lists the account profiles at /api/v2/home/users', () {
+      final Uri url = PlexTvEndpoints.homeUsers();
+      expect(url.toString(), 'https://plex.tv/api/v2/home/users');
+      // The token rides in the header, so the URL itself is token-free.
+      expect(url.query, isEmpty);
+    });
+  });
+
+  group('switchHomeUser', () {
+    test('switches a profile by uuid, no pin', () {
+      final Uri url = PlexTvEndpoints.switchHomeUser(uuid: 'uuid-kids');
+      expect(
+        url.toString(),
+        'https://plex.tv/api/v2/home/users/uuid-kids/switch',
+      );
+      expect(url.query, isEmpty);
+    });
+
+    test('passes a profile pin as a query param', () {
+      final Uri url =
+          PlexTvEndpoints.switchHomeUser(uuid: 'uuid-kids', pin: '1234');
+      expect(url.path, '/api/v2/home/users/uuid-kids/switch');
+      expect(url.queryParameters['pin'], '1234');
+    });
+
+    test('an empty pin is omitted, not sent blank', () {
+      final Uri url =
+          PlexTvEndpoints.switchHomeUser(uuid: 'uuid-kids', pin: '');
+      expect(url.query, isEmpty);
+    });
+
+    test('percent-encodes the uuid and pin', () {
+      final Uri url =
+          PlexTvEndpoints.switchHomeUser(uuid: 'a/b uuid', pin: '12&34');
+      final String text = url.toString();
+      expect(text, contains('home/users/a%2Fb%20uuid/switch'));
+      expect(text, contains('pin=12%2634'));
+    });
+
+    test('never carries a token parameter', () {
+      final Uri url =
+          PlexTvEndpoints.switchHomeUser(uuid: 'uuid-kids', pin: '1234');
+      expect(url.toString().toLowerCase(), isNot(contains('x-plex-token')));
+    });
+  });
+
   group('authApp', () {
     test('builds the hosted sign-in page with params in the fragment', () {
       final Uri url = PlexTvEndpoints.authApp(

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -79,6 +79,27 @@ const PlexResource _atticResource = PlexResource(
   ],
 );
 
+/// The same office server but with no server-scoped token, so
+/// `connectToServer` falls back to whatever account/profile token the flow
+/// carries — letting a test assert the *profile* token ends up in the session.
+const PlexResource _unscopedOfficeResource = PlexResource(
+  name: 'Office Server',
+  clientIdentifier: 'fake-machine-id',
+  provides: 'server',
+  connections: <PlexResourceConnection>[
+    PlexResourceConnection(uri: 'https://office.abc.plex.direct:32400'),
+  ],
+);
+
+const String _kidsToken = 'super-secret-kids-account-token';
+
+const PlexHomeUser _ownerUser =
+    PlexHomeUser(uuid: 'uuid-owner', title: 'Dad', admin: true);
+const PlexHomeUser _kidUser =
+    PlexHomeUser(uuid: 'uuid-kid', title: 'Kids', restricted: true);
+const PlexHomeUser _protectedUser =
+    PlexHomeUser(uuid: 'uuid-teen', title: 'Teen', protected: true);
+
 /// An [ExternalLinkLauncher] that records what it was asked to open and
 /// never touches a real browser.
 class _RecordingLauncher implements ExternalLinkLauncher {
@@ -1887,6 +1908,286 @@ void main() {
         expect(text, isNot(contains(secret)));
       }
       expect(text, contains('<redacted>'));
+    });
+  });
+
+  group('connect with Plex (user selection)', () {
+    test('a multi-profile account shows the user picker before any sync',
+        () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          homeUsers: const <PlexHomeUser>[_ownerUser, _kidUser],
+          resources: const <PlexResource>[_officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.pickingUser);
+      expect(state.users, const <PlexUserChoice>[
+        PlexUserChoice(uuid: 'uuid-owner', title: 'Dad', admin: true),
+        PlexUserChoice(uuid: 'uuid-kid', title: 'Kids', restricted: true),
+      ]);
+      // Nothing connected, synced, or even server-listed yet — the whole point
+      // is that onboarding pauses here instead of barrelling into a sync.
+      expect(state.servers, isEmpty);
+      expect(notifier.session, isNull);
+      expect(container.read(plexMusicSourceProvider), isNull);
+    });
+
+    test('picking the owner connects with the account token — no switch',
+        () async {
+      final store = InMemoryPlexSessionStore();
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        homeUsers: const <PlexHomeUser>[_ownerUser, _kidUser],
+        resources: const <PlexResource>[_officeResource],
+      );
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      final ok = await notifier.selectUser('uuid-owner');
+
+      expect(ok, isTrue);
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.connected,
+      );
+      // The owner already holds the account token: no switch call was made…
+      expect(tvClient.switchCount, 0);
+      // …and the servers were listed as the owner.
+      expect(tvClient.lastResourcesToken, _accountToken);
+      expect((await store.read())!.token, _serverScopedToken);
+    });
+
+    test(
+        'picking a managed profile switches into it and connects scoped to '
+        'that profile', () async {
+      final store = InMemoryPlexSessionStore();
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        homeUsers: const <PlexHomeUser>[_ownerUser, _kidUser],
+        switchTokens: <String, String>{'uuid-kid': _kidsToken},
+        // Unscoped, so the persisted token is the *profile* token — proof the
+        // session (and so every later sync) is scoped to the picked user.
+        resources: const <PlexResource>[_unscopedOfficeResource],
+      );
+      final container = _container(store: store, tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      final ok = await notifier.selectUser('uuid-kid');
+
+      expect(ok, isTrue);
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.connected,
+      );
+      // The flow switched into the kid profile once…
+      expect(tvClient.switchCount, 1);
+      expect(tvClient.lastSwitchedUuid, 'uuid-kid');
+      expect(tvClient.lastSwitchToken, _accountToken);
+      // …and everything after the switch ran as that profile: the servers were
+      // listed with the profile token, and the session carries it.
+      expect(tvClient.lastResourcesToken, _kidsToken);
+      expect((await store.read())!.token, _kidsToken);
+    });
+
+    test('a protected profile is switched with the entered PIN', () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        homeUsers: const <PlexHomeUser>[_ownerUser, _protectedUser],
+        switchTokens: <String, String>{'uuid-teen': 'teen-token'},
+        resources: const <PlexResource>[_officeResource],
+      );
+      final container = _container(tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      await notifier.selectUser('uuid-teen', pin: '4242');
+
+      expect(tvClient.lastSwitchedUuid, 'uuid-teen');
+      expect(tvClient.lastSwitchPin, '4242');
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.connected,
+      );
+    });
+
+    test('a wrong PIN returns to the user picker, then retries successfully',
+        () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        homeUsers: const <PlexHomeUser>[_ownerUser, _protectedUser],
+        switchError: PlexException.signInRejected(),
+        resources: const <PlexResource>[_officeResource],
+      );
+      final container = _container(tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      final ok = await notifier.selectUser('uuid-teen', pin: '0000');
+
+      expect(ok, isFalse);
+      var state = container.read(plexSettingsControllerProvider);
+      // Back on the picker, both profiles still offered, nothing connected.
+      expect(state.phase, PlexConnectionPhase.pickingUser);
+      expect(state.users, hasLength(2));
+      expect(state.errorMessage, contains('PIN'));
+      expect(state.errorKind, PlexErrorKind.unauthorized);
+      expect(notifier.session, isNull);
+
+      // Entering the right PIN switches and connects.
+      tvClient.switchError = null;
+      final retry = await notifier.selectUser('uuid-teen', pin: '4242');
+      expect(retry, isTrue);
+      state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.errorMessage, isNull);
+    });
+
+    test('a single-profile account skips the picker entirely', () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        // Plex Home off (or just the owner): one user, nothing to choose.
+        homeUsers: const <PlexHomeUser>[_ownerUser],
+        resources: const <PlexResource>[_officeResource],
+      );
+      final container = _container(tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      // Straight to connected, as the owner — no picker, no switch.
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.connected,
+      );
+      expect(tvClient.switchCount, 0);
+      expect(tvClient.lastResourcesToken, _accountToken);
+    });
+
+    test('a home-users fetch failure falls back to connecting as the owner',
+        () async {
+      final tvClient = FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        homeUsersError: PlexException.plexTvError(503),
+        resources: const <PlexResource>[_officeResource],
+      );
+      final container = _container(tvClient: tvClient);
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      await notifier.connectWithPlex();
+
+      // The picker is an enhancement, never a gate: the sign-in still connects,
+      // with no error from the swallowed profiles lookup.
+      final state = container.read(plexSettingsControllerProvider);
+      expect(state.phase, PlexConnectionPhase.connected);
+      expect(state.errorMessage, isNull);
+      expect(tvClient.lastResourcesToken, _accountToken);
+    });
+
+    test('cancelling from the user picker restores the signed-out card',
+        () async {
+      final store = InMemoryPlexSessionStore();
+      final container = _container(
+        store: store,
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          homeUsers: const <PlexHomeUser>[_ownerUser, _kidUser],
+          resources: const <PlexResource>[_officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.pickingUser,
+      );
+
+      notifier.cancelPlexLink();
+
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.disconnected,
+      );
+      // The abandoned flow released its profiles: picking now is a no-op.
+      expect(await notifier.selectUser('uuid-kid'), isFalse);
+      expect(await store.read(), isNull);
+      expect(notifier.session, isNull);
+    });
+
+    test('selecting an unknown profile id is a no-op', () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          homeUsers: const <PlexHomeUser>[_ownerUser, _kidUser],
+          resources: const <PlexResource>[_officeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+      await notifier.connectWithPlex();
+
+      expect(await notifier.selectUser('uuid-nobody'), isFalse);
+      expect(
+        container.read(plexSettingsControllerProvider).phase,
+        PlexConnectionPhase.pickingUser,
+      );
+    });
+
+    test('no profile or account token ever reaches the state through the flow',
+        () async {
+      final container = _container(
+        tvClient: FakePlexTvClient(
+          checkPinScript: <Object?>[_accountToken],
+          homeUsers: const <PlexHomeUser>[_ownerUser, _kidUser],
+          switchTokens: <String, String>{'uuid-kid': _kidsToken},
+          resources: const <PlexResource>[_unscopedOfficeResource],
+        ),
+      );
+      final notifier = container.read(plexSettingsControllerProvider.notifier);
+      await _settle();
+
+      const List<String> secrets = <String>[_accountToken, _kidsToken];
+      void expectStateTokenFree() {
+        final state = container.read(plexSettingsControllerProvider);
+        final List<String> texts = <String>[
+          state.baseUrl ?? '',
+          state.serverName ?? '',
+          state.statusMessage ?? '',
+          state.errorMessage ?? '',
+          for (final PlexUserChoice user in state.users) user.toString(),
+        ];
+        for (final String text in texts) {
+          for (final String secret in secrets) {
+            expect(text, isNot(contains(secret)));
+          }
+        }
+      }
+
+      await notifier.connectWithPlex();
+      expectStateTokenFree();
+      await notifier.selectUser('uuid-kid');
+      expectStateTokenFree();
+
+      // The live session still redacts its (profile-scoped) token when printed.
+      final String text = notifier.session.toString();
+      for (final String secret in secrets) {
+        expect(text, isNot(contains(secret)));
+      }
     });
   });
 }

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -517,6 +517,78 @@ void main() {
     expect((await store.read())!.token, 'super-secret-attic-token');
   });
 
+  testWidgets('a multi-profile account picks from the user list first',
+      (tester) async {
+    final store = InMemoryPlexSessionStore();
+    await _pump(
+      tester,
+      client: FakePlexClient(sections: const [_musicSection]),
+      store: store,
+      tvClient: FakePlexTvClient(
+        checkPinScript: <Object?>[_accountToken],
+        homeUsers: const <PlexHomeUser>[
+          PlexHomeUser(uuid: 'uuid-owner', title: 'Dad', admin: true),
+          PlexHomeUser(uuid: 'uuid-kid', title: 'Kids', restricted: true),
+        ],
+        resources: const <PlexResource>[_officeResource],
+      ),
+    );
+
+    await tester.tap(find.text('Connect with Plex'));
+    await tester.pumpAndSettle();
+
+    // The user picker leads, before any server or library step.
+    expect(find.text('Choose your Plex user'), findsOneWidget);
+    expect(find.text('Dad'), findsOneWidget);
+    expect(find.text('Kids'), findsOneWidget);
+    expect(find.textContaining('Account owner'), findsOneWidget);
+    expect(find.textContaining('Managed profile'), findsOneWidget);
+    // Not connected yet — onboarding paused on the picker, no library sync.
+    expect(find.text('Music libraries'), findsNothing);
+
+    await tester.tap(find.text('Kids'));
+    await tester.pumpAndSettle();
+
+    // Picking the profile carries the flow through to the connected card.
+    expect(find.text('Music libraries'), findsOneWidget);
+    expect(find.text('Disconnect Plex'), findsOneWidget);
+  });
+
+  testWidgets('a protected profile reveals an inline PIN entry to continue',
+      (tester) async {
+    final tvClient = FakePlexTvClient(
+      checkPinScript: <Object?>[_accountToken],
+      homeUsers: const <PlexHomeUser>[
+        PlexHomeUser(uuid: 'uuid-owner', title: 'Dad', admin: true),
+        PlexHomeUser(uuid: 'uuid-teen', title: 'Teen', protected: true),
+      ],
+      resources: const <PlexResource>[_officeResource],
+    );
+    await _pump(
+      tester,
+      client: FakePlexClient(sections: const [_musicSection]),
+      tvClient: tvClient,
+    );
+
+    await tester.tap(find.text('Connect with Plex'));
+    await tester.pumpAndSettle();
+
+    // The protected profile is flagged and, when tapped, asks for its PIN
+    // inline (part of the card, not a dialog) instead of switching at once.
+    expect(find.textContaining('PIN protected'), findsOneWidget);
+    await tester.tap(find.text('Teen'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Enter the PIN for Teen'), findsOneWidget);
+    await tester.enterText(find.byType(TextField), '4242');
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    // The PIN was forwarded to the switch, and the flow connected.
+    expect(tvClient.lastSwitchPin, '4242');
+    expect(find.text('Disconnect Plex'), findsOneWidget);
+  });
+
   testWidgets('an account with no servers shows a clean empty state',
       (tester) async {
     await _pump(


### PR DESCRIPTION
## What & why

Improves the Plex onboarding flow by adding a **user/profile selection step** after authentication, so a fresh sign-in pauses to let the person choose *whose* library to use instead of barrelling toward a sync. This keeps perceived onboarding fast and scopes the catalog to exactly what the chosen profile may play.

After the existing "Connect with Plex" PIN sign-in grants the account token, Linthra now lists the account's **Plex Home** users (`GET /api/v2/home/users`) and, when there is more than one, shows a picker **before** the server step and any library sync.

## Flow

```
PIN approve → (account token) → fetch Home users
   ├─ 0/1 user (or fetch fails) → connect as owner  ← unchanged behaviour
   └─ >1 users → USER PICKER
        ├─ owner      → use account token (no switch)
        └─ managed    → switch into profile (PIN if protected) → profile token
   → find/pick server → connect
```

- **Owner/admin** already holds the account token — no switch.
- **Managed profile** is switched into (`POST /api/v2/home/users/{uuid}/switch`, with the profile's PIN when protected) to mint that profile's own token; servers are then listed and the session built with it, so a restricted profile only syncs the libraries the owner shared.
- The picker is an **enhancement, never a gate**: an account without Plex Home, or a plex.tv hiccup while listing profiles, simply skips it and connects as the owner — identical to today.
- **No automatic full sync on login** (already true for Plex): a fresh connect starts with an empty selection and clears the Plex catalog slice rather than kicking a library walk. The existing library picker + *Sync* path is unchanged.

## Requirements ↔ changes

| Requirement | Where |
| --- | --- |
| Fetch available Plex users/profiles after auth | `fetchHomeUsers` (tv client / `PlexPinAuth`), `PlexHomeUser` DTO |
| Selection screen before sync | `pickingUser` phase + `_UserPickerView` (inline PIN for protected) |
| Sync only the selected user's data | `switchToUser` → profile-scoped token flows into the session |
| No auto full-sync after login | unchanged: fresh connect clears the slice, never syncs |
| Minimal, fast UI | one picker view added to the existing Plex card; no redesign |

## Scope / constraints

- Touches **Plex login only** — Jellyfin, Subsonic/Navidrome, the playback engine, and the rest of the UI are untouched.
- All existing link-flow race guards (slow startup-restore mid-flow, cancel, client-identity deferral) and token-safety invariants are preserved. The per-profile token lives only in the controller's in-memory flow state until the session is persisted (encrypted) and never reaches `state`, a log, or an exception. The switch URL carries the **profile PIN** (a low-entropy local PIN, not `X-Plex-Token`) as a query param; the account token always rides in the header.

## Tests

New coverage for the endpoints, `PlexHomeUser` parsing, the HTTP client (incl. token-free failures), the `PlexPinAuth` seams, the controller flow (multi-profile picker, owner-no-switch, managed-switch scoping, protected-PIN, wrong-PIN retry, single-user skip, fetch-failure fallback, cancel, token sweep), and two widget tests (user list + inline PIN entry). Full suite green locally: **2375 passed**, `flutter analyze` clean, `dart format` compliant.


---
_Generated by [Claude Code](https://claude.ai/code/session_013JKQ6L7mXSsVDxM3Vx3Q8L)_