### PR TITLE
docs(release): public-facing v0.1.6 release notes (no tester checklist)

### DIFF
--- a/docs/release-notes/v0.1.6.md
+++ b/docs/release-notes/v0.1.6.md
@@ -1,0 +1,63 @@
+# Linthra v0.1.6 — release notes
+
+**Linthra is a modern, local-first, privacy-focused music player for people who
+own their music.** v0.1.6 makes Plex a first-class source: you can now take your
+Plex music offline, the same way you already could with Jellyfin and
+Navidrome/Subsonic.
+
+- **Version:** `0.1.6` (`versionName`), `versionCode` `106999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+- **Get it:** [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/)
+  or the signed APKs on the [GitHub Releases page](https://github.com/TheZupZup/Linthra/releases)
+
+## What's new
+
+- **Plex offline caching.** Download Plex tracks for offline playback, just like
+  Jellyfin and Navidrome/Subsonic. Cached tracks play straight from your device
+  and fall back to streaming automatically when a cached file is missing or can't
+  be opened.
+- **Plex is now a fully supported provider.** Streaming, lyrics, and offline
+  caching all ship in v0.1.6, so the "Experimental" label is gone. (Cast,
+  favorites, and playlists for Plex are still on the way — see *Known
+  limitations*.)
+- **Choose how much to pre-cache.** Smart pre-cache can now warm more upcoming
+  tracks — pick 20, 50, or a custom count up to 200. The default stays a modest
+  3, so nothing changes unless you raise it.
+
+## Technical summary
+
+- **Atomic downloads.** Offline downloads are written to a temporary file,
+  length-validated, then renamed into place, so an interrupted download can never
+  leave a half-written or 0-byte file masquerading as cached. This hardens
+  downloads for every provider (Jellyfin, Navidrome/Subsonic, and Plex).
+- **Streaming fallback for unreadable caches.** A cached track whose file is
+  missing — or present but corrupt or unreadable — now falls back to live
+  streaming instead of erroring out.
+- **Collision-proof offline cache.** The cache is keyed by a provider-aware
+  identity (source + track id), and smart cleanup compares that same key, so two
+  providers that happen to share a track id (for example, Plex `101` and Subsonic
+  `101`) can no longer overwrite, shadow, or evict each other.
+- **F-Droid-reproducible builds.** Per-ABI release APKs are now built one ABI at
+  a time from a clean tree, mirroring F-Droid's split-APK build so the arm64-v8a
+  and x86_64 APKs reproduce byte-for-byte.
+
+## Upgrade notes
+
+- **Nothing to do.** Upgrading keeps your existing settings; the smart pre-cache
+  default is unchanged (3 tracks).
+- **Your Plex token stays private.** Plex cached files are keyed to your library
+  item identity and named only from the non-secret track id — your Plex token is
+  never written to disk or included in a cache file name.
+- **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
+  key, while the F-Droid build of the same version is signed with F-Droid's key;
+  the two can't update each other. Stick with one source.
+
+## Known limitations
+
+- **Plex cast, favorites, and playlists aren't supported yet.** Those actions
+  stay hidden or disabled for Plex; only streaming, lyrics, and offline caching
+  are available this release.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/docs/release-notes/v0.1.6.md
+++ b/docs/release-notes/v0.1.6.md
@@ -18,7 +18,7 @@ Navidrome/Subsonic.
   Jellyfin and Navidrome/Subsonic. Cached tracks play straight from your device
   and fall back to streaming automatically when a cached file is missing or can't
   be opened.
-- **Plex is now a fully supported provider.** Streaming, lyrics, and offline
+- **Plex is now a supported provider.** Streaming, lyrics, and offline
   caching all ship in v0.1.6, so the "Experimental" label is gone. (Cast,
   favorites, and playlists for Plex are still on the way — see *Known
   limitations*.)

--- a/docs/release-notes/v0.1.6.md
+++ b/docs/release-notes/v0.1.6.md
@@ -47,9 +47,11 @@ Navidrome/Subsonic.
 
 - **Nothing to do.** Upgrading keeps your existing settings; the smart pre-cache
   default is unchanged (3 tracks).
-- **Your Plex token stays private.** Plex cached files are keyed to your library
-  item identity and named only from the non-secret track id — your Plex token is
-  never written to disk or included in a cache file name.
+- **Your Plex token stays out of the offline cache.** Plex cached files are keyed
+  to your library item identity and named only from the non-secret track id, so
+  your Plex token is never written into a cached file, its metadata, or a cache
+  file name. Your sign-in session is stored separately in the device's encrypted,
+  Android Keystore-backed secure storage — never in plaintext.
 - **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
   key, while the F-Droid build of the same version is signed with F-Droid's key;
   the two can't update each other. Stick with one source.


### PR DESCRIPTION
## Summary

Adds `docs/release-notes/v0.1.6.md` as the **clean, public-facing** release notes for v0.1.6 (Plex offline caching). This is the corrected final release text requested for the v0.1.6 release prep.

Per the request, the public release notes **keep**:
- **What's New** (Plex offline caching, Plex now a supported provider, configurable smart pre-cache count)
- A short **technical summary** (atomic downloads, streaming fallback for unreadable caches, collision-proof provider-aware cache, F-Droid-reproducible per-ABI builds)
- **Upgrade notes** (no action needed; Plex token never written to disk; don't mix GitHub vs F-Droid install sources)
- **Known limitations** (Plex cast / favorites / playlists still unsupported)

…and deliberately **omit**:
- ❌ tester checklist
- ❌ manual QA checklist
- ❌ anything that reads like internal testing instructions

## What's intentionally unchanged
- The **internal pre-tag verification** stays in place — `scripts/release_preflight.sh` and the pre-tag invariants in `docs/release-process.md` are untouched.
- The in-app "Tester checklist" card (`lib/features/settings/about/tester_checklist_section.dart`, #228) is **not** modified — this change is scoped to the public release-notes text only.
- **No tag is cut.** Holding for approval before tagging v0.1.6.

`docs/release-notes/**` is the sanctioned home for the longer GitHub-Release notes (allowed by `scripts/check_release_bump_files.sh`), and no test constrains its format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LfFvX2jgZWXqvM8SipTqo