### PR TITLE
feat(plex): map album-artist & album-cover fallbacks for canonical tracks

### DIFF
--- a/docs/plex.md
+++ b/docs/plex.md
@@ -209,7 +209,16 @@ The `MusicSource` contract is small (`id`, `displayName`,
   code edit phase 1 makes (plus a new provider-matrix row in docs).
 - **Type mapping** → Plex **8 → `Artist`**, **9 → `Album`**, **10 → `Track`**,
   using `parentRatingKey` / `grandparentRatingKey` to fill artist/album names,
-  mirroring Jellyfin's mapper, with missing-field fallbacks.
+  mirroring Jellyfin's mapper, with missing-field fallbacks. A track's
+  `index` → `Track.trackNumber` (album order), `parentTitle` → `albumName`, and
+  `grandparentTitle` (the **album artist**) → `artistName`. Two fallbacks mirror
+  the other providers so a Plex track carries the same canonical fields: the
+  artist falls back to the track's own credited `originalTitle` when PMS didn't
+  denormalise the album-artist link (Jellyfin does `albumArtist ?? artist`),
+  and a track with no `thumb` falls back to its album cover (`parentThumb`) so
+  it shows art the way a Subsonic track's `coverArt` always does. The shared
+  `Track` model carries no **disc** number, so Plex's `parentIndex` is left
+  unmapped — matching Jellyfin and Subsonic, which carry no disc field either.
 - **Track URIs** → `plex:<ratingKey>`. The `ratingKey` is the stable per-server
   id; it is **not** the Part key, so it carries no credential and never names a
   file path.

--- a/lib/core/sources/plex/plex_api.dart
+++ b/lib/core/sources/plex/plex_api.dart
@@ -250,7 +250,9 @@ class PlexMetadata {
     this.grandparentRatingKey,
     this.parentTitle,
     this.grandparentTitle,
+    this.originalTitle,
     this.thumb,
+    this.parentThumb,
     this.duration,
     this.index,
     this.year,
@@ -278,14 +280,32 @@ class PlexMetadata {
   /// reported — a free fallback so the mapper needn't refetch the parent.
   final String? parentTitle;
 
-  /// The grandparent's title (a track's artist name), when reported.
+  /// The grandparent's title (a track's **album-artist** name — the artist node
+  /// the album hangs under), when reported.
   final String? grandparentTitle;
+
+  /// A track's own credited artist (PMS `originalTitle`), when it differs from
+  /// the album artist — Plex sets this on compilation / "various artists" and
+  /// featured-artist tracks. The mapper uses it only as a **fallback** for a
+  /// track whose [grandparentTitle] (album artist) PMS didn't denormalise, so a
+  /// real performer name is preferred over folding into "Unknown Artist".
+  /// `null` for albums/artists and for ordinary tracks whose artist matches the
+  /// album artist.
+  final String? originalTitle;
 
   /// The item's cover-art *path* (e.g. `/library/metadata/123/thumb/167…`), when
   /// present. A path, not a URL: the token is woven in only at render time by
   /// [PlexEndpoints.coverArt], and the catalog stores a credential-free
   /// `plex-thumb:` reference (a later PR), never this turned into a tokened URL.
   final String? thumb;
+
+  /// The **parent's** cover-art path (a track's album cover, an album's artist
+  /// image — PMS `parentThumb`), when reported. The mapper uses it only as a
+  /// **fallback** for a track that carries no [thumb] of its own, so a Plex
+  /// track still shows its album cover the way a Subsonic track (whose
+  /// `coverArt` is the album's) always does. A path, not a URL — same
+  /// credential-free, render-time-only treatment as [thumb].
+  final String? parentThumb;
 
   /// Duration in **milliseconds**, when reported (PMS reports track length in
   /// ms, unlike Subsonic's whole seconds or Jellyfin's 100-ns ticks).
@@ -352,7 +372,9 @@ class PlexMetadata {
       grandparentRatingKey: _asString(json['grandparentRatingKey']),
       parentTitle: _asString(json['parentTitle']),
       grandparentTitle: _asString(json['grandparentTitle']),
+      originalTitle: _asString(json['originalTitle']),
       thumb: _asString(json['thumb']),
+      parentThumb: _asString(json['parentThumb']),
       duration: (json['duration'] as num?)?.toInt(),
       index: (json['index'] as num?)?.toInt(),
       year: (json['year'] as num?)?.toInt(),

--- a/lib/core/sources/plex/plex_track_mapper.dart
+++ b/lib/core/sources/plex/plex_track_mapper.dart
@@ -30,10 +30,14 @@ import 'plex_api.dart';
 /// Relationships: the domain models reference artists/albums by *name* — there
 /// is no album/artist id slot on [Track]/[Album] today (grouping is name-based,
 /// see `library_grouping.dart`) — so the parent/grandparent links Plex reports
-/// are carried via their titles: a track's `grandparentTitle` →
-/// [Track.artistName] and `parentTitle` → [Track.albumName]; an album's
-/// `parentTitle` → [Album.artistName]. When PMS omits them they stay `null`
-/// and the grouping layer folds the item into its Unknown Album/Artist buckets.
+/// are carried via their titles: a track's `grandparentTitle` (its album
+/// artist) → [Track.artistName] and `parentTitle` → [Track.albumName]; an
+/// album's `parentTitle` → [Album.artistName]. A track with no album-artist
+/// link falls back to its own credited `originalTitle`, and a track with no
+/// `thumb` to its album's `parentThumb`, so a Plex track carries the same
+/// artist + cover a Subsonic/Jellyfin track does (see [toTrack]). When PMS omits
+/// every candidate they stay `null` and the grouping layer folds the item into
+/// its Unknown Album/Artist buckets.
 abstract final class PlexTrackMapper {
   /// Prefix marking a [Track.uri] as a Plex item (`plex:<ratingKey>`) rather
   /// than a file path or another provider's item.
@@ -48,22 +52,44 @@ abstract final class PlexTrackMapper {
   /// Display fallback for the rare track whose Plex `title` is missing/blank.
   static const String _untitledTrack = 'Untitled';
 
-  /// Maps a **track** (Plex type 10) listing/metadata item, carrying its
-  /// **track number** ([Track.trackNumber]) from PMS's `index` so albums play
-  /// and display in order — mirroring Jellyfin's `indexNumber` and Subsonic's
-  /// `track`. Plex's separate **disc** number (`parentIndex`) is intentionally
-  /// not mapped: the shared [Track] model has no disc field (see
-  /// [PlexMetadata.index]).
+  /// Maps a **track** (Plex type 10) listing/metadata item into the canonical
+  /// [Track], mirroring `JellyfinTrackMapper` / `SubsonicTrackMapper` field for
+  /// field:
+  ///
+  ///  - **track number** ([Track.trackNumber]) from PMS's `index`, so albums
+  ///    play and display in order — Jellyfin's `indexNumber`, Subsonic's
+  ///    `track`. A non-positive index folds to `null` (see [_positiveOrNull]).
+  ///  - **artist** ([Track.artistName]) from `grandparentTitle` (the
+  ///    **album artist** the album hangs under), falling back to the track's own
+  ///    credited `originalTitle` when PMS didn't denormalise the album-artist
+  ///    link. Preferring the album artist keeps every track of one album under a
+  ///    single (album, artist) grouping key (`library_grouping.dart`) instead of
+  ///    splitting a compilation per track — the same reason
+  ///    `JellyfinTrackMapper` prefers `albumArtist` over the per-track artist.
+  ///  - **album** ([Track.albumName]) from `parentTitle`.
+  ///  - **artwork** ([Track.artworkUri]) from the track's own `thumb`, falling
+  ///    back to its album cover (`parentThumb`) so a track without distinct art
+  ///    still shows its album cover — exactly as a Subsonic track (whose
+  ///    `coverArt` is the album's) always does.
+  ///
+  /// Plex's separate **disc** number (`parentIndex`) is intentionally not
+  /// mapped: the shared [Track] model carries no disc field, and adding one is a
+  /// model + DB-schema change neither Jellyfin nor Subsonic share (see
+  /// [PlexMetadata.index]). For a single-disc album, `index` alone is the full
+  /// order; a multi-disc album orders by track number within whatever order the
+  /// grouping layer lists it, the same limitation every provider has today.
   static Track toTrack(PlexMetadata item) {
     return Track(
       id: item.ratingKey,
       title: _nonBlank(item.title) ?? _untitledTrack,
       uri: '$uriScheme${item.ratingKey}',
-      artistName: _nonBlank(item.grandparentTitle),
+      artistName: _firstNonBlank(item.grandparentTitle, item.originalTitle),
       albumName: _nonBlank(item.parentTitle),
       duration: _durationFromMillis(item.duration),
       trackNumber: _positiveOrNull(item.index),
-      artworkUri: _artworkReference(item.thumb),
+      artworkUri: _artworkReference(
+        _firstNonBlank(item.thumb, item.parentThumb),
+      ),
     );
   }
 
@@ -157,6 +183,15 @@ abstract final class PlexTrackMapper {
     if (value == null || value <= 0) return null;
     return value;
   }
+
+  /// The first of [primary] / [fallback] that carries real (non-blank) text, or
+  /// `null` when neither does. Lets a track fall back from its album-artist link
+  /// to its own credited artist, and from its own thumb to the album cover —
+  /// the same shape as `JellyfinTrackMapper`'s `albumArtist ?? artists.first`.
+  /// A blank (whitespace-only) primary is treated as absent, so the fallback
+  /// still wins.
+  static String? _firstNonBlank(String? primary, String? fallback) =>
+      _nonBlank(primary) ?? _nonBlank(fallback);
 
   /// Trims [text] and treats blank as absent, so a whitespace-only Plex field
   /// falls back the same way a missing one does.

--- a/test/core/sources/plex/plex_api_test.dart
+++ b/test/core/sources/plex/plex_api_test.dart
@@ -192,6 +192,33 @@ void main() {
       expect(track.firstPartKey, '/library/parts/12345/167/file.flac');
     });
 
+    test('parses a track\'s originalTitle and parentThumb fallback fields', () {
+      final PlexMetadata track = _single(<String, dynamic>{
+        'ratingKey': '321',
+        'type': 'track',
+        'title': 'Avril 14th',
+        // A compilation entry: the album artist (grandparentTitle) is the
+        // various-artists umbrella, while originalTitle credits the performer.
+        'grandparentTitle': 'Various Artists',
+        'originalTitle': 'Aphex Twin',
+        // No own thumb, only the album's (parentThumb).
+        'parentThumb': '/library/metadata/200/thumb/55',
+      });
+      expect(track.originalTitle, 'Aphex Twin');
+      expect(track.parentThumb, '/library/metadata/200/thumb/55');
+      expect(track.thumb, isNull);
+    });
+
+    test('leaves originalTitle / parentThumb null when PMS omits them', () {
+      final PlexMetadata track = _single(<String, dynamic>{
+        'ratingKey': '322',
+        'type': 'track',
+        'title': 'Plain track',
+      });
+      expect(track.originalTitle, isNull);
+      expect(track.parentThumb, isNull);
+    });
+
     test('tolerates a track without duration or media', () {
       final PlexMetadata track = _single(<String, dynamic>{
         'ratingKey': '124',

--- a/test/core/sources/plex/plex_track_mapper_test.dart
+++ b/test/core/sources/plex/plex_track_mapper_test.dart
@@ -100,6 +100,76 @@ void main() {
       expect(track.albumName, isNull);
     });
 
+    test('prefers the album artist (grandparentTitle) over originalTitle', () {
+      const item = PlexMetadata(
+        ratingKey: '301',
+        title: 'Nightcall',
+        grandparentTitle: 'Kavinsky',
+        originalTitle: 'Lovefoxxx',
+      );
+      // The album artist keeps every track of one album under a single
+      // grouping key, mirroring Jellyfin's albumArtist preference — so the
+      // per-track originalTitle is only a fallback, never an override.
+      expect(PlexTrackMapper.toTrack(item).artistName, 'Kavinsky');
+    });
+
+    test('falls back to the credited originalTitle when no album artist', () {
+      const missing = PlexMetadata(
+        ratingKey: '301',
+        title: 'Avril 14th',
+        originalTitle: 'Aphex Twin',
+      );
+      const blank = PlexMetadata(
+        ratingKey: '302',
+        title: 'Avril 14th',
+        grandparentTitle: '   ',
+        originalTitle: 'Aphex Twin',
+      );
+      // A track whose album-artist link PMS didn't denormalise still surfaces
+      // its real performer instead of folding into "Unknown Artist".
+      expect(PlexTrackMapper.toTrack(missing).artistName, 'Aphex Twin');
+      expect(PlexTrackMapper.toTrack(blank).artistName, 'Aphex Twin');
+    });
+
+    test('prefers the track\'s own thumb over the album cover (parentThumb)',
+        () {
+      const item = PlexMetadata(
+        ratingKey: '301',
+        title: 'Nightcall',
+        thumb: '/library/metadata/301/thumb/1',
+        parentThumb: '/library/metadata/201/thumb/9',
+      );
+      expect(
+        PlexTrackMapper.toTrack(item).artworkUri.toString(),
+        'plex-thumb:/library/metadata/301/thumb/1',
+      );
+    });
+
+    test('falls back to the album cover (parentThumb) when no track thumb', () {
+      const missing = PlexMetadata(
+        ratingKey: '301',
+        title: 'Nightcall',
+        parentThumb: '/library/metadata/201/thumb/9',
+      );
+      const blank = PlexMetadata(
+        ratingKey: '302',
+        title: 'Nightcall',
+        thumb: '  ',
+        parentThumb: '/library/metadata/201/thumb/9',
+      );
+      // A track without distinct art still shows its album cover, the way a
+      // Subsonic track (whose coverArt is the album's) always does — and the
+      // reference stays a credential-free plex-thumb: path.
+      expect(
+        PlexTrackMapper.toTrack(missing).artworkUri.toString(),
+        'plex-thumb:/library/metadata/201/thumb/9',
+      );
+      expect(
+        PlexTrackMapper.toTrack(blank).artworkUri.toString(),
+        'plex-thumb:/library/metadata/201/thumb/9',
+      );
+    });
+
     test('maps absent or zero duration to zero', () {
       const absent = PlexMetadata(ratingKey: '1', title: 't');
       const zero = PlexMetadata(ratingKey: '2', title: 't', duration: 0);


### PR DESCRIPTION
## Goal

Make the read-only **Plex** provider return the same **canonical track metadata** Subsonic/Navidrome and Jellyfin already produce, so a Plex copy of a song looks identical to any other provider's in the unified catalog.

**Scope honored:** changes are confined to the Plex **parsing/mapping layer** (`plex_api.dart` DTO + `plex_track_mapper.dart`). No UI, no playback engine, no schema, and **no change to the shared `Track`/`Album`/`Artist` model** — everything maps into the existing fields.

## Mapping differences fixed (Plex vs. the other providers)

The unified `Track` model is `{id, title, uri, artistName, albumName, duration, trackNumber, artworkUri}`. Field-by-field, here's where Plex stood and what changed:

| Canonical field | Subsonic | Jellyfin | Plex — before | Plex — after |
| --- | --- | --- | --- | --- |
| **track number** | `track` | `indexNumber` | `index` ✅ | unchanged ✅ |
| **album** (`albumName`) | `album` | `album` | `parentTitle` ✅ | unchanged ✅ |
| **album artist** (`artistName`) | `artist` | `albumArtist ?? artists.first` | `grandparentTitle` only | **`grandparentTitle` ?? `originalTitle`** |
| **artwork** (`artworkUri`) | `coverArt` (album cover) | track primary image | `thumb` only | **`thumb` ?? `parentThumb`** |
| **album year** | `Album.year` | `productionYear` | `year` ✅ | unchanged ✅ |
| **album track ordering** | by `trackNumber` | by `trackNumber` | by `trackNumber` ✅ | unchanged ✅ |
| **disc number** | not mapped | not mapped | not mapped | **intentionally not mapped** (see below) |

### What was actually missing, and why it matters

1. **Album-artist robustness (`artistName`).** Plex used only `grandparentTitle` (the album artist) with no fallback. That's the right *primary* — it keeps every track of one album under a single `(album, artist)` grouping key in `library_grouping.dart`, so a compilation doesn't split per track (the same reason `JellyfinTrackMapper` prefers `albumArtist`). But a track whose album-artist link PMS didn't denormalise would fold into **"Unknown Artist"**. Now it falls back to the track's own credited `originalTitle`, mirroring Jellyfin's `albumArtist ?? artists.first`.

2. **Track cover-art reliability (`artworkUri`).** Plex used only the track's own `thumb`. A track without distinct art lost its cover, whereas a Subsonic track (whose `coverArt` is the album's) always shows one. Now it falls back to the album cover (`parentThumb`). It stays a credential-free `plex-thumb:` reference — the token is still woven in only at render time.

### Already canonical (verified, unchanged)

`trackNumber` (`index`), `albumName` (`parentTitle`), album `year` and `trackCount`, and album-order sorting were already correct (shipped in #207). This PR does not touch them.

### Disc number — deliberately left unmapped

The shared `Track` model has **no disc field**, and **neither Jellyfin nor Subsonic carry one**. Adding it would be a model + DB-schema change (and a grouping-layer ordering change) — out of scope for "fix the Plex mapping layer / stay consistent with the existing unified model". For single-disc albums `index` is the full order; multi-disc ordering is a shared limitation across all providers today, documented in `library_grouping.dart` and `docs/plex.md`.

## Tests

- **DTO parse** (`plex_api_test.dart`): `originalTitle` / `parentThumb` parse, and stay `null` when PMS omits them.
- **Mapper** (`plex_track_mapper_test.dart`): album artist preferred over `originalTitle`; `originalTitle` used when the album artist is missing/blank; `thumb` preferred over `parentThumb`; `parentThumb` used when `thumb` is missing/blank.
- Existing token-leakage and `plex-thumb:` round-trip tests still pass.

`dart format --set-exit-if-changed`, `flutter analyze`, and the full `test/core/sources/plex/` + Plex settings/sync/lyrics suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1hCvzBzF8bJx7yZFbed2v

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1hCvzBzF8bJx7yZFbed2v)_