### PR TITLE
feat(backup): add Backup/Restore V1 service and import preview

### DIFF
--- a/lib/features/backup_restore/backup_import_plan.dart
+++ b/lib/features/backup_restore/backup_import_plan.dart
@@ -1,0 +1,349 @@
+/// The **restore preview** for a Linthra Backup V1 document: a pure-Dart,
+/// read-only description of *what a restore would do*, produced by
+/// `BackupRestoreService.previewRestore` / `planRestore` from a parsed backup
+/// and the user's current setup.
+///
+/// This model never mutates app state and never carries a credential — it only
+/// classifies the backup's entries so a (future) restore screen can show the
+/// user exactly what will happen before they confirm:
+///
+/// - [BackupImportPlan.serversToAdd] — valid, known sources not already
+///   configured. Each lands needing a [BackupRestoreFollowUp] (sign-in for a
+///   network provider, folder re-pick for a local source) because V1 never
+///   restores secrets.
+/// - [BackupImportPlan.serversAlreadyConfigured] — entries whose
+///   (`type`, normalized `baseUrl`) identity already exists; left as-is, never
+///   duplicated.
+/// - [BackupImportPlan.unknownServers] — a `type` this build doesn't recognise;
+///   skipped with a notice, per the format's forward-compatibility rule.
+/// - [BackupImportPlan.skippedServers] — malformed/unusable raw entries.
+/// - [BackupImportPlan.preferences] — the clamped, ready-to-apply preferences,
+///   plus what was clamped and which unknown keys were ignored.
+///
+/// It is deliberately free of Flutter, plugin, session, or store coupling so
+/// the *same* preview can be reused by Linthra Desktop (Phase 4).
+library;
+
+import 'backup_models.dart';
+
+/// The server `type` strings this build understands. Anything else is treated
+/// as an [UnknownBackupServer] and skipped on restore (with a notice). Kept as
+/// a set so the planner can branch before delegating to [BackupServer.fromJson]
+/// (which itself encodes the same knowledge for the typed hierarchy).
+const Set<String> kKnownBackupServerTypes = <String>{
+  'jellyfin',
+  'subsonic',
+  'plex',
+  'local',
+};
+
+/// Whether [type] is a server type this build can restore.
+bool isKnownBackupServerType(String type) =>
+    kKnownBackupServerTypes.contains(type);
+
+/// Normalizes a server base URL into a stable key for duplicate detection.
+///
+/// Two addresses that point at the same server must collapse to the same key,
+/// so the comparison is generous about the cosmetic differences a hand-typed or
+/// hand-edited URL carries — without ever merging two genuinely different
+/// servers:
+///
+/// - a missing scheme defaults to `https` (matching how the app normalizes a
+///   typed address — a bare host is reached over TLS);
+/// - the scheme and host are lower-cased (both are case-insensitive per the URL
+///   spec);
+/// - the default port for the scheme (`:80` for http, `:443` for https) is
+///   dropped, while any other explicit port is kept (a LAN server is reached by
+///   host:port);
+/// - a trailing slash, query, and fragment are stripped.
+///
+/// The path case is preserved (a reverse-proxy subpath can be case-sensitive).
+/// An unparseable string falls back to its trimmed, lower-cased, slash-free
+/// form so two identical junk values still match.
+String normalizeBackupBaseUrl(String? raw) {
+  final String trimmed = (raw ?? '').trim();
+  if (trimmed.isEmpty) return '';
+
+  final String withScheme =
+      trimmed.contains('://') ? trimmed : 'https://$trimmed';
+  final Uri? uri = Uri.tryParse(withScheme);
+  if (uri == null || uri.host.isEmpty) {
+    return _stripTrailingSlashes(trimmed.toLowerCase());
+  }
+
+  final String scheme = uri.scheme.toLowerCase();
+  final String host = uri.host.toLowerCase();
+  final int? port = uri.hasPort ? uri.port : null;
+  final bool isDefaultPort =
+      (scheme == 'http' && port == 80) || (scheme == 'https' && port == 443);
+
+  final StringBuffer key = StringBuffer()
+    ..write(scheme)
+    ..write('://')
+    ..write(host);
+  if (port != null && !isDefaultPort) {
+    key
+      ..write(':')
+      ..write(port);
+  }
+  key.write(_stripTrailingSlashes(uri.path));
+  return key.toString();
+}
+
+String _stripTrailingSlashes(String path) {
+  int end = path.length;
+  while (end > 0 && path[end - 1] == '/') {
+    end--;
+  }
+  return path.substring(0, end);
+}
+
+/// The base URL of a parsed [server], or `null` for a source that has none
+/// (a [LocalBackupServer], or an [UnknownBackupServer] without one).
+String? backupServerBaseUrl(BackupServer server) {
+  if (server is JellyfinBackupServer) return server.baseUrl;
+  if (server is SubsonicBackupServer) return server.baseUrl;
+  if (server is PlexBackupServer) return server.baseUrl;
+  if (server is UnknownBackupServer) {
+    final Object? raw = server.raw['baseUrl'];
+    return (raw is String && raw.isNotEmpty) ? raw : null;
+  }
+  return null; // LocalBackupServer
+}
+
+/// The identity used to decide whether two sources are "the same server":
+/// provider [type] plus the [normalizedBaseUrl]. A URL-less source (e.g.
+/// `local`) keys on its type alone (empty URL), so a second on-device folder
+/// entry is recognised as already configured rather than duplicated.
+class BackupServerIdentity {
+  const BackupServerIdentity({
+    required this.type,
+    required this.normalizedBaseUrl,
+  });
+
+  /// Builds an identity from a raw [type] and (optional) [baseUrl], normalizing
+  /// the URL. This is the constructor the app uses to describe an *already
+  /// configured* source for duplicate detection.
+  factory BackupServerIdentity.of(String type, String? baseUrl) =>
+      BackupServerIdentity(
+        type: type,
+        normalizedBaseUrl: normalizeBackupBaseUrl(baseUrl),
+      );
+
+  /// Builds the identity of a parsed backup [server].
+  factory BackupServerIdentity.forServer(BackupServer server) =>
+      BackupServerIdentity.of(server.type, backupServerBaseUrl(server));
+
+  /// The provider type (`jellyfin` / `subsonic` / `plex` / `local`).
+  final String type;
+
+  /// The normalized base URL, or the empty string for a URL-less source.
+  final String normalizedBaseUrl;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is BackupServerIdentity &&
+          other.type == type &&
+          other.normalizedBaseUrl == normalizedBaseUrl);
+
+  @override
+  int get hashCode => Object.hash(type, normalizedBaseUrl);
+
+  @override
+  String toString() =>
+      normalizedBaseUrl.isEmpty ? type : '$type@$normalizedBaseUrl';
+}
+
+/// What a restored server needs before it can play. V1 never restores a
+/// credential, so every added server requires one of these one-time follow-ups.
+enum BackupRestoreFollowUp {
+  /// A network provider (`jellyfin` / `subsonic` / `plex`) must be signed in
+  /// again — the user re-enters a password or pastes a token.
+  signIn,
+
+  /// An on-device folder (`local`) must be re-picked: an Android SAF grant is
+  /// per-device and can't transfer, so restore carries only a hint.
+  reselectFolder,
+}
+
+/// The follow-up a restored [server] requires: [BackupRestoreFollowUp.signIn]
+/// for a network provider, [BackupRestoreFollowUp.reselectFolder] for a local
+/// folder.
+BackupRestoreFollowUp backupRestoreFollowUpFor(BackupServer server) =>
+    server is LocalBackupServer
+        ? BackupRestoreFollowUp.reselectFolder
+        : BackupRestoreFollowUp.signIn;
+
+/// A known, valid backup server the plan **will add**. It carries no
+/// credential; after restore it lands in a *needs-[followUp]* state.
+class PlannedServerAddition {
+  const PlannedServerAddition({required this.server, required this.identity});
+
+  /// The parsed, non-secret server model to add.
+  final BackupServer server;
+
+  /// Its duplicate-detection identity (type + normalized base URL).
+  final BackupServerIdentity identity;
+
+  String get type => server.type;
+  String? get displayName => server.displayName;
+  String get normalizedBaseUrl => identity.normalizedBaseUrl;
+
+  /// The one-time action the user must take after restore.
+  BackupRestoreFollowUp get followUp => backupRestoreFollowUpFor(server);
+
+  /// Whether this server lands needing a sign-in (true for every network
+  /// provider; false only for a local folder, which needs a re-pick instead).
+  bool get needsSignIn => followUp == BackupRestoreFollowUp.signIn;
+}
+
+/// A known backup server **skipped because it is already configured** — its
+/// (`type`, normalized `baseUrl`) identity matches a source the user already
+/// has. Restore leaves the existing one untouched rather than duplicating it.
+class PlannedDuplicateServer {
+  const PlannedDuplicateServer({required this.server, required this.identity});
+
+  final BackupServer server;
+  final BackupServerIdentity identity;
+
+  String get type => server.type;
+  String? get displayName => server.displayName;
+}
+
+/// A backup server whose `type` this build does not recognise (a newer
+/// provider, or a platform-specific type like `local` on Desktop). Restore
+/// **skips it with a notice**, never an error — the format is forward-compatible
+/// by design.
+class PlannedUnknownServer {
+  const PlannedUnknownServer({required this.typeName, this.displayName});
+
+  /// The unrecognised `type` string from the file.
+  final String typeName;
+
+  /// The entry's display name, if it carried one (shown in the skip notice).
+  final String? displayName;
+}
+
+/// Why a raw server entry could not be used and was skipped.
+enum BackupServerSkipReason {
+  /// The entry was not a JSON object.
+  notAnObject,
+
+  /// The entry had no usable `type` at all.
+  missingType,
+
+  /// A known type was missing a required field (e.g. a server with no
+  /// `baseUrl`) and so could not be restored.
+  missingRequiredField,
+}
+
+/// A raw server entry that was malformed/unusable and is skipped, with the
+/// [reason] why.
+class PlannedSkippedServer {
+  const PlannedSkippedServer({required this.reason, this.typeName});
+
+  final BackupServerSkipReason reason;
+
+  /// The entry's declared `type` when it had a usable one (e.g. a known type
+  /// missing its `baseUrl`); `null` when the entry had no type.
+  final String? typeName;
+}
+
+/// A numeric preference value the file carried out of range, reported with how
+/// it was clamped to the live setting's accepted range.
+class BackupPreferenceClamp {
+  const BackupPreferenceClamp({
+    required this.field,
+    required this.originalValue,
+    required this.clampedValue,
+  });
+
+  /// Dotted field name, e.g. `cache.maxBytes` or `cache.precacheCount`.
+  final String field;
+
+  /// The value the backup file declared.
+  final int originalValue;
+
+  /// The value after clamping to the live range.
+  final int clampedValue;
+}
+
+/// The preferences portion of a [BackupImportPlan]: the validated, clamped
+/// preferences that would be applied, what was clamped, and which keys were
+/// ignored.
+class BackupPreferencesPlan {
+  const BackupPreferencesPlan({
+    this.applied = const BackupPreferences(),
+    this.clamps = const <BackupPreferenceClamp>[],
+    this.ignoredKeys = const <String>[],
+  });
+
+  /// The preferences ready to apply: only the keys the file actually carried,
+  /// with numeric values already clamped to the live ranges. Applying these is
+  /// the future restore step — this PR only *previews* them.
+  final BackupPreferences applied;
+
+  /// Numeric values that were clamped into range, for the user to see.
+  final List<BackupPreferenceClamp> clamps;
+
+  /// Preference keys present in the file that this build does not understand
+  /// (including any secret-looking key a hand-edited file might carry) and so
+  /// ignores. They never reach [applied].
+  final List<String> ignoredKeys;
+
+  /// Whether applying this plan would set any preference at all.
+  bool get hasChanges => applied.toJson().isNotEmpty;
+}
+
+/// A read-only preview of what restoring a backup would do. Produced by
+/// `BackupRestoreService`; it mutates nothing and contains no credentials.
+class BackupImportPlan {
+  const BackupImportPlan({
+    this.serversToAdd = const <PlannedServerAddition>[],
+    this.serversAlreadyConfigured = const <PlannedDuplicateServer>[],
+    this.unknownServers = const <PlannedUnknownServer>[],
+    this.skippedServers = const <PlannedSkippedServer>[],
+    this.preferences = const BackupPreferencesPlan(),
+    this.generatedBy,
+    this.createdAt,
+  });
+
+  /// Valid, known sources not already configured — what restore will add.
+  final List<PlannedServerAddition> serversToAdd;
+
+  /// Entries already configured (same type + normalized base URL); left as-is.
+  final List<PlannedDuplicateServer> serversAlreadyConfigured;
+
+  /// Entries with an unrecognised `type`; skipped with a notice.
+  final List<PlannedUnknownServer> unknownServers;
+
+  /// Malformed/unusable raw entries; skipped.
+  final List<PlannedSkippedServer> skippedServers;
+
+  /// The preferences that would be applied, with clamp/ignore notes.
+  final BackupPreferencesPlan preferences;
+
+  /// Diagnostics-only provenance from the file (display only).
+  final BackupGeneratedBy? generatedBy;
+
+  /// The file's `createdAt` timestamp, if any (display only).
+  final String? createdAt;
+
+  int get addCount => serversToAdd.length;
+  int get duplicateCount => serversAlreadyConfigured.length;
+  int get unknownCount => unknownServers.length;
+  int get skippedCount => skippedServers.length;
+
+  bool get hasServersToAdd => serversToAdd.isNotEmpty;
+  bool get hasPreferencesToApply => preferences.hasChanges;
+
+  /// True when applying this plan would change nothing — no new server and no
+  /// preference to set.
+  bool get isEmpty => serversToAdd.isEmpty && !preferences.hasChanges;
+
+  /// The servers that will land needing the user to sign in again (every
+  /// network provider in [serversToAdd]).
+  Iterable<PlannedServerAddition> get serversNeedingSignIn =>
+      serversToAdd.where((PlannedServerAddition s) => s.needsSignIn);
+}

--- a/lib/features/backup_restore/backup_restore_service.dart
+++ b/lib/features/backup_restore/backup_restore_service.dart
@@ -1,0 +1,368 @@
+/// The Backup/Restore V1 **service layer**: a small, pure-Dart facade that
+/// composes the format building blocks from PR #246 into the two operations the
+/// (future) UI needs, while keeping every safety rule in one testable place.
+///
+/// 1. **Export** — [BackupRestoreService.buildBackup] projects the live,
+///    secret-bearing app setup into a non-secret [LinthraBackup]. It is the
+///    *only* place a backup document is assembled, and it routes every server
+///    through the `backup_export_mapper` projection, so a credential structurally
+///    cannot reach the file (the models have no field for one).
+/// 2. **Restore preview** — [BackupRestoreService.previewRestore] reads a file's
+///    text and, for a valid backup, returns a [BackupImportPlan] describing what
+///    a restore *would* do (servers to add, already-configured duplicates,
+///    unknown types, skipped/malformed entries, and the clamped preferences).
+///    It **plans only**: it mutates no app state and writes no credential.
+///
+/// Everything here is pure Dart (no Flutter, no plugins, no I/O), so it runs the
+/// same on Android, on Desktop (Phase 4), and in tests, and so Linthra Connect
+/// (Phase 3) can reuse it as a thin transport over this same plan.
+library;
+
+import 'dart:convert';
+
+import '../../core/models/jellyfin_session.dart';
+import '../../core/models/plex_session.dart';
+import '../../core/models/subsonic_session.dart';
+import 'backup_export_mapper.dart';
+import 'backup_import_plan.dart';
+import 'backup_models.dart';
+import 'backup_validation.dart';
+
+/// The non-secret on-device folder source, supplied to [BackupRestoreService.
+/// buildBackup]. There is no session (and no secret) for a local folder; the
+/// [folderHint] is the SAF tree URI carried for the user's reference only.
+class LocalFolderBackup {
+  const LocalFolderBackup({this.displayName, this.folderHint});
+
+  final String? displayName;
+  final String? folderHint;
+}
+
+/// The outcome of [BackupRestoreService.previewRestore]: either a ready
+/// [BackupImportPlan] or a typed, user-facing reason the file can't be read.
+sealed class BackupRestorePreview {
+  const BackupRestorePreview();
+}
+
+/// A readable backup: [plan] describes what a restore would do.
+class BackupRestorePreviewReady extends BackupRestorePreview {
+  const BackupRestorePreviewReady(this.plan);
+
+  final BackupImportPlan plan;
+}
+
+/// The file could not be read as a usable backup; [failure] carries the typed
+/// reason and a clear, user-facing message (reused from `backup_validation`).
+class BackupRestorePreviewUnreadable extends BackupRestorePreview {
+  const BackupRestorePreviewUnreadable(this.failure);
+
+  final BackupReadFailure failure;
+}
+
+/// Builds backups and previews restores for the Backup/Restore V1 format.
+/// Stateless and `const`-constructible, so it can be shared or injected freely.
+class BackupRestoreService {
+  const BackupRestoreService();
+
+  /// **Export.** Builds a non-secret [LinthraBackup] from the live setup: each
+  /// supplied session is projected through its `backup_export_mapper`
+  /// projection (which copies out only the documented, non-secret fields), and
+  /// the non-secret [preferences] are carried as-is. A `null` provider is simply
+  /// omitted.
+  ///
+  /// The result structurally cannot contain a Jellyfin/Plex token, a Subsonic
+  /// salt/token, a password, or any device-/session-specific id — see
+  /// `backup_models.dart` and the security tests.
+  LinthraBackup buildBackup({
+    JellyfinSession? jellyfin,
+    SubsonicSession? subsonic,
+    PlexSession? plex,
+    LocalFolderBackup? local,
+    BackupPreferences preferences = const BackupPreferences(),
+    BackupGeneratedBy? generatedBy,
+    String? createdAt,
+  }) {
+    final List<BackupServer> servers = <BackupServer>[
+      if (jellyfin != null) jellyfinBackupServerFromSession(jellyfin),
+      if (subsonic != null) subsonicBackupServerFromSession(subsonic),
+      if (plex != null) plexBackupServerFromSession(plex),
+      if (local != null)
+        localBackupServer(
+          displayName: local.displayName,
+          folderHint: local.folderHint,
+        ),
+    ];
+    return LinthraBackup(
+      generatedBy: generatedBy,
+      createdAt: createdAt,
+      servers: servers,
+      preferences: preferences,
+    );
+  }
+
+  /// Serializes [backup] to the pretty-printed JSON text of a backup file.
+  /// A thin convenience over [encodeBackup] so callers need only this service.
+  String encode(LinthraBackup backup) => encodeBackup(backup);
+
+  /// **Restore preview from file text.** Validates the envelope and version via
+  /// [readBackup]; on a readable backup, returns a [BackupRestorePreviewReady]
+  /// wrapping the [BackupImportPlan]. A non-JSON, non-Linthra, newer-version, or
+  /// malformed file becomes a [BackupRestorePreviewUnreadable] carrying the
+  /// typed reason and message — never a throw, never a partial import.
+  ///
+  /// [existingServers] is the user's current setup (one [BackupServerIdentity]
+  /// per configured source); it drives duplicate detection. Pass none to preview
+  /// onto a fresh install (everything known is "to add").
+  BackupRestorePreview previewRestore(
+    String text, {
+    Iterable<BackupServerIdentity> existingServers =
+        const <BackupServerIdentity>[],
+  }) {
+    final BackupReadResult result = readBackup(text);
+    if (result is BackupReadFailure) {
+      return BackupRestorePreviewUnreadable(result);
+    }
+    final LinthraBackup backup = (result as BackupReadSuccess).backup;
+    // Re-read the raw inner object so the plan can also report entries the
+    // lenient model parser silently drops (malformed servers) and unknown
+    // preference keys. The text already parsed cleanly inside [readBackup], so
+    // this can't fail; the parsed model's own JSON is a safe fallback.
+    final Map<String, dynamic> inner = _innerObjectOf(text) ?? backup.toJson();
+    return BackupRestorePreviewReady(
+      planRestore(inner, existingServers: existingServers),
+    );
+  }
+
+  /// **The planner.** Classifies the raw [inner] backup object (the value under
+  /// the `linthraBackup` envelope) against the current setup into a
+  /// [BackupImportPlan]. Works directly on the raw map so it can count entries
+  /// the typed parser drops; reuses [BackupServer.fromJson] /
+  /// [BackupPreferences.fromJson] for the actual parsing so the model stays the
+  /// single source of truth.
+  ///
+  /// Mutates nothing and reads no credential.
+  BackupImportPlan planRestore(
+    Map<String, dynamic> inner, {
+    Iterable<BackupServerIdentity> existingServers =
+        const <BackupServerIdentity>[],
+  }) {
+    final List<PlannedServerAddition> toAdd = <PlannedServerAddition>[];
+    final List<PlannedDuplicateServer> duplicates = <PlannedDuplicateServer>[];
+    final List<PlannedUnknownServer> unknown = <PlannedUnknownServer>[];
+    final List<PlannedSkippedServer> skipped = <PlannedSkippedServer>[];
+
+    // Seed "already present" from the live config, then grow it as entries are
+    // accepted so a file that lists the same server twice adds it only once
+    // (merge, never duplicate).
+    final Set<BackupServerIdentity> seen = <BackupServerIdentity>{
+      ...existingServers,
+    };
+
+    final Object? rawServers = inner['servers'];
+    if (rawServers is List) {
+      for (final Object? entry in rawServers) {
+        _classifyServer(
+          entry,
+          seen: seen,
+          toAdd: toAdd,
+          duplicates: duplicates,
+          unknown: unknown,
+          skipped: skipped,
+        );
+      }
+    }
+
+    return BackupImportPlan(
+      serversToAdd: toAdd,
+      serversAlreadyConfigured: duplicates,
+      unknownServers: unknown,
+      skippedServers: skipped,
+      preferences: _planPreferences(inner['preferences']),
+      generatedBy: BackupGeneratedBy.fromJson(inner['generatedBy']),
+      createdAt: _nonEmptyString(inner['createdAt']),
+    );
+  }
+
+  /// Classifies one raw server [entry], appending it to exactly one of the
+  /// outcome lists.
+  void _classifyServer(
+    Object? entry, {
+    required Set<BackupServerIdentity> seen,
+    required List<PlannedServerAddition> toAdd,
+    required List<PlannedDuplicateServer> duplicates,
+    required List<PlannedUnknownServer> unknown,
+    required List<PlannedSkippedServer> skipped,
+  }) {
+    final Map<String, dynamic>? map = backupJsonObject(entry);
+    if (map == null) {
+      skipped.add(
+        const PlannedSkippedServer(reason: BackupServerSkipReason.notAnObject),
+      );
+      return;
+    }
+
+    final String? type = _nonEmptyString(map['type']);
+    if (type == null) {
+      skipped.add(
+        const PlannedSkippedServer(reason: BackupServerSkipReason.missingType),
+      );
+      return;
+    }
+
+    if (!isKnownBackupServerType(type)) {
+      unknown.add(
+        PlannedUnknownServer(
+          typeName: type,
+          displayName: _nonEmptyString(map['displayName']),
+        ),
+      );
+      return;
+    }
+
+    final BackupServer? server = BackupServer.fromJson(map);
+    if (server == null) {
+      // A known type whose required field (baseUrl) was missing/blank.
+      skipped.add(
+        PlannedSkippedServer(
+          reason: BackupServerSkipReason.missingRequiredField,
+          typeName: type,
+        ),
+      );
+      return;
+    }
+
+    final BackupServerIdentity identity =
+        BackupServerIdentity.forServer(server);
+    if (seen.contains(identity)) {
+      duplicates.add(
+        PlannedDuplicateServer(server: server, identity: identity),
+      );
+      return;
+    }
+    seen.add(identity);
+    toAdd.add(PlannedServerAddition(server: server, identity: identity));
+  }
+
+  /// Builds the preferences portion of the plan: the clamped, ready-to-apply
+  /// preferences, the list of numeric values that were clamped, and the unknown
+  /// keys (including any secret-looking ones) that are ignored.
+  BackupPreferencesPlan _planPreferences(Object? rawPreferences) {
+    final BackupPreferences parsed = BackupPreferences.fromJson(rawPreferences);
+    final BackupPreferences applied = clampBackupPreferences(parsed);
+
+    final List<BackupPreferenceClamp> clamps = <BackupPreferenceClamp>[];
+    final BackupCachePreferences? before = parsed.cache;
+    final BackupCachePreferences? after = applied.cache;
+    if (before != null && after != null) {
+      _addClamp(
+        clamps,
+        field: 'cache.maxBytes',
+        before: before.maxBytes,
+        after: after.maxBytes,
+      );
+      _addClamp(
+        clamps,
+        field: 'cache.precacheCount',
+        before: before.precacheCount,
+        after: after.precacheCount,
+      );
+    }
+
+    final Map<String, dynamic>? raw = backupJsonObject(rawPreferences);
+    final List<String> ignored =
+        raw == null ? const <String>[] : _ignoredPreferenceKeys(raw);
+
+    return BackupPreferencesPlan(
+      applied: applied,
+      clamps: clamps,
+      ignoredKeys: ignored,
+    );
+  }
+
+  void _addClamp(
+    List<BackupPreferenceClamp> clamps, {
+    required String field,
+    required int? before,
+    required int? after,
+  }) {
+    if (before != null && after != null && before != after) {
+      clamps.add(
+        BackupPreferenceClamp(
+          field: field,
+          originalValue: before,
+          clampedValue: after,
+        ),
+      );
+    }
+  }
+
+  /// Collects every preference key the file carried that this build does not
+  /// model — at the top level and within the structured `cache` / `playback` /
+  /// `appearance` sub-objects (nested keys are prefixed, e.g. `cache.foo`). A
+  /// secret-looking key (`password`, `token`, …) lands here, proving it was
+  /// seen and dropped rather than applied.
+  List<String> _ignoredPreferenceKeys(Map<String, dynamic> raw) {
+    final List<String> ignored = <String>[];
+    for (final String key in raw.keys) {
+      if (!_knownPreferenceKeys.contains(key)) ignored.add(key);
+    }
+    ignored.addAll(_ignoredNestedKeys(raw['cache'], _knownCacheKeys, 'cache'));
+    ignored.addAll(
+      _ignoredNestedKeys(raw['playback'], _knownPlaybackKeys, 'playback'),
+    );
+    ignored.addAll(
+      _ignoredNestedKeys(raw['appearance'], _knownAppearanceKeys, 'appearance'),
+    );
+    return ignored;
+  }
+
+  List<String> _ignoredNestedKeys(
+    Object? value,
+    Set<String> known,
+    String prefix,
+  ) {
+    final Map<String, dynamic>? map = backupJsonObject(value);
+    if (map == null) return const <String>[];
+    final List<String> out = <String>[];
+    for (final String key in map.keys) {
+      if (!known.contains(key)) out.add('$prefix.$key');
+    }
+    return out;
+  }
+
+  /// Re-decodes [text] and returns the raw object under the `linthraBackup`
+  /// envelope, or `null` if it isn't present/decodable.
+  Map<String, dynamic>? _innerObjectOf(String text) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(text);
+    } on FormatException {
+      return null;
+    }
+    final Map<String, dynamic>? root = backupJsonObject(decoded);
+    if (root == null) return null;
+    return backupJsonObject(root[kBackupEnvelopeKey]);
+  }
+}
+
+/// Reads [value] as a non-empty `String`, or `null` otherwise.
+String? _nonEmptyString(Object? value) =>
+    (value is String && value.isNotEmpty) ? value : null;
+
+/// The preference keys this build understands at each level of the document.
+const Set<String> _knownPreferenceKeys = <String>{
+  'defaultProvider',
+  'preferredSourceOrder',
+  'playbackSourceStrategy',
+  'cache',
+  'playback',
+  'appearance',
+};
+const Set<String> _knownCacheKeys = <String>{
+  'maxBytes',
+  'allowMobileData',
+  'smartPrecacheEnabled',
+  'precacheCount',
+};
+const Set<String> _knownPlaybackKeys = <String>{'normalizeVolume'};
+const Set<String> _knownAppearanceKeys = <String>{'appIconVariant'};

--- a/test/features/backup_restore/backup_import_plan_test.dart
+++ b/test/features/backup_restore/backup_import_plan_test.dart
@@ -1,0 +1,278 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/backup_restore/backup_import_plan.dart';
+import 'package:linthra/features/backup_restore/backup_models.dart';
+
+void main() {
+  group('normalizeBackupBaseUrl', () {
+    test('strips a trailing slash', () {
+      expect(
+        normalizeBackupBaseUrl('https://music.example.com/'),
+        'https://music.example.com',
+      );
+    });
+
+    test('lower-cases the scheme and host (both case-insensitive)', () {
+      expect(
+        normalizeBackupBaseUrl('HTTPS://Music.Example.COM'),
+        'https://music.example.com',
+      );
+    });
+
+    test('assumes https when no scheme is typed', () {
+      expect(
+        normalizeBackupBaseUrl('music.example.com'),
+        'https://music.example.com',
+      );
+    });
+
+    test('drops the default port but keeps a non-default one', () {
+      expect(
+        normalizeBackupBaseUrl('https://music.example.com:443'),
+        'https://music.example.com',
+      );
+      expect(
+        normalizeBackupBaseUrl('http://192.168.1.10:80/'),
+        'http://192.168.1.10',
+      );
+      expect(
+        normalizeBackupBaseUrl('https://plex.example.com:32400'),
+        'https://plex.example.com:32400',
+      );
+    });
+
+    test('preserves a reverse-proxy subpath (case kept) and drops the query',
+        () {
+      expect(
+        normalizeBackupBaseUrl('https://example.com/Jellyfin/?x=1'),
+        'https://example.com/Jellyfin',
+      );
+    });
+
+    test('an empty or null value is the empty key', () {
+      expect(normalizeBackupBaseUrl(''), '');
+      expect(normalizeBackupBaseUrl(null), '');
+      expect(normalizeBackupBaseUrl('   '), '');
+    });
+
+    test('cosmetic variants of the same server collapse to one key', () {
+      final String a = normalizeBackupBaseUrl('https://music.example.com');
+      final String b = normalizeBackupBaseUrl('HTTPS://music.example.com/');
+      final String c = normalizeBackupBaseUrl('music.example.com:443/');
+      expect(a, b);
+      expect(b, c);
+    });
+  });
+
+  group('backupServerBaseUrl', () {
+    test('returns the URL for each network type and null for local', () {
+      expect(
+        backupServerBaseUrl(
+          const JellyfinBackupServer(baseUrl: 'https://jf.example.com'),
+        ),
+        'https://jf.example.com',
+      );
+      expect(
+        backupServerBaseUrl(
+          const SubsonicBackupServer(baseUrl: 'https://nd.example.com'),
+        ),
+        'https://nd.example.com',
+      );
+      expect(
+        backupServerBaseUrl(
+          const PlexBackupServer(baseUrl: 'https://plex.example.com:32400'),
+        ),
+        'https://plex.example.com:32400',
+      );
+      expect(backupServerBaseUrl(const LocalBackupServer()), isNull);
+    });
+
+    test('reads a baseUrl out of an unknown server entry when present', () {
+      const UnknownBackupServer unknown = UnknownBackupServer(
+        typeName: 'futuresonic',
+        raw: <String, dynamic>{
+          'type': 'futuresonic',
+          'baseUrl': 'https://future.example.com',
+        },
+      );
+      expect(backupServerBaseUrl(unknown), 'https://future.example.com');
+      expect(
+        backupServerBaseUrl(
+          const UnknownBackupServer(typeName: 'futuresonic'),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('isKnownBackupServerType', () {
+    test('recognises exactly the four V1 types', () {
+      expect(isKnownBackupServerType('jellyfin'), isTrue);
+      expect(isKnownBackupServerType('subsonic'), isTrue);
+      expect(isKnownBackupServerType('plex'), isTrue);
+      expect(isKnownBackupServerType('local'), isTrue);
+      expect(isKnownBackupServerType('futuresonic'), isFalse);
+      expect(isKnownBackupServerType(''), isFalse);
+    });
+  });
+
+  group('BackupServerIdentity', () {
+    test('normalizes the URL and compares by (type, normalized URL)', () {
+      final BackupServerIdentity a = BackupServerIdentity.of(
+        'jellyfin',
+        'https://music.example.com',
+      );
+      final BackupServerIdentity b = BackupServerIdentity.of(
+        'jellyfin',
+        'https://music.example.com/',
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(<BackupServerIdentity>{a, b}, hasLength(1));
+    });
+
+    test('a different type or host is a different identity', () {
+      final BackupServerIdentity jellyfin = BackupServerIdentity.of(
+        'jellyfin',
+        'https://music.example.com',
+      );
+      expect(
+        jellyfin,
+        isNot(BackupServerIdentity.of('plex', 'https://music.example.com')),
+      );
+      expect(
+        jellyfin,
+        isNot(BackupServerIdentity.of('jellyfin', 'https://other.example.com')),
+      );
+    });
+
+    test('forServer derives the identity from a parsed server', () {
+      final BackupServerIdentity jellyfin = BackupServerIdentity.forServer(
+        const JellyfinBackupServer(baseUrl: 'https://music.example.com/'),
+      );
+      expect(jellyfin.type, 'jellyfin');
+      expect(jellyfin.normalizedBaseUrl, 'https://music.example.com');
+    });
+
+    test('a local source keys on its type alone (empty URL)', () {
+      final BackupServerIdentity local =
+          BackupServerIdentity.forServer(const LocalBackupServer());
+      expect(local.type, 'local');
+      expect(local.normalizedBaseUrl, '');
+      // Two local sources are "the same" identity (only one folder source).
+      expect(local, BackupServerIdentity.of('local', null));
+    });
+  });
+
+  group('backupRestoreFollowUpFor', () {
+    test('network providers need a sign-in; local needs a folder re-pick', () {
+      expect(
+        backupRestoreFollowUpFor(
+          const JellyfinBackupServer(baseUrl: 'https://jf.example.com'),
+        ),
+        BackupRestoreFollowUp.signIn,
+      );
+      expect(
+        backupRestoreFollowUpFor(
+          const SubsonicBackupServer(baseUrl: 'https://nd.example.com'),
+        ),
+        BackupRestoreFollowUp.signIn,
+      );
+      expect(
+        backupRestoreFollowUpFor(
+          const PlexBackupServer(baseUrl: 'https://plex.example.com:32400'),
+        ),
+        BackupRestoreFollowUp.signIn,
+      );
+      expect(
+        backupRestoreFollowUpFor(const LocalBackupServer()),
+        BackupRestoreFollowUp.reselectFolder,
+      );
+    });
+  });
+
+  group('PlannedServerAddition', () {
+    test('exposes type/displayName and the right follow-up per server', () {
+      const JellyfinBackupServer server = JellyfinBackupServer(
+        displayName: 'Home Jellyfin',
+        baseUrl: 'https://music.example.com',
+        username: 'alice',
+      );
+      final PlannedServerAddition addition = PlannedServerAddition(
+        server: server,
+        identity: BackupServerIdentity.forServer(server),
+      );
+      expect(addition.type, 'jellyfin');
+      expect(addition.displayName, 'Home Jellyfin');
+      expect(addition.normalizedBaseUrl, 'https://music.example.com');
+      expect(addition.needsSignIn, isTrue);
+      expect(addition.followUp, BackupRestoreFollowUp.signIn);
+    });
+
+    test('a local addition needs a folder re-pick, not a sign-in', () {
+      const LocalBackupServer server = LocalBackupServer(
+        displayName: 'Phone music',
+      );
+      final PlannedServerAddition addition = PlannedServerAddition(
+        server: server,
+        identity: BackupServerIdentity.forServer(server),
+      );
+      expect(addition.needsSignIn, isFalse);
+      expect(addition.followUp, BackupRestoreFollowUp.reselectFolder);
+    });
+  });
+
+  group('BackupPreferencesPlan', () {
+    test('hasChanges reflects whether any preference would be applied', () {
+      const BackupPreferencesPlan empty = BackupPreferencesPlan();
+      expect(empty.hasChanges, isFalse);
+
+      const BackupPreferencesPlan some = BackupPreferencesPlan(
+        applied: BackupPreferences(defaultProvider: 'jellyfin'),
+      );
+      expect(some.hasChanges, isTrue);
+    });
+  });
+
+  group('BackupImportPlan convenience', () {
+    test('an all-empty plan is isEmpty with zero counts', () {
+      const BackupImportPlan plan = BackupImportPlan();
+      expect(plan.isEmpty, isTrue);
+      expect(plan.hasServersToAdd, isFalse);
+      expect(plan.hasPreferencesToApply, isFalse);
+      expect(plan.addCount, 0);
+      expect(plan.duplicateCount, 0);
+      expect(plan.unknownCount, 0);
+      expect(plan.skippedCount, 0);
+      expect(plan.serversNeedingSignIn, isEmpty);
+    });
+
+    test('counts entries; only network servers need sign-in', () {
+      const JellyfinBackupServer jellyfin = JellyfinBackupServer(
+        baseUrl: 'https://music.example.com',
+      );
+      const LocalBackupServer local = LocalBackupServer();
+      final BackupImportPlan plan = BackupImportPlan(
+        serversToAdd: <PlannedServerAddition>[
+          PlannedServerAddition(
+            server: jellyfin,
+            identity: BackupServerIdentity.forServer(jellyfin),
+          ),
+          PlannedServerAddition(
+            server: local,
+            identity: BackupServerIdentity.forServer(local),
+          ),
+        ],
+        preferences: const BackupPreferencesPlan(
+          applied: BackupPreferences(defaultProvider: 'jellyfin'),
+        ),
+      );
+
+      expect(plan.isEmpty, isFalse);
+      expect(plan.addCount, 2);
+      expect(plan.hasPreferencesToApply, isTrue);
+      // Only the Jellyfin server needs a sign-in; the local folder does not.
+      expect(plan.serversNeedingSignIn, hasLength(1));
+      expect(plan.serversNeedingSignIn.single.type, 'jellyfin');
+    });
+  });
+}

--- a/test/features/backup_restore/backup_restore_service_test.dart
+++ b/test/features/backup_restore/backup_restore_service_test.dart
@@ -1,0 +1,575 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/cache_size.dart';
+import 'package:linthra/core/models/jellyfin_session.dart';
+import 'package:linthra/core/models/plex_session.dart';
+import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/repositories/download_preferences.dart';
+import 'package:linthra/features/backup_restore/backup_import_plan.dart';
+import 'package:linthra/features/backup_restore/backup_models.dart';
+import 'package:linthra/features/backup_restore/backup_restore_service.dart';
+import 'package:linthra/features/backup_restore/backup_validation.dart';
+
+/// Secret/excluded keys that must NEVER appear in anything the service writes
+/// or plans to apply (mirrors `backup_security_test.dart`).
+const Set<String> _forbiddenKeys = <String>{
+  'accessToken',
+  'token',
+  'salt',
+  'password',
+  'deviceId',
+  'userId',
+  'serverId',
+  'machineIdentifier',
+  'clientIdentifier',
+  'serverVersion',
+  'apiVersion',
+  'productName',
+};
+
+/// Recursively collects every object key in a decoded JSON tree.
+Set<String> _allKeys(Object? node) {
+  final Set<String> keys = <String>{};
+  if (node is Map) {
+    node.forEach((Object? key, Object? value) {
+      keys.add(key.toString());
+      keys.addAll(_allKeys(value));
+    });
+  } else if (node is List) {
+    for (final Object? element in node) {
+      keys.addAll(_allKeys(element));
+    }
+  }
+  return keys;
+}
+
+/// Frames an inner backup object as the full document JSON text.
+String _wrap(Map<String, dynamic> inner) =>
+    jsonEncode(<String, dynamic>{kBackupEnvelopeKey: inner});
+
+/// Convenience: the plan for [text], asserting the file was readable.
+BackupImportPlan _planOf(
+  String text, {
+  Iterable<BackupServerIdentity> existing = const <BackupServerIdentity>[],
+}) {
+  const BackupRestoreService service = BackupRestoreService();
+  final BackupRestorePreview preview =
+      service.previewRestore(text, existingServers: existing);
+  expect(preview, isA<BackupRestorePreviewReady>());
+  return (preview as BackupRestorePreviewReady).plan;
+}
+
+// Secret-bearing sessions: every must-not-export field carries `SENTINEL-`.
+const JellyfinSession _secretJellyfin = JellyfinSession(
+  baseUrl: 'https://music.example.com',
+  userId: 'SENTINEL-jf-user-id',
+  accessToken: 'SENTINEL-jf-access-token',
+  deviceId: 'SENTINEL-jf-device-id',
+  userName: 'alice',
+  serverId: 'SENTINEL-jf-server-id',
+  serverName: 'Home Jellyfin',
+  serverVersion: 'SENTINEL-jf-server-version',
+  productName: 'SENTINEL-jf-product-name',
+);
+
+const SubsonicSession _secretSubsonic = SubsonicSession(
+  baseUrl: 'https://nd.example.com',
+  username: 'alice',
+  salt: 'SENTINEL-sub-salt',
+  token: 'SENTINEL-sub-token',
+  serverType: 'navidrome',
+  serverVersion: 'SENTINEL-sub-server-version',
+  apiVersion: 'SENTINEL-sub-api-version',
+);
+
+const PlexSession _secretPlex = PlexSession(
+  baseUrl: 'https://plex.example.com:32400',
+  token: 'SENTINEL-plex-token',
+  machineIdentifier: 'SENTINEL-plex-machine-id',
+  serverName: 'Living-room Plex',
+  serverVersion: 'SENTINEL-plex-server-version',
+  clientIdentifier: 'SENTINEL-plex-client-id',
+  selectedSectionKeys: <String>['3', '7'],
+);
+
+void main() {
+  const BackupRestoreService service = BackupRestoreService();
+
+  group('export — buildBackup', () {
+    test('build → encode → read round-trips the same document', () {
+      final LinthraBackup backup = service.buildBackup(
+        jellyfin: _secretJellyfin,
+        subsonic: _secretSubsonic,
+        plex: _secretPlex,
+        local: const LocalFolderBackup(
+          displayName: 'Phone music folder',
+          folderHint: 'content://com.android.externalstorage.documents/'
+              'tree/primary%3AMusic',
+        ),
+        preferences: const BackupPreferences(
+          defaultProvider: 'jellyfin',
+          preferredSourceOrder: <String>['local', 'jellyfin', 'subsonic'],
+          cache: BackupCachePreferences(maxBytes: 5368709120),
+        ),
+        generatedBy: const BackupGeneratedBy(
+          app: 'Linthra Android',
+          appVersion: '0.1.7',
+        ),
+        createdAt: '2026-06-24T12:00:00Z',
+      );
+
+      expect(backup.servers, hasLength(4));
+
+      final BackupReadResult result = readBackup(service.encode(backup));
+      expect(result, isA<BackupReadSuccess>());
+      expect((result as BackupReadSuccess).backup.toJson(), backup.toJson());
+    });
+
+    test('omits a provider that is not configured', () {
+      final LinthraBackup backup =
+          service.buildBackup(jellyfin: _secretJellyfin);
+      expect(backup.servers, hasLength(1));
+      expect(backup.servers.single, isA<JellyfinBackupServer>());
+    });
+
+    test('an empty setup builds an empty (but valid) backup', () {
+      final LinthraBackup backup = service.buildBackup();
+      expect(backup.servers, isEmpty);
+      final BackupReadResult result = readBackup(service.encode(backup));
+      expect(result, isA<BackupReadSuccess>());
+    });
+  });
+
+  group('export — settings, never secrets', () {
+    test('a backup the service builds carries no secret/excluded value', () {
+      final String json = service.encode(
+        service.buildBackup(
+          jellyfin: _secretJellyfin,
+          subsonic: _secretSubsonic,
+          plex: _secretPlex,
+          local: const LocalFolderBackup(displayName: 'Phone'),
+        ),
+      );
+
+      // Not one seeded secret/id/version string leaks.
+      expect(json, isNot(contains('SENTINEL-')));
+
+      // No forbidden key appears anywhere in the document.
+      final Set<String> leaked =
+          _allKeys(jsonDecode(json)).intersection(_forbiddenKeys);
+      expect(leaked, isEmpty, reason: 'leaked secret keys: $leaked');
+
+      // The non-secret settings ARE present (it isn't just an empty file).
+      expect(json, contains('https://music.example.com'));
+      expect(json, contains('https://nd.example.com'));
+      expect(json, contains('alice'));
+      expect(json, contains('navidrome'));
+    });
+  });
+
+  group('restore preview — reading & gating malformed files', () {
+    test('a valid backup yields a ready plan', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'kind': 'settings',
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{},
+      });
+      expect(service.previewRestore(text), isA<BackupRestorePreviewReady>());
+    });
+
+    test('not JSON → unreadable (notJson)', () {
+      final BackupRestorePreview preview =
+          service.previewRestore('{not valid json');
+      expect(preview, isA<BackupRestorePreviewUnreadable>());
+      expect(
+        (preview as BackupRestorePreviewUnreadable).failure.reason,
+        BackupReadFailureReason.notJson,
+      );
+    });
+
+    test('valid JSON without the marker → unreadable (notLinthraBackup)', () {
+      final BackupRestorePreview preview =
+          service.previewRestore('{"somethingElse": true}');
+      expect(
+        (preview as BackupRestorePreviewUnreadable).failure.reason,
+        BackupReadFailureReason.notLinthraBackup,
+      );
+    });
+
+    test('a newer formatVersion → unreadable (unsupportedVersion)', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': kBackupFormatVersion + 1,
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{},
+      });
+      final BackupRestorePreview preview = service.previewRestore(text);
+      final BackupRestorePreviewUnreadable unreadable =
+          preview as BackupRestorePreviewUnreadable;
+      expect(
+        unreadable.failure.reason,
+        BackupReadFailureReason.unsupportedVersion,
+      );
+      expect(unreadable.failure.message, contains('newer version'));
+    });
+
+    test('a missing/invalid formatVersion → unreadable (malformed)', () {
+      final String text = _wrap(<String, dynamic>{
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{},
+      });
+      expect(
+        (service.previewRestore(text) as BackupRestorePreviewUnreadable)
+            .failure
+            .reason,
+        BackupReadFailureReason.malformed,
+      );
+    });
+  });
+
+  group('import preview — server classification', () {
+    test('adds known servers, flags unknown, and skips malformed entries', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[
+          <String, dynamic>{
+            'type': 'jellyfin',
+            'baseUrl': 'https://music.example.com',
+            'username': 'alice',
+          },
+          <String, dynamic>{
+            'type': 'subsonic',
+            'baseUrl': 'https://nd.example.com',
+            'serverType': 'navidrome',
+          },
+          <String, dynamic>{
+            'type': 'plex',
+            'baseUrl': 'https://plex.example.com:32400',
+            'selectedSectionKeys': <String>['3'],
+          },
+          <String, dynamic>{'type': 'local', 'folderHint': 'content://x'},
+          // Unknown provider type — skipped with a notice, not dropped.
+          <String, dynamic>{
+            'type': 'futuresonic',
+            'displayName': 'Future Server',
+            'baseUrl': 'https://future.example.com',
+          },
+          // Malformed: a known type missing its required baseUrl.
+          <String, dynamic>{'type': 'jellyfin', 'username': 'bob'},
+          // Malformed: no usable type.
+          <String, dynamic>{'displayName': 'No type'},
+          // Malformed: not even an object.
+          'junk',
+        ],
+        'preferences': <String, dynamic>{},
+      });
+
+      final BackupImportPlan plan = _planOf(text);
+
+      expect(plan.addCount, 4);
+      expect(
+        plan.serversToAdd.map((PlannedServerAddition s) => s.type).toList(),
+        <String>['jellyfin', 'subsonic', 'plex', 'local'],
+      );
+
+      // Every network server lands needing a sign-in; the local one needs a
+      // folder re-pick instead.
+      expect(plan.serversNeedingSignIn, hasLength(3));
+      final PlannedServerAddition local = plan.serversToAdd
+          .firstWhere((PlannedServerAddition s) => s.type == 'local');
+      expect(local.needsSignIn, isFalse);
+      expect(local.followUp, BackupRestoreFollowUp.reselectFolder);
+
+      // Unknown type preserved as skippable, with its label for the notice.
+      expect(plan.unknownServers, hasLength(1));
+      expect(plan.unknownServers.single.typeName, 'futuresonic');
+      expect(plan.unknownServers.single.displayName, 'Future Server');
+
+      // The three malformed entries are skipped, each with the right reason.
+      expect(
+        plan.skippedServers.map((PlannedSkippedServer s) => s.reason).toSet(),
+        <BackupServerSkipReason>{
+          BackupServerSkipReason.missingRequiredField,
+          BackupServerSkipReason.missingType,
+          BackupServerSkipReason.notAnObject,
+        },
+      );
+      final PlannedSkippedServer missingUrl = plan.skippedServers.firstWhere(
+        (PlannedSkippedServer s) =>
+            s.reason == BackupServerSkipReason.missingRequiredField,
+      );
+      expect(missingUrl.typeName, 'jellyfin');
+    });
+  });
+
+  group('import preview — duplicate detection (type + normalized URL)', () {
+    test('an already-configured server is flagged, not re-added', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[
+          // Same server as the existing one, but with a cosmetic trailing
+          // slash — must still be recognised as already configured.
+          <String, dynamic>{
+            'type': 'jellyfin',
+            'baseUrl': 'https://music.example.com/',
+          },
+          <String, dynamic>{
+            'type': 'plex',
+            'baseUrl': 'https://plex.example.com:32400',
+          },
+        ],
+        'preferences': <String, dynamic>{},
+      });
+
+      final BackupImportPlan plan = _planOf(
+        text,
+        existing: <BackupServerIdentity>[
+          BackupServerIdentity.of('jellyfin', 'https://music.example.com'),
+        ],
+      );
+
+      expect(plan.addCount, 1);
+      expect(plan.serversToAdd.single.type, 'plex');
+      expect(plan.duplicateCount, 1);
+      expect(plan.serversAlreadyConfigured.single.type, 'jellyfin');
+    });
+
+    test('the same server listed twice in one file is added only once', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[
+          <String, dynamic>{
+            'type': 'subsonic',
+            'baseUrl': 'https://nd.example.com',
+          },
+          <String, dynamic>{
+            'type': 'subsonic',
+            'baseUrl': 'https://nd.example.com',
+          },
+        ],
+        'preferences': <String, dynamic>{},
+      });
+
+      final BackupImportPlan plan = _planOf(text);
+      expect(plan.addCount, 1);
+      expect(plan.duplicateCount, 1);
+    });
+
+    test('a different provider sharing a URL is not a duplicate', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[
+          <String, dynamic>{
+            'type': 'subsonic',
+            'baseUrl': 'https://media.example.com',
+          },
+        ],
+        'preferences': <String, dynamic>{},
+      });
+
+      // Existing Jellyfin at the same URL must NOT shadow a Subsonic add.
+      final BackupImportPlan plan = _planOf(
+        text,
+        existing: <BackupServerIdentity>[
+          BackupServerIdentity.of('jellyfin', 'https://media.example.com'),
+        ],
+      );
+      expect(plan.addCount, 1);
+      expect(plan.duplicateCount, 0);
+    });
+  });
+
+  group('import preview — preferences (applied / clamped / ignored)', () {
+    test('known preferences apply; numeric values are clamped to range', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{
+          'defaultProvider': 'plex',
+          'cache': <String, dynamic>{
+            'maxBytes': 1, // below the floor → clamps up
+            'precacheCount': 9999, // above the cap → clamps down
+            'allowMobileData': true,
+          },
+        },
+      });
+
+      final BackupImportPlan plan = _planOf(text);
+      final BackupPreferencesPlan prefs = plan.preferences;
+
+      expect(prefs.applied.defaultProvider, 'plex');
+      expect(prefs.applied.cache?.maxBytes, CacheSize.minLimit);
+      expect(prefs.applied.cache?.precacheCount, kMaxPrecacheCount);
+      expect(prefs.applied.cache?.allowMobileData, isTrue);
+
+      expect(
+        prefs.clamps.map((BackupPreferenceClamp c) => c.field).toSet(),
+        <String>{'cache.maxBytes', 'cache.precacheCount'},
+      );
+      final BackupPreferenceClamp count = prefs.clamps.firstWhere(
+        (BackupPreferenceClamp c) => c.field == 'cache.precacheCount',
+      );
+      expect(count.originalValue, 9999);
+      expect(count.clampedValue, kMaxPrecacheCount);
+    });
+
+    test('in-range values apply unchanged and report no clamp', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{
+          'cache': <String, dynamic>{
+            'maxBytes': 5368709120,
+            'precacheCount': 7,
+          },
+        },
+      });
+      final BackupPreferencesPlan prefs = _planOf(text).preferences;
+      expect(prefs.applied.cache?.maxBytes, 5368709120);
+      expect(prefs.applied.cache?.precacheCount, 7);
+      expect(prefs.clamps, isEmpty);
+    });
+
+    test('unknown preference keys are ignored (and reported), not applied', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{
+          'defaultProvider': 'jellyfin',
+          'futurePreference': 42,
+          'cache': <String, dynamic>{
+            'maxBytes': 5368709120,
+            'futureCacheKnob': 'ignored',
+          },
+        },
+      });
+      final BackupPreferencesPlan prefs = _planOf(text).preferences;
+
+      expect(prefs.applied.defaultProvider, 'jellyfin');
+      expect(prefs.applied.cache?.maxBytes, 5368709120);
+      expect(prefs.ignoredKeys, contains('futurePreference'));
+      expect(prefs.ignoredKeys, contains('cache.futureCacheKnob'));
+      // The applied preferences carry only known keys.
+      expect(prefs.applied.toJson().containsKey('futurePreference'), isFalse);
+    });
+
+    test('a wrong-typed preference is dropped, not crashed on', () {
+      final String text = _wrap(<String, dynamic>{
+        'formatVersion': 1,
+        'servers': <Object>[],
+        'preferences': <String, dynamic>{
+          'defaultProvider': 123,
+          'cache': <String, dynamic>{'maxBytes': 'huge'},
+        },
+      });
+      final BackupPreferencesPlan prefs = _planOf(text).preferences;
+      expect(prefs.applied.defaultProvider, isNull);
+      expect(prefs.applied.cache, isNull);
+    });
+  });
+
+  group('restore planning never writes credentials or imports secrets', () {
+    // A hostile/hand-edited backup: every server and the preferences carry
+    // secret-looking keys seeded with `SENTINEL-` values.
+    String hostileBackup() => _wrap(<String, dynamic>{
+          'formatVersion': 1,
+          'kind': 'settings',
+          'servers': <Object>[
+            <String, dynamic>{
+              'type': 'jellyfin',
+              'baseUrl': 'https://music.example.com',
+              'username': 'alice',
+              'accessToken': 'SENTINEL-jf-token',
+              'deviceId': 'SENTINEL-jf-device',
+              'password': 'SENTINEL-jf-password',
+            },
+            <String, dynamic>{
+              'type': 'subsonic',
+              'baseUrl': 'https://nd.example.com',
+              'username': 'alice',
+              'salt': 'SENTINEL-sub-salt',
+              'token': 'SENTINEL-sub-token',
+            },
+            <String, dynamic>{
+              'type': 'plex',
+              'baseUrl': 'https://plex.example.com:32400',
+              'token': 'SENTINEL-plex-token',
+              'machineIdentifier': 'SENTINEL-plex-machine',
+              'selectedSectionKeys': <String>['3'],
+            },
+          ],
+          'preferences': <String, dynamic>{
+            'defaultProvider': 'jellyfin',
+            'password': 'SENTINEL-pref-password',
+            'token': 'SENTINEL-pref-token',
+            'cache': <String, dynamic>{
+              'maxBytes': 5368709120,
+              'secretKnob': 'SENTINEL-cache-secret',
+            },
+          },
+        });
+
+    test('no planned server addition carries a secret/excluded field', () {
+      final BackupImportPlan plan = _planOf(hostileBackup());
+      expect(plan.addCount, 3);
+
+      for (final PlannedServerAddition addition in plan.serversToAdd) {
+        final Map<String, dynamic> json = addition.server.toJson();
+        expect(
+          json.keys.toSet().intersection(_forbiddenKeys),
+          isEmpty,
+          reason: 'a ${addition.type} addition leaked: ${json.keys}',
+        );
+        expect(jsonEncode(json), isNot(contains('SENTINEL-')));
+      }
+
+      // The non-secret settings DID survive (it isn't dropping everything).
+      final Set<String> urls = plan.serversToAdd
+          .map((PlannedServerAddition s) => s.normalizedBaseUrl)
+          .toSet();
+      expect(urls, contains('https://music.example.com'));
+    });
+
+    test('every restored network server is treated as needs-sign-in', () {
+      final BackupImportPlan plan = _planOf(hostileBackup());
+      // No credential was imported, so all three must require signing in again.
+      expect(plan.serversNeedingSignIn, hasLength(3));
+      for (final PlannedServerAddition addition in plan.serversToAdd) {
+        expect(addition.needsSignIn, isTrue);
+      }
+    });
+
+    test('applied preferences contain no secret, and secret keys are ignored',
+        () {
+      final BackupPreferencesPlan prefs = _planOf(hostileBackup()).preferences;
+
+      // The legitimate preference still applied.
+      expect(prefs.applied.defaultProvider, 'jellyfin');
+      expect(prefs.applied.cache?.maxBytes, 5368709120);
+
+      // Nothing secret reached the applied set.
+      final Map<String, dynamic> appliedJson = prefs.applied.toJson();
+      expect(
+        _allKeys(appliedJson).intersection(_forbiddenKeys),
+        isEmpty,
+      );
+      expect(jsonEncode(appliedJson), isNot(contains('SENTINEL-')));
+
+      // The secret-looking keys were seen and explicitly ignored.
+      expect(prefs.ignoredKeys, contains('password'));
+      expect(prefs.ignoredKeys, contains('token'));
+      expect(prefs.ignoredKeys, contains('cache.secretKnob'));
+    });
+
+    test('the whole plan, re-serialized, contains no seeded secret value', () {
+      final BackupImportPlan plan = _planOf(hostileBackup());
+      final StringBuffer everything = StringBuffer()
+        ..write(jsonEncode(plan.preferences.applied.toJson()));
+      for (final PlannedServerAddition addition in plan.serversToAdd) {
+        everything.write(jsonEncode(addition.server.toJson()));
+      }
+      expect(everything.toString(), isNot(contains('SENTINEL-')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The **service layer** for Backup/Restore V1, built on top of the format models merged in #246. It's still small, safe, and focused: a pure-Dart service that **exports** a non-secret backup and **previews** a restore, plus an import-plan model describing exactly what a restore would do. **No app UI yet, and no restore mutation yet — this PR is preview / planning only.**

Linthra works on its own; this adds no account, no Docker, no desktop dependency, no QR/pairing, no cloud sync, and no new dependencies.

## What's in this PR

All new files under `lib/features/backup_restore/` (pure Dart, no Flutter/UI/store coupling, reusable by Linthra Desktop):

| File | Purpose |
| --- | --- |
| `backup_restore_service.dart` | `BackupRestoreService` — `buildBackup(...)` (export), `previewRestore(text)` / `planRestore(inner)` (restore preview), and `encode(...)`. |
| `backup_import_plan.dart` | `BackupImportPlan` and its parts: planned additions, duplicates, unknown types, skipped/malformed entries, and a preferences plan (applied / clamped / ignored). Plus `normalizeBackupBaseUrl`, `BackupServerIdentity`, and the restore follow-up enum. |
| `test/.../backup_restore_service_test.dart` | Export roundtrip, gating of malformed files, classification, duplicate handling, preference clamp/ignore, and the "never imports a secret" proofs (21). |
| `test/.../backup_import_plan_test.dart` | URL normalization, identity/dedup keying, follow-up mapping, and plan getters (20). |

## Export — settings, never secrets

`buildBackup()` projects the live (secret-bearing) sessions plus the non-secret preferences into a `LinthraBackup`, routing every server through the existing `backup_export_mapper` projection. A token/secret **structurally cannot** reach the file (the models have no field for one). The export tests feed the **service** sessions full of `SENTINEL-` secrets/ids and assert none reach the encoded JSON.

## Import preview — plans only, never writes a credential

`previewRestore(text)`:
1. Validates the envelope + version via the #246 reader, returning a **typed unreadable failure** for a not-JSON / not-Linthra / **newer-version** / malformed file (with the user-facing message), never a partial import.
2. For a readable backup, returns a `BackupImportPlan` that classifies every entry:
   - **valid servers to add** — each marked **needs-sign-in** (network providers) or **folder-re-pick** (local), because V1 restores no credential;
   - **already configured** — matched by (`type`, normalized `baseUrl`); left as-is, never duplicated;
   - **unknown server types** — skipped with a notice (forward-compatible);
   - **malformed / skipped** entries — with the reason (not-an-object / missing-type / missing-required-field). The planner works off the **raw** inner object so it can report entries the lenient model parser silently drops.
   - **preferences** — the clamped, ready-to-apply set, plus which numeric values were **clamped** and which unknown keys were **ignored**.

The plan mutates nothing and contains no credential by construction.

## Duplicate detection

By **provider type + normalized base URL** — tolerant of scheme/host case, the default port (`:443`/`:80`), and a trailing slash, so a server typed slightly differently isn't re-added. A URL-less `local` source keys on its type alone. Dedup also runs **within** a single file (the same server listed twice is added once).

## Security

- V1 exports **settings only** — never the Jellyfin `accessToken`, the Subsonic `salt`/`token`, the Plex `X-Plex-Token`, or any password.
- **Restore planning imports no credential.** Every restored server is treated as **needs-sign-in**; nothing plays until the user re-authenticates.
- **Secret-looking keys in a user-supplied backup are ignored** (and surfaced in the plan's `ignoredKeys`) — proven by a test that feeds a hostile backup whose servers and preferences carry `accessToken` / `token` / `salt` / `password` and asserts none reach any planned addition or the applied preferences.

## Out of scope (per the plan)

Export/import UI, the actual restore mutation, and Linthra Connect pairing/QR are **not** in this PR.

## Verification (pinned Flutter 3.27.4 / Dart 3.6.2)

- `dart format --set-exit-if-changed .` — clean (0 changed)
- `flutter analyze` — clean (No issues found)
- `flutter test` — **2704 passing** (incl. 41 new)
- `./scripts/check_secrets.sh` — clean
- `flutter pub get --enforce-lockfile` — clean (no lockfile drift)
- Diff is **new files only** — no existing source touched, nothing imports the new code yet, so no runtime behavior (playback, audio focus, cache, providers, Plex/Jellyfin/Subsonic clients, Cast, Android Auto) is affected. No version, dependency, or F-Droid metadata change.

Kept as a **draft** until CI (Flutter checks · Build debug APK · Secret scan) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPsu1ts88ro27r5zPfaJis

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPsu1ts88ro27r5zPfaJis)_