### PR TITLE
fix(playback): guard against stale updates when rapidly skipping tracks

### DIFF
--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -809,7 +809,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// before a resolved candidate reaches the engine, so a stale rapid-skip can't
   /// hand the engine a track the user has already moved past. Null is distinct
   /// from a real failure (which throws).
-  Future<({Track track, ResolvedPlayable resolved})?> _loadFirstWorkingCandidate(
+  Future<({Track track, ResolvedPlayable resolved})?>
+      _loadFirstWorkingCandidate(
     List<Track> candidates,
     int generation,
   ) async {

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -179,6 +179,18 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   // so each track (and each successful stretch) gets its own one-retry budget.
   int _retriesForCurrent = 0;
 
+  // Guards against overlapping playback transitions. Every action that changes
+  // what's playing — skip to next/previous, jump within the queue or history,
+  // load a new queue, restart, resume after a cast handoff, or seek — bumps this
+  // counter; the in-flight [_playCurrent] captures it at its start and abandons
+  // its async result (resolve + engine load) the moment the counter moves on. So
+  // when the user rapidly skips, only the latest action's track is ever loaded,
+  // emitted, or played: a stale resolve that finishes late can't override the
+  // track they actually landed on. The queue itself stays correct independently
+  // of this — its mutations are synchronous — so this only gates the async
+  // load/playback, never the queue order.
+  int _playbackGeneration = 0;
+
   // The latest engine position awaiting a coalesced flush, and the timer that
   // flushes it. The engine's positionStream can fire several times a second
   // (more in bursts during seeking/buffering); emitting a new state for every
@@ -679,6 +691,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     bool autoplay = true,
     bool isRetry = false,
   }) async {
+    // Open a new playback generation: this transition supersedes any earlier
+    // one still resolving/loading. Captured locally so the awaits below can tell
+    // when a newer skip/seek has taken over and bail before clobbering it.
+    final int generation = ++_playbackGeneration;
     final track = _queue.current;
     if (track == null) return;
 
@@ -732,14 +748,24 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // one can't resolve or start. A single-source track has just one candidate,
     // so this behaves exactly as a direct load did.
     final List<Track> candidates = _candidates.candidatesFor(track);
-    final ({Track track, ResolvedPlayable resolved}) outcome;
+    final ({Track track, ResolvedPlayable resolved})? outcome;
     try {
-      outcome = await _loadFirstWorkingCandidate(candidates);
+      outcome = await _loadFirstWorkingCandidate(candidates, generation);
     } on PlaybackResolutionException catch (error) {
+      // A failure from a transition the user has already skipped past must not
+      // surface as an error on the track they actually landed on.
+      if (generation != _playbackGeneration) return;
       // Every candidate failed: surface one friendly, secret-free message.
       _emitError(track, error.message);
       return;
     }
+
+    // Superseded while resolving/loading — a newer skip/seek bumped the
+    // generation (outcome is null when it raced before the engine load, or the
+    // counter moved on after it returned). Drop this stale result without
+    // touching the queue, the emitted state, or playback: the newer transition
+    // now owns the engine and will load/play its own track.
+    if (outcome == null || generation != _playbackGeneration) return;
 
     // Make the copy that actually started the current one, so the queue, the
     // mini-player, and the "Playing from …" indicator all reflect the source
@@ -760,6 +786,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // handoff; then start — the source is already loaded.
     await _applyVolume();
     if (startAt > Duration.zero) await _player.seek(startAt);
+    // One last check before audio starts: a skip/seek that landed while this
+    // track was loading owns playback now, so don't start a track the user has
+    // already moved past.
+    if (generation != _playbackGeneration) return;
     // play()'s future completes when playback ends, so we don't await it.
     if (autoplay) unawaited(_player.play());
   }
@@ -773,8 +803,15 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// worded exactly as before; only a genuine multi-source all-fail collapses to
   /// the generic "any available source" message. It makes a single pass and
   /// never retries, so it always terminates.
-  Future<({Track track, ResolvedPlayable resolved})> _loadFirstWorkingCandidate(
+  ///
+  /// Returns null instead — without loading anything — when a newer playback
+  /// transition supersedes [generation] (the captured [_playbackGeneration])
+  /// before a resolved candidate reaches the engine, so a stale rapid-skip can't
+  /// hand the engine a track the user has already moved past. Null is distinct
+  /// from a real failure (which throws).
+  Future<({Track track, ResolvedPlayable resolved})?> _loadFirstWorkingCandidate(
     List<Track> candidates,
+    int generation,
   ) async {
     final List<PlaybackResolutionException> failures =
         <PlaybackResolutionException>[];
@@ -796,6 +833,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         ));
         continue;
       }
+      // The user skipped or seeked while this candidate was resolving: abandon
+      // the load before handing a now-stale source to the engine, so only the
+      // newest transition's track is ever loaded or played. Checked after the
+      // resolve await (which is where the time goes) and before touching the
+      // shared engine.
+      if (generation != _playbackGeneration) return null;
       try {
         // setUrl handles file://, content:// (Android), and https:// URIs alike,
         // so local files, SAF documents, and remote streams share one path. The
@@ -903,6 +946,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   @override
   Future<void> seek(Duration position) async {
     if (_suspended) return;
+    // A seek is a playback action too: bump the generation so a still-resolving
+    // earlier load can't complete afterwards and yank playback off the spot the
+    // user just chose (or onto a different track). In normal flow nothing is
+    // loading when a seek arrives — the progress bar only seeks once a duration
+    // is known — so this just invalidates a stale in-flight load when one races.
+    _playbackGeneration++;
     return _player.seek(position);
   }
 

--- a/test/core/services/just_audio_playback_controller_race_test.dart
+++ b/test/core/services/just_audio_playback_controller_race_test.dart
@@ -1,0 +1,235 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+
+/// A fake engine that records, in order, every source it was handed and every
+/// play/seek it was asked to perform — so a test can prove a stale rapid-skip
+/// never reaches the engine. No platform channel is touched.
+class _RecordingPlayer extends Fake implements AudioPlayer {
+  final List<String> setUrlCalls = <String>[];
+  final List<Duration> seekCalls = <Duration>[];
+  int playCalls = 0;
+
+  @override
+  Stream<PlayerState> get playerStateStream =>
+      const Stream<PlayerState>.empty();
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream<Duration?>.empty();
+  @override
+  Stream<PlaybackEvent> get playbackEventStream =>
+      const Stream<PlaybackEvent>.empty();
+
+  @override
+  Future<Duration?> setUrl(
+    String url, {
+    Map<String, String>? headers,
+    Duration? initialPosition,
+    bool preload = true,
+    dynamic tag,
+  }) async {
+    setUrlCalls.add(url);
+    return const Duration(minutes: 3);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> play() async => playCalls++;
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {
+    if (position != null) seekCalls.add(position);
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+/// A resolver whose per-track completion the test drives by hand: a uri in
+/// [immediate] resolves on the next microtask; any other uri parks on a
+/// [Completer] the test releases with [release], so resolution order — and thus
+/// the race — is fully deterministic.
+class _GatedResolver implements PlayableUriResolver {
+  _GatedResolver(this.immediate);
+
+  final Map<String, ResolvedPlayable> immediate;
+  final Map<String, Completer<ResolvedPlayable>> _gates =
+      <String, Completer<ResolvedPlayable>>{};
+  final List<String> calls = <String>[];
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) {
+    calls.add(track.uri);
+    final ResolvedPlayable? r = immediate[track.uri];
+    if (r != null) return Future<ResolvedPlayable>.value(r);
+    return _gates
+        .putIfAbsent(track.uri, () => Completer<ResolvedPlayable>())
+        .future;
+  }
+
+  void release(String uri, ResolvedPlayable resolved) =>
+      _gates[uri]!.complete(resolved);
+
+  void releaseError(String uri, Object error) =>
+      _gates[uri]!.completeError(error);
+}
+
+Track _track(String id) => Track(
+      id: id,
+      title: id,
+      uri: 'jellyfin:$id',
+      duration: const Duration(minutes: 3),
+    );
+
+String _url(String id) => 'https://host/stream/$id';
+
+ResolvedPlayable _stream(String id) =>
+    ResolvedPlayable(Uri.parse(_url(id)), PlaybackSource.streamingDirect);
+
+/// Flushes pending microtasks (and the zero-delay timer) so awaited
+/// continuations run to completion.
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('rapid skip is race-safe (playback generation guard)', () {
+    test(
+        'a stale skip whose load finishes late never loads, plays, or shows '
+        'its track', () async {
+      final a = _track('a');
+      final b = _track('b');
+      final c = _track('c');
+      final player = _RecordingPlayer();
+      // A and C resolve immediately; B is gated so its load can finish *after*
+      // the user has already skipped past it to C — the exact overlap that used
+      // to leave the wrong track playing.
+      final resolver = _GatedResolver(<String, ResolvedPlayable>{
+        'jellyfin:a': _stream('a'),
+        'jellyfin:c': _stream('c'),
+      });
+      final controller =
+          JustAudioPlaybackController(player: player, resolver: resolver);
+      addTearDown(controller.dispose);
+
+      await controller.playTracks(<Track>[a, b, c]);
+      expect(controller.state.currentTrack?.id, 'a');
+
+      // Rapid skip A → B (B parks on its gate) → C before B resolves.
+      final Future<void> toB = controller.skipToNext();
+      final Future<void> toC = controller.skipToNext();
+      await _settle();
+
+      // C is the track that actually reached the engine and started.
+      expect(controller.state.currentTrack?.id, 'c');
+      expect(player.setUrlCalls, <String>[_url('a'), _url('c')]);
+      // Queue order is intact: A and B are history, nothing is up next.
+      expect(controller.state.previous.map((Track t) => t.id).toList(),
+          <String>['a', 'b']);
+      expect(controller.state.upNext, isEmpty);
+
+      // B's slow resolve finally lands — it must be ignored entirely.
+      resolver.release('jellyfin:b', _stream('b'));
+      await _settle();
+      await Future.wait(<Future<void>>[toB, toC]);
+
+      expect(controller.state.currentTrack?.id, 'c',
+          reason: 'a skip that resolved late must not change the track');
+      expect(player.setUrlCalls, isNot(contains(_url('b'))),
+          reason: 'the engine must never be handed the superseded track');
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+    });
+
+    test('a stale candidate that fails late does not surface an error',
+        () async {
+      // The stale load eventually *fails* (B never resolves successfully). A
+      // late failure on a track the user skipped past must not show an error on
+      // the track they actually landed on.
+      final a = _track('a');
+      final b = _track('b');
+      final c = _track('c');
+      final player = _RecordingPlayer();
+      final resolver = _GatedResolver(<String, ResolvedPlayable>{
+        'jellyfin:a': _stream('a'),
+        'jellyfin:c': _stream('c'),
+      });
+      final controller =
+          JustAudioPlaybackController(player: player, resolver: resolver);
+      addTearDown(controller.dispose);
+
+      await controller.playTracks(<Track>[a, b, c]);
+      final Future<void> toB = controller.skipToNext();
+      final Future<void> toC = controller.skipToNext();
+      await _settle();
+      expect(controller.state.currentTrack?.id, 'c');
+
+      // B's gate completes with a failure now that we've already moved on.
+      resolver.releaseError(
+        'jellyfin:b',
+        const PlaybackResolutionException(
+          'That source needs attention.',
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        ),
+      );
+      await _settle();
+      await Future.wait(<Future<void>>[toB, toC]);
+
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+      expect(controller.state.currentTrack?.id, 'c');
+    });
+  });
+
+  group('normal playback flow is unchanged', () {
+    test('a single skip loads and plays the next track', () async {
+      final a = _track('a');
+      final b = _track('b');
+      final player = _RecordingPlayer();
+      final resolver = _GatedResolver(<String, ResolvedPlayable>{
+        'jellyfin:a': _stream('a'),
+        'jellyfin:b': _stream('b'),
+      });
+      final controller =
+          JustAudioPlaybackController(player: player, resolver: resolver);
+      addTearDown(controller.dispose);
+
+      await controller.playTracks(<Track>[a, b]);
+      await controller.skipToNext();
+
+      expect(controller.state.currentTrack?.id, 'b');
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+      expect(player.setUrlCalls, <String>[_url('a'), _url('b')]);
+      expect(player.playCalls, 2);
+    });
+
+    test('seek on a playing track is forwarded to the engine', () async {
+      final a = _track('a');
+      final player = _RecordingPlayer();
+      final resolver = _GatedResolver(<String, ResolvedPlayable>{
+        'jellyfin:a': _stream('a'),
+      });
+      final controller =
+          JustAudioPlaybackController(player: player, resolver: resolver);
+      addTearDown(controller.dispose);
+
+      await controller.playTracks(<Track>[a]);
+      await controller.seek(const Duration(seconds: 30));
+
+      expect(player.seekCalls, contains(const Duration(seconds: 30)));
+      expect(controller.state.currentTrack?.id, 'a');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Rapid skip / previous (or seek) could sometimes leave the **wrong track playing**. Each playback action advances the queue *synchronously* and then resolves + loads the new track *asynchronously*. Two quick actions overlap, and a slower **earlier** load can finish **last** — handing the engine a track the user already skipped past and emitting its state on top of the newer one. The queue order was fine; the audible/visible track wasn't.

## Fix

A minimal **playback generation guard**, contained entirely within `JustAudioPlaybackController` — no UI, provider, engine, or dependency changes.

- A monotonic `_playbackGeneration` counter, bumped by every playback action: next / previous / jump within queue or history / new queue / restart / resume (all funnel through `_playCurrent`), and `seek`.
- `_playCurrent` captures the generation at its start and **abandons its async result the moment the counter moves on** — before mutating the queue, emitting state, handing the source to the engine, or starting playback.
- `_loadFirstWorkingCandidate` checks the generation after each resolve and returns `null` (superseded) **before touching the shared engine**, so a stale candidate is never `setUrl`'d.

The `PlaybackQueue` model is untouched and its mutations stay synchronous, so **queue order remains correct** — only the async load/playback is gated.

## Behavior change

None beyond fixing the race:
- A superseded rapid-skip can no longer load, play, show its track, or surface a late error.
- Normal single-skip and seek flows are unchanged (the progress bar only seeks once a duration is known, so nothing is loading when a normal seek arrives).

## Tests

Adds `just_audio_playback_controller_race_test.dart`, which uses a gated resolver to **force an out-of-order resolution** (the stale skip finishes after the user has moved on) and asserts the superseded transition is fully ignored, plus regression coverage for normal skip and seek. Full suite: **2389 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dPMFJj1xaAnQ2KmYHnWXi

---
_Generated by [Claude Code](https://claude.ai/code/session_014dPMFJj1xaAnQ2KmYHnWXi)_