### PR TITLE
feat(plex): enable offline cache downloads

### DIFF
--- a/lib/core/services/remote_track_downloader.dart
+++ b/lib/core/services/remote_track_downloader.dart
@@ -16,9 +16,10 @@ class RemoteTrackData {
 ///
 /// This is the seam the download repository uses to obtain a remote source's
 /// audio without knowing anything about that source's protocol, URLs, or auth.
-/// The Jellyfin implementation lives behind it; the repository depends only on
-/// this interface, so the offline-cache policy stays source-agnostic and tests
-/// can drive downloads with a fake that returns canned bytes.
+/// The Jellyfin, Subsonic/Navidrome, and Plex implementations live behind it;
+/// the repository depends only on this interface, so the offline-cache policy
+/// stays source-agnostic and tests can drive downloads with a fake that returns
+/// canned bytes.
 ///
 /// Security invariant: an implementation resolves any authenticated URL only at
 /// fetch time and must never return, log, or embed an access token — or that

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -259,26 +259,23 @@ abstract final class MusicProviders {
     ),
   );
 
-  /// Plex (phase 1, experimental — see docs/plex.md and issue #178).
+  /// Plex (experimental — see docs/plex.md and issue #178).
   /// `plex:<ratingKey>` URIs are recognized end to end, and the Settings card
-  /// (badged Experimental) lets the user connect with a manual server URL +
-  /// token and pick which music libraries to include.
+  /// lets the user connect, pick which music libraries to include, and sync a
+  /// token-free local catalog slice.
   ///
-  /// Stream + lyrics: caching, favorites, playlists, and cast stay declared
-  /// unsupported so their actions stay hidden/disabled rather than failing —
-  /// exactly how Subsonic shipped streaming first. Lyrics are fetched on demand
-  /// from the track's Plex lyric stream (synced `.lrc` or plain), the one read
-  /// beyond streaming. Cast stays off in phase 1 to keep the credential-in-URL
-  /// surface small (a Plex stream URL carries the token as a query param).
+  /// Streaming, lyrics, and offline caching are implemented. Favorites,
+  /// playlists, and cast stay declared unsupported so their actions remain
+  /// hidden/disabled rather than failing. Cast stays off for now to keep the
+  /// credential-in-URL surface small (a Plex stream URL carries the token as a
+  /// query param).
   static const MusicProvider plex = MusicProvider(
     sourceId: 'plex',
     displayName: 'Plex',
     serverUrlLabel: 'Server URL',
     capabilities: MusicProviderCapabilities(
       canStream: true,
-      // Offline caching is a documented follow-up (docs/plex.md → Out of
-      // scope), so there is no app-managed copy to remove either.
-      canCache: false,
+      canCache: true,
       canFavoriteTracks: false,
       canReadFavoriteState: false,
       canSyncFavorites: false,
@@ -287,9 +284,9 @@ abstract final class MusicProviders {
       canLyrics: true,
       canCast: false,
       canRemoveFromLibrary: true,
-      canRemoveOfflineCopy: false,
+      canRemoveOfflineCopy: true,
       canDeleteLocalFile: false,
-      // Phase 1 is read-only: Linthra never writes to a Plex server.
+      // Plex remains library-read-only: Linthra never deletes items from PMS.
       canDeleteRemoteItem: false,
       canListPlaylists: false,
       canCreatePlaylist: false,

--- a/lib/core/sources/plex/plex_download_source.dart
+++ b/lib/core/sources/plex/plex_download_source.dart
@@ -1,0 +1,23 @@
+import '../../models/track.dart';
+
+/// The narrow capability the offline downloader needs from a signed-in Plex
+/// connection: confirm the session still works, then mint a tokenized direct
+/// file URL for a track's original `Part`.
+///
+/// Mirrors `JellyfinDownloadSource`. [PlexMusicSource] implements it so the
+/// offline cache can fetch Plex bytes without knowing anything about Plex HTTP,
+/// sessions, or token handling.
+///
+/// Security: Plex file URLs carry `X-Plex-Token` in their query because the
+/// cache downloader fetches raw bytes with a plain HTTP request. The URL is
+/// minted only at download time and must never be stored on [track], cached in
+/// metadata, logged, or surfaced in thrown errors.
+abstract interface class PlexDownloadSource {
+  /// Confirms the session is still valid and the server reachable. Throws a
+  /// token-free `PlexException` when it is not.
+  Future<void> verifyReachable();
+
+  /// The tokenized URL to download [track]'s original file, or `null` when the
+  /// Plex item carries no playable/downloadable part.
+  Future<Uri?> resolveDownloadUri(Track track);
+}

--- a/lib/core/sources/plex/plex_music_source.dart
+++ b/lib/core/sources/plex/plex_music_source.dart
@@ -6,6 +6,7 @@ import '../../services/music_source.dart';
 import '../../services/playback_diagnostics.dart';
 import 'plex_api.dart';
 import 'plex_client.dart';
+import 'plex_download_source.dart';
 import 'plex_endpoints.dart';
 import 'plex_exception.dart';
 import 'plex_stream_source.dart';
@@ -29,16 +30,17 @@ import 'plex_track_mapper.dart';
 /// library picker in Settings fills it — simply yields empty lists, never an
 /// error.
 ///
-/// Playback is two-step by design (see docs/plex.md → MusicSource mapping): a
-/// track's opaque `plex:<ratingKey>` URI is resolved at play time via a
-/// `GET /library/metadata/{ratingKey}` lookup, because the playable `Part` key
+/// Playback and offline caching both resolve through the same live metadata
+/// lookup: a track's opaque `plex:<ratingKey>` URI is expanded at play/download
+/// time via `GET /library/metadata/{ratingKey}`, because the playable `Part` key
 /// differs from the `ratingKey`. That live lookup doubles as the reachability/
-/// auth check Jellyfin and Subsonic get from probing their stream URL: an
-/// expired token, an offline server, or a vanished item surfaces as a typed,
-/// token-free `PlexException` before the audio engine ever touches a URL. Only
-/// then is the tokenized stream URL minted — the token never reaches a
+/// auth check Jellyfin and Subsonic get from probing their stream/download URL:
+/// an expired token, an offline server, or a vanished item surfaces as a typed,
+/// token-free `PlexException` before the audio engine or cache ever touches a
+/// URL. Only then is the tokenized Part URL minted — the token never reaches a
 /// [Track], the catalog, or an error message.
-class PlexMusicSource implements MusicSource, PlexStreamSource {
+class PlexMusicSource
+    implements MusicSource, PlexStreamSource, PlexDownloadSource {
   const PlexMusicSource({required this.session, required PlexClient client})
       : _client = client;
 
@@ -107,9 +109,9 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
   }
 
   /// Confirms the token is still accepted and the server reachable, via
-  /// `GET /identity`, so the player can surface a precise error before
-  /// attempting to stream. Throws a `PlexException` on failure; the token
-  /// never appears in it.
+  /// `GET /identity`, so the player/downloader can surface a precise error
+  /// before attempting to stream or cache bytes. Throws a `PlexException` on
+  /// failure; the token never appears in it.
   @override
   Future<void> verifyReachable() async {
     await _client.fetchIdentity(baseUrl: session.baseUrl, token: session.token);
@@ -130,17 +132,7 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
   @override
   Future<Uri?> resolvePlayableUri(Track track) async {
     final String ratingKey = _ratingKey(track);
-    if (ratingKey.trim().isEmpty) {
-      // No ratingKey can name no item; `GET /library/metadata/` (no id) is a
-      // junk request, so fail as the same typed "not available" a vanished
-      // item gets — friendly in the player, never a raw HTTP error.
-      throw PlexException.notFound();
-    }
-    final PlexMetadata item = await _client.fetchMetadata(
-      baseUrl: session.baseUrl,
-      token: session.token,
-      ratingKey: ratingKey,
-    );
+    final PlexMetadata item = await _fetchMetadataForRatingKey(ratingKey);
     // Log the (non-secret) resolution before minting any tokenized URL, so a
     // track that resolves to no playable part is still diagnosable.
     PlaybackDiagnostics.resolved(
@@ -150,19 +142,44 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
     );
     final String? partKey = item.firstPartKey;
     if (partKey == null) return null;
-    return _mintStreamUrl(partKey);
+    return _mintTokenizedPartUrl(partKey);
   }
 
-  /// Mints the tokenized direct-play URL for [partKey] — the only call site of
-  /// [PlexEndpoints.streamUrl].
+  /// Resolves a `plex:<ratingKey>` track to the same original-file Part URL the
+  /// player direct-plays, for offline caching. The URL is minted only for the
+  /// cache fetch and never stored in catalog/cache metadata.
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async {
+    final PlexMetadata item = await _fetchMetadataForRatingKey(_ratingKey(track));
+    final String? partKey = item.firstPartKey;
+    if (partKey == null) return null;
+    return _mintTokenizedPartUrl(partKey);
+  }
+
+  Future<PlexMetadata> _fetchMetadataForRatingKey(String ratingKey) {
+    if (ratingKey.trim().isEmpty) {
+      // No ratingKey can name no item; `GET /library/metadata/` (no id) is a
+      // junk request, so fail as the same typed "not available" a vanished
+      // item gets — friendly in the player/downloader, never a raw HTTP error.
+      throw PlexException.notFound();
+    }
+    return _client.fetchMetadata(
+      baseUrl: session.baseUrl,
+      token: session.token,
+      ratingKey: ratingKey,
+    );
+  }
+
+  /// Mints the tokenized direct-file URL for [partKey] — the only call site of
+  /// [PlexEndpoints.streamUrl]. Plex uses the same Part key for direct playback
+  /// and original-file cache fetches.
   ///
   /// A real Part key is always a server-absolute path (`/library/parts/…`); a
   /// relative one would splice into the base URL's authority (corrupting the
   /// port, or pointing at a different host), so it is refused — and a key the
-  /// URL parser rejects outright is refused the same way — as the typed
-  /// "response Linthra could not use", keeping the "only `PlexException`
-  /// escapes" contract instead of handing the player an untyped failure.
-  Uri _mintStreamUrl(String partKey) {
+  /// URL parser can't use fails the same way — as the typed "response Linthra
+  /// could not use", keeping the "only `PlexException` escapes" contract.
+  Uri _mintTokenizedPartUrl(String partKey) {
     if (!partKey.startsWith('/')) {
       throw PlexException.unsupportedResponse();
     }

--- a/lib/core/sources/plex/plex_music_source.dart
+++ b/lib/core/sources/plex/plex_music_source.dart
@@ -150,7 +150,8 @@ class PlexMusicSource
   /// cache fetch and never stored in catalog/cache metadata.
   @override
   Future<Uri?> resolveDownloadUri(Track track) async {
-    final PlexMetadata item = await _fetchMetadataForRatingKey(_ratingKey(track));
+    final PlexMetadata item =
+        await _fetchMetadataForRatingKey(_ratingKey(track));
     final String? partKey = item.firstPartKey;
     if (partKey == null) return null;
     return _mintTokenizedPartUrl(partKey);

--- a/lib/core/sources/plex/plex_stream_source.dart
+++ b/lib/core/sources/plex/plex_stream_source.dart
@@ -3,12 +3,12 @@ import '../../models/track.dart';
 /// The narrow capability the playback resolver needs from a signed-in Plex
 /// connection: confirm the session still works, then mint a stream URL.
 ///
-/// [PlexMusicSource] implements it; keeping it tiny lets the future resolver
-/// depend on just this (not the whole source or any HTTP), and lets tests fake
-/// the source directly to drive every outcome — expired token, unreachable
-/// server, a vanished item — without a real server. Mirrors
-/// `JellyfinStreamSource`; phase 1 is stream-only (no offline cache), so unlike
-/// `SubsonicStreamSource` there is no download seam to expose.
+/// [PlexMusicSource] implements it; keeping it tiny lets the resolver depend on
+/// just this (not the whole source or any HTTP), and lets tests fake the source
+/// directly to drive every outcome — expired token, unreachable server, a
+/// vanished item — without a real server. Offline caching uses the separate
+/// `PlexDownloadSource` seam so playback and download responsibilities remain
+/// independent.
 ///
 /// Security: a Plex stream URL carries the `X-Plex-Token` in its **query** (the
 /// audio engine can't set headers), so it is minted here on demand, at play

--- a/lib/core/sources/plex/plex_track_downloader.dart
+++ b/lib/core/sources/plex/plex_track_downloader.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/track.dart';
+import '../../services/remote_track_downloader.dart';
+import '../audio_file_extension.dart';
+import 'plex_download_source.dart';
+import 'plex_track_mapper.dart';
+
+/// The [RemoteTrackDownloader] for Plex tracks.
+///
+/// Resolves the tokenized original-file URL only at fetch time — through the live
+/// signed-in [PlexDownloadSource], read via a getter so signing in or out is
+/// picked up without rebuilding the downloader — then fetches the bytes over
+/// HTTP. The URL, and the `X-Plex-Token` woven into it, never leave [fetch]: it
+/// is not stored, not returned, and not placed in any thrown error.
+class PlexTrackDownloader implements RemoteTrackDownloader {
+  PlexTrackDownloader(this._source, {http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final PlexDownloadSource? Function() _source;
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(minutes: 5);
+
+  @override
+  bool isRemote(Track track) => track.uri.startsWith(PlexTrackMapper.uriScheme);
+
+  @override
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    final PlexDownloadSource? source = _source();
+    if (source == null) {
+      throw StateError('Not signed in to Plex.');
+    }
+
+    // Confirm the session still works before fetching. A PlexException thrown
+    // here is friendly and token-free by design.
+    await source.verifyReachable();
+
+    final Uri? uri = await source.resolveDownloadUri(track);
+    if (uri == null) {
+      throw StateError('No Plex download URL for this track.');
+    }
+
+    try {
+      // Stream the body so progress can be reported as bytes arrive. The
+      // request carries the token in its URL, but the URL never leaves this
+      // method, is never logged, and any transport error below is replaced with
+      // a generic message so it cannot leak.
+      final http.StreamedResponse response =
+          await _client.send(http.Request('GET', uri)).timeout(_timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        await response.stream.drain<void>();
+        throw StateError('Plex download failed (HTTP ${response.statusCode}).');
+      }
+
+      final int? total =
+          (response.contentLength != null && response.contentLength! > 0)
+              ? response.contentLength
+              : null;
+      final BytesBuilder builder = BytesBuilder(copy: false);
+      int received = 0;
+      onProgress?.call(received, total);
+      await for (final List<int> chunk in response.stream.timeout(_timeout)) {
+        builder.add(chunk);
+        received += chunk.length;
+        onProgress?.call(received, total);
+      }
+
+      return RemoteTrackData(
+        bytes: builder.takeBytes(),
+        fileExtension:
+            AudioFileExtension.forContentType(response.headers['content-type']),
+      );
+    } on StateError {
+      // Our own friendly, token-free messages (bad status / not signed in):
+      // surface them as-is.
+      rethrow;
+    } on Exception {
+      // Never rethrow the original error: a ClientException/SocketException (or
+      // a TimeoutException) can embed the tokenized URL in its message.
+      throw StateError('Plex download failed.');
+    }
+  }
+}

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -10,10 +10,12 @@ import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/remote_track_downloader.dart';
 import '../../core/services/routing_remote_track_downloader.dart';
 import '../../core/sources/jellyfin/jellyfin_track_downloader.dart';
+import '../../core/sources/plex/plex_track_downloader.dart';
 import '../../core/sources/subsonic/subsonic_track_downloader.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/plex/plex_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 
 /// The live download status of a single track, for the Library row indicator.
@@ -30,7 +32,7 @@ final trackDownloadStatusProvider =
 /// The live byte progress of a single in-flight download, for the row's
 /// determinate ring. Null when the track isn't downloading (or its server
 /// didn't report a size, leaving progress indeterminate). Auto-disposed so
-/// off-screen rows drop the subscription.
+/// off-screen rows drop their subscription.
 final trackDownloadProgressProvider = StreamProvider.autoDispose
     .family<DownloadProgress?, String>((ref, trackId) {
   final repository = ref.watch(downloadRepositoryProvider);
@@ -230,13 +232,13 @@ final precacheCountProvider =
   PrecacheCountController.new,
 );
 
-/// Production binding: makes remote (Jellyfin and Subsonic/Navidrome) tracks
-/// downloadable for offline use by routing the remote downloader across both
-/// sources, each wired to its live signed-in source (read lazily, so sign-in/out
-/// is picked up without a rebuild). The credential-bearing download URL is
-/// minted only at fetch time inside each downloader; nothing here stores it.
-/// Applied in `main`; tests override [remoteTrackDownloaderProvider] with their
-/// own fake.
+/// Production binding: makes remote (Jellyfin, Subsonic/Navidrome, and Plex)
+/// tracks downloadable for offline use by routing the remote downloader across
+/// all signed-in sources, each wired to its live source (read lazily, so
+/// sign-in/out is picked up without a rebuild). Credential-bearing download URLs
+/// are minted only at fetch time inside each downloader; nothing here stores
+/// them. Applied in `main`; tests override [remoteTrackDownloaderProvider] with
+/// their own fake.
 final remoteTrackDownloaderOverride =
     remoteTrackDownloaderProvider.overrideWith((ref) {
   // Read (not watch) the live sources lazily at fetch time, mirroring the
@@ -245,5 +247,6 @@ final remoteTrackDownloaderOverride =
   return RoutingRemoteTrackDownloader(<RemoteTrackDownloader>[
     JellyfinTrackDownloader(() => ref.read(jellyfinMusicSourceProvider)),
     SubsonicTrackDownloader(() => ref.read(subsonicMusicSourceProvider)),
+    PlexTrackDownloader(() => ref.read(plexMusicSourceProvider)),
   ]);
 });

--- a/test/core/services/routing_remote_track_downloader_test.dart
+++ b/test/core/services/routing_remote_track_downloader_test.dart
@@ -30,14 +30,17 @@ class _FakeDownloader implements RemoteTrackDownloader {
 void main() {
   late _FakeDownloader jellyfin;
   late _FakeDownloader subsonic;
+  late _FakeDownloader plex;
   late RoutingRemoteTrackDownloader router;
 
   setUp(() {
     jellyfin = _FakeDownloader('jellyfin:', 'j');
     subsonic = _FakeDownloader('subsonic:', 's');
+    plex = _FakeDownloader('plex:', 'p');
     router = RoutingRemoteTrackDownloader(<RemoteTrackDownloader>[
       jellyfin,
       subsonic,
+      plex,
     ]);
   });
 
@@ -48,6 +51,10 @@ void main() {
     );
     expect(
       router.isRemote(const Track(id: 'j1', title: 'x', uri: 'jellyfin:j1')),
+      isTrue,
+    );
+    expect(
+      router.isRemote(const Track(id: 'p1', title: 'x', uri: 'plex:p1')),
       isTrue,
     );
     expect(
@@ -63,6 +70,17 @@ void main() {
     expect(data.fileExtension, 's');
     expect(subsonic.fetched, <String>['s1']);
     expect(jellyfin.fetched, isEmpty);
+    expect(plex.fetched, isEmpty);
+  });
+
+  test('fetch routes Plex tracks to the Plex downloader', () async {
+    final data =
+        await router.fetch(const Track(id: 'p1', title: 'x', uri: 'plex:p1'));
+
+    expect(data.fileExtension, 'p');
+    expect(plex.fetched, <String>['p1']);
+    expect(jellyfin.fetched, isEmpty);
+    expect(subsonic.fetched, isEmpty);
   });
 
   test('throws for a track no member can fetch', () {

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -46,28 +46,27 @@ void main() {
       expect(caps.canListPlaylists, isFalse);
     });
 
-    test('plex: stream + lyrics in phase 1 (docs/plex.md capability matrix)',
-        () {
+    test('plex: stream/cache/lyrics implemented; server writes stay off', () {
       final caps = MusicProviders.plex.capabilities;
       expect(caps.canStream, isTrue);
+      expect(caps.canCache, isTrue);
+      expect(caps.canRemoveOfflineCopy, isTrue);
       // Lyrics are fetched on demand from the track's Plex lyric stream (synced
-      // `.lrc` or plain), so they read ✅ — the one capability beyond streaming.
+      // `.lrc` or plain), so they read ✅ — the one capability beyond playback
+      // and offline caching.
       expect(caps.canLyrics, isTrue);
       // Everything else is declared unsupported so its actions stay hidden/
       // disabled rather than failing — exactly how Subsonic deferred features.
-      expect(caps.canCache, isFalse);
       expect(caps.canFavoriteTracks, isFalse);
       expect(caps.canReadFavoriteState, isFalse);
       expect(caps.canSyncFavorites, isFalse);
-      // Cast stays off in phase 1 to keep the credential-in-URL surface small.
+      // Cast stays off for now to keep the credential-in-URL surface small.
       expect(caps.canCast, isFalse);
       expect(caps.canListPlaylists, isFalse);
       expect(caps.canCreatePlaylist, isFalse);
       expect(caps.canEditPlaylist, isFalse);
       expect(caps.canDeletePlaylist, isFalse);
       expect(caps.canSyncPlaylists, isFalse);
-      // No cache means no app-managed offline copy to remove.
-      expect(caps.canRemoveOfflineCopy, isFalse);
     });
 
     test('identity fields', () {
@@ -88,13 +87,15 @@ void main() {
       expect(MusicProviders.plex.capabilities.canRemoveFromLibrary, isTrue);
 
       // On-device tracks have no app-managed offline copy to remove; remote
-      // providers do.
+      // providers with offline cache support do.
       expect(MusicProviders.local.capabilities.canRemoveOfflineCopy, isFalse);
       expect(MusicProviders.jellyfin.capabilities.canRemoveOfflineCopy, isTrue);
+      expect(MusicProviders.subsonic.capabilities.canRemoveOfflineCopy, isTrue);
+      expect(MusicProviders.plex.capabilities.canRemoveOfflineCopy, isTrue);
 
       // Destructive file/server deletes are not enabled in this release for any
       // provider, so those actions stay hidden everywhere. Plex is additionally
-      // read-only by design (phase 1 never writes to the server).
+      // library-read-only by design and never deletes items from PMS.
       for (final caps in <MusicProviderCapabilities>[
         MusicProviders.local.capabilities,
         MusicProviders.jellyfin.capabilities,

--- a/test/core/sources/plex/plex_download_source_test.dart
+++ b/test/core/sources/plex/plex_download_source_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/sources/plex/plex_api.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_music_source.dart';
+
+import 'fake_plex_client.dart';
+
+const String _token = 'tok-secret-123';
+
+const PlexSession _session = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: _token,
+  machineIdentifier: 'machine-abc',
+  serverName: 'Living Room',
+  selectedSectionKeys: <String>['3'],
+);
+
+const Track _track = Track(id: '301', title: 'Nightcall', uri: 'plex:301');
+
+void main() {
+  group('PlexMusicSource.resolveDownloadUri', () {
+    late FakePlexClient client;
+    late PlexMusicSource source;
+
+    setUp(() {
+      client = FakePlexClient();
+      source = PlexMusicSource(session: _session, client: client);
+    });
+
+    test('looks up metadata and mints a tokenized original-file URL', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(
+          ratingKey: '301',
+          type: 'track',
+          title: 'Nightcall',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[
+              PlexPart(key: '/library/parts/9001/1700000000/file.flac'),
+            ]),
+          ],
+        ),
+      };
+
+      final Uri? uri = await source.resolveDownloadUri(_track);
+
+      expect(client.requestedRatingKeys, <String>['301']);
+      expect(uri, isNotNull);
+      expect(uri!.path, '/library/parts/9001/1700000000/file.flac');
+      expect(uri.queryParameters['X-Plex-Token'], _token);
+      expect(_track.uri, 'plex:301');
+      expect(_track.uri, isNot(contains(_token)));
+    });
+
+    test('returns null when the item has no playable part', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(ratingKey: '301', type: 'track', title: 'x'),
+      };
+
+      expect(await source.resolveDownloadUri(_track), isNull);
+    });
+
+    test('a vanished item surfaces as a typed, token-free PlexException', () {
+      expect(
+        () => source.resolveDownloadUri(_track),
+        throwsA(
+          isA<PlexException>()
+              .having((e) => e.kind, 'kind', PlexErrorKind.notFound)
+              .having((e) => e.message, 'message', isNot(contains(_token)))
+              .having((e) => e.toString(), 'toString', isNot(contains(_token))),
+        ),
+      );
+    });
+
+    test('a Part key that is not server-absolute fails typed', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(
+          ratingKey: '301',
+          type: 'track',
+          title: 'x',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[PlexPart(key: 'file.flac')]),
+          ],
+        ),
+      };
+
+      await expectLater(
+        source.resolveDownloadUri(_track),
+        throwsA(
+          isA<PlexException>()
+              .having((e) => e.kind, 'kind', PlexErrorKind.unsupportedResponse)
+              .having((e) => e.message, 'message', isNot(contains(_token))),
+        ),
+      );
+    });
+
+    test('a uri with no ratingKey fails typed without issuing a junk request',
+        () async {
+      const Track malformed = Track(id: '', title: 'x', uri: 'plex:');
+
+      await expectLater(
+        source.resolveDownloadUri(malformed),
+        throwsA(
+          isA<PlexException>()
+              .having((e) => e.kind, 'kind', PlexErrorKind.notFound)
+              .having((e) => e.message, 'message', isNot(contains(_token))),
+        ),
+      );
+      expect(client.requestedRatingKeys, isEmpty);
+    });
+  });
+}

--- a/test/core/sources/plex/plex_track_downloader_test.dart
+++ b/test/core/sources/plex/plex_track_downloader_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/remote_track_downloader.dart';
+import 'package:linthra/core/sources/plex/plex_download_source.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_track_downloader.dart';
+
+class _FakeDownloadSource implements PlexDownloadSource {
+  _FakeDownloadSource({this.verifyError, this.downloadUri});
+
+  final PlexException? verifyError;
+  final Uri? downloadUri;
+  int verifyCount = 0;
+
+  @override
+  Future<void> verifyReachable() async {
+    verifyCount++;
+    final PlexException? error = verifyError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async => downloadUri;
+}
+
+const Track _track = Track(id: '301', title: 'Nightcall', uri: 'plex:301');
+final Uri _downloadUri = Uri.parse(
+  'https://plex.example.com/library/parts/9001/file.flac?X-Plex-Token=secret',
+);
+
+void main() {
+  group('PlexTrackDownloader', () {
+    test('isRemote is true only for Plex tracks', () {
+      final PlexTrackDownloader downloader = PlexTrackDownloader(() => null);
+
+      expect(downloader.isRemote(_track), isTrue);
+      expect(
+        downloader.isRemote(const Track(id: 'l', title: 'x', uri: '/a.mp3')),
+        isFalse,
+      );
+    });
+
+    test('verifies the session, then fetches bytes from the minted URL',
+        () async {
+      final _FakeDownloadSource source =
+          _FakeDownloadSource(downloadUri: _downloadUri);
+      Uri? requested;
+      final MockClient client = MockClient((http.Request request) async {
+        requested = request.url;
+        return http.Response(
+          'audio-bytes',
+          200,
+          headers: const <String, String>{'content-type': 'audio/flac'},
+        );
+      });
+      final PlexTrackDownloader downloader = PlexTrackDownloader(
+        () => source,
+        httpClient: client,
+      );
+
+      final RemoteTrackData data = await downloader.fetch(_track);
+
+      expect(source.verifyCount, 1);
+      expect(requested, _downloadUri);
+      expect(utf8.decode(data.bytes), 'audio-bytes');
+      expect(data.fileExtension, 'flac');
+    });
+
+    test('maps an mpeg content type to an mp3 extension', () async {
+      final MockClient client = MockClient((_) async {
+        return http.Response.bytes(
+          <int>[1],
+          200,
+          headers: const <String, String>{'content-type': 'audio/mpeg'},
+        );
+      });
+      final PlexTrackDownloader downloader = PlexTrackDownloader(
+        () => _FakeDownloadSource(downloadUri: _downloadUri),
+        httpClient: client,
+      );
+
+      final RemoteTrackData data = await downloader.fetch(_track);
+
+      expect(data.fileExtension, 'mp3');
+    });
+
+    test('throws when not signed in', () async {
+      final PlexTrackDownloader downloader = PlexTrackDownloader(() => null);
+
+      await expectLater(downloader.fetch(_track), throwsA(isA<StateError>()));
+    });
+
+    test('surfaces a verification failure', () async {
+      final _FakeDownloadSource source = _FakeDownloadSource(
+        verifyError: PlexException.unauthorized(),
+      );
+
+      await expectLater(
+        PlexTrackDownloader(() => source).fetch(_track),
+        throwsA(isA<PlexException>()),
+      );
+    });
+
+    test('throws when no download URL can be built', () async {
+      final _FakeDownloadSource source = _FakeDownloadSource(downloadUri: null);
+
+      await expectLater(
+        PlexTrackDownloader(() => source).fetch(_track),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('throws on a non-2xx response', () async {
+      final MockClient client = MockClient((_) async => http.Response('no', 404));
+      final PlexTrackDownloader downloader = PlexTrackDownloader(
+        () => _FakeDownloadSource(downloadUri: _downloadUri),
+        httpClient: client,
+      );
+
+      await expectLater(downloader.fetch(_track), throwsA(isA<StateError>()));
+    });
+
+    test('a transport failure is re-raised without leaking the tokenized URL',
+        () async {
+      final MockClient client = MockClient(
+        (_) async => throw http.ClientException(
+          'failed talking to $_downloadUri',
+          _downloadUri,
+        ),
+      );
+      final PlexTrackDownloader downloader = PlexTrackDownloader(
+        () => _FakeDownloadSource(downloadUri: _downloadUri),
+        httpClient: client,
+      );
+
+      try {
+        await downloader.fetch(_track);
+        fail('expected fetch to throw');
+      } catch (error) {
+        expect(error.toString(), isNot(contains('secret')));
+        expect(error.toString(), isNot(contains('X-Plex-Token')));
+        expect(error.toString(), isNot(contains('plex.example.com')));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Enables offline cache downloads for Plex tracks.

This PR adds the missing Plex-side download path behind the existing source-agnostic offline cache system:

- Adds a `PlexDownloadSource` seam for download-time URL resolution.
- Makes `PlexMusicSource` implement that seam by resolving the live Plex metadata item and minting the tokenized `Part` URL only at download time.
- Adds `PlexTrackDownloader`, mirroring the Jellyfin/Subsonic remote downloaders.
- Routes the production `RemoteTrackDownloader` through Plex in addition to Jellyfin and Subsonic/Navidrome.
- Marks Plex as cache-capable in the provider capability matrix.
- Adds tests for Plex download URL resolution, Plex byte fetching, token-safe errors, routing, and capabilities.

## Why

Plex already streams via opaque `plex:<ratingKey>` catalog entries. Offline cache needs the same safety model: keep the catalog credential-free, resolve the real `Part` key only when needed, and never persist or surface the tokenized URL.

## Security notes

Plex stream/download URLs carry `X-Plex-Token` in the query because the audio/cache fetch path cannot attach Plex auth headers. This PR keeps that URL strictly transient:

- no tokenized URL is stored on `Track`
- no tokenized URL is written to cache metadata
- no tokenized URL is returned from the downloader
- transport errors are replaced with generic token-free messages
- tests assert that tokenized URL details do not leak through failures

## Scope

This is limited to Plex offline-cache plumbing.

No database migrations, Android Auto changes, Cast changes, playlist/favorite sync, Plex server writes, or playback selection behavior changes are included.

## Files

- `lib/core/sources/plex/plex_download_source.dart` *(new)* — Plex download URL seam
- `lib/core/sources/plex/plex_track_downloader.dart` *(new)* — Plex remote byte fetcher
- `lib/core/sources/plex/plex_music_source.dart` — implements Plex download URL resolution
- `lib/features/downloads/download_providers.dart` — routes remote downloads to Plex
- `lib/core/sources/music_provider.dart` — marks Plex cache support as available
- tests for Plex downloader, URL resolution, routing, and provider capabilities

## Validation

Expected checks:

- `dart format`
- `flutter analyze`
- `flutter test test/core/sources/plex/ test/core/services/routing_remote_track_downloader_test.dart test/core/sources/music_provider_test.dart`

Manual verification suggested:

1. Connect Plex.
2. Sync a selected music library.
3. Tap download/cache on a Plex track.
4. Confirm the track reaches downloaded state.
5. Disable network and confirm the cached Plex track can play from offline cache.

🤖 Generated with ChatGPT