### PR TITLE
feat(settings): add a tester-friendly "Report a bug" email action

### DIFF
--- a/lib/features/settings/about/bug_report_email.dart
+++ b/lib/features/settings/about/bug_report_email.dart
@@ -1,0 +1,54 @@
+/// Builds the prefilled `mailto:` link behind the Support card's "Report a bug"
+/// action — the low-friction path for Google Play closed testers to send a
+/// useful report.
+///
+/// Pure and plugin-free: it only assembles a [Uri], so it is trivial to unit
+/// test and does no I/O. The Support card hands the link to the shared external
+/// link launcher, which opens the user's own mail app at a draft addressed to
+/// support, with the subject and a fill-in body already in place. Nothing is
+/// sent — the tester reviews the draft and sends it themselves.
+abstract final class BugReportEmail {
+  /// Where tester bug reports go (the support inbox documented in PRIVACY.md
+  /// and shown by the Support card's "Email support" row).
+  static const String recipient = 'support@linthra.ca';
+
+  /// A fixed, recognisable subject so reports are easy to spot and triage.
+  static const String subject = 'Linthra bug report';
+
+  /// The fill-in template the tester sees in the draft body. Blank lines invite
+  /// a short answer under each prompt; the device/version/source lines nudge
+  /// testers to include the details that make a report actionable.
+  static const String body = 'Hi Linthra team,\n'
+      '\n'
+      'I found an issue while testing Linthra.\n'
+      '\n'
+      'What happened:\n'
+      '\n'
+      '\n'
+      'What I expected:\n'
+      '\n'
+      '\n'
+      'Steps to reproduce:\n'
+      '1.\n'
+      '2.\n'
+      '3.\n'
+      '\n'
+      'Device:\n'
+      'Android version:\n'
+      'Linthra version:\n'
+      'Music source: Local / Jellyfin / Navidrome / Subsonic\n'
+      'Additional notes:\n';
+
+  /// The `mailto:` link that opens a prefilled draft to [recipient].
+  ///
+  /// [subject] and [body] are percent-encoded with [Uri.encodeComponent]
+  /// (spaces become `%20`, newlines `%0A`) and assembled into the query by
+  /// hand, then parsed back into a [Uri]. Encoding the values ourselves — rather
+  /// than via `Uri(queryParameters: …)`, which uses `+` for spaces that some
+  /// mail apps render literally — keeps the draft reading exactly as written.
+  static Uri mailtoUri() {
+    final String query = 'subject=${Uri.encodeComponent(subject)}'
+        '&body=${Uri.encodeComponent(body)}';
+    return Uri.parse('mailto:$recipient?$query');
+  }
+}

--- a/lib/features/settings/about/support_section.dart
+++ b/lib/features/settings/about/support_section.dart
@@ -3,15 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
 import '../../../app/external_link_launcher_provider.dart';
+import 'bug_report_email.dart';
 
 /// The "Support" card on the About page: a one-line description of what Linthra
-/// is, the support inbox, and a link to the privacy policy.
+/// is, a tester-friendly "Report a bug" action, the support inbox, and a link to
+/// the privacy policy.
 ///
-/// The email row opens the user's mail app through a `mailto:` link; the privacy
-/// policy opens in the browser. Both go through the shared
-/// [externalLinkLauncherProvider] — the same seam the rest of the About page and
-/// the "Report a bug" flow use — so every launch is an explicit tap and widget
-/// tests stay plugin-free.
+/// "Report a bug" and "Email support" open the user's mail app through a
+/// `mailto:` link (the bug action prefills a recipient, subject, and a fill-in
+/// body for Google Play closed testers); the privacy policy opens in the
+/// browser. All go through the shared [externalLinkLauncherProvider] — the same
+/// seam the rest of the About page and the diagnostics "Report a bug" flow use —
+/// so every launch is an explicit tap and widget tests stay plugin-free.
 class SupportSection extends ConsumerWidget {
   const SupportSection({super.key});
 
@@ -62,6 +65,13 @@ class SupportSection extends ConsumerWidget {
                 ),
               ],
             ),
+          ),
+          const Divider(height: 0),
+          _SupportRow(
+            icon: Icons.bug_report_outlined,
+            label: 'Report a bug',
+            value: 'Email us a prefilled report',
+            onTap: () => _open(context, ref, BugReportEmail.mailtoUri()),
           ),
           const Divider(height: 0),
           _SupportRow(

--- a/test/features/settings/about/bug_report_email_test.dart
+++ b/test/features/settings/about/bug_report_email_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/about/bug_report_email.dart';
+
+void main() {
+  group('BugReportEmail.mailtoUri', () {
+    test('addresses the support inbox with the bug-report subject', () {
+      final Uri uri = BugReportEmail.mailtoUri();
+
+      expect(uri.scheme, 'mailto');
+      expect(uri.path, 'support@linthra.ca');
+      // queryParameters round-trips the percent-encoding back to plain text.
+      expect(uri.queryParameters['subject'], 'Linthra bug report');
+    });
+
+    test('prefills the fill-in body template', () {
+      final String body = BugReportEmail.mailtoUri().queryParameters['body']!;
+
+      expect(body, BugReportEmail.body);
+      // The prompts a tester fills in are all present and in order.
+      expect(body, contains('What happened:'));
+      expect(body, contains('What I expected:'));
+      expect(body, contains('Steps to reproduce:\n1.\n2.\n3.'));
+      expect(body, contains('Device:'));
+      expect(body, contains('Android version:'));
+      expect(body, contains('Linthra version:'));
+      expect(
+        body,
+        contains('Music source: Local / Jellyfin / Navidrome / Subsonic'),
+      );
+      expect(body, contains('Additional notes:'));
+    });
+
+    test('encodes spaces as %20, never as + (mail apps render + literally)',
+        () {
+      final Uri uri = BugReportEmail.mailtoUri();
+
+      expect(uri.query, contains('subject=Linthra%20bug%20report'));
+      expect(uri.query, isNot(contains('+')));
+    });
+  });
+}

--- a/test/features/settings/about/support_section_test.dart
+++ b/test/features/settings/about/support_section_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/external_link_launcher_provider.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/settings/about/bug_report_email.dart';
 import 'package:linthra/features/settings/about/support_section.dart';
 
 class _FakeLinkLauncher implements ExternalLinkLauncher {
@@ -47,9 +48,25 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(find.text('Report a bug'), findsOneWidget);
       expect(find.text('Email support'), findsOneWidget);
       expect(find.text('support@linthra.ca'), findsOneWidget);
       expect(find.text('Privacy policy'), findsOneWidget);
+    });
+
+    testWidgets('tapping "Report a bug" opens a prefilled mailto draft',
+        (tester) async {
+      final _FakeLinkLauncher launcher = await _pump(tester);
+
+      await tester.tap(find.text('Report a bug'));
+      await tester.pumpAndSettle();
+
+      final Uri? opened = launcher.opened;
+      expect(opened, isNotNull);
+      expect(opened!.scheme, 'mailto');
+      expect(opened.path, 'support@linthra.ca');
+      expect(opened.queryParameters['subject'], 'Linthra bug report');
+      expect(opened.queryParameters['body'], BugReportEmail.body);
     });
 
     testWidgets('tapping "Email support" opens a mailto link', (tester) async {

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -55,10 +55,11 @@ void main() {
       expect(find.text('License (MPL-2.0)'), findsOneWidget);
     });
 
-    testWidgets('composes the support section (email + privacy policy)',
+    testWidgets('composes the support section (bug report + email + privacy)',
         (tester) async {
       await _pump(tester);
 
+      expect(find.text('Report a bug'), findsOneWidget);
       expect(find.text('Email support'), findsOneWidget);
       expect(find.text('support@linthra.ca'), findsOneWidget);
       expect(find.text('Privacy policy'), findsOneWidget);


### PR DESCRIPTION
## What & why

Google Play **closed testers** need a low-friction way to send a *useful* bug report. This adds a **"Report a bug"** row to the Support card on **Settings → About** that opens the tester's own mail app at a prefilled draft:

| Field | Value |
| --- | --- |
| **To** | `support@linthra.ca` |
| **Subject** | `Linthra bug report` |
| **Body** | a short fill-in template (what happened, what was expected, steps, device / Android version / Linthra version, music source, notes) |

Nothing is sent automatically — the tester reviews the draft and taps send themselves.

## How it works

- A small, pure, plugin-free helper `BugReportEmail` (`lib/features/settings/about/bug_report_email.dart`) builds the `mailto:` `Uri`. Subject and body are percent-encoded with `Uri.encodeComponent` (spaces become `%20`, **not** `+` — which some Android mail clients render literally), so the draft reads exactly as written.
- The Support card opens the link through the **existing shared `externalLinkLauncherProvider` seam** — the same path the card's "Email support" row already uses. No new dependency; `url_launcher` was already in the project. The native `launchUrl` path uses `startActivity(ACTION_VIEW, mailto:)`, which resolves without any manifest `<queries>` change (only `canLaunchUrl` is gated by package visibility, and this path never calls it), so **AndroidManifest.xml is untouched**.

This **complements** the heavier diagnostics-based "Report a bug" flow under *Diagnostics & support* (GitHub-issue oriented) with a plain-email path for testers who would rather just write to us.

## Scope

Limited to **Settings / support-related UI**. No playback, cache, providers, database migrations, Android Auto, Cast, manifest, or release configuration was touched.

**Files**
- `lib/features/settings/about/bug_report_email.dart` *(new)* — pure mailto helper
- `lib/features/settings/about/support_section.dart` — adds the "Report a bug" row
- `test/features/settings/about/bug_report_email_test.dart` *(new)* — helper unit tests
- `test/features/settings/about/support_section_test.dart` — widget test for the new row
- `test/features/settings/hub/about_screen_test.dart` — assert the row composes onto the page

## Validation

- `dart format --set-exit-if-changed .` → clean (0 changed)
- `flutter analyze` → No issues found
- `flutter test` → **2398 passed**
- `./scripts/check_secrets.sh` → passed
- A widget test verifies that tapping **"Report a bug"** launches the exact prefilled `mailto:` URI (recipient, subject, and body) through the launcher seam; unit tests assert the recipient/subject/body and the `%20`-not-`+` encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PA4FakLfubLSqa1T3Kygp

---
_Generated by [Claude Code](https://claude.ai/code/session_015PA4FakLfubLSqa1T3Kygp)_