### PR TITLE
fix(prefs): provider-aware identity for favorites, play history & playlists

### DIFF
--- a/lib/core/models/play_history.dart
+++ b/lib/core/models/play_history.dart
@@ -2,9 +2,9 @@ import 'package:flutter/foundation.dart';
 
 /// How often a single track has been played, and when it last finished.
 ///
-/// Deliberately tiny and id-free: the owning [PlayHistory] keys these by track
-/// id, so this carries no track identity, no uri, and never a token or stream
-/// URL. Play history is on-device only.
+/// Deliberately tiny and identity-free: the owning [PlayHistory] keys these by
+/// the track's uri, so this value carries no identity itself and never a token
+/// or stream URL. Play history is on-device only.
 @immutable
 class TrackPlayStats {
   const TrackPlayStats({required this.playCount, required this.lastPlayedAt});
@@ -23,52 +23,78 @@ class TrackPlayStats {
 /// On-device playback history: per-track play counts and last-played times.
 ///
 /// The data behind "Recently played", "Most played", and "Never played" smart
-/// mixes. Stores only non-secret track ids mapped to [TrackPlayStats] — never a
-/// uri, token, or authenticated URL — and stays on the device (no telemetry, no
-/// server upload).
+/// mixes. Keyed by the provider-namespaced [Track.uri] (e.g. `jellyfin:101`, a
+/// local path), not the bare server-side id — so playing `jellyfin:101` never
+/// makes `subsonic:101` look played. Stores only that non-secret uri mapped to
+/// [TrackPlayStats] (the same identity the catalog and "recently added" store
+/// persist) — never a token or authenticated stream URL — and stays on the
+/// device (no telemetry, no server upload).
 @immutable
 class PlayHistory {
   const PlayHistory({this.stats = const <String, TrackPlayStats>{}});
 
   static const PlayHistory empty = PlayHistory();
 
-  /// Per-track stats keyed by stable Linthra track id.
+  /// Per-track stats keyed by the provider-namespaced [Track.uri].
   final Map<String, TrackPlayStats> stats;
 
-  bool hasPlayed(String trackId) => stats.containsKey(trackId);
+  bool hasPlayed(String trackUri) => stats.containsKey(trackUri);
 
-  int playCountFor(String trackId) => stats[trackId]?.playCount ?? 0;
+  int playCountFor(String trackUri) => stats[trackUri]?.playCount ?? 0;
 
-  DateTime? lastPlayedFor(String trackId) => stats[trackId]?.lastPlayedAt;
+  DateTime? lastPlayedFor(String trackUri) => stats[trackUri]?.lastPlayedAt;
 
-  /// Track ids that have been played, ordered most-recently-played first.
-  List<String> get recentlyPlayedIds {
-    final List<String> ids = stats.keys.toList();
-    ids.sort((String a, String b) =>
+  /// Track uris that have been played, ordered most-recently-played first.
+  List<String> get recentlyPlayedKeys {
+    final List<String> keys = stats.keys.toList();
+    keys.sort((String a, String b) =>
         stats[b]!.lastPlayedAt.compareTo(stats[a]!.lastPlayedAt));
-    return ids;
+    return keys;
   }
 
-  /// Track ids that have been played, ordered most-played first; ties are
+  /// Track uris that have been played, ordered most-played first; ties are
   /// broken by most-recently-played so the order is stable and meaningful.
-  List<String> get mostPlayedIds {
-    final List<String> ids = stats.keys.toList();
-    ids.sort((String a, String b) {
+  List<String> get mostPlayedKeys {
+    final List<String> keys = stats.keys.toList();
+    keys.sort((String a, String b) {
       final int byCount = stats[b]!.playCount.compareTo(stats[a]!.playCount);
       if (byCount != 0) return byCount;
       return stats[b]!.lastPlayedAt.compareTo(stats[a]!.lastPlayedAt);
     });
-    return ids;
+    return keys;
   }
 
-  /// Returns a copy with one more completed play for [trackId] recorded at [at].
-  PlayHistory recordPlay(String trackId, DateTime at) {
+  /// Returns a copy with one more completed play for [trackUri] recorded at
+  /// [at].
+  PlayHistory recordPlay(String trackUri, DateTime at) {
     final Map<String, TrackPlayStats> next =
         Map<String, TrackPlayStats>.of(stats);
-    final TrackPlayStats? existing = next[trackId];
-    next[trackId] = existing == null
+    final TrackPlayStats? existing = next[trackUri];
+    next[trackUri] = existing == null
         ? TrackPlayStats(playCount: 1, lastPlayedAt: at)
         : existing.bumped(at);
+    return PlayHistory(stats: next);
+  }
+
+  /// Returns a copy with [from]'s stats merged onto the [to] key and the [from]
+  /// key removed. Used by the one-time bare-id → uri migration: a play count
+  /// recorded under the legacy bare id is folded into the same track's uri
+  /// (counts summed, the later last-played time kept). A no-op when [from]
+  /// carries no stats.
+  PlayHistory remapKey(String from, String to) {
+    final TrackPlayStats? moving = stats[from];
+    if (moving == null || from == to) return this;
+    final Map<String, TrackPlayStats> next =
+        Map<String, TrackPlayStats>.of(stats)..remove(from);
+    final TrackPlayStats? existing = next[to];
+    next[to] = existing == null
+        ? moving
+        : TrackPlayStats(
+            playCount: existing.playCount + moving.playCount,
+            lastPlayedAt: existing.lastPlayedAt.isAfter(moving.lastPlayedAt)
+                ? existing.lastPlayedAt
+                : moving.lastPlayedAt,
+          );
     return PlayHistory(stats: next);
   }
 }

--- a/lib/core/models/playlist.dart
+++ b/lib/core/models/playlist.dart
@@ -49,10 +49,12 @@ enum PlaylistSyncState {
 
 /// A user-created, ordered collection of tracks.
 ///
-/// Stores stable Linthra track ids (for a Jellyfin playlist these equal the
-/// Jellyfin item ids; for a local playlist they are local track ids) rather than
-/// full [Track] objects, so ordering and membership persist cheaply and survive
-/// a catalog re-scan.
+/// Stores provider-namespaced [Track.uri]s (`jellyfin:101`, `subsonic:101`, a
+/// local path) rather than full [Track] objects, so ordering and membership
+/// persist cheaply and survive a catalog re-scan — and so a member `jellyfin:101`
+/// is never confused with `subsonic:101`. A Jellyfin-synced playlist holds only
+/// `jellyfin:` uris; the repository maps each to its bare item id at the server
+/// boundary, since the Jellyfin API speaks bare ids.
 ///
 /// Security invariant: a playlist is *persisted* metadata, so it must never
 /// carry a secret. [remoteId] is the non-secret server playlist id; do not add a
@@ -88,7 +90,7 @@ class Playlist {
   /// local-only playlist (or one whose remote create has not landed yet).
   final String? remoteId;
 
-  /// Ordered, stable track ids. Empty for a brand-new playlist.
+  /// Ordered, provider-namespaced track uris. Empty for a brand-new playlist.
   final List<String> trackIds;
 
   final DateTime? createdAt;

--- a/lib/core/repositories/favorites_repository.dart
+++ b/lib/core/repositories/favorites_repository.dart
@@ -10,13 +10,15 @@ import 'remote_sync_result.dart';
 /// storage directly — mirroring how the player reads a [PlaybackState] and never
 /// the audio engine.
 abstract interface class FavoritesRepository {
-  /// Emits the current favourite track-id set immediately, then on every change.
+  /// Emits the current favourite track-uri set immediately, then on every
+  /// change. Entries are provider-namespaced [Track.uri]s, so a same-id track
+  /// from another provider is never wrongly reported as a favourite.
   Stream<Set<String>> get favoritesStream;
 
-  /// Whether [trackId] is currently a favourite. A synchronous best-effort read
+  /// Whether [trackUri] is currently a favourite. A synchronous best-effort read
   /// of the in-memory mirror (empty until the first load); the stream is what
-  /// the UI should bind to.
-  bool isFavorite(String trackId);
+  /// the UI should bind to. Keyed by the provider-namespaced uri.
+  bool isFavorite(String trackUri);
 
   /// Marks (or unmarks) [track] as a favourite. Updates immediately and, for a
   /// Jellyfin track while signed in, pushes the change to the server. Never

--- a/lib/core/repositories/favorites_store.dart
+++ b/lib/core/repositories/favorites_store.dart
@@ -2,6 +2,11 @@ import 'package:flutter/foundation.dart';
 
 /// The persisted favourite sets, split by source so a remote refresh can replace
 /// the server-owned set without disturbing favourites on local-only tracks.
+///
+/// Both sets hold the provider-namespaced [Track.uri] (`jellyfin:101`, a local
+/// path), not the bare server-side id — so a favourite on `jellyfin:101` is
+/// never confused with `subsonic:101`. The split is by *source*, not identity:
+/// `localIds` are on-device tracks, `remoteIds` are the server-mirrored ones.
 @immutable
 class FavoritesData {
   const FavoritesData({
@@ -11,10 +16,12 @@ class FavoritesData {
 
   static const FavoritesData empty = FavoritesData();
 
-  /// Favourite track ids that live only on this device (local-folder tracks).
+  /// Favourite track uris that live only on this device (local-folder tracks).
   final Set<String> localIds;
 
-  /// Favourite Jellyfin item ids, mirrored from and pushed to the server.
+  /// Favourite remote track uris (Jellyfin), mirrored from and pushed to the
+  /// server. The server speaks bare item ids, so the repository maps each uri to
+  /// its bare id at the request boundary.
   final Set<String> remoteIds;
 
   FavoritesData copyWith({Set<String>? localIds, Set<String>? remoteIds}) {

--- a/lib/core/repositories/play_history_repository.dart
+++ b/lib/core/repositories/play_history_repository.dart
@@ -9,9 +9,13 @@ import '../models/track.dart';
 /// touching the backing store directly, mirroring how the player reads a
 /// `PlaybackState` and never the audio engine.
 ///
-/// Privacy invariant: only the track *id* is recorded — never its uri, a token,
-/// or an authenticated URL — and the history stays on the device (no telemetry,
-/// no server upload).
+/// History is keyed by the provider-namespaced [Track.uri], so a play of
+/// `jellyfin:101` never makes `subsonic:101` look played.
+///
+/// Privacy invariant: only the non-secret [Track.uri] is recorded — the same
+/// identity the catalog and "recently added" store persist — never a token or
+/// an authenticated stream URL, and the history stays on the device (no
+/// telemetry, no server upload).
 abstract interface class PlayHistoryRepository {
   /// Emits the current history immediately, then on every recorded play.
   Stream<PlayHistory> get historyStream;
@@ -20,6 +24,6 @@ abstract interface class PlayHistoryRepository {
   PlayHistory get current;
 
   /// Records that [track] finished playing: increments its play count and sets
-  /// its last-played time to now. Only [Track.id] is read. Never throws.
+  /// its last-played time to now, keyed by [Track.uri]. Never throws.
   Future<void> recordCompletion(Track track);
 }

--- a/lib/core/repositories/playlist_repository.dart
+++ b/lib/core/repositories/playlist_repository.dart
@@ -35,14 +35,18 @@ abstract interface class PlaylistRepository {
 
   Future<void> deletePlaylist(String id);
 
-  /// Appends [trackId] to the playlist if it is not already present (a no-op for
-  /// a duplicate, so adding the same track twice can't create a double entry).
-  Future<void> addTrack(String playlistId, String trackId);
+  /// Appends [trackUri] (a provider-namespaced [Track.uri]) to the playlist if it
+  /// is not already present (a no-op for a duplicate, so adding the same track
+  /// twice can't create a double entry). Identity is the uri, so the same
+  /// server-side id from another provider is a distinct entry, not a duplicate.
+  Future<void> addTrack(String playlistId, String trackUri);
 
-  /// Appends every id in [trackIds] not already present, preserving their order.
-  Future<void> addTracks(String playlistId, List<String> trackIds);
+  /// Appends every uri in [trackUris] not already present, preserving their
+  /// order. Entries are provider-namespaced [Track.uri]s.
+  Future<void> addTracks(String playlistId, List<String> trackUris);
 
-  Future<void> removeTrack(String playlistId, String trackId);
+  /// Removes the entry for [trackUri] (a provider-namespaced [Track.uri]).
+  Future<void> removeTrack(String playlistId, String trackUri);
 
   /// Moves the track at [oldIndex] to [newIndex] within the playlist.
   Future<void> reorderTracks(String playlistId, int oldIndex, int newIndex);

--- a/lib/core/services/media_browser_tree.dart
+++ b/lib/core/services/media_browser_tree.dart
@@ -507,12 +507,14 @@ class MediaBrowserTree {
   /// track. Favourite ids with no matching catalog track (e.g. a server
   /// favourite not synced to this device) are dropped — they can't be played.
   Future<List<Track>> _favoriteTracks() async {
-    final Set<String> ids = await _favoriteIds();
-    if (ids.isEmpty) return const <Track>[];
+    final Set<String> uris = await _favoriteIds();
+    if (uris.isEmpty) return const <Track>[];
     final List<Track> tracks = await _allTracks();
+    // Match on the provider-namespaced uri the favourites set now holds, so a
+    // favourite on `jellyfin:101` never surfaces `subsonic:101` in the car.
     return <Track>[
       for (final Track track in tracks)
-        if (ids.contains(track.id)) track,
+        if (uris.contains(track.uri)) track,
     ];
   }
 
@@ -539,12 +541,14 @@ class MediaBrowserTree {
     if (playlists == null) return const <Track>[];
     final Playlist? playlist = await _playlistById(playlists, playlistId);
     if (playlist == null || playlist.trackIds.isEmpty) return const <Track>[];
-    final Map<String, Track> byId = <String, Track>{
-      for (final Track track in await _allTracks()) track.id: track,
+    // Resolve by the provider-namespaced uri the membership now stores, so a
+    // `jellyfin:101` entry can't resolve to a same-id `subsonic:101` track.
+    final Map<String, Track> byUri = <String, Track>{
+      for (final Track track in await _allTracks()) track.uri: track,
     };
     return <Track>[
-      for (final String id in playlist.trackIds)
-        if (byId[id] != null) byId[id]!,
+      for (final String uri in playlist.trackIds)
+        if (byUri[uri] != null) byUri[uri]!,
     ];
   }
 
@@ -561,9 +565,10 @@ class MediaBrowserTree {
     }
   }
 
-  /// The current favourite track-id set, read from the repository's stream
-  /// (which yields the current set immediately). Guarded: any failure yields an
-  /// empty set so a misbehaving favourites backend can't break browsing.
+  /// The current favourite track-uri set (provider-namespaced), read from the
+  /// repository's stream (which yields the current set immediately). Guarded: any
+  /// failure yields an empty set so a misbehaving favourites backend can't break
+  /// browsing.
   Future<Set<String>> _favoriteIds() async {
     final FavoritesRepository? favorites = _favorites;
     if (favorites == null) return const <String>{};

--- a/lib/core/services/smart_playlist_resolver.dart
+++ b/lib/core/services/smart_playlist_resolver.dart
@@ -40,9 +40,9 @@ class SmartPlaylistResolver {
       case SmartPlaylistKind.recentlyAdded:
         return _recentlyAdded(allTracks, addedAt);
       case SmartPlaylistKind.recentlyPlayed:
-        return _byIdOrder(allTracks, history.recentlyPlayedIds);
+        return _byUriOrder(allTracks, history.recentlyPlayedKeys);
       case SmartPlaylistKind.mostPlayed:
-        return _byIdOrder(allTracks, history.mostPlayedIds);
+        return _byUriOrder(allTracks, history.mostPlayedKeys);
       case SmartPlaylistKind.favorites:
         return _filter(allTracks, favoriteIds);
       case SmartPlaylistKind.downloaded:
@@ -53,7 +53,7 @@ class SmartPlaylistResolver {
         return _bounded(
           <Track>[
             for (final Track track in allTracks)
-              if (!history.hasPlayed(track.id)) track,
+              if (!history.hasPlayed(track.uri)) track,
           ],
         );
     }
@@ -91,24 +91,27 @@ class SmartPlaylistResolver {
     return _epoch;
   }
 
-  /// Resolves [orderedIds] against the catalog, preserving the given order and
-  /// dropping ids the catalog no longer has.
-  List<Track> _byIdOrder(List<Track> allTracks, List<String> orderedIds) {
-    final Map<String, Track> byId = <String, Track>{
-      for (final Track track in allTracks) track.id: track,
+  /// Resolves [orderedUris] (provider-namespaced play-history keys) against the
+  /// catalog, preserving the given order and dropping uris the catalog no longer
+  /// has. Keying on [Track.uri] keeps the right copy when two providers share a
+  /// bare id, so a play of `jellyfin:101` never surfaces `subsonic:101`.
+  List<Track> _byUriOrder(List<Track> allTracks, List<String> orderedUris) {
+    final Map<String, Track> byUri = <String, Track>{
+      for (final Track track in allTracks) track.uri: track,
     };
     return _bounded(<Track>[
-      for (final String id in orderedIds)
-        if (byId[id] != null) byId[id]!,
+      for (final String uri in orderedUris)
+        if (byUri[uri] != null) byUri[uri]!,
     ]);
   }
 
-  /// Catalog-ordered subset whose ids are in [ids] — the favourites mix. Not
+  /// Catalog-ordered subset whose uris are in [uris] — the favourites mix. Keyed
+  /// by [Track.uri] so a same-id copy from another provider isn't pulled in. Not
   /// bounded: favourites are user-curated, so the mix shows all of them.
-  List<Track> _filter(List<Track> allTracks, Set<String> ids) {
+  List<Track> _filter(List<Track> allTracks, Set<String> uris) {
     return <Track>[
       for (final Track track in allTracks)
-        if (ids.contains(track.id)) track,
+        if (uris.contains(track.uri)) track,
     ];
   }
 

--- a/lib/data/repositories/default_play_history_repository.dart
+++ b/lib/data/repositories/default_play_history_repository.dart
@@ -13,17 +13,32 @@ import '../../core/repositories/play_history_store.dart';
 /// Mirrors `JellyfinSyncedFavoritesRepository`'s shape (load-once, emit,
 /// persist) minus any server sync — play history is on-device only.
 ///
-/// Privacy: [recordCompletion] reads only [Track.id]; no uri, token, or
-/// authenticated URL is ever recorded, and nothing is sent off the device.
+/// Identity is the provider-namespaced [Track.uri], not the bare server-side
+/// id, so completing `jellyfin:101` never makes `subsonic:101` look played. A
+/// pre-uri store (keyed by the bare id) is migrated to uris once, against the
+/// catalog's current owner of each id (see [_maybeMigrateLegacyKeysOnce]); an id
+/// the catalog exposes under more than one provider is left untouched rather
+/// than mis-attributed.
+///
+/// Privacy: the stored key is the non-secret [Track.uri] — the same identity the
+/// catalog DB and "recently added" store already persist — never a token or an
+/// authenticated stream URL, and nothing is sent off the device.
 class DefaultPlayHistoryRepository implements PlayHistoryRepository {
   DefaultPlayHistoryRepository({
     required PlayHistoryStore store,
     DateTime Function()? now,
+    Future<List<Track>> Function()? catalogForMigration,
   })  : _store = store,
-        _now = now ?? DateTime.now;
+        _now = now ?? DateTime.now,
+        _catalogForMigration = catalogForMigration;
 
   final PlayHistoryStore _store;
   final DateTime Function() _now;
+
+  /// Supplies the current catalog for the one-time bare-id → uri migration, or
+  /// null when no migration is needed (tests, the in-memory default). Read lazily
+  /// so the migration resolves against the catalog as it stands on first read.
+  final Future<List<Track>> Function()? _catalogForMigration;
 
   final StreamController<PlayHistory> _changes =
       StreamController<PlayHistory>.broadcast();
@@ -31,14 +46,20 @@ class DefaultPlayHistoryRepository implements PlayHistoryRepository {
   PlayHistory _history = PlayHistory.empty;
   bool _loaded = false;
 
+  /// Guards the one-time legacy-key migration so it runs at most once, after the
+  /// catalog is available (see [_maybeMigrateLegacyKeysOnce]).
+  bool _migratedLegacyKeys = false;
+
   // Serialises writes so two quick completions can't race on load-then-save and
   // lose a count: each recorded play runs only after the previous one persists.
   Future<void> _writes = Future<void>.value();
 
   Future<void> _ensureLoaded() async {
-    if (_loaded) return;
-    _history = await _store.load();
-    _loaded = true;
+    if (!_loaded) {
+      _history = await _store.load();
+      _loaded = true;
+    }
+    await _maybeMigrateLegacyKeysOnce();
   }
 
   @override
@@ -53,12 +74,13 @@ class DefaultPlayHistoryRepository implements PlayHistoryRepository {
 
   @override
   Future<void> recordCompletion(Track track) {
-    // Capture only the id (never the uri) and chain onto the write queue.
-    final String trackId = track.id;
+    // Capture the provider-namespaced uri (the stable, collision-free identity)
+    // and chain onto the write queue.
+    final String trackUri = track.uri;
     _writes = _writes.then((_) async {
       try {
         await _ensureLoaded();
-        _history = _history.recordPlay(trackId, _now());
+        _history = _history.recordPlay(trackUri, _now());
         if (!_changes.isClosed) _changes.add(_history);
         await _store.save(_history);
       } catch (_) {
@@ -67,6 +89,68 @@ class DefaultPlayHistoryRepository implements PlayHistoryRepository {
       }
     });
     return _writes;
+  }
+
+  /// Re-keys a pre-uri store's bare-`id`-keyed stats onto the provider-namespaced
+  /// [Track.uri], once, after the catalog is available.
+  ///
+  /// Each legacy bare id is resolved against the catalog's current owner of that
+  /// id: a unique owner adopts the count (folding it into any uri-keyed count for
+  /// the same track), while an id exposed by more than one provider — or absent
+  /// from the catalog — is left as-is. A leftover bare key simply never matches a
+  /// `track.uri` at read time, so it can't cross-contaminate another provider; it
+  /// is preserved (not dropped) so unambiguous data isn't lost. Runs on first
+  /// read, before any new play is recorded, so the legacy count is in place when
+  /// the same track is next played.
+  Future<void> _maybeMigrateLegacyKeysOnce() async {
+    if (_migratedLegacyKeys) return;
+    final Future<List<Track>> Function()? oracle = _catalogForMigration;
+    if (oracle == null) {
+      _migratedLegacyKeys = true;
+      return;
+    }
+    if (_history.stats.isEmpty) {
+      _migratedLegacyKeys = true;
+      return;
+    }
+    final List<Track> tracks;
+    try {
+      tracks = await oracle();
+    } catch (_) {
+      // Transient catalog read failure: defer so a later read can retry.
+      return;
+    }
+    // An empty catalog this early is almost certainly "not loaded yet" rather
+    // than "no library"; defer so we don't strand unambiguous legacy counts.
+    if (tracks.isEmpty) return;
+    _migratedLegacyKeys = true;
+
+    final Set<String> catalogUris = <String>{
+      for (final Track track in tracks) track.uri,
+    };
+    // bare id -> owner uri, or null when more than one provider exposes that id.
+    final Map<String, String?> ownerByBareId = <String, String?>{};
+    for (final Track track in tracks) {
+      // Local tracks have id == uri, so they are never legacy bare-id-keyed.
+      if (track.uri == track.id) continue;
+      ownerByBareId[track.id] =
+          ownerByBareId.containsKey(track.id) ? null : track.uri;
+    }
+
+    PlayHistory migrated = _history;
+    for (final String key in _history.stats.keys) {
+      // Already a valid uri (local path or namespaced) — nothing to do.
+      if (catalogUris.contains(key)) continue;
+      final String? ownerUri = ownerByBareId[key];
+      // Unknown id, or ambiguous across providers: leave it (don't guess).
+      if (ownerUri == null) continue;
+      migrated = migrated.remapKey(key, ownerUri);
+    }
+    if (!identical(migrated, _history)) {
+      _history = migrated;
+      if (!_changes.isClosed) _changes.add(_history);
+      await _store.save(_history);
+    }
   }
 
   Future<void> dispose() => _changes.close();

--- a/lib/data/repositories/jellyfin_synced_favorites_repository.dart
+++ b/lib/data/repositories/jellyfin_synced_favorites_repository.dart
@@ -11,12 +11,15 @@ import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
 /// The app's [FavoritesRepository]: an optimistic local mirror with Jellyfin
 /// sync layered on top.
 ///
-/// Favourites live in a [FavoritesStore] split into device-local ids (local
-/// tracks) and remote ids (Jellyfin item ids). A toggle updates the right set
-/// immediately, emits, and persists; for a Jellyfin track while signed in it
-/// then pushes to the server best-effort. [refreshFromRemote] adopts the
-/// server's set as the remote truth, leaving local-track favourites alone, so
-/// favourites set on another client show up here.
+/// Favourites live in a [FavoritesStore] split into device-local uris (local
+/// tracks) and remote uris (Jellyfin), keyed by the provider-namespaced
+/// [Track.uri] so a favourite on `jellyfin:101` can't collide with
+/// `subsonic:101`. A toggle updates the right set immediately, emits, and
+/// persists; for a Jellyfin track while signed in it then pushes to the server
+/// best-effort using the bare item id. [refreshFromRemote] adopts the server's
+/// set (namespaced back to jellyfin: uris) as the remote truth, leaving
+/// local-track favourites alone, so favourites set on another client show up
+/// here.
 ///
 /// Security: only non-secret track/item ids are stored or sent. The session
 /// (with its token) is read lazily through [_session] for the request header —
@@ -63,27 +66,30 @@ class JellyfinSyncedFavoritesRepository implements FavoritesRepository {
   }
 
   @override
-  bool isFavorite(String trackId) =>
-      _data.localIds.contains(trackId) || _data.remoteIds.contains(trackId);
+  bool isFavorite(String trackUri) =>
+      _data.localIds.contains(trackUri) || _data.remoteIds.contains(trackUri);
 
   @override
   Future<void> setFavorite(Track track, bool favorite) async {
     await _ensureLoaded();
     final bool remote = _isRemote(track);
+    // Identity is the provider-namespaced uri so two providers' same-id tracks
+    // stay distinct; the server push below still uses the bare item id.
+    final String key = track.uri;
     if (remote) {
       final Set<String> ids = <String>{..._data.remoteIds};
       if (favorite) {
-        ids.add(track.id);
+        ids.add(key);
       } else {
-        ids.remove(track.id);
+        ids.remove(key);
       }
       _data = _data.copyWith(remoteIds: ids);
     } else {
       final Set<String> ids = <String>{..._data.localIds};
       if (favorite) {
-        ids.add(track.id);
+        ids.add(key);
       } else {
-        ids.remove(track.id);
+        ids.remove(key);
       }
       _data = _data.copyWith(localIds: ids);
     }
@@ -115,16 +121,22 @@ class JellyfinSyncedFavoritesRepository implements FavoritesRepository {
     }
     try {
       final Set<String> serverIds = await client.fetchFavoriteIds(session);
+      // The server speaks bare item ids; namespace them to the jellyfin: uri the
+      // store and UI key on, so a server favourite matches its catalog track.
+      final Set<String> serverUris = <String>{
+        for (final String id in serverIds)
+          '${JellyfinTrackMapper.uriScheme}$id',
+      };
       // Skip the emit/save when nothing actually changed, to avoid churn — but
       // still report the (unchanged) count as a successful sync.
-      final bool unchanged = serverIds.length == _data.remoteIds.length &&
-          serverIds.containsAll(_data.remoteIds);
+      final bool unchanged = serverUris.length == _data.remoteIds.length &&
+          serverUris.containsAll(_data.remoteIds);
       if (!unchanged) {
-        _data = _data.copyWith(remoteIds: serverIds);
+        _data = _data.copyWith(remoteIds: serverUris);
         _emit();
         await _store.save(_data);
       }
-      return FavoritesSyncResult.synced(serverIds.length);
+      return FavoritesSyncResult.synced(serverUris.length);
     } catch (_) {
       // Offline or transient: keep what we have and report a friendly failure.
       return const FavoritesSyncResult.failed();

--- a/lib/data/repositories/play_history_repository_provider.dart
+++ b/lib/data/repositories/play_history_repository_provider.dart
@@ -4,6 +4,7 @@ import '../../core/repositories/play_history_repository.dart';
 import '../../core/repositories/play_history_store.dart';
 import 'default_play_history_repository.dart';
 import 'in_memory_play_history_store.dart';
+import 'music_library_repository_provider.dart';
 import 'shared_preferences_play_history_store.dart';
 
 /// Durable store of the user's play history. Defaults to in-memory so tests and
@@ -17,8 +18,13 @@ final playHistoryStoreProvider = Provider<PlayHistoryStore>((ref) {
 /// completions into it and the smart-mix UI reads its stream) and disposed with
 /// the scope.
 final playHistoryRepositoryProvider = Provider<PlayHistoryRepository>((ref) {
-  final DefaultPlayHistoryRepository repository =
-      DefaultPlayHistoryRepository(store: ref.watch(playHistoryStoreProvider));
+  final DefaultPlayHistoryRepository repository = DefaultPlayHistoryRepository(
+    store: ref.watch(playHistoryStoreProvider),
+    // Resolve legacy bare-id history onto provider uris against the live catalog
+    // (unambiguous ids only); see DefaultPlayHistoryRepository for the rules.
+    catalogForMigration: () =>
+        ref.read(musicLibraryRepositoryProvider).getAllTracks(),
+  );
   ref.onDispose(repository.dispose);
   return repository;
 });

--- a/lib/data/repositories/playlist_repository_provider.dart
+++ b/lib/data/repositories/playlist_repository_provider.dart
@@ -5,6 +5,7 @@ import '../../core/repositories/playlist_store.dart';
 import '../../features/settings/jellyfin/jellyfin_settings_controller.dart';
 import '../../features/settings/jellyfin/jellyfin_settings_providers.dart';
 import 'in_memory_playlist_store.dart';
+import 'music_library_repository_provider.dart';
 import 'shared_preferences_playlist_store.dart';
 import 'synced_playlist_repository.dart';
 
@@ -22,6 +23,10 @@ final playlistStoreProvider = Provider<PlaylistStore>((ref) {
 final playlistRepositoryProvider = Provider<PlaylistRepository>((ref) {
   final SyncedPlaylistRepository repository = SyncedPlaylistRepository(
     store: ref.watch(playlistStoreProvider),
+    // Resolve legacy bare-id local-playlist membership onto provider uris
+    // against the live catalog (unambiguous ids only).
+    catalogForMigration: () =>
+        ref.read(musicLibraryRepositoryProvider).getAllTracks(),
   );
   ref.onDispose(repository.dispose);
   return repository;
@@ -45,6 +50,8 @@ final jellyfinPlaylistSyncOverride =
     client: ref.read(jellyfinClientProvider),
     session: () =>
         ref.read(jellyfinSettingsControllerProvider.notifier).session,
+    catalogForMigration: () =>
+        ref.read(musicLibraryRepositoryProvider).getAllTracks(),
   );
   ref.onDispose(repository.dispose);
   return repository;

--- a/lib/data/repositories/shared_preferences_favorites_store.dart
+++ b/lib/data/repositories/shared_preferences_favorites_store.dart
@@ -3,35 +3,56 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/repositories/favorites_store.dart';
+import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
+import '../../core/sources/music_provider.dart';
 
 /// A [FavoritesStore] backed by `shared_preferences`.
 ///
-/// Favourites are a small set of non-secret track ids, so a key/value document
-/// is the right weight (the same reasoning the offline-download set follows).
-/// Stored as `{ "local": [...], "remote": [...] }` so the device-local
-/// favourites and the server-mirrored ones survive a restart and can be
-/// reconciled independently.
+/// Favourites are a small set of non-secret track identities, so a key/value
+/// document is the right weight (the same reasoning the offline-download set
+/// follows). Stored as `{ "local": [...], "remote": [...] }` so the
+/// device-local favourites and the server-mirrored ones survive a restart and
+/// can be reconciled independently.
+///
+/// Identity is the provider-namespaced [Track.uri] (`jellyfin:101`, a local
+/// path), matching the catalog re-key — so favouriting `jellyfin:101` can never
+/// be confused with `subsonic:101`. The local set already held uris (a local
+/// track's id *is* its path); the remote set held bare Jellyfin item ids.
+///
+/// Versioning:
+///  * **v1** (`favorites_v1`) — bare ids: local paths in `local`, bare Jellyfin
+///    item ids in `remote`.
+///  * **v2** (`favorites_v2`) — provider-namespaced uris in both sets.
+///
+/// A v1 store is migrated to uris on first load (the v1 key is left untouched so
+/// the data is recoverable). The remote set could only ever hold Jellyfin items
+/// — Subsonic/Plex don't support favouriting — so prefixing each bare id with
+/// the `jellyfin:` scheme is unambiguous and never mis-attributes a favourite.
 class SharedPreferencesFavoritesStore implements FavoritesStore {
   const SharedPreferencesFavoritesStore();
 
-  static const String _key = 'favorites_v1';
+  static const String _key = 'favorites_v2';
+  static const String _legacyKey = 'favorites_v1';
 
   @override
   Future<FavoritesData> load() async {
     final prefs = await SharedPreferences.getInstance();
     final String? raw = prefs.getString(_key);
-    if (raw == null || raw.isEmpty) return FavoritesData.empty;
-    Object? decoded;
-    try {
-      decoded = jsonDecode(raw);
-    } on FormatException {
-      // A corrupt record reads as "no favourites" rather than crashing.
-      return FavoritesData.empty;
+    if (raw != null && raw.isNotEmpty) {
+      return _decode(raw) ?? FavoritesData.empty;
     }
-    if (decoded is! Map<String, dynamic>) return FavoritesData.empty;
+    // No v2 yet: migrate a pre-uri v1 store if present. Local ids were already
+    // the track's uri (a local path); remote ids were bare Jellyfin item ids,
+    // so namespacing them yields the provider uri the rest of the app keys on.
+    final String? legacy = prefs.getString(_legacyKey);
+    if (legacy == null || legacy.isEmpty) return FavoritesData.empty;
+    final FavoritesData? old = _decode(legacy);
+    if (old == null) return FavoritesData.empty;
     return FavoritesData(
-      localIds: _ids(decoded['local']),
-      remoteIds: _ids(decoded['remote']),
+      localIds: old.localIds,
+      remoteIds: <String>{
+        for (final String id in old.remoteIds) _remoteUriForLegacyId(id),
+      },
     );
   }
 
@@ -43,6 +64,29 @@ class SharedPreferencesFavoritesStore implements FavoritesStore {
       'remote': data.remoteIds.toList(),
     });
     await prefs.setString(_key, raw);
+  }
+
+  /// The provider-namespaced uri for a legacy v1 remote id. A bare Jellyfin item
+  /// id (the v1 form) gets the `jellyfin:` scheme; an id that already carries a
+  /// known scheme (a partially-migrated or hand-edited store) is left as-is.
+  static String _remoteUriForLegacyId(String id) =>
+      MusicProviders.bareRemoteIdForTrackUri(id) != null
+          ? id
+          : '${JellyfinTrackMapper.uriScheme}$id';
+
+  static FavoritesData? _decode(String raw) {
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      // A corrupt record reads as "no favourites" rather than crashing.
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+    return FavoritesData(
+      localIds: _ids(decoded['local']),
+      remoteIds: _ids(decoded['remote']),
+    );
   }
 
   static Set<String> _ids(Object? value) {

--- a/lib/data/repositories/shared_preferences_play_history_store.dart
+++ b/lib/data/repositories/shared_preferences_play_history_store.dart
@@ -7,13 +7,16 @@ import '../../core/repositories/play_history_store.dart';
 
 /// A [PlayHistoryStore] backed by `shared_preferences`.
 ///
-/// Play history is a small map of non-secret track ids to a play count and a
+/// Play history is a small map of non-secret track uris to a play count and a
 /// last-played timestamp, so a key/value document is the right weight (the same
 /// reasoning favourites and the offline-download set follow). Stored as
-/// `{ "<trackId>": { "c": <count>, "t": <epochMs> }, ... }`.
+/// `{ "<trackUri>": { "c": <count>, "t": <epochMs> }, ... }`, where the key is
+/// the provider-namespaced [Track.uri] (`jellyfin:101`, a local path) so two
+/// providers' same-id tracks keep separate counts.
 ///
-/// Privacy: only ids, counts, and timestamps are written — never a uri, token,
-/// or authenticated URL — so the document can never carry a secret, and it
+/// Privacy: only that uri, counts, and timestamps are written — the same
+/// identity the catalog and "recently added" store persist — never a token or
+/// an authenticated stream URL, so the document can never carry a secret, and it
 /// stays on the device.
 class SharedPreferencesPlayHistoryStore implements PlayHistoryStore {
   const SharedPreferencesPlayHistoryStore();
@@ -34,12 +37,12 @@ class SharedPreferencesPlayHistoryStore implements PlayHistoryStore {
     }
     if (decoded is! Map<String, dynamic>) return PlayHistory.empty;
     final Map<String, TrackPlayStats> stats = <String, TrackPlayStats>{};
-    decoded.forEach((String id, Object? value) {
-      if (id.isEmpty || value is! Map<String, dynamic>) return;
+    decoded.forEach((String key, Object? value) {
+      if (key.isEmpty || value is! Map<String, dynamic>) return;
       final Object? count = value['c'];
       final Object? millis = value['t'];
       if (count is! int || count <= 0 || millis is! int) return;
-      stats[id] = TrackPlayStats(
+      stats[key] = TrackPlayStats(
         playCount: count,
         lastPlayedAt: DateTime.fromMillisecondsSinceEpoch(millis),
       );

--- a/lib/data/repositories/synced_playlist_repository.dart
+++ b/lib/data/repositories/synced_playlist_repository.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 
 import '../../core/models/jellyfin_session.dart';
 import '../../core/models/playlist.dart';
+import '../../core/models/track.dart';
 import '../../core/repositories/playlist_repository.dart';
 import '../../core/repositories/playlist_store.dart';
 import '../../core/repositories/remote_sync_result.dart';
 import '../../core/sources/jellyfin/jellyfin_api.dart';
 import '../../core/sources/jellyfin/jellyfin_client.dart';
 import '../../core/sources/jellyfin/jellyfin_exception.dart';
+import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
+import '../../core/sources/music_provider.dart';
 
 /// The app's [PlaylistRepository]: a local, persisted set of playlists with
 /// optional best-effort Jellyfin sync layered on top.
@@ -32,13 +35,21 @@ class SyncedPlaylistRepository implements PlaylistRepository {
     JellyfinSession? Function()? session,
     String Function()? idGenerator,
     DateTime Function()? now,
+    Future<List<Track>> Function()? catalogForMigration,
   })  : _store = store,
         _client = client,
         _session = session,
         _newId = idGenerator ?? _defaultIdGenerator(),
-        _now = now ?? DateTime.now;
+        _now = now ?? DateTime.now,
+        _catalogForMigration = catalogForMigration;
 
   final PlaylistStore _store;
+
+  /// Supplies the current catalog for the one-time bare-id → uri membership
+  /// migration of *local* playlists, or null when none is needed (tests, the
+  /// data-layer default). A Jellyfin playlist needs no oracle — its bare ids are
+  /// unambiguously Jellyfin items.
+  final Future<List<Track>> Function()? _catalogForMigration;
 
   /// The Jellyfin HTTP seam, or `null` when playlists are local-only (tests, the
   /// data-layer default). Read lazily alongside [_session].
@@ -57,6 +68,10 @@ class SyncedPlaylistRepository implements PlaylistRepository {
   List<Playlist> _playlists = <Playlist>[];
   bool _loaded = false;
 
+  /// Guards the one-time legacy bare-id → uri membership migration so it runs at
+  /// most once, after the catalog is available (see [_migrateLegacyTrackIdsOnce]).
+  bool _migratedLegacyTrackIds = false;
+
   static String Function() _defaultIdGenerator() {
     int counter = 0;
     return () {
@@ -67,9 +82,11 @@ class SyncedPlaylistRepository implements PlaylistRepository {
   }
 
   Future<void> _ensureLoaded() async {
-    if (_loaded) return;
-    _playlists = await _store.load();
-    _loaded = true;
+    if (!_loaded) {
+      _playlists = await _store.load();
+      _loaded = true;
+    }
+    await _migrateLegacyTrackIdsOnce();
   }
 
   JellyfinSession? _liveSession() => _session?.call();
@@ -170,20 +187,20 @@ class SyncedPlaylistRepository implements PlaylistRepository {
   }
 
   @override
-  Future<void> addTrack(String playlistId, String trackId) =>
-      addTracks(playlistId, <String>[trackId]);
+  Future<void> addTrack(String playlistId, String trackUri) =>
+      addTracks(playlistId, <String>[trackUri]);
 
   @override
-  Future<void> addTracks(String playlistId, List<String> trackIds) async {
+  Future<void> addTracks(String playlistId, List<String> trackUris) async {
     await _ensureLoaded();
     final Playlist? playlist = _byId(playlistId);
     if (playlist == null) return;
     final List<String> added = <String>[];
     final List<String> updated = <String>[...playlist.trackIds];
-    for (final String trackId in trackIds) {
-      if (trackId.isEmpty || updated.contains(trackId)) continue;
-      updated.add(trackId);
-      added.add(trackId);
+    for (final String trackUri in trackUris) {
+      if (trackUri.isEmpty || updated.contains(trackUri)) continue;
+      updated.add(trackUri);
+      added.add(trackUri);
     }
     if (added.isEmpty) return;
     await _mutate(
@@ -193,18 +210,20 @@ class SyncedPlaylistRepository implements PlaylistRepository {
     await _pushMembership(
       playlistId,
       (JellyfinClient client, JellyfinSession session, String remoteId) =>
-          client.addItemsToPlaylist(session, remoteId, added),
+          // The server speaks bare item ids; a synced playlist only holds
+          // jellyfin: uris, so map them back at the request boundary.
+          client.addItemsToPlaylist(session, remoteId, _jellyfinItemIds(added)),
     );
   }
 
   @override
-  Future<void> removeTrack(String playlistId, String trackId) async {
+  Future<void> removeTrack(String playlistId, String trackUri) async {
     await _ensureLoaded();
     final Playlist? playlist = _byId(playlistId);
-    if (playlist == null || !playlist.trackIds.contains(trackId)) return;
+    if (playlist == null || !playlist.trackIds.contains(trackUri)) return;
     final List<String> updated = <String>[
-      for (final String id in playlist.trackIds)
-        if (id != trackId) id,
+      for (final String uri in playlist.trackIds)
+        if (uri != trackUri) uri,
     ];
     await _mutate(
       playlistId,
@@ -213,7 +232,8 @@ class SyncedPlaylistRepository implements PlaylistRepository {
     await _pushMembership(
       playlistId,
       (JellyfinClient client, JellyfinSession session, String remoteId) =>
-          client.removeItemsFromPlaylist(session, remoteId, <String>[trackId]),
+          client.removeItemsFromPlaylist(
+              session, remoteId, _jellyfinItemIds(<String>[trackUri])),
     );
   }
 
@@ -294,12 +314,14 @@ class SyncedPlaylistRepository implements PlaylistRepository {
     ];
     bool changed = next.length != _playlists.length;
     for (final JellyfinPlaylistDto dto in remote) {
-      List<String> itemIds;
+      List<String> trackUris;
       try {
         final List<JellyfinPlaylistEntry> entries =
             await client.fetchPlaylistEntries(session, dto.id);
-        itemIds = <String>[
-          for (final JellyfinPlaylistEntry e in entries) e.itemId,
+        // The server returns bare item ids; namespace them to jellyfin: uris so
+        // imported membership keys the same way local edits and the catalog do.
+        trackUris = <String>[
+          for (final JellyfinPlaylistEntry e in entries) _jellyfinUri(e.itemId),
         ];
       } on JellyfinException catch (_) {
         // Skip this playlist's membership refresh; keep the rest going.
@@ -314,7 +336,7 @@ class SyncedPlaylistRepository implements PlaylistRepository {
             name: dto.name,
             source: PlaylistSource.jellyfin,
             remoteId: dto.id,
-            trackIds: itemIds,
+            trackIds: trackUris,
             createdAt: _now(),
             updatedAt: _now(),
             syncState: PlaylistSyncState.synced,
@@ -326,7 +348,7 @@ class SyncedPlaylistRepository implements PlaylistRepository {
         if (index >= 0) {
           next[index] = existing.copyWith(
             name: dto.name,
-            trackIds: itemIds,
+            trackIds: trackUris,
             syncState: PlaylistSyncState.synced,
             lastSyncError: () => null,
             updatedAt: _now(),
@@ -367,6 +389,128 @@ class SyncedPlaylistRepository implements PlaylistRepository {
 
   // --- Internal helpers --------------------------------------------------
 
+  /// Re-keys a pre-uri store's bare-`id` membership onto the provider-namespaced
+  /// [Track.uri], once, after the catalog is available.
+  ///
+  /// A Jellyfin-synced playlist could only ever hold Jellyfin items, so each of
+  /// its bare ids is namespaced with the `jellyfin:` scheme unambiguously. A
+  /// local playlist's members are resolved against the catalog: a local path is
+  /// already its own uri; a bare remote id adopts its catalog owner's uri when a
+  /// single provider exposes it, and is left untouched when more than one does —
+  /// or when the catalog doesn't have it — so a member is never mis-attributed
+  /// to the wrong provider. Persists locally only (never pushes to the server).
+  Future<void> _migrateLegacyTrackIdsOnce() async {
+    if (_migratedLegacyTrackIds) return;
+    final bool anyMembers =
+        _playlists.any((Playlist p) => p.trackIds.isNotEmpty);
+    if (!anyMembers) {
+      _migratedLegacyTrackIds = true;
+      return;
+    }
+
+    // Resolve local-playlist members against the catalog. A Jellyfin playlist
+    // needs no oracle, so only fetch when a local playlist actually has members.
+    Set<String> catalogUris = const <String>{};
+    Map<String, String?> ownerByBareId = const <String, String?>{};
+    final Future<List<Track>> Function()? oracle = _catalogForMigration;
+    final bool needCatalog = oracle != null &&
+        _playlists.any((Playlist p) =>
+            p.source == PlaylistSource.local && p.trackIds.isNotEmpty);
+    if (needCatalog) {
+      final List<Track> tracks;
+      try {
+        tracks = await oracle();
+      } catch (_) {
+        return; // Transient read failure: defer so a later call can retry.
+      }
+      // An empty catalog this early is "not loaded yet", not "no library";
+      // defer so an unambiguous local membership isn't stranded as a bare id.
+      if (tracks.isEmpty) return;
+      catalogUris = <String>{for (final Track t in tracks) t.uri};
+      final Map<String, String?> owners = <String, String?>{};
+      for (final Track t in tracks) {
+        if (t.uri == t.id) continue; // local: id == uri, never a bare-id key.
+        owners[t.id] = owners.containsKey(t.id) ? null : t.uri;
+      }
+      ownerByBareId = owners;
+    }
+    _migratedLegacyTrackIds = true;
+
+    bool changed = false;
+    final List<Playlist> next = <Playlist>[];
+    for (final Playlist playlist in _playlists) {
+      final List<String> migrated =
+          _migrateTrackIds(playlist, catalogUris, ownerByBareId);
+      if (identical(migrated, playlist.trackIds)) {
+        next.add(playlist);
+      } else {
+        changed = true;
+        next.add(playlist.copyWith(trackIds: migrated));
+      }
+    }
+    if (changed) {
+      _playlists = next;
+      await _persistAndEmit();
+    }
+  }
+
+  /// The migrated membership for [playlist], or its existing list unchanged when
+  /// nothing needed re-keying. Collapses any duplicate the re-key introduces
+  /// (preserving first-seen order), so a playlist can't end up with two entries
+  /// for the same track.
+  List<String> _migrateTrackIds(
+    Playlist playlist,
+    Set<String> catalogUris,
+    Map<String, String?> ownerByBareId,
+  ) {
+    if (playlist.trackIds.isEmpty) return playlist.trackIds;
+    bool changed = false;
+    final Set<String> seen = <String>{};
+    final List<String> result = <String>[];
+    for (final String id in playlist.trackIds) {
+      final String mapped =
+          _migrateOneTrackId(id, playlist.source, catalogUris, ownerByBareId);
+      if (mapped != id) changed = true;
+      if (seen.add(mapped)) {
+        result.add(mapped);
+      } else {
+        changed = true; // a duplicate collapsed away
+      }
+    }
+    return changed ? result : playlist.trackIds;
+  }
+
+  /// Maps one legacy membership entry to its provider uri. Entries that already
+  /// carry a known scheme are returned unchanged.
+  String _migrateOneTrackId(
+    String id,
+    PlaylistSource source,
+    Set<String> catalogUris,
+    Map<String, String?> ownerByBareId,
+  ) {
+    // Already provider-namespaced (jellyfin:/subsonic:/plex:): nothing to do.
+    if (MusicProviders.bareRemoteIdForTrackUri(id) != null) return id;
+    // A synced playlist's bare ids are unambiguously Jellyfin item ids.
+    if (source == PlaylistSource.jellyfin) return _jellyfinUri(id);
+    // Local playlist: a local path is already its own uri.
+    if (catalogUris.contains(id)) return id;
+    // A bare remote id adopts its unique catalog owner (ambiguous/unknown → as-is).
+    return ownerByBareId[id] ?? id;
+  }
+
+  /// The provider uri for a bare Jellyfin item id (`101` → `jellyfin:101`).
+  static String _jellyfinUri(String itemId) =>
+      '${JellyfinTrackMapper.uriScheme}$itemId';
+
+  /// The bare Jellyfin item ids for the `jellyfin:` uris in [uris], in order.
+  /// Non-Jellyfin uris are dropped: a Jellyfin server playlist can only hold
+  /// Jellyfin items, so this is what the server API is given.
+  static List<String> _jellyfinItemIds(List<String> uris) => <String>[
+        for (final String uri in uris)
+          if (uri.startsWith(JellyfinTrackMapper.uriScheme))
+            uri.substring(JellyfinTrackMapper.uriScheme.length),
+      ];
+
   /// Pushes a freshly created playlist to the server, returning the updated
   /// playlist (with a [Playlist.remoteId] + [PlaylistSyncState.synced] on
   /// success, or [PlaylistSyncState.syncFailed] + a friendly error on failure).
@@ -378,7 +522,9 @@ class SyncedPlaylistRepository implements PlaylistRepository {
       final String remoteId = await client.createPlaylist(
         session,
         name: playlist.name,
-        itemIds: playlist.trackIds,
+        // Map the playlist's jellyfin: uris back to the bare item ids the
+        // server API expects (non-Jellyfin uris, if any, are dropped).
+        itemIds: _jellyfinItemIds(playlist.trackIds),
       );
       return await _mutate(
         playlist.id,

--- a/lib/features/favorites/favorites_controller.dart
+++ b/lib/features/favorites/favorites_controller.dart
@@ -6,11 +6,12 @@ import '../player/favorites_providers.dart';
 
 /// The favourited tracks to show in the Favorites view.
 ///
-/// Joins the favourite id set (from [favoriteIdsProvider] — local-folder
+/// Joins the favourite uri set (from [favoriteIdsProvider] — local-folder
 /// favourites plus the Jellyfin server's set, which is the source of truth for
-/// remote tracks) against the offline catalog, so every liked track that's in
-/// the library appears whether it's local or Jellyfin. Re-resolves whenever the
-/// favourite set changes, keeping the list live as hearts toggle.
+/// remote tracks) against the offline catalog, matching on the
+/// provider-namespaced [Track.uri] so a same-id track from another provider is
+/// never surfaced by mistake. Re-resolves whenever the favourite set changes,
+/// keeping the list live as hearts toggle.
 final favoriteTracksProvider = FutureProvider<List<Track>>((ref) async {
   final Set<String> ids = await ref.watch(favoriteIdsProvider.future);
   if (ids.isEmpty) return const <Track>[];
@@ -18,6 +19,6 @@ final favoriteTracksProvider = FutureProvider<List<Track>>((ref) async {
       await ref.watch(musicLibraryRepositoryProvider).getAllTracks();
   return <Track>[
     for (final Track track in tracks)
-      if (ids.contains(track.id)) track,
+      if (ids.contains(track.uri)) track,
   ];
 });

--- a/lib/features/player/favorites_providers.dart
+++ b/lib/features/player/favorites_providers.dart
@@ -5,17 +5,20 @@ import '../../data/repositories/jellyfin_synced_favorites_repository.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
 
-/// Streams the favourite track-id set for the UI.
+/// Streams the favourite track-uri set for the UI. Entries are
+/// provider-namespaced [Track.uri]s, so `jellyfin:101` and `subsonic:101` are
+/// tracked independently.
 final favoriteIdsProvider = StreamProvider<Set<String>>((ref) {
   return ref.watch(favoritesRepositoryProvider).favoritesStream;
 });
 
 /// Whether a single track is currently a favourite — for the heart toggle. It
 /// recomputes whenever the favourites set changes, so the icon stays live.
-final isFavoriteProvider = Provider.family<bool, String>((ref, trackId) {
+/// Keyed by the provider-namespaced [Track.uri], not the bare id.
+final isFavoriteProvider = Provider.family<bool, String>((ref, trackUri) {
   final Set<String> ids =
       ref.watch(favoriteIdsProvider).valueOrNull ?? const <String>{};
-  return ids.contains(trackId);
+  return ids.contains(trackUri);
 });
 
 /// Production binding: syncs favourites with the signed-in Jellyfin server.

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -28,7 +28,7 @@ class NowPlayingActions extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    final bool isFavorite = ref.watch(isFavoriteProvider(track.id));
+    final bool isFavorite = ref.watch(isFavoriteProvider(track.uri));
     final bool sleepTimerActive = ref.watch(
       sleepTimerControllerProvider.select((s) => s.isActive),
     );

--- a/lib/features/player/widgets/queue_sheet.dart
+++ b/lib/features/player/widgets/queue_sheet.dart
@@ -196,7 +196,7 @@ class QueueSheet extends ConsumerWidget {
     );
     await repository.addTracks(
       created.id,
-      <String>[for (final Track track in tracks) track.id],
+      <String>[for (final Track track in tracks) track.uri],
     );
     messenger.showSnackBar(
       SnackBar(

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -58,7 +58,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
         tracksAsync.valueOrNull ?? PlaylistTracks.empty;
     final List<Track> selected = <Track>[
       for (final Track track in resolved.tracks)
-        if (_selectedIds.contains(track.id)) track,
+        if (_selectedIds.contains(track.uri)) track,
     ];
 
     return PopScope(
@@ -169,7 +169,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
       itemCount: tracks.length,
       itemBuilder: (context, index) {
         final Track track = tracks[index];
-        final bool selected = _selectedIds.contains(track.id);
+        final bool selected = _selectedIds.contains(track.uri);
         return ListTile(
           selected: selected,
           leading: SizedBox.square(
@@ -236,7 +236,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     final NowPlayingRowState? nowPlaying =
         ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
     return ListTile(
-      key: ValueKey<String>(track.id),
+      key: ValueKey<String>(track.uri),
       leading: TrackArtwork(
         artworkUri: track.artworkUri,
         nowPlaying: nowPlaying,
@@ -370,14 +370,14 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
       _selecting = true;
       _selectedIds
         ..clear()
-        ..add(track.id);
+        ..add(track.uri);
     });
   }
 
   void _toggle(Track track) {
     setState(() {
-      if (!_selectedIds.add(track.id)) {
-        _selectedIds.remove(track.id);
+      if (!_selectedIds.add(track.uri)) {
+        _selectedIds.remove(track.uri);
       }
       if (_selectedIds.isEmpty) _selecting = false;
     });
@@ -450,13 +450,13 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
   Future<void> _removeOneFromPlaylist(Playlist playlist, Track track) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final repository = ref.read(playlistRepositoryProvider);
-    await repository.removeTrack(playlist.id, track.id);
+    await repository.removeTrack(playlist.id, track.uri);
     messenger.showSnackBar(
       SnackBar(
         content: Text('Removed “${track.title}” from playlist.'),
         action: SnackBarAction(
           label: 'Undo',
-          onPressed: () => repository.addTrack(playlist.id, track.id),
+          onPressed: () => repository.addTrack(playlist.id, track.uri),
         ),
       ),
     );
@@ -476,7 +476,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     if (!confirmed) return;
     final repository = ref.read(playlistRepositoryProvider);
     for (final Track track in selected) {
-      await repository.removeTrack(widget.playlistId, track.id);
+      await repository.removeTrack(widget.playlistId, track.uri);
     }
     messenger.showSnackBar(
       SnackBar(

--- a/lib/features/playlists/playlist_providers.dart
+++ b/lib/features/playlists/playlist_providers.dart
@@ -36,7 +36,7 @@ class PlaylistTracks {
   final int missingCount;
 }
 
-/// Resolves a playlist's stored track ids to catalog [Track]s, preserving order
+/// Resolves a playlist's stored track uris to catalog [Track]s, preserving order
 /// and gracefully dropping (and counting) any that the catalog no longer has.
 /// Re-runs whenever the playlist changes.
 final playlistTracksProvider =
@@ -47,13 +47,15 @@ final playlistTracksProvider =
   }
   final List<Track> all =
       await ref.watch(musicLibraryRepositoryProvider).getAllTracks();
-  final Map<String, Track> byId = <String, Track>{
-    for (final Track track in all) track.id: track,
+  // Resolve by the provider-namespaced uri, so a `jellyfin:101` entry can never
+  // resolve to a `subsonic:101` catalog track that merely shares the bare id.
+  final Map<String, Track> byUri = <String, Track>{
+    for (final Track track in all) track.uri: track,
   };
   final List<Track> resolved = <Track>[];
   int missing = 0;
-  for (final String trackId in playlist.trackIds) {
-    final Track? track = byId[trackId];
+  for (final String trackUri in playlist.trackIds) {
+    final Track? track = byUri[trackUri];
     if (track != null) {
       resolved.add(track);
     } else {

--- a/lib/features/playlists/widgets/add_to_playlist_sheet.dart
+++ b/lib/features/playlists/widgets/add_to_playlist_sheet.dart
@@ -131,14 +131,16 @@ class _AddToPlaylistSheet extends ConsumerWidget {
       );
       return;
     }
-    // The repository skips ids already in the playlist, so the count the user
-    // sees must be the genuinely-new ones — not the whole addable list.
+    // The repository skips uris already in the playlist, so the count the user
+    // sees must be the genuinely-new ones — not the whole addable list. Keyed by
+    // the provider-namespaced uri, so adding `subsonic:101` to a playlist that
+    // holds `jellyfin:101` is a real add, not a no-op "already there".
     final Set<String> existing = playlist.trackIds.toSet();
     final int added =
-        addable.where((Track t) => !existing.contains(t.id)).length;
+        addable.where((Track t) => !existing.contains(t.uri)).length;
     await ref.read(playlistRepositoryProvider).addTracks(
       playlist.id,
-      <String>[for (final Track track in addable) track.id],
+      <String>[for (final Track track in addable) track.uri],
     );
     navigator.pop();
     messenger.showSnackBar(
@@ -171,7 +173,7 @@ class _AddToPlaylistSheet extends ConsumerWidget {
     if (addable.isNotEmpty) {
       await repository.addTracks(
         created.id,
-        <String>[for (final Track track in addable) track.id],
+        <String>[for (final Track track in addable) track.uri],
       );
     }
     navigator.pop();

--- a/test/core/services/media_browser_tree_test.dart
+++ b/test/core/services/media_browser_tree_test.dart
@@ -88,7 +88,7 @@ void main() {
         final tree = treeWith(
           tracks: library,
           playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
-          favorites: {'a'},
+          favorites: {'/a.mp3'},
           downloads: {'b'},
         );
 
@@ -135,7 +135,7 @@ void main() {
               .map((n) => n.id),
           isNot(contains(MediaId.favorites)),
         );
-        final tree = treeWith(tracks: library, favorites: {'a'});
+        final tree = treeWith(tracks: library, favorites: {'/a.mp3'});
         expect((await _kids(tree, MediaId.root)).map((n) => n.id),
             contains(MediaId.favorites));
       });
@@ -157,7 +157,7 @@ void main() {
         final tree = treeWith(
           tracks: library,
           playlists: [const Playlist(id: 'p1', name: 'Roadtrip')],
-          favorites: {'a'},
+          favorites: {'/a.mp3'},
           downloads: {'b'},
         );
 
@@ -422,8 +422,11 @@ void main() {
 
     group('playlists', () {
       final playlists = <Playlist>[
-        // 'x' is not in the catalog and must be dropped (it can't be played).
-        const Playlist(id: 'p1', name: 'Roadtrip', trackIds: ['c', 'a', 'x']),
+        // '/x.mp3' is not in the catalog and must be dropped (can't be played).
+        const Playlist(
+            id: 'p1',
+            name: 'Roadtrip',
+            trackIds: ['/c.mp3', '/a.mp3', '/x.mp3']),
         const Playlist(id: 'p2', name: 'Empty'),
       ];
 
@@ -487,15 +490,35 @@ void main() {
             await _pick(buildTree(), MediaId.playlistTrack('nope', 0)), isNull);
         expect(await _kids(buildTree(), MediaId.playlist('nope')), isEmpty);
       });
+
+      test('a member resolves to its own provider, not a same-id sibling',
+          () async {
+        const Track jelly =
+            Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+        const Track sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+        final tree = MediaBrowserTree(
+          FakeMusicLibraryRepository(tracks: const <Track>[jelly, sub]),
+          playlists: FakePlaylistRepository(<Playlist>[
+            const Playlist(
+                id: 'p1', name: 'Mix', trackIds: <String>['jellyfin:101']),
+          ]),
+        );
+
+        final nodes = await _kids(tree, MediaId.playlist('p1'));
+        // The `jellyfin:101` entry resolves to the Jellyfin track only.
+        expect(nodes.map((n) => n.title), <String>['Alpha']);
+      });
     });
 
     group('favorites', () {
-      // Catalog order is a, b, c; favouriting a and c (plus a stale 'x' not in
-      // the catalog) must list/resolve as [a, c] in catalog order.
-      MediaBrowserTree buildTree([Set<String> ids = const {'a', 'c', 'x'}]) {
+      // Catalog order is a, b, c; favouriting a and c (plus a stale '/x.mp3' not
+      // in the catalog) must list/resolve as [a, c] in catalog order. Favourites
+      // are keyed by uri, matching _track's '/$id.mp3'.
+      MediaBrowserTree buildTree(
+          [Set<String> uris = const {'/a.mp3', '/c.mp3', '/x.mp3'}]) {
         return MediaBrowserTree(
           FakeMusicLibraryRepository(tracks: library),
-          favorites: FakeFavoritesRepository(ids),
+          favorites: FakeFavoritesRepository(uris),
         );
       }
 
@@ -528,6 +551,21 @@ void main() {
 
       test('an out-of-range favourite index resolves to null', () async {
         expect(await _pick(buildTree(), MediaId.favoriteItem(9)), isNull);
+      });
+
+      test('a favourite on one provider never surfaces a same-id sibling',
+          () async {
+        const Track jelly =
+            Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+        const Track sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+        final tree = MediaBrowserTree(
+          FakeMusicLibraryRepository(tracks: const <Track>[jelly, sub]),
+          favorites: FakeFavoritesRepository(const <String>{'jellyfin:101'}),
+        );
+
+        final nodes = await _kids(tree, MediaId.favorites);
+        // Only the favourited copy appears — not its same-id Subsonic sibling.
+        expect(nodes.map((n) => n.title), <String>['Alpha']);
       });
     });
 

--- a/test/core/services/smart_playlist_resolver_test.dart
+++ b/test/core/services/smart_playlist_resolver_test.dart
@@ -16,11 +16,16 @@ void main() {
   // A small catalog plus the on-device signals each mix is built from.
   final List<Track> catalog = <Track>[_t('a'), _t('b'), _t('c'), _t('d')];
 
+  // Keyed by the provider-namespaced uri (jellyfin:<id> here, matching the _t
+  // helper), the way play history now records completions.
   final PlayHistory history = PlayHistory(
     stats: <String, TrackPlayStats>{
-      'a': TrackPlayStats(playCount: 5, lastPlayedAt: DateTime(2024, 1, 1)),
-      'b': TrackPlayStats(playCount: 1, lastPlayedAt: DateTime(2024, 1, 3)),
-      'c': TrackPlayStats(playCount: 3, lastPlayedAt: DateTime(2024, 1, 2)),
+      'jellyfin:a':
+          TrackPlayStats(playCount: 5, lastPlayedAt: DateTime(2024, 1, 1)),
+      'jellyfin:b':
+          TrackPlayStats(playCount: 1, lastPlayedAt: DateTime(2024, 1, 3)),
+      'jellyfin:c':
+          TrackPlayStats(playCount: 3, lastPlayedAt: DateTime(2024, 1, 2)),
     },
   );
 
@@ -91,11 +96,11 @@ void main() {
           _ids(resolve(SmartPlaylistKind.mostPlayed)), <String>['a', 'c', 'b']);
     });
 
-    test('favorites mix uses the favorite id set', () {
+    test('favorites mix uses the favorite uri set', () {
       final List<Track> result = resolve(
         SmartPlaylistKind.favorites,
         // 'z' isn't in the catalog and must be ignored gracefully.
-        favoriteIds: <String>{'b', 'd', 'z'},
+        favoriteIds: <String>{'jellyfin:b', 'jellyfin:d', 'jellyfin:z'},
       );
       expect(_ids(result), <String>['b', 'd']);
     });
@@ -128,6 +133,57 @@ void main() {
     test('never played excludes anything in the play history', () {
       // a, b, c have history; only d is never played.
       expect(_ids(resolve(SmartPlaylistKind.neverPlayed)), <String>['d']);
+    });
+
+    group('does not cross-contaminate same-id provider copies', () {
+      // jellyfin:101 and subsonic:101 share the bare id 101; only the Jellyfin
+      // copy has play history / is favourited.
+      const Track jelly = Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+      const Track sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+      final List<Track> twoProviders = <Track>[jelly, sub];
+      final PlayHistory jellyOnly = PlayHistory(
+        stats: <String, TrackPlayStats>{
+          'jellyfin:101':
+              TrackPlayStats(playCount: 4, lastPlayedAt: DateTime(2024, 1, 1)),
+        },
+      );
+
+      List<Track> resolveTwo(SmartPlaylistKind kind,
+          {Set<String> favoriteIds = const <String>{}}) {
+        return const SmartPlaylistResolver().resolve(
+          kind,
+          allTracks: twoProviders,
+          history: jellyOnly,
+          addedAt: const <String, DateTime>{},
+          favoriteIds: favoriteIds,
+          downloadedKeys: const <String>{},
+        );
+      }
+
+      test('recently played shows only the played copy', () {
+        expect(resolveTwo(SmartPlaylistKind.recentlyPlayed).map((t) => t.uri),
+            <String>['jellyfin:101']);
+      });
+
+      test('most played shows only the played copy', () {
+        expect(resolveTwo(SmartPlaylistKind.mostPlayed).map((t) => t.uri),
+            <String>['jellyfin:101']);
+      });
+
+      test('never played keeps the unplayed sibling', () {
+        // The Jellyfin copy was played; the Subsonic copy never was, so only it
+        // appears — not excluded by its sibling's history.
+        expect(resolveTwo(SmartPlaylistKind.neverPlayed).map((t) => t.uri),
+            <String>['subsonic:101']);
+      });
+
+      test('favorites shows only the favourited copy', () {
+        expect(
+          resolveTwo(SmartPlaylistKind.favorites,
+              favoriteIds: <String>{'jellyfin:101'}).map((t) => t.uri),
+          <String>['jellyfin:101'],
+        );
+      });
     });
 
     test('random mix is bounded by maxTracks', () {

--- a/test/data/repositories/default_play_history_repository_test.dart
+++ b/test/data/repositories/default_play_history_repository_test.dart
@@ -14,9 +14,16 @@ void main() {
       store = InMemoryPlayHistoryStore();
     });
 
-    DefaultPlayHistoryRepository build({DateTime Function()? now}) {
+    DefaultPlayHistoryRepository build({
+      DateTime Function()? now,
+      Future<List<Track>> Function()? catalogForMigration,
+    }) {
       final DefaultPlayHistoryRepository repository =
-          DefaultPlayHistoryRepository(store: store, now: now);
+          DefaultPlayHistoryRepository(
+        store: store,
+        now: now,
+        catalogForMigration: catalogForMigration,
+      );
       addTearDown(repository.dispose);
       return repository;
     }
@@ -25,10 +32,10 @@ void main() {
       final DefaultPlayHistoryRepository repository = build();
 
       await repository.recordCompletion(_t('a'));
-      expect(repository.current.playCountFor('a'), 1);
+      expect(repository.current.playCountFor('jellyfin:a'), 1);
 
       await repository.recordCompletion(_t('a'));
-      expect(repository.current.playCountFor('a'), 2);
+      expect(repository.current.playCountFor('jellyfin:a'), 2);
     });
 
     test('updates last-played time on completion', () async {
@@ -36,11 +43,13 @@ void main() {
       final DefaultPlayHistoryRepository repository = build(now: () => clock);
 
       await repository.recordCompletion(_t('a'));
-      expect(repository.current.lastPlayedFor('a'), DateTime(2024, 1, 1, 9));
+      expect(repository.current.lastPlayedFor('jellyfin:a'),
+          DateTime(2024, 1, 1, 9));
 
       clock = DateTime(2024, 1, 1, 10);
       await repository.recordCompletion(_t('a'));
-      expect(repository.current.lastPlayedFor('a'), DateTime(2024, 1, 1, 10));
+      expect(repository.current.lastPlayedFor('jellyfin:a'),
+          DateTime(2024, 1, 1, 10));
     });
 
     test('recently played reflects completion order, most-recent first',
@@ -56,11 +65,13 @@ void main() {
       await repository.recordCompletion(_t('a'));
       await repository.recordCompletion(_t('b'));
       await repository.recordCompletion(_t('c'));
-      expect(repository.current.recentlyPlayedIds, <String>['c', 'b', 'a']);
+      expect(repository.current.recentlyPlayedKeys,
+          <String>['jellyfin:c', 'jellyfin:b', 'jellyfin:a']);
 
       // Replaying 'a' moves it back to the front.
       await repository.recordCompletion(_t('a'));
-      expect(repository.current.recentlyPlayedIds, <String>['a', 'c', 'b']);
+      expect(repository.current.recentlyPlayedKeys,
+          <String>['jellyfin:a', 'jellyfin:c', 'jellyfin:b']);
     });
 
     test('most played orders by count', () async {
@@ -71,14 +82,15 @@ void main() {
       await repository.recordCompletion(_t('b'));
       await repository.recordCompletion(_t('c'));
       await repository.recordCompletion(_t('c'));
-      expect(repository.current.mostPlayedIds, <String>['b', 'c', 'a']);
+      expect(repository.current.mostPlayedKeys,
+          <String>['jellyfin:b', 'jellyfin:c', 'jellyfin:a']);
     });
 
     test('historyStream emits the initial history then every change', () async {
       final DefaultPlayHistoryRepository repository = build();
       final List<int> counts = <int>[];
       final sub = repository.historyStream
-          .listen((PlayHistory h) => counts.add(h.playCountFor('a')));
+          .listen((PlayHistory h) => counts.add(h.playCountFor('jellyfin:a')));
 
       await Future<void>.delayed(Duration.zero); // initial (empty) emission
       await repository.recordCompletion(_t('a'));
@@ -98,21 +110,128 @@ void main() {
       final DefaultPlayHistoryRepository second = build();
       // Touch the stream to force a load.
       await second.historyStream.first;
-      expect(second.current.playCountFor('a'), 2);
+      expect(second.current.playCountFor('jellyfin:a'), 2);
     });
 
-    test('only the track id is recorded — never its uri', () async {
-      const String token = 'secret-token-abc123';
+    test('records the provider-namespaced uri, not the bare id', () async {
+      // The stored key is the uri (the catalog's identity), so a same-id track
+      // from another provider keeps its own count — and the bare id is never the
+      // key, so it never collides.
       final DefaultPlayHistoryRepository repository = build();
-      const Track tokenized =
-          Track(id: 'a', title: 'A', uri: 'https://x/?t=$token');
-      await repository.recordCompletion(tokenized);
+      await repository.recordCompletion(_t('a'));
 
-      expect(repository.current.stats.containsKey('a'), isTrue);
-      // The stats carry only count + time, never the uri/token.
-      final TrackPlayStats stats = repository.current.stats['a']!;
-      expect(stats.playCount, 1);
-      expect(stats.toString(), isNot(contains(token)));
+      expect(repository.current.stats.containsKey('jellyfin:a'), isTrue);
+      expect(repository.current.stats.containsKey('a'), isFalse);
+    });
+
+    test('a play of one provider never marks a same-id sibling played',
+        () async {
+      // jellyfin:101 and subsonic:101 share the bare id 101 but are different
+      // tracks; completing one must not touch the other.
+      final DefaultPlayHistoryRepository repository = build();
+      const Track jelly = Track(id: '101', title: 'Alpha', uri: 'jellyfin:101');
+      const Track sub = Track(id: '101', title: 'Beta', uri: 'subsonic:101');
+
+      await repository.recordCompletion(jelly);
+
+      expect(repository.current.hasPlayed('jellyfin:101'), isTrue);
+      expect(repository.current.hasPlayed('subsonic:101'), isFalse);
+      expect(repository.current.playCountFor('subsonic:101'), 0);
+      expect(repository.current.playCountFor(sub.uri), 0);
+    });
+
+    group('legacy bare-id migration', () {
+      test('re-keys an unambiguous legacy bare-id count onto its uri',
+          () async {
+        store = InMemoryPlayHistoryStore(
+          PlayHistory(stats: <String, TrackPlayStats>{
+            '101': TrackPlayStats(
+                playCount: 3, lastPlayedAt: DateTime(2024, 1, 1)),
+          }),
+        );
+        // The catalog exposes id 101 under a single provider, so it's safe to
+        // attribute the legacy count to that uri.
+        final DefaultPlayHistoryRepository repository = build(
+          catalogForMigration: () async => const <Track>[
+            Track(id: '101', title: 'Alpha', uri: 'jellyfin:101'),
+          ],
+        );
+
+        await repository.historyStream.first; // triggers the load + migration
+
+        expect(repository.current.playCountFor('jellyfin:101'), 3);
+        expect(repository.current.stats.containsKey('101'), isFalse);
+        // Persisted, so the next launch reads the migrated form.
+        expect((await store.load()).stats.containsKey('jellyfin:101'), isTrue);
+      });
+
+      test('folds a legacy count into an existing uri count', () async {
+        store = InMemoryPlayHistoryStore(
+          PlayHistory(stats: <String, TrackPlayStats>{
+            '101': TrackPlayStats(
+                playCount: 2, lastPlayedAt: DateTime(2024, 1, 1)),
+            'jellyfin:101': TrackPlayStats(
+                playCount: 5, lastPlayedAt: DateTime(2024, 1, 3)),
+          }),
+        );
+        final DefaultPlayHistoryRepository repository = build(
+          catalogForMigration: () async => const <Track>[
+            Track(id: '101', title: 'Alpha', uri: 'jellyfin:101'),
+          ],
+        );
+
+        await repository.historyStream.first;
+
+        // Counts summed (2 + 5) and the later last-played kept.
+        expect(repository.current.playCountFor('jellyfin:101'), 7);
+        expect(repository.current.lastPlayedFor('jellyfin:101'),
+            DateTime(2024, 1, 3));
+        expect(repository.current.stats.containsKey('101'), isFalse);
+      });
+
+      test('leaves an ambiguous legacy bare id untouched (never guesses)',
+          () async {
+        store = InMemoryPlayHistoryStore(
+          PlayHistory(stats: <String, TrackPlayStats>{
+            '101': TrackPlayStats(
+                playCount: 4, lastPlayedAt: DateTime(2024, 1, 1)),
+          }),
+        );
+        // Two providers both expose id 101: the legacy count can't be safely
+        // attributed to either, so it stays a bare key (inert under uri reads).
+        final DefaultPlayHistoryRepository repository = build(
+          catalogForMigration: () async => const <Track>[
+            Track(id: '101', title: 'Alpha', uri: 'jellyfin:101'),
+            Track(id: '101', title: 'Beta', uri: 'subsonic:101'),
+          ],
+        );
+
+        await repository.historyStream.first;
+
+        expect(repository.current.hasPlayed('jellyfin:101'), isFalse);
+        expect(repository.current.hasPlayed('subsonic:101'), isFalse);
+        // Preserved, not dropped.
+        expect(repository.current.stats.containsKey('101'), isTrue);
+        expect(repository.current.playCountFor('101'), 4);
+      });
+
+      test('a local path key (id == uri) is left as-is', () async {
+        store = InMemoryPlayHistoryStore(
+          PlayHistory(stats: <String, TrackPlayStats>{
+            '/music/song.mp3': TrackPlayStats(
+                playCount: 1, lastPlayedAt: DateTime(2024, 1, 1)),
+          }),
+        );
+        final DefaultPlayHistoryRepository repository = build(
+          catalogForMigration: () async => const <Track>[
+            Track(id: '/music/song.mp3', title: 'Song', uri: '/music/song.mp3'),
+          ],
+        );
+
+        await repository.historyStream.first;
+
+        expect(repository.current.playCountFor('/music/song.mp3'), 1);
+      });
     });
   });
 }

--- a/test/data/repositories/jellyfin_synced_favorites_repository_test.dart
+++ b/test/data/repositories/jellyfin_synced_favorites_repository_test.dart
@@ -45,13 +45,15 @@ void main() {
 
       await repo.setFavorite(_jellyfin('j1'), true);
 
-      expect(repo.isFavorite('j1'), isTrue);
+      // Tracked by the provider-namespaced uri…
+      expect(repo.isFavorite('jellyfin:j1'), isTrue);
+      // …but the server push still uses the bare item id.
       expect(
         client.favoriteCalls,
         <({String itemId, bool favorite})>[(itemId: 'j1', favorite: true)],
       );
-      // Persisted under the (server-owned) remote set.
-      expect((await store.load()).remoteIds, <String>{'j1'});
+      // Persisted under the (server-owned) remote set, as a uri.
+      expect((await store.load()).remoteIds, <String>{'jellyfin:j1'});
     });
 
     test('unfavoriting a Jellyfin track deletes it on the server', () async {
@@ -60,7 +62,7 @@ void main() {
 
       await repo.setFavorite(_jellyfin('j1'), false);
 
-      expect(repo.isFavorite('j1'), isFalse);
+      expect(repo.isFavorite('jellyfin:j1'), isFalse);
       expect(client.favoriteCalls.last, (itemId: 'j1', favorite: false));
     });
 
@@ -70,11 +72,23 @@ void main() {
 
       await repo.setFavorite(_local('a'), true);
 
-      expect(repo.isFavorite('a'), isTrue);
+      expect(repo.isFavorite('file:///a.mp3'), isTrue);
       expect(client.favoriteCalls, isEmpty);
       final loaded = await store.load();
-      expect(loaded.localIds, <String>{'a'});
+      expect(loaded.localIds, <String>{'file:///a.mp3'});
       expect(loaded.remoteIds, isEmpty);
+    });
+
+    test('favoriting one provider never favourites a same-id sibling',
+        () async {
+      // Only Jellyfin supports favouriting today, but the heart is keyed by uri
+      // so a future provider's same-id copy can never be wrongly flagged.
+      final repo = build(session: _session);
+
+      await repo.setFavorite(_jellyfin('101'), true);
+
+      expect(repo.isFavorite('jellyfin:101'), isTrue);
+      expect(repo.isFavorite('subsonic:101'), isFalse);
     });
 
     test('favoritesStream emits the union of local and remote favourites',
@@ -88,7 +102,7 @@ void main() {
       await repo.setFavorite(_jellyfin('j1'), true);
       await _settle();
 
-      expect(emissions.last, <String>{'a', 'j1'});
+      expect(emissions.last, <String>{'file:///a.mp3', 'jellyfin:j1'});
       await sub.cancel();
     });
 
@@ -101,8 +115,9 @@ void main() {
 
       await repo.refreshFromRemote();
 
-      expect(repo.isFavorite('a'), isTrue); // local kept
-      expect(repo.isFavorite('j9'), isTrue); // remote adopted
+      expect(repo.isFavorite('file:///a.mp3'), isTrue); // local kept
+      // Adopted and namespaced to the jellyfin: uri the UI keys on.
+      expect(repo.isFavorite('jellyfin:j9'), isTrue);
     });
 
     test('refreshFromRemote reports the synced favourite count', () async {
@@ -141,8 +156,8 @@ void main() {
       await repo.setFavorite(_jellyfin('j1'), true);
 
       // Still favourited locally despite the failed push.
-      expect(repo.isFavorite('j1'), isTrue);
-      expect((await store.load()).remoteIds, <String>{'j1'});
+      expect(repo.isFavorite('jellyfin:j1'), isTrue);
+      expect((await store.load()).remoteIds, <String>{'jellyfin:j1'});
     });
 
     test('without a session, favourites stay purely local', () async {
@@ -151,20 +166,23 @@ void main() {
       await repo.setFavorite(_jellyfin('j1'), true);
       await repo.refreshFromRemote();
 
-      expect(repo.isFavorite('j1'), isTrue);
+      expect(repo.isFavorite('jellyfin:j1'), isTrue);
       expect(client.favoriteCalls, isEmpty);
     });
 
     test('loads persisted favourites from the store on first read', () async {
       store = InMemoryFavoritesStore(
-        const FavoritesData(localIds: <String>{'a'}, remoteIds: <String>{'j1'}),
+        const FavoritesData(
+          localIds: <String>{'file:///a.mp3'},
+          remoteIds: <String>{'jellyfin:j1'},
+        ),
       );
       final repo = build(session: _session);
 
       // The synchronous mirror is empty until the first stream read loads it.
       final ids = await repo.favoritesStream.first;
 
-      expect(ids, <String>{'a', 'j1'});
+      expect(ids, <String>{'file:///a.mp3', 'jellyfin:j1'});
     });
 
     test('clearRemote drops server favourites but keeps on-device ones',
@@ -172,17 +190,17 @@ void main() {
       final repo = build(session: _session);
       await repo.setFavorite(_jellyfin('j1'), true); // server-synced
       await repo.setFavorite(_local('a'), true); // device-local
-      expect(repo.isFavorite('j1'), isTrue);
-      expect(repo.isFavorite('a'), isTrue);
+      expect(repo.isFavorite('jellyfin:j1'), isTrue);
+      expect(repo.isFavorite('file:///a.mp3'), isTrue);
 
       await repo.clearRemote();
 
       // The remote (account) favourite is gone; the local one survives.
-      expect(repo.isFavorite('j1'), isFalse);
-      expect(repo.isFavorite('a'), isTrue);
+      expect(repo.isFavorite('jellyfin:j1'), isFalse);
+      expect(repo.isFavorite('file:///a.mp3'), isTrue);
       final loaded = await store.load();
       expect(loaded.remoteIds, isEmpty);
-      expect(loaded.localIds, <String>{'a'});
+      expect(loaded.localIds, <String>{'file:///a.mp3'});
     });
 
     test('clearRemote emits the reduced set on the stream', () async {
@@ -196,7 +214,7 @@ void main() {
       await _settle();
       await sub.cancel();
 
-      expect(emissions.last, isNot(contains('j1')));
+      expect(emissions.last, isNot(contains('jellyfin:j1')));
     });
 
     test('clearRemote is a no-op when there are no server favourites',
@@ -206,8 +224,8 @@ void main() {
 
       await repo.clearRemote();
 
-      expect(repo.isFavorite('a'), isTrue);
-      expect((await store.load()).localIds, <String>{'a'});
+      expect(repo.isFavorite('file:///a.mp3'), isTrue);
+      expect((await store.load()).localIds, <String>{'file:///a.mp3'});
     });
   });
 }

--- a/test/data/repositories/shared_preferences_favorites_store_test.dart
+++ b/test/data/repositories/shared_preferences_favorites_store_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/repositories/favorites_store.dart';
+import 'package:linthra/data/repositories/shared_preferences_favorites_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('SharedPreferencesFavoritesStore', () {
+    const SharedPreferencesFavoritesStore store =
+        SharedPreferencesFavoritesStore();
+
+    test('round-trips local and remote uri sets', () async {
+      await store.save(const FavoritesData(
+        localIds: <String>{'file:///a.mp3'},
+        remoteIds: <String>{'jellyfin:101'},
+      ));
+      final FavoritesData loaded = await store.load();
+      expect(loaded.localIds, <String>{'file:///a.mp3'});
+      expect(loaded.remoteIds, <String>{'jellyfin:101'});
+    });
+
+    test('returns empty when nothing is stored', () async {
+      expect((await store.load()).localIds, isEmpty);
+      expect((await store.load()).remoteIds, isEmpty);
+    });
+
+    test('save writes the v2 key', () async {
+      await store.save(const FavoritesData(remoteIds: <String>{'jellyfin:1'}));
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('favorites_v2'), isNotNull);
+    });
+
+    group('v1 → v2 migration', () {
+      test('namespaces bare Jellyfin remote ids and keeps local paths',
+          () async {
+        // A pre-uri store: local ids were already paths, remote ids were bare
+        // Jellyfin item ids (only Jellyfin could favourite).
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'favorites_v1': jsonEncode(<String, dynamic>{
+            'local': <String>['file:///a.mp3'],
+            'remote': <String>['101', '202'],
+          }),
+        });
+
+        final FavoritesData loaded = await store.load();
+
+        expect(loaded.localIds, <String>{'file:///a.mp3'});
+        expect(loaded.remoteIds, <String>{'jellyfin:101', 'jellyfin:202'});
+      });
+
+      test('prefers v2 over a leftover v1', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'favorites_v1': jsonEncode(<String, dynamic>{
+            'local': <String>[],
+            'remote': <String>['legacy'],
+          }),
+          'favorites_v2': jsonEncode(<String, dynamic>{
+            'local': <String>[],
+            'remote': <String>['jellyfin:current'],
+          }),
+        });
+
+        final FavoritesData loaded = await store.load();
+
+        expect(loaded.remoteIds, <String>{'jellyfin:current'});
+      });
+
+      test('does not double-namespace an already-namespaced id', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'favorites_v1': jsonEncode(<String, dynamic>{
+            'local': <String>[],
+            'remote': <String>['jellyfin:101'],
+          }),
+        });
+
+        final FavoritesData loaded = await store.load();
+
+        expect(loaded.remoteIds, <String>{'jellyfin:101'});
+      });
+
+      test('a corrupt v1 reads as no favourites', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          'favorites_v1': 'not json {',
+        });
+        final FavoritesData loaded = await store.load();
+        expect(loaded.localIds, isEmpty);
+        expect(loaded.remoteIds, isEmpty);
+      });
+    });
+  });
+}

--- a/test/data/repositories/shared_preferences_play_history_store_test.dart
+++ b/test/data/repositories/shared_preferences_play_history_store_test.dart
@@ -16,18 +16,20 @@ void main() {
           SharedPreferencesPlayHistoryStore();
       final PlayHistory history = PlayHistory(
         stats: <String, TrackPlayStats>{
-          'a': TrackPlayStats(playCount: 3, lastPlayedAt: DateTime(2024, 5, 1)),
-          'b': TrackPlayStats(playCount: 1, lastPlayedAt: DateTime(2024, 5, 2)),
+          'jellyfin:a':
+              TrackPlayStats(playCount: 3, lastPlayedAt: DateTime(2024, 5, 1)),
+          'subsonic:b':
+              TrackPlayStats(playCount: 1, lastPlayedAt: DateTime(2024, 5, 2)),
         },
       );
 
       await store.save(history);
       final PlayHistory loaded = await store.load();
 
-      expect(loaded.playCountFor('a'), 3);
-      expect(loaded.lastPlayedFor('a'), DateTime(2024, 5, 1));
-      expect(loaded.playCountFor('b'), 1);
-      expect(loaded.lastPlayedFor('b'), DateTime(2024, 5, 2));
+      expect(loaded.playCountFor('jellyfin:a'), 3);
+      expect(loaded.lastPlayedFor('jellyfin:a'), DateTime(2024, 5, 1));
+      expect(loaded.playCountFor('subsonic:b'), 1);
+      expect(loaded.lastPlayedFor('subsonic:b'), DateTime(2024, 5, 2));
     });
 
     test('returns empty for no stored value', () async {
@@ -57,17 +59,16 @@ void main() {
       expect(loaded.playCountFor('a'), 2);
     });
 
-    test('the persisted document holds only ids/counts/times — no token',
+    test('the persisted document holds only uris/counts/times — no token',
         () async {
-      // Even if a track carried a tokenized uri, play history stores only the
-      // id, so the persisted JSON can never leak it.
+      // The stored key is the provider-namespaced uri (the catalog's identity),
+      // never a token or authenticated stream URL, so the JSON can't leak one.
       const String token = 'super-secret-token-1234567890';
       const SharedPreferencesPlayHistoryStore store =
           SharedPreferencesPlayHistoryStore();
-      // The id is the only track field play history ever sees.
       await store.save(PlayHistory(
         stats: <String, TrackPlayStats>{
-          'track-1': TrackPlayStats(
+          'jellyfin:track-1': TrackPlayStats(
             playCount: 1,
             lastPlayedAt: DateTime(2024, 1, 1),
           ),
@@ -76,7 +77,7 @@ void main() {
 
       final SharedPreferences prefs = await SharedPreferences.getInstance();
       final String raw = prefs.getString('play_history_v1') ?? '';
-      expect(raw, contains('track-1'));
+      expect(raw, contains('jellyfin:track-1'));
       expect(raw, isNot(contains(token)));
       expect(raw, isNot(contains('http')));
     });

--- a/test/data/repositories/shared_preferences_playlist_store_test.dart
+++ b/test/data/repositories/shared_preferences_playlist_store_test.dart
@@ -21,7 +21,7 @@ void main() {
           id: 'p1',
           name: 'Local Mix',
           description: 'desc',
-          trackIds: const <String>['a', 'b'],
+          trackIds: const <String>['file:///a.mp3', 'subsonic:b'],
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 2),
         ),
@@ -30,7 +30,7 @@ void main() {
           name: 'Server Mix',
           source: PlaylistSource.jellyfin,
           remoteId: 'srv-1',
-          trackIds: <String>['x'],
+          trackIds: <String>['jellyfin:x'],
           syncState: PlaylistSyncState.synced,
         ),
       ];
@@ -41,7 +41,7 @@ void main() {
       expect(loaded, hasLength(2));
       expect(loaded[0].name, 'Local Mix');
       expect(loaded[0].description, 'desc');
-      expect(loaded[0].trackIds, <String>['a', 'b']);
+      expect(loaded[0].trackIds, <String>['file:///a.mp3', 'subsonic:b']);
       expect(loaded[0].createdAt, DateTime(2024, 1, 1));
       expect(loaded[1].source, PlaylistSource.jellyfin);
       expect(loaded[1].remoteId, 'srv-1');

--- a/test/data/repositories/synced_playlist_repository_test.dart
+++ b/test/data/repositories/synced_playlist_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/playlist.dart';
+import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/remote_sync_result.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_exception.dart';
@@ -83,6 +84,23 @@ void main() {
       await repository.removeTrack(created.id, 'b');
       final Playlist? updated = await repository.getPlaylistById(created.id);
       expect(updated!.trackIds, <String>['a', 'c']);
+    });
+
+    test('same-id tracks from different providers are distinct members',
+        () async {
+      // jellyfin:101 and subsonic:101 share the bare id 101; adding the second
+      // is a real add, not a duplicate, and removing one keeps the other.
+      final Playlist created = await repository.createPlaylist('Mix');
+      await repository.addTrack(created.id, 'jellyfin:101');
+      await repository.addTrack(created.id, 'subsonic:101');
+      // Re-adding an existing uri is still a no-op.
+      await repository.addTrack(created.id, 'jellyfin:101');
+      expect((await repository.getPlaylistById(created.id))!.trackIds,
+          <String>['jellyfin:101', 'subsonic:101']);
+
+      await repository.removeTrack(created.id, 'jellyfin:101');
+      expect((await repository.getPlaylistById(created.id))!.trackIds,
+          <String>['subsonic:101']);
     });
 
     test('reorders tracks (ReorderableListView index convention)', () async {
@@ -177,11 +195,13 @@ void main() {
         'Server Mix',
         source: PlaylistSource.jellyfin,
       );
-      await repository.addTrack(created.id, 'jelly-item-7');
+      await repository.addTrack(created.id, 'jellyfin:jelly-item-7');
       expect(client.addItemCalls.single.playlistId, 'srv-1');
+      // Membership is stored as a jellyfin: uri but the server gets the bare id.
       expect(client.addItemCalls.single.itemIds, <String>['jelly-item-7']);
       final Playlist? updated = await repository.getPlaylistById(created.id);
-      expect(updated!.syncState, PlaylistSyncState.synced);
+      expect(updated!.trackIds, <String>['jellyfin:jelly-item-7']);
+      expect(updated.syncState, PlaylistSyncState.synced);
     });
 
     test('deletes the server playlist when deleting a synced one', () async {
@@ -230,10 +250,10 @@ void main() {
       );
       // Now make the next server call fail.
       client.playlistError = JellyfinException.notReachable();
-      await repository.addTrack(created.id, 'jelly-item-1');
+      await repository.addTrack(created.id, 'jellyfin:jelly-item-1');
       final Playlist? updated = await repository.getPlaylistById(created.id);
       // The local add still stands…
-      expect(updated!.trackIds, contains('jelly-item-1'));
+      expect(updated!.trackIds, contains('jellyfin:jelly-item-1'));
       // …but the sync state is honest about the failure.
       expect(updated.syncState, PlaylistSyncState.syncFailed);
     });
@@ -252,7 +272,8 @@ void main() {
       expect(all.single.name, 'From Server');
       expect(all.single.remoteId, 'srv-77');
       expect(all.single.source, PlaylistSource.jellyfin);
-      expect(all.single.trackIds, <String>['a', 'b']);
+      // Server item ids are namespaced to jellyfin: uris on import.
+      expect(all.single.trackIds, <String>['jellyfin:a', 'jellyfin:b']);
       expect(all.single.syncState, PlaylistSyncState.synced);
     });
 
@@ -370,15 +391,92 @@ void main() {
         'Server Mix',
         source: PlaylistSource.jellyfin,
       );
-      await repository.addTrack(created.id, 'jelly-item-1');
+      await repository.addTrack(created.id, 'jellyfin:jelly-item-1');
       for (final Playlist p in await repository.getAllPlaylists()) {
         expect(p.remoteId, isNot(contains(_token)));
         expect(p.id, isNot(contains(_token)));
         expect(p.lastSyncError ?? '', isNot(contains(_token)));
-        for (final String trackId in p.trackIds) {
-          expect(trackId, isNot(contains(_token)));
+        for (final String trackUri in p.trackIds) {
+          expect(trackUri, isNot(contains(_token)));
         }
       }
+    });
+  });
+
+  group('SyncedPlaylistRepository (legacy bare-id membership migration)', () {
+    late InMemoryPlaylistStore store;
+
+    setUp(() {
+      store = InMemoryPlaylistStore();
+    });
+
+    SyncedPlaylistRepository build({
+      Future<List<Track>> Function()? catalog,
+    }) {
+      return SyncedPlaylistRepository(
+        store: store,
+        idGenerator: () => 'pl-x',
+        now: () => DateTime(2024, 1, 1),
+        catalogForMigration: catalog,
+      );
+    }
+
+    test('namespaces a Jellyfin playlist\'s bare item ids (no oracle needed)',
+        () async {
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Server Mix',
+          source: PlaylistSource.jellyfin,
+          remoteId: 'srv-1',
+          trackIds: <String>['101', '202'],
+          syncState: PlaylistSyncState.synced,
+        ),
+      ]);
+      final SyncedPlaylistRepository repository = build();
+
+      final Playlist? migrated = await repository.getPlaylistById('p1');
+      expect(migrated!.trackIds, <String>['jellyfin:101', 'jellyfin:202']);
+    });
+
+    test('resolves a local playlist\'s bare remote id against the catalog',
+        () async {
+      await store.save(<Playlist>[
+        const Playlist(
+          id: 'p1',
+          name: 'Local Mix',
+          // A local path (already a uri) and a bare remote id from adding a
+          // streamed track to a local playlist.
+          trackIds: <String>['/music/song.mp3', '101'],
+        ),
+      ]);
+      // The catalog exposes id 101 under a single provider → safe to attribute.
+      final SyncedPlaylistRepository repository = build(
+        catalog: () async => const <Track>[
+          Track(id: '/music/song.mp3', title: 'Song', uri: '/music/song.mp3'),
+          Track(id: '101', title: 'Alpha', uri: 'subsonic:101'),
+        ],
+      );
+
+      final Playlist? migrated = await repository.getPlaylistById('p1');
+      expect(migrated!.trackIds, <String>['/music/song.mp3', 'subsonic:101']);
+    });
+
+    test('leaves an ambiguous local bare id untouched (never guesses)',
+        () async {
+      await store.save(<Playlist>[
+        const Playlist(id: 'p1', name: 'Local Mix', trackIds: <String>['101']),
+      ]);
+      // Two providers expose id 101 → the entry can't be safely attributed.
+      final SyncedPlaylistRepository repository = build(
+        catalog: () async => const <Track>[
+          Track(id: '101', title: 'Alpha', uri: 'jellyfin:101'),
+          Track(id: '101', title: 'Beta', uri: 'subsonic:101'),
+        ],
+      );
+
+      final Playlist? migrated = await repository.getPlaylistById('p1');
+      expect(migrated!.trackIds, <String>['101']); // preserved, not mis-keyed
     });
   });
 }

--- a/test/features/favorites/favorites_screen_test.dart
+++ b/test/features/favorites/favorites_screen_test.dart
@@ -68,8 +68,8 @@ void main() {
           Track(id: 'other', title: 'Charlie', uri: 'file:///c.mp3'),
         ],
         favorites: const FavoritesData(
-          localIds: {'local1'},
-          remoteIds: {'remote1'},
+          localIds: {'file:///a.mp3'},
+          remoteIds: {'jellyfin:remote1'},
         ),
       );
 
@@ -101,7 +101,7 @@ void main() {
       await _pump(
         tester,
         tracks: const <Track>[],
-        favorites: const FavoritesData(remoteIds: {'j1'}),
+        favorites: const FavoritesData(remoteIds: {'jellyfin:j1'}),
         libraryError: Exception('boom'),
       );
 
@@ -121,7 +121,8 @@ void main() {
           Track(id: 'b', title: 'Bravo', uri: 'file:///b.mp3'),
           Track(id: 'c', title: 'Charlie', uri: 'file:///c.mp3'),
         ],
-        favorites: const FavoritesData(localIds: {'a', 'b', 'c'}),
+        favorites: const FavoritesData(
+            localIds: {'file:///a.mp3', 'file:///b.mp3', 'file:///c.mp3'}),
         playback: controller,
       );
 

--- a/test/features/player/play_history_recording_test.dart
+++ b/test/features/player/play_history_recording_test.dart
@@ -36,12 +36,12 @@ void main() {
 
       controller.completeCurrent(); // 'a' finishes, 'b' starts
       await Future<void>.delayed(Duration.zero);
-      expect(history.current.playCountFor('a'), 1);
-      expect(history.current.playCountFor('b'), 0);
+      expect(history.current.playCountFor('jellyfin:a'), 1);
+      expect(history.current.playCountFor('jellyfin:b'), 0);
 
       controller.completeCurrent(); // 'b' finishes (queue ends)
       await Future<void>.delayed(Duration.zero);
-      expect(history.current.playCountFor('b'), 1);
+      expect(history.current.playCountFor('jellyfin:b'), 1);
     });
 
     test('repeat-one counts each completed loop as a play', () async {
@@ -52,7 +52,7 @@ void main() {
       controller.completeCurrent();
       await Future<void>.delayed(Duration.zero);
 
-      expect(history.current.playCountFor('a'), 2);
+      expect(history.current.playCountFor('jellyfin:a'), 2);
     });
 
     test('skipping a track does NOT count as a play', () async {
@@ -61,8 +61,8 @@ void main() {
       await controller.skipToNext(); // user skip, not a completion
       await Future<void>.delayed(Duration.zero);
 
-      expect(history.current.hasPlayed('a'), isFalse);
-      expect(history.current.hasPlayed('b'), isFalse);
+      expect(history.current.hasPlayed('jellyfin:a'), isFalse);
+      expect(history.current.hasPlayed('jellyfin:b'), isFalse);
     });
   });
 }

--- a/test/features/player/queue_sheet_test.dart
+++ b/test/features/player/queue_sheet_test.dart
@@ -147,8 +147,8 @@ void main() {
       final List<Playlist> saved = await store.load();
       expect(saved, hasLength(1));
       expect(saved.single.name, 'My Queue');
-      // Order is history + current + up-next: [A, B, C].
-      expect(saved.single.trackIds, <String>['A', 'B', 'C']);
+      // Order is history + current + up-next, stored by provider uri.
+      expect(saved.single.trackIds, <String>['/A.mp3', '/B.mp3', '/C.mp3']);
       expect(saved.single.source, PlaylistSource.local);
       expect(find.textContaining('Saved 3 songs to'), findsOneWidget);
     });

--- a/test/features/playlists/add_to_playlist_sheet_test.dart
+++ b/test/features/playlists/add_to_playlist_sheet_test.dart
@@ -43,9 +43,10 @@ void main() {
     testWidgets('reports only the genuinely-added count, not duplicates',
         (tester) async {
       final store = InMemoryPlaylistStore();
-      // 'a' is already in the playlist; only 'b' is genuinely new.
+      // 'a' is already in the playlist (by uri); only 'b' is genuinely new.
       await store.save(<Playlist>[
-        const Playlist(id: 'p1', name: 'My Mix', trackIds: <String>['a']),
+        const Playlist(
+            id: 'p1', name: 'My Mix', trackIds: <String>['file:///a.mp3']),
       ]);
       await _pump(tester, store, <Track>[_track('a'), _track('b')]);
 
@@ -65,7 +66,7 @@ void main() {
         const Playlist(
           id: 'p1',
           name: 'My Mix',
-          trackIds: <String>['a', 'b'],
+          trackIds: <String>['file:///a.mp3', 'file:///b.mp3'],
         ),
       ]);
       await _pump(tester, store, <Track>[_track('a'), _track('b')]);

--- a/test/features/playlists/playlist_detail_screen_test.dart
+++ b/test/features/playlists/playlist_detail_screen_test.dart
@@ -57,7 +57,10 @@ Future<void> _pump(
 Future<InMemoryPlaylistStore> _seededStore() async {
   final InMemoryPlaylistStore store = InMemoryPlaylistStore();
   await store.save(<Playlist>[
-    const Playlist(id: 'p1', name: 'Road Trip', trackIds: <String>['a', 'b']),
+    const Playlist(
+        id: 'p1',
+        name: 'Road Trip',
+        trackIds: <String>['file:///a.mp3', 'file:///b.mp3']),
   ]);
   return store;
 }

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -316,7 +316,8 @@ void main() {
           .where((p) => p.remoteId == 'srv-1');
       expect(imported, hasLength(1));
       expect(imported.single.name, 'Road Trip');
-      expect(imported.single.trackIds, <String>['a']);
+      // Server item ids are namespaced to jellyfin: uris on import.
+      expect(imported.single.trackIds, <String>['jellyfin:a']);
     });
 
     test('a library sync adopts Jellyfin favourites and reports them',
@@ -339,8 +340,9 @@ void main() {
       final state = container.read(jellyfinSyncControllerProvider);
       expect(state.favoriteCount, 2);
       expect(state.message, contains('2 favorites'));
-      expect(favorites.isFavorite('fav-1'), isTrue);
-      expect(favorites.isFavorite('fav-2'), isTrue);
+      // Server favourites are namespaced to jellyfin: uris.
+      expect(favorites.isFavorite('jellyfin:fav-1'), isTrue);
+      expect(favorites.isFavorite('jellyfin:fav-2'), isTrue);
     });
 
     test('a playlist sync failure is reported without failing the track sync',


### PR DESCRIPTION
## Summary

v0.1.7 stability — **PR 2 of the identity series** (follows #238, which re-keyed the catalog and runtime identity on `Track.uri`).

The prefs/app-state stores still keyed on the **bare server-side id**, so two providers' tracks sharing an id (e.g. `jellyfin:101` vs `subsonic:101`) collided: favouriting / playing / adding one copy silently affected the other. This keys **favorites, play history, and playlist membership** on the provider-namespaced `Track.uri` instead — matching the catalog re-key — while the Jellyfin server APIs keep speaking the bare item id (mapped only at the request boundary).

Scope is deliberately limited to prefs/app-state identity: no new Plex playlist/favorite/cast features, no artwork-cache or Plex-cache playback changes, no F-Droid metadata, **no version bump**.

## Favorites
- Stored/checked by `Track.uri` (the local set already held paths; the remote set now holds `jellyfin:` uris). The Jellyfin push/fetch still uses the **bare item id**; `refreshFromRemote` namespaces the server's ids back to `jellyfin:` uris.
- `isFavorite(trackUri)`, `isFavoriteProvider` keyed on `track.uri`, favorites list + Android Auto Favorites node match by uri.
- **Migration** `favorites_v1` → `favorites_v2`: local paths kept; bare remote ids namespaced to `jellyfin:` (only Jellyfin could favourite, so unambiguous). `v1` left intact for recovery.

## Play history
- `recordCompletion` records `Track.uri`; `PlayHistory` keyed by uri (`recentlyPlayedKeys` / `mostPlayedKeys` / `hasPlayed`). The smart resolver resolves recently/most/never-played **and** favourites by uri.
- **Migration** (one-time, against the catalog's current owner of each id): a unique owner adopts the count (folding into any existing uri-keyed count); an id exposed by **more than one** provider — or absent from the catalog — is **left as a bare key** (inert under uri reads, never cross-contaminating, preserved not dropped).

## Playlists
- `Playlist.trackIds` store `Track.uri`s; resolution (playlist screen + Android Auto) and add/duplicate-detection key on uri, so adding `subsonic:101` to a playlist holding `jellyfin:101` is a real add, not a "duplicate".
- Jellyfin server boundary keeps its shape: create/add/remove map `jellyfin:` uris → bare item ids; refresh namespaces server item ids → `jellyfin:` uris.
- **Migration** (one-time): a Jellyfin playlist's bare ids → `jellyfin:` (unambiguous); a local playlist's bare ids resolve against the catalog (ambiguous/unknown left untouched).

## Android Auto / smart mixes
Favorites, playlist, and (via the resolver) smart-mix nodes no longer fall back to bare-id collisions.

## Migration safety
Migrations run early (before colliding providers are typically added) and follow #238's rule: **never guess** an ambiguous bare id, never assign it to the wrong provider, and preserve existing data where safe. Ambiguous/unresolvable legacy entries stay as bare keys, which are inert under uri-only reads.

## Tests
- Same-bare-id collision: favorites, play history, playlists, smart mixes, and Android Auto favorites/playlist nodes.
- Migration preserves unambiguous data; ambiguous legacy data is left untouched; `favorites_v1`→`v2` namespacing.
- `flutter analyze` clean · `flutter test` **2540 passing** · `dart format` + secret scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqNNBpTqqVjWkcPJzPBByF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqNNBpTqqVjWkcPJzPBByF)_