### PR TITLE
Add support@linthra.ca as public support contact on the website

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -73,4 +73,4 @@ https://github.com/TheZupZup/Linthra
 
 For privacy questions or support, contact:
 
-thezupzup@gmail.com
+support@linthra.ca

--- a/docs/index.html
+++ b/docs/index.html
@@ -236,6 +236,10 @@
             <span>Testing track, coming soon</span>
           </span>
         </div>
+        <p class="section-lead center">
+          Need help or found a bug? Contact us at
+          <a href="mailto:support@linthra.ca">support@linthra.ca</a>.
+        </p>
         <p class="muted-note">
           Looking for older builds? See
           <a href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">previous versions &amp; changelog</a>
@@ -274,6 +278,7 @@
         <a href="privacy.html">Privacy Policy</a>
         <a href="https://github.com/TheZupZup/Linthra/blob/main/LICENSE" rel="noopener">License (MPL-2.0)</a>
       </nav>
+      <p class="footer-support">Need help or found a bug? Contact us at <a href="mailto:support@linthra.ca">support@linthra.ca</a>.</p>
       <p class="footer-credit">Built by <a href="https://github.com/TheZupZup" rel="noopener">TheZupZup</a> in Canada. 🇨🇦</p>
     </div>
   </footer>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -177,7 +177,7 @@
           <h2>Contact</h2>
           <p>
             For privacy questions or support, contact:
-            <a href="mailto:thezupzup@gmail.com">thezupzup@gmail.com</a>
+            <a href="mailto:support@linthra.ca">support@linthra.ca</a>
           </p>
 
           <a class="legal-back" href="index.html">&larr; Back to home</a>
@@ -200,6 +200,7 @@
         <a href="privacy.html">Privacy Policy</a>
         <a href="https://github.com/TheZupZup/Linthra/blob/main/LICENSE" rel="noopener">License (MPL-2.0)</a>
       </nav>
+      <p class="footer-support">Need help or found a bug? Contact us at <a href="mailto:support@linthra.ca">support@linthra.ca</a>.</p>
       <p class="footer-credit">Built by <a href="https://github.com/TheZupZup" rel="noopener">TheZupZup</a> in Canada. &#127464;&#127462;</p>
     </div>
   </footer>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -452,6 +452,7 @@ h1, h2, h3 { line-height: 1.2; margin: 0; }
 .footer-links a { color: var(--muted); font-size: 0.92rem; }
 .footer-links a:hover { color: var(--text); }
 .footer-credit { margin: 0; color: var(--muted); font-size: 0.92rem; }
+.footer-support { margin: 0; color: var(--muted); font-size: 0.92rem; }
 
 /* ---------- Legal / privacy page ---------- */
 .legal { padding: 56px 0 72px; }


### PR DESCRIPTION
## What & why

Adds `support@linthra.ca` as the public support contact for Linthra so users — and Google Play testers — can easily find where to report bugs or ask for help. Also stops exposing a personal Gmail address on the site.

Suggested copy is used verbatim: *“Need help or found a bug? Contact us at support@linthra.ca.”*

## Changes

| File | Change |
| --- | --- |
| `docs/index.html` | Added the support line to the **footer** (site-wide) and to the **“Get Linthra”** section, right under the Google Play “testing soon” note where testers look. Both link to `mailto:support@linthra.ca`. |
| `docs/privacy.html` | Replaced the personal Gmail in the existing **Contact** section with `support@linthra.ca`, and added the same support line to the footer. |
| `docs/styles.css` | Added one `.footer-support` rule mirroring the existing `.footer-credit` style so the new footer line matches the current look. |
| `PRIVACY.md` | Updated the **Contact** section (a verbatim mirror of `privacy.html`) to use `support@linthra.ca` instead of the personal address, keeping the two copies consistent. |

Total: **9 insertions, 2 deletions** across 4 files.

## Scope notes

- Reused existing classes/styles — visual style and layout are unchanged.
- The personal Gmail address is fully removed from the site and docs (`grep` confirms no remaining `gmail.com` references).
- **Not touched** (intentionally out of scope): the README (it has no contact/support section), `docs/privacy-policy.md` (the Play-Store-linked draft, which already uses GitHub issues), `fastlane/` & `metadata/` Play Store / F-Droid config, Android code, and release files.

## Verification

- ✅ `grep` confirms no personal Gmail remains anywhere in the repo.
- ✅ All four links resolve to exactly `mailto:support@linthra.ca`.
- ✅ Static site “builds”: it's a GitHub Pages site served from `docs/` (has `.nojekyll`, no build step). Both `index.html` and `privacy.html` pass an HTML tag-balance/well-formedness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fJXJZBebGQwcJsdyiNrLP

---
_Generated by [Claude Code](https://claude.ai/code/session_018fJXJZBebGQwcJsdyiNrLP)_