### PR TITLE
Linthra UI Lab / editable design structure for Now Playing

### DIFF
--- a/docs/codebase-tour.md
+++ b/docs/codebase-tour.md
@@ -67,6 +67,7 @@ class is bound to its interface, and where tests swap in fakes.
 | Smart mixes | `lib/features/smart_mixes/`, `lib/core/services/smart_playlist_resolver.dart` |
 | Diagnostics & "Report a bug" | `lib/core/diagnostics/`, `lib/features/settings/bug_report/` |
 | Settings UI | `lib/features/settings/settings_screen.dart` + section folders beside it |
+| Now Playing **look** (spacing, sizes, button order, labels) | `lib/ui_linthra/` — see the [UI editing guide](ui-editing-guide.md) |
 | Stored preferences vs. secrets | `lib/data/repositories/shared_preferences_*.dart` vs. `secure_*_session_store.dart` |
 
 ## Playback

--- a/docs/ui-editing-guide.md
+++ b/docs/ui-editing-guide.md
@@ -1,0 +1,283 @@
+# UI editing guide — the Now Playing screen
+
+This guide is for the **maintainer** who wants to adjust how the Now Playing
+screen looks — move a button, change spacing, swap an icon, retune the artwork
+size — **without** wading through the playback, provider, or networking code.
+
+Almost everything you'll want to change lives in one folder:
+
+```
+lib/ui_linthra/
+```
+
+> **The current design is the reference and is preserved.** The files in
+> `lib/ui_linthra/` were filled in with the *exact* values the screen already
+> uses, so nothing looks different until you change a number there.
+
+---
+
+## 1. Open the project on Windows
+
+You need Flutter installed once. The short version:
+
+1. **Install Git for Windows** — <https://git-scm.com/download/win>.
+2. **Install the Flutter SDK** — follow
+   <https://docs.flutter.dev/get-started/install/windows>. Linthra is pinned to
+   the Flutter version in the repo's [`.flutter-version`](../.flutter-version)
+   file; install that version to avoid spurious formatting diffs.
+3. **Enable Windows desktop support** (so you can run the preview on your PC
+   without an emulator):
+   ```powershell
+   flutter config --enable-windows-desktop
+   ```
+4. **Get an editor** — [VS Code](https://code.visualstudio.com/) with the
+   *Flutter* extension is the easiest. Open the Linthra folder in it.
+5. **Fetch dependencies** once, from the project folder in a terminal:
+   ```powershell
+   flutter pub get
+   ```
+
+You don't need an Android phone, an emulator, or any Plex/Jellyfin server to
+edit and preview the UI — see [§9](#9-test-your-changes).
+
+---
+
+## 2. Where the Now Playing UI files are
+
+| File | What you edit it for |
+| --- | --- |
+| `lib/ui_linthra/design_tokens.dart` | Sizes & numbers: artwork size, blur strength, corner radius, shadows, button/icon sizes, text weights, muted-text opacity. |
+| `lib/ui_linthra/now_playing_layout_config.dart` | Spacing/gaps/paddings, every on-screen **word** (captions, tooltips, empty-state text), and the **text styles**. |
+| `lib/ui_linthra/now_playing_actions_config.dart` | The bottom action row: **button order, which buttons appear, icons, labels**. |
+| `lib/ui_linthra/now_playing_preview_data.dart` | The fake songs used by the preview (see [§9](#9-test-your-changes)). |
+| `lib/app/colors.dart` | The brand colour palette (violet + orange). |
+
+The actual screen widgets live in `lib/features/player/` and **read** their
+numbers and words from the files above. You rarely need to open them.
+
+---
+
+## 3. Change the bottom button order (or hide/show a button)
+
+Open **`lib/ui_linthra/now_playing_actions_config.dart`** and find
+`nowPlayingActionOrder`:
+
+```dart
+const List<NowPlayingAction> nowPlayingActionOrder = <NowPlayingAction>[
+  NowPlayingAction.favorite,
+  NowPlayingAction.addToPlaylist,
+  NowPlayingAction.queue,
+  NowPlayingAction.lyrics,
+  NowPlayingAction.sleepTimer,
+  // NowPlayingAction.shuffle, // ← uncomment to add a shuffle toggle to the row
+  // NowPlayingAction.repeat,  // ← uncomment to add a repeat toggle to the row
+];
+```
+
+- **Reorder:** move the lines up or down. The row is laid out left → right in
+  exactly this order.
+- **Hide a button:** delete (or comment out with `//`) its line.
+- **Show an optional button:** add (or uncomment) its line. `shuffle` and
+  `repeat` are supported here too — they're already wired.
+
+### Change a button's icon or label
+
+In the same file, edit that action's entry in `nowPlayingActionStyles`. For
+example, to give "Add to playlist" a different icon and tooltip:
+
+```dart
+NowPlayingAction.addToPlaylist: NowPlayingActionStyle(
+  icon: Icons.library_add,        // was Icons.playlist_add
+  label: 'Save to a playlist',    // was 'Add to playlist'
+),
+```
+
+Icon names come from Flutter's built-in
+[Material Icons](https://fonts.google.com/icons) — type `Icons.` in your editor
+and it will suggest them.
+
+You do **not** need to touch any playback code to do any of this — what each
+button *does* stays wired in `lib/features/player/widgets/now_playing_actions.dart`.
+
+---
+
+## 4. Change spacing
+
+Open **`lib/ui_linthra/now_playing_layout_config.dart`** → `NowPlayingLayout`.
+The screen is three stacked bands (artwork · title/artist/album · controls), and
+the gaps between them are named plainly:
+
+```dart
+static const double gapArtworkToMetadata = 32; // artwork → title block
+static const double gapMetadataToControls = 24; // title block → controls
+static const double gapControlsToActions = 16; // transport → bottom buttons
+```
+
+Make a gap bigger or smaller by changing its number (logical pixels). The outer
+margins are right there too (`headerPadding`, `contentPadding`).
+
+---
+
+## 5. Change colors
+
+The two-colour identity — violet **brand** + warm orange **accent** — lives in
+**`lib/app/colors.dart`** (`AppColors`). For example, the play button and the
+progress bar use the orange accent:
+
+```dart
+static const Color accent = Color(0xFFFF9F43);      // the live/accent orange
+static const Color accentBright = Color(0xFFFFB867); // play-button gradient top
+static const Color accentDeep = Color(0xFFF2861E);   // play-button gradient bottom
+```
+
+Colours are written as `Color(0xAARRGGBB)` (alpha, red, green, blue in hex). To
+soften how strongly a colour shows on the Now Playing screen — without changing
+the palette — adjust the opacities in `NowPlayingOpacityTokens`
+(`design_tokens.dart`), e.g. how dim the album line or the resting action icons
+are.
+
+> Changing `AppColors` affects the **whole app**, not just Now Playing — that's
+> intentional, so the brand stays consistent.
+
+---
+
+## 6. Change the artwork size, blur, corner radius, or shadow
+
+Open **`lib/ui_linthra/design_tokens.dart`**.
+
+```dart
+// NowPlayingArtworkTokens
+static const double maxWidth = 480;      // biggest the cover gets on tablets
+static const double cornerRadius = 24;   // higher = rounder corners
+static const double shadowBlur = 40;     // softness of the drop shadow
+
+// NowPlayingBackgroundTokens
+static const double blurStrength = 40;   // how blurred the backdrop artwork is
+```
+
+Each value has a comment explaining what it does and which direction makes it
+bigger/softer/rounder.
+
+---
+
+## 7. Change the play button / transport / progress bar sizes
+
+Also in **`design_tokens.dart`**:
+
+```dart
+// NowPlayingButtonTokens
+static const double playButtonDiameter = 72; // the big round play/pause button
+static const double skipIconSize = 38;        // previous / next
+static const double modeIconSize = 24;        // shuffle / repeat
+static const double actionIconSize = 22;      // the bottom action row
+
+// NowPlayingProgressTokens
+static const double trackHeight = 4;          // thickness of the progress bar
+static const double thumbRadius = 6;          // the draggable dot
+```
+
+---
+
+## 8. Change labels and text sizes
+
+### Words
+
+Open **`now_playing_layout_config.dart`** → `NowPlayingLabels`. Every visible
+word is here:
+
+```dart
+static const String header = 'Now Playing';
+static const String emptyTitle = 'Nothing playing';
+static const String emptyMessage = 'Pick a track to start listening.';
+```
+
+### Text sizes / weights
+
+In the same file, `NowPlayingTextStyles` builds each line's style. To make the
+**title bigger**, swap which text-theme role it uses (or add an explicit
+`fontSize`):
+
+```dart
+static TextStyle? title(ThemeData theme) =>
+    theme.textTheme.headlineMedium?.copyWith( // was headlineSmall (bigger now)
+      fontWeight: NowPlayingTypeTokens.titleWeight,
+      letterSpacing: NowPlayingTypeTokens.titleLetterSpacing,
+      height: NowPlayingTypeTokens.titleHeight,
+    );
+```
+
+The weights and letter-spacing are tokens in `design_tokens.dart`
+(`NowPlayingTypeTokens`) if you'd rather tune those.
+
+---
+
+## 9. Test your changes
+
+### Preview with fake data (recommended — no server needed)
+
+Run the **dev-only preview** of the Now Playing screen. It uses fake songs, so
+you don't need Plex, Jellyfin, or Navidrome connected:
+
+```powershell
+flutter run -t lib/ui_linthra/preview/now_playing_preview_main.dart
+```
+
+- A dropdown at the top flips between sample states — different providers,
+  paused / buffering / error, a long title, and the no-artwork fallback.
+- After editing a file in `lib/ui_linthra/`, press **`r`** in the terminal for
+  **hot reload** to see the change instantly (or **`R`** for a full restart).
+- Add your own samples by editing `lib/ui_linthra/now_playing_preview_data.dart`.
+
+You can run the preview on **Windows desktop** (`flutter run -d windows -t …`)
+or on an Android device/emulator if you have one.
+
+### Run the automated checks before committing
+
+These are the same checks CI runs:
+
+```powershell
+flutter analyze   # static analysis / lints
+flutter test      # widget & unit tests
+```
+
+The Now Playing widget tests (`test/features/player/player_screen_test.dart`)
+assert the screen's labels, tooltips, icons, and behaviour — so if a change
+accidentally breaks the design contract, these will tell you.
+
+---
+
+## 10. What **not** to edit (unless you're changing playback behaviour)
+
+These files hold **logic**, not look. Leave them alone for visual tweaks — and
+changing them can affect playback, providers, security, or tokens:
+
+| Don't edit for UI changes | Why |
+| --- | --- |
+| `lib/features/player/player_providers.dart` | Wires playback, resolvers, caching, reporting. |
+| `lib/core/services/**` (e.g. `*_playback_controller.dart`, `playable_uri_resolver*.dart`) | The audio engine and how a track becomes a playable URL. |
+| `lib/core/sources/**` (jellyfin / plex / subsonic / local) | Provider logic, sessions, and tokens. |
+| `lib/core/services/playback_source_label.dart` | The safe "Playing from …" naming (never exposes a URL/token). |
+| `lib/features/player/cast/**` | Cast logic. |
+| `lib/features/player/*_providers.dart`, `sleep_timer_controller.dart`, `lyrics_*` | Favorites, lyrics, sleep-timer behaviour. |
+
+The widgets in `lib/features/player/widgets/` are the *rendering* of the screen.
+They now read their values from `lib/ui_linthra/`, so for look-and-feel changes
+you should edit the config there, not the widgets. Reach into a widget only when
+you need to change **structure** (add/remove an element), not spacing, sizes,
+icons, labels, or button order.
+
+---
+
+## Quick reference
+
+| I want to… | Edit |
+| --- | --- |
+| Reorder / hide / show bottom buttons | `now_playing_actions_config.dart` → `nowPlayingActionOrder` |
+| Change a button's icon or label | `now_playing_actions_config.dart` → `nowPlayingActionStyles` |
+| Change spacing / gaps / margins | `now_playing_layout_config.dart` → `NowPlayingLayout` |
+| Change on-screen words | `now_playing_layout_config.dart` → `NowPlayingLabels` |
+| Change text size / weight | `now_playing_layout_config.dart` → `NowPlayingTextStyles` |
+| Change artwork size / blur / radius / shadow | `design_tokens.dart` → `NowPlayingArtworkTokens` / `NowPlayingBackgroundTokens` |
+| Change button / progress sizes | `design_tokens.dart` → `NowPlayingButtonTokens` / `NowPlayingProgressTokens` |
+| Change colours | `lib/app/colors.dart` |
+| Preview without a server | `flutter run -t lib/ui_linthra/preview/now_playing_preview_main.dart` |

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -5,6 +5,8 @@ import '../../app/dimens.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
+import '../../ui_linthra/design_tokens.dart';
+import '../../ui_linthra/now_playing_layout_config.dart';
 import 'cast/cast_button.dart';
 import 'cast/cast_providers.dart';
 import 'player_providers.dart';
@@ -69,28 +71,21 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.xs,
-        vertical: AppSpacing.xs,
-      ),
+      padding: NowPlayingLayout.headerPadding,
       child: Row(
         children: [
           IconButton(
             onPressed: () => Navigator.of(context).maybePop(),
-            icon: const Icon(Icons.keyboard_arrow_down),
-            tooltip: 'Close',
+            icon: const Icon(NowPlayingLabels.closeIcon),
+            tooltip: NowPlayingLabels.closeTooltip,
           ),
           Expanded(
             // A calm, tracked eyebrow rather than a heavy title, so the artwork
             // below is unmistakably the hero of the screen.
             child: Text(
-              'Now Playing',
+              NowPlayingLabels.header,
               textAlign: TextAlign.center,
-              style: theme.textTheme.labelLarge?.copyWith(
-                fontWeight: FontWeight.w600,
-                letterSpacing: 1.0,
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
-              ),
+              style: NowPlayingTextStyles.header(theme),
             ),
           ),
           // Trailing cast control; ~48dp wide, balancing the leading button so
@@ -108,9 +103,9 @@ class _EmptyNowPlaying extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const EmptyState(
-      icon: Icons.music_note_outlined,
-      title: 'Nothing playing',
-      message: 'Pick a track to start listening.',
+      icon: NowPlayingLabels.emptyIcon,
+      title: NowPlayingLabels.emptyTitle,
+      message: NowPlayingLabels.emptyMessage,
     );
   }
 }
@@ -125,13 +120,11 @@ class _NowPlaying extends StatelessWidget {
     // A tighter side margin lets the artwork breathe wider and gives the
     // transport controls more room to spread, while the generous gaps below
     // group the screen into three calm bands: artwork · metadata · controls.
+    // All of these numbers live in lib/ui_linthra/ so they can be retuned there.
+    final BorderRadius artworkRadius =
+        BorderRadius.circular(NowPlayingArtworkTokens.cornerRadius);
     return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.sm,
-        AppSpacing.md,
-        AppSpacing.lg,
-      ),
+      padding: NowPlayingLayout.contentPadding,
       child: Column(
         children: [
           Expanded(
@@ -139,42 +132,46 @@ class _NowPlaying extends StatelessWidget {
               child: ConstrainedBox(
                 // Cap the hero on tablets/foldables so it stays a square cover,
                 // not an oversized panel; phones use the full width.
-                constraints: const BoxConstraints(maxWidth: 480),
+                constraints: const BoxConstraints(
+                  maxWidth: NowPlayingArtworkTokens.maxWidth,
+                ),
                 child: AspectRatio(
-                  aspectRatio: 1,
+                  aspectRatio: NowPlayingArtworkTokens.aspectRatio,
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(AppRadii.lg),
+                      borderRadius: artworkRadius,
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.4),
-                          blurRadius: 40,
-                          spreadRadius: -12,
-                          offset: const Offset(0, 20),
+                          color: Colors.black.withValues(
+                            alpha: NowPlayingArtworkTokens.shadowOpacity,
+                          ),
+                          blurRadius: NowPlayingArtworkTokens.shadowBlur,
+                          spreadRadius: NowPlayingArtworkTokens.shadowSpread,
+                          offset: NowPlayingArtworkTokens.shadowOffset,
                         ),
                       ],
                     ),
                     child: AlbumArtwork(
                       artworkUri: track.artworkUri,
-                      borderRadius: BorderRadius.circular(AppRadii.lg),
+                      borderRadius: artworkRadius,
                     ),
                   ),
                 ),
               ),
             ),
           ),
-          const SizedBox(height: AppSpacing.xl),
+          const SizedBox(height: NowPlayingLayout.gapArtworkToMetadata),
           TrackMetadata(
             title: track.title,
             artistName: track.artistName,
             albumName: track.albumName,
           ),
-          const SizedBox(height: AppSpacing.lg),
+          const SizedBox(height: NowPlayingLayout.gapMetadataToControls),
           // The only part of the screen that follows the live, high-frequency
           // playback state — kept separate so the artwork, metadata, and the
           // blurred background above never rebuild on a position tick.
           const _LiveControls(),
-          const SizedBox(height: AppSpacing.md),
+          const SizedBox(height: NowPlayingLayout.gapControlsToActions),
           NowPlayingActions(track: track),
         ],
       ),
@@ -197,14 +194,14 @@ class _LiveControls extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         _SourceOrError(state: state),
-        const SizedBox(height: AppSpacing.md),
+        const SizedBox(height: NowPlayingLayout.gapSourceToProgress),
         PlaybackProgressBar(
           position: state.position,
           duration: state.duration,
           onSeek: (position) =>
               ref.read(playbackControllerProvider).seek(position),
         ),
-        const SizedBox(height: AppSpacing.sm),
+        const SizedBox(height: NowPlayingLayout.gapProgressToTransport),
         PlaybackControls(state: state),
       ],
     );
@@ -238,7 +235,7 @@ class _SourceOrError extends ConsumerWidget {
 
     if (state.status == PlaybackStatus.error) {
       return Text(
-        state.errorMessage ?? "Couldn't play this track",
+        state.errorMessage ?? NowPlayingLabels.genericError,
         style: theme.textTheme.bodyMedium?.copyWith(
           color: theme.colorScheme.error,
         ),
@@ -254,7 +251,9 @@ class _SourceOrError extends ConsumerWidget {
     if (source == null) {
       // Reserve the inline chip's height so the column doesn't shift when the
       // source resolves a beat after the track loads.
-      return const SizedBox(height: 22);
+      return const SizedBox(
+        height: NowPlayingProgressTokens.sourceLineReservedHeight,
+      );
     }
     return PlaybackSourceChip(
       source: source,
@@ -284,7 +283,7 @@ class _BufferingIndicator extends StatelessWidget {
         ),
         const SizedBox(width: AppSpacing.xs),
         Text(
-          'Buffering…',
+          NowPlayingLabels.buffering,
           style: theme.textTheme.labelLarge?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
             letterSpacing: 0.3,
@@ -310,14 +309,14 @@ class _CastingIndicator extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Icon(
-          Icons.cast_connected,
+          NowPlayingLabels.castingIcon,
           size: 16,
           color: theme.colorScheme.primary,
         ),
         const SizedBox(width: AppSpacing.xs),
         Flexible(
           child: Text(
-            'Casting to $deviceName',
+            NowPlayingLabels.casting(deviceName),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: theme.textTheme.labelLarge?.copyWith(

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -2,10 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
+import '../../../core/models/playback_state.dart';
+import '../../../core/models/repeat_mode.dart';
 import '../../../core/models/track.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
+import '../../../ui_linthra/design_tokens.dart';
+import '../../../ui_linthra/now_playing_actions_config.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../favorites_providers.dart';
+import '../player_providers.dart';
 import '../sleep_timer_controller.dart';
 import 'lyrics_view.dart';
 import 'queue_sheet.dart';
@@ -14,12 +19,15 @@ import 'sleep_timer_sheet.dart';
 /// Bottom action row on the now-playing screen: favorite · playlist · queue ·
 /// lyrics · sleep timer.
 ///
-/// They're live: favorite toggles a heart synced through the
-/// [FavoritesRepository] (to Jellyfin for remote tracks, on-device for local
-/// ones), queue opens the up-next list, lyrics fetches the track's lyrics from
-/// the source — falling back to an honest "no lyrics" state when there are none
-/// (or for a local track / when signed out) — and the sleep timer (a moon that
-/// lights up while a countdown is running) opens the delay picker.
+/// The row's **order, which buttons appear, and each button's icon/label** are
+/// declared in `lib/ui_linthra/now_playing_actions_config.dart` — edit that file
+/// to retune the row. This widget owns only the *wiring* (what each button does):
+/// favorite toggles a heart synced through the [FavoritesRepository] (to Jellyfin
+/// for remote tracks, on-device for local ones), queue opens the up-next list,
+/// lyrics fetches the track's lyrics from the source — falling back to an honest
+/// "no lyrics" state when there are none (or for a local track / when signed out)
+/// — and the sleep timer (a moon that lights up while a countdown is running)
+/// opens the delay picker.
 class NowPlayingActions extends ConsumerWidget {
   const NowPlayingActions({super.key, required this.track});
 
@@ -32,57 +40,147 @@ class NowPlayingActions extends ConsumerWidget {
     final bool sleepTimerActive = ref.watch(
       sleepTimerControllerProvider.select((s) => s.isActive),
     );
+
+    // Shuffle and repeat normally live in the transport row, but the config may
+    // place them here too. Only subscribe to their playback state when they are
+    // actually in the row, so by default this row stays off the high-frequency
+    // position ticks (it rebuilds only on a favorite or sleep-timer change).
+    const List<NowPlayingAction> order = nowPlayingActionOrder;
+    final bool needsTransport = order.contains(NowPlayingAction.shuffle) ||
+        order.contains(NowPlayingAction.repeat);
+    final (bool, RepeatMode)? transport = needsTransport
+        ? ref.watch(playbackStateProvider.select((s) {
+            final PlaybackState? state = s.valueOrNull;
+            return (
+              state?.shuffleEnabled ?? false,
+              state?.repeatMode ?? RepeatMode.off,
+            );
+          }))
+        : null;
+
     // A calm, uniform tint keeps this row reading as tertiary beneath the
     // transport controls; favorite and the sleep timer still light up when
     // active.
-    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.7);
+    final Color muted = theme.colorScheme.onSurface
+        .withValues(alpha: NowPlayingOpacityTokens.action);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        IconButton(
-          iconSize: 22,
-          onPressed: () => ref
-              .read(favoritesRepositoryProvider)
-              .setFavorite(track, !isFavorite),
-          icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
-          color: isFavorite ? theme.colorScheme.primary : muted,
-          isSelected: isFavorite,
-          tooltip: isFavorite ? 'Remove from favorites' : 'Favorite',
-        ),
-        IconButton(
-          iconSize: 22,
-          onPressed: () => showAddToPlaylistSheet(context, <Track>[track]),
-          icon: const Icon(Icons.playlist_add),
-          color: muted,
-          tooltip: 'Add to playlist',
-        ),
-        IconButton(
-          iconSize: 22,
-          onPressed: () => _openQueue(context),
-          icon: const Icon(Icons.queue_music_outlined),
-          color: muted,
-          tooltip: 'Queue',
-        ),
-        IconButton(
-          iconSize: 22,
-          onPressed: () => _openLyrics(context),
-          icon: const Icon(Icons.lyrics_outlined),
-          color: muted,
-          tooltip: 'Lyrics',
-        ),
-        IconButton(
-          iconSize: 22,
-          onPressed: () => showSleepTimerSheet(context),
-          icon: Icon(
-            sleepTimerActive ? Icons.bedtime : Icons.bedtime_outlined,
+      children: <Widget>[
+        for (final NowPlayingAction action in order)
+          _actionButton(
+            context,
+            ref,
+            theme,
+            action,
+            muted: muted,
+            isFavorite: isFavorite,
+            sleepTimerActive: sleepTimerActive,
+            shuffleEnabled: transport?.$1 ?? false,
+            repeatMode: transport?.$2 ?? RepeatMode.off,
           ),
-          color: sleepTimerActive ? theme.colorScheme.primary : muted,
-          isSelected: sleepTimerActive,
-          tooltip: sleepTimerActive ? 'Sleep timer (on)' : 'Sleep timer',
-        ),
       ],
     );
+  }
+
+  /// Builds one button from its config [NowPlayingActionStyle] plus the live
+  /// state and wiring for that specific action. Keeping the look in the config
+  /// and the behaviour here is what lets the maintainer reorder/hide/relabel the
+  /// row without reading any playback code.
+  Widget _actionButton(
+    BuildContext context,
+    WidgetRef ref,
+    ThemeData theme,
+    NowPlayingAction action, {
+    required Color muted,
+    required bool isFavorite,
+    required bool sleepTimerActive,
+    required bool shuffleEnabled,
+    required RepeatMode repeatMode,
+  }) {
+    final NowPlayingActionStyle style = nowPlayingActionStyles[action]!;
+
+    // Per-action live state (is it "on"?), what it does on tap, and any
+    // mode-specific glyph/tooltip overrides (repeat is tri-state).
+    bool active = false;
+    VoidCallback? onPressed;
+    IconData icon = style.icon;
+    String tooltip = style.label;
+
+    switch (action) {
+      case NowPlayingAction.favorite:
+        active = isFavorite;
+        onPressed = () => ref
+            .read(favoritesRepositoryProvider)
+            .setFavorite(track, !isFavorite);
+      case NowPlayingAction.addToPlaylist:
+        onPressed = () => showAddToPlaylistSheet(context, <Track>[track]);
+      case NowPlayingAction.queue:
+        onPressed = () => _openQueue(context);
+      case NowPlayingAction.lyrics:
+        onPressed = () => _openLyrics(context);
+      case NowPlayingAction.sleepTimer:
+        active = sleepTimerActive;
+        onPressed = () => showSleepTimerSheet(context);
+      case NowPlayingAction.shuffle:
+        active = shuffleEnabled;
+        onPressed = () =>
+            ref.read(playbackControllerProvider).setShuffleEnabled(!active);
+      case NowPlayingAction.repeat:
+        active = repeatMode != RepeatMode.off;
+        icon = repeatMode == RepeatMode.one ? Icons.repeat_one : style.icon;
+        tooltip = _repeatTooltip(repeatMode);
+        onPressed = () =>
+            ref.read(playbackControllerProvider).setRepeatMode(repeatMode.next);
+    }
+
+    // When "on", swap in the active glyph/word (if the action defines them) and
+    // light up with the action's tint; otherwise stay the calm muted tint.
+    if (active) {
+      icon = action == NowPlayingAction.repeat
+          ? icon // repeat picked its glyph above
+          : (style.activeIcon ?? icon);
+      tooltip = action == NowPlayingAction.repeat
+          ? tooltip // repeat picked its tooltip above
+          : (style.activeLabel ?? tooltip);
+    }
+
+    // Only toggleable actions (favorite, sleep, shuffle, repeat — the ones with
+    // a tint) are toggle buttons; the momentary ones stay plain (isSelected
+    // null), exactly as before.
+    final bool toggleable = style.tint != NowPlayingActionTint.none;
+    return IconButton(
+      iconSize: NowPlayingButtonTokens.actionIconSize,
+      onPressed: onPressed,
+      icon: Icon(icon),
+      color: active ? _tintColor(theme, style.tint) : muted,
+      isSelected: toggleable ? active : null,
+      tooltip: tooltip,
+    );
+  }
+
+  /// Maps an action's [NowPlayingActionTint] to the theme colour it lights up
+  /// with when active.
+  Color _tintColor(ThemeData theme, NowPlayingActionTint tint) {
+    switch (tint) {
+      case NowPlayingActionTint.brand:
+        return theme.colorScheme.primary;
+      case NowPlayingActionTint.accent:
+        return theme.colorScheme.secondary;
+      case NowPlayingActionTint.none:
+        return theme.colorScheme.primary;
+    }
+  }
+
+  static String _repeatTooltip(RepeatMode mode) {
+    switch (mode) {
+      case RepeatMode.off:
+        return 'Repeat';
+      case RepeatMode.all:
+        return 'Repeat all';
+      case RepeatMode.one:
+        return 'Repeat one';
+    }
   }
 
   void _openQueue(BuildContext context) {
@@ -123,9 +221,9 @@ class _LyricsSheet extends StatelessWidget {
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
+            children: <Widget>[
               Row(
-                children: [
+                children: <Widget>[
                   Icon(Icons.lyrics_outlined, color: theme.colorScheme.primary),
                   const SizedBox(width: AppSpacing.sm),
                   Text('Lyrics', style: theme.textTheme.titleMedium),

--- a/lib/features/player/widgets/now_playing_background.dart
+++ b/lib/features/player/widgets/now_playing_background.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../app/colors.dart';
 import '../../../shared/widgets/artwork_image.dart';
+import '../../../ui_linthra/design_tokens.dart';
 
 /// The full-bleed backdrop behind the now-playing content.
 ///
@@ -35,7 +36,10 @@ class NowPlayingBackground extends StatelessWidget {
           _Gradient(theme: theme),
           if (uri != null)
             ImageFiltered(
-              imageFilter: ui.ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+              imageFilter: ui.ImageFilter.blur(
+                sigmaX: NowPlayingBackgroundTokens.blurStrength,
+                sigmaY: NowPlayingBackgroundTokens.blurStrength,
+              ),
               child: Image(
                 image: artworkImageProvider(uri),
                 fit: BoxFit.cover,
@@ -55,11 +59,17 @@ class NowPlayingBackground extends StatelessWidget {
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
                 colors: [
-                  theme.colorScheme.surface.withValues(alpha: 0.30),
-                  theme.colorScheme.surface.withValues(alpha: 0.70),
-                  theme.colorScheme.surface.withValues(alpha: 0.92),
+                  theme.colorScheme.surface.withValues(
+                    alpha: NowPlayingBackgroundTokens.scrimTopOpacity,
+                  ),
+                  theme.colorScheme.surface.withValues(
+                    alpha: NowPlayingBackgroundTokens.scrimMidOpacity,
+                  ),
+                  theme.colorScheme.surface.withValues(
+                    alpha: NowPlayingBackgroundTokens.scrimBottomOpacity,
+                  ),
                 ],
-                stops: const [0.0, 0.55, 1.0],
+                stops: NowPlayingBackgroundTokens.scrimStops,
               ),
             ),
           ),
@@ -84,16 +94,20 @@ class _Gradient extends StatelessWidget {
           end: Alignment.bottomRight,
           colors: [
             Color.alphaBlend(
-              AppColors.brand.withValues(alpha: 0.32),
+              AppColors.brand.withValues(
+                alpha: NowPlayingBackgroundTokens.fallbackBrandTint,
+              ),
               surface,
             ),
             surface,
             Color.alphaBlend(
-              AppColors.accent.withValues(alpha: 0.12),
+              AppColors.accent.withValues(
+                alpha: NowPlayingBackgroundTokens.fallbackAccentTint,
+              ),
               surface,
             ),
           ],
-          stops: const [0.0, 0.55, 1.0],
+          stops: NowPlayingBackgroundTokens.fallbackStops,
         ),
       ),
     );

--- a/lib/features/player/widgets/playback_controls.dart
+++ b/lib/features/player/widgets/playback_controls.dart
@@ -5,6 +5,7 @@ import '../../../app/colors.dart';
 import '../../../core/models/playback_state.dart';
 import '../../../core/models/repeat_mode.dart';
 import '../../../core/services/playback_controller.dart';
+import '../../../ui_linthra/design_tokens.dart';
 import '../player_providers.dart';
 
 /// The transport row: shuffle · previous · play/pause · next · repeat.
@@ -29,14 +30,14 @@ class PlaybackControls extends ConsumerWidget {
       children: [
         _ShuffleButton(state: state, controller: controller),
         IconButton(
-          iconSize: 38,
+          iconSize: NowPlayingButtonTokens.skipIconSize,
           onPressed: state.hasPrevious ? controller.skipToPrevious : null,
           icon: const Icon(Icons.skip_previous),
           tooltip: 'Previous',
         ),
         _PlayPauseButton(state: state, controller: controller),
         IconButton(
-          iconSize: 38,
+          iconSize: NowPlayingButtonTokens.skipIconSize,
           onPressed: state.hasNext ? controller.skipToNext : null,
           icon: const Icon(Icons.skip_next),
           tooltip: 'Next',
@@ -60,7 +61,7 @@ class _ShuffleButton extends StatelessWidget {
     final theme = Theme.of(context);
     final enabled = state.shuffleEnabled;
     return IconButton(
-      iconSize: 24,
+      iconSize: NowPlayingButtonTokens.modeIconSize,
       onPressed: () => controller.setShuffleEnabled(!enabled),
       icon: const Icon(Icons.shuffle),
       isSelected: enabled,
@@ -68,7 +69,8 @@ class _ShuffleButton extends StatelessWidget {
       // play button; warm accent when on, matching the rest of the app.
       color: enabled
           ? theme.colorScheme.secondary
-          : theme.colorScheme.onSurface.withValues(alpha: 0.65),
+          : theme.colorScheme.onSurface
+              .withValues(alpha: NowPlayingOpacityTokens.inactiveMode),
       tooltip: enabled ? 'Shuffle on' : 'Shuffle',
     );
   }
@@ -88,7 +90,7 @@ class _RepeatButton extends StatelessWidget {
     final mode = state.repeatMode;
     final active = mode != RepeatMode.off;
     return IconButton(
-      iconSize: 24,
+      iconSize: NowPlayingButtonTokens.modeIconSize,
       onPressed: () => controller.setRepeatMode(mode.next),
       icon: Icon(
         mode == RepeatMode.one ? Icons.repeat_one : Icons.repeat,
@@ -96,7 +98,8 @@ class _RepeatButton extends StatelessWidget {
       isSelected: active,
       color: active
           ? theme.colorScheme.secondary
-          : theme.colorScheme.onSurface.withValues(alpha: 0.65),
+          : theme.colorScheme.onSurface
+              .withValues(alpha: NowPlayingOpacityTokens.inactiveMode),
       tooltip: _tooltipFor(mode),
     );
   }
@@ -144,17 +147,18 @@ class _PlayPauseButton extends StatelessWidget {
     return Tooltip(
       message: playing ? 'Pause' : 'Play',
       child: Container(
-        width: 72,
-        height: 72,
+        width: NowPlayingButtonTokens.playButtonDiameter,
+        height: NowPlayingButtonTokens.playButtonDiameter,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
           gradient: _gradient,
           boxShadow: [
             BoxShadow(
-              color: AppColors.accent.withValues(alpha: 0.45),
-              blurRadius: 24,
-              spreadRadius: -4,
-              offset: const Offset(0, 8),
+              color: AppColors.accent
+                  .withValues(alpha: NowPlayingButtonTokens.playGlowOpacity),
+              blurRadius: NowPlayingButtonTokens.playGlowBlur,
+              spreadRadius: NowPlayingButtonTokens.playGlowSpread,
+              offset: NowPlayingButtonTokens.playGlowOffset,
             ),
           ],
         ),
@@ -175,9 +179,9 @@ class _PlayPauseButton extends StatelessWidget {
 
   Widget _loadingIcon() {
     return const SizedBox.square(
-      dimension: 26,
+      dimension: NowPlayingButtonTokens.playSpinnerSize,
       child: CircularProgressIndicator(
-        strokeWidth: 2.5,
+        strokeWidth: NowPlayingButtonTokens.playSpinnerStroke,
         valueColor: AlwaysStoppedAnimation<Color>(AppColors.onAccent),
       ),
     );
@@ -186,7 +190,7 @@ class _PlayPauseButton extends StatelessWidget {
   Widget _playIcon(bool playing) {
     return Icon(
       playing ? Icons.pause : Icons.play_arrow,
-      size: 40,
+      size: NowPlayingButtonTokens.playIconSize,
       color: AppColors.onAccent,
     );
   }

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../../app/dimens.dart';
+import '../../../ui_linthra/design_tokens.dart';
+import '../../../ui_linthra/now_playing_layout_config.dart';
 
 /// Seekable progress bar showing the current position and total duration.
 ///
@@ -52,22 +53,22 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
     final double sliderValue = _dragMs ?? posMs.toDouble();
     final double elapsedMs = _dragMs ?? posMs.toDouble();
 
-    final muted = theme.colorScheme.onSurfaceVariant;
-    final labelStyle = theme.textTheme.labelSmall?.copyWith(
-      color: muted,
-      letterSpacing: 0.4,
-      fontFeatures: const [FontFeature.tabularFigures()],
-    );
+    final labelStyle = NowPlayingTextStyles.time(theme);
 
     return Column(
       children: [
         SliderTheme(
           data: SliderTheme.of(context).copyWith(
-            trackHeight: 4,
-            overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
-            inactiveTrackColor:
-                theme.colorScheme.onSurface.withValues(alpha: 0.15),
+            trackHeight: NowPlayingProgressTokens.trackHeight,
+            overlayShape: const RoundSliderOverlayShape(
+              overlayRadius: NowPlayingProgressTokens.overlayRadius,
+            ),
+            thumbShape: const RoundSliderThumbShape(
+              enabledThumbRadius: NowPlayingProgressTokens.thumbRadius,
+            ),
+            inactiveTrackColor: theme.colorScheme.onSurface.withValues(
+              alpha: NowPlayingOpacityTokens.inactiveProgressTrack,
+            ),
           ),
           child: Slider(
             value: sliderValue,
@@ -79,7 +80,8 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
         // Snug under the track and aligned to its ends, so the times read as a
         // caption for the bar rather than a separate, floating row.
         Padding(
-          padding: const EdgeInsets.only(top: AppSpacing.xs),
+          padding:
+              const EdgeInsets.only(top: NowPlayingLayout.gapProgressToTimes),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [

--- a/lib/features/player/widgets/track_metadata.dart
+++ b/lib/features/player/widgets/track_metadata.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 
-import '../../../app/dimens.dart';
 import '../../../core/models/playback_source.dart';
 import '../../../core/services/playback_source_label.dart';
+import '../../../ui_linthra/design_tokens.dart';
+import '../../../ui_linthra/now_playing_layout_config.dart';
 
 /// Title / artist / album block for the now-playing screen.
 ///
@@ -26,8 +27,8 @@ class TrackMetadata extends StatelessWidget {
     final theme = Theme.of(context);
     // A deliberate three-step hierarchy: the title carries full weight, the
     // artist is a clear secondary line, and the album recedes to a quiet tag.
-    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.75);
-    final fainter = theme.colorScheme.onSurface.withValues(alpha: 0.5);
+    // The exact styles live in NowPlayingTextStyles so they can be retuned in
+    // one place; the gaps live in NowPlayingLayout.
     final hasArtist = artistName != null && artistName!.isNotEmpty;
     final hasAlbum = albumName != null && albumName!.isNotEmpty;
 
@@ -36,36 +37,26 @@ class TrackMetadata extends StatelessWidget {
       children: [
         Text(
           title,
-          style: theme.textTheme.headlineSmall?.copyWith(
-            fontWeight: FontWeight.w700,
-            letterSpacing: -0.2,
-            height: 1.15,
-          ),
+          style: NowPlayingTextStyles.title(theme),
           textAlign: TextAlign.center,
-          maxLines: 2,
+          maxLines: NowPlayingTypeTokens.titleMaxLines,
           overflow: TextOverflow.ellipsis,
         ),
         if (hasArtist) ...[
-          const SizedBox(height: AppSpacing.sm),
+          const SizedBox(height: NowPlayingLayout.gapTitleToArtist),
           Text(
             artistName!,
-            style: theme.textTheme.titleMedium?.copyWith(
-              color: muted,
-              fontWeight: FontWeight.w500,
-            ),
+            style: NowPlayingTextStyles.artist(theme),
             textAlign: TextAlign.center,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
         ],
         if (hasAlbum) ...[
-          const SizedBox(height: AppSpacing.xs),
+          const SizedBox(height: NowPlayingLayout.gapArtistToAlbum),
           Text(
             albumName!,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: fainter,
-              letterSpacing: 0.1,
-            ),
+            style: NowPlayingTextStyles.album(theme),
             textAlign: TextAlign.center,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
@@ -110,18 +101,18 @@ class PlaybackSourceChip extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Icon(_iconFor(source), size: 15, color: color),
-        const SizedBox(width: AppSpacing.xs + 2),
+        Icon(
+          _iconFor(source),
+          size: NowPlayingProgressTokens.sourceIconSize,
+          color: color,
+        ),
+        const SizedBox(width: NowPlayingLayout.gapSourceIconToText),
         Flexible(
           child: Text(
             PlaybackSourceLabel.phrase(trackUri: trackUri, source: source),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: theme.textTheme.labelMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.2,
-              color: color,
-            ),
+            style: NowPlayingTextStyles.source(theme),
           ),
         ),
       ],

--- a/lib/ui_linthra/README.md
+++ b/lib/ui_linthra/README.md
@@ -1,0 +1,51 @@
+# `lib/ui_linthra/` — the Now Playing design surface
+
+This folder is the **maintainer-friendly home for the Now Playing screen's
+look**. Everything you'd normally want to tweak — spacing, the album-art size,
+blur strength, corner radius, button sizes, text sizes, the bottom button
+order, icons, and labels — lives here in plain, heavily-commented Dart, so you
+can adjust the design without reading the playback, provider, or networking
+code.
+
+> **The current Now Playing design is the reference and is preserved.** These
+> files were filled in with the *exact* values the screen already uses, so
+> nothing changes until you change a number here.
+
+## What's in here
+
+| File | Edit it to change… |
+| --- | --- |
+| [`design_tokens.dart`](design_tokens.dart) | Raw numbers: artwork size, blur strength, corner radius, shadows, button & icon sizes, text weights, and the opacity of muted text. |
+| [`now_playing_layout_config.dart`](now_playing_layout_config.dart) | Where things sit (paddings, the gaps between the three bands), every on-screen **word**, and the assembled **text styles**. |
+| [`now_playing_actions_config.dart`](now_playing_actions_config.dart) | The bottom action row: **button order**, which buttons show, and each button's icon + label. |
+| [`now_playing_preview_data.dart`](now_playing_preview_data.dart) | The fake tracks/states used by the dev preview. |
+| [`preview/`](preview/) | The dev-only preview app (see below). Not part of the shipping app. |
+
+## Preview the screen with fake data (no server needed)
+
+You can see the real Now Playing screen — with fake songs, different providers,
+paused/buffering/error states, long titles, and the no-artwork fallback —
+without connecting Plex, Jellyfin, or Navidrome:
+
+```bash
+flutter run -t lib/ui_linthra/preview/now_playing_preview_main.dart
+```
+
+Use the dropdown at the top to flip between samples. Edit any file in this
+folder and **hot-reload** (press `r`) to see your change instantly.
+
+## How the design connects to the widgets
+
+The widgets in `lib/features/player/` (the actual screen) read their numbers,
+words, and styles from this folder. For example, the album-art corner radius in
+`player_screen.dart` comes from `NowPlayingArtworkTokens.cornerRadius`, and the
+bottom button order comes from `nowPlayingActionOrder`. You change the value
+here; the widget picks it up.
+
+The **wiring** (what a button does, how playback works, how providers resolve a
+song) deliberately stays in `lib/features/player/` and `lib/core/`. You almost
+never need to open those to retune the look.
+
+See [`docs/ui-editing-guide.md`](../../docs/ui-editing-guide.md) for a friendly,
+step-by-step guide (including how to open the project on Windows and exactly
+which lines to edit for common changes).

--- a/lib/ui_linthra/design_tokens.dart
+++ b/lib/ui_linthra/design_tokens.dart
@@ -1,0 +1,184 @@
+/// # Now Playing design tokens
+///
+/// Every tunable *number* that shapes the Now Playing screen lives here, grouped
+/// by what it controls. Change a value, hot-reload (or rebuild), and the screen
+/// updates — you should never have to read the playback or provider code to
+/// retune the look.
+///
+/// What is **not** here:
+///  - **Colours** — the brand violet / warm orange palette lives in
+///    `lib/app/colors.dart` (`AppColors`). This file only holds the *opacities*
+///    used to soften those colours (see [NowPlayingOpacityTokens]).
+///  - **Spacing / gaps / paddings** — those are assembled, with names that say
+///    where they sit, in `now_playing_layout_config.dart`.
+///  - **Button order / icons / labels** — those live in
+///    `now_playing_actions_config.dart`.
+///
+/// These are plain `const` values, so they are baked in at build time and cost
+/// nothing at runtime.
+library;
+
+import 'package:flutter/material.dart';
+
+/// The album cover "hero" at the top of the screen — its size, rounding, and the
+/// soft drop shadow that lifts it off the blurred background.
+abstract final class NowPlayingArtworkTokens {
+  /// Largest the cover is allowed to get, in logical pixels. Phones fill the
+  /// available width; tablets/foldables stop here so the cover stays a square
+  /// album, not an oversized panel. Increase for a bigger hero on large screens.
+  static const double maxWidth = 480;
+
+  /// Cover shape. 1 = a perfect square (the album-cover look). Values > 1 make it
+  /// wider than tall; < 1 makes it taller than wide.
+  static const double aspectRatio = 1;
+
+  /// Corner rounding of the cover, in logical pixels. Higher = rounder corners.
+  /// (Matches the app's large radius, `AppRadii.lg`.)
+  static const double cornerRadius = 24;
+
+  /// The drop shadow under the cover. Together these read as a soft, lifted card.
+  ///  - [shadowOpacity]  how dark the shadow is (0 = none, 1 = solid black).
+  ///  - [shadowBlur]     how soft/spread the shadow edge is (higher = softer).
+  ///  - [shadowSpread]   negative pulls the shadow *in* so it hugs the cover.
+  ///  - [shadowOffset]   how far the shadow falls; `(0, 20)` = straight down 20px.
+  static const double shadowOpacity = 0.4;
+  static const double shadowBlur = 40;
+  static const double shadowSpread = -12;
+  static const Offset shadowOffset = Offset(0, 20);
+}
+
+/// The full-screen backdrop: a heavily blurred copy of the artwork (or a calm
+/// brand gradient when there is no artwork) under a darkening scrim that keeps
+/// the title, slider, and controls readable.
+abstract final class NowPlayingBackgroundTokens {
+  /// Blur strength of the artwork backdrop, in logical pixels. Higher = dreamier
+  /// and less detailed; lower lets more of the cover show through. 0 = no blur.
+  static const double blurStrength = 40;
+
+  /// The darkening scrim laid over the backdrop, from the top of the screen to
+  /// the bottom. Each value is how much of the surface (background) colour is
+  /// mixed in at that point — higher = darker / more opaque. The bottom is the
+  /// most opaque so the controls sit on a calm, legible base.
+  static const double scrimTopOpacity = 0.30;
+  static const double scrimMidOpacity = 0.70;
+  static const double scrimBottomOpacity = 0.92;
+
+  /// Where along the top→bottom run each scrim stop sits (0 = very top,
+  /// 1 = very bottom). Keep this the same length as the three opacities above.
+  static const List<double> scrimStops = <double>[0.0, 0.55, 1.0];
+
+  /// The fallback gradient shown when a track has no artwork: a whisper of the
+  /// brand violet at the top-left and the warm accent at the bottom-right, over
+  /// the surface colour. These are how strongly each brand colour tints the
+  /// surface (0 = invisible, 1 = full strength).
+  static const double fallbackBrandTint = 0.32;
+  static const double fallbackAccentTint = 0.12;
+  static const List<double> fallbackStops = <double>[0.0, 0.55, 1.0];
+}
+
+/// Sizes for the two button rows: the transport row (shuffle · previous ·
+/// play/pause · next · repeat) and, just below it, the secondary action row
+/// (favorite · playlist · queue · lyrics · sleep timer).
+abstract final class NowPlayingButtonTokens {
+  /// Icon size of every button in the bottom **action** row, in logical pixels.
+  static const double actionIconSize = 22;
+
+  /// Icon size of the shuffle and repeat buttons that flank the transport row.
+  /// Kept smaller than the skip buttons so they read as secondary.
+  static const double modeIconSize = 24;
+
+  /// Icon size of the previous / next (skip) buttons.
+  static const double skipIconSize = 38;
+
+  /// The dominant play/pause button — the one bold, "this is the music" moment.
+  ///  - [playButtonDiameter] the size of the round button, in logical pixels.
+  ///  - [playIconSize]       the play/pause glyph inside it.
+  ///  - [playSpinnerSize]    the loading spinner shown while a track resolves.
+  ///  - [playSpinnerStroke]  thickness of that spinner.
+  static const double playButtonDiameter = 72;
+  static const double playIconSize = 40;
+  static const double playSpinnerSize = 26;
+  static const double playSpinnerStroke = 2.5;
+
+  /// The warm glow under the play button. Same idea as the artwork shadow:
+  /// opacity (how strong), blur (how soft), spread (negative hugs the button),
+  /// and offset (how far it falls).
+  static const double playGlowOpacity = 0.45;
+  static const double playGlowBlur = 24;
+  static const double playGlowSpread = -4;
+  static const Offset playGlowOffset = Offset(0, 8);
+}
+
+/// The seekable progress bar and the small source/label glyphs around it.
+abstract final class NowPlayingProgressTokens {
+  /// Thickness of the progress track, in logical pixels.
+  static const double trackHeight = 4;
+
+  /// Radius of the draggable thumb on the progress bar.
+  static const double thumbRadius = 6;
+
+  /// Radius of the soft halo that appears around the thumb while dragging.
+  static const double overlayRadius = 12;
+
+  /// Icon size of the small "Playing from …" / buffering / casting glyph shown
+  /// just under the metadata.
+  static const double sourceIconSize = 15;
+
+  /// Reserved height (in logical pixels) for the source line while a track is
+  /// still resolving, so the layout never jumps when the label appears.
+  static const double sourceLineReservedHeight = 22;
+}
+
+/// Type *weight and shape* for the title / artist / album block and the header
+/// caption. The base font **sizes** come from the app's text theme (see
+/// `now_playing_layout_config.dart`, where each style is assembled); these are
+/// the finishing touches layered on top.
+abstract final class NowPlayingTypeTokens {
+  /// Title (song name): bold, very slightly tightened, with snug line spacing,
+  /// wrapping to at most two lines before it ellipsises.
+  static const FontWeight titleWeight = FontWeight.w700;
+  static const double titleLetterSpacing = -0.2;
+  static const double titleHeight = 1.15;
+  static const int titleMaxLines = 2;
+
+  /// Artist: a clear secondary line, medium weight.
+  static const FontWeight artistWeight = FontWeight.w500;
+
+  /// Album: the quietest line, with a touch of letter spacing.
+  static const double albumLetterSpacing = 0.1;
+
+  /// The "Now Playing" caption in the header: a calm, tracked eyebrow.
+  static const FontWeight headerWeight = FontWeight.w600;
+  static const double headerLetterSpacing = 1.0;
+
+  /// The "Playing from …" source label: a confident small caps-y caption.
+  static const FontWeight sourceWeight = FontWeight.w600;
+  static const double sourceLetterSpacing = 0.2;
+
+  /// The elapsed / remaining time labels under the progress bar.
+  static const double timeLetterSpacing = 0.4;
+}
+
+/// How strongly the calmer elements are dimmed. Every value is an *opacity*
+/// applied to a theme colour (almost always `onSurface`): 0 = invisible,
+/// 1 = full strength. Nudging these is the easiest way to make the screen feel
+/// quieter or more present without touching the palette in `app/colors.dart`.
+abstract final class NowPlayingOpacityTokens {
+  /// The header caption ("Now Playing") and its close affordance.
+  static const double header = 0.7;
+
+  /// The resting tint of the bottom action-row icons (before any light up).
+  static const double action = 0.7;
+
+  /// The artist line.
+  static const double artist = 0.75;
+
+  /// The album line (the faintest text on the screen).
+  static const double album = 0.5;
+
+  /// Shuffle / repeat when they are *off* (they switch to a solid accent on).
+  static const double inactiveMode = 0.65;
+
+  /// The unfilled remainder of the progress track.
+  static const double inactiveProgressTrack = 0.15;
+}

--- a/lib/ui_linthra/now_playing_actions_config.dart
+++ b/lib/ui_linthra/now_playing_actions_config.dart
@@ -1,0 +1,163 @@
+/// # Now Playing action-row config
+///
+/// The bottom action row on the Now Playing screen — favorite · add to playlist
+/// · queue · lyrics · sleep timer — is driven entirely by this file. Reorder,
+/// hide, show, re-label, or re-icon the buttons here; you never have to touch the
+/// playback or provider code to do it.
+///
+/// The split:
+///  - **What the row contains and in what order** → [nowPlayingActionOrder].
+///  - **How each button looks (icon + words)** → [nowPlayingActionStyles].
+///  - **What each button *does* (the wiring)** → stays in the widget
+///    `lib/features/player/widgets/now_playing_actions.dart`. You almost never
+///    need to open it.
+///
+/// ## Reorder the buttons
+/// Move the lines in [nowPlayingActionOrder] up or down. The row is laid out
+/// left → right in exactly this order.
+///
+/// ## Hide a button
+/// Delete (or comment out) its line in [nowPlayingActionOrder].
+///
+/// ## Show an optional button
+/// Add (or uncomment) its line. `shuffle` and `repeat` normally live in the
+/// transport row above, but are fully supported here too — uncomment them in the
+/// order list and they appear in the action row, already wired.
+///
+/// ## Change an icon or label
+/// Edit that action's entry in [nowPlayingActionStyles].
+library;
+
+import 'package:flutter/material.dart';
+
+/// Every action the bottom row knows how to show. Adding the id to
+/// [nowPlayingActionOrder] makes it appear; removing it hides it.
+enum NowPlayingAction {
+  /// Heart the current track (synced to Jellyfin for remote tracks, on-device
+  /// for local ones).
+  favorite,
+
+  /// Open the "add to playlist" sheet for the current track.
+  addToPlaylist,
+
+  /// Open the up-next queue.
+  queue,
+
+  /// Open the lyrics sheet for the current track.
+  lyrics,
+
+  /// Open the sleep-timer picker.
+  sleepTimer,
+
+  /// Toggle shuffle. Normally shown in the transport row; optional here.
+  shuffle,
+
+  /// Cycle repeat off → all → one. Normally shown in the transport row; optional
+  /// here. (Its glyph and tooltip change with the mode, handled by the widget.)
+  repeat,
+}
+
+/// Which brand colour a button lights up with when it is "on". Buttons that
+/// never toggle use [none] and stay the calm resting tint.
+enum NowPlayingActionTint {
+  /// Never highlights (it is a momentary action, not a toggle).
+  none,
+
+  /// Lights up violet (the app's primary identity colour) when active. Used by
+  /// favorite and the sleep timer.
+  brand,
+
+  /// Lights up warm orange (the "live" accent) when active. Used by shuffle and
+  /// repeat, matching the transport row.
+  accent,
+}
+
+/// The look of a single action button: its resting glyph and word, the glyph and
+/// word to swap in while it is "on" (for toggles), and which colour it lights up.
+@immutable
+class NowPlayingActionStyle {
+  const NowPlayingActionStyle({
+    required this.icon,
+    required this.label,
+    this.activeIcon,
+    this.activeLabel,
+    this.tint = NowPlayingActionTint.none,
+  });
+
+  /// The glyph shown at rest.
+  final IconData icon;
+
+  /// The tooltip / accessibility label shown at rest.
+  final String label;
+
+  /// The glyph to swap in while the button is "on". Null for buttons whose glyph
+  /// doesn't change (the same icon is reused).
+  final IconData? activeIcon;
+
+  /// The tooltip to swap in while the button is "on". Null reuses [label].
+  final String? activeLabel;
+
+  /// The colour the button takes while "on" (see [NowPlayingActionTint]).
+  final NowPlayingActionTint tint;
+}
+
+/// The default order and contents of the bottom action row, left → right.
+///
+/// This is the one obvious knob for the row. Reorder by moving lines; hide by
+/// removing a line; show an optional button by uncommenting its line.
+const List<NowPlayingAction> nowPlayingActionOrder = <NowPlayingAction>[
+  NowPlayingAction.favorite,
+  NowPlayingAction.addToPlaylist,
+  NowPlayingAction.queue,
+  NowPlayingAction.lyrics,
+  NowPlayingAction.sleepTimer,
+  // NowPlayingAction.shuffle, // ← uncomment to add a shuffle toggle to the row
+  // NowPlayingAction.repeat,  // ← uncomment to add a repeat toggle to the row
+];
+
+/// The look of each action. Edit an entry to change that button's icon or words;
+/// the wiring (what it does on tap) is unaffected.
+const Map<NowPlayingAction, NowPlayingActionStyle> nowPlayingActionStyles =
+    <NowPlayingAction, NowPlayingActionStyle>{
+  NowPlayingAction.favorite: NowPlayingActionStyle(
+    icon: Icons.favorite_border,
+    activeIcon: Icons.favorite,
+    label: 'Favorite',
+    activeLabel: 'Remove from favorites',
+    tint: NowPlayingActionTint.brand,
+  ),
+  NowPlayingAction.addToPlaylist: NowPlayingActionStyle(
+    icon: Icons.playlist_add,
+    label: 'Add to playlist',
+  ),
+  NowPlayingAction.queue: NowPlayingActionStyle(
+    icon: Icons.queue_music_outlined,
+    label: 'Queue',
+  ),
+  NowPlayingAction.lyrics: NowPlayingActionStyle(
+    icon: Icons.lyrics_outlined,
+    label: 'Lyrics',
+  ),
+  NowPlayingAction.sleepTimer: NowPlayingActionStyle(
+    icon: Icons.bedtime_outlined,
+    activeIcon: Icons.bedtime,
+    label: 'Sleep timer',
+    activeLabel: 'Sleep timer (on)',
+    tint: NowPlayingActionTint.brand,
+  ),
+  NowPlayingAction.shuffle: NowPlayingActionStyle(
+    icon: Icons.shuffle,
+    label: 'Shuffle',
+    activeLabel: 'Shuffle on',
+    tint: NowPlayingActionTint.accent,
+  ),
+  NowPlayingAction.repeat: NowPlayingActionStyle(
+    icon: Icons.repeat,
+    // While repeating one track the widget swaps in this glyph; "repeat all"
+    // keeps the plain glyph above. The mode-specific tooltip is derived in the
+    // widget.
+    activeIcon: Icons.repeat_one,
+    label: 'Repeat',
+    tint: NowPlayingActionTint.accent,
+  ),
+};

--- a/lib/ui_linthra/now_playing_layout_config.dart
+++ b/lib/ui_linthra/now_playing_layout_config.dart
@@ -1,0 +1,185 @@
+/// # Now Playing layout config
+///
+/// This is the "where things sit and what they say" file for the Now Playing
+/// screen. It turns the raw numbers in `design_tokens.dart` into named layout
+/// values (paddings, the gaps between the three bands, the source-line spacing)
+/// and gathers every visible word and the few decorative icons in one place.
+///
+/// The screen is grouped into three calm bands, top to bottom:
+///
+/// ```
+///  ┌───────────────── header ─────────────────┐  ← close · "Now Playing" · cast
+///  │                                           │
+///  │            ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓                │  ← album artwork  (band 1)
+///  │            ▓▓▓ artwork ▓▓▓                │
+///  │            ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓                │
+///  │                                           │
+///  │                Song title                 │  ← title / artist / album
+///  │                  Artist                   │     (band 2)
+///  │                  Album                     │
+///  │                                           │
+///  │             Playing from Plex             │  ← source · progress · transport
+///  │   ──────────●──────────────────────────   │     (band 3)
+///  │   ⤮   ⏮      ▶      ⏭   ⟳                 │
+///  │   ♥   ＋   ☰   ✎   ☾                      │  ← bottom action row
+///  └───────────────────────────────────────────┘
+/// ```
+///
+/// Editing tips:
+///  - To change a **gap or margin**, edit the matching value below.
+///  - To change a **word** (caption, tooltip, empty-state copy), edit
+///    [NowPlayingLabels].
+///  - To change **text weight / size**, edit [NowPlayingTextStyles] (and the
+///    weight/spacing tokens it reads from in `design_tokens.dart`).
+library;
+
+import 'package:flutter/material.dart';
+
+import 'design_tokens.dart';
+
+/// Paddings, band gaps, and the small internal spacings of the Now Playing
+/// screen. Values mirror the app's base spacing scale (`AppSpacing`): xs = 4,
+/// sm = 8, md = 16, lg = 24, xl = 32.
+abstract final class NowPlayingLayout {
+  // ── Outer frame ──────────────────────────────────────────────────────────
+
+  /// Padding around the header row (close · caption · cast).
+  static const EdgeInsets headerPadding = EdgeInsets.symmetric(
+    horizontal: 4, // AppSpacing.xs
+    vertical: 4, // AppSpacing.xs
+  );
+
+  /// Padding around the main content (everything below the header). A tighter
+  /// side margin lets the artwork breathe wider; the larger bottom keeps the
+  /// action row off the screen edge.
+  static const EdgeInsets contentPadding = EdgeInsets.fromLTRB(
+    16, // left  — AppSpacing.md
+    8, // top   — AppSpacing.sm
+    16, // right — AppSpacing.md
+    24, // bottom— AppSpacing.lg
+  );
+
+  // ── Gaps between the three bands ───────────────────────────────────────────
+
+  /// Space between the album artwork and the title block.
+  static const double gapArtworkToMetadata = 32; // AppSpacing.xl
+
+  /// Space between the title block and the live controls (source/progress/
+  /// transport).
+  static const double gapMetadataToControls = 24; // AppSpacing.lg
+
+  /// Space between the transport controls and the bottom action row.
+  static const double gapControlsToActions = 16; // AppSpacing.md
+
+  // ── Inside the metadata block ──────────────────────────────────────────────
+
+  /// Space between the title and the artist line.
+  static const double gapTitleToArtist = 8; // AppSpacing.sm
+
+  /// Space between the artist and the album line.
+  static const double gapArtistToAlbum = 4; // AppSpacing.xs
+
+  // ── Inside the live-controls block ─────────────────────────────────────────
+
+  /// Space between the "Playing from …" source line and the progress bar.
+  static const double gapSourceToProgress = 16; // AppSpacing.md
+
+  /// Space between the progress bar and the transport row.
+  static const double gapProgressToTransport = 8; // AppSpacing.sm
+
+  /// Space between the progress track and the elapsed / remaining time row.
+  static const double gapProgressToTimes = 4; // AppSpacing.xs
+
+  /// Space between the source glyph and its "Playing from …" text.
+  static const double gapSourceIconToText = 6; // AppSpacing.xs + 2
+}
+
+/// Every visible word on the Now Playing screen, plus the handful of purely
+/// decorative icons (the ones that are *not* tappable actions — those live in
+/// `now_playing_actions_config.dart`).
+abstract final class NowPlayingLabels {
+  /// The calm eyebrow caption centered in the header.
+  static const String header = 'Now Playing';
+
+  /// Tooltip on the collapse (down-chevron) button.
+  static const String closeTooltip = 'Close';
+
+  /// The chevron used to collapse the screen.
+  static const IconData closeIcon = Icons.keyboard_arrow_down;
+
+  /// Empty state shown when nothing is loaded.
+  static const IconData emptyIcon = Icons.music_note_outlined;
+  static const String emptyTitle = 'Nothing playing';
+  static const String emptyMessage = 'Pick a track to start listening.';
+
+  /// Shown (with a small spinner) during a mid-stream re-buffer.
+  static const String buffering = 'Buffering…';
+
+  /// Shown when playback fails but no specific reason was reported.
+  static const String genericError = "Couldn't play this track";
+
+  /// The "Casting to …" indicator. The glyph sits before the device name.
+  static const IconData castingIcon = Icons.cast_connected;
+  static String casting(String deviceName) => 'Casting to $deviceName';
+}
+
+/// The resolved text styles for the metadata block, header, source label, and
+/// time readouts. Each is built from a role in the app's [TextTheme] (so it
+/// follows the global type ramp) plus the finishing touches in
+/// [NowPlayingTypeTokens] / [NowPlayingOpacityTokens].
+///
+/// To make a line **bigger or smaller**, change which `textTheme` role it reads
+/// (e.g. swap `headlineSmall` → `headlineMedium` for a larger title), or add an
+/// explicit `fontSize:` to the `copyWith` below. Everything stays in this one
+/// spot — no need to open the widget files.
+abstract final class NowPlayingTextStyles {
+  /// Song title — the heaviest line, the hero of the text block.
+  static TextStyle? title(ThemeData theme) =>
+      theme.textTheme.headlineSmall?.copyWith(
+        fontWeight: NowPlayingTypeTokens.titleWeight,
+        letterSpacing: NowPlayingTypeTokens.titleLetterSpacing,
+        height: NowPlayingTypeTokens.titleHeight,
+      );
+
+  /// Artist — the clear secondary line.
+  static TextStyle? artist(ThemeData theme) =>
+      theme.textTheme.titleMedium?.copyWith(
+        color: theme.colorScheme.onSurface
+            .withValues(alpha: NowPlayingOpacityTokens.artist),
+        fontWeight: NowPlayingTypeTokens.artistWeight,
+      );
+
+  /// Album — the quietest line.
+  static TextStyle? album(ThemeData theme) =>
+      theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurface
+            .withValues(alpha: NowPlayingOpacityTokens.album),
+        letterSpacing: NowPlayingTypeTokens.albumLetterSpacing,
+      );
+
+  /// The "Now Playing" header caption.
+  static TextStyle? header(ThemeData theme) =>
+      theme.textTheme.labelLarge?.copyWith(
+        fontWeight: NowPlayingTypeTokens.headerWeight,
+        letterSpacing: NowPlayingTypeTokens.headerLetterSpacing,
+        color: theme.colorScheme.onSurface
+            .withValues(alpha: NowPlayingOpacityTokens.header),
+      );
+
+  /// The "Playing from …" source caption.
+  static TextStyle? source(ThemeData theme) =>
+      theme.textTheme.labelMedium?.copyWith(
+        fontWeight: NowPlayingTypeTokens.sourceWeight,
+        letterSpacing: NowPlayingTypeTokens.sourceLetterSpacing,
+        color: theme.colorScheme.onSurfaceVariant,
+      );
+
+  /// The elapsed / remaining time readouts under the progress bar. Uses tabular
+  /// figures so the digits don't jitter as the time ticks.
+  static TextStyle? time(ThemeData theme) =>
+      theme.textTheme.labelSmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+        letterSpacing: NowPlayingTypeTokens.timeLetterSpacing,
+        fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
+      );
+}

--- a/lib/ui_linthra/now_playing_preview_data.dart
+++ b/lib/ui_linthra/now_playing_preview_data.dart
@@ -1,0 +1,227 @@
+/// # Now Playing preview data
+///
+/// Hand-written, fake playback states for the dev-only Now Playing preview
+/// (`now_playing_preview_main.dart`). They let you see every variation of the
+/// screen — different providers, paused / buffering / error states, long titles,
+/// missing artwork — **without** connecting Plex, Jellyfin, or Navidrome.
+///
+/// This file is pure data: it never reaches the network or a real provider. The
+/// track URIs (`plex:` / `jellyfin:` / `subsonic:` / a file path) only drive the
+/// "Playing from …" label, exactly as they do in the real app.
+///
+/// Add your own sample by appending a [NowPlayingPreviewSample] to
+/// [nowPlayingPreviewSamples].
+library;
+
+import '../core/models/playback_source.dart';
+import '../core/models/playback_state.dart';
+import '../core/models/repeat_mode.dart';
+import '../core/models/track.dart';
+
+/// One named sample shown in the preview's picker.
+class NowPlayingPreviewSample {
+  const NowPlayingPreviewSample({
+    required this.name,
+    required this.state,
+    this.showArtwork = true,
+  });
+
+  /// The label shown in the preview's sample picker.
+  final String name;
+
+  /// The fake playback state the Now Playing screen renders.
+  final PlaybackState state;
+
+  /// Whether the preview should inject a real (bundled) cover so you can see the
+  /// blurred-artwork hero and background. Set false to preview the no-artwork
+  /// fallback (placeholder cover + brand gradient backdrop).
+  final bool showArtwork;
+}
+
+// A handful of fake tracks. Artwork is injected by the preview screen (from a
+// bundled image) for samples with showArtwork = true, so these stay offline.
+const Track _localTrack = Track(
+  id: 'preview-local',
+  title: 'Midnight Pull',
+  uri: '/music/the-violet-hours/midnight_pull.mp3',
+  artistName: 'The Violet Hours',
+  albumName: 'Afterglow',
+  duration: Duration(minutes: 3, seconds: 48),
+);
+
+const Track _plexTrack = Track(
+  id: 'preview-plex',
+  title: 'Paper Lanterns',
+  uri: 'plex:60412',
+  artistName: 'Harbor & Vine',
+  albumName: 'Tideline',
+  duration: Duration(minutes: 4, seconds: 5),
+);
+
+const Track _jellyfinTrack = Track(
+  id: 'preview-jellyfin',
+  title: 'Slow Static',
+  uri: 'jellyfin:9f3a2b',
+  artistName: 'Carrier Wave',
+  albumName: 'Low Orbit',
+  duration: Duration(minutes: 3, seconds: 21),
+);
+
+const Track _subsonicTrack = Track(
+  id: 'preview-subsonic',
+  title: 'Copper Sky',
+  uri: 'subsonic:tr-8841',
+  artistName: 'Marisol Reyes',
+  albumName: 'Dust & Gold',
+  duration: Duration(minutes: 5, seconds: 12),
+);
+
+const Track _longTrack = Track(
+  id: 'preview-long',
+  title:
+      'An Almost Unreasonably Long Song Title That Should Wrap and Ellipsize',
+  uri: 'jellyfin:long-1',
+  artistName: 'A Collective With a Notably Long and Winding Name Ensemble',
+  albumName: 'The Deluxe Anniversary Remastered Edition (Bonus Tracks)',
+  duration: Duration(minutes: 6, seconds: 2),
+);
+
+// A couple of upcoming tracks so the Next button is enabled and the queue sheet
+// has something to show.
+const List<Track> _upNext = <Track>[
+  Track(
+    id: 'preview-next-1',
+    title: 'Glasswing',
+    uri: 'plex:60413',
+    artistName: 'Harbor & Vine',
+    albumName: 'Tideline',
+    duration: Duration(minutes: 3, seconds: 30),
+  ),
+  Track(
+    id: 'preview-next-2',
+    title: 'Northbound',
+    uri: 'plex:60414',
+    artistName: 'Harbor & Vine',
+    albumName: 'Tideline',
+    duration: Duration(minutes: 4, seconds: 1),
+  ),
+];
+
+/// The samples shown in the preview, in picker order. Edit, reorder, or extend
+/// this list freely — it only affects the dev preview.
+const List<NowPlayingPreviewSample> nowPlayingPreviewSamples =
+    <NowPlayingPreviewSample>[
+  NowPlayingPreviewSample(
+    name: 'Playing · Plex',
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _plexTrack,
+      source: PlaybackSource.streamingDirect,
+      upNext: _upNext,
+      hasPrevious: true,
+      position: Duration(minutes: 1, seconds: 12),
+      duration: Duration(minutes: 4, seconds: 5),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Playing · Jellyfin',
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _jellyfinTrack,
+      source: PlaybackSource.streamingDirect,
+      upNext: _upNext,
+      hasPrevious: true,
+      position: Duration(minutes: 0, seconds: 47),
+      duration: Duration(minutes: 3, seconds: 21),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Playing · Navidrome',
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _subsonicTrack,
+      source: PlaybackSource.streamingDirect,
+      position: Duration(minutes: 2, seconds: 30),
+      duration: Duration(minutes: 5, seconds: 12),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Playing · Local file',
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _localTrack,
+      source: PlaybackSource.localFile,
+      upNext: _upNext,
+      hasPrevious: true,
+      position: Duration(minutes: 1, seconds: 40),
+      duration: Duration(minutes: 3, seconds: 48),
+      shuffleEnabled: true,
+      repeatMode: RepeatMode.all,
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Playing · Offline cache',
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _jellyfinTrack,
+      source: PlaybackSource.offlineCache,
+      position: Duration(minutes: 0, seconds: 18),
+      duration: Duration(minutes: 3, seconds: 21),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Paused',
+    state: PlaybackState(
+      status: PlaybackStatus.paused,
+      currentTrack: _plexTrack,
+      source: PlaybackSource.streamingDirect,
+      position: Duration(minutes: 1, seconds: 12),
+      duration: Duration(minutes: 4, seconds: 5),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Buffering',
+    state: PlaybackState(
+      status: PlaybackStatus.buffering,
+      currentTrack: _jellyfinTrack,
+      source: PlaybackSource.streamingDirect,
+      position: Duration(minutes: 0, seconds: 5),
+      duration: Duration(minutes: 3, seconds: 21),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Long title & artist',
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _longTrack,
+      source: PlaybackSource.streamingDirect,
+      position: Duration(minutes: 3, seconds: 0),
+      duration: Duration(minutes: 6, seconds: 2),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'No artwork',
+    showArtwork: false,
+    state: PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _localTrack,
+      source: PlaybackSource.localFile,
+      position: Duration(minutes: 0, seconds: 30),
+      duration: Duration(minutes: 3, seconds: 48),
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Error',
+    showArtwork: false,
+    state: PlaybackState(
+      status: PlaybackStatus.error,
+      currentTrack: _jellyfinTrack,
+      errorMessage: 'Your Jellyfin session has expired.',
+    ),
+  ),
+  NowPlayingPreviewSample(
+    name: 'Nothing playing',
+    showArtwork: false,
+    state: PlaybackState.idle,
+  ),
+];

--- a/lib/ui_linthra/preview/now_playing_preview_main.dart
+++ b/lib/ui_linthra/preview/now_playing_preview_main.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../app/theme.dart';
+import 'now_playing_preview_screen.dart';
+
+/// Dev-only entry point for previewing the Now Playing screen with fake data —
+/// no Plex / Jellyfin / Navidrome connection required.
+///
+/// Run it instead of the normal app:
+///
+/// ```
+/// flutter run -t lib/ui_linthra/preview/now_playing_preview_main.dart
+/// ```
+///
+/// Use the dropdown at the top to flip between sample states (different
+/// providers, paused / buffering / error, long titles, missing artwork). Edit
+/// the design in `lib/ui_linthra/` and hot-reload to see changes instantly.
+///
+/// This file is never part of the shipping app (the app's entry point is
+/// `lib/main.dart`).
+void main() {
+  runApp(const _NowPlayingPreviewApp());
+}
+
+class _NowPlayingPreviewApp extends StatelessWidget {
+  const _NowPlayingPreviewApp();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Linthra — Now Playing preview',
+      debugShowCheckedModeBanner: false,
+      // Dark mode is Linthra's primary experience, so the preview matches it.
+      theme: AppTheme.dark,
+      home: const NowPlayingPreviewScreen(),
+    );
+  }
+}

--- a/lib/ui_linthra/preview/now_playing_preview_screen.dart
+++ b/lib/ui_linthra/preview/now_playing_preview_screen.dart
@@ -1,0 +1,219 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/colors.dart';
+import '../../core/models/playback_state.dart';
+import '../../features/player/player_providers.dart';
+import '../../features/player/player_screen.dart';
+import '../now_playing_preview_data.dart';
+import 'preview_playback_controller.dart';
+
+/// Dev-only host for the real [PlayerScreen], fed by fake data.
+///
+/// It renders the **actual** Now Playing screen (the same widgets the app ships)
+/// inside a nested [ProviderScope] whose playback controller is a
+/// [PreviewPlaybackController]. A thin bar at the top lets you flip between the
+/// sample states in `now_playing_preview_data.dart`. Nothing here runs in the
+/// shipping app — launch it with:
+///
+/// ```
+/// flutter run -t lib/ui_linthra/preview/now_playing_preview_main.dart
+/// ```
+class NowPlayingPreviewScreen extends StatefulWidget {
+  const NowPlayingPreviewScreen({super.key});
+
+  @override
+  State<NowPlayingPreviewScreen> createState() =>
+      _NowPlayingPreviewScreenState();
+}
+
+class _NowPlayingPreviewScreenState extends State<NowPlayingPreviewScreen> {
+  late final PreviewPlaybackController _controller;
+  int _selected = 0;
+
+  /// A generated cover written to a temp file so the blurred-artwork hero shows
+  /// up offline (the app's artwork loader reads `file:` covers from disk). Null
+  /// until prepared — or if preparation fails — in which case the preview simply
+  /// shows the no-artwork look.
+  Uri? _artwork;
+
+  NowPlayingPreviewSample get _current => nowPlayingPreviewSamples[_selected];
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PreviewPlaybackController(_resolved(_current));
+    _prepareArtwork();
+  }
+
+  /// Applies the prepared cover to a sample's state (for samples that want it),
+  /// so the real artwork/background widgets have something to render offline.
+  PlaybackState _resolved(NowPlayingPreviewSample sample) {
+    final Uri? art = _artwork;
+    final track = sample.state.currentTrack;
+    if (!sample.showArtwork || art == null || track == null) {
+      return sample.state;
+    }
+    return sample.state.copyWith(
+      currentTrack: track.copyWith(artworkUri: art),
+    );
+  }
+
+  /// Paints a calm brand-gradient square and writes it to a temp PNG, so the
+  /// preview can show a real cover and blurred backdrop without bundling any
+  /// asset or hitting the network.
+  Future<void> _prepareArtwork() async {
+    try {
+      final ui.Image image = await _paintPreviewCover();
+      final ByteData? png =
+          await image.toByteData(format: ui.ImageByteFormat.png);
+      image.dispose();
+      if (png == null) return;
+      final Directory dir =
+          await Directory.systemTemp.createTemp('linthra_np_preview');
+      final File file = File('${dir.path}/cover.png');
+      await file.writeAsBytes(
+        png.buffer.asUint8List(png.offsetInBytes, png.lengthInBytes),
+      );
+      if (!mounted) return;
+      setState(() => _artwork = file.uri);
+      _controller.load(_resolved(_current));
+    } catch (_) {
+      // Best-effort: the preview still works without a cover image.
+    }
+  }
+
+  Future<ui.Image> _paintPreviewCover() async {
+    const double size = 512;
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    canvas.drawRect(
+      const Rect.fromLTWH(0, 0, size, size),
+      Paint()
+        ..shader = ui.Gradient.linear(
+          Offset.zero,
+          const Offset(size, size),
+          const <Color>[
+            AppColors.brandBright,
+            AppColors.brandDeep,
+            AppColors.accentDeep,
+          ],
+          const <double>[0.0, 0.55, 1.0],
+        ),
+    );
+    // A soft glow so the heavily-blurred backdrop has some structure to it.
+    canvas.drawCircle(
+      const Offset(size * 0.66, size * 0.34),
+      size * 0.24,
+      Paint()..color = AppColors.accentBright.withValues(alpha: 0.35),
+    );
+    return recorder.endRecording().toImage(size.toInt(), size.toInt());
+  }
+
+  void _select(int index) {
+    setState(() => _selected = index);
+    _controller.load(_resolved(_current));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: theme.colorScheme.surface,
+      body: Column(
+        children: [
+          SafeArea(
+            bottom: false,
+            child: _PreviewBar(
+              samples: nowPlayingPreviewSamples,
+              selected: _selected,
+              onSelected: _select,
+            ),
+          ),
+          Expanded(
+            // The real Now Playing screen, with only its playback controller
+            // swapped for the fake one. Everything else (cast, favorites, sleep
+            // timer, lyrics) uses its normal in-memory default, so no provider
+            // needs a server.
+            child: ProviderScope(
+              overrides: [
+                playbackControllerProvider.overrideWithValue(_controller),
+              ],
+              child: const PlayerScreen(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The thin dev toolbar above the previewed screen: a clear "fake data" note and
+/// a dropdown to pick which sample state to render. Intentionally plain — it is
+/// not part of the design under review.
+class _PreviewBar extends StatelessWidget {
+  const _PreviewBar({
+    required this.samples,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final List<NowPlayingPreviewSample> samples;
+  final int selected;
+  final ValueChanged<int> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          children: [
+            Icon(
+              Icons.science_outlined,
+              size: 18,
+              color: theme.colorScheme.secondary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Now Playing — UI preview (fake data)',
+                style: theme.textTheme.labelMedium,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 8),
+            DropdownButton<int>(
+              value: selected,
+              underline: const SizedBox.shrink(),
+              borderRadius: BorderRadius.circular(12),
+              items: [
+                for (int i = 0; i < samples.length; i++)
+                  DropdownMenuItem<int>(
+                    value: i,
+                    child: Text(samples[i].name),
+                  ),
+              ],
+              onChanged: (i) {
+                if (i != null) onSelected(i);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_linthra/preview/preview_playback_controller.dart
+++ b/lib/ui_linthra/preview/preview_playback_controller.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import '../../core/models/playback_state.dart';
+import '../../core/models/repeat_mode.dart';
+import '../../core/models/track.dart';
+import '../../core/services/playback_controller.dart';
+
+/// A tiny, in-memory [PlaybackController] used **only** by the Now Playing UI
+/// preview (`now_playing_preview_main.dart`).
+///
+/// It never touches `just_audio`, the network, or any music provider — it simply
+/// holds a [PlaybackState] you hand it and emits it to the screen, plus enough
+/// interactivity (play/pause, seek, shuffle, repeat, light queue edits) that the
+/// real Now Playing widgets feel alive while you tweak the design. It is not used
+/// by the shipping app and has no effect on real playback.
+class PreviewPlaybackController implements PlaybackController {
+  PreviewPlaybackController(PlaybackState initial) : _state = initial;
+
+  final StreamController<PlaybackState> _states =
+      StreamController<PlaybackState>.broadcast();
+  PlaybackState _state;
+
+  @override
+  PlaybackState get state => _state;
+
+  @override
+  Stream<PlaybackState> get stateStream => _states.stream;
+
+  void _emit(PlaybackState next) {
+    _state = next;
+    _states.add(next);
+  }
+
+  /// Swaps in a different sample state. Used by the preview's sample picker.
+  void load(PlaybackState sample) => _emit(sample);
+
+  @override
+  Future<void> play() async {
+    _emit(_state.copyWith(status: PlaybackStatus.playing));
+  }
+
+  @override
+  Future<void> pause() async {
+    _emit(_state.copyWith(status: PlaybackStatus.paused));
+  }
+
+  @override
+  Future<void> seek(Duration position) async {
+    _emit(_state.copyWith(position: position));
+  }
+
+  @override
+  void setShuffleEnabled(bool enabled) {
+    _emit(_state.copyWith(shuffleEnabled: enabled));
+  }
+
+  @override
+  void setRepeatMode(RepeatMode mode) {
+    _emit(_state.copyWith(repeatMode: mode));
+  }
+
+  @override
+  void clearQueue() {
+    _emit(_state.copyWith(upNext: const <Track>[]));
+  }
+
+  @override
+  void removeFromQueue(int upNextIndex) {
+    if (upNextIndex < 0 || upNextIndex >= _state.upNext.length) return;
+    final List<Track> next = List<Track>.of(_state.upNext)
+      ..removeAt(upNextIndex);
+    _emit(_state.copyWith(upNext: next));
+  }
+
+  @override
+  void reorderQueue(int oldIndex, int newIndex) {
+    if (oldIndex < 0 || oldIndex >= _state.upNext.length) return;
+    final List<Track> next = List<Track>.of(_state.upNext);
+    final Track moved = next.removeAt(oldIndex);
+    next.insert(newIndex.clamp(0, next.length), moved);
+    _emit(_state.copyWith(upNext: next));
+  }
+
+  // ── The rest are inert: the preview never changes tracks or starts real
+  //    playback, so these are deliberate no-ops. ───────────────────────────────
+
+  @override
+  Future<void> playTrack(Track track) async {}
+
+  @override
+  Future<void> playTracks(List<Track> tracks, {int startIndex = 0}) async {}
+
+  @override
+  void playNext(Track track) {}
+
+  @override
+  void addToQueue(Track track) {}
+
+  @override
+  Future<void> playFromQueue(int upNextIndex) async {}
+
+  @override
+  Future<void> playFromHistory(int previousIndex) async {}
+
+  @override
+  Future<void> skipToNext() async {}
+
+  @override
+  Future<void> skipToPrevious() async {}
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+}

--- a/test/ui_linthra/now_playing_preview_test.dart
+++ b/test/ui_linthra/now_playing_preview_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/ui_linthra/now_playing_preview_data.dart';
+import 'package:linthra/ui_linthra/preview/now_playing_preview_screen.dart';
+import 'package:linthra/ui_linthra/preview/preview_playback_controller.dart';
+
+const _track = Track(
+  id: 'x',
+  title: 'Sample',
+  uri: 'jellyfin:x',
+  artistName: 'Artist',
+  albumName: 'Album',
+);
+
+void main() {
+  group('PreviewPlaybackController', () {
+    test('starts from, and emits, the state it is given', () async {
+      final controller = PreviewPlaybackController(
+        const PlaybackState(
+          status: PlaybackStatus.paused,
+          currentTrack: _track,
+          source: PlaybackSource.streamingDirect,
+        ),
+      );
+      addTearDown(controller.dispose);
+
+      expect(controller.state.currentTrack?.title, 'Sample');
+
+      final emitted = <PlaybackState>[];
+      final sub = controller.stateStream.listen(emitted.add);
+
+      controller.load(
+        const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, PlaybackStatus.playing);
+      expect(emitted.single.status, PlaybackStatus.playing);
+      await sub.cancel();
+    });
+
+    test('play / pause / seek update the state', () async {
+      final controller = PreviewPlaybackController(
+        const PlaybackState(
+            status: PlaybackStatus.paused, currentTrack: _track),
+      );
+      addTearDown(controller.dispose);
+
+      await controller.play();
+      expect(controller.state.status, PlaybackStatus.playing);
+
+      await controller.pause();
+      expect(controller.state.status, PlaybackStatus.paused);
+
+      await controller.seek(const Duration(seconds: 42));
+      expect(controller.state.position, const Duration(seconds: 42));
+    });
+
+    test('shuffle and repeat toggles update the state', () async {
+      final controller = PreviewPlaybackController(
+        const PlaybackState(
+            status: PlaybackStatus.playing, currentTrack: _track),
+      );
+      addTearDown(controller.dispose);
+
+      controller.setShuffleEnabled(true);
+      expect(controller.state.shuffleEnabled, isTrue);
+
+      controller.setRepeatMode(RepeatMode.one);
+      expect(controller.state.repeatMode, RepeatMode.one);
+    });
+
+    test('queue edits stay in bounds', () async {
+      final controller = PreviewPlaybackController(
+        const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: _track,
+          upNext: <Track>[
+            Track(id: 'a', title: 'A', uri: 'jellyfin:a'),
+            Track(id: 'b', title: 'B', uri: 'jellyfin:b'),
+          ],
+        ),
+      );
+      addTearDown(controller.dispose);
+
+      controller.removeFromQueue(5); // out of range: no-op
+      expect(controller.state.upNext.length, 2);
+
+      controller.removeFromQueue(0);
+      expect(controller.state.upNext.single.id, 'b');
+
+      controller.clearQueue();
+      expect(controller.state.upNext, isEmpty);
+    });
+  });
+
+  group('NowPlayingPreviewScreen', () {
+    testWidgets('renders the real PlayerScreen with the first sample',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.dark,
+          home: const NowPlayingPreviewScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The dev toolbar and the genuine Now Playing screen are both present.
+      expect(find.text('Now Playing — UI preview (fake data)'), findsOneWidget);
+      expect(find.byType(PlayerScreen), findsOneWidget);
+
+      // The first sample's metadata flows through to the real widgets.
+      final first = nowPlayingPreviewSamples.first.state.currentTrack!;
+      expect(find.text(first.title), findsOneWidget);
+
+      // No broken-image or layout exceptions from the fake data / generated art.
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Goal

Make the **current** Now Playing design easy for the maintainer to edit by hand (on Windows) without digging through playback/provider logic.

> **The current Now Playing design is the reference and is preserved.** This is *not* a redesign. The config files were filled in with the exact values the screen already used, so the rendered screen is unchanged — only *where the numbers live* moved.

## What changed

A new, heavily-commented design surface at **`lib/ui_linthra/`**:

| File | Edit it to change… |
| --- | --- |
| `design_tokens.dart` | Artwork size, blur strength, corner radius, shadows, button/icon sizes, text weights, muted-text opacity |
| `now_playing_layout_config.dart` | Spacing/gaps/paddings, every on-screen **word**, and the **text styles** |
| `now_playing_actions_config.dart` | The bottom action row: **button order**, which buttons show, icons, labels |
| `now_playing_preview_data.dart` | Fake states for the preview |
| `preview/` | Dev-only preview app (real screen + fake data) |
| `README.md` | Folder overview |

The player widgets (`lib/features/player/…`) now **read** their values from these files instead of hard-coding numbers. Playback logic, provider logic, and the "Playing from …" safe labelling are untouched.

### Easy button editing

`nowPlayingActionOrder` is the one obvious knob for the bottom row:

```dart
const List<NowPlayingAction> nowPlayingActionOrder = <NowPlayingAction>[
  NowPlayingAction.favorite,
  NowPlayingAction.addToPlaylist,
  NowPlayingAction.queue,
  NowPlayingAction.lyrics,
  NowPlayingAction.sleepTimer,
  // NowPlayingAction.shuffle, // ← uncomment to add a shuffle toggle here
  // NowPlayingAction.repeat,  // ← uncomment to add a repeat toggle here
];
```

- **Reorder** → move a line. **Hide** → delete/comment a line. **Show** → uncomment a line.
- `favorite`, `addToPlaylist`, `queue`, `lyrics`, `sleepTimer`, `shuffle`, `repeat` are all supported and wired. No playback code to touch.

### Dev-only preview (no server needed)

```bash
flutter run -t lib/ui_linthra/preview/now_playing_preview_main.dart
```

Renders the **real** `PlayerScreen` with fake data and a dropdown to flip between samples (Plex / Jellyfin / Navidrome / local / cache, paused / buffering / error, long titles, no-artwork). Works fully offline — the preview paints its own cover so the blurred-artwork hero shows without Plex/Jellyfin/Navidrome. Hot-reload to see edits instantly.

### Docs

- **`docs/ui-editing-guide.md`** — how to open the project on Windows, exactly which file/line to edit for button order, spacing, colours, artwork size, labels, text size; how to preview/test; and which files **not** to edit unless changing playback logic.
- Pointer added from the codebase tour.

## Preserved behaviour ✅

- Current Now Playing screen looks the same (large artwork, blurred dynamic background, centered title/artist/album, "Playing from …" source label, orange progress + play button, clean bottom action row).
- Existing / Plex / Jellyfin / Subsonic-Navidrome / local playback paths unchanged.
- Cast button and source label retained.
- No provider/token/security behaviour changed.

## Out of scope (as requested)

No redesign, no new provider, no lyrics implementation, no cache/offline changes, no Plex.tv OAuth, no version bump, no user-facing theme editor / runtime customization UI.

## Verification

- `flutter analyze` — clean
- `dart format --set-exit-if-changed .` — clean
- `flutter test` — full suite passes, including the existing Now Playing widget tests (labels, tooltips, icons, source badges, transport) and new tests for the preview controller + screen.

https://claude.ai/code/session_01Bv1N4G2akQmaLGzSNAWgqb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bv1N4G2akQmaLGzSNAWgqb)_