### PR TITLE
feat(backup): add Backup/Restore V1 format foundation

### DIFF
--- a/lib/features/backup_restore/backup_export_mapper.dart
+++ b/lib/features/backup_restore/backup_export_mapper.dart
@@ -1,0 +1,74 @@
+import '../../core/models/jellyfin_session.dart';
+import '../../core/models/plex_session.dart';
+import '../../core/models/subsonic_session.dart';
+import 'backup_models.dart';
+
+/// Projects a live, secret-bearing session into the **non-secret** backup
+/// server model — the single place the "settings, not secrets" rule is enforced
+/// in code.
+///
+/// Why this exists as a separate, deliberate projection (and not a reuse of each
+/// session's `toJson()`): a session's own `toJson()` *includes* its credential
+/// on purpose — its only caller is the encrypted on-device store. Routing that
+/// through a plaintext backup would leak the token. These mappers instead copy
+/// out only the fields the format documents and **structurally cannot** carry a
+/// secret, because [BackupServer] has no field for one. `backup_security_test.dart`
+/// feeds these mappers sessions full of sentinel secrets and asserts none of
+/// them — nor the device-/session-specific ids — ever reach the exported JSON,
+/// so a future field added to a session can't silently start leaking.
+///
+/// This file is the only part of the backup feature that depends on the app's
+/// session models; the format models and the reader stay pure so Desktop can
+/// reuse them.
+
+/// A human label for a source: the server's reported friendly name when it has
+/// one, otherwise the URL host (and the raw URL only if it can't be parsed).
+/// Mirrors how Linthra already labels a source today.
+String _displayNameFor(String? serverName, String baseUrl) {
+  if (serverName != null && serverName.isNotEmpty) return serverName;
+  final String? host = Uri.tryParse(baseUrl)?.host;
+  if (host != null && host.isNotEmpty) return host;
+  return baseUrl;
+}
+
+/// Projects a [JellyfinSession] to its backup entry. Carries `baseUrl` and the
+/// sign-in `username`; deliberately omits `accessToken`, `deviceId`, `userId`,
+/// `serverId`, and version strings.
+JellyfinBackupServer jellyfinBackupServerFromSession(JellyfinSession session) {
+  return JellyfinBackupServer(
+    displayName: _displayNameFor(session.serverName, session.baseUrl),
+    baseUrl: session.baseUrl,
+    username: session.userName,
+  );
+}
+
+/// Projects a [SubsonicSession] to its backup entry. Carries `baseUrl`,
+/// `username`, and the informational `serverType`; deliberately omits the
+/// `salt`/`token` credential pair and version strings.
+SubsonicBackupServer subsonicBackupServerFromSession(SubsonicSession session) {
+  return SubsonicBackupServer(
+    // Subsonic sessions carry no friendly server name, so the host is the label.
+    displayName: _displayNameFor(null, session.baseUrl),
+    baseUrl: session.baseUrl,
+    username: session.username,
+    serverType: session.serverType,
+  );
+}
+
+/// Projects a [PlexSession] to its backup entry. Carries `baseUrl` and the
+/// user's chosen `selectedSectionKeys`; deliberately omits the `X-Plex-Token`,
+/// `machineIdentifier`, `clientIdentifier`, and version strings.
+PlexBackupServer plexBackupServerFromSession(PlexSession session) {
+  return PlexBackupServer(
+    displayName: _displayNameFor(session.serverName, session.baseUrl),
+    baseUrl: session.baseUrl,
+    selectedSectionKeys: session.selectedSectionKeys,
+  );
+}
+
+/// Builds the on-device folder entry from the saved folder URI. There is no
+/// session (and no secret) for the local source; [folderHint] is the SAF tree
+/// URI carried for the user's reference only.
+LocalBackupServer localBackupServer({String? displayName, String? folderHint}) {
+  return LocalBackupServer(displayName: displayName, folderHint: folderHint);
+}

--- a/lib/features/backup_restore/backup_models.dart
+++ b/lib/features/backup_restore/backup_models.dart
@@ -1,0 +1,601 @@
+/// Typed, pure-Dart models for the **Linthra Backup / Restore V1** file format
+/// documented in `docs/backup-restore-format.md`.
+///
+/// This file is the in-memory shape of the JSON envelope. It is deliberately
+/// free of any Android/UI, plugin, or app-state coupling so the *same* models
+/// can be reused by Linthra Desktop (Phase 4) and by Linthra Connect (Phase 3,
+/// an optional transport). Nothing here reads a session, a store, or a file;
+/// projecting live app state into these models lives in
+/// `backup_export_mapper.dart`, and version-gating/clamping/reading a document
+/// lives in `backup_validation.dart`.
+///
+/// ## Safety by construction
+///
+/// V1 is **settings, not secrets** (see the spec → Security). These models have
+/// **no field** for a Jellyfin `accessToken`, a Subsonic `salt`/`token`, a Plex
+/// `X-Plex-Token`, any password, or the device-/session-specific ids
+/// (`deviceId` / `userId` / `serverId` / `machineIdentifier` /
+/// `clientIdentifier` / version strings). Because the field simply does not
+/// exist, [toJson] can never emit one — and `backup_security_test.dart` asserts
+/// exactly that against the real projection.
+///
+/// ## Forward-compatibility
+///
+/// Every [fromJson] here is *lenient*: it reads only the keys it knows, ignores
+/// unknown object fields, tolerates a missing optional, and never throws on a
+/// surprising value (it falls back instead). An unrecognised server `type` is
+/// preserved as an [UnknownBackupServer] rather than crashing the parse, so a
+/// newer file (or a Desktop-only server type) still restores everything else.
+/// Rejecting a too-new `formatVersion` is the reader's job, not the model's.
+library;
+
+/// The JSON key that wraps the whole document and identifies the file as a
+/// Linthra backup. A file is recognised by this marker (and [formatVersion]),
+/// not by its name, so a renamed `*.json` still restores.
+const String kBackupEnvelopeKey = 'linthraBackup';
+
+/// The format version this build reads and writes. V1 = `1`. A backup whose
+/// `formatVersion` is greater than this is rejected by the reader with a clear
+/// message; within this major version, changes are additive only.
+const int kBackupFormatVersion = 1;
+
+/// The only `kind` V1 understands. Reserved so a future
+/// `"settings+credentials"` or `"library"` document can be told apart without a
+/// format-version bump.
+const String kBackupKindSettings = 'settings';
+
+/// Coerces [value] to a `Map<String, dynamic>` when it is a JSON object,
+/// otherwise returns `null`. Shared by every model parser here and by the
+/// `backup_validation.dart` reader so a non-object is treated identically
+/// everywhere (skipped, never a crash). Handles both the `Map<String, dynamic>`
+/// that `jsonDecode` produces and a differently-typed `Map` a hand-built test
+/// or other source might pass.
+Map<String, dynamic>? backupJsonObject(Object? value) {
+  if (value is Map<String, dynamic>) return value;
+  if (value is Map) {
+    return value.map(
+      (Object? key, Object? v) => MapEntry<String, dynamic>(key.toString(), v),
+    );
+  }
+  return null;
+}
+
+/// Reads [value] as a list of strings, dropping any non-string element, or an
+/// empty list when [value] is not a list. Keeps a hand-edited array from
+/// crashing the parse.
+List<String> _backupStringList(Object? value) {
+  if (value is List) {
+    return value.whereType<String>().toList(growable: false);
+  }
+  return const <String>[];
+}
+
+/// Reads [value] as an `int`, or `null` for anything else (so a missing key, a
+/// string, or a float falls back to the setting's default at clamp time rather
+/// than throwing). JSON integers decode to `int`, which is what a real backup
+/// carries.
+int? _backupInt(Object? value) => value is int ? value : null;
+
+/// Reads [value] as a non-empty `String`, or `null` otherwise (empty and
+/// missing are treated the same — "not present").
+String? _backupString(Object? value) =>
+    (value is String && value.isNotEmpty) ? value : null;
+
+/// The full contents of a backup — everything under the [kBackupEnvelopeKey]
+/// wrapper. [toJson] returns this inner object; framing it as
+/// `{ "linthraBackup": { ... } }` and pretty-printing is
+/// `backup_validation.dart`'s job, mirroring how a session's `toJson` returns
+/// its own object and the store wraps it.
+class LinthraBackup {
+  const LinthraBackup({
+    this.formatVersion = kBackupFormatVersion,
+    this.kind = kBackupKindSettings,
+    this.generatedBy,
+    this.createdAt,
+    this.servers = const <BackupServer>[],
+    this.preferences = const BackupPreferences(),
+  });
+
+  /// Format version of this document. Written as [kBackupFormatVersion] on
+  /// export; on import it is whatever the file declared (the reader has already
+  /// rejected a value newer than [kBackupFormatVersion] before this is built).
+  final int formatVersion;
+
+  /// `"settings"` in V1. Carried verbatim so a future reader can branch on it.
+  final String kind;
+
+  /// Optional diagnostics about the writer. Readers must not depend on it.
+  final BackupGeneratedBy? generatedBy;
+
+  /// Optional ISO-8601 UTC timestamp the backup was written, kept as a string
+  /// because it is display-only and the model should never choke on an odd
+  /// date.
+  final String? createdAt;
+
+  /// The configured sources. May be empty. Unknown/unsupported types survive as
+  /// [UnknownBackupServer] so the rest still imports.
+  final List<BackupServer> servers;
+
+  /// App / playback / cache / source preferences. Never null; an absent
+  /// `preferences` object parses to an empty [BackupPreferences].
+  final BackupPreferences preferences;
+
+  /// Serializes the inner backup object in the documented key order. `servers`
+  /// and `preferences` are always present (required, possibly empty);
+  /// `generatedBy` and `createdAt` are omitted when absent.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'formatVersion': formatVersion,
+        'kind': kind,
+        if (generatedBy != null) 'generatedBy': generatedBy!.toJson(),
+        if (createdAt != null) 'createdAt': createdAt,
+        'servers': <Map<String, dynamic>>[
+          for (final BackupServer server in servers) server.toJson(),
+        ],
+        'preferences': preferences.toJson(),
+      };
+
+  /// Rebuilds a backup from the inner object (the value under
+  /// [kBackupEnvelopeKey]). Lenient by design: unknown fields are ignored, a
+  /// missing/invalid `formatVersion` defaults to [kBackupFormatVersion] (the
+  /// reader gates the real version first), malformed server entries are
+  /// dropped, and an absent `preferences` becomes empty.
+  static LinthraBackup fromJson(Map<String, dynamic> json) {
+    final List<BackupServer> servers = <BackupServer>[];
+    final Object? rawServers = json['servers'];
+    if (rawServers is List) {
+      for (final Object? entry in rawServers) {
+        final Map<String, dynamic>? map = backupJsonObject(entry);
+        if (map == null) continue;
+        final BackupServer? server = BackupServer.fromJson(map);
+        if (server != null) servers.add(server);
+      }
+    }
+    return LinthraBackup(
+      formatVersion: _backupInt(json['formatVersion']) ?? kBackupFormatVersion,
+      kind: _backupString(json['kind']) ?? kBackupKindSettings,
+      generatedBy: BackupGeneratedBy.fromJson(json['generatedBy']),
+      createdAt: _backupString(json['createdAt']),
+      servers: servers,
+      preferences: BackupPreferences.fromJson(json['preferences']),
+    );
+  }
+}
+
+/// Diagnostics-only provenance of a backup. Both fields are optional and a
+/// reader must not depend on them.
+class BackupGeneratedBy {
+  const BackupGeneratedBy({this.app, this.appVersion});
+
+  /// e.g. `"Linthra Android"` / `"Linthra Desktop"`.
+  final String? app;
+
+  /// The writing app's version string, e.g. `"0.1.7"`.
+  final String? appVersion;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (app != null) 'app': app,
+        if (appVersion != null) 'appVersion': appVersion,
+      };
+
+  /// Parses [value] tolerantly, returning `null` when it is not an object or
+  /// carries neither field — so an absent or junk `generatedBy` simply
+  /// disappears rather than failing the import.
+  static BackupGeneratedBy? fromJson(Object? value) {
+    final Map<String, dynamic>? map = backupJsonObject(value);
+    if (map == null) return null;
+    final String? app = _backupString(map['app']);
+    final String? appVersion = _backupString(map['appVersion']);
+    if (app == null && appVersion == null) return null;
+    return BackupGeneratedBy(app: app, appVersion: appVersion);
+  }
+}
+
+/// One configured source, tagged by [type]. This is a sealed hierarchy so the
+/// known types are exhaustive at compile time, while [UnknownBackupServer]
+/// absorbs any `type` this build doesn't recognise — that's what keeps an older
+/// reader (or Desktop) from crashing on a newer file's server type.
+///
+/// Per-type fields are **all non-secret** by construction; see the file header.
+sealed class BackupServer {
+  const BackupServer({this.displayName});
+
+  /// The human label Linthra shows for this source. Non-secret; derived from the
+  /// server's reported name (falling back to the URL host) at export time.
+  final String? displayName;
+
+  /// The stable type tag: `"jellyfin"`, `"subsonic"`, `"plex"`, `"local"`, or —
+  /// for [UnknownBackupServer] — whatever unrecognised string the file carried.
+  String get type;
+
+  /// Serializes this entry, always leading with `type` so the document is
+  /// self-describing and an older reader can skip what it doesn't know.
+  Map<String, dynamic> toJson();
+
+  /// Dispatches on `type`. Returns:
+  /// - a typed server for a known type, or `null` if that entry is missing a
+  ///   required field (a corrupt known entry, dropped on import);
+  /// - an [UnknownBackupServer] for a non-empty unrecognised type (preserved so
+  ///   restore can skip it *with a notice*, per the spec);
+  /// - `null` for an entry with no usable `type` at all.
+  static BackupServer? fromJson(Map<String, dynamic> json) {
+    final String? type = _backupString(json['type']);
+    switch (type) {
+      case 'jellyfin':
+        return JellyfinBackupServer.fromJson(json);
+      case 'subsonic':
+        return SubsonicBackupServer.fromJson(json);
+      case 'plex':
+        return PlexBackupServer.fromJson(json);
+      case 'local':
+        return LocalBackupServer.fromJson(json);
+      case null:
+        return null;
+      default:
+        return UnknownBackupServer(
+          typeName: type,
+          displayName: _backupString(json['displayName']),
+          raw: Map<String, dynamic>.of(json),
+        );
+    }
+  }
+}
+
+/// A Jellyfin source. Exports only the non-secret `baseUrl` and sign-in
+/// `username`; the `accessToken`, `deviceId`, `userId`, `serverId`, and version
+/// strings are never modelled here.
+class JellyfinBackupServer extends BackupServer {
+  const JellyfinBackupServer({
+    super.displayName,
+    required this.baseUrl,
+    this.username,
+  });
+
+  /// Server base URL, no trailing slash (e.g. `https://music.example.com`).
+  final String baseUrl;
+
+  /// Sign-in name, to pre-fill the login form on restore.
+  final String? username;
+
+  @override
+  String get type => 'jellyfin';
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': type,
+        if (displayName != null) 'displayName': displayName,
+        'baseUrl': baseUrl,
+        if (username != null) 'username': username,
+      };
+
+  /// Returns `null` when `baseUrl` is missing/blank — a Jellyfin entry with no
+  /// address can't be restored, so it is dropped rather than half-imported.
+  static JellyfinBackupServer? fromJson(Map<String, dynamic> json) {
+    final String? baseUrl = _backupString(json['baseUrl']);
+    if (baseUrl == null) return null;
+    return JellyfinBackupServer(
+      displayName: _backupString(json['displayName']),
+      baseUrl: baseUrl,
+      username: _backupString(json['username']),
+    );
+  }
+}
+
+/// A Subsonic / Navidrome (and other OpenSubsonic) source. Exports `baseUrl`,
+/// `username`, and the informational `serverType`; the `salt`/`token`
+/// credential pair and version strings are never modelled here.
+class SubsonicBackupServer extends BackupServer {
+  const SubsonicBackupServer({
+    super.displayName,
+    required this.baseUrl,
+    this.username,
+    this.serverType,
+  });
+
+  /// Server base URL, no trailing slash.
+  final String baseUrl;
+
+  /// Sign-in name, to pre-fill the login form on restore.
+  final String? username;
+
+  /// OpenSubsonic server product (e.g. `navidrome`), if known. Informational.
+  final String? serverType;
+
+  @override
+  String get type => 'subsonic';
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': type,
+        if (displayName != null) 'displayName': displayName,
+        'baseUrl': baseUrl,
+        if (username != null) 'username': username,
+        if (serverType != null) 'serverType': serverType,
+      };
+
+  /// Returns `null` when `baseUrl` is missing/blank (see
+  /// [JellyfinBackupServer.fromJson]).
+  static SubsonicBackupServer? fromJson(Map<String, dynamic> json) {
+    final String? baseUrl = _backupString(json['baseUrl']);
+    if (baseUrl == null) return null;
+    return SubsonicBackupServer(
+      displayName: _backupString(json['displayName']),
+      baseUrl: baseUrl,
+      username: _backupString(json['username']),
+      serverType: _backupString(json['serverType']),
+    );
+  }
+}
+
+/// A Plex source. Exports `baseUrl` and the user's chosen music-library
+/// `selectedSectionKeys` (a genuine choice worth restoring); the
+/// `X-Plex-Token`, `machineIdentifier`, `clientIdentifier`, and version strings
+/// are never modelled here. Plex has no username in a session, so none is
+/// exported.
+class PlexBackupServer extends BackupServer {
+  const PlexBackupServer({
+    super.displayName,
+    required this.baseUrl,
+    this.selectedSectionKeys = const <String>[],
+  });
+
+  /// Server base URL incl. port (e.g. `https://plex.example.com:32400`).
+  final String baseUrl;
+
+  /// The music-library section keys the user chose to include.
+  final List<String> selectedSectionKeys;
+
+  @override
+  String get type => 'plex';
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': type,
+        if (displayName != null) 'displayName': displayName,
+        'baseUrl': baseUrl,
+        if (selectedSectionKeys.isNotEmpty)
+          'selectedSectionKeys': selectedSectionKeys,
+      };
+
+  /// Returns `null` when `baseUrl` is missing/blank (see
+  /// [JellyfinBackupServer.fromJson]).
+  static PlexBackupServer? fromJson(Map<String, dynamic> json) {
+    final String? baseUrl = _backupString(json['baseUrl']);
+    if (baseUrl == null) return null;
+    return PlexBackupServer(
+      displayName: _backupString(json['displayName']),
+      baseUrl: baseUrl,
+      selectedSectionKeys: _backupStringList(json['selectedSectionKeys']),
+    );
+  }
+}
+
+/// An on-device folder source. [folderHint] is the previously chosen Android SAF
+/// tree URI, **informational only**: a SAF grant is per-device and cannot
+/// transfer, so on restore Linthra shows it as a hint and asks the user to
+/// re-pick the folder. Desktop ignores it.
+class LocalBackupServer extends BackupServer {
+  const LocalBackupServer({super.displayName, this.folderHint});
+
+  /// The SAF tree URI of the previously chosen folder, for the user's
+  /// reference. Not a credential and grants no access.
+  final String? folderHint;
+
+  @override
+  String get type => 'local';
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'type': type,
+        if (displayName != null) 'displayName': displayName,
+        if (folderHint != null) 'folderHint': folderHint,
+      };
+
+  static LocalBackupServer fromJson(Map<String, dynamic> json) {
+    return LocalBackupServer(
+      displayName: _backupString(json['displayName']),
+      folderHint: _backupString(json['folderHint']),
+    );
+  }
+}
+
+/// A server entry whose `type` this build does not recognise — a future
+/// provider, or a platform-specific type (e.g. `local` on Desktop). It is kept
+/// (not dropped) so the importer can skip it *with a notice*. The original
+/// object is preserved in [raw] so nothing is silently lost and the entry can
+/// round-trip unchanged.
+class UnknownBackupServer extends BackupServer {
+  const UnknownBackupServer({
+    required this.typeName,
+    super.displayName,
+    this.raw = const <String, dynamic>{},
+  });
+
+  /// The unrecognised `type` string from the file.
+  final String typeName;
+
+  /// The entry exactly as it appeared, so re-serializing loses nothing.
+  final Map<String, dynamic> raw;
+
+  @override
+  String get type => typeName;
+
+  @override
+  Map<String, dynamic> toJson() => raw.isNotEmpty
+      ? Map<String, dynamic>.of(raw)
+      : <String, dynamic>{
+          'type': typeName,
+          if (displayName != null) 'displayName': displayName,
+        };
+}
+
+/// Non-secret user preferences read from `shared_preferences`. Every field is
+/// optional: a backup carries only the keys the user actually has, and a reader
+/// applies only the keys present (clamping/validating each — see
+/// `backup_validation.dart`).
+class BackupPreferences {
+  const BackupPreferences({
+    this.defaultProvider,
+    this.preferredSourceOrder = const <String>[],
+    this.playbackSourceStrategy,
+    this.cache,
+    this.playback,
+    this.appearance,
+  });
+
+  /// Explicit default source id (`jellyfin` / `subsonic` / `plex` / `local`),
+  /// or `null` for Automatic.
+  final String? defaultProvider;
+
+  /// Source ids, most-preferred first. May be empty.
+  final List<String> preferredSourceOrder;
+
+  /// Playback-source strategy enum name (e.g. `preferLocalCache`), or `null`
+  /// for the default.
+  final String? playbackSourceStrategy;
+
+  /// Offline-cache preferences, or `null` when none are set.
+  final BackupCachePreferences? cache;
+
+  /// Playback preferences, or `null` when none are set.
+  final BackupPlaybackPreferences? playback;
+
+  /// Appearance preferences, or `null` when none are set.
+  final BackupAppearancePreferences? appearance;
+
+  /// Serializes only the keys that are set, producing `{}` when nothing is —
+  /// exactly the "apply only the keys present" contract, in reverse.
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic>? cacheJson = cache?.toJson();
+    final Map<String, dynamic>? playbackJson = playback?.toJson();
+    final Map<String, dynamic>? appearanceJson = appearance?.toJson();
+    return <String, dynamic>{
+      if (defaultProvider != null) 'defaultProvider': defaultProvider,
+      if (preferredSourceOrder.isNotEmpty)
+        'preferredSourceOrder': preferredSourceOrder,
+      if (playbackSourceStrategy != null)
+        'playbackSourceStrategy': playbackSourceStrategy,
+      if (cacheJson != null && cacheJson.isNotEmpty) 'cache': cacheJson,
+      if (playbackJson != null && playbackJson.isNotEmpty)
+        'playback': playbackJson,
+      if (appearanceJson != null && appearanceJson.isNotEmpty)
+        'appearance': appearanceJson,
+    };
+  }
+
+  /// Parses [value] tolerantly: a non-object (or absent) `preferences` becomes
+  /// an empty instance, unknown keys are ignored, and each sub-object is itself
+  /// parsed leniently.
+  static BackupPreferences fromJson(Object? value) {
+    final Map<String, dynamic>? map = backupJsonObject(value);
+    if (map == null) return const BackupPreferences();
+    return BackupPreferences(
+      defaultProvider: _backupString(map['defaultProvider']),
+      preferredSourceOrder: _backupStringList(map['preferredSourceOrder']),
+      playbackSourceStrategy: _backupString(map['playbackSourceStrategy']),
+      cache: BackupCachePreferences.fromJson(map['cache']),
+      playback: BackupPlaybackPreferences.fromJson(map['playback']),
+      appearance: BackupAppearancePreferences.fromJson(map['appearance']),
+    );
+  }
+}
+
+/// Offline-cache preferences. The numeric fields are stored verbatim here and
+/// clamped to the live ranges by `backup_validation.dart` on restore — never
+/// pushed out of bounds by a hand-edited or newer file.
+class BackupCachePreferences {
+  const BackupCachePreferences({
+    this.maxBytes,
+    this.allowMobileData,
+    this.smartPrecacheEnabled,
+    this.precacheCount,
+  });
+
+  /// Offline-cache size ceiling, in bytes (LRU eviction above it).
+  final int? maxBytes;
+
+  /// Whether downloads / pre-cache may use metered data.
+  final bool? allowMobileData;
+
+  /// Whether upcoming queued tracks are warmed into the cache.
+  final bool? smartPrecacheEnabled;
+
+  /// How many upcoming tracks smart pre-cache warms ahead.
+  final int? precacheCount;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (maxBytes != null) 'maxBytes': maxBytes,
+        if (allowMobileData != null) 'allowMobileData': allowMobileData,
+        if (smartPrecacheEnabled != null)
+          'smartPrecacheEnabled': smartPrecacheEnabled,
+        if (precacheCount != null) 'precacheCount': precacheCount,
+      };
+
+  /// Returns `null` when [value] is not an object or carries none of the known
+  /// keys, so an empty/absent `cache` simply doesn't appear.
+  static BackupCachePreferences? fromJson(Object? value) {
+    final Map<String, dynamic>? map = backupJsonObject(value);
+    if (map == null) return null;
+    final int? maxBytes = _backupInt(map['maxBytes']);
+    final bool? allowMobileData =
+        map['allowMobileData'] is bool ? map['allowMobileData'] as bool : null;
+    final bool? smartPrecacheEnabled = map['smartPrecacheEnabled'] is bool
+        ? map['smartPrecacheEnabled'] as bool
+        : null;
+    final int? precacheCount = _backupInt(map['precacheCount']);
+    if (maxBytes == null &&
+        allowMobileData == null &&
+        smartPrecacheEnabled == null &&
+        precacheCount == null) {
+      return null;
+    }
+    return BackupCachePreferences(
+      maxBytes: maxBytes,
+      allowMobileData: allowMobileData,
+      smartPrecacheEnabled: smartPrecacheEnabled,
+      precacheCount: precacheCount,
+    );
+  }
+}
+
+/// Playback preferences.
+class BackupPlaybackPreferences {
+  const BackupPlaybackPreferences({this.normalizeVolume});
+
+  /// Apply ReplayGain (attenuation-only) for even loudness.
+  final bool? normalizeVolume;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (normalizeVolume != null) 'normalizeVolume': normalizeVolume,
+      };
+
+  /// Returns `null` when [value] is not an object or carries no known key.
+  static BackupPlaybackPreferences? fromJson(Object? value) {
+    final Map<String, dynamic>? map = backupJsonObject(value);
+    if (map == null) return null;
+    final bool? normalizeVolume =
+        map['normalizeVolume'] is bool ? map['normalizeVolume'] as bool : null;
+    if (normalizeVolume == null) return null;
+    return BackupPlaybackPreferences(normalizeVolume: normalizeVolume);
+  }
+}
+
+/// Appearance preferences. Cosmetic only.
+class BackupAppearancePreferences {
+  const BackupAppearancePreferences({this.appIconVariant});
+
+  /// Chosen Linthra logo/branding variant id; cosmetic.
+  final String? appIconVariant;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        if (appIconVariant != null) 'appIconVariant': appIconVariant,
+      };
+
+  /// Returns `null` when [value] is not an object or carries no known key.
+  static BackupAppearancePreferences? fromJson(Object? value) {
+    final Map<String, dynamic>? map = backupJsonObject(value);
+    if (map == null) return null;
+    final String? appIconVariant = _backupString(map['appIconVariant']);
+    if (appIconVariant == null) return null;
+    return BackupAppearancePreferences(appIconVariant: appIconVariant);
+  }
+}

--- a/lib/features/backup_restore/backup_validation.dart
+++ b/lib/features/backup_restore/backup_validation.dart
@@ -1,0 +1,198 @@
+import 'dart:convert';
+
+import '../../core/models/cache_size.dart';
+import '../../core/repositories/download_preferences.dart';
+import 'backup_models.dart';
+
+/// Reading, version-gating, framing, and clamping for the Backup/Restore V1
+/// format — the safety layer that sits on top of the pure models in
+/// `backup_models.dart`.
+///
+/// Two jobs:
+///
+/// 1. **Read safely.** [readBackup] turns raw file text into a typed result that
+///    distinguishes "not JSON", "not a Linthra backup", "made by a newer
+///    Linthra" (a too-new `formatVersion`, rejected with a clear message — never
+///    a silent half-import), and "malformed". Only a clean, supported document
+///    yields a [LinthraBackup].
+///
+/// 2. **Clamp like the live settings.** A backup is just a file — it can be
+///    hand-edited or written by a newer build — so every numeric preference is
+///    clamped to *exactly* the same range the live setting enforces. These
+///    helpers delegate to [CacheSize.clamp] and [sanitizePrecacheCount] so the
+///    backup path can never drift from the app path: there is one definition of
+///    "in range", reused.
+///
+/// All of this is pure Dart (no plugins, no I/O), so it runs the same on
+/// Android, on Desktop, and in tests.
+
+/// Whether this build can read a document declaring [formatVersion]. V1 accepts
+/// `1`; a version below `1` is malformed and one above [kBackupFormatVersion] is
+/// from a newer Linthra. Written as a range so a future build that bumps
+/// [kBackupFormatVersion] keeps accepting older files unchanged.
+bool isSupportedBackupFormatVersion(int formatVersion) =>
+    formatVersion >= 1 && formatVersion <= kBackupFormatVersion;
+
+/// Clamps a backed-up cache ceiling to the supported byte range, identically to
+/// the live "Max cache size" setting.
+int clampBackupCacheMaxBytes(int bytes) => CacheSize.clamp(bytes);
+
+/// Clamps a backed-up pre-cache count to the supported range, identically to the
+/// live "how many upcoming tracks" setting (junk → default, over-range →
+/// capped).
+int clampBackupPrecacheCount(int count) => sanitizePrecacheCount(count);
+
+/// Returns a copy of [cache] with its numeric fields clamped to the live ranges
+/// ([maxBytes] via [clampBackupCacheMaxBytes], [precacheCount] via
+/// [clampBackupPrecacheCount]). Booleans and absent fields are left untouched.
+BackupCachePreferences clampBackupCachePreferences(
+  BackupCachePreferences cache,
+) {
+  final int? maxBytes = cache.maxBytes;
+  final int? precacheCount = cache.precacheCount;
+  return BackupCachePreferences(
+    maxBytes: maxBytes == null ? null : clampBackupCacheMaxBytes(maxBytes),
+    allowMobileData: cache.allowMobileData,
+    smartPrecacheEnabled: cache.smartPrecacheEnabled,
+    precacheCount:
+        precacheCount == null ? null : clampBackupPrecacheCount(precacheCount),
+  );
+}
+
+/// Returns a copy of [preferences] safe to apply: numeric cache fields clamped
+/// to the live ranges, everything else preserved. The eventual restore importer
+/// calls this before applying, so a hand-edited or newer file can never push a
+/// setting out of bounds. Non-numeric choices that the app already resolves with
+/// a fallback at read time (`playbackSourceStrategy` →
+/// `PlaybackSourceStrategy.fromStorage`, `appIconVariant` →
+/// `AppIconVariants.byId`) are left verbatim so that single source of truth
+/// stays in charge.
+BackupPreferences clampBackupPreferences(BackupPreferences preferences) {
+  final BackupCachePreferences? cache = preferences.cache;
+  return BackupPreferences(
+    defaultProvider: preferences.defaultProvider,
+    preferredSourceOrder: preferences.preferredSourceOrder,
+    playbackSourceStrategy: preferences.playbackSourceStrategy,
+    cache: cache == null ? null : clampBackupCachePreferences(cache),
+    playback: preferences.playback,
+    appearance: preferences.appearance,
+  );
+}
+
+/// Frames [backup] as the full document map `{ "linthraBackup": { ... } }` ready
+/// for `jsonEncode`. Pairs with [readBackupRoot], which unwraps the same key.
+Map<String, dynamic> wrapBackupDocument(LinthraBackup backup) =>
+    <String, dynamic>{kBackupEnvelopeKey: backup.toJson()};
+
+/// Encodes [backup] as the pretty-printed UTF-8 JSON text of a backup file
+/// (two-space indent), exactly the human-inspectable shape the format
+/// documents.
+String encodeBackup(LinthraBackup backup) =>
+    const JsonEncoder.withIndent('  ').convert(wrapBackupDocument(backup));
+
+/// Why a document could not be read as a usable backup.
+enum BackupReadFailureReason {
+  /// The text isn't valid JSON at all.
+  notJson,
+
+  /// Valid JSON, but it has no [kBackupEnvelopeKey] object — not a Linthra
+  /// backup.
+  notLinthraBackup,
+
+  /// A Linthra backup, but its `formatVersion` is newer than this build
+  /// supports. The user should update Linthra.
+  unsupportedVersion,
+
+  /// A Linthra backup whose envelope is structurally invalid (e.g. a missing or
+  /// non-integer `formatVersion`).
+  malformed,
+}
+
+/// The outcome of reading a backup document: either a parsed [LinthraBackup] or
+/// a typed failure carrying a user-facing [message].
+sealed class BackupReadResult {
+  const BackupReadResult();
+}
+
+/// A successfully read backup. The contained [backup] is parsed but **not**
+/// clamped — call [clampBackupPreferences] before applying its preferences.
+class BackupReadSuccess extends BackupReadResult {
+  const BackupReadSuccess(this.backup);
+
+  final LinthraBackup backup;
+}
+
+/// A document that could not be read, with the [reason] and a clear, user-facing
+/// [message] suitable to show on the (future) restore screen.
+class BackupReadFailure extends BackupReadResult {
+  const BackupReadFailure(this.reason, this.message);
+
+  final BackupReadFailureReason reason;
+  final String message;
+}
+
+/// Reads backup [text]: decodes the JSON, then validates the envelope via
+/// [readBackupRoot]. Never throws — invalid JSON becomes a
+/// [BackupReadFailureReason.notJson] failure.
+BackupReadResult readBackup(String text) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(text);
+  } on FormatException {
+    return const BackupReadFailure(
+      BackupReadFailureReason.notJson,
+      'This file is not valid JSON, so it is not a Linthra backup.',
+    );
+  }
+  final Map<String, dynamic>? root = backupJsonObject(decoded);
+  if (root == null) {
+    return const BackupReadFailure(
+      BackupReadFailureReason.notLinthraBackup,
+      'This file does not look like a Linthra backup.',
+    );
+  }
+  return readBackupRoot(root);
+}
+
+/// Validates an already-decoded document [root] and, on success, builds the
+/// [LinthraBackup]. Splitting this out lets a caller that already has a decoded
+/// map (or a test) reuse the exact envelope/version checks.
+///
+/// Order matters: the [kBackupEnvelopeKey] marker is checked first (is this even
+/// a backup?), then `formatVersion` (can we read it?), and only then is the body
+/// parsed. A too-new version is reported as [BackupReadFailureReason.unsupportedVersion]
+/// with a clear message rather than parsed partially.
+BackupReadResult readBackupRoot(Map<String, dynamic> root) {
+  final Map<String, dynamic>? inner =
+      backupJsonObject(root[kBackupEnvelopeKey]);
+  if (inner == null) {
+    return const BackupReadFailure(
+      BackupReadFailureReason.notLinthraBackup,
+      'This file is missing the Linthra backup marker, so it cannot be '
+      'restored.',
+    );
+  }
+
+  final Object? rawVersion = inner['formatVersion'];
+  if (rawVersion is! int) {
+    return const BackupReadFailure(
+      BackupReadFailureReason.malformed,
+      'This backup is missing a valid format version and cannot be restored.',
+    );
+  }
+  if (rawVersion < 1) {
+    return BackupReadFailure(
+      BackupReadFailureReason.malformed,
+      'This backup reports an invalid format version ($rawVersion).',
+    );
+  }
+  if (rawVersion > kBackupFormatVersion) {
+    return BackupReadFailure(
+      BackupReadFailureReason.unsupportedVersion,
+      'This backup was made by a newer version of Linthra (backup format '
+      'v$rawVersion). Update Linthra to restore it.',
+    );
+  }
+
+  return BackupReadSuccess(LinthraBackup.fromJson(inner));
+}

--- a/test/features/backup_restore/backup_models_test.dart
+++ b/test/features/backup_restore/backup_models_test.dart
@@ -1,0 +1,416 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cache_size.dart';
+import 'package:linthra/core/repositories/download_preferences.dart';
+import 'package:linthra/features/backup_restore/backup_models.dart';
+import 'package:linthra/features/backup_restore/backup_validation.dart';
+
+/// A fully-populated backup mirroring the spec's worked example, used as the
+/// fixture for round-trip and framing tests.
+LinthraBackup _exampleBackup() => const LinthraBackup(
+      generatedBy: BackupGeneratedBy(
+        app: 'Linthra Android',
+        appVersion: '0.1.7',
+      ),
+      createdAt: '2026-06-24T12:00:00Z',
+      servers: <BackupServer>[
+        JellyfinBackupServer(
+          displayName: 'Home Jellyfin',
+          baseUrl: 'https://music.example.com',
+          username: 'alice',
+        ),
+        SubsonicBackupServer(
+          displayName: 'Navidrome',
+          baseUrl: 'https://nd.example.com',
+          username: 'alice',
+          serverType: 'navidrome',
+        ),
+        PlexBackupServer(
+          displayName: 'Living-room Plex',
+          baseUrl: 'https://plex.example.com:32400',
+          selectedSectionKeys: <String>['3', '7'],
+        ),
+        LocalBackupServer(
+          displayName: 'Phone music folder',
+          folderHint:
+              'content://com.android.externalstorage.documents/tree/primary%3AMusic',
+        ),
+      ],
+      preferences: BackupPreferences(
+        defaultProvider: 'jellyfin',
+        preferredSourceOrder: <String>['local', 'jellyfin', 'subsonic'],
+        playbackSourceStrategy: 'preferLocalCache',
+        cache: BackupCachePreferences(
+          maxBytes: 5368709120,
+          allowMobileData: false,
+          smartPrecacheEnabled: true,
+          precacheCount: 3,
+        ),
+        playback: BackupPlaybackPreferences(normalizeVolume: false),
+        appearance: BackupAppearancePreferences(appIconVariant: 'classic'),
+      ),
+    );
+
+void main() {
+  group('envelope & framing', () {
+    test('encodeBackup wraps the document under the linthraBackup marker', () {
+      final Map<String, dynamic> doc =
+          jsonDecode(encodeBackup(_exampleBackup())) as Map<String, dynamic>;
+
+      expect(doc.keys, <String>[kBackupEnvelopeKey]);
+      final Map<String, dynamic> inner =
+          doc[kBackupEnvelopeKey] as Map<String, dynamic>;
+      expect(inner['formatVersion'], kBackupFormatVersion);
+      expect(inner['formatVersion'], 1);
+      expect(inner['kind'], kBackupKindSettings);
+    });
+
+    test('servers and preferences are always present, even when empty', () {
+      const LinthraBackup empty = LinthraBackup();
+      final Map<String, dynamic> json = empty.toJson();
+
+      expect(json['servers'], isEmpty);
+      expect(json['preferences'], isEmpty);
+      // Optional diagnostics are omitted when absent.
+      expect(json.containsKey('generatedBy'), isFalse);
+      expect(json.containsKey('createdAt'), isFalse);
+    });
+
+    test('empty preferences serialize to {} and omit absent sub-objects', () {
+      const BackupPreferences prefs = BackupPreferences();
+      expect(prefs.toJson(), isEmpty);
+
+      const BackupPreferences partial = BackupPreferences(
+        defaultProvider: 'plex',
+      );
+      expect(partial.toJson(), <String, dynamic>{'defaultProvider': 'plex'});
+      expect(partial.toJson().containsKey('cache'), isFalse);
+    });
+  });
+
+  group('round-trip fidelity', () {
+    test('encode → read returns an identical document', () {
+      final LinthraBackup original = _exampleBackup();
+
+      final BackupReadResult result = readBackup(encodeBackup(original));
+
+      expect(result, isA<BackupReadSuccess>());
+      final LinthraBackup restored = (result as BackupReadSuccess).backup;
+      expect(restored.toJson(), original.toJson());
+    });
+
+    test('each server type preserves its documented fields', () {
+      final LinthraBackup restored =
+          (readBackup(encodeBackup(_exampleBackup())) as BackupReadSuccess)
+              .backup;
+
+      final JellyfinBackupServer jellyfin =
+          restored.servers[0] as JellyfinBackupServer;
+      expect(jellyfin.baseUrl, 'https://music.example.com');
+      expect(jellyfin.username, 'alice');
+
+      final SubsonicBackupServer subsonic =
+          restored.servers[1] as SubsonicBackupServer;
+      expect(subsonic.serverType, 'navidrome');
+
+      final PlexBackupServer plex = restored.servers[2] as PlexBackupServer;
+      expect(plex.selectedSectionKeys, <String>['3', '7']);
+
+      final LocalBackupServer local = restored.servers[3] as LocalBackupServer;
+      expect(local.folderHint, contains('tree/primary'));
+    });
+  });
+
+  group('forward-compatibility: unknown fields are ignored', () {
+    test('unknown top-level, server, and preference keys do not break parsing',
+        () {
+      final Map<String, dynamic> root = <String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 1,
+          'kind': 'settings',
+          // A field a future Linthra might add at the envelope level.
+          'futureEnvelopeField': <String, dynamic>{'anything': true},
+          'servers': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'type': 'jellyfin',
+              'baseUrl': 'https://music.example.com',
+              'username': 'alice',
+              // A field a future Linthra might add to a known server type.
+              'futureServerField': 'ignored',
+            },
+          ],
+          'preferences': <String, dynamic>{
+            'defaultProvider': 'jellyfin',
+            // A preference key this build has never heard of.
+            'futurePreference': 42,
+            'cache': <String, dynamic>{
+              'maxBytes': 5368709120,
+              'futureCacheKnob': 'ignored',
+            },
+          },
+        },
+      };
+
+      final BackupReadResult result = readBackupRoot(root);
+
+      expect(result, isA<BackupReadSuccess>());
+      final LinthraBackup backup = (result as BackupReadSuccess).backup;
+      expect(backup.servers, hasLength(1));
+      expect(backup.servers.single, isA<JellyfinBackupServer>());
+      expect(backup.preferences.defaultProvider, 'jellyfin');
+      expect(backup.preferences.cache?.maxBytes, 5368709120);
+      // The unknown keys are gone — not re-emitted on a known type's toJson.
+      expect(backup.servers.single.toJson().containsKey('futureServerField'),
+          isFalse);
+    });
+  });
+
+  group('forward-compatibility: unknown server types', () {
+    test('an unknown type is preserved (skippable) and others still import',
+        () {
+      final Map<String, dynamic> root = <String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 1,
+          'servers': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'type': 'jellyfin',
+              'baseUrl': 'https://music.example.com',
+            },
+            <String, dynamic>{
+              // A provider this build doesn't know (a newer Android, or a
+              // Desktop-only source).
+              'type': 'futuresonic',
+              'displayName': 'Future Server',
+              'baseUrl': 'https://future.example.com',
+            },
+          ],
+          'preferences': <String, dynamic>{},
+        },
+      };
+
+      final LinthraBackup backup =
+          (readBackupRoot(root) as BackupReadSuccess).backup;
+
+      expect(backup.servers, hasLength(2));
+      expect(backup.servers[0], isA<JellyfinBackupServer>());
+
+      final BackupServer unknown = backup.servers[1];
+      expect(unknown, isA<UnknownBackupServer>());
+      expect(unknown.type, 'futuresonic');
+      expect(unknown.displayName, 'Future Server');
+      // The original entry round-trips losslessly so nothing is silently lost.
+      expect(unknown.toJson()['baseUrl'], 'https://future.example.com');
+    });
+
+    test('a typeless server entry is dropped, not crashed on', () {
+      final Map<String, dynamic> root = <String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 1,
+          'servers': <Object>[
+            <String, dynamic>{'displayName': 'No type here'},
+            'not even an object',
+          ],
+          'preferences': <String, dynamic>{},
+        },
+      };
+
+      final LinthraBackup backup =
+          (readBackupRoot(root) as BackupReadSuccess).backup;
+      expect(backup.servers, isEmpty);
+    });
+  });
+
+  group('version gating', () {
+    test('a newer formatVersion is rejected with a clear message', () {
+      final Map<String, dynamic> root = <String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': kBackupFormatVersion + 1,
+          'servers': <Object>[],
+          'preferences': <String, dynamic>{},
+        },
+      };
+
+      final BackupReadResult result = readBackupRoot(root);
+
+      expect(result, isA<BackupReadFailure>());
+      final BackupReadFailure failure = result as BackupReadFailure;
+      expect(failure.reason, BackupReadFailureReason.unsupportedVersion);
+      expect(failure.message, contains('newer version'));
+    });
+
+    test('isSupportedBackupFormatVersion accepts only the supported range', () {
+      expect(isSupportedBackupFormatVersion(1), isTrue);
+      expect(isSupportedBackupFormatVersion(kBackupFormatVersion), isTrue);
+      expect(isSupportedBackupFormatVersion(kBackupFormatVersion + 1), isFalse);
+      expect(isSupportedBackupFormatVersion(0), isFalse);
+      expect(isSupportedBackupFormatVersion(-1), isFalse);
+    });
+
+    test('a missing or non-integer formatVersion is malformed', () {
+      final BackupReadResult missing = readBackupRoot(<String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'servers': <Object>[],
+          'preferences': <String, dynamic>{},
+        },
+      });
+      expect((missing as BackupReadFailure).reason,
+          BackupReadFailureReason.malformed);
+
+      final BackupReadResult notInt = readBackupRoot(<String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 'one',
+          'servers': <Object>[],
+          'preferences': <String, dynamic>{},
+        },
+      });
+      expect((notInt as BackupReadFailure).reason,
+          BackupReadFailureReason.malformed);
+    });
+
+    test('a version below 1 is malformed', () {
+      final BackupReadResult result = readBackupRoot(<String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{'formatVersion': 0},
+      });
+      expect((result as BackupReadFailure).reason,
+          BackupReadFailureReason.malformed);
+    });
+  });
+
+  group('reader rejects non-backups', () {
+    test('invalid JSON → notJson', () {
+      final BackupReadResult result = readBackup('{not valid json');
+      expect((result as BackupReadFailure).reason,
+          BackupReadFailureReason.notJson);
+    });
+
+    test('valid JSON without the marker → notLinthraBackup', () {
+      final BackupReadResult result = readBackup('{"somethingElse": true}');
+      expect((result as BackupReadFailure).reason,
+          BackupReadFailureReason.notLinthraBackup);
+    });
+
+    test('a non-object JSON value → notLinthraBackup', () {
+      final BackupReadResult result = readBackup('[1, 2, 3]');
+      expect((result as BackupReadFailure).reason,
+          BackupReadFailureReason.notLinthraBackup);
+    });
+  });
+
+  group('lenient parsing of malformed bodies', () {
+    test('a known server missing its baseUrl is dropped', () {
+      final LinthraBackup backup = (readBackupRoot(<String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 1,
+          'servers': <Map<String, dynamic>>[
+            <String, dynamic>{'type': 'jellyfin', 'username': 'alice'},
+          ],
+          'preferences': <String, dynamic>{},
+        },
+      }) as BackupReadSuccess)
+          .backup;
+      expect(backup.servers, isEmpty);
+    });
+
+    test('a non-list servers value parses to no servers', () {
+      final LinthraBackup backup = (readBackupRoot(<String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 1,
+          'servers': 'not a list',
+          'preferences': <String, dynamic>{},
+        },
+      }) as BackupReadSuccess)
+          .backup;
+      expect(backup.servers, isEmpty);
+    });
+
+    test('wrong-typed preference values fall back instead of throwing', () {
+      final LinthraBackup backup = (readBackupRoot(<String, dynamic>{
+        kBackupEnvelopeKey: <String, dynamic>{
+          'formatVersion': 1,
+          'servers': <Object>[],
+          'preferences': <String, dynamic>{
+            // Wrong types throughout — each should be ignored, none should crash.
+            'defaultProvider': 123,
+            'preferredSourceOrder': 'jellyfin',
+            'cache': <String, dynamic>{'maxBytes': 'huge'},
+            'playback': <String, dynamic>{'normalizeVolume': 'yes'},
+          },
+        },
+      }) as BackupReadSuccess)
+          .backup;
+
+      expect(backup.preferences.defaultProvider, isNull);
+      expect(backup.preferences.preferredSourceOrder, isEmpty);
+      // cache had only an invalid maxBytes → it collapses to "no cache prefs".
+      expect(backup.preferences.cache, isNull);
+      expect(backup.preferences.playback, isNull);
+    });
+  });
+
+  group('preference clamping (matches the live settings ranges)', () {
+    test('maxBytes below the floor clamps up to the live minimum', () {
+      const BackupPreferences prefs = BackupPreferences(
+        cache: BackupCachePreferences(maxBytes: 1),
+      );
+      final BackupPreferences clamped = clampBackupPreferences(prefs);
+      expect(clamped.cache?.maxBytes, CacheSize.minLimit);
+    });
+
+    test('maxBytes above the ceiling clamps down to the live maximum', () {
+      const BackupPreferences prefs = BackupPreferences(
+        cache: BackupCachePreferences(maxBytes: 999999999999999),
+      );
+      final BackupPreferences clamped = clampBackupPreferences(prefs);
+      expect(clamped.cache?.maxBytes, CacheSize.maxLimit);
+    });
+
+    test('precacheCount junk → default, over-range → capped', () {
+      const BackupPreferences low = BackupPreferences(
+        cache: BackupCachePreferences(precacheCount: 0),
+      );
+      expect(
+        clampBackupPreferences(low).cache?.precacheCount,
+        kDefaultPrecacheCount,
+      );
+
+      const BackupPreferences high = BackupPreferences(
+        cache: BackupCachePreferences(precacheCount: 9999),
+      );
+      expect(
+        clampBackupPreferences(high).cache?.precacheCount,
+        kMaxPrecacheCount,
+      );
+    });
+
+    test('in-range values and booleans are preserved unchanged', () {
+      const BackupPreferences prefs = BackupPreferences(
+        cache: BackupCachePreferences(
+          maxBytes: 5368709120,
+          allowMobileData: true,
+          smartPrecacheEnabled: false,
+          precacheCount: 7,
+        ),
+      );
+      final BackupCachePreferences? cache = clampBackupPreferences(prefs).cache;
+      expect(cache?.maxBytes, 5368709120);
+      expect(cache?.precacheCount, 7);
+      expect(cache?.allowMobileData, isTrue);
+      expect(cache?.smartPrecacheEnabled, isFalse);
+    });
+
+    test('clamping leaves non-cache preferences untouched', () {
+      const BackupPreferences prefs = BackupPreferences(
+        defaultProvider: 'plex',
+        preferredSourceOrder: <String>['plex', 'local'],
+        playbackSourceStrategy: 'preferHighestQuality',
+        appearance: BackupAppearancePreferences(appIconVariant: 'gold'),
+      );
+      final BackupPreferences clamped = clampBackupPreferences(prefs);
+      expect(clamped.defaultProvider, 'plex');
+      expect(clamped.preferredSourceOrder, <String>['plex', 'local']);
+      expect(clamped.playbackSourceStrategy, 'preferHighestQuality');
+      expect(clamped.appearance?.appIconVariant, 'gold');
+    });
+  });
+}

--- a/test/features/backup_restore/backup_security_test.dart
+++ b/test/features/backup_restore/backup_security_test.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/features/backup_restore/backup_export_mapper.dart';
+import 'package:linthra/features/backup_restore/backup_models.dart';
+import 'package:linthra/features/backup_restore/backup_validation.dart';
+
+/// JSON keys that must NEVER appear anywhere in an exported backup: the secrets
+/// (Jellyfin access token, Subsonic salt+token, Plex token, any password) and
+/// the device-/session-specific ids and version strings the spec excludes on
+/// purpose (they are re-derived at re-auth and carrying them would let one
+/// device impersonate another). See docs/backup-restore-format.md → Security.
+const Set<String> _forbiddenKeys = <String>{
+  'accessToken',
+  'token',
+  'salt',
+  'password',
+  'deviceId',
+  'userId',
+  'serverId',
+  'machineIdentifier',
+  'clientIdentifier',
+  'serverVersion',
+  'apiVersion',
+  'productName',
+};
+
+/// Recursively collects every object key in a decoded JSON tree, so a secret
+/// hidden in a nested object can't slip past a shallow check.
+Set<String> _allKeys(Object? node) {
+  final Set<String> keys = <String>{};
+  if (node is Map) {
+    node.forEach((Object? key, Object? value) {
+      keys.add(key.toString());
+      keys.addAll(_allKeys(value));
+    });
+  } else if (node is List) {
+    for (final Object? element in node) {
+      keys.addAll(_allKeys(element));
+    }
+  }
+  return keys;
+}
+
+/// Sessions seeded with `SENTINEL-` secrets/ids. Every field that must never be
+/// exported carries the `SENTINEL-` prefix, so a single check ("no `SENTINEL-`
+/// in the file") proves none of them leaked, while the non-secret fields
+/// (`baseUrl`, `username`, `serverType`, section keys) use ordinary values that
+/// are *expected* to appear.
+const JellyfinSession _jellyfin = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'SENTINEL-jf-user-id',
+  accessToken: 'SENTINEL-jf-access-token',
+  deviceId: 'SENTINEL-jf-device-id',
+  userName: 'alice',
+  serverId: 'SENTINEL-jf-server-id',
+  serverName: 'Home Jellyfin',
+  serverVersion: 'SENTINEL-jf-server-version',
+  productName: 'SENTINEL-jf-product-name',
+);
+
+const SubsonicSession _subsonic = SubsonicSession(
+  baseUrl: 'https://nd.example.com',
+  username: 'alice',
+  salt: 'SENTINEL-sub-salt',
+  token: 'SENTINEL-sub-token',
+  serverType: 'navidrome',
+  serverVersion: 'SENTINEL-sub-server-version',
+  apiVersion: 'SENTINEL-sub-api-version',
+);
+
+const PlexSession _plex = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'SENTINEL-plex-token',
+  machineIdentifier: 'SENTINEL-plex-machine-id',
+  serverName: 'Living-room Plex',
+  serverVersion: 'SENTINEL-plex-server-version',
+  clientIdentifier: 'SENTINEL-plex-client-id',
+  selectedSectionKeys: <String>['3', '7'],
+);
+
+LinthraBackup _backupFromSecretSessions() => LinthraBackup(
+      generatedBy: const BackupGeneratedBy(app: 'Linthra Android'),
+      servers: <BackupServer>[
+        jellyfinBackupServerFromSession(_jellyfin),
+        subsonicBackupServerFromSession(_subsonic),
+        plexBackupServerFromSession(_plex),
+        localBackupServer(
+          displayName: 'Phone music folder',
+          folderHint:
+              'content://com.android.externalstorage.documents/tree/primary%3AMusic',
+        ),
+      ],
+      preferences: const BackupPreferences(
+        defaultProvider: 'jellyfin',
+        preferredSourceOrder: <String>['local', 'jellyfin', 'subsonic'],
+        cache: BackupCachePreferences(maxBytes: 5368709120),
+      ),
+    );
+
+void main() {
+  group('a backup exports settings, never secrets', () {
+    test('no secret/excluded value reaches the exported JSON', () {
+      final String json = encodeBackup(_backupFromSecretSessions());
+
+      // The single strongest regression: every secret and every excluded id /
+      // version string was seeded with `SENTINEL-`. If ANY of them appears, the
+      // projection leaked it — and this fails.
+      expect(json, isNot(contains('SENTINEL-')));
+    });
+
+    test('no forbidden key appears anywhere in the document', () {
+      final Object? decoded =
+          jsonDecode(encodeBackup(_backupFromSecretSessions()));
+
+      final Set<String> present = _allKeys(decoded);
+      final Set<String> leaked = present.intersection(_forbiddenKeys);
+
+      expect(
+        leaked,
+        isEmpty,
+        reason: 'These secret/excluded keys must never be exported: $leaked',
+      );
+    });
+
+    test('the non-secret settings ARE exported (the projection keeps them)',
+        () {
+      final String json = encodeBackup(_backupFromSecretSessions());
+
+      // URLs, usernames, server type, and section keys are the whole point of a
+      // settings backup.
+      expect(json, contains('https://music.example.com'));
+      expect(json, contains('https://nd.example.com'));
+      expect(json, contains('https://plex.example.com:32400'));
+      expect(json, contains('alice'));
+      expect(json, contains('navidrome'));
+      expect(json, contains('"3"'));
+      expect(json, contains('"7"'));
+    });
+  });
+
+  group('the projection — not the session — is what drops the secret', () {
+    test('the sessions really do carry the secrets that must be dropped', () {
+      // Sanity: prove the inputs are secret-bearing, so the absence above is
+      // the mapper doing its job, not an empty fixture.
+      expect(
+          jsonEncode(_jellyfin.toJson()), contains('SENTINEL-jf-access-token'));
+      expect(jsonEncode(_subsonic.toJson()), contains('SENTINEL-sub-token'));
+      expect(jsonEncode(_subsonic.toJson()), contains('SENTINEL-sub-salt'));
+      expect(jsonEncode(_plex.toJson()), contains('SENTINEL-plex-token'));
+    });
+  });
+
+  group('each mapper emits only its allow-listed, non-secret fields', () {
+    test('Jellyfin → {type, displayName, baseUrl, username} only', () {
+      final Map<String, dynamic> json =
+          jellyfinBackupServerFromSession(_jellyfin).toJson();
+      expect(
+        json.keys.toSet(),
+        <String>{'type', 'displayName', 'baseUrl', 'username'},
+      );
+      expect(json.keys.toSet().intersection(_forbiddenKeys), isEmpty);
+    });
+
+    test('Subsonic → {type, displayName, baseUrl, username, serverType} only',
+        () {
+      final Map<String, dynamic> json =
+          subsonicBackupServerFromSession(_subsonic).toJson();
+      expect(
+        json.keys.toSet(),
+        <String>{'type', 'displayName', 'baseUrl', 'username', 'serverType'},
+      );
+      expect(json.keys.toSet().intersection(_forbiddenKeys), isEmpty);
+    });
+
+    test('Plex → {type, displayName, baseUrl, selectedSectionKeys} only', () {
+      final Map<String, dynamic> json =
+          plexBackupServerFromSession(_plex).toJson();
+      expect(
+        json.keys.toSet(),
+        <String>{'type', 'displayName', 'baseUrl', 'selectedSectionKeys'},
+      );
+      expect(json.keys.toSet().intersection(_forbiddenKeys), isEmpty);
+    });
+  });
+
+  group('passwords are never part of the format', () {
+    test('no password field exists anywhere in a full backup', () {
+      // Linthra never stores a password (it derives a token once, then discards
+      // it), and the format has no field for one — assert both: the key is
+      // absent from the model output entirely.
+      final Object? decoded =
+          jsonDecode(encodeBackup(_backupFromSecretSessions()));
+      expect(_allKeys(decoded).contains('password'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First, foundational code for **Backup/Restore V1**, implementing the file format documented in `docs/backup-restore-format.md` (the spec merged in #245). This is **models and helpers only** — small, safe, and focused. No exporter/importer UI, no restore workflow, no pairing/QR.

Linthra works on its own; this adds no account, no Docker, no desktop dependency, and no new dependencies.

## What's in this PR

All new files under `lib/features/backup_restore/` (pure Dart, no Android/UI coupling, reusable by Linthra Desktop):

| File | Purpose |
| --- | --- |
| `backup_models.dart` | Typed models for the `linthraBackup` envelope, a **sealed** server hierarchy (`jellyfin` / `subsonic` / `plex` / `local`, plus `UnknownBackupServer`), and preferences. JSON `toJson`/`fromJson`. |
| `backup_validation.dart` | Envelope framing + a typed reader (`readBackup`) that rejects a too-new `formatVersion` with a clear message, and clamp helpers that **delegate to the live ranges** (`CacheSize.clamp`, `sanitizePrecacheCount`). |
| `backup_export_mapper.dart` | The single, deliberate projection from a live (secret-bearing) session to its **non-secret** backup entry. |
| `test/.../backup_models_test.dart` | Format-safety & forward-compatibility tests (23). |
| `test/.../backup_security_test.dart` | "Never export a secret" regression tests (8). |

## Security — settings, not secrets

- The format has **no field** for the Jellyfin `accessToken`, the Subsonic `salt`/`token` pair, the Plex `X-Plex-Token`, any password, or the device-/session-specific ids and version strings the spec excludes. A secret cannot be represented, let alone exported.
- `backup_security_test.dart` feeds the mappers sessions full of `SENTINEL-` secrets/ids and asserts **none** reach the exported JSON via three independent checks: a blanket `SENTINEL-` scan, a recursive forbidden-key walk of the whole document, and per-type field allow-lists. This is the regression test that **fails if a token/secret field ever appears in the exported JSON**.
- Server URLs, display names, server type, username, selected Plex section keys, cache prefs, provider order, and appearance prefs **are** exported (asserted present).

## Forward-compatibility

Covered by `backup_models_test.dart`:
- Unknown object fields and unknown preference keys are **ignored**.
- An unknown/future server `type` is **preserved** (`UnknownBackupServer`) and skippable — never crashes the parse — while known servers still import.
- An unsupported (newer) `formatVersion` is **rejected clearly**; missing/`<1` is malformed.
- Known numeric preferences are **clamped to the live ranges** (so a hand-edited or newer file can't push a setting out of bounds).
- Lenient parsing: malformed entries are dropped, wrong-typed values fall back.

## Out of scope (per the plan)

Export/import UI, the restore workflow, and Linthra Connect pairing/QR are **not** in this PR.

## Verification

- `flutter analyze` — clean (No issues found)
- `dart format --set-exit-if-changed .` — clean (0 changed)
- `flutter test` — **2663 passed** (incl. 31 new)
- `./scripts/check_secrets.sh` — clean
- `flutter pub get --enforce-lockfile` — clean (no lockfile drift)
- Diff is **new files only** — no existing source touched, nothing imports the new code yet, so no runtime behavior (playback, audio focus, cache, providers, Plex/Jellyfin/Subsonic clients, Cast, Android Auto) is affected.

Kept as a **draft** as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUGTP5fzhS51sg3RMfLDDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUGTP5fzhS51sg3RMfLDDK)_