### PR TITLE
feat(playback): cache provider reachability so an offline server falls back fast

### DIFF
--- a/lib/core/services/provider_reachability.dart
+++ b/lib/core/services/provider_reachability.dart
@@ -1,0 +1,95 @@
+import 'reachability.dart';
+
+/// A short-lived, per-provider memory of the last reachability outcome, so the
+/// app can stop hammering a server that just failed and instead fall straight to
+/// a cached or alternate copy.
+///
+/// Why this exists: playing an album from a server that's gone offline would,
+/// without a memory, re-run the full session-check + connect timeout for *every*
+/// track — a 10–20 s stall before each fallback. Recording the first failure
+/// lets the next few tracks skip the doomed probe entirely. The memory is
+/// deliberately **brief** (a handful of seconds): long enough to cover a burst
+/// of tracks, short enough that a server coming back is retried almost
+/// immediately — so "retry after connectivity returns" needs no manual reset.
+///
+/// Keys are caller-defined and are expected to be *provider-namespaced* (e.g.
+/// `jellyfin`, `subsonic`, `plex`), never a bare track id. That keeps two
+/// providers that happen to share a server-side id (`jellyfin:101` vs
+/// `subsonic:101`) fully isolated: marking one provider unreachable never
+/// suppresses the other's copy. This mirrors the provider-aware identity model
+/// the catalog and prefs already use.
+abstract interface class ProviderReachability {
+  /// The remembered status for [key], or `null` when nothing is remembered or
+  /// the remembered value has aged out. Never performs a network probe.
+  ReachabilityStatus? statusOf(String key);
+
+  /// Remembers [status] for [key], (re)starting its short time-to-live. A later
+  /// [reachable] overwrites an earlier outage, so a recovered server is trusted
+  /// again immediately rather than waiting out the previous failure's TTL.
+  void record(String key, ReachabilityStatus status);
+
+  /// Forgets any remembered status for [key] — e.g. on sign-out or a server
+  /// change, where a stale outage must not carry over to a new session.
+  void forget(String key);
+
+  /// Forgets every remembered status.
+  void clear();
+}
+
+/// In-memory [ProviderReachability] with a per-entry time-to-live.
+///
+/// Holds only a tiny map of `key -> (status, recordedAt)` on the heap; nothing
+/// is persisted, so a restart starts fresh (the safe default — it just re-probes
+/// once). The [clock] is injectable so tests can advance time deterministically
+/// without sleeping, and so the TTL logic is exercised without flakiness.
+class CachingProviderReachability implements ProviderReachability {
+  CachingProviderReachability({
+    Duration ttl = const Duration(seconds: 10),
+    DateTime Function()? clock,
+  })  : _ttl = ttl,
+        _now = clock ?? DateTime.now;
+
+  /// How long a remembered status stays valid. Short by design: it only needs to
+  /// span a burst of plays (an album), not a long absence — a server that
+  /// recovers should be retried within a few seconds, not minutes.
+  final Duration _ttl;
+  final DateTime Function() _now;
+
+  final Map<String, _Entry> _entries = <String, _Entry>{};
+
+  @override
+  ReachabilityStatus? statusOf(String key) {
+    final _Entry? entry = _entries[key];
+    if (entry == null) return null;
+    if (_now().difference(entry.recordedAt) >= _ttl) {
+      // Aged out: drop it so the map can't grow without bound, and report
+      // "unknown" so the caller probes for a fresh answer.
+      _entries.remove(key);
+      return null;
+    }
+    return entry.status;
+  }
+
+  @override
+  void record(String key, ReachabilityStatus status) {
+    _entries[key] = _Entry(status, _now());
+  }
+
+  @override
+  void forget(String key) {
+    _entries.remove(key);
+  }
+
+  @override
+  void clear() {
+    _entries.clear();
+  }
+}
+
+/// A remembered status and when it was recorded, for TTL comparison.
+class _Entry {
+  _Entry(this.status, this.recordedAt);
+
+  final ReachabilityStatus status;
+  final DateTime recordedAt;
+}

--- a/lib/core/services/reachability.dart
+++ b/lib/core/services/reachability.dart
@@ -1,0 +1,90 @@
+import 'playable_uri_resolver.dart';
+
+/// Why a provider (Jellyfin, Plex, Subsonic/Navidrome) could or couldn't be
+/// reached, at a finer grain than a bare "online/offline".
+///
+/// Wi-Fi being up does **not** mean a given server is reachable — a tunnel can
+/// be down, the box can be asleep, a session can have expired, or the server can
+/// simply be slow. Folding all of those into one "offline" bit makes the app
+/// give the wrong advice (telling someone to "check your connection" when the
+/// real fix is to sign in again). These five states are the vocabulary the rest
+/// of the app branches on so it can pick a cached copy, fall back to another
+/// provider, or show the *right* message:
+///
+///  - [reachable]: the server answered and accepted the session.
+///  - [networkUnavailable]: the device has no usable network at all, so no
+///    server can be reached — don't even try.
+///  - [serverUnreachable]: there is a network, but this server couldn't be
+///    reached (DNS, refused connection, TLS, or a 5xx). Another provider, or a
+///    cached copy, may still work.
+///  - [authFailure]: the server *was* reached but rejected the session
+///    (expired/!invalid credentials). Retrying the same request won't help;
+///    the user has to sign in again. Deliberately distinct from the offline
+///    states so the UI never tells someone to "check your connection" when the
+///    real fix is re-authenticating.
+///  - [timeout]: a reachability probe ran past its deadline without an answer —
+///    a hung or very slow server. Treated like [serverUnreachable] for
+///    fallback, but named so diagnostics and messages can say "not responding"
+///    rather than "couldn't connect".
+enum ReachabilityStatus {
+  reachable,
+  networkUnavailable,
+  serverUnreachable,
+  authFailure,
+  timeout;
+
+  /// The server answered and accepted the session.
+  bool get isReachable => this == ReachabilityStatus.reachable;
+
+  /// The device has no usable network at all.
+  bool get isOffline => this == ReachabilityStatus.networkUnavailable;
+
+  /// The server was reached but rejected the session — a sign-in problem, not a
+  /// connectivity one.
+  bool get isAuthFailure => this == ReachabilityStatus.authFailure;
+
+  /// A transient inability to reach the server: no network, the server is down,
+  /// or a probe timed out. These are the states where retrying the *same*
+  /// provider right now is pointless, so a caller should prefer a cached or
+  /// alternate copy and skip a doomed network round-trip.
+  ///
+  /// [authFailure] is intentionally **not** included: the server is reachable
+  /// (so another request might be answered), and the fix is re-authenticating,
+  /// not waiting/retrying — so it must never be cached as "don't bother trying".
+  bool get isTransientOutage =>
+      this == ReachabilityStatus.networkUnavailable ||
+      this == ReachabilityStatus.serverUnreachable ||
+      this == ReachabilityStatus.timeout;
+}
+
+/// Classifies a [PlaybackResolutionException] into the reachability signal it
+/// implies about the *provider* (not the individual track), or `null` when the
+/// failure says nothing reliable about whether the server is reachable.
+///
+/// This is the single bridge between the playback layer's per-track resolution
+/// errors and the provider-wide reachability cache, so the two never drift: a
+/// new [PlaybackResolutionErrorKind] is a compile error here rather than a
+/// silently-misclassified outage.
+///
+/// Returns `null` for track-specific or content failures
+/// ([PlaybackResolutionErrorKind.streamUnavailable],
+/// [PlaybackResolutionErrorKind.invalidStream],
+/// [PlaybackResolutionErrorKind.serverReturnedWebPage]) and for
+/// [PlaybackResolutionErrorKind.notSignedIn]: the server may well be fine for
+/// the *next* track, so caching "unreachable" off one of these would wrongly
+/// suppress good copies.
+ReachabilityStatus? reachabilityFromPlaybackError(
+  PlaybackResolutionErrorKind kind,
+) {
+  switch (kind) {
+    case PlaybackResolutionErrorKind.serverUnreachable:
+      return ReachabilityStatus.serverUnreachable;
+    case PlaybackResolutionErrorKind.sessionExpired:
+      return ReachabilityStatus.authFailure;
+    case PlaybackResolutionErrorKind.notSignedIn:
+    case PlaybackResolutionErrorKind.invalidStream:
+    case PlaybackResolutionErrorKind.serverReturnedWebPage:
+    case PlaybackResolutionErrorKind.streamUnavailable:
+      return null;
+  }
+}

--- a/lib/core/services/reachability.dart
+++ b/lib/core/services/reachability.dart
@@ -43,16 +43,19 @@ enum ReachabilityStatus {
   /// connectivity one.
   bool get isAuthFailure => this == ReachabilityStatus.authFailure;
 
-  /// A transient inability to reach the server: no network, the server is down,
-  /// or a probe timed out. These are the states where retrying the *same*
-  /// provider right now is pointless, so a caller should prefer a cached or
-  /// alternate copy and skip a doomed network round-trip.
+  /// A *server-level* outage worth remembering briefly so the next track skips a
+  /// doomed probe: this server was found unreachable, or a probe ran past its
+  /// deadline. These are the cacheable "don't re-try this server for a moment"
+  /// states — a caller should prefer a cached or alternate copy instead.
   ///
-  /// [authFailure] is intentionally **not** included: the server is reachable
-  /// (so another request might be answered), and the fix is re-authenticating,
-  /// not waiting/retrying — so it must never be cached as "don't bother trying".
-  bool get isTransientOutage =>
-      this == ReachabilityStatus.networkUnavailable ||
+  /// Two states are deliberately excluded:
+  ///  - [networkUnavailable] is a *device-global* condition that flips the
+  ///    instant the network returns, so it is judged fresh from connectivity on
+  ///    every attempt and never cached — otherwise a stale "offline" would block
+  ///    a working server for the cache's lifetime after a reconnect.
+  ///  - [authFailure] means the server *was* reached; the fix is
+  ///    re-authenticating, which must work immediately — never "don't bother".
+  bool get isServerOutage =>
       this == ReachabilityStatus.serverUnreachable ||
       this == ReachabilityStatus.timeout;
 }

--- a/lib/core/services/reachability_aware_playable_uri_resolver.dart
+++ b/lib/core/services/reachability_aware_playable_uri_resolver.dart
@@ -12,11 +12,14 @@ import 'reachability.dart';
 /// the source router) and adds a short-lived reachability memory around it:
 ///
 ///  1. **No network at all** → fail fast with a clear "you're offline" message
-///     instead of attempting a doomed connection. (Only when a
-///     [ConnectivityService] is wired and reports offline.)
-///  2. **Recently seen unreachable** (within the cache's brief TTL) → skip the
-///     probe and fail fast, so the *next* tracks in a burst fall straight to a
-///     cached copy or another provider rather than each re-paying the timeout.
+///     instead of attempting a doomed connection. Judged fresh from the
+///     [ConnectivityService] every call and never cached, so the moment the
+///     network returns this stops firing. (Only when a [ConnectivityService] is
+///     wired and reports offline.)
+///  2. **This server seen unreachable recently** (a server-level outage within
+///     the cache's brief TTL) → skip the probe and fail fast, so the *next*
+///     tracks in a burst fall straight to a cached copy or another provider
+///     rather than each re-paying the timeout.
 ///  3. **Otherwise** → resolve for real and record the outcome (reachable, or
 ///     the kind of failure), so the memory stays current.
 ///
@@ -73,15 +76,20 @@ class ReachabilityAwarePlayableUriResolver implements PlayableUriResolver {
     //    a connection that can only time out. The offline-first resolver above
     //    has already tried (and missed) a downloaded copy by the time we get
     //    here, so this is the honest end of the line for a streamed track.
+    //    Judged fresh every call and never cached: the instant connectivity
+    //    returns this is false again, so a reconnect is never blocked by a stale
+    //    "offline" the way a cached value would be.
     if (await _isOffline()) {
-      _reachability.record(key, ReachabilityStatus.networkUnavailable);
       throw _failFast(ReachabilityStatus.networkUnavailable);
     }
 
-    // 2. We saw this provider fail to respond very recently — skip the doomed
-    //    probe and let the caller fall back immediately.
+    // 2. We have a network, but saw this server fail to respond very recently —
+    //    skip the doomed probe and let the caller fall back immediately. Only a
+    //    server-level outage gates this (never the device-offline state from
+    //    step 1, which is already judged fresh), so a reconnected device probes
+    //    a recovered server straight away.
     final ReachabilityStatus? remembered = _reachability.statusOf(key);
-    if (remembered != null && remembered.isTransientOutage) {
+    if (remembered != null && remembered.isServerOutage) {
       throw _failFast(remembered);
     }
 

--- a/lib/core/services/reachability_aware_playable_uri_resolver.dart
+++ b/lib/core/services/reachability_aware_playable_uri_resolver.dart
@@ -1,0 +1,142 @@
+import '../models/track.dart';
+import 'connectivity_service.dart';
+import 'playable_uri_resolver.dart';
+import 'provider_reachability.dart';
+import 'reachability.dart';
+
+/// A [PlayableUriResolver] decorator that remembers, briefly, when a provider is
+/// unreachable — so a server that's offline doesn't stall every track behind its
+/// own connect timeout before the player falls back.
+///
+/// It wraps one provider's resolver (the Jellyfin/Plex/Subsonic resolver inside
+/// the source router) and adds a short-lived reachability memory around it:
+///
+///  1. **No network at all** → fail fast with a clear "you're offline" message
+///     instead of attempting a doomed connection. (Only when a
+///     [ConnectivityService] is wired and reports offline.)
+///  2. **Recently seen unreachable** (within the cache's brief TTL) → skip the
+///     probe and fail fast, so the *next* tracks in a burst fall straight to a
+///     cached copy or another provider rather than each re-paying the timeout.
+///  3. **Otherwise** → resolve for real and record the outcome (reachable, or
+///     the kind of failure), so the memory stays current.
+///
+/// What it deliberately does **not** do:
+///  - It never short-circuits an [ReachabilityStatus.authFailure]. The server is
+///    reachable; the fix is re-authenticating, and a fresh sign-in must work
+///    immediately — so an auth failure is recorded (for diagnostics/UI) but
+///    never used to suppress a later attempt.
+///  - It never touches the offline cache or cross-provider fallback. Those live
+///    *above* this in the chain (the offline-first resolver tries a downloaded
+///    copy before this runs; the controller tries sibling provider candidates
+///    when this throws). This only makes those existing paths fire promptly.
+///
+/// The fast-fail it throws always carries
+/// [PlaybackResolutionErrorKind.serverUnreachable], so every downstream caller
+/// treats it exactly like a live "couldn't reach the server" — no new branch is
+/// needed and the cross-provider fallback engages unchanged.
+class ReachabilityAwarePlayableUriResolver implements PlayableUriResolver {
+  ReachabilityAwarePlayableUriResolver({
+    required PlayableUriResolver inner,
+    required String? Function() providerKey,
+    required ProviderReachability reachability,
+    ConnectivityService? connectivity,
+  })  : _inner = inner,
+        _providerKey = providerKey,
+        _reachability = reachability,
+        _connectivity = connectivity;
+
+  final PlayableUriResolver _inner;
+
+  /// The provider-namespaced cache key (e.g. `jellyfin`), or `null` when no
+  /// session is connected — in which case reachability is irrelevant and the
+  /// inner resolver's own "not signed in" answer is what the user should see.
+  final String? Function() _providerKey;
+
+  final ProviderReachability _reachability;
+
+  /// Optional device-level signal. When absent (tests, or before a real
+  /// connectivity backend is wired) the offline short-circuit is simply skipped
+  /// and reachability is judged purely from probe outcomes.
+  final ConnectivityService? _connectivity;
+
+  @override
+  bool handles(Track track) => _inner.handles(track);
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    final String? key = _providerKey();
+    // No connected session for this provider: let the inner resolver give its
+    // own precise answer ("sign in first"); reachability doesn't apply.
+    if (key == null) return _inner.resolve(track);
+
+    // 1. The whole device is offline — no server is reachable, so don't attempt
+    //    a connection that can only time out. The offline-first resolver above
+    //    has already tried (and missed) a downloaded copy by the time we get
+    //    here, so this is the honest end of the line for a streamed track.
+    if (await _isOffline()) {
+      _reachability.record(key, ReachabilityStatus.networkUnavailable);
+      throw _failFast(ReachabilityStatus.networkUnavailable);
+    }
+
+    // 2. We saw this provider fail to respond very recently — skip the doomed
+    //    probe and let the caller fall back immediately.
+    final ReachabilityStatus? remembered = _reachability.statusOf(key);
+    if (remembered != null && remembered.isTransientOutage) {
+      throw _failFast(remembered);
+    }
+
+    // 3. Resolve for real, recording what we learn so the memory stays current.
+    try {
+      final ResolvedPlayable resolved = await _inner.resolve(track);
+      _reachability.record(key, ReachabilityStatus.reachable);
+      return resolved;
+    } on PlaybackResolutionException catch (error) {
+      final ReachabilityStatus? status =
+          reachabilityFromPlaybackError(error.kind);
+      if (status != null) _reachability.record(key, status);
+      rethrow;
+    }
+  }
+
+  /// Whether the device currently has no usable network. Defensive: any failure
+  /// reading the signal is treated as "not offline" so a connectivity hiccup can
+  /// never block playback that might otherwise work.
+  Future<bool> _isOffline() async {
+    final ConnectivityService? connectivity = _connectivity;
+    if (connectivity == null) return false;
+    try {
+      return await connectivity.currentStatus() == NetworkStatus.offline;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Builds the fast-fail error for a [status], with a clear, secret-free
+  /// message. Always [PlaybackResolutionErrorKind.serverUnreachable] so it is
+  /// handled identically to a live unreachable result (cross-provider fallback,
+  /// offline-cache retry) with no extra branching downstream.
+  PlaybackResolutionException _failFast(ReachabilityStatus status) {
+    switch (status) {
+      case ReachabilityStatus.networkUnavailable:
+        return const PlaybackResolutionException(
+          "You appear to be offline. Connect to a network to stream this "
+          'track, or play a downloaded copy.',
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
+      case ReachabilityStatus.timeout:
+        return const PlaybackResolutionException(
+          "Your music server isn't responding right now.",
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
+      case ReachabilityStatus.serverUnreachable:
+      case ReachabilityStatus.reachable:
+      case ReachabilityStatus.authFailure:
+        // Only the transient-outage states reach here (the guard above), but the
+        // switch stays exhaustive; the rest share the generic unreachable line.
+        return const PlaybackResolutionException(
+          "Couldn't reach your music server. It may be offline.",
+          kind: PlaybackResolutionErrorKind.serverUnreachable,
+        );
+    }
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_account_fingerprint.dart
+++ b/lib/core/sources/subsonic/subsonic_account_fingerprint.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+import '../../models/subsonic_session.dart';
+
+/// An opaque, non-secret fingerprint identifying a Subsonic/Navidrome
+/// **server + account**.
+///
+/// Mirrors `jellyfinAccountFingerprint`: it answers "is this the same
+/// server/account as before?" without carrying anything sensitive. The inputs
+/// are the (non-secret) base URL and username — never the salt or token, which
+/// are credentials and rotate per session — and they are SHA-256 hashed, so the
+/// value reveals neither the server address nor the username and is safe to put
+/// in an in-memory key or surface in diagnostics. A re-login to the same account
+/// (a fresh salt/token) keeps the same fingerprint; pointing at a different
+/// server, or signing in as a different user, changes it.
+String subsonicAccountFingerprint(SubsonicSession session) {
+  // A NUL separator (which can appear in neither a URL nor a username) keeps
+  // e.g. ("ab","c") distinct from ("a","bc").
+  final String separator = String.fromCharCode(0);
+  final String material = '${session.baseUrl}$separator${session.username}';
+  return sha256.convert(utf8.encode(material)).toString();
+}

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -25,12 +25,14 @@ import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/services/routing_server_playback_reporter.dart';
 import '../../core/services/server_playback_reporter.dart';
 import '../../core/services/smart_precache_service.dart';
+import '../../core/sources/jellyfin/jellyfin_account_fingerprint.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playback_reporter.dart';
 import '../../core/sources/jellyfin/jellyfin_remote_control_receiver.dart';
 import '../../core/sources/jellyfin/jellyfin_track_mapper.dart';
 import '../../core/sources/plex/plex_playable_uri_resolver.dart';
 import '../../core/sources/plex/plex_playback_reporter.dart';
+import '../../core/sources/subsonic/subsonic_account_fingerprint.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playback_reporter.dart';
 import '../../data/repositories/download_repository_provider.dart';
@@ -77,10 +79,14 @@ final providerReachabilityProvider = Provider<ProviderReachability>((ref) {
 /// Each remote resolver is wrapped in a [ReachabilityAwarePlayableUriResolver]
 /// so a server that's offline fails fast (and the player falls back to a cached
 /// copy or another provider promptly) instead of re-paying a connect timeout for
-/// every track. The wrapper keys on the provider id, so the Jellyfin/Plex/
-/// Subsonic memories stay isolated even when two providers share a bare track
-/// id. The on-device resolver is never wrapped — a local file doesn't go
-/// offline.
+/// every track. The wrapper keys on the **provider + signed-in server/account**
+/// (a non-secret fingerprint), not just the provider name: a Jellyfin/Plex/
+/// Subsonic memory stays isolated from the other providers, *and* an outage
+/// recorded for one server never fast-fails a different server the user signs
+/// into — the key changes, so the new server is probed fresh rather than
+/// inheriting the old one's stale "offline". A signed-out provider has no key,
+/// so it's never cached. The on-device resolver is never wrapped — a local file
+/// doesn't go offline.
 final remoteSourceRouterProvider = Provider<RoutingPlayableUriResolver>((ref) {
   PlayableUriResolver reachabilityAware(
     PlayableUriResolver inner,
@@ -97,18 +103,33 @@ final remoteSourceRouterProvider = Provider<RoutingPlayableUriResolver>((ref) {
   return RoutingPlayableUriResolver(<PlayableUriResolver>[
     reachabilityAware(
       JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
-      () => ref.read(jellyfinMusicSourceProvider) == null ? null : 'jellyfin',
+      () {
+        final source = ref.read(jellyfinMusicSourceProvider);
+        return source == null
+            ? null
+            : 'jellyfin:${jellyfinAccountFingerprint(source.session)}';
+      },
     ),
     reachabilityAware(
       SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
-      () => ref.read(subsonicMusicSourceProvider) == null ? null : 'subsonic',
+      () {
+        final source = ref.read(subsonicMusicSourceProvider);
+        return source == null
+            ? null
+            : 'subsonic:${subsonicAccountFingerprint(source.session)}';
+      },
     ),
     // With no Plex session the source provider is null and a plex: track
     // resolves to a friendly "not signed in" rather than falling through
     // as unplayable.
     reachabilityAware(
       PlexPlayableUriResolver(() => ref.read(plexMusicSourceProvider)),
-      () => ref.read(plexMusicSourceProvider) == null ? null : 'plex',
+      () {
+        final source = ref.read(plexMusicSourceProvider);
+        return source == null
+            ? null
+            : 'plex:${source.session.machineIdentifier}';
+      },
     ),
     const LocalPlayableUriResolver(),
   ]);

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -12,6 +12,8 @@ import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
 import '../../core/services/playback_reporting_service.dart';
+import '../../core/services/provider_reachability.dart';
+import '../../core/services/reachability_aware_playable_uri_resolver.dart';
 import '../../core/services/remote_cache/remote_cache_resolver.dart';
 import '../../core/services/remote_cache/remote_playback_cache.dart';
 import '../../core/services/remote_cache/remote_stream_prebufferer.dart';
@@ -54,20 +56,60 @@ final remotePlaybackCacheProvider = Provider<RemotePlaybackCache>((ref) {
   return RemotePlaybackCache();
 });
 
+/// A brief, per-provider memory of reachability outcomes, shared for the whole
+/// session so the play path and the background prebuffer agree on whether a
+/// server is currently reachable.
+///
+/// Pinned (not rebuilt on sign-in/out) so a recorded outage survives across the
+/// burst of tracks it's meant to cover; its own short TTL ages entries out, and
+/// the per-provider keys mean signing out of one provider can't strand another.
+final providerReachabilityProvider = Provider<ProviderReachability>((ref) {
+  return CachingProviderReachability();
+});
+
 /// The source router: Jellyfin, Subsonic, Plex, then the on-device catch-all.
 ///
 /// Depends only on lazily-read source getters, so signing in/out is picked up
 /// without rebuilding (keeping the instance stable for the session). Shared by
 /// the cache resolver (which reads through it on a miss) and the prebufferer
 /// (which warms through it), so both mint URLs exactly the same way.
+///
+/// Each remote resolver is wrapped in a [ReachabilityAwarePlayableUriResolver]
+/// so a server that's offline fails fast (and the player falls back to a cached
+/// copy or another provider promptly) instead of re-paying a connect timeout for
+/// every track. The wrapper keys on the provider id, so the Jellyfin/Plex/
+/// Subsonic memories stay isolated even when two providers share a bare track
+/// id. The on-device resolver is never wrapped — a local file doesn't go
+/// offline.
 final remoteSourceRouterProvider = Provider<RoutingPlayableUriResolver>((ref) {
+  PlayableUriResolver reachabilityAware(
+    PlayableUriResolver inner,
+    String? Function() providerKey,
+  ) {
+    return ReachabilityAwarePlayableUriResolver(
+      inner: inner,
+      providerKey: providerKey,
+      reachability: ref.read(providerReachabilityProvider),
+      connectivity: ref.read(connectivityServiceProvider),
+    );
+  }
+
   return RoutingPlayableUriResolver(<PlayableUriResolver>[
-    JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
-    SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
+    reachabilityAware(
+      JellyfinPlayableUriResolver(() => ref.read(jellyfinMusicSourceProvider)),
+      () => ref.read(jellyfinMusicSourceProvider) == null ? null : 'jellyfin',
+    ),
+    reachabilityAware(
+      SubsonicPlayableUriResolver(() => ref.read(subsonicMusicSourceProvider)),
+      () => ref.read(subsonicMusicSourceProvider) == null ? null : 'subsonic',
+    ),
     // With no Plex session the source provider is null and a plex: track
     // resolves to a friendly "not signed in" rather than falling through
     // as unplayable.
-    PlexPlayableUriResolver(() => ref.read(plexMusicSourceProvider)),
+    reachabilityAware(
+      PlexPlayableUriResolver(() => ref.read(plexMusicSourceProvider)),
+      () => ref.read(plexMusicSourceProvider) == null ? null : 'plex',
+    ),
     const LocalPlayableUriResolver(),
   ]);
 });

--- a/test/core/services/offline_first_playable_uri_resolver_test.dart
+++ b/test/core/services/offline_first_playable_uri_resolver_test.dart
@@ -4,6 +4,8 @@ import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/services/cached_track_locator.dart';
 import 'package:linthra/core/services/offline_first_playable_uri_resolver.dart';
 import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/provider_reachability.dart';
+import 'package:linthra/core/services/reachability_aware_playable_uri_resolver.dart';
 
 /// A locator that returns a canned cached path (or null for a miss).
 class _FakeLocator implements CachedTrackLocator {
@@ -132,6 +134,28 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('prefers the cached copy even when the streaming provider is offline',
+        () async {
+      // The full offline-recovery path: a downloaded copy plays without ever
+      // touching the unreachable provider. The offline-first resolver returns
+      // the cache hit before the reachability-aware streaming fallback runs, so
+      // a server being down can't stop a track the user already has.
+      final offlineProvider = ReachabilityAwarePlayableUriResolver(
+        inner: _OfflineResolver(), // always "couldn't reach the server"
+        providerKey: () => 'jellyfin',
+        reachability: CachingProviderReachability(),
+      );
+      final resolver = OfflineFirstPlayableUriResolver(
+        locator: _FakeLocator('/offline_audio/t1.mp3'),
+        fallback: offlineProvider,
+      );
+
+      final resolved = await resolver.resolve(_track);
+
+      expect(resolved.source, PlaybackSource.offlineCache);
+      expect(resolved.uri.toFilePath(), '/offline_audio/t1.mp3');
     });
 
     test('prefers a cached Plex file, reporting the offline-cache source',

--- a/test/core/services/provider_reachability_test.dart
+++ b/test/core/services/provider_reachability_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/provider_reachability.dart';
+import 'package:linthra/core/services/reachability.dart';
+
+void main() {
+  group('CachingProviderReachability', () {
+    test('an unknown key has no remembered status', () {
+      final reachability = CachingProviderReachability();
+      expect(reachability.statusOf('jellyfin'), isNull);
+    });
+
+    test('a recorded status is remembered within its TTL', () {
+      DateTime now = DateTime(2026, 6, 22, 12, 0, 0);
+      final reachability = CachingProviderReachability(
+        ttl: const Duration(seconds: 10),
+        clock: () => now,
+      );
+
+      reachability.record('jellyfin', ReachabilityStatus.serverUnreachable);
+
+      now = now.add(const Duration(seconds: 9));
+      expect(
+        reachability.statusOf('jellyfin'),
+        ReachabilityStatus.serverUnreachable,
+      );
+    });
+
+    test('a remembered status ages out after the TTL — so retry works', () {
+      // This is what makes "retry after connectivity returns" automatic: once
+      // the brief memory expires, the next attempt probes for a fresh answer
+      // rather than staying stuck on the old failure.
+      DateTime now = DateTime(2026, 6, 22, 12, 0, 0);
+      final reachability = CachingProviderReachability(
+        ttl: const Duration(seconds: 10),
+        clock: () => now,
+      );
+
+      reachability.record('jellyfin', ReachabilityStatus.serverUnreachable);
+      now = now.add(const Duration(seconds: 10));
+
+      expect(reachability.statusOf('jellyfin'), isNull);
+    });
+
+    test('a later success overwrites an earlier outage immediately', () {
+      DateTime now = DateTime(2026, 6, 22, 12, 0, 0);
+      final reachability = CachingProviderReachability(clock: () => now);
+
+      reachability.record('plex', ReachabilityStatus.serverUnreachable);
+      now = now.add(const Duration(seconds: 2));
+      reachability.record('plex', ReachabilityStatus.reachable);
+
+      expect(reachability.statusOf('plex'), ReachabilityStatus.reachable);
+    });
+
+    test('per-provider keys stay isolated (same bare id, different provider)',
+        () {
+      // jellyfin:101 and subsonic:101 share a server-side id but are different
+      // providers. Marking one unreachable must never suppress the other.
+      final reachability = CachingProviderReachability();
+
+      reachability.record('jellyfin', ReachabilityStatus.serverUnreachable);
+
+      expect(
+        reachability.statusOf('jellyfin'),
+        ReachabilityStatus.serverUnreachable,
+      );
+      expect(reachability.statusOf('subsonic'), isNull);
+    });
+
+    test('forget drops a single provider without touching others', () {
+      final reachability = CachingProviderReachability();
+      reachability.record('jellyfin', ReachabilityStatus.serverUnreachable);
+      reachability.record('subsonic', ReachabilityStatus.reachable);
+
+      reachability.forget('jellyfin');
+
+      expect(reachability.statusOf('jellyfin'), isNull);
+      expect(reachability.statusOf('subsonic'), ReachabilityStatus.reachable);
+    });
+
+    test('clear drops every remembered status', () {
+      final reachability = CachingProviderReachability();
+      reachability.record('jellyfin', ReachabilityStatus.serverUnreachable);
+      reachability.record('plex', ReachabilityStatus.timeout);
+
+      reachability.clear();
+
+      expect(reachability.statusOf('jellyfin'), isNull);
+      expect(reachability.statusOf('plex'), isNull);
+    });
+  });
+}

--- a/test/core/services/reachability_aware_playable_uri_resolver_test.dart
+++ b/test/core/services/reachability_aware_playable_uri_resolver_test.dart
@@ -34,18 +34,18 @@ class _FakeInner implements PlayableUriResolver {
   }
 }
 
-/// A connectivity service pinned to a single status.
+/// A connectivity service whose status a test can flip, to simulate the network
+/// dropping and returning between resolve calls.
 class _FakeConnectivity implements ConnectivityService {
-  _FakeConnectivity(this._status);
+  _FakeConnectivity(this.status);
 
-  final NetworkStatus _status;
-
-  @override
-  Stream<NetworkStatus> get statusStream =>
-      Stream<NetworkStatus>.value(_status);
+  NetworkStatus status;
 
   @override
-  Future<NetworkStatus> currentStatus() async => _status;
+  Stream<NetworkStatus> get statusStream => Stream<NetworkStatus>.value(status);
+
+  @override
+  Future<NetworkStatus> currentStatus() async => status;
 }
 
 const Track _track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
@@ -193,10 +193,35 @@ void main() {
             )),
       );
       expect(inner.calls, 0, reason: 'offline must not hit the network');
-      expect(
-        reachability.statusOf('jellyfin'),
-        ReachabilityStatus.networkUnavailable,
+      // Device-offline is judged fresh and never cached, so it doesn't poison
+      // the per-server memory — a reconnect probes straight away (next test).
+      expect(reachability.statusOf('jellyfin'), isNull);
+    });
+
+    test(
+        'a reconnect probes immediately, not blocked by a prior offline result',
+        () async {
+      // Regression guard: once offline and then online again, the next resolve
+      // must probe the recovered server rather than replay a stale "offline" for
+      // the cache's lifetime.
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner();
+      final connectivity = _FakeConnectivity(NetworkStatus.offline);
+      final resolver = _build(
+        inner: inner,
+        reachability: reachability,
+        connectivity: connectivity,
       );
+
+      // Offline: fails fast without probing.
+      await expectLater(resolver.resolve(_track), throwsA(anything));
+      expect(inner.calls, 0);
+
+      // Network returns: the very next resolve probes and succeeds.
+      connectivity.status = NetworkStatus.wifi;
+      final ResolvedPlayable resolved = await resolver.resolve(_track);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(inner.calls, 1);
     });
 
     test('does not crash and resolves normally when network is available',

--- a/test/core/services/reachability_aware_playable_uri_resolver_test.dart
+++ b/test/core/services/reachability_aware_playable_uri_resolver_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/connectivity_service.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/provider_reachability.dart';
+import 'package:linthra/core/services/reachability.dart';
+import 'package:linthra/core/services/reachability_aware_playable_uri_resolver.dart';
+
+/// An inner resolver that either returns a canned stream URL or throws a given
+/// failure kind, counting how many times it was actually invoked so a test can
+/// prove a fast-fail skipped the (doomed) probe.
+class _FakeInner implements PlayableUriResolver {
+  _FakeInner({this.failWith});
+
+  /// When non-null, every resolve throws this kind; otherwise it succeeds.
+  final PlaybackResolutionErrorKind? failWith;
+  int calls = 0;
+
+  @override
+  bool handles(Track track) => track.uri.startsWith('jellyfin:');
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    calls++;
+    final PlaybackResolutionErrorKind? kind = failWith;
+    if (kind != null) {
+      throw PlaybackResolutionException('inner failed', kind: kind);
+    }
+    return ResolvedPlayable(
+      Uri.parse('https://stream/${track.id}'),
+      PlaybackSource.streamingDirect,
+    );
+  }
+}
+
+/// A connectivity service pinned to a single status.
+class _FakeConnectivity implements ConnectivityService {
+  _FakeConnectivity(this._status);
+
+  final NetworkStatus _status;
+
+  @override
+  Stream<NetworkStatus> get statusStream =>
+      Stream<NetworkStatus>.value(_status);
+
+  @override
+  Future<NetworkStatus> currentStatus() async => _status;
+}
+
+const Track _track = Track(id: 't1', title: 'One', uri: 'jellyfin:t1');
+
+ReachabilityAwarePlayableUriResolver _build({
+  required PlayableUriResolver inner,
+  required ProviderReachability reachability,
+  String? Function()? providerKey,
+  ConnectivityService? connectivity,
+}) {
+  return ReachabilityAwarePlayableUriResolver(
+    inner: inner,
+    providerKey: providerKey ?? () => 'jellyfin',
+    reachability: reachability,
+    connectivity: connectivity,
+  );
+}
+
+void main() {
+  group('ReachabilityAwarePlayableUriResolver', () {
+    test('handles delegates to the inner resolver', () {
+      final resolver = _build(
+        inner: _FakeInner(),
+        reachability: CachingProviderReachability(),
+      );
+      expect(resolver.handles(_track), isTrue);
+      expect(
+        resolver.handles(const Track(id: 'x', title: 'X', uri: 'subsonic:x')),
+        isFalse,
+      );
+    });
+
+    test('a successful resolve passes through and records reachable', () async {
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner();
+      final resolver = _build(inner: inner, reachability: reachability);
+
+      final ResolvedPlayable resolved = await resolver.resolve(_track);
+
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(reachability.statusOf('jellyfin'), ReachabilityStatus.reachable);
+    });
+
+    test('an unreachable failure is recorded and rethrown', () async {
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner(
+        failWith: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+      final resolver = _build(inner: inner, reachability: reachability);
+
+      await expectLater(
+        resolver.resolve(_track),
+        throwsA(isA<PlaybackResolutionException>().having(
+          (PlaybackResolutionException e) => e.kind,
+          'kind',
+          PlaybackResolutionErrorKind.serverUnreachable,
+        )),
+      );
+      expect(
+        reachability.statusOf('jellyfin'),
+        ReachabilityStatus.serverUnreachable,
+      );
+    });
+
+    test(
+        'once unreachable is remembered, the next resolve fails fast (no probe)',
+        () async {
+      // The core anti-stall behavior: a server that just failed isn't probed
+      // again for every following track — the second attempt skips the inner
+      // resolver entirely and falls straight through to the caller's fallback.
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner(
+        failWith: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+      final resolver = _build(inner: inner, reachability: reachability);
+
+      await expectLater(resolver.resolve(_track), throwsA(anything));
+      expect(inner.calls, 1);
+
+      // Second attempt: still throws serverUnreachable, but without touching the
+      // network again.
+      await expectLater(
+        resolver.resolve(_track),
+        throwsA(isA<PlaybackResolutionException>().having(
+          (PlaybackResolutionException e) => e.kind,
+          'kind',
+          PlaybackResolutionErrorKind.serverUnreachable,
+        )),
+      );
+      expect(inner.calls, 1, reason: 'the second resolve must skip the probe');
+    });
+
+    test('an auth failure is recorded but never fast-failed', () async {
+      // A session problem must keep probing: the moment the user re-signs-in, a
+      // fresh request has to be attempted, so an auth failure is never cached as
+      // "don't bother". It also classifies as authFailure, not an outage.
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner(
+        failWith: PlaybackResolutionErrorKind.sessionExpired,
+      );
+      final resolver = _build(inner: inner, reachability: reachability);
+
+      await expectLater(resolver.resolve(_track), throwsA(anything));
+      expect(reachability.statusOf('jellyfin'), ReachabilityStatus.authFailure);
+
+      // Second attempt still probes (no fast-fail), so a recovered session works.
+      await expectLater(resolver.resolve(_track), throwsA(anything));
+      expect(inner.calls, 2, reason: 'auth failures must not suppress retries');
+    });
+
+    test('a recovered server (cache says reachable) is probed normally',
+        () async {
+      final reachability = CachingProviderReachability()
+        ..record('jellyfin', ReachabilityStatus.reachable);
+      final inner = _FakeInner();
+      final resolver = _build(inner: inner, reachability: reachability);
+
+      await resolver.resolve(_track);
+
+      expect(inner.calls, 1);
+    });
+
+    test('offline short-circuits to a clear error without probing', () async {
+      // Network unavailable: don't attempt a connection that can only time out.
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner();
+      final resolver = _build(
+        inner: inner,
+        reachability: reachability,
+        connectivity: _FakeConnectivity(NetworkStatus.offline),
+      );
+
+      await expectLater(
+        resolver.resolve(_track),
+        throwsA(isA<PlaybackResolutionException>()
+            .having(
+              (PlaybackResolutionException e) => e.kind,
+              'kind',
+              PlaybackResolutionErrorKind.serverUnreachable,
+            )
+            .having(
+              (PlaybackResolutionException e) => e.message,
+              'message',
+              contains('offline'),
+            )),
+      );
+      expect(inner.calls, 0, reason: 'offline must not hit the network');
+      expect(
+        reachability.statusOf('jellyfin'),
+        ReachabilityStatus.networkUnavailable,
+      );
+    });
+
+    test('does not crash and resolves normally when network is available',
+        () async {
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner();
+      final resolver = _build(
+        inner: inner,
+        reachability: reachability,
+        connectivity: _FakeConnectivity(NetworkStatus.wifi),
+      );
+
+      final ResolvedPlayable resolved = await resolver.resolve(_track);
+
+      expect(resolved.source, PlaybackSource.streamingDirect);
+    });
+
+    test('with no session (null key) it delegates without caching', () async {
+      final reachability = CachingProviderReachability();
+      final inner = _FakeInner(
+        failWith: PlaybackResolutionErrorKind.notSignedIn,
+      );
+      final resolver = _build(
+        inner: inner,
+        reachability: reachability,
+        providerKey: () => null,
+      );
+
+      await expectLater(resolver.resolve(_track), throwsA(anything));
+      // Nothing is cached for a signed-out provider, and the inner answer (not
+      // signed in) is surfaced unchanged.
+      expect(reachability.statusOf('jellyfin'), isNull);
+    });
+
+    test('a remembered jellyfin outage never fast-fails a subsonic resolve',
+        () async {
+      // Two decorators sharing one reachability memory, keyed per provider. A
+      // jellyfin outage must not suppress the subsonic copy of a same-bare-id
+      // song (jellyfin:101 vs subsonic:101).
+      final reachability = CachingProviderReachability();
+      final jellyInner = _FakeInner(
+        failWith: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+      final subInner = _FakeInner();
+      final jelly = ReachabilityAwarePlayableUriResolver(
+        inner: jellyInner,
+        providerKey: () => 'jellyfin',
+        reachability: reachability,
+      );
+      final sub = ReachabilityAwarePlayableUriResolver(
+        inner: subInner,
+        providerKey: () => 'subsonic',
+        reachability: reachability,
+      );
+      const Track j101 = Track(id: '101', title: 'X', uri: 'jellyfin:101');
+      const Track s101 = Track(id: '101', title: 'X', uri: 'subsonic:101');
+
+      await expectLater(jelly.resolve(j101), throwsA(anything));
+
+      // Subsonic still resolves: its key has no remembered outage.
+      final ResolvedPlayable resolved = await sub.resolve(s101);
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(subInner.calls, 1);
+    });
+  });
+}

--- a/test/core/services/reachability_test.dart
+++ b/test/core/services/reachability_test.dart
@@ -26,19 +26,21 @@ void main() {
       expect(auth.isAuthFailure, isTrue);
       expect(auth.isOffline, isFalse);
       expect(auth.isReachable, isFalse);
-      // And crucially it is NOT a transient outage, so it is never cached as
-      // "don't bother retrying" — a fresh sign-in must work immediately.
-      expect(auth.isTransientOutage, isFalse);
+      // And crucially it is NOT a cacheable server outage, so it is never cached
+      // as "don't bother retrying" — a fresh sign-in must work immediately.
+      expect(auth.isServerOutage, isFalse);
     });
 
-    test('the transient-outage states are exactly the three reach failures',
+    test('the server-outage states are exactly server-unreachable and timeout',
         () {
-      expect(ReachabilityStatus.networkUnavailable.isTransientOutage, isTrue);
-      expect(ReachabilityStatus.serverUnreachable.isTransientOutage, isTrue);
-      expect(ReachabilityStatus.timeout.isTransientOutage, isTrue);
-      // Reachable and auth failure are deliberately excluded.
-      expect(ReachabilityStatus.reachable.isTransientOutage, isFalse);
-      expect(ReachabilityStatus.authFailure.isTransientOutage, isFalse);
+      // Only these two are worth caching as "skip the probe for a moment".
+      expect(ReachabilityStatus.serverUnreachable.isServerOutage, isTrue);
+      expect(ReachabilityStatus.timeout.isServerOutage, isTrue);
+      // networkUnavailable is device-global (judged fresh, never cached);
+      // reachable and authFailure are not outages — all three are excluded.
+      expect(ReachabilityStatus.networkUnavailable.isServerOutage, isFalse);
+      expect(ReachabilityStatus.reachable.isServerOutage, isFalse);
+      expect(ReachabilityStatus.authFailure.isServerOutage, isFalse);
     });
   });
 

--- a/test/core/services/reachability_test.dart
+++ b/test/core/services/reachability_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/reachability.dart';
+
+void main() {
+  group('ReachabilityStatus', () {
+    test('isReachable is true only for reachable', () {
+      expect(ReachabilityStatus.reachable.isReachable, isTrue);
+      for (final ReachabilityStatus s in ReachabilityStatus.values) {
+        if (s != ReachabilityStatus.reachable) {
+          expect(s.isReachable, isFalse, reason: '$s');
+        }
+      }
+    });
+
+    test('isOffline is true only for networkUnavailable', () {
+      expect(ReachabilityStatus.networkUnavailable.isOffline, isTrue);
+      expect(ReachabilityStatus.serverUnreachable.isOffline, isFalse);
+      expect(ReachabilityStatus.authFailure.isOffline, isFalse);
+    });
+
+    test('an auth failure is kept distinct from the offline states', () {
+      // The whole point of the enum: "server rejected the session" must never be
+      // confused with "couldn't reach the server" — they need different fixes.
+      const ReachabilityStatus auth = ReachabilityStatus.authFailure;
+      expect(auth.isAuthFailure, isTrue);
+      expect(auth.isOffline, isFalse);
+      expect(auth.isReachable, isFalse);
+      // And crucially it is NOT a transient outage, so it is never cached as
+      // "don't bother retrying" — a fresh sign-in must work immediately.
+      expect(auth.isTransientOutage, isFalse);
+    });
+
+    test('the transient-outage states are exactly the three reach failures',
+        () {
+      expect(ReachabilityStatus.networkUnavailable.isTransientOutage, isTrue);
+      expect(ReachabilityStatus.serverUnreachable.isTransientOutage, isTrue);
+      expect(ReachabilityStatus.timeout.isTransientOutage, isTrue);
+      // Reachable and auth failure are deliberately excluded.
+      expect(ReachabilityStatus.reachable.isTransientOutage, isFalse);
+      expect(ReachabilityStatus.authFailure.isTransientOutage, isFalse);
+    });
+  });
+
+  group('reachabilityFromPlaybackError', () {
+    test('maps an unreachable server to a server-unreachable outage', () {
+      expect(
+        reachabilityFromPlaybackError(
+          PlaybackResolutionErrorKind.serverUnreachable,
+        ),
+        ReachabilityStatus.serverUnreachable,
+      );
+    });
+
+    test('maps an expired session to an auth failure, not an outage', () {
+      // Separation of concerns: a session problem must classify as authFailure
+      // so the offline fast-fail path never swallows it.
+      expect(
+        reachabilityFromPlaybackError(
+          PlaybackResolutionErrorKind.sessionExpired,
+        ),
+        ReachabilityStatus.authFailure,
+      );
+    });
+
+    test('returns null for track-specific or not-signed-in failures', () {
+      // These say nothing reliable about whether the *server* is reachable, so
+      // they must not poison the provider-wide reachability memory.
+      for (final PlaybackResolutionErrorKind kind
+          in <PlaybackResolutionErrorKind>[
+        PlaybackResolutionErrorKind.notSignedIn,
+        PlaybackResolutionErrorKind.invalidStream,
+        PlaybackResolutionErrorKind.serverReturnedWebPage,
+        PlaybackResolutionErrorKind.streamUnavailable,
+      ]) {
+        expect(reachabilityFromPlaybackError(kind), isNull, reason: '$kind');
+      }
+    });
+  });
+}

--- a/test/core/sources/subsonic/subsonic_account_fingerprint_test.dart
+++ b/test/core/sources/subsonic/subsonic_account_fingerprint_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/sources/subsonic/subsonic_account_fingerprint.dart';
+
+const _session = SubsonicSession(
+  baseUrl: 'https://music.example.com',
+  username: 'alice',
+  salt: 'salt-value',
+  token: 'super-secret-token-value',
+);
+
+void main() {
+  group('subsonicAccountFingerprint', () {
+    test('is stable for the same server + account', () {
+      expect(
+        subsonicAccountFingerprint(_session),
+        subsonicAccountFingerprint(_session),
+      );
+    });
+
+    test('changes when the server URL changes', () {
+      final other = _session.copyWith(baseUrl: 'https://other.example.com');
+      expect(
+        subsonicAccountFingerprint(other),
+        isNot(subsonicAccountFingerprint(_session)),
+      );
+    });
+
+    test('changes when the user changes', () {
+      final other = _session.copyWith(username: 'bob');
+      expect(
+        subsonicAccountFingerprint(other),
+        isNot(subsonicAccountFingerprint(_session)),
+      );
+    });
+
+    test('a credential change alone never changes the fingerprint', () {
+      // It identifies the *account*, not the session secret — so a fresh
+      // salt/token (a re-login to the same account) is still "the same account".
+      final reauthed = _session.copyWith(salt: 'new-salt', token: 'new-token');
+      expect(
+        subsonicAccountFingerprint(reauthed),
+        subsonicAccountFingerprint(_session),
+      );
+    });
+
+    test('does not contain the credentials, the URL, or the username', () {
+      // A one-way hash: it must reveal no secret and no identifying value.
+      final String fingerprint = subsonicAccountFingerprint(_session);
+      expect(fingerprint, isNot(contains('super-secret-token-value')));
+      expect(fingerprint, isNot(contains('salt-value')));
+      expect(fingerprint, isNot(contains('music.example.com')));
+      expect(fingerprint, isNot(contains('alice')));
+      // A hex SHA-256 digest.
+      expect(fingerprint, matches(RegExp(r'^[0-9a-f]{64}$')));
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -35,12 +35,15 @@ const _session = JellyfinSession(
 /// A recording [MusicLibraryRepository] that captures the last upsert so a test
 /// can assert what the sync stored, and can be made to throw on upsert.
 class _RecordingRepository implements MusicLibraryRepository {
-  _RecordingRepository({this.upsertError});
+  _RecordingRepository({
+    this.upsertError,
+    List<Track> existing = const <Track>[],
+  }) : upsertedTracks = existing;
 
   final Object? upsertError;
 
   String? upsertedSourceId;
-  List<Track> upsertedTracks = const <Track>[];
+  List<Track> upsertedTracks;
   List<Album> upsertedAlbums = const <Album>[];
   List<Artist> upsertedArtists = const <Artist>[];
   int upsertCount = 0;
@@ -217,6 +220,31 @@ void main() {
       final state = container.read(jellyfinSyncControllerProvider);
       expect(state.status, JellyfinSyncStatus.error);
       expect(state.message, contains("Couldn't reach"));
+    });
+
+    test('keeps existing catalog rows when the server is unreachable',
+        () async {
+      // Offline-recovery guarantee: a failed sync must never wipe the local
+      // catalog, so an already-synced library stays visible while the server is
+      // temporarily offline.
+      const existing = <Track>[
+        Track(id: 'j1', title: 'Old One', uri: 'jellyfin:j1'),
+      ];
+      final repository = _RecordingRepository(existing: existing);
+      final container = _container(
+        repository: repository,
+        source: _source(itemsError: JellyfinException.notReachable()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      expect(
+        container.read(jellyfinSyncControllerProvider).status,
+        JellyfinSyncStatus.error,
+      );
+      // The write was never reached, so the existing rows are untouched.
+      expect(repository.upsertCount, 0);
+      expect(await repository.getAllTracks(), existing);
     });
 
     test('maps an expired token to a sign-in-again message', () async {

--- a/test/features/settings/plex/plex_sync_controller_test.dart
+++ b/test/features/settings/plex/plex_sync_controller_test.dart
@@ -81,7 +81,13 @@ List<PlexMetadata> _trackItems(int count) => <PlexMetadata>[
 /// is kept only for interface completeness and is not used by the controller).
 class _RecordingRepository
     implements MusicLibraryRepository, IncrementalCatalogWriter {
-  _RecordingRepository({this.beginError, this.appendGate});
+  _RecordingRepository({
+    this.beginError,
+    this.appendGate,
+    List<Track> existing = const <Track>[],
+  }) {
+    stored.addAll(existing);
+  }
 
   /// When set, the first (begin) write throws it, so a storage failure can be
   /// proven to surface friendly and never half-write.
@@ -242,6 +248,31 @@ void main() {
       expect(state.isError, isTrue);
       expect(state.message, contains('Connect to your Plex server'));
       expect(repo.writeCount, 0);
+    });
+
+    test('keeps existing catalog rows when the server is unreachable',
+        () async {
+      // Offline-recovery guarantee: a failed scan must not delete the Plex slice
+      // it was about to replace — the begin/append writes are never reached, so
+      // the already-synced rows stay visible while the server is offline.
+      const existing = <Track>[
+        Track(id: 'p1', title: 'Old One', uri: 'plex:p1'),
+      ];
+      final repo = _RecordingRepository(existing: existing);
+      final container = _container(
+        client: FakePlexClient(itemsError: PlexException.notReachable()),
+        session: _session,
+        repository: repo,
+      );
+      await container
+          .read(plexSettingsControllerProvider.notifier)
+          .ensureLoaded();
+
+      await container.read(plexSyncControllerProvider.notifier).sync();
+
+      expect(container.read(plexSyncControllerProvider).isError, isTrue);
+      expect(repo.writeCount, 0);
+      expect(await repo.getAllTracks(), existing);
     });
 
     test(

--- a/test/features/settings/subsonic/subsonic_sync_controller_test.dart
+++ b/test/features/settings/subsonic/subsonic_sync_controller_test.dart
@@ -23,12 +23,15 @@ const _session = SubsonicSession(
 );
 
 class _RecordingRepository implements MusicLibraryRepository {
-  _RecordingRepository({this.upsertError});
+  _RecordingRepository({
+    this.upsertError,
+    List<Track> existing = const <Track>[],
+  }) : upsertedTracks = existing;
 
   final Object? upsertError;
 
   String? upsertedSourceId;
-  List<Track> upsertedTracks = const <Track>[];
+  List<Track> upsertedTracks;
   int upsertCount = 0;
 
   @override
@@ -173,6 +176,31 @@ void main() {
       final state = container.read(subsonicSyncControllerProvider);
       expect(state.status, SubsonicSyncStatus.error);
       expect(state.message, contains("Couldn't reach"));
+    });
+
+    test('keeps existing catalog rows when the server is unreachable',
+        () async {
+      // Offline-recovery guarantee: a failed sync must never wipe what's already
+      // in the local catalog, so the library stays usable while the server is
+      // temporarily unreachable.
+      const existing = <Track>[
+        Track(id: 's1', title: 'Old One', uri: 'subsonic:s1'),
+      ];
+      final repository = _RecordingRepository(existing: existing);
+      final container = _container(
+        repository: repository,
+        source: _source(listError: SubsonicException.notReachable()),
+      );
+
+      await container.read(subsonicSyncControllerProvider.notifier).sync();
+
+      expect(
+        container.read(subsonicSyncControllerProvider).status,
+        SubsonicSyncStatus.error,
+      );
+      // The write was never reached, so the existing rows are untouched.
+      expect(repository.upsertCount, 0);
+      expect(await repository.getAllTracks(), existing);
     });
 
     test('does not leak the credential through an error message', () async {


### PR DESCRIPTION
v0.1.7 stability, PR 3 of the series (follows #238/#240, which made catalog, runtime, and prefs identity provider-aware). This PR focuses purely on **connectivity / offline recovery**: making playback resilient when a server is temporarily unreachable or the device is offline — without ever assuming "Wi-Fi is up" means "every provider is reachable".

## The problem

Connectivity was a stub (`OptimisticConnectivityService` always reports Wi-Fi) and there was no memory of reachability. Each play re-ran a provider's full session-check + connect timeout, so an album from a server that had just gone offline stalled 10–20 s before **every** track's fallback. There was also no vocabulary to tell "no network", "server down", "session expired", and "timed out" apart, so the app couldn't pick the right recovery or message.

## What this adds

- **`ReachabilityStatus`** — the five states the rest of the app branches on: `reachable` / `networkUnavailable` / `serverUnreachable` / `authFailure` / `timeout`, plus `reachabilityFromPlaybackError()`, the single bridge from a per-track `PlaybackResolutionErrorKind` to a provider-wide signal (a new kind is a compile error there, so the two can't drift). An **auth failure is kept deliberately distinct from the offline states** — the server *was* reached, so the fix is signing in again, not "check your connection".
- **`CachingProviderReachability`** — a brief (10 s TTL), per-provider memory of the last outcome, keyed by provider id (`jellyfin` / `subsonic` / `plex`), **never a bare track id** — so two providers sharing a server-side id stay isolated, preserving the #238/#240 identity model. The short TTL is what makes "retry after connectivity returns" automatic: a recovered server is re-probed within seconds, no manual reset.
- **`ReachabilityAwarePlayableUriResolver`** — wraps each remote resolver in the source router. When the device is offline, or the provider was just seen unreachable, it **fails fast** (no doomed probe) so the player falls straight to a cached copy or another provider; otherwise it resolves for real and records the outcome. It never short-circuits an auth failure (a fresh sign-in must work immediately), and never touches the offline cache or cross-provider fallback — those live *above* it and simply fire promptly now. Its fast-fail always carries `serverUnreachable`, so every downstream caller engages unchanged.

## Playback & sync recovery

- A downloaded copy still plays even when its provider is unreachable (the offline-first resolver returns the cache hit before this runs).
- A failed sync never wipes the catalog: a thrown server-unreachable aborts before any write, so already-synced rows stay visible offline. Added explicit "keeps existing catalog rows when the server is unreachable" tests for **Jellyfin, Subsonic, and Plex**.
- Clearer, secret-free offline / not-responding messages flow through the existing player error state — **no new noisy snackbars**.

## Tests

`ReachabilityStatus` + mapper (auth vs offline separation); the cache (TTL expiry = retry works, per-provider isolation, forget/clear); the decorator (fast-fail without re-probing, auth never suppressed, offline short-circuit, null-session passthrough, same-bare-id isolation); cached-copy-preferred-when-offline; and the three sync no-wipe guards. `dart format`, `flutter analyze`, `flutter test` (2568 pass), and the secret scan are all green.

## Scope / guarantees

- No version bump, no F-Droid metadata, no artwork/offline-cache behaviour change.
- No new Plex playlists/favorites/cast features.
- Provider-aware identity from #238/#240 is preserved (reachability is keyed per provider, never per bare id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQLZFGqYQPZYLNykmy9VKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQLZFGqYQPZYLNykmy9VKw)_