### PR TITLE
docs(roadmap): post-#244 product roadmap + Backup/Restore format spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Linthra is built to respect the people who use it:
 
 ## Roadmap
 
+The phased **[product roadmap](./docs/roadmap.md)** — v0.1.7 stabilization →
+Backup/Restore → optional Linthra Connect → Linthra Desktop — has the direction and
+its one guiding rule: **Linthra works on its own; Linthra Connect is optional** (no
+Docker, no account, no desktop dependency, no required pairing). The feature-level
+view:
+
 **Next up:** local tag/metadata parsing + album artwork · Subsonic favourites,
 lyrics & cover art · full playlist sync · album/playlist "download all" +
 background download manager · real connectivity detection for the Wi-Fi gate ·
@@ -197,7 +203,9 @@ partial playlist sync, optimistic connectivity) are documented per feature.
 | Topic | Doc |
 | --- | --- |
 | Contributing & setup | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Product roadmap (phased direction) | [docs/roadmap.md](./docs/roadmap.md) |
 | Where to help (contributor roadmap) | [docs/contributor-roadmap.md](./docs/contributor-roadmap.md) |
+| Backup & restore (file format) | [docs/backup-restore-format.md](./docs/backup-restore-format.md) |
 | Supporting Linthra (optional supporter model) | [docs/SUPPORT.md](./docs/SUPPORT.md) |
 | Codebase tour (where everything lives) | [docs/codebase-tour.md](./docs/codebase-tour.md) |
 | Architecture & extension points | [docs/architecture.md](./docs/architecture.md) |

--- a/docs/backup-restore-format.md
+++ b/docs/backup-restore-format.md
@@ -1,0 +1,333 @@
+# Linthra Backup / Restore — file format (V1)
+
+This is the documented format for **Linthra Backup** and **Linthra Restore**
+(Phase 2 of the [product roadmap](./roadmap.md)). It lets a user move their
+Linthra **setup** — which servers they use and how they like the app — to a new
+phone, with **no Docker, no account, and no cloud**.
+
+The format is deliberately small, human-readable, and versioned, because it is the
+shared contract between three things:
+
+- **Android** exports and imports it (Phase 2, V1).
+- **Linthra Desktop** (Phase 4) reads and writes the *same* document.
+- **Linthra Connect** (Phase 3) is just an *optional* transport for it — the
+  pairing/QR flow moves this exact file between devices; nothing about the format
+  depends on Connect existing.
+
+> **Status:** this is a **design spec**, written before the feature so it can be
+> built in small, reviewable PRs. No exporter/importer ships yet.
+
+## Principles
+
+- **Settings, not secrets.** V1 backs up your *setup* (servers, preferences). It
+  **never** contains passwords or tokens — see [Security](#security).
+- **Settings, not your library.** Favorites, playlists, play history, and the
+  offline cache are **data**, not setup. They are out of scope for V1 (see
+  [Out of scope](#out-of-scope-for-v1)).
+- **One file, no infrastructure.** A backup is a single UTF-8 JSON file you can
+  move any way you like — Android share sheet, Downloads folder, USB, or (later)
+  Linthra Connect. No server, no account, no internet required.
+- **Forward-compatible.** A newer Linthra can add fields and server types without
+  breaking an older reader; an older reader skips what it doesn't understand. See
+  [Versioning](#versioning--forward-compatibility).
+- **Same rules as the rest of the app.** Credentials stay encrypted on-device and
+  are never written to a plaintext sink — exactly as documented for each provider
+  in [docs/providers.md](./providers.md).
+
+## Security
+
+V1 takes the simplest safe position: **the backup contains no credentials at
+all.**
+
+- **Never exported:** the Jellyfin `accessToken`, the Subsonic `salt` + `token`
+  pair, and the Plex `X-Plex-Token`. These live in `flutter_secure_storage`
+  (Android Keystore-backed) and the exporter must never read them into the file.
+- **After restore, re-authenticate.** Each restored server appears in Settings in
+  a *needs-sign-in* state; the user re-enters the password (Jellyfin/Subsonic) or
+  pastes a token (Plex) once. This mirrors how Linthra already treats a password:
+  used once to derive a token, then discarded.
+- **Not secret, but not public either.** The file *does* list your **server URLs
+  and usernames**. That reveals where your private server lives — so treat a
+  backup like a list of bookmarks to a private service: fine to keep and move
+  around, not something to post publicly. Because there are no passwords/tokens in
+  it, V1 needs no encryption.
+- **Encrypted credential backup is a separate, later, opt-in design.** If we ever
+  let users include credentials (so a restore needs no re-typing), that is its own
+  feature with its own threat model and explicit user consent — never the default,
+  and never in V1.
+
+## File shape
+
+- **Encoding:** UTF-8 JSON, pretty-printed (human-inspectable on purpose).
+- **Suggested name:** `linthra-backup-YYYY-MM-DD.json`.
+- **Extension / MIME:** `.json`, `application/json`, for maximum
+  interoperability (Desktop, text editors, inspection). A backup is identified by
+  its **content** — the `linthraBackup` envelope and `formatVersion` — not by its
+  filename, so a renamed file still restores.
+
+### Envelope
+
+```json
+{
+  "linthraBackup": {
+    "formatVersion": 1,
+    "kind": "settings",
+    "generatedBy": { "app": "Linthra Android", "appVersion": "0.1.7" },
+    "createdAt": "2026-06-24T12:00:00Z",
+    "servers": [],
+    "preferences": {}
+  }
+}
+```
+
+| Field | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `linthraBackup` | object | yes | Top-level marker; its presence identifies the file. |
+| `formatVersion` | integer | yes | Format version. V1 = `1`. See [Versioning](#versioning--forward-compatibility). |
+| `kind` | string | yes | `"settings"` in V1. Reserved so a future `"settings+credentials"` or `"library"` kind can be distinguished. |
+| `generatedBy` | object | no | Diagnostics only: `app` (e.g. `"Linthra Android"` / `"Linthra Desktop"`) and `appVersion`. Readers must not depend on it. |
+| `createdAt` | string | no | ISO-8601 UTC timestamp the backup was written. Display only. |
+| `servers` | array | yes | The configured sources — see [Servers](#servers). May be empty. |
+| `preferences` | object | yes | App/playback/cache/source preferences — see [Preferences](#preferences). May be empty. |
+
+### Servers
+
+Each entry is tagged by `type`. Common fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `type` | string | `"jellyfin"`, `"subsonic"`, `"plex"`, or `"local"`. |
+| `displayName` | string | The human label Linthra shows for this source. Today it's derived from the server's reported name (falling back to the URL host); a future user-editable label uses the same field. |
+
+Per-type fields (**all non-secret** — credentials are excluded by design):
+
+**`jellyfin`**
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `baseUrl` | string | Server base URL, no trailing slash (e.g. `https://music.example.com`). |
+| `username` | string | Sign-in name, to pre-fill the login form on restore. |
+
+**`subsonic`** (Navidrome and other Subsonic-compatible servers)
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `baseUrl` | string | Server base URL, no trailing slash. |
+| `username` | string | Sign-in name, to pre-fill the login form. |
+| `serverType` | string? | OpenSubsonic server product (e.g. `navidrome`), if known. Informational. |
+
+**`plex`**
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `baseUrl` | string | Server base URL incl. port (e.g. `https://plex.example.com:32400`). |
+| `selectedSectionKeys` | string[] | The music-library section keys the user chose to include — a genuine user choice worth restoring. |
+
+**`local`** (on-device folder)
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `folderHint` | string? | The Android SAF tree URI of the previously chosen folder, **informational only**. The SAF permission grant does **not** transfer to another device (or survive a reinstall), so on restore Linthra shows this as a hint and asks the user to re-pick the folder to re-grant access. Desktop ignores it. |
+
+> **Excluded on purpose** (non-secret but device- or session-specific, re-derived
+> at re-auth): Jellyfin `deviceId` / `userId` / `serverId`, Plex
+> `machineIdentifier` / `clientIdentifier`, and every server's version strings are
+> **not** part of a backup. They are re-established when the user signs back in, so
+> carrying them would only risk one device impersonating another.
+
+### Preferences
+
+All values below are non-secret user choices read from `shared_preferences`.
+
+```json
+"preferences": {
+  "defaultProvider": "jellyfin",
+  "preferredSourceOrder": ["local", "jellyfin", "subsonic"],
+  "playbackSourceStrategy": "preferLocalCache",
+  "cache": {
+    "maxBytes": 5368709120,
+    "allowMobileData": false,
+    "smartPrecacheEnabled": true,
+    "precacheCount": 3
+  },
+  "playback": { "normalizeVolume": false },
+  "appearance": { "appIconVariant": "classic" }
+}
+```
+
+| Field | Type | Meaning | Default |
+| --- | --- | --- | --- |
+| `defaultProvider` | string? | Explicit default source id (`jellyfin` / `subsonic` / `plex` / `local`), or omitted for Automatic. | Automatic |
+| `preferredSourceOrder` | string[] | Source ids, most-preferred first — picks which copy of a song shared across providers plays. | empty |
+| `playbackSourceStrategy` | string? | Strategy enum name for ordering playback candidates (e.g. `preferLocalCache`), or omitted for the default. | default |
+| `cache.maxBytes` | integer | Offline-cache size ceiling, in bytes (LRU eviction above it). | ~5 GiB |
+| `cache.allowMobileData` | boolean | Whether downloads / pre-cache may use metered data. | `false` |
+| `cache.smartPrecacheEnabled` | boolean | Whether upcoming queued tracks are warmed into the cache. | `true` |
+| `cache.precacheCount` | integer | How many upcoming tracks smart pre-cache warms ahead (1–200). | `3` |
+| `playback.normalizeVolume` | boolean | Apply ReplayGain (attenuation-only) for even loudness. | `false` |
+| `appearance.appIconVariant` | string? | Chosen Linthra logo/branding variant id; cosmetic. | Classic |
+
+A reader applies only the keys present and clamps/validates each to its own
+accepted range (e.g. `precacheCount`, `maxBytes`) exactly as the live setting
+does — a hand-edited or newer file can never push a setting out of bounds.
+
+## Restore semantics
+
+1. **Validate the envelope.** Reject a file with no `linthraBackup` object, or a
+   `formatVersion` newer than the reader supports, with a clear message
+   ("This backup was made by a newer version of Linthra"). See
+   [Versioning](#versioning--forward-compatibility).
+2. **Merge, don't wipe.** Importing **adds** servers and **applies** preferences;
+   it does not delete anything already set up. A server already configured —
+   matched by (`type`, normalized `baseUrl`) — is left as-is rather than
+   duplicated.
+3. **Re-authenticate per server.** Restored servers land in a *needs-sign-in*
+   state. The user signs in once each; nothing plays until they do.
+4. **Skip unknown server types.** A `type` the reader doesn't recognise (e.g. a
+   future provider, or `local` on Desktop) is skipped with a notice, not an error.
+5. **Apply known preferences, ignore the rest.** Unknown preference keys are
+   ignored; known ones are validated/clamped before applying.
+
+## Versioning & forward-compatibility
+
+- `formatVersion` is a single integer. V1 = `1`.
+- **Readers must ignore unknown object fields** and unknown `preferences` keys.
+- **Readers must reject a higher `formatVersion`** than they support, with a clear
+  message — never silently half-import.
+- **Within a major `formatVersion`, changes are additive only** (new optional
+  fields, new server `type`s). A breaking change bumps `formatVersion`.
+- **New server types are forward-compatible:** an older reader (say, an older
+  Desktop reading a newer Android backup) skips a `type` it doesn't know and
+  imports the rest. That's why each server entry is self-describing.
+
+## Worked example
+
+```json
+{
+  "linthraBackup": {
+    "formatVersion": 1,
+    "kind": "settings",
+    "generatedBy": { "app": "Linthra Android", "appVersion": "0.1.7" },
+    "createdAt": "2026-06-24T12:00:00Z",
+    "servers": [
+      {
+        "type": "jellyfin",
+        "displayName": "Home Jellyfin",
+        "baseUrl": "https://music.example.com",
+        "username": "alice"
+      },
+      {
+        "type": "subsonic",
+        "displayName": "Navidrome",
+        "baseUrl": "https://nd.example.com",
+        "username": "alice",
+        "serverType": "navidrome"
+      },
+      {
+        "type": "plex",
+        "displayName": "Living-room Plex",
+        "baseUrl": "https://plex.example.com:32400",
+        "selectedSectionKeys": ["3", "7"]
+      },
+      {
+        "type": "local",
+        "displayName": "Phone music folder",
+        "folderHint": "content://com.android.externalstorage.documents/tree/primary%3AMusic"
+      }
+    ],
+    "preferences": {
+      "defaultProvider": "jellyfin",
+      "preferredSourceOrder": ["local", "jellyfin", "subsonic"],
+      "playbackSourceStrategy": "preferLocalCache",
+      "cache": {
+        "maxBytes": 5368709120,
+        "allowMobileData": false,
+        "smartPrecacheEnabled": true,
+        "precacheCount": 3
+      },
+      "playback": { "normalizeVolume": false },
+      "appearance": { "appIconVariant": "classic" }
+    }
+  }
+}
+```
+
+## Implementation notes (Android)
+
+Captured so the eventual exporter/importer is built safely; these are the
+non-obvious bits.
+
+- **Server config and its secret share one secure-storage blob.** Each provider's
+  whole session — non-secret `baseUrl` / `serverName` **and** the secret token —
+  is serialized together into `flutter_secure_storage` under a single key
+  (`jellyfin_session_v1`, `subsonic_session_v1`, `plex_session_v1`). So the
+  exporter **cannot** simply read `shared_preferences`; it must read each session
+  via its store and **project out the non-secret subset.**
+- **Add a dedicated non-secret projection, don't reuse `toJson()`.** The existing
+  `JellyfinSession.toJson()` / `SubsonicSession.toJson()` / `PlexSession.toJson()`
+  include the credential on purpose (their only caller is the encrypted store).
+  The exporter should use a separate `toBackupJson()` (or a mapper) that omits
+  `accessToken` / `salt` / `token` / `deviceId` / `clientIdentifier` /
+  `machineIdentifier`, so a future refactor can't accidentally leak a token into a
+  plaintext backup. A unit test should assert no backup ever contains those keys.
+- **Preferences come from `shared_preferences`.** `default_provider_source_id_v1`,
+  `preferred_source_order_v1`, `playback_source_strategy_v1`,
+  `selected_app_icon_variant_v1`, `playback_normalize_volume`, and the
+  `downloads_*` keys (see the [appendix](#appendix-current-internal-storage-keys)).
+- **Export/import via the Storage Access Framework** — the same scoped, no-broad-
+  permission approach the local-folder picker already uses. No new storage
+  permission.
+- **The local folder is the one thing that can't fully restore.** Carry
+  `folderHint` for the user's reference, but a SAF permission grant is per-device
+  and can't be transferred — restore must prompt a re-pick.
+
+## Desktop interoperability (Phase 4)
+
+Linthra Desktop reads and writes the **same** envelope. Differences are handled by
+the forward-compatibility rules, not by a separate format:
+
+- Desktop **skips** `type: "local"` (and ignores `folderHint`) — an Android SAF
+  URI is meaningless on Windows; Desktop offers its own folder picker.
+- Desktop may **add** server types Android doesn't have yet; an older Android
+  reader skips them.
+- A backup made on Desktop restores on Android and vice-versa, minus the
+  platform-specific entries each side can't use.
+
+This is what lets **Linthra Connect** (Phase 3) stay a thin, optional transport:
+it moves this document between devices over a temporary, user-approved local
+pairing — it does not define its own data model.
+
+## Out of scope for V1
+
+Deliberately deferred, each its own later design:
+
+- **Credentials.** No passwords/tokens in V1; an *encrypted, opt-in* credential
+  backup is a separate feature with its own threat model.
+- **Library data.** Favorites, playlists, play history, and the offline cache are
+  data, not setup. A future `kind: "library"` (or a second section) can carry them
+  without changing this settings format.
+- **The QR / pairing transport.** That's Linthra Connect (Phase 3); it will carry
+  *this* file, so it needs no format changes here.
+- **Multi-device live sync / conflict resolution.** A Phase 5 concern, explicitly
+  not a backup-file concern.
+
+## Appendix: current internal storage keys
+
+Implementation detail, for the importer/exporter — **not** part of the file
+format, and free to change. The JSON field names above are the stable contract.
+
+| Backup field | Current storage | Key | Type |
+| --- | --- | --- | --- |
+| `servers[type=jellyfin]` | secure storage | `jellyfin_session_v1` | JSON blob (non-secret subset exported) |
+| `servers[type=subsonic]` | secure storage | `subsonic_session_v1` | JSON blob (non-secret subset exported) |
+| `servers[type=plex]` | secure storage | `plex_session_v1` | JSON blob (non-secret subset exported) |
+| `servers[type=local].folderHint` | shared_preferences | `selected_music_folder` | String |
+| `preferences.defaultProvider` | shared_preferences | `default_provider_source_id_v1` | String |
+| `preferences.preferredSourceOrder` | shared_preferences | `preferred_source_order_v1` | JSON array (String) |
+| `preferences.playbackSourceStrategy` | shared_preferences | `playback_source_strategy_v1` | String |
+| `preferences.cache.maxBytes` | shared_preferences | `downloads_max_cache_bytes` | int |
+| `preferences.cache.allowMobileData` | shared_preferences | `downloads_allow_mobile_data` | bool |
+| `preferences.cache.smartPrecacheEnabled` | shared_preferences | `downloads_preload_enabled` | bool |
+| `preferences.cache.precacheCount` | shared_preferences | `downloads_precache_count` | int |
+| `preferences.playback.normalizeVolume` | shared_preferences | `playback_normalize_volume` | bool |
+| `preferences.appearance.appIconVariant` | shared_preferences | `selected_app_icon_variant_v1` | String |

--- a/docs/contributor-roadmap.md
+++ b/docs/contributor-roadmap.md
@@ -5,6 +5,11 @@ roadmap or a promise of dates. Linthra is early alpha, built by a small group of
 people who care about owning their music. Pick whatever looks fun; small
 contributions are welcome and land fast.
 
+For the higher-level product direction — the phased plan from the v0.1.7
+stabilization pass through Backup/Restore, the optional Linthra Connect, and
+Linthra Desktop — see the [product roadmap](./roadmap.md). This page is its
+task-level companion.
+
 New to the project? Start with [CONTRIBUTING.md](../CONTRIBUTING.md) for setup,
 then come back here to find something to work on.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,172 @@
+# Product roadmap
+
+This is the **product direction** for Linthra after v0.1.6 — what we want to build
+next and, just as importantly, what we deliberately won't. It is a direction, not
+a set of dated promises: Linthra is early alpha, built by a small group, and the
+order below can shift as real-device testing tells us what actually matters.
+
+For "where an extra pair of hands helps most right now," see the
+[contributor roadmap](./contributor-roadmap.md) — that's the task-level companion
+to this higher-level plan.
+
+## North star
+
+> **Linthra works on its own. Linthra Connect is optional.**
+
+Every phase below is held to one rule: Linthra must stay **fully usable** without
+any of the following.
+
+- **No Docker.** No server-side component is ever required to use the app.
+- **No account.** Nothing to sign up for; nothing phones home.
+- **No desktop app.** The phone is complete on its own; Desktop (when it lands)
+  is complete on its own too. Neither depends on the other.
+- **No pairing code.** Pairing / QR (Linthra Connect, Phase 3) is a convenience
+  for moving settings between devices — **optional, never a gate.**
+
+If a feature can only work with a cloud service, a mandatory pairing step, or a
+container running somewhere, it doesn't fit Linthra. These are non-negotiables,
+not preferences.
+
+## Phase 0 — Finish PR #244 cleanly ✅ done
+
+[PR #244](https://github.com/thezupzup/linthra/pull/244) — *"Fix Android audio
+focus: never stay silently ducked"* — is **merged**. It is scoped strictly to
+audio focus / session / background-playback recovery, with no
+provider/cache/Plex-Jellyfin-Subsonic/Cast-Android-Auto/version/F-Droid/dependency
+changes.
+
+- ✅ Battery tradeoff documented (in the PR and in code): keeping the media
+  service foreground across a pause holds a `PARTIAL_WAKE_LOCK` only while
+  *paused-not-stopped*; active playback and the stopped state are unaffected. See
+  [docs/battery.md](./battery.md).
+- ✅ CI green — Flutter checks, Build debug APK, and the Secret & privacy scan all
+  passed on the merged commit.
+- ✅ Real-device acceptance confirmed (text app keeps sound, voice start/stop
+  restores, screen lock keeps playing, another app taking focus recovers without
+  reopening Linthra).
+
+The one intentional follow-up it left behind — a *battery-optimal* audio-focus
+mode that keeps the service alive **only during a transient-focus pause** — rolls
+into Phase 1.
+
+## Phase 1 — v0.1.7 stabilization pass
+
+**Goal:** make Linthra feel reliable as a daily-driver music player. Stability
+before new features. The output is a *small set of focused PRs*, each
+independently reviewable and validated on a real device — not one big change.
+
+Focus areas, with the existing issues they map to:
+
+- **Background playback reliability** — keep the gains from #244 solid across
+  Doze, screen-off, and long pauses.
+- **Audio-focus regressions** — guard the #244 behaviour with the deterministic
+  focus tests already in place, and land the **battery-optimal follow-up** (keep
+  `stopForegroundOnPause: true`, hold the service only across a transient-focus
+  pause). See [docs/battery.md](./battery.md) → *Possible future work*.
+- **Screen-lock playback** — no pause/mute on a brief screen-off focus blip.
+- **Android Auto sanity** — real head-unit and Desktop-Head-Unit passes
+  ([#82](https://github.com/thezupzup/linthra/issues/82)).
+- **Offline cache reliability** — eviction, "keep offline" pinning, and
+  Wi-Fi/mobile-data gating behave predictably ([docs/offline-cache.md](./offline-cache.md)).
+- **Provider fallback reliability** — building on cached provider-reachability
+  (#241), make an offline server fall back fast and correctly; finish
+  provider-aware identity so favorites / play history / playlists never collide
+  across providers ([#239](https://github.com/thezupzup/linthra/issues/239)).
+- **UI polish where bugs are obvious** — empty states
+  ([#89](https://github.com/thezupzup/linthra/issues/89)) and accessibility
+  labels ([#90](https://github.com/thezupzup/linthra/issues/90)).
+- **Streaming resilience on weak networks** — graceful stall/recovery without
+  duplicate playback or leaked tokens
+  ([#83](https://github.com/thezupzup/linthra/issues/83)).
+- **Crash / log diagnostics** — extend the secret-free `StabilityDiagnostics`
+  breadcrumbs only where they earn their keep.
+
+**Deliberately out of scope for v0.1.7:** big new features · desktop work ·
+Docker / server work · cloud / account work · large architecture rewrites (unless
+a rewrite is genuinely required to fix a stability bug). Small issue cleanup only.
+
+## Phase 2 — Backup / Restore without Docker
+
+**Goal:** let users recover their Linthra setup on a new phone without Docker, an
+account, or the cloud.
+
+**V1 behaviour:** export a Linthra backup **file** from Android; import it on
+another Android device. File export/import is the simplest first step; an optional
+QR/code flow can be layered on later (Phase 3) using the *same* file as its
+payload.
+
+**What's in V1:** server type (Jellyfin / Navidrome / Subsonic / Plex / local),
+server display name and URL, provider priority / default-source preferences, cache
+preferences, and UI/app preferences. Favorites/playlists may come later but are
+**not** required for V1.
+
+**Security:** no passwords or tokens — V1 **does not export credentials at all**.
+After restore, the user re-enters credentials per server. (An encrypted credential
+backup is a separate, opt-in design for later.) Because there are no secrets, the
+file needs no encryption — but it *does* list your server addresses, so it's
+"treat like a bookmark," not "publish publicly."
+
+The format is the deliverable: a small, documented, versioned JSON document that
+Android exports/imports today and that **Linthra Desktop (Phase 4)** and **Linthra
+Connect (Phase 3)** both understand. Full spec:
+**[docs/backup-restore-format.md](./backup-restore-format.md).**
+
+## Phase 3 — Linthra Connect foundation (optional)
+
+**Goal:** an *optional* local pairing/sync concept for phone ↔ desktop. Linthra
+must work fully without it — Connect only saves you from typing.
+
+**V1 idea:** the phone shows a temporary pairing code / QR; the desktop
+enters/scans it; the devices exchange setup data **locally** (the Phase 2 backup
+document is the payload). Pairing can be revoked.
+
+**Security requirements (all mandatory):**
+
+- The code is **temporary**.
+- The user must **approve** each pairing.
+- A **"disconnect all paired devices"** control exists.
+- **No public internet exposure** by default — local exchange only.
+- **No mandatory account.**
+- Connect only syncs/controls **Linthra** — never full phone control.
+
+**Use cases:** import servers from phone to desktop · restore settings to a new
+phone · (later) remote control and queue sync.
+
+This phase is **design-first** — it starts as a design doc (like
+[#178](https://github.com/thezupzup/linthra/issues/178) Plex and
+[#86](https://github.com/thezupzup/linthra/issues/86) WebDAV did), with the
+transport, the pairing handshake, and the approval/revocation model settled on
+paper before any code.
+
+## Phase 4 — Linthra Desktop / Windows MVP
+
+**Goal:** Linthra as a real Windows app — **not** a remote for the phone. Desktop
+must not depend on a phone being present.
+
+**Normal flow:** install on Windows → add Jellyfin / Navidrome / Subsonic / Plex
+servers directly → listen to music on Windows.
+
+**Optional flow:** use a Linthra Connect code/QR (or a Phase 2 backup file) to
+import server settings from Android — then re-enter passwords/tokens manually.
+
+**V1 scope:** Windows first · standalone app · add/manage servers · browse/play
+music · import settings from an Android backup or Connect if available.
+
+**Avoid in V1:** full multi-device cloud sync · complex conflict resolution ·
+mandatory accounts · any Docker dependency · server-side cache/preload.
+
+## Phase 5 — Remote control & sync polish
+
+Only **after** Android and Desktop basics are solid.
+
+**Potential features:** control phone playback from desktop (play/pause/next/prev)
+· view now-playing · view/edit the queue · launch playlists/albums from desktop to
+phone · optional history/favorites sync · optional backup sync.
+
+## Positioning
+
+Linthra should grow into a **self-hosted music ecosystem** — phone, then desktop,
+then optional links between them — **without ever forcing cloud, Docker, or
+accounts** on anyone. The single line that keeps every phase honest:
+
+> **Linthra works on its own. Linthra Connect is optional.**


### PR DESCRIPTION
## Summary

Now that **#244 (audio focus / background-playback recovery) is merged**, this PR
captures the **next roadmap** as repo docs — before any feature code — so the
cross-device work has a shared, reviewed reference. **Docs only:** no code,
version, dependency, or F-Droid metadata changes.

The whole plan is held to one rule:

> **Linthra works on its own. Linthra Connect is optional.** — no Docker, no
> account, no desktop dependency, pairing/QR optional only.

## What's here

- **`docs/roadmap.md`** — the phased product roadmap (Phases 0–5):
  - **Phase 0 — ✅ done.** #244 is merged: scoped strictly to audio focus /
    session / background-playback recovery, battery tradeoff documented (PR +
    code + `docs/battery.md`), CI green (Flutter checks · Build debug APK · Secret
    & privacy scan), real-device validated. The one intentional follow-up (a
    *battery-optimal* mode that holds the service only across a transient-focus
    pause) rolls into Phase 1.
  - **Phase 1 — v0.1.7 stabilization.** A small set of focused, real-device-
    validated PRs (no big features), mapped to existing issues: #83 streaming
    resilience, #239 provider-aware identity, #82 Android Auto, #89 empty states,
    #90 accessibility.
  - **Phases 2–5 — design-first** (matching how #178 Plex and #86 WebDAV started):
    Backup/Restore → optional Linthra Connect → Linthra Desktop (Windows MVP) →
    remote-control & sync polish.
- **`docs/backup-restore-format.md`** — the **Phase 2 V1 file format**: a small,
  versioned, human-readable JSON document that Android exports/imports and that
  future **Linthra Desktop** + **Linthra Connect** also understand (Connect is just
  an optional transport for this same file).
  - **Settings, not secrets:** V1 exports server type / display name / URL,
    provider priority, cache prefs, and UI prefs — and **never credentials**.
    Tokens stay in `flutter_secure_storage`; the user re-enters them after restore.
  - Grounded in the real session/preference stores, including the load-bearing
    gotcha that non-secret server config shares one secure-storage blob with the
    token — so the doc specifies a **non-secret projection** (and a test) so a
    token can't leak into a backup.
- **`README.md` + `docs/contributor-roadmap.md`** — cross-link the new docs.

## Why draft

Marked draft for review of the **direction and the format** before any
exporter/importer or Phase 1 PRs are written. Happy to adjust scope, field set, or
phase ordering.

## CI

Markdown-only: the Dart checks (`dart format` / `analyze` / `test`) are untouched,
the release-bump guard is skipped on a non-`release/*` branch, and the secret &
privacy scan passes (verified locally via `./scripts/check_secrets.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaGP6Yjuqwf4TM6dJheHXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaGP6Yjuqwf4TM6dJheHXA)_