### PR TITLE
chore(support): harden donation/support screen before 0.1.7

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -68,7 +68,7 @@ Everything lives under [`lib/features/support/`](../lib/features/support/):
 | File | Responsibility |
 | ---- | -------------- |
 | `support_action.dart` | `SupportAction` — one way to support, as plain data (id, title, description, icon, `kind`, optional `url`). `SupportActionKind` is a small closed set: `externalLink` or `comingSoon`. |
-| `support_actions_provider.dart` | The build seam: `SupportDistribution` (the channel), `supportActionsFor(distribution)` (a pure catalog), `SupportLinks` (the URLs in one place), and `supportActionsProvider` (what the screen reads). |
+| `support_actions_provider.dart` | The build seam: `SupportDistribution` (the channel), `supportActionsFor(distribution)` (a pure catalog), `SupportLinks` (the URLs in one place), `supportLinksEnabled` (the per-channel kill switch), and `supportActionsProvider` / `supportLinksEnabledProvider` (what the screen and About page read). |
 | `support_screen.dart` | `SupportScreen` — renders the copy and whatever actions the provider yields. It owns **no** donation or payment logic. |
 
 Two deliberate properties:
@@ -85,6 +85,24 @@ Two deliberate properties:
    `LINTHRA_VERSION_NAME` override). The default is the safe one: a plain
    `flutter build` gets external links only.
 
+3. **A per-channel kill switch can drop support entirely.**
+   `supportLinksEnabled` reads `--dart-define=LINTHRA_SUPPORT_LINKS=...` and
+   **defaults to enabled**. Build with `LINTHRA_SUPPORT_LINKS=off` (also
+   `false`, `0`, `no`, `disabled`) and the in-app entry point disappears (the
+   About page hides its "Support Linthra" card) and `supportActionsProvider`
+   yields an empty list, so the screen — if reached directly — degrades to a
+   purely informational "free & open source" page with no links. This is the
+   lever for a distribution channel whose policy forbids in-app donation links,
+   or a fork that wants none. Like the distribution flag it is **support-only**:
+   it never affects playback, caching, providers, Android Auto, Cast,
+   Backup/Restore, or any other app behavior.
+
+The launcher path is also guarded: the screen only ever opens an `http`/`https`
+web link (`isLaunchableHttpUrl`). Every shipped link is an `https` constant, so
+this always passes today; the guard is defense in depth so a future mis-edited
+link with a non-web scheme (a `tel:`, `mailto:`, `file:`, or custom app intent)
+fails safe instead of being handed to the OS.
+
 ## 5. F-Droid safety
 
 - The default `SupportDistribution` is `fdroid`, so an ordinary `flutter build`
@@ -100,6 +118,23 @@ Two deliberate properties:
   **only** in the Play flavor — never as a shared/default dependency.
 
 ## 6. The future Play Store build (not in this PR)
+
+> **Store-policy note — external donation/payment links.** F-Droid and GitHub
+> builds may link out to donations freely. **A Play Store build may not.**
+> Google Play's payments policy can restrict apps from linking out to external
+> donations/payments unless the developer is a registered charity (and outright
+> requires Google Play Billing for in-app purchases of digital goods). So a Play
+> build may need to **change or remove** the external donation links — not just
+> add billing. Two levers already exist and need **no screen change**:
+>
+> - `--dart-define=LINTHRA_DISTRIBUTION=play` — keep the links but adjust the set
+>   per policy (e.g. swap GitHub Sponsors for a Play-Billing supporter action).
+> - `--dart-define=LINTHRA_SUPPORT_LINKS=off` — drop the external links and the
+>   entry point entirely for a channel that forbids them.
+>
+> Confirm the current Play policy before shipping a Play build; this is a policy
+> question, not a code one, and the levers above are how the code adapts to the
+> answer.
 
 Play Store billing will be implemented **only in Play builds, later.** The
 structure is already in place:
@@ -130,11 +165,17 @@ the F-Droid build.**
 ## 7. Tests
 
 - `test/features/support/support_action_test.dart` — the data model (URL
-  parsing, the `externalLink`-needs-a-`url` assertion).
+  parsing, the `externalLink`-needs-a-`url` assertion) and the
+  `isLaunchableHttpUrl` launch guard (accepts http/https, rejects null, non-web
+  schemes, and host-less URLs).
 - `test/features/support/support_actions_provider_test.dart` — the distribution
-  parser and that F-Droid offers links only while Play adds the disabled
-  placeholder; every external link is a well-formed `https` URL.
-- `test/features/support/support_screen_test.dart` — the copy, link taps (via a
-  fake launcher), the disabled placeholder, and the snackbar fallback.
-- `test/features/settings/hub/about_screen_test.dart` — the About entry and that
-  it navigates to the support route.
+  parser, the `LINTHRA_SUPPORT_LINKS` kill-switch parser, and that F-Droid
+  offers links only while Play adds the disabled placeholder; every external
+  link is a well-formed `https` URL that passes the runtime launch guard.
+- `test/features/support/support_screen_test.dart` — the copy (including the
+  "donating does not unlock features" line), link taps (via a fake launcher),
+  the disabled placeholder, the snackbar fallback, refusal to open a non-web
+  link, and the links-disabled informational page (no actions card, no aside).
+- `test/features/settings/hub/about_screen_test.dart` — the About entry, that it
+  navigates to the support route, and that it hides when support links are
+  disabled (while the help/contact card stays).

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -7,6 +7,7 @@ import '../../../app/external_link_launcher_provider.dart';
 import '../../../app/routes.dart';
 import '../../../core/app_info.dart';
 import '../../appearance/selected_logo_mark.dart';
+import '../../support/support_actions_provider.dart';
 import '../about/support_section.dart';
 import '../about/whats_new_section.dart';
 import 'settings_detail_scaffold.dart';
@@ -29,6 +30,11 @@ class AboutScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // The "Support Linthra" entry hides itself in a links-disabled build
+    // (LINTHRA_SUPPORT_LINKS=off), so a channel that forbids in-app donation
+    // links has no entry point. It is the only support-aware bit of this page;
+    // everything else (help/contact, links) is unaffected.
+    final bool showSupport = ref.watch(supportLinksEnabledProvider);
     return SettingsDetailScaffold(
       title: 'About',
       children: <Widget>[
@@ -38,10 +44,12 @@ class AboutScreen extends ConsumerWidget {
         const SizedBox(height: AppSpacing.md),
         const WhatsNewSection(),
         const SizedBox(height: AppSpacing.md),
-        _SupportLinthraCard(
-          onTap: () => context.push(AppRoutes.settingsSupport),
-        ),
-        const SizedBox(height: AppSpacing.md),
+        if (showSupport) ...<Widget>[
+          _SupportLinthraCard(
+            onTap: () => context.push(AppRoutes.settingsSupport),
+          ),
+          const SizedBox(height: AppSpacing.md),
+        ],
         const SupportSection(),
         const SizedBox(height: AppSpacing.md),
         _LinksCard(

--- a/lib/features/support/support_action.dart
+++ b/lib/features/support/support_action.dart
@@ -68,3 +68,19 @@ class SupportAction {
   /// The [url] as a [Uri], or null when this action has none.
   Uri? get uri => url == null ? null : Uri.parse(url!);
 }
+
+/// Whether [uri] is safe for the Support screen to hand to the external browser
+/// launcher: a non-empty `http`/`https` web link and nothing else.
+///
+/// Defense in depth. Every link that ships today is an `https` constant in
+/// `SupportLinks`, so in a correct build this always passes; the guard exists so
+/// that a future mis-edited link carrying a non-web scheme — a `tel:`,
+/// `mailto:`, `file:`, `javascript:`, or a custom app-intent URI — fails *safe*:
+/// the screen declines to launch it rather than handing an unexpected scheme to
+/// the OS. It is the runtime backstop to the compile-time `https` check the
+/// support-links test enforces, and it is pure so it is unit-testable without a
+/// widget or a real launcher.
+bool isLaunchableHttpUrl(Uri? uri) =>
+    uri != null &&
+    (uri.isScheme('https') || uri.isScheme('http')) &&
+    uri.host.isNotEmpty;

--- a/lib/features/support/support_actions_provider.dart
+++ b/lib/features/support/support_actions_provider.dart
@@ -20,6 +20,13 @@ enum SupportDistribution {
   /// the Google Play Billing supporter purchase a later, Play-only PR will
   /// implement. Selecting it today changes only which rows are listed; it adds
   /// no billing code or dependency.
+  ///
+  /// Store-policy note: a Play build may need to handle the **external**
+  /// donation links differently from F-Droid — Google Play's payments policy can
+  /// restrict linking out to donations for non-charity developers. The Play-only
+  /// PR should adjust those links per policy (e.g. route supporters to Play
+  /// Billing instead), and `LINTHRA_SUPPORT_LINKS=off` can drop the external
+  /// links entirely for a channel that forbids them. See docs/SUPPORT.md §6.
   play;
 
   /// The channel this build was compiled for, from the dart-define (default
@@ -39,6 +46,43 @@ enum SupportDistribution {
       default:
         return SupportDistribution.fdroid;
     }
+  }
+}
+
+/// Whether this build offers any voluntary support links at all.
+///
+/// Read once from `--dart-define=LINTHRA_SUPPORT_LINKS=...`, **defaulting to
+/// enabled**, and parsed by [supportLinksEnabledFromDefine]. Build with
+/// `--dart-define=LINTHRA_SUPPORT_LINKS=off` (also: `false`, `0`, `no`,
+/// `disabled`) to compile an edition with the in-app "Support Linthra" entry
+/// point and every external donation link removed entirely.
+///
+/// This is the per-channel kill switch the audit asks for: it is the seam for a
+/// distribution channel whose policy forbids in-app donation links (some app
+/// stores restrict linking out to donations for non-charity developers — see
+/// docs/SUPPORT.md §6), or for a fork that wants none. Like
+/// [SupportDistribution] it is read from the environment and is **support-only**:
+/// it changes nothing but which support actions (if any) are offered, and never
+/// touches playback, caching, providers, Android Auto, Cast, Backup/Restore, or
+/// any other app behavior.
+bool get supportLinksEnabled => supportLinksEnabledFromDefine(
+      const String.fromEnvironment('LINTHRA_SUPPORT_LINKS'),
+    );
+
+/// Pure parser behind [supportLinksEnabled]: maps the dart-define string to a
+/// flag, **defaulting to enabled** for the empty or unknown value so an ordinary
+/// `flutter build` keeps the links. Exposed so the mapping is unit-testable
+/// without recompiling under a dart-define.
+bool supportLinksEnabledFromDefine(String value) {
+  switch (value.trim().toLowerCase()) {
+    case 'off':
+    case 'false':
+    case '0':
+    case 'no':
+    case 'disabled':
+      return false;
+    default:
+      return true;
   }
 }
 
@@ -126,6 +170,22 @@ List<SupportAction> supportActionsFor(SupportDistribution distribution) {
 /// [supportActionsFor]) to surface its supporter purchase, while F-Droid and
 /// dev builds keep the external links and nothing else. Declaring it as a
 /// provider also lets widget tests inject a fixed list without a dart-define.
+///
+/// When [supportLinksEnabled] is false (the per-channel kill switch) this yields
+/// an empty list, so a build compiled with `LINTHRA_SUPPORT_LINKS=off` offers no
+/// support actions at all and the screen degrades to a purely informational
+/// page.
 final supportActionsProvider = Provider<List<SupportAction>>(
-  (ref) => supportActionsFor(SupportDistribution.current),
+  (ref) => supportLinksEnabled
+      ? supportActionsFor(SupportDistribution.current)
+      : const <SupportAction>[],
 );
+
+/// Whether the in-app "Support Linthra" entry point should be shown.
+///
+/// Mirrors [supportLinksEnabled] behind a provider so the About page can hide
+/// its "Support Linthra" card in a links-disabled build, and so widget tests can
+/// flip the switch without a dart-define. Reads the same env flag, so the entry
+/// point and the actions are always consistent.
+final supportLinksEnabledProvider =
+    Provider<bool>((ref) => supportLinksEnabled);

--- a/lib/features/support/support_screen.dart
+++ b/lib/features/support/support_screen.dart
@@ -26,22 +26,30 @@ class SupportScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final List<SupportAction> actions = ref.watch(supportActionsProvider);
+    // A links-disabled build (LINTHRA_SUPPORT_LINKS=off) yields no actions; the
+    // screen then degrades to a purely informational page — the free/optional
+    // copy with no actions card and no call-to-action aside.
+    final bool hasActions = actions.isNotEmpty;
     return Scaffold(
       appBar: AppBar(title: const Text('Support Linthra')),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
         children: <Widget>[
           const _IntroCard(),
-          const SizedBox(height: AppSpacing.md),
-          _ActionsCard(
-            actions: actions,
-            onOpenLink: (SupportAction action) =>
-                _openLink(context, ref, action),
-          ),
+          if (hasActions) ...<Widget>[
+            const SizedBox(height: AppSpacing.md),
+            _ActionsCard(
+              actions: actions,
+              onOpenLink: (SupportAction action) =>
+                  _openLink(context, ref, action),
+            ),
+          ],
           const SizedBox(height: AppSpacing.md),
           const _FreeForeverNote(),
-          const SizedBox(height: AppSpacing.md),
-          const _LonelyMaintainerNote(),
+          if (hasActions) ...<Widget>[
+            const SizedBox(height: AppSpacing.md),
+            const _LonelyMaintainerNote(),
+          ],
         ],
       ),
     );
@@ -57,12 +65,19 @@ class SupportScreen extends ConsumerWidget {
     SupportAction action,
   ) async {
     final Uri? url = action.uri;
-    if (url == null) {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    // Only ever hand the OS an http(s) web link. A correct build always passes
+    // this (every shipped link is an https constant in SupportLinks); the guard
+    // makes a mis-edited non-web link fail safe — we decline rather than launch
+    // an unexpected scheme.
+    if (!isLaunchableHttpUrl(url)) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text("Couldn't open the link.")),
+      );
       return;
     }
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final bool launched =
-        await ref.read(externalLinkLauncherProvider).open(url);
+        await ref.read(externalLinkLauncherProvider).open(url!);
     if (!launched) {
       messenger.showSnackBar(
         const SnackBar(content: Text("Couldn't open the link.")),
@@ -105,9 +120,9 @@ class _IntroCard extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.sm),
             Text(
-              'Supporting Linthra is completely optional. Every feature is '
-              'free, with no ads and no tracking — support simply helps the '
-              'project keep going.',
+              'Supporting Linthra is completely optional and never required. '
+              'Every feature is free, with no ads and no tracking — support '
+              'simply helps the project keep going.',
               style: theme.textTheme.bodyMedium?.copyWith(color: muted),
             ),
             const SizedBox(height: AppSpacing.sm),
@@ -116,6 +131,12 @@ class _IntroCard extends StatelessWidget {
               style: theme.textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Donating does not unlock features — core playback and '
+              'self-hosted music features stay free.',
+              style: theme.textTheme.bodyMedium?.copyWith(color: muted),
             ),
             const SizedBox(height: AppSpacing.md),
             Text(

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
 import 'package:linthra/features/settings/about/whats_new_section.dart';
 import 'package:linthra/features/settings/hub/about_screen.dart';
+import 'package:linthra/features/support/support_actions_provider.dart';
 
 class _FakeLinkLauncher implements ExternalLinkLauncher {
   _FakeLinkLauncher({this.result = true});
@@ -116,6 +117,37 @@ void main() {
         find.text('Free and open source — support is optional'),
         findsOneWidget,
       );
+    });
+
+    testWidgets(
+        'hides the "Support Linthra" entry when support links are disabled',
+        (tester) async {
+      // A links-disabled build (LINTHRA_SUPPORT_LINKS=off): the donation entry
+      // point must disappear, while the help/contact "Support" card stays.
+      tester.view.physicalSize = const Size(1000, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            externalLinkLauncherProvider.overrideWithValue(_FakeLinkLauncher()),
+            supportLinksEnabledProvider.overrideWithValue(false),
+          ],
+          child: const MaterialApp(home: AboutScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The donation entry is gone...
+      expect(find.text('Support Linthra'), findsNothing);
+      expect(
+        find.text('Free and open source — support is optional'),
+        findsNothing,
+      );
+      // ...but the help/contact "Support" card is unaffected.
+      expect(find.text('Report a bug'), findsOneWidget);
+      expect(find.text('Privacy policy'), findsOneWidget);
     });
 
     testWidgets('tapping "Support Linthra" opens the support screen',

--- a/test/features/support/support_action_test.dart
+++ b/test/features/support/support_action_test.dart
@@ -43,4 +43,27 @@ void main() {
       );
     });
   });
+
+  group('isLaunchableHttpUrl', () {
+    test('accepts http and https web links', () {
+      expect(
+        isLaunchableHttpUrl(Uri.parse('https://github.com/sponsors/thezupzup')),
+        isTrue,
+      );
+      expect(
+          isLaunchableHttpUrl(Uri.parse('http://example.org/donate')), isTrue);
+    });
+
+    test('rejects null, non-web schemes, and host-less urls', () {
+      // The runtime backstop: anything that is not an http(s) web link with a
+      // host must fail safe so the screen never hands the OS an odd scheme.
+      expect(isLaunchableHttpUrl(null), isFalse);
+      expect(
+          isLaunchableHttpUrl(Uri.parse('mailto:support@linthra.ca')), isFalse);
+      expect(isLaunchableHttpUrl(Uri.parse('tel:+15551234567')), isFalse);
+      expect(isLaunchableHttpUrl(Uri.parse('javascript:alert(1)')), isFalse);
+      expect(isLaunchableHttpUrl(Uri.parse('file:///etc/passwd')), isFalse);
+      expect(isLaunchableHttpUrl(Uri.parse('https://')), isFalse);
+    });
+  });
 }

--- a/test/features/support/support_actions_provider_test.dart
+++ b/test/features/support/support_actions_provider_test.dart
@@ -38,6 +38,33 @@ void main() {
     });
   });
 
+  group('supportLinksEnabledFromDefine', () {
+    test('defaults to enabled for the empty or unknown value', () {
+      expect(supportLinksEnabledFromDefine(''), isTrue);
+      expect(supportLinksEnabledFromDefine('whatever'), isTrue);
+      expect(supportLinksEnabledFromDefine('on'), isTrue);
+      expect(supportLinksEnabledFromDefine('true'), isTrue);
+    });
+
+    test('disables for the off aliases, case- and space-insensitively', () {
+      for (final String value in <String>[
+        'off',
+        'false',
+        '0',
+        'no',
+        'disabled',
+        '  OFF ',
+        'False',
+      ]) {
+        expect(
+          supportLinksEnabledFromDefine(value),
+          isFalse,
+          reason: '"$value" should disable support links',
+        );
+      }
+    });
+  });
+
   group('supportActionsFor', () {
     test('the F-Droid build offers external links only — no billing seat', () {
       final List<SupportAction> actions =
@@ -88,6 +115,24 @@ void main() {
           expect(uri, isNotNull, reason: '${action.id} must have a url');
           expect(uri!.scheme, 'https', reason: '${action.id} must be https');
           expect(uri.host, isNotEmpty);
+        }
+      }
+    });
+
+    test('every shipped support link passes the runtime launch guard', () {
+      // The same links the https check above asserts must also satisfy the
+      // runtime guard the screen uses, so a correct build never trips it.
+      for (final SupportDistribution distribution
+          in SupportDistribution.values) {
+        for (final SupportAction action in supportActionsFor(distribution)) {
+          if (action.kind != SupportActionKind.externalLink) {
+            continue;
+          }
+          expect(
+            isLaunchableHttpUrl(action.uri),
+            isTrue,
+            reason: '${action.id} must be a launchable web link',
+          );
         }
       }
     });

--- a/test/features/support/support_screen_test.dart
+++ b/test/features/support/support_screen_test.dart
@@ -82,9 +82,15 @@ void main() {
       expect(find.text('Support Linthra'), findsWidgets);
       expect(find.text('Linthra is free and open source'), findsOneWidget);
       expect(find.textContaining('completely optional'), findsOneWidget);
+      expect(find.textContaining('never required'), findsOneWidget);
       // The crisp, scannable trio stays visible.
       expect(
         find.text('No ads. No tracking. No locked core features.'),
+        findsOneWidget,
+      );
+      // The explicit "support doesn't buy features" line.
+      expect(
+        find.textContaining('Donating does not unlock features'),
         findsOneWidget,
       );
 
@@ -158,6 +164,46 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text("Couldn't open the link."), findsOneWidget);
+    });
+
+    testWidgets('refuses to open a non-web (non-http) link', (tester) async {
+      const List<SupportAction> nonWeb = <SupportAction>[
+        SupportAction(
+          id: 'bad-scheme',
+          title: 'Sketchy link',
+          description: 'Not a web link.',
+          icon: Icons.warning_amber_outlined,
+          kind: SupportActionKind.externalLink,
+          url: 'tel:+15551234567',
+        ),
+      ];
+      final _FakeLinkLauncher launcher = await _pump(tester, actions: nonWeb);
+
+      await tester.tap(find.text('Sketchy link'));
+      await tester.pumpAndSettle();
+
+      // The guard declined to launch the odd scheme and fell back to a snackbar.
+      expect(launcher.opened, isNull);
+      expect(find.text("Couldn't open the link."), findsOneWidget);
+    });
+
+    testWidgets(
+        'a links-disabled build shows the info copy but no actions or aside',
+        (tester) async {
+      // What supportActionsProvider yields when LINTHRA_SUPPORT_LINKS=off.
+      await _pump(tester, actions: const <SupportAction>[]);
+
+      // The free/optional explanation still renders.
+      expect(find.text('Linthra is free and open source'), findsOneWidget);
+      expect(
+        find.textContaining('All core features stay free'),
+        findsOneWidget,
+      );
+
+      // No action rows, and no call-to-action aside (nothing to act on).
+      expect(find.byType(ListTile), findsNothing);
+      expect(find.text('GitHub Sponsors'), findsNothing);
+      expect(find.textContaining("I'm lonely"), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Why

Before the **0.1.7** pre-release, audit and harden the voluntary Support / Donation screen (added in #242) so it is safe, clear, and store-friendly — and so it can't accidentally create payment-policy, privacy, or trust issues.

**Linthra stays free and fully usable. Support is optional and gates nothing.** This PR adds **no Play Billing, no payment SDK, no new dependencies, no telemetry/analytics, no account, no cloud service, no crypto, and no in-app payment form.** The screen remains plain copy plus external links.

## Audit result

The #242 module already met most of the bar (optional, no ads/tracking, no payment collection, external links via the shared launcher, centralized URLs, F-Droid-safe default). The audit found and closed these genuine gaps:

| Gap | Fix |
| --- | --- |
| No way to **disable** support links for a channel that forbids them | Added `LINTHRA_SUPPORT_LINKS` kill switch (default enabled) |
| Launch path trusted `SupportLinks` blindly | Added `isLaunchableHttpUrl` runtime guard (http/https only) |
| Docs covered Play *billing* but not external *donation-link* store policy | Added explicit store-policy note + inline comments |
| Wording implied but didn't plainly state "support ≠ features" | Added "never required" + "Donating does not unlock features" lines |

## What changed (small, support-only — no playback/provider/cache/Auto/Cast/Backup behavior touched)

- **Per-channel kill switch.** `--dart-define=LINTHRA_SUPPORT_LINKS=off` (also `false`/`0`/`no`/`disabled`) compiles a build with the entry point and **all external links removed**: `supportActionsProvider` yields an empty list, the About page hides its "Support Linthra" card, and the screen — if reached directly — degrades to a purely informational "free & open source" page (no actions card, no aside). Defaults to enabled, so an ordinary `flutter build` (CI / F-Droid) is unchanged.
- **Launch-path guard.** The screen now only opens `http`/`https` web links via `isLaunchableHttpUrl`. A mis-edited non-web scheme (`tel:`/`mailto:`/`file:`/custom intent) fails safe instead of being handed to the OS — a runtime backstop to the compile-time `https` check the tests enforce.
- **Clearer wording.** Adds *"Supporting Linthra is completely optional and never required"* and an explicit *"Donating does not unlock features — core playback and self-hosted music features stay free."*
- **Docs.** `docs/SUPPORT.md` documents the kill switch and adds a store-policy note: a Play build may need to **change or remove** external donation/payment links (not just add billing) depending on policy; the distribution + kill-switch flags are the levers. Inline comments mirror it.

## Easy to update / re-target later

URLs stay centralized in `SupportLinks`; the channel (`LINTHRA_DISTRIBUTION`) and the kill switch (`LINTHRA_SUPPORT_LINKS`) are the two env levers, both read with safe defaults and unit-tested parsers — no screen change needed to swap, disable, or re-target links per distribution channel.

## Tests / verification

New tests lock every guarantee: kill-switch parser, scheme guard (accept http(s); reject null/non-web/host-less), every shipped link passes the guard, the links-disabled informational screen, the About entry hiding when disabled, and the new copy.

- ✅ `dart format` clean
- ✅ `flutter analyze` clean (No issues found)
- ✅ `flutter test` — full suite green (2712 tests)
- ✅ secret/privacy scan clean (`./scripts/check_secrets.sh`)
- ⏳ Android Debug APK — via CI
- ✅ no runtime playback/provider changes

Kept as **draft** until CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQRzCy7Dz3Z2XsCvm2kLLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQRzCy7Dz3Z2XsCvm2kLLT)_