### PR TITLE
chore(release): prepare 0.1.7 audio stability pre-release

### DIFF
--- a/docs/release-notes/v0.1.7-alpha.1.md
+++ b/docs/release-notes/v0.1.7-alpha.1.md
@@ -1,0 +1,66 @@
+# Linthra v0.1.7-alpha.1 — Android audio stability (pre-release)
+
+**Linthra is a modern, local-first, privacy-focused music player for people who
+own their music.** This is a **testing pre-release** focused on background and
+audio-focus stability after the big audio fix in
+[PR #244](https://github.com/TheZupZup/Linthra/pull/244). It is meant for
+GitHub / Obtainium testers to validate the audio behaviour — especially in
+Android Auto — before it is promoted to a stable `0.1.7`.
+
+- **Version:** `0.1.7-alpha.1` (`versionName`), `versionCode` `107001`
+- **Channel:** pre-release / release candidate (alpha) — **for testers**
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+- **Get it:** from the
+  [GitHub Releases page](https://github.com/TheZupZup/Linthra/releases) as a
+  **pre-release** (signed APKs). Obtainium can track the GitHub Releases and
+  pick this build up. The F-Droid build follows the stable release, not alphas.
+
+## Highlights
+
+The main user-facing fix this release is
+[PR #244](https://github.com/TheZupZup/Linthra/pull/244) — it makes Linthra
+behave like a normal Android media player when other apps take audio focus and
+when the screen locks.
+
+- Fixed cases where Linthra could get stuck silent after another app took audio
+  focus.
+- Improved recovery after notification sounds and short audio interruptions.
+- Improved recovery after voice/microphone interruptions.
+- Improved playback reliability when the screen locks.
+- Linthra should no longer require reopening the app to restore sound after an
+  interruption.
+- Improved Android Auto reliability after the audio/background playback fixes.
+- Background playback now behaves more like a normal Android music player.
+
+## Battery note
+
+- Linthra may keep its playback service alive longer while paused so it can
+  recover reliably in the background.
+- This may use slightly more battery only if Linthra is left paused for a long
+  time.
+- This is intentional for reliability and can be optimized later if needed.
+
+## Android Auto
+
+Android Auto reliability was validated and **improved** after the audio /
+background playback fixes — it is **more stable in Android Auto** than before.
+This is a reliability improvement, not a claim of perfection; please keep
+reporting any Android Auto issues so they can be tracked.
+
+## Upgrade notes
+
+- **Nothing to do.** Upgrading keeps your existing settings.
+- **This is a pre-release.** Expect rough edges and please report what you find.
+- **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
+  key, while the F-Droid build is signed with F-Droid's key; the two can't
+  update each other. Stick with one source.
+
+## Known limitations
+
+- This is an alpha aimed at confirming the audio/background-playback stability
+  work on real devices and in Android Auto before a stable `0.1.7`.
+- Android Auto is improved but not guaranteed perfect — feedback welcome.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/fastlane/metadata/android/en-US/changelogs/107001.txt
+++ b/fastlane/metadata/android/en-US/changelogs/107001.txt
@@ -1,0 +1,26 @@
+Linthra 0.1.7-alpha.1 — Android audio stability (testing pre-release).
+
+This testing pre-release focuses on background and audio-focus
+reliability after the audio fixes in PR #244.
+
+Fixed:
+- Linthra could get stuck silent after another app took audio focus
+  (notification sounds, voice/microphone, and short interruptions).
+- Sound sometimes only came back after reopening the app; it now
+  recovers in the background.
+- Playback could stop or mute when the screen locked.
+
+Improved:
+- More stable in Android Auto after the audio/background fixes.
+- Background playback now behaves more like a normal Android music
+  player.
+
+Battery note:
+- Linthra may keep its playback service alive a little longer while
+  paused so it can recover reliably in the background. This may use
+  slightly more battery only if Linthra is left paused for a long
+  time. It is intentional for reliability and can be optimized later.
+
+This is a pre-release for testers; expect to report rough edges.
+
+No ads, no tracking, no analytics, no telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.6';
+  static const String _devVersionName = '0.1.7-alpha.1';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.6+106999
+version: 0.1.7-alpha.1+107001
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Release-preparation PR (not a feature PR) that bumps Linthra to **`0.1.7-alpha.1`** as an **audio / background-playback stability pre-release** for GitHub / Obtainium testers. It is built on the audio-focus recovery work merged in **[PR #244](https://github.com/TheZupZup/Linthra/pull/244)** — the main user-facing fix this release.

This is a **pre-release / release-candidate**: the goal is to let testers validate the audio behaviour on real devices (especially in **Android Auto**) before promoting it to a stable `0.1.7`.

> Keep as **draft** until CI is green.

## Version

| Field | Value |
| ----- | ----- |
| `versionName` | `0.1.7-alpha.1` |
| `versionCode` | `107001` |
| `pubspec.yaml` `version:` | `0.1.7-alpha.1+107001` |
| Tag (after merge, manual) | `v0.1.7-alpha.1` |

`107001` is the canonical encoding from `tool/version_from_tag.dart`
(`MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + alphaRank(1)`). It is **strictly monotonic**: above the `0.1.6` release (`106999`) and below a future stable `0.1.7` (`107999`), so the eventual stable promotion still sorts correctly for Android and F-Droid.

## What changed (version-only diff — 4 files)

- **`pubspec.yaml`** — `0.1.6+106999` → `0.1.7-alpha.1+107001`.
- **`lib/core/app_info.dart`** — `_devVersionName` mirror → `'0.1.7-alpha.1'` (kept in lockstep; enforced by `app_info_version_test.dart`).
- **`fastlane/metadata/android/en-US/changelogs/107001.txt`** — short F-Droid "What's new" (required by `release_changelog_test.dart`).
- **`docs/release-notes/v0.1.7-alpha.1.md`** — longer GitHub pre-release notes.

**Deliberately not touched** (per scope): Backup/Restore, Linthra Connect, Desktop/Windows, provider clients, cache/offline behaviour, Plex/Jellyfin/Subsonic runtime logic, Cast, Android Auto code, dependencies — and the **F-Droid metadata** (`io.github.thezupzup.linthra.yml`). The F-Droid recipe uses `AutoUpdateMode: Version`, so it auto-detects from `pubspec.yaml`; the v0.1.6 bump left it untouched too, and the guardrail test only requires `pubspec versionCode ≥ CurrentVersion` (`107001 ≥ 100039` ✓).

## Pre-release notes for testers (copy-paste for the GitHub Release)

> **Title:** `Linthra 0.1.7-alpha — Android audio stability`
> Mark the GitHub Release as **pre-release**.

**Highlights** — the main fix is [PR #244](https://github.com/TheZupZup/Linthra/pull/244), which makes Linthra behave like a normal Android media player when other apps take audio focus and when the screen locks:

- Fixed cases where Linthra could get stuck silent after another app took audio focus.
- Improved recovery after notification sounds and short audio interruptions.
- Improved recovery after voice/microphone interruptions.
- Improved playback reliability when the screen locks.
- Linthra should no longer require reopening the app to restore sound after an interruption.
- Improved Android Auto reliability after the audio/background playback fixes.
- Background playback now behaves more like a normal Android music player.

**Battery note:**

- Linthra may keep its playback service alive longer while paused so it can recover reliably in the background.
- This may use slightly more battery only if Linthra is left paused for a long time.
- This is intentional for reliability and can be optimized later if needed.

**Android Auto:** reliability was validated and **improved** — it is **more stable in Android Auto** after the audio/background fixes. This is a reliability improvement, not a claim of perfection; please keep reporting Android Auto issues.

## Verification

- ✅ Secret/privacy scan — `./scripts/check_secrets.sh` passed locally.
- ✅ Release-bump scope — `check_release_bump_files.sh` confirms a version-only diff (4 allowed files).
- ✅ Version invariants by construction — canonical `versionCode` (`107001`), in-app mirror in sync, changelog present, monotonic vs F-Droid metadata.
- ⏳ `dart format` / `flutter analyze` / `flutter test` / Android Debug APK — run in CI (Flutter toolchain isn't available in this environment). Only a `const` string and metadata/notes files changed, so no runtime behaviour is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGMQ86yvj8cy8q6AqtQzBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGMQ86yvj8cy8q6AqtQzBJ)_