### PR TITLE
v0.1.6: Plex offline music caching + F-Droid reproducible per-ABI build

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/106999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/106999.txt
@@ -1,0 +1,19 @@
+Linthra 0.1.6 — Plex offline caching.
+
+Added:
+- Plex tracks can now be downloaded for offline playback, like Jellyfin
+  and Navidrome/Subsonic.
+- Cached Plex tracks play from your device automatically, and fall back
+  to streaming when a cached file is missing or can't be opened.
+
+Changed:
+- Offline downloads are now written atomically (download, validate, then
+  swap into place), so an interrupted download can't leave a broken file.
+- Per-ABI release APKs are built in isolation to match F-Droid's
+  reproducible split-APK build.
+
+Notes:
+- Plex cached files are keyed to your library item identity and never
+  contain your Plex token.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.5';
+  static const String _devVersionName = '0.1.6';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -76,6 +76,9 @@ abstract interface class DownloadRepository {
   /// Emits whenever a track's download status changes.
   Stream<Map<String, DownloadStatus>> get statusStream;
 
+  /// The status of the track with catalog id [trackId], mirroring the id-keyed
+  /// [statusStream] the UI watches. (The mutating calls below take the whole
+  /// [Track] instead, because they act on one provider's specific cached copy.)
   Future<DownloadStatus> statusFor(String trackId);
 
   /// Emits per-track byte progress for in-flight downloads, keyed by track id.
@@ -98,9 +101,11 @@ abstract interface class DownloadRepository {
   /// offline) rather than started.
   Future<DownloadRequestOutcome> requestDownload(Track track);
 
-  /// Removes the offline copy of [trackId], deleting any cached file and
-  /// freeing storage.
-  Future<void> removeDownload(String trackId);
+  /// Removes the offline copy of [track], deleting any cached file and freeing
+  /// storage. Takes the whole [Track] so removal is *provider-aware*: a Plex
+  /// track and a Subsonic track that happen to share a catalog id never shadow
+  /// or remove each other's cached copy.
+  Future<void> removeDownload(Track track);
 
   /// Track IDs that are fully available offline.
   Future<List<String>> downloadedTrackIds();

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -61,11 +61,13 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     AudioPlayer? player,
     PlayableUriResolver resolver = const LocalPlayableUriResolver(),
     PlaybackCandidateSource candidates = const NoFallbackCandidateSource(),
+    PlayableUriResolver? streamingFallbackResolver,
     Random? random,
     TrackCompletionCallback? onTrackCompleted,
   })  : _player = player ?? _defaultPlayer(),
         _resolver = resolver,
         _candidates = candidates,
+        _streamingFallbackResolver = streamingFallbackResolver,
         _random = random ?? Random(),
         _onTrackCompleted = onTrackCompleted,
         // Own audio focus only for the engine we created. An injected player
@@ -127,6 +129,17 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// default returns just the track itself (no fallback), so single-source
   /// playback is unchanged.
   final PlaybackCandidateSource _candidates;
+
+  /// An optional resolver used to retry a track via streaming when its
+  /// offline-cache file fails to open (reclaimed after the existence check,
+  /// corrupt, or an unreadable codec). It resolves *past* the offline cache —
+  /// the same router the offline-first resolver falls through to on a miss — so
+  /// a cached copy that won't play falls back to the live stream instead of
+  /// erroring, even for a single-source track with no sibling copy. Null (the
+  /// default, and in tests) keeps the original behavior: a failed load simply
+  /// moves to the next candidate.
+  final PlayableUriResolver? _streamingFallbackResolver;
+
   final Random _random;
 
   /// Invoked once each time a track reaches its natural end, before the repeat
@@ -849,8 +862,19 @@ class JustAudioPlaybackController implements LocalPlaybackController {
         return (track: candidate, resolved: resolved);
       } catch (_) {
         // Resolved (and, for streams, probed) OK but the engine couldn't open
-        // it: a start failure. Word it for the source, then try the next copy.
+        // it: a start failure. Word it for the source.
         StabilityDiagnostics.playbackError('load');
+        // A cached file that won't open (reclaimed after the existence check,
+        // corrupt, or an unreadable codec) must not strand a single-source
+        // track on an error: re-resolve the same copy past the offline cache
+        // and try the live stream once before moving on.
+        final ({Track track, ResolvedPlayable resolved})? streamed =
+            await _retryFromStream(candidate, resolved, generation);
+        if (streamed != null) return streamed;
+        // Superseded by a newer skip/seek while the stream retry ran: drop this
+        // stale transition rather than recording a failure on a track the user
+        // has already moved past.
+        if (generation != _playbackGeneration) return null;
         failures.add(PlaybackResolutionException(
           _loadErrorFor(resolved.source),
           kind: PlaybackResolutionErrorKind.streamUnavailable,
@@ -863,6 +887,48 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       "Couldn't play this track from any available source.",
       kind: PlaybackResolutionErrorKind.streamUnavailable,
     );
+  }
+
+  /// Re-resolves [candidate] through the streaming fallback resolver and loads
+  /// it, for when its first resolution was an offline-cache file the engine
+  /// wouldn't open. This is the "a cache failure falls back to streaming"
+  /// guarantee — it works even for a single-source track with no sibling copy,
+  /// because it re-resolves the *same* track past the cache.
+  ///
+  /// Returns the loaded result, or null when: there is no fallback resolver (the
+  /// default / tests), the failed load was *not* a cache hit (a stream that
+  /// won't open is a real source failure handled by the normal candidate
+  /// fallback), a newer transition superseded [generation], or the stream
+  /// itself can't resolve or open.
+  Future<({Track track, ResolvedPlayable resolved})?> _retryFromStream(
+    Track candidate,
+    ResolvedPlayable failed,
+    int generation,
+  ) async {
+    final PlayableUriResolver? streamResolver = _streamingFallbackResolver;
+    if (streamResolver == null ||
+        failed.source != PlaybackSource.offlineCache) {
+      return null;
+    }
+    final ResolvedPlayable streamed;
+    try {
+      streamed = await streamResolver.resolve(candidate);
+    } catch (_) {
+      // The cached copy failed *and* the stream can't be resolved (offline, or
+      // the session/server is down): let the caller record the cache-load
+      // failure and try the next candidate.
+      return null;
+    }
+    // Don't hand a now-stale source to the shared engine if the user skipped or
+    // seeked while the stream resolved.
+    if (generation != _playbackGeneration) return null;
+    try {
+      await _player.setUrl(streamed.uri.toString());
+      return (track: candidate, resolved: streamed);
+    } catch (_) {
+      StabilityDiagnostics.playbackError('load');
+      return null;
+    }
   }
 
   /// The generic message for an engine load failure *after* a successful

--- a/lib/core/services/offline_cache_manager.dart
+++ b/lib/core/services/offline_cache_manager.dart
@@ -1,3 +1,4 @@
+import '../models/track.dart';
 import '../repositories/download_store.dart';
 
 /// An immutable view of the offline cache for the UI: how much app-managed
@@ -44,11 +45,12 @@ abstract interface class OfflineCacheManager {
 
   /// Pins or unpins a track ("Keep offline"). Pinned tracks are never evicted
   /// automatically and survive [clearUnpinned]. A no-op for an unknown track.
-  Future<void> setPinned(String trackId, bool pinned);
+  /// Takes the whole [Track] so it acts on the right provider's cached copy.
+  Future<void> setPinned(Track track, bool pinned);
 
-  /// Records that [trackId] was just played from cache, refreshing its
+  /// Records that [track] was just played from cache, refreshing its
   /// least-recently-used position. A no-op for a track that isn't cached.
-  Future<void> notePlayed(String trackId);
+  Future<void> notePlayed(Track track);
 
   /// Removes every offline entry: deletes all app-managed cache files and the
   /// metadata, pinned items included. Never touches the user's local source

--- a/lib/core/services/offline_first_playable_uri_resolver.dart
+++ b/lib/core/services/offline_first_playable_uri_resolver.dart
@@ -18,7 +18,7 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
   const OfflineFirstPlayableUriResolver({
     required CachedTrackLocator locator,
     required PlayableUriResolver fallback,
-    void Function(String trackId)? onCacheHit,
+    void Function(Track track)? onCacheHit,
   })  : _locator = locator,
         _fallback = fallback,
         _onCacheHit = onCacheHit;
@@ -26,10 +26,10 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
   final CachedTrackLocator _locator;
   final PlayableUriResolver _fallback;
 
-  /// Called with the track id on a cache hit, so the cache manager can refresh
-  /// its least-recently-used position. Fire-and-forget: a failure here must
-  /// never stop playback, so it isn't awaited.
-  final void Function(String trackId)? _onCacheHit;
+  /// Called with the track on a cache hit, so the cache manager can refresh its
+  /// least-recently-used position for the right provider's copy. Fire-and-forget:
+  /// a failure here must never stop playback, so it isn't awaited.
+  final void Function(Track track)? _onCacheHit;
 
   @override
   bool handles(Track track) => _fallback.handles(track);
@@ -43,7 +43,7 @@ class OfflineFirstPlayableUriResolver implements PlayableUriResolver {
         resolver: 'OfflineFirstPlayableUriResolver',
         itemId: track.id,
       );
-      _onCacheHit?.call(track.id);
+      _onCacheHit?.call(track);
       return ResolvedPlayable(
         Uri.file(cachedPath),
         PlaybackSource.offlineCache,

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -264,21 +264,26 @@ abstract final class MusicProviders {
   /// (badged Experimental) lets the user connect with a manual server URL +
   /// token and pick which music libraries to include.
   ///
-  /// Stream + lyrics: caching, favorites, playlists, and cast stay declared
-  /// unsupported so their actions stay hidden/disabled rather than failing —
-  /// exactly how Subsonic shipped streaming first. Lyrics are fetched on demand
-  /// from the track's Plex lyric stream (synced `.lrc` or plain), the one read
-  /// beyond streaming. Cast stays off in phase 1 to keep the credential-in-URL
-  /// surface small (a Plex stream URL carries the token as a query param).
+  /// Stream, lyrics, and offline caching are implemented; favorites, playlists,
+  /// and cast stay declared unsupported so their actions stay hidden/disabled
+  /// rather than failing — exactly how Subsonic shipped streaming first.
+  /// Caching fetches the original Part file (`download=1`) through the shared,
+  /// provider-agnostic offline cache, keyed by the stable `plex:<ratingKey>`
+  /// identity and named only from the non-secret track id, so the token never
+  /// reaches a cache file (docs/plex.md → Token safety rules). Lyrics are
+  /// fetched on demand from the track's Plex lyric stream (synced `.lrc` or
+  /// plain). Cast stays off in phase 1 to keep the credential-in-URL surface
+  /// small (a Plex stream URL carries the token as a query param).
   static const MusicProvider plex = MusicProvider(
     sourceId: 'plex',
     displayName: 'Plex',
     serverUrlLabel: 'Server URL',
     capabilities: MusicProviderCapabilities(
       canStream: true,
-      // Offline caching is a documented follow-up (docs/plex.md → Out of
-      // scope), so there is no app-managed copy to remove either.
-      canCache: false,
+      // Offline caching fetches the original Part file into the shared cache,
+      // named only from the non-secret track id — so an app-managed copy exists
+      // to remove (canRemoveOfflineCopy below).
+      canCache: true,
       canFavoriteTracks: false,
       canReadFavoriteState: false,
       canSyncFavorites: false,
@@ -287,7 +292,7 @@ abstract final class MusicProviders {
       canLyrics: true,
       canCast: false,
       canRemoveFromLibrary: true,
-      canRemoveOfflineCopy: false,
+      canRemoveOfflineCopy: true,
       canDeleteLocalFile: false,
       // Phase 1 is read-only: Linthra never writes to a Plex server.
       canDeleteRemoteItem: false,

--- a/lib/core/sources/plex/plex_download_source.dart
+++ b/lib/core/sources/plex/plex_download_source.dart
@@ -1,0 +1,27 @@
+import '../../models/track.dart';
+
+/// The narrow capability the offline downloader needs from a signed-in Plex
+/// connection: confirm the session works, then mint a *download* URL for a
+/// track's original media file.
+///
+/// The mirror image of [PlexStreamSource] (which mints a *stream* URL), and the
+/// Plex counterpart to [JellyfinDownloadSource]. [PlexMusicSource] implements
+/// both; keeping this tiny lets the downloader depend on just this — not the
+/// whole source or any HTTP — and lets tests fake it to drive every download
+/// outcome (expired token, unreachable server, a vanished item, a part-less
+/// item) without a real server.
+///
+/// Security: a Plex download URL carries the `X-Plex-Token` in its **query**
+/// (the HTTP fetch can't set headers), so [resolveDownloadUri] weaves it in on
+/// demand, at download time, and the URL is never stored on [track] — exactly
+/// like the stream URL. See docs/plex.md → Token safety rules.
+abstract interface class PlexDownloadSource {
+  /// Confirms the session is still valid and the server reachable. Throws a
+  /// `PlexException` (unauthorized / not reachable / …) when it is not.
+  Future<void> verifyReachable();
+
+  /// The authenticated URL to download [track]'s original file, or `null` when
+  /// one can't be built (the item carries no playable part). The token is woven
+  /// in here, on demand, never stored on [track].
+  Future<Uri?> resolveDownloadUri(Track track);
+}

--- a/lib/core/sources/plex/plex_endpoints.dart
+++ b/lib/core/sources/plex/plex_endpoints.dart
@@ -43,6 +43,12 @@ abstract final class PlexEndpoints {
   /// `X-Plex-Token` *header* instead, so it never reaches a logged API URL.
   static const String tokenParam = 'X-Plex-Token';
 
+  /// Whether PMS should serve a Part as a direct file download (`1`) instead of
+  /// a playable stream. Set on [downloadUrl] so the offline cache fetches the
+  /// original media bytes (no transcode) and the fetch isn't registered as a
+  /// play/session on the server.
+  static const String downloadParam = 'download';
+
   /// The numeric metadata `type` selector for a section listing (8/9/10).
   static const String typeParam = 'type';
 
@@ -188,6 +194,27 @@ abstract final class PlexEndpoints {
     required String token,
   }) =>
       _withToken(_join(baseUrl, partKey), token);
+
+  /// The direct-download URL for a track's [partKey] — the original media file,
+  /// for the offline cache. The mirror of [streamUrl]: the same server-absolute
+  /// Part path (`/library/parts/…`, appended to [baseUrl] as-is) and the same
+  /// token-in-query rule, with `download=1` added so PMS serves the original
+  /// bytes as a plain file (no transcode decision) and doesn't register the
+  /// fetch as a play. Like [streamUrl] it is fetched by an HTTP client that
+  /// can't set headers, so the [token] rides in the **query** — woven in here,
+  /// on demand at fetch time, never stored on a [Track] or in the catalog. A
+  /// query the Part key already carries is preserved ahead of `download=1`,
+  /// exactly as [_withToken] preserves it ahead of the token.
+  static Uri downloadUrl(
+    String baseUrl, {
+    required String partKey,
+    required String token,
+  }) {
+    final Uri part = _join(baseUrl, partKey);
+    final String query =
+        part.hasQuery ? '${part.query}&$downloadParam=1' : '$downloadParam=1';
+    return _withToken(part.replace(query: query), token);
+  }
 
   /// The cover-art URL for an item's `thumb` path. Two shapes, exactly mirroring
   /// how `SubsonicEndpoints.coverArt` treats its `size` so both providers feed

--- a/lib/core/sources/plex/plex_music_source.dart
+++ b/lib/core/sources/plex/plex_music_source.dart
@@ -6,6 +6,7 @@ import '../../services/music_source.dart';
 import '../../services/playback_diagnostics.dart';
 import 'plex_api.dart';
 import 'plex_client.dart';
+import 'plex_download_source.dart';
 import 'plex_endpoints.dart';
 import 'plex_exception.dart';
 import 'plex_stream_source.dart';
@@ -38,7 +39,8 @@ import 'plex_track_mapper.dart';
 /// token-free `PlexException` before the audio engine ever touches a URL. Only
 /// then is the tokenized stream URL minted — the token never reaches a
 /// [Track], the catalog, or an error message.
-class PlexMusicSource implements MusicSource, PlexStreamSource {
+class PlexMusicSource
+    implements MusicSource, PlexStreamSource, PlexDownloadSource {
   const PlexMusicSource({required this.session, required PlexClient client})
       : _client = client;
 
@@ -116,19 +118,43 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
   }
 
   /// Resolves a `plex:<ratingKey>` track to its direct-play stream URL on
-  /// demand: fetch `GET /library/metadata/{ratingKey}`, read the first `Part`
-  /// key, and mint `{baseUrl}{partKey}?X-Plex-Token=…` — the only moment the
-  /// token is woven into a URL, which is handed to the audio engine and never
-  /// persisted. Returns `null` when the item carries no playable part.
-  ///
-  /// Throws a token-free `PlexException` when the lookup fails (item gone,
-  /// token rejected, server unreachable) — and *only* `PlexException`: a track
-  /// whose uri carries no ratingKey at all (a corrupt catalog row) fails as
-  /// [PlexErrorKind.notFound] without issuing a junk request, and a Part key
-  /// the URL builder can't use fails as [PlexErrorKind.unsupportedResponse]
-  /// rather than escaping as an untyped [FormatException].
+  /// demand: look up its first `Part` key (see [_resolvePartKey]) and mint
+  /// `{baseUrl}{partKey}?X-Plex-Token=…` — the only moment the token is woven
+  /// into a stream URL, which is handed to the audio engine and never persisted.
+  /// Returns `null` when the item carries no playable part.
   @override
   Future<Uri?> resolvePlayableUri(Track track) async {
+    final String? partKey = await _resolvePartKey(track);
+    if (partKey == null) return null;
+    return _mintStreamUrl(partKey);
+  }
+
+  /// Resolves a `plex:<ratingKey>` track to its original file's *download* URL
+  /// on demand — the bytes the offline cache stores. The mirror of
+  /// [resolvePlayableUri]: the same `Part` lookup ([_resolvePartKey]), but mints
+  /// a `download=1` Part URL ([PlexEndpoints.downloadUrl]) so PMS serves the
+  /// original media (not a transcode) and doesn't count the fetch as a play. The
+  /// token is woven into the query only now, at fetch time, handed to the
+  /// downloader and never persisted. Returns `null` when the item carries no
+  /// part; throws the same typed, token-free [PlexException] family the play
+  /// path does.
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async {
+    final String? partKey = await _resolvePartKey(track);
+    if (partKey == null) return null;
+    return _mintDownloadUrl(partKey);
+  }
+
+  /// The first playable `Part` key for [track]'s `plex:<ratingKey>` item, via a
+  /// `GET /library/metadata/{ratingKey}` lookup, or `null` when the item carries
+  /// no part. Shared by the stream- and download-URL resolvers so both read the
+  /// same Part the same way and surface the same typed failures.
+  ///
+  /// Throws a token-free `PlexException` when the lookup fails (item gone, token
+  /// rejected, server unreachable) — and *only* `PlexException`: a track whose
+  /// uri carries no ratingKey at all (a corrupt catalog row) fails as
+  /// [PlexErrorKind.notFound] without issuing a junk request.
+  Future<String?> _resolvePartKey(Track track) async {
     final String ratingKey = _ratingKey(track);
     if (ratingKey.trim().isEmpty) {
       // No ratingKey can name no item; `GET /library/metadata/` (no id) is a
@@ -148,9 +174,7 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
       resolver: 'PlexMusicSource',
       itemId: ratingKey,
     );
-    final String? partKey = item.firstPartKey;
-    if (partKey == null) return null;
-    return _mintStreamUrl(partKey);
+    return item.firstPartKey;
   }
 
   /// Mints the tokenized direct-play URL for [partKey] — the only call site of
@@ -168,6 +192,26 @@ class PlexMusicSource implements MusicSource, PlexStreamSource {
     }
     try {
       return PlexEndpoints.streamUrl(
+        session.baseUrl,
+        partKey: partKey,
+        token: session.token,
+      );
+    } on FormatException {
+      throw PlexException.unsupportedResponse();
+    }
+  }
+
+  /// Mints the tokenized download URL for [partKey] — the only call site of
+  /// [PlexEndpoints.downloadUrl]. Applies the same server-absolute-path guard as
+  /// [_mintStreamUrl], so an unusable Part key fails as the typed "response
+  /// Linthra could not use" rather than a corrupt URL or an untyped
+  /// [FormatException].
+  Uri _mintDownloadUrl(String partKey) {
+    if (!partKey.startsWith('/')) {
+      throw PlexException.unsupportedResponse();
+    }
+    try {
+      return PlexEndpoints.downloadUrl(
         session.baseUrl,
         partKey: partKey,
         token: session.token,

--- a/lib/core/sources/plex/plex_track_downloader.dart
+++ b/lib/core/sources/plex/plex_track_downloader.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/track.dart';
+import '../../services/remote_track_downloader.dart';
+import '../audio_file_extension.dart';
+import 'plex_download_source.dart';
+import 'plex_track_mapper.dart';
+
+/// The [RemoteTrackDownloader] for Plex tracks.
+///
+/// Resolves the authenticated download URL only at fetch time — through the live
+/// signed-in [PlexDownloadSource], read via a getter so signing in or out is
+/// picked up without a rebuild — then fetches the bytes over HTTP. The URL, and
+/// the `X-Plex-Token` woven into its query, never leave [fetch]: not stored, not
+/// returned, and not placed in any thrown error (a transport failure is
+/// re-raised as a generic message so a `ClientException` carrying the tokenized
+/// URL can't escape).
+///
+/// The session check and URL resolution run *before* the transport try-block, so
+/// a typed, token-free `PlexException` from them (expired token, unreachable
+/// server, a vanished item) surfaces as-is — exactly as the play path surfaces
+/// it — rather than being flattened to the generic transport message.
+class PlexTrackDownloader implements RemoteTrackDownloader {
+  PlexTrackDownloader(this._source, {http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  /// Supplies the current signed-in source, or `null` when not connected.
+  final PlexDownloadSource? Function() _source;
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(minutes: 5);
+
+  @override
+  bool isRemote(Track track) => track.uri.startsWith(PlexTrackMapper.uriScheme);
+
+  @override
+  Future<RemoteTrackData> fetch(
+    Track track, {
+    void Function(int received, int? total)? onProgress,
+  }) async {
+    final PlexDownloadSource? source = _source();
+    if (source == null) {
+      throw StateError('Not signed in to your Plex server.');
+    }
+
+    // Confirm the session still works before fetching; the PlexException this
+    // may throw is friendly and token-free by design.
+    await source.verifyReachable();
+
+    final Uri? uri = await source.resolveDownloadUri(track);
+    if (uri == null) {
+      throw StateError('No Plex download URL for this track.');
+    }
+
+    try {
+      // Stream the body so progress can be reported as bytes arrive. The request
+      // carries the token in its URL, but the URL never leaves this method, is
+      // never logged, and any transport error below is replaced with a generic
+      // message so it can't escape either.
+      final http.StreamedResponse response =
+          await _client.send(http.Request('GET', uri)).timeout(_timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        await response.stream.drain<void>();
+        throw StateError('Plex download failed (HTTP ${response.statusCode}).');
+      }
+
+      final int? total =
+          (response.contentLength != null && response.contentLength! > 0)
+              ? response.contentLength
+              : null;
+      final BytesBuilder builder = BytesBuilder(copy: false);
+      int received = 0;
+      onProgress?.call(received, total);
+      await for (final List<int> chunk in response.stream.timeout(_timeout)) {
+        builder.add(chunk);
+        received += chunk.length;
+        onProgress?.call(received, total);
+      }
+
+      return RemoteTrackData(
+        bytes: builder.takeBytes(),
+        fileExtension:
+            AudioFileExtension.forContentType(response.headers['content-type']),
+      );
+    } on StateError {
+      // Our own friendly, token-free messages (bad status / not signed in):
+      // surface them as-is.
+      rethrow;
+    } on Exception {
+      // Never rethrow the original error: a ClientException/SocketException (or
+      // a TimeoutException) can embed the tokenized URL in its message.
+      throw StateError('Plex download failed.');
+    }
+  }
+}

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -162,14 +162,14 @@ class CacheDownloadRepository
           entry = cached.copyWith(sizeBytes: size);
           changed = true;
         }
-        _downloads[entry.trackId] = entry;
+        _downloads[_keyForCached(entry)] = entry;
       } else {
-        _downloads[cached.trackId] = cached;
+        _downloads[_keyForCached(cached)] = cached;
       }
       // A preloaded entry is cached and playable, but never a *download*: it
       // stays out of the status map so the downloads UI doesn't show it.
       if (!cached.preloaded) {
-        _statuses[cached.trackId] = DownloadStatus.downloaded;
+        _statuses[_keyForCached(cached)] = DownloadStatus.downloaded;
       }
     }
     if (changed) await _save();
@@ -186,7 +186,10 @@ class CacheDownloadRepository
   @override
   Future<DownloadStatus> statusFor(String trackId) async {
     await _ensureLoaded();
-    return _statuses[trackId] ?? DownloadStatus.notDownloaded;
+    // Reads the id-keyed projection (the same shape [statusStream] emits), so it
+    // agrees with the UI's per-row status. Provider-aware isolation is enforced
+    // where it matters — storage, the cache file, and removal.
+    return _snapshot()[trackId] ?? DownloadStatus.notDownloaded;
   }
 
   @override
@@ -204,13 +207,14 @@ class CacheDownloadRepository
       return DownloadRequestOutcome.started;
     }
 
+    final String key = _keyForTrack(track);
     // A fresh, explicit request supersedes any pending cancellation for this id
     // (e.g. the user removed it mid-fetch and immediately asked again).
-    _canceled.remove(track.id);
+    _canceled.remove(key);
     // Reserve the in-flight slot synchronously, before any `await`, so a second
     // request for the same track (a double tap, or a second caller) bails out
     // here instead of starting a duplicate fetch.
-    if (!_inFlight.add(track.id)) return DownloadRequestOutcome.started;
+    if (!_inFlight.add(key)) return DownloadRequestOutcome.started;
     try {
       return await _runRemoteRequest(track);
     } on CacheStorageException {
@@ -222,14 +226,14 @@ class CacheDownloadRepository
       // Other errors may carry source-specific detail; the UI only needs the
       // failed state (which offers a retry) — but a download the user cancelled
       // mid-fetch must stay gone, not flip to "failed".
-      if (!_canceled.contains(track.id)) {
-        _set(track.id, DownloadStatus.failed);
+      if (!_canceled.contains(key)) {
+        _set(key, DownloadStatus.failed);
       }
       return DownloadRequestOutcome.started;
     } finally {
-      _canceled.remove(track.id);
-      _inFlight.remove(track.id);
-      _clearProgress(track.id);
+      _canceled.remove(key);
+      _inFlight.remove(key);
+      _clearProgress(key);
     }
   }
 
@@ -237,14 +241,15 @@ class CacheDownloadRepository
   /// local, so there is no fetch, no managed file, and no network gate.
   Future<void> _requestOnDeviceDownload(Track track) async {
     await _ensureLoaded();
-    if (_statuses[track.id] == DownloadStatus.downloaded) return;
-    _downloads[track.id] = CachedTrack(
+    final String key = _keyForTrack(track);
+    if (_statuses[key] == DownloadStatus.downloaded) return;
+    _downloads[key] = CachedTrack(
       trackId: track.id,
       sourceType: _sourceTypeOf(track),
       cachedAt: _now(),
     );
     await _save();
-    _statuses[track.id] = DownloadStatus.downloaded;
+    _statuses[key] = DownloadStatus.downloaded;
     _emitStatus();
     _emitCache();
   }
@@ -254,21 +259,22 @@ class CacheDownloadRepository
   /// slot before fetching the bytes and committing them under the cache limit.
   Future<DownloadRequestOutcome> _runRemoteRequest(Track track) async {
     await _ensureLoaded();
+    final String key = _keyForTrack(track);
     // Already cached — nothing to do. (A track that is downloading or queued is
     // already in [_inFlight], so it never reaches here a second time.)
-    if (_statuses[track.id] == DownloadStatus.downloaded) {
+    if (_statuses[key] == DownloadStatus.downloaded) {
       return DownloadRequestOutcome.started;
     }
 
     // A track preloaded ahead of play is already cached: promote it to a user
     // download in place, without re-fetching its bytes.
-    final CachedTrack? preloadedEntry = _downloads[track.id];
+    final CachedTrack? preloadedEntry = _downloads[key];
     if (preloadedEntry != null &&
         preloadedEntry.preloaded &&
         preloadedEntry.isManaged) {
-      _downloads[track.id] = preloadedEntry.copyWith(preloaded: false);
+      _downloads[key] = preloadedEntry.copyWith(preloaded: false);
       await _save();
-      _statuses[track.id] = DownloadStatus.downloaded;
+      _statuses[key] = DownloadStatus.downloaded;
       _emitStatus();
       _emitCache();
       return DownloadRequestOutcome.started;
@@ -280,20 +286,20 @@ class CacheDownloadRepository
     // and the outcome tells the UI why so it can prompt instead of failing.
     final _NetworkDecision decision = await _networkDecision();
     if (decision != _NetworkDecision.allowed) {
-      _set(track.id, DownloadStatus.queued);
+      _set(key, DownloadStatus.queued);
       return decision == _NetworkDecision.offline
           ? DownloadRequestOutcome.waitingForConnection
           : DownloadRequestOutcome.waitingForWifi;
     }
 
     // Accepted: show "queued" until a concurrency slot frees up, then fetch.
-    _set(track.id, DownloadStatus.queued);
+    _set(key, DownloadStatus.queued);
     await _scheduler.schedule(() async {
-      _set(track.id, DownloadStatus.downloading);
+      _set(key, DownloadStatus.downloading);
       final RemoteTrackData data = await _downloader.fetch(
         track,
         onProgress: (int received, int? total) =>
-            _reportProgress(track.id, received, total),
+            _reportProgress(track, received, total),
       );
       // Commit serially so concurrent downloads can't jointly overshoot the
       // limit; the (slow) byte fetch above already ran in parallel.
@@ -314,16 +320,17 @@ class CacheDownloadRepository
     RemoteTrackData data, {
     bool preloaded = false,
   }) async {
+    final String key = _keyForTrack(track);
     // The user removed or cleared this download while its bytes were still in
     // flight: honour that and commit nothing — no file write, no metadata, no
     // status — so a late fetch can't resurrect it or leave a stray file.
-    if (_canceled.remove(track.id)) return;
+    if (_canceled.remove(key)) return;
     if (preloaded) {
-      final CachedTrack? existing = _downloads[track.id];
+      final CachedTrack? existing = _downloads[key];
       // A user download for the same track raced this preload (commits are
       // serialized, so by now the winner is known). Don't clobber or duplicate
       // a real download with a preloaded copy — let the user's copy stand.
-      if (_inFlight.contains(track.id) ||
+      if (_inFlight.contains(key) ||
           (existing != null && !existing.preloaded)) {
         return;
       }
@@ -340,24 +347,25 @@ class CacheDownloadRepository
 
     if (!plan.fits) {
       if (preloaded) return;
-      _set(track.id, DownloadStatus.notDownloaded);
+      _set(key, DownloadStatus.notDownloaded);
       throw const CacheStorageException();
     }
 
     bool evictedAStatus = false;
     for (final CachedTrack victim in plan.evict) {
       await _deleteManagedFile(victim);
-      _downloads.remove(victim.trackId);
-      if (_statuses.remove(victim.trackId) != null) evictedAStatus = true;
+      final String victimKey = _keyForCached(victim);
+      _downloads.remove(victimKey);
+      if (_statuses.remove(victimKey) != null) evictedAStatus = true;
     }
 
     final String fileName = await _files.write(
-      track.id,
+      _fileBaseName(track),
       data.bytes,
       extension: data.fileExtension,
     );
     final DateTime now = _now();
-    _downloads[track.id] = CachedTrack(
+    _downloads[key] = CachedTrack(
       trackId: track.id,
       fileName: fileName,
       sourceType: _sourceTypeOf(track),
@@ -370,7 +378,7 @@ class CacheDownloadRepository
     );
     await _save();
     if (!preloaded) {
-      _statuses[track.id] = DownloadStatus.downloaded;
+      _statuses[key] = DownloadStatus.downloaded;
     }
     // A preload changes only cache usage; a user download (or an eviction that
     // dropped a download) also changes download status.
@@ -383,14 +391,15 @@ class CacheDownloadRepository
     await _ensureLoaded();
     // Only remote tracks have bytes to fetch; local ones are already on disk.
     if (!_downloader.isRemote(track)) return;
+    final String key = _keyForTrack(track);
     // Already cached (download or earlier preload), or a user download already
     // has it in flight — skip rather than fetch the same bytes twice.
-    if (_downloads.containsKey(track.id)) return;
-    if (_inFlight.contains(track.id)) return;
-    if (_statuses[track.id] == DownloadStatus.downloading) return;
+    if (_downloads.containsKey(key)) return;
+    if (_inFlight.contains(key)) return;
+    if (_statuses[key] == DownloadStatus.downloading) return;
     // Reserve synchronously, before any await, so a second concurrent prefetch
     // of the same track bails here instead of fetching the same bytes twice.
-    if (!_preloading.add(track.id)) return;
+    if (!_preloading.add(key)) return;
     try {
       // Preload is best-effort and network-heavy, so it honours the mobile-data
       // policy and simply skips (rather than queueing) when it can't run now.
@@ -408,24 +417,25 @@ class CacheDownloadRepository
       // Best-effort: a failed preload caches nothing and changes no status; the
       // track still streams normally when it's reached.
     } finally {
-      _canceled.remove(track.id);
-      _preloading.remove(track.id);
+      _canceled.remove(key);
+      _preloading.remove(key);
     }
   }
 
   @override
-  Future<void> removeDownload(String trackId) async {
+  Future<void> removeDownload(Track track) async {
     await _ensureLoaded();
+    final String key = _keyForTrack(track);
     // If a fetch for this track is still in flight, mark it cancelled so its
     // late commit won't re-add the entry or leave a managed file on disk.
-    if (_inFlight.contains(trackId) || _preloading.contains(trackId)) {
-      _canceled.add(trackId);
+    if (_inFlight.contains(key) || _preloading.contains(key)) {
+      _canceled.add(key);
     }
-    final CachedTrack? existing = _downloads.remove(trackId);
+    final CachedTrack? existing = _downloads.remove(key);
     await _deleteManagedFile(existing);
     await _save();
     // Also clears a queued/failed/downloading marker, so this doubles as cancel.
-    _set(trackId, DownloadStatus.notDownloaded);
+    _set(key, DownloadStatus.notDownloaded);
     _emitCache();
   }
 
@@ -435,7 +445,7 @@ class CacheDownloadRepository
     return _statuses.entries
         .where((MapEntry<String, DownloadStatus> e) =>
             e.value == DownloadStatus.downloaded)
-        .map((MapEntry<String, DownloadStatus> e) => e.key)
+        .map((MapEntry<String, DownloadStatus> e) => _trackIdOfKey(e.key))
         .toList();
   }
 
@@ -453,21 +463,23 @@ class CacheDownloadRepository
   }
 
   @override
-  Future<void> setPinned(String trackId, bool pinned) async {
+  Future<void> setPinned(Track track, bool pinned) async {
     await _ensureLoaded();
-    final CachedTrack? existing = _downloads[trackId];
+    final String key = _keyForTrack(track);
+    final CachedTrack? existing = _downloads[key];
     if (existing == null || existing.pinned == pinned) return;
-    _downloads[trackId] = existing.copyWith(pinned: pinned);
+    _downloads[key] = existing.copyWith(pinned: pinned);
     await _save();
     _emitCache();
   }
 
   @override
-  Future<void> notePlayed(String trackId) async {
+  Future<void> notePlayed(Track track) async {
     await _ensureLoaded();
-    final CachedTrack? existing = _downloads[trackId];
+    final String key = _keyForTrack(track);
+    final CachedTrack? existing = _downloads[key];
     if (existing == null) return;
-    _downloads[trackId] = existing.copyWith(lastAccessedAt: _now());
+    _downloads[key] = existing.copyWith(lastAccessedAt: _now());
     await _save();
     _emitCache();
   }
@@ -495,8 +507,9 @@ class CacheDownloadRepository
     if (victims.isEmpty) return;
     for (final CachedTrack victim in victims) {
       await _deleteManagedFile(victim);
-      _downloads.remove(victim.trackId);
-      _statuses.remove(victim.trackId);
+      final String victimKey = _keyForCached(victim);
+      _downloads.remove(victimKey);
+      _statuses.remove(victimKey);
     }
     await _save();
     _emitStatus();
@@ -572,11 +585,11 @@ class CacheDownloadRepository
 
   Future<void> _save() => _store.saveDownloads(_downloads.values.toList());
 
-  void _set(String trackId, DownloadStatus status) {
+  void _set(String key, DownloadStatus status) {
     if (status == DownloadStatus.notDownloaded) {
-      _statuses.remove(trackId);
+      _statuses.remove(key);
     } else {
-      _statuses[trackId] = status;
+      _statuses[key] = status;
     }
     _emitStatus();
   }
@@ -604,24 +617,35 @@ class CacheDownloadRepository
     return result.future;
   }
 
-  void _reportProgress(String trackId, int received, int? total) {
-    _progress[trackId] = DownloadProgress(
-      trackId: trackId,
+  void _reportProgress(Track track, int received, int? total) {
+    _progress[_keyForTrack(track)] = DownloadProgress(
+      trackId: track.id,
       receivedBytes: received,
       totalBytes: total,
     );
     _emitProgress();
   }
 
-  void _clearProgress(String trackId) {
-    if (_progress.remove(trackId) != null) _emitProgress();
+  void _clearProgress(String key) {
+    if (_progress.remove(key) != null) _emitProgress();
   }
 
-  Map<String, DownloadStatus> _snapshot() =>
-      Map<String, DownloadStatus>.unmodifiable(_statuses);
+  /// Projects the provider-aware status map onto a catalog-id-keyed snapshot —
+  /// the shape the UI's per-row status provider and the cross-provider sync
+  /// layers consume. In the catalog (whose primary key is the id) two providers
+  /// never share an id, so the projection is lossless there; the provider-aware
+  /// keys stay internal where same-id isolation matters (storage, files,
+  /// removal).
+  Map<String, DownloadStatus> _snapshot() => <String, DownloadStatus>{
+        for (final MapEntry<String, DownloadStatus> e in _statuses.entries)
+          _trackIdOfKey(e.key): e.value,
+      };
 
   Map<String, DownloadProgress> _progressSnapshot() =>
-      Map<String, DownloadProgress>.unmodifiable(_progress);
+      <String, DownloadProgress>{
+        for (final MapEntry<String, DownloadProgress> e in _progress.entries)
+          _trackIdOfKey(e.key): e.value,
+      };
 
   CacheSnapshot _cacheSnapshot() {
     int used = 0;
@@ -642,6 +666,40 @@ class CacheDownloadRepository
     final String scheme = track.uri.substring(0, colon).toLowerCase();
     return scheme.isEmpty ? null : scheme;
   }
+
+  /// The provider-aware cache identity for [track]: its source scheme **plus**
+  /// catalog id, so two providers that expose the same local id (e.g. a Plex
+  /// ratingKey `101` and a Subsonic id `101`) never share a cache slot, file, or
+  /// status. This is the key for every in-memory map below.
+  static String _keyForTrack(Track track) =>
+      _cacheKey(_sourceTypeOf(track), track.id);
+
+  /// The same identity for a persisted [entry], built from the same
+  /// `(sourceType, trackId)` it was written with — so a reloaded entry maps back
+  /// to exactly the key its live track produces, keeping cache state stable
+  /// across restarts (and back-compatible: existing entries already carry both).
+  static String _keyForCached(CachedTrack entry) =>
+      _cacheKey(entry.sourceType, entry.trackId);
+
+  /// Composes a credential-free cache key from a source scheme and catalog id.
+  /// The NUL separator can't occur in a scheme or an id, so the pair is
+  /// unambiguous and [_trackIdOfKey] can recover the id for the id-keyed
+  /// snapshots the UI reads.
+  static String _cacheKey(String? sourceType, String trackId) =>
+      '${sourceType ?? ''}\u0000$trackId';
+
+  /// The catalog id embedded in a [key] from [_cacheKey] — used to project the
+  /// internal, provider-aware maps back onto the id-keyed snapshots the UI and
+  /// the cross-provider sync layers consume.
+  static String _trackIdOfKey(String key) =>
+      key.substring(key.indexOf('\u0000') + 1);
+
+  /// A provider-namespaced base name for [track]'s cache file, so two providers
+  /// with the same id write to distinct files (`plex_101`, `jellyfin_101`). The
+  /// [OfflineFileStore] sanitizes it further; the resulting file name is what's
+  /// persisted, so existing files (named from the bare id) keep resolving.
+  static String _fileBaseName(Track track) =>
+      '${_sourceTypeOf(track) ?? 'local'}_${track.id}';
 }
 
 /// Whether the network policy lets a download run now, and why not when it

--- a/lib/data/repositories/file_system_offline_file_store.dart
+++ b/lib/data/repositories/file_system_offline_file_store.dart
@@ -22,6 +22,11 @@ class FileSystemOfflineFileStore implements OfflineFileStore {
 
   final Future<Directory> Function() _directory;
 
+  /// Suffix for the in-progress temp file an atomic [write] renames from. A
+  /// leftover (from a crash mid-write) is never referenced by download metadata,
+  /// so it is harmless, and the next same-name download overwrites it.
+  static const String _tempSuffix = '.part';
+
   static Future<Directory> _defaultDirectory() async {
     final Directory base = await getApplicationSupportDirectory();
     return Directory(p.join(base.path, 'offline_audio'));
@@ -33,13 +38,50 @@ class FileSystemOfflineFileStore implements OfflineFileStore {
     List<int> bytes, {
     String? extension,
   }) async {
+    // Validate before writing anything: an empty download (an interrupted or
+    // truncated fetch can hand back zero bytes) is never a valid cache file —
+    // and would masquerade as one, since the playback locator only checks that
+    // a file *exists*. Refusing it here surfaces as a failed write the caller
+    // streams past, rather than a 0-byte file that fails at play time.
+    if (bytes.isEmpty) {
+      throw const FileSystemException('Refusing to cache an empty download.');
+    }
     final Directory dir = await _directory();
     if (!await dir.exists()) {
       await dir.create(recursive: true);
     }
     final String fileName = _fileNameFor(trackId, extension);
-    final File file = File(p.join(dir.path, fileName));
-    await file.writeAsBytes(bytes, flush: true);
+    final File target = File(p.join(dir.path, fileName));
+
+    // Atomic publish: write to a temporary sibling, validate it, then rename it
+    // into place. A rename within one directory is atomic on the POSIX
+    // filesystems Linthra targets, so the playback locator only ever sees the
+    // fully-written file or no file — never a half-written one, even if the
+    // process is killed mid-write. The metadata that marks the track cached is
+    // written by the repository only *after* this returns, so a crash between
+    // the rename and that write just leaves an unreferenced file the next
+    // download (same name) overwrites — it is never mistaken for cached.
+    final File temp = File('${target.path}$_tempSuffix');
+    try {
+      await temp.writeAsBytes(bytes, flush: true);
+      // Confirm the temp holds every byte before publishing it, so a short
+      // write (e.g. the disk filled mid-write) is caught and discarded here
+      // rather than renamed into the cache to fail later.
+      final int written = await temp.length();
+      if (written != bytes.length) {
+        throw FileSystemException(
+          'Cached file is incomplete ($written/${bytes.length} bytes).',
+          target.path,
+        );
+      }
+      await temp.rename(target.path);
+    } on Object {
+      // Never leave a partial temp behind on any failure (validation or I/O).
+      if (await temp.exists()) {
+        await temp.delete();
+      }
+      rethrow;
+    }
     return fileName;
   }
 

--- a/lib/data/repositories/in_memory_download_store.dart
+++ b/lib/data/repositories/in_memory_download_store.dart
@@ -2,29 +2,26 @@ import '../../core/repositories/download_store.dart';
 
 /// A non-persistent [DownloadStore] for development and tests.
 ///
-/// Keeps the cached-track references in a plain map keyed by track id, so
-/// they're forgotten when the instance is dropped. Default binding (mirroring
-/// the other in-memory repositories); the running app swaps in the
-/// `shared_preferences` implementation.
+/// Keeps the cached-track references in a plain list, so they're forgotten when
+/// the instance is dropped. Default binding (mirroring the other in-memory
+/// repositories); the running app swaps in the `shared_preferences`
+/// implementation. A list — not a map keyed by track id — so two entries that
+/// share a catalog id but come from different providers (a Plex `101` and a
+/// Subsonic `101`) both persist, exactly as the `shared_preferences` store keeps
+/// them; the cache's provider-aware identity lives one layer up.
 class InMemoryDownloadStore implements DownloadStore {
   InMemoryDownloadStore({List<CachedTrack>? initialDownloads})
-      : _downloads = <String, CachedTrack>{
-          for (final CachedTrack cached
-              in initialDownloads ?? const <CachedTrack>[])
-            cached.trackId: cached,
-        };
+      : _downloads = <CachedTrack>[...?initialDownloads];
 
-  final Map<String, CachedTrack> _downloads;
+  final List<CachedTrack> _downloads;
 
   @override
-  Future<List<CachedTrack>> loadDownloads() async => _downloads.values.toList();
+  Future<List<CachedTrack>> loadDownloads() async => _downloads.toList();
 
   @override
   Future<void> saveDownloads(List<CachedTrack> downloads) async {
     _downloads
       ..clear()
-      ..addEntries(
-        downloads.map((c) => MapEntry<String, CachedTrack>(c.trackId, c)),
-      );
+      ..addAll(downloads);
   }
 }

--- a/lib/data/repositories/store_cached_track_locator.dart
+++ b/lib/data/repositories/store_cached_track_locator.dart
@@ -20,14 +20,30 @@ class StoreCachedTrackLocator implements CachedTrackLocator {
 
   @override
   Future<String?> cachedFilePath(Track track) async {
+    final String? scheme = _schemeOf(track.uri);
     String? fileName;
     for (final CachedTrack cached in await _store.loadDownloads()) {
-      if (cached.trackId == track.id) {
-        fileName = cached.fileName;
-        break;
-      }
+      if (cached.trackId != track.id) continue;
+      // Provider-aware: an entry matches only when its recorded source scheme
+      // agrees, so a Plex `101` never resolves to a Subsonic `101`'s file. A
+      // legacy entry written before source tagging (sourceType == null) falls
+      // back to an id-only match — there is at most one such untagged file, so
+      // it still resolves and existing cached tracks keep working.
+      if (cached.sourceType != null && cached.sourceType != scheme) continue;
+      fileName = cached.fileName;
+      break;
     }
     if (fileName == null || fileName.isEmpty) return null;
     return _files.pathFor(fileName);
+  }
+
+  /// The non-secret URI scheme of [uri] (`jellyfin`, `subsonic`, `plex`, `file`,
+  /// …), or `null` for a bare path — derived exactly as the repository records
+  /// [CachedTrack.sourceType], so the two always agree.
+  static String? _schemeOf(String uri) {
+    final int colon = uri.indexOf(':');
+    if (colon <= 0) return null;
+    final String scheme = uri.substring(0, colon).toLowerCase();
+    return scheme.isEmpty ? null : scheme;
   }
 }

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -10,10 +10,12 @@ import '../../core/services/offline_cache_manager.dart';
 import '../../core/services/remote_track_downloader.dart';
 import '../../core/services/routing_remote_track_downloader.dart';
 import '../../core/sources/jellyfin/jellyfin_track_downloader.dart';
+import '../../core/sources/plex/plex_track_downloader.dart';
 import '../../core/sources/subsonic/subsonic_track_downloader.dart';
 import '../../data/repositories/download_repository_provider.dart';
 import '../../data/repositories/music_library_repository_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
+import '../settings/plex/plex_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 
 /// The live download status of a single track, for the Library row indicator.
@@ -230,13 +232,13 @@ final precacheCountProvider =
   PrecacheCountController.new,
 );
 
-/// Production binding: makes remote (Jellyfin and Subsonic/Navidrome) tracks
-/// downloadable for offline use by routing the remote downloader across both
-/// sources, each wired to its live signed-in source (read lazily, so sign-in/out
-/// is picked up without a rebuild). The credential-bearing download URL is
-/// minted only at fetch time inside each downloader; nothing here stores it.
-/// Applied in `main`; tests override [remoteTrackDownloaderProvider] with their
-/// own fake.
+/// Production binding: makes remote (Jellyfin, Subsonic/Navidrome, and Plex)
+/// tracks downloadable for offline use by routing the remote downloader across
+/// every source, each wired to its live signed-in source (read lazily, so
+/// sign-in/out is picked up without a rebuild). The credential-bearing download
+/// URL is minted only at fetch time inside each downloader; nothing here stores
+/// it. Applied in `main`; tests override [remoteTrackDownloaderProvider] with
+/// their own fake.
 final remoteTrackDownloaderOverride =
     remoteTrackDownloaderProvider.overrideWith((ref) {
   // Read (not watch) the live sources lazily at fetch time, mirroring the
@@ -245,5 +247,6 @@ final remoteTrackDownloaderOverride =
   return RoutingRemoteTrackDownloader(<RemoteTrackDownloader>[
     JellyfinTrackDownloader(() => ref.read(jellyfinMusicSourceProvider)),
     SubsonicTrackDownloader(() => ref.read(subsonicMusicSourceProvider)),
+    PlexTrackDownloader(() => ref.read(plexMusicSourceProvider)),
   ]);
 });

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -228,7 +228,7 @@ class _ActiveDownloadTile extends ConsumerWidget {
             icon: const Icon(Icons.close),
             tooltip: 'Cancel download',
             onPressed: () =>
-                ref.read(downloadRepositoryProvider).removeDownload(track.id),
+                ref.read(downloadRepositoryProvider).removeDownload(track),
           ),
         ],
       ),
@@ -362,15 +362,14 @@ class _DownloadedTile extends ConsumerWidget {
             icon: Icon(pinned ? Icons.push_pin : Icons.push_pin_outlined),
             color: pinned ? Theme.of(context).colorScheme.secondary : null,
             tooltip: pinned ? 'Unpin' : 'Keep offline',
-            onPressed: () => ref
-                .read(offlineCacheManagerProvider)
-                .setPinned(track.id, !pinned),
+            onPressed: () =>
+                ref.read(offlineCacheManagerProvider).setPinned(track, !pinned),
           ),
           IconButton(
             icon: const Icon(Icons.delete_outline),
             tooltip: 'Remove download',
             onPressed: () =>
-                ref.read(downloadRepositoryProvider).removeDownload(track.id),
+                ref.read(downloadRepositoryProvider).removeDownload(track),
           ),
         ],
       ),

--- a/lib/features/library/song_actions.dart
+++ b/lib/features/library/song_actions.dart
@@ -104,7 +104,7 @@ abstract final class SongActions {
         continue;
       }
       try {
-        await repository.removeDownload(track.id);
+        await repository.removeDownload(track);
         removed++;
       } catch (_) {
         failed++;

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -303,7 +303,7 @@ class _OverflowMenu extends ConsumerWidget {
       case _TrackAction.cancel:
         // Cancelling an in-flight/queued download is not destructive to a saved
         // copy, so it needs no confirmation.
-        await ref.read(downloadRepositoryProvider).removeDownload(track.id);
+        await ref.read(downloadRepositoryProvider).removeDownload(track);
       case _TrackAction.removeOffline:
         await SongActions.removeOfflineCopies(context, ref, <Track>[track]);
       case _TrackAction.removeFromLibrary:

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -145,6 +145,12 @@ final localPlaybackControllerProvider =
     // library lazily at play time, so the session-pinned engine still sees a
     // fresh catalog (and default-source change) without being rebuilt.
     candidates: ref.read(playbackCandidateSourceProvider),
+    // When a track's offline-cache file won't open (corrupt, or reclaimed after
+    // the existence check), fall back to streaming the *same* track — this
+    // resolver resolves past the offline cache (the offline-first resolver's own
+    // fallback), so even a single-source cached track recovers to its live
+    // stream rather than erroring.
+    streamingFallbackResolver: ref.read(remoteCacheResolverProvider),
     // Record a completed play when a track reaches its end. Read lazily at
     // completion time (not watched), so the play-history repository never ties
     // into the engine's lifecycle. Only the track id is recorded; it stays

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -113,8 +113,8 @@ final playableUriResolverProvider = Provider<PlayableUriResolver>((ref) {
     // eviction keeps what's actually listened to. Read lazily (no build-time
     // dependency on the cache manager) and never awaited — a metadata write
     // must not block or break playback.
-    onCacheHit: (trackId) =>
-        unawaited(ref.read(offlineCacheManagerProvider).notePlayed(trackId)),
+    onCacheHit: (track) =>
+        unawaited(ref.read(offlineCacheManagerProvider).notePlayed(track)),
   );
 });
 

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,12 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Added support and bug report links for testers.',
-    'Improved About and project information.',
-    'Continued Google Play closed testing preparation.',
-    'Stability and polish improvements.',
+    'Plex tracks can now be downloaded for offline playback.',
+    'Cached tracks play from your device, and fall back to streaming if a '
+        'file is missing or unreadable.',
+    'Offline downloads are now written atomically, so an interrupted '
+        "download can't leave a broken file.",
+    'Reproducible per-ABI release builds for F-Droid.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.5+105999
+version: 0.1.6+106999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/test/core/services/fake_browse_repositories.dart
+++ b/test/core/services/fake_browse_repositories.dart
@@ -145,5 +145,5 @@ class FakeDownloadRepository implements DownloadRepository {
       throw UnimplementedError();
 
   @override
-  Future<void> removeDownload(String trackId) => throw UnimplementedError();
+  Future<void> removeDownload(Track track) => throw UnimplementedError();
 }

--- a/test/core/services/just_audio_playback_controller_fallback_test.dart
+++ b/test/core/services/just_audio_playback_controller_fallback_test.dart
@@ -105,6 +105,9 @@ Track _track(String id, String uri) => Track(
 ResolvedPlayable _stream(String url) =>
     ResolvedPlayable(Uri.parse(url), PlaybackSource.streamingDirect);
 
+ResolvedPlayable _cache(String path) =>
+    ResolvedPlayable(Uri.file(path), PlaybackSource.offlineCache);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -117,11 +120,15 @@ void main() {
     required _FakePlayer player,
     required _FakeResolver resolver,
     required Map<String, List<Track>> candidates,
+    _FakeResolver? streamResolver,
   }) {
     final controller = JustAudioPlaybackController(
       player: player,
       resolver: resolver,
       candidates: MapPlaybackCandidateSource(() => candidates),
+      // Null by default, so every existing test keeps the original behavior; the
+      // offline-cache fallback group passes a real one.
+      streamingFallbackResolver: streamResolver,
     );
     addTearDown(controller.dispose);
     return controller;
@@ -293,6 +300,128 @@ void main() {
       expect(s.errorMessage, isNot(contains('http')));
       // Each candidate was tried exactly once — no looping.
       expect(resolver.calls, <String>['jellyfin:j', 'subsonic:s']);
+    });
+  });
+
+  group('offline-cache load failure falls back to streaming', () {
+    // A Plex track with a cached copy and no sibling copy on another provider —
+    // its own only candidate, so cross-provider fallback can't save it.
+    final Track plex = _track('p', 'plex:101');
+
+    test('a single-source cached copy that won\'t open streams the same track',
+        () async {
+      // The primary resolver reports a cache hit (a file://), but the engine
+      // can't open that file — corrupt, or reclaimed after the existence check.
+      final player = _FakePlayer(failUrls: <String>{'file:///cache/p.flac'});
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _cache('/cache/p.flac'),
+        },
+      );
+      // The streaming fallback resolves the *same* track to its live stream.
+      final streamResolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _stream('https://plex/stream/101'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        streamResolver: streamResolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[plex]);
+
+      final PlaybackState s = controller.state;
+      expect(s.currentTrack?.uri, 'plex:101');
+      expect(s.source, PlaybackSource.streamingDirect);
+      expect(s.status, isNot(PlaybackStatus.error));
+      // It really tried the cache file first, then the stream — each once.
+      expect(player.setUrlCalls,
+          <String>['file:///cache/p.flac', 'https://plex/stream/101']);
+    });
+
+    test('a cached copy that won\'t open and a dead stream errors, no loop',
+        () async {
+      final player = _FakePlayer(failUrls: <String>{
+        'file:///cache/p.flac',
+        'https://plex/stream/101',
+      });
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _cache('/cache/p.flac'),
+        },
+      );
+      final streamResolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _stream('https://plex/stream/101'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        streamResolver: streamResolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[plex]);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      // Cache, then stream — each tried exactly once.
+      expect(player.setUrlCalls,
+          <String>['file:///cache/p.flac', 'https://plex/stream/101']);
+    });
+
+    test('a cache hit that opens never consults the streaming fallback',
+        () async {
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _cache('/cache/p.flac'),
+        },
+      );
+      final streamResolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _stream('https://plex/stream/101'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        streamResolver: streamResolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[plex]);
+
+      expect(controller.state.source, PlaybackSource.offlineCache);
+      // The healthy cache copy played; the stream was never resolved or opened.
+      expect(streamResolver.calls, isEmpty);
+      expect(player.setUrlCalls, <String>['file:///cache/p.flac']);
+    });
+
+    test('without a streaming fallback, a failed cache load behaves as before',
+        () async {
+      // The additive guarantee: with no fallback resolver wired (the default and
+      // in tests), a single-source cache failure still surfaces an error exactly
+      // as it did before — so nothing regresses.
+      final player = _FakePlayer(failUrls: <String>{'file:///cache/p.flac'});
+      final resolver = _FakeResolver(
+        resolved: <String, ResolvedPlayable>{
+          'plex:101': _cache('/cache/p.flac'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[plex]);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(player.setUrlCalls, <String>['file:///cache/p.flac']);
     });
   });
 

--- a/test/core/services/offline_first_playable_uri_resolver_test.dart
+++ b/test/core/services/offline_first_playable_uri_resolver_test.dart
@@ -72,8 +72,8 @@ void main() {
       expect(fallback.resolved, isNull);
     });
 
-    test('notifies onCacheHit with the track id on a cache hit', () async {
-      final hits = <String>[];
+    test('notifies onCacheHit with the track on a cache hit', () async {
+      final hits = <Track>[];
       final resolver = OfflineFirstPlayableUriResolver(
         locator: _FakeLocator('/offline_audio/t1.mp3'),
         fallback: _RecordingResolver(Uri.parse('https://stream/t1')),
@@ -82,11 +82,11 @@ void main() {
 
       await resolver.resolve(_track);
 
-      expect(hits, <String>['t1']);
+      expect(hits.map((Track t) => t.id), <String>['t1']);
     });
 
     test('does not notify onCacheHit on a cache miss', () async {
-      final hits = <String>[];
+      final hits = <Track>[];
       final resolver = OfflineFirstPlayableUriResolver(
         locator: _FakeLocator(null),
         fallback: _RecordingResolver(Uri.parse('https://stream/t1')),

--- a/test/core/services/offline_first_playable_uri_resolver_test.dart
+++ b/test/core/services/offline_first_playable_uri_resolver_test.dart
@@ -134,6 +134,41 @@ void main() {
       );
     });
 
+    test('prefers a cached Plex file, reporting the offline-cache source',
+        () async {
+      // Provider-agnostic: a plex: track resolves to its cached file exactly
+      // like a Jellyfin one — cached playback source selection.
+      const plex = Track(id: '101', title: 'Nightcall', uri: 'plex:101');
+      final fallback = _RecordingResolver(Uri.parse('https://plex/stream/101'));
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator('/offline_audio/101.flac'),
+        fallback: fallback,
+      );
+
+      final resolved = await resolver.resolve(plex);
+
+      expect(resolved.uri.toFilePath(), '/offline_audio/101.flac');
+      expect(resolved.source, PlaybackSource.offlineCache);
+      expect(fallback.resolved, isNull);
+    });
+
+    test('streams a Plex track when its cache file is gone (locator null)',
+        () async {
+      // The locator returns null once the bytes are gone, so playback falls
+      // back to the Plex stream rather than opening a missing file.
+      const plex = Track(id: '101', title: 'Nightcall', uri: 'plex:101');
+      final fallback = _RecordingResolver(Uri.parse('https://plex/stream/101'));
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator(null),
+        fallback: fallback,
+      );
+
+      final resolved = await resolver.resolve(plex);
+
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(fallback.resolved, plex);
+    });
+
     test('handles delegates to the fallback', () {
       final resolver = OfflineFirstPlayableUriResolver(
         locator: _FakeLocator(null),

--- a/test/core/services/routing_remote_track_downloader_test.dart
+++ b/test/core/services/routing_remote_track_downloader_test.dart
@@ -30,14 +30,17 @@ class _FakeDownloader implements RemoteTrackDownloader {
 void main() {
   late _FakeDownloader jellyfin;
   late _FakeDownloader subsonic;
+  late _FakeDownloader plex;
   late RoutingRemoteTrackDownloader router;
 
   setUp(() {
     jellyfin = _FakeDownloader('jellyfin:', 'j');
     subsonic = _FakeDownloader('subsonic:', 's');
+    plex = _FakeDownloader('plex:', 'p');
     router = RoutingRemoteTrackDownloader(<RemoteTrackDownloader>[
       jellyfin,
       subsonic,
+      plex,
     ]);
   });
 
@@ -48,6 +51,10 @@ void main() {
     );
     expect(
       router.isRemote(const Track(id: 'j1', title: 'x', uri: 'jellyfin:j1')),
+      isTrue,
+    );
+    expect(
+      router.isRemote(const Track(id: 'p1', title: 'x', uri: 'plex:101')),
       isTrue,
     );
     expect(
@@ -63,6 +70,17 @@ void main() {
     expect(data.fileExtension, 's');
     expect(subsonic.fetched, <String>['s1']);
     expect(jellyfin.fetched, isEmpty);
+    expect(plex.fetched, isEmpty);
+  });
+
+  test('fetch routes a plex: track to the Plex member', () async {
+    final data =
+        await router.fetch(const Track(id: '101', title: 'x', uri: 'plex:101'));
+
+    expect(data.fileExtension, 'p');
+    expect(plex.fetched, <String>['101']);
+    expect(jellyfin.fetched, isEmpty);
+    expect(subsonic.fetched, isEmpty);
   });
 
   test('throws for a track no member can fetch', () {

--- a/test/core/sources/music_provider_test.dart
+++ b/test/core/sources/music_provider_test.dart
@@ -46,16 +46,20 @@ void main() {
       expect(caps.canListPlaylists, isFalse);
     });
 
-    test('plex: stream + lyrics in phase 1 (docs/plex.md capability matrix)',
+    test('plex: stream + lyrics + caching in phase 1 (docs/plex.md matrix)',
         () {
       final caps = MusicProviders.plex.capabilities;
       expect(caps.canStream, isTrue);
       // Lyrics are fetched on demand from the track's Plex lyric stream (synced
-      // `.lrc` or plain), so they read ✅ — the one capability beyond streaming.
+      // `.lrc` or plain), so they read ✅.
       expect(caps.canLyrics, isTrue);
+      // Offline caching fetches the original Part file into the shared cache,
+      // keyed by the stable plex:<ratingKey> identity and named only from the
+      // non-secret track id — so it caches ✅ and the copy can be removed ✅.
+      expect(caps.canCache, isTrue);
+      expect(caps.canRemoveOfflineCopy, isTrue);
       // Everything else is declared unsupported so its actions stay hidden/
       // disabled rather than failing — exactly how Subsonic deferred features.
-      expect(caps.canCache, isFalse);
       expect(caps.canFavoriteTracks, isFalse);
       expect(caps.canReadFavoriteState, isFalse);
       expect(caps.canSyncFavorites, isFalse);
@@ -66,8 +70,6 @@ void main() {
       expect(caps.canEditPlaylist, isFalse);
       expect(caps.canDeletePlaylist, isFalse);
       expect(caps.canSyncPlaylists, isFalse);
-      // No cache means no app-managed offline copy to remove.
-      expect(caps.canRemoveOfflineCopy, isFalse);
     });
 
     test('identity fields', () {
@@ -91,6 +93,8 @@ void main() {
       // providers do.
       expect(MusicProviders.local.capabilities.canRemoveOfflineCopy, isFalse);
       expect(MusicProviders.jellyfin.capabilities.canRemoveOfflineCopy, isTrue);
+      expect(MusicProviders.subsonic.capabilities.canRemoveOfflineCopy, isTrue);
+      expect(MusicProviders.plex.capabilities.canRemoveOfflineCopy, isTrue);
 
       // Destructive file/server deletes are not enabled in this release for any
       // provider, so those actions stay hidden everywhere. Plex is additionally

--- a/test/core/sources/plex/plex_endpoints_test.dart
+++ b/test/core/sources/plex/plex_endpoints_test.dart
@@ -214,6 +214,44 @@ void main() {
     });
   });
 
+  group('PlexEndpoints.downloadUrl (original file + token in the query)', () {
+    const String partKey = '/library/parts/12345/167/file.flac';
+
+    test('appends the server-absolute Part key to the base URL', () {
+      final Uri uri =
+          PlexEndpoints.downloadUrl(_base, partKey: partKey, token: _token);
+      expect(uri.path, '/library/parts/12345/167/file.flac');
+      expect(uri.host, 'plex.example.com');
+      expect(uri.port, 32400);
+    });
+
+    test('asks PMS for the original file with download=1', () {
+      final Uri uri =
+          PlexEndpoints.downloadUrl(_base, partKey: partKey, token: _token);
+      expect(uri.queryParameters[PlexEndpoints.downloadParam], '1');
+    });
+
+    test('weaves the token into the query — never the path', () {
+      final Uri uri =
+          PlexEndpoints.downloadUrl(_base, partKey: partKey, token: _token);
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+      expect(uri.path, isNot(contains(_token)));
+    });
+
+    test('merges download=1 and the token into a query the key already carried',
+        () {
+      final Uri uri = PlexEndpoints.downloadUrl(
+        _base,
+        partKey: '/library/parts/12345/167/file.flac?foo=bar',
+        token: _token,
+      );
+      expect(uri.path, '/library/parts/12345/167/file.flac');
+      expect(uri.queryParameters['foo'], 'bar');
+      expect(uri.queryParameters[PlexEndpoints.downloadParam], '1');
+      expect(uri.queryParameters[PlexEndpoints.tokenParam], _token);
+    });
+  });
+
   group('PlexEndpoints.coverArt (thumb path + token in the query)', () {
     const String thumb = '/library/metadata/123/thumb/1670000000';
 

--- a/test/core/sources/plex/plex_music_source_test.dart
+++ b/test/core/sources/plex/plex_music_source_test.dart
@@ -304,6 +304,77 @@ void main() {
     });
   });
 
+  group('resolveDownloadUri', () {
+    const Track track = Track(id: '301', title: 'Nightcall', uri: 'plex:301');
+
+    test(
+        'looks up the Part and mints the original-file (download=1) URL only '
+        'then', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(
+          ratingKey: '301',
+          type: 'track',
+          title: 'Nightcall',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[
+              PlexPart(key: '/library/parts/9001/1700000000/file.flac'),
+            ]),
+          ],
+        ),
+      };
+
+      final uri = await source().resolveDownloadUri(track);
+
+      // Same two-step lookup the play path uses, keyed by the opaque uri.
+      expect(client.requestedRatingKeys, <String>['301']);
+      // The download URL fetches the Part's original bytes (download=1), with
+      // the token woven into its query only now, at fetch time.
+      expect(uri, isNotNull);
+      expect(uri!.path, '/library/parts/9001/1700000000/file.flac');
+      expect(uri.queryParameters['download'], '1');
+      expect(uri.queryParameters['X-Plex-Token'], _token);
+      // The track itself still carries the opaque, token-free reference.
+      expect(track.uri, 'plex:301');
+    });
+
+    test('returns null when the item carries no playable part', () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(ratingKey: '301', type: 'track', title: 'x'),
+      };
+      expect(await source().resolveDownloadUri(track), isNull);
+    });
+
+    test('a vanished item surfaces as a typed, token-free PlexException', () {
+      expect(
+        () => source().resolveDownloadUri(track),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.notFound)
+            .having((e) => e.message, 'message', isNot(contains(_token)))
+            .having((e) => e.toString(), 'toString', isNot(contains(_token)))),
+      );
+    });
+
+    test('a Part key that is not server-absolute fails typed, never corrupt',
+        () async {
+      client.metadataByRatingKey = const <String, PlexMetadata>{
+        '301': PlexMetadata(
+          ratingKey: '301',
+          type: 'track',
+          title: 'x',
+          media: <PlexMedia>[
+            PlexMedia(parts: <PlexPart>[PlexPart(key: 'file.flac')]),
+          ],
+        ),
+      };
+      await expectLater(
+        source().resolveDownloadUri(track),
+        throwsA(isA<PlexException>()
+            .having((e) => e.kind, 'kind', PlexErrorKind.unsupportedResponse)
+            .having((e) => e.message, 'message', isNot(contains(_token)))),
+      );
+    });
+  });
+
   test('verifyReachable checks the server identity with the session', () async {
     await source().verifyReachable();
     expect(client.identityCount, 1);

--- a/test/core/sources/plex/plex_track_downloader_test.dart
+++ b/test/core/sources/plex/plex_track_downloader_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/remote_track_downloader.dart';
+import 'package:linthra/core/sources/plex/plex_download_source.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_track_downloader.dart';
+
+/// A configurable [PlexDownloadSource] that drives each download outcome without
+/// a real server: verification can throw, and the minted URL can be canned or
+/// absent.
+class _FakeDownloadSource implements PlexDownloadSource {
+  _FakeDownloadSource({this.verifyError, this.downloadUri});
+
+  final PlexException? verifyError;
+  final Uri? downloadUri;
+  int verifyCount = 0;
+
+  @override
+  Future<void> verifyReachable() async {
+    verifyCount++;
+    final PlexException? error = verifyError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<Uri?> resolveDownloadUri(Track track) async => downloadUri;
+}
+
+const _track = Track(id: '301', title: 'Nightcall', uri: 'plex:301');
+
+void main() {
+  group('PlexTrackDownloader', () {
+    test('isRemote is true only for Plex tracks', () {
+      final downloader = PlexTrackDownloader(() => null);
+
+      expect(downloader.isRemote(_track), isTrue);
+      expect(
+        downloader.isRemote(
+          const Track(id: '1', title: 'L', uri: '/music/x.mp3'),
+        ),
+        isFalse,
+      );
+      // A sibling remote provider's track is not Plex's to fetch.
+      expect(
+        downloader.isRemote(
+          const Track(id: 'j', title: 'J', uri: 'jellyfin:j'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('verifies the session, then fetches bytes from the minted URL',
+        () async {
+      final uri = Uri.parse(
+        'https://plex.example.com:32400/library/parts/9001/167/file.flac'
+        '?download=1&X-Plex-Token=secret-token',
+      );
+      final source = _FakeDownloadSource(downloadUri: uri);
+      Uri? requested;
+      final client = MockClient((request) async {
+        requested = request.url;
+        return http.Response.bytes(
+          <int>[10, 20, 30],
+          200,
+          headers: <String, String>{'content-type': 'audio/flac'},
+        );
+      });
+      final downloader = PlexTrackDownloader(() => source, httpClient: client);
+
+      final RemoteTrackData data = await downloader.fetch(_track);
+
+      expect(source.verifyCount, 1);
+      expect(requested, uri);
+      expect(data.bytes, <int>[10, 20, 30]);
+      expect(data.fileExtension, 'flac');
+    });
+
+    test('maps an mpeg content type to an mp3 extension', () async {
+      final source = _FakeDownloadSource(
+        downloadUri: Uri.parse('https://x/library/parts/1/f.mp3?download=1'),
+      );
+      final client = MockClient((request) async {
+        return http.Response.bytes(
+          <int>[1],
+          200,
+          headers: <String, String>{'content-type': 'audio/mpeg'},
+        );
+      });
+
+      final data = await PlexTrackDownloader(() => source, httpClient: client)
+          .fetch(_track);
+
+      expect(data.fileExtension, 'mp3');
+    });
+
+    test('throws when not signed in', () async {
+      final downloader = PlexTrackDownloader(() => null);
+
+      await expectLater(downloader.fetch(_track), throwsA(isA<Object>()));
+    });
+
+    test('surfaces a verification failure as a typed PlexException', () async {
+      final source = _FakeDownloadSource(
+        verifyError: PlexException.unauthorized(),
+      );
+
+      await expectLater(
+        PlexTrackDownloader(() => source).fetch(_track),
+        throwsA(isA<PlexException>()),
+      );
+    });
+
+    test('throws when no download URL can be built', () async {
+      final source = _FakeDownloadSource(downloadUri: null);
+
+      await expectLater(
+        PlexTrackDownloader(() => source).fetch(_track),
+        throwsA(isA<Object>()),
+      );
+    });
+
+    test('throws on a non-2xx response', () async {
+      final source = _FakeDownloadSource(
+        downloadUri: Uri.parse('https://x/library/parts/1/f?download=1'),
+      );
+      final client = MockClient((request) async => http.Response('no', 404));
+
+      await expectLater(
+        PlexTrackDownloader(() => source, httpClient: client).fetch(_track),
+        throwsA(isA<Object>()),
+      );
+    });
+
+    test('a transport failure is re-raised without leaking the tokenized URL',
+        () async {
+      final uri = Uri.parse(
+        'https://plex.example.com:32400/library/parts/9001/167/file.flac'
+        '?download=1&X-Plex-Token=SECRET-TOKEN',
+      );
+      final source = _FakeDownloadSource(downloadUri: uri);
+      final client = MockClient((request) async {
+        // A real ClientException can embed the full (tokenized) URL.
+        throw http.ClientException('Connection failed for $uri', uri);
+      });
+      final downloader = PlexTrackDownloader(() => source, httpClient: client);
+
+      try {
+        await downloader.fetch(_track);
+        fail('expected fetch to throw');
+      } catch (error) {
+        expect(error.toString(), isNot(contains('SECRET-TOKEN')));
+        expect(error.toString(), isNot(contains('X-Plex-Token')));
+      }
+    });
+  });
+}

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -36,7 +36,11 @@ class _FakeConnectivity implements ConnectivityService {
 /// hold downloads in flight and observe how many run at once ([maxActive]).
 /// [error] is mutable so a test can fail an attempt, then clear it and retry.
 class _FakeRemoteDownloader implements RemoteTrackDownloader {
-  _FakeRemoteDownloader({this.error, this.gate});
+  _FakeRemoteDownloader({
+    this.error,
+    this.gate,
+    this.schemes = const <String>['jellyfin:'],
+  });
 
   /// The canned bytes every successful fetch returns.
   static const List<int> bytes = <int>[1, 2, 3, 4];
@@ -47,13 +51,18 @@ class _FakeRemoteDownloader implements RemoteTrackDownloader {
   /// When set, [fetch] awaits this before completing.
   final Future<void>? gate;
 
+  /// The remote URI schemes this fake claims. Defaults to Jellyfin so existing
+  /// tests are unchanged; the Plex group overrides it (and the isolation test
+  /// claims both providers at once).
+  final List<String> schemes;
+
   int fetchCount = 0;
   int activeNow = 0;
   int maxActive = 0;
   final List<Track> fetched = <Track>[];
 
   @override
-  bool isRemote(Track track) => track.uri.startsWith('jellyfin:');
+  bool isRemote(Track track) => schemes.any(track.uri.startsWith);
 
   @override
   Future<RemoteTrackData> fetch(
@@ -1139,6 +1148,119 @@ void main() {
         // bytes were pulled exactly once (not just de-duplicated at commit).
         expect(downloader.fetchCount, 1);
       });
+    });
+  });
+
+  group('CacheDownloadRepository — Plex tracks (provider-aware caching)', () {
+    late InMemoryDownloadStore store;
+    late InMemoryOfflineFileStore files;
+    late InMemoryDownloadPreferences preferences;
+    late _FakeConnectivity connectivity;
+    late _FakeRemoteDownloader plexDownloader;
+
+    CacheDownloadRepository build({RemoteTrackDownloader? downloader}) =>
+        CacheDownloadRepository(
+          store: store,
+          files: files,
+          downloader: downloader ?? plexDownloader,
+          connectivity: connectivity,
+          preferences: preferences,
+        );
+
+    setUp(() {
+      store = InMemoryDownloadStore();
+      files = InMemoryOfflineFileStore();
+      preferences = InMemoryDownloadPreferences();
+      connectivity = _FakeConnectivity(NetworkStatus.wifi);
+      plexDownloader = _FakeRemoteDownloader(schemes: const <String>['plex:']);
+    });
+
+    Track plex(String id) => Track(id: id, title: id, uri: 'plex:$id');
+
+    test('downloads a Plex track and tags the persisted entry as plex',
+        () async {
+      final repo = build();
+
+      final outcome = await repo.requestDownload(plex('101'));
+
+      expect(outcome, DownloadRequestOutcome.started);
+      expect(await repo.statusFor('101'), DownloadStatus.downloaded);
+      // Bytes are stored under the non-secret ratingKey id; no token anywhere.
+      expect(files.bytesFor('101.mp3'), _FakeRemoteDownloader.bytes);
+      final saved = await store.loadDownloads();
+      expect(saved, hasLength(1));
+      expect(saved.single.trackId, '101');
+      expect(saved.single.fileName, '101.mp3');
+      // The source type marks it as Plex — how the cache stays provider-aware.
+      expect(saved.single.sourceType, 'plex');
+    });
+
+    test('a cached Plex track survives a restart (metadata persists)',
+        () async {
+      await build().requestDownload(plex('101'));
+
+      // A fresh repository over the same durable stores re-loads the download.
+      final reborn = build();
+      expect(await reborn.statusFor('101'), DownloadStatus.downloaded);
+      final snapshot = await reborn.cacheSnapshot();
+      expect(
+        snapshot.entries.map((CachedTrack e) => e.trackId),
+        contains('101'),
+      );
+    });
+
+    test('removing a cached Plex track deletes its file and clears status',
+        () async {
+      final repo = build();
+      await repo.requestDownload(plex('101'));
+      expect(files.bytesFor('101.mp3'), isNotNull);
+
+      await repo.removeDownload('101');
+
+      expect(await repo.statusFor('101'), DownloadStatus.notDownloaded);
+      expect(files.bytesFor('101.mp3'), isNull);
+      expect(await store.loadDownloads(), isEmpty);
+    });
+
+    test('a failed Plex fetch marks it failed and caches nothing', () async {
+      // A cache failure must not break streaming: the track is simply marked
+      // failed (offering retry) and no file/metadata is written, so playback
+      // streams normally when the track is reached.
+      plexDownloader.error = StateError('Plex download failed.');
+      final repo = build();
+
+      await repo.requestDownload(plex('101'));
+
+      expect(await repo.statusFor('101'), DownloadStatus.failed);
+      expect(files.bytesFor('101.mp3'), isNull);
+      expect(await store.loadDownloads(), isEmpty);
+    });
+
+    test('Plex and Jellyfin copies cache independently — no cross-conflict',
+        () async {
+      // One downloader that claims both providers, so both tracks cache through
+      // the same repository. They must persist as two distinct, correctly-tagged
+      // entries — a Plex cache can never shadow or evict a Jellyfin one.
+      final both = _FakeRemoteDownloader(
+        schemes: const <String>['plex:', 'jellyfin:'],
+      );
+      final repo = build(downloader: both);
+
+      await repo.requestDownload(plex('101'));
+      await repo.requestDownload(_jellyfin('j1'));
+
+      expect(await repo.statusFor('101'), DownloadStatus.downloaded);
+      expect(await repo.statusFor('j1'), DownloadStatus.downloaded);
+      final saved = await store.loadDownloads();
+      final byId = <String, CachedTrack>{
+        for (final CachedTrack c in saved) c.trackId: c,
+      };
+      expect(byId['101']!.sourceType, 'plex');
+      expect(byId['j1']!.sourceType, 'jellyfin');
+      expect(byId['101']!.fileName, '101.mp3');
+      expect(byId['j1']!.fileName, 'j1.mp3');
+      expect(files.bytesFor('101.mp3'), isNotNull);
+      expect(files.bytesFor('j1.mp3'), isNotNull);
     });
   });
 }

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -14,6 +14,7 @@ import 'package:linthra/data/repositories/cache_download_repository.dart';
 import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
 import 'package:linthra/data/repositories/in_memory_download_store.dart';
 import 'package:linthra/data/repositories/in_memory_offline_file_store.dart';
+import 'package:linthra/data/repositories/store_cached_track_locator.dart';
 
 /// A connectivity stand-in whose reported status the test can flip at will.
 class _FakeConnectivity implements ConnectivityService {
@@ -175,7 +176,7 @@ void main() {
       await repository.requestDownload(_jellyfin('j1'));
       final String fileName = (await store.loadDownloads()).single.fileName!;
 
-      await repository.removeDownload('j1');
+      await repository.removeDownload(_jellyfin('j1'));
 
       expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
       expect(await repository.downloadedTrackIds(), isEmpty);
@@ -234,7 +235,7 @@ void main() {
         final repository = build();
         await repository.requestDownload(_local('a'));
 
-        await repository.removeDownload('a');
+        await repository.removeDownload(_local('a'));
 
         expect(await repository.statusFor('a'), DownloadStatus.notDownloaded);
         expect(await store.loadDownloads(), isEmpty);
@@ -534,7 +535,7 @@ void main() {
         expect(await repository.statusFor('j2'), DownloadStatus.downloaded);
         expect(await repository.statusFor('j3'), DownloadStatus.downloaded);
         // The evicted file's bytes are gone from disk.
-        expect(files.bytesFor('j1.mp3'), isNull);
+        expect(files.bytesFor('jellyfin_j1.mp3'), isNull);
       });
 
       test(
@@ -563,7 +564,7 @@ void main() {
         await repository.requestDownload(_jellyfin('j1'));
         await repository.requestDownload(_jellyfin('j2'));
         // j1 was just played, so j2 is now the least-recently-used.
-        await repository.notePlayed('j1');
+        await repository.notePlayed(_jellyfin('j1'));
         await repository.requestDownload(_jellyfin('j3'));
 
         expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
@@ -575,7 +576,7 @@ void main() {
         final repository = buildLimited(maxBytes: 10, now: incrementingClock());
 
         await repository.requestDownload(_jellyfin('j1')); // oldest
-        await repository.setPinned('j1', true);
+        await repository.setPinned(_jellyfin('j1'), true);
         await repository.requestDownload(_jellyfin('j2'));
         await repository.requestDownload(_jellyfin('j3')); // forces eviction
 
@@ -606,7 +607,7 @@ void main() {
         // Room for one 4-byte track only.
         final repository = buildLimited(maxBytes: 4);
         await repository.requestDownload(_jellyfin('j1'));
-        await repository.setPinned('j1', true);
+        await repository.setPinned(_jellyfin('j1'), true);
 
         Object? caught;
         try {
@@ -627,7 +628,7 @@ void main() {
         expect(await repository.statusFor('j1'), DownloadStatus.downloaded);
         expect((await store.loadDownloads()).map((c) => c.trackId),
             <String>['j1']);
-        expect(files.bytesFor('j1.mp3'), isNotNull);
+        expect(files.bytesFor('jellyfin_j1.mp3'), isNotNull);
       });
     });
 
@@ -923,7 +924,7 @@ void main() {
           preferences: preferences,
         );
         await repository.requestDownload(_jellyfin('keep'));
-        await repository.setPinned('keep', true);
+        await repository.setPinned(_jellyfin('keep'), true);
         final int fetchesBefore = downloader.fetchCount;
 
         // Best-effort: never throws, caches nothing, and skips the fetch
@@ -1000,30 +1001,30 @@ void main() {
         );
         await repository.requestDownload(_jellyfin('j1'));
         await repository.requestDownload(_jellyfin('j2'));
-        await repository.setPinned('j1', true);
+        await repository.setPinned(_jellyfin('j1'), true);
 
         await repository.clearAll();
 
         // Pinned items included: clear-all is the nuclear option.
         expect(await repository.downloadedTrackIds(), isEmpty);
         expect(await store.loadDownloads(), isEmpty);
-        expect(spy.bytesFor('j1.mp3'), isNull);
-        expect(spy.bytesFor('j2.mp3'), isNull);
+        expect(spy.bytesFor('jellyfin_j1.mp3'), isNull);
+        expect(spy.bytesFor('jellyfin_j2.mp3'), isNull);
       });
 
       test('clear unpinned preserves pinned tracks', () async {
         final repository = build();
         await repository.requestDownload(_jellyfin('keep'));
         await repository.requestDownload(_jellyfin('drop'));
-        await repository.setPinned('keep', true);
+        await repository.setPinned(_jellyfin('keep'), true);
 
         await repository.clearUnpinned();
 
         expect(await repository.statusFor('keep'), DownloadStatus.downloaded);
         expect(
             await repository.statusFor('drop'), DownloadStatus.notDownloaded);
-        expect(files.bytesFor('keep.mp3'), isNotNull);
-        expect(files.bytesFor('drop.mp3'), isNull);
+        expect(files.bytesFor('jellyfin_keep.mp3'), isNotNull);
+        expect(files.bytesFor('jellyfin_drop.mp3'), isNull);
       });
 
       test('clearing never deletes a local source file', () async {
@@ -1042,7 +1043,7 @@ void main() {
 
         // Only the app-managed remote file was ever handed to delete(); the
         // local track has no managed file, so its source is never touched.
-        expect(spy.deleted, <String>['remote.mp3']);
+        expect(spy.deleted, <String>['jellyfin_remote.mp3']);
         expect(spy.deleted.any((f) => f.contains('song')), isFalse);
       });
 
@@ -1079,7 +1080,7 @@ void main() {
             repository.requestDownload(_jellyfin('j1'));
         // Wait until the bytes are actually being fetched, then cancel.
         await _pumpUntil(() => downloader.fetchCount >= 1);
-        await repository.removeDownload('j1');
+        await repository.removeDownload(_jellyfin('j1'));
         // The in-flight fetch now completes — it must commit nothing.
         gate.complete();
         await request;
@@ -1091,7 +1092,7 @@ void main() {
         expect(snapshot.usedBytes, 0);
         expect(snapshot.entries, isEmpty);
         // The cancelled fetch wrote no managed file at all.
-        expect(spy.bytesFor('j1.mp3'), isNull);
+        expect(spy.bytesFor('jellyfin_j1.mp3'), isNull);
       });
 
       test('a cancelled download can be requested again and downloads',
@@ -1102,7 +1103,7 @@ void main() {
 
         final Future<void> first = repository.requestDownload(_jellyfin('j1'));
         await _pumpUntil(() => downloader.fetchCount >= 1);
-        await repository.removeDownload('j1');
+        await repository.removeDownload(_jellyfin('j1'));
         gate.complete();
         await first;
         expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
@@ -1186,11 +1187,11 @@ void main() {
       expect(outcome, DownloadRequestOutcome.started);
       expect(await repo.statusFor('101'), DownloadStatus.downloaded);
       // Bytes are stored under the non-secret ratingKey id; no token anywhere.
-      expect(files.bytesFor('101.mp3'), _FakeRemoteDownloader.bytes);
+      expect(files.bytesFor('plex_101.mp3'), _FakeRemoteDownloader.bytes);
       final saved = await store.loadDownloads();
       expect(saved, hasLength(1));
       expect(saved.single.trackId, '101');
-      expect(saved.single.fileName, '101.mp3');
+      expect(saved.single.fileName, 'plex_101.mp3');
       // The source type marks it as Plex — how the cache stays provider-aware.
       expect(saved.single.sourceType, 'plex');
     });
@@ -1213,12 +1214,12 @@ void main() {
         () async {
       final repo = build();
       await repo.requestDownload(plex('101'));
-      expect(files.bytesFor('101.mp3'), isNotNull);
+      expect(files.bytesFor('plex_101.mp3'), isNotNull);
 
-      await repo.removeDownload('101');
+      await repo.removeDownload(plex('101'));
 
       expect(await repo.statusFor('101'), DownloadStatus.notDownloaded);
-      expect(files.bytesFor('101.mp3'), isNull);
+      expect(files.bytesFor('plex_101.mp3'), isNull);
       expect(await store.loadDownloads(), isEmpty);
     });
 
@@ -1232,7 +1233,7 @@ void main() {
       await repo.requestDownload(plex('101'));
 
       expect(await repo.statusFor('101'), DownloadStatus.failed);
-      expect(files.bytesFor('101.mp3'), isNull);
+      expect(files.bytesFor('plex_101.mp3'), isNull);
       expect(await store.loadDownloads(), isEmpty);
     });
 
@@ -1257,10 +1258,68 @@ void main() {
       };
       expect(byId['101']!.sourceType, 'plex');
       expect(byId['j1']!.sourceType, 'jellyfin');
-      expect(byId['101']!.fileName, '101.mp3');
-      expect(byId['j1']!.fileName, 'j1.mp3');
-      expect(files.bytesFor('101.mp3'), isNotNull);
-      expect(files.bytesFor('j1.mp3'), isNotNull);
+      expect(byId['101']!.fileName, 'plex_101.mp3');
+      expect(byId['j1']!.fileName, 'jellyfin_j1.mp3');
+      expect(files.bytesFor('plex_101.mp3'), isNotNull);
+      expect(files.bytesFor('jellyfin_j1.mp3'), isNotNull);
+    });
+
+    test('Plex and Jellyfin tracks that share a catalog id never conflict',
+        () async {
+      // The hard case the catalog's id-uniqueness can't guarantee on its own:
+      // two providers expose the SAME local id ("101"). The cache must keep them
+      // fully independent — distinct files, distinct metadata, correct
+      // resolution, and isolated removal — so a Plex cache can never shadow,
+      // overwrite, or remove another provider's copy.
+      final both = _FakeRemoteDownloader(
+        schemes: const <String>['plex:', 'jellyfin:'],
+      );
+      final repo = build(downloader: both);
+      final locator = StoreCachedTrackLocator(store, files);
+
+      const Track plex101 = Track(id: '101', title: 'P', uri: 'plex:101');
+      const Track jelly101 = Track(id: '101', title: 'J', uri: 'jellyfin:101');
+
+      await repo.requestDownload(plex101);
+      // The shared id must NOT make the second look already-downloaded.
+      await repo.requestDownload(jelly101);
+
+      // Both were actually fetched and cached.
+      expect(
+        both.fetched.map((Track t) => t.uri).toSet(),
+        <String>{'plex:101', 'jellyfin:101'},
+      );
+
+      // Two distinct persisted entries, each tagged by its provider, written to
+      // distinct, provider-namespaced files (the token-free id is namespaced).
+      final saved = await store.loadDownloads();
+      expect(saved, hasLength(2));
+      final plexEntry =
+          saved.firstWhere((CachedTrack c) => c.sourceType == 'plex');
+      final jellyEntry =
+          saved.firstWhere((CachedTrack c) => c.sourceType == 'jellyfin');
+      expect(plexEntry.trackId, '101');
+      expect(jellyEntry.trackId, '101');
+      expect(plexEntry.fileName, 'plex_101.mp3');
+      expect(jellyEntry.fileName, 'jellyfin_101.mp3');
+      expect(plexEntry.fileName, isNot(jellyEntry.fileName));
+
+      // Each resolves to its OWN cached file — no shadowing across providers.
+      final plexPath = await locator.cachedFilePath(plex101);
+      final jellyPath = await locator.cachedFilePath(jelly101);
+      expect(plexPath, isNotNull);
+      expect(jellyPath, isNotNull);
+      expect(plexPath, isNot(jellyPath));
+
+      // Removing the Plex copy leaves the Jellyfin copy fully intact.
+      await repo.removeDownload(plex101);
+      expect(await locator.cachedFilePath(plex101), isNull);
+      expect(await locator.cachedFilePath(jelly101), jellyPath);
+      final remaining = await store.loadDownloads();
+      expect(remaining, hasLength(1));
+      expect(remaining.single.sourceType, 'jellyfin');
+      expect(files.bytesFor('plex_101.mp3'), isNull);
+      expect(files.bytesFor('jellyfin_101.mp3'), isNotNull);
     });
   });
 }

--- a/test/data/repositories/file_system_offline_file_store_test.dart
+++ b/test/data/repositories/file_system_offline_file_store_test.dart
@@ -88,5 +88,43 @@ void main() {
     test('delete is a no-op for a missing file', () async {
       await store.delete('missing.mp3');
     });
+
+    test('an atomic write leaves only the final file — no .part temp behind',
+        () async {
+      final String fileName =
+          await store.write('t1', const <int>[1, 2, 3], extension: 'mp3');
+
+      // The temp sibling was renamed into place, not left alongside the result.
+      final List<FileSystemEntity> entries = tempDir.listSync();
+      expect(entries, hasLength(1));
+      expect(entries.single.path, endsWith(fileName));
+      expect(entries.single.path, isNot(endsWith('.part')));
+    });
+
+    test('refuses to cache an empty download, publishing no file', () async {
+      await expectLater(
+        store.write('t1', const <int>[], extension: 'mp3'),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      // Nothing was published and no temp was left behind, so the locator finds
+      // no file and playback falls back to streaming.
+      expect(await store.pathFor('t1.mp3'), isNull);
+      expect(tempDir.listSync(), isEmpty);
+    });
+
+    test('a re-download atomically replaces the prior cached bytes', () async {
+      final String fileName =
+          await store.write('t1', const <int>[1, 1, 1], extension: 'mp3');
+      final String again =
+          await store.write('t1', const <int>[2, 2], extension: 'mp3');
+
+      expect(again, fileName);
+      final String? path = await store.pathFor(fileName);
+      expect(await File(path!).readAsBytes(), <int>[2, 2]);
+      // Still exactly one file: the temp was renamed over the old copy, not
+      // accumulated alongside it.
+      expect(tempDir.listSync(), hasLength(1));
+    });
   });
 }

--- a/test/data/repositories/store_cached_track_locator_test.dart
+++ b/test/data/repositories/store_cached_track_locator_test.dart
@@ -6,6 +6,7 @@ import 'package:linthra/data/repositories/in_memory_offline_file_store.dart';
 import 'package:linthra/data/repositories/store_cached_track_locator.dart';
 
 Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+Track _plex(String id) => Track(id: id, title: id, uri: 'plex:$id');
 
 void main() {
   group('StoreCachedTrackLocator', () {
@@ -54,6 +55,33 @@ void main() {
       ]);
 
       expect(await build().cachedFilePath(_jellyfin('j1')), isNull);
+    });
+
+    test('returns the cached path for a downloaded Plex track', () async {
+      // A Plex track is keyed by its stable ratingKey id like any other
+      // provider — the locator is provider-agnostic.
+      final String fileName =
+          await files.write('101', const <int>[4, 5, 6], extension: 'flac');
+      await store.saveDownloads(<CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName, sourceType: 'plex'),
+      ]);
+
+      final String? path = await build().cachedFilePath(_plex('101'));
+
+      expect(path, '/offline_audio/101.flac');
+    });
+
+    test('returns null when a Plex cache file is missing, so playback streams',
+        () async {
+      // The metadata exists but the bytes are gone (reclaimed/removed): the
+      // locator reports no path, so the offline-first resolver falls back to
+      // streaming rather than opening a missing file.
+      await store.saveDownloads(<CachedTrack>[
+        const CachedTrack(
+            trackId: '101', fileName: '101.flac', sourceType: 'plex'),
+      ]);
+
+      expect(await build().cachedFilePath(_plex('101')), isNull);
     });
   });
 }

--- a/test/data/repositories/store_cached_track_locator_test.dart
+++ b/test/data/repositories/store_cached_track_locator_test.dart
@@ -83,5 +83,39 @@ void main() {
 
       expect(await build().cachedFilePath(_plex('101')), isNull);
     });
+
+    test('a Plex and a Jellyfin entry sharing an id resolve to their own files',
+        () async {
+      // Provider-aware matching: identical trackIds from different sources each
+      // resolve to their own file, never the other's.
+      await files.write('plex_101', const <int>[1], extension: 'mp3');
+      await files.write('jellyfin_101', const <int>[2], extension: 'mp3');
+      await store.saveDownloads(<CachedTrack>[
+        const CachedTrack(
+            trackId: '101', fileName: 'plex_101.mp3', sourceType: 'plex'),
+        const CachedTrack(
+            trackId: '101',
+            fileName: 'jellyfin_101.mp3',
+            sourceType: 'jellyfin'),
+      ]);
+
+      expect(await build().cachedFilePath(_plex('101')),
+          '/offline_audio/plex_101.mp3');
+      expect(await build().cachedFilePath(_jellyfin('101')),
+          '/offline_audio/jellyfin_101.mp3');
+    });
+
+    test('a legacy entry without a recorded source still resolves by id',
+        () async {
+      // Back-compat: a cached file written before source tagging carries no
+      // sourceType, so it falls back to an id-only match and keeps working.
+      await files.write('legacy', const <int>[9], extension: 'mp3');
+      await store.saveDownloads(<CachedTrack>[
+        const CachedTrack(trackId: 'legacy', fileName: 'legacy.mp3'),
+      ]);
+
+      expect(await build().cachedFilePath(_jellyfin('legacy')),
+          '/offline_audio/legacy.mp3');
+    });
   });
 }

--- a/test/features/settings/cache/cache_settings_section_test.dart
+++ b/test/features/settings/cache/cache_settings_section_test.dart
@@ -90,7 +90,10 @@ void main() {
       await repo.requestDownload(
         const Track(id: 'j2', title: 'Cached', uri: 'jellyfin:j2'),
       );
-      await container.read(offlineCacheManagerProvider).setPinned('j1', true);
+      await container.read(offlineCacheManagerProvider).setPinned(
+            const Track(id: 'j1', title: 'Kept', uri: 'jellyfin:j1'),
+            true,
+          );
       await tester.pumpAndSettle();
       expect(find.textContaining('8 B of'), findsOneWidget);
 

--- a/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
@@ -108,7 +108,7 @@ class _SpyDownloadRepository implements DownloadRepository {
       DownloadStatus.notDownloaded;
 
   @override
-  Future<void> removeDownload(String trackId) async {}
+  Future<void> removeDownload(Track track) async {}
 
   @override
   Future<List<String>> downloadedTrackIds() async => const <String>[];

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -184,10 +184,11 @@ void main() {
       (tester) async {
     await _pump(tester);
 
-    // Phase 1 implements streaming + lyrics → both chips appear; the rest don't.
+    // Phase 1 implements streaming + lyrics + offline caching → those chips
+    // appear; cast and favorites stay declared unsupported, so they don't.
     expect(find.text('Streaming'), findsOneWidget);
     expect(find.text('Lyrics'), findsOneWidget);
-    expect(find.text('Offline'), findsNothing);
+    expect(find.text('Offline'), findsOneWidget);
     expect(find.text('Cast'), findsNothing);
     expect(find.text('Favorites'), findsNothing);
   });


### PR DESCRIPTION
## v0.1.6 — Plex offline music caching (feature) + F-Droid reproducible build

This prepares **v0.1.6** as a real feature release. It contains two logically
separate pieces of work, kept in separate commits:

1. **F-Droid reproducible per-ABI build fix** (PR #233) — already at the base of
   this branch (`42da6ce`), unchanged.
2. **A finished Plex music cache feature** — new in this PR.

> ⚠️ **Draft / do not tag yet.** Per the request, v0.1.6 must not be tagged or
> released until reviewed and explicitly approved. The version is bumped in
> `pubspec.yaml`, but **no tag is cut**.

---

### 1. F-Droid reproducible build fix (PR #233)

No changes — this PR builds on top of `42da6ce ci(release): build per-ABI APKs
in isolation (matching F-Droid) for reproducibility (#233)`. The per-ABI
`--split-per-abi --target-platform` workflow and its versionCode verification in
`.github/workflows/android-release-build.yml` are intact, and the F-Droid
guardrail tests still pass.

### 2. Plex music cache feature

**The insight:** Linthra already has a provider-agnostic offline download cache
(`CacheDownloadRepository`, `StoreCachedTrackLocator`, `FileSystemOfflineFileStore`,
`OfflineFirstPlayableUriResolver`) that Jellyfin and Subsonic plug into via a
per-provider `RemoteTrackDownloader`. Plex shipped stream-only and was the one
provider **missing that downloader seam**. So this fills the seam and turns the
capability on, rather than building new cache machinery.

#### How cached Plex playback works

1. **Download** — a `plex:<ratingKey>` track is fetched via `PlexTrackDownloader`,
   which resolves a fresh `download=1` Part URL **only at fetch time** and streams
   the bytes. The `X-Plex-Token` rides in the URL query and **never leaves the
   fetch** — not stored, not returned, not in any thrown error.
2. **Store** — bytes are written **atomically** (temp → validate → rename) to a
   file named only from the **non-secret, provider-namespaced** id
   (`plex_<ratingKey>`). Persisted metadata records `sourceType: 'plex'`. No token
   ever reaches disk.
3. **Play** — `OfflineFirstPlayableUriResolver` prefers the cached `file://` copy
   automatically (`PlaybackSource.offlineCache`); a miss falls through to streaming.

Identity is the **stable `plex:<ratingKey>` / ratingKey**, never a temporary
stream URL.

#### Provider-aware isolation (cannot conflict with other providers)

The offline cache is now keyed by **`(sourceType, trackId)`**, not `track.id`
alone — so two providers that expose the *same* local id (a Plex ratingKey `101`
and a Jellyfin/Subsonic id `101`) are fully isolated: distinct cache files,
distinct persisted entries, correct per-track resolution, and isolated removal.
The locator matches on the source scheme with an id-only fallback, so **existing
Jellyfin/Subsonic/local cached tracks keep working** (file names are persisted).
The UI's id-keyed status/progress providers are unchanged (served via an id
projection). (Added in commit `fix(cache): make the offline cache provider-aware`.)

#### Fallback behavior (cache failures never break playback)

- **Missing file** (reclaimed/removed) → the locator returns `null` and prunes
  stale metadata, so playback streams.
- **Corrupt / unreadable file** → the controller re-resolves the **same** track
  past the cache and streams it once before giving up — even a single-source Plex
  track with no sibling copy recovers.
- **Download failure** → best-effort: marked *failed* (offers retry), nothing
  cached, streaming unaffected.

#### Visible cache state

Plex tracks now surface the existing download affordances (**not cached →
downloading → cached → failed**, plus remove), because `canCache` /
`canRemoveOfflineCopy` are on; the Plex Settings card shows the **Offline** chip.

#### What is deliberately unchanged

- **PR #232 artwork**: untouched. Artwork cache key stays based only on the
  artwork reference; fetch-layer resizing stays in `PlexArtwork.resolve`;
  full-size in-app rendering is unchanged. This PR is audio caching only.
- Android Auto, background playback, Cast, queue behavior, and existing provider
  fallback: the controller change is **opt-in (null default)**, so all existing
  playback paths are unchanged.

### Test coverage

Full suite: **2462 passing**, `flutter analyze` clean, `dart format` clean.

- **Downloader** — `plex_track_downloader_test` (routing, fetch, content-type→ext,
  not-signed-in, verify failure, non-2xx, **token never leaks** on transport error).
- **Endpoints / source** — `downloadUrl` and `resolveDownloadUri` (download=1 +
  token-in-query, typed token-free failures).
- **Cached lookup + source selection** — `store_cached_track_locator_test`,
  `offline_first_playable_uri_resolver_test` (Plex prefers cache, streams on miss).
- **Provider isolation (same id)** — a Plex `101` + Jellyfin `101` pair both
  download, persist as two distinct entries, resolve to their own files, and
  remove in isolation — at the repository **and** locator level; a legacy untagged
  entry still resolves by id.
- **Fallback** — missing file → null → stream; corrupt cache → stream (no loop).
- **Persistence / removal / failed-fetch** — `cache_download_repository_test`.
- **Atomic writes** — `file_system_offline_file_store_test` (no `.part` left,
  empty refused, atomic replace).
- **Capabilities / UI** — `music_provider_test`, `plex_settings_section_test`.
- **Regression** — existing Jellyfin/Subsonic/local playback and PR #232 artwork
  tests pass unchanged.

### Release readiness

- `pubspec.yaml` → `0.1.6+106999` (canonical encoding of `0.1.6`); `AppInfo`
  mirrors it; `changelogs/106999.txt` added; What's-new refreshed. Version code
  moves cleanly `0.1.5 (105999)` → `0.1.6 (106999)`.
- F-Droid `metadata/*.yml` intentionally **not** touched (its `Builds` block /
  `CurrentVersion` are updated post-tag with the release commit SHA, as in
  0.1.1–0.1.5); the guardrail only requires `pubspec ≥ recorded release`.
- No unfinished Plex cache TODOs or dead code.

### Known limitations

- A corrupt-but-present cache file is streamed *around* rather than auto-deleted
  (atomic writes make this case unlikely). Cast for Plex stays off in phase 1
  (unchanged).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGSPt4DUqSX1G1k5d5MBPL