### PR TITLE
fix(jellyfin): make music sync tolerant and resilient

### DIFF
--- a/docs/jellyfin-compatibility.md
+++ b/docs/jellyfin-compatibility.md
@@ -85,9 +85,9 @@ between call sites and the full surface is auditable here.
 | Server info | `GET /System/Info/Public` | No auth. Backs Test connection + version/capability read. |
 | Sign in | `POST /Users/AuthenticateByName` | Body `{Username, Pw}`; returns the access token. |
 | Verify session | `GET /Users/Me` | Tiny authenticated check before streaming (401 ⇒ expired). |
-| List tracks | `GET /Items?IncludeItemTypes=Audio&Recursive=true&…` | Sorted; `Fields=RunTimeTicks`. |
-| List albums | `GET /Items?IncludeItemTypes=MusicAlbum&Recursive=true&…` | `Fields=ProductionYear,ChildCount`. |
-| List artists | `GET /Artists?…` | Dedicated artists endpoint. |
+| List tracks | `GET /Items?IncludeItemTypes=Audio&Recursive=true&…` | Sorted; `Fields=RunTimeTicks`. Paged via `StartIndex`/`Limit`. |
+| List albums | `GET /Items?IncludeItemTypes=MusicAlbum&Recursive=true&…` | `Fields=ProductionYear,ChildCount`. Paged. Best-effort (a failure doesn't sink the track sync). |
+| List artists | `GET /Artists?…` | Dedicated artists endpoint. Paged. Best-effort. |
 | Favourite ids | `GET /Items?Filters=IsFavorite&IncludeItemTypes=Audio&…` | `EnableImages=false`. |
 | Toggle favourite | `POST` / `DELETE /Users/{userId}/FavoriteItems/{itemId}` | POST marks, DELETE clears. |
 | Lyrics | `GET /Audio/{itemId}/Lyrics` | 404 = "no lyrics", a normal outcome. |
@@ -129,9 +129,22 @@ error:
 - **No version-gated request behavior.** The version is read for diagnostics
   only. Do not add `if (version >= x) useEndpointA else useEndpointB` branches;
   prefer endpoints stable across the 10.x line.
-- **Tolerant parsing.** Unknown JSON fields are ignored, a missing `Items`
-  array reads as empty, and malformed entries are skipped, so a server that adds
-  fields won't break listing.
+- **Tolerant parsing.** Unknown JSON fields are ignored and a missing `Items`
+  array reads as empty. Every mapped field is read through a *coercing* helper,
+  so an item that omits a field — or sends it with the **wrong type** (a number
+  where a string is expected, a numeric string for `RunTimeTicks`, …) — yields a
+  safe fallback for that one field instead of throwing. An entry too malformed
+  to use at all (missing `Id`/`Name`, or not an object) is **skipped and
+  counted**, never thrown, so one bad track can't fail the whole sync; the
+  sync then reports "some items could not be synced" rather than an error.
+- **Paginated, bounded reads.** Library listings are pulled in bounded pages
+  (`StartIndex`/`Limit`) with a brief yield between them, so a large/slow
+  library can't time out one unbounded request or hammer the server, and
+  playback/UI stay responsive during a sync. A transient page failure (timeout,
+  dropped connection, 5xx/408/429) is retried a **bounded** number of times with
+  exponential backoff; auth (401/403) and other client errors are never retried.
+  A page that ultimately fails aborts the sync (the previous catalog is kept)
+  rather than committing a truncated library.
 - **`static=true` direct play** is the safest streaming path: it serves the
   original bytes the engine can open, avoiding transcode/HLS negotiation that
   varies between server versions and codecs.

--- a/docs/jellyfin-sync.md
+++ b/docs/jellyfin-sync.md
@@ -112,6 +112,15 @@ favourites and **local-only** playlists are kept.
 - **The first sync is taking a while.** A large library takes a moment to pull;
   the app stays responsive and the Library shows a "syncing" note until the
   tracks land. There's nothing to do but wait — it finishes in the background.
+  The library is pulled in **bounded pages** with brief yields between them, so a
+  big/slow server can't time out one giant request, playback keeps working
+  throughout, and a brief network/server blip is **retried a few times** before
+  it gives up.
+- **"Some items could not be synced."** A few tracks had metadata too malformed
+  to read (a missing title, a wrong-typed field). They are **skipped** so the
+  rest of your library still syncs — this is a calm note, not a failure, and the
+  usable music is fully available. The skipped count is in the debug log /
+  bug-report event trail (kind + counts only, never titles).
 - **"Connected, but the library sync didn't finish."** The connection is fine,
   but the sync hit a snag (server briefly unreachable, an expired session, a
   hiccup saving locally). Tap **Retry** on the Jellyfin card. Your sign-in is

--- a/docs/jellyfin-sync.md
+++ b/docs/jellyfin-sync.md
@@ -122,9 +122,19 @@ favourites and **local-only** playlists are kept.
   usable music is fully available. The skipped count is in the debug log /
   bug-report event trail (kind + counts only, never titles).
 - **"Connected, but the library sync didn't finish."** The connection is fine,
-  but the sync hit a snag (server briefly unreachable, an expired session, a
-  hiccup saving locally). Tap **Retry** on the Jellyfin card. Your sign-in is
-  untouched, and nothing was half-written.
+  but the sync hit a snag (a slow/large listing that timed out, a transient
+  server error, a partial response). When a sync fails, Linthra **probes the
+  live session** (a tiny `/Users/Me` check) to tell apart three cases, so it
+  never shows a misleading message:
+  - **the probe succeeds** → the server and your session are fine and only the
+    *library sync* failed. You'll see "Connected — the library sync didn't
+    finish, but your existing music is still available", your library is kept
+    intact, and **Retry** is the only thing to do. (This is the common case for
+    a large library on a slow server, and it never asks you to sign in.)
+  - **the probe is rejected (401)** → your session really has expired; only then
+    are you asked to sign out and back in.
+  - **the probe also can't reach the server** → a genuine "couldn't reach your
+    Jellyfin server".
 - **Server unreachable.** If the sync can't reach the server, you'll see a
   friendly "couldn't reach your Jellyfin server" message — check the server is
   online and reachable from the device, then Retry.

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -10,6 +10,7 @@ import 'jellyfin_auth_header.dart';
 import 'jellyfin_client.dart';
 import 'jellyfin_endpoints.dart';
 import 'jellyfin_exception.dart';
+import 'jellyfin_sync_diagnostics.dart';
 
 /// The real [JellyfinClient], backed by `package:http`.
 ///
@@ -22,12 +23,53 @@ import 'jellyfin_exception.dart';
 /// Every failure becomes a [JellyfinException]; the password and token are
 /// never written to an exception, so a leaked error string can't expose them.
 class HttpJellyfinClient implements JellyfinClient {
-  HttpJellyfinClient({http.Client? httpClient})
-      : _client = httpClient ?? http.Client();
+  HttpJellyfinClient({
+    http.Client? httpClient,
+    int maxItemFetchAttempts = 3,
+    Duration retryBackoff = const Duration(milliseconds: 400),
+    int itemPageSize = 500,
+    Duration pageGap = const Duration(milliseconds: 30),
+    int maxItemPages = 10000,
+  })  : assert(maxItemFetchAttempts >= 1),
+        assert(itemPageSize >= 1),
+        assert(maxItemPages >= 1),
+        _client = httpClient ?? http.Client(),
+        _maxItemFetchAttempts = maxItemFetchAttempts,
+        _retryBackoff = retryBackoff,
+        _itemPageSize = itemPageSize,
+        _pageGap = pageGap,
+        _maxItemPages = maxItemPages;
 
   final http.Client _client;
 
   static const Duration _timeout = Duration(seconds: 20);
+
+  /// How many times a single library page is attempted before its transient
+  /// failure surfaces — bounded, so a flaky network/server is ridden out but a
+  /// genuinely down one fails in finite time rather than retrying forever.
+  final int _maxItemFetchAttempts;
+
+  /// Base backoff between page retries; the wait grows exponentially per
+  /// attempt. Injectable (and `Duration.zero` in tests) so the retry path is
+  /// covered without slowing the suite.
+  final Duration _retryBackoff;
+
+  /// How many items a single library page requests. Bounds each request so a
+  /// large/slow server can't time out one unbounded fetch of the whole library.
+  final int _itemPageSize;
+
+  /// A brief yield between library pages, to keep playback/UI responsive and
+  /// avoid hammering the server with back-to-back requests. Injectable (zero in
+  /// tests) so pagination is covered without real delays.
+  final Duration _pageGap;
+
+  /// An absolute backstop on how many pages one listing will fetch. A real
+  /// server always advances `StartIndex` (or reports a `TotalRecordCount`), so
+  /// this only ever bites a broken server that ignores paging and would
+  /// otherwise loop forever; at the default page size it still allows millions
+  /// of items — far beyond any real music library. Injectable so a test can
+  /// drive the backstop without 10,000 pages.
+  final int _maxItemPages;
 
   @override
   Future<JellyfinServerInfo> fetchServerInfo(String baseUrl) async {
@@ -80,41 +122,105 @@ class HttpJellyfinClient implements JellyfinClient {
   }
 
   @override
-  Future<List<JellyfinItemDto>> fetchItems(
+  Future<JellyfinItemListing> fetchItems(
     JellyfinSession session, {
     required JellyfinItemKind kind,
   }) async {
-    final Uri uri = JellyfinEndpoints.items(
-      session.baseUrl,
-      userId: session.userId,
-      kind: kind,
-    );
-    final http.Response response = await _send(
-      () => _client.get(uri, headers: <String, String>{
-        'Accept': 'application/json',
-        'Authorization':
-            JellyfinAuthHeader.forToken(session.deviceId, session.accessToken),
-      }),
-    );
-    _checkStatus(response);
-
-    final Map<String, dynamic> json = _decodeObject(response);
-    final Object? rawItems = json['Items'];
-    if (rawItems is! List) {
-      // A valid but empty library, or a shape we don't recognize — treat as
-      // "nothing to list" rather than an error.
-      return const <JellyfinItemDto>[];
-    }
     final List<JellyfinItemDto> items = <JellyfinItemDto>[];
-    for (final Object? entry in rawItems) {
-      if (entry is Map<String, dynamic>) {
-        final JellyfinItemDto? dto = JellyfinItemDto.fromJson(entry);
-        if (dto != null) {
-          items.add(dto);
-        }
+    int skipped = 0;
+    int startIndex = 0;
+    int page = 0;
+
+    // Page through the whole library in bounded chunks. A page-level transient
+    // failure is retried inside `_sendRetrying`; if it ultimately fails it
+    // *throws* here — so the caller keeps the previous catalog rather than
+    // committing a truncated one — while a single unparseable *item* is skipped
+    // (counted, never thrown) so one bad track can't fail the whole sync.
+    while (true) {
+      // Absolute backstop: stop (and flag the truncation) if a broken server
+      // ignores paging and would otherwise loop forever. A real server always
+      // advances or reports a total, so this never fires in practice.
+      if (page >= _maxItemPages) {
+        JellyfinSyncDiagnostics.capped(kind: kind, pages: page);
+        break;
       }
+      page++;
+
+      final Uri uri = JellyfinEndpoints.items(
+        session.baseUrl,
+        userId: session.userId,
+        kind: kind,
+        startIndex: startIndex,
+        limit: _itemPageSize,
+      );
+      final http.Response response = await _sendRetrying(
+        () => _client.get(uri, headers: <String, String>{
+          'Accept': 'application/json',
+          'Authorization': JellyfinAuthHeader.forToken(
+              session.deviceId, session.accessToken),
+        }),
+        kind: kind,
+      );
+      _checkStatus(response);
+
+      final Map<String, dynamic> json = _decodeObject(response);
+      final Object? rawItems = json['Items'];
+      if (rawItems is! List) {
+        // A valid but empty library, or a shape we don't recognize — stop here
+        // rather than treating it as an error.
+        break;
+      }
+
+      for (final Object? entry in rawItems) {
+        if (entry is! Map<String, dynamic>) {
+          skipped++;
+          continue;
+        }
+        final JellyfinItemDto? dto = _parseItem(entry);
+        if (dto == null) {
+          skipped++;
+          continue;
+        }
+        items.add(dto);
+      }
+
+      final int received = rawItems.length;
+      startIndex += received;
+
+      final Object? rawTotal = json['TotalRecordCount'];
+      final int? total = rawTotal is num ? rawTotal.toInt() : null;
+      final bool reachedTotal = total != null && startIndex >= total;
+
+      // Stop on the server's own total, on a short (final) page, or on an empty
+      // page. (A server that returns a *full* page forever is caught by the
+      // page-count backstop at the top of the loop instead.)
+      if (received == 0 || received < _itemPageSize || reachedTotal) {
+        break;
+      }
+
+      await _pageDelay();
     }
-    return items;
+
+    JellyfinSyncDiagnostics.skipped(
+      kind: kind,
+      skipped: skipped,
+      kept: items.length,
+    );
+    return JellyfinItemListing(items: items, skippedCount: skipped);
+  }
+
+  /// Parses one wire entry into a DTO, or `null` when it is unusable.
+  ///
+  /// Defence-in-depth: [JellyfinItemDto.fromJson] already coerces every field
+  /// so it shouldn't throw, but guarding here guarantees one malformed entry is
+  /// skipped — never propagated — even if a future field is added without a
+  /// coercing read.
+  static JellyfinItemDto? _parseItem(Map<String, dynamic> entry) {
+    try {
+      return JellyfinItemDto.fromJson(entry);
+    } catch (_) {
+      return null;
+    }
   }
 
   @override
@@ -477,6 +583,76 @@ class HttpJellyfinClient implements JellyfinClient {
     }
   }
 
+  /// Like [_send] but bounded-retries *transient* failures — a timeout, a
+  /// dropped connection, or a retryable server status (5xx / 408 / 429) — with
+  /// exponential backoff, for the idempotent paged reads [fetchItems] makes.
+  ///
+  /// Auth (401/403) and other client errors are returned unretried for
+  /// [_checkStatus] to map (retrying them is pointless and could lock an
+  /// account out). Non-idempotent writes deliberately keep using single-shot
+  /// [_send] so a retried POST can't double-apply. After the last attempt a
+  /// retryable status is returned as-is so [_checkStatus] still maps it to a
+  /// friendly error; a transient transport failure throws "not reachable".
+  Future<http.Response> _sendRetrying(
+    Future<http.Response> Function() request, {
+    required JellyfinItemKind kind,
+  }) async {
+    JellyfinException lastTransport = JellyfinException.notReachable();
+    for (int attempt = 1; attempt <= _maxItemFetchAttempts; attempt++) {
+      if (attempt > 1) {
+        JellyfinSyncDiagnostics.retry(
+          kind: kind,
+          attempt: attempt,
+          maxAttempts: _maxItemFetchAttempts,
+        );
+        await _backoff(attempt);
+      }
+      final http.Response response;
+      try {
+        response = await request().timeout(_timeout);
+      } on TimeoutException {
+        lastTransport = JellyfinException.notReachable();
+        continue;
+      } on http.ClientException {
+        lastTransport = JellyfinException.notReachable();
+        continue;
+      } on Exception {
+        lastTransport = JellyfinException.notReachable();
+        continue;
+      }
+      final bool canRetryAgain = attempt < _maxItemFetchAttempts;
+      if (canRetryAgain && _isRetryableStatus(response.statusCode)) {
+        continue;
+      }
+      return response;
+    }
+    throw lastTransport;
+  }
+
+  /// Whether an HTTP status is worth retrying: a server-side 5xx, a request
+  /// timeout (408), or a rate-limit (429). A 4xx like 401/403/404 is the
+  /// server's settled answer and is never retried.
+  static bool _isRetryableStatus(int code) =>
+      code >= 500 || code == 408 || code == 429;
+
+  /// Exponential backoff before a page retry: base, 2×, 4× … per attempt. A
+  /// `Duration.zero` base (tests) waits not at all, keeping the retry path fast
+  /// to cover.
+  Future<void> _backoff(int attempt) {
+    if (_retryBackoff == Duration.zero) return Future<void>.value();
+    // `attempt` is >= 2 here (attempt 1 never backs off), so the factor is
+    // 1, 2, 4, … for attempts 2, 3, 4 …
+    final int factor = 1 << (attempt - 2);
+    return Future<void>.delayed(_retryBackoff * factor);
+  }
+
+  /// A brief yield between library pages (see [_pageGap]). Zero-cost when the
+  /// gap is `Duration.zero` (tests).
+  Future<void> _pageDelay() {
+    if (_pageGap == Duration.zero) return Future<void>.value();
+    return Future<void>.delayed(_pageGap);
+  }
+
   /// Maps an HTTP status to a [JellyfinException]. 2xx passes; everything else
   /// throws before the body is parsed, so error handling never depends on
   /// response content (and never echoes it).
@@ -489,6 +665,15 @@ class HttpJellyfinClient implements JellyfinClient {
       throw JellyfinException.unauthorized();
     }
     if (code >= 500) {
+      throw JellyfinException.serverError(code);
+    }
+    if (code == 408 || code == 429) {
+      // A request timeout or a rate-limit (often a Cloudflare/reverse-proxy
+      // 429) is *transient*, not a wrong address — surface it as a server error
+      // so the sync's calm "try again in a moment" path is taken rather than the
+      // misleading "doesn't look like a Jellyfin server". Matches the retryable
+      // set in `_isRetryableStatus`, so a persistent one that outlived its
+      // retries still reads honestly.
       throw JellyfinException.serverError(code);
     }
     // Other 4xx (wrong path, Cloudflare 4xx, …) usually mean the address isn't

--- a/lib/core/sources/jellyfin/jellyfin_api.dart
+++ b/lib/core/sources/jellyfin/jellyfin_api.dart
@@ -201,20 +201,19 @@ class JellyfinItemDto {
   /// builds an artwork URL when there's actually an image to fetch.
   final bool hasPrimaryImage;
 
-  /// Parses one item, or returns `null` when it lacks an id/name (skipped by
-  /// the caller) so a single malformed entry can't break a whole listing.
+  /// Parses one item, or returns `null` when it lacks a usable id/name (skipped
+  /// by the caller) so a single malformed entry can't break a whole listing.
+  ///
+  /// Tolerant by construction: every optional field is read through a *coercing*
+  /// helper ([_string], [_int], [_stringList]) rather than a raw `as` cast, so a
+  /// weird server that sends a number where a string is expected (or vice versa)
+  /// yields a safe fallback (`null`/empty) for that one field instead of
+  /// throwing a `TypeError` that would abort the whole sync. Only a missing or
+  /// blank id/name — an item Linthra cannot reference or label — is rejected.
   static JellyfinItemDto? fromJson(Map<String, dynamic> json) {
-    final String? id = json['Id'] as String?;
-    final String? name = json['Name'] as String?;
-    if (id == null || id.isEmpty || name == null) return null;
-
-    final Object? rawArtists = json['Artists'];
-    final List<String> artists = rawArtists is List
-        ? <String>[
-            for (final Object? a in rawArtists)
-              if (a is String && a.isNotEmpty) a,
-          ]
-        : const <String>[];
+    final String? id = _string(json['Id']);
+    final String? name = _string(json['Name']);
+    if (id == null || id.isEmpty || name == null || name.isEmpty) return null;
 
     final Object? imageTags = json['ImageTags'];
     final bool hasPrimary = imageTags is Map && imageTags['Primary'] != null;
@@ -222,17 +221,81 @@ class JellyfinItemDto {
     return JellyfinItemDto(
       id: id,
       name: name,
-      album: json['Album'] as String?,
-      albumId: json['AlbumId'] as String?,
-      albumArtist: json['AlbumArtist'] as String?,
-      artists: artists,
-      runTimeTicks: (json['RunTimeTicks'] as num?)?.toInt(),
-      indexNumber: (json['IndexNumber'] as num?)?.toInt(),
-      productionYear: (json['ProductionYear'] as num?)?.toInt(),
-      childCount: (json['ChildCount'] as num?)?.toInt(),
+      album: _string(json['Album']),
+      albumId: _string(json['AlbumId']),
+      albumArtist: _string(json['AlbumArtist']),
+      artists: _stringList(json['Artists']),
+      runTimeTicks: _int(json['RunTimeTicks']),
+      indexNumber: _int(json['IndexNumber']),
+      productionYear: _int(json['ProductionYear']),
+      childCount: _int(json['ChildCount']),
       hasPrimaryImage: hasPrimary,
     );
   }
+
+  /// A trimmed non-empty [String] from a wire value, or `null` for anything
+  /// else (a number, bool, list, missing, or blank). Trimming means a field
+  /// that is all whitespace reads as absent rather than a blank label.
+  static String? _string(Object? value) {
+    if (value is! String) return null;
+    final String trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  /// An [int] from a wire value, accepting the JSON `num` Jellyfin normally
+  /// sends *and* a numeric string some plugins/proxies emit. Returns `null` for
+  /// anything non-numeric (a non-number string, bool, list, …) so one weird
+  /// field never throws.
+  static int? _int(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) {
+      final String trimmed = value.trim();
+      // Symmetric with the `num` path: a fractional numeric string ("123.9")
+      // truncates exactly like the JSON number 123.9 would, rather than being
+      // dropped because `int.tryParse` rejects the decimal point.
+      return int.tryParse(trimmed) ?? double.tryParse(trimmed)?.toInt();
+    }
+    return null;
+  }
+
+  /// The non-empty strings from a wire list, or an empty list when the value
+  /// isn't a list at all. Non-string entries inside the list are dropped rather
+  /// than throwing, so a partially malformed `Artists` array still yields the
+  /// good names.
+  static List<String> _stringList(Object? value) {
+    if (value is! List) return const <String>[];
+    return <String>[
+      for (final Object? entry in value)
+        if (entry is String && entry.trim().isNotEmpty) entry.trim(),
+    ];
+  }
+}
+
+/// The outcome of listing one [JellyfinItemKind] from the server: the items
+/// that parsed cleanly, plus how many wire entries were **skipped** because
+/// they were too malformed to use (missing id/name, or not an object).
+///
+/// Carrying [skippedCount] alongside the items lets a sync stay tolerant —
+/// drop the bad entries rather than fail — while still telling the user, calmly,
+/// that "some items could not be synced". It is a plain count, never the raw
+/// entries, so nothing sensitive rides along.
+class JellyfinItemListing {
+  const JellyfinItemListing({
+    required this.items,
+    this.skippedCount = 0,
+  });
+
+  /// An empty listing (nothing fetched, nothing skipped) — the "valid but empty
+  /// library" outcome a missing `Items` array maps to.
+  static const JellyfinItemListing empty =
+      JellyfinItemListing(items: <JellyfinItemDto>[]);
+
+  /// The items that parsed into a usable DTO, in server order.
+  final List<JellyfinItemDto> items;
+
+  /// How many wire entries were dropped as unparseable across every page.
+  final int skippedCount;
 }
 
 /// A playlist item from `GET /Users/<userId>/Items?IncludeItemTypes=Playlist`.

--- a/lib/core/sources/jellyfin/jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/jellyfin_client.dart
@@ -31,7 +31,16 @@ abstract interface class JellyfinClient {
   });
 
   /// Lists library items of one [kind] for the signed-in user in [session].
-  Future<List<JellyfinItemDto>> fetchItems(
+  ///
+  /// Pulls the whole library in bounded pages (so a large/slow server can't
+  /// time out a single unbounded request) and is tolerant per item: an entry
+  /// too malformed to use is skipped, never thrown, and counted in the returned
+  /// [JellyfinItemListing.skippedCount]. A transient network/5xx failure is
+  /// retried a bounded number of times before it surfaces as a
+  /// [JellyfinException]; auth (401/403) and other client errors are not
+  /// retried. A failure *between* pages throws (so the caller keeps the
+  /// previous catalog) rather than returning a truncated listing.
+  Future<JellyfinItemListing> fetchItems(
     JellyfinSession session, {
     required JellyfinItemKind kind,
   });

--- a/lib/core/sources/jellyfin/jellyfin_endpoints.dart
+++ b/lib/core/sources/jellyfin/jellyfin_endpoints.dart
@@ -61,11 +61,23 @@ abstract final class JellyfinEndpoints {
   ///
   /// Audio and albums share `/Items` filtered by type; artists have their own
   /// `/Artists` endpoint. The sort/field choices match what Linthra maps.
+  ///
+  /// [startIndex] and [limit] page the listing (`StartIndex`/`Limit`, the
+  /// standard Jellyfin paging params) so a large library is pulled in bounded
+  /// chunks rather than one unbounded request that can time out on a big/slow
+  /// server. They are stable across the 10.x line and ignored by servers that
+  /// don't paginate, so adding them is always safe.
   static Uri items(
     String baseUrl, {
     required String userId,
     required JellyfinItemKind kind,
+    int? startIndex,
+    int? limit,
   }) {
+    final Map<String, String> paging = <String, String>{
+      if (startIndex != null) 'StartIndex': '$startIndex',
+      if (limit != null) 'Limit': '$limit',
+    };
     switch (kind) {
       case JellyfinItemKind.audio:
         return _join(baseUrl, _itemsPath).replace(
@@ -76,6 +88,7 @@ abstract final class JellyfinEndpoints {
             'SortBy': 'AlbumArtist,Album,IndexNumber,SortName',
             'SortOrder': 'Ascending',
             'Fields': 'RunTimeTicks',
+            ...paging,
           },
         );
       case JellyfinItemKind.album:
@@ -87,6 +100,7 @@ abstract final class JellyfinEndpoints {
             'SortBy': 'AlbumArtist,SortName',
             'SortOrder': 'Ascending',
             'Fields': 'ProductionYear,ChildCount',
+            ...paging,
           },
         );
       case JellyfinItemKind.artist:
@@ -95,6 +109,7 @@ abstract final class JellyfinEndpoints {
             userIdParam: userId,
             'SortBy': 'SortName',
             'SortOrder': 'Ascending',
+            ...paging,
           },
         );
     }

--- a/lib/core/sources/jellyfin/jellyfin_music_source.dart
+++ b/lib/core/sources/jellyfin/jellyfin_music_source.dart
@@ -48,32 +48,74 @@ class JellyfinMusicSource
 
   @override
   Future<List<Track>> fetchTracks() async {
-    final List<JellyfinItemDto> items =
+    final JellyfinItemListing listing =
         await _client.fetchItems(session, kind: JellyfinItemKind.audio);
     return <Track>[
-      for (final JellyfinItemDto item in items)
+      for (final JellyfinItemDto item in listing.items)
         JellyfinTrackMapper.toTrack(item, baseUrl: session.baseUrl),
     ];
   }
 
   @override
   Future<List<Album>> fetchAlbums() async {
-    final List<JellyfinItemDto> items =
+    final JellyfinItemListing listing =
         await _client.fetchItems(session, kind: JellyfinItemKind.album);
     return <Album>[
-      for (final JellyfinItemDto item in items)
+      for (final JellyfinItemDto item in listing.items)
         JellyfinTrackMapper.toAlbum(item, baseUrl: session.baseUrl),
     ];
   }
 
   @override
   Future<List<Artist>> fetchArtists() async {
-    final List<JellyfinItemDto> items =
+    final JellyfinItemListing listing =
         await _client.fetchItems(session, kind: JellyfinItemKind.artist);
     return <Artist>[
-      for (final JellyfinItemDto item in items)
+      for (final JellyfinItemDto item in listing.items)
         JellyfinTrackMapper.toArtist(item, baseUrl: session.baseUrl),
     ];
+  }
+
+  /// Pulls the whole library for a sync in one call: [Track]s — the only slice
+  /// the catalog persists and the part a sync exists to deliver — plus albums
+  /// and artists as **best-effort** extras, and a count of track entries the
+  /// server returned that were too malformed to map.
+  ///
+  /// Tracks are fetched first, so any *global* failure (an expired session, an
+  /// unreachable server, a 5xx that outlived its retries) throws here and aborts
+  /// the sync — leaving the previous catalog untouched. Albums and artists are
+  /// then fetched independently and a [JellyfinException] in either is swallowed
+  /// to an empty list: they are secondary (the Library derives them from tracks
+  /// and the durable catalog doesn't store them), so a hiccup reading them must
+  /// never sink an otherwise-good track sync.
+  Future<JellyfinLibrarySync> fetchLibraryForSync() async {
+    final JellyfinItemListing trackListing =
+        await _client.fetchItems(session, kind: JellyfinItemKind.audio);
+    final List<Track> tracks = <Track>[
+      for (final JellyfinItemDto item in trackListing.items)
+        JellyfinTrackMapper.toTrack(item, baseUrl: session.baseUrl),
+    ];
+    return JellyfinLibrarySync(
+      tracks: tracks,
+      albums: await _bestEffort(fetchAlbums, const <Album>[]),
+      artists: await _bestEffort(fetchArtists, const <Artist>[]),
+      skippedCount: trackListing.skippedCount,
+    );
+  }
+
+  /// Runs [fetch] and returns its result, or [fallback] if it raises a
+  /// [JellyfinException] — the best-effort wrapper for the secondary
+  /// albums/artists reads. Only the typed Jellyfin failure is swallowed; an
+  /// unexpected error still propagates so it isn't masked.
+  Future<List<T>> _bestEffort<T>(
+    Future<List<T>> Function() fetch,
+    List<T> fallback,
+  ) async {
+    try {
+      return await fetch();
+    } on JellyfinException {
+      return fallback;
+    }
   }
 
   /// Confirms the session is still valid and the server reachable, so the
@@ -177,4 +219,25 @@ class JellyfinMusicSource
       track.uri.startsWith(JellyfinTrackMapper.uriScheme)
           ? track.uri.substring(JellyfinTrackMapper.uriScheme.length)
           : track.id;
+}
+
+/// The result of [JellyfinMusicSource.fetchLibraryForSync]: the mapped catalog
+/// plus the number of track entries dropped as unparseable, so the sync can
+/// commit the good data and report skips calmly ("some items could not be
+/// synced") instead of failing outright.
+class JellyfinLibrarySync {
+  const JellyfinLibrarySync({
+    required this.tracks,
+    required this.albums,
+    required this.artists,
+    required this.skippedCount,
+  });
+
+  final List<Track> tracks;
+  final List<Album> albums;
+  final List<Artist> artists;
+
+  /// How many track entries the server returned that were too malformed to map
+  /// (missing id/name, or not an object). Zero on a clean sync.
+  final int skippedCount;
 }

--- a/lib/core/sources/jellyfin/jellyfin_sync_diagnostics.dart
+++ b/lib/core/sources/jellyfin/jellyfin_sync_diagnostics.dart
@@ -53,6 +53,32 @@ abstract final class JellyfinSyncDiagnostics {
     );
   }
 
+  /// Records a classified sync failure for diagnostics: the failure [category]
+  /// (the error-kind name), the HTTP [statusCode] when one is known, the
+  /// [action] being synced (e.g. `library`), and whether the follow-up
+  /// reachability/auth probe found the server [reachable] and the session
+  /// [authOk] (`null` when not probed). This is exactly the breakdown needed to
+  /// tell "server unreachable" from "connected but sync failed" from "sign in
+  /// again" in a bug report — and is secret-free: category/action are fixed
+  /// labels, the status is a number, the probe results are booleans. No URL,
+  /// token, title, or raw error rides along.
+  static void failure({
+    required String category,
+    required String action,
+    int? statusCode,
+    bool? reachable,
+    bool? authOk,
+  }) {
+    String tri(bool? v) => v == null ? 'unknown' : (v ? 'yes' : 'no');
+    final String detail = 'fail:$action category=$category '
+        'status=${statusCode ?? '-'} '
+        'reachable=${tri(reachable)} auth=${tri(authOk)}';
+    SafeEventLog.instance.record('jellyfin-sync', detail);
+    if (kDebugMode) {
+      developer.log(detail, name: name);
+    }
+  }
+
   /// Records that paging [kind] hit the safety page cap and stopped early after
   /// [pages] pages — a backstop that only fires for a server that ignores
   /// `StartIndex` (a real one always advances or reports a total). Mirrored to

--- a/lib/core/sources/jellyfin/jellyfin_sync_diagnostics.dart
+++ b/lib/core/sources/jellyfin/jellyfin_sync_diagnostics.dart
@@ -1,0 +1,68 @@
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+
+import '../../diagnostics/safe_event_log.dart';
+import 'jellyfin_api.dart';
+
+/// Debug-only, secret-free breadcrumbs for Jellyfin library sync.
+///
+/// Surfaces *why* a sync skipped, retried, or paged the way it did — counts and
+/// fixed labels only — so a partial or slow sync is diagnosable from a debug log
+/// and the "Report a bug" event trail, without anyone re-running it. It mirrors
+/// the plugin-free, static style of [LocalScanDiagnostics] /
+/// `PlaybackDiagnostics`.
+///
+/// Secret-free by construction: there is no parameter for a token, password,
+/// authenticated URL, server address, or item title — only the item *kind*
+/// (an enum name) and structural counts. So nothing sensitive can be recorded,
+/// in a debug log or the release-visible [SafeEventLog].
+abstract final class JellyfinSyncDiagnostics {
+  /// The developer-log channel these breadcrumbs go to (debug builds only).
+  static const String name = 'linthra.jellyfin.sync';
+
+  /// Records that a listing dropped [skipped] unparseable entries (keeping
+  /// [kept]) for one [kind]. Silent when nothing was skipped, so a clean sync
+  /// leaves no noise.
+  static void skipped({
+    required JellyfinItemKind kind,
+    required int skipped,
+    required int kept,
+  }) {
+    if (skipped <= 0) return;
+    final String detail = 'skip:${kind.name} dropped=$skipped kept=$kept';
+    SafeEventLog.instance.record('jellyfin-sync', detail);
+    if (kDebugMode) {
+      developer.log(detail, name: name);
+    }
+  }
+
+  /// Records that a paged read retried after a transient failure on [kind]
+  /// (attempt [attempt] of [maxAttempts]). A debug-only signal — it is not
+  /// mirrored into the release event log, to keep that trail to outcomes rather
+  /// than every transient blip.
+  static void retry({
+    required JellyfinItemKind kind,
+    required int attempt,
+    required int maxAttempts,
+  }) {
+    if (!kDebugMode) return;
+    developer.log(
+      'retry:${kind.name} attempt=$attempt/$maxAttempts',
+      name: name,
+    );
+  }
+
+  /// Records that paging [kind] hit the safety page cap and stopped early after
+  /// [pages] pages — a backstop that only fires for a server that ignores
+  /// `StartIndex` (a real one always advances or reports a total). Mirrored to
+  /// the event log because it means the listing was *truncated*, which the
+  /// "No silent caps" rule says must be visible rather than read as complete.
+  static void capped({required JellyfinItemKind kind, required int pages}) {
+    final String detail = 'cap:${kind.name} pages=$pages';
+    SafeEventLog.instance.record('jellyfin-sync', detail);
+    if (kDebugMode) {
+      developer.log(detail, name: name);
+    }
+  }
+}

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -343,10 +343,14 @@ class _ConnectedView extends StatelessWidget {
         if (syncState.isError) ...[
           const SizedBox(height: AppSpacing.sm),
           // Keep the connection plainly intact ("you're still signed in"), then
-          // the specific, secret-free reason from the sync controller, then a
-          // clear way to try again.
-          const _StatusLine(
-            message: "Connected, but the library sync didn't finish.",
+          // the specific, secret-free reason from the sync controller. For a
+          // rejected session we frame it as "needs refreshing" and point at
+          // sign-in; every other failure is transient and offers Retry.
+          _StatusLine(
+            message: syncState.needsSignIn
+                ? "You're still signed in, but your Jellyfin session needs "
+                    'refreshing.'
+                : "Connected, but the library sync didn't finish.",
             isError: true,
           ),
           if (syncState.message != null) ...[
@@ -354,17 +358,22 @@ class _ConnectedView extends StatelessWidget {
             _StatusLine(message: syncState.message!, isError: true),
           ],
           const SizedBox(height: AppSpacing.sm),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: OutlinedButton.icon(
-              onPressed: onSync,
-              icon: const Icon(Icons.refresh, size: 18),
-              label: const Text('Retry sync'),
+          // A rejected session won't be fixed by re-running the same sync, so
+          // point at the "Sign out & clear" action below instead of a Retry
+          // that would just fail again. Every other failure is transient.
+          if (!syncState.needsSignIn)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                onPressed: onSync,
+                icon: const Icon(Icons.refresh, size: 18),
+                label: const Text('Retry sync'),
+              ),
             ),
-          ),
         ] else if (syncState.message != null) ...[
           // Syncing ("Syncing your Jellyfin library…") or the success summary
-          // ("Synced N tracks…"); both read as friendly status, not an error.
+          // ("Synced N tracks…", possibly "Some items could not be synced");
+          // both read as friendly status, not an error.
           const SizedBox(height: AppSpacing.sm),
           _StatusLine(message: syncState.message!, isError: false),
         ],

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -345,12 +345,17 @@ class _ConnectedView extends StatelessWidget {
           // Keep the connection plainly intact ("you're still signed in"), then
           // the specific, secret-free reason from the sync controller. For a
           // rejected session we frame it as "needs refreshing" and point at
-          // sign-in; every other failure is transient and offers Retry.
+          // sign-in; when the server is reachable but the library sync failed we
+          // reassure the existing library is intact; every other failure is
+          // transient and offers Retry.
           _StatusLine(
             message: syncState.needsSignIn
                 ? "You're still signed in, but your Jellyfin session needs "
                     'refreshing.'
-                : "Connected, but the library sync didn't finish.",
+                : syncState.connectionOkButSyncFailed
+                    ? 'Connected — the library sync didn\'t finish, but your '
+                        'existing music is still available.'
+                    : "Connected, but the library sync didn't finish.",
             isError: true,
           ),
           if (syncState.message != null) ...[

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -108,18 +108,34 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
     _syncing = true;
     state = const JellyfinSyncState.syncing();
     try {
-      final tracks = await source.fetchTracks();
-      final albums = await source.fetchAlbums();
-      final artists = await source.fetchArtists();
+      // One tolerant pull: tracks (the catalog that matters) plus best-effort
+      // albums/artists, and a count of entries too malformed to map. A bad item
+      // is skipped here, not thrown; a global failure (auth/unreachable/5xx)
+      // throws below and leaves the old catalog intact.
+      final JellyfinLibrarySync library = await source.fetchLibraryForSync();
 
-      // Upsert only when there's something to store, so an empty fetch can
-      // never wipe an existing catalog.
-      if (tracks.isNotEmpty) {
+      // Cancellation safety: if the user signed out or switched servers/users
+      // while the (possibly long) fetch ran, the live source is gone or
+      // different. Don't commit this now-stale result over the current
+      // account's catalog. Reset to idle before bailing — leaving the abandoned
+      // run's `syncing()` state would pin the card on a perpetual "Syncing…"
+      // spinner for the *new* account (whose own sync drives the card from
+      // here); the catalog the active source left is untouched.
+      if (!_isStillCurrent(source)) {
+        state = const JellyfinSyncState();
+        return;
+      }
+
+      // Upsert only when there's something to store, so an empty (or
+      // all-skipped) fetch can never wipe an existing catalog. The write
+      // replaces the slice atomically, so the old library stays visible until a
+      // valid new one is ready to commit.
+      if (library.tracks.isNotEmpty) {
         await ref.read(musicLibraryRepositoryProvider).upsertCatalog(
               sourceId: source.id,
-              tracks: tracks,
-              albums: albums,
-              artists: artists,
+              tracks: library.tracks,
+              albums: library.albums,
+              artists: library.artists,
             );
         // Reload the Library so the freshly synced tracks show up immediately.
         await ref.read(libraryControllerProvider.notifier).refresh();
@@ -132,13 +148,15 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
       final FavoritesSyncResult favorites = await _refreshFavorites();
 
       state = JellyfinSyncState.success(
-        trackCount: tracks.length,
+        trackCount: library.tracks.length,
+        skippedCount: library.skippedCount,
         playlistCount: playlists.didSync ? playlists.playlistCount : 0,
         favoriteCount: favorites.didSync ? favorites.favoriteCount : 0,
         playlistsFailed: playlists.didFail,
         favoritesFailed: favorites.didFail,
         message: _composeMessage(
-          trackCount: tracks.length,
+          trackCount: library.tracks.length,
+          skippedCount: library.skippedCount,
           playlists: playlists,
           favorites: favorites,
         ),
@@ -157,7 +175,13 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
         }
       }
     } on JellyfinException catch (error) {
-      state = JellyfinSyncState.error(_friendlyMessage(error));
+      // A typed failure: surface a friendly line *and* a typed reason so the UI
+      // can offer the right next step (reconnect vs retry) instead of one
+      // generic error.
+      state = JellyfinSyncState.error(
+        _friendlyMessage(error),
+        reason: _failureReason(error.kind),
+      );
     } catch (_) {
       // A non-Jellyfin failure (e.g. the local store): keep it generic and
       // secret-free rather than dumping a raw error.
@@ -190,11 +214,13 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
   }
 
   /// Builds the friendly success line from what actually synced: tracks,
-  /// playlists, and favourites that came across, plus an honest note for any
-  /// part that couldn't load — so a partial failure reads clearly. All values
-  /// are display-safe; no secret can reach here.
+  /// playlists, and favourites that came across, plus a calm note for any items
+  /// skipped or any part that couldn't load — so a partial outcome reads clearly
+  /// ("Some items could not be synced") rather than as a scary failure. All
+  /// values are display-safe; no secret can reach here.
   String _composeMessage({
     required int trackCount,
+    required int skippedCount,
     required PlaylistSyncResult playlists,
     required FavoritesSyncResult favorites,
   }) {
@@ -215,7 +241,9 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
     if (playlists.didFail) failures.add('playlists could not be loaded');
     if (favorites.didFail) failures.add('favorites could not be synced');
 
-    if (synced.isEmpty && failures.isEmpty) {
+    // Nothing came across, nothing was skipped, nothing failed: a genuinely
+    // empty library.
+    if (synced.isEmpty && skippedCount == 0 && failures.isEmpty) {
       return 'Your Jellyfin library looks empty — nothing to sync yet.';
     }
 
@@ -223,11 +251,55 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
     if (synced.isNotEmpty) {
       message.write('Synced ${_joinAnd(synced)} from your Jellyfin library.');
     }
+
+    // A calm, non-scary note for entries that couldn't be mapped — never a raw
+    // error, just "some items could not be synced".
+    if (skippedCount > 0) {
+      if (message.isNotEmpty) message.write(' ');
+      message.write(
+        synced.isEmpty
+            ? 'Some items in your Jellyfin library could not be synced.'
+            : 'Some items could not be synced.',
+      );
+    }
+
     if (failures.isNotEmpty) {
       if (message.isNotEmpty) message.write(' ');
       message.write('${_capitalize(_joinAnd(failures))}.');
     }
     return message.toString();
+  }
+
+  /// Whether [source] is still the live Jellyfin source for the *current*
+  /// account — i.e. the user hasn't signed out or switched servers/users while
+  /// this sync's fetch was in flight. Compared by session value, so a sign-out
+  /// (the source goes null) or a reconnect as a different account makes a
+  /// mid-flight sync abort instead of committing stale data.
+  bool _isStillCurrent(JellyfinMusicSource source) {
+    final JellyfinMusicSource? live = ref.read(jellyfinMusicSourceProvider);
+    return live != null && live.session == source.session;
+  }
+
+  /// Maps a typed Jellyfin failure to the calm next step the UI should offer:
+  /// reconnect for a rejected session, "try again" for an unreachable or
+  /// briefly-erroring server, and a neutral retry otherwise.
+  JellyfinSyncFailureReason _failureReason(JellyfinErrorKind kind) {
+    switch (kind) {
+      case JellyfinErrorKind.notReachable:
+        return JellyfinSyncFailureReason.serverUnreachable;
+      case JellyfinErrorKind.unauthorized:
+        return JellyfinSyncFailureReason.signInRequired;
+      case JellyfinErrorKind.serverError:
+        return JellyfinSyncFailureReason.retryLater;
+      case JellyfinErrorKind.invalidUrl:
+      case JellyfinErrorKind.notJellyfin:
+      case JellyfinErrorKind.webPage:
+      case JellyfinErrorKind.notAudioStream:
+      case JellyfinErrorKind.streamUnavailable:
+      case JellyfinErrorKind.unsupportedResponse:
+      case JellyfinErrorKind.unexpected:
+        return JellyfinSyncFailureReason.generic;
+    }
   }
 
   /// Joins parts with commas and a trailing "and": `["a"]` → "a";

--- a/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_controller.dart
@@ -5,6 +5,7 @@ import '../../../core/repositories/remote_sync_result.dart';
 import '../../../core/sources/jellyfin/jellyfin_account_fingerprint.dart';
 import '../../../core/sources/jellyfin/jellyfin_exception.dart';
 import '../../../core/sources/jellyfin/jellyfin_music_source.dart';
+import '../../../core/sources/jellyfin/jellyfin_sync_diagnostics.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../../data/repositories/jellyfin_auto_sync_store_provider.dart';
 import '../../../data/repositories/music_library_repository_provider.dart';
@@ -175,12 +176,17 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
         }
       }
     } on JellyfinException catch (error) {
-      // A typed failure: surface a friendly line *and* a typed reason so the UI
-      // can offer the right next step (reconnect vs retry) instead of one
-      // generic error.
+      // A typed failure. Classify it by *probing the live session*, so a
+      // library-sync failure on a reachable server (a slow/large listing, a
+      // transient error, a partial response) isn't mislabeled "couldn't reach
+      // server" or "sign in again" — the misleading case seen in the field where
+      // the app had clearly reached the server (it knew the name/version) yet
+      // reported it unreachable. The probe also records a diagnostics breadcrumb.
+      final JellyfinSyncFailureReason reason =
+          await _classifyFailure(source, error);
       state = JellyfinSyncState.error(
-        _friendlyMessage(error),
-        reason: _failureReason(error.kind),
+        _messageForReason(reason, error),
+        reason: reason,
       );
     } catch (_) {
       // A non-Jellyfin failure (e.g. the local store): keep it generic and
@@ -280,10 +286,68 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
     return live != null && live.session == source.session;
   }
 
-  /// Maps a typed Jellyfin failure to the calm next step the UI should offer:
-  /// reconnect for a rejected session, "try again" for an unreachable or
-  /// briefly-erroring server, and a neutral retry otherwise.
-  JellyfinSyncFailureReason _failureReason(JellyfinErrorKind kind) {
+  /// Classifies a sync [error] into the calm next step the UI should offer, by
+  /// *probing the live session* rather than blindly trusting the sync error's
+  /// kind.
+  ///
+  /// This is the fix for the misleading field case: a slow/large listing that
+  /// times out mid-sync throws [JellyfinErrorKind.notReachable] even though the
+  /// server is plainly up (we just identified its name/version). Mapping that
+  /// straight to "server unreachable" is wrong. So instead:
+  ///  - an auth failure on the sync call is already definitive → sign in again;
+  ///  - otherwise the tiny `/Users/Me` reachability probe gives ground truth:
+  ///    it succeeds → the server/session are fine and only the *library sync*
+  ///    failed (keep the library, retry) → [librarySyncFailed]; the probe
+  ///    reports 401 → [signInRequired]; the probe can't reach it either →
+  ///    [serverUnreachable]; any other probe failure → the sync error's own
+  ///    static mapping.
+  /// A secret-free diagnostics breadcrumb records the category, status, and the
+  /// reachability/auth outcome either way.
+  Future<JellyfinSyncFailureReason> _classifyFailure(
+    JellyfinMusicSource source,
+    JellyfinException error,
+  ) async {
+    if (error.kind == JellyfinErrorKind.unauthorized) {
+      _recordFailure(error, reachable: true, authOk: false);
+      return JellyfinSyncFailureReason.signInRequired;
+    }
+    try {
+      await source.verifyReachable();
+      _recordFailure(error, reachable: true, authOk: true);
+      return JellyfinSyncFailureReason.librarySyncFailed;
+    } on JellyfinException catch (probe) {
+      switch (probe.kind) {
+        case JellyfinErrorKind.unauthorized:
+          _recordFailure(error, reachable: true, authOk: false);
+          return JellyfinSyncFailureReason.signInRequired;
+        case JellyfinErrorKind.notReachable:
+          _recordFailure(error, reachable: false, authOk: null);
+          return JellyfinSyncFailureReason.serverUnreachable;
+        default:
+          _recordFailure(error, reachable: null, authOk: null);
+          return _staticReason(error.kind);
+      }
+    }
+  }
+
+  /// Drops a secret-free diagnostics breadcrumb for a classified sync failure.
+  void _recordFailure(
+    JellyfinException error, {
+    required bool? reachable,
+    required bool? authOk,
+  }) {
+    JellyfinSyncDiagnostics.failure(
+      category: error.kind.name,
+      action: 'library',
+      statusCode: error.statusCode,
+      reachable: reachable,
+      authOk: authOk,
+    );
+  }
+
+  /// Maps a typed Jellyfin failure straight to a reason without probing — the
+  /// fallback used when the reachability probe itself failed inconclusively.
+  JellyfinSyncFailureReason _staticReason(JellyfinErrorKind kind) {
     switch (kind) {
       case JellyfinErrorKind.notReachable:
         return JellyfinSyncFailureReason.serverUnreachable;
@@ -314,28 +378,30 @@ class JellyfinSyncController extends Notifier<JellyfinSyncState> {
   String _capitalize(String text) =>
       text.isEmpty ? text : '${text[0].toUpperCase()}${text.substring(1)}';
 
-  /// Turns a typed Jellyfin failure into a friendly, actionable line. Branches
-  /// on [JellyfinErrorKind] rather than message text so the wording can change
-  /// without breaking this mapping.
-  String _friendlyMessage(JellyfinException error) {
-    switch (error.kind) {
-      case JellyfinErrorKind.notReachable:
+  /// The friendly, secret-free line for a classified failure [reason]. Branches
+  /// on the *reason* (the probe-informed classification) rather than the raw
+  /// error kind, so the message always matches the next step the UI offers —
+  /// and a connected-but-sync-failed never reads as "couldn't reach server".
+  String _messageForReason(
+    JellyfinSyncFailureReason reason,
+    JellyfinException error,
+  ) {
+    switch (reason) {
+      case JellyfinSyncFailureReason.serverUnreachable:
         return "Couldn't reach your Jellyfin server. Check your connection and "
             'that the server is online.';
-      case JellyfinErrorKind.unauthorized:
+      case JellyfinSyncFailureReason.signInRequired:
         return 'Your Jellyfin session has expired. Sign out and sign in again '
             'to refresh it.';
-      case JellyfinErrorKind.notJellyfin:
-      case JellyfinErrorKind.webPage:
-        return "That server didn't respond like Jellyfin. Double-check the "
-            'server address in Settings.';
-      case JellyfinErrorKind.serverError:
+      case JellyfinSyncFailureReason.librarySyncFailed:
+        return 'Your server is connected, but the library could not be fully '
+            'synced just now. Your existing music is still here — try again in '
+            'a moment.';
+      case JellyfinSyncFailureReason.retryLater:
         return 'Your Jellyfin server reported an error. Try again in a moment.';
-      case JellyfinErrorKind.invalidUrl:
-      case JellyfinErrorKind.notAudioStream:
-      case JellyfinErrorKind.streamUnavailable:
-      case JellyfinErrorKind.unsupportedResponse:
-      case JellyfinErrorKind.unexpected:
+      case JellyfinSyncFailureReason.generic:
+        // Fall back to the typed error's own friendly, secret-free message
+        // (e.g. "doesn't look like a Jellyfin server").
         return error.message;
     }
   }

--- a/lib/features/settings/jellyfin/jellyfin_sync_state.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_state.dart
@@ -9,7 +9,8 @@ enum JellyfinSyncStatus { idle, syncing, success, error }
 /// merely unreachable or briefly erroring, and a neutral fallback otherwise —
 /// the user-facing states the sync is meant to surface.
 enum JellyfinSyncFailureReason {
-  /// The server couldn't be reached (offline, tunnel down, timeout). Retrying
+  /// The server couldn't be reached at all (offline, tunnel down) — confirmed by
+  /// a follow-up reachability probe that *also* failed to reach it. Retrying
   /// later is the fix.
   serverUnreachable,
 
@@ -17,8 +18,15 @@ enum JellyfinSyncFailureReason {
   /// to retry the same sync — so the UI points at reconnect, not "Retry".
   signInRequired,
 
-  /// The server answered but with a transient error (5xx). Retrying in a moment
-  /// is the fix.
+  /// The connection and session are fine (a reachability probe succeeded), but
+  /// the *library sync itself* didn't finish — a slow/large listing, a transient
+  /// listing error, a partial response. The existing library is kept and the
+  /// fix is simply to retry; crucially, this is NOT "server unreachable" and NOT
+  /// "sign in again", so the UI stays calm and accurate.
+  librarySyncFailed,
+
+  /// The server answered but with a transient error (5xx) on both the sync and
+  /// the reachability probe. Retrying in a moment is the fix.
   retryLater,
 
   /// Anything else (a non-Jellyfin response, an unusable shape, a local save
@@ -121,4 +129,10 @@ class JellyfinSyncState {
   /// should prompt to reconnect rather than offer a pointless "Retry".
   bool get needsSignIn =>
       failureReason == JellyfinSyncFailureReason.signInRequired;
+
+  /// The connection/session checked out but the library sync failed — the calm
+  /// "your music is still here, try again" state. Lets the UI reassure the user
+  /// the server is fine and the existing library is intact.
+  bool get connectionOkButSyncFailed =>
+      failureReason == JellyfinSyncFailureReason.librarySyncFailed;
 }

--- a/lib/features/settings/jellyfin/jellyfin_sync_state.dart
+++ b/lib/features/settings/jellyfin/jellyfin_sync_state.dart
@@ -1,11 +1,37 @@
 /// Where a Jellyfin library sync is in its lifecycle.
 enum JellyfinSyncStatus { idle, syncing, success, error }
 
+/// Why a Jellyfin sync failed, so the UI can offer the *right* calm next step
+/// instead of one generic "error".
+///
+/// Branching on this (not on message text) lets the settings card show a
+/// reconnect prompt for an expired session, a "try again" for a server that's
+/// merely unreachable or briefly erroring, and a neutral fallback otherwise —
+/// the user-facing states the sync is meant to surface.
+enum JellyfinSyncFailureReason {
+  /// The server couldn't be reached (offline, tunnel down, timeout). Retrying
+  /// later is the fix.
+  serverUnreachable,
+
+  /// The session/token was rejected (401/403). The fix is to sign in again, not
+  /// to retry the same sync — so the UI points at reconnect, not "Retry".
+  signInRequired,
+
+  /// The server answered but with a transient error (5xx). Retrying in a moment
+  /// is the fix.
+  retryLater,
+
+  /// Anything else (a non-Jellyfin response, an unusable shape, a local save
+  /// hiccup): a neutral failure the user can retry.
+  generic,
+}
+
 /// Immutable snapshot the Jellyfin settings UI renders the sync action from.
 ///
 /// Like every other state object in the app, this holds only display-safe
-/// values: a status, a friendly [message], and how many tracks/playlists/
-/// favourites landed. It never carries a token, password, or streaming URL.
+/// values: a status, a friendly [message], how many tracks/playlists/favourites
+/// landed, how many items were skipped, and — on failure — a typed
+/// [failureReason]. It never carries a token, password, or streaming URL.
 class JellyfinSyncState {
   const JellyfinSyncState({
     this.status = JellyfinSyncStatus.idle,
@@ -13,8 +39,10 @@ class JellyfinSyncState {
     this.trackCount = 0,
     this.playlistCount = 0,
     this.favoriteCount = 0,
+    this.skippedCount = 0,
     this.playlistsFailed = false,
     this.favoritesFailed = false,
+    this.failureReason,
   });
 
   const JellyfinSyncState.syncing()
@@ -28,6 +56,7 @@ class JellyfinSyncState {
     required String message,
     int playlistCount = 0,
     int favoriteCount = 0,
+    int skippedCount = 0,
     bool playlistsFailed = false,
     bool favoritesFailed = false,
   }) : this(
@@ -36,12 +65,19 @@ class JellyfinSyncState {
           message: message,
           playlistCount: playlistCount,
           favoriteCount: favoriteCount,
+          skippedCount: skippedCount,
           playlistsFailed: playlistsFailed,
           favoritesFailed: favoritesFailed,
         );
 
-  const JellyfinSyncState.error(String message)
-      : this(status: JellyfinSyncStatus.error, message: message);
+  const JellyfinSyncState.error(
+    String message, {
+    JellyfinSyncFailureReason reason = JellyfinSyncFailureReason.generic,
+  }) : this(
+          status: JellyfinSyncStatus.error,
+          message: message,
+          failureReason: reason,
+        );
 
   final JellyfinSyncStatus status;
 
@@ -57,6 +93,11 @@ class JellyfinSyncState {
   /// How many server-synced favourites the last successful sync reconciled.
   final int favoriteCount;
 
+  /// How many items the last sync skipped because they were too malformed to
+  /// map. A successful sync with a non-zero count is the "synced with skipped
+  /// items" outcome — usable music landed, a few entries were dropped.
+  final int skippedCount;
+
   /// Whether the playlist part of the last sync failed (tracks may still have
   /// synced), so the UI can be honest about the partial outcome.
   final bool playlistsFailed;
@@ -64,6 +105,20 @@ class JellyfinSyncState {
   /// Whether the favourites part of the last sync failed.
   final bool favoritesFailed;
 
+  /// Why the last sync failed, when it did — so the UI can pick the right next
+  /// step. Null unless [status] is [JellyfinSyncStatus.error].
+  final JellyfinSyncFailureReason? failureReason;
+
   bool get isSyncing => status == JellyfinSyncStatus.syncing;
   bool get isError => status == JellyfinSyncStatus.error;
+
+  /// A success that nonetheless dropped some unparseable items — the calm
+  /// "synced, but some items could not be synced" state.
+  bool get syncedWithSkippedItems =>
+      status == JellyfinSyncStatus.success && skippedCount > 0;
+
+  /// The failure needs a fresh sign-in (an expired/rejected session), so the UI
+  /// should prompt to reconnect rather than offer a pointless "Retry".
+  bool get needsSignIn =>
+      failureReason == JellyfinSyncFailureReason.signInRequired;
 }

--- a/test/core/sources/jellyfin/fake_jellyfin_client.dart
+++ b/test/core/sources/jellyfin/fake_jellyfin_client.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/models/lyrics.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
@@ -27,6 +29,23 @@ class FakeJellyfinClient implements JellyfinClient {
   JellyfinException? authError;
   JellyfinException? itemsError;
   JellyfinException? verifyError;
+
+  /// How many entries [fetchItems] reports as skipped per kind, so a sync test
+  /// can exercise the "synced with skipped items" outcome without a real
+  /// malformed payload.
+  Map<JellyfinItemKind, int> skippedByKind = const <JellyfinItemKind, int>{};
+
+  /// A failure [fetchItems] throws for one specific kind only (takes precedence
+  /// over [itemsError]), so a test can fail e.g. the albums read while the
+  /// tracks read succeeds — proving the best-effort secondary fetches don't sink
+  /// a good track sync.
+  Map<JellyfinItemKind, JellyfinException> errorByKind =
+      const <JellyfinItemKind, JellyfinException>{};
+
+  /// When set, every [fetchItems] call awaits this before returning, so a test
+  /// can hold a sync "in flight" and prove a second concurrent sync is bounced
+  /// by the controller's guard rather than running in parallel.
+  Completer<void>? itemsGate;
 
   /// Canned result for [probeStream]; defaults to a healthy `audio/mpeg` 200 so
   /// tests that only care about the minted URL don't have to set it.
@@ -236,16 +255,21 @@ class FakeJellyfinClient implements JellyfinClient {
   }
 
   @override
-  Future<List<JellyfinItemDto>> fetchItems(
+  Future<JellyfinItemListing> fetchItems(
     JellyfinSession session, {
     required JellyfinItemKind kind,
   }) async {
     requestedKinds.add(kind);
-    final JellyfinException? error = itemsError;
+    final Completer<void>? gate = itemsGate;
+    if (gate != null) await gate.future;
+    final JellyfinException? error = errorByKind[kind] ?? itemsError;
     if (error != null) {
       throw error;
     }
-    return itemsByKind[kind] ?? const <JellyfinItemDto>[];
+    return JellyfinItemListing(
+      items: itemsByKind[kind] ?? const <JellyfinItemDto>[],
+      skippedCount: skippedByKind[kind] ?? 0,
+    );
   }
 
   @override

--- a/test/core/sources/jellyfin/http_jellyfin_client_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:linthra/core/diagnostics/safe_event_log.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
 import 'package:linthra/core/sources/jellyfin/http_jellyfin_client.dart';
 import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
@@ -19,6 +20,33 @@ const _session = JellyfinSession(
 
 HttpJellyfinClient _client(MockClient mock) =>
     HttpJellyfinClient(httpClient: mock);
+
+/// A client tuned for the paging/retry tests: tiny page size and zero waits so
+/// pagination and bounded retry are exercised without real delays.
+HttpJellyfinClient _itemsClient(
+  MockClient mock, {
+  int pageSize = 500,
+  int attempts = 3,
+  int maxPages = 10000,
+}) =>
+    HttpJellyfinClient(
+      httpClient: mock,
+      itemPageSize: pageSize,
+      maxItemFetchAttempts: attempts,
+      maxItemPages: maxPages,
+      retryBackoff: Duration.zero,
+      pageGap: Duration.zero,
+    );
+
+http.Response _jsonItems(List<Map<String, dynamic>> items, {int? total}) =>
+    http.Response(
+      jsonEncode(<String, dynamic>{
+        'Items': items,
+        if (total != null) 'TotalRecordCount': total,
+      }),
+      200,
+      headers: <String, String>{'content-type': 'application/json'},
+    );
 
 void main() {
   group('fetchServerInfo', () {
@@ -207,13 +235,14 @@ void main() {
         );
       }));
 
-      final items =
+      final listing =
           await client.fetchItems(_session, kind: JellyfinItemKind.audio);
 
-      expect(items.map((JellyfinItemDto i) => i.id).toList(), <String>[
+      expect(listing.items.map((JellyfinItemDto i) => i.id).toList(), <String>[
         't1',
         't2',
       ]);
+      expect(listing.skippedCount, 0);
       expect(captured!.url.path, '/Items');
       expect(captured!.url.queryParameters['IncludeItemTypes'], 'Audio');
       expect(captured!.url.queryParameters['UserId'], 'user-1');
@@ -241,10 +270,10 @@ void main() {
             (_) async => http.Response(jsonEncode(<String, dynamic>{}), 200)),
       );
 
-      final items =
+      final listing =
           await client.fetchItems(_session, kind: JellyfinItemKind.album);
 
-      expect(items, isEmpty);
+      expect(listing.items, isEmpty);
     });
 
     test('maps an expired token (401) to unauthorized', () async {
@@ -258,6 +287,437 @@ void main() {
           JellyfinErrorKind.unauthorized,
         )),
       );
+    });
+  });
+
+  group('fetchItems pagination', () {
+    test('pages through the library until TotalRecordCount and concatenates',
+        () async {
+      final List<int> starts = <int>[];
+      final client = _itemsClient(
+        MockClient((http.Request request) async {
+          final int start =
+              int.parse(request.url.queryParameters['StartIndex'] ?? '0');
+          starts.add(start);
+          if (start == 0) {
+            return _jsonItems(<Map<String, dynamic>>[
+              <String, dynamic>{'Id': 't1', 'Name': 'One'},
+              <String, dynamic>{'Id': 't2', 'Name': 'Two'},
+            ], total: 3);
+          }
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't3', 'Name': 'Three'},
+          ], total: 3);
+        }),
+        pageSize: 2,
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(
+        listing.items.map((JellyfinItemDto i) => i.id).toList(),
+        <String>['t1', 't2', 't3'],
+      );
+      // Exactly two pages — it didn't loop past the total or stop early.
+      expect(starts, <int>[0, 2]);
+      // The page size rides in the request.
+      expect(listing.skippedCount, 0);
+    });
+
+    test('stops on a short final page when the server gives no total',
+        () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((http.Request request) async {
+          calls++;
+          final int start =
+              int.parse(request.url.queryParameters['StartIndex'] ?? '0');
+          if (start == 0) {
+            return _jsonItems(<Map<String, dynamic>>[
+              <String, dynamic>{'Id': 't1', 'Name': 'One'},
+              <String, dynamic>{'Id': 't2', 'Name': 'Two'},
+            ]);
+          }
+          // A short page (1 < pageSize) signals the end.
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't3', 'Name': 'Three'},
+          ]);
+        }),
+        pageSize: 2,
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items, hasLength(3));
+      expect(calls, 2);
+    });
+
+    test('a single full page with no total stops after one empty next page',
+        () async {
+      // Exactly pageSize items and no total: the client fetches one more page to
+      // be sure, gets an empty one, and stops — never an infinite loop.
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((http.Request request) async {
+          calls++;
+          final int start =
+              int.parse(request.url.queryParameters['StartIndex'] ?? '0');
+          if (start == 0) {
+            return _jsonItems(<Map<String, dynamic>>[
+              <String, dynamic>{'Id': 't1', 'Name': 'One'},
+              <String, dynamic>{'Id': 't2', 'Name': 'Two'},
+            ]);
+          }
+          return _jsonItems(const <Map<String, dynamic>>[]);
+        }),
+        pageSize: 2,
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items, hasLength(2));
+      expect(calls, 2);
+    });
+
+    test('a persistent failure on a later page aborts (no truncated listing)',
+        () async {
+      // The headline durability guarantee: if page 1 succeeds but a later page
+      // fails for good, fetchItems THROWS rather than returning the partial
+      // page-1 items — so the caller keeps the previous catalog instead of
+      // committing a truncated library.
+      final client = _itemsClient(
+        MockClient((http.Request request) async {
+          final int start =
+              int.parse(request.url.queryParameters['StartIndex'] ?? '0');
+          if (start == 0) {
+            return _jsonItems(<Map<String, dynamic>>[
+              <String, dynamic>{'Id': 't1', 'Name': 'One'},
+              <String, dynamic>{'Id': 't2', 'Name': 'Two'},
+            ], total: 4);
+          }
+          // The second page is down for good (outlives the retry budget).
+          return http.Response('down', 500);
+        }),
+        pageSize: 2,
+        attempts: 2,
+      );
+
+      await expectLater(
+        client.fetchItems(_session, kind: JellyfinItemKind.audio),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.serverError,
+        )),
+      );
+    });
+
+    test('a server that ignores paging is bounded by the page-count backstop',
+        () async {
+      // Pathological server: always returns a full page and never a total, so
+      // only the backstop can stop the loop. It must stop after exactly maxPages
+      // requests rather than spinning forever.
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((http.Request request) async {
+          calls++;
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't1', 'Name': 'One'},
+            <String, dynamic>{'Id': 't2', 'Name': 'Two'},
+          ]);
+        }),
+        pageSize: 2,
+        maxPages: 3,
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      // Exactly maxPages requests, then it stopped.
+      expect(calls, 3);
+      expect(listing.items.length, greaterThan(0));
+    });
+  });
+
+  group('fetchItems item tolerance', () {
+    test('skips an unparseable item in a page, keeps the rest, counts the skip',
+        () async {
+      final client = _itemsClient(
+        MockClient((_) async => _jsonItems(<Map<String, dynamic>>[
+              <String, dynamic>{'Id': 't1', 'Name': 'One'},
+              // No Name → unusable → skipped (counted).
+              <String, dynamic>{'Id': 'bad'},
+              // Wrong-typed Album → still usable → kept (Album dropped).
+              <String, dynamic>{'Id': 't3', 'Name': 'Three', 'Album': 123},
+            ], total: 3)),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(
+        listing.items.map((JellyfinItemDto i) => i.id).toList(),
+        <String>['t1', 't3'],
+      );
+      expect(listing.skippedCount, 1);
+      // The kept item with a bad field has the field dropped, not a crash.
+      expect(listing.items.last.album, isNull);
+    });
+
+    test('a non-object entry in the Items array is skipped, not fatal',
+        () async {
+      final client = _itemsClient(
+        MockClient((_) async => http.Response(
+              jsonEncode(<String, dynamic>{
+                'Items': <dynamic>[
+                  'a bare string, not an object',
+                  <String, dynamic>{'Id': 't1', 'Name': 'One'},
+                ],
+                'TotalRecordCount': 2,
+              }),
+              200,
+            )),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items.single.id, 't1');
+      expect(listing.skippedCount, 1);
+    });
+
+    test('a real skip emits a secret-free diagnostics breadcrumb', () async {
+      SafeEventLog.instance.clear();
+      addTearDown(SafeEventLog.instance.clear);
+
+      final client = _itemsClient(
+        MockClient((_) async => _jsonItems(<Map<String, dynamic>>[
+              <String, dynamic>{'Id': 't1', 'Name': 'One'},
+              <String, dynamic>{'Id': 'bad'}, // no Name → skipped
+            ], total: 2)),
+      );
+
+      await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      // The skip is recorded end-to-end (kind + counts only — no title/url).
+      expect(
+        SafeEventLog.instance.lines,
+        contains('jellyfin-sync: skip:audio dropped=1 kept=1'),
+      );
+    });
+  });
+
+  group('fetchItems retry + backoff', () {
+    test('retries a transient 5xx, then succeeds', () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          if (calls == 1) return http.Response('busy', 503);
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't1', 'Name': 'One'},
+          ], total: 1);
+        }),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items.single.id, 't1');
+      expect(calls, 2);
+    });
+
+    test('retries a transient transport failure, then succeeds', () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          if (calls == 1) throw http.ClientException('connection reset');
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't1', 'Name': 'One'},
+          ], total: 1);
+        }),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items.single.id, 't1');
+      expect(calls, 2);
+    });
+
+    test('gives up after the attempt budget on a persistent 5xx', () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          return http.Response('still down', 500);
+        }),
+        attempts: 3,
+      );
+
+      await expectLater(
+        client.fetchItems(_session, kind: JellyfinItemKind.audio),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.serverError,
+        )),
+      );
+      // Bounded: it tried exactly the budget, not forever.
+      expect(calls, 3);
+    });
+
+    test('gives up after the attempt budget on a persistent transport failure',
+        () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          throw http.ClientException('offline');
+        }),
+        attempts: 3,
+      );
+
+      await expectLater(
+        client.fetchItems(_session, kind: JellyfinItemKind.audio),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.notReachable,
+        )),
+      );
+      expect(calls, 3);
+    });
+
+    test('retries a 429 rate-limit, then succeeds', () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          if (calls == 1) return http.Response('slow down', 429);
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't1', 'Name': 'One'},
+          ], total: 1);
+        }),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items.single.id, 't1');
+      expect(calls, 2);
+    });
+
+    test('retries a 408 request-timeout, then succeeds', () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          if (calls == 1) return http.Response('timeout', 408);
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't1', 'Name': 'One'},
+          ], total: 1);
+        }),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items.single.id, 't1');
+      expect(calls, 2);
+    });
+
+    test('does NOT retry a 404 — a non-retryable client status', () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          return http.Response('nope', 404);
+        }),
+        attempts: 3,
+      );
+
+      await expectLater(
+        client.fetchItems(_session, kind: JellyfinItemKind.audio),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.notJellyfin,
+        )),
+      );
+      expect(calls, 1);
+    });
+
+    test('a persistent 429 rate-limit surfaces as a (transient) server error',
+        () async {
+      // After exhausting retries, a 429/408 must read as a transient server
+      // error (→ "try again later"), not "doesn't look like a Jellyfin server".
+      final client = _itemsClient(
+        MockClient((_) async => http.Response('slow down', 429)),
+        attempts: 2,
+      );
+
+      await expectLater(
+        client.fetchItems(_session, kind: JellyfinItemKind.audio),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.serverError,
+        )),
+      );
+    });
+
+    test('runs the real (non-zero) exponential backoff path between retries',
+        () async {
+      // Exercises `_backoff` (the 1<<(attempt-2) shift + the awaited delay) with
+      // a non-zero base, which the zero-backoff helper otherwise skips. Tiny
+      // delays keep it fast; the point is the path runs and still succeeds.
+      int calls = 0;
+      final client = HttpJellyfinClient(
+        httpClient: MockClient((_) async {
+          calls++;
+          if (calls < 3) return http.Response('busy', 503);
+          return _jsonItems(<Map<String, dynamic>>[
+            <String, dynamic>{'Id': 't1', 'Name': 'One'},
+          ], total: 1);
+        }),
+        maxItemFetchAttempts: 3,
+        retryBackoff: const Duration(milliseconds: 1),
+        pageGap: Duration.zero,
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.audio);
+
+      expect(listing.items.single.id, 't1');
+      expect(calls, 3);
+    });
+
+    test('does NOT retry a 401 — auth is the server\'s settled answer',
+        () async {
+      int calls = 0;
+      final client = _itemsClient(
+        MockClient((_) async {
+          calls++;
+          return http.Response('denied', 401);
+        }),
+        attempts: 3,
+      );
+
+      await expectLater(
+        client.fetchItems(_session, kind: JellyfinItemKind.audio),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.unauthorized,
+        )),
+      );
+      // One attempt only: retrying an auth failure is pointless.
+      expect(calls, 1);
     });
   });
 

--- a/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
@@ -61,6 +61,30 @@ void main() {
       expect(uri.path, '/Artists');
       expect(uri.queryParameters['UserId'], 'user-1');
     });
+
+    test('carries StartIndex/Limit paging params when given', () {
+      final Uri uri = JellyfinEndpoints.items(
+        _base,
+        userId: 'user-1',
+        kind: JellyfinItemKind.audio,
+        startIndex: 500,
+        limit: 250,
+      );
+      expect(uri.queryParameters['StartIndex'], '500');
+      expect(uri.queryParameters['Limit'], '250');
+      // Paging is additive — the type/sort filters are still present.
+      expect(uri.queryParameters['IncludeItemTypes'], 'Audio');
+    });
+
+    test('omits paging params entirely when not given', () {
+      final Uri uri = JellyfinEndpoints.items(
+        _base,
+        userId: 'user-1',
+        kind: JellyfinItemKind.audio,
+      );
+      expect(uri.queryParameters.containsKey('StartIndex'), isFalse);
+      expect(uri.queryParameters.containsKey('Limit'), isFalse);
+    });
   });
 
   group('JellyfinEndpoints favourites / lyrics / artwork', () {

--- a/test/core/sources/jellyfin/jellyfin_item_dto_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_item_dto_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+
+/// Tolerant parsing of one Jellyfin item. The guarantee under test: a server
+/// that omits fields, or sends them with the *wrong type*, yields a safe DTO (or
+/// a clean skip) — never a thrown `TypeError` that would abort a whole sync.
+void main() {
+  group('JellyfinItemDto.fromJson — required fields', () {
+    test('parses a full audio item', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'Album': 'Album',
+        'AlbumId': 'alb-1',
+        'AlbumArtist': 'Artist',
+        'Artists': <dynamic>['Artist', 'Feature'],
+        'RunTimeTicks': 2400000000,
+        'IndexNumber': 3,
+        'ProductionYear': 1999,
+        'ChildCount': 12,
+        'ImageTags': <String, dynamic>{'Primary': 'abc'},
+      })!;
+
+      expect(dto.id, 't1');
+      expect(dto.name, 'One');
+      expect(dto.album, 'Album');
+      expect(dto.albumArtist, 'Artist');
+      expect(dto.artists, <String>['Artist', 'Feature']);
+      expect(dto.runTimeTicks, 2400000000);
+      expect(dto.indexNumber, 3);
+      expect(dto.productionYear, 1999);
+      expect(dto.childCount, 12);
+      expect(dto.hasPrimaryImage, isTrue);
+    });
+
+    test('skips an item with no Id', () {
+      expect(
+        JellyfinItemDto.fromJson(<String, dynamic>{'Name': 'No id'}),
+        isNull,
+      );
+    });
+
+    test('skips an item with no Name', () {
+      expect(
+        JellyfinItemDto.fromJson(<String, dynamic>{'Id': 't1'}),
+        isNull,
+      );
+    });
+
+    test('skips an item with a blank / whitespace-only Name', () {
+      expect(
+        JellyfinItemDto.fromJson(<String, dynamic>{'Id': 't1', 'Name': '   '}),
+        isNull,
+      );
+    });
+
+    test('skips an item whose Id is the wrong type (a number)', () {
+      // A weird server sending a numeric Id: coerced to "no usable id" → skip,
+      // not a crash.
+      expect(
+        JellyfinItemDto.fromJson(<String, dynamic>{'Id': 12, 'Name': 'One'}),
+        isNull,
+      );
+    });
+  });
+
+  group('JellyfinItemDto.fromJson — missing optional fields use fallbacks', () {
+    test('a minimal item (only Id + Name) parses with safe defaults', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+      })!;
+
+      expect(dto.album, isNull);
+      expect(dto.albumArtist, isNull);
+      expect(dto.artists, isEmpty);
+      expect(dto.runTimeTicks, isNull);
+      expect(dto.indexNumber, isNull);
+      expect(dto.productionYear, isNull);
+      expect(dto.childCount, isNull);
+      expect(dto.hasPrimaryImage, isFalse);
+    });
+
+    test('missing Artists list reads as empty', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'AlbumArtist': 'Solo',
+      })!;
+      expect(dto.artists, isEmpty);
+      expect(dto.albumArtist, 'Solo');
+    });
+
+    test('missing ImageTags means no primary image', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'ImageTags': <String, dynamic>{'Backdrop': 'x'},
+      })!;
+      expect(dto.hasPrimaryImage, isFalse);
+    });
+  });
+
+  group('JellyfinItemDto.fromJson — wrong field types never throw', () {
+    test('a numeric Album is dropped, not crashed on', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'Album': 1999,
+      })!;
+      expect(dto.album, isNull);
+    });
+
+    test('a string RunTimeTicks is coerced from a numeric string', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'RunTimeTicks': '2400000000',
+      })!;
+      expect(dto.runTimeTicks, 2400000000);
+    });
+
+    test('a fractional numeric-string RunTimeTicks truncates like a number',
+        () {
+      // Symmetric with the JSON-number path: "123.9" and 123.9 both truncate.
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'RunTimeTicks': '2400000000.9',
+      })!;
+      expect(dto.runTimeTicks, 2400000000);
+    });
+
+    test('a non-numeric string RunTimeTicks falls back to null', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'RunTimeTicks': 'not-a-number',
+      })!;
+      expect(dto.runTimeTicks, isNull);
+    });
+
+    test('a floating-point RunTimeTicks is truncated to an int', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'RunTimeTicks': 2400000000.9,
+      })!;
+      expect(dto.runTimeTicks, 2400000000);
+    });
+
+    test('an Artists value that is a String (not a list) reads as empty', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'Artists': 'Not A List',
+      })!;
+      expect(dto.artists, isEmpty);
+    });
+
+    test('non-string entries inside Artists are dropped, good ones kept', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'Artists': <dynamic>['Good', 42, null, '', '  ', 'Also Good'],
+      })!;
+      expect(dto.artists, <String>['Good', 'Also Good']);
+    });
+
+    test('a boolean where a number is expected falls back to null', () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'IndexNumber': true,
+        'ProductionYear': <String, dynamic>{'weird': 'object'},
+        'ChildCount': <dynamic>[1, 2],
+      })!;
+      expect(dto.indexNumber, isNull);
+      expect(dto.productionYear, isNull);
+      expect(dto.childCount, isNull);
+    });
+
+    test('a whole grab-bag of wrong types parses without throwing', () {
+      // The belt-and-suspenders case: one entry where *every* optional field is
+      // the wrong type still yields a usable DTO rather than aborting a sync.
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'Album': 7,
+        'AlbumId': <dynamic>[],
+        'AlbumArtist': false,
+        'Artists': 99,
+        'RunTimeTicks': <String, dynamic>{},
+        'IndexNumber': 'x',
+        'ProductionYear': true,
+        'ChildCount': 'many',
+        'ImageTags': 'not-a-map',
+      })!;
+      expect(dto.id, 't1');
+      expect(dto.name, 'One');
+      expect(dto.album, isNull);
+      expect(dto.artists, isEmpty);
+      expect(dto.hasPrimaryImage, isFalse);
+    });
+  });
+
+  group('JellyfinItemListing', () {
+    test('empty carries no items and no skips', () {
+      expect(JellyfinItemListing.empty.items, isEmpty);
+      expect(JellyfinItemListing.empty.skippedCount, 0);
+    });
+  });
+}

--- a/test/core/sources/jellyfin/jellyfin_music_source_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_music_source_test.dart
@@ -70,6 +70,73 @@ void main() {
       );
     });
 
+    group('fetchLibraryForSync', () {
+      test('returns mapped tracks plus the skipped count', () async {
+        final client = FakeJellyfinClient(
+          itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+            JellyfinItemKind.audio: <JellyfinItemDto>[
+              const JellyfinItemDto(id: 't1', name: 'One'),
+              const JellyfinItemDto(id: 't2', name: 'Two'),
+            ],
+            JellyfinItemKind.album: <JellyfinItemDto>[
+              const JellyfinItemDto(id: 'a1', name: 'Album'),
+            ],
+            JellyfinItemKind.artist: <JellyfinItemDto>[
+              const JellyfinItemDto(id: 'ar1', name: 'Artist'),
+            ],
+          },
+        );
+        client.skippedByKind = <JellyfinItemKind, int>{
+          JellyfinItemKind.audio: 3,
+        };
+
+        final library = await _source(client).fetchLibraryForSync();
+
+        expect(library.tracks.map((t) => t.id).toList(), <String>['t1', 't2']);
+        expect(library.albums.single.title, 'Album');
+        expect(library.artists.single.name, 'Artist');
+        expect(library.skippedCount, 3);
+      });
+
+      test('albums/artists are best-effort — a failure there keeps the tracks',
+          () async {
+        final client = FakeJellyfinClient(
+          itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+            JellyfinItemKind.audio: <JellyfinItemDto>[
+              const JellyfinItemDto(id: 't1', name: 'One'),
+            ],
+          },
+          // Tracks succeed; the secondary album/artist reads fail.
+        );
+        client.errorByKind = <JellyfinItemKind, JellyfinException>{
+          JellyfinItemKind.album: JellyfinException.serverError(500),
+          JellyfinItemKind.artist: JellyfinException.serverError(500),
+        };
+
+        final library = await _source(client).fetchLibraryForSync();
+
+        expect(library.tracks.single.id, 't1');
+        expect(library.albums, isEmpty);
+        expect(library.artists, isEmpty);
+      });
+
+      test('a tracks failure propagates (so the caller preserves the catalog)',
+          () async {
+        final client = FakeJellyfinClient(
+          itemsError: JellyfinException.unauthorized(),
+        );
+
+        await expectLater(
+          _source(client).fetchLibraryForSync(),
+          throwsA(isA<JellyfinException>().having(
+            (JellyfinException e) => e.kind,
+            'kind',
+            JellyfinErrorKind.unauthorized,
+          )),
+        );
+      });
+    });
+
     test(
         'resolvePlayableUri mints a direct-stream URL with the token at play '
         'time', () async {

--- a/test/core/sources/jellyfin/jellyfin_sync_diagnostics_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_sync_diagnostics_test.dart
@@ -46,4 +46,39 @@ void main() {
       expect(line, 'jellyfin-sync: skip:artist dropped=1 kept=0');
     });
   });
+
+  group('JellyfinSyncDiagnostics.failure', () {
+    setUp(SafeEventLog.instance.clear);
+    tearDown(SafeEventLog.instance.clear);
+
+    test('records category, status, action, and probe outcome', () {
+      JellyfinSyncDiagnostics.failure(
+        category: 'notReachable',
+        action: 'library',
+        statusCode: null,
+        reachable: true,
+        authOk: true,
+      );
+
+      final String line = SafeEventLog.instance.lines.single;
+      expect(
+        line,
+        'jellyfin-sync: fail:library category=notReachable status=- '
+        'reachable=yes auth=yes',
+      );
+    });
+
+    test('renders unknown probe results as "unknown" and a status code', () {
+      JellyfinSyncDiagnostics.failure(
+        category: 'serverError',
+        action: 'library',
+        statusCode: 503,
+      );
+
+      final String line = SafeEventLog.instance.lines.single;
+      expect(line, contains('status=503'));
+      expect(line, contains('reachable=unknown'));
+      expect(line, contains('auth=unknown'));
+    });
+  });
 }

--- a/test/core/sources/jellyfin/jellyfin_sync_diagnostics_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_sync_diagnostics_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/safe_event_log.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_api.dart';
+import 'package:linthra/core/sources/jellyfin/jellyfin_sync_diagnostics.dart';
+
+void main() {
+  group('JellyfinSyncDiagnostics.skipped', () {
+    setUp(SafeEventLog.instance.clear);
+    tearDown(SafeEventLog.instance.clear);
+
+    test('records a secret-free breadcrumb when items were skipped', () {
+      JellyfinSyncDiagnostics.skipped(
+        kind: JellyfinItemKind.audio,
+        skipped: 2,
+        kept: 40,
+      );
+
+      expect(SafeEventLog.instance.lines, hasLength(1));
+      final String line = SafeEventLog.instance.lines.single;
+      expect(line, contains('jellyfin-sync'));
+      expect(line, contains('skip:audio'));
+      expect(line, contains('dropped=2'));
+      expect(line, contains('kept=40'));
+    });
+
+    test('is silent when nothing was skipped', () {
+      JellyfinSyncDiagnostics.skipped(
+        kind: JellyfinItemKind.album,
+        skipped: 0,
+        kept: 12,
+      );
+
+      expect(SafeEventLog.instance.isEmpty, isTrue);
+    });
+
+    test('carries only the kind name and counts — never free text', () {
+      // The API has no parameter for a title, URL, or token; this guards that
+      // the recorded detail is structural only.
+      JellyfinSyncDiagnostics.skipped(
+        kind: JellyfinItemKind.artist,
+        skipped: 1,
+        kept: 0,
+      );
+
+      final String line = SafeEventLog.instance.lines.single;
+      expect(line, 'jellyfin-sync: skip:artist dropped=1 kept=0');
+    });
+  });
+}

--- a/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_auto_sync_test.dart
@@ -346,7 +346,9 @@ void main() {
         authenticator: FakeJellyfinAuthenticator(session: _sessionFor()),
         repository: repo,
         autoSyncStore: store,
-        // The catalog fetch fails (server unreachable) once connected.
+        // The catalog fetch fails once connected, but the server itself stays
+        // reachable (the fake's verifySession succeeds), so this is a
+        // library-sync failure — not "server unreachable".
         client:
             FakeJellyfinClient(itemsError: JellyfinException.notReachable()),
       );
@@ -356,14 +358,21 @@ void main() {
       expect(await _signIn(container), isTrue);
       await _drainAutoSync();
 
-      // Still connected, sync errored with a friendly, secret-free message.
+      // Still connected, sync errored with a friendly, secret-free message that
+      // correctly says the connection is fine and the library was kept — NOT
+      // the misleading "couldn't reach your server".
       expect(
         container.read(jellyfinSettingsControllerProvider).phase,
         JellyfinConnectionPhase.connected,
       );
       final syncState = container.read(jellyfinSyncControllerProvider);
       expect(syncState.status, JellyfinSyncStatus.error);
-      expect(syncState.message, contains("Couldn't reach"));
+      expect(
+        syncState.failureReason,
+        JellyfinSyncFailureReason.librarySyncFailed,
+      );
+      expect(syncState.message, isNot(contains("Couldn't reach")));
+      expect(syncState.message, contains('still here'));
       expect(syncState.message, isNot(contains('secret-token-value')));
       // The account is NOT recorded, so the next fresh connection retries.
       expect(await store.read(), isNull);

--- a/test/features/settings/jellyfin/jellyfin_settings_section_sync_ui_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_settings_section_sync_ui_test.dart
@@ -120,6 +120,28 @@ void main() {
       expect(find.text('Retry sync'), findsNothing);
     });
 
+    testWidgets(
+        'a connected-but-sync-failed state reassures and offers Retry, not '
+        '"couldn\'t reach"', (tester) async {
+      await _pumpConnected(
+        tester,
+        const JellyfinSyncState.error(
+          'Your server is connected, but the library could not be fully synced '
+          'just now. Your existing music is still here — try again in a moment.',
+          reason: JellyfinSyncFailureReason.librarySyncFailed,
+        ),
+      );
+
+      // Reassuring framing — the library is intact — and a Retry, with no
+      // misleading "couldn't reach server" anywhere.
+      expect(find.textContaining('still available'), findsOneWidget);
+      expect(find.textContaining('still here'), findsOneWidget);
+      expect(find.text('Retry sync'), findsOneWidget);
+      expect(find.textContaining("Couldn't reach"), findsNothing);
+      // Not framed as needing a fresh sign-in.
+      expect(find.textContaining('session needs'), findsNothing);
+    });
+
     testWidgets('shows a friendly failure with a Retry action', (tester) async {
       await _pumpConnected(
         tester,

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/album.dart';
@@ -289,6 +291,148 @@ void main() {
       // The raw error is not surfaced to the user.
       expect(state.message, isNot(contains('disk full')));
       expect(state.message, contains('Please try again'));
+    });
+  });
+
+  group('JellyfinSyncController resilience', () {
+    test('a malformed track is skipped without failing the whole sync',
+        () async {
+      // The headline guarantee: bad items are dropped, the good ones still sync,
+      // and the outcome is a calm "synced with skipped items" — not an error.
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a'), _audio('b')],
+        },
+      );
+      client.skippedByKind = <JellyfinItemKind, int>{JellyfinItemKind.audio: 1};
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _sourceOver(client),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.success);
+      expect(state.trackCount, 2);
+      expect(state.skippedCount, 1);
+      expect(state.syncedWithSkippedItems, isTrue);
+      expect(state.message, contains('2 tracks'));
+      expect(state.message, contains('Some items could not be synced'));
+      // The good tracks still landed in the catalog.
+      expect(repository.upsertedTracks, hasLength(2));
+    });
+
+    test('an expired token reports a sign-in-required reason', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.unauthorized()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.error);
+      expect(state.failureReason, JellyfinSyncFailureReason.signInRequired);
+      expect(state.needsSignIn, isTrue);
+    });
+
+    test('an unreachable server reports a server-unreachable reason', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.notReachable()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.failureReason, JellyfinSyncFailureReason.serverUnreachable);
+      expect(state.needsSignIn, isFalse);
+    });
+
+    test('a transient server error reports a retry-later reason', () async {
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.serverError(503)),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.failureReason, JellyfinSyncFailureReason.retryLater);
+    });
+
+    test('a second concurrent sync is bounced by the in-flight guard',
+        () async {
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+        },
+      );
+      final gate = Completer<void>();
+      client.itemsGate = gate;
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _sourceOver(client),
+      );
+      final notifier = container.read(jellyfinSyncControllerProvider.notifier);
+
+      // First sync starts and parks inside the (gated) item fetch.
+      final Future<void> first = notifier.sync();
+      // Second sync, fired while the first is in flight, must bail at once.
+      await notifier.sync();
+
+      // Release the first and let it finish.
+      gate.complete();
+      await first;
+
+      // Exactly one sync ran: one audio fetch, one catalog write.
+      expect(
+        client.requestedKinds
+            .where((JellyfinItemKind k) => k == JellyfinItemKind.audio)
+            .length,
+        1,
+      );
+      expect(repository.upsertCount, 1);
+    });
+
+    test('a sign-out mid-sync abandons the result without writing the catalog',
+        () async {
+      // Cancellation safety: if the live source disappears (sign-out) or changes
+      // (a different account) while the fetch is in flight, the stale result is
+      // not committed over the current catalog.
+      final client = FakeJellyfinClient(
+        itemsByKind: <JellyfinItemKind, List<JellyfinItemDto>>{
+          JellyfinItemKind.audio: <JellyfinItemDto>[_audio('a')],
+        },
+      );
+      final gate = Completer<void>();
+      client.itemsGate = gate;
+      final repository = _RecordingRepository();
+      final container = _container(
+        repository: repository,
+        source: _sourceOver(client),
+      );
+      final notifier = container.read(jellyfinSyncControllerProvider.notifier);
+
+      final Future<void> run = notifier.sync();
+      // Simulate sign-out: the live Jellyfin source is now gone.
+      container.updateOverrides(<Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(repository),
+        jellyfinMusicSourceProvider.overrideWithValue(null),
+      ]);
+      gate.complete();
+      await run;
+
+      // The fetch completed, but the now-stale result was never written.
+      expect(repository.upsertCount, 0);
+      // …and the abandoned run did not pin the card on a perpetual "Syncing…":
+      // it reset to idle so the new account's own sync can drive the card.
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.idle);
+      expect(state.isSyncing, isFalse);
     });
   });
 

--- a/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
+++ b/test/features/settings/jellyfin/jellyfin_sync_controller_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/diagnostics/safe_event_log.dart';
 import 'package:linthra/core/models/album.dart';
 import 'package:linthra/core/models/artist.dart';
 import 'package:linthra/core/models/jellyfin_session.dart';
@@ -96,10 +97,15 @@ JellyfinMusicSource _source({
   Map<JellyfinItemKind, List<JellyfinItemDto>> items =
       const <JellyfinItemKind, List<JellyfinItemDto>>{},
   JellyfinException? itemsError,
+  JellyfinException? verifyError,
 }) {
   return JellyfinMusicSource(
     session: _session,
-    client: FakeJellyfinClient(itemsByKind: items, itemsError: itemsError),
+    client: FakeJellyfinClient(
+      itemsByKind: items,
+      itemsError: itemsError,
+      verifyError: verifyError,
+    ),
   );
 }
 
@@ -211,16 +217,22 @@ void main() {
       expect(repository.upsertCount, 0);
     });
 
-    test('maps an unreachable server to a friendly message', () async {
+    test('maps a truly unreachable server to a friendly message', () async {
+      // Both the sync AND the reachability probe fail to reach the server, so
+      // this is a genuine "server unreachable".
       final container = _container(
         repository: _RecordingRepository(),
-        source: _source(itemsError: JellyfinException.notReachable()),
+        source: _source(
+          itemsError: JellyfinException.notReachable(),
+          verifyError: JellyfinException.notReachable(),
+        ),
       );
 
       await container.read(jellyfinSyncControllerProvider.notifier).sync();
 
       final state = container.read(jellyfinSyncControllerProvider);
       expect(state.status, JellyfinSyncStatus.error);
+      expect(state.failureReason, JellyfinSyncFailureReason.serverUnreachable);
       expect(state.message, contains("Couldn't reach"));
     });
 
@@ -338,10 +350,14 @@ void main() {
       expect(state.needsSignIn, isTrue);
     });
 
-    test('an unreachable server reports a server-unreachable reason', () async {
+    test('an unreachable server (probe also fails) reports server-unreachable',
+        () async {
       final container = _container(
         repository: _RecordingRepository(),
-        source: _source(itemsError: JellyfinException.notReachable()),
+        source: _source(
+          itemsError: JellyfinException.notReachable(),
+          verifyError: JellyfinException.notReachable(),
+        ),
       );
 
       await container.read(jellyfinSyncControllerProvider.notifier).sync();
@@ -351,16 +367,92 @@ void main() {
       expect(state.needsSignIn, isFalse);
     });
 
-    test('a transient server error reports a retry-later reason', () async {
+    test('a 5xx on both the sync and the probe reports a retry-later reason',
+        () async {
       final container = _container(
         repository: _RecordingRepository(),
-        source: _source(itemsError: JellyfinException.serverError(503)),
+        source: _source(
+          itemsError: JellyfinException.serverError(503),
+          verifyError: JellyfinException.serverError(503),
+        ),
       );
 
       await container.read(jellyfinSyncControllerProvider.notifier).sync();
 
       final state = container.read(jellyfinSyncControllerProvider);
       expect(state.failureReason, JellyfinSyncFailureReason.retryLater);
+    });
+
+    test(
+        'a sync failure on a still-reachable server reports library-sync-failed '
+        'and keeps the old library', () async {
+      // The reported field case: the server is plainly reachable (the probe
+      // succeeds), but the library listing failed (e.g. a timeout on a large
+      // library). It must NOT read as "server unreachable" or "sign in again".
+      const existing = <Track>[
+        Track(id: 'j1', title: 'Old One', uri: 'jellyfin:j1'),
+      ];
+      final repository = _RecordingRepository(existing: existing);
+      final container = _container(
+        repository: repository,
+        // Items fetch fails as notReachable (a mid-sync timeout), but the
+        // session probe succeeds (verifyError is null) → connection is fine.
+        source: _source(itemsError: JellyfinException.notReachable()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.status, JellyfinSyncStatus.error);
+      expect(state.failureReason, JellyfinSyncFailureReason.librarySyncFailed);
+      expect(state.connectionOkButSyncFailed, isTrue);
+      expect(state.needsSignIn, isFalse);
+      // Not the misleading "couldn't reach" line — a calm, library-kept message.
+      expect(state.message, isNot(contains("Couldn't reach")));
+      expect(state.message, contains('still here'));
+      // The old library is untouched.
+      expect(repository.upsertCount, 0);
+      expect(await repository.getAllTracks(), existing);
+    });
+
+    test('a sync failure whose session probe is rejected needs sign-in',
+        () async {
+      // The library fetch failed and the follow-up probe says 401 — the session
+      // really is invalid, so (and only so) we ask the user to sign in again.
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(
+          itemsError: JellyfinException.notReachable(),
+          verifyError: JellyfinException.unauthorized(),
+        ),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      final state = container.read(jellyfinSyncControllerProvider);
+      expect(state.failureReason, JellyfinSyncFailureReason.signInRequired);
+      expect(state.needsSignIn, isTrue);
+    });
+
+    test('records a secret-free failure breadcrumb for diagnostics', () async {
+      SafeEventLog.instance.clear();
+      addTearDown(SafeEventLog.instance.clear);
+      final container = _container(
+        repository: _RecordingRepository(),
+        source: _source(itemsError: JellyfinException.notReachable()),
+      );
+
+      await container.read(jellyfinSyncControllerProvider.notifier).sync();
+
+      // The breadcrumb carries the category/action and the probe outcome, no
+      // token/url/title.
+      final Iterable<String> failLines = SafeEventLog.instance.lines
+          .where((String l) => l.contains('fail:library'));
+      expect(failLines, isNotEmpty);
+      final String line = failLines.first;
+      expect(line, contains('category=notReachable'));
+      expect(line, contains('reachable=yes'));
+      expect(line, isNot(contains('secret-token')));
     });
 
     test('a second concurrent sync is bounced by the in-flight guard',


### PR DESCRIPTION
## Summary

Makes Jellyfin **library sync** tolerant of bad/missing/weird server data and resilient to transient failures, and **classifies sync failures accurately** so the app stops showing app‑breaking or misleading errors — **without hiding errors**. Scope is Jellyfin sync only; Plex/Subsonic/audio‑focus/icons/backup/Connect/donations/versioning are untouched.

## Audit — failure points found

The sync controller was already well‑guarded (catches errors, has a `_syncing` flag, only writes a non‑empty fetch). The fragility was **below** it, plus a misleading error‑classification bug surfaced from a real device:

- **One wrong‑typed field aborted the whole sync.** `JellyfinItemDto.fromJson` used unguarded `as String?` / `as num?` casts, so an item with e.g. `"Album": 1999` or `"RunTimeTicks": "123"` threw a `TypeError` → generic "Something went wrong".
- **No pagination.** The entire library was fetched in one 20 s‑bounded request per kind — a large/slow library timed out though the server was fine.
- **No retry**; **albums/artists failures sank a good track sync**; **no structured states**.
- **Misleading failure message (real device, Jellyfin 10.11.11).** A device showed the server *Connected* — name, version, signed‑in user all identified — yet sync failed with **"Couldn't reach your Jellyfin server."** Any non‑auth sync failure's error kind was mapped straight to a reason, so a slow listing that timed out mid‑sync (kind `notReachable`) read as a full outage.

## What changed

**Failure classification — the field bug (commit 2)**
- On a sync failure the controller now **probes the live session** (`/Users/Me`) to get ground truth before classifying:
  - probe succeeds → server + session fine, only the **library sync** failed → new `librarySyncFailed` reason + calm message *"Your server is connected, but the library could not be fully synced just now. Your existing music is still here — try again in a moment."* The card reassures the library is intact; **no** "couldn't reach", **no** sign‑in prompt.
  - probe rejected (401) → session really invalid → **sign in again** (and only then).
  - probe also unreachable → genuine **server unreachable**.
- This cleanly separates connection/auth/reachability from a library‑sync failure; the existing library is preserved on any failure; sign‑out is never requested unless the session is actually invalid.
- New secret‑free `JellyfinSyncDiagnostics.failure` breadcrumb records failure **category, HTTP status, action, and auth/reachability outcome** — the exact breakdown to triage a sync failure from a bug report.

**Parsing & per‑item tolerance**
- Every `JellyfinItemDto` field is coerced; a missing/null/wrong‑typed field falls back safely instead of throwing. Unusable entries (no id/name) are skipped + counted (with a secret‑free breadcrumb). One malformed track/album/page can't fail the sync.

**Pagination, retry & no‑hammer**
- `StartIndex`/`Limit` paging with yields between pages (responsive, no hammering) + a page‑count backstop; bounded exponential‑backoff retry for transient 5xx/408/429/transport failures (never auth/4xx, never forever); a between‑pages failure throws so the old catalog is preserved.

**Orchestration & user‑facing states**
- Best‑effort albums/artists; commit‑only‑when‑valid; duplicate‑sync guard; cancellation guard (resets the card instead of pinning "Syncing…").
- `JellyfinSyncState` carries `skippedCount` + a typed `failureReason` (**serverUnreachable / signInRequired / librarySyncFailed / retryLater / generic**) covering the requested states: connected · syncing · synced · synced‑with‑skipped‑items · sync‑failed‑library‑kept · server‑unreachable · sign‑in‑again.

## Testing

`flutter analyze`, `dart format --set-exit-if-changed`, secret‑scan, and the full **`flutter test` (2777 tests)** pass locally. New/extended tests cover tolerant parsing, pagination, bounded retry/backoff, 401/404/408/429 handling, malformed‑item skip, mid‑pagination abort, partial‑preserve, the failure‑classification matrix (connected‑but‑sync‑failed vs. probe‑rejected vs. both‑unreachable vs. both‑5xx), the diagnostics breadcrumbs, and the settings‑card rendering of the calm library‑kept state. The change also went through an adversarial multi‑dimension review (correctness/security/requirements/tests/Dart‑CI) — no secret‑leak paths; one real bug it surfaced is fixed and covered.

## Manual QA (suggested)

- Sync a large real library; sync while Jellyfin is restarted/stopped; sync with bad/missing metadata.
- Confirm a sync failure on a still‑reachable server reads as "connected, library kept — retry" (not "couldn't reach"); confirm a genuinely‑offline server still reads "couldn't reach"; confirm an expired session asks to sign in.
- Sync twice quickly (no duplicate run); confirm old music stays visible after a failed sync; confirm playback works during/after sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYD2ATankoqUZSFEwUaPEm