### PR TITLE
v0.1.6 prep: configurable pre-cache count, drop Plex "Experimental", provider-agnostic smart cleanup

### DIFF
--- a/docs/offline-cache.md
+++ b/docs/offline-cache.md
@@ -77,12 +77,12 @@ wanted.
 
 ## Smart pre-cache follows the same policy
 
-Smart pre-cache warms a small, fixed number of **upcoming** queued tracks (1, 3,
-5, or 10 — configurable in **Settings → Smart pre-cache**) so the next songs
-start instantly and play offline. It is deliberately modest and **never
-downloads the whole library**. It follows the **same mobile-data policy** as
-manual downloads: on Wi-Fi always, on mobile data only when you've allowed it,
-and never offline. Pre-cache is best-effort — when the connection isn't allowed
+Smart pre-cache warms a small number of **upcoming** queued tracks (1, 3, 5, 10,
+20, or 50 — or a custom value up to 200 — configurable in **Settings → Smart
+pre-cache**, default 3) so the next songs start instantly and play offline. It
+is deliberately modest and **never downloads the whole library**. It follows the
+**same mobile-data policy** as manual downloads: on Wi-Fi always, on mobile data
+only when you've allowed it, and never offline. Pre-cache is best-effort — when the connection isn't allowed
 it simply skips (it doesn't queue), and pre-cached tracks are the first to be
 evicted under the cache limit.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -34,10 +34,9 @@ so no secret reaches the persisted catalog.
 | Local music           | `local`    |   ✅   |  —    | ✅ local  | ✅ local  |   ✅   |  —   |
 | Jellyfin              | `jellyfin` |   ✅   |  ✅   | ✅ synced | ✅ synced |   ✅   |  ✅  |
 | Navidrome / Subsonic  | `subsonic` |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  ✅  |
-| Plex                  | `plex`     |   🚧   |  🔜   |    🔜     |    🔜     |   ✅   |  🔜  |
+| Plex                  | `plex`     |   ✅   |  ✅   |    🔜     |    🔜     |   ✅   |  🔜  |
 
-✅ implemented · 🚧 in development (Plex is connectable in Settings, marked
-**Experimental**) · 🔜 planned follow-up · — not applicable. "local"
+✅ implemented · 🔜 planned follow-up · — not applicable. "local"
 favourites/playlists stay on-device; "synced" ones mirror with the server
 (server is the source of truth on refresh).
 
@@ -187,17 +186,17 @@ actions stay hidden/disabled rather than failing:
 - **In-app browse/search by artist/album** — the synced catalog lists tracks;
   richer browsing is shared work across all providers.
 
-## Plex (in development, experimental)
+## Plex
 
-A **read-only** [Plex Media Server](https://www.plex.tv/) provider is being
-built in small PRs behind the same `MusicSource` seam — see [plex.md](plex.md)
-for the full design and issue #178 for the plan. **Connecting is now possible
-in Settings** (the card is clearly badged *Experimental*): the user pastes a
-server URL + Plex token, Linthra verifies them against `/identity`, persists
-the session encrypted at rest, and — unlike Jellyfin/Subsonic, which sync the
-whole server — asks the user to **pick which music libraries** to include
-(the selection is saved with the session and scopes every fetch; connected
-with nothing selected simply means an empty library).
+A **read-only** [Plex Media Server](https://www.plex.tv/) provider built behind
+the same `MusicSource` seam — see [plex.md](plex.md) for the full design and
+issue #178 for the history. **Connect from Settings** with your Plex account
+(the in-app *Connect with Plex* sign-in) or, under *Manual setup (advanced)*, a
+server URL + Plex token. Linthra verifies the server, persists the session
+encrypted at rest, and — unlike Jellyfin/Subsonic, which sync the whole
+server — asks the user to **pick which music libraries** to include (the
+selection is saved with the session and scopes every fetch; connected with
+nothing selected simply means an empty library).
 
 **Syncing follows the selection.** Choosing a library kicks a background
 catalog sync automatically (rapid checkbox changes coalesce into one re-run),
@@ -207,19 +206,19 @@ the Plex library, a sync **replaces** the catalog's Plex slice even when the
 result is empty — deselecting a library really removes its tracks. A library
 deleted on the server is pruned from the selection on the next refresh.
 **Disconnecting** removes the Plex session *and* the synced Plex rows (without
-a session — and with no offline cache in phase 1 — they could never play
-again); reconnecting to the **same** server keeps the library selection, while
-a different server starts clean.
+a session, streaming can't resolve a play URL again); reconnecting to the
+**same** server keeps the library selection, while a different server starts
+clean.
 
-Underneath, the full plumbing is wired: the stream-only capability set,
-recognition of `plex:<ratingKey>` track URIs in the playback router (two-step
-play resolution, minting the tokenized stream URL only at play time), and
-render-time resolution of credential-free `plex-thumb:` cover references.
-Phase 1 is stream-only (direct play); offline cache, favorites, playlists,
-lyrics, cast, and the plex.tv PIN sign-in are declared unsupported /
-follow-ups — and Plex follows the same token-safety rules as every other
-provider (token encrypted at rest, never logged, never shown again after
-saving, never woven into a persisted URI or cache filename).
+Underneath, the full plumbing is wired: recognition of `plex:<ratingKey>` track
+URIs in the playback router (two-step play resolution, minting the tokenized
+stream URL only at play time), and render-time resolution of credential-free
+`plex-thumb:` cover references. **Streaming, lyrics, and offline caching are
+supported**, alongside the plex.tv *Connect with Plex* sign-in; **favorites,
+playlists, and cast stay unsupported** — declared off so their actions stay
+hidden rather than offered and failing. Plex follows the same token-safety
+rules as every other provider (token encrypted at rest, never logged, never
+shown again after saving, never woven into a persisted URI or cache filename).
 
 Linthra also reports a playback **timeline**, so it appears as an active player
 in the server's Now Playing dashboard. That report is one-way, though, so the

--- a/lib/core/repositories/download_preferences.dart
+++ b/lib/core/repositories/download_preferences.dart
@@ -1,19 +1,39 @@
 import '../models/cache_size.dart';
 
-/// The number-of-upcoming-tracks choices offered for smart pre-cache, shown in
-/// Settings. Small on purpose: enough for seamless playback without hoarding
-/// the cache or risking a "download the whole library" feel.
-const List<int> kPrecacheCountOptions = <int>[1, 3, 5, 10];
+/// The named number-of-upcoming-tracks presets offered for smart pre-cache,
+/// shown in Settings (smallest first). The small values keep playback seamless
+/// without hoarding the cache; the larger ones let users warm a longer run of
+/// the queue. Anything in between — up to [kMaxPrecacheCount] — is reachable as
+/// a custom value, so this list is just the convenient one-tap choices.
+const List<int> kPrecacheCountOptions = <int>[1, 3, 5, 10, 20, 50];
 
 /// How many upcoming tracks smart pre-cache warms when the user hasn't chosen.
-/// Modest by design — a few tracks ahead, never the whole queue.
+/// Modest by design — a few tracks ahead, never the whole queue. Kept at 3 so
+/// upgrading users see no change in behaviour.
 const int kDefaultPrecacheCount = 3;
 
-/// Clamps an arbitrary value to one of [kPrecacheCountOptions], so a corrupt or
-/// out-of-range stored value can never widen pre-caching beyond the offered
-/// choices. Returns [kDefaultPrecacheCount] when [value] isn't an offered count.
-int sanitizePrecacheCount(int value) =>
-    kPrecacheCountOptions.contains(value) ? value : kDefaultPrecacheCount;
+/// Safe bounds for the pre-cache count (inclusive). The minimum keeps the
+/// feature meaningful (at least the next track); the maximum stops a custom
+/// value from queuing a flood of downloads — pre-cache warms the next few
+/// songs, never the whole library.
+const int kMinPrecacheCount = 1;
+const int kMaxPrecacheCount = 200;
+
+/// Clamps an arbitrary pre-cache count into the supported range so a corrupt,
+/// out-of-range, or hand-typed value can never disable pre-cache or queue
+/// thousands of downloads. A value below [kMinPrecacheCount] is treated as junk
+/// and restored to [kDefaultPrecacheCount]; a value above [kMaxPrecacheCount] is
+/// capped at the maximum; any value already in range — a [kPrecacheCountOptions]
+/// preset or a custom number — is kept as-is.
+int sanitizePrecacheCount(int value) {
+  if (value < kMinPrecacheCount) return kDefaultPrecacheCount;
+  if (value > kMaxPrecacheCount) return kMaxPrecacheCount;
+  return value;
+}
+
+/// Whether [count] is one of the named [kPrecacheCountOptions], so the picker
+/// can show it as a selected preset rather than a custom value.
+bool isPrecacheCountPreset(int count) => kPrecacheCountOptions.contains(count);
 
 /// The user's download/offline preferences.
 ///
@@ -49,7 +69,9 @@ abstract interface class DownloadPreferences {
   Future<void> setPreloadEnabled(bool value);
 
   /// How many upcoming tracks smart pre-cache warms ahead of the current one.
-  /// One of [kPrecacheCountOptions]; defaults to [kDefaultPrecacheCount].
+  /// A [kPrecacheCountOptions] preset or any custom value within
+  /// [kMinPrecacheCount]–[kMaxPrecacheCount]; defaults to
+  /// [kDefaultPrecacheCount].
   Future<int> precacheCount();
 
   Future<void> setPrecacheCount(int value);

--- a/lib/core/repositories/download_store.dart
+++ b/lib/core/repositories/download_store.dart
@@ -59,6 +59,24 @@ class CachedTrack {
   /// on-device track that is merely marked available offline).
   bool get isManaged => fileName != null && fileName!.isNotEmpty;
 
+  /// The provider-aware cache identity — the source scheme plus the catalog id —
+  /// so two providers that expose the same catalog id (a Plex ratingKey `101`
+  /// and a Subsonic id `101`) never share a cache slot, file, or eviction
+  /// decision. The shared cache and [CacheEvictionPolicy] key on this, never on
+  /// the bare [trackId].
+  String get cacheKey => cacheKeyFor(sourceType, trackId);
+
+  /// Builds a [cacheKey] from a raw `(sourceType, trackId)` pair, so a live
+  /// track (which has no [CachedTrack] yet) keys exactly the way a persisted
+  /// entry keys itself. The NUL separator can't occur in a scheme or an id, so
+  /// the pair is unambiguous.
+  static String cacheKeyFor(String? sourceType, String trackId) =>
+      '${sourceType ?? ''}${String.fromCharCode(_keySeparator)}$trackId';
+
+  /// Separator between scheme and id in a [cacheKey]: NUL, which can't occur in
+  /// a URI scheme or a catalog id, so the `(scheme, id)` pair is unambiguous.
+  static const int _keySeparator = 0;
+
   CachedTrack copyWith({
     String? fileName,
     String? sourceType,

--- a/lib/core/services/cache_eviction_policy.dart
+++ b/lib/core/services/cache_eviction_policy.dart
@@ -23,6 +23,12 @@ class EvictionPlan {
 /// returns a plan — which keeps the rules exhaustively testable and the
 /// repository free of branching policy logic.
 ///
+/// Provider-agnostic but provider-aware: it ranks and evicts cached tracks from
+/// every remote source together (Jellyfin, Subsonic/Navidrome, Plex) by the same
+/// rules, and identifies the incoming and protected tracks by the provider-aware
+/// [CachedTrack.cacheKey] (`scheme + id`), so two providers that expose the same
+/// catalog id never shadow, protect, or evict each other.
+///
 /// Rules, in order:
 ///  - On-device tracks and zero-byte records don't count toward the budget and
 ///    are never evicted (they hold no app-managed bytes).
@@ -42,20 +48,22 @@ class CacheEvictionPolicy {
     required Iterable<CachedTrack> cached,
     required int incomingBytes,
     required int maxBytes,
-    String? protectTrackId,
-    String? incomingTrackId,
+    String? protectKey,
+    String? incomingKey,
   }) {
     int used = 0;
     final List<CachedTrack> candidates = <CachedTrack>[];
     for (final CachedTrack track in cached) {
       // A re-download replaces its own old copy, so it doesn't count as
-      // already-used space and can't evict itself.
-      if (track.trackId == incomingTrackId) continue;
+      // already-used space and can't evict itself. Keyed by the provider-aware
+      // [CachedTrack.cacheKey] (scheme + id), so a same-id track from a
+      // *different* provider is never mistaken for the incoming track's copy.
+      if (track.cacheKey == incomingKey) continue;
       used += track.sizeBytes;
       final bool evictable = track.isManaged &&
           track.sizeBytes > 0 &&
           !track.pinned &&
-          track.trackId != protectTrackId;
+          track.cacheKey != protectKey;
       if (evictable) candidates.add(track);
     }
 

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -259,10 +259,10 @@ abstract final class MusicProviders {
     ),
   );
 
-  /// Plex (phase 1, experimental — see docs/plex.md and issue #178).
+  /// Plex (see docs/plex.md and issue #178).
   /// `plex:<ratingKey>` URIs are recognized end to end, and the Settings card
-  /// (badged Experimental) lets the user connect with a manual server URL +
-  /// token and pick which music libraries to include.
+  /// lets the user connect with their Plex account (or a manual server URL +
+  /// token) and pick which music libraries to include.
   ///
   /// Stream, lyrics, and offline caching are implemented; favorites, playlists,
   /// and cast stay declared unsupported so their actions stay hidden/disabled
@@ -272,7 +272,7 @@ abstract final class MusicProviders {
   /// identity and named only from the non-secret track id, so the token never
   /// reaches a cache file (docs/plex.md → Token safety rules). Lyrics are
   /// fetched on demand from the track's Plex lyric stream (synced `.lrc` or
-  /// plain). Cast stays off in phase 1 to keep the credential-in-URL surface
+  /// plain). Cast stays off for now to keep the credential-in-URL surface
   /// small (a Plex stream URL carries the token as a query param).
   static const MusicProvider plex = MusicProvider(
     sourceId: 'plex',
@@ -294,7 +294,7 @@ abstract final class MusicProviders {
       canRemoveFromLibrary: true,
       canRemoveOfflineCopy: true,
       canDeleteLocalFile: false,
-      // Phase 1 is read-only: Linthra never writes to a Plex server.
+      // Read-only: Linthra never writes to a Plex server.
       canDeleteRemoteItem: false,
       canListPlaylists: false,
       canCreatePlaylist: false,

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -67,7 +67,7 @@ class CacheDownloadRepository
     required DownloadPreferences preferences,
     CacheEvictionPolicy policy = const CacheEvictionPolicy(),
     DownloadScheduler? scheduler,
-    String? Function()? currentlyPlayingTrackId,
+    Track? Function()? currentlyPlayingTrack,
     DateTime Function()? now,
   })  : _store = store,
         _files = files,
@@ -76,7 +76,7 @@ class CacheDownloadRepository
         _preferences = preferences,
         _policy = policy,
         _scheduler = scheduler ?? DownloadScheduler(),
-        _currentlyPlayingTrackId = currentlyPlayingTrackId,
+        _currentlyPlayingTrack = currentlyPlayingTrack,
         _now = now ?? DateTime.now;
 
   final DownloadStore _store;
@@ -89,10 +89,12 @@ class CacheDownloadRepository
   /// Bounds how many remote downloads fetch their bytes at the same time.
   final DownloadScheduler _scheduler;
 
-  /// Supplies the id of the track currently playing (or `null`), so it is never
-  /// evicted out from under the user. Read lazily so the repository doesn't
-  /// depend on the playback layer at construction.
-  final String? Function()? _currentlyPlayingTrackId;
+  /// Supplies the track currently playing (or `null`), so it is never evicted
+  /// out from under the user. A whole [Track] (not just an id) so its
+  /// provider-aware [CachedTrack.cacheKey] protects exactly that provider's
+  /// copy — a same-id track from another provider stays evictable. Read lazily
+  /// so the repository doesn't depend on the playback layer at construction.
+  final Track? Function()? _currentlyPlayingTrack;
 
   final DateTime Function() _now;
 
@@ -341,8 +343,8 @@ class CacheDownloadRepository
       cached: _downloads.values,
       incomingBytes: incoming,
       maxBytes: maxBytes,
-      protectTrackId: _currentlyPlayingTrackId?.call(),
-      incomingTrackId: track.id,
+      protectKey: _protectKey(),
+      incomingKey: key,
     );
 
     if (!plan.fits) {
@@ -530,7 +532,7 @@ class CacheDownloadRepository
   /// could ever take, so the caller skips the fetch entirely. A cheap, in-memory
   /// scan — the exact fit is decided by [CacheEvictionPolicy] at commit time.
   bool _hasRoomForPrecache(int maxBytes) {
-    final String? protectId = _currentlyPlayingTrackId?.call();
+    final String? protectKey = _protectKey();
     int used = 0;
     bool hasEvictable = false;
     for (final CachedTrack c in _downloads.values) {
@@ -538,11 +540,19 @@ class CacheDownloadRepository
       if (c.isManaged &&
           c.sizeBytes > 0 &&
           !c.pinned &&
-          c.trackId != protectId) {
+          c.cacheKey != protectKey) {
         hasEvictable = true;
       }
     }
     return used < maxBytes || hasEvictable;
+  }
+
+  /// The provider-aware cache key of the currently playing track (or `null`),
+  /// for the eviction policy to protect exactly that provider's copy. Built from
+  /// the live [Track] so a same-id track from another provider isn't shielded.
+  String? _protectKey() {
+    final Track? playing = _currentlyPlayingTrack?.call();
+    return playing == null ? null : _keyForTrack(playing);
   }
 
   /// The connectivity gate as a simple yes/no, for the best-effort pre-cache
@@ -674,25 +684,25 @@ class CacheDownloadRepository
   static String _keyForTrack(Track track) =>
       _cacheKey(_sourceTypeOf(track), track.id);
 
-  /// The same identity for a persisted [entry], built from the same
-  /// `(sourceType, trackId)` it was written with — so a reloaded entry maps back
-  /// to exactly the key its live track produces, keeping cache state stable
-  /// across restarts (and back-compatible: existing entries already carry both).
-  static String _keyForCached(CachedTrack entry) =>
-      _cacheKey(entry.sourceType, entry.trackId);
+  /// The same identity for a persisted [entry] — its provider-aware
+  /// [CachedTrack.cacheKey], built from the same `(sourceType, trackId)` it was
+  /// written with, so a reloaded entry maps back to exactly the key its live
+  /// track produces and cache state stays stable across restarts.
+  static String _keyForCached(CachedTrack entry) => entry.cacheKey;
 
-  /// Composes a credential-free cache key from a source scheme and catalog id.
-  /// The NUL separator can't occur in a scheme or an id, so the pair is
-  /// unambiguous and [_trackIdOfKey] can recover the id for the id-keyed
+  /// Composes a credential-free cache key from a source scheme and catalog id —
+  /// delegating to the one shared definition [CachedTrack.cacheKeyFor], so the
+  /// repository, the metadata records, and the eviction policy can never drift
+  /// to different key formats. [_trackIdOfKey] recovers the id for the id-keyed
   /// snapshots the UI reads.
   static String _cacheKey(String? sourceType, String trackId) =>
-      '${sourceType ?? ''}\u0000$trackId';
+      CachedTrack.cacheKeyFor(sourceType, trackId);
 
   /// The catalog id embedded in a [key] from [_cacheKey] — used to project the
   /// internal, provider-aware maps back onto the id-keyed snapshots the UI and
   /// the cross-provider sync layers consume.
   static String _trackIdOfKey(String key) =>
-      key.substring(key.indexOf('\u0000') + 1);
+      key.substring(key.indexOf(String.fromCharCode(0)) + 1);
 
   /// A provider-namespaced base name for [track]'s cache file, so two providers
   /// with the same id write to distinct files (`plex_101`, `jellyfin_101`). The

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -56,13 +56,15 @@ final connectivityServiceProvider = Provider<ConnectivityService>((ref) {
   return const OptimisticConnectivityService();
 });
 
-/// Supplies the id of the currently playing track so the cache policy never
-/// evicts it. The data layer defaults to "nothing playing" (keeping it free of
+/// Supplies the currently playing track so the cache policy never evicts it. A
+/// whole [Track] (not just an id) so the policy protects exactly that provider's
+/// copy by its provider-aware key — a same-id track from another provider stays
+/// evictable. The data layer defaults to "nothing playing" (keeping it free of
 /// any playback dependency); the app overrides this to read the live
-/// [PlaybackController] (see `currentlyPlayingTrackIdOverride`). The closure is
+/// [PlaybackController] (see `currentlyPlayingTrackOverride`). The closure is
 /// read lazily at eviction time, so wiring it never rebuilds the repository.
-final currentlyPlayingTrackIdProvider =
-    Provider<String? Function()?>((ref) => null);
+final currentlyPlayingTrackProvider =
+    Provider<Track? Function()?>((ref) => null);
 
 /// The single [CacheDownloadRepository] the app drives offline downloads
 /// through. It composes the seams above and centralizes the user-initiated,
@@ -76,7 +78,7 @@ final _cacheDownloadRepositoryProvider =
     downloader: ref.watch(remoteTrackDownloaderProvider),
     connectivity: ref.watch(connectivityServiceProvider),
     preferences: ref.watch(downloadPreferencesProvider),
-    currentlyPlayingTrackId: ref.watch(currentlyPlayingTrackIdProvider),
+    currentlyPlayingTrack: ref.watch(currentlyPlayingTrackProvider),
   );
   ref.onDispose(repository.dispose);
   return repository;

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -210,10 +210,10 @@ final smartPrecacheEnabledProvider =
   SmartPrecacheEnabledController.new,
 );
 
-/// Owns the "Upcoming tracks to pre-cache" count: loads the persisted value and
-/// writes changes back through [DownloadPreferences], sanitized to one of
-/// [kPrecacheCountOptions] so it can never widen pre-caching beyond the offered
-/// choices.
+/// Owns the "Songs to pre-cache" count: loads the persisted value and writes
+/// changes back through [DownloadPreferences], clamped to the supported range
+/// ([kMinPrecacheCount]–[kMaxPrecacheCount]) so a corrupt or hand-typed value
+/// can never disable pre-cache or queue a flood of downloads.
 class PrecacheCountController extends AsyncNotifier<int> {
   @override
   Future<int> build() {

--- a/lib/features/player/now_playing.dart
+++ b/lib/features/player/now_playing.dart
@@ -63,5 +63,5 @@ class NowPlaying {
 /// watch it without pulling in `just_audio`/cast (and tests render rows without a
 /// perpetually-animating indicator or a real audio plugin). Production wires it
 /// to the live `PlaybackState` via `nowPlayingOverride` in `main.dart`, mirroring
-/// `currentlyPlayingTrackIdProvider`/`currentlyPlayingTrackIdOverride`.
+/// `currentlyPlayingTrackProvider`/`currentlyPlayingTrackOverride`.
 final nowPlayingProvider = Provider<NowPlaying>((ref) => const NowPlaying());

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -337,13 +337,15 @@ final remoteControlActivatorProvider = Provider<RemoteControlActivator>((ref) {
 });
 
 /// Production binding: lets the cache eviction policy see the currently playing
-/// track so it's never deleted to make room. The closure reads the controller's
-/// latest state lazily at eviction time, so applying this override doesn't tie
-/// the download repository to the controller's lifecycle. Applied in `main`;
-/// tests keep the data-layer default (nothing playing).
-final currentlyPlayingTrackIdOverride =
-    currentlyPlayingTrackIdProvider.overrideWith(
-  (ref) => () => ref.read(playbackControllerProvider).state.currentTrack?.id,
+/// track so it's never deleted to make room. Passes the whole [Track] so the
+/// policy protects exactly that provider's copy by its provider-aware key. The
+/// closure reads the controller's latest state lazily at eviction time, so
+/// applying this override doesn't tie the download repository to the
+/// controller's lifecycle. Applied in `main`; tests keep the data-layer default
+/// (nothing playing).
+final currentlyPlayingTrackOverride =
+    currentlyPlayingTrackProvider.overrideWith(
+  (ref) => () => ref.read(playbackControllerProvider).state.currentTrack,
 );
 
 /// Production binding: drives the now-playing indicator on every track row from

--- a/lib/features/settings/hub/connections_settings_screen.dart
+++ b/lib/features/settings/hub/connections_settings_screen.dart
@@ -22,8 +22,8 @@ class ConnectionsSettingsScreen extends StatelessWidget {
         SizedBox(height: AppSpacing.md),
         SubsonicProviderCard(),
         SizedBox(height: AppSpacing.md),
-        // Plex is phase 1 (stream-only) and clearly badged Experimental until
-        // the remaining capabilities ship.
+        // Plex supports streaming, lyrics, and offline caching; advanced
+        // features (cast, favorites, playlists) are not offered until they ship.
         PlexProviderCard(),
         SizedBox(height: AppSpacing.md),
         // Local music is a connection here, deliberately kept away from the

--- a/lib/features/settings/plex/plex_settings_section.dart
+++ b/lib/features/settings/plex/plex_settings_section.dart
@@ -9,7 +9,7 @@ import 'plex_settings_state.dart';
 import 'plex_sync_controller.dart';
 import 'plex_sync_state.dart';
 
-/// The Plex connection card on the Settings screen (experimental).
+/// The Plex connection card on the Settings screen.
 ///
 /// The primary path is **Connect with Plex**: a plex.tv sign-in in the
 /// browser, a server picker when the account has several servers, then the
@@ -171,8 +171,6 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
                 const SizedBox(width: AppSpacing.sm),
                 Text(state.isConnected ? state.displayName : 'Plex',
                     style: theme.textTheme.titleMedium),
-                const SizedBox(width: AppSpacing.sm),
-                const _ExperimentalBadge(),
               ],
             ),
             const SizedBox(height: AppSpacing.xs),
@@ -405,32 +403,6 @@ class _PlexSettingsSectionState extends ConsumerState<PlexSettingsSection> {
           ],
         ),
       ],
-    );
-  }
-}
-
-/// Marks the whole card as a work-in-progress, so nobody mistakes Plex for a
-/// finished provider while caching/favorites/lyrics/cast are still follow-ups
-/// (docs/plex.md → Out of scope).
-class _ExperimentalBadge extends StatelessWidget {
-  const _ExperimentalBadge();
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    return Container(
-      padding:
-          const EdgeInsets.symmetric(horizontal: AppSpacing.sm, vertical: 2),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(AppRadii.sm),
-      ),
-      child: Text(
-        'Experimental',
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: theme.colorScheme.onSecondaryContainer,
-        ),
-      ),
     );
   }
 }

--- a/lib/features/settings/precache/precache_settings_section.dart
+++ b/lib/features/settings/precache/precache_settings_section.dart
@@ -75,11 +75,74 @@ class PrecacheSettingsSection extends ConsumerWidget {
                       .setEnabled(value),
             ),
             const SizedBox(height: AppSpacing.xs),
-            _UpcomingCountSelector(
+            _SongsToPrecacheTile(
               count: count,
               enabled: isOn,
-              onChanged: (int value) =>
-                  ref.read(precacheCountProvider.notifier).setCount(value),
+              onChange: () => _changeCount(context, ref, count),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _changeCount(
+    BuildContext context,
+    WidgetRef ref,
+    int current,
+  ) async {
+    final int? chosen = await showDialog<int>(
+      context: context,
+      builder: (_) => _PrecacheCountDialog(current: current),
+    );
+    if (chosen != null) {
+      await ref.read(precacheCountProvider.notifier).setCount(chosen);
+    }
+  }
+}
+
+/// The "Songs to pre-cache" row: shows the current count and a Change button
+/// that opens the picker. Greyed out (and inert) while smart pre-cache is off,
+/// so it reads as "this tunes the feature above".
+class _SongsToPrecacheTile extends StatelessWidget {
+  const _SongsToPrecacheTile({
+    required this.count,
+    required this.enabled,
+    required this.onChange,
+  });
+
+  final int count;
+  final bool enabled;
+  final VoidCallback onChange;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+
+    return Opacity(
+      opacity: enabled ? 1.0 : 0.5,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Songs to pre-cache', style: theme.textTheme.bodyLarge),
+                  const SizedBox(height: 2),
+                  Text(
+                    count == 1 ? '1 upcoming track' : '$count upcoming tracks',
+                    style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            OutlinedButton(
+              onPressed: enabled ? onChange : null,
+              child: const Text('Change'),
             ),
           ],
         ),
@@ -88,52 +151,107 @@ class PrecacheSettingsSection extends ConsumerWidget {
   }
 }
 
-/// The "how many upcoming tracks" picker: a compact segmented control over
-/// [kPrecacheCountOptions]. Greyed out (and inert) while smart pre-cache is off,
-/// so it reads as "this tunes the feature above".
-class _UpcomingCountSelector extends StatelessWidget {
-  const _UpcomingCountSelector({
-    required this.count,
-    required this.enabled,
-    required this.onChanged,
-  });
+/// The "Songs to pre-cache" picker: the named [kPrecacheCountOptions] presets
+/// plus a custom value, bounded to [kMinPrecacheCount]–[kMaxPrecacheCount] so a
+/// hand-typed number can never queue a flood of downloads. Mirrors the cache
+/// size "Change limit" dialog so the two settings feel the same.
+class _PrecacheCountDialog extends StatefulWidget {
+  const _PrecacheCountDialog({required this.current});
 
-  final int count;
-  final bool enabled;
-  final ValueChanged<int> onChanged;
+  final int current;
+
+  @override
+  State<_PrecacheCountDialog> createState() => _PrecacheCountDialogState();
+}
+
+class _PrecacheCountDialogState extends State<_PrecacheCountDialog> {
+  late bool _custom;
+  late int _selectedPreset;
+  late final TextEditingController _customController;
+
+  @override
+  void initState() {
+    super.initState();
+    _custom = !isPrecacheCountPreset(widget.current);
+    _selectedPreset = isPrecacheCountPreset(widget.current)
+        ? widget.current
+        : kDefaultPrecacheCount;
+    _customController = TextEditingController(text: '${widget.current}');
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    super.dispose();
+  }
+
+  /// The count the dialog would save, or null when the custom field is empty or
+  /// non-positive (so Save is disabled). An in-range custom number is kept; an
+  /// over-range one is capped at [kMaxPrecacheCount].
+  int? get _resolvedCount {
+    if (!_custom) return _selectedPreset;
+    final int? typed = int.tryParse(_customController.text.trim());
+    if (typed == null || typed <= 0) return null;
+    return sanitizePrecacheCount(typed);
+  }
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
-    final int selected = sanitizePrecacheCount(count);
-
-    return Opacity(
-      opacity: enabled ? 1.0 : 0.5,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            'Upcoming tracks to cache',
-            style: theme.textTheme.bodyMedium?.copyWith(color: muted),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: SegmentedButton<int>(
-              showSelectedIcon: false,
-              segments: <ButtonSegment<int>>[
-                for (final int option in kPrecacheCountOptions)
-                  ButtonSegment<int>(value: option, label: Text('$option')),
-              ],
-              selected: <int>{selected},
-              onSelectionChanged: enabled
-                  ? (Set<int> selection) => onChanged(selection.first)
-                  : null,
+    return AlertDialog(
+      title: const Text('Songs to pre-cache'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final int preset in kPrecacheCountOptions)
+              RadioListTile<int>(
+                contentPadding: EdgeInsets.zero,
+                title: Text('$preset'),
+                value: preset,
+                groupValue: _custom ? null : _selectedPreset,
+                onChanged: (value) => setState(() {
+                  _custom = false;
+                  if (value != null) _selectedPreset = value;
+                }),
+              ),
+            RadioListTile<bool>(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Custom'),
+              value: true,
+              groupValue: _custom,
+              onChanged: (_) => setState(() => _custom = true),
             ),
-          ),
-        ],
+            if (_custom)
+              Padding(
+                padding: const EdgeInsets.only(left: AppSpacing.md),
+                child: TextField(
+                  controller: _customController,
+                  autofocus: true,
+                  keyboardType: TextInputType.number,
+                  onChanged: (_) => setState(() {}),
+                  decoration: const InputDecoration(
+                    labelText: 'Songs',
+                    helperText:
+                        'Between $kMinPrecacheCount and $kMaxPrecacheCount',
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _resolvedCount == null
+              ? null
+              : () => Navigator.of(context).pop(_resolvedCount),
+          child: const Text('Save'),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/settings/source/provider_summary_cards.dart
+++ b/lib/features/settings/source/provider_summary_cards.dart
@@ -80,7 +80,8 @@ class ProviderSummaryCard extends StatelessWidget {
   /// Renders [detail] in the error colour (e.g. a sync that didn't finish).
   final bool detailIsError;
 
-  /// An optional pill beside the title (e.g. "Experimental").
+  /// An optional status pill beside the title (e.g. "Beta"). No provider sets
+  /// one right now; kept as a small, reusable affordance.
   final String? badgeLabel;
 
   /// The action buttons, laid out as equal-width columns. Manage is always
@@ -224,8 +225,7 @@ class _StatusLine extends StatelessWidget {
   }
 }
 
-/// A muted pill beside a card's title (e.g. "Experimental"), mirroring the
-/// badge the Plex section already uses.
+/// A muted pill beside a card's title (e.g. "Beta") for an optional status tag.
 class _Badge extends StatelessWidget {
   const _Badge({required this.label});
 
@@ -480,8 +480,9 @@ class SubsonicProviderCard extends ConsumerWidget {
   }
 }
 
-/// The Plex source as a compact card. Kept fully functional and badged
-/// "Experimental", matching the detailed section.
+/// The Plex source as a compact card, matching the detailed section. Plex is a
+/// supported provider (streaming, lyrics, and offline caching); the advanced
+/// features it doesn't support yet simply don't appear as actions.
 class PlexProviderCard extends ConsumerWidget {
   const PlexProviderCard({super.key});
 
@@ -519,7 +520,6 @@ class PlexProviderCard extends ConsumerWidget {
     return ProviderSummaryCard(
       icon: Icons.dns_outlined,
       title: 'Plex',
-      badgeLabel: 'Experimental',
       statusLabel: connected ? 'Connected' : 'Not connected',
       statusTone:
           connected ? ProviderStatusTone.positive : ProviderStatusTone.neutral,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,7 +80,7 @@ Future<void> main() async {
       // preferred source fails to resolve or start (the candidates come from the
       // unified library, in default-source-first order).
       playbackCandidateSourceOverride,
-      currentlyPlayingTrackIdOverride,
+      currentlyPlayingTrackOverride,
       // Drive the now-playing indicator on track rows from live playback (the
       // current logical track + play/pause), so every list surface marks the
       // playing song. Inert by default in tests.

--- a/test/core/services/cache_eviction_policy_test.dart
+++ b/test/core/services/cache_eviction_policy_test.dart
@@ -28,8 +28,7 @@ CachedTrack _managed(
 
 /// The provider-aware key the policy compares against, for a given `(source,
 /// id)` — mirrors [CachedTrack.cacheKey].
-String _key(String id, {String? source}) =>
-    CachedTrack.cacheKeyFor(source, id);
+String _key(String id, {String? source}) => CachedTrack.cacheKeyFor(source, id);
 
 void main() {
   const CacheEvictionPolicy policy = CacheEvictionPolicy();
@@ -211,7 +210,8 @@ void main() {
     });
 
     group('provider isolation (same id across providers)', () {
-      test('a re-download only skips its own provider, not a same-id other', () {
+      test('a re-download only skips its own provider, not a same-id other',
+          () {
         // Plex 101 is being re-downloaded; a Subsonic 101 must NOT be mistaken
         // for its old copy — it still counts toward usage and stays evictable.
         final plan = policy.plan(

--- a/test/core/services/cache_eviction_policy_test.dart
+++ b/test/core/services/cache_eviction_policy_test.dart
@@ -3,8 +3,11 @@ import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/cache_eviction_policy.dart';
 
 /// A managed cache entry (has a file + size), the only kind eviction considers.
+/// [source] is the provider scheme (`plex`/`jellyfin`/`subsonic`); when omitted
+/// the entry has no source, exercising the legacy/source-less path.
 CachedTrack _managed(
   String id, {
+  String? source,
   int size = 100,
   DateTime? accessed,
   DateTime? cached,
@@ -13,7 +16,8 @@ CachedTrack _managed(
 }) {
   return CachedTrack(
     trackId: id,
-    fileName: '$id.mp3',
+    sourceType: source,
+    fileName: '${source ?? 'x'}_$id.mp3',
     sizeBytes: size,
     lastAccessedAt: accessed,
     cachedAt: cached,
@@ -21,6 +25,11 @@ CachedTrack _managed(
     preloaded: preloaded,
   );
 }
+
+/// The provider-aware key the policy compares against, for a given `(source,
+/// id)` — mirrors [CachedTrack.cacheKey].
+String _key(String id, {String? source}) =>
+    CachedTrack.cacheKeyFor(source, id);
 
 void main() {
   const CacheEvictionPolicy policy = CacheEvictionPolicy();
@@ -102,7 +111,7 @@ void main() {
         ],
         incomingBytes: 100,
         maxBytes: 250,
-        protectTrackId: 'playing',
+        protectKey: _key('playing'),
       );
 
       expect(plan.fits, isTrue);
@@ -117,7 +126,7 @@ void main() {
         ],
         incomingBytes: 100,
         maxBytes: 250, // used 200 + 100 = 300 > 250, nothing safe to drop
-        protectTrackId: 'playing',
+        protectKey: _key('playing'),
       );
 
       expect(plan.fits, isFalse);
@@ -193,12 +202,76 @@ void main() {
         ],
         incomingBytes: 100,
         maxBytes: 200,
-        incomingTrackId: 'a', // 'a' is being re-downloaded
+        incomingKey: _key('a'), // 'a' is being re-downloaded
       );
 
       // 'a' doesn't count as existing use, so b(100) + a(100) = 200 fits.
       expect(plan.fits, isTrue);
       expect(plan.evict, isEmpty);
+    });
+
+    group('provider isolation (same id across providers)', () {
+      test('a re-download only skips its own provider, not a same-id other', () {
+        // Plex 101 is being re-downloaded; a Subsonic 101 must NOT be mistaken
+        // for its old copy — it still counts toward usage and stays evictable.
+        final plan = policy.plan(
+          cached: <CachedTrack>[
+            _managed('101',
+                source: 'plex', size: 100, accessed: DateTime(2024, 1, 1)),
+            _managed('101',
+                source: 'subsonic', size: 100, accessed: DateTime(2024, 2, 1)),
+          ],
+          incomingBytes: 100,
+          // plex:101 replaces its own old copy (skipped); subsonic:101 (100)
+          // plus the incoming (100) exceed 150, so subsonic:101 must give way.
+          // Were it shadowed by the raw id, the policy would evict nothing.
+          maxBytes: 150,
+          incomingKey: _key('101', source: 'plex'),
+        );
+
+        expect(plan.fits, isTrue);
+        // The same-id Subsonic track is evicted (it was NOT shadowed away).
+        expect(plan.evict.length, 1);
+        expect(plan.evict.single.sourceType, 'subsonic');
+      });
+
+      test('protecting the playing track protects only its provider', () {
+        // Plex 101 is playing; a Jellyfin 101 with the same id is a different
+        // track and must remain evictable.
+        final plan = policy.plan(
+          cached: <CachedTrack>[
+            _managed('101',
+                source: 'plex', size: 100, accessed: DateTime(2024, 1, 1)),
+            _managed('101',
+                source: 'jellyfin', size: 100, accessed: DateTime(2024, 2, 1)),
+          ],
+          incomingBytes: 100,
+          maxBytes: 250, // must free one; the playing plex:101 is protected
+          protectKey: _key('101', source: 'plex'),
+        );
+
+        expect(plan.fits, isTrue);
+        expect(plan.evict.single.sourceType, 'jellyfin');
+      });
+    });
+
+    test('evicts least-recently-used across providers, oldest first', () {
+      // A mixed cache (Plex, Jellyfin, Subsonic) is ranked as one LRU list.
+      final plan = policy.plan(
+        cached: <CachedTrack>[
+          _managed('p', source: 'plex', size: 100, accessed: DateTime(2024, 3)),
+          _managed('j',
+              source: 'jellyfin', size: 100, accessed: DateTime(2024, 1)),
+          _managed('s',
+              source: 'subsonic', size: 100, accessed: DateTime(2024, 2)),
+        ],
+        incomingBytes: 100,
+        maxBytes: 300, // free exactly 1 of 3 → the least-recently-used 'j'
+      );
+
+      expect(plan.fits, isTrue);
+      expect(plan.evict.single.trackId, 'j');
+      expect(plan.evict.single.sourceType, 'jellyfin');
     });
   });
 }

--- a/test/core/services/smart_precache_service_test.dart
+++ b/test/core/services/smart_precache_service_test.dart
@@ -114,6 +114,24 @@ void main() {
       await service.dispose();
     });
 
+    test('honours a large configured count beyond the old 10 ceiling',
+        () async {
+      // The pre-cache loop reads the configured count — there is no hardcoded
+      // 10 — so a user choosing 20 warms 20 upcoming tracks, not 10.
+      preferences = InMemoryDownloadPreferences(precacheCount: 20);
+      final service = build();
+
+      final upNext = <Track>[for (int i = 0; i < 30; i++) _t('t$i')];
+      states.add(_playing(_t('cur'), upNext));
+      await _settle();
+
+      expect(
+        prefetcher.prefetched,
+        <String>[for (int i = 0; i < 20; i++) 't$i'],
+      );
+      await service.dispose();
+    });
+
     test('shuffle uses the shuffled upcoming order', () async {
       preferences = InMemoryDownloadPreferences(precacheCount: 3);
       final service = build();

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -1485,7 +1485,8 @@ void main() {
       expect((await repo.cacheSnapshot()).usedBytes, 4);
     });
 
-    test('pre-cache is skipped safely when cleanup cannot free enough', () async {
+    test('pre-cache is skipped safely when cleanup cannot free enough',
+        () async {
       // The cache is full of a pinned download (never evictable). A pre-cache
       // must skip rather than break — no fetch, no throw, nothing cached.
       final repo = buildLimited(maxBytes: 4, now: incrementingClock());
@@ -1497,7 +1498,8 @@ void main() {
       final saved = await store.loadDownloads();
       expect(saved, hasLength(1));
       expect(saved.single.trackId, 'pinned');
-      expect(downloader.fetched.any((Track t) => t.uri == 'plex:want'), isFalse);
+      expect(
+          downloader.fetched.any((Track t) => t.uri == 'plex:want'), isFalse);
       expect((await repo.cacheSnapshot()).usedBytes, 4);
     });
   });

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -117,6 +117,8 @@ class _SpyOfflineFileStore implements OfflineFileStore {
 
 Track _local(String id) => Track(id: id, title: id, uri: 'file:///$id.mp3');
 Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
+Track _plex(String id) => Track(id: id, title: id, uri: 'plex:$id');
+Track _subsonic(String id) => Track(id: id, title: id, uri: 'subsonic:$id');
 
 void main() {
   group('CacheDownloadRepository', () {
@@ -495,7 +497,7 @@ void main() {
 
       CacheDownloadRepository buildLimited({
         required int maxBytes,
-        String? Function()? currentlyPlaying,
+        Track? Function()? currentlyPlaying,
         DateTime Function()? now,
       }) {
         preferences = InMemoryDownloadPreferences(maxCacheBytes: maxBytes);
@@ -505,7 +507,7 @@ void main() {
           downloader: downloader,
           connectivity: connectivity,
           preferences: preferences,
-          currentlyPlayingTrackId: currentlyPlaying,
+          currentlyPlayingTrack: currentlyPlaying,
           now: now,
         );
       }
@@ -589,7 +591,7 @@ void main() {
       test('the currently playing track is never evicted', () async {
         final repository = buildLimited(
           maxBytes: 10,
-          currentlyPlaying: () => 'j1',
+          currentlyPlaying: () => _jellyfin('j1'),
           now: incrementingClock(),
         );
 
@@ -972,7 +974,7 @@ void main() {
           downloader: downloader,
           connectivity: connectivity,
           preferences: preferences,
-          currentlyPlayingTrackId: () => 'now',
+          currentlyPlayingTrack: () => _jellyfin('now'),
         );
         await repository.prefetch(_jellyfin('now'));
         expect((await store.loadDownloads()).single.trackId, 'now');
@@ -1320,6 +1322,183 @@ void main() {
       expect(remaining.single.sourceType, 'jellyfin');
       expect(files.bytesFor('plex_101.mp3'), isNull);
       expect(files.bytesFor('jellyfin_101.mp3'), isNotNull);
+    });
+  });
+
+  // Smart cleanup is one shared, provider-agnostic policy: every offline-capable
+  // remote provider (Plex, Jellyfin, Subsonic/Navidrome) caches through the same
+  // repository and is evicted by the same LRU rules — keyed by the provider-aware
+  // (sourceType, trackId) identity so same-id tracks never shadow or evict each
+  // other. These tests drive one repository whose downloader claims all three.
+  group('CacheDownloadRepository — provider-agnostic smart cleanup', () {
+    late InMemoryDownloadStore store;
+    late InMemoryOfflineFileStore files;
+    late InMemoryDownloadPreferences preferences;
+    late _FakeConnectivity connectivity;
+    late _FakeRemoteDownloader downloader;
+
+    // A clock that advances one minute per call, so least-recently-used ordering
+    // is deterministic across providers.
+    DateTime Function() incrementingClock() {
+      int tick = 0;
+      return () => DateTime(2024, 1, 1).add(Duration(minutes: tick++));
+    }
+
+    CacheDownloadRepository buildLimited({
+      required int maxBytes,
+      Track? Function()? currentlyPlaying,
+      DateTime Function()? now,
+    }) {
+      preferences = InMemoryDownloadPreferences(maxCacheBytes: maxBytes);
+      return CacheDownloadRepository(
+        store: store,
+        files: files,
+        downloader: downloader,
+        connectivity: connectivity,
+        preferences: preferences,
+        currentlyPlayingTrack: currentlyPlaying,
+        now: now,
+      );
+    }
+
+    setUp(() {
+      store = InMemoryDownloadStore();
+      files = InMemoryOfflineFileStore();
+      connectivity = _FakeConnectivity(NetworkStatus.wifi);
+      downloader = _FakeRemoteDownloader(
+        schemes: const <String>['plex:', 'jellyfin:', 'subsonic:'],
+      );
+    });
+
+    test('a Subsonic/Navidrome track is evicted like any other provider',
+        () async {
+      final repo = buildLimited(maxBytes: 10, now: incrementingClock());
+
+      await repo.requestDownload(_subsonic('s1')); // oldest
+      await repo.requestDownload(_subsonic('s2'));
+      await repo.requestDownload(_subsonic('s3')); // forces eviction
+
+      expect(await repo.statusFor('s1'), DownloadStatus.notDownloaded);
+      expect(await repo.statusFor('s2'), DownloadStatus.downloaded);
+      expect(await repo.statusFor('s3'), DownloadStatus.downloaded);
+      expect(files.bytesFor('subsonic_s1.mp3'), isNull);
+    });
+
+    test('eviction ranks Plex, Jellyfin, and Subsonic together as one LRU list',
+        () async {
+      // Room for three 4-byte tracks; a fourth evicts the least-recently-used
+      // across ALL providers (the plex track cached first).
+      final repo = buildLimited(maxBytes: 12, now: incrementingClock());
+
+      await repo.requestDownload(_plex('a')); // oldest, across providers
+      await repo.requestDownload(_jellyfin('b'));
+      await repo.requestDownload(_subsonic('c'));
+      await repo.requestDownload(_jellyfin('d')); // forces one eviction
+
+      expect(await repo.statusFor('a'), DownloadStatus.notDownloaded);
+      expect(await repo.statusFor('b'), DownloadStatus.downloaded);
+      expect(await repo.statusFor('c'), DownloadStatus.downloaded);
+      expect(await repo.statusFor('d'), DownloadStatus.downloaded);
+      expect(files.bytesFor('plex_a.mp3'), isNull);
+    });
+
+    test('a recently played cross-provider track is kept; a stale one evicted',
+        () async {
+      final repo = buildLimited(maxBytes: 12, now: incrementingClock());
+
+      await repo.requestDownload(_plex('a')); // oldest
+      await repo.requestDownload(_jellyfin('b'));
+      await repo.requestDownload(_subsonic('c'));
+      // Replaying the oldest (Plex 'a') makes the Jellyfin 'b' the LRU now.
+      await repo.notePlayed(_plex('a'));
+      await repo.requestDownload(_subsonic('d')); // forces one eviction
+
+      expect(await repo.statusFor('a'), DownloadStatus.downloaded); // refreshed
+      expect(await repo.statusFor('b'), DownloadStatus.notDownloaded); // stale
+      expect(await repo.statusFor('c'), DownloadStatus.downloaded);
+      expect(await repo.statusFor('d'), DownloadStatus.downloaded);
+    });
+
+    test('a download evicts a same-id track from another provider (no shadow)',
+        () async {
+      // The exact same-id collision: subsonic:101 is cached and is the only
+      // evictable track; downloading plex:101 (same catalog id, different
+      // provider) must EVICT it to fit — never treat it as the incoming track's
+      // own old copy and silently overshoot the limit.
+      final repo = buildLimited(maxBytes: 4, now: incrementingClock());
+
+      await repo.requestDownload(_subsonic('101'));
+      expect(await repo.statusFor('101'), DownloadStatus.downloaded);
+
+      final outcome = await repo.requestDownload(_plex('101'));
+      expect(outcome, DownloadRequestOutcome.started);
+
+      // subsonic:101 gave way; plex:101 is the lone copy and the limit held.
+      final saved = await store.loadDownloads();
+      expect(saved, hasLength(1));
+      expect(saved.single.sourceType, 'plex');
+      expect(files.bytesFor('subsonic_101.mp3'), isNull);
+      expect(files.bytesFor('plex_101.mp3'), isNotNull);
+      expect((await repo.cacheSnapshot()).usedBytes, 4);
+    });
+
+    test('the playing track is protected per-provider, not by bare id',
+        () async {
+      // plex:101 is playing; a jellyfin:101 with the SAME id is a different
+      // track and must stay evictable — only the playing provider's copy is safe.
+      final repo = buildLimited(
+        maxBytes: 8,
+        currentlyPlaying: () => _plex('101'),
+        now: incrementingClock(),
+      );
+
+      await repo.requestDownload(_plex('101')); // playing
+      await repo.requestDownload(_jellyfin('101')); // same id, other provider
+      await repo.requestDownload(_subsonic('x')); // full → forces one eviction
+
+      final Set<String?> sources =
+          (await store.loadDownloads()).map((c) => c.sourceType).toSet();
+      expect(sources, containsAll(<String>['plex', 'subsonic']));
+      // The same-id, non-playing Jellyfin copy was evicted, not the playing one.
+      expect(sources, isNot(contains('jellyfin')));
+      expect(files.bytesFor('plex_101.mp3'), isNotNull);
+      expect(files.bytesFor('jellyfin_101.mp3'), isNull);
+    });
+
+    test('pre-cache continues after cleanup frees cross-provider space',
+        () async {
+      // A Jellyfin pre-cache fills the cache; a Plex pre-cache then evicts it
+      // (pre-cached entries are sacrificed first) and caches itself — pre-cache
+      // resumes after cleanup, and the limit holds.
+      final repo = buildLimited(maxBytes: 4, now: incrementingClock());
+
+      await repo.prefetch(_jellyfin('old'));
+      expect((await store.loadDownloads()).single.trackId, 'old');
+
+      await repo.prefetch(_plex('new'));
+
+      final saved = await store.loadDownloads();
+      expect(saved, hasLength(1));
+      expect(saved.single.sourceType, 'plex');
+      expect(saved.single.trackId, 'new');
+      expect(saved.single.preloaded, isTrue);
+      expect((await repo.cacheSnapshot()).usedBytes, 4);
+    });
+
+    test('pre-cache is skipped safely when cleanup cannot free enough', () async {
+      // The cache is full of a pinned download (never evictable). A pre-cache
+      // must skip rather than break — no fetch, no throw, nothing cached.
+      final repo = buildLimited(maxBytes: 4, now: incrementingClock());
+      await repo.requestDownload(_jellyfin('pinned'));
+      await repo.setPinned(_jellyfin('pinned'), true);
+
+      await repo.prefetch(_plex('want')); // no room, nothing safe to evict
+
+      final saved = await store.loadDownloads();
+      expect(saved, hasLength(1));
+      expect(saved.single.trackId, 'pinned');
+      expect(downloader.fetched.any((Track t) => t.uri == 'plex:want'), isFalse);
+      expect((await repo.cacheSnapshot()).usedBytes, 4);
     });
   });
 }

--- a/test/data/repositories/download_preferences_precache_test.dart
+++ b/test/data/repositories/download_preferences_precache_test.dart
@@ -6,36 +6,61 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('sanitizePrecacheCount', () {
-    test('passes through an offered count', () {
+    test('passes through a named preset', () {
       for (final int option in kPrecacheCountOptions) {
         expect(sanitizePrecacheCount(option), option);
       }
     });
 
-    test('falls back to the default for an unoffered or junk value', () {
-      expect(sanitizePrecacheCount(2), kDefaultPrecacheCount);
+    test('keeps an in-range custom value that is not a preset', () {
+      // Anything within the bounds is honoured, presets or not.
+      expect(sanitizePrecacheCount(2), 2);
+      expect(sanitizePrecacheCount(7), 7);
+      expect(sanitizePrecacheCount(42), 42);
+      expect(sanitizePrecacheCount(kMinPrecacheCount), kMinPrecacheCount);
+      expect(sanitizePrecacheCount(kMaxPrecacheCount), kMaxPrecacheCount);
+    });
+
+    test('restores the default for a below-minimum or junk value', () {
       expect(sanitizePrecacheCount(0), kDefaultPrecacheCount);
       expect(sanitizePrecacheCount(-5), kDefaultPrecacheCount);
-      expect(sanitizePrecacheCount(9999), kDefaultPrecacheCount);
+    });
+
+    test('caps an above-maximum value at the max (never thousands)', () {
+      expect(sanitizePrecacheCount(kMaxPrecacheCount + 1), kMaxPrecacheCount);
+      expect(sanitizePrecacheCount(9999), kMaxPrecacheCount);
+      expect(sanitizePrecacheCount(1000000), kMaxPrecacheCount);
     });
   });
 
   group('precacheCount preference', () {
-    test('in-memory defaults to the default and round-trips an offered value',
-        () async {
+    test('in-memory defaults to 3 (unchanged for upgrading users)', () async {
       final prefs = InMemoryDownloadPreferences();
+      // Default stays 3 so upgrading users see no behaviour change.
       expect(await prefs.precacheCount(), kDefaultPrecacheCount);
-
-      await prefs.setPrecacheCount(10);
-      expect(await prefs.precacheCount(), 10);
+      expect(kDefaultPrecacheCount, 3);
     });
 
-    test('in-memory clamps an unoffered value to the default', () async {
-      final prefs = InMemoryDownloadPreferences(precacheCount: 7);
-      expect(await prefs.precacheCount(), kDefaultPrecacheCount);
+    test('in-memory round-trips the new larger presets (20, 50)', () async {
+      final prefs = InMemoryDownloadPreferences();
 
-      await prefs.setPrecacheCount(4);
-      expect(await prefs.precacheCount(), kDefaultPrecacheCount);
+      await prefs.setPrecacheCount(20);
+      expect(await prefs.precacheCount(), 20);
+
+      await prefs.setPrecacheCount(50);
+      expect(await prefs.precacheCount(), 50);
+    });
+
+    test('in-memory keeps a custom value and clamps an out-of-range one',
+        () async {
+      final prefs = InMemoryDownloadPreferences(precacheCount: 42);
+      expect(await prefs.precacheCount(), 42); // custom, in range → kept
+
+      await prefs.setPrecacheCount(9999);
+      expect(await prefs.precacheCount(), kMaxPrecacheCount); // capped at 200
+
+      await prefs.setPrecacheCount(0);
+      expect(await prefs.precacheCount(), kDefaultPrecacheCount); // junk → 3
     });
 
     group('shared_preferences', () {
@@ -46,18 +71,34 @@ void main() {
         expect(await prefs.precacheCount(), kDefaultPrecacheCount);
       });
 
-      test('persists an offered count across instances', () async {
+      test('persists a preset across instances', () async {
         const prefs = SharedPreferencesDownloadPreferences();
-        await prefs.setPrecacheCount(5);
+        await prefs.setPrecacheCount(20);
 
         const reopened = SharedPreferencesDownloadPreferences();
-        expect(await reopened.precacheCount(), 5);
+        expect(await reopened.precacheCount(), 20);
       });
 
-      test('sanitizes an out-of-range stored value on read', () async {
-        // Simulate a value written outside the offered set.
+      test('persists a custom value across instances', () async {
+        const prefs = SharedPreferencesDownloadPreferences();
+        await prefs.setPrecacheCount(42);
+
+        const reopened = SharedPreferencesDownloadPreferences();
+        expect(await reopened.precacheCount(), 42);
+      });
+
+      test('caps an above-maximum stored value on read', () async {
+        // Simulate a value written far outside the safe range.
         SharedPreferences.setMockInitialValues(<String, Object>{
-          'downloads_precache_count': 42,
+          'downloads_precache_count': 5000,
+        });
+        const prefs = SharedPreferencesDownloadPreferences();
+        expect(await prefs.precacheCount(), kMaxPrecacheCount);
+      });
+
+      test('restores the default for a junk stored value on read', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'downloads_precache_count': 0,
         });
         const prefs = SharedPreferencesDownloadPreferences();
         expect(await prefs.precacheCount(), kDefaultPrecacheCount);

--- a/test/features/settings/plex/plex_settings_section_test.dart
+++ b/test/features/settings/plex/plex_settings_section_test.dart
@@ -160,7 +160,8 @@ void main() {
     await _pump(tester);
 
     expect(find.text('Plex'), findsOneWidget);
-    expect(find.text('Experimental'), findsOneWidget);
+    // Plex is a supported provider now — no "Experimental" badge.
+    expect(find.text('Experimental'), findsNothing);
     expect(find.text('Connect with Plex'), findsOneWidget);
     expect(find.text('Manual setup (advanced)'), findsOneWidget);
     // No token hunting up front: the manual fields are hidden by default.

--- a/test/features/settings/precache/precache_settings_section_test.dart
+++ b/test/features/settings/precache/precache_settings_section_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/download_preferences.dart';
 import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
 import 'package:linthra/features/downloads/download_providers.dart';
@@ -30,19 +31,19 @@ void main() {
       return container;
     }
 
-    testWidgets('shows the smart pre-cache copy and controls', (tester) async {
+    testWidgets('shows the smart pre-cache copy and the current count',
+        (tester) async {
       await pump(tester);
 
       expect(find.text('Smart pre-cache'), findsOneWidget);
       expect(find.text('Pre-cache upcoming tracks'), findsOneWidget);
-      expect(find.text('Upcoming tracks to cache'), findsOneWidget);
+      expect(find.text('Songs to pre-cache'), findsOneWidget);
       // The automatic/evictable vs. Keep offline (protected) distinction.
       expect(find.textContaining('removed automatically'), findsWidgets);
       expect(find.textContaining('Keep offline'), findsOneWidget);
-      // The count options render, with the default (3) selected.
-      for (final String label in <String>['1', '3', '5', '10']) {
-        expect(find.text(label), findsOneWidget);
-      }
+      // The default count (3) is shown, and there's a control to change it.
+      expect(find.text('3 upcoming tracks'), findsOneWidget);
+      expect(find.text('Change'), findsOneWidget);
     });
 
     testWidgets('toggling smart pre-cache off persists the choice',
@@ -57,30 +58,84 @@ void main() {
       expect(container.read(smartPrecacheEnabledProvider).valueOrNull, isFalse);
     });
 
-    testWidgets('choosing a different count persists the new value',
-        (tester) async {
-      final container = await pump(tester);
-      expect(await preferences.precacheCount(), 3);
-
-      await tester.tap(find.text('10'));
-      await tester.pumpAndSettle();
-
-      expect(await preferences.precacheCount(), 10);
-      expect(container.read(precacheCountProvider).valueOrNull, 10);
-    });
-
-    testWidgets('the count selector is inert while pre-cache is off',
+    testWidgets('the dialog offers all presets including the new larger ones',
         (tester) async {
       await pump(tester);
 
-      // Turn smart pre-cache off, then try to change the count.
-      await tester.tap(find.text('Pre-cache upcoming tracks'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('10'));
+      await tester.tap(find.text('Change'));
       await tester.pumpAndSettle();
 
-      // The selector is disabled, so the count is unchanged.
-      expect(await preferences.precacheCount(), 3);
+      for (final int option in kPrecacheCountOptions) {
+        expect(find.text('$option'), findsOneWidget);
+      }
+      // The larger options the user asked for are present.
+      expect(find.text('20'), findsOneWidget);
+      expect(find.text('50'), findsOneWidget);
+      expect(find.text('Custom'), findsOneWidget);
+    });
+
+    testWidgets('choosing a larger preset (50) persists the new value',
+        (tester) async {
+      final container = await pump(tester);
+      expect(await preferences.precacheCount(), kDefaultPrecacheCount);
+
+      await tester.tap(find.text('Change'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('50'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.precacheCount(), 50);
+      expect(container.read(precacheCountProvider).valueOrNull, 50);
+    });
+
+    testWidgets('entering a custom value persists it', (tester) async {
+      final container = await pump(tester);
+
+      await tester.tap(find.text('Change'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Custom'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '42');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(await preferences.precacheCount(), 42);
+      expect(container.read(precacheCountProvider).valueOrNull, 42);
+    });
+
+    testWidgets('an out-of-range custom value is clamped to the max on save',
+        (tester) async {
+      await pump(tester);
+
+      await tester.tap(find.text('Change'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Custom'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), '9999');
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      // Never thousands of downloads: capped at the safe maximum.
+      expect(await preferences.precacheCount(), kMaxPrecacheCount);
+    });
+
+    testWidgets('the Change button is disabled while pre-cache is off',
+        (tester) async {
+      await pump(tester);
+
+      // Turn smart pre-cache off, then try to open the picker.
+      await tester.tap(find.text('Pre-cache upcoming tracks'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Change'));
+      await tester.pumpAndSettle();
+
+      // No dialog opened (no Save action), and the count is unchanged.
+      expect(find.text('Save'), findsNothing);
+      expect(await preferences.precacheCount(), kDefaultPrecacheCount);
     });
   });
 }


### PR DESCRIPTION
Three small, independent v0.1.6-prep changes on this branch (one commit each). **v0.1.6 is not tagged**; `pubspec` version and F-Droid metadata are untouched throughout.

---

## 1. Configurable smart pre-cache song count (`2ccc6da`)

Raised the pre-cache count ceiling: presets `[1,3,5,10]` → `[1,3,5,10,20,50]` plus a **Custom** value (1–200). Default stays **3** (no behaviour change for existing users). `sanitizePrecacheCount` clamps into `[1,200]`. Persisted; applies to every offline-capable provider.

## 2. Drop the "Experimental" label from Plex (`f03a6ee`)

Removed the badge from the Plex settings card and the compact provider card; refreshed copy/docs. **No capability flags changed** — cast/favorites/playlists stay hidden. Capability chips show exactly Streaming / Offline / Lyrics.

## 3. Make smart cleanup collision-proof across all remote providers (`bf951b6`)

**Finding:** the shared offline cache + smart pre-cache were *already* provider-agnostic — one `CacheDownloadRepository` caches and evicts Jellyfin, Subsonic, and Plex together by the configurable count, keyed by a provider-aware `(sourceType, trackId)` identity for storage, files, status, and removal. The **one gap** was the eviction *policy*: it compared the **bare catalog id** for the incoming and currently-playing tracks, so two providers sharing an id (Plex `101`, Subsonic `101`) could *shadow* or *over-protect* each other in cleanup accounting.

**Fix (entirely in the shared layer — no Plex-specific cleanup logic):**
- `CacheEvictionPolicy` now identifies the incoming and protected tracks by the provider-aware `CachedTrack.cacheKey` (`scheme + id`) instead of the bare `trackId`.
- The currently-playing dependency carries the whole `Track` (not just its id) so its key protects exactly that provider's copy; renamed `currentlyPlayingTrack(Provider/Override)`.
- Hoisted cache-key composition to one shared definition (`CachedTrack.cacheKeyFor`) the repository, metadata, and policy reuse, so the format can't drift.

### Acceptance criteria (change 3)
- ✅ Plex, Jellyfin, Navidrome/Subsonic share one configurable pre-cache count and one smart cleanup.
- ✅ LRU eviction across providers; least-recently-used unpinned evicted first.
- ✅ Provider collisions impossible even with identical ids (incoming **and** playing now keyed by `(sourceType, id)`).
- ✅ Pinned/manual and currently-playing tracks preserved; downloading tracks hold no committed entry so can't be evicted.
- ✅ Pre-cache continues after cleanup frees space; skipped safely when nothing is evictable.
- ✅ Playback unaffected if cleanup fails (best-effort, never throws on the pre-cache path).
- ⚠️ *Queued* (upcoming) tracks beyond the one playing are **not** explicitly protected — queue state isn't injected into the cleanup layer, matching req #9's "where that state is available". Pre-cached entries are sacrificed before user downloads regardless, so this is best-effort by design.

---

## Guardrails (all three)
- ✅ Plex cache **playback** behaviour unchanged; **artwork cache** unchanged; F-Droid metadata untouched; **v0.1.6 not tagged**.

## Tests
- **Full suite: 2481 tests, all passing.** `flutter analyze`: no issues.
- New cleanup tests: same-id provider isolation (incoming **and** playing), mixed-provider LRU, Subsonic/Navidrome eviction, recently-played preserved, pinned preserved, pre-cache continues after cross-provider cleanup, pre-cache skipped when nothing is evictable. Existing Plex/Jellyfin streaming + cached-playback suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CctXPYsCerau4F2PYupDzY