### PR TITLE
feat(settings): add a What’s new section

### DIFF
--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/app_info.dart';
+
+/// The "What's new" card on the About page.
+///
+/// This is a small, static release-note surface for closed testers. It keeps the
+/// current test build's highlights visible without adding network calls, remote
+/// config, or release-file coupling.
+class WhatsNewSection extends StatelessWidget {
+  const WhatsNewSection({super.key});
+
+  static const List<String> _notes = <String>[
+    'Added support and bug report links for testers.',
+    'Added a copyable app-info block for easier bug reports.',
+    'Improved About and project information.',
+    'Continued Google Play closed testing preparation.',
+    'Stability and polish improvements.',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.new_releases_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text("What's new", style: theme.textTheme.titleMedium),
+                      const SizedBox(height: 2),
+                      Text(
+                        'Linthra ${AppInfo.version}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: muted,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            for (final String note in _notes) _ReleaseNoteRow(note: note),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReleaseNoteRow extends StatelessWidget {
+  const _ReleaseNoteRow({required this.note});
+
+  final String note;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(
+            Icons.check_circle_outline,
+            size: 18,
+            color: theme.colorScheme.primary,
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(child: Text(note, style: theme.textTheme.bodyMedium)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -6,15 +6,16 @@ import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/app_info.dart';
 import '../../../shared/widgets/linthra_logo_mark.dart';
 import '../about/support_section.dart';
+import '../about/whats_new_section.dart';
 import 'settings_detail_scaffold.dart';
 
 /// The "About" page of the Settings hub.
 ///
 /// A calm brand panel (the Linthra mark, name, and tagline), the version/build
-/// the app is running, and a short list of project links. The links open in the
-/// browser through the shared [externalLinkLauncherProvider] — the same seam the
-/// "Report a bug" flow uses — so every launch is an explicit tap and tests stay
-/// plugin-free.
+/// the app is running, recent test-build notes, and a short list of project
+/// links. The links open in the browser through the shared
+/// [externalLinkLauncherProvider] — the same seam the "Report a bug" flow uses —
+/// so every launch is an explicit tap and tests stay plugin-free.
 class AboutScreen extends ConsumerWidget {
   const AboutScreen({super.key});
 
@@ -32,6 +33,8 @@ class AboutScreen extends ConsumerWidget {
         const _BrandPanel(),
         const SizedBox(height: AppSpacing.md),
         const _BuildInfoCard(),
+        const SizedBox(height: AppSpacing.md),
+        const WhatsNewSection(),
         const SizedBox(height: AppSpacing.md),
         const SupportSection(),
         const SizedBox(height: AppSpacing.md),

--- a/test/features/settings/about/whats_new_section_test.dart
+++ b/test/features/settings/about/whats_new_section_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/app_info.dart';
+import 'package:linthra/features/settings/about/whats_new_section.dart';
+
+Future<void> _pump(WidgetTester tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(home: Scaffold(body: WhatsNewSection())),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('WhatsNewSection', () {
+    testWidgets('shows the section title and current app version',
+        (tester) async {
+      await _pump(tester);
+
+      expect(find.text("What's new"), findsOneWidget);
+      expect(find.text('Linthra ${AppInfo.version}'), findsOneWidget);
+    });
+
+    testWidgets('shows the closed-testing release notes', (tester) async {
+      await _pump(tester);
+
+      expect(
+        find.text('Added support and bug report links for testers.'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Added a copyable app-info block for easier bug reports.'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Improved About and project information.'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Continued Google Play closed testing preparation.'),
+        findsOneWidget,
+      );
+      expect(find.text('Stability and polish improvements.'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -24,9 +24,10 @@ Future<_FakeLinkLauncher> _pump(
   bool launchResult = true,
 }) async {
   final _FakeLinkLauncher launcher = _FakeLinkLauncher(result: launchResult);
-  // A tall surface so every card (brand, build info, support, and links) is laid
-  // out and hittable — a ListView only builds the rows it can show.
-  tester.view.physicalSize = const Size(1000, 2000);
+  // A tall surface so every card (brand, build info, what's new, support, and
+  // links) is laid out and hittable — a ListView only builds the rows it can
+  // show.
+  tester.view.physicalSize = const Size(1000, 2200);
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
@@ -53,6 +54,17 @@ void main() {
       expect(find.text('Source code'), findsOneWidget);
       expect(find.text('Releases'), findsOneWidget);
       expect(find.text('License (MPL-2.0)'), findsOneWidget);
+    });
+
+    testWidgets("composes the What's new section", (tester) async {
+      await _pump(tester);
+
+      expect(find.text("What's new"), findsOneWidget);
+      expect(find.text('Linthra ${AppInfo.version}'), findsOneWidget);
+      expect(
+        find.text('Continued Google Play closed testing preparation.'),
+        findsOneWidget,
+      );
     });
 
     testWidgets(


### PR DESCRIPTION
## What

Adds a small **What’s new** card to **Settings → About** so Google Play closed testers can quickly see what changed in the current testing build.

The new card shows:

- the current Linthra version from `AppInfo.version`
- short static release notes for the current testing cycle
- a visual style consistent with the existing About/Support cards

## Why

Closed testers need a simple in-app place to understand what changed without checking GitHub releases or commit history. This keeps the information visible inside Linthra while staying intentionally small and offline-only.

## Scope

Limited to Settings/About UI.

No playback, cache, providers, database migrations, Android Auto, Cast, release config, Play Store metadata, network calls, remote changelog, or new dependencies were changed.

## Files

- `lib/features/settings/about/whats_new_section.dart` *(new)* — static What’s new card
- `lib/features/settings/hub/about_screen.dart` — composes the new section
- `test/features/settings/about/whats_new_section_test.dart` *(new)* — widget tests for the card
- `test/features/settings/hub/about_screen_test.dart` — verifies About composes the section

## Validation

Expected checks:

- `dart format`
- `flutter analyze`
- relevant Settings/About Flutter tests

Manual verification:

- Open Settings → About
- Confirm the What’s new card appears after build info and before Support
- Confirm the app version matches the current `AppInfo.version`

🤖 Generated with ChatGPT