### PR TITLE
feat(settings): group settings into a Master Settings Hub

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -10,6 +10,12 @@ import '../features/player/player_screen.dart';
 import '../features/playlists/playlist_detail_screen.dart';
 import '../features/playlists/playlists_screen.dart';
 import '../features/settings/bug_report/bug_report_screen.dart';
+import '../features/settings/hub/about_screen.dart';
+import '../features/settings/hub/cache_and_data_screen.dart';
+import '../features/settings/hub/connections_settings_screen.dart';
+import '../features/settings/hub/diagnostics_support_screen.dart';
+import '../features/settings/hub/music_and_playback_screen.dart';
+import '../features/settings/hub/offline_downloads_screen.dart';
 import '../features/settings/settings_screen.dart';
 import '../features/shell/home_shell.dart';
 import '../features/smart_mixes/smart_mix_detail_screen.dart';
@@ -96,6 +102,32 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                 path: AppRoutes.settings,
                 builder: (context, state) => const SettingsScreen(),
                 routes: [
+                  GoRoute(
+                    path: 'connections',
+                    builder: (context, state) =>
+                        const ConnectionsSettingsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'playback',
+                    builder: (context, state) => const MusicAndPlaybackScreen(),
+                  ),
+                  GoRoute(
+                    path: 'cache',
+                    builder: (context, state) => const CacheAndDataScreen(),
+                  ),
+                  GoRoute(
+                    path: 'downloads',
+                    builder: (context, state) => const OfflineDownloadsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'diagnostics',
+                    builder: (context, state) =>
+                        const DiagnosticsSupportScreen(),
+                  ),
+                  GoRoute(
+                    path: 'about',
+                    builder: (context, state) => const AboutScreen(),
+                  ),
                   GoRoute(
                     path: 'report-bug',
                     builder: (context, state) => const BugReportScreen(),

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -43,10 +43,37 @@ abstract final class AppRoutes {
   static String smartMixPath(String id) => '$smartMixes/$id';
 
   static const String downloads = '/downloads';
+
+  /// The Settings hub: a list of categories, each opening its own detail page
+  /// below. The categories are children of [settings] so they keep the bottom
+  /// nav and pop back into that tab.
   static const String settings = '/settings';
 
-  /// The "Report a bug" builder, reached from Settings. A child of [settings]
-  /// so it keeps the bottom nav and pops back into that tab.
+  /// "Connections" — the music-source connections (Jellyfin, Plex,
+  /// Navidrome/Subsonic, local files). A child of [settings].
+  static const String settingsConnections = '/settings/connections';
+
+  /// "Music & playback" — default source and playback behaviour. A child of
+  /// [settings].
+  static const String settingsPlayback = '/settings/playback';
+
+  /// "Cache & data" — smart pre-cache and the on-device cache limit. A child of
+  /// [settings].
+  static const String settingsCache = '/settings/cache';
+
+  /// "Offline & downloads" — the Wi-Fi / mobile-data download policy. A child of
+  /// [settings].
+  static const String settingsDownloads = '/settings/downloads';
+
+  /// "Diagnostics & support" — report a bug and copy a safe diagnostics
+  /// snapshot. A child of [settings].
+  static const String settingsDiagnostics = '/settings/diagnostics';
+
+  /// "About" — version, build, and project links. A child of [settings].
+  static const String settingsAbout = '/settings/about';
+
+  /// The "Report a bug" builder, reached from Diagnostics & support. A child of
+  /// [settings] so it keeps the bottom nav and pops back into that tab.
   static const String reportBug = '/settings/report-bug';
 
   /// Full-screen now-playing view, pushed above the shell.

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../app/external_link_launcher_provider.dart';
+import '../../../core/app_info.dart';
+import '../../../shared/widgets/linthra_logo_mark.dart';
+import 'settings_detail_scaffold.dart';
+
+/// The "About" page of the Settings hub.
+///
+/// A calm brand panel (the Linthra mark, name, and tagline), the version/build
+/// the app is running, and a short list of project links. The links open in the
+/// browser through the shared [externalLinkLauncherProvider] — the same seam the
+/// "Report a bug" flow uses — so every launch is an explicit tap and tests stay
+/// plugin-free.
+class AboutScreen extends ConsumerWidget {
+  const AboutScreen({super.key});
+
+  static const String _repoUrl = 'https://github.com/thezupzup/linthra';
+  static const String _releasesUrl =
+      'https://github.com/thezupzup/linthra/releases';
+  static const String _licenseUrl =
+      'https://github.com/thezupzup/linthra/blob/main/LICENSE';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SettingsDetailScaffold(
+      title: 'About',
+      children: <Widget>[
+        const _BrandPanel(),
+        const SizedBox(height: AppSpacing.md),
+        const _BuildInfoCard(),
+        const SizedBox(height: AppSpacing.md),
+        _LinksCard(
+          onOpenRepo: () => _open(context, ref, _repoUrl),
+          onOpenReleases: () => _open(context, ref, _releasesUrl),
+          onOpenLicense: () => _open(context, ref, _licenseUrl),
+        ),
+      ],
+    );
+  }
+
+  /// Opens [url] in the browser, falling back to a snackbar if the platform
+  /// can't (the launcher never throws). The messenger is captured before the
+  /// await so we don't touch [context] across an async gap.
+  Future<void> _open(BuildContext context, WidgetRef ref, String url) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool launched =
+        await ref.read(externalLinkLauncherProvider).open(Uri.parse(url));
+    if (!launched) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text("Couldn't open the link.")),
+      );
+    }
+  }
+}
+
+/// The Linthra mark, name, and tagline — the same calm brand footer the old
+/// settings screen carried, promoted to the top of the About page.
+class _BrandPanel extends StatelessWidget {
+  const _BrandPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Row(
+          children: <Widget>[
+            const LinthraLogoMark(size: 48),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    AppInfo.name,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: -0.3,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    AppInfo.tagline,
+                    style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Version and build details, read from [AppInfo] (the single in-app source of
+/// truth, kept in lockstep with `pubspec.yaml`).
+class _BuildInfoCard extends StatelessWidget {
+  const _BuildInfoCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: <Widget>[
+          // AppInfo.version is a runtime getter, so this row can't be const.
+          _InfoRow(
+            icon: Icons.info_outline,
+            label: 'Version',
+            value: AppInfo.version,
+          ),
+          const Divider(height: 0),
+          const _InfoRow(
+            icon: Icons.flag_outlined,
+            label: 'Release channel',
+            value: 'Alpha',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A read-only label/value row inside the build-info card.
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return ListTile(
+      leading: Icon(icon, color: theme.colorScheme.primary),
+      title: Text(label),
+      trailing: Text(
+        value,
+        style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+      ),
+    );
+  }
+}
+
+/// External project links, each opening in the browser.
+class _LinksCard extends StatelessWidget {
+  const _LinksCard({
+    required this.onOpenRepo,
+    required this.onOpenReleases,
+    required this.onOpenLicense,
+  });
+
+  final VoidCallback onOpenRepo;
+  final VoidCallback onOpenReleases;
+  final VoidCallback onOpenLicense;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: <Widget>[
+          _LinkRow(
+            icon: Icons.code_outlined,
+            label: 'Source code',
+            onTap: onOpenRepo,
+          ),
+          const Divider(height: 0),
+          _LinkRow(
+            icon: Icons.new_releases_outlined,
+            label: 'Releases',
+            onTap: onOpenReleases,
+          ),
+          const Divider(height: 0),
+          _LinkRow(
+            icon: Icons.gavel_outlined,
+            label: 'License (MPL-2.0)',
+            onTap: onOpenLicense,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single tappable link row inside the links card.
+class _LinkRow extends StatelessWidget {
+  const _LinkRow({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return ListTile(
+      leading: Icon(icon, color: theme.colorScheme.primary),
+      title: Text(label),
+      trailing: Icon(Icons.open_in_new, size: 18, color: muted),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/features/settings/hub/cache_and_data_screen.dart
+++ b/lib/features/settings/hub/cache_and_data_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../cache/cache_settings_section.dart';
+import '../precache/precache_settings_section.dart';
+import 'settings_detail_scaffold.dart';
+
+/// The "Cache & data" page of the Settings hub.
+///
+/// Groups the on-device storage Linthra manages itself: the smart pre-cache and
+/// the cache-size limit (with "Free up storage"). The Wi-Fi / mobile-data
+/// download policy lives on the "Offline & downloads" page instead, since it is
+/// about *when* downloads run rather than *how much* they keep.
+class CacheAndDataScreen extends StatelessWidget {
+  const CacheAndDataScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SettingsDetailScaffold(
+      title: 'Cache & data',
+      children: <Widget>[
+        CacheSettingsSection(),
+        SizedBox(height: AppSpacing.md),
+        PrecacheSettingsSection(),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/hub/connections_settings_screen.dart
+++ b/lib/features/settings/hub/connections_settings_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../source/provider_summary_cards.dart';
+import 'settings_detail_scaffold.dart';
+
+/// The "Connections" page of the Settings hub.
+///
+/// Stacks the existing music-source cards — Jellyfin, Navidrome/Subsonic, Plex,
+/// and Local music — each of which already shows status and offers edit /
+/// reconnect / remove behind its own "Manage" sheet. This page only groups the
+/// cards; how a source connects or syncs is unchanged.
+class ConnectionsSettingsScreen extends StatelessWidget {
+  const ConnectionsSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SettingsDetailScaffold(
+      title: 'Connections',
+      children: <Widget>[
+        JellyfinProviderCard(),
+        SizedBox(height: AppSpacing.md),
+        SubsonicProviderCard(),
+        SizedBox(height: AppSpacing.md),
+        // Plex is phase 1 (stream-only) and clearly badged Experimental until
+        // the remaining capabilities ship.
+        PlexProviderCard(),
+        SizedBox(height: AppSpacing.md),
+        // Local music is a connection here, deliberately kept away from the
+        // offline-downloads page so it is not confused with offline downloads.
+        LocalMusicProviderCard(),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/hub/diagnostics_support_screen.dart
+++ b/lib/features/settings/hub/diagnostics_support_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../bug_report/report_bug_settings_section.dart';
+import '../diagnostics/diagnostics_settings_section.dart';
+import 'settings_detail_scaffold.dart';
+
+/// The "Diagnostics & support" page of the Settings hub.
+///
+/// Groups the two ways to get help: building a safe, secret-free bug report,
+/// and copying or saving a diagnostics snapshot to paste into one. Both are the
+/// existing sections, unchanged — nothing is generated or sent on its own.
+class DiagnosticsSupportScreen extends StatelessWidget {
+  const DiagnosticsSupportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SettingsDetailScaffold(
+      title: 'Diagnostics & support',
+      children: <Widget>[
+        ReportBugSettingsSection(),
+        SizedBox(height: AppSpacing.md),
+        DiagnosticsSettingsSection(),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/hub/music_and_playback_screen.dart
+++ b/lib/features/settings/hub/music_and_playback_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../playback/playback_settings_section.dart';
+import '../source/default_provider_section.dart';
+import '../source/playback_source_strategy_section.dart';
+import 'settings_detail_scaffold.dart';
+
+/// The "Music & playback" page of the Settings hub.
+///
+/// Groups the choices about *which* copy of a song plays and *how* it sounds:
+/// the default source, the playback source strategy, and volume normalization.
+/// Each card is the existing section, unchanged — nothing here touches the
+/// playback engine or provider logic.
+class MusicAndPlaybackScreen extends StatelessWidget {
+  const MusicAndPlaybackScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SettingsDetailScaffold(
+      title: 'Music & playback',
+      children: <Widget>[
+        DefaultProviderSettingsSection(),
+        SizedBox(height: AppSpacing.md),
+        PlaybackSourceStrategySettingsSection(),
+        SizedBox(height: AppSpacing.md),
+        PlaybackSettingsSection(),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/hub/offline_downloads_screen.dart
+++ b/lib/features/settings/hub/offline_downloads_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../app/dimens.dart';
+import '../../../app/routes.dart';
+import '../network/network_settings_section.dart';
+import 'settings_detail_scaffold.dart';
+
+/// The "Offline & downloads" page of the Settings hub.
+///
+/// Hosts the Wi-Fi / mobile-data download policy and a shortcut to the
+/// Downloads tab where the actual offline tracks are managed. The mobile-data
+/// switch is the existing section, unchanged; the download/cache policy still
+/// lives in the repository.
+class OfflineDownloadsScreen extends StatelessWidget {
+  const OfflineDownloadsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsDetailScaffold(
+      title: 'Offline & downloads',
+      children: <Widget>[
+        const NetworkSettingsSection(),
+        const SizedBox(height: AppSpacing.md),
+        _ManageDownloadsCard(onTap: () => context.go(AppRoutes.downloads)),
+      ],
+    );
+  }
+}
+
+/// A shortcut into the Downloads tab, where tracks kept for offline play are
+/// listed and managed. Switching tabs (rather than pushing) keeps the Downloads
+/// screen the single home for that list.
+class _ManageDownloadsCard extends StatelessWidget {
+  const _ManageDownloadsCard({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: ListTile(
+        leading:
+            Icon(Icons.download_outlined, color: theme.colorScheme.primary),
+        title: const Text('Manage downloads'),
+        subtitle: Text(
+          'See and remove the tracks you kept for offline play.',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+        trailing: Icon(Icons.chevron_right, color: muted),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/lib/features/settings/hub/settings_category_tile.dart
+++ b/lib/features/settings/hub/settings_category_tile.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+
+/// One tappable category row on the Settings hub (e.g. "Connections",
+/// "Cache & data").
+///
+/// It is presentation only: a tinted leading glyph, a title, a one-line
+/// description, and a trailing chevron, wrapped in a Material 3 card that opens
+/// [onTap]. Grouping the settings behind these rows is what turns the old long
+/// technical form into a short, scannable hub — the actual settings live
+/// unchanged on the page each row opens.
+class SettingsCategoryTile extends StatelessWidget {
+  const SettingsCategoryTile({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  /// The category's glyph, shown in the tinted leading square.
+  final IconData icon;
+
+  /// The category's name (e.g. "Connections").
+  final String title;
+
+  /// A short line under the title naming what lives inside the category.
+  final String subtitle;
+
+  /// Opens the category's detail page.
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Row(
+            children: <Widget>[
+              _CategoryIcon(icon: icon),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      title,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Icon(Icons.chevron_right, color: muted),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The rounded, tinted glyph at the start of a category row. Mirrors the
+/// leading icon the provider summary cards use, so the hub reads as part of the
+/// same family of cards.
+class _CategoryIcon extends StatelessWidget {
+  const _CategoryIcon({required this.icon});
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Container(
+      width: 44,
+      height: 44,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(AppRadii.sm),
+      ),
+      child: Icon(icon, color: theme.colorScheme.primary),
+    );
+  }
+}

--- a/lib/features/settings/hub/settings_detail_scaffold.dart
+++ b/lib/features/settings/hub/settings_detail_scaffold.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+
+/// The shared frame for a Settings category page (the screen a hub row opens).
+///
+/// It is a thin host — an [AppBar] with the category [title] and a scrolling
+/// body — so every category page looks and scrolls the same and the page files
+/// stay a plain list of the *existing* setting cards. The cards themselves are
+/// unchanged; only where they are shown moves here.
+class SettingsDetailScaffold extends StatelessWidget {
+  const SettingsDetailScaffold({
+    super.key,
+    required this.title,
+    required this.children,
+  });
+
+  /// The category name shown in the app bar.
+  final String title;
+
+  /// The setting cards/sections to stack on the page, top to bottom.
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: ListView(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        children: children,
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,21 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
+import '../../app/routes.dart';
 import '../../core/app_info.dart';
 import '../../shared/widgets/linthra_logo_mark.dart';
-import '../../shared/widgets/settings_section_header.dart';
-import 'bug_report/report_bug_settings_section.dart';
-import 'cache/cache_settings_section.dart';
-import 'diagnostics/diagnostics_settings_section.dart';
-import 'network/network_settings_section.dart';
-import 'playback/playback_settings_section.dart';
-import 'precache/precache_settings_section.dart';
-import 'source/default_provider_section.dart';
-import 'source/playback_source_strategy_section.dart';
-import 'source/provider_summary_cards.dart';
+import 'hub/settings_category_tile.dart';
 
-/// Settings. Hosts the connection/source and offline-storage options, plus a
-/// quiet brand/about footer. Theme and other options will join them here.
+/// The Settings hub: a short, scannable list of categories rather than one long
+/// technical form. Each row opens its own page (Connections, Music & playback,
+/// Cache & data, …) where the existing setting cards live, unchanged. Grouping
+/// the options this way is the whole point — it reorganises Settings to feel
+/// like a modern app, without changing what any setting does.
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
@@ -25,97 +21,95 @@ class SettingsScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('Settings')),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
-        children: const [
-          // Music sources — where Linthra finds music to play. Each source is a
-          // compact card: status at a glance, with the full connection settings
-          // a tap away behind "Manage". Local music is a source here,
-          // deliberately kept away from the Storage & offline group below so it
-          // is not confused with offline downloads.
-          SettingsSectionHeader('Music sources'),
-          SizedBox(height: AppSpacing.sm),
-          JellyfinProviderCard(),
-          SizedBox(height: AppSpacing.md),
-          SubsonicProviderCard(),
-          SizedBox(height: AppSpacing.md),
-          LocalMusicProviderCard(),
-          SizedBox(height: AppSpacing.md),
-          // Plex is phase 1 (stream-only) and clearly badged Experimental
-          // until the remaining capabilities ship.
-          PlexProviderCard(),
-          SizedBox(height: AppSpacing.md),
-          DefaultProviderSettingsSection(),
-          SizedBox(height: AppSpacing.md),
-          PlaybackSourceStrategySettingsSection(),
-          SizedBox(height: AppSpacing.lg),
-          // Storage & offline — Linthra-managed on-device storage: songs you
-          // download for offline playback and the cache that speeds playback up.
-          SettingsSectionHeader('Storage & offline'),
-          SizedBox(height: AppSpacing.sm),
-          CacheSettingsSection(),
-          SizedBox(height: AppSpacing.md),
-          NetworkSettingsSection(),
-          SizedBox(height: AppSpacing.md),
-          PrecacheSettingsSection(),
-          SizedBox(height: AppSpacing.lg),
-          SettingsSectionHeader('Playback'),
-          SizedBox(height: AppSpacing.sm),
-          PlaybackSettingsSection(),
-          SizedBox(height: AppSpacing.lg),
-          SettingsSectionHeader('Help & diagnostics'),
-          SizedBox(height: AppSpacing.sm),
-          ReportBugSettingsSection(),
-          SizedBox(height: AppSpacing.md),
-          DiagnosticsSettingsSection(),
-          SizedBox(height: AppSpacing.md),
-          _AboutCard(),
+        children: <Widget>[
+          const _BrandHeader(),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
+            icon: Icons.hub_outlined,
+            title: 'Connections',
+            subtitle: 'Jellyfin, Plex, Navidrome/Subsonic, local files',
+            onTap: () => context.push(AppRoutes.settingsConnections),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
+            icon: Icons.play_circle_outline,
+            title: 'Music & playback',
+            subtitle: 'Default source and playback behaviour',
+            onTap: () => context.push(AppRoutes.settingsPlayback),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
+            icon: Icons.sd_storage_outlined,
+            title: 'Cache & data',
+            subtitle: 'Smart pre-cache and cache size',
+            onTap: () => context.push(AppRoutes.settingsCache),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
+            icon: Icons.download_outlined,
+            title: 'Offline & downloads',
+            subtitle: 'Mobile data and offline downloads',
+            onTap: () => context.push(AppRoutes.settingsDownloads),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
+            icon: Icons.help_outline,
+            title: 'Diagnostics & support',
+            subtitle: 'Report a bug, copy diagnostics',
+            onTap: () => context.push(AppRoutes.settingsDiagnostics),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
+            icon: Icons.info_outline,
+            title: 'About',
+            subtitle: 'Version and project links',
+            onTap: () => context.push(AppRoutes.settingsAbout),
+          ),
         ],
       ),
     );
   }
 }
 
-/// A calm brand footer: the Linthra mark, name, tagline, and version. Keeps the
-/// identity present in-app without shouting.
-class _AboutCard extends StatelessWidget {
-  const _AboutCard();
+/// A compact brand presence at the top of the hub: the Linthra mark, name, and
+/// tagline. Keeps the identity in view without the full About panel (which lives
+/// one tap away under "About").
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader();
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
-        child: Row(
-          children: [
-            const LinthraLogoMark(size: 44),
-            const SizedBox(width: AppSpacing.md),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    AppInfo.name,
-                    style: theme.textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w700,
-                      letterSpacing: -0.3,
-                    ),
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.sm,
+      ),
+      child: Row(
+        children: <Widget>[
+          const LinthraLogoMark(size: 40),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  AppInfo.name,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.3,
                   ),
-                  const SizedBox(height: 2),
-                  Text(
-                    AppInfo.tagline,
-                    style: theme.textTheme.bodySmall?.copyWith(color: muted),
-                  ),
-                  const SizedBox(height: AppSpacing.xs),
-                  Text(
-                    'Version ${AppInfo.version}',
-                    style: theme.textTheme.labelSmall?.copyWith(color: muted),
-                  ),
-                ],
-              ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  AppInfo.tagline,
+                  style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/external_link_launcher_provider.dart';
+import 'package:linthra/core/app_info.dart';
+import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/settings/hub/about_screen.dart';
+
+class _FakeLinkLauncher implements ExternalLinkLauncher {
+  _FakeLinkLauncher({this.result = true});
+
+  final bool result;
+  Uri? opened;
+
+  @override
+  Future<bool> open(Uri url) async {
+    opened = url;
+    return result;
+  }
+}
+
+Future<_FakeLinkLauncher> _pump(
+  WidgetTester tester, {
+  bool launchResult = true,
+}) async {
+  final _FakeLinkLauncher launcher = _FakeLinkLauncher(result: launchResult);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        externalLinkLauncherProvider.overrideWithValue(launcher),
+      ],
+      child: const MaterialApp(home: AboutScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return launcher;
+}
+
+void main() {
+  group('AboutScreen', () {
+    testWidgets('shows brand, version, and the link rows', (tester) async {
+      await _pump(tester);
+
+      expect(find.text(AppInfo.name), findsOneWidget);
+      // The running version is shown verbatim.
+      expect(find.text(AppInfo.version), findsOneWidget);
+      expect(find.text('Source code'), findsOneWidget);
+      expect(find.text('Releases'), findsOneWidget);
+      expect(find.text('License (MPL-2.0)'), findsOneWidget);
+    });
+
+    testWidgets('tapping "Source code" opens the repository', (tester) async {
+      final launcher = await _pump(tester);
+
+      await tester.tap(find.text('Source code'));
+      await tester.pumpAndSettle();
+
+      expect(
+          launcher.opened, Uri.parse('https://github.com/thezupzup/linthra'));
+    });
+
+    testWidgets('shows a snackbar when a link cannot be opened',
+        (tester) async {
+      await _pump(tester, launchResult: false);
+
+      await tester.tap(find.text('Releases'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Couldn't open the link."), findsOneWidget);
+    });
+  });
+}

--- a/test/features/settings/hub/settings_category_tile_test.dart
+++ b/test/features/settings/hub/settings_category_tile_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/hub/settings_category_tile.dart';
+
+void main() {
+  group('SettingsCategoryTile', () {
+    testWidgets('shows the icon, title, and subtitle', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SettingsCategoryTile(
+              icon: Icons.hub_outlined,
+              title: 'Connections',
+              subtitle: 'Jellyfin, Plex, local files',
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Connections'), findsOneWidget);
+      expect(find.text('Jellyfin, Plex, local files'), findsOneWidget);
+      expect(find.byIcon(Icons.hub_outlined), findsOneWidget);
+      // A chevron signals the row drills into its own page.
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('invokes onTap when tapped', (tester) async {
+      int taps = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SettingsCategoryTile(
+              icon: Icons.info_outline,
+              title: 'About',
+              subtitle: 'Version and links',
+              onTap: () => taps++,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('About'));
+      expect(taps, 1);
+    });
+  });
+}

--- a/test/features/settings/hub/settings_detail_scaffold_test.dart
+++ b/test/features/settings/hub/settings_detail_scaffold_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/hub/settings_detail_scaffold.dart';
+
+void main() {
+  group('SettingsDetailScaffold', () {
+    testWidgets('shows the category title and stacks its children', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SettingsDetailScaffold(
+            title: 'Connections',
+            children: <Widget>[
+              Text('CARD_ONE'),
+              Text('CARD_TWO'),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.widgetWithText(AppBar, 'Connections'), findsOneWidget);
+      expect(find.text('CARD_ONE'), findsOneWidget);
+      expect(find.text('CARD_TWO'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/app_info.dart';
+import 'package:linthra/features/settings/settings_screen.dart';
+
+/// The hub renders into a router whose category routes resolve to simple markers,
+/// so a tap can be proven to navigate to the right page without pulling in the
+/// provider-heavy real category screens.
+GoRouter _router() {
+  GoRoute leaf(String path, String marker) => GoRoute(
+        path: path,
+        builder: (_, __) => Scaffold(body: Text(marker)),
+      );
+  return GoRouter(
+    initialLocation: AppRoutes.settings,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.settings,
+        builder: (_, __) => const SettingsScreen(),
+      ),
+      leaf(AppRoutes.settingsConnections, 'CONNECTIONS_PAGE'),
+      leaf(AppRoutes.settingsPlayback, 'PLAYBACK_PAGE'),
+      leaf(AppRoutes.settingsCache, 'CACHE_PAGE'),
+      leaf(AppRoutes.settingsDownloads, 'DOWNLOADS_PAGE'),
+      leaf(AppRoutes.settingsDiagnostics, 'DIAGNOSTICS_PAGE'),
+      leaf(AppRoutes.settingsAbout, 'ABOUT_PAGE'),
+    ],
+  );
+}
+
+Future<void> _pump(WidgetTester tester) async {
+  // A tall surface so the whole list of categories is laid out (a ListView
+  // only builds on-screen rows) and every tile is hittable.
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(MaterialApp.router(routerConfig: _router()));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('SettingsScreen (hub)', () {
+    testWidgets('shows the brand header and every category', (tester) async {
+      await _pump(tester);
+
+      // Brand stays present on the hub.
+      expect(find.text(AppInfo.name), findsOneWidget);
+      expect(find.text(AppInfo.tagline), findsOneWidget);
+
+      // The six categories of the Master Settings Hub.
+      expect(find.text('Connections'), findsOneWidget);
+      expect(find.text('Music & playback'), findsOneWidget);
+      expect(find.text('Cache & data'), findsOneWidget);
+      expect(find.text('Offline & downloads'), findsOneWidget);
+      expect(find.text('Diagnostics & support'), findsOneWidget);
+      expect(find.text('About'), findsOneWidget);
+    });
+
+    testWidgets('each category opens its page', (tester) async {
+      const cases = <(String, String)>[
+        ('Connections', 'CONNECTIONS_PAGE'),
+        ('Music & playback', 'PLAYBACK_PAGE'),
+        ('Cache & data', 'CACHE_PAGE'),
+        ('Offline & downloads', 'DOWNLOADS_PAGE'),
+        ('Diagnostics & support', 'DIAGNOSTICS_PAGE'),
+        ('About', 'ABOUT_PAGE'),
+      ];
+
+      for (final (String title, String marker) in cases) {
+        await _pump(tester);
+        await tester.tap(find.text(title));
+        await tester.pumpAndSettle();
+        expect(find.text(marker), findsOneWidget,
+            reason: 'tapping "$title" should open its page');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Settings was one long technical form. This reorganises it into a short, scannable **Master Settings Hub** — six categories, each opening its own page — so Settings feels like a modern app (Google/Spotify style) instead of an endless list.

This is a **pure reorganisation**. Every existing setting card is reused **unchanged** behind the new pages. No playback-engine changes, no provider-logic changes, nothing removed.

## The hub

| Category | What's inside (existing sections, reused) |
| --- | --- |
| **Connections** | Jellyfin, Navidrome/Subsonic, Plex, Local music cards (status + edit/reconnect/remove behind each card's *Manage*) |
| **Music & playback** | Default source · Playback source strategy · Normalize volume |
| **Cache & data** | Offline downloads & cache (size limit, free up storage) · Smart pre-cache |
| **Offline & downloads** | Allow mobile data for downloads · shortcut to the Downloads tab |
| **Diagnostics & support** | Report a bug · Copy/save diagnostics |
| **About** | Version/build info · project links (source, releases, license) |

The hub keeps a compact Linthra brand header; **About** is a new page that promotes the old brand footer and adds version/build details and external links (opened through the existing `externalLinkLauncherProvider` seam).

## How it's built (small & incremental)

- New `features/settings/hub/`: `SettingsCategoryTile` (hub row), `SettingsDetailScaffold` (shared page frame), and the six category pages — thin compositions of the **existing** section widgets.
- `SettingsScreen` becomes the hub; six child routes wired under `/settings`.
- Net diff is mostly additive; the only rewritten file is `settings_screen.dart`.

## Scope note

The brief also listed four net-new *behavioural* features (Data usage mode, Offline mode, Auto-download favorites, Network test). Those require wiring into the playback/provider/network engine, which conflicts with the "don't change the engine / keep it small / only reorganise" constraints — so per the chosen scope they're **deferred to follow-up PRs**, leaving clean homes for them (Cache & data / Offline & downloads / Diagnostics & support).

## Constraints honoured

- ✅ Material 3 throughout (Cards, ListTiles, theme tokens; leading icons match the existing provider cards)
- ✅ Linthra branding kept (hub header + About panel)
- ✅ Playback engine untouched · provider logic untouched
- ✅ No existing setting broken — only relocated

## Testing

- `flutter analyze` — clean
- `flutter test` — **2349 passed** (incl. new tests for hub rendering, navigation to each page, the tile, the shared scaffold, and About's link launching + failure fallback)
- `dart format` — clean · secret/privacy scan — clean

> Note: this is a UI change for an Android Flutter app; I couldn't capture an on-device screenshot in this environment, so reviewers may want to eyeball the hub and the six pages on a device/emulator.

https://claude.ai/code/session_014m3V6Qi3WbpWhKAhYxMvHz

---
_Generated by [Claude Code](https://claude.ai/code/session_014m3V6Qi3WbpWhKAhYxMvHz)_