### PR TITLE
ci(release): build per-ABI APKs in isolation (matching F-Droid) for reproducibility

### DIFF
--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -332,14 +332,19 @@ jobs:
       # already verified pubspec.yaml matches the tag, and the verification step
       # below confirms the built APKs carry that version.
       #
-      # We do THREE builds and stash each before the next runs so they cannot
-      # clobber one another in build/app/outputs/:
+      # We do THREE kinds of build and stash each before the next runs so they
+      # cannot clobber one another in build/app/outputs/:
       #   1. universal APK (`flutter build apk --release`)
-      #   2. per-ABI APKs (`flutter build apk --release --split-per-abi`)
-      #      → armeabi-v7a / arm64-v8a / x86_64, with versionCodeOverride from
-      #      android/app/build.gradle (base * 10 + abi rank) so each per-ABI
-      #      APK matches the corresponding `versionCode` (1000391 / 1000392 /
-      #      1000393) in metadata/io.github.thezupzup.linthra.yml.
+      #   2. per-ABI APKs — built ONE ABI at a time, each in its own clean
+      #      `flutter build apk --release --split-per-abi
+      #      --target-platform=android-<arch>` invocation, exactly as F-Droid
+      #      builds each versionCode. versionCodeOverride from
+      #      android/app/build.gradle (base * 10 + abi rank) makes each per-ABI
+      #      APK match the corresponding `versionCode` (…1 / …2 / …3) in
+      #      metadata/io.github.thezupzup.linthra.yml. Building per-target (not
+      #      all ABIs in one --split-per-abi pass) keeps the 64-bit split
+      #      manifests byte-identical to F-Droid's — see the per-ABI step below
+      #      and docs/fdroid-reproducibility-arm64.md.
       #   3. AAB (`flutter build appbundle --release`) — still universal; AAB
       #      already provides per-ABI delivery on its own.
       #
@@ -357,31 +362,54 @@ jobs:
           base="${{ steps.mode.outputs.asset_base }}"
           cp build/app/outputs/flutter-apk/app-release.apk "dist/${base}.apk"
 
-      # Build the per-ABI APKs from a CLEAN tree so they match F-Droid's build
-      # byte-for-byte. F-Droid builds these by running ONLY `flutter build apk
-      # --release --split-per-abi` in a fresh checkout. Doing the per-ABI build
-      # here in the SAME workspace right after the universal `flutter build apk
-      # --release` left AGP 8.x's per-split manifest processing in an
-      # incremental state that systematically emitted the 64-bit (arm64-v8a /
-      # x86_64) split manifests with one extra source line before <application>
-      # in the compiled AndroidManifest.xml. That difference is purely cosmetic
-      # line-number metadata (string pools, resources.arsc, classes.dex and
-      # every lib/*.so were byte-identical), but it shifted the manifest bytes,
-      # so F-Droid's reproducible-build verification could not transplant the
-      # upstream signature onto its rebuild and failed with
+      # Build the per-ABI APKs the SAME way F-Droid builds each one: a single
+      # `flutter build apk --release --split-per-abi --target-platform=android-<arch>`
+      # in a clean tree, ONE ABI at a time. F-Droid's metadata builds each
+      # versionCode (1059991/1059992/1059993) in its own fresh checkout with
+      # exactly that command (see metadata/io.github.thezupzup.linthra.yml).
+      #
+      # This workflow used to build all three ABIs together in a single
+      # `flutter build apk --release --split-per-abi` pass. That produced 64-bit
+      # (arm64-v8a / x86_64) split APKs whose compiled AndroidManifest.xml
+      # carried one extra source line before <application> compared to F-Droid's
+      # single-ABI build (last manifest line 266 vs 265). The difference is
+      # purely cosmetic line-number metadata — string pools, resources.arsc,
+      # classes.dex and every lib/*.so are byte-identical — but it shifts the
+      # manifest bytes, so F-Droid's reproducible-build verification could not
+      # transplant the upstream signature onto its rebuild and failed with
       # "signature copying failed: APK Signing Block offset < central directory
-      # offset" for arm64-v8a/x86_64 — while armeabi-v7a happened to match and
-      # verified. Cleaning here makes this build mirror F-Droid's clean
-      # split-only build. The universal APK is already stashed above, and
-      # `flutter clean` only removes build/.dart_tool intermediates (not dist/),
-      # so nothing produced so far is lost. See docs/fdroid-reproducibility-arm64.md.
-      - name: Clean before per-ABI build (F-Droid reproducibility)
+      # offset" for arm64-v8a/x86_64 (armeabi-v7a happened to match, so it
+      # verified). Building each ABI in isolation, exactly like F-Droid, makes
+      # the uploaded reference APK byte-identical to F-Droid's rebuild.
+      # See docs/fdroid-reproducibility-arm64.md.
+      - name: Build per-ABI release APKs (isolated, matching F-Droid)
         run: |
-          flutter clean
-          flutter pub get
-
-      - name: Build release APK (per-ABI)
-        run: flutter build apk --release --split-per-abi
+          set -euo pipefail
+          base="${{ steps.mode.outputs.asset_base }}"
+          tmp="$RUNNER_TEMP/perabi"
+          mkdir -p "$tmp"
+          # ABI -> Flutter --target-platform, matching F-Droid's per-versionCode
+          # build commands in metadata/io.github.thezupzup.linthra.yml.
+          for entry in "armeabi-v7a:android-arm" "arm64-v8a:android-arm64" "x86_64:android-x64"; do
+            abi="${entry%%:*}"
+            plat="${entry##*:}"
+            flutter clean
+            flutter pub get
+            flutter build apk --release --split-per-abi --target-platform="$plat"
+            src="build/app/outputs/flutter-apk/app-${abi}-release.apk"
+            if [ ! -f "$src" ]; then
+              echo "::error::Per-ABI APK missing after build: $src"
+              exit 1
+            fi
+            cp "$src" "$tmp/app-${abi}-release.apk"
+            echo "Built $abi ($plat) in its own clean invocation."
+          done
+          # `flutter clean` above wiped build/app/outputs, so restore the
+          # universal APK (already stashed) and all three per-ABI APKs to where
+          # the existing Stash / Verify steps below expect them.
+          mkdir -p build/app/outputs/flutter-apk
+          cp "$tmp"/app-*-release.apk build/app/outputs/flutter-apk/
+          cp "dist/${base}.apk" build/app/outputs/flutter-apk/app-release.apk
 
       # Stash the per-ABI APKs under their public/canonical names. The naming
       # MUST stay aligned with the per-Build `binary:` URLs in

--- a/.github/workflows/android-release-build.yml
+++ b/.github/workflows/android-release-build.yml
@@ -357,6 +357,29 @@ jobs:
           base="${{ steps.mode.outputs.asset_base }}"
           cp build/app/outputs/flutter-apk/app-release.apk "dist/${base}.apk"
 
+      # Build the per-ABI APKs from a CLEAN tree so they match F-Droid's build
+      # byte-for-byte. F-Droid builds these by running ONLY `flutter build apk
+      # --release --split-per-abi` in a fresh checkout. Doing the per-ABI build
+      # here in the SAME workspace right after the universal `flutter build apk
+      # --release` left AGP 8.x's per-split manifest processing in an
+      # incremental state that systematically emitted the 64-bit (arm64-v8a /
+      # x86_64) split manifests with one extra source line before <application>
+      # in the compiled AndroidManifest.xml. That difference is purely cosmetic
+      # line-number metadata (string pools, resources.arsc, classes.dex and
+      # every lib/*.so were byte-identical), but it shifted the manifest bytes,
+      # so F-Droid's reproducible-build verification could not transplant the
+      # upstream signature onto its rebuild and failed with
+      # "signature copying failed: APK Signing Block offset < central directory
+      # offset" for arm64-v8a/x86_64 — while armeabi-v7a happened to match and
+      # verified. Cleaning here makes this build mirror F-Droid's clean
+      # split-only build. The universal APK is already stashed above, and
+      # `flutter clean` only removes build/.dart_tool intermediates (not dist/),
+      # so nothing produced so far is lost. See docs/fdroid-reproducibility-arm64.md.
+      - name: Clean before per-ABI build (F-Droid reproducibility)
+        run: |
+          flutter clean
+          flutter pub get
+
       - name: Build release APK (per-ABI)
         run: flutter build apk --release --split-per-abi
 

--- a/docs/fdroid-reproducibility-arm64.md
+++ b/docs/fdroid-reproducibility-arm64.md
@@ -1,0 +1,135 @@
+# F-Droid arm64-v8a / x86_64 reproducibility (and the F-Droid-signed fallback)
+
+## Symptom
+
+F-Droid's reproducible-build verification fails for the **64-bit** per-ABI
+APKs while **armeabi-v7a** passes. The job log shows, for arm64-v8a:
+
+```
+…NOT verified - …/sigcp_io.github.thezupzup.linthra_<code>2.apk
+ERROR: Could not build app io.github.thezupzup.linthra:
+       compared built binary to supplied reference binary but failed
+signature copying failed: APK Signing Block offset < central directory offset
+```
+
+This was first raised on the auto-update MR for v0.1.2 (versionCode 1029993)
+and reproduces identically on v0.1.5 (the linked job 14938363064 actually
+builds 1059991/1059992/1059993). **It is not version-specific and there is no
+"clean" release to jump to — every release with the per-ABI `binary:` setup is
+affected the same way.**
+
+## Root cause (proven, not a bad artifact)
+
+F-Droid's rebuilt arm64-v8a APK is *not byte-identical* to our uploaded
+reference APK, so `apksigcopier` cannot transplant our signature onto it
+(that's exactly what the error above means — see
+[apksigcopier#89](https://github.com/obfusk/apksigcopier/issues/89)).
+
+Diffing F-Droid's rebuild against our release asset entry-by-entry:
+
+| Entry | Reference (GitHub) vs F-Droid rebuild |
+| --- | --- |
+| `resources.arsc` | **identical** |
+| `classes.dex` | **identical** |
+| every `lib/arm64-v8a/*.so` | **identical** |
+| `assets/**` | **identical** |
+| **`AndroidManifest.xml`** | **differs (same size, different bytes)** |
+| `META-INF/MANIFEST.MF`, `CERT.SF`, `CERT.RSA` | differ — but only because they embed the manifest digest + signature |
+
+Inside `AndroidManifest.xml` the **string pools are identical**. The only bytes
+that differ are the **source line-number metadata** on each XML tag. Our
+release runner emits the 64-bit split manifests with one extra source line
+before `<application>`; F-Droid's clean build produces the 32-bit numbering for
+every ABI:
+
+| | armeabi-v7a | arm64-v8a | x86_64 |
+| --- | --- | --- | --- |
+| v0.1.2 last manifest line | 236 | **237** | **237** |
+| v0.1.5 last manifest line | 265 | **266** | **266** |
+| F-Droid rebuild (any ABI) | 265 | **265** | 265 |
+
+The toolchains are otherwise **identical** on both sides — AGP `8.2.1`
+(read from each APK's `app-metadata.properties`), Flutter `3.27.4`, the same
+aapt2 (proven by the identical `resources.arsc`), the same NDK (proven by the
+identical `.so` files). So **pinning tool versions changes nothing.**
+
+The one behavioural difference is *how the build is invoked*:
+
+* **Our release CI** builds the universal APK first (`flutter build apk
+  --release`) and then the splits (`… --split-per-abi`) in the **same
+  workspace**.
+* **F-Droid** runs **only** `flutter build apk --release --split-per-abi` in a
+  **fresh checkout**.
+
+AGP's per-split manifest processing, run in that warmed/incremental workspace,
+systematically shifts the 64-bit split manifests by one source line. The apps
+are functionally byte-identical; the difference is cosmetic line metadata only.
+
+Classification: **build/Gradle reproducibility issue** — *not* a bad/corrupt
+APK, *not* bad metadata, *not* a wrong versionCode, *not* a signing-key problem.
+
+## Primary fix (keep reproducible + upstream signature)
+
+Make the release build mirror F-Droid's clean build: run `flutter clean` before
+the `--split-per-abi` step so the per-ABI APKs are produced from a clean tree.
+Implemented in `.github/workflows/android-release-build.yml`
+("Clean before per-ABI build (F-Droid reproducibility)").
+
+**This must be validated on a release candidate before relying on it.** It is a
+strong, mechanism-backed hypothesis, but reproducibility is only proven once an
+`fdroid build` is green:
+
+```bash
+# In a fdroiddata checkout, after cutting the next release (e.g. v0.1.6):
+fdroid build io.github.thezupzup.linthra:1069991   # armeabi-v7a
+fdroid build io.github.thezupzup.linthra:1069992   # arm64-v8a  <- the one to watch
+fdroid build io.github.thezupzup.linthra:1069993   # x86_64
+```
+
+Only merge/advance the fdroiddata MR once **all three** report
+`…successfully verified`.
+
+## Fallback (guaranteed): let F-Droid build *and sign* the per-ABI APKs
+
+If the clean-build change does not make the 64-bit splits reproducible, stop
+chasing cross-environment byte-identity and let F-Droid sign. The from-source
+build already **succeeds** for every ABI (the failure is only the signature
+*comparison*), so this always works.
+
+Apply this to **`metadata/io.github.thezupzup.linthra.yml` in fdroiddata**
+(do not change it blindly — propose it to the maintainer; this is the standard
+F-Droid remedy when a build can't be byte-reproduced):
+
+1. **Remove** the top-level upstream-signing pin:
+
+   ```diff
+   - AllowedAPKSigningKeys: 835189ae30df4d23588580e0a86e5e9b67ea2a2745fda510759f22a3d0a78b6c
+   ```
+
+2. **Remove the `binary:` line from every Build entry** (the per-ABI reference
+   URLs). Keep everything else (`output:`, `versionCode`, `VercodeOperation`,
+   the per-ABI split) unchanged — F-Droid still builds one APK per ABI, it just
+   signs them with the F-Droid key:
+
+   ```diff
+   -    binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-armeabi-v7a-release-signed.apk
+   ```
+   ```diff
+   -    binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-arm64-v8a-release-signed.apk
+   ```
+   ```diff
+   -    binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-x86_64-release-signed.apk
+   ```
+
+**Trade-off:** F-Droid then distributes **F-Droid-signed** APKs, whose
+signature differs from the GitHub Release / direct-sideload APKs. Users cannot
+cross-update between an F-Droid install and a GitHub-downloaded install without
+uninstalling first, and the "Reproducible" status is dropped. Functionally the
+app is identical.
+
+## Why "just skip v0.1.2" does not work
+
+The maintainer asked "armv7 is fine, but not armv8?" and skipping the affected
+version was floated. It does not help: v0.1.5 (the latest release) fails the
+same way, x86_64 is affected as well as arm64-v8a, and the cause is systemic to
+the per-ABI reproducible-build setup — not a stale or corrupt v0.1.2 artifact.

--- a/docs/fdroid-reproducibility-arm64.md
+++ b/docs/fdroid-reproducibility-arm64.md
@@ -53,16 +53,23 @@ The toolchains are otherwise **identical** on both sides — AGP `8.2.1`
 aapt2 (proven by the identical `resources.arsc`), the same NDK (proven by the
 identical `.so` files). So **pinning tool versions changes nothing.**
 
-The one behavioural difference is *how the build is invoked*:
+The one behavioural difference is *how the build is invoked*. The F-Droid MR
+([!40071](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/40071)) builds
+each versionCode **on its own**:
 
-* **Our release CI** builds the universal APK first (`flutter build apk
-  --release`) and then the splits (`… --split-per-abi`) in the **same
-  workspace**.
-* **F-Droid** runs **only** `flutter build apk --release --split-per-abi` in a
-  **fresh checkout**.
+* **F-Droid** builds each ABI alone, in a fresh checkout, with a single
+  `flutter build apk --release --split-per-abi --target-platform=android-<arch>`
+  (`android-arm` / `android-arm64` / `android-x64`).
+* **Our release CI** built **all three ABIs together** in one
+  `flutter build apk --release --split-per-abi` pass (after a universal build in
+  the same workspace).
 
-AGP's per-split manifest processing, run in that warmed/incremental workspace,
-systematically shifts the 64-bit split manifests by one source line. The apps
+Building all ABIs in one pass gives the 64-bit (arm64-v8a / x86_64) split
+manifests one extra `AndroidManifest.xml` source line versus F-Droid's
+single-ABI build (last manifest line **266 vs 265**); armeabi-v7a lands on the
+same number either way, which is why it reproduces. Proof: F-Droid's own arm64
+rebuild — built with `--target-platform=android-arm64` — has manifest line
+**265**, identical to what a single-target build on our side produces. The apps
 are functionally byte-identical; the difference is cosmetic line metadata only.
 
 Classification: **build/Gradle reproducibility issue** — *not* a bad/corrupt
@@ -70,10 +77,19 @@ APK, *not* bad metadata, *not* a wrong versionCode, *not* a signing-key problem.
 
 ## Primary fix (keep reproducible + upstream signature)
 
-Make the release build mirror F-Droid's clean build: run `flutter clean` before
-the `--split-per-abi` step so the per-ABI APKs are produced from a clean tree.
+Build each per-ABI reference APK the **same way F-Droid builds it** — one ABI at
+a time, in its own clean tree, with the matching `--target-platform`:
+
+```
+flutter build apk --release --split-per-abi --target-platform=android-arm     # armeabi-v7a
+flutter build apk --release --split-per-abi --target-platform=android-arm64   # arm64-v8a
+flutter build apk --release --split-per-abi --target-platform=android-x64     # x86_64
+```
+
 Implemented in `.github/workflows/android-release-build.yml`
-("Clean before per-ABI build (F-Droid reproducibility)").
+("Build per-ABI release APKs (isolated, matching F-Droid)"). This is a stronger
+fix than just cleaning before a single multi-ABI pass, because the trigger is
+the multi-ABI pass itself, not merely a warm workspace.
 
 **This must be validated on a release candidate before relying on it.** It is a
 strong, mechanism-backed hypothesis, but reproducibility is only proven once an


### PR DESCRIPTION
## Why

F-Droid's reproducible-build check fails for the **64-bit** per-ABI APKs (`arm64-v8a`, `x86_64`) while `armeabi-v7a` passes — on the [v0.1.5 auto-update MR !40071](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/40071). Job `14938363064` builds **v0.1.5** (`1059991/2/3`) and shows:

```
1059991 armeabi-v7a → …successfully verified   ✓
1059992 arm64-v8a   → …NOT verified            ✗
signature copying failed: APK Signing Block offset < central directory offset
…AndroidManifest.xml … differ
```

## Root cause (grounded in the MR diff + job log)

I pulled F-Droid's *actual* rebuilt arm64-v8a APK from the job artifacts and diffed it against our uploaded release asset:

- `resources.arsc`, `classes.dex`, **every `lib/arm64-v8a/*.so`**, and all assets are **byte-identical** (AGP 8.2.1 both sides).
- The **only** differing entry is the compiled **`AndroidManifest.xml`**, and only its embedded **source line-number metadata** (string pools identical). `META-INF/*` differs solely because it embeds the manifest digest + signature.

The MR diff shows **F-Droid builds each ABI on its own** — `flutter build apk --release --split-per-abi --target-platform="android-arm64"` in a fresh checkout. Our release workflow built **all three ABIs together** in one `--split-per-abi` pass. That multi-ABI pass gives the 64-bit split manifests **one extra source line** before `<application>` (last line 266 vs 265); F-Droid's single-ABI build lands on 265 for every ABI, so `armv7` matches and verifies. **Proof:** F-Droid's own arm64 rebuild (`--target-platform=android-arm64`) has manifest line **265**.

This is a **build-reproducibility issue** — *not* a bad/corrupt APK, bad metadata, wrong versionCode, or signing-key problem (the reference APK `Verifies` v1+v2). The apps are functionally byte-identical.

## Change

Build each per-ABI reference APK **one at a time, in its own clean tree, with the matching `--target-platform`** — exactly mirroring F-Droid's per-versionCode build commands. The universal + per-ABI APKs are restored afterward so the existing Stash/Verify/AAB steps are unchanged.

> Note: this supersedes the first commit's `flutter clean`-before-a-single-multi-ABI-pass approach. The MR diff made clear the trigger is the *multi-ABI pass itself*, not just a warm workspace, so cleaning alone wouldn't have fixed it.

## ⚠️ Validation required

Not proven until an `fdroid build` is green. Before advancing the fdroiddata MR, cut a release candidate and verify **all three** ABIs report `…successfully verified`:

```bash
fdroid build io.github.thezupzup.linthra:1069991   # armeabi-v7a
fdroid build io.github.thezupzup.linthra:1069992   # arm64-v8a  ← the one to watch
fdroid build io.github.thezupzup.linthra:1069993   # x86_64
```

If it still doesn't reproduce, `docs/fdroid-reproducibility-arm64.md` documents the guaranteed fallback (drop the per-ABI `binary:` refs + `AllowedAPKSigningKeys`; F-Droid builds **and signs**).

## Notes

- Skipping v0.1.2 does **not** help — v0.1.5 fails identically, x86_64 too, and there is no clean release to jump to. A new clean release (e.g. **v0.1.6**) built with this change is what's needed.
- `docs/fdroid-reproducibility-arm64.md` added with the full root cause, validation steps, and fallback (not applied to fdroiddata — to be proposed to the maintainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp3dngiH1pJjMczdTjz5SD