### PR TITLE
Add voluntary "Support Linthra" screen and support module

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ where help is most useful right now. The
 
 Found Linthra useful? A **GitHub star** helps others discover it.
 
+**Support development (optional).** Linthra is free, with no ads and no
+tracking, and every core feature stays free. If you'd like to help fund
+development, testing devices, app-store costs, and long-term maintenance, the
+app has an in-app **Settings → About → Support Linthra** screen. The supporter
+model — and how Play Store billing will be added **only** in Play builds later,
+while F-Droid builds stay free of any proprietary billing dependency — is
+described in [docs/SUPPORT.md](./docs/SUPPORT.md).
+
 ## Self-hosted sources
 
 Sources sit behind one interface, so the app treats them uniformly:
@@ -190,6 +198,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | --- | --- |
 | Contributing & setup | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 | Where to help (contributor roadmap) | [docs/contributor-roadmap.md](./docs/contributor-roadmap.md) |
+| Supporting Linthra (optional supporter model) | [docs/SUPPORT.md](./docs/SUPPORT.md) |
 | Codebase tour (where everything lives) | [docs/codebase-tour.md](./docs/codebase-tour.md) |
 | Architecture & extension points | [docs/architecture.md](./docs/architecture.md) |
 | Development, build & CI | [docs/development.md](./docs/development.md) |

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -24,6 +24,12 @@ build-safe structure that lets a future Play Store build add supporter purchases
   future build offers a "supporter" purchase, it buys goodwill (and a thank-you),
   not functionality.
 
+A small, deliberately **secondary and playful** "lonely maintainer" aside sits
+at the bottom of the screen. It is tone only: rendered inline (never a popup),
+below the serious explanation (never the headline), it keeps "No pressure"
+visible, blocks no navigation, and unlocks/changes nothing. It is not premium
+wording and is F-Droid/Play-safe.
+
 ## 2. Reaching the screen
 
 In the app: **Settings → About → Support Linthra**.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,134 @@
+# Supporting Linthra
+
+Linthra is **free and open source, and stays that way.** This document explains
+the voluntary supporter model, the in-app "Support Linthra" screen, and the
+build-safe structure that lets a future Play Store build add supporter purchases
+**without** ever touching the F-Droid build.
+
+> **TL;DR for reviewers / packagers:** this is a screen with copy and a few
+> external links. There is **no billing SDK, no Google Play Billing, no ads, no
+> tracking, and no feature gating** in this code path. An ordinary
+> `flutter build` (CI and F-Droid alike) compiles the F-Droid action set only.
+
+## 1. The supporter model
+
+- **Linthra is free.** Every feature is available to everyone at no cost.
+- **Support is optional.** Nothing in the app is locked, time-limited, or
+  degraded if you don't contribute. The Support screen is an invitation, not a
+  paywall.
+- **No ads, no tracking.** Supporting the project does not change that, and the
+  Support screen adds neither.
+- **Where support goes.** Voluntary contributions help fund development, testing
+  devices, app-store/distribution costs, and long-term maintenance.
+- **Core features stay free — always.** Support never gates a feature. If a
+  future build offers a "supporter" purchase, it buys goodwill (and a thank-you),
+  not functionality.
+
+## 2. Reaching the screen
+
+In the app: **Settings → About → Support Linthra**.
+
+The About page carries a "Support Linthra" card (distinct from the existing
+"Support" help/contact card) that opens the screen at the route
+`/settings/support` (`AppRoutes.settingsSupport`). The screen states the model
+above and lists a few ways to help.
+
+## 3. What the screen offers today
+
+The actions are **data**, assembled per build (see §4). The default
+(F-Droid / dev / GitHub-Release) set is external links only:
+
+| Action | Opens | Notes |
+| ------ | ----- | ----- |
+| **GitHub Sponsors** | `https://github.com/sponsors/thezupzup` | Placeholder handle — replace/confirm when Sponsors is enabled on the account. |
+| **Funding & supporter model** | this document on GitHub | The authoritative explanation of the model. |
+| **View source code** | the repository | Reading, building, starring, and contributing are always free. |
+
+Links open through the shared `externalLinkLauncherProvider` — the same browser
+seam the About page and "Report a bug" flow use — so every launch is an explicit
+user tap, nothing opens on its own, and widget tests stay plugin-free.
+
+> **Placeholder URLs.** The donation handle above is a placeholder. The screen
+> and tests only assert each link is well-formed (`https`, non-empty host),
+> never that an account exists, so a maintainer can update
+> `SupportLinks` in
+> [`lib/features/support/support_actions_provider.dart`](../lib/features/support/support_actions_provider.dart)
+> in one place when the real accounts are live.
+
+## 4. Architecture — a small, extensible module
+
+Everything lives under [`lib/features/support/`](../lib/features/support/):
+
+| File | Responsibility |
+| ---- | -------------- |
+| `support_action.dart` | `SupportAction` — one way to support, as plain data (id, title, description, icon, `kind`, optional `url`). `SupportActionKind` is a small closed set: `externalLink` or `comingSoon`. |
+| `support_actions_provider.dart` | The build seam: `SupportDistribution` (the channel), `supportActionsFor(distribution)` (a pure catalog), `SupportLinks` (the URLs in one place), and `supportActionsProvider` (what the screen reads). |
+| `support_screen.dart` | `SupportScreen` — renders the copy and whatever actions the provider yields. It owns **no** donation or payment logic. |
+
+Two deliberate properties:
+
+1. **The screen never hard-codes platform-specific donation/payment behavior.**
+   It renders by the generic `SupportActionKind` only — an `externalLink` opens
+   through the shared launcher; a `comingSoon` row is shown disabled. Which
+   actions exist, and for which build, is decided by the provider, not the
+   screen.
+
+2. **The action set is chosen per build, behind one seam.**
+   `SupportDistribution.current` reads `--dart-define=LINTHRA_DISTRIBUTION=...`
+   and **defaults to `fdroid`** (mirroring how `AppInfo` reads its optional
+   `LINTHRA_VERSION_NAME` override). The default is the safe one: a plain
+   `flutter build` gets external links only.
+
+## 5. F-Droid safety
+
+- The default `SupportDistribution` is `fdroid`, so an ordinary `flutter build`
+  — local, CI, and the F-Droid build server — compiles the **external-links-only**
+  set. No billing row is even listed.
+- **No dependency changes.** This feature adds no packages to `pubspec.yaml`; it
+  reuses the existing `url_launcher`-backed `externalLinkLauncher` seam. There is
+  no Google Play Billing dependency, no proprietary SDK, and no GMS anywhere in
+  the path.
+- **No permission, playback, cache, or provider changes.**
+- F-Droid builds **must remain free of any proprietary billing dependency.** The
+  Play supporter purchase (below) must therefore be added in a way that ships
+  **only** in the Play flavor — never as a shared/default dependency.
+
+## 6. The future Play Store build (not in this PR)
+
+Play Store billing will be implemented **only in Play builds, later.** The
+structure is already in place:
+
+- `SupportDistribution.play` exists, and `supportActionsFor` already appends a
+  single **disabled `comingSoon` placeholder** ("Become a supporter") for that
+  channel. The placeholder carries no `url` and no billing code, so even if it is
+  ever shown it does nothing.
+- That placeholder is the reserved seat for a Google Play Billing supporter
+  purchase.
+
+When the Play build is implemented in a separate, Play-only PR, the intended
+shape is:
+
+1. Add the billing dependency and the purchase code **behind the Play flavor
+   only** (e.g. a Play-only source set / conditional import / overridden
+   provider), so it never enters the F-Droid build or `pubspec.yaml`'s default
+   dependencies.
+2. Add a new `SupportActionKind` (e.g. `purchase`) or override
+   `supportActionsProvider` in the Play flavor to replace the `comingSoon`
+   placeholder with a real purchase action.
+3. Keep the supporter purchase **non-gating** — it must not unlock any feature.
+
+Because the screen renders by `kind` and reads actions from the provider, adding
+the purchase action requires **no change to `SupportScreen`** and **no change to
+the F-Droid build.**
+
+## 7. Tests
+
+- `test/features/support/support_action_test.dart` — the data model (URL
+  parsing, the `externalLink`-needs-a-`url` assertion).
+- `test/features/support/support_actions_provider_test.dart` — the distribution
+  parser and that F-Droid offers links only while Play adds the disabled
+  placeholder; every external link is a well-formed `https` URL.
+- `test/features/support/support_screen_test.dart` — the copy, link taps (via a
+  fake launcher), the disabled placeholder, and the snackbar fallback.
+- `test/features/settings/hub/about_screen_test.dart` — the About entry and that
+  it navigates to the support route.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -27,8 +27,8 @@ build-safe structure that lets a future Play Store build add supporter purchases
 A small, deliberately **secondary and playful** "lonely maintainer" aside sits
 at the bottom of the screen. It is tone only: rendered inline (never a popup),
 below the serious explanation (never the headline), it keeps "No pressure"
-visible, blocks no navigation, and unlocks/changes nothing. It is not premium
-wording and is F-Droid/Play-safe.
+visible, blocks no navigation, and unlocks/changes nothing. It is not a paywall
+or upsell, and is F-Droid/Play-safe.
 
 ## 2. Reaching the screen
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -20,6 +20,7 @@ import '../features/settings/settings_screen.dart';
 import '../features/shell/home_shell.dart';
 import '../features/smart_mixes/smart_mix_detail_screen.dart';
 import '../features/smart_mixes/smart_mixes_screen.dart';
+import '../features/support/support_screen.dart';
 import 'routes.dart';
 
 /// Single source of truth for navigation. Exposed through Riverpod so future
@@ -127,6 +128,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: 'about',
                     builder: (context, state) => const AboutScreen(),
+                  ),
+                  GoRoute(
+                    path: 'support',
+                    builder: (context, state) => const SupportScreen(),
                   ),
                   GoRoute(
                     path: 'report-bug',

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -72,6 +72,12 @@ abstract final class AppRoutes {
   /// "About" — version, build, and project links. A child of [settings].
   static const String settingsAbout = '/settings/about';
 
+  /// "Support Linthra" — voluntary, optional ways to support development.
+  /// Reached from About; a child of [settings] so it keeps the bottom nav and
+  /// pops back into that tab. Free and open-source: nothing here gates a
+  /// feature.
+  static const String settingsSupport = '/settings/support';
+
   /// The "Report a bug" builder, reached from Diagnostics & support. A child of
   /// [settings] so it keeps the bottom nav and pops back into that tab.
   static const String reportBug = '/settings/report-bug';

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../app/dimens.dart';
 import '../../../app/external_link_launcher_provider.dart';
+import '../../../app/routes.dart';
 import '../../../core/app_info.dart';
 import '../../../shared/widgets/linthra_logo_mark.dart';
 import '../about/support_section.dart';
@@ -35,6 +37,10 @@ class AboutScreen extends ConsumerWidget {
         const _BuildInfoCard(),
         const SizedBox(height: AppSpacing.md),
         const WhatsNewSection(),
+        const SizedBox(height: AppSpacing.md),
+        _SupportLinthraCard(
+          onTap: () => context.push(AppRoutes.settingsSupport),
+        ),
         const SizedBox(height: AppSpacing.md),
         const SupportSection(),
         const SizedBox(height: AppSpacing.md),
@@ -154,6 +160,39 @@ class _InfoRow extends StatelessWidget {
       trailing: Text(
         value,
         style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+      ),
+    );
+  }
+}
+
+/// A call-to-action that opens the "Support Linthra" screen.
+///
+/// Linthra is free and open source; supporting it is optional, so this is an
+/// invitation, not a gate — every core feature works without it. It is distinct
+/// from the "Support" (help/contact) card below: this one is about supporting
+/// the project, that one is about getting help.
+class _SupportLinthraCard extends StatelessWidget {
+  const _SupportLinthraCard({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: ListTile(
+        leading: Icon(
+          Icons.favorite_outline,
+          color: theme.colorScheme.primary,
+        ),
+        title: const Text('Support Linthra'),
+        subtitle: Text(
+          'Free and open source — support is optional',
+          style: theme.textTheme.bodySmall?.copyWith(color: muted),
+        ),
+        trailing: Icon(Icons.chevron_right, color: muted),
+        onTap: onTap,
       ),
     );
   }

--- a/lib/features/support/support_action.dart
+++ b/lib/features/support/support_action.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+/// How a [SupportAction] behaves when the user taps it.
+///
+/// A small, closed set so the Support screen can render any action uniformly
+/// and never embeds donation or payment logic itself (the product rule). A
+/// future build adds a new kind for its channel — e.g. a Google Play Billing
+/// supporter purchase — and supplies the matching set through
+/// `supportActionsProvider`, rather than the screen growing platform-specific
+/// branches.
+enum SupportActionKind {
+  /// Opens an external page in the browser through the shared
+  /// `externalLinkLauncherProvider` seam (GitHub Sponsors, the funding/supporter
+  /// doc, the source repository). The only kind F-Droid and dev builds offer
+  /// today, and the only kind that ever ships in an F-Droid build: it pulls in
+  /// no billing dependency.
+  externalLink,
+
+  /// A reserved, non-actionable placeholder shown disabled with a short
+  /// "coming soon" hint. It is the seat held for Google Play Billing supporter
+  /// purchases, which are implemented only in a future Play-only build; the
+  /// placeholder itself carries no billing code, so it is safe in every build.
+  comingSoon,
+}
+
+/// One voluntary way to support Linthra's development, described as plain data.
+///
+/// The Support feature is deliberately data-driven: `supportActionsProvider`
+/// assembles the right list for the current build (external links for
+/// F-Droid/dev, with room for a Play supporter purchase later) and
+/// `SupportScreen` renders whatever it is given. Keeping actions as data — not
+/// hard-coded widgets — is what lets future builds swap the set without
+/// touching the screen, and keeps the whole feature unit-testable without a
+/// real browser or store.
+class SupportAction {
+  const SupportAction({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.kind,
+    this.url,
+  }) : assert(
+          kind != SupportActionKind.externalLink || url != null,
+          'An externalLink action must carry the URL to open.',
+        );
+
+  /// Stable identifier, handy for widget keys and tests. Never shown to users.
+  final String id;
+
+  /// Short, scannable label for the action (e.g. "GitHub Sponsors").
+  final String title;
+
+  /// One line under the [title] explaining what the action does.
+  final String description;
+
+  /// Leading glyph for the row.
+  final IconData icon;
+
+  /// What happens on tap — see [SupportActionKind].
+  final SupportActionKind kind;
+
+  /// The page to open for a [SupportActionKind.externalLink] action; null for
+  /// every other kind. Exposed as a parsed [uri] so the screen never parses raw
+  /// strings.
+  final String? url;
+
+  /// The [url] as a [Uri], or null when this action has none.
+  Uri? get uri => url == null ? null : Uri.parse(url!);
+}

--- a/lib/features/support/support_actions_provider.dart
+++ b/lib/features/support/support_actions_provider.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'support_action.dart';
+
+/// The distribution channel a build targets, used **only** to decide which
+/// support actions to offer.
+///
+/// Read once from `--dart-define=LINTHRA_DISTRIBUTION=...` and defaulting to
+/// [fdroid]. The default is the safe one: an ordinary `flutter build` — local,
+/// CI, and the F-Droid build server alike — gets external donation links only
+/// and never the Play billing seat, so F-Droid builds stay free of any
+/// proprietary billing path. This mirrors how `AppInfo` reads its optional
+/// `LINTHRA_VERSION_NAME` override from the environment.
+enum SupportDistribution {
+  /// F-Droid, dev, and GitHub-Release builds: external donation links only.
+  fdroid,
+
+  /// A future Play-Store-only build: keeps the links and adds a placeholder for
+  /// the Google Play Billing supporter purchase a later, Play-only PR will
+  /// implement. Selecting it today changes only which rows are listed; it adds
+  /// no billing code or dependency.
+  play;
+
+  /// The channel this build was compiled for, from the dart-define (default
+  /// [fdroid]).
+  static SupportDistribution get current =>
+      fromDefine(const String.fromEnvironment('LINTHRA_DISTRIBUTION'));
+
+  /// Pure parser behind [current]: maps the dart-define string to a channel,
+  /// falling back to [fdroid] for the empty or unknown value. Exposed so the
+  /// mapping is unit-testable without recompiling under a dart-define.
+  static SupportDistribution fromDefine(String value) {
+    switch (value.trim().toLowerCase()) {
+      case 'play':
+      case 'playstore':
+      case 'google':
+        return SupportDistribution.play;
+      default:
+        return SupportDistribution.fdroid;
+    }
+  }
+}
+
+/// External destinations the support links point at, in one place so a
+/// maintainer can update a handle without touching the screen.
+///
+/// Treat the donation handles as placeholders until the matching accounts are
+/// live (see docs/SUPPORT.md): the screen and tests only assert that each link
+/// is well-formed, never that an account exists.
+abstract final class SupportLinks {
+  /// GitHub Sponsors page for the project owner. Placeholder until Sponsors is
+  /// enabled on the account.
+  static const String gitHubSponsors = 'https://github.com/sponsors/thezupzup';
+
+  /// The supporter-model doc shipped in this repository — what support funds,
+  /// and how the F-Droid vs Play distinction works.
+  static const String supporterModel =
+      'https://github.com/thezupzup/linthra/blob/main/docs/SUPPORT.md';
+
+  /// The public source repository — supporting by reading, building, starring,
+  /// or contributing is always free.
+  static const String sourceCode = 'https://github.com/thezupzup/linthra';
+}
+
+/// Builds the support actions offered for [distribution].
+///
+/// Pure and Flutter-light (only icon constants) so it is unit-testable without
+/// a `ProviderScope`, a browser, or a build flavor. Every build gets the same
+/// external links; the [SupportDistribution.play] channel additionally lists
+/// the disabled "supporter purchase" placeholder that a future Play-only PR
+/// will turn into a real Google Play Billing action. No billing code lives
+/// here.
+List<SupportAction> supportActionsFor(SupportDistribution distribution) {
+  final List<SupportAction> actions = <SupportAction>[
+    const SupportAction(
+      id: 'github-sponsors',
+      title: 'GitHub Sponsors',
+      description: 'Sponsor Linthra on GitHub — one-off or monthly.',
+      icon: Icons.favorite_outline,
+      kind: SupportActionKind.externalLink,
+      url: SupportLinks.gitHubSponsors,
+    ),
+    const SupportAction(
+      id: 'supporter-model',
+      title: 'Funding & supporter model',
+      description: 'How support is used and what is planned.',
+      icon: Icons.volunteer_activism_outlined,
+      kind: SupportActionKind.externalLink,
+      url: SupportLinks.supporterModel,
+    ),
+    const SupportAction(
+      id: 'source-code',
+      title: 'View source code',
+      description: 'Linthra is open source — read, build, and contribute.',
+      icon: Icons.code_outlined,
+      kind: SupportActionKind.externalLink,
+      url: SupportLinks.sourceCode,
+    ),
+  ];
+
+  // Reserved seat for Play Store supporter purchases. Listed only in a Play
+  // build and only as a disabled "coming soon" row — the real Google Play
+  // Billing action ships in a later, Play-only PR, so F-Droid never carries a
+  // billing dependency.
+  if (distribution == SupportDistribution.play) {
+    actions.add(
+      const SupportAction(
+        id: 'play-supporter',
+        title: 'Become a supporter',
+        description: 'One-time supporter purchases are coming to the Play '
+            'Store edition.',
+        icon: Icons.workspace_premium_outlined,
+        kind: SupportActionKind.comingSoon,
+      ),
+    );
+  }
+
+  return actions;
+}
+
+/// The support actions for the current build, read by `SupportScreen`.
+///
+/// This is the seam future builds extend: a Play-only build overrides this
+/// provider (or relies on the [SupportDistribution.play] branch in
+/// [supportActionsFor]) to surface its supporter purchase, while F-Droid and
+/// dev builds keep the external links and nothing else. Declaring it as a
+/// provider also lets widget tests inject a fixed list without a dart-define.
+final supportActionsProvider = Provider<List<SupportAction>>(
+  (ref) => supportActionsFor(SupportDistribution.current),
+);

--- a/lib/features/support/support_actions_provider.dart
+++ b/lib/features/support/support_actions_provider.dart
@@ -110,7 +110,7 @@ List<SupportAction> supportActionsFor(SupportDistribution distribution) {
         title: 'Become a supporter',
         description: 'One-time supporter purchases are coming to the Play '
             'Store edition.',
-        icon: Icons.workspace_premium_outlined,
+        icon: Icons.card_giftcard_outlined,
         kind: SupportActionKind.comingSoon,
       ),
     );

--- a/lib/features/support/support_screen.dart
+++ b/lib/features/support/support_screen.dart
@@ -110,6 +110,13 @@ class _IntroCard extends StatelessWidget {
               'project keep going.',
               style: theme.textTheme.bodyMedium?.copyWith(color: muted),
             ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'No ads. No tracking. No locked core features.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
             const SizedBox(height: AppSpacing.md),
             Text(
               'Where your support goes',

--- a/lib/features/support/support_screen.dart
+++ b/lib/features/support/support_screen.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/dimens.dart';
+import '../../app/external_link_launcher_provider.dart';
+import 'support_action.dart';
+import 'support_actions_provider.dart';
+
+/// The "Support Linthra" screen, reached from Settings → About.
+///
+/// Linthra is free and open source and stays that way: this screen exists only
+/// to make *voluntary* support easy to find. It states plainly that support is
+/// optional and that every core feature stays free, explains where
+/// contributions go (development, testing devices, app-store costs, and
+/// long-term maintenance), and lists a few ways to help.
+///
+/// It owns no donation or payment logic. The actions come from
+/// [supportActionsProvider] — external links for F-Droid and dev builds, with a
+/// disabled placeholder reserved for a future Play Store supporter purchase —
+/// and links open through the shared [externalLinkLauncherProvider], the same
+/// browser seam the About page uses, so every launch is an explicit tap and
+/// widget tests stay plugin-free.
+class SupportScreen extends ConsumerWidget {
+  const SupportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<SupportAction> actions = ref.watch(supportActionsProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Support Linthra')),
+      body: ListView(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        children: <Widget>[
+          const _IntroCard(),
+          const SizedBox(height: AppSpacing.md),
+          _ActionsCard(
+            actions: actions,
+            onOpenLink: (SupportAction action) =>
+                _openLink(context, ref, action),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          const _FreeForeverNote(),
+        ],
+      ),
+    );
+  }
+
+  /// Opens an [SupportActionKind.externalLink] action through the shared
+  /// launcher, falling back to a snackbar if the platform can't (the launcher
+  /// never throws). The messenger is captured before the await so we don't
+  /// touch [context] across an async gap — the same guard the About page uses.
+  Future<void> _openLink(
+    BuildContext context,
+    WidgetRef ref,
+    SupportAction action,
+  ) async {
+    final Uri? url = action.uri;
+    if (url == null) {
+      return;
+    }
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool launched =
+        await ref.read(externalLinkLauncherProvider).open(url);
+    if (!launched) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text("Couldn't open the link.")),
+      );
+    }
+  }
+}
+
+/// The explanatory header: Linthra is free and open source, support is
+/// optional, and a short list of where support goes.
+class _IntroCard extends StatelessWidget {
+  const _IntroCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.favorite_outline,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'Linthra is free and open source',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Supporting Linthra is completely optional. Every feature is '
+              'free, with no ads and no tracking — support simply helps the '
+              'project keep going.',
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Text(
+              'Where your support goes',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            const _SupportUse(
+              icon: Icons.build_outlined,
+              text: 'Development and new features',
+            ),
+            const _SupportUse(
+              icon: Icons.phone_android_outlined,
+              text: 'Testing devices',
+            ),
+            const _SupportUse(
+              icon: Icons.storefront_outlined,
+              text: 'App store and distribution costs',
+            ),
+            const _SupportUse(
+              icon: Icons.update_outlined,
+              text: 'Long-term maintenance',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single "where your support goes" line: a muted glyph and a label.
+class _SupportUse extends StatelessWidget {
+  const _SupportUse({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, size: 20, color: muted),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(child: Text(text, style: theme.textTheme.bodyMedium)),
+        ],
+      ),
+    );
+  }
+}
+
+/// Callback a support row uses to open its external link, wired by the screen.
+typedef _OpenSupportLink = void Function(SupportAction action);
+
+/// The card listing the support actions, one row each with dividers between.
+class _ActionsCard extends StatelessWidget {
+  const _ActionsCard({required this.actions, required this.onOpenLink});
+
+  final List<SupportAction> actions;
+  final _OpenSupportLink onOpenLink;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> rows = <Widget>[];
+    for (final SupportAction action in actions) {
+      if (rows.isNotEmpty) {
+        rows.add(const Divider(height: 0));
+      }
+      rows.add(_SupportActionRow(action: action, onOpenLink: onOpenLink));
+    }
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: rows,
+      ),
+    );
+  }
+}
+
+/// One support action rendered by its [SupportActionKind]: a tappable external
+/// link, or a disabled "coming soon" placeholder. The row interprets only the
+/// generic kind — never which build it is or any payment behaviour — so the
+/// screen stays free of platform-specific donation logic.
+class _SupportActionRow extends StatelessWidget {
+  const _SupportActionRow({required this.action, required this.onOpenLink});
+
+  final SupportAction action;
+  final _OpenSupportLink onOpenLink;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    switch (action.kind) {
+      case SupportActionKind.externalLink:
+        return ListTile(
+          leading: Icon(action.icon, color: theme.colorScheme.primary),
+          title: Text(action.title),
+          subtitle: Text(action.description),
+          trailing: Icon(Icons.open_in_new, size: 18, color: muted),
+          onTap: () => onOpenLink(action),
+        );
+      case SupportActionKind.comingSoon:
+        return ListTile(
+          enabled: false,
+          leading: Icon(action.icon, color: muted),
+          title: Text(action.title),
+          subtitle: Text(action.description),
+          trailing: Text(
+            'Coming soon',
+            style: theme.textTheme.labelSmall?.copyWith(color: muted),
+          ),
+        );
+    }
+  }
+}
+
+/// A closing reassurance: support never gates anything — the core stays free.
+class _FreeForeverNote extends StatelessWidget {
+  const _FreeForeverNote();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(Icons.lock_open_outlined, size: 18, color: muted),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: Text(
+            'All core features stay free and unlocked — support never gates '
+            'anything in Linthra.',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/support/support_screen.dart
+++ b/lib/features/support/support_screen.dart
@@ -40,6 +40,8 @@ class SupportScreen extends ConsumerWidget {
           ),
           const SizedBox(height: AppSpacing.md),
           const _FreeForeverNote(),
+          const SizedBox(height: AppSpacing.md),
+          const _LonelyMaintainerNote(),
         ],
       ),
     );
@@ -245,12 +247,61 @@ class _FreeForeverNote extends StatelessWidget {
         const SizedBox(width: AppSpacing.sm),
         Expanded(
           child: Text(
-            'All core features stay free and unlocked — support never gates '
-            'anything in Linthra.',
+            'All core features stay free and unlocked. Support never gates '
+            'anything, unlocks nothing, and changes nothing about how the app '
+            'works.',
             style: theme.textTheme.bodySmall?.copyWith(color: muted),
           ),
         ),
       ],
+    );
+  }
+}
+
+/// A small, deliberately secondary and playful aside beneath the serious
+/// explanation. It is tone only: it sits at the bottom (never the headline),
+/// is rendered inline (never a popup), blocks no navigation, gates and unlocks
+/// nothing, and keeps "No pressure" in view so it never reads as a guilt-trip.
+class _LonelyMaintainerNote extends StatelessWidget {
+  const _LonelyMaintainerNote();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color faint = theme.colorScheme.onSurface.withValues(alpha: 0.5);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.primary.withValues(alpha: 0.05),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              "I'm lonely… I'm so lonely… I got nobody 🥺",
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: faint,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              'Nobody to help me keep Linthra alive except you.',
+              style: theme.textTheme.bodySmall?.copyWith(color: faint),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            // Kept the most readable line of the aside so the reassurance — not
+            // the lament — is what stands out.
+            Text(
+              'No pressure. Just support if you want to help this lonely '
+              'maintainer build something cool. ❤️',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:linthra/app/external_link_launcher_provider.dart';
+import 'package:linthra/app/routes.dart';
 import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
 import 'package:linthra/features/settings/about/whats_new_section.dart';
@@ -104,6 +106,56 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("Couldn't open the link."), findsOneWidget);
+    });
+
+    testWidgets('offers a "Support Linthra" entry', (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Support Linthra'), findsOneWidget);
+      expect(
+        find.text('Free and open source — support is optional'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping "Support Linthra" opens the support screen',
+        (tester) async {
+      final _FakeLinkLauncher launcher = _FakeLinkLauncher();
+      // A tall surface so the support card (mid-page) is laid out and hittable.
+      tester.view.physicalSize = const Size(1000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      // A minimal router so the tap can be proven to push the support route,
+      // standing in the real SupportScreen with a marker leaf.
+      final GoRouter router = GoRouter(
+        initialLocation: AppRoutes.settingsAbout,
+        routes: <RouteBase>[
+          GoRoute(
+            path: AppRoutes.settingsAbout,
+            builder: (_, __) => const AboutScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.settingsSupport,
+            builder: (_, __) => const Scaffold(body: Text('SUPPORT_PAGE')),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            externalLinkLauncherProvider.overrideWithValue(launcher),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Support Linthra'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('SUPPORT_PAGE'), findsOneWidget);
     });
   });
 }

--- a/test/features/support/support_action_test.dart
+++ b/test/features/support/support_action_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/support/support_action.dart';
+
+void main() {
+  group('SupportAction', () {
+    test('an externalLink action exposes its url as a parsed Uri', () {
+      const SupportAction action = SupportAction(
+        id: 'github-sponsors',
+        title: 'GitHub Sponsors',
+        description: 'Sponsor on GitHub.',
+        icon: Icons.favorite_outline,
+        kind: SupportActionKind.externalLink,
+        url: 'https://github.com/sponsors/thezupzup',
+      );
+
+      expect(action.uri, Uri.parse('https://github.com/sponsors/thezupzup'));
+    });
+
+    test('a comingSoon action carries no url', () {
+      const SupportAction action = SupportAction(
+        id: 'play-supporter',
+        title: 'Become a supporter',
+        description: 'Coming to the Play Store edition.',
+        icon: Icons.workspace_premium_outlined,
+        kind: SupportActionKind.comingSoon,
+      );
+
+      expect(action.url, isNull);
+      expect(action.uri, isNull);
+    });
+
+    test('an externalLink action without a url fails the assertion', () {
+      expect(
+        () => SupportAction(
+          id: 'broken',
+          title: 'Broken',
+          description: 'Missing url.',
+          icon: Icons.error_outline,
+          kind: SupportActionKind.externalLink,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/test/features/support/support_action_test.dart
+++ b/test/features/support/support_action_test.dart
@@ -22,7 +22,7 @@ void main() {
         id: 'play-supporter',
         title: 'Become a supporter',
         description: 'Coming to the Play Store edition.',
-        icon: Icons.workspace_premium_outlined,
+        icon: Icons.card_giftcard_outlined,
         kind: SupportActionKind.comingSoon,
       );
 

--- a/test/features/support/support_actions_provider_test.dart
+++ b/test/features/support/support_actions_provider_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/support/support_action.dart';
+import 'package:linthra/features/support/support_actions_provider.dart';
+
+void main() {
+  group('SupportDistribution.fromDefine', () {
+    test('defaults to fdroid for the empty dart-define', () {
+      expect(SupportDistribution.fromDefine(''), SupportDistribution.fdroid);
+    });
+
+    test('defaults to fdroid for an unknown value', () {
+      expect(
+        SupportDistribution.fromDefine('something-else'),
+        SupportDistribution.fdroid,
+      );
+    });
+
+    test('maps the known Play aliases to play, case- and space-insensitively',
+        () {
+      for (final String value in <String>['play', 'PlayStore', '  google ']) {
+        expect(
+          SupportDistribution.fromDefine(value),
+          SupportDistribution.play,
+          reason: '"$value" should select the Play channel',
+        );
+      }
+    });
+
+    test('"fdroid" and "github" resolve to fdroid', () {
+      expect(
+        SupportDistribution.fromDefine('fdroid'),
+        SupportDistribution.fdroid,
+      );
+      expect(
+        SupportDistribution.fromDefine('github'),
+        SupportDistribution.fdroid,
+      );
+    });
+  });
+
+  group('supportActionsFor', () {
+    test('the F-Droid build offers external links only — no billing seat', () {
+      final List<SupportAction> actions =
+          supportActionsFor(SupportDistribution.fdroid);
+
+      expect(
+        actions.map((SupportAction a) => a.id),
+        <String>['github-sponsors', 'supporter-model', 'source-code'],
+      );
+      // Every F-Droid action is an external link; nothing is a billing/coming
+      // -soon placeholder, so an F-Droid build never carries a billing path.
+      expect(
+        actions.every(
+          (SupportAction a) => a.kind == SupportActionKind.externalLink,
+        ),
+        isTrue,
+      );
+    });
+
+    test('the Play build adds a disabled supporter-purchase placeholder', () {
+      final List<SupportAction> actions =
+          supportActionsFor(SupportDistribution.play);
+
+      // The same external links, plus the reserved Play seat at the end.
+      expect(
+        actions.map((SupportAction a) => a.id),
+        <String>[
+          'github-sponsors',
+          'supporter-model',
+          'source-code',
+          'play-supporter',
+        ],
+      );
+      final SupportAction playSeat = actions.last;
+      expect(playSeat.kind, SupportActionKind.comingSoon);
+      // A placeholder only — it opens nothing and pulls in no billing code.
+      expect(playSeat.url, isNull);
+    });
+
+    test('every external-link action has a well-formed https URL', () {
+      for (final SupportDistribution distribution
+          in SupportDistribution.values) {
+        for (final SupportAction action in supportActionsFor(distribution)) {
+          if (action.kind != SupportActionKind.externalLink) {
+            continue;
+          }
+          final Uri? uri = action.uri;
+          expect(uri, isNotNull, reason: '${action.id} must have a url');
+          expect(uri!.scheme, 'https', reason: '${action.id} must be https');
+          expect(uri.host, isNotEmpty);
+        }
+      }
+    });
+  });
+}

--- a/test/features/support/support_screen_test.dart
+++ b/test/features/support/support_screen_test.dart
@@ -43,7 +43,7 @@ const List<SupportAction> _actions = <SupportAction>[
     id: 'play-supporter',
     title: 'Become a supporter',
     description: 'Coming soon to the Play Store edition.',
-    icon: Icons.workspace_premium_outlined,
+    icon: Icons.card_giftcard_outlined,
     kind: SupportActionKind.comingSoon,
   ),
 ];
@@ -82,6 +82,11 @@ void main() {
       expect(find.text('Support Linthra'), findsWidgets);
       expect(find.text('Linthra is free and open source'), findsOneWidget);
       expect(find.textContaining('completely optional'), findsOneWidget);
+      // The crisp, scannable trio stays visible.
+      expect(
+        find.text('No ads. No tracking. No locked core features.'),
+        findsOneWidget,
+      );
 
       // Where support goes — the four funded areas.
       expect(find.text('Where your support goes'), findsOneWidget);

--- a/test/features/support/support_screen_test.dart
+++ b/test/features/support/support_screen_test.dart
@@ -90,9 +90,25 @@ void main() {
       expect(find.text('App store and distribution costs'), findsOneWidget);
       expect(find.text('Long-term maintenance'), findsOneWidget);
 
-      // The core-stays-free reassurance.
+      // The core-stays-free reassurance — support changes nothing.
       expect(
           find.textContaining('All core features stay free'), findsOneWidget);
+      expect(find.textContaining('unlocks nothing'), findsOneWidget);
+    });
+
+    testWidgets(
+        'includes a secondary, playful "lonely maintainer" note with '
+        '"No pressure" kept visible', (tester) async {
+      await _pump(tester);
+
+      expect(find.textContaining("I'm lonely"), findsOneWidget);
+      expect(
+        find.textContaining('keep Linthra alive except you'),
+        findsOneWidget,
+      );
+      // The anti-guilt-trip reassurance is present and visible.
+      expect(find.textContaining('No pressure'), findsOneWidget);
+      expect(find.textContaining('build something cool'), findsOneWidget);
     });
 
     testWidgets('renders a row per action from the provider', (tester) async {

--- a/test/features/support/support_screen_test.dart
+++ b/test/features/support/support_screen_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/external_link_launcher_provider.dart';
+import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/features/support/support_action.dart';
+import 'package:linthra/features/support/support_actions_provider.dart';
+import 'package:linthra/features/support/support_screen.dart';
+
+class _FakeLinkLauncher implements ExternalLinkLauncher {
+  _FakeLinkLauncher({this.result = true});
+
+  final bool result;
+  Uri? opened;
+
+  @override
+  Future<bool> open(Uri url) async {
+    opened = url;
+    return result;
+  }
+}
+
+/// A fixed action list — two external links and a disabled placeholder — so the
+/// screen test is independent of the build flavor and exercises both kinds.
+const List<SupportAction> _actions = <SupportAction>[
+  SupportAction(
+    id: 'github-sponsors',
+    title: 'GitHub Sponsors',
+    description: 'Sponsor on GitHub.',
+    icon: Icons.favorite_outline,
+    kind: SupportActionKind.externalLink,
+    url: 'https://example.com/sponsors',
+  ),
+  SupportAction(
+    id: 'source-code',
+    title: 'View source code',
+    description: 'Read the code.',
+    icon: Icons.code_outlined,
+    kind: SupportActionKind.externalLink,
+    url: 'https://example.com/repo',
+  ),
+  SupportAction(
+    id: 'play-supporter',
+    title: 'Become a supporter',
+    description: 'Coming soon to the Play Store edition.',
+    icon: Icons.workspace_premium_outlined,
+    kind: SupportActionKind.comingSoon,
+  ),
+];
+
+Future<_FakeLinkLauncher> _pump(
+  WidgetTester tester, {
+  bool launchResult = true,
+  List<SupportAction> actions = _actions,
+}) async {
+  final _FakeLinkLauncher launcher = _FakeLinkLauncher(result: launchResult);
+  // A tall surface so every card and row is laid out and hittable — a ListView
+  // only builds the rows it can show.
+  tester.view.physicalSize = const Size(1000, 2000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        externalLinkLauncherProvider.overrideWithValue(launcher),
+        supportActionsProvider.overrideWithValue(actions),
+      ],
+      child: const MaterialApp(home: SupportScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return launcher;
+}
+
+void main() {
+  group('SupportScreen', () {
+    testWidgets('explains that Linthra is free, optional, and stays free',
+        (tester) async {
+      await _pump(tester);
+
+      expect(find.text('Support Linthra'), findsWidgets);
+      expect(find.text('Linthra is free and open source'), findsOneWidget);
+      expect(find.textContaining('completely optional'), findsOneWidget);
+
+      // Where support goes — the four funded areas.
+      expect(find.text('Where your support goes'), findsOneWidget);
+      expect(find.text('Development and new features'), findsOneWidget);
+      expect(find.text('Testing devices'), findsOneWidget);
+      expect(find.text('App store and distribution costs'), findsOneWidget);
+      expect(find.text('Long-term maintenance'), findsOneWidget);
+
+      // The core-stays-free reassurance.
+      expect(
+          find.textContaining('All core features stay free'), findsOneWidget);
+    });
+
+    testWidgets('renders a row per action from the provider', (tester) async {
+      await _pump(tester);
+
+      expect(find.text('GitHub Sponsors'), findsOneWidget);
+      expect(find.text('View source code'), findsOneWidget);
+      expect(find.text('Become a supporter'), findsOneWidget);
+    });
+
+    testWidgets('tapping an external-link action opens its URL',
+        (tester) async {
+      final _FakeLinkLauncher launcher = await _pump(tester);
+
+      await tester.tap(find.text('GitHub Sponsors'));
+      await tester.pumpAndSettle();
+
+      expect(launcher.opened, Uri.parse('https://example.com/sponsors'));
+    });
+
+    testWidgets('the coming-soon placeholder is disabled and opens nothing',
+        (tester) async {
+      final _FakeLinkLauncher launcher = await _pump(tester);
+
+      expect(find.text('Coming soon'), findsOneWidget);
+      final ListTile tile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text('Become a supporter'),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect(tile.enabled, isFalse);
+      expect(tile.onTap, isNull);
+      expect(launcher.opened, isNull);
+    });
+
+    testWidgets('shows a snackbar when a link cannot be opened',
+        (tester) async {
+      await _pump(tester, launchResult: false);
+
+      await tester.tap(find.text('View source code'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Couldn't open the link."), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an optional, opt-in **"Support Linthra"** screen reached from **Settings → About**. Linthra remains free and open source — this PR adds only the screen, copy, navigation entry, and a build‑safe structure for future monetization. **No ads, no tracking, no feature gating, no new dependencies, no Google Play Billing.**

The implementation is a small, data‑driven module so it's easy to extend: the screen renders whatever actions a provider gives it, and the action set is chosen per build behind one seam.

## Files changed

**New — `lib/features/support/`**
- `support_action.dart` — `SupportAction` model + `SupportActionKind` (`externalLink` | `comingSoon`). Plain data, so future builds can swap the set without touching the screen.
- `support_actions_provider.dart` — the per‑build seam: `SupportDistribution` (read from `--dart-define=LINTHRA_DISTRIBUTION`, **defaults to `fdroid`**), the pure `supportActionsFor()` catalog, `SupportLinks` (URLs in one place), and `supportActionsProvider`.
- `support_screen.dart` — `SupportScreen`. Renders the copy (free & open source, optional, where support goes, core features stay free) and the provider's actions. Owns **no** donation/payment logic; links open via the existing `externalLinkLauncher` seam.

**Wiring**
- `lib/app/routes.dart` — `AppRoutes.settingsSupport` (`/settings/support`).
- `lib/app/router.dart` — the `support` route.
- `lib/features/settings/hub/about_screen.dart` — a "Support Linthra" card that opens the screen (distinct from the existing "Support" help/contact card).

**Docs**
- `docs/SUPPORT.md` — the supporter model, architecture, F‑Droid safety, and the future Play plan.
- `README.md` — doc‑table entry + a short "Support development (optional)" note.

**Tests**
- `test/features/support/support_action_test.dart`, `support_actions_provider_test.dart`, `support_screen_test.dart`
- `test/features/settings/hub/about_screen_test.dart` — the About entry + navigation.

## How the screen is reached

**Settings → About → "Support Linthra"** card → `/settings/support`.

## Today's actions (F‑Droid / dev default)

External links only: **GitHub Sponsors**, **Funding & supporter model** (docs/SUPPORT.md), **View source code**. The donation handle is a placeholder centralized in `SupportLinks`; tests assert links are well‑formed `https`, not that accounts exist.

## Why this is safe for F‑Droid

- `SupportDistribution` **defaults to `fdroid`**, so a plain `flutter build` (CI and the F‑Droid build server) compiles the **external‑links‑only** set — no billing row is even listed.
- **No dependency changes** — reuses the existing `url_launcher`-backed launcher seam. No Google Play Billing, no proprietary SDK, no GMS.
- No permission, playback, cache, or provider changes.
- The Play supporter purchase is a disabled **"coming soon"** placeholder that exists only for the `play` channel and carries no `url` and no billing code.

## What the next PR should be

The **Play‑only** supporter purchase: add the Google Play Billing dependency and purchase code **behind the Play flavor only** (so it never enters the F‑Droid build or default `pubspec.yaml`), then replace the `comingSoon` placeholder with a real, **non‑gating** purchase action — either a new `SupportActionKind` or a Play‑flavor override of `supportActionsProvider`. Because the screen renders by `kind`, this needs **no change to `SupportScreen`** and **no change to the F‑Droid build**. Details in `docs/SUPPORT.md §6`.

## Verification

`dart format`, `flutter analyze` (clean), `./scripts/check_secrets.sh` (clean), and the full `flutter test` suite (**2591 passing**) all green with the pinned Flutter 3.27.4 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2NDjFP6Km92fHhBAps8q4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2NDjFP6Km92fHhBAps8q4)_