### PR TITLE
feat(settings): add a "Copy app info" action for testers

### DIFF
--- a/lib/features/settings/about/app_info_report.dart
+++ b/lib/features/settings/about/app_info_report.dart
@@ -1,0 +1,55 @@
+/// Builds the plain-text "app info" block the Support card's "Copy app info"
+/// action puts on the clipboard — a short, paste-ready diagnostic a Google Play
+/// closed tester can drop into a bug report.
+///
+/// Pure and plugin-free: it only formats the values it is handed into text, so
+/// it does no I/O and is trivial to unit test. The Support card reads the live
+/// app version (and, on Android, the OS version) and passes them in. By
+/// construction the block carries no personal data, server URL, auth token,
+/// username, file path, or library name — only the app version and, when known,
+/// the Android OS version, followed by blank fill-in prompts the tester
+/// completes themselves.
+///
+/// Fields with no safe, already-available source on this build — the build
+/// number (the Android-only `versionCode`, intentionally absent from AppInfo),
+/// the device model, and the install source — are left as blank prompts rather
+/// than guessed or backed by a new dependency. The tester fills those in if they
+/// can.
+abstract final class AppInfoReport {
+  /// The header line that opens the block, so a pasted report is recognisable.
+  static const String header = 'Linthra app info';
+
+  /// The music-source prompt, listing the sources Linthra can play from so the
+  /// tester just indicates which they were using. Mirrors the wording of the
+  /// "Report a bug" email template.
+  static const String musicSourceOptions =
+      'Local / Jellyfin / Navidrome / Subsonic';
+
+  /// Assembles the block. [linthraVersion] is filled in from the app's existing
+  /// version source; [androidVersion] is filled when known (Android only) and
+  /// left as a blank prompt otherwise. A trailing newline lets the tester start
+  /// typing on a fresh line after the final prompt.
+  static String build({
+    required String linthraVersion,
+    String? androidVersion,
+  }) {
+    final List<String> lines = <String>[
+      header,
+      '',
+      _field('Linthra version', linthraVersion),
+      _field('Build number'),
+      _field('Android version', androidVersion),
+      _field('Device model'),
+      _field('Install source'),
+      _field('Music source used', musicSourceOptions),
+      _field('Issue summary'),
+    ];
+    return '${lines.join('\n')}\n';
+  }
+
+  /// One `Label: value` line, or a blank `Label:` prompt when [value] is null or
+  /// empty — so an unknown field reads as a clean fill-in, never `Label: ` with
+  /// a dangling space.
+  static String _field(String label, [String? value]) =>
+      (value == null || value.isEmpty) ? '$label:' : '$label: $value';
+}

--- a/lib/features/settings/about/support_section.dart
+++ b/lib/features/settings/about/support_section.dart
@@ -1,13 +1,18 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
 import '../../../app/external_link_launcher_provider.dart';
+import '../../../core/app_info.dart';
+import 'app_info_report.dart';
 import 'bug_report_email.dart';
 
 /// The "Support" card on the About page: a one-line description of what Linthra
-/// is, a tester-friendly "Report a bug" action, the support inbox, and a link to
-/// the privacy policy.
+/// is, a tester-friendly "Report a bug" action, a "Copy app info" action, the
+/// support inbox, and a link to the privacy policy.
 ///
 /// "Report a bug" and "Email support" open the user's mail app through a
 /// `mailto:` link (the bug action prefills a recipient, subject, and a fill-in
@@ -15,6 +20,12 @@ import 'bug_report_email.dart';
 /// browser. All go through the shared [externalLinkLauncherProvider] — the same
 /// seam the rest of the About page and the diagnostics "Report a bug" flow use —
 /// so every launch is an explicit tap and widget tests stay plugin-free.
+///
+/// "Copy app info" is kept separate from the email flow: it copies a short,
+/// paste-ready app-info block (built by [AppInfoReport]) to the clipboard and
+/// confirms with a snackbar. It sends nothing and collects no personal data —
+/// only the app version and, on Android, the OS version, with blank prompts the
+/// tester fills in.
 class SupportSection extends ConsumerWidget {
   const SupportSection({super.key});
 
@@ -75,6 +86,14 @@ class SupportSection extends ConsumerWidget {
           ),
           const Divider(height: 0),
           _SupportRow(
+            icon: Icons.info_outline,
+            label: 'Copy app info',
+            value: 'Version & device details for a bug report',
+            trailingIcon: Icons.copy_outlined,
+            onTap: () => _copyAppInfo(context),
+          ),
+          const Divider(height: 0),
+          _SupportRow(
             icon: Icons.mail_outline,
             label: 'Email support',
             value: _supportEmail,
@@ -109,23 +128,47 @@ class SupportSection extends ConsumerWidget {
       );
     }
   }
+
+  /// Copies a short, paste-ready app-info block to the clipboard and confirms
+  /// with a snackbar — the low-friction path for a tester to attach useful
+  /// details to a bug report. The block is assembled by [AppInfoReport] from the
+  /// app version and, on Android, the OS version; nothing is sent and no
+  /// personal data, server URL, token, username, or path is included. The
+  /// messenger is captured before the await so we don't touch [context] across
+  /// an async gap — the same guard the link rows use.
+  Future<void> _copyAppInfo(BuildContext context) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final String info = AppInfoReport.build(
+      linthraVersion: AppInfo.version,
+      androidVersion:
+          Platform.isAndroid ? Platform.operatingSystemVersion : null,
+    );
+    await Clipboard.setData(ClipboardData(text: info));
+    messenger.showSnackBar(
+      const SnackBar(content: Text('App info copied to the clipboard.')),
+    );
+  }
 }
 
-/// A single tappable row in the support card: a leading icon, a label, and the
-/// "opens externally" affordance. An optional [value] (the support address) is
-/// shown as a subtitle so the inbox is visible without tapping.
+/// A single tappable row in the support card: a leading icon, a label, and a
+/// trailing affordance ([trailingIcon], the "opens externally" arrow by
+/// default; the copy row overrides it with a copy glyph). An optional [value]
+/// (e.g. the support address) is shown as a subtitle so the detail is visible
+/// without tapping.
 class _SupportRow extends StatelessWidget {
   const _SupportRow({
     required this.icon,
     required this.label,
     required this.onTap,
     this.value,
+    this.trailingIcon = Icons.open_in_new,
   });
 
   final IconData icon;
   final String label;
   final VoidCallback onTap;
   final String? value;
+  final IconData? trailingIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -135,7 +178,9 @@ class _SupportRow extends StatelessWidget {
       leading: Icon(icon, color: theme.colorScheme.primary),
       title: Text(label),
       subtitle: value == null ? null : Text(value!),
-      trailing: Icon(Icons.open_in_new, size: 18, color: muted),
+      trailing: trailingIcon == null
+          ? null
+          : Icon(trailingIcon, size: 18, color: muted),
       onTap: onTap,
     );
   }

--- a/test/features/settings/about/app_info_report_test.dart
+++ b/test/features/settings/about/app_info_report_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/about/app_info_report.dart';
+
+void main() {
+  group('AppInfoReport.build', () {
+    test('opens with the recognisable header line', () {
+      final String text = AppInfoReport.build(linthraVersion: '0.1.5');
+
+      expect(text, startsWith('Linthra app info\n'));
+    });
+
+    test('fills in the Linthra version from the supplied value', () {
+      final String text = AppInfoReport.build(linthraVersion: '1.2.3');
+
+      expect(text, contains('Linthra version: 1.2.3'));
+    });
+
+    test('fills in the Android version when one is known', () {
+      final String text = AppInfoReport.build(
+        linthraVersion: '0.1.5',
+        androidVersion: 'Android 14 (API 34)',
+      );
+
+      expect(text, contains('Android version: Android 14 (API 34)'));
+    });
+
+    test('leaves the Android version a blank prompt when unknown', () {
+      final String text = AppInfoReport.build(linthraVersion: '0.1.5');
+
+      // The label is present as a fill-in, with no trailing value or space.
+      expect(text, contains('\nAndroid version:\n'));
+    });
+
+    test(
+      'leaves build number, device model, and install source as blank prompts '
+      '(no dependency-free source for them)',
+      () {
+        final String text = AppInfoReport.build(linthraVersion: '0.1.5');
+
+        expect(text, contains('\nBuild number:\n'));
+        expect(text, contains('\nDevice model:\n'));
+        expect(text, contains('\nInstall source:\n'));
+      },
+    );
+
+    test('lists the music sources for the tester to pick from', () {
+      final String text = AppInfoReport.build(linthraVersion: '0.1.5');
+
+      expect(
+        text,
+        contains('Music source used: Local / Jellyfin / Navidrome / Subsonic'),
+      );
+    });
+
+    test('ends with a blank Issue summary prompt on its own line', () {
+      final String text = AppInfoReport.build(linthraVersion: '0.1.5');
+
+      expect(text, endsWith('Issue summary:\n'));
+    });
+
+    test('keeps the field order matching the suggested template', () {
+      final String text = AppInfoReport.build(
+        linthraVersion: '0.1.5',
+        androidVersion: 'Android 14 (API 34)',
+      );
+
+      const List<String> expected = <String>[
+        'Linthra app info',
+        '',
+        'Linthra version: 0.1.5',
+        'Build number:',
+        'Android version: Android 14 (API 34)',
+        'Device model:',
+        'Install source:',
+        'Music source used: Local / Jellyfin / Navidrome / Subsonic',
+        'Issue summary:',
+      ];
+      expect(text, '${expected.join('\n')}\n');
+    });
+
+    test('carries no server URL, credential, or username', () {
+      final String text = AppInfoReport.build(
+        linthraVersion: '0.1.5',
+        androidVersion: 'Android 14 (API 34)',
+      );
+
+      expect(text, isNot(contains('://')));
+      expect(text, isNot(contains('http')));
+      expect(text, isNot(contains('@')));
+      expect(text.toLowerCase(), isNot(contains('token')));
+      expect(text.toLowerCase(), isNot(contains('password')));
+    });
+  });
+}

--- a/test/features/settings/about/support_section_test.dart
+++ b/test/features/settings/about/support_section_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/external_link_launcher_provider.dart';
+import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/settings/about/app_info_report.dart';
 import 'package:linthra/features/settings/about/bug_report_email.dart';
 import 'package:linthra/features/settings/about/support_section.dart';
 
@@ -49,6 +52,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('Report a bug'), findsOneWidget);
+      expect(find.text('Copy app info'), findsOneWidget);
       expect(find.text('Email support'), findsOneWidget);
       expect(find.text('support@linthra.ca'), findsOneWidget);
       expect(find.text('Privacy policy'), findsOneWidget);
@@ -102,6 +106,55 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("Couldn't open the link."), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping "Copy app info" copies the app-info block and confirms with '
+        'a snackbar', (tester) async {
+      final List<MethodCall> clipboardCalls = <MethodCall>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall call) async {
+          if (call.method == 'Clipboard.setData') {
+            clipboardCalls.add(call);
+          }
+          return null;
+        },
+      );
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      await _pump(tester);
+
+      await tester.tap(find.text('Copy app info'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(clipboardCalls, hasLength(1));
+      final Map<dynamic, dynamic> args =
+          clipboardCalls.single.arguments as Map<dynamic, dynamic>;
+      final String copied = args['text'] as String;
+
+      // The widget copies exactly what the pure helper builds for this host
+      // (a test runs off-Android, so the Android version stays a blank prompt).
+      expect(copied, AppInfoReport.build(linthraVersion: AppInfo.version));
+      expect(copied, startsWith('Linthra app info'));
+      expect(copied, contains('Linthra version: ${AppInfo.version}'));
+      expect(
+        copied,
+        contains('Music source used: Local / Jellyfin / Navidrome / Subsonic'),
+      );
+      expect(copied, contains('Issue summary:'));
+      // No server URL, credential, or username leaks into the copied block.
+      expect(copied, isNot(contains('://')));
+      expect(copied, isNot(contains('@')));
+
+      // The confirmation SnackBar appears.
+      expect(find.textContaining('App info copied'), findsOneWidget);
+
+      // Let the SnackBar's auto-dismiss timer fire so no timers are pending.
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -55,11 +55,13 @@ void main() {
       expect(find.text('License (MPL-2.0)'), findsOneWidget);
     });
 
-    testWidgets('composes the support section (bug report + email + privacy)',
-        (tester) async {
+    testWidgets(
+        'composes the support section (bug report + copy info + email + '
+        'privacy)', (tester) async {
       await _pump(tester);
 
       expect(find.text('Report a bug'), findsOneWidget);
+      expect(find.text('Copy app info'), findsOneWidget);
       expect(find.text('Email support'), findsOneWidget);
       expect(find.text('support@linthra.ca'), findsOneWidget);
       expect(find.text('Privacy policy'), findsOneWidget);


### PR DESCRIPTION
## What

Adds a **"Copy app info"** row to **Settings → About → Support**. Tapping it copies a short, paste-ready diagnostic block to the clipboard and shows a snackbar confirming the copy.

This makes it easy for Google Play closed testers to attach useful app/device details when reporting a bug, without having to type them out.

The copied block looks like:

```text
Linthra app info

Linthra version: 0.1.5
Build number:
Android version: Android 14 (API 34)
Device model:
Install source:
Music source used: Local / Jellyfin / Navidrome / Subsonic
Issue summary:
```

(`Android version` is filled only on Android; off-device it stays a blank prompt.)

## Why this design

- **Separate from "Report a bug".** The existing email action is untouched — this row *copies*, it never sends. Nothing is transmitted automatically.
- **No personal data, by construction.** The block contains no server URL, auth token, username, file path, or library name. It fills in only the app version and (on Android) the OS version.
- **No new dependencies.** Build number, device model, and install source have no safe, already-available runtime source in the project, so they're left as blank fill-in prompts rather than pulled in via a new plugin. The app version comes from the existing `AppInfo` source; the Android version uses the same `Platform` API the diagnostics collector already uses.
- **Pure, testable helper.** A new `AppInfoReport` helper assembles the text and does no I/O, so the content/ordering is unit-tested directly; the widget just feeds it live values and writes the clipboard.

## Scope

Limited to the Settings/About support UI. No changes to playback, cache, providers, database migrations, Android Auto, Cast, release config, or Play Store metadata.

## Files

- `lib/features/settings/about/app_info_report.dart` *(new)* — pure block builder
- `lib/features/settings/about/support_section.dart` — new row + clipboard/snackbar handler
- `test/features/settings/about/app_info_report_test.dart` *(new)* — content, ordering, and privacy assertions
- `test/features/settings/about/support_section_test.dart` — clipboard write + snackbar widget test
- `test/features/settings/hub/about_screen_test.dart` — row presence assertion

## Validation

- `dart format` — clean (0 changed)
- `flutter analyze` — No issues found
- `flutter test test/features/settings/` — 253 passing
- `./scripts/check_secrets.sh` — secret/privacy scan passed

## Manual verification note

Tapping the row builds the block from the live app/OS version, calls `Clipboard.setData`, and shows the **"App info copied to the clipboard."** snackbar. The widget test asserts the clipboard receives exactly what `AppInfoReport.build` produces and that the snackbar appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV3tMQKvp2ZzhfSWwieCQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01KV3tMQKvp2ZzhfSWwieCQm)_