### PR TITLE
feat(settings): add a tester checklist card to Settings → About

### DIFF
--- a/lib/features/settings/about/tester_checklist_section.dart
+++ b/lib/features/settings/about/tester_checklist_section.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+
+/// The "Tester checklist" card on the About page: a short, static list of the
+/// things a Google Play closed tester can try in a couple of minutes, plus a
+/// reminder of the feedback that helps most.
+///
+/// It is informational only. There is no completion state to tick off, nothing
+/// is stored, no analytics are recorded, and nothing is sent — the card just
+/// points testers at what to look at. The items are intentionally static and
+/// local, so there is no network call or extra dependency. To change what
+/// testers are pointed at for a build, edit [items]; the card renders whatever
+/// is in the list, and the widget test asserts each line shows without
+/// duplicating the copy.
+class TesterChecklistSection extends StatelessWidget {
+  const TesterChecklistSection({super.key});
+
+  /// Short, tester-facing things to try, in the order they read on the card.
+  /// Kept concise and easy to update when the testing focus changes; exposed so
+  /// the widget test can assert each item renders.
+  static const List<String> items = <String>[
+    'Open the local music library.',
+    'Try the playback controls.',
+    'Try search.',
+    'Try a self-hosted source if you use Jellyfin, Navidrome, or Subsonic.',
+    'Try offline and cache behavior if available.',
+    'Report any crash, playback issue, layout bug, or confusing flow.',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.checklist_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'Tester checklist',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'A few quick things to try. Nothing here is saved or sent.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            for (int i = 0; i < items.length; i++) ...<Widget>[
+              if (i > 0) const SizedBox(height: AppSpacing.sm),
+              _CheckItem(text: items[i]),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single checklist line: a check icon and the item text, aligned to the top
+/// so a wrapped line keeps the icon on the first row.
+class _CheckItem extends StatelessWidget {
+  const _CheckItem({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextStyle? body = theme.textTheme.bodyMedium;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(
+          Icons.check_circle_outline,
+          size: 18,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(child: Text(text, style: body)),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -6,6 +6,7 @@ import '../../../app/external_link_launcher_provider.dart';
 import '../../../core/app_info.dart';
 import '../../../shared/widgets/linthra_logo_mark.dart';
 import '../about/support_section.dart';
+import '../about/tester_checklist_section.dart';
 import '../about/whats_new_section.dart';
 import 'settings_detail_scaffold.dart';
 
@@ -35,6 +36,8 @@ class AboutScreen extends ConsumerWidget {
         const _BuildInfoCard(),
         const SizedBox(height: AppSpacing.md),
         const WhatsNewSection(),
+        const SizedBox(height: AppSpacing.md),
+        const TesterChecklistSection(),
         const SizedBox(height: AppSpacing.md),
         const SupportSection(),
         const SizedBox(height: AppSpacing.md),

--- a/test/features/settings/about/tester_checklist_section_test.dart
+++ b/test/features/settings/about/tester_checklist_section_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/settings/about/tester_checklist_section.dart';
+
+Future<void> _pump(WidgetTester tester) async {
+  // A tall surface so the whole card lays out and every item is rendered.
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    const MaterialApp(home: Scaffold(body: TesterChecklistSection())),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('TesterChecklistSection', () {
+    testWidgets('shows the checklist title', (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Tester checklist'), findsOneWidget);
+    });
+
+    testWidgets('renders every checklist item', (tester) async {
+      await _pump(tester);
+
+      // There is at least one thing to try, and the items are kept short.
+      expect(TesterChecklistSection.items, isNotEmpty);
+      for (final String item in TesterChecklistSection.items) {
+        expect(find.text(item), findsOneWidget);
+      }
+    });
+  });
+}

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/app/external_link_launcher_provider.dart';
 import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/settings/about/tester_checklist_section.dart';
 import 'package:linthra/features/settings/about/whats_new_section.dart';
 import 'package:linthra/features/settings/hub/about_screen.dart';
 
@@ -76,6 +77,14 @@ void main() {
       expect(find.text('Version ${AppInfo.version}'), findsOneWidget);
       // The static highlights are shown verbatim.
       expect(find.text(WhatsNewSection.releaseNotes.first), findsOneWidget);
+    });
+
+    testWidgets('composes the tester checklist', (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Tester checklist'), findsOneWidget);
+      // The static checklist items are shown verbatim.
+      expect(find.text(TesterChecklistSection.items.first), findsOneWidget);
     });
 
     testWidgets('tapping "Source code" opens the repository', (tester) async {


### PR DESCRIPTION
## Summary

Adds a small, informational **Tester checklist** card to **Settings → About** so Google Play closed testers can see at a glance what to try in a couple of minutes and what feedback is most useful.

The card sits just below the existing **What's new** card and lists a handful of static, easy-to-update items:

- Open the local music library.
- Try the playback controls.
- Try search.
- Try a self-hosted source if you use Jellyfin, Navidrome, or Subsonic.
- Try offline and cache behavior if available.
- Report any crash, playback issue, layout bug, or confusing flow.

## Design

- New `TesterChecklistSection` widget (`lib/features/settings/about/tester_checklist_section.dart`), modeled on the existing `WhatsNewSection` card so the About page stays visually consistent — same `Card` + header-icon layout, same `AppSpacing` scale, simple check-icon rows.
- The copy lives in a single `static const List<String> items`, so it's trivial to edit when the testing focus changes.

## Guardrails (as requested)

- ✅ Informational only — no checklist completion state is stored.
- ✅ No analytics.
- ✅ Nothing is sent — no network calls, no new dependencies.
- ✅ Out of scope and untouched: playback, cache, providers, database migrations, Android Auto, Cast, release config, Play Store metadata.

## Tests

- New `tester_checklist_section_test.dart` verifies the checklist title and every item render.
- `about_screen_test.dart` gains a composition check that the card appears on the About page.

## Validation

- `dart format` — no changes.
- `flutter analyze` — no issues.
- `flutter test test/features/settings/` — all 259 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7BgXP8HMbtQ2je6HD8X8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7BgXP8HMbtQ2je6HD8X8p)_