### PR TITLE
fix(catalog): make track writes idempotent so a duplicate id can't fail a sync

### DIFF
--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -90,9 +90,20 @@ class DriftMusicLibraryRepository
   Future<void> _insertTracks(String sourceId, List<Track> tracks) async {
     if (tracks.isEmpty) return;
     await _db.batch((Batch batch) {
+      // insertOrReplace makes the write idempotent: a source can legitimately
+      // hand us the same stable track id twice within one sync — e.g. a Subsonic
+      // album that shifts across paginated `getAlbumList2` pages and so is
+      // fetched twice, or an `appendToCatalog` batch that overlaps an earlier
+      // one during an incremental replacement. A plain insert would raise a
+      // UNIQUE-constraint error on the duplicate id and roll back the whole
+      // transaction, failing an otherwise-good sync. The id is the track's
+      // stable identity, so a duplicate is the same track; collapsing to one row
+      // (last wins) is the correct resolution. `tracks` is the only table and
+      // has no foreign keys, so the replace can never cascade.
       batch.insertAll(
         _db.tracks,
         tracks.map((Track t) => trackToCompanion(t, sourceId)).toList(),
+        mode: InsertMode.insertOrReplace,
       );
     });
   }

--- a/test/data/repositories/drift_music_library_repository_test.dart
+++ b/test/data/repositories/drift_music_library_repository_test.dart
@@ -120,5 +120,54 @@ void main() {
         containsAll(<String>['local-1', 'jellyfin-1']),
       );
     });
+
+    test(
+        'upsertCatalog with a duplicate track id collapses to one row '
+        '(idempotent, last wins) instead of failing the sync', () async {
+      // A duplicate stable id within one sync (e.g. a Subsonic album fetched
+      // twice across shifting pagination) must not raise a UNIQUE-constraint
+      // error and roll back the whole catalog.
+      await repository.upsertCatalog(
+        sourceId: 'subsonic',
+        tracks: <Track>[
+          _track('dup', durationMs: 1000),
+          _track('other'),
+          _track('dup', durationMs: 2000),
+        ],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(all.map((Track t) => t.id), containsAll(<String>['dup', 'other']));
+      final Track? dup = await repository.getTrackById('dup');
+      expect(dup, isNotNull);
+      expect(dup!.duration, const Duration(milliseconds: 2000));
+    });
+
+    test('incremental append tolerates a duplicate id across batches',
+        () async {
+      // The Plex incremental path writes in batches; the same id can appear in
+      // two batches. The second append must not fail on a UNIQUE constraint.
+      await repository.beginCatalogReplacement(
+        sourceId: 'plex',
+        tracks: <Track>[_track('a'), _track('shared', durationMs: 1000)],
+      );
+      await repository.appendToCatalog(
+        sourceId: 'plex',
+        tracks: <Track>[_track('b'), _track('shared', durationMs: 2000)],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(3));
+      expect(
+        all.map((Track t) => t.id),
+        containsAll(<String>['a', 'b', 'shared']),
+      );
+      final Track? shared = await repository.getTrackById('shared');
+      expect(shared, isNotNull);
+      expect(shared!.duration, const Duration(milliseconds: 2000));
+    });
   });
 }


### PR DESCRIPTION
## What & why

A music source can hand the catalog the **same stable track id twice within one sync**. The most reachable case is a **Subsonic / Navidrome** library whose albums shift across paginated `getAlbumList2` pages between requests, so the same album is fetched twice and contributes the same song ids twice. (An incremental `appendToCatalog` batch that overlaps an earlier one can do the same.)

`_insertTracks` used Drift's default `InsertMode.insert`, so a duplicate id raised a **UNIQUE-constraint error and rolled back the whole transaction** — intermittently failing an otherwise-good re-sync with a generic "something went wrong saving your library". Because it depends on server-side timing, it looks random.

## The fix

`_insertTracks` now uses `InsertMode.insertOrReplace`. The id is the track's stable identity, so a duplicate is the same track; collapsing to one row (last wins) is the correct resolution.

- Fixing it at `_insertTracks` covers **both** write paths — the single-shot `upsertCatalog` and the incremental `beginCatalogReplacement` + `appendToCatalog` (so a cross-batch duplicate in the Plex path is handled too).
- **Cascade-safe:** `tracks` is the only table and has no foreign keys, so the replace can never cascade.

## Tests

Added two regression tests (against real in-memory SQLite):
- `upsertCatalog` with a duplicate id collapses to one row (idempotent, last wins) instead of failing.
- Incremental append tolerates a duplicate id across batches.

## Verification

- `flutter test test/data/repositories/drift_music_library_repository_test.dart` → **8/8 pass** (incl. both new tests).
- `flutter analyze` on the changed files → **No issues found**.

## Scope

Intentionally limited to **only** the duplicate-id catalog-write fix. No changes to playback, Plex, artwork, the mobile-data gate, or local-scan threading. This is the first item from a broader stability audit; other findings will be handled in their own separate PRs.

Opened as a **draft** for review before merge.

https://claude.ai/code/session_014utneRnLSPjTcm3kaFr2wT

---
_Generated by [Claude Code](https://claude.ai/code/session_014utneRnLSPjTcm3kaFr2wT)_