### PR TITLE
feat(appearance): app icon & branding customization (in-app foundation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Reporting a bug | [docs/reporting-bugs.md](./docs/reporting-bugs.md) |
 | Playlists & safe removal | [docs/playlists-and-delete.md](./docs/playlists-and-delete.md) |
 | Smart mixes (automatic playlists) | [docs/smart-mixes.md](./docs/smart-mixes.md) |
+| App icon & branding (in-app personalization) | [docs/app-icon-branding.md](./docs/app-icon-branding.md) |
 | Manual QA checklist | [docs/manual-test-checklist.md](./docs/manual-test-checklist.md) |
 | Release process & signing | [docs/release-process.md](./docs/release-process.md) · [signing](./docs/release-signing.md) |
 | F-Droid readiness | [docs/fdroid-readiness.md](./docs/fdroid-readiness.md) |

--- a/docs/app-icon-branding.md
+++ b/docs/app-icon-branding.md
@@ -1,0 +1,125 @@
+# App icon & branding
+
+Linthra lets you choose how its brand mark looks across the app. The picker
+lives under **Settings → Appearance → App icon & branding**.
+
+This is purely cosmetic. Every variant is free and available to everyone in
+every build, the choice gates nothing, and it changes nothing about how Linthra
+plays, syncs, caches, or stores your music.
+
+## What a "variant" is
+
+Linthra's in-app mark — the rounded equalizer bars under a single vertical
+gradient — is drawn in Dart by
+[`LinthraLogoMark`](../lib/shared/widgets/linthra_logo_mark.dart), the twin of
+the launcher/store icon in [`tool/branding/`](../tool/branding). A *variant* is
+just a different **gradient** (top colour first) over a different **bar
+pattern**. Because variants are plain data — no images, no extra assets — the
+whole catalog is `const`, ships in every build, adds no dependencies, and is
+trivially unit-testable.
+
+Every variant keeps the equalizer-bar identity, so Linthra stays recognisable.
+The built-in set (see
+[`app_icon_variant.dart`](../lib/features/appearance/app_icon_variant.dart)):
+
+| id         | Label             | Look                                   |
+| ---------- | ----------------- | -------------------------------------- |
+| `classic`  | Classic (default) | Signature violet→orange equalizer      |
+| `dark`     | Dark              | Stealthy single-violet                 |
+| `neon`     | Neon              | Violet → electric cyan                  |
+| `server`   | Self-hosted       | Rising teal→violet signal bars         |
+| `waveform` | Waveform          | Symmetric sound wave                   |
+| `lonely`   | Lonely maintainer | One bar standing on its own            |
+| `gold`     | Gold              | Warm gold (cosmetic supporter preview) |
+
+## Architecture
+
+A small, data-driven feature that mirrors the Support module's per-build seam:
+
+- **Catalog** — `AppIconVariant` / `AppIconVariants` define the variants and a
+  pure `byId(String?)` resolver that returns **Classic** for a null, empty, or
+  unknown id. This is the single place the "unknown → Classic" rule lives.
+- **Storage** — `AppIconVariantStore` persists one non-secret variant id.
+  `InMemoryAppIconVariantStore` is the test/default binding;
+  `SharedPreferencesAppIconVariantStore` (key `selected_app_icon_variant_v1`)
+  is wired in `main`.
+- **Controller** — `AppIconController` (a Riverpod `Notifier`) loads the stored
+  choice on startup, serves Classic until then, and persists every change.
+- **In-app use** — `SelectedLinthraLogoMark` watches the controller and feeds
+  the chosen variant into the pure `LinthraLogoMark`, so the About page and the
+  Settings header reflect the choice immediately. `LinthraLogoMark` itself stays
+  presentational and state-free; its default constructor renders the classic
+  mark byte-for-byte as before.
+
+## F-Droid safety
+
+- **No new dependencies, no proprietary SDKs, no billing, no tracking.** The
+  feature is pure Dart + the existing `shared_preferences`.
+- **Every variant is available in the default/F-Droid build**, including the
+  `gold` style. There is no gating field anywhere in the model, so nothing can
+  be locked.
+- The `AppIconTier.supporter` field is a *data* seam only (see below). It is not
+  a gate, and the F-Droid build always offers every tier.
+
+## Cosmetic "supporter" preview (and the future Play-only plan)
+
+`gold` carries `AppIconTier.supporter` and shows a neutral **"Preview"** badge.
+In this build — and always in F-Droid — it is fully selectable like any other
+variant. The tier exists purely to *prepare* for a future, **Play-only** PR that
+may present supporter-tier styles as cosmetic supporter rewards behind the Play
+flavor, in the same spirit as the Play supporter purchase reserved in
+[`docs/SUPPORT.md`](SUPPORT.md).
+
+If/when that lands, it must:
+
+- live **behind the Play flavor only**, never entering the F-Droid build or the
+  default `pubspec.yaml`;
+- gate **cosmetics only** — it can never affect playback, offline cache,
+  providers, Android Auto, or any core feature; and
+- keep the F-Droid build fully functional with every variant available.
+
+The seam for it is already here: filter or mark variants in
+`appIconVariantsFor(SupportDistribution)` (the choke point the
+`availableAppIconVariantsProvider` reads), exactly as `supportActionsFor()`
+adds its Play-only row. The picker screen renders whatever list it is given, so
+that change needs no screen edits and no change to the F-Droid build.
+
+## Launcher icon switching — deferred, documented here
+
+This PR customises **in-app** branding only. Switching the actual Android
+**launcher** icon is deliberately out of scope because it is invasive and risks
+F-Droid reproducibility. Documented here so a future PR has a starting point:
+
+### The `activity-alias` approach
+
+Android can expose several launcher icons for one app by declaring multiple
+`<activity-alias>` entries in `AndroidManifest.xml`, each pointing at the main
+activity but with its own `android:icon`/`android:roundIcon` and an
+`android.intent.category.LAUNCHER` intent filter. Exactly one alias is enabled
+at a time; switching is done at runtime with:
+
+```kotlin
+packageManager.setComponentEnabledSetting(
+    ComponentName(context, "<package>.<AliasName>"),
+    PackageManager.COMPONENT_ENABLED_STATE_ENABLED, // or DISABLED for the others
+    PackageManager.DONT_KILL_APP,
+)
+```
+
+driven from Dart over a small platform `MethodChannel`.
+
+### Why it is deferred
+
+- **Multiple pre-rendered icon sets.** Each alias needs its own mipmap set in
+  every density, regenerated via `tool/branding/generate_icons.py`. That
+  multiplies committed PNGs and the icon-generation surface.
+- **Manifest churn + launcher behaviour.** Each variant adds an alias; toggling
+  one typically makes the launcher drop and re-add the icon (it can briefly
+  disappear or move), which is a jarring UX that needs care.
+- **F-Droid reproducibility.** More generated binary assets and manifest entries
+  enlarge the reproducible-build surface that
+  [`docs/fdroid-reproducibility-arm64.md`](fdroid-reproducibility-arm64.md)
+  guards.
+
+Given that, real launcher-icon switching is left to a later, focused PR. The
+in-app branding here is intentionally self-contained and does not depend on it.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../features/appearance/appearance_settings_screen.dart';
 import '../features/downloads/downloads_screen.dart';
 import '../features/favorites/favorites_screen.dart';
 import '../features/library/album_detail_screen.dart';
@@ -119,6 +120,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: 'downloads',
                     builder: (context, state) => const OfflineDownloadsScreen(),
+                  ),
+                  GoRoute(
+                    path: 'appearance',
+                    builder: (context, state) =>
+                        const AppearanceSettingsScreen(),
                   ),
                   GoRoute(
                     path: 'diagnostics',

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -65,6 +65,10 @@ abstract final class AppRoutes {
   /// [settings].
   static const String settingsDownloads = '/settings/downloads';
 
+  /// "Appearance" — pick an in-app branding variant for the Linthra mark. Purely
+  /// cosmetic; a child of [settings].
+  static const String settingsAppearance = '/settings/appearance';
+
   /// "Diagnostics & support" — report a bug and copy a safe diagnostics
   /// snapshot. A child of [settings].
   static const String settingsDiagnostics = '/settings/diagnostics';

--- a/lib/core/repositories/app_icon_variant_store.dart
+++ b/lib/core/repositories/app_icon_variant_store.dart
@@ -1,0 +1,15 @@
+/// Persists the user's selected app-icon / branding variant.
+///
+/// The stored value is a single non-secret variant id (e.g. `classic`,
+/// `neon`), or `null` when the user has not chosen one (the default, which
+/// resolves to Classic). It carries no credential, URL, or library content, so
+/// a lightweight key/value store is the right weight — the same reasoning the
+/// default-provider store follows.
+abstract interface class AppIconVariantStore {
+  /// The persisted variant id, or `null` when the user has not chosen one.
+  Future<String?> read();
+
+  /// Persists [variantId], or clears the choice (back to the default) when
+  /// `null` or empty.
+  Future<void> write(String? variantId);
+}

--- a/lib/data/repositories/app_icon_variant_store_provider.dart
+++ b/lib/data/repositories/app_icon_variant_store_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/repositories/app_icon_variant_store.dart';
+import 'in_memory_app_icon_variant_store.dart';
+import 'shared_preferences_app_icon_variant_store.dart';
+
+/// The single [AppIconVariantStore] the app reads/writes the selected branding
+/// variant through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesAppIconVariantStoreOverride] so the choice persists across
+/// restarts.
+final appIconVariantStoreProvider = Provider<AppIconVariantStore>((ref) {
+  return InMemoryAppIconVariantStore();
+});
+
+/// Production binding: persists the selected variant via `shared_preferences`.
+/// Applied in `main`.
+final sharedPreferencesAppIconVariantStoreOverride =
+    appIconVariantStoreProvider.overrideWithValue(
+  const SharedPreferencesAppIconVariantStore(),
+);

--- a/lib/data/repositories/in_memory_app_icon_variant_store.dart
+++ b/lib/data/repositories/in_memory_app_icon_variant_store.dart
@@ -1,0 +1,23 @@
+import '../../core/repositories/app_icon_variant_store.dart';
+
+/// An in-memory [AppIconVariantStore] for tests and the default provider
+/// binding.
+///
+/// Holds the selected variant id in a field so widget and unit tests stay free
+/// of platform plugins; the running app swaps in the `shared_preferences`
+/// implementation so the choice persists across restarts. An optional [initial]
+/// value seeds a "already chosen" state for tests.
+class InMemoryAppIconVariantStore implements AppIconVariantStore {
+  InMemoryAppIconVariantStore([String? initial])
+      : _variantId = (initial == null || initial.isEmpty) ? null : initial;
+
+  String? _variantId;
+
+  @override
+  Future<String?> read() async => _variantId;
+
+  @override
+  Future<void> write(String? variantId) async {
+    _variantId = (variantId == null || variantId.isEmpty) ? null : variantId;
+  }
+}

--- a/lib/data/repositories/shared_preferences_app_icon_variant_store.dart
+++ b/lib/data/repositories/shared_preferences_app_icon_variant_store.dart
@@ -1,0 +1,35 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/repositories/app_icon_variant_store.dart';
+
+/// An [AppIconVariantStore] backed by `shared_preferences`.
+///
+/// The selection is a single non-secret variant id, so one string under one key
+/// is plenty — no token, URL, or library content is ever written here. An
+/// absent or empty value reads as "no choice" (`null`) rather than throwing, so
+/// a storage hiccup falls back to the default (Classic) and never breaks the UI.
+class SharedPreferencesAppIconVariantStore implements AppIconVariantStore {
+  const SharedPreferencesAppIconVariantStore();
+
+  static const String _key = 'selected_app_icon_variant_v1';
+
+  @override
+  Future<String?> read() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? value = prefs.getString(_key);
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    return value;
+  }
+
+  @override
+  Future<void> write(String? variantId) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (variantId == null || variantId.isEmpty) {
+      await prefs.remove(_key);
+      return;
+    }
+    await prefs.setString(_key, variantId);
+  }
+}

--- a/lib/features/appearance/app_icon_controller.dart
+++ b/lib/features/appearance/app_icon_controller.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/repositories/app_icon_variant_store_provider.dart';
+import '../support/support_actions_provider.dart';
+import 'app_icon_variant.dart';
+
+/// Holds the user's selected app-icon / branding variant, defaulting to
+/// [AppIconVariants.classic].
+///
+/// The choice is loaded from the [appIconVariantStoreProvider] store at startup
+/// and persisted on every change, so it survives a restart. Until the async
+/// load lands the controller serves Classic, and an unknown or absent stored id
+/// resolves to Classic too (via [AppIconVariants.byId]) — so the mark always has
+/// a valid look and a storage hiccup can never break the UI.
+class AppIconController extends Notifier<AppIconVariant> {
+  bool _loadStarted = false;
+
+  @override
+  AppIconVariant build() {
+    if (!_loadStarted) {
+      _loadStarted = true;
+      _load();
+    }
+    return AppIconVariants.classic;
+  }
+
+  Future<void> _load() async {
+    try {
+      final String? stored = await ref.read(appIconVariantStoreProvider).read();
+      final AppIconVariant resolved = AppIconVariants.byId(stored);
+      if (resolved.id != state.id) {
+        state = resolved;
+      }
+    } catch (_) {
+      // A storage hiccup must never break the UI; keep Classic.
+    }
+  }
+
+  /// Selects [variant] and persists it. A no-op when nothing changes.
+  Future<void> select(AppIconVariant variant) async {
+    if (variant.id == state.id) {
+      return;
+    }
+    state = variant;
+    try {
+      await ref.read(appIconVariantStoreProvider).write(variant.id);
+    } catch (_) {
+      // Best-effort persistence: the in-memory choice still applies this session.
+    }
+  }
+}
+
+/// The user's selected branding variant. The Appearance screen reads and writes
+/// this; the in-app mark watches it so About and the Settings header reflect the
+/// choice immediately.
+final appIconControllerProvider =
+    NotifierProvider<AppIconController, AppIconVariant>(
+  AppIconController.new,
+);
+
+/// The branding variants offered for [distribution].
+///
+/// Foundation PR: every variant is offered and selectable on every channel,
+/// F-Droid included, so this returns the full catalog unchanged. The
+/// [AppIconVariant.tier] field together with [distribution] is the seam a
+/// future, Play-only PR uses to present supporter-tier styles as cosmetic
+/// rewards — purely cosmetic, never gating playback, cache, providers, Android
+/// Auto, or any core feature, and F-Droid always keeps every variant available.
+List<AppIconVariant> appIconVariantsFor(SupportDistribution distribution) {
+  return AppIconVariants.all;
+}
+
+/// The branding variants offered in this build, read by the Appearance screen.
+///
+/// Declared as a provider so a future build can override the set without
+/// touching the screen, and so widget tests can inject a fixed list. Mirrors the
+/// `supportActionsProvider` seam from the Support feature.
+final availableAppIconVariantsProvider = Provider<List<AppIconVariant>>(
+  (ref) => appIconVariantsFor(SupportDistribution.current),
+);

--- a/lib/features/appearance/app_icon_variant.dart
+++ b/lib/features/appearance/app_icon_variant.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+
+import '../../app/colors.dart';
+
+/// Which builds may offer an [AppIconVariant], and how.
+///
+/// This is a *data* seam, not a gate. In this build — and always in the F-Droid
+/// build — every tier is fully available and selectable; the field exists only
+/// so a future, Play-only PR can present [supporter] styles as cosmetic
+/// supporter rewards behind the Play flavor. Even then it must stay purely
+/// cosmetic: it can never affect playback, offline cache, providers, Android
+/// Auto, or any core feature, and the F-Droid build keeps every variant
+/// available.
+enum AppIconTier {
+  /// Always offered everywhere, with no strings attached.
+  free,
+
+  /// A cosmetic style earmarked for a possible future Play-only supporter
+  /// edition. Offered and selectable here too — shown only with a neutral
+  /// "Preview" badge — because this PR adds no gating or billing of any kind.
+  supporter,
+}
+
+/// One Linthra brand-mark variant: a recolour/restyle of the same equalizer
+/// mark, described as plain data.
+///
+/// Every variant keeps Linthra's identity — rounded equalizer bars under a
+/// single vertical gradient — so the brand stays recognisable; a variant is
+/// just a different [gradient] (top colour first) over a different [bars]
+/// pattern. Because variants are data (no images, no extra assets), the whole
+/// catalog is `const`, ships in every build, and is trivially unit-testable.
+@immutable
+class AppIconVariant {
+  const AppIconVariant({
+    required this.id,
+    required this.label,
+    required this.description,
+    required this.tier,
+    required this.gradient,
+    required this.bars,
+  });
+
+  /// Stable identifier persisted in preferences and used for widget keys and
+  /// tests. Never shown to users.
+  final String id;
+
+  /// Short, scannable name shown on the picker tile (e.g. "Neon").
+  final String label;
+
+  /// One line describing the look, surfaced as the tile's tooltip.
+  final String description;
+
+  /// Whether this is a free style or a cosmetic [AppIconTier.supporter] preview.
+  /// Never gates anything in this build (see [AppIconTier]).
+  final AppIconTier tier;
+
+  /// The mark's vertical gradient, top colour first. Fed straight to the logo
+  /// mark's shader.
+  final List<Color> gradient;
+
+  /// Bar heights as fractions of the mark's box (0..1), left to right. The mark
+  /// lays out however many bars this lists, so a variant can read as a level
+  /// meter, a rising signal, or a symmetric waveform.
+  final List<double> bars;
+}
+
+// Cosmetic tints used only by the optional icon variants. Kept out of
+// [AppColors] so the core palette stays focused on Linthra's primary
+// violet+orange identity.
+const Color _neonViolet = Color(0xFFB14DFF);
+const Color _neonCyan = Color(0xFF22E0D6);
+const Color _serverTeal = Color(0xFF34D9C7);
+const Color _lonelyViolet = Color(0xFF8A7BC0);
+const Color _lonelyAmber = Color(0xFFC98A52);
+const Color _goldBright = Color(0xFFFFE08A);
+const Color _goldDeep = Color(0xFFE6A200);
+
+/// The built-in Linthra brand-mark variants and helpers to resolve them.
+abstract final class AppIconVariants {
+  /// The default identity — today's violet→orange equalizer mark. Also the
+  /// fallback for an unknown or absent stored choice (see [byId]).
+  static const AppIconVariant classic = AppIconVariant(
+    id: 'classic',
+    label: 'Classic',
+    description: "Linthra's signature violet-to-orange equalizer.",
+    tier: AppIconTier.free,
+    gradient: <Color>[AppColors.brandBright, AppColors.accent],
+    bars: <double>[0.46, 0.70, 0.56, 0.34],
+  );
+
+  /// A stealthy single-violet take on the mark.
+  static const AppIconVariant dark = AppIconVariant(
+    id: 'dark',
+    label: 'Dark',
+    description: 'A stealthy single-violet take on the mark.',
+    tier: AppIconTier.free,
+    gradient: <Color>[AppColors.brandBright, AppColors.brandDeep],
+    bars: <double>[0.46, 0.70, 0.56, 0.34],
+  );
+
+  /// High-energy violet into electric cyan.
+  static const AppIconVariant neon = AppIconVariant(
+    id: 'neon',
+    label: 'Neon',
+    description: 'High-energy violet into electric cyan.',
+    tier: AppIconTier.free,
+    gradient: <Color>[_neonViolet, _neonCyan],
+    bars: <double>[0.55, 0.85, 0.70, 0.45],
+  );
+
+  /// Rising signal bars in teal and violet — a nod to self-hosting.
+  static const AppIconVariant server = AppIconVariant(
+    id: 'server',
+    label: 'Self-hosted',
+    description: 'Rising signal bars in teal and violet.',
+    tier: AppIconTier.free,
+    gradient: <Color>[_serverTeal, AppColors.brand],
+    bars: <double>[0.42, 0.58, 0.74, 0.90],
+  );
+
+  /// A symmetric sound wave in the brand colours.
+  static const AppIconVariant waveform = AppIconVariant(
+    id: 'waveform',
+    label: 'Waveform',
+    description: 'A symmetric sound wave in the brand colours.',
+    tier: AppIconTier.free,
+    gradient: <Color>[AppColors.brandBright, AppColors.accent],
+    bars: <double>[0.40, 0.70, 0.90, 0.70, 0.40],
+  );
+
+  /// One bar standing bravely on its own — for the lonely maintainer.
+  static const AppIconVariant lonely = AppIconVariant(
+    id: 'lonely',
+    label: 'Lonely maintainer',
+    description: 'One bar standing bravely on its own. 🥺',
+    tier: AppIconTier.free,
+    gradient: <Color>[_lonelyViolet, _lonelyAmber],
+    bars: <double>[0.18, 0.86, 0.22, 0.16],
+  );
+
+  /// A warm gold treatment. Cosmetic only and fully available here; see
+  /// [AppIconTier.supporter].
+  static const AppIconVariant gold = AppIconVariant(
+    id: 'gold',
+    label: 'Gold',
+    description: 'A warm gold treatment of the mark.',
+    tier: AppIconTier.supporter,
+    gradient: <Color>[_goldBright, _goldDeep],
+    bars: <double>[0.46, 0.70, 0.56, 0.34],
+  );
+
+  /// Every variant in display order; Classic first.
+  static const List<AppIconVariant> all = <AppIconVariant>[
+    classic,
+    dark,
+    neon,
+    server,
+    waveform,
+    lonely,
+    gold,
+  ];
+
+  /// Resolves a stored [id] to its variant, falling back to [classic] for a
+  /// null, empty, or unrecognised value.
+  ///
+  /// This is the single place the "unknown selection → Classic" rule lives, so
+  /// the controller and UI never have to guard for a bad id.
+  static AppIconVariant byId(String? id) {
+    if (id == null || id.isEmpty) {
+      return classic;
+    }
+    for (final AppIconVariant variant in all) {
+      if (variant.id == id) {
+        return variant;
+      }
+    }
+    return classic;
+  }
+}

--- a/lib/features/appearance/appearance_settings_screen.dart
+++ b/lib/features/appearance/appearance_settings_screen.dart
@@ -1,0 +1,243 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/colors.dart';
+import '../../app/dimens.dart';
+import '../../shared/widgets/linthra_logo_mark.dart';
+import 'app_icon_controller.dart';
+import 'app_icon_variant.dart';
+
+/// "App icon & branding" — reached from Settings → Appearance.
+///
+/// Lets the user pick how the Linthra mark looks across the app. It is purely
+/// cosmetic: every variant is free and available to everyone, the choice gates
+/// nothing, and it changes nothing about playback, sync, or storage. Selecting a
+/// variant persists it through [appIconControllerProvider] and is reflected
+/// immediately wherever the mark is shown (About, the Settings header).
+class AppearanceSettingsScreen extends ConsumerWidget {
+  const AppearanceSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<AppIconVariant> variants =
+        ref.watch(availableAppIconVariantsProvider);
+    final AppIconVariant selected = ref.watch(appIconControllerProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('App icon & branding')),
+      body: ListView(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        children: <Widget>[
+          const _IntroCard(),
+          const SizedBox(height: AppSpacing.md),
+          _VariantGrid(
+            variants: variants,
+            selectedId: selected.id,
+            onSelect: (AppIconVariant variant) =>
+                ref.read(appIconControllerProvider.notifier).select(variant),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The explanatory header: branding is cosmetic, free, and gates nothing.
+class _IntroCard extends StatelessWidget {
+  const _IntroCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color muted = theme.colorScheme.onSurface.withValues(alpha: 0.6);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(Icons.palette_outlined, color: theme.colorScheme.primary),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'Make Linthra yours',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Choose how the Linthra mark looks across the app — in About, the '
+              'Settings header, and more. Every variant is free and available to '
+              'everyone, and your choice is purely cosmetic: it changes nothing '
+              'about how Linthra plays, syncs, or stores your music.',
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The wrapping grid of selectable variant tiles.
+class _VariantGrid extends StatelessWidget {
+  const _VariantGrid({
+    required this.variants,
+    required this.selectedId,
+    required this.onSelect,
+  });
+
+  final List<AppIconVariant> variants;
+  final String selectedId;
+  final ValueChanged<AppIconVariant> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSpacing.md,
+      runSpacing: AppSpacing.md,
+      alignment: WrapAlignment.center,
+      children: <Widget>[
+        for (final AppIconVariant variant in variants)
+          _VariantTile(
+            variant: variant,
+            selected: variant.id == selectedId,
+            onTap: () => onSelect(variant),
+          ),
+      ],
+    );
+  }
+}
+
+/// One variant: its mark on a dark squircle, a label, and a "Preview" badge for
+/// the cosmetic supporter tier. The selected tile gets a highlighted border and
+/// a check. Tapping anywhere on the tile selects it.
+class _VariantTile extends StatelessWidget {
+  const _VariantTile({
+    required this.variant,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final AppIconVariant variant;
+  final bool selected;
+  final VoidCallback onTap;
+
+  static const double _tileWidth = 104;
+  static const double _iconBox = 72;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final Color borderColor =
+        selected ? theme.colorScheme.primary : theme.colorScheme.outline;
+    return SizedBox(
+      width: _tileWidth,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadii.md),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xs),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Stack(
+                clipBehavior: Clip.none,
+                children: <Widget>[
+                  Tooltip(
+                    message: variant.description,
+                    child: Container(
+                      width: _iconBox,
+                      height: _iconBox,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: AppColors.darkBackground,
+                        borderRadius: BorderRadius.circular(AppRadii.md),
+                        border: Border.all(
+                          color: borderColor,
+                          width: selected ? 2 : 1,
+                        ),
+                      ),
+                      child: LinthraLogoMark(
+                        size: 44,
+                        gradient: variant.gradient,
+                        bars: variant.bars,
+                      ),
+                    ),
+                  ),
+                  if (selected)
+                    const Positioned(
+                        top: -6, right: -6, child: _SelectedBadge()),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                variant.label,
+                textAlign: TextAlign.center,
+                maxLines: 2,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                ),
+              ),
+              if (variant.tier == AppIconTier.supporter) ...<Widget>[
+                const SizedBox(height: 2),
+                const _PreviewBadge(),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The check badge pinned to the corner of the selected tile.
+class _SelectedBadge extends StatelessWidget {
+  const _SelectedBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary,
+        shape: BoxShape.circle,
+        border: Border.all(color: theme.colorScheme.surface, width: 2),
+      ),
+      child: Icon(Icons.check, size: 14, color: theme.colorScheme.onPrimary),
+    );
+  }
+}
+
+/// A neutral "Preview" pill shown under cosmetic supporter-tier variants. It is
+/// a label only — never a lock, a price, or an upsell.
+class _PreviewBadge extends StatelessWidget {
+  const _PreviewBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(AppRadii.pill),
+      ),
+      child: Text(
+        'Preview',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/appearance/selected_logo_mark.dart
+++ b/lib/features/appearance/selected_logo_mark.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/widgets/linthra_logo_mark.dart';
+import 'app_icon_controller.dart';
+import 'app_icon_variant.dart';
+
+/// The Linthra mark rendered in the user's currently selected branding variant.
+///
+/// A thin consumer over [LinthraLogoMark]: it watches [appIconControllerProvider]
+/// and feeds the chosen variant's gradient and bar pattern to the pure mark, so
+/// the brand reflects the Appearance choice anywhere this is dropped in (About,
+/// the Settings header, …) without those screens knowing about variants. The
+/// presentational [LinthraLogoMark] stays free of Riverpod.
+class SelectedLinthraLogoMark extends ConsumerWidget {
+  const SelectedLinthraLogoMark({this.size = 40, super.key});
+
+  /// The mark's width and height, in logical pixels.
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppIconVariant variant = ref.watch(appIconControllerProvider);
+    return LinthraLogoMark(
+      size: size,
+      gradient: variant.gradient,
+      bars: variant.bars,
+    );
+  }
+}

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -6,7 +6,7 @@ import '../../../app/dimens.dart';
 import '../../../app/external_link_launcher_provider.dart';
 import '../../../app/routes.dart';
 import '../../../core/app_info.dart';
-import '../../../shared/widgets/linthra_logo_mark.dart';
+import '../../appearance/selected_logo_mark.dart';
 import '../about/support_section.dart';
 import '../about/whats_new_section.dart';
 import 'settings_detail_scaffold.dart';
@@ -82,7 +82,7 @@ class _BrandPanel extends StatelessWidget {
         padding: const EdgeInsets.all(AppSpacing.lg),
         child: Row(
           children: <Widget>[
-            const LinthraLogoMark(size: 48),
+            const SelectedLinthraLogoMark(size: 48),
             const SizedBox(width: AppSpacing.md),
             Expanded(
               child: Column(

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../app/dimens.dart';
 import '../../app/routes.dart';
 import '../../core/app_info.dart';
-import '../../shared/widgets/linthra_logo_mark.dart';
+import '../appearance/selected_logo_mark.dart';
 import 'hub/settings_category_tile.dart';
 
 /// The Settings hub: a short, scannable list of categories rather than one long
@@ -53,6 +53,13 @@ class SettingsScreen extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.md),
           SettingsCategoryTile(
+            icon: Icons.palette_outlined,
+            title: 'Appearance',
+            subtitle: 'App icon and in-app branding',
+            onTap: () => context.push(AppRoutes.settingsAppearance),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          SettingsCategoryTile(
             icon: Icons.help_outline,
             title: 'Diagnostics & support',
             subtitle: 'Report a bug, copy diagnostics',
@@ -88,7 +95,7 @@ class _BrandHeader extends StatelessWidget {
       ),
       child: Row(
         children: <Widget>[
-          const LinthraLogoMark(size: 40),
+          const SelectedLinthraLogoMark(size: 40),
           const SizedBox(width: AppSpacing.md),
           Expanded(
             child: Column(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'core/models/subsonic_session.dart';
 import 'core/services/linthra_audio_handler.dart';
 import 'core/sources/plex/plex_artwork.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
+import 'data/repositories/app_icon_variant_store_provider.dart';
 import 'data/repositories/default_provider_store_provider.dart';
 import 'data/repositories/download_repository_provider.dart';
 import 'data/repositories/favorites_repository_provider.dart';
@@ -103,6 +104,9 @@ Future<void> main() async {
       // Persist on-device play history (counts + last-played) for the
       // "Recently played" / "Most played" / "Never played" smart mixes.
       sharedPreferencesPlayHistoryStoreOverride,
+      // Persist the user's chosen in-app branding variant (Settings →
+      // Appearance). A single non-secret variant id; purely cosmetic.
+      sharedPreferencesAppIconVariantStoreOverride,
       // Lyrics from whichever source owns the track: a signed-in Jellyfin or
       // Subsonic/Navidrome server, or a sidecar .lrc/.txt next to a local file.
       lyricsServiceOverride,

--- a/lib/shared/widgets/linthra_logo_mark.dart
+++ b/lib/shared/widgets/linthra_logo_mark.dart
@@ -2,45 +2,80 @@ import 'package:flutter/material.dart';
 
 import '../../app/colors.dart';
 
-/// Linthra's brand mark, rendered in-app: four rounded equalizer bars under a
-/// single violet→orange gradient, echoing a now-playing visualizer.
+/// Linthra's brand mark, rendered in-app: rounded equalizer bars under a single
+/// vertical gradient, echoing a now-playing visualizer.
 ///
 /// It is the Dart twin of the launcher/store icon (`tool/branding/`), drawn from
 /// the same bar proportions and the same two-colour identity, so the brand reads
 /// consistently from the home screen into the app. Sizes to a [size]×[size] box;
 /// the dark squircle behind it is supplied by the surface it sits on.
+///
+/// The default mark is Linthra's classic violet→orange look. Callers can pass a
+/// different [gradient] (top colour first) and [bars] pattern to render one of
+/// the optional branding variants — the bar group always spans the same
+/// footprint and keeps the same gap-to-bar proportions, so any bar count stays
+/// centred and never overflows the box. This widget is purely presentational and
+/// holds no state; `SelectedLinthraLogoMark` is the consumer that feeds it the
+/// user's chosen variant.
 class LinthraLogoMark extends StatelessWidget {
-  const LinthraLogoMark({this.size = 40, super.key});
+  const LinthraLogoMark({
+    this.size = 40,
+    this.gradient = classicGradient,
+    this.bars = classicBars,
+    super.key,
+  });
 
   final double size;
 
-  /// Bar heights as fractions of [size], matching the launcher icon mark.
-  static const _heights = <double>[0.46, 0.70, 0.56, 0.34];
+  /// The mark's vertical gradient, top colour first.
+  final List<Color> gradient;
+
+  /// Bar heights as fractions of [size], left to right.
+  final List<double> bars;
+
+  /// The classic violet→orange gradient — the default mark and Linthra's
+  /// primary identity.
+  static const List<Color> classicGradient = <Color>[
+    AppColors.brandBright,
+    AppColors.accent,
+  ];
+
+  /// The classic four-bar pattern.
+  static const List<double> classicBars = <double>[0.46, 0.70, 0.56, 0.34];
+
+  /// The fraction of [size] the bar group spans, and the gap-to-bar-width ratio.
+  /// Both come from the original four-bar mark (`4·0.15 + 3·0.085 = 0.855`,
+  /// gap/bar `= 0.085/0.15`), so the classic four-bar look is byte-for-byte
+  /// unchanged and any other bar count scales to the same footprint.
+  static const double _footprint = 0.855;
+  static const double _gapToBar = 0.085 / 0.15;
 
   @override
   Widget build(BuildContext context) {
-    final double barWidth = size * 0.15;
-    final double gap = size * 0.085;
+    final int count = bars.length;
+    final double barWidth =
+        size * _footprint / (count + _gapToBar * (count - 1));
+    final double gap = barWidth * _gapToBar;
     final double radius = barWidth / 2;
     return SizedBox(
       width: size,
       height: size,
       child: ShaderMask(
         blendMode: BlendMode.srcIn,
-        shaderCallback: (rect) => const LinearGradient(
+        shaderCallback: (Rect rect) => LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: [AppColors.brandBright, AppColors.accent],
+          colors: gradient,
         ).createShader(rect),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            for (var i = 0; i < _heights.length; i++) ...[
+          children: <Widget>[
+            for (int i = 0; i < count; i++) ...<Widget>[
               if (i > 0) SizedBox(width: gap),
               Container(
                 width: barWidth,
-                height: size * _heights[i],
+                height: size * bars[i],
                 decoration: BoxDecoration(
                   color: Colors.white,
                   borderRadius: BorderRadius.circular(radius),

--- a/test/features/appearance/app_icon_controller_test.dart
+++ b/test/features/appearance/app_icon_controller_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/app_icon_variant_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_app_icon_variant_store.dart';
+import 'package:linthra/features/appearance/app_icon_controller.dart';
+import 'package:linthra/features/appearance/app_icon_variant.dart';
+import 'package:linthra/features/support/support_actions_provider.dart';
+
+void main() {
+  group('AppIconController', () {
+    late InMemoryAppIconVariantStore store;
+
+    Future<ProviderContainer> pump(
+      WidgetTester tester, {
+      String? initial,
+    }) async {
+      store = InMemoryAppIconVariantStore(initial);
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          appIconVariantStoreProvider.overrideWithValue(store),
+        ],
+      );
+      addTearDown(container.dispose);
+      // A trivial consumer instantiates the controller so its one-shot load runs.
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: Consumer(
+            builder: (_, WidgetRef ref, __) {
+              ref.watch(appIconControllerProvider);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets('defaults to Classic with no stored choice', (tester) async {
+      final ProviderContainer container = await pump(tester);
+      expect(
+        container.read(appIconControllerProvider),
+        AppIconVariants.classic,
+      );
+    });
+
+    testWidgets('loads a persisted variant', (tester) async {
+      final ProviderContainer container = await pump(tester, initial: 'neon');
+      expect(container.read(appIconControllerProvider), AppIconVariants.neon);
+    });
+
+    testWidgets('falls back to Classic for an unknown persisted id',
+        (tester) async {
+      final ProviderContainer container =
+          await pump(tester, initial: 'totally-bogus');
+      expect(
+        container.read(appIconControllerProvider),
+        AppIconVariants.classic,
+      );
+    });
+
+    testWidgets('selecting a variant updates state and persists it',
+        (tester) async {
+      final ProviderContainer container = await pump(tester);
+
+      await container
+          .read(appIconControllerProvider.notifier)
+          .select(AppIconVariants.waveform);
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(appIconControllerProvider),
+        AppIconVariants.waveform,
+      );
+      expect(await store.read(), 'waveform');
+    });
+
+    testWidgets('the cosmetic supporter (gold) variant is selectable here',
+        (tester) async {
+      final ProviderContainer container = await pump(tester);
+
+      await container
+          .read(appIconControllerProvider.notifier)
+          .select(AppIconVariants.gold);
+      await tester.pumpAndSettle();
+
+      // No gate in the default build: choosing the supporter-tier style works
+      // and persists exactly like any free one.
+      expect(container.read(appIconControllerProvider), AppIconVariants.gold);
+      expect(await store.read(), 'gold');
+    });
+  });
+
+  group('appIconVariantsFor', () {
+    test('offers every variant on every channel — F-Droid included', () {
+      for (final SupportDistribution distribution
+          in SupportDistribution.values) {
+        expect(
+          appIconVariantsFor(distribution),
+          AppIconVariants.all,
+          reason: 'all variants must be available on $distribution',
+        );
+        // The cosmetic supporter style is offered, never withheld.
+        expect(
+          appIconVariantsFor(distribution),
+          contains(AppIconVariants.gold),
+        );
+      }
+    });
+  });
+}

--- a/test/features/appearance/app_icon_variant_test.dart
+++ b/test/features/appearance/app_icon_variant_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/appearance/app_icon_variant.dart';
+
+void main() {
+  group('AppIconVariants catalog', () {
+    test('Classic is the first/default variant', () {
+      expect(AppIconVariants.all.first, AppIconVariants.classic);
+      expect(AppIconVariants.classic.id, 'classic');
+      expect(AppIconVariants.classic.tier, AppIconTier.free);
+    });
+
+    test('every variant id is unique', () {
+      final List<String> ids =
+          AppIconVariants.all.map((AppIconVariant v) => v.id).toList();
+      expect(ids.toSet().length, ids.length);
+    });
+
+    test('every variant is well-formed (gradient + in-range bars)', () {
+      for (final AppIconVariant variant in AppIconVariants.all) {
+        expect(variant.id, isNotEmpty);
+        expect(variant.label, isNotEmpty);
+        expect(
+          variant.gradient.length,
+          greaterThanOrEqualTo(2),
+          reason: '${variant.id} needs a gradient with at least two stops',
+        );
+        expect(variant.bars, isNotEmpty, reason: '${variant.id} needs bars');
+        for (final double height in variant.bars) {
+          expect(height, greaterThan(0));
+          expect(height, lessThanOrEqualTo(1));
+        }
+      }
+    });
+
+    test('gold is the cosmetic supporter tier and ships in the catalog', () {
+      expect(AppIconVariants.gold.tier, AppIconTier.supporter);
+      // It ships in the catalog like any other variant — there is no gating
+      // field anywhere, so nothing can lock it.
+      expect(AppIconVariants.all, contains(AppIconVariants.gold));
+    });
+
+    test('gold is the only supporter-tier variant; the rest are free', () {
+      final List<AppIconVariant> supporters = AppIconVariants.all
+          .where((AppIconVariant v) => v.tier == AppIconTier.supporter)
+          .toList();
+      expect(supporters, <AppIconVariant>[AppIconVariants.gold]);
+    });
+  });
+
+  group('AppIconVariants.byId', () {
+    test('resolves each known id to its variant', () {
+      for (final AppIconVariant variant in AppIconVariants.all) {
+        expect(AppIconVariants.byId(variant.id), variant);
+      }
+    });
+
+    test('falls back to Classic for null, empty, or unknown ids', () {
+      expect(AppIconVariants.byId(null), AppIconVariants.classic);
+      expect(AppIconVariants.byId(''), AppIconVariants.classic);
+      expect(AppIconVariants.byId('   '), AppIconVariants.classic);
+      expect(AppIconVariants.byId('does-not-exist'), AppIconVariants.classic);
+    });
+  });
+}

--- a/test/features/appearance/appearance_settings_screen_test.dart
+++ b/test/features/appearance/appearance_settings_screen_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/data/repositories/app_icon_variant_store_provider.dart';
+import 'package:linthra/data/repositories/in_memory_app_icon_variant_store.dart';
+import 'package:linthra/features/appearance/app_icon_controller.dart';
+import 'package:linthra/features/appearance/app_icon_variant.dart';
+import 'package:linthra/features/appearance/appearance_settings_screen.dart';
+import 'package:linthra/features/settings/hub/about_screen.dart';
+import 'package:linthra/shared/widgets/linthra_logo_mark.dart';
+
+void main() {
+  group('AppearanceSettingsScreen', () {
+    late InMemoryAppIconVariantStore store;
+
+    Future<ProviderContainer> pump(
+      WidgetTester tester, {
+      String? initial,
+    }) async {
+      store = InMemoryAppIconVariantStore(initial);
+      // A tall surface so the whole variant grid lays out and every tile is
+      // hittable.
+      tester.view.physicalSize = const Size(1200, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          appIconVariantStoreProvider.overrideWithValue(store),
+        ],
+      );
+      addTearDown(container.dispose);
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: AppearanceSettingsScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return container;
+    }
+
+    testWidgets('lists every built-in variant', (tester) async {
+      await pump(tester);
+      for (final AppIconVariant variant in AppIconVariants.all) {
+        expect(
+          find.text(variant.label),
+          findsOneWidget,
+          reason: '${variant.label} tile should render',
+        );
+      }
+    });
+
+    testWidgets('defaults to Classic', (tester) async {
+      final ProviderContainer container = await pump(tester);
+      expect(
+        container.read(appIconControllerProvider),
+        AppIconVariants.classic,
+      );
+    });
+
+    testWidgets('tapping a variant selects and persists it', (tester) async {
+      final ProviderContainer container = await pump(tester);
+
+      await tester.tap(find.text('Neon'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(appIconControllerProvider), AppIconVariants.neon);
+      expect(await store.read(), 'neon');
+    });
+
+    testWidgets('the gold variant shows a "Preview" badge and is selectable',
+        (tester) async {
+      final ProviderContainer container = await pump(tester);
+
+      // The cosmetic supporter style is labelled a preview — not locked.
+      expect(find.text('Preview'), findsOneWidget);
+
+      await tester.tap(find.text('Gold'));
+      await tester.pumpAndSettle();
+
+      expect(container.read(appIconControllerProvider), AppIconVariants.gold);
+      expect(await store.read(), 'gold');
+    });
+
+    testWidgets('shows no premium / locking / purchase wording',
+        (tester) async {
+      await pump(tester);
+
+      final Iterable<String> texts = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((Text t) => (t.data ?? '').toLowerCase());
+      const List<String> forbidden = <String>[
+        'premium',
+        'locked',
+        'unlock',
+        'upgrade',
+        'buy',
+        'supporter-only',
+        'supporter only',
+      ];
+      for (final String word in forbidden) {
+        expect(
+          texts.any((String s) => s.contains(word)),
+          isFalse,
+          reason: '"$word" must not appear in the default build',
+        );
+      }
+    });
+  });
+
+  group('Selected branding in About', () {
+    testWidgets('About renders the mark in the selected variant',
+        (tester) async {
+      final InMemoryAppIconVariantStore store =
+          InMemoryAppIconVariantStore('neon');
+      tester.view.physicalSize = const Size(1200, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            appIconVariantStoreProvider.overrideWithValue(store),
+          ],
+          child: const MaterialApp(home: AboutScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final LinthraLogoMark mark =
+          tester.widget<LinthraLogoMark>(find.byType(LinthraLogoMark));
+      expect(mark.gradient, AppIconVariants.neon.gradient);
+      expect(mark.bars, AppIconVariants.neon.bars);
+    });
+  });
+}

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linthra/app/routes.dart';
@@ -24,6 +25,7 @@ GoRouter _router() {
       leaf(AppRoutes.settingsPlayback, 'PLAYBACK_PAGE'),
       leaf(AppRoutes.settingsCache, 'CACHE_PAGE'),
       leaf(AppRoutes.settingsDownloads, 'DOWNLOADS_PAGE'),
+      leaf(AppRoutes.settingsAppearance, 'APPEARANCE_PAGE'),
       leaf(AppRoutes.settingsDiagnostics, 'DIAGNOSTICS_PAGE'),
       leaf(AppRoutes.settingsAbout, 'ABOUT_PAGE'),
     ],
@@ -37,7 +39,9 @@ Future<void> _pump(WidgetTester tester) async {
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
-  await tester.pumpWidget(MaterialApp.router(routerConfig: _router()));
+  await tester.pumpWidget(
+    ProviderScope(child: MaterialApp.router(routerConfig: _router())),
+  );
   await tester.pumpAndSettle();
 }
 
@@ -50,11 +54,12 @@ void main() {
       expect(find.text(AppInfo.name), findsOneWidget);
       expect(find.text(AppInfo.tagline), findsOneWidget);
 
-      // The six categories of the Master Settings Hub.
+      // The seven categories of the Master Settings Hub.
       expect(find.text('Connections'), findsOneWidget);
       expect(find.text('Music & playback'), findsOneWidget);
       expect(find.text('Cache & data'), findsOneWidget);
       expect(find.text('Offline & downloads'), findsOneWidget);
+      expect(find.text('Appearance'), findsOneWidget);
       expect(find.text('Diagnostics & support'), findsOneWidget);
       expect(find.text('About'), findsOneWidget);
     });
@@ -65,6 +70,7 @@ void main() {
         ('Music & playback', 'PLAYBACK_PAGE'),
         ('Cache & data', 'CACHE_PAGE'),
         ('Offline & downloads', 'DOWNLOADS_PAGE'),
+        ('Appearance', 'APPEARANCE_PAGE'),
         ('Diagnostics & support', 'DIAGNOSTICS_PAGE'),
         ('About', 'ABOUT_PAGE'),
       ];


### PR DESCRIPTION
## Summary

Adds a small, **F-Droid-safe** Appearance area where users choose how Linthra's brand mark looks across the app. Reached from **Settings → Appearance → "App icon & branding"**.

The in-app mark (`LinthraLogoMark`) is **pure Dart**, so a "variant" is just a different **gradient + bar pattern** — **no images, no new assets, no new dependencies**. Seven original built-in variants keep the equalizer-bar identity so Linthra stays recognisable:

| id | Label | Look |
| --- | --- | --- |
| `classic` | Classic *(default)* | Signature violet→orange equalizer |
| `dark` | Dark | Stealthy single-violet |
| `neon` | Neon | Violet → electric cyan |
| `server` | Self-hosted | Rising teal→violet signal bars |
| `waveform` | Waveform | Symmetric sound wave |
| `lonely` | Lonely maintainer | One bar standing on its own 🥺 |
| `gold` | Gold | Warm gold (cosmetic supporter **Preview**) |

## How it works

- **Catalog** — `AppIconVariant` / `AppIconVariants` (data-driven, like the Support module) with a pure `byId(String?)` that **falls back to Classic** for a null/empty/unknown id.
- **Storage** — `AppIconVariantStore` persists one non-secret variant id; `SharedPreferences` impl wired in `main`, in-memory default for tests.
- **Controller** — `AppIconController` (Riverpod `Notifier`) loads the choice on startup; the new `SelectedLinthraLogoMark` consumer feeds it into the pure mark, so **About** and the **Settings header** reflect the choice immediately. `LinthraLogoMark`'s default render is **byte-for-byte unchanged**.

## Supporter architecture — prepared, not gated

The `gold` variant carries an `AppIconTier.supporter` **data** tag and shows a neutral **"Preview"** badge, but is **fully available and selectable in every build**. `appIconVariantsFor(distribution)` is the seam a future **Play-only** PR can use to present supporter-tier styles as cosmetic rewards — purely cosmetic, never touching playback, cache, providers, or Android Auto.

**No billing, ads, tracking, analytics, premium wording, or feature gating.** The F-Droid build keeps every variant available. A widget test asserts no `premium`/`locked`/`unlock`/`upgrade`/`buy`/`supporter-only` wording appears in the default build.

## Launcher icon switching — deferred & documented

Real Android launcher-icon switching (via `activity-alias` + `PackageManager.setComponentEnabledSetting`) is **invasive** (per-variant mipmap sets, manifest churn, launcher restart, F-Droid reproducibility risk), so it's **deferred to a later PR**. The approach is written up in [`docs/app-icon-branding.md`](./docs/app-icon-branding.md) for whoever picks it up. This PR customizes **in-app** branding only.

## Tests

`test/features/appearance/`:
- Catalog invariants + Classic fallback (null/empty/unknown → Classic)
- Controller: default Classic, persistence, unknown-id fallback, Gold selectable (no gate)
- Screen: renders all variants, select + persist, Gold shows a "Preview" badge, **no premium/locking/purchase wording**
- About renders the mark in the selected variant
- `appIconVariantsFor` offers every variant on every channel (F-Droid included)

## Verification (Flutter 3.27.4)

- `dart format --set-exit-if-changed .` ✅ (0 changed)
- `flutter analyze` ✅ No issues found
- `flutter test` ✅ **2611 passing**
- `./scripts/check_secrets.sh` ✅ clean

## Guardrails honored

✅ No new dependencies · ✅ no version bump · ✅ no F-Droid metadata changes · ✅ no `pubspec` changes · ✅ no billing/ads/tracking/analytics · ✅ no playback/cache/provider/Plex/Jellyfin/Subsonic/Android-Auto changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qwet2gQ7f9rKTaM5DFjaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qwet2gQ7f9rKTaM5DFjaFK)_