### PR TITLE
fix(stability): honor mobile-data setting for pre-cache + move local scan off the main thread

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/SafDocumentScanner.kt
@@ -4,12 +4,16 @@ import android.content.Context
 import android.content.Intent
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.provider.DocumentsContract
 import io.flutter.plugin.common.MethodChannel
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
 import java.util.ArrayDeque
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
 /**
  * Walks a user-picked Storage Access Framework tree URI through the content
@@ -31,14 +35,32 @@ import java.util.ArrayDeque
  */
 class SafDocumentScanner(private val context: Context) {
 
-    /** Lists audio documents under [treeUri], reporting back through [result]. */
+    /**
+     * Lists audio documents under [treeUri], reporting back through [result].
+     *
+     * The walk does blocking content-resolver queries and a per-file
+     * [MediaMetadataRetriever] read (plus embedded-artwork extraction), so on a
+     * large library it can take many seconds. The method-channel handler runs on
+     * the platform main thread, so doing the walk inline would freeze the UI —
+     * the bug this guards against. The walk therefore runs on a background
+     * executor, and the reply is posted back to the main thread, which is where
+     * Flutter requires [MethodChannel.Result] to be answered. The walk itself
+     * (and the result it produces) is unchanged.
+     */
     fun listAudioDocuments(treeUri: String, result: MethodChannel.Result) {
-        try {
-            result.success(walk(Uri.parse(treeUri)))
-        } catch (e: SecurityException) {
-            result.error("saf_permission", "No access to the selected folder.", null)
-        } catch (e: Exception) {
-            result.error("saf_failed", "Failed to read the selected folder.", null)
+        scanExecutor.execute {
+            try {
+                val documents = walk(Uri.parse(treeUri))
+                mainHandler.post { result.success(documents) }
+            } catch (e: SecurityException) {
+                mainHandler.post {
+                    result.error("saf_permission", "No access to the selected folder.", null)
+                }
+            } catch (e: Exception) {
+                mainHandler.post {
+                    result.error("saf_failed", "Failed to read the selected folder.", null)
+                }
+            }
         }
     }
 
@@ -369,6 +391,20 @@ class SafDocumentScanner(private val context: Context) {
     }
 
     companion object {
+        // A single background thread for the (potentially long) folder walk, so a
+        // large-library scan never runs on the platform main thread and freezes
+        // the UI. Process-wide and serialized — one scan at a time, matching the
+        // previous (main-thread) behaviour minus the freeze — and a daemon thread
+        // so it never keeps the process alive on its own.
+        private val scanExecutor: ExecutorService =
+            Executors.newSingleThreadExecutor { runnable ->
+                Thread(runnable, "linthra-saf-scan").apply { isDaemon = true }
+            }
+
+        // Posts the method-channel reply back to the main thread, where Flutter
+        // requires MethodChannel.Result to be answered.
+        private val mainHandler = Handler(Looper.getMainLooper())
+
         private val AUDIO_EXTENSIONS =
             listOf(".mp3", ".flac", ".m4a", ".aac", ".ogg", ".opus", ".wav")
 

--- a/docs/dependency-license-audit.md
+++ b/docs/dependency-license-audit.md
@@ -79,6 +79,7 @@ compatible with MPL-2.0 and acceptable to F-Droid.
 | `cast`                   | `^2.1.0`     | (johnvuko)          | MIT            | Pure-Dart Google Cast v2 protocol for real Chromecast — **no** Google Play Services / proprietary Cast SDK. See §5 (Casting). |
 | `bonsoir`                | `^5.1.11`    | (Skyost)            | MIT            | mDNS/Bonjour service discovery used by `cast`; Android side is AOSP `NsdManager`, not GMS. Pinned to 5.x for Dart 3.6 (6.x+ needs Dart ≥3.8). See §5 (Casting). |
 | `url_launcher`           | `^6.3.0`     | flutter.dev         | BSD-3-Clause   | Opens the browser for the "Report a bug" → "Open GitHub issue" action (a prefilled, **unsubmitted** issue the user reviews). AOSP `ACTION_VIEW` intent; **no** GMS. See note below and §7 (Reporting a bug). |
+| `connectivity_plus`      | `^6.1.0`     | (fluttercommunity)  | BSD-3-Clause   | Detects Wi-Fi vs mobile/cellular vs offline for the offline-download + smart-pre-cache **mobile-data gate**. Android side is the **AOSP** `ConnectivityManager` (**no** GMS); adds **no new permission** (`ACCESS_NETWORK_STATE` is already merged via Media3, §5). See note below. |
 
 > The `http` and `flutter_secure_storage` entries were added with the Jellyfin
 > source foundation; `cast` and `bonsoir` were added with real Chromecast
@@ -91,6 +92,20 @@ compatible with MPL-2.0 and acceptable to F-Droid.
 > Services). It is wrapped behind the `ExternalLinkLauncher` interface and is
 > invoked only on an explicit user tap — the app never opens a link on its own.
 > See §7.
+>
+> `connectivity_plus` was added for the offline-download / smart-pre-cache
+> **mobile-data gate** — detecting Wi-Fi vs mobile/cellular so "Allow mobile
+> data" can actually hold caching back off a metered link. It is a Flutter
+> Community ("plus") plugin (**BSD-3-Clause**), wrapped behind the
+> `ConnectivityService` interface (`ConnectivityPlusConnectivityService`); the
+> rest of the app never touches it directly. On Android it reads the **AOSP**
+> `ConnectivityManager` — **no** Google Play Services — and adds **no new
+> Android permission**: `ACCESS_NETWORK_STATE` is already merged into the
+> manifest via Media3 (§5). Its transitive `connectivity_plus_platform_interface`
+> is **BSD-3-Clause**; the only other pull-in, `nm` (Linux NetworkManager D-Bus,
+> Canonical), is **MPL-2.0** — the same license as Linthra — and is
+> **desktop-Linux-only**, never shipped in the Android APK. Re-run the mechanical
+> transitive count (§9) on this change.
 
 ## 4. Dev / build-only dependencies (NOT shipped in the APK)
 

--- a/lib/core/services/connectivity_plus_connectivity_service.dart
+++ b/lib/core/services/connectivity_plus_connectivity_service.dart
@@ -1,0 +1,70 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'connectivity_service.dart';
+
+/// The real [ConnectivityService], backed by the `connectivity_plus` plugin, so
+/// the offline-download and smart-pre-cache mobile-data gate sees the *actual*
+/// link type instead of the optimistic "always Wi-Fi" placeholder
+/// ([OptimisticConnectivityService]). This is the implementation the existing
+/// gate was designed for; wiring it in is what makes "Allow mobile data"
+/// actually hold pre-cache and downloads back off a metered connection.
+///
+/// The mapping is deliberately conservative — the safe default is "don't spend
+/// mobile data without permission":
+///  - Wi-Fi or Ethernet (unmetered) -> [NetworkStatus.wifi].
+///  - Mobile/cellular -> [NetworkStatus.mobile] (allowed only when the user
+///    turned on "Allow mobile data").
+///  - No connection -> [NetworkStatus.offline].
+///  - Anything else or indeterminate (VPN, Bluetooth, satellite, "other", an
+///    empty list, or a failed read) -> [NetworkStatus.unknown], which the policy
+///    already treats like mobile data — so an undetermined link is never assumed
+///    unmetered and never pre-caches silently over a metered connection.
+///
+/// The platform can report several transports at once (e.g. `[wifi, vpn]`); the
+/// mapping prefers the safe interpretation, only reporting [NetworkStatus.wifi]
+/// when an unmetered transport is actually present.
+///
+/// It depends only on `connectivity_plus`, which reads Android's standard
+/// `ConnectivityManager` (no Google Play Services), so it stays F-Droid /
+/// open-source compatible. The rest of the app keeps depending on the
+/// [ConnectivityService] interface, never on the plugin directly.
+class ConnectivityPlusConnectivityService implements ConnectivityService {
+  ConnectivityPlusConnectivityService({Connectivity? connectivity})
+      : _connectivity = connectivity ?? Connectivity();
+
+  final Connectivity _connectivity;
+
+  @override
+  Stream<NetworkStatus> get statusStream =>
+      _connectivity.onConnectivityChanged.map(_mapResults);
+
+  @override
+  Future<NetworkStatus> currentStatus() async {
+    try {
+      return _mapResults(await _connectivity.checkConnectivity());
+    } catch (_) {
+      // A failed read must never be mistaken for unmetered Wi-Fi; fall back to
+      // the conservative "unknown" so the user's mobile-data choice still wins.
+      return NetworkStatus.unknown;
+    }
+  }
+
+  /// Collapses the platform's (possibly multi-transport) result list into a
+  /// single [NetworkStatus], preferring the safe reading when transports mix.
+  static NetworkStatus _mapResults(List<ConnectivityResult> results) {
+    if (results.isEmpty ||
+        results.every((ConnectivityResult r) => r == ConnectivityResult.none)) {
+      return NetworkStatus.offline;
+    }
+    if (results.contains(ConnectivityResult.wifi) ||
+        results.contains(ConnectivityResult.ethernet)) {
+      return NetworkStatus.wifi;
+    }
+    if (results.contains(ConnectivityResult.mobile)) {
+      return NetworkStatus.mobile;
+    }
+    // VPN / Bluetooth / satellite / "other" / unrecognised: don't assume the
+    // link is unmetered — treat it as unknown so the mobile-data gate applies.
+    return NetworkStatus.unknown;
+  }
+}

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -6,6 +6,7 @@ import '../../core/repositories/download_repository.dart';
 import '../../core/repositories/download_store.dart';
 import '../../core/repositories/offline_file_store.dart';
 import '../../core/services/cached_track_locator.dart';
+import '../../core/services/connectivity_plus_connectivity_service.dart';
 import '../../core/services/connectivity_service.dart';
 import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/optimistic_connectivity_service.dart';
@@ -130,6 +131,17 @@ final sharedPreferencesDownloadPreferencesOverride =
 final fileSystemOfflineFileStoreOverride =
     offlineFileStoreProvider.overrideWithValue(
   FileSystemOfflineFileStore(),
+);
+
+/// Production binding: detect the real connection type with `connectivity_plus`
+/// so the mobile-data gate actually holds offline downloads and smart pre-cache
+/// back off a metered (or undetermined) link. Without this override the
+/// optimistic default reports Wi-Fi and the gate can never engage — which is the
+/// "pre-cache runs on mobile data" bug. Applied in `main`; tests keep the
+/// plugin-free optimistic default (or inject a fake) so they stay device-free.
+final connectivityPlusServiceOverride =
+    connectivityServiceProvider.overrideWith(
+  (ref) => ConnectivityPlusConnectivityService(),
 );
 
 /// The fallback [RemoteTrackDownloader] when no source can fetch a track: it

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,6 +75,10 @@ Future<void> main() async {
       sharedPreferencesDownloadPreferencesOverride,
       sharedPreferencesPlaybackPreferencesOverride,
       fileSystemOfflineFileStoreOverride,
+      // Detect the real Wi-Fi/mobile/offline link so the mobile-data gate holds
+      // downloads and smart pre-cache back off a metered connection (the
+      // optimistic default always reported Wi-Fi, so the gate never engaged).
+      connectivityPlusServiceOverride,
       remoteTrackDownloaderOverride,
       // Let playback fall back to another copy of the same song when the
       // preferred source fails to resolve or start (the candidates come from the

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   convert:
     dependency: transitive
     description:
@@ -616,6 +632,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,14 @@ dependencies:
   # the rest of the app depends on the JellyfinClient interface, never on http
   # directly. The Dart-team package, so it stays small and dependency-light.
   http: ^1.2.0
+  # Network reachability (Wi-Fi vs mobile/cellular vs offline) for the offline
+  # download + smart pre-cache mobile-data gate. Used only by
+  # ConnectivityPlusConnectivityService behind the ConnectivityService
+  # interface; the policy that consults it lives in CacheDownloadRepository and
+  # the rest of the app never touches connectivity_plus directly. A Flutter
+  # Community ("plus") plugin that reads Android's standard ConnectivityManager
+  # (no Google Play Services), so it stays F-Droid/open-source compatible.
+  connectivity_plus: ^6.1.0
   # MD5 hashing for the Subsonic/Navidrome token+salt auth scheme
   # (token = md5(password + salt)). Used only by SubsonicAuth so a Subsonic
   # session can authenticate every request without ever persisting the

--- a/test/core/services/connectivity_plus_connectivity_service_test.dart
+++ b/test/core/services/connectivity_plus_connectivity_service_test.dart
@@ -1,0 +1,149 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/connectivity_plus_connectivity_service.dart';
+import 'package:linthra/core/services/connectivity_service.dart';
+
+/// A stand-in for the plugin's [Connectivity] that returns canned results, so
+/// the mapping from `connectivity_plus`' transport list to [NetworkStatus] can
+/// be exercised without a device or platform channel.
+class _FakeConnectivity implements Connectivity {
+  _FakeConnectivity(this.results,
+      {this.changes = const <List<ConnectivityResult>>[],
+      this.throwOnCheck = false});
+
+  /// What [checkConnectivity] reports.
+  List<ConnectivityResult> results;
+
+  /// What [onConnectivityChanged] emits, in order.
+  final List<List<ConnectivityResult>> changes;
+
+  /// When true, [checkConnectivity] throws, to prove a failed read is handled.
+  final bool throwOnCheck;
+
+  @override
+  Future<List<ConnectivityResult>> checkConnectivity() async {
+    if (throwOnCheck) throw Exception('platform read failed');
+    return results;
+  }
+
+  @override
+  Stream<List<ConnectivityResult>> get onConnectivityChanged =>
+      Stream<List<ConnectivityResult>>.fromIterable(changes);
+}
+
+void main() {
+  Future<NetworkStatus> statusFor(List<ConnectivityResult> results) {
+    return ConnectivityPlusConnectivityService(
+      connectivity: _FakeConnectivity(results),
+    ).currentStatus();
+  }
+
+  group('ConnectivityPlusConnectivityService.currentStatus', () {
+    test('Wi-Fi is unmetered', () async {
+      expect(await statusFor([ConnectivityResult.wifi]), NetworkStatus.wifi);
+    });
+
+    test('Ethernet is treated as unmetered Wi-Fi', () async {
+      expect(
+        await statusFor([ConnectivityResult.ethernet]),
+        NetworkStatus.wifi,
+      );
+    });
+
+    test('mobile/cellular is metered', () async {
+      expect(
+        await statusFor([ConnectivityResult.mobile]),
+        NetworkStatus.mobile,
+      );
+    });
+
+    test('no connection is offline', () async {
+      expect(await statusFor([ConnectivityResult.none]), NetworkStatus.offline);
+    });
+
+    test('an empty result list is offline (never assumed unmetered)', () async {
+      expect(await statusFor(<ConnectivityResult>[]), NetworkStatus.offline);
+    });
+
+    test('VPN alone is unknown (conservative, not assumed Wi-Fi)', () async {
+      expect(await statusFor([ConnectivityResult.vpn]), NetworkStatus.unknown);
+    });
+
+    test('Bluetooth alone is unknown (conservative)', () async {
+      expect(
+        await statusFor([ConnectivityResult.bluetooth]),
+        NetworkStatus.unknown,
+      );
+    });
+
+    test('satellite alone is unknown (conservative)', () async {
+      expect(
+        await statusFor([ConnectivityResult.satellite]),
+        NetworkStatus.unknown,
+      );
+    });
+
+    test('Wi-Fi alongside VPN still reads as unmetered Wi-Fi', () async {
+      expect(
+        await statusFor([ConnectivityResult.wifi, ConnectivityResult.vpn]),
+        NetworkStatus.wifi,
+      );
+    });
+
+    test('mobile alongside VPN stays metered', () async {
+      expect(
+        await statusFor([ConnectivityResult.mobile, ConnectivityResult.vpn]),
+        NetworkStatus.mobile,
+      );
+    });
+
+    test('mobile alongside satellite stays metered', () async {
+      expect(
+        await statusFor(
+          [ConnectivityResult.mobile, ConnectivityResult.satellite],
+        ),
+        NetworkStatus.mobile,
+      );
+    });
+
+    test('Wi-Fi present with mobile prefers unmetered Wi-Fi', () async {
+      expect(
+        await statusFor([ConnectivityResult.wifi, ConnectivityResult.mobile]),
+        NetworkStatus.wifi,
+      );
+    });
+
+    test('a failed platform read falls back to unknown, never Wi-Fi', () async {
+      final service = ConnectivityPlusConnectivityService(
+        connectivity: _FakeConnectivity(
+          const <ConnectivityResult>[],
+          throwOnCheck: true,
+        ),
+      );
+      expect(await service.currentStatus(), NetworkStatus.unknown);
+    });
+  });
+
+  group('ConnectivityPlusConnectivityService.statusStream', () {
+    test('maps each emitted transport list to a NetworkStatus', () async {
+      final service = ConnectivityPlusConnectivityService(
+        connectivity: _FakeConnectivity(
+          const <ConnectivityResult>[],
+          changes: const <List<ConnectivityResult>>[
+            [ConnectivityResult.wifi],
+            [ConnectivityResult.mobile],
+            [ConnectivityResult.none],
+          ],
+        ),
+      );
+      expect(
+        await service.statusStream.toList(),
+        <NetworkStatus>[
+          NetworkStatus.wifi,
+          NetworkStatus.mobile,
+          NetworkStatus.offline,
+        ],
+      );
+    });
+  });
+}


### PR DESCRIPTION
A focused, minimal stability PR. Two independent fixes; no UI/design changes, no architecture refactor, no Plex/playback/caching-logic changes, no new features.

---

## 1. Mobile-data / pre-cache safety

**Problem.** Smart pre-cache (and user downloads) could pull bytes over mobile data even with **"Allow mobile data" off** — the safe default wasn't actually safe.

**Root cause.** The mobile-data gate already exists in `CacheDownloadRepository` (`_networkDecision()` → Wi-Fi always / mobile only if opted in / never offline), and the `DownloadPreferences` default is already `allowMobileData = false`. But the gate reads connectivity from `OptimisticConnectivityService`, which **always reports Wi-Fi**, so the gate could never engage. The whole policy + UI ("Allow mobile data" switch, "waiting for Wi-Fi" download state) was built for this and just never received a truthful signal.

**Fix (minimal, reusable).** Add real detection and feed the existing gate — no caching logic touched:
- New `ConnectivityPlusConnectivityService` (behind the existing `ConnectivityService` interface), backed by `connectivity_plus` — the package the seam was explicitly designed for.
- Conservative, safe-by-default mapping: Wi-Fi/Ethernet → `wifi`, cellular → `mobile`, no link → `offline`, and anything indeterminate (VPN / Bluetooth / satellite / "other" / a failed read) → `unknown`, which the policy already treats like mobile data. An undetermined link is never assumed unmetered.
- Wired in production via `connectivityPlusServiceOverride` in `main.dart`; tests keep the plugin-free optimistic default or inject fakes.
- All three download trigger points already funnel through this one gate (`smart_precache_service → prefetch`, and the two `requestDownload` call sites), so the fix is centralized — no scattered guards.

`connectivity_plus` reads the **AOSP `ConnectivityManager`** (no Google Play Services) and adds **no new Android permission** (`ACCESS_NETWORK_STATE` is already merged via Media3). Documented in `docs/dependency-license-audit.md`.

## 2. Local music scan thread fix (Android)

**Problem.** A large-library scan could freeze the UI.

**Root cause.** `SafDocumentScanner.listAudioDocuments` did the recursive content-resolver walk — plus a per-file `MediaMetadataRetriever` read and embedded-artwork extraction — **inline in the method-channel handler, which runs on the platform main thread**.

**Fix (threading only).** Run the walk on a single background executor thread and post the `MethodChannel.Result` reply back to the main thread (where Flutter requires it). The `walk()` algorithm, its result shape, and all error handling are **unchanged**. The Dart caller already `await`s the channel, so the now-async reply is transparent.

---

## What changed
- `pubspec.yaml` / `pubspec.lock` — add `connectivity_plus: ^6.1.0` (+ transitive `connectivity_plus_platform_interface`, and Linux-desktop-only `nm`).
- `lib/core/services/connectivity_plus_connectivity_service.dart` — **new** real `ConnectivityService`.
- `lib/data/repositories/download_repository_provider.dart` — add `connectivityPlusServiceOverride`.
- `lib/main.dart` — apply the override in production.
- `test/core/services/connectivity_plus_connectivity_service_test.dart` — **new**, 14 tests covering the mapping (incl. mixed transports + failed reads).
- `docs/dependency-license-audit.md` — document the new dependency (license / GMS-free / no new permission).
- `android/.../SafDocumentScanner.kt` — background-thread the SAF walk; reply on the main thread.

## Testing
- `dart format --set-exit-if-changed .` ✓
- `flutter analyze` ✓ (No issues found)
- `flutter test` ✓ (**2399 passed**, was 2385 + 14 new)
- `flutter pub get --enforce-lockfile` ✓ · secret/privacy scan ✓
- Kotlin is compiled by the existing Android-debug-APK PR workflow (no Android SDK in this env).

## Behavior change to note (intended)
On **mobile data with "Allow mobile data" off** (the default), pre-cache now skips and **user-initiated downloads now queue as "waiting for Wi-Fi"** instead of running — previously they ran because connectivity was hard-coded to Wi-Fi. This is the documented, already-built intent of the setting, not a new feature. On Wi-Fi, behavior is unchanged. Offline downloads are now correctly held instead of attempted-and-failed.

## Risk
- Low. The connectivity service mapping is pure and unit-tested; the gate, preferences, and UI were already in place. Tests are unaffected (they inject fakes / use the optimistic default).
- Conservative edge case: a **VPN** can mask the underlying transport and map to `unknown` (treated like mobile data), so a VPN-on-Wi-Fi user with "Allow mobile data" off may see pre-cache pause / downloads wait. This is the safe choice per the requirement ("no accidental mobile data usage") and matches the existing `NetworkStatus.unknown` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1k2PwX3HnEs2r3HReXyNT

---
_Generated by [Claude Code](https://claude.ai/code/session_01E1k2PwX3HnEs2r3HReXyNT)_