### PR TITLE
feat(settings): add a "What's new" card to Settings → About

### DIFF
--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/app_info.dart';
+
+/// The "What's new" card on the About page: a short, static summary of what
+/// changed in the current testing build, so closed-testing testers can see at a
+/// glance what's worth a look without leaving the app.
+///
+/// The highlights are intentionally static and local — no remote changelog,
+/// network call, or extra dependency. The version label is read from [AppInfo]
+/// (the single in-app source of truth, kept in lockstep with `pubspec.yaml`), so
+/// the card always names the build the tester is actually running. To prepare a
+/// new testing release, edit [releaseNotes]; the version follows `pubspec.yaml`
+/// on its own.
+class WhatsNewSection extends StatelessWidget {
+  const WhatsNewSection({super.key});
+
+  /// Short, tester-facing highlights for the current testing release. Kept to a
+  /// handful of concise bullets and updated when cutting a new build; exposed so
+  /// the widget test can assert each line renders without duplicating the copy.
+  static const List<String> releaseNotes = <String>[
+    'Added support and bug report links for testers.',
+    'Improved About and project information.',
+    'Continued Google Play closed testing preparation.',
+    'Stability and polish improvements.',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.auto_awesome_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text("What's new", style: theme.textTheme.titleMedium),
+                ),
+                // Ties the highlights below to the build the tester is running.
+                Text(
+                  'Version ${AppInfo.version}',
+                  style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            for (int i = 0; i < releaseNotes.length; i++) ...<Widget>[
+              if (i > 0) const SizedBox(height: AppSpacing.sm),
+              _NoteBullet(text: releaseNotes[i]),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single highlight line: a small accent bullet and the note text, aligned to
+/// the top so a wrapped line keeps the bullet at the first row.
+class _NoteBullet extends StatelessWidget {
+  const _NoteBullet({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextStyle? body = theme.textTheme.bodyMedium;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('•', style: body?.copyWith(color: theme.colorScheme.primary)),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(child: Text(text, style: body)),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -6,6 +6,7 @@ import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/app_info.dart';
 import '../../../shared/widgets/linthra_logo_mark.dart';
 import '../about/support_section.dart';
+import '../about/whats_new_section.dart';
 import 'settings_detail_scaffold.dart';
 
 /// The "About" page of the Settings hub.
@@ -32,6 +33,8 @@ class AboutScreen extends ConsumerWidget {
         const _BrandPanel(),
         const SizedBox(height: AppSpacing.md),
         const _BuildInfoCard(),
+        const SizedBox(height: AppSpacing.md),
+        const WhatsNewSection(),
         const SizedBox(height: AppSpacing.md),
         const SupportSection(),
         const SizedBox(height: AppSpacing.md),

--- a/test/features/settings/about/whats_new_section_test.dart
+++ b/test/features/settings/about/whats_new_section_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/app_info.dart';
+import 'package:linthra/features/settings/about/whats_new_section.dart';
+
+Future<void> _pump(WidgetTester tester) async {
+  // A tall surface so the whole card lays out and every bullet is rendered.
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    const MaterialApp(home: Scaffold(body: WhatsNewSection())),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('WhatsNewSection', () {
+    testWidgets('shows the title and the running app version', (tester) async {
+      await _pump(tester);
+
+      expect(find.text("What's new"), findsOneWidget);
+      // The current version comes from AppInfo (the in-app source of truth),
+      // shown beside the title so the highlights are tied to this build.
+      expect(find.text('Version ${AppInfo.version}'), findsOneWidget);
+    });
+
+    testWidgets('renders every release-note bullet', (tester) async {
+      await _pump(tester);
+
+      // There is at least one highlight to show, and they are kept short.
+      expect(WhatsNewSection.releaseNotes, isNotEmpty);
+      for (final String note in WhatsNewSection.releaseNotes) {
+        expect(find.text(note), findsOneWidget);
+      }
+    });
+  });
+}

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/external_link_launcher_provider.dart';
 import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/settings/about/whats_new_section.dart';
 import 'package:linthra/features/settings/hub/about_screen.dart';
 
 class _FakeLinkLauncher implements ExternalLinkLauncher {
@@ -65,6 +66,16 @@ void main() {
       expect(find.text('Email support'), findsOneWidget);
       expect(find.text('support@linthra.ca'), findsOneWidget);
       expect(find.text('Privacy policy'), findsOneWidget);
+    });
+
+    testWidgets('composes the "What\'s new" section for the running version',
+        (tester) async {
+      await _pump(tester);
+
+      expect(find.text("What's new"), findsOneWidget);
+      expect(find.text('Version ${AppInfo.version}'), findsOneWidget);
+      // The static highlights are shown verbatim.
+      expect(find.text(WhatsNewSection.releaseNotes.first), findsOneWidget);
     });
 
     testWidgets('tapping "Source code" opens the repository', (tester) async {


### PR DESCRIPTION
## What & why

Google Play **closed testers** need a simple place *inside the app* to see what changed in the build they are running, without leaving for GitHub releases or commit history. This adds a small, static **What's new** card to **Settings → About**.

The card shows:

- the **current version**, read from the existing `AppInfo.version` source (the in-app source of truth that mirrors `pubspec.yaml`), so the highlights are tied to the build the tester actually has;
- a handful of **short, static highlights** for the current testing release.

## Design

- A new `WhatsNewSection` widget under `lib/features/settings/about/`, following the per-section convention already used by `SupportSection`.
- A `Card` with an `AppSpacing`-based layout, `colorScheme.primary` accent icon, and muted `onSurface` secondary text — consistent with the existing About/Support cards.
- Placed between the build-info card and the Support section, so the page reads: brand → version/channel → **what's new in this version** → support → links.
- `releaseNotes` is exposed as a `static const` so the copy is easy to update for the next testing cycle and the widget test can assert each line without duplicating the strings.

## Scope

Intentionally **local and static** — no remote changelog, network call, or new dependency. Limited to Settings/About UI; **no** playback, cache, providers, database migrations, Android Auto, Cast, release config, version numbers, or Play Store metadata were touched.

## Files

- `lib/features/settings/about/whats_new_section.dart` *(new)* — the static What's new card
- `lib/features/settings/hub/about_screen.dart` — composes the section
- `test/features/settings/about/whats_new_section_test.dart` *(new)* — widget tests for the card
- `test/features/settings/hub/about_screen_test.dart` — verifies About composes the section

## Validation

- `dart format --set-exit-if-changed .` — clean (0 changed)
- `flutter analyze` — No issues found
- `flutter test test/features/settings/` — **256 passing**, including the new `WhatsNewSection` tests (title, running version, and every highlight render) and the About-page composition check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NG3Bc1RMYtQiF9QicPEUup

---
_Generated by [Claude Code](https://claude.ai/code/session_01NG3Bc1RMYtQiF9QicPEUup)_