### PR TITLE
fix(catalog): provider-aware identity — stop cross-provider track-id collisions

### DIFF
--- a/lib/core/catalog/logical_track.dart
+++ b/lib/core/catalog/logical_track.dart
@@ -86,18 +86,22 @@ class LogicalTrack {
     return primaryTrack.copyWith(artworkUri: art);
   }
 
-  /// A stable id for the logical row: the preferred copy's track id. Stable for
-  /// a given catalog + preference, which is all the UI (keys, selection) needs.
-  String get id => primaryTrack.id;
+  /// A stable id for the logical row: the preferred copy's provider-namespaced
+  /// [Track.uri]. Stable for a given catalog + preference, which is all the UI
+  /// (keys, selection) needs — and collision-free across providers, unlike the
+  /// bare track id.
+  String get id => primaryTrack.uri;
 
   /// Every source id this song can be played from, in preference order.
   List<String> get sourceIds =>
       <String>[for (final TrackSourceCandidate c in candidates) c.sourceId];
 
-  /// Every source copy's track id. Removing a logical track from the library
-  /// forgets *all* of these, so a hidden duplicate can't resurrect the row.
-  List<String> get allTrackIds =>
-      <String>[for (final TrackSourceCandidate c in candidates) c.track.id];
+  /// Every source copy's provider-namespaced [Track.uri]. Removing a logical
+  /// track from the library forgets *all* of these (the catalog is keyed by uri),
+  /// so a hidden duplicate can't resurrect the row — and no other provider's
+  /// same-id copy is taken down with it.
+  List<String> get allTrackUris =>
+      <String>[for (final TrackSourceCandidate c in candidates) c.track.uri];
 
   /// Whether this song is available from more than one provider.
   bool get hasMultipleSources => candidates.length > 1;

--- a/lib/core/catalog/now_playing_match.dart
+++ b/lib/core/catalog/now_playing_match.dart
@@ -7,10 +7,13 @@ import 'track_identity.dart';
 ///
 /// Two deterministic, deliberately conservative layers:
 ///
-///  * **Exact id.** The everyday case: the row is literally the playing copy
-///    (same provider, same track id). This is also the only thing that can match
-///    an untagged local file, which carries too little metadata to be matched any
-///    other way — so it only ever lights up its own row.
+///  * **Exact copy.** The everyday case: the row is literally the playing copy —
+///    the same provider-namespaced [Track.uri] (`jellyfin:101`, a local path, …).
+///    Matching on the uri, not the bare id, is what keeps a playing `jellyfin:101`
+///    from lighting up a *different* song that happens to be `subsonic:101`. It is
+///    also the only thing that can match an untagged local file, which carries too
+///    little metadata to be matched any other way — so it only ever lights up its
+///    own row.
 ///  * **Cross-provider fallback.** When [row] and [current] come from *different*
 ///    providers, they count as the same song only when [isLikelySameTrack]
 ///    confidently agrees. This is the exact predicate the library unifier merges
@@ -19,12 +22,12 @@ import 'track_identity.dart';
 ///    tapped a Jellyfin row but playback fell back to the Navidrome copy, the
 ///    Jellyfin row still reads as currently playing.
 ///
-/// Two rows from the *same* provider never match by metadata (only by id),
+/// Two rows from the *same* provider never match by metadata (only by exact uri),
 /// mirroring the unifier's rule that a single provider's own rows are assumed
 /// already de-duplicated — so two distinct rows from one source can't both claim
 /// to be the playing track.
 bool isCurrentPlaybackTrack(Track row, Track current) {
-  if (row.id == current.id) return true;
+  if (row.uri == current.uri) return true;
   if (trackSourceId(row) == trackSourceId(current)) return false;
   return isLikelySameTrack(row, current);
 }

--- a/lib/core/catalog/track_unifier.dart
+++ b/lib/core/catalog/track_unifier.dart
@@ -41,19 +41,21 @@ import 'track_identity.dart';
 /// list, say) sees the same ordering it always did.
 List<LogicalTrack> unifyTracks(List<Track> tracks, SourcePriority priority) {
   // First pass: bucket eligible tracks by block key, then resolve each block
-  // into same-song groups. groupByTrackId maps a track id to the members of its
-  // group (a group of one for a track that matched nothing).
+  // into same-song groups. groupByUri maps a track's provider-namespaced uri to
+  // the members of its group (a group of one for a track that matched nothing).
+  // Keying by uri — not the bare id — keeps two providers' same-id tracks from
+  // overwriting each other's group, which would mis-merge or duplicate a row.
   final Map<String, List<Track>> blocks = <String, List<Track>>{};
   for (final Track track in tracks) {
     final String? key = matchBlockKey(track);
     if (key == null) continue;
     blocks.putIfAbsent(key, () => <Track>[]).add(track);
   }
-  final Map<String, List<Track>> groupByTrackId = <String, List<Track>>{};
+  final Map<String, List<Track>> groupByUri = <String, List<Track>>{};
   for (final List<Track> block in blocks.values) {
     for (final List<Track> group in _groupBlock(block, priority)) {
       for (final Track member in group) {
-        groupByTrackId[member.id] = group;
+        groupByUri[member.uri] = group;
       }
     }
   }
@@ -65,14 +67,14 @@ List<LogicalTrack> unifyTracks(List<Track> tracks, SourcePriority priority) {
   final Set<String> emittedAnchors = <String>{};
   final List<LogicalTrack> result = <LogicalTrack>[];
   for (final Track track in tracks) {
-    final List<Track>? group = groupByTrackId[track.id];
+    final List<Track>? group = groupByUri[track.uri];
     if (group == null || _distinctSourceCount(group) < 2) {
       result.add(LogicalTrack.single(_candidate(track)));
       continue;
     }
-    // group.first is the block's stable anchor, so it is a deterministic id for
-    // "have I already emitted this merged group?".
-    if (!emittedAnchors.add(group.first.id)) continue;
+    // group.first is the block's stable anchor, so its uri is a deterministic key
+    // for "have I already emitted this merged group?".
+    if (!emittedAnchors.add(group.first.uri)) continue;
     result.add(LogicalTrack(_orderedCandidates(group, priority)));
   }
   return result;
@@ -121,7 +123,8 @@ int _distinctSourceCount(List<Track> members) {
 }
 
 /// Orders a merged group's copies best-first by source preference, breaking ties
-/// on the track id so the result is total and deterministic.
+/// on the provider-namespaced uri so the result is total and deterministic even
+/// when two copies share a bare id across providers.
 List<TrackSourceCandidate> _orderedCandidates(
   List<Track> members,
   SourcePriority priority,
@@ -133,20 +136,21 @@ List<TrackSourceCandidate> _orderedCandidates(
     final int byRank =
         priority.rankOf(a.sourceId).compareTo(priority.rankOf(b.sourceId));
     if (byRank != 0) return byRank;
-    return a.track.id.compareTo(b.track.id);
+    return a.track.uri.compareTo(b.track.uri);
   });
   return candidates;
 }
 
-/// A total comparator ordering tracks by source preference, then by id, so a
+/// A total comparator ordering tracks by source preference, then by uri, so a
 /// block's anchor (its first element) is the most-preferred copy and the grouping
-/// never depends on the input order.
+/// never depends on the input order. Ties break on the uri (not the bare id) so
+/// two providers' same-id tracks still order deterministically.
 int Function(Track, Track) _byPriorityThenId(SourcePriority priority) {
   return (Track a, Track b) {
     final int byRank = priority
         .rankOf(trackSourceId(a))
         .compareTo(priority.rankOf(trackSourceId(b)));
     if (byRank != 0) return byRank;
-    return a.id.compareTo(b.id);
+    return a.uri.compareTo(b.uri);
   };
 }

--- a/lib/core/models/playback_queue.dart
+++ b/lib/core/models/playback_queue.dart
@@ -162,9 +162,16 @@ class PlaybackQueue {
     final absolute = currentIndex + 1 + upNextIndex;
     final removed = tracks[absolute];
     final updated = List<Track>.of(tracks)..removeAt(absolute);
-    final updatedOriginal = originalOrder == null
-        ? null
-        : (List<Track>.of(originalOrder!)..remove(removed));
+    // Drop the same copy from originalOrder by uri (not Track == on the bare id),
+    // so a shuffled queue holding two providers' same-id rows removes the right
+    // one and a later unshuffle can't resurrect it or swap identity.
+    List<Track>? updatedOriginal;
+    if (originalOrder != null) {
+      updatedOriginal = List<Track>.of(originalOrder!);
+      final int i =
+          updatedOriginal.indexWhere((Track t) => t.uri == removed.uri);
+      if (i >= 0) updatedOriginal.removeAt(i);
+    }
     return PlaybackQueue(
       tracks: updated,
       currentIndex: currentIndex,
@@ -252,7 +259,12 @@ class PlaybackQueue {
     final original = originalOrder;
     if (original == null) return this;
     final track = current;
-    final index = track == null ? -1 : original.indexOf(track);
+    // Find the current copy by uri (not Track == on the bare id) so unshuffling a
+    // queue with two providers' same-id rows keeps the copy that's actually
+    // current, instead of jumping to the first row sharing the bare id.
+    final index = track == null
+        ? -1
+        : original.indexWhere((Track t) => t.uri == track.uri);
     return PlaybackQueue(
       tracks: List<Track>.of(original),
       currentIndex: index < 0 ? (original.isEmpty ? -1 : 0) : index,

--- a/lib/core/models/playback_queue.dart
+++ b/lib/core/models/playback_queue.dart
@@ -263,15 +263,21 @@ class PlaybackQueue {
   /// up-next, history, and shuffle intact. Used when playback fell back to
   /// another source copy of the same song, so the queue (and the now-playing UI)
   /// reflects the copy that actually started. A no-op on an empty queue or when
-  /// [track] equals the current one. When shuffled, the same swap is applied to
-  /// [originalOrder] so a later [unshuffled] keeps the copy that played.
+  /// [track] is the same copy (same provider-namespaced uri) as the current one.
+  /// When shuffled, the same swap is applied to [originalOrder] so a later
+  /// [unshuffled] keeps the copy that played.
+  ///
+  /// Identity is compared by [Track.uri], not [Track]'s `==` (which keys on the
+  /// bare id): two providers' copies of one song can share a bare id (e.g.
+  /// `jellyfin:101` falling back to `subsonic:101`), and that swap must take
+  /// effect so `current` reflects the copy that actually started.
   PlaybackQueue replaceCurrent(Track track) {
     final Track? old = current;
-    if (old == null || old == track) return this;
+    if (old == null || old.uri == track.uri) return this;
     final updated = List<Track>.of(tracks)..[currentIndex] = track;
     List<Track>? updatedOriginal = originalOrder;
     if (originalOrder != null) {
-      final int i = originalOrder!.indexOf(old);
+      final int i = originalOrder!.indexWhere((Track t) => t.uri == old.uri);
       if (i >= 0) {
         updatedOriginal = List<Track>.of(originalOrder!)..[i] = track;
       }

--- a/lib/core/models/track.dart
+++ b/lib/core/models/track.dart
@@ -66,10 +66,18 @@ class Track {
     );
   }
 
+  /// Identity is the provider-namespaced [uri], not the bare [id]: two copies of
+  /// the same server-side id from different providers (e.g. `jellyfin:101` and
+  /// `subsonic:101`) are genuinely different tracks and must not compare equal,
+  /// or they'd collide in Sets/Maps, `List` equality, `Stream.distinct`, and
+  /// Riverpod family keys. Same-provider re-fetches share a uri, so a `copyWith`
+  /// that only refreshes metadata still compares equal (as before). Code that
+  /// wants to group same-id copies across providers keys on [id] explicitly (the
+  /// catalog unifier), so this never affects that.
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || (other is Track && other.id == id);
+      identical(this, other) || (other is Track && other.uri == uri);
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => uri.hashCode;
 }

--- a/lib/core/repositories/download_repository.dart
+++ b/lib/core/repositories/download_repository.dart
@@ -73,19 +73,25 @@ class CacheStorageException implements Exception {
 /// offline without any network fetch. The authenticated URL a remote fetch
 /// needs is resolved on demand, at download time, and never stored on the track.
 abstract interface class DownloadRepository {
-  /// Emits whenever a track's download status changes.
+  /// Emits the download status of every tracked copy whenever one changes, keyed
+  /// by the provider-aware cache key (`CachedTrack.cacheKeyForTrack`) so two
+  /// providers' same-id copies never share a status. The UI's per-row status
+  /// joins on that key.
   Stream<Map<String, DownloadStatus>> get statusStream;
 
-  /// The status of the track with catalog id [trackId], mirroring the id-keyed
-  /// [statusStream] the UI watches. (The mutating calls below take the whole
-  /// [Track] instead, because they act on one provider's specific cached copy.)
+  /// The status of the track with catalog id [trackId] — a plain-id convenience
+  /// (the catalog's primary key makes ids unique there). The app's per-row status
+  /// instead watches [statusStream], which is keyed provider-aware; the mutating
+  /// calls below take the whole [Track], so they act on one provider's copy.
   Future<DownloadStatus> statusFor(String trackId);
 
-  /// Emits per-track byte progress for in-flight downloads, keyed by track id.
-  /// An entry appears while a track is downloading and is removed once it
-  /// finishes, fails, or is canceled. Best-effort: a track whose server didn't
-  /// report a content length has a null total ([DownloadProgress.fraction] is
-  /// `null`), so the UI shows an indeterminate spinner rather than a bar.
+  /// Emits per-track byte progress for in-flight downloads, keyed by the
+  /// provider-aware cache key (`CachedTrack.cacheKeyForTrack`) — so two providers'
+  /// same-id copies never share a progress ring. An entry appears while a track
+  /// is downloading and is removed once it finishes, fails, or is canceled.
+  /// Best-effort: a track whose server didn't report a content length has a null
+  /// total ([DownloadProgress.fraction] is `null`), so the UI shows an
+  /// indeterminate spinner rather than a bar.
   Stream<Map<String, DownloadProgress>> get progressStream;
 
   /// Queues an explicit download for [track]. For remote tracks this is subject
@@ -107,6 +113,9 @@ abstract interface class DownloadRepository {
   /// or remove each other's cached copy.
   Future<void> removeDownload(Track track);
 
-  /// Track IDs that are fully available offline.
-  Future<List<String>> downloadedTrackIds();
+  /// The provider-aware cache keys (`CachedTrack.cacheKeyForTrack`) of every
+  /// track fully available offline — keys, not bare ids, so two providers'
+  /// same-id copies stay distinct and only the copy actually downloaded is
+  /// listed. Join against a catalog [Track] with `CachedTrack.cacheKeyForTrack`.
+  Future<List<String>> downloadedTrackKeys();
 }

--- a/lib/core/repositories/download_store.dart
+++ b/lib/core/repositories/download_store.dart
@@ -1,3 +1,5 @@
+import '../models/track.dart';
+
 /// A reference to a single offline-cached track: which track it is, the file
 /// that holds its downloaded bytes (when there is one), and the small bits of
 /// metadata the cache manager needs to clean up intelligently.
@@ -72,6 +74,24 @@ class CachedTrack {
   /// the pair is unambiguous.
   static String cacheKeyFor(String? sourceType, String trackId) =>
       '${sourceType ?? ''}${String.fromCharCode(_keySeparator)}$trackId';
+
+  /// The [cacheKey] a live catalog [track] maps to — the same `(sourceType,
+  /// trackId)` identity a persisted entry keys itself by, so a caller can join a
+  /// [Track] to its cache state (status, progress, the downloaded/offline sets)
+  /// without the bare-id collision two providers' same-id copies (`jellyfin:101`
+  /// vs `subsonic:101`) would cause. Mirrors the repository's internal key, so a
+  /// live track and a persisted entry for it land on exactly the same key.
+  static String cacheKeyForTrack(Track track) =>
+      cacheKeyFor(schemeOf(track.uri), track.id);
+
+  /// The non-secret URI scheme of [uri] (`jellyfin`, `file`, …), lowercased, or
+  /// `null` when it has none — the `sourceType` half of a [cacheKey].
+  static String? schemeOf(String uri) {
+    final int colon = uri.indexOf(':');
+    if (colon <= 0) return null;
+    final String scheme = uri.substring(0, colon).toLowerCase();
+    return scheme.isEmpty ? null : scheme;
+  }
 
   /// Separator between scheme and id in a [cacheKey]: NUL, which can't occur in
   /// a URI scheme or a catalog id, so the `(scheme, id)` pair is unambiguous.

--- a/lib/core/repositories/library_added_store.dart
+++ b/lib/core/repositories/library_added_store.dart
@@ -1,14 +1,16 @@
 /// Durable storage for when each catalog track was first added to the library.
 ///
-/// Records a `trackId -> firstSeen` map that powers the "Recently added" smart
+/// Records a `trackUri -> firstSeen` map that powers the "Recently added" smart
 /// mix. It's written by [RecordingMusicLibraryRepository] as a side effect of a
-/// scan/sync (stamping newly-seen track ids with the time they first appeared),
-/// and read by the smart-mix layer. Kept as a separate seam so the backing
-/// store swaps freely (in-memory for tests, key/value in the app), mirroring
-/// [FavoritesStore].
+/// scan/sync (stamping newly-seen tracks with the time they first appeared),
+/// and read by the smart-mix layer. Keyed by the provider-namespaced
+/// [Track.uri] (e.g. `jellyfin:101`, `plex:101`, or a local path) so the same
+/// server-side id from two providers can't share a timestamp. Kept as a separate
+/// seam so the backing store swaps freely (in-memory for tests, key/value in the
+/// app), mirroring [FavoritesStore].
 ///
-/// Privacy: only non-secret track ids and timestamps are stored here — never a
-/// uri, token, or authenticated URL. It never leaves the device.
+/// Privacy: only non-secret, namespaced track uris and timestamps are stored
+/// here — never a token or an authenticated URL. It never leaves the device.
 abstract interface class LibraryAddedStore {
   Future<Map<String, DateTime>> load();
   Future<void> save(Map<String, DateTime> addedAt);

--- a/lib/core/repositories/music_library_repository.dart
+++ b/lib/core/repositories/music_library_repository.dart
@@ -16,7 +16,12 @@ abstract interface class MusicLibraryRepository {
   Future<List<Track>> getAllTracks();
   Future<List<Album>> getAllAlbums();
   Future<List<Artist>> getAllArtists();
-  Future<Track?> getTrackById(String id);
+
+  /// Looks up a single track by its provider-namespaced [Track.uri] (e.g.
+  /// `jellyfin:101`, `plex:101`, or a local path) — the catalog's canonical,
+  /// collision-free identity. The bare server-side `id` is *not* used as a key
+  /// because two providers can share one (`plex:101` vs `subsonic:101`).
+  Future<Track?> getTrackByUri(String uri);
 
   /// Replaces the cached catalog for a given source after a scan/sync.
   Future<void> upsertCatalog({
@@ -26,13 +31,15 @@ abstract interface class MusicLibraryRepository {
     required List<Artist> artists,
   });
 
-  /// Removes the tracks with [trackIds] from the local catalog/index only.
+  /// Removes the tracks with the given provider-namespaced [Track.uri]s
+  /// ([trackUris]) from the local catalog/index only.
   ///
   /// This is the "Remove from Linthra library" primitive: it deletes nothing on
   /// disk and nothing on a server — it only forgets the rows in Linthra's own
   /// index. The original local file or remote server item is untouched, so a
   /// later re-scan / re-sync of that source can bring the track back. A safe,
   /// reversible default, deliberately distinct from deleting a file or a server
-  /// item.
-  Future<void> removeTracks(List<String> trackIds);
+  /// item. Keyed on the `uri` (not the bare `id`) so removing one provider's copy
+  /// can't take a different provider's same-id row with it.
+  Future<void> removeTracks(List<String> trackUris);
 }

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -112,7 +112,15 @@ class ActivePlaybackController implements PlaybackController {
 
   void _emitMerged() {
     final PlaybackState next = _merge();
-    if (next == _lastEmitted) return;
+    // PlaybackState == leans on Track == (bare id), so a same-bare-id provider
+    // swap (a retry/fallback from jellyfin:101 to subsonic:101, same status and
+    // source) compares equal even though a different copy is now current.
+    // Compare the current uri too, so that swap still reaches UI/reporting
+    // instead of being suppressed by this guard.
+    if (next == _lastEmitted &&
+        next.currentTrack?.uri == _lastEmitted.currentTrack?.uri) {
+      return;
+    }
     _lastEmitted = next;
     if (!_states.isClosed) _states.add(next);
   }

--- a/lib/core/services/cast/default_cast_service.dart
+++ b/lib/core/services/cast/default_cast_service.dart
@@ -93,12 +93,14 @@ class DefaultCastService implements CastService {
   /// changes within a session). Null until the receiver reports one.
   CastVolume? _volume;
 
-  /// The id of the track currently loaded on the receiver, so a re-emission of
-  /// the *same* track (a duplicate stream event, a metadata refresh) is a no-op
-  /// instead of a needless re-resolve + reload — which would restart playback on
-  /// the receiver and re-mint a stream URL. Cleared whenever the session ends or
-  /// nothing castable is loaded. Distinct track changes still reload.
-  String? _castingTrackId;
+  /// The provider-namespaced [Track.uri] of the track currently loaded on the
+  /// receiver, so a re-emission of the *same* track (a duplicate stream event, a
+  /// metadata refresh) is a no-op instead of a needless re-resolve + reload —
+  /// which would restart playback on the receiver and re-mint a stream URL. Keyed
+  /// by uri (not the bare id) so switching to another provider's copy that shares
+  /// a server-side id (`jellyfin:101` → `subsonic:101`) still reloads the
+  /// receiver. Cleared whenever the session ends or nothing castable is loaded.
+  String? _castingTrackUri;
 
   @override
   CastState get state => _state;
@@ -253,7 +255,7 @@ class DefaultCastService implements CastService {
     if (handle == null) return; // disconnected mid-flight
 
     if (track == null) {
-      _castingTrackId = null;
+      _castingTrackUri = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device));
       return;
@@ -262,10 +264,11 @@ class DefaultCastService implements CastService {
     // Already streaming this exact track on the receiver: a duplicate emission
     // (or a metadata-only change carrying the same track) must not reload — that
     // would restart receiver playback and re-resolve the stream URL for nothing.
-    if (_state.isCasting && _castingTrackId == track.id) return;
+    // Compare by uri so a different provider's same-id copy still reloads.
+    if (_state.isCasting && _castingTrackUri == track.uri) return;
 
     if (!_mediaResolver.canCast(track)) {
-      _castingTrackId = null;
+      _castingTrackUri = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device, message: localFileLimitation));
       return;
@@ -275,12 +278,12 @@ class DefaultCastService implements CastService {
     try {
       media = await _mediaResolver.resolve(track);
     } on CastMediaException catch (error) {
-      _castingTrackId = null;
+      _castingTrackUri = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device, message: error.message));
       return;
     } catch (_) {
-      _castingTrackId = null;
+      _castingTrackUri = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device, message: "Couldn't cast this track."));
       return;
@@ -292,7 +295,7 @@ class DefaultCastService implements CastService {
     try {
       await handle.loadMedia(media);
     } catch (_) {
-      _castingTrackId = null;
+      _castingTrackUri = null;
       _emitPlayback(CastPlaybackStatus.idle);
       _emit(_connected(device,
           message: "Couldn't start playback on ${device.name}."));
@@ -300,7 +303,7 @@ class DefaultCastService implements CastService {
     }
     // Remember what is now loaded so a duplicate emission of the same track is a
     // no-op (see the guard above).
-    _castingTrackId = track.id;
+    _castingTrackUri = track.uri;
 
     // Playing on the receiver now. Marking isCasting true is the signal the
     // ActivePlaybackController uses to silence the local engine. Report a fresh
@@ -430,7 +433,7 @@ class DefaultCastService implements CastService {
     _volume = null;
     // Forget what was loaded so a reconnect re-casts the current track from
     // scratch rather than treating it as a duplicate of the last session.
-    _castingTrackId = null;
+    _castingTrackUri = null;
     final CastSessionHandle? handle = _handle;
     _handle = null;
     if (handle != null) await _safeClose(handle);

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -785,7 +785,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // that succeeded — not the preferred one that may have failed. The resolved
     // source rides along on later position/status updates until the next load.
     final Track played = outcome.track;
-    if (played.id != track.id) _queue = _queue.replaceCurrent(played);
+    // Compare by uri, not the bare id: a fallback can land on another provider's
+    // copy that shares the bare id (jellyfin:101 -> subsonic:101), and the queue
+    // must still swap to it so completion/retry read the copy that started.
+    if (played.uri != track.uri) _queue = _queue.replaceCurrent(played);
     _emit(_state.copyWith(
       currentTrack: played,
       source: outcome.resolved.source,

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -472,8 +472,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     }
   }
 
-  void _emit(PlaybackState next) {
-    if (next == _state) return;
+  void _emit(PlaybackState next, {bool force = false}) {
+    // [force] bypasses the equality guard for a state that differs only in a way
+    // PlaybackState == can't see — namely a same-bare-id provider swap, where
+    // Track == compares only the bare id (jellyfin:101 == subsonic:101), so the
+    // new state compares equal even though a different provider's copy is now
+    // playing. Without it the update would be dropped and UI/reporting would keep
+    // showing the failed provider.
+    if (!force && next == _state) return;
     _state = next;
     if (!_states.isClosed) _states.add(next);
   }
@@ -788,14 +794,21 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // Compare by uri, not the bare id: a fallback can land on another provider's
     // copy that shares the bare id (jellyfin:101 -> subsonic:101), and the queue
     // must still swap to it so completion/retry read the copy that started.
-    if (played.uri != track.uri) _queue = _queue.replaceCurrent(played);
-    _emit(_state.copyWith(
-      currentTrack: played,
-      source: outcome.resolved.source,
-      upNext: _queue.upNext,
-      previous: _queue.history,
-      hasPrevious: _queue.hasPrevious,
-    ));
+    final bool swappedProvider = played.uri != track.uri;
+    if (swappedProvider) _queue = _queue.replaceCurrent(played);
+    _emit(
+      _state.copyWith(
+        currentTrack: played,
+        source: outcome.resolved.source,
+        upNext: _queue.upNext,
+        previous: _queue.history,
+        hasPrevious: _queue.hasPrevious,
+      ),
+      // A same-bare-id provider swap leaves every field equal under
+      // PlaybackState == (Track == is by bare id), so force the emission —
+      // otherwise UI/reporting keep showing the failed provider's copy.
+      force: swappedProvider,
+    );
 
     // Level this track before it's heard (its ReplayGain, or full volume when
     // normalization is off); resume at the preserved position after a cast

--- a/lib/core/services/media_artwork_prewarm_service.dart
+++ b/lib/core/services/media_artwork_prewarm_service.dart
@@ -89,12 +89,14 @@ class MediaArtworkPrewarmService {
     }
   }
 
-  /// A fingerprint of the now-playing + look-ahead track ids, so warming reacts
-  /// to queue/track changes but not to position/status ticks (same key).
+  /// A fingerprint of the now-playing + look-ahead track uris, so warming reacts
+  /// to queue/track changes but not to position/status ticks (same key). Keyed by
+  /// uri (not the bare id) so switching between two providers' same-id copies
+  /// still triggers a warm.
   String _keyFor(PlaybackState state) {
-    final String current = state.currentTrack?.id ?? '-';
+    final String current = state.currentTrack?.uri ?? '-';
     final String ahead =
-        state.upNext.take(_lookahead).map((Track t) => t.id).join(',');
+        state.upNext.take(_lookahead).map((Track t) => t.uri).join(',');
     return '$current|$ahead';
   }
 

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 
 import '../catalog/library_grouping.dart';
@@ -17,7 +20,8 @@ import '../repositories/playlist_repository.dart';
 /// Category IDs are plain constants; leaf and container IDs encode where the
 /// item lives so a later `playFromMediaId` can be resolved back to a track
 /// without extra state:
-///  - `library/<trackId>` — a catalog track (the Songs list).
+///  - `library/<uriHash>` — a catalog track (the Songs list), keyed by an
+///    opaque hash of the track uri so two providers' same-id songs never collide.
 ///  - `album/<albumId>` — an album *container* (browsable); its children are
 ///    `album/<albumId>/<index>` track leaves.
 ///  - `artist/<artistId>` — an artist *container* (browsable); its children are
@@ -34,11 +38,11 @@ import '../repositories/playlist_repository.dart';
 /// (or an `al-`/`ar-`/`unknown-...` sentinel) that never itself contains a `/`.
 ///
 /// Security invariant: every id is built only from non-secret, opaque ids — a
-/// catalog/track id (the bare item id, never the `jellyfin:`/`subsonic:` uri), a
-/// derived album/artist grouping id, a local playlist id, or a small integer
-/// index. No id ever carries a Jellyfin/Subsonic access token or an
-/// authenticated stream URL; the stream URL is minted lazily at play time by the
-/// resolver, never here.
+/// derived album/artist grouping id, a local playlist id, a small integer index,
+/// or an opaque hash of the track uri (the Songs leaf). No id ever carries a
+/// `jellyfin:`/`subsonic:` uri, a local file path, a Jellyfin/Subsonic access
+/// token, or an authenticated stream URL; the stream URL is minted lazily at play
+/// time by the resolver, never here.
 abstract final class MediaId {
   /// The root the platform requests first (audio_service's `browsableRootId`).
   static const String root = 'root';
@@ -66,7 +70,22 @@ abstract final class MediaId {
   static const String _favoritePrefix = 'favorite/';
   static const String _offlinePrefix = 'offline/';
 
-  static String libraryTrack(String trackId) => '$_libraryPrefix$trackId';
+  /// A playable leaf for a flat-"Songs" track, keyed by an opaque hash of the
+  /// track's provider-namespaced [Track.uri]. Hashing (not the raw uri) keeps the
+  /// id collision-free across providers — two songs that share a bare server-side
+  /// id (`jellyfin:101` vs `subsonic:101`) get distinct leaves — while upholding
+  /// the security invariant above: the id carries no scheme, path, or uri, only
+  /// hex. It is also stable for a given track (same uri → same hash), so a
+  /// `playFromMediaId` resolves deterministically. Resolve by re-hashing each
+  /// candidate's uri and matching against [libraryTrackId].
+  static String libraryTrack(String trackUri) =>
+      '$_libraryPrefix${libraryTrackHash(trackUri)}';
+
+  /// The opaque, collision-free, leak-safe hash of [trackUri] used as the Songs
+  /// leaf id. SHA-256 hex; carries no scheme/path/token.
+  static String libraryTrackHash(String trackUri) =>
+      sha256.convert(utf8.encode(trackUri)).toString();
+
   static String queueItem(int index) => '$_queuePrefix$index';
 
   /// An album *container* node id (its children are the album's tracks).
@@ -110,6 +129,8 @@ abstract final class MediaId {
   static bool isArtistTrack(String id) => _isLeaf(id, _artistPrefix);
   static bool isPlaylistTrack(String id) => _isLeaf(id, _playlistPrefix);
 
+  /// The opaque track hash encoded in a library leaf id (`library/<hash>`),
+  /// matched against [libraryTrackHash] of a candidate's uri to resolve it.
   static String libraryTrackId(String id) =>
       id.substring(_libraryPrefix.length);
 
@@ -296,8 +317,11 @@ class MediaBrowserTree {
   ) async {
     if (MediaId.isLibraryTrack(mediaId)) {
       final List<Track> tracks = await _allTracks();
-      final String trackId = MediaId.libraryTrackId(mediaId);
-      final int index = tracks.indexWhere((Track t) => t.id == trackId);
+      // Match by the uri hash, so two providers' same-id songs resolve to the
+      // right copy (the flat Songs list can now hold both).
+      final String trackHash = MediaId.libraryTrackId(mediaId);
+      final int index = tracks.indexWhere(
+          (Track t) => MediaId.libraryTrackHash(t.uri) == trackHash);
       if (index < 0) return null;
       return MediaPlaybackRequest(tracks: tracks, startIndex: index);
     }
@@ -367,7 +391,9 @@ class MediaBrowserTree {
     if (tracks.isEmpty) return _placeholder('Sync your library first');
     return <MediaNode>[
       for (final Track track in tracks)
-        _trackNode(MediaId.libraryTrack(track.id), track),
+        // Key the leaf by a hash of the provider-namespaced uri so two same-id
+        // songs from different providers get distinct, collision-free media ids.
+        _trackNode(MediaId.libraryTrack(track.uri), track),
     ];
   }
 

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -10,6 +10,7 @@ import '../models/playback_state.dart';
 import '../models/playlist.dart';
 import '../models/track.dart';
 import '../repositories/download_repository.dart';
+import '../repositories/download_store.dart';
 import '../repositories/favorites_repository.dart';
 import '../repositories/music_library_repository.dart';
 import '../repositories/playlist_repository.dart';
@@ -384,7 +385,7 @@ class MediaBrowserTree {
 
   Future<bool> _hasFavorites() async => (await _favoriteIds()).isNotEmpty;
 
-  Future<bool> _hasOffline() async => (await _downloadedIds()).isNotEmpty;
+  Future<bool> _hasOffline() async => (await _downloadedKeys()).isNotEmpty;
 
   Future<List<MediaNode>> _songNodes() async {
     final List<Track> tracks = await _allTracks();
@@ -522,12 +523,12 @@ class MediaBrowserTree {
   /// repository, so they never leak into this section. Ids with no catalog track
   /// are dropped.
   Future<List<Track>> _offlineTracks() async {
-    final Set<String> ids = await _downloadedIds();
-    if (ids.isEmpty) return const <Track>[];
+    final Set<String> keys = await _downloadedKeys();
+    if (keys.isEmpty) return const <Track>[];
     final List<Track> tracks = await _allTracks();
     return <Track>[
       for (final Track track in tracks)
-        if (ids.contains(track.id)) track,
+        if (keys.contains(CachedTrack.cacheKeyForTrack(track))) track,
     ];
   }
 
@@ -573,13 +574,13 @@ class MediaBrowserTree {
     }
   }
 
-  /// The current downloaded track-id set. Guarded: any failure yields an empty
-  /// set so a misbehaving download backend can't break browsing.
-  Future<Set<String>> _downloadedIds() async {
+  /// The current downloaded cache-key set (provider-aware). Guarded: any failure
+  /// yields an empty set so a misbehaving download backend can't break browsing.
+  Future<Set<String>> _downloadedKeys() async {
     final DownloadRepository? downloads = _downloads;
     if (downloads == null) return const <String>{};
     try {
-      return (await downloads.downloadedTrackIds()).toSet();
+      return (await downloads.downloadedTrackKeys()).toSet();
     } catch (_) {
       return const <String>{};
     }

--- a/lib/core/services/playback_candidate_source.dart
+++ b/lib/core/services/playback_candidate_source.dart
@@ -32,23 +32,24 @@ class NoFallbackCandidateSource implements PlaybackCandidateSource {
   List<Track> candidatesFor(Track track) => <Track>[track];
 }
 
-/// A [PlaybackCandidateSource] backed by a lazily-read map of *display track id*
-/// → ordered candidates.
+/// A [PlaybackCandidateSource] backed by a lazily-read map of *provider-namespaced
+/// [Track.uri]* → ordered candidates.
 ///
 /// The map is read through a callback at every [candidatesFor] call, never cached,
 /// so the session-pinned playback controller always sees the latest library
 /// (after a scan, sync, sign-in, or a change to the default-source setting)
 /// without being rebuilt. A track absent from the map — a single-source song, or
 /// any track that isn't a unified library row — yields `[track]`, i.e. no
-/// fallback.
+/// fallback. Keyed by uri (not the bare id) so a queued `subsonic:101` can't
+/// resolve to a different song's candidates that happen to be `jellyfin:101`.
 class MapPlaybackCandidateSource implements PlaybackCandidateSource {
-  const MapPlaybackCandidateSource(this._candidatesById);
+  const MapPlaybackCandidateSource(this._candidatesByUri);
 
-  final Map<String, List<Track>> Function() _candidatesById;
+  final Map<String, List<Track>> Function() _candidatesByUri;
 
   @override
   List<Track> candidatesFor(Track track) {
-    final List<Track>? candidates = _candidatesById()[track.id];
+    final List<Track>? candidates = _candidatesByUri()[track.uri];
     if (candidates == null || candidates.isEmpty) return <Track>[track];
     return candidates;
   }

--- a/lib/core/services/playback_reporting_service.dart
+++ b/lib/core/services/playback_reporting_service.dart
@@ -91,10 +91,13 @@ class PlaybackReportingService {
     final Track? track = state.currentTrack;
     final Track? previous = _track;
 
-    if (track?.id != previous?.id) {
-      // The queue moved (skip, natural advance, or cleared to nothing). Tell
-      // reporters even when the new track never starts, so the outgoing
-      // track's session is always closed.
+    if (track?.uri != previous?.uri) {
+      // The queue moved (skip, natural advance, a same-id provider fallback, or
+      // cleared to nothing). Compare by uri so a fallback that swaps providers
+      // but keeps the bare id (jellyfin:101 → subsonic:101) still closes the
+      // outgoing session and opens one for the copy actually playing. Tell
+      // reporters even when the new track never starts, so the outgoing track's
+      // session is always closed.
       if (previous != null && _isActive) {
         final Track? next = track;
         _enqueue(() => _reporter.onTrackChanged(previous, next));

--- a/lib/core/services/remote_prebuffer_service.dart
+++ b/lib/core/services/remote_prebuffer_service.dart
@@ -60,7 +60,7 @@ class RemotePrebufferService {
   /// position/duration/status so listening doesn't thrash on playback ticks.
   String _keyFor(PlaybackState state) {
     final StringBuffer buffer = StringBuffer()
-      ..write(state.currentTrack?.id ?? '-')
+      ..write(state.currentTrack?.uri ?? '-')
       ..write('|')
       ..write(state.shuffleEnabled)
       ..write('|')
@@ -70,7 +70,7 @@ class RemotePrebufferService {
         _ahead < state.upNext.length ? _ahead : state.upNext.length;
     for (int i = 0; i < count; i++) {
       buffer
-        ..write(state.upNext[i].id)
+        ..write(state.upNext[i].uri)
         ..write(',');
     }
     return buffer.toString();

--- a/lib/core/services/smart_playlist_resolver.dart
+++ b/lib/core/services/smart_playlist_resolver.dart
@@ -65,16 +65,29 @@ class SmartPlaylistResolver {
     List<Track> allTracks,
     Map<String, DateTime> addedAt,
   ) {
-    // Keyed by the provider-namespaced [Track.uri] (see
-    // RecordingMusicLibraryRepository), so two providers' same-id tracks don't
-    // share a first-seen timestamp.
     final List<Track> sorted = List<Track>.of(allTracks)
-      ..sort((a, b) {
-        final DateTime ta = addedAt[a.uri] ?? _epoch;
-        final DateTime tb = addedAt[b.uri] ?? _epoch;
-        return tb.compareTo(ta);
-      });
+      ..sort(
+          (a, b) => _addedTime(b, addedAt).compareTo(_addedTime(a, addedAt)));
     return _bounded(sorted);
+  }
+
+  /// First-seen time for [track] (the newest-first sort key). Reads the
+  /// provider-namespaced [Track.uri] key written by
+  /// RecordingMusicLibraryRepository so two providers' same-id tracks don't share
+  /// a timestamp. Falls back to the legacy bare-`id` key for a remote track whose
+  /// timestamp predates the uri-keyed store and hasn't been migrated yet — the
+  /// first post-upgrade sync migrates it in place, but this read can run before
+  /// that, so the fallback keeps Recently Added in order immediately after an
+  /// upgrade instead of collapsing the whole library to catalog order until the
+  /// next sync. Unknown tracks sort oldest (at [_epoch]).
+  DateTime _addedTime(Track track, Map<String, DateTime> addedAt) {
+    final DateTime? byUri = addedAt[track.uri];
+    if (byUri != null) return byUri;
+    if (track.uri != track.id) {
+      final DateTime? legacy = addedAt[track.id];
+      if (legacy != null) return legacy;
+    }
+    return _epoch;
   }
 
   /// Resolves [orderedIds] against the catalog, preserving the given order and

--- a/lib/core/services/smart_playlist_resolver.dart
+++ b/lib/core/services/smart_playlist_resolver.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import '../models/play_history.dart';
 import '../models/smart_playlist.dart';
 import '../models/track.dart';
+import '../repositories/download_store.dart';
 
 /// Turns a [SmartPlaylistKind] plus the on-device signals into an ordered track
 /// list. Pure and synchronous: it takes everything it needs as arguments and
@@ -32,7 +33,7 @@ class SmartPlaylistResolver {
     required PlayHistory history,
     required Map<String, DateTime> addedAt,
     required Set<String> favoriteIds,
-    required Set<String> downloadedIds,
+    required Set<String> downloadedKeys,
     Random? random,
   }) {
     switch (kind) {
@@ -45,7 +46,7 @@ class SmartPlaylistResolver {
       case SmartPlaylistKind.favorites:
         return _filter(allTracks, favoriteIds);
       case SmartPlaylistKind.downloaded:
-        return _filter(allTracks, downloadedIds);
+        return _filterByKey(allTracks, downloadedKeys);
       case SmartPlaylistKind.random:
         return _random(allTracks, random);
       case SmartPlaylistKind.neverPlayed:
@@ -102,12 +103,23 @@ class SmartPlaylistResolver {
     ]);
   }
 
-  /// Catalog-ordered subset whose ids are in [ids]. Not bounded: favourites and
-  /// downloads are user-curated, so the mix shows all of them.
+  /// Catalog-ordered subset whose ids are in [ids] — the favourites mix. Not
+  /// bounded: favourites are user-curated, so the mix shows all of them.
   List<Track> _filter(List<Track> allTracks, Set<String> ids) {
     return <Track>[
       for (final Track track in allTracks)
         if (ids.contains(track.id)) track,
+    ];
+  }
+
+  /// Catalog-ordered subset whose provider-aware cache key is in [keys] — the
+  /// downloaded mix. Keyed by [CachedTrack.cacheKeyForTrack] (not the bare id) so
+  /// only the copy actually downloaded appears, never a same-id copy from another
+  /// provider that isn't cached. Not bounded: downloads are user-curated.
+  List<Track> _filterByKey(List<Track> allTracks, Set<String> keys) {
+    return <Track>[
+      for (final Track track in allTracks)
+        if (keys.contains(CachedTrack.cacheKeyForTrack(track))) track,
     ];
   }
 

--- a/lib/core/services/smart_playlist_resolver.dart
+++ b/lib/core/services/smart_playlist_resolver.dart
@@ -65,10 +65,13 @@ class SmartPlaylistResolver {
     List<Track> allTracks,
     Map<String, DateTime> addedAt,
   ) {
+    // Keyed by the provider-namespaced [Track.uri] (see
+    // RecordingMusicLibraryRepository), so two providers' same-id tracks don't
+    // share a first-seen timestamp.
     final List<Track> sorted = List<Track>.of(allTracks)
       ..sort((a, b) {
-        final DateTime ta = addedAt[a.id] ?? _epoch;
-        final DateTime tb = addedAt[b.id] ?? _epoch;
+        final DateTime ta = addedAt[a.uri] ?? _epoch;
+        final DateTime tb = addedAt[b.uri] ?? _epoch;
         return tb.compareTo(ta);
       });
     return _bounded(sorted);

--- a/lib/core/services/smart_precache_service.dart
+++ b/lib/core/services/smart_precache_service.dart
@@ -78,7 +78,7 @@ class SmartPrecacheService {
   /// position/duration/status so listening doesn't thrash on playback ticks.
   static String _keyFor(PlaybackState state) {
     final StringBuffer buffer = StringBuffer()
-      ..write(state.currentTrack?.id ?? '-')
+      ..write(state.currentTrack?.uri ?? '-')
       ..write('|')
       ..write(state.shuffleEnabled)
       ..write('|')
@@ -86,7 +86,7 @@ class SmartPrecacheService {
       ..write('|');
     for (final Track track in state.upNext) {
       buffer
-        ..write(track.id)
+        ..write(track.uri)
         ..write(',');
     }
     return buffer.toString();

--- a/lib/core/sources/music_provider.dart
+++ b/lib/core/sources/music_provider.dart
@@ -313,6 +313,23 @@ abstract final class MusicProviders {
     return local;
   }
 
+  /// The bare server-side id inside a remote provider's `scheme:id` [trackUri]
+  /// (the `101` in `jellyfin:101`), or `null` for a local track — whose id is
+  /// the uri itself. Used to clean up a pre-v2, *bare-id*-keyed store entry that
+  /// the uri-keyed model no longer matches (e.g. `LibraryAddedStore`).
+  static String? bareRemoteIdForTrackUri(String trackUri) {
+    for (final String scheme in const <String>[
+      JellyfinTrackMapper.uriScheme,
+      SubsonicTrackMapper.uriScheme,
+      PlexTrackMapper.uriScheme,
+    ]) {
+      if (trackUri.startsWith(scheme)) {
+        return trackUri.substring(scheme.length);
+      }
+    }
+    return null;
+  }
+
   /// The capabilities of the provider that owns [trackUri].
   static MusicProviderCapabilities capabilitiesForTrackUri(String trackUri) =>
       forTrackUri(trackUri).capabilities;

--- a/lib/data/database/linthra_database.dart
+++ b/lib/data/database/linthra_database.dart
@@ -13,9 +13,11 @@ part 'linthra_database.g.dart';
 /// from. Kept deliberately outside the UI and feature layers; repositories in
 /// `data/repositories/` are the only callers.
 ///
-/// Schema is at v1 with no migrations yet. When the schema changes, bump
-/// [schemaVersion] and add a `MigrationStrategy`; we are not pre-building that
-/// machinery while there is nothing to migrate from.
+/// Schema history:
+///  * **v1** — `tracks`, keyed by the bare server-side `id`.
+///  * **v2** — `tracks` re-keyed on the provider-namespaced `uri`, so the same
+///    server-side `id` from two providers (e.g. Plex `101` and Subsonic `101`)
+///    can coexist instead of overwriting each other. See [migration].
 @DriftDatabase(tables: [Tracks])
 class LinthraDatabase extends _$LinthraDatabase {
   LinthraDatabase() : super(_openConnection());
@@ -25,7 +27,49 @@ class LinthraDatabase extends _$LinthraDatabase {
   LinthraDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+        onCreate: (Migrator m) async {
+          await m.createAll();
+        },
+        onUpgrade: (Migrator m, int from, int to) async {
+          if (from < 2) {
+            await _migrateTracksKeyToUri(m);
+          }
+        },
+      );
+
+  /// v1 → v2: move the `tracks` primary key from the bare `id` to the
+  /// provider-namespaced `uri`.
+  ///
+  /// SQLite can't alter a primary key in place, so the table is rebuilt: rename
+  /// the old one aside, create the new-shaped `tracks`, copy every row across,
+  /// then drop the old. All of it runs in one transaction so a reader never sees
+  /// a half-migrated catalog (and a failure rolls the whole thing back).
+  ///
+  /// **Data is preserved.** A v1 catalog could only ever store one row per bare
+  /// `id` (that was exactly the collision bug — a second provider's same-id row
+  /// overwrote the first), so every surviving row already has a distinct `uri`
+  /// and the copy keeps them all. `INSERT OR REPLACE` keeps the copy total even
+  /// if some older build had somehow persisted two rows sharing one `uri`.
+  Future<void> _migrateTracksKeyToUri(Migrator m) async {
+    await transaction(() async {
+      await m.database.customStatement(
+        'ALTER TABLE tracks RENAME TO tracks_legacy_v1;',
+      );
+      await m.createTable(tracks);
+      await m.database.customStatement(
+        'INSERT OR REPLACE INTO tracks '
+        '(id, source_id, title, uri, artist_name, album_name, '
+        'duration_ms, track_number, artwork_uri) '
+        'SELECT id, source_id, title, uri, artist_name, album_name, '
+        'duration_ms, track_number, artwork_uri FROM tracks_legacy_v1;',
+      );
+      await m.database.customStatement('DROP TABLE tracks_legacy_v1;');
+    });
+  }
 }
 
 QueryExecutor _openConnection() {

--- a/lib/data/database/linthra_database.g.dart
+++ b/lib/data/database/linthra_database.g.dart
@@ -138,7 +138,7 @@ class $TracksTable extends Tracks with TableInfo<$TracksTable, TrackRow> {
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => {id};
+  Set<GeneratedColumn> get $primaryKey => {uri};
   @override
   TrackRow map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';

--- a/lib/data/database/tables/tracks_table.dart
+++ b/lib/data/database/tables/tracks_table.dart
@@ -10,6 +10,16 @@ import 'package:drift/drift.dart';
 /// source can replace just its rows (see `upsertCatalog`) without touching the
 /// others. `durationMs` and `artworkUri` are stored as primitives (SQLite has
 /// no Duration/Uri types); the mappers rebuild the rich types on read.
+///
+/// The primary key is [uri], not [id]. `id` is the *bare* server-side id
+/// (Jellyfin item id, Subsonic/Plex `ratingKey`, or a local path), which is only
+/// unique *within* a provider — two providers can hand us the same `id` (e.g.
+/// Plex `101` and Subsonic `101`). `uri` is the provider-namespaced identity the
+/// rest of the app already keys off (`jellyfin:101`, `plex:101`, a local path),
+/// so keying the row on it lets the same server-side id from different providers
+/// coexist instead of silently overwriting each other under `insertOrReplace`.
+/// `id` is kept as a column because the per-provider server APIs (e.g. Jellyfin
+/// favourites/playlists) still address items by it.
 @DataClassName('TrackRow')
 class Tracks extends Table {
   TextColumn get id => text()();
@@ -23,5 +33,5 @@ class Tracks extends Table {
   TextColumn get artworkUri => text().nullable()();
 
   @override
-  Set<Column> get primaryKey => {id};
+  Set<Column> get primaryKey => {uri};
 }

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -69,6 +69,7 @@ class CacheDownloadRepository
     DownloadScheduler? scheduler,
     Track? Function()? currentlyPlayingTrack,
     DateTime Function()? now,
+    Future<List<Track>> Function()? catalogForMigration,
   })  : _store = store,
         _files = files,
         _downloader = downloader,
@@ -77,7 +78,8 @@ class CacheDownloadRepository
         _policy = policy,
         _scheduler = scheduler ?? DownloadScheduler(),
         _currentlyPlayingTrack = currentlyPlayingTrack,
-        _now = now ?? DateTime.now;
+        _now = now ?? DateTime.now,
+        _catalogForMigration = catalogForMigration;
 
   final DownloadStore _store;
   final OfflineFileStore _files;
@@ -97,6 +99,15 @@ class CacheDownloadRepository
   final Track? Function()? _currentlyPlayingTrack;
 
   final DateTime Function() _now;
+
+  /// Resolves the current catalog tracks, used once on load to migrate legacy
+  /// (pre-v0.1.6, `sourceType`-less) cache records to provider-aware keys by
+  /// inferring each record's provider from the catalog. The pre-v0.1.6 catalog is
+  /// 1:1 bare-id→provider, so an unambiguous match is safe; an id the catalog now
+  /// exposes under two providers is left unmigrated rather than mis-attributed.
+  /// Null in tests/dev that don't exercise migration; the app wires it to the
+  /// music library.
+  final Future<List<Track>> Function()? _catalogForMigration;
 
   final Map<String, DownloadStatus> _statuses = <String, DownloadStatus>{};
 
@@ -150,7 +161,23 @@ class CacheDownloadRepository
   Future<void> _ensureLoaded() async {
     if (_loaded) return;
     bool changed = false;
-    for (final CachedTrack cached in await _store.loadDownloads()) {
+    final List<CachedTrack> records = await _store.loadDownloads();
+    final Map<String, String?> legacyScheme = await _legacySchemeFor(records);
+    for (final CachedTrack record in records) {
+      CachedTrack cached = record;
+      // Legacy (pre-v0.1.6) records carry no sourceType, so they key as
+      // `\0<id>` while a live track keys as `<scheme>\0<id>` — the download would
+      // look missing to the row/offline consumers, and a fresh request would
+      // re-fetch it. Re-key by inferring the provider from the catalog
+      // (unambiguous matches only); the cache file name is untouched, so the
+      // bytes keep resolving, and re-saving heals the record for next launch.
+      final String? inferred = legacyScheme[cached.trackId];
+      if (inferred != null &&
+          inferred.isNotEmpty &&
+          (cached.sourceType == null || cached.sourceType!.isEmpty)) {
+        cached = cached.copyWith(sourceType: inferred);
+        changed = true;
+      }
       if (cached.isManaged) {
         final int? size = await _files.sizeFor(cached.fileName!);
         if (size == null) {
@@ -159,15 +186,12 @@ class CacheDownloadRepository
           changed = true;
           continue;
         }
-        CachedTrack entry = cached;
         if (cached.sizeBytes == 0 && size > 0) {
-          entry = cached.copyWith(sizeBytes: size);
+          cached = cached.copyWith(sizeBytes: size);
           changed = true;
         }
-        _downloads[_keyForCached(entry)] = entry;
-      } else {
-        _downloads[_keyForCached(cached)] = cached;
       }
+      _downloads[_keyForCached(cached)] = cached;
       // A preloaded entry is cached and playable, but never a *download*: it
       // stays out of the status map so the downloads UI doesn't show it.
       if (!cached.preloaded) {
@@ -176,6 +200,32 @@ class CacheDownloadRepository
     }
     if (changed) await _save();
     _loaded = true;
+  }
+
+  /// The provider scheme for each legacy (sourceType-less) record's bare id,
+  /// resolved via the catalog oracle so those records can be re-keyed to
+  /// provider-aware identity. Empty when there's nothing to migrate or no oracle
+  /// is wired. A bare id the catalog exposes under more than one provider maps to
+  /// null (ambiguous → left unmigrated rather than mis-attributed).
+  Future<Map<String, String?>> _legacySchemeFor(
+      List<CachedTrack> records) async {
+    final Future<List<Track>> Function()? oracle = _catalogForMigration;
+    if (oracle == null) return const <String, String?>{};
+    final bool hasLegacy = records
+        .any((CachedTrack c) => c.sourceType == null || c.sourceType!.isEmpty);
+    if (!hasLegacy) return const <String, String?>{};
+    final List<Track> tracks;
+    try {
+      tracks = await oracle();
+    } catch (_) {
+      return const <String, String?>{};
+    }
+    final Map<String, String?> byId = <String, String?>{};
+    for (final Track track in tracks) {
+      byId[track.id] =
+          byId.containsKey(track.id) ? null : CachedTrack.schemeOf(track.uri);
+    }
+    return byId;
   }
 
   @override

--- a/lib/data/repositories/cache_download_repository.dart
+++ b/lib/data/repositories/cache_download_repository.dart
@@ -188,10 +188,16 @@ class CacheDownloadRepository
   @override
   Future<DownloadStatus> statusFor(String trackId) async {
     await _ensureLoaded();
-    // Reads the id-keyed projection (the same shape [statusStream] emits), so it
-    // agrees with the UI's per-row status. Provider-aware isolation is enforced
-    // where it matters — storage, the cache file, and removal.
-    return _snapshot()[trackId] ?? DownloadStatus.notDownloaded;
+    // A plain catalog-id convenience: the catalog's primary key makes ids unique
+    // there, so a bare id resolves to one track. The cache itself is keyed
+    // provider-aware (see [_snapshot]) and [statusStream] emits those keys — the
+    // app's per-row status joins on the cache key, never this. Scans the
+    // provider-aware map by id so a caller can still ask by plain id; under a
+    // cross-provider same-id collision it returns the first matching copy.
+    for (final MapEntry<String, DownloadStatus> e in _statuses.entries) {
+      if (_trackIdOfKey(e.key) == trackId) return e.value;
+    }
+    return DownloadStatus.notDownloaded;
   }
 
   @override
@@ -442,12 +448,12 @@ class CacheDownloadRepository
   }
 
   @override
-  Future<List<String>> downloadedTrackIds() async {
+  Future<List<String>> downloadedTrackKeys() async {
     await _ensureLoaded();
     return _statuses.entries
         .where((MapEntry<String, DownloadStatus> e) =>
             e.value == DownloadStatus.downloaded)
-        .map((MapEntry<String, DownloadStatus> e) => _trackIdOfKey(e.key))
+        .map((MapEntry<String, DownloadStatus> e) => e.key)
         .toList();
   }
 
@@ -640,22 +646,18 @@ class CacheDownloadRepository
     if (_progress.remove(key) != null) _emitProgress();
   }
 
-  /// Projects the provider-aware status map onto a catalog-id-keyed snapshot —
-  /// the shape the UI's per-row status provider and the cross-provider sync
-  /// layers consume. In the catalog (whose primary key is the id) two providers
-  /// never share an id, so the projection is lossless there; the provider-aware
-  /// keys stay internal where same-id isolation matters (storage, files,
-  /// removal).
-  Map<String, DownloadStatus> _snapshot() => <String, DownloadStatus>{
-        for (final MapEntry<String, DownloadStatus> e in _statuses.entries)
-          _trackIdOfKey(e.key): e.value,
-      };
+  /// A copy of the provider-aware status map, keyed by each track's
+  /// [CachedTrack.cacheKey] (`scheme\0id`) — the very key a live [Track] produces
+  /// via [CachedTrack.cacheKeyForTrack]. Keeping the provider-aware key in the
+  /// public projection is what stops two providers' same-id copies (`jellyfin:101`
+  /// vs `subsonic:101`) from sharing a status: the per-row status/progress
+  /// providers and the downloaded/offline sets all join on this key, so a
+  /// download of one copy never lights up the other.
+  Map<String, DownloadStatus> _snapshot() =>
+      Map<String, DownloadStatus>.of(_statuses);
 
   Map<String, DownloadProgress> _progressSnapshot() =>
-      <String, DownloadProgress>{
-        for (final MapEntry<String, DownloadProgress> e in _progress.entries)
-          _trackIdOfKey(e.key): e.value,
-      };
+      Map<String, DownloadProgress>.of(_progress);
 
   CacheSnapshot _cacheSnapshot() {
     int used = 0;
@@ -669,13 +671,11 @@ class CacheDownloadRepository
   }
 
   /// The track's non-secret URI scheme (`jellyfin`, `file`, …), never the full
-  /// URL — safe to persist as the cached track's source type.
-  static String? _sourceTypeOf(Track track) {
-    final int colon = track.uri.indexOf(':');
-    if (colon <= 0) return null;
-    final String scheme = track.uri.substring(0, colon).toLowerCase();
-    return scheme.isEmpty ? null : scheme;
-  }
+  /// URL — safe to persist as the cached track's source type. Delegates to
+  /// [CachedTrack.schemeOf] so the repository's stored key and the key a consumer
+  /// computes from a live [Track] via [CachedTrack.cacheKeyForTrack] can never
+  /// drift to different scheme logic.
+  static String? _sourceTypeOf(Track track) => CachedTrack.schemeOf(track.uri);
 
   /// The provider-aware cache identity for [track]: its source scheme **plus**
   /// catalog id, so two providers that expose the same local id (e.g. a Plex

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -117,6 +117,11 @@ final cachedTrackLocatorProvider = Provider<CachedTrackLocator>((ref) {
   return StoreCachedTrackLocator(
     ref.watch(downloadStoreProvider),
     ref.watch(offlineFileStoreProvider),
+    // A legacy untagged cache record is served by bare id only when the catalog
+    // shows that id maps to one provider — never another provider's same-id copy.
+    // Read lazily so wiring it never rebuilds the locator.
+    catalogForLegacyMatch: () =>
+        ref.read(musicLibraryRepositoryProvider).getAllTracks(),
   );
 });
 

--- a/lib/data/repositories/download_repository_provider.dart
+++ b/lib/data/repositories/download_repository_provider.dart
@@ -16,6 +16,7 @@ import 'file_system_offline_file_store.dart';
 import 'in_memory_download_preferences.dart';
 import 'in_memory_download_store.dart';
 import 'in_memory_offline_file_store.dart';
+import 'music_library_repository_provider.dart';
 import 'shared_preferences_download_preferences.dart';
 import 'shared_preferences_download_store.dart';
 import 'store_cached_track_locator.dart';
@@ -79,6 +80,11 @@ final _cacheDownloadRepositoryProvider =
     connectivity: ref.watch(connectivityServiceProvider),
     preferences: ref.watch(downloadPreferencesProvider),
     currentlyPlayingTrack: ref.watch(currentlyPlayingTrackProvider),
+    // One-time migration of legacy (pre-v0.1.6, sourceType-less) cache records to
+    // provider-aware keys, inferring each one's provider from the catalog. Read
+    // lazily (not watched) so wiring it never rebuilds the repository.
+    catalogForMigration: () =>
+        ref.read(musicLibraryRepositoryProvider).getAllTracks(),
   );
   ref.onDispose(repository.dispose);
   return repository;

--- a/lib/data/repositories/drift_music_library_repository.dart
+++ b/lib/data/repositories/drift_music_library_repository.dart
@@ -30,9 +30,9 @@ class DriftMusicLibraryRepository
   }
 
   @override
-  Future<Track?> getTrackById(String id) async {
+  Future<Track?> getTrackByUri(String uri) async {
     final TrackRow? row = await (_db.select(_db.tracks)
-          ..where((t) => t.id.equals(id)))
+          ..where((t) => t.uri.equals(uri)))
         .getSingleOrNull();
     return row == null ? null : trackFromRow(row);
   }
@@ -91,15 +91,18 @@ class DriftMusicLibraryRepository
     if (tracks.isEmpty) return;
     await _db.batch((Batch batch) {
       // insertOrReplace makes the write idempotent: a source can legitimately
-      // hand us the same stable track id twice within one sync — e.g. a Subsonic
-      // album that shifts across paginated `getAlbumList2` pages and so is
-      // fetched twice, or an `appendToCatalog` batch that overlaps an earlier
-      // one during an incremental replacement. A plain insert would raise a
-      // UNIQUE-constraint error on the duplicate id and roll back the whole
-      // transaction, failing an otherwise-good sync. The id is the track's
-      // stable identity, so a duplicate is the same track; collapsing to one row
-      // (last wins) is the correct resolution. `tracks` is the only table and
-      // has no foreign keys, so the replace can never cascade.
+      // hand us the same track twice within one sync — e.g. a Subsonic album that
+      // shifts across paginated `getAlbumList2` pages and so is fetched twice, or
+      // an `appendToCatalog` batch that overlaps an earlier one during an
+      // incremental replacement. A plain insert would raise a UNIQUE-constraint
+      // error on the duplicate and roll back the whole transaction, failing an
+      // otherwise-good sync. The row's identity is its provider-namespaced `uri`
+      // (the primary key), so a duplicate uri is the same track; collapsing to
+      // one row (last wins) is the correct resolution. Because the key is the
+      // uri — not the bare `id` — a same-`id` row from a *different* provider has
+      // a different uri and is kept as its own row rather than overwritten.
+      // `tracks` is the only table and has no foreign keys, so the replace can
+      // never cascade.
       batch.insertAll(
         _db.tracks,
         tracks.map((Track t) => trackToCompanion(t, sourceId)).toList(),
@@ -112,8 +115,8 @@ class DriftMusicLibraryRepository
   /// and nothing on a server — it is purely an index removal (see
   /// [MusicLibraryRepository.removeTracks]).
   @override
-  Future<void> removeTracks(List<String> trackIds) async {
-    if (trackIds.isEmpty) return;
-    await (_db.delete(_db.tracks)..where((t) => t.id.isIn(trackIds))).go();
+  Future<void> removeTracks(List<String> trackUris) async {
+    if (trackUris.isEmpty) return;
+    await (_db.delete(_db.tracks)..where((t) => t.uri.isIn(trackUris))).go();
   }
 }

--- a/lib/data/repositories/in_memory_music_library_repository.dart
+++ b/lib/data/repositories/in_memory_music_library_repository.dart
@@ -52,10 +52,10 @@ class InMemoryMusicLibraryRepository
   }
 
   @override
-  Future<Track?> getTrackById(String id) async {
+  Future<Track?> getTrackByUri(String uri) async {
     for (final List<Track> tracks in _tracksBySource.values) {
       for (final Track track in tracks) {
-        if (track.id == id) {
+        if (track.uri == uri) {
           return track;
         }
       }
@@ -100,13 +100,13 @@ class InMemoryMusicLibraryRepository
   }
 
   @override
-  Future<void> removeTracks(List<String> trackIds) async {
-    if (trackIds.isEmpty) return;
-    final Set<String> ids = trackIds.toSet();
+  Future<void> removeTracks(List<String> trackUris) async {
+    if (trackUris.isEmpty) return;
+    final Set<String> uris = trackUris.toSet();
     for (final String sourceId in _tracksBySource.keys.toList()) {
       _tracksBySource[sourceId] = <Track>[
         for (final Track track in _tracksBySource[sourceId]!)
-          if (!ids.contains(track.id)) track,
+          if (!uris.contains(track.uri)) track,
       ];
     }
   }

--- a/lib/data/repositories/recording_music_library_repository.dart
+++ b/lib/data/repositories/recording_music_library_repository.dart
@@ -4,6 +4,7 @@ import '../../core/models/track.dart';
 import '../../core/repositories/incremental_catalog_writer.dart';
 import '../../core/repositories/library_added_store.dart';
 import '../../core/repositories/music_library_repository.dart';
+import '../../core/sources/music_provider.dart';
 
 /// A [MusicLibraryRepository] decorator that stamps each track with the time it
 /// first entered the library, so the "Recently added" smart mix has a signal to
@@ -140,6 +141,12 @@ class RecordingMusicLibraryRepository
     bool changed = false;
     for (final String uri in trackUris) {
       if (addedAt.remove(uri) != null) changed = true;
+      // Also drop a pre-v2 bare-id entry for a remote track that hasn't been
+      // migrated yet, so a remove-then-readd before the first post-upgrade sync
+      // is correctly treated as newly added (rather than adopting the stale
+      // legacy timestamp in _stampFirstSeen).
+      final String? legacyId = MusicProviders.bareRemoteIdForTrackUri(uri);
+      if (legacyId != null && addedAt.remove(legacyId) != null) changed = true;
     }
     if (changed) await _addedStore.save(addedAt);
   }

--- a/lib/data/repositories/recording_music_library_repository.dart
+++ b/lib/data/repositories/recording_music_library_repository.dart
@@ -10,15 +10,22 @@ import '../../core/repositories/music_library_repository.dart';
 /// rank by.
 ///
 /// It wraps the real repository and, on every [upsertCatalog] (the single point
-/// every source — local, Jellyfin, Subsonic — funnels a scan/sync through),
-/// records `now` for any track id not seen before, preserving the original
-/// timestamp for ids that already had one. That means a routine re-sync never
+/// every source — local, Jellyfin, Subsonic, Plex — funnels a scan/sync
+/// through), records `now` for any track not seen before, preserving the original
+/// timestamp for tracks that already had one. That means a routine re-sync never
 /// resets "recently added": only genuinely new tracks bubble to the top.
-/// [removeTracks] forgets the timestamps for ids it removes, so a track that's
-/// removed and later re-added is correctly treated as new again.
+/// [removeTracks] forgets the timestamps for the tracks it removes, so a track
+/// that's removed and later re-added is correctly treated as new again.
+///
+/// The map is keyed by the provider-namespaced [Track.uri] (e.g. `jellyfin:101`,
+/// `plex:101`, or a local path), not the bare `id`, so the same server-side id
+/// from two providers can't share — or clobber — one timestamp. Stores stamped
+/// under the old id key are migrated to the uri key in place the first time each
+/// track is seen again (see [_stampFirstSeen]), preserving the original time.
 ///
 /// Reads (`getAllTracks`, etc.) pass straight through. The stored map holds only
-/// non-secret track ids and timestamps; it never carries a uri or token.
+/// non-secret, namespaced track uris and timestamps; it never carries a token or
+/// an authenticated URL.
 ///
 /// Incremental writes ([beginCatalogReplacement] / [appendToCatalog]) stamp each
 /// streamed batch the same way [upsertCatalog] does, so a progressively-synced
@@ -49,7 +56,7 @@ class RecordingMusicLibraryRepository
   Future<List<Artist>> getAllArtists() => _delegate.getAllArtists();
 
   @override
-  Future<Track?> getTrackById(String id) => _delegate.getTrackById(id);
+  Future<Track?> getTrackByUri(String uri) => _delegate.getTrackByUri(uri);
 
   @override
   Future<void> upsertCatalog({
@@ -100,31 +107,39 @@ class RecordingMusicLibraryRepository
     await _stampFirstSeen(tracks);
   }
 
-  /// Records `now` as the first-seen time for any track id not seen before,
+  /// Records `now` as the first-seen time for any track not seen before,
   /// preserving earlier timestamps so a routine re-sync never resets "recently
   /// added". Shared by the whole-catalog and incremental write paths.
+  ///
+  /// Entries are keyed by [Track.uri]. A timestamp left under the legacy bare-`id`
+  /// key (from before this store was provider-namespaced) is migrated to the uri
+  /// key in place — preserving the original time — the first time the track is
+  /// seen again, so an upgrade never resets a user's "recently added" ordering.
   Future<void> _stampFirstSeen(List<Track> tracks) async {
     if (tracks.isEmpty) return;
     final Map<String, DateTime> addedAt = await _addedStore.load();
     final DateTime now = _now();
     bool changed = false;
     for (final Track track in tracks) {
-      if (!addedAt.containsKey(track.id)) {
-        addedAt[track.id] = now;
-        changed = true;
-      }
+      if (addedAt.containsKey(track.uri)) continue;
+      // Adopt a legacy id-keyed timestamp if one exists (and id != uri, i.e. a
+      // remote track); otherwise this is genuinely new and gets `now`.
+      final DateTime? legacy =
+          track.uri == track.id ? null : addedAt.remove(track.id);
+      addedAt[track.uri] = legacy ?? now;
+      changed = true;
     }
     if (changed) await _addedStore.save(addedAt);
   }
 
   @override
-  Future<void> removeTracks(List<String> trackIds) async {
-    await _delegate.removeTracks(trackIds);
-    if (trackIds.isEmpty) return;
+  Future<void> removeTracks(List<String> trackUris) async {
+    await _delegate.removeTracks(trackUris);
+    if (trackUris.isEmpty) return;
     final Map<String, DateTime> addedAt = await _addedStore.load();
     bool changed = false;
-    for (final String id in trackIds) {
-      if (addedAt.remove(id) != null) changed = true;
+    for (final String uri in trackUris) {
+      if (addedAt.remove(uri) != null) changed = true;
     }
     if (changed) await _addedStore.save(addedAt);
   }

--- a/lib/data/repositories/recording_music_library_repository.dart
+++ b/lib/data/repositories/recording_music_library_repository.dart
@@ -156,15 +156,15 @@ class RecordingMusicLibraryRepository
     // bare id -> owner uri, or null when more than one provider exposes that id.
     final Map<String, String?> ownerByBareId = <String, String?>{};
     for (final Track track in await _delegate.getAllTracks()) {
-      if (track.uri == track.id)
-        continue; // local: id == uri, never legacy-keyed
+      // Local tracks have id == uri, so they are never legacy bare-id-keyed.
+      if (track.uri == track.id) continue;
       ownerByBareId[track.id] =
           ownerByBareId.containsKey(track.id) ? null : track.uri;
     }
     bool changed = false;
     ownerByBareId.forEach((String bareId, String? ownerUri) {
-      if (ownerUri == null)
-        return; // ambiguous — leave for the read-time fallback
+      // Ambiguous bare id — leave it for the read-time fallback, don't guess.
+      if (ownerUri == null) return;
       final DateTime? legacy = addedAt[bareId];
       if (legacy == null) return;
       // Don't clobber an existing uri-keyed time; just drop the legacy key.

--- a/lib/data/repositories/recording_music_library_repository.dart
+++ b/lib/data/repositories/recording_music_library_repository.dart
@@ -20,9 +20,11 @@ import '../../core/sources/music_provider.dart';
 ///
 /// The map is keyed by the provider-namespaced [Track.uri] (e.g. `jellyfin:101`,
 /// `plex:101`, or a local path), not the bare `id`, so the same server-side id
-/// from two providers can't share — or clobber — one timestamp. Stores stamped
-/// under the old id key are migrated to the uri key in place the first time each
-/// track is seen again (see [_stampFirstSeen]), preserving the original time.
+/// from two providers can't share — or clobber — one timestamp. A store written
+/// by a pre-v2 build (keyed by the bare id) is migrated to uri keys once, before
+/// the first catalog write, against the catalog's current owner of each id (see
+/// [_migrateLegacyAddedKeysOnce]) — so the original time lands on the row that
+/// owned it and a later same-id row from a newly-added provider can't steal it.
 ///
 /// Reads (`getAllTracks`, etc.) pass straight through. The stored map holds only
 /// non-secret, namespaced track uris and timestamps; it never carries a token or
@@ -47,6 +49,10 @@ class RecordingMusicLibraryRepository
   final LibraryAddedStore _addedStore;
   final DateTime Function() _now;
 
+  /// Guards the one-time legacy added-at key migration so it runs at most once,
+  /// at the first catalog write (see [_migrateLegacyAddedKeysOnce]).
+  bool _migratedLegacyAddedKeys = false;
+
   @override
   Future<List<Track>> getAllTracks() => _delegate.getAllTracks();
 
@@ -66,6 +72,7 @@ class RecordingMusicLibraryRepository
     required List<Album> albums,
     required List<Artist> artists,
   }) async {
+    await _migrateLegacyAddedKeysOnce();
     await _delegate.upsertCatalog(
       sourceId: sourceId,
       tracks: tracks,
@@ -80,6 +87,7 @@ class RecordingMusicLibraryRepository
     required String sourceId,
     required List<Track> tracks,
   }) async {
+    await _migrateLegacyAddedKeysOnce();
     final MusicLibraryRepository delegate = _delegate;
     if (delegate is IncrementalCatalogWriter) {
       await (delegate as IncrementalCatalogWriter)
@@ -100,6 +108,7 @@ class RecordingMusicLibraryRepository
     required String sourceId,
     required List<Track> tracks,
   }) async {
+    await _migrateLegacyAddedKeysOnce();
     final MusicLibraryRepository delegate = _delegate;
     if (delegate is IncrementalCatalogWriter) {
       await (delegate as IncrementalCatalogWriter)
@@ -112,10 +121,10 @@ class RecordingMusicLibraryRepository
   /// preserving earlier timestamps so a routine re-sync never resets "recently
   /// added". Shared by the whole-catalog and incremental write paths.
   ///
-  /// Entries are keyed by [Track.uri]. A timestamp left under the legacy bare-`id`
-  /// key (from before this store was provider-namespaced) is migrated to the uri
-  /// key in place — preserving the original time — the first time the track is
-  /// seen again, so an upgrade never resets a user's "recently added" ordering.
+  /// Entries are keyed by [Track.uri]. Legacy bare-`id`-keyed timestamps are
+  /// re-keyed to the owning uri by [_migrateLegacyAddedKeysOnce] (which runs
+  /// before any catalog write), so by the time a track is stamped here a missing
+  /// uri key always means genuinely new — never a legacy entry to adopt.
   Future<void> _stampFirstSeen(List<Track> tracks) async {
     if (tracks.isEmpty) return;
     final Map<String, DateTime> addedAt = await _addedStore.load();
@@ -123,13 +132,46 @@ class RecordingMusicLibraryRepository
     bool changed = false;
     for (final Track track in tracks) {
       if (addedAt.containsKey(track.uri)) continue;
-      // Adopt a legacy id-keyed timestamp if one exists (and id != uri, i.e. a
-      // remote track); otherwise this is genuinely new and gets `now`.
-      final DateTime? legacy =
-          track.uri == track.id ? null : addedAt.remove(track.id);
-      addedAt[track.uri] = legacy ?? now;
+      addedAt[track.uri] = now;
       changed = true;
     }
+    if (changed) await _addedStore.save(addedAt);
+  }
+
+  /// Migrates a pre-v2 store's bare-`id`-keyed timestamps onto the
+  /// provider-namespaced [Track.uri] key, once, before the first catalog write.
+  ///
+  /// Each legacy id is resolved against the catalog's *current* owner of that id.
+  /// Running before the first write is what makes this safe: the catalog is still
+  /// the upgraded-in-place, 1:1 bare-id→provider state, so the timestamp lands on
+  /// the row that actually owned it — a later same-id row from a newly-added
+  /// provider (synced after this) can't adopt it. A bare id the catalog already
+  /// exposes under more than one provider is left untouched (ambiguous → not
+  /// mis-attributed; the read-time fallback still surfaces it).
+  Future<void> _migrateLegacyAddedKeysOnce() async {
+    if (_migratedLegacyAddedKeys) return;
+    _migratedLegacyAddedKeys = true;
+    final Map<String, DateTime> addedAt = await _addedStore.load();
+    if (addedAt.isEmpty) return;
+    // bare id -> owner uri, or null when more than one provider exposes that id.
+    final Map<String, String?> ownerByBareId = <String, String?>{};
+    for (final Track track in await _delegate.getAllTracks()) {
+      if (track.uri == track.id)
+        continue; // local: id == uri, never legacy-keyed
+      ownerByBareId[track.id] =
+          ownerByBareId.containsKey(track.id) ? null : track.uri;
+    }
+    bool changed = false;
+    ownerByBareId.forEach((String bareId, String? ownerUri) {
+      if (ownerUri == null)
+        return; // ambiguous — leave for the read-time fallback
+      final DateTime? legacy = addedAt[bareId];
+      if (legacy == null) return;
+      // Don't clobber an existing uri-keyed time; just drop the legacy key.
+      addedAt.putIfAbsent(ownerUri, () => legacy);
+      addedAt.remove(bareId);
+      changed = true;
+    });
     if (changed) await _addedStore.save(addedAt);
   }
 

--- a/lib/data/repositories/store_cached_track_locator.dart
+++ b/lib/data/repositories/store_cached_track_locator.dart
@@ -48,31 +48,35 @@ class StoreCachedTrackLocator implements CachedTrackLocator {
     }
     if (exact != null && exact.isNotEmpty) return _files.pathFor(exact);
     if (untagged == null || untagged.isEmpty) return null;
-    // A legacy untagged file carries no provider, so it could belong to a
-    // different provider that shares this bare id; only serve it when the catalog
-    // shows the id is unambiguous (or no oracle is wired — back-compat).
-    if (await _isAmbiguousId(track.id)) return null;
+    // A legacy untagged file carries no provider, so it could be another
+    // provider's bytes (an id shared by two providers, or a stale queued copy
+    // whose source was removed). Serve it only when the catalog attributes this
+    // bare id to exactly one provider and that provider is the requested track's.
+    if (!await _legacyOwnerMatches(track)) return null;
     return _files.pathFor(untagged);
   }
 
-  /// Whether more than one provider in the catalog exposes [bareId], in which
-  /// case a legacy untagged cache file can't be safely attributed to [bareId]'s
-  /// requested copy. False when no catalog oracle is wired, or on any error, so
-  /// playback never blocks on this check.
-  Future<bool> _isAmbiguousId(String bareId) async {
+  /// Whether a legacy untagged cache file for [track]'s bare id can be safely
+  /// attributed to [track]: true only when the catalog exposes that id under
+  /// exactly one provider and it is [track]'s own, so the untagged bytes are this
+  /// copy's — not a same-id sibling's, and not a different provider's when
+  /// [track] itself is no longer in the catalog. True when no catalog oracle is
+  /// wired, or on any error, so playback never blocks (plain id-only back-compat).
+  Future<bool> _legacyOwnerMatches(Track track) async {
     final Future<List<Track>> Function()? oracle = _catalogForLegacyMatch;
-    if (oracle == null) return false;
+    if (oracle == null) return true;
+    final String requested = _schemeOf(track.uri) ?? '';
     try {
-      final Set<String> providers = <String>{};
-      for (final Track track in await oracle()) {
-        if (track.id != bareId) continue;
-        providers.add(_schemeOf(track.uri) ?? '');
-        if (providers.length > 1) return true;
+      final Set<String> owners = <String>{};
+      for (final Track t in await oracle()) {
+        if (t.id != track.id) continue;
+        owners.add(_schemeOf(t.uri) ?? '');
+        if (owners.length > 1) return false;
       }
+      return owners.length == 1 && owners.first == requested;
     } catch (_) {
-      return false;
+      return true;
     }
-    return false;
   }
 
   /// The non-secret URI scheme of [uri] (`jellyfin`, `subsonic`, `plex`, `file`,

--- a/lib/data/repositories/store_cached_track_locator.dart
+++ b/lib/data/repositories/store_cached_track_locator.dart
@@ -13,28 +13,66 @@ import '../../core/services/cached_track_locator.dart';
 /// file (including any already-local on-device track) resolves to `null`, so
 /// playback falls back to its normal source.
 class StoreCachedTrackLocator implements CachedTrackLocator {
-  const StoreCachedTrackLocator(this._store, this._files);
+  const StoreCachedTrackLocator(
+    this._store,
+    this._files, {
+    Future<List<Track>> Function()? catalogForLegacyMatch,
+  }) : _catalogForLegacyMatch = catalogForLegacyMatch;
 
   final DownloadStore _store;
   final OfflineFileStore _files;
 
+  /// Resolves the current catalog so a legacy (untagged, pre-v0.1.6) cache record
+  /// is matched by bare id only when that id maps to a single provider — never
+  /// serving one provider's bytes for another provider's same-id track. Null
+  /// keeps the plain id-only back-compat (tests/dev without provider collisions);
+  /// the app wires it to the music library.
+  final Future<List<Track>> Function()? _catalogForLegacyMatch;
+
   @override
   Future<String?> cachedFilePath(Track track) async {
     final String? scheme = _schemeOf(track.uri);
-    String? fileName;
+    // Prefer an exact, provider-tagged match (a Plex `101` never resolves to a
+    // Subsonic `101`'s file). Fall back to a legacy untagged record (written
+    // before source tagging) only if no tagged entry matches.
+    String? exact;
+    String? untagged;
     for (final CachedTrack cached in await _store.loadDownloads()) {
       if (cached.trackId != track.id) continue;
-      // Provider-aware: an entry matches only when its recorded source scheme
-      // agrees, so a Plex `101` never resolves to a Subsonic `101`'s file. A
-      // legacy entry written before source tagging (sourceType == null) falls
-      // back to an id-only match — there is at most one such untagged file, so
-      // it still resolves and existing cached tracks keep working.
-      if (cached.sourceType != null && cached.sourceType != scheme) continue;
-      fileName = cached.fileName;
-      break;
+      if (cached.sourceType == null) {
+        untagged ??= cached.fileName;
+      } else if (cached.sourceType == scheme) {
+        exact = cached.fileName;
+        break;
+      }
     }
-    if (fileName == null || fileName.isEmpty) return null;
-    return _files.pathFor(fileName);
+    if (exact != null && exact.isNotEmpty) return _files.pathFor(exact);
+    if (untagged == null || untagged.isEmpty) return null;
+    // A legacy untagged file carries no provider, so it could belong to a
+    // different provider that shares this bare id; only serve it when the catalog
+    // shows the id is unambiguous (or no oracle is wired — back-compat).
+    if (await _isAmbiguousId(track.id)) return null;
+    return _files.pathFor(untagged);
+  }
+
+  /// Whether more than one provider in the catalog exposes [bareId], in which
+  /// case a legacy untagged cache file can't be safely attributed to [bareId]'s
+  /// requested copy. False when no catalog oracle is wired, or on any error, so
+  /// playback never blocks on this check.
+  Future<bool> _isAmbiguousId(String bareId) async {
+    final Future<List<Track>> Function()? oracle = _catalogForLegacyMatch;
+    if (oracle == null) return false;
+    try {
+      final Set<String> providers = <String>{};
+      for (final Track track in await oracle()) {
+        if (track.id != bareId) continue;
+        providers.add(_schemeOf(track.uri) ?? '');
+        if (providers.length > 1) return true;
+      }
+    } catch (_) {
+      return false;
+    }
+    return false;
   }
 
   /// The non-secret URI scheme of [uri] (`jellyfin`, `subsonic`, `plex`, `file`,

--- a/lib/features/downloads/download_providers.dart
+++ b/lib/features/downloads/download_providers.dart
@@ -19,25 +19,29 @@ import '../settings/plex/plex_settings_controller.dart';
 import '../settings/subsonic/subsonic_settings_controller.dart';
 
 /// The live download status of a single track, for the Library row indicator.
-/// Defaults to [DownloadStatus.notDownloaded] until the repository reports
-/// otherwise. Auto-disposed so off-screen rows drop their subscription.
+/// The family argument is the track's provider-aware cache key
+/// ([CachedTrack.cacheKeyForTrack]) so two providers' same-id copies each show
+/// their own status. Defaults to [DownloadStatus.notDownloaded] until the
+/// repository reports otherwise. Auto-disposed so off-screen rows drop their
+/// subscription.
 final trackDownloadStatusProvider =
-    StreamProvider.autoDispose.family<DownloadStatus, String>((ref, trackId) {
+    StreamProvider.autoDispose.family<DownloadStatus, String>((ref, cacheKey) {
   final repository = ref.watch(downloadRepositoryProvider);
   return repository.statusStream
-      .map((statuses) => statuses[trackId] ?? DownloadStatus.notDownloaded)
+      .map((statuses) => statuses[cacheKey] ?? DownloadStatus.notDownloaded)
       .distinct();
 });
 
 /// The live byte progress of a single in-flight download, for the row's
-/// determinate ring. Null when the track isn't downloading (or its server
-/// didn't report a size, leaving progress indeterminate). Auto-disposed so
-/// off-screen rows drop the subscription.
+/// determinate ring. The family argument is the track's provider-aware cache key
+/// ([CachedTrack.cacheKeyForTrack]). Null when the track isn't downloading (or
+/// its server didn't report a size, leaving progress indeterminate).
+/// Auto-disposed so off-screen rows drop the subscription.
 final trackDownloadProgressProvider = StreamProvider.autoDispose
-    .family<DownloadProgress?, String>((ref, trackId) {
+    .family<DownloadProgress?, String>((ref, cacheKey) {
   final repository = ref.watch(downloadRepositoryProvider);
   return repository.progressStream
-      .map((progress) => progress[trackId])
+      .map((progress) => progress[cacheKey])
       .distinct();
 });
 
@@ -47,12 +51,14 @@ final downloadedTracksProvider = StreamProvider<List<Track>>((ref) async* {
   final repository = ref.watch(downloadRepositoryProvider);
   final library = ref.watch(musicLibraryRepositoryProvider);
   await for (final statuses in repository.statusStream) {
-    final downloadedIds = statuses.entries
+    final downloadedKeys = statuses.entries
         .where((e) => e.value == DownloadStatus.downloaded)
         .map((e) => e.key)
         .toSet();
     final tracks = await library.getAllTracks();
-    yield tracks.where((t) => downloadedIds.contains(t.id)).toList();
+    yield tracks
+        .where((t) => downloadedKeys.contains(CachedTrack.cacheKeyForTrack(t)))
+        .toList();
   }
 });
 
@@ -82,11 +88,13 @@ final activeDownloadsProvider =
       continue;
     }
     final tracks = await library.getAllTracks();
-    final byId = <String, Track>{for (final t in tracks) t.id: t};
+    final byKey = <String, Track>{
+      for (final t in tracks) CachedTrack.cacheKeyForTrack(t): t,
+    };
     yield <ActiveDownload>[
       for (final entry in active.entries)
-        if (byId[entry.key] != null)
-          (track: byId[entry.key]!, status: entry.value),
+        if (byKey[entry.key] != null)
+          (track: byKey[entry.key]!, status: entry.value),
     ]..sort(_compareActiveDownloads);
   }
 });
@@ -118,35 +126,40 @@ final cacheSnapshotProvider = StreamProvider<CacheSnapshot>((ref) {
   return ref.watch(offlineCacheManagerProvider).cacheStream;
 });
 
-/// The cached-track metadata keyed by track id, for quick per-row lookups.
-final cacheEntriesByIdProvider = Provider<Map<String, CachedTrack>>((ref) {
+/// The cached-track metadata keyed by the provider-aware cache key
+/// ([CachedTrack.cacheKey]), for quick per-row lookups. Keyed by cache key (not
+/// the bare id) so two providers' same-id copies never shadow each other; look up
+/// with [CachedTrack.cacheKeyForTrack].
+final cacheEntriesByKeyProvider = Provider<Map<String, CachedTrack>>((ref) {
   final snapshot = ref.watch(cacheSnapshotProvider).valueOrNull;
   if (snapshot == null) return const <String, CachedTrack>{};
   return <String, CachedTrack>{
-    for (final entry in snapshot.entries) entry.trackId: entry,
+    for (final entry in snapshot.entries) entry.cacheKey: entry,
   };
 });
 
-/// The ids of tracks that have an offline copy on disk (a downloaded or
-/// pre-cached copy with managed bytes) — the safe, in-memory signal the playback
-/// source strategy uses to favour cache/local copies, without a disk scan or any
-/// path/URL.
+/// The provider-aware cache keys ([CachedTrack.cacheKey]) of tracks that have an
+/// offline copy on disk (a downloaded or pre-cached copy with managed bytes) —
+/// the safe, in-memory signal the playback source strategy uses to favour
+/// cache/local copies, without a disk scan or any path/URL. Keyed by cache key
+/// (not bare id), so a download of `subsonic:101` never makes `jellyfin:101` look
+/// cached; join with [CachedTrack.cacheKeyForTrack].
 ///
 /// Defaults to empty so the library/playback layers don't pull the whole cache
-/// stack in tests; `main` applies [offlineAvailableTrackIdsOverride] to derive
+/// stack in tests; `main` applies [offlineAvailableTrackKeysOverride] to derive
 /// it live from the cache snapshot. Tests override it directly with a set.
-final offlineAvailableTrackIdsProvider =
+final offlineAvailableTrackKeysProvider =
     Provider<Set<String>>((ref) => const <String>{});
 
-/// Production binding: the live set of offline-available track ids, recomputed
-/// from [cacheEntriesByIdProvider] whenever the cache changes. Only entries with
+/// Production binding: the live set of offline-available cache keys, recomputed
+/// from [cacheEntriesByKeyProvider] whenever the cache changes. Only entries with
 /// managed bytes count (an on-device marker with no file is not a cached copy).
-final offlineAvailableTrackIdsOverride =
-    offlineAvailableTrackIdsProvider.overrideWith((ref) {
-  final Map<String, CachedTrack> entries = ref.watch(cacheEntriesByIdProvider);
+final offlineAvailableTrackKeysOverride =
+    offlineAvailableTrackKeysProvider.overrideWith((ref) {
+  final Map<String, CachedTrack> entries = ref.watch(cacheEntriesByKeyProvider);
   return <String>{
     for (final CachedTrack entry in entries.values)
-      if (entry.isManaged) entry.trackId,
+      if (entry.isManaged) entry.cacheKey,
   };
 });
 

--- a/lib/features/downloads/downloads_screen.dart
+++ b/lib/features/downloads/downloads_screen.dart
@@ -201,7 +201,10 @@ class _ActiveDownloadTile extends ConsumerWidget {
     // Only the downloading row subscribes to byte progress; queued/failed rows
     // need none, so idle rows add no stream listener.
     final DownloadProgress? progress = status == DownloadStatus.downloading
-        ? ref.watch(trackDownloadProgressProvider(track.id)).valueOrNull
+        ? ref
+            .watch(trackDownloadProgressProvider(
+                CachedTrack.cacheKeyForTrack(track)))
+            .valueOrNull
         : null;
     final NowPlayingRowState? nowPlaying =
         ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
@@ -343,7 +346,8 @@ class _DownloadedTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final CachedTrack? entry = ref.watch(cacheEntriesByIdProvider)[track.id];
+    final CachedTrack? entry = ref
+        .watch(cacheEntriesByKeyProvider)[CachedTrack.cacheKeyForTrack(track)];
     final bool pinned = entry?.pinned ?? false;
     final NowPlayingRowState? nowPlaying =
         ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -45,7 +45,7 @@ class LibraryScreen extends ConsumerStatefulWidget {
 
 class _LibraryScreenState extends ConsumerState<LibraryScreen>
     with SingleTickerProviderStateMixin {
-  final Set<String> _selectedIds = <String>{};
+  final Set<String> _selectedUris = <String>{};
   bool _selecting = false;
 
   late final TabController _tabController;
@@ -101,11 +101,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       jellyfinSyncControllerProvider.select((s) => s.isSyncing),
     );
 
-    // Drop any selected ids that are no longer in the catalog (e.g. after a
-    // removal) so the count and actions stay accurate.
+    // Drop any selected rows no longer in the catalog (e.g. after a removal) so
+    // the count and actions stay accurate. Keyed by the provider-namespaced uri,
+    // not the bare id, so two different-provider songs sharing an id can't be
+    // selected (or bulk-acted on) together.
     final List<Track> selected = <Track>[
       for (final Track track in songs)
-        if (_selectedIds.contains(track.id)) track,
+        if (_selectedUris.contains(track.uri)) track,
     ];
 
     if (_selecting) {
@@ -264,7 +266,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
       tracks: tracks,
       selectable: true,
       selectionActive: _selecting,
-      selectedIds: _selectedIds,
+      selectedUris: _selectedUris,
       onSelectStart: _enterSelection,
       onSelectToggle: _toggle,
     );
@@ -309,25 +311,25 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   void _enterSelection(Track track) {
     setState(() {
       _selecting = true;
-      _selectedIds
+      _selectedUris
         ..clear()
-        ..add(track.id);
+        ..add(track.uri);
     });
   }
 
   void _toggle(Track track) {
     setState(() {
-      if (!_selectedIds.add(track.id)) {
-        _selectedIds.remove(track.id);
+      if (!_selectedUris.add(track.uri)) {
+        _selectedUris.remove(track.uri);
       }
-      if (_selectedIds.isEmpty) _selecting = false;
+      if (_selectedUris.isEmpty) _selecting = false;
     });
   }
 
   void _exitSelection() {
     setState(() {
       _selecting = false;
-      _selectedIds.clear();
+      _selectedUris.clear();
     });
   }
 

--- a/lib/features/library/playback_candidates_provider.dart
+++ b/lib/features/library/playback_candidates_provider.dart
@@ -4,6 +4,7 @@ import '../../core/catalog/logical_track.dart';
 import '../../core/catalog/source_capability.dart';
 import '../../core/catalog/source_strategy.dart';
 import '../../core/models/track.dart';
+import '../../core/repositories/download_store.dart';
 import '../../core/services/playback_candidate_source.dart';
 import '../downloads/download_providers.dart';
 import '../player/player_providers.dart';
@@ -40,14 +41,16 @@ final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
   final List<LogicalTrack> logicals = ref.watch(libraryLogicalTracksProvider);
   final PlaybackSourceStrategy strategy =
       ref.watch(playbackSourceStrategyProvider);
-  final Set<String> cachedIds = ref.watch(offlineAvailableTrackIdsProvider);
+  final Set<String> cachedKeys = ref.watch(offlineAvailableTrackKeysProvider);
 
   // A candidate's capability, made cache-aware from the in-memory offline set so
-  // "prefer cache/local" can favour a downloaded copy without a disk scan.
+  // "prefer cache/local" can favour a downloaded copy without a disk scan. Keyed
+  // by the provider-aware cache key so a downloaded `subsonic:101` makes only the
+  // subsonic copy look cached — never a same-id `jellyfin:101` streaming copy.
   PlaybackSourceCapability profileOf(Track track) =>
       PlaybackSourceCapability.fromTrack(
         track,
-        cachedOffline: cachedIds.contains(track.id),
+        cachedOffline: cachedKeys.contains(CachedTrack.cacheKeyForTrack(track)),
       );
 
   final Map<String, List<Track>> byTrackUri = <String, List<Track>>{};

--- a/lib/features/library/playback_candidates_provider.dart
+++ b/lib/features/library/playback_candidates_provider.dart
@@ -10,17 +10,18 @@ import '../player/player_providers.dart';
 import 'playback_source_strategy_controller.dart';
 import 'unified_library_providers.dart';
 
-/// Maps *every source copy's* track id to its song's ordered source candidates,
-/// so playback can fall back to another copy of the same song when the preferred
-/// one fails — no matter which copy was the one actually queued.
+/// Maps *every source copy's* [Track.uri] to its song's ordered source
+/// candidates, so playback can fall back to another copy of the same song when
+/// the preferred one fails — no matter which copy was the one actually queued.
 ///
-/// Keying by every copy's id (not just the displayed/primary one) is what keeps
+/// Keying by every copy's uri (not just the displayed/primary one) is what keeps
 /// the queue honest when the user changes the default source: the displayed copy
 /// flips to the new provider, but a copy already sitting in the queue (or saved in
-/// a playlist) keeps its old id. Mapping that id to the *same* freshly-ordered
+/// a playlist) keeps its old uri. Mapping that uri to the *same* freshly-ordered
 /// candidate list means the next play of that queued copy uses the new preferred
 /// source — and still has its fallbacks — instead of being orphaned to the old
-/// source until the queue is rebuilt (an app restart).
+/// source until the queue is rebuilt (an app restart). The uri (not the bare id)
+/// is the key so two providers' same-id copies never collide on one entry.
 ///
 /// Only de-duplicated rows that actually span more than one provider are listed —
 /// a single-source song needs no fallback and is left out (the controller treats
@@ -49,7 +50,7 @@ final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
         cachedOffline: cachedIds.contains(track.id),
       );
 
-  final Map<String, List<Track>> byTrackId = <String, List<Track>>{};
+  final Map<String, List<Track>> byTrackUri = <String, List<Track>>{};
   for (final LogicalTrack logical in logicals) {
     if (!logical.hasMultipleSources) continue;
     final List<Track> candidates = <Track>[
@@ -60,14 +61,14 @@ final playbackCandidatesProvider = Provider<Map<String, List<Track>>>((ref) {
     // PR1/PR2 default-source order (and runtime fallback over it) is unchanged.
     final List<Track> ordered =
         orderBySourceStrategy(candidates, strategy, profileOf);
-    // Index the same list under every copy's id, so whichever copy is queued
-    // resolves to it. Ids are unique to one logical song, so the keys never
-    // collide across rows.
+    // Index the same list under every copy's provider-namespaced uri, so
+    // whichever copy is queued resolves to it. Uris are globally unique to one
+    // copy, so two providers' same-id tracks never collide on one entry.
     for (final Track candidate in candidates) {
-      byTrackId[candidate.id] = ordered;
+      byTrackUri[candidate.uri] = ordered;
     }
   }
-  return byTrackId;
+  return byTrackUri;
 });
 
 /// Wires the real, library-backed [PlaybackCandidateSource] into the playback

--- a/lib/features/library/song_actions.dart
+++ b/lib/features/library/song_actions.dart
@@ -117,26 +117,27 @@ abstract final class SongActions {
     return true;
   }
 
-  /// The track ids to forget for [tracks]. When [expandLogicalSources] is set
-  /// (library/album/artist surfaces, where each row is a logical track), a
-  /// row's id is expanded to every provider copy via [logicalSourceIdsProvider]
-  /// so removing the row can't leave a hidden duplicate behind. Elsewhere (a
-  /// playlist's specific tracks) the ids are taken verbatim.
+  /// The track uris to forget for [tracks] (the catalog is keyed by [Track.uri]).
+  /// When [expandLogicalSources] is set (library/album/artist surfaces, where
+  /// each row is a logical track), a row's uri is expanded to every provider
+  /// copy's uri via [logicalSourceIdsProvider] so removing the row can't leave a
+  /// hidden duplicate behind. Elsewhere (a playlist's specific tracks) the uris
+  /// are taken verbatim.
   static List<String> _removalIds(
     WidgetRef ref,
     List<Track> tracks,
     bool expandLogicalSources,
   ) {
     if (!expandLogicalSources) {
-      return <String>[for (final Track track in tracks) track.id];
+      return <String>[for (final Track track in tracks) track.uri];
     }
     final Map<String, List<String>> bySource =
         ref.read(logicalSourceIdsProvider);
-    final List<String> ids = <String>[];
+    final List<String> uris = <String>[];
     for (final Track track in tracks) {
-      ids.addAll(bySource[track.id] ?? <String>[track.id]);
+      uris.addAll(bySource[track.uri] ?? <String>[track.uri]);
     }
-    return ids;
+    return uris;
   }
 
   static String _offlineSummary(int removed, int failed, int skipped) {

--- a/lib/features/library/song_actions.dart
+++ b/lib/features/library/song_actions.dart
@@ -91,15 +91,16 @@ abstract final class SongActions {
     );
     if (!confirmed) return false;
 
-    final String? playingId =
-        ref.read(playbackControllerProvider).state.currentTrack?.id;
+    final String? playingUri =
+        ref.read(playbackControllerProvider).state.currentTrack?.uri;
     final repository = ref.read(downloadRepositoryProvider);
     int removed = 0;
     int failed = 0;
     int skipped = 0;
     for (final Track track in tracks) {
-      // Never delete the cached file backing what's playing right now.
-      if (track.id == playingId) {
+      // Never delete the cached file backing what's playing right now. Compare
+      // by uri so a same-id copy from another provider isn't wrongly skipped.
+      if (track.uri == playingUri) {
         skipped++;
         continue;
       }

--- a/lib/features/library/unified_library_providers.dart
+++ b/lib/features/library/unified_library_providers.dart
@@ -36,16 +36,18 @@ final libraryUnifiedTracksProvider = Provider<List<Track>>((ref) {
   ];
 });
 
-/// Maps a preferred-copy track id to every source copy's track id, so removing a
-/// displayed (logical) row from the library forgets all of its provider copies —
-/// otherwise a hidden duplicate would resurrect the row on the next reload.
+/// Maps a preferred-copy [Track.uri] to every source copy's [Track.uri], so
+/// removing a displayed (logical) row from the library forgets all of its
+/// provider copies — otherwise a hidden duplicate would resurrect the row on the
+/// next reload. Keyed by uri (not the bare id) so a row's removal targets exactly
+/// its own provider copies and never a different provider's same-id track.
 ///
-/// Ids that aren't a logical primary (e.g. a specific track chosen inside a
+/// Uris that aren't a logical primary (e.g. a specific track chosen inside a
 /// playlist) map to just themselves, so non-library callers are unaffected.
 final logicalSourceIdsProvider = Provider<Map<String, List<String>>>((ref) {
   final Map<String, List<String>> byPrimary = <String, List<String>>{};
   for (final LogicalTrack logical in ref.watch(libraryLogicalTracksProvider)) {
-    byPrimary[logical.id] = logical.allTrackIds;
+    byPrimary[logical.id] = logical.allTrackUris;
   }
   return byPrimary;
 });

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -19,7 +19,7 @@ class AlphabetTrackList extends StatefulWidget {
     required this.tracks,
     this.selectable = false,
     this.selectionActive = false,
-    this.selectedIds = const <String>{},
+    this.selectedUris = const <String>{},
     this.onSelectToggle,
     this.onSelectStart,
     super.key,
@@ -33,8 +33,10 @@ class AlphabetTrackList extends StatefulWidget {
   /// Whether the host is currently in selection mode.
   final bool selectionActive;
 
-  /// Ids of the currently-selected tracks.
-  final Set<String> selectedIds;
+  /// Provider-namespaced uris ([Track.uri]) of the currently-selected tracks.
+  /// Keyed by uri, not the bare id, so two different-provider songs that share a
+  /// server-side id are never selected together.
+  final Set<String> selectedUris;
 
   /// Toggles a track's selection (tap while in selection mode).
   final void Function(Track track)? onSelectToggle;
@@ -189,7 +191,7 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
               index: trackIndex,
               selectable: widget.selectable,
               selectionActive: widget.selectionActive,
-              selected: widget.selectedIds.contains(track.id),
+              selected: widget.selectedUris.contains(track.uri),
               onSelectToggle: widget.onSelectToggle == null
                   ? null
                   : () => widget.onSelectToggle!(track),

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../app/routes.dart';
 import '../../../core/models/track.dart';
 import '../../../core/repositories/download_repository.dart';
+import '../../../core/repositories/download_store.dart';
 import '../../../data/repositories/download_repository_provider.dart';
 import '../../downloads/download_providers.dart';
 import '../../player/now_playing.dart';
@@ -84,15 +85,18 @@ class TrackTile extends ConsumerWidget {
     // doesn't affect this row never rebuilds it.
     final NowPlayingRowState? nowPlaying =
         ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
+    // The provider-aware cache key joins this row to its own copy's status, so
+    // two providers' same-id copies never share a download indicator.
+    final String cacheKey = CachedTrack.cacheKeyForTrack(track);
     final status =
-        ref.watch(trackDownloadStatusProvider(track.id)).valueOrNull ??
+        ref.watch(trackDownloadStatusProvider(cacheKey)).valueOrNull ??
             DownloadStatus.notDownloaded;
     final isRemote = ref.watch(remoteTrackDownloaderProvider).isRemote(track);
     // Only the actively-downloading row watches byte progress, so idle rows add
     // no subscription. Null total (or not downloading) leaves the ring spinning.
     final double? downloadFraction = status == DownloadStatus.downloading
         ? ref
-            .watch(trackDownloadProgressProvider(track.id))
+            .watch(trackDownloadProgressProvider(cacheKey))
             .valueOrNull
             ?.fraction
         : null;

--- a/lib/features/player/cast/cast_providers.dart
+++ b/lib/features/player/cast/cast_providers.dart
@@ -71,7 +71,12 @@ final chromecastCastServiceOverride = castServiceProvider.overrideWith((ref) {
     transport: ChromecastCastTransport(),
     mediaResolver: ref.read(castMediaResolverProvider),
     currentTrack: () => local.state.currentTrack,
-    trackChanges: local.stateStream.map((s) => s.currentTrack).distinct(),
+    // Distinct by uri, not Track == (which is bare-id), so a same-bare-id cast
+    // skip/fallback (jellyfin:101 -> subsonic:101) still reaches the receiver
+    // instead of being filtered out before _handOff sees it.
+    trackChanges: local.stateStream
+        .map((s) => s.currentTrack)
+        .distinct((a, b) => a?.uri == b?.uri),
   );
   ref.onDispose(service.dispose);
   return service;

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -31,15 +31,17 @@ final lyricsServiceProvider = Provider<LyricsService>((ref) {
 });
 
 /// Lyrics for a single track, keyed by the track itself (whose equality is its
-/// stable id), fetched on demand and cached while watched. Auto-disposed so a
-/// track that is no longer current drops its request.
+/// provider-namespaced uri), fetched on demand and cached while watched — so two
+/// same-bare-id copies from different providers (`jellyfin:101`, `subsonic:101`)
+/// resolve independently. Auto-disposed so a track no longer current drops its
+/// request.
 final trackLyricsProvider =
     FutureProvider.autoDispose.family<Lyrics?, Track>((ref, track) {
   return ref.watch(lyricsServiceProvider).lyricsFor(track);
 });
 
-/// The track playing right now, distinct by id. Selecting `currentTrack` (whose
-/// equality is id-based) means this changes only when the *track* changes — not
+/// The track playing right now, distinct by uri. Selecting `currentTrack` (whose
+/// equality is uri-based) means this changes only when the *track* changes — not
 /// on every position tick — so lyrics aren't refetched every second. Falls back
 /// to the controller's latest state until the first stream event arrives, so
 /// opening lyrics mid-playback resolves immediately (mirroring the player UI).
@@ -53,7 +55,8 @@ final _currentlyPlayingTrackProvider = Provider.autoDispose<Track?>((ref) {
 
 /// Lyrics for whatever is playing now — the seam the Now Playing lyrics view
 /// watches. It re-resolves whenever the current track changes (keyed, through
-/// [trackLyricsProvider], by the track's stable id) and reports loading during
+/// [trackLyricsProvider], by the track's provider-namespaced uri) and reports
+/// loading during
 /// the switch, so the previous song's lines never linger. Resolves to
 /// `data(null)` when nothing is playing. The UI watches this and never calls a
 /// lyrics provider directly.

--- a/lib/features/smart_mixes/smart_mix_providers.dart
+++ b/lib/features/smart_mixes/smart_mix_providers.dart
@@ -23,9 +23,11 @@ final playHistoryProvider = StreamProvider<PlayHistory>((ref) {
   return ref.watch(playHistoryRepositoryProvider).historyStream;
 });
 
-/// The set of fully-downloaded (offline) track ids, recomputed whenever the
-/// download status map changes, so the "Downloaded" mix tracks the cache.
-final _downloadedTrackIdsProvider = StreamProvider<Set<String>>((ref) {
+/// The set of fully-downloaded (offline) cache keys, recomputed whenever the
+/// download status map changes, so the "Downloaded" mix tracks the cache. The
+/// status map's keys are the provider-aware cache keys, so a download of one
+/// provider's copy never pulls a same-id copy from another provider into the mix.
+final _downloadedTrackKeysProvider = StreamProvider<Set<String>>((ref) {
   final DownloadRepository repository = ref.watch(downloadRepositoryProvider);
   return repository.statusStream.map((Map<String, DownloadStatus> statuses) {
     return <String>{
@@ -43,7 +45,7 @@ typedef SmartPlaylistInputs = ({
   PlayHistory history,
   Map<String, DateTime> addedAt,
   Set<String> favoriteIds,
-  Set<String> downloadedIds,
+  Set<String> downloadedKeys,
 });
 
 final smartPlaylistInputsProvider =
@@ -56,8 +58,8 @@ final smartPlaylistInputsProvider =
       ref.watch(playHistoryProvider).valueOrNull ?? PlayHistory.empty;
   final Set<String> favoriteIds =
       ref.watch(favoriteIdsProvider).valueOrNull ?? const <String>{};
-  final Set<String> downloadedIds =
-      ref.watch(_downloadedTrackIdsProvider).valueOrNull ?? const <String>{};
+  final Set<String> downloadedKeys =
+      ref.watch(_downloadedTrackKeysProvider).valueOrNull ?? const <String>{};
 
   final List<Track> allTracks = await library.getAllTracks();
   final Map<String, DateTime> addedAt = await addedStore.load();
@@ -67,7 +69,7 @@ final smartPlaylistInputsProvider =
     history: history,
     addedAt: addedAt,
     favoriteIds: favoriteIds,
-    downloadedIds: downloadedIds,
+    downloadedKeys: downloadedKeys,
   );
 });
 
@@ -103,7 +105,7 @@ final smartPlaylistTracksProvider = FutureProvider.autoDispose
       history: PlayHistory.empty,
       addedAt: const <String, DateTime>{},
       favoriteIds: const <String>{},
-      downloadedIds: const <String>{},
+      downloadedKeys: const <String>{},
       random: Random(),
     );
   }
@@ -119,7 +121,7 @@ List<Track> _resolve(SmartPlaylistKind kind, SmartPlaylistInputs inputs) {
     history: inputs.history,
     addedAt: inputs.addedAt,
     favoriteIds: inputs.favoriteIds,
-    downloadedIds: inputs.downloadedIds,
+    downloadedKeys: inputs.downloadedKeys,
     random: Random(),
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,7 +70,7 @@ Future<void> main() async {
       // quality, lower data, balanced, or default).
       sharedPreferencesPlaybackSourceStrategyStoreOverride,
       // Make the playback source strategy cache-aware from the live offline set.
-      offlineAvailableTrackIdsOverride,
+      offlineAvailableTrackKeysOverride,
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
       sharedPreferencesPlaybackPreferencesOverride,

--- a/test/core/catalog/now_playing_match_test.dart
+++ b/test/core/catalog/now_playing_match_test.dart
@@ -88,13 +88,28 @@ void main() {
       );
     });
 
-    test('untagged local files only match by exact id', () {
+    test('untagged local files only match by exact uri', () {
       const Track a =
           Track(id: 'file:///a.mp3', title: 'a', uri: 'file:///a.mp3');
       const Track b =
           Track(id: 'file:///b.mp3', title: 'b', uri: 'file:///b.mp3');
       expect(isCurrentPlaybackTrack(a, a), isTrue);
       expect(isCurrentPlaybackTrack(a, b), isFalse);
+    });
+
+    test('a different song sharing a bare id across providers is NOT current',
+        () {
+      // Regression for the bare-id short-circuit: a playing jellyfin:101 must
+      // not mark an unrelated subsonic:101 as the now-playing row.
+      expect(
+        isCurrentPlaybackTrack(
+          _jelly('101', title: 'Alpha', album: 'A'),
+          _sub('101', title: 'Beta', album: 'B'),
+        ),
+        isFalse,
+      );
+      // The same song across providers with a shared bare id still matches.
+      expect(isCurrentPlaybackTrack(_jelly('101'), _sub('101')), isTrue);
     });
   });
 }

--- a/test/core/catalog/track_unifier_test.dart
+++ b/test/core/catalog/track_unifier_test.dart
@@ -54,7 +54,46 @@ void main() {
 
       expect(logical, hasLength(1));
       expect(logical.single.hasMultipleSources, isTrue);
-      expect(logical.single.allTrackIds, containsAll(<String>['j', 's']));
+      expect(logical.single.allTrackUris,
+          containsAll(<String>['jellyfin:j', 'subsonic:s']));
+    });
+
+    test(
+        'two DIFFERENT songs that share a bare server-side id across providers '
+        'stay separate (no mis-group or duplicate row)', () {
+      // Grouping keys on the provider-namespaced uri, so a Jellyfin "101" and a
+      // Subsonic "101" that are unrelated songs never collide into one group —
+      // and neither is duplicated or dropped.
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('101', title: 'Alpha', album: 'A'),
+          _sub('101', title: 'Beta', album: 'B'),
+        ],
+        _subsonicPreferred,
+      );
+
+      expect(logical, hasLength(2));
+      expect(
+        logical.map((LogicalTrack l) => l.primaryTrack.uri),
+        containsAll(<String>['jellyfin:101', 'subsonic:101']),
+      );
+      expect(logical.every((LogicalTrack l) => !l.hasMultipleSources), isTrue);
+    });
+
+    test('the SAME song still merges even when the two copies share a bare id',
+        () {
+      final List<LogicalTrack> logical = unifyTracks(
+        <Track>[
+          _jelly('101', title: 'Hello'),
+          _sub('101', title: 'Hello'),
+        ],
+        _subsonicPreferred,
+      );
+
+      expect(logical, hasLength(1));
+      expect(logical.single.hasMultipleSources, isTrue);
+      expect(logical.single.allTrackUris,
+          containsAll(<String>['jellyfin:101', 'subsonic:101']));
     });
 
     test('prefers the active/default provider for the playable copy', () {
@@ -194,7 +233,8 @@ void main() {
       );
 
       expect(logical, hasLength(1));
-      expect(logical.single.allTrackIds, containsAll(<String>['j', 's']));
+      expect(logical.single.allTrackUris,
+          containsAll(<String>['jellyfin:j', 'subsonic:s']));
     });
 
     test('an album edition suffix does not split a match', () {
@@ -263,7 +303,8 @@ void main() {
       // Two rows: the merged "Hello" (first seen at index 0) then the local file.
       expect(logical, hasLength(2));
       expect(logical.first.hasMultipleSources, isTrue);
-      expect(logical.first.allTrackIds, containsAll(<String>['j', 's']));
+      expect(logical.first.allTrackUris,
+          containsAll(<String>['jellyfin:j', 'subsonic:s']));
       expect(logical.last.primaryTrack.id, localOnly.id);
     });
   });

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -417,4 +417,44 @@ void main() {
       expect(restored.current, _track('A'));
     });
   });
+
+  group('provider-aware identity (two rows share a bare id across providers)',
+      () {
+    const jelly = Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+    const sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+
+    test('unshuffle keeps the current copy, not the first row sharing the id',
+        () {
+      // Shuffled state: the subsonic copy is current; pre-shuffle order had the
+      // jellyfin copy first. indexOf-by-id would jump current to jellyfin.
+      const shuffled = PlaybackQueue(
+        tracks: <Track>[sub, jelly],
+        currentIndex: 0,
+        originalOrder: <Track>[jelly, sub],
+      );
+
+      final restored = shuffled.unshuffled();
+
+      expect(restored.current!.uri, 'subsonic:101');
+      expect(restored.tracks.map((Track t) => t.uri),
+          <String>['jellyfin:101', 'subsonic:101']);
+    });
+
+    test('removeUpNextAt drops the right copy from originalOrder by uri', () {
+      // current = jelly, upNext = [sub], same originalOrder. Removing the upNext
+      // entry must drop the subsonic copy — not the jellyfin one that shares its
+      // bare id (which `List.remove` via Track == would have hit first).
+      const q = PlaybackQueue(
+        tracks: <Track>[jelly, sub],
+        currentIndex: 0,
+        originalOrder: <Track>[jelly, sub],
+      );
+
+      final result = q.removeUpNextAt(0);
+
+      expect(result.upNext, isEmpty);
+      expect(result.unshuffled().tracks.map((Track t) => t.uri),
+          <String>['jellyfin:101']);
+    });
+  });
 }

--- a/test/core/models/playback_queue_test.dart
+++ b/test/core/models/playback_queue_test.dart
@@ -388,6 +388,21 @@ void main() {
       expect(identical(queue.replaceCurrent(_track('a')), queue), isTrue);
     });
 
+    test('swaps to another provider copy that shares the bare id (fallback)',
+        () {
+      // jellyfin:101 falling back to subsonic:101 — same bare id, different uri.
+      // The swap must take effect (it previously no-op'd via Track == on id), so
+      // `current` reflects the copy that actually started.
+      const jelly = Track(id: '101', title: 'Hello', uri: 'jellyfin:101');
+      const sub = Track(id: '101', title: 'Hello', uri: 'subsonic:101');
+      final queue = PlaybackQueue.of(<Track>[jelly]);
+
+      final replaced = queue.replaceCurrent(sub);
+
+      expect(identical(replaced, queue), isFalse);
+      expect(replaced.current!.uri, 'subsonic:101');
+    });
+
     test('a later unshuffle keeps the replaced copy, not the original', () {
       final queue = PlaybackQueue.of([_track('a'), _track('b'), _track('c')])
           .shuffled(Random(1));

--- a/test/core/models/playback_state_test.dart
+++ b/test/core/models/playback_state_test.dart
@@ -27,19 +27,24 @@ void main() {
       expect(before, isNot(after));
     });
 
-    test('a current-track provider swap with the same bare id is not equal', () {
-      final PlaybackState a = const PlaybackState(status: PlaybackStatus.playing)
-          .copyWith(currentTrack: _jelly('101'));
-      final PlaybackState b = const PlaybackState(status: PlaybackStatus.playing)
-          .copyWith(currentTrack: _sub('101'));
+    test('a current-track provider swap with the same bare id is not equal',
+        () {
+      final PlaybackState a =
+          const PlaybackState(status: PlaybackStatus.playing)
+              .copyWith(currentTrack: _jelly('101'));
+      final PlaybackState b =
+          const PlaybackState(status: PlaybackStatus.playing)
+              .copyWith(currentTrack: _sub('101'));
       expect(a, isNot(b));
     });
 
     test('identical states stay equal and hash the same', () {
-      final PlaybackState a = const PlaybackState(status: PlaybackStatus.playing)
-          .copyWith(currentTrack: _jelly('101'), upNext: <Track>[_jelly('2')]);
-      final PlaybackState b = const PlaybackState(status: PlaybackStatus.playing)
-          .copyWith(currentTrack: _jelly('101'), upNext: <Track>[_jelly('2')]);
+      final PlaybackState a =
+          const PlaybackState(status: PlaybackStatus.playing).copyWith(
+              currentTrack: _jelly('101'), upNext: <Track>[_jelly('2')]);
+      final PlaybackState b =
+          const PlaybackState(status: PlaybackStatus.playing).copyWith(
+              currentTrack: _jelly('101'), upNext: <Track>[_jelly('2')]);
       expect(a, b);
       expect(a.hashCode, b.hashCode);
     });

--- a/test/core/models/playback_state_test.dart
+++ b/test/core/models/playback_state_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+
+Track _jelly(String id) => Track(id: id, title: 't', uri: 'jellyfin:$id');
+Track _sub(String id) => Track(id: id, title: 't', uri: 'subsonic:$id');
+
+void main() {
+  group('PlaybackState ==', () {
+    test('up-next reordered among same-bare-id copies is not equal', () {
+      // Reordering two same-id copies from different providers must change
+      // equality (Track == is uri-based) so the controller's _emit guard does
+      // not drop the new queue while the internal queue advances in the new
+      // order.
+      const PlaybackState a = PlaybackState(
+        status: PlaybackStatus.playing,
+        upNext: <Track>[],
+      );
+      final PlaybackState before = a.copyWith(
+        currentTrack: _jelly('1'),
+        upNext: <Track>[_jelly('101'), _sub('101')],
+      );
+      final PlaybackState after = a.copyWith(
+        currentTrack: _jelly('1'),
+        upNext: <Track>[_sub('101'), _jelly('101')],
+      );
+      expect(before, isNot(after));
+    });
+
+    test('a current-track provider swap with the same bare id is not equal', () {
+      final PlaybackState a = const PlaybackState(status: PlaybackStatus.playing)
+          .copyWith(currentTrack: _jelly('101'));
+      final PlaybackState b = const PlaybackState(status: PlaybackStatus.playing)
+          .copyWith(currentTrack: _sub('101'));
+      expect(a, isNot(b));
+    });
+
+    test('identical states stay equal and hash the same', () {
+      final PlaybackState a = const PlaybackState(status: PlaybackStatus.playing)
+          .copyWith(currentTrack: _jelly('101'), upNext: <Track>[_jelly('2')]);
+      final PlaybackState b = const PlaybackState(status: PlaybackStatus.playing)
+          .copyWith(currentTrack: _jelly('101'), upNext: <Track>[_jelly('2')]);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+}

--- a/test/core/models/track_test.dart
+++ b/test/core/models/track_test.dart
@@ -30,4 +30,39 @@ void main() {
       expect(_track(artist: '', album: '').artistAlbumLabel, isEmpty);
     });
   });
+
+  group('Track identity (== / hashCode)', () {
+    Track jelly(String id) => Track(id: id, title: 't', uri: 'jellyfin:$id');
+    Track sub(String id) => Track(id: id, title: 't', uri: 'subsonic:$id');
+
+    test('two copies sharing a uri are equal and hash the same', () {
+      // A metadata-only refresh keeps the uri, so it still compares equal.
+      final Track a = jelly('101');
+      final Track b = jelly('101')
+          .copyWith(title: 'refreshed', duration: const Duration(minutes: 4));
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('the same bare id from two providers is not equal', () {
+      expect(jelly('101'), isNot(sub('101')));
+      expect(jelly('101').hashCode, isNot(sub('101').hashCode));
+    });
+
+    test('same-id copies stay distinct in a Set (no collision)', () {
+      final Set<Track> set = <Track>{jelly('101'), sub('101')};
+      expect(set.length, 2);
+      expect(set.contains(jelly('101')), isTrue);
+      expect(set.contains(sub('101')), isTrue);
+    });
+
+    test('same-id copies are distinct Map/family keys', () {
+      final Map<Track, String> byTrack = <Track, String>{
+        jelly('101'): 'jelly',
+        sub('101'): 'sub',
+      };
+      expect(byTrack[jelly('101')], 'jelly');
+      expect(byTrack[sub('101')], 'sub');
+    });
+  });
 }

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -97,6 +97,35 @@ void main() {
       expect(state.position, const Duration(seconds: 42));
     });
 
+    test('emits a same-bare-id provider swap the merge guard would hide',
+        () async {
+      // A retry/fallback swaps the current copy to another provider that shares
+      // the bare id (jellyfin:101 -> subsonic:101), same status. PlaybackState ==
+      // leans on Track == (bare id), so the merge guard must compare the uri too
+      // or this swap never reaches UI/reporting.
+      const Track jelly = Track(id: '101', title: 'X', uri: 'jellyfin:101');
+      const Track sub = Track(id: '101', title: 'X', uri: 'subsonic:101');
+      local = FakePlaybackController(
+        initial: const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: jelly,
+        ),
+      );
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      local.emit(const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: sub,
+      ));
+
+      final PlaybackState state = await _waitFor(
+        controller,
+        (s) => s.currentTrack?.uri == 'subsonic:101',
+      );
+      expect(state.currentTrack?.uri, 'subsonic:101');
+    });
+
     test('passive position updates never re-issue play or load', () async {
       local = FakePlaybackController();
       await local.playTracks(const <Track>[_trackA, _trackB]);

--- a/test/core/services/android_auto_cast_test.dart
+++ b/test/core/services/android_auto_cast_test.dart
@@ -60,7 +60,7 @@ void main() {
     final int playedBefore = local.playedTracks.length;
 
     // Android Auto selects a library track.
-    await handler.playFromMediaId(MediaId.libraryTrack('b'));
+    await handler.playFromMediaId(MediaId.libraryTrack('/b.mp3'));
     await _settle();
 
     // The queue advanced (so the receiver can be told what to play), but the
@@ -128,7 +128,7 @@ void main() {
       await local.dispose();
     });
 
-    await handler.playFromMediaId(MediaId.libraryTrack('b'));
+    await handler.playFromMediaId(MediaId.libraryTrack('/b.mp3'));
     await _settle();
 
     // Local output is active, so the selection really plays on the device.

--- a/test/core/services/cast/default_cast_service_test.dart
+++ b/test/core/services/cast/default_cast_service_test.dart
@@ -342,6 +342,30 @@ void main() {
       expect(service.state.isCasting, isTrue);
     });
 
+    test('re-casts a same-bare-id copy from another provider (uri de-dupe)',
+        () async {
+      // Two castable copies that share a server-side id: switching from one to
+      // the other must reload the receiver, not be dropped as the "same track"
+      // (the de-dupe keys on the uri, not the bare id).
+      const jelly101 = Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+      const sub101 = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+      current = jelly101;
+      final handle = _FakeHandle();
+      transport.handle = handle;
+      final service = build();
+      addTearDown(service.dispose);
+
+      await service.connect(_d1);
+      expect(handle.loaded, hasLength(1));
+
+      current = sub101;
+      trackChanges.add(sub101);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(handle.loaded, hasLength(2));
+      expect(handle.loaded.last.title, 'Beta');
+    });
+
     test('reconnecting re-casts the current track (no stale dedupe)', () async {
       current = _jellyfinTrack;
       final firstHandle = _FakeHandle();

--- a/test/core/services/fake_browse_repositories.dart
+++ b/test/core/services/fake_browse_repositories.dart
@@ -115,16 +115,16 @@ class FakeFavoritesRepository implements FavoritesRepository {
 }
 
 /// Minimal [DownloadRepository] for browse-tree tests: reports a fixed set of
-/// downloaded (offline) track ids. Only the read the media browser uses
-/// ([downloadedTrackIds]) is implemented; the download lifecycle surface throws,
-/// so a test that accidentally relied on it would fail loudly.
+/// downloaded (offline) provider-aware cache keys. Only the read the media
+/// browser uses ([downloadedTrackKeys]) is implemented; the download lifecycle
+/// surface throws, so a test that accidentally relied on it would fail loudly.
 class FakeDownloadRepository implements DownloadRepository {
-  FakeDownloadRepository(Set<String> downloadedIds) : _ids = downloadedIds;
+  FakeDownloadRepository(Set<String> downloadedKeys) : _keys = downloadedKeys;
 
-  final Set<String> _ids;
+  final Set<String> _keys;
 
   @override
-  Future<List<String>> downloadedTrackIds() async => _ids.toList();
+  Future<List<String>> downloadedTrackKeys() async => _keys.toList();
 
   // Download lifecycle surface — not exercised by the media browser, so it
   // throws to fail loudly if a test ever depends on it.

--- a/test/core/services/just_audio_playback_controller_fallback_test.dart
+++ b/test/core/services/just_audio_playback_controller_fallback_test.dart
@@ -149,7 +149,7 @@ void main() {
         resolver: resolver,
         // Jellyfin is the default, so it leads the candidate order.
         candidates: <String, List<Track>>{
-          'j': <Track>[jelly, sub],
+          'jellyfin:j': <Track>[jelly, sub],
         },
       );
 
@@ -180,7 +180,7 @@ void main() {
         resolver: resolver,
         // Navidrome is the default, so the displayed copy is the Subsonic one.
         candidates: <String, List<Track>>{
-          's': <Track>[sub, jelly],
+          'subsonic:s': <Track>[sub, jelly],
         },
       );
 
@@ -211,7 +211,7 @@ void main() {
         player: player,
         resolver: resolver,
         candidates: <String, List<Track>>{
-          'j': <Track>[jelly, sub],
+          'jellyfin:j': <Track>[jelly, sub],
         },
       );
 
@@ -236,7 +236,7 @@ void main() {
         player: player,
         resolver: resolver,
         candidates: <String, List<Track>>{
-          'j': <Track>[jelly, sub],
+          'jellyfin:j': <Track>[jelly, sub],
         },
       );
 
@@ -266,7 +266,7 @@ void main() {
         player: player,
         resolver: resolver,
         candidates: <String, List<Track>>{
-          'j': <Track>[jelly, sub],
+          'jellyfin:j': <Track>[jelly, sub],
         },
       );
 
@@ -286,7 +286,7 @@ void main() {
         player: player,
         resolver: resolver,
         candidates: <String, List<Track>>{
-          'j': <Track>[jelly, sub],
+          'jellyfin:j': <Track>[jelly, sub],
         },
       );
 
@@ -485,7 +485,7 @@ void main() {
         player: player,
         resolver: resolver,
         candidates: <String, List<Track>>{
-          'j': <Track>[jelly, sub],
+          'jellyfin:j': <Track>[jelly, sub],
         },
       );
 
@@ -502,7 +502,7 @@ void main() {
   // Regression: when the user changes the default source mid-queue, the candidate
   // source recomputes under the controller (it reads it lazily). End-of-track
   // continuation must pick up the new order for the *next* queued copy — and must
-  // never get stuck on stale source state. The map is keyed by every copy's id,
+  // never get stuck on stale source state. The map is keyed by every copy's uri,
   // so a queued Jellyfin copy still resolves to its candidates after the switch.
   group('end-of-track continuation after a source change', () {
     final Track j1 = _track('j1', 'jellyfin:j1');
@@ -510,19 +510,19 @@ void main() {
     final Track j2 = _track('j2', 'jellyfin:j2');
     final Track s2 = _track('s2', 'subsonic:s2');
 
-    // The live candidate map, keyed by every copy's id (what
+    // The live candidate map, keyed by every copy's uri (what
     // playbackCandidatesProvider produces). Mutated in place to model a switch.
     Map<String, List<Track>> jellyfinFirst() => <String, List<Track>>{
-          'j1': <Track>[j1, s1],
-          's1': <Track>[j1, s1],
-          'j2': <Track>[j2, s2],
-          's2': <Track>[j2, s2],
+          'jellyfin:j1': <Track>[j1, s1],
+          'subsonic:s1': <Track>[j1, s1],
+          'jellyfin:j2': <Track>[j2, s2],
+          'subsonic:s2': <Track>[j2, s2],
         };
     Map<String, List<Track>> subsonicFirst() => <String, List<Track>>{
-          'j1': <Track>[s1, j1],
-          's1': <Track>[s1, j1],
-          'j2': <Track>[s2, j2],
-          's2': <Track>[s2, j2],
+          'jellyfin:j1': <Track>[s1, j1],
+          'subsonic:s1': <Track>[s1, j1],
+          'jellyfin:j2': <Track>[s2, j2],
+          'subsonic:s2': <Track>[s2, j2],
         };
 
     void completeCurrent(JustAudioPlaybackController controller) {

--- a/test/core/services/just_audio_playback_controller_fallback_test.dart
+++ b/test/core/services/just_audio_playback_controller_fallback_test.dart
@@ -167,6 +167,35 @@ void main() {
       expect(resolver.calls, <String>['jellyfin:j', 'subsonic:s']);
     });
 
+    test('falls back across providers that share a bare id (101 -> 101)',
+        () async {
+      // jellyfin:101 and subsonic:101 are the same song with the *same* bare id.
+      // The candidate map (uri-keyed) and the queue swap (uri-compared) must
+      // still fall back to the Subsonic copy and reflect it as current.
+      final Track j101 = _track('101', 'jellyfin:101');
+      final Track s101 = _track('101', 'subsonic:101');
+      final player = _FakePlayer();
+      final resolver = _FakeResolver(
+        resolveFailures: <String>{'jellyfin:101'},
+        resolved: <String, ResolvedPlayable>{
+          'subsonic:101': _stream('https://sub/stream/101'),
+        },
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:101': <Track>[j101, s101],
+        },
+      );
+
+      await controller.playTracks(<Track>[j101]);
+
+      final PlaybackState s = controller.state;
+      expect(s.currentTrack?.uri, 'subsonic:101');
+      expect(resolver.calls, <String>['jellyfin:101', 'subsonic:101']);
+    });
+
     test('default Navidrome fails → plays Jellyfin, shows Jellyfin', () async {
       final player = _FakePlayer();
       final resolver = _FakeResolver(

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -392,10 +392,12 @@ void main() {
       test('library lists every catalog track as a playable leaf', () async {
         final children = await handler.getChildren(MediaId.library);
 
+        // Leaves are keyed by a hash of the uri; libraryTrack() hashes, so we
+        // compare to it built from each track's uri (/<id>.mp3 here).
         expect(children.map((i) => i.id), [
-          MediaId.libraryTrack('a'),
-          MediaId.libraryTrack('b'),
-          MediaId.libraryTrack('c'),
+          MediaId.libraryTrack('/a.mp3'),
+          MediaId.libraryTrack('/b.mp3'),
+          MediaId.libraryTrack('/c.mp3'),
         ]);
         expect(children.first.title, 'Song a');
         expect(children.first.playable, isTrue);
@@ -451,7 +453,7 @@ void main() {
       });
 
       test('selecting a library track plays it and queues the rest', () async {
-        await handler.playFromMediaId(MediaId.libraryTrack('b'));
+        await handler.playFromMediaId(MediaId.libraryTrack('/b.mp3'));
         await _settle();
 
         expect(controller.state.currentTrack?.id, 'b');
@@ -649,7 +651,7 @@ void main() {
       test('a queue selected from the car supports next & previous', () async {
         // Selecting a library track in the car builds the queue (the rest of
         // the library becomes up-next), then car skip moves within that queue.
-        await handler.playFromMediaId(MediaId.libraryTrack('a'));
+        await handler.playFromMediaId(MediaId.libraryTrack('/a.mp3'));
         await _settle();
         expect(handler.mediaItem.value?.id, 'a');
 
@@ -826,9 +828,10 @@ void main() {
 
         final items = await libHandler.getChildren(MediaId.library);
 
+        // Keyed by a hash of the uri; pass the same uris libraryTrack() hashes.
         expect(items.map((i) => i.id), [
-          MediaId.libraryTrack('jf-guid-123'),
-          MediaId.libraryTrack('local-1'),
+          MediaId.libraryTrack('jellyfin:jf-guid-123'),
+          MediaId.libraryTrack('/storage/music/local.mp3'),
         ]);
         for (final item in items) {
           // Ids never carry a token, an auth query, a URI scheme, or a stream

--- a/test/core/services/linthra_audio_handler_test.dart
+++ b/test/core/services/linthra_audio_handler_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/repeat_mode.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/linthra_audio_handler.dart';
 import 'package:linthra/core/services/media_artwork_source.dart';
 import 'package:linthra/core/services/media_browser_tree.dart';
@@ -491,7 +492,10 @@ void main() {
           MediaBrowserTree(
             FakeMusicLibraryRepository(tracks: _library),
             favorites: FakeFavoritesRepository({'a'}),
-            downloads: FakeDownloadRepository({'b', 'c'}),
+            downloads: FakeDownloadRepository(<String>{
+              CachedTrack.cacheKeyForTrack(_track('b')),
+              CachedTrack.cacheKeyForTrack(_track('c')),
+            }),
           ),
         );
       });

--- a/test/core/services/media_browser_tree_test.dart
+++ b/test/core/services/media_browser_tree_test.dart
@@ -167,10 +167,13 @@ void main() {
       test('exposes every catalog track as a playable leaf', () async {
         final nodes = await _kids(treeOf(library), MediaId.library);
 
+        // Leaves are keyed by an opaque hash of the track uri (collision-free
+        // across providers); libraryTrack() does the hashing, so we compare to
+        // it built from each track's uri.
         expect(nodes.map((n) => n.id), [
-          MediaId.libraryTrack('a'),
-          MediaId.libraryTrack('b'),
-          MediaId.libraryTrack('c'),
+          MediaId.libraryTrack('/a.mp3'),
+          MediaId.libraryTrack('/b.mp3'),
+          MediaId.libraryTrack('/c.mp3'),
         ]);
         expect(nodes.every((n) => n.playable), isTrue);
         expect(nodes.first.track, library.first);
@@ -196,7 +199,8 @@ void main() {
 
       test('a library track resolves to the whole catalog at its index',
           () async {
-        final request = await _pick(treeOf(library), MediaId.libraryTrack('b'));
+        final request =
+            await _pick(treeOf(library), MediaId.libraryTrack('/b.mp3'));
 
         expect(request, isNotNull);
         expect(request!.tracks, library);
@@ -205,9 +209,32 @@ void main() {
 
       test('a missing library track resolves to null', () async {
         expect(
-          await _pick(treeOf(library), MediaId.libraryTrack('zzz')),
+          await _pick(treeOf(library), MediaId.libraryTrack('/zzz.mp3')),
           isNull,
         );
+      });
+
+      test(
+          'same bare-id songs from different providers get distinct media ids '
+          'and resolve to the right copy', () async {
+        const jelly = Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+        const sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+        final tree = treeOf(<Track>[jelly, sub]);
+
+        final nodes = await _kids(tree, MediaId.library);
+        // Distinct, collision-free leaf ids (would have collided on the bare id).
+        final List<String> ids = nodes.map((n) => n.id).toList();
+        expect(ids, <String>[
+          MediaId.libraryTrack('jellyfin:101'),
+          MediaId.libraryTrack('subsonic:101'),
+        ]);
+        expect(ids[0], isNot(ids[1]));
+
+        // Each leaf resolves to its own provider copy, not whichever shares 101.
+        final jReq = await _pick(tree, MediaId.libraryTrack('jellyfin:101'));
+        final sReq = await _pick(tree, MediaId.libraryTrack('subsonic:101'));
+        expect(jReq!.tracks[jReq.startIndex].uri, 'jellyfin:101');
+        expect(sReq!.tracks[sReq.startIndex].uri, 'subsonic:101');
       });
     });
 

--- a/test/core/services/media_browser_tree_test.dart
+++ b/test/core/services/media_browser_tree_test.dart
@@ -3,6 +3,7 @@ import 'package:linthra/core/catalog/library_grouping.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/playlist.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/media_browser_tree.dart';
 
 import '../../features/library/fake_music_library_repository.dart';
@@ -18,6 +19,13 @@ Track _track(String id, {String? artist, String? album, int? trackNumber}) {
     trackNumber: trackNumber,
   );
 }
+
+/// The provider-aware download cache keys for catalog ids built with [_track],
+/// so a test can express downloaded tracks by plain id while the repository (and
+/// the media browser) join on the cache key.
+Set<String> _dlKeys(Iterable<String> ids) => <String>{
+      for (final String id in ids) CachedTrack.cacheKeyForTrack(_track(id))
+    };
 
 PlaybackState _playing(Track current, {List<Track> upNext = const <Track>[]}) {
   return PlaybackState(
@@ -56,7 +64,7 @@ void main() {
           FakeMusicLibraryRepository(tracks: tracks),
           playlists: FakePlaylistRepository(playlists),
           favorites: FakeFavoritesRepository(favorites),
-          downloads: FakeDownloadRepository(downloads),
+          downloads: FakeDownloadRepository(_dlKeys(downloads)),
         );
       }
 
@@ -529,7 +537,7 @@ void main() {
       MediaBrowserTree buildTree([Set<String> ids = const {'b', 'c', 'x'}]) {
         return MediaBrowserTree(
           FakeMusicLibraryRepository(tracks: library),
-          downloads: FakeDownloadRepository(ids),
+          downloads: FakeDownloadRepository(_dlKeys(ids)),
         );
       }
 

--- a/test/core/services/playback_candidate_source_test.dart
+++ b/test/core/services/playback_candidate_source_test.dart
@@ -19,14 +19,14 @@ void main() {
 
     test('returns the mapped, ordered candidates for a known track', () {
       final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
-            'j': <Track>[jelly, sub],
+            'jellyfin:j': <Track>[jelly, sub],
           });
       expect(source.candidatesFor(jelly), <Track>[jelly, sub]);
     });
 
     test('an unknown (single-source) track yields just itself', () {
       final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
-            'j': <Track>[jelly, sub],
+            'jellyfin:j': <Track>[jelly, sub],
           });
       final Track lonely = _t('x', 'jellyfin:x');
       expect(source.candidatesFor(lonely), <Track>[lonely]);
@@ -34,9 +34,22 @@ void main() {
 
     test('an empty mapped list falls back to the track itself', () {
       final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
-            'j': <Track>[],
+            'jellyfin:j': <Track>[],
           });
       expect(source.candidatesFor(jelly), <Track>[jelly]);
+    });
+
+    test('keys on the uri, so a shared bare id resolves to the right song', () {
+      // Two unrelated songs that share the bare id "101" across providers.
+      final Track jelly101 = _t('101', 'jellyfin:101');
+      final Track sub101 = _t('101', 'subsonic:101');
+      final source = MapPlaybackCandidateSource(() => <String, List<Track>>{
+            'jellyfin:101': <Track>[jelly101],
+            'subsonic:101': <Track>[sub101],
+          });
+      // Each resolves to its own entry — not the other provider's same-id song.
+      expect(source.candidatesFor(jelly101), <Track>[jelly101]);
+      expect(source.candidatesFor(sub101), <Track>[sub101]);
     });
 
     test('the map is read lazily on every call (live library)', () {
@@ -48,7 +61,7 @@ void main() {
 
       // The library updates; the same source now sees the new candidates.
       map = <String, List<Track>>{
-        'j': <Track>[jelly, sub],
+        'jellyfin:j': <Track>[jelly, sub],
       };
       expect(source.candidatesFor(jelly), <Track>[jelly, sub]);
     });

--- a/test/core/services/playback_reporting_service_test.dart
+++ b/test/core/services/playback_reporting_service_test.dart
@@ -356,6 +356,29 @@ void main() {
       await service.dispose();
     });
 
+    test('a same-id provider fallback is reported as a track change', () async {
+      // A preferred copy fails and playback falls back to another provider's
+      // copy that shares the bare id. The reporting identity is the uri, so the
+      // failed copy's session is closed (onTrackChanged) and the copy actually
+      // playing opens its own start — distinguished here by its duration.
+      final service = build();
+      const Track jelly = Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+      const Track sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+
+      states.add(_state(PlaybackStatus.playing, jelly,
+          duration: const Duration(minutes: 3)));
+      states.add(_state(PlaybackStatus.playing, sub,
+          duration: const Duration(minutes: 2)));
+      await _settle();
+
+      expect(reporter.events, <String>[
+        'started:101@0/180000', // the failed-preferred jellyfin copy (3 min)
+        'changed:101->101',
+        'started:101@0/120000', // the subsonic copy actually playing (2 min)
+      ]);
+      await service.dispose();
+    });
+
     test('a skip while paused still closes the outgoing track', () async {
       final service = build();
       final Track a = _track('a');

--- a/test/core/services/smart_playlist_resolver_test.dart
+++ b/test/core/services/smart_playlist_resolver_test.dart
@@ -57,6 +57,26 @@ void main() {
           <String>['d', 'b', 'c', 'a']);
     });
 
+    test('recently added falls back to a legacy bare-id timestamp', () {
+      // An upgraded user whose store predates uri keys: a remote track's
+      // first-seen time is still under the bare id until the next sync migrates
+      // it. The read must honor that key so Recently Added keeps its order right
+      // after the upgrade instead of collapsing to catalog order.
+      final List<Track> result = SmartPlaylistResolver(maxTracks: 100).resolve(
+        SmartPlaylistKind.recentlyAdded,
+        allTracks: <Track>[_t('a'), _t('b')],
+        history: history,
+        addedAt: <String, DateTime>{
+          'jellyfin:a': DateTime(2024, 1, 1), // already migrated to the uri key
+          'b': DateTime(2024, 1, 5), // legacy bare-id key, and newer
+        },
+        favoriteIds: const <String>{},
+        downloadedIds: const <String>{},
+      );
+      // 'b' (legacy key, Jan 5) outranks 'a' (uri key, Jan 1).
+      expect(_ids(result), <String>['b', 'a']);
+    });
+
     test('recently played is most-recently-played first, played-only', () {
       // a@Jan1, b@Jan3, c@Jan2 → b, c, a; d was never played so it's excluded.
       expect(_ids(resolve(SmartPlaylistKind.recentlyPlayed)),

--- a/test/core/services/smart_playlist_resolver_test.dart
+++ b/test/core/services/smart_playlist_resolver_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/play_history.dart';
 import 'package:linthra/core/models/smart_playlist.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/smart_playlist_resolver.dart';
 
 Track _t(String id) => Track(id: id, title: 'Title $id', uri: 'jellyfin:$id');
@@ -36,7 +37,7 @@ void main() {
     SmartPlaylistKind kind, {
     List<Track>? tracks,
     Set<String> favoriteIds = const <String>{},
-    Set<String> downloadedIds = const <String>{},
+    Set<String> downloadedKeys = const <String>{},
     int maxTracks = 100,
     Random? random,
   }) {
@@ -46,7 +47,7 @@ void main() {
       history: history,
       addedAt: addedAt,
       favoriteIds: favoriteIds,
-      downloadedIds: downloadedIds,
+      downloadedKeys: downloadedKeys,
       random: random,
     );
   }
@@ -72,7 +73,7 @@ void main() {
           'b': DateTime(2024, 1, 5), // legacy bare-id key, and newer
         },
         favoriteIds: const <String>{},
-        downloadedIds: const <String>{},
+        downloadedKeys: const <String>{},
       );
       // 'b' (legacy key, Jan 5) outranks 'a' (uri key, Jan 1).
       expect(_ids(result), <String>['b', 'a']);
@@ -99,12 +100,29 @@ void main() {
       expect(_ids(result), <String>['b', 'd']);
     });
 
-    test('downloaded mix uses the cached (downloaded) id set', () {
+    test('downloaded mix uses the cached (downloaded) cache-key set', () {
       final List<Track> result = resolve(
         SmartPlaylistKind.downloaded,
-        downloadedIds: <String>{'a', 'c'},
+        downloadedKeys: <String>{
+          CachedTrack.cacheKeyForTrack(_t('a')),
+          CachedTrack.cacheKeyForTrack(_t('c')),
+        },
       );
       expect(_ids(result), <String>['a', 'c']);
+    });
+
+    test('downloaded mix is provider-aware for same-id copies', () {
+      // Two providers expose the same bare id 101; only the Subsonic copy is
+      // downloaded. The mix must show that copy alone — never the Jellyfin copy
+      // that merely shares the id.
+      const Track jelly = Track(id: '101', title: 'A', uri: 'jellyfin:101');
+      const Track sub = Track(id: '101', title: 'A', uri: 'subsonic:101');
+      final List<Track> result = resolve(
+        SmartPlaylistKind.downloaded,
+        tracks: <Track>[jelly, sub],
+        downloadedKeys: <String>{CachedTrack.cacheKeyForTrack(sub)},
+      );
+      expect(result.map((Track t) => t.uri).toList(), <String>['subsonic:101']);
     });
 
     test('never played excludes anything in the play history', () {

--- a/test/core/services/smart_playlist_resolver_test.dart
+++ b/test/core/services/smart_playlist_resolver_test.dart
@@ -62,7 +62,8 @@ void main() {
       // first-seen time is still under the bare id until the next sync migrates
       // it. The read must honor that key so Recently Added keeps its order right
       // after the upgrade instead of collapsing to catalog order.
-      final List<Track> result = SmartPlaylistResolver(maxTracks: 100).resolve(
+      final List<Track> result =
+          const SmartPlaylistResolver(maxTracks: 100).resolve(
         SmartPlaylistKind.recentlyAdded,
         allTracks: <Track>[_t('a'), _t('b')],
         history: history,

--- a/test/core/services/smart_playlist_resolver_test.dart
+++ b/test/core/services/smart_playlist_resolver_test.dart
@@ -23,11 +23,13 @@ void main() {
     },
   );
 
+  // Keyed by the provider-namespaced uri (jellyfin:<id> here, matching the _t
+  // helper), the way RecordingMusicLibraryRepository now stamps first-seen times.
   final Map<String, DateTime> addedAt = <String, DateTime>{
-    'a': DateTime(2024, 1, 1),
-    'b': DateTime(2024, 1, 3),
-    'c': DateTime(2024, 1, 2),
-    'd': DateTime(2024, 1, 4),
+    'jellyfin:a': DateTime(2024, 1, 1),
+    'jellyfin:b': DateTime(2024, 1, 3),
+    'jellyfin:c': DateTime(2024, 1, 2),
+    'jellyfin:d': DateTime(2024, 1, 4),
   };
 
   List<Track> resolve(

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -343,6 +343,38 @@ void main() {
       expect((await store.loadDownloads()).single.sourceType, isNull);
     });
 
+    test('a migrated legacy cache belongs only to the matched provider copy',
+        () async {
+      // Pre-v0.1.6 the catalog was 1:1, so a legacy download for id 101 was one
+      // provider's (Plex here). After it migrates, a later same-bare-id copy from
+      // another provider (subsonic:101) must NOT inherit the download.
+      files = InMemoryOfflineFileStore();
+      final String fileName =
+          await files.write('101', <int>[1, 2, 3, 4], extension: 'mp3');
+      store = InMemoryDownloadStore(initialDownloads: <CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName, sizeBytes: 4),
+      ]);
+      final repository = CacheDownloadRepository(
+        store: store,
+        files: files,
+        downloader: downloader,
+        connectivity: connectivity,
+        preferences: preferences,
+        catalogForMigration: () async => <Track>[_plex('101')],
+      );
+
+      // Migrated to the Plex copy only…
+      expect(await repository.downloadedTrackKeys(),
+          <String>[CachedTrack.cacheKeyForTrack(_plex('101'))]);
+      // …so a same-id Subsonic copy is not seen as downloaded.
+      final Map<String, DownloadStatus> snapshot =
+          await repository.statusStream.first;
+      expect(
+          snapshot.containsKey(CachedTrack.cacheKeyForTrack(_subsonic('101'))),
+          isFalse);
+      expect(await repository.statusFor('101'), DownloadStatus.downloaded);
+    });
+
     test('statusStream seeds the current snapshot then emits changes',
         () async {
       await build().requestDownload(_jellyfin('j1'));

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -288,6 +288,61 @@ void main() {
       expect(snapshot.containsKey(jellyKey), isFalse);
     });
 
+    test('migrates a legacy (sourceType-less) record to a provider-aware key',
+        () async {
+      // Seed a pre-v0.1.6 download: a managed file plus a CachedTrack with no
+      // sourceType, which keys as `\0101`.
+      files = InMemoryOfflineFileStore();
+      final String fileName =
+          await files.write('101', <int>[1, 2, 3, 4], extension: 'mp3');
+      store = InMemoryDownloadStore(initialDownloads: <CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName, sizeBytes: 4),
+      ]);
+      // The catalog resolves bare id 101 to one provider (1:1 pre-upgrade).
+      final repository = CacheDownloadRepository(
+        store: store,
+        files: files,
+        downloader: downloader,
+        connectivity: connectivity,
+        preferences: preferences,
+        catalogForMigration: () async => <Track>[_jellyfin('101')],
+      );
+
+      // The download now resolves under the provider-aware key…
+      expect(await repository.downloadedTrackKeys(),
+          <String>[CachedTrack.cacheKeyForTrack(_jellyfin('101'))]);
+      // …and the record was re-saved with the inferred sourceType (so it stays
+      // provider-aware next launch), with its cache file untouched.
+      final List<CachedTrack> saved = await store.loadDownloads();
+      expect(saved.single.sourceType, 'jellyfin');
+      expect(saved.single.fileName, fileName);
+    });
+
+    test('leaves a legacy record unmigrated when its bare id is ambiguous',
+        () async {
+      files = InMemoryOfflineFileStore();
+      final String fileName =
+          await files.write('101', <int>[1, 2, 3, 4], extension: 'mp3');
+      store = InMemoryDownloadStore(initialDownloads: <CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName, sizeBytes: 4),
+      ]);
+      // Two providers now expose id 101 — the legacy download can't be safely
+      // attributed, so it must be left as-is rather than mis-keyed.
+      final repository = CacheDownloadRepository(
+        store: store,
+        files: files,
+        downloader: downloader,
+        connectivity: connectivity,
+        preferences: preferences,
+        catalogForMigration: () async =>
+            <Track>[_jellyfin('101'), _subsonic('101')],
+      );
+
+      expect(await repository.downloadedTrackKeys(),
+          <String>[CachedTrack.cacheKeyFor(null, '101')]);
+      expect((await store.loadDownloads()).single.sourceType, isNull);
+    });
+
     test('statusStream seeds the current snapshot then emits changes',
         () async {
       await build().requestDownload(_jellyfin('j1'));

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -152,7 +152,7 @@ void main() {
         await repository.statusFor('j1'),
         DownloadStatus.notDownloaded,
       );
-      expect(await repository.downloadedTrackIds(), isEmpty);
+      expect(await repository.downloadedTrackKeys(), isEmpty);
     });
 
     test('downloading a Jellyfin track stores a cached file reference',
@@ -181,7 +181,7 @@ void main() {
       await repository.removeDownload(_jellyfin('j1'));
 
       expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
-      expect(await repository.downloadedTrackIds(), isEmpty);
+      expect(await repository.downloadedTrackKeys(), isEmpty);
       expect(await store.loadDownloads(), isEmpty);
       expect(files.bytesFor(fileName), isNull);
     });
@@ -195,7 +195,7 @@ void main() {
 
       expect(await repository.statusFor('j1'), DownloadStatus.failed);
       expect(await store.loadDownloads(), isEmpty);
-      expect(await repository.downloadedTrackIds(), isEmpty);
+      expect(await repository.downloadedTrackKeys(), isEmpty);
     });
 
     test('a failed Jellyfin track can be retried', () async {
@@ -266,7 +266,26 @@ void main() {
 
       final reopened = build();
       expect(await reopened.statusFor('j1'), DownloadStatus.downloaded);
-      expect(await reopened.downloadedTrackIds(), <String>['j1']);
+      expect(await reopened.downloadedTrackKeys(),
+          <String>[CachedTrack.cacheKeyForTrack(_jellyfin('j1'))]);
+    });
+
+    test('the downloaded projection is provider-aware for same-id copies',
+        () async {
+      // Two providers expose the same bare id 101; only the Subsonic copy is
+      // downloaded. The public projection (downloaded keys + status snapshot)
+      // must mark that copy alone — never the Jellyfin copy sharing the id.
+      final repository = build();
+      await repository.requestDownload(_subsonic('101'));
+
+      final String subKey = CachedTrack.cacheKeyForTrack(_subsonic('101'));
+      final String jellyKey = CachedTrack.cacheKeyForTrack(_jellyfin('101'));
+      expect(await repository.downloadedTrackKeys(), <String>[subKey]);
+
+      final Map<String, DownloadStatus> snapshot =
+          await repository.statusStream.first;
+      expect(snapshot[subKey], DownloadStatus.downloaded);
+      expect(snapshot.containsKey(jellyKey), isFalse);
     });
 
     test('statusStream seeds the current snapshot then emits changes',
@@ -279,13 +298,15 @@ void main() {
       await _settle();
 
       expect(emissions.first, <String, DownloadStatus>{
-        'j1': DownloadStatus.downloaded,
+        CachedTrack.cacheKeyForTrack(_jellyfin('j1')):
+            DownloadStatus.downloaded,
       });
 
       await repository.requestDownload(_jellyfin('j2'));
       await _settle();
 
-      expect(emissions.last['j2'], DownloadStatus.downloaded);
+      expect(emissions.last[CachedTrack.cacheKeyForTrack(_jellyfin('j2'))],
+          DownloadStatus.downloaded);
       await sub.cancel();
     });
 
@@ -519,9 +540,12 @@ void main() {
         await repository.requestDownload(_jellyfin('j1'));
         await repository.requestDownload(_jellyfin('j2'));
 
-        final List<String> ids = await repository.downloadedTrackIds();
+        final List<String> ids = await repository.downloadedTrackKeys();
         ids.sort();
-        expect(ids, <String>['j1', 'j2']);
+        expect(ids, <String>[
+          CachedTrack.cacheKeyForTrack(_jellyfin('j1')),
+          CachedTrack.cacheKeyForTrack(_jellyfin('j2')),
+        ]);
         expect((await repository.cacheSnapshot()).usedBytes, 8);
       });
 
@@ -676,9 +700,13 @@ void main() {
         await Future.wait(futures);
         expect(downloader.fetchCount, 3);
         expect(downloader.maxActive, 2);
-        final List<String> ids = await repository.downloadedTrackIds();
+        final List<String> ids = await repository.downloadedTrackKeys();
         ids.sort();
-        expect(ids, <String>['j1', 'j2', 'j3']);
+        expect(ids, <String>[
+          CachedTrack.cacheKeyForTrack(_jellyfin('j1')),
+          CachedTrack.cacheKeyForTrack(_jellyfin('j2')),
+          CachedTrack.cacheKeyForTrack(_jellyfin('j3')),
+        ]);
       });
 
       test('a duplicate request for the same track is not started twice',
@@ -740,13 +768,14 @@ void main() {
         downloader = _FakeRemoteDownloader(gate: gate.future);
         final repository = build();
 
+        final String j1Key = CachedTrack.cacheKeyForTrack(_jellyfin('j1'));
         final emissions = <Map<String, DownloadProgress>>[];
         final sub = repository.progressStream.listen(emissions.add);
 
         final future = repository.requestDownload(_jellyfin('j1'));
-        await _pumpUntil(() => emissions.any((m) => m['j1'] != null));
+        await _pumpUntil(() => emissions.any((m) => m[j1Key] != null));
 
-        final DownloadProgress? mid = emissions.last['j1'];
+        final DownloadProgress? mid = emissions.last[j1Key];
         expect(mid, isNotNull);
         expect(mid!.receivedBytes, 2);
         expect(mid.totalBytes, 4);
@@ -757,7 +786,7 @@ void main() {
         await _settle();
 
         // Progress is cleared once the download finishes.
-        expect(emissions.last['j1'], isNull);
+        expect(emissions.last[j1Key], isNull);
         await sub.cancel();
       });
 
@@ -787,7 +816,7 @@ void main() {
 
         // Invisible as a download, but cached and counted toward usage.
         expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
-        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await repository.downloadedTrackKeys(), isEmpty);
         final CachedTrack saved = (await store.loadDownloads()).single;
         expect(saved.trackId, 'j1');
         expect(saved.preloaded, isTrue);
@@ -962,7 +991,7 @@ void main() {
         final List<CachedTrack> saved = await store.loadDownloads();
         expect(saved.single.trackId, 'new');
         expect(saved.single.preloaded, isTrue);
-        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await repository.downloadedTrackKeys(), isEmpty);
       });
 
       test('a pre-cache never evicts the currently playing track', () async {
@@ -1008,7 +1037,7 @@ void main() {
         await repository.clearAll();
 
         // Pinned items included: clear-all is the nuclear option.
-        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await repository.downloadedTrackKeys(), isEmpty);
         expect(await store.loadDownloads(), isEmpty);
         expect(spy.bytesFor('jellyfin_j1.mp3'), isNull);
         expect(spy.bytesFor('jellyfin_j2.mp3'), isNull);
@@ -1088,7 +1117,7 @@ void main() {
         await request;
 
         expect(await repository.statusFor('j1'), DownloadStatus.notDownloaded);
-        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await repository.downloadedTrackKeys(), isEmpty);
         expect(await store.loadDownloads(), isEmpty);
         final CacheSnapshot snapshot = await repository.cacheSnapshot();
         expect(snapshot.usedBytes, 0);
@@ -1128,7 +1157,7 @@ void main() {
         gate.complete();
         await request;
 
-        expect(await repository.downloadedTrackIds(), isEmpty);
+        expect(await repository.downloadedTrackKeys(), isEmpty);
         expect(await store.loadDownloads(), isEmpty);
         expect((await repository.cacheSnapshot()).usedBytes, 0);
       });

--- a/test/data/repositories/drift_music_library_repository_test.dart
+++ b/test/data/repositories/drift_music_library_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/album.dart';
@@ -10,6 +12,25 @@ Track _track(String id, {int durationMs = 0, String? artworkUri}) => Track(
       id: id,
       title: 'Track $id',
       uri: 'file:///$id.flac',
+      artistName: 'Artist $id',
+      albumName: 'Album $id',
+      duration: Duration(milliseconds: durationMs),
+      trackNumber: 1,
+      artworkUri: artworkUri == null ? null : Uri.parse(artworkUri),
+    );
+
+/// A track with an explicit provider-namespaced [uri] but a caller-chosen bare
+/// [id], so a test can give two providers the *same* server-side id.
+Track _providerTrack(
+  String uri, {
+  required String id,
+  int durationMs = 0,
+  String? artworkUri,
+}) =>
+    Track(
+      id: id,
+      title: 'Track $uri',
+      uri: uri,
       artistName: 'Artist $id',
       albumName: 'Album $id',
       duration: Duration(milliseconds: durationMs),
@@ -60,7 +81,7 @@ void main() {
         artists: const <Artist>[],
       );
 
-      final Track? track = await repository.getTrackById('a');
+      final Track? track = await repository.getTrackByUri('file:///a.flac');
       expect(track, isNotNull);
       expect(track!.duration, const Duration(milliseconds: 187000));
       expect(track.artworkUri, Uri.parse('file:///art/a.jpg'));
@@ -69,7 +90,7 @@ void main() {
       expect(track.trackNumber, 1);
     });
 
-    test('getTrackById returns null when absent', () async {
+    test('getTrackByUri returns null when absent', () async {
       await repository.upsertCatalog(
         sourceId: 'local',
         tracks: <Track>[_track('a')],
@@ -77,7 +98,7 @@ void main() {
         artists: const <Artist>[],
       );
 
-      expect(await repository.getTrackById('missing'), isNull);
+      expect(await repository.getTrackByUri('file:///missing.flac'), isNull);
     });
 
     test('second upsert for a source replaces its tracks', () async {
@@ -96,7 +117,7 @@ void main() {
 
       final List<Track> all = await repository.getAllTracks();
       expect(all.map((Track t) => t.id), <String>['new']);
-      expect(await repository.getTrackById('old'), isNull);
+      expect(await repository.getTrackByUri('file:///old.flac'), isNull);
     });
 
     test('upserting another source leaves existing tracks intact', () async {
@@ -141,7 +162,7 @@ void main() {
       final List<Track> all = await repository.getAllTracks();
       expect(all, hasLength(2));
       expect(all.map((Track t) => t.id), containsAll(<String>['dup', 'other']));
-      final Track? dup = await repository.getTrackById('dup');
+      final Track? dup = await repository.getTrackByUri('file:///dup.flac');
       expect(dup, isNotNull);
       expect(dup!.duration, const Duration(milliseconds: 2000));
     });
@@ -165,9 +186,226 @@ void main() {
         all.map((Track t) => t.id),
         containsAll(<String>['a', 'b', 'shared']),
       );
-      final Track? shared = await repository.getTrackById('shared');
+      final Track? shared =
+          await repository.getTrackByUri('file:///shared.flac');
       expect(shared, isNotNull);
       expect(shared!.duration, const Duration(milliseconds: 2000));
+    });
+
+    test(
+        'a Jellyfin and a Plex track that share a server-side id both survive '
+        'a sync (no cross-provider overwrite)', () async {
+      // The bug this fixes: the catalog was keyed by the bare server-side id, so
+      // `insertOrReplace` let the second provider's row clobber the first.
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[
+          _providerTrack('jellyfin:101', id: '101', durationMs: 1000),
+        ],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'plex',
+        tracks: <Track>[
+          _providerTrack('plex:101', id: '101', durationMs: 2000),
+        ],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(
+        all.map((Track t) => t.uri),
+        containsAll(<String>['jellyfin:101', 'plex:101']),
+      );
+      // Each copy keeps its own metadata — neither overwrote the other.
+      expect((await repository.getTrackByUri('jellyfin:101'))!.duration,
+          const Duration(milliseconds: 1000));
+      expect((await repository.getTrackByUri('plex:101'))!.duration,
+          const Duration(milliseconds: 2000));
+    });
+
+    test(
+        'a Jellyfin and a Navidrome/Subsonic track that share a server-side id '
+        'both survive a sync', () async {
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_providerTrack('jellyfin:101', id: '101')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'subsonic',
+        tracks: <Track>[_providerTrack('subsonic:101', id: '101')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(
+        all.map((Track t) => t.uri),
+        containsAll(<String>['jellyfin:101', 'subsonic:101']),
+      );
+    });
+
+    test('removeTracks deletes by uri, sparing another provider\'s same id',
+        () async {
+      await repository.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_providerTrack('jellyfin:101', id: '101')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await repository.upsertCatalog(
+        sourceId: 'subsonic',
+        tracks: <Track>[_providerTrack('subsonic:101', id: '101')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      await repository.removeTracks(<String>['jellyfin:101']);
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all.map((Track t) => t.uri), <String>['subsonic:101']);
+    });
+  });
+
+  group('LinthraDatabase v1 -> v2 migration (tracks re-keyed id -> uri)', () {
+    late Directory tempDir;
+    late File dbFile;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('linthra_migration_test');
+      dbFile = File('${tempDir.path}/linthra.sqlite');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+    });
+
+    /// Builds the v1-shaped `tracks` table (primary key on the bare `id`) on
+    /// [dbFile], seeds it with [rows], and stamps `user_version = 1` so the next
+    /// open of [LinthraDatabase] (schemaVersion 2) runs the real upgrade.
+    Future<void> seedV1(List<Map<String, Object?>> rows) async {
+      final LinthraDatabase setup =
+          LinthraDatabase.forTesting(NativeDatabase(dbFile));
+      await setup.customStatement('DROP TABLE tracks;');
+      await setup.customStatement(
+        'CREATE TABLE tracks ('
+        'id TEXT NOT NULL, source_id TEXT NOT NULL, title TEXT NOT NULL, '
+        'uri TEXT NOT NULL, artist_name TEXT, album_name TEXT, '
+        'duration_ms INTEGER NOT NULL DEFAULT 0, track_number INTEGER, '
+        'artwork_uri TEXT, PRIMARY KEY (id));',
+      );
+      for (final Map<String, Object?> r in rows) {
+        await setup.customStatement(
+          'INSERT INTO tracks (id, source_id, title, uri, artist_name, '
+          'album_name, duration_ms, track_number, artwork_uri) '
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);',
+          <Object?>[
+            r['id'],
+            r['source_id'],
+            r['title'],
+            r['uri'],
+            r['artist_name'],
+            r['album_name'],
+            r['duration_ms'],
+            r['track_number'],
+            r['artwork_uri'],
+          ],
+        );
+      }
+      await setup.customStatement('PRAGMA user_version = 1;');
+      await setup.close();
+    }
+
+    test('preserves every existing row, re-keyed on uri', () async {
+      await seedV1(<Map<String, Object?>>[
+        <String, Object?>{
+          'id': '101',
+          'source_id': 'jellyfin',
+          'title': 'J Song',
+          'uri': 'jellyfin:101',
+          'artist_name': 'Adele',
+          'album_name': '25',
+          'duration_ms': 187000,
+          'track_number': 3,
+          'artwork_uri': 'https://art/1.jpg',
+        },
+        <String, Object?>{
+          'id': '7',
+          'source_id': 'local',
+          'title': 'L Song',
+          'uri': 'file:///7.flac',
+          'artist_name': null,
+          'album_name': null,
+          'duration_ms': 0,
+          'track_number': null,
+          'artwork_uri': null,
+        },
+      ]);
+
+      // Opening at schemaVersion 2 over a user_version-1 file runs the upgrade.
+      final LinthraDatabase db =
+          LinthraDatabase.forTesting(NativeDatabase(dbFile));
+      addTearDown(db.close);
+      final repository = DriftMusicLibraryRepository(db);
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+
+      final Track? j = await repository.getTrackByUri('jellyfin:101');
+      expect(j, isNotNull);
+      expect(j!.id, '101');
+      expect(j.title, 'J Song');
+      expect(j.duration, const Duration(milliseconds: 187000));
+      expect(j.trackNumber, 3);
+      expect(j.artworkUri, Uri.parse('https://art/1.jpg'));
+
+      final Track? local = await repository.getTrackByUri('file:///7.flac');
+      expect(local, isNotNull);
+      expect(local!.title, 'L Song');
+      expect(local.artistName, isNull);
+    });
+
+    test('after upgrade a same-id row from another provider can coexist',
+        () async {
+      await seedV1(<Map<String, Object?>>[
+        <String, Object?>{
+          'id': '101',
+          'source_id': 'jellyfin',
+          'title': 'J Song',
+          'uri': 'jellyfin:101',
+          'artist_name': 'Adele',
+          'album_name': '25',
+          'duration_ms': 1000,
+          'track_number': 1,
+          'artwork_uri': null,
+        },
+      ]);
+
+      final LinthraDatabase db =
+          LinthraDatabase.forTesting(NativeDatabase(dbFile));
+      addTearDown(db.close);
+      final repository = DriftMusicLibraryRepository(db);
+
+      // The migrated Jellyfin 101 and a freshly-synced Plex 101 coexist.
+      await repository.upsertCatalog(
+        sourceId: 'plex',
+        tracks: <Track>[_providerTrack('plex:101', id: '101')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+
+      final List<Track> all = await repository.getAllTracks();
+      expect(all, hasLength(2));
+      expect(
+        all.map((Track t) => t.uri),
+        containsAll(<String>['jellyfin:101', 'plex:101']),
+      );
     });
   });
 }

--- a/test/data/repositories/in_memory_music_library_repository_test.dart
+++ b/test/data/repositories/in_memory_music_library_repository_test.dart
@@ -59,7 +59,7 @@ void main() {
       expect(await repository.getAllArtists(), <Artist>[_artist('a')]);
     });
 
-    test('getTrackById returns a match, or null if absent', () async {
+    test('getTrackByUri returns a match, or null if absent', () async {
       await repository.upsertCatalog(
         sourceId: 'local',
         tracks: <Track>[_track('a'), _track('b')],
@@ -67,8 +67,8 @@ void main() {
         artists: const <Artist>[],
       );
 
-      expect(await repository.getTrackById('b'), _track('b'));
-      expect(await repository.getTrackById('missing'), isNull);
+      expect(await repository.getTrackByUri('b'), _track('b'));
+      expect(await repository.getTrackByUri('missing'), isNull);
     });
 
     test('second upsert for a source replaces its tracks', () async {
@@ -86,7 +86,7 @@ void main() {
       );
 
       expect(await repository.getAllTracks(), <Track>[_track('new')]);
-      expect(await repository.getTrackById('old'), isNull);
+      expect(await repository.getTrackByUri('old'), isNull);
     });
 
     test('upserting another source keeps existing tracks', () async {
@@ -123,7 +123,7 @@ void main() {
       expect(all, hasLength(2));
       expect(all, contains(_track('a')));
       expect(all, contains(_track('c')));
-      expect(await repository.getTrackById('b'), isNull);
+      expect(await repository.getTrackByUri('b'), isNull);
     });
 
     test('removeTracks spans sources and leaves others intact', () async {

--- a/test/data/repositories/recording_music_library_repository_test.dart
+++ b/test/data/repositories/recording_music_library_repository_test.dart
@@ -96,6 +96,24 @@ void main() {
     });
 
     test(
+        'removing a remote track before migration also clears its legacy id key',
+        () async {
+      // Pre-v2 store: an id-keyed entry that no sync has migrated yet.
+      final DateTime legacy = DateTime(2023, 1, 1);
+      await addedStore.save(<String, DateTime>{'101': legacy});
+
+      final RecordingMusicLibraryRepository repo =
+          build(now: () => DateTime(2024, 6, 10));
+      // Remove by uri (the catalog key) before any stamp has migrated '101'.
+      await repo.removeTracks(<String>['jellyfin:101']);
+      expect((await addedStore.load()).containsKey('101'), isFalse);
+
+      // A later re-sync now treats it as genuinely new, not the stale legacy time.
+      await sync(repo, <Track>[_t('101')]); // uri: jellyfin:101
+      expect((await addedStore.load())['jellyfin:101'], DateTime(2024, 6, 10));
+    });
+
+    test(
         'migrates a legacy id-keyed timestamp to the uri key, preserving the time',
         () async {
       // A store written by a pre-v2 build keyed entries by the bare id. The first

--- a/test/data/repositories/recording_music_library_repository_test.dart
+++ b/test/data/repositories/recording_music_library_repository_test.dart
@@ -46,8 +46,9 @@ void main() {
       await sync(repo, <Track>[_t('a'), _t('b')]);
 
       final Map<String, DateTime> added = await addedStore.load();
-      expect(added['a'], now);
-      expect(added['b'], now);
+      // Keyed by the provider-namespaced uri, not the bare id.
+      expect(added['jellyfin:a'], now);
+      expect(added['jellyfin:b'], now);
       // The catalog write itself still went through to the delegate.
       expect((await repo.getAllTracks()).map((Track t) => t.id),
           containsAll(<String>['a', 'b']));
@@ -59,7 +60,7 @@ void main() {
       final RecordingMusicLibraryRepository repo = build(now: () => clock);
 
       await sync(repo, <Track>[_t('a')]);
-      final DateTime firstSeenA = (await addedStore.load())['a']!;
+      final DateTime firstSeenA = (await addedStore.load())['jellyfin:a']!;
 
       // A later re-sync that still includes 'a' and adds 'b'.
       clock = DateTime(2024, 6, 10);
@@ -67,8 +68,8 @@ void main() {
 
       final Map<String, DateTime> added = await addedStore.load();
       // 'a' keeps its original first-seen time; only 'b' gets the new time.
-      expect(added['a'], firstSeenA);
-      expect(added['b'], DateTime(2024, 6, 10));
+      expect(added['jellyfin:a'], firstSeenA);
+      expect(added['jellyfin:b'], DateTime(2024, 6, 10));
     });
 
     test('forgets the timestamp when a track is removed', () async {
@@ -76,21 +77,40 @@ void main() {
           build(now: () => DateTime(2024, 6, 1));
       await sync(repo, <Track>[_t('a'), _t('b')]);
 
-      await repo.removeTracks(<String>['a']);
+      // removeTracks is keyed by uri (the catalog's identity).
+      await repo.removeTracks(<String>['jellyfin:a']);
 
       final Map<String, DateTime> added = await addedStore.load();
-      expect(added.containsKey('a'), isFalse);
-      expect(added.containsKey('b'), isTrue);
+      expect(added.containsKey('jellyfin:a'), isFalse);
+      expect(added.containsKey('jellyfin:b'), isTrue);
     });
 
-    test('the timestamp store never holds a track uri', () async {
+    test('keys the timestamp store by the provider-namespaced uri', () async {
       final RecordingMusicLibraryRepository repo = build();
-      await sync(repo, const <Track>[
-        Track(id: 'a', title: 'A', uri: 'https://server/stream?token=secret'),
-      ]);
+      await sync(repo, <Track>[_t('a')]);
       final Map<String, DateTime> added = await addedStore.load();
-      expect(added.keys, <String>['a']);
-      expect(added.toString(), isNot(contains('secret')));
+      // The credential-free uri (scheme:id) is the key — never the bare id, so
+      // two providers' same-id tracks can't share a timestamp. (Track.uri is
+      // guaranteed credential-free by the source mappers, tested there.)
+      expect(added.keys, <String>['jellyfin:a']);
+    });
+
+    test(
+        'migrates a legacy id-keyed timestamp to the uri key, preserving the time',
+        () async {
+      // A store written by a pre-v2 build keyed entries by the bare id. The first
+      // sync that sees the track again must adopt that timestamp under the uri
+      // key, not reset it to "now".
+      final DateTime legacy = DateTime(2023, 1, 1);
+      await addedStore.save(<String, DateTime>{'a': legacy});
+
+      final RecordingMusicLibraryRepository repo =
+          build(now: () => DateTime(2024, 6, 10));
+      await sync(repo, <Track>[_t('a')]);
+
+      final Map<String, DateTime> added = await addedStore.load();
+      expect(added['jellyfin:a'], legacy); // original time preserved
+      expect(added.containsKey('a'), isFalse); // legacy key cleaned up
     });
   });
 }

--- a/test/data/repositories/recording_music_library_repository_test.dart
+++ b/test/data/repositories/recording_music_library_repository_test.dart
@@ -116,10 +116,16 @@ void main() {
     test(
         'migrates a legacy id-keyed timestamp to the uri key, preserving the time',
         () async {
-      // A store written by a pre-v2 build keyed entries by the bare id. The first
-      // sync that sees the track again must adopt that timestamp under the uri
-      // key, not reset it to "now".
+      // A pre-v2 store keyed entries by the bare id; the catalog (migrated to v2)
+      // already holds the track under its uri. The one-time migration at the next
+      // catalog write must re-key the timestamp to the uri, not reset it to "now".
       final DateTime legacy = DateTime(2023, 1, 1);
+      await delegate.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_t('a')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
       await addedStore.save(<String, DateTime>{'a': legacy});
 
       final RecordingMusicLibraryRepository repo =
@@ -129,6 +135,36 @@ void main() {
       final Map<String, DateTime> added = await addedStore.load();
       expect(added['jellyfin:a'], legacy); // original time preserved
       expect(added.containsKey('a'), isFalse); // legacy key cleaned up
+    });
+
+    test('a newly-added same-id provider cannot steal a legacy timestamp',
+        () async {
+      // jellyfin:101 existed pre-upgrade (legacy timestamp under bare id 101);
+      // the migrated catalog already holds it. The user adds a Plex source that
+      // also exposes id 101, and Plex syncs first.
+      final DateTime legacy = DateTime(2023, 1, 1);
+      await delegate.upsertCatalog(
+        sourceId: 'jellyfin',
+        tracks: <Track>[_t('101')],
+        albums: const <Album>[],
+        artists: const <Artist>[],
+      );
+      await addedStore.save(<String, DateTime>{'101': legacy});
+
+      final RecordingMusicLibraryRepository repo =
+          build(now: () => DateTime(2024, 6, 10));
+      await sync(
+        repo,
+        <Track>[const Track(id: '101', title: 'P', uri: 'plex:101')],
+        sourceId: 'plex',
+      );
+
+      final Map<String, DateTime> added = await addedStore.load();
+      // The legacy time stays with the original Jellyfin row…
+      expect(added['jellyfin:101'], legacy);
+      // …and the newly-added Plex copy is correctly treated as new.
+      expect(added['plex:101'], DateTime(2024, 6, 10));
+      expect(added.containsKey('101'), isFalse);
     });
   });
 }

--- a/test/data/repositories/store_cached_track_locator_test.dart
+++ b/test/data/repositories/store_cached_track_locator_test.dart
@@ -157,5 +157,25 @@ void main() {
       expect(await locator.cachedFilePath(_jellyfin('101')),
           '/offline_audio/legacy101.mp3');
     });
+
+    test(
+        'a legacy untagged record is withheld when the sole owner is a '
+        'different provider', () async {
+      // The requested copy (plex:101) is no longer in the catalog (its source was
+      // removed) but stays queued; the only owner of id 101 is now Jellyfin, so
+      // the untagged file is Jellyfin's and must not play for the Plex copy.
+      final String fileName =
+          await files.write('legacy101', const <int>[9], extension: 'mp3');
+      await store.saveDownloads(<CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName),
+      ]);
+      final StoreCachedTrackLocator locator = StoreCachedTrackLocator(
+        store,
+        files,
+        catalogForLegacyMatch: () async => <Track>[_jellyfin('101')],
+      );
+
+      expect(await locator.cachedFilePath(_plex('101')), isNull);
+    });
   });
 }

--- a/test/data/repositories/store_cached_track_locator_test.dart
+++ b/test/data/repositories/store_cached_track_locator_test.dart
@@ -7,6 +7,7 @@ import 'package:linthra/data/repositories/store_cached_track_locator.dart';
 
 Track _jellyfin(String id) => Track(id: id, title: id, uri: 'jellyfin:$id');
 Track _plex(String id) => Track(id: id, title: id, uri: 'plex:$id');
+Track _subsonic(String id) => Track(id: id, title: id, uri: 'subsonic:$id');
 
 void main() {
   group('StoreCachedTrackLocator', () {
@@ -116,6 +117,45 @@ void main() {
 
       expect(await build().cachedFilePath(_jellyfin('legacy')),
           '/offline_audio/legacy.mp3');
+    });
+
+    test('a legacy untagged record is not served when the id is ambiguous',
+        () async {
+      // jellyfin:101 was cached pre-tagging (untagged). A Subsonic source now
+      // also exposes id 101, so the untagged bytes can't be attributed — the
+      // locator must serve neither copy from them (it streams instead).
+      final String fileName =
+          await files.write('legacy101', const <int>[9], extension: 'mp3');
+      await store.saveDownloads(<CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName),
+      ]);
+      final StoreCachedTrackLocator locator = StoreCachedTrackLocator(
+        store,
+        files,
+        catalogForLegacyMatch: () async =>
+            <Track>[_jellyfin('101'), _subsonic('101')],
+      );
+
+      expect(await locator.cachedFilePath(_jellyfin('101')), isNull);
+      expect(await locator.cachedFilePath(_subsonic('101')), isNull);
+    });
+
+    test('a legacy untagged record is served when the id is unambiguous',
+        () async {
+      // Only one provider exposes id 101, so the untagged bytes are safely its.
+      final String fileName =
+          await files.write('legacy101', const <int>[9], extension: 'mp3');
+      await store.saveDownloads(<CachedTrack>[
+        CachedTrack(trackId: '101', fileName: fileName),
+      ]);
+      final StoreCachedTrackLocator locator = StoreCachedTrackLocator(
+        store,
+        files,
+        catalogForLegacyMatch: () async => <Track>[_jellyfin('101')],
+      );
+
+      expect(await locator.cachedFilePath(_jellyfin('101')),
+          '/offline_audio/legacy101.mp3');
     });
   });
 }

--- a/test/features/library/fake_music_library_repository.dart
+++ b/test/features/library/fake_music_library_repository.dart
@@ -13,16 +13,16 @@ class FakeMusicLibraryRepository implements MusicLibraryRepository {
   final List<Track> tracks;
   final Object? error;
 
-  /// Track ids passed to [removeTracks], in order, so a test can assert that a
+  /// Track uris passed to [removeTracks], in order, so a test can assert that a
   /// "Remove from Linthra library" action only removed from the index.
-  final List<String> removedTrackIds = <String>[];
+  final List<String> removedTrackUris = <String>[];
 
   @override
   Future<List<Track>> getAllTracks() async {
     if (error != null) throw error!;
     return <Track>[
       for (final Track track in tracks)
-        if (!removedTrackIds.contains(track.id)) track,
+        if (!removedTrackUris.contains(track.uri)) track,
     ];
   }
 
@@ -33,9 +33,9 @@ class FakeMusicLibraryRepository implements MusicLibraryRepository {
   Future<List<Artist>> getAllArtists() async => const <Artist>[];
 
   @override
-  Future<Track?> getTrackById(String id) async {
+  Future<Track?> getTrackByUri(String uri) async {
     for (final track in tracks) {
-      if (track.id == id) return track;
+      if (track.uri == uri) return track;
     }
     return null;
   }
@@ -49,7 +49,7 @@ class FakeMusicLibraryRepository implements MusicLibraryRepository {
   }) async {}
 
   @override
-  Future<void> removeTracks(List<String> trackIds) async {
-    removedTrackIds.addAll(trackIds);
+  Future<void> removeTracks(List<String> trackUris) async {
+    removedTrackUris.addAll(trackUris);
   }
 }

--- a/test/features/library/library_selection_test.dart
+++ b/test/features/library/library_selection_test.dart
@@ -100,10 +100,14 @@ void main() {
       expect(find.widgetWithText(TextButton, 'Cancel'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, 'Remove'), findsOneWidget);
 
-      // Confirming removes only from the index (the fake records the ids).
+      // Confirming removes only from the index (the fake records the uris — the
+      // catalog's provider-namespaced identity, not the bare id).
       await tester.tap(find.widgetWithText(FilledButton, 'Remove'));
       await tester.pumpAndSettle();
-      expect(repository.removedTrackIds, containsAll(<String>['a', 'b']));
+      expect(
+        repository.removedTrackUris,
+        containsAll(<String>['file:///a.mp3', 'jellyfin:b']),
+      );
     });
   });
 }

--- a/test/features/library/library_selection_test.dart
+++ b/test/features/library/library_selection_test.dart
@@ -14,6 +14,12 @@ const List<Track> _mixed = <Track>[
   Track(id: 'b', title: 'Song B', uri: 'jellyfin:b'),
 ];
 
+// Two unrelated songs that share a bare server-side id across providers.
+const List<Track> _sameBareId = <Track>[
+  Track(id: '101', title: 'Alpha', uri: 'jellyfin:101'),
+  Track(id: '101', title: 'Beta', uri: 'subsonic:101'),
+];
+
 Future<FakeMusicLibraryRepository> _pump(
   WidgetTester tester, {
   List<Track> tracks = _mixed,
@@ -47,6 +53,19 @@ void main() {
       await tester.tap(find.text('Song B'));
       await tester.pumpAndSettle();
       expect(find.text('2 selected'), findsOneWidget);
+    });
+
+    testWidgets(
+        'same bare-id rows from different providers select independently',
+        (tester) async {
+      await _pump(tester, tracks: _sameBareId);
+
+      // Long-press one of the two same-id rows: only it is selected, because
+      // selection keys on the provider-namespaced uri, not the bare id.
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.text('2 selected'), findsNothing);
     });
 
     testWidgets('offers safe actions and hides unsafe destructive deletes',

--- a/test/features/library/playback_candidates_provider_test.dart
+++ b/test/features/library/playback_candidates_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:linthra/core/catalog/source_strategy.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_store.dart';
 import 'package:linthra/core/services/playback_candidate_source.dart';
 import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
@@ -58,7 +59,7 @@ Future<ProviderContainer> _seed({
   required List<Track> jellyfin,
   required List<Track> subsonic,
   PlaybackSourceStrategy strategy = PlaybackSourceStrategy.preferDefault,
-  Set<String> cachedIds = const <String>{},
+  Set<String> cachedKeys = const <String>{},
 }) async {
   final repo = InMemoryMusicLibraryRepository();
   final container = ProviderContainer(
@@ -68,7 +69,7 @@ Future<ProviderContainer> _seed({
           .overrideWith(() => _FixedPreference(priority)),
       playbackSourceStrategyProvider
           .overrideWith(() => _FixedStrategy(strategy)),
-      offlineAvailableTrackIdsProvider.overrideWithValue(cachedIds),
+      offlineAvailableTrackKeysProvider.overrideWithValue(cachedKeys),
     ],
   );
   addTearDown(container.dispose);
@@ -167,7 +168,7 @@ void main() {
         jellyfin: <Track>[_jelly('j', title: 'Hello')],
         subsonic: <Track>[_sub('s', title: 'Hello')],
         strategy: PlaybackSourceStrategy.preferLocalCache,
-        cachedIds: <String>{'s'},
+        cachedKeys: <String>{CachedTrack.cacheKeyFor('subsonic', 's')},
       );
 
       final Map<String, List<Track>> map =
@@ -175,6 +176,26 @@ void main() {
       // Same display id (Jellyfin primary), but the cached Subsonic copy leads.
       expect(map['jellyfin:j']!.map((Track t) => t.uri).toList(),
           <String>['subsonic:s', 'jellyfin:j']);
+    });
+
+    test('preferLocalCache is provider-aware for same-bare-id copies',
+        () async {
+      // Jellyfin and Subsonic both expose id 101; only the Subsonic copy is
+      // downloaded. "Prefer local/cache" must lead with the actually-cached
+      // Subsonic copy — the same-id Jellyfin copy must not be treated as cached
+      // just because they share the bare id.
+      final container = await _seed(
+        priority: const SourcePriority(<String>['jellyfin', 'subsonic']),
+        jellyfin: <Track>[_jelly('101', title: 'Hello')],
+        subsonic: <Track>[_sub('101', title: 'Hello')],
+        strategy: PlaybackSourceStrategy.preferLocalCache,
+        cachedKeys: <String>{CachedTrack.cacheKeyFor('subsonic', '101')},
+      );
+
+      final Map<String, List<Track>> map =
+          container.read(playbackCandidatesProvider);
+      expect(map['jellyfin:101']!.map((Track t) => t.uri).toList(),
+          <String>['subsonic:101', 'jellyfin:101']);
     });
 
     test(
@@ -206,7 +227,7 @@ void main() {
       final repo = InMemoryMusicLibraryRepository();
       final container = ProviderContainer(overrides: <Override>[
         musicLibraryRepositoryProvider.overrideWithValue(repo),
-        offlineAvailableTrackIdsProvider.overrideWithValue(const <String>{}),
+        offlineAvailableTrackKeysProvider.overrideWithValue(const <String>{}),
         // The exact production wiring the playback controller uses.
         playbackCandidateSourceOverride,
       ]);

--- a/test/features/library/playback_candidates_provider_test.dart
+++ b/test/features/library/playback_candidates_provider_test.dart
@@ -101,13 +101,13 @@ void main() {
       final Map<String, List<Track>> map =
           container.read(playbackCandidatesProvider);
 
-      // Keyed by *every* copy's id (not just the displayed/primary one), so a
+      // Keyed by *every* copy's uri (not just the displayed/primary one), so a
       // copy already in the queue resolves to the song's candidates whichever
-      // one it is. Both ids map to the same ordered list; Jellyfin is preferred.
-      expect(map.keys, unorderedEquals(<String>['j', 's']));
+      // one it is. Both uris map to the same ordered list; Jellyfin is preferred.
+      expect(map.keys, unorderedEquals(<String>['jellyfin:j', 'subsonic:s']));
       const List<String> order = <String>['jellyfin:j', 'subsonic:s'];
-      expect(map['j']!.map((Track t) => t.uri).toList(), order);
-      expect(map['s']!.map((Track t) => t.uri).toList(), order);
+      expect(map['jellyfin:j']!.map((Track t) => t.uri).toList(), order);
+      expect(map['subsonic:s']!.map((Track t) => t.uri).toList(), order);
     });
 
     test('every candidate carries the row\'s best-available cover', () async {
@@ -123,7 +123,7 @@ void main() {
           container.read(playbackCandidatesProvider);
 
       // Displayed copy is the Subsonic one; Jellyfin is the fallback.
-      final List<Track> candidates = map['s']!;
+      final List<Track> candidates = map['subsonic:s']!;
       expect(candidates.map((Track t) => t.uri).toList(),
           <String>['subsonic:s', 'jellyfin:j']);
       expect(candidates.every((Track t) => t.artworkUri == _jellyArt), isTrue);
@@ -154,7 +154,7 @@ void main() {
 
       final Map<String, List<Track>> map =
           container.read(playbackCandidatesProvider);
-      expect(map['j']!.map((Track t) => t.uri).toList(),
+      expect(map['jellyfin:j']!.map((Track t) => t.uri).toList(),
           <String>['jellyfin:j', 'subsonic:s']);
     });
 
@@ -173,7 +173,7 @@ void main() {
       final Map<String, List<Track>> map =
           container.read(playbackCandidatesProvider);
       // Same display id (Jellyfin primary), but the cached Subsonic copy leads.
-      expect(map['j']!.map((Track t) => t.uri).toList(),
+      expect(map['jellyfin:j']!.map((Track t) => t.uri).toList(),
           <String>['subsonic:s', 'jellyfin:j']);
     });
 
@@ -190,7 +190,7 @@ void main() {
 
       final Map<String, List<Track>> map =
           container.read(playbackCandidatesProvider);
-      expect(map['j']!.map((Track t) => t.uri).toList(),
+      expect(map['jellyfin:j']!.map((Track t) => t.uri).toList(),
           <String>['jellyfin:j', 'subsonic:s']);
     });
   });

--- a/test/features/library/unified_library_providers_test.dart
+++ b/test/features/library/unified_library_providers_test.dart
@@ -165,8 +165,12 @@ void main() {
 
       final Map<String, List<String>> bySource =
           container.read(logicalSourceIdsProvider);
-      // The visible row is the Subsonic primary; removing it forgets both copies.
-      expect(bySource['s'], containsAll(<String>['j', 's']));
+      // The visible row is the Subsonic primary; the map is keyed by its uri and
+      // removing it forgets both copies (also by uri).
+      expect(
+        bySource['subsonic:s'],
+        containsAll(<String>['jellyfin:j', 'subsonic:s']),
+      );
     });
   });
 }

--- a/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
@@ -78,7 +78,7 @@ class _RecordingRepository implements MusicLibraryRepository {
   Future<List<Artist>> getAllArtists() async => const <Artist>[];
 
   @override
-  Future<Track?> getTrackById(String id) async => null;
+  Future<Track?> getTrackByUri(String uri) async => null;
 
   @override
   Future<void> removeTracks(List<String> trackIds) async {}

--- a/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
@@ -111,7 +111,7 @@ class _SpyDownloadRepository implements DownloadRepository {
   Future<void> removeDownload(Track track) async {}
 
   @override
-  Future<List<String>> downloadedTrackIds() async => const <String>[];
+  Future<List<String>> downloadedTrackKeys() async => const <String>[];
 }
 
 ProviderContainer _container({

--- a/test/features/settings/jellyfin/jellyfin_settings_section_sync_ui_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_section_sync_ui_test.dart
@@ -62,7 +62,7 @@ class _RecordingRepository implements MusicLibraryRepository {
   @override
   Future<List<Artist>> getAllArtists() async => const <Artist>[];
   @override
-  Future<Track?> getTrackById(String id) async => null;
+  Future<Track?> getTrackByUri(String uri) async => null;
   @override
   Future<void> removeTracks(List<String> trackIds) async {}
 }

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -70,7 +70,7 @@ class _RecordingRepository implements MusicLibraryRepository {
   Future<List<Artist>> getAllArtists() async => upsertedArtists;
 
   @override
-  Future<Track?> getTrackById(String id) async => null;
+  Future<Track?> getTrackByUri(String uri) async => null;
 
   @override
   Future<void> removeTracks(List<String> trackIds) async {}

--- a/test/features/settings/plex/plex_settings_controller_test.dart
+++ b/test/features/settings/plex/plex_settings_controller_test.dart
@@ -254,7 +254,7 @@ class _RecordingRepository implements MusicLibraryRepository {
   Future<List<Artist>> getAllArtists() async => const <Artist>[];
 
   @override
-  Future<Track?> getTrackById(String id) async => null;
+  Future<Track?> getTrackByUri(String uri) async => null;
 
   @override
   Future<void> removeTracks(List<String> trackIds) async {}

--- a/test/features/settings/plex/plex_sync_controller_test.dart
+++ b/test/features/settings/plex/plex_sync_controller_test.dart
@@ -158,7 +158,7 @@ class _RecordingRepository
   Future<List<Artist>> getAllArtists() async => const <Artist>[];
 
   @override
-  Future<Track?> getTrackById(String id) async => null;
+  Future<Track?> getTrackByUri(String uri) async => null;
 
   @override
   Future<void> removeTracks(List<String> trackIds) async {}

--- a/test/features/settings/subsonic/subsonic_sync_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_sync_controller_test.dart
@@ -54,7 +54,7 @@ class _RecordingRepository implements MusicLibraryRepository {
   Future<List<Artist>> getAllArtists() async => const <Artist>[];
 
   @override
-  Future<Track?> getTrackById(String id) async => null;
+  Future<Track?> getTrackByUri(String uri) async => null;
 
   @override
   Future<void> removeTracks(List<String> trackIds) async {}


### PR DESCRIPTION
## v0.1.7 stability — PR 1: provider-aware SQLite/catalog identity

First PR of the v0.1.7 identity-stability series. Fixes cross-provider track-id collisions so Plex, Jellyfin, Navidrome/Subsonic, and local tracks can't overwrite or shadow each other when they share the same server-side `id`.

### The problem
Every `Track` carries two id-like fields:
- **`Track.id`** — the *bare* server-side id (Jellyfin item id, Subsonic/Plex `ratingKey`, or a local path). Only unique **within** a provider. Plex `101` and Subsonic `101` are both `101`.
- **`Track.uri`** — the *provider-namespaced* identity (`jellyfin:101`, `plex:101`, a local path). Globally unique. Already the key the playback resolvers, cache files, and source labels use.

The SQLite catalog's primary key was the **bare `id`** (`tracks_table.dart`), and sync writes with `InsertMode.insertOrReplace`. So syncing one provider could **silently overwrite** a different provider's same-id row — a data-loss bug, most likely between Plex and Navidrome/Subsonic (both commonly use numeric ids). The same bare-id assumption also lived in the de-dup unifier, the now-playing indicator, the playback fallback map, and the "Recently added" first-seen store.

### Chosen canonical identity
**`Track.uri`** — it's already provider-namespaced, already stored as a catalog column, already the basis for `trackSourceId()`/cache/remote-cache keys, and is credential-free by construction (the source mappers never put a token in it). So no new identity concept is introduced; collision-prone bare-`id` keys are switched to the uri.

### Database migration
- `tracks` primary key **`id` → `uri`** (`schemaVersion` 1 → 2).
- New `MigrationStrategy` rebuilds the table inside one transaction (SQLite can't alter a PK in place): rename aside → create the new-shaped `tracks` → `INSERT OR REPLACE … SELECT …` every column → drop the old.
- **Data is preserved:** a v1 catalog could only ever store one row per bare id (that *was* the collision bug), so every surviving row already has a distinct uri and the copy keeps them all.

### What changed (lib)
- `data/database/tables/tracks_table.dart` — primary key `id` → `uri`.
- `data/database/linthra_database.dart` (+ regenerated `.g.dart`, one line) — `schemaVersion` 2 + the v1→v2 migration.
- `core/repositories/music_library_repository.dart`, `drift_…`, `in_memory_…`, `recording_…` — `getTrackById` → `getTrackByUri`; `removeTracks` deletes by uri.
- `core/catalog/track_unifier.dart` — group/anchor/tie-break by uri (no cross-provider mis-group or duplicate row).
- `core/catalog/logical_track.dart` + `features/library/unified_library_providers.dart` + `features/library/song_actions.dart` — logical-row id and removal expansion use uri.
- `core/catalog/now_playing_match.dart` — exact-match on uri, not bare id.
- `core/services/playback_candidate_source.dart` + `features/library/playback_candidates_provider.dart` — fallback map keyed by uri.
- `data/repositories/recording_music_library_repository.dart` + `core/services/smart_playlist_resolver.dart` + `core/repositories/library_added_store.dart` — "Recently added" first-seen store keyed by uri, with a **lazy id→uri migration on next sync** that preserves the original timestamps.

### Tests added / updated
- **Catalog coexistence:** Jellyfin `101` + Plex `101`, and Jellyfin `101` + Subsonic `101`, both survive a sync; `removeTracks` by uri spares the other provider's same id.
- **Migration:** a seeded v1 (PK `id`) DB upgrades to v2 preserving every row's fields, and afterwards a same-id row from another provider can coexist.
- **Unifier:** two *different* songs sharing a bare id stay separate (no mis-group/duplicate); the *same* song still merges across providers when they share a bare id.
- **Now-playing & fallback:** a playing `jellyfin:101` does not light an unrelated `subsonic:101`; the fallback map resolves a shared bare id to the right song.
- **Recently-added:** a legacy id-keyed timestamp migrates to the uri key, preserving its time.
- Existing fakes/tests updated to the uri-keyed contract.

### Verification
`flutter analyze` clean · `flutter test` **2489 passing** · `dart format` clean · `scripts/check_secrets.sh` clean.

### Scope / discipline
No app-version bump, no F-Droid metadata changes, no Plex playlists/favorites/cast, no artwork (PR #232) or offline-cache behaviour change. **Favorites, play history, and playlist identity** (the prefs-layer collisions, which need their own data migrations + touch smart mixes and Android Auto) are the natural **next PR** in this series — kept separate to keep this one small and the DB migration low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6kfGeCbzxZfL4Rry9uo2S

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6kfGeCbzxZfL4Rry9uo2S)_