### PR TITLE
fix(jellyfin): prepare compatibility layer for Jellyfin 12

### DIFF
--- a/docs/jellyfin-compatibility.md
+++ b/docs/jellyfin-compatibility.md
@@ -33,12 +33,29 @@ trusted LAN is also accepted.
 
 ### Server version support
 
-Linthra is tested against **Jellyfin 10.8.0 and newer**. The REST endpoints it
-uses (below) are long-standing across the 10.x line, so an older server is
-labelled *untested* (and the user is gently warned) rather than blocked. The
-reported version is parsed only for this **diagnostic** classification — it never
+Linthra is actively tested against the **Jellyfin 10.10.x and 10.11.x** line and
+treats **Jellyfin 12** — the next release after 10.11, as there is no 11 — as
+*forward-tolerant*: allowed, never blocked, and never version-branched. The
+reported version is parsed only for a **diagnostic** classification — it never
 changes which endpoints or parameters Linthra sends. Deliberately avoiding
 version-sniffing keeps the integration robust against future server updates.
+
+`jellyfinServerSupportFor` classifies the reported version into four bands, each
+surfaced in the settings note and the diagnostics report:
+
+| Band | When | What the user sees |
+| --- | --- | --- |
+| **supported** | major ≤ `kMaximumTestedJellyfinMajor` (10) **and** ≥ `kMinimumTestedJellyfinVersion` (10.8.0) | nothing — the normal case |
+| **newer than tested** | major **above** the tested ceiling (Jellyfin 12+) | a calm "newer major version Linthra hasn't validated — streaming should still work; please report any issues" |
+| **untested (older)** | below the 10.8.0 floor | "older than Linthra is tested against — should still work, but untested" |
+| **unknown** | version absent or unparseable | nothing actionable; still recorded in diagnostics |
+
+Both bounds are conservative *diagnostic* markers, never gates: a server outside
+the tested range is gently flagged, not refused. The version parser tolerates the
+usual shapes — `10.11.11`, `12.0`, `12.0.0`, `12.0.0-rc1`, a 4th segment, a
+`+build` suffix — and falls back to *unknown* (not a crash) for anything it can't
+read. Raise `kMaximumTestedJellyfinMajor` (or the floor) only once a newer
+baseline has actually been tested.
 
 ## Expected server URL examples
 
@@ -92,18 +109,31 @@ between call sites and the full surface is auditable here.
 | Toggle favourite | `POST` / `DELETE /Users/{userId}/FavoriteItems/{itemId}` | POST marks, DELETE clears. |
 | Lyrics | `GET /Audio/{itemId}/Lyrics` | 404 = "no lyrics", a normal outcome. |
 | Cover art | `GET /Items/{itemId}/Images/Primary` | **Token-free**; safe to cache/persist. |
-| Direct stream | `GET /Audio/{itemId}/stream?static=true&api_key=…&UserId=…&DeviceId=…` | `static=true` serves the original file (no transcode). Token in query. |
-| Download | `GET /Items/{itemId}/Download?api_key=…` | Original file for the offline cache. Token in query. |
+| Direct stream | `GET /Audio/{itemId}/stream?static=true&ApiKey=…&UserId=…&DeviceId=…` | `static=true` serves the original file (no transcode). Token in the `ApiKey` query (see Authentication). |
+| Download | `GET /Items/{itemId}/Download?ApiKey=…` | Original file for the offline cache. Token in the `ApiKey` query. |
 | Report playback start | `POST /Sessions/Playing` | Body `{ItemId, PositionTicks, …}`; shows Linthra on the dashboard. Best-effort. |
 | Report playback progress | `POST /Sessions/Playing/Progress` | Throttled heartbeat; `IsPaused` carries pause/resume. Best-effort. |
 | Report playback stop | `POST /Sessions/Playing/Stopped` | Settles the server's session/play state. Best-effort. |
 
-**Authentication header.** Authenticated JSON calls send the standard Jellyfin
+**Authentication.** Authenticated JSON calls send the standard Jellyfin
 `Authorization: MediaBrowser Client="Linthra", Device="Linthra", DeviceId="…",
-Version="…", Token="…"` header, built once in `JellyfinAuthHeader`. The token is
-woven into a header or an `api_key` query only at request time and is **never**
-stored on a track, written to the catalog, logged, shown in the UI, or placed in
-an error.
+Version="…", Token="…"` header — the modern, non-legacy scheme — built once in
+`JellyfinAuthHeader`. Media URLs the audio engine fetches directly (the stream,
+download, and control-socket URLs) can't carry a header, so they carry the token
+in the **`ApiKey`** query parameter instead.
+
+Why `ApiKey` (PascalCase), not the older `api_key`? Jellyfin 12 disables *legacy*
+authorization by default (the server's `EnableLegacyAuthorization` switch), which
+gates the lowercase `api_key` query parameter and the `X-Emby-*` headers. The
+PascalCase `ApiKey` is Jellyfin's canonical, non-legacy query key, read
+*unconditionally* on both the 10.x line and Jellyfin 12 — so using it everywhere
+keeps media URLs authenticated on a stock Jellyfin 12 server while staying fully
+backward compatible with 10.8+. (A media URL sent with the legacy `api_key` would
+arrive unauthenticated — a 401 — on a default-config Jellyfin 12.)
+
+The token is woven into a header or the `ApiKey` query only at request time and
+is **never** stored on a track, written to the catalog, logged, shown in the UI,
+or placed in an error.
 
 ### How streaming responses are classified
 
@@ -129,14 +159,19 @@ error:
 - **No version-gated request behavior.** The version is read for diagnostics
   only. Do not add `if (version >= x) useEndpointA else useEndpointB` branches;
   prefer endpoints stable across the 10.x line.
-- **Tolerant parsing.** Unknown JSON fields are ignored and a missing `Items`
-  array reads as empty. Every mapped field is read through a *coercing* helper,
-  so an item that omits a field — or sends it with the **wrong type** (a number
-  where a string is expected, a numeric string for `RunTimeTicks`, …) — yields a
-  safe fallback for that one field instead of throwing. An entry too malformed
-  to use at all (missing `Id`/`Name`, or not an object) is **skipped and
-  counted**, never thrown, so one bad track can't fail the whole sync; the
-  sync then reports "some items could not be synced" rather than an error.
+- **Tolerant parsing.** Unknown JSON fields are ignored and a missing **or
+  `null`** `Items` array reads as empty. Every mapped field is read through a
+  *coercing* helper, so an item that omits a field — or sends it with the
+  **wrong type** (a number where a string is expected, a numeric string for
+  `RunTimeTicks`, a restructured `ImageTags`, …) — yields a safe fallback for
+  that one field instead of throwing. The same coercions now cover **every** wire
+  DTO — server info, the auth result, and playlists/entries — not just library
+  items, so a retyped `Version`, token, or playlist id fails *cleanly* (a clear
+  "not a Jellyfin server" / sign-in error, or a skipped entry) rather than
+  crashing with a `TypeError`. An entry too malformed to use at all (missing
+  `Id`/`Name`, or not an object) is **skipped and counted**, never thrown, so one
+  bad track can't fail the whole sync; the sync then reports "some items could
+  not be synced" rather than an error.
 - **Paginated, bounded reads.** Library listings are pulled in bounded pages
   (`StartIndex`/`Limit`) with a brief yield between them, so a large/slow
   library can't time out one unbounded request or hammer the server, and
@@ -151,6 +186,37 @@ error:
 - **Bump the tested floor** (`kMinimumTestedJellyfinVersion`) only when you have
   actually tested against, and intend to require, a newer baseline.
 
+### Stable API contract assumptions
+
+Because Linthra never version-branches, it instead relies on a small set of
+long-standing API contracts. They hold across the 10.x line and Jellyfin 12; if a
+verified future Jellyfin release changes one, this is the list to check, and the
+fix is centralized (usually one line in `JellyfinEndpoints`):
+
+- **Auth rejection is `401`/`403`.** Only these statuses mean "token rejected"
+  (and only from an auth-verifying call — `/Users/Me` or `AuthenticateByName`).
+  A changed status would mis-message but **cannot** force a sign-out or wipe the
+  catalog: sign-out is user-initiated only, and a failed/empty sync always keeps
+  the existing library.
+- **Token query auth is `ApiKey`.** The non-legacy, always-read query key (see
+  Authentication). The legacy lowercase `api_key` is off by default on Jellyfin
+  12.
+- **Paging is `StartIndex`/`Limit`**, and a listing is `{ "Items": [...],
+  "TotalRecordCount": n }`. A missing/`null` `Items` reads as empty; a
+  missing/non-numeric `TotalRecordCount` falls back to short-page/empty-page
+  termination (with a page-count backstop), so the worst case of a paging change
+  is bounded truncation — never an infinite loop or a wipe.
+- **Stable paths:** `/System/Info/Public`, `/Users/AuthenticateByName`,
+  `/Users/Me`, `/Items`, `/Artists`, `/Playlists/{id}/Items`, the `/Sessions/*`
+  reporting/capabilities endpoints, and the `/socket` control WebSocket.
+- **Favourites use the per-user path form** `…/Users/{userId}/FavoriteItems/
+  {itemId}`. Jellyfin has deprecated path-embedded user ids in favour of
+  query-param forms but still honours this through Jellyfin 12. It is best-effort
+  (a failure never wipes the catalog or signs the user out); if a future release
+  removes it, treat a `404` on toggle as "favourites unsupported" rather than
+  adding a version branch. Library and favourite *listing* already use the modern
+  `/Items?UserId=…` query form.
+
 ## Safe troubleshooting steps
 
 1. **Test connection first.** It checks reachability and that the address is
@@ -164,8 +230,11 @@ error:
    page; confirm the tunnel is healthy and Zero Trust isn't gating the host.
 6. **"This track isn't available"** (404) → the item may have been moved/removed
    or lives in a library your user can't see; re-sync the library.
-7. **Untested-version note** → streaming usually still works; upgrade the server
-   if you hit issues.
+7. **Untested-version note** (older server) → streaming usually still works;
+   upgrade the server if you hit issues.
+8. **"Newer than tested" note** (Jellyfin 12+) → Linthra hasn't validated this
+   major version yet; streaming should still work — please report any issues so
+   the tested ceiling can be raised.
 
 ## Reporting a Jellyfin issue without leaking secrets
 
@@ -184,8 +253,10 @@ Last error: none
 ```
 
 What it includes: app version, connection state, server name/version/product,
-the version-support classification, the **host only** (never a full URL), and
-the **kind** of the last error.
+the version-support classification (`supported` / `newer than tested` /
+`untested (older than recommended)` / `unknown` — enough to spot a Jellyfin 12
+server at a glance), the **host only** (never a full URL), and the **kind** of
+the last error.
 
 What it never includes: your **password**, the **access token**, the
 `Authorization` header, or any **full authenticated URL** (the address is

--- a/lib/core/sources/jellyfin/http_jellyfin_client.dart
+++ b/lib/core/sources/jellyfin/http_jellyfin_client.dart
@@ -246,7 +246,7 @@ class HttpJellyfinClient implements JellyfinClient {
     // its media endpoints (it powers seeking), so this returns `206` with two
     // bytes rather than the whole file.
     //
-    // Auth rides in the URL's `api_key` query — exactly how the engine will
+    // Auth rides in the URL's `ApiKey` query — exactly how the engine will
     // fetch it — so no `Authorization` header is added here: the probe must
     // mirror what `just_audio`/ExoPlayer actually sends, and query auth also
     // survives the redirects (e.g. Cloudflare) a stripped header would not. The
@@ -555,7 +555,10 @@ class HttpJellyfinClient implements JellyfinClient {
       if (entry is! Map<String, dynamic>) continue;
       final Object? text = entry['Text'];
       if (text is! String) continue;
-      final int? ticks = (entry['Start'] as num?)?.toInt();
+      // Tolerant read: a server that sends `Start` as a string (or omits it)
+      // yields a plain, un-timed line rather than throwing on an `as num` cast.
+      final Object? rawStart = entry['Start'];
+      final int? ticks = rawStart is num ? rawStart.toInt() : null;
       lines.add(LyricLine(
         text: text,
         start: (ticks != null && ticks >= 0)

--- a/lib/core/sources/jellyfin/jellyfin_api.dart
+++ b/lib/core/sources/jellyfin/jellyfin_api.dart
@@ -111,16 +111,22 @@ class JellyfinServerInfo {
   /// Parses the response, or returns `null` when the body lacks the fields a
   /// real Jellyfin server always sends (so the client can report "not a
   /// Jellyfin server" instead of surfacing a half-empty object).
+  ///
+  /// Every field is read through [_coerceString], so a server that sends a
+  /// required field with an unexpected type (a numeric `Version`, say) reads as
+  /// absent — a clean "not a Jellyfin server" — rather than throwing a
+  /// `TypeError` that would crash Test-connection / version detection. The
+  /// optional fields simply degrade to `null`.
   static JellyfinServerInfo? fromJson(Map<String, dynamic> json) {
-    final String? name = json['ServerName'] as String?;
-    final String? version = json['Version'] as String?;
+    final String? name = _coerceString(json['ServerName']);
+    final String? version = _coerceString(json['Version']);
     if (name == null || version == null) return null;
     return JellyfinServerInfo(
       serverName: name,
       version: version,
-      id: json['Id'] as String?,
-      productName: json['ProductName'] as String?,
-      operatingSystem: json['OperatingSystem'] as String?,
+      id: _coerceString(json['Id']),
+      productName: _coerceString(json['ProductName']),
+      operatingSystem: _coerceString(json['OperatingSystem']),
     );
   }
 }
@@ -143,20 +149,24 @@ class JellyfinAuthResult {
   final String? serverId;
 
   /// Parses the auth response, or returns `null` if the token/user are absent
-  /// (an unexpected body) so the client can fail clearly.
+  /// or the wrong type (an unexpected body) so the client can fail clearly with
+  /// a sign-in error rather than throw a `TypeError`. Every field is read
+  /// through [_coerceString], which already rejects empty/whitespace, so a
+  /// blank token or user id is treated as absent.
   static JellyfinAuthResult? fromJson(Map<String, dynamic> json) {
-    final String? token = json['AccessToken'] as String?;
+    final String? token = _coerceString(json['AccessToken']);
     final Object? user = json['User'];
     final String? userId =
-        user is Map<String, dynamic> ? user['Id'] as String? : null;
-    if (token == null || token.isEmpty || userId == null || userId.isEmpty) {
+        user is Map<String, dynamic> ? _coerceString(user['Id']) : null;
+    if (token == null || userId == null) {
       return null;
     }
     return JellyfinAuthResult(
       accessToken: token,
       userId: userId,
-      userName: user is Map<String, dynamic> ? user['Name'] as String? : null,
-      serverId: json['ServerId'] as String?,
+      userName:
+          user is Map<String, dynamic> ? _coerceString(user['Name']) : null,
+      serverId: _coerceString(json['ServerId']),
     );
   }
 
@@ -205,15 +215,16 @@ class JellyfinItemDto {
   /// by the caller) so a single malformed entry can't break a whole listing.
   ///
   /// Tolerant by construction: every optional field is read through a *coercing*
-  /// helper ([_string], [_int], [_stringList]) rather than a raw `as` cast, so a
-  /// weird server that sends a number where a string is expected (or vice versa)
-  /// yields a safe fallback (`null`/empty) for that one field instead of
-  /// throwing a `TypeError` that would abort the whole sync. Only a missing or
-  /// blank id/name — an item Linthra cannot reference or label — is rejected.
+  /// helper ([_coerceString], [_coerceInt], [_coerceStringList]) rather than a
+  /// raw `as` cast, so a weird server that sends a number where a string is
+  /// expected (or vice versa) yields a safe fallback (`null`/empty) for that one
+  /// field instead of throwing a `TypeError` that would abort the whole sync.
+  /// Only a missing or blank id/name — an item Linthra cannot reference or
+  /// label — is rejected.
   static JellyfinItemDto? fromJson(Map<String, dynamic> json) {
-    final String? id = _string(json['Id']);
-    final String? name = _string(json['Name']);
-    if (id == null || id.isEmpty || name == null || name.isEmpty) return null;
+    final String? id = _coerceString(json['Id']);
+    final String? name = _coerceString(json['Name']);
+    if (id == null || name == null) return null;
 
     final Object? imageTags = json['ImageTags'];
     final bool hasPrimary = imageTags is Map && imageTags['Primary'] != null;
@@ -221,55 +232,66 @@ class JellyfinItemDto {
     return JellyfinItemDto(
       id: id,
       name: name,
-      album: _string(json['Album']),
-      albumId: _string(json['AlbumId']),
-      albumArtist: _string(json['AlbumArtist']),
-      artists: _stringList(json['Artists']),
-      runTimeTicks: _int(json['RunTimeTicks']),
-      indexNumber: _int(json['IndexNumber']),
-      productionYear: _int(json['ProductionYear']),
-      childCount: _int(json['ChildCount']),
+      album: _coerceString(json['Album']),
+      albumId: _coerceString(json['AlbumId']),
+      albumArtist: _coerceString(json['AlbumArtist']),
+      artists: _coerceStringList(json['Artists']),
+      runTimeTicks: _coerceInt(json['RunTimeTicks']),
+      indexNumber: _coerceInt(json['IndexNumber']),
+      productionYear: _coerceInt(json['ProductionYear']),
+      childCount: _coerceInt(json['ChildCount']),
       hasPrimaryImage: hasPrimary,
     );
   }
+}
 
-  /// A trimmed non-empty [String] from a wire value, or `null` for anything
-  /// else (a number, bool, list, missing, or blank). Trimming means a field
-  /// that is all whitespace reads as absent rather than a blank label.
-  static String? _string(Object? value) {
-    if (value is! String) return null;
+/// Shared, tolerant coercions for the wire values every DTO in this file reads.
+///
+/// Jellyfin 12 (and the occasional proxy or plugin) can send a field with an
+/// unexpected type — a number where a string is expected, a numeric string for
+/// a count — or omit it entirely. Reading every field through these coercions,
+/// rather than a raw `as` cast, means such a value yields a safe fallback for
+/// that one field instead of throwing a `TypeError` that would abort parsing an
+/// entire response. The rule across the app: missing / renamed / null / retyped
+/// fields are non-fatal. Proven first on [JellyfinItemDto] (PR #253) and hoisted
+/// here so the server-info, auth, and playlist DTOs are equally robust.
+
+/// A trimmed non-empty [String] from a wire value, or `null` for anything
+/// else (a number, bool, list, missing, or blank). Trimming means a field
+/// that is all whitespace reads as absent rather than a blank label.
+String? _coerceString(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+/// An [int] from a wire value, accepting the JSON `num` Jellyfin normally
+/// sends *and* a numeric string some plugins/proxies emit. Returns `null` for
+/// anything non-numeric (a non-number string, bool, list, …) so one weird
+/// field never throws.
+int? _coerceInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) {
     final String trimmed = value.trim();
-    return trimmed.isEmpty ? null : trimmed;
+    // Symmetric with the `num` path: a fractional numeric string ("123.9")
+    // truncates exactly like the JSON number 123.9 would, rather than being
+    // dropped because `int.tryParse` rejects the decimal point.
+    return int.tryParse(trimmed) ?? double.tryParse(trimmed)?.toInt();
   }
+  return null;
+}
 
-  /// An [int] from a wire value, accepting the JSON `num` Jellyfin normally
-  /// sends *and* a numeric string some plugins/proxies emit. Returns `null` for
-  /// anything non-numeric (a non-number string, bool, list, …) so one weird
-  /// field never throws.
-  static int? _int(Object? value) {
-    if (value is int) return value;
-    if (value is num) return value.toInt();
-    if (value is String) {
-      final String trimmed = value.trim();
-      // Symmetric with the `num` path: a fractional numeric string ("123.9")
-      // truncates exactly like the JSON number 123.9 would, rather than being
-      // dropped because `int.tryParse` rejects the decimal point.
-      return int.tryParse(trimmed) ?? double.tryParse(trimmed)?.toInt();
-    }
-    return null;
-  }
-
-  /// The non-empty strings from a wire list, or an empty list when the value
-  /// isn't a list at all. Non-string entries inside the list are dropped rather
-  /// than throwing, so a partially malformed `Artists` array still yields the
-  /// good names.
-  static List<String> _stringList(Object? value) {
-    if (value is! List) return const <String>[];
-    return <String>[
-      for (final Object? entry in value)
-        if (entry is String && entry.trim().isNotEmpty) entry.trim(),
-    ];
-  }
+/// The non-empty strings from a wire list, or an empty list when the value
+/// isn't a list at all. Non-string entries inside the list are dropped rather
+/// than throwing, so a partially malformed `Artists` array still yields the
+/// good names.
+List<String> _coerceStringList(Object? value) {
+  if (value is! List) return const <String>[];
+  return <String>[
+    for (final Object? entry in value)
+      if (entry is String && entry.trim().isNotEmpty) entry.trim(),
+  ];
 }
 
 /// The outcome of listing one [JellyfinItemKind] from the server: the items
@@ -308,12 +330,14 @@ class JellyfinPlaylistDto {
   final String id;
   final String name;
 
-  /// Parses one playlist entry, or `null` when it lacks an id/name so a single
-  /// malformed entry can't break a whole listing.
+  /// Parses one playlist entry, or `null` when it lacks a usable id/name (or
+  /// sends either with the wrong type) so a single malformed entry is skipped
+  /// by the caller rather than throwing a `TypeError` that aborts the whole
+  /// playlist listing. Both fields are read through [_coerceString].
   static JellyfinPlaylistDto? fromJson(Map<String, dynamic> json) {
-    final String? id = json['Id'] as String?;
-    final String? name = json['Name'] as String?;
-    if (id == null || id.isEmpty || name == null) return null;
+    final String? id = _coerceString(json['Id']);
+    final String? name = _coerceString(json['Name']);
+    if (id == null || name == null) return null;
     return JellyfinPlaylistDto(id: id, name: name);
   }
 }
@@ -332,11 +356,11 @@ class JellyfinPlaylistEntry {
   final String? playlistItemId;
 
   static JellyfinPlaylistEntry? fromJson(Map<String, dynamic> json) {
-    final String? id = json['Id'] as String?;
-    if (id == null || id.isEmpty) return null;
+    final String? id = _coerceString(json['Id']);
+    if (id == null) return null;
     return JellyfinPlaylistEntry(
       itemId: id,
-      playlistItemId: json['PlaylistItemId'] as String?,
+      playlistItemId: _coerceString(json['PlaylistItemId']),
     );
   }
 }

--- a/lib/core/sources/jellyfin/jellyfin_control_socket.dart
+++ b/lib/core/sources/jellyfin/jellyfin_control_socket.dart
@@ -26,7 +26,7 @@ typedef JellyfinControlSocketConnector = Future<JellyfinControlSocket> Function(
 );
 
 /// Production connector: a `dart:io` [WebSocket]. The [url] carries the access
-/// token in its `api_key` query, so it must never be logged here.
+/// token in its `ApiKey` query, so it must never be logged here.
 Future<JellyfinControlSocket> connectJellyfinControlSocket(Uri url) async {
   final WebSocket socket = await WebSocket.connect(url.toString());
   return _WebSocketJellyfinControlSocket(socket);

--- a/lib/core/sources/jellyfin/jellyfin_endpoints.dart
+++ b/lib/core/sources/jellyfin/jellyfin_endpoints.dart
@@ -34,10 +34,21 @@ abstract final class JellyfinEndpoints {
 
   // --- Query-parameter keys, named once so a typo can't split a request. ---
 
-  /// The access token, carried in a media URL's query (not an `Authorization`
-  /// header) so it survives the redirects a stripped header would not and
-  /// matches exactly what the audio engine fetches with.
-  static const String apiKeyParam = 'api_key';
+  /// The query-parameter name that carries the access token in a media URL —
+  /// the stream, download, and control-socket URLs — instead of an
+  /// `Authorization` header, because that is what the Android audio engine
+  /// (`just_audio`/ExoPlayer) fetches with, and query auth survives the
+  /// redirects a stripped header would not.
+  ///
+  /// This is the PascalCase `ApiKey`: Jellyfin's canonical, non-legacy query
+  /// key, read unconditionally across the 10.x line *and* Jellyfin 12. The
+  /// lowercase `api_key` (and the `X-Emby-*` headers) is a legacy form Jellyfin
+  /// 12 only honours when the server opts back in with `EnableLegacyAuthorization`
+  /// — off by default — so an `api_key` media URL would arrive unauthenticated
+  /// (401) on a stock Jellyfin 12 server while `ApiKey` keeps working. `ApiKey`
+  /// has been accepted since well before 10.8, so this is also fully backward
+  /// compatible. See docs/jellyfin-compatibility.md.
+  static const String apiKeyParam = 'ApiKey';
 
   /// `static=true` asks Jellyfin to serve the original file bytes as-is.
   static const String staticParam = 'static';
@@ -243,11 +254,11 @@ abstract final class JellyfinEndpoints {
   static Uri capabilitiesFull(String baseUrl) =>
       _join(baseUrl, _capabilitiesFullPath);
 
-  /// The session control WebSocket: `{ws|wss}://<host>/socket?api_key=…&deviceId=…`.
+  /// The session control WebSocket: `{ws|wss}://<host>/socket?ApiKey=…&deviceId=…`.
   ///
   /// Built from [baseUrl] by switching the scheme to `ws`/`wss`. The server
   /// pushes remote-control (Playstate/GeneralCommand) messages down this socket
-  /// once the session is registered. Auth rides in the [accessToken] `api_key`
+  /// once the session is registered. Auth rides in the [accessToken] `ApiKey`
   /// query — exactly like the audio stream URL ([audioStream]) — so the receiver
   /// must treat this Uri as a secret and never log it.
   static Uri controlSocket(
@@ -299,7 +310,7 @@ abstract final class JellyfinEndpoints {
         },
       );
 
-  /// The original-file download URL: `/Items/<id>/Download?api_key=…`, used so
+  /// The original-file download URL: `/Items/<id>/Download?ApiKey=…`, used so
   /// the offline copy is the real source file rather than a transcode. Like
   /// [audioStream], the token is woven in on demand and never stored.
   static Uri download(

--- a/lib/core/sources/jellyfin/jellyfin_music_source.dart
+++ b/lib/core/sources/jellyfin/jellyfin_music_source.dart
@@ -133,7 +133,7 @@ class JellyfinMusicSource
   /// stream endpoint (`/Audio/<id>/stream` with `static=true`) so the server
   /// returns the original file bytes — what `just_audio`/ExoPlayer can open
   /// directly — rather than negotiating a transcode/HLS variant the engine may
-  /// reject. Auth rides in the `api_key` query (not a header) because that is
+  /// reject. Auth rides in the `ApiKey` query (not a header) because that is
   /// what the engine fetches with, and query auth survives the redirects a
   /// stripped header would not.
   @override

--- a/lib/core/sources/jellyfin/jellyfin_remote_control_receiver.dart
+++ b/lib/core/sources/jellyfin/jellyfin_remote_control_receiver.dart
@@ -25,7 +25,7 @@ import 'jellyfin_remote_command.dart';
 /// playback. [stop] disconnects without ending the command stream (a later
 /// [start] resumes); [dispose] closes everything.
 ///
-/// Token safety: the access token rides in the WebSocket URL's `api_key` query
+/// Token safety: the access token rides in the WebSocket URL's `ApiKey` query
 /// (like the audio stream URL) and the capability POST's `Authorization`
 /// header; the URL is never logged, and nothing here is persisted.
 class JellyfinRemoteControlReceiver implements RemoteControlReceiver {

--- a/lib/core/sources/jellyfin/jellyfin_server_capabilities.dart
+++ b/lib/core/sources/jellyfin/jellyfin_server_capabilities.dart
@@ -2,13 +2,14 @@
 ///
 /// This is intentionally *diagnostic only*: it parses the version string a
 /// server reports and classifies how well Linthra expects to work with it, so
-/// the user (and a bug report) can see "you're on an older, untested server".
+/// the user (and a bug report) can see "you're on an older, untested server" or
+/// "you're on a newer major version we haven't validated yet".
 ///
 /// It must never be used to branch request behavior — the endpoints Linthra
 /// uses (see [JellyfinEndpoints] and docs/jellyfin-compatibility.md) are stable
-/// across the Jellyfin 10.x line, so there is no need for version-sniffing
-/// hacks, and adding them would be exactly the kind of fragile coupling this
-/// hardening pass is meant to avoid.
+/// across the Jellyfin 10.x line and into Jellyfin 12, so there is no need for
+/// version-sniffing hacks, and adding them would be exactly the kind of fragile
+/// coupling this hardening pass is meant to avoid.
 library;
 
 /// A parsed Jellyfin `major.minor.patch` version.
@@ -64,8 +65,16 @@ class JellyfinServerVersion implements Comparable<JellyfinServerVersion> {
 
 /// How well Linthra expects to work with a server's reported version.
 enum JellyfinServerSupport {
-  /// At or above the oldest version Linthra is tested against.
+  /// Within the tested range: at or above the oldest tested version and at or
+  /// below the newest tested major.
   supported,
+
+  /// Newer than the newest tested **major** (e.g. Jellyfin 12, where Linthra is
+  /// tested through the 10.x line). Forward-tolerant: Linthra allows it and
+  /// expects it to work — the endpoints it uses are stable and it never
+  /// version-branches — but the combination is not yet validated, so the user
+  /// is gently told to report any issues.
+  newerUntested,
 
   /// Older than the tested minimum. Linthra may still work — the endpoints it
   /// uses are long-standing — but the combination is untested.
@@ -79,6 +88,8 @@ enum JellyfinServerSupport {
     switch (this) {
       case JellyfinServerSupport.supported:
         return 'supported';
+      case JellyfinServerSupport.newerUntested:
+        return 'newer than tested';
       case JellyfinServerSupport.untested:
         return 'untested (older than recommended)';
       case JellyfinServerSupport.unknown:
@@ -95,7 +106,22 @@ enum JellyfinServerSupport {
 const JellyfinServerVersion kMinimumTestedJellyfinVersion =
     JellyfinServerVersion(10, 8, 0);
 
-/// Classifies a reported [version] string against [kMinimumTestedJellyfinVersion].
+/// The newest Jellyfin **major** version Linthra is actively tested against.
+///
+/// Jellyfin's next release after the 10.x line is **12.0** (there is no 11), so
+/// a server reporting major 12 or above is a forward jump Linthra has not yet
+/// validated. Like the floor, this is a conservative diagnostic boundary, never
+/// a gate: such a server is labelled [JellyfinServerSupport.newerUntested] (and
+/// the user is gently told streaming should still work) — never blocked — and
+/// it never changes which endpoints or parameters Linthra sends. Raise it only
+/// when a newer major has actually been tested.
+const int kMaximumTestedJellyfinMajor = 10;
+
+/// Classifies a reported [version] string into a [JellyfinServerSupport] band,
+/// using [kMinimumTestedJellyfinVersion] as the floor and
+/// [kMaximumTestedJellyfinMajor] as the forward ceiling. Diagnostic only — the
+/// result drives a calm note and the diagnostics report, never request
+/// behavior.
 JellyfinServerSupport jellyfinServerSupportFor(String? version) {
   if (version == null || version.trim().isEmpty) {
     return JellyfinServerSupport.unknown;
@@ -103,6 +129,9 @@ JellyfinServerSupport jellyfinServerSupportFor(String? version) {
   final JellyfinServerVersion? parsed = JellyfinServerVersion.tryParse(version);
   if (parsed == null) {
     return JellyfinServerSupport.unknown;
+  }
+  if (parsed.major > kMaximumTestedJellyfinMajor) {
+    return JellyfinServerSupport.newerUntested;
   }
   return parsed >= kMinimumTestedJellyfinVersion
       ? JellyfinServerSupport.supported

--- a/lib/features/settings/jellyfin/jellyfin_settings_section.dart
+++ b/lib/features/settings/jellyfin/jellyfin_settings_section.dart
@@ -325,6 +325,17 @@ class _ConnectedView extends StatelessWidget {
             isError: false,
           ),
         ],
+        if (state.serverVersion != null &&
+            jellyfinServerSupportFor(state.serverVersion) ==
+                JellyfinServerSupport.newerUntested) ...[
+          const SizedBox(height: AppSpacing.sm),
+          const _StatusLine(
+            message: 'This is a newer major version of Jellyfin than Linthra '
+                'has been tested against. Streaming should still work — please '
+                'report any issues.',
+            isError: false,
+          ),
+        ],
         const SizedBox(height: AppSpacing.md),
         // The manual "Sync library" stays available at all times (disabled only
         // while a sync is running). After sign-in the first sync starts on its

--- a/test/core/services/remote_cache/remote_cache_key_test.dart
+++ b/test/core/services/remote_cache/remote_cache_key_test.dart
@@ -62,6 +62,12 @@ void main() {
         RemoteCacheKey.forUri('jellyfin:abc?api_key=SECRET'),
         isNull,
       );
+      // The PascalCase ApiKey (Jellyfin's canonical token query key) is caught
+      // too — the denylist is matched case-insensitively.
+      expect(
+        RemoteCacheKey.forUri('jellyfin:abc?ApiKey=SECRET'),
+        isNull,
+      );
       expect(
         RemoteCacheKey.forUri('plex:101?X-Plex-Token=SECRET'),
         isNull,

--- a/test/core/sources/jellyfin/http_jellyfin_client_playlist_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_playlist_test.dart
@@ -51,6 +51,25 @@ void main() {
       // The token rides only in the auth header, never logged elsewhere.
       expect(captured!.headers['Authorization'], contains(_token));
     });
+
+    test('skips a malformed playlist (numeric Id/Name), keeping the good one',
+        () async {
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        return _json(<String, dynamic>{
+          'Items': <dynamic>[
+            <String, dynamic>{'Id': 123, 'Name': 'Bad'},
+            <String, dynamic>{'Id': 'pl-good', 'Name': 'Good'},
+          ],
+        });
+      }));
+
+      final List<JellyfinPlaylistDto> playlists =
+          await client.fetchPlaylists(_session);
+
+      // The numeric-Id playlist coerces away and is skipped; the listing loop
+      // does not throw, and the good playlist still loads.
+      expect(playlists.map((p) => p.id), <String>['pl-good']);
+    });
   });
 
   group('fetchPlaylistEntries', () {
@@ -69,6 +88,21 @@ void main() {
           await client.fetchPlaylistEntries(_session, 'pl-1');
       expect(entries.map((e) => e.itemId), <String>['a', 'b']);
       expect(entries.first.playlistItemId, 'e-a');
+    });
+
+    test('skips an entry with a non-string Id, keeping the rest', () async {
+      final HttpJellyfinClient client = _client(MockClient((request) async {
+        return _json(<String, dynamic>{
+          'Items': <dynamic>[
+            <String, dynamic>{'Id': 42, 'PlaylistItemId': 'e-bad'},
+            <String, dynamic>{'Id': 'b', 'PlaylistItemId': 'e-b'},
+          ],
+        });
+      }));
+
+      final List<JellyfinPlaylistEntry> entries =
+          await client.fetchPlaylistEntries(_session, 'pl-1');
+      expect(entries.map((e) => e.itemId), <String>['b']);
     });
   });
 

--- a/test/core/sources/jellyfin/http_jellyfin_client_test.dart
+++ b/test/core/sources/jellyfin/http_jellyfin_client_test.dart
@@ -187,6 +187,34 @@ void main() {
       expect(body['Pw'], 'pw-secret');
     });
 
+    test('a retyped token/user id fails as notJellyfin, not a TypeError',
+        () async {
+      // A server that sends AccessToken or User.Id as a number must not crash
+      // sign-in with a TypeError; the auth body is unusable, so it surfaces as
+      // a clean "not a Jellyfin server" from a null fromJson rather than a throw.
+      final client = _client(MockClient((_) async => http.Response(
+            jsonEncode(<String, dynamic>{
+              'AccessToken': 12345,
+              'User': <String, dynamic>{'Id': 67890, 'Name': 'Alice'},
+            }),
+            200,
+          )));
+
+      await expectLater(
+        client.authenticateByName(
+          baseUrl: _base,
+          username: 'alice',
+          password: 'pw-secret',
+          deviceId: 'dev-1',
+        ),
+        throwsA(isA<JellyfinException>().having(
+          (JellyfinException e) => e.kind,
+          'kind',
+          JellyfinErrorKind.notJellyfin,
+        )),
+      );
+    });
+
     test('maps 401 to unauthorized without leaking the password', () async {
       final client = _client(
         MockClient((_) async => http.Response('Unauthorized', 401)),
@@ -274,6 +302,23 @@ void main() {
           await client.fetchItems(_session, kind: JellyfinItemKind.album);
 
       expect(listing.items, isEmpty);
+    });
+
+    test('treats an explicit Items: null as an empty listing', () async {
+      // JF12 may send `Items: null` rather than omitting the field; the client
+      // must read it as empty (no items) rather than null-dereferencing.
+      final client = _client(
+        MockClient((_) async => http.Response(
+              jsonEncode(<String, dynamic>{'Items': null}),
+              200,
+            )),
+      );
+
+      final listing =
+          await client.fetchItems(_session, kind: JellyfinItemKind.album);
+
+      expect(listing.items, isEmpty);
+      expect(listing.skippedCount, 0);
     });
 
     test('maps an expired token (401) to unauthorized', () async {
@@ -869,6 +914,25 @@ void main() {
       final client = _client(MockClient((_) async => http.Response('', 404)));
 
       expect(await client.fetchLyrics(_session, 'item-7'), isNull);
+    });
+
+    test('a non-numeric Start yields a plain (un-timed) line, not a throw',
+        () async {
+      // JF12 / a plugin sending Start as a string must not throw on the cast;
+      // the line is kept without a timestamp.
+      final client = _client(MockClient((_) async => http.Response(
+            jsonEncode(<String, dynamic>{
+              'Lyrics': <Map<String, dynamic>>[
+                <String, dynamic>{'Text': 'Line', 'Start': 'oops'},
+              ],
+            }),
+            200,
+            headers: <String, String>{'content-type': 'application/json'},
+          )));
+
+      final lyrics = await client.fetchLyrics(_session, 'item-7');
+      expect(lyrics!.lines.single.text, 'Line');
+      expect(lyrics.lines.single.start, isNull);
     });
   });
 

--- a/test/core/sources/jellyfin/jellyfin_diagnostics_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_diagnostics_test.dart
@@ -20,11 +20,11 @@ void main() {
 
     test('drops scheme, path, and query (so no token can ride along)', () {
       final String? host = JellyfinDiagnostics.hostOnly(
-        'https://music.example.com/Audio/t1/stream?api_key=secret',
+        'https://music.example.com/Audio/t1/stream?ApiKey=secret',
       );
       expect(host, 'music.example.com');
       expect(host, isNot(contains('secret')));
-      expect(host, isNot(contains('api_key')));
+      expect(host, isNot(contains('ApiKey')));
       expect(host, isNot(contains('https')));
     });
 
@@ -56,6 +56,17 @@ void main() {
       expect(report, contains('Last error: none'));
     });
 
+    test('emits the forward-tolerant label for a newer-than-tested server', () {
+      final String report = JellyfinDiagnostics.describe(
+        appVersion: '0.1.0',
+        connectionState: 'connected',
+        serverVersion: '12.0.0',
+        versionSupport: JellyfinServerSupport.newerUntested,
+      );
+      expect(report, contains('Server version: 12.0.0'));
+      expect(report, contains('Version support: newer than tested'));
+    });
+
     test('reports the last error kind when present', () {
       final String report = JellyfinDiagnostics.describe(
         appVersion: '0.1.0',
@@ -72,14 +83,14 @@ void main() {
         appVersion: '0.1.0',
         connectionState: 'connected',
         serverHost: JellyfinDiagnostics.hostOnly(
-          'https://music.example.com/Audio/t1/stream?api_key=tok-secret',
+          'https://music.example.com/Audio/t1/stream?ApiKey=tok-secret',
         ),
         serverName: 'Home',
         serverVersion: '10.9.11',
       );
 
       expect(report, isNot(contains('tok-secret')));
-      expect(report, isNot(contains('api_key')));
+      expect(report, isNot(contains('ApiKey')));
       expect(report, isNot(contains('Token')));
       expect(report, isNot(contains('password')));
       expect(report, isNot(contains('/Audio/')));

--- a/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_endpoints_test.dart
@@ -115,8 +115,9 @@ void main() {
     test('primaryImage is a token-free cover-art URL', () {
       final Uri uri = JellyfinEndpoints.primaryImage(_base, itemId: 'item-7');
       expect(uri.path, '/Items/item-7/Images/Primary');
-      // Artwork needs no auth, so it carries no token (safe to persist/cache).
-      expect(uri.toString(), isNot(contains('api_key')));
+      // Artwork needs no auth, so it carries no token at all (safe to
+      // persist/cache) — neither the canonical ApiKey nor the legacy api_key.
+      expect(uri.hasQuery, isFalse);
     });
   });
 
@@ -160,8 +161,13 @@ void main() {
       expect(uri.queryParameters['DeviceId'], 'device-1');
     });
 
-    test('weaves the token into the api_key query, never the path', () {
-      expect(uri.queryParameters['api_key'], _token);
+    test('weaves the token into the canonical ApiKey query, never the path',
+        () {
+      expect(uri.queryParameters['ApiKey'], _token);
+      // The PascalCase ApiKey is read unconditionally by Jellyfin 10.x and 12;
+      // the legacy lowercase api_key is gated off by default on Jellyfin 12, so
+      // it must not be the carrier.
+      expect(uri.queryParameters.containsKey('api_key'), isFalse);
       // The token is in the query only — never in the path the catalog/logs see.
       expect(uri.path, isNot(contains(_token)));
     });
@@ -178,9 +184,30 @@ void main() {
       expect(uri.path, '/Items/t1/Download');
     });
 
-    test('weaves the token into the api_key query, never the path', () {
-      expect(uri.queryParameters['api_key'], _token);
+    test('weaves the token into the canonical ApiKey query, never the path',
+        () {
+      expect(uri.queryParameters['ApiKey'], _token);
+      expect(uri.queryParameters.containsKey('api_key'), isFalse);
       expect(uri.path, isNot(contains(_token)));
+    });
+  });
+
+  group('JellyfinEndpoints.controlSocket', () {
+    final Uri uri = JellyfinEndpoints.controlSocket(
+      _base,
+      accessToken: _token,
+      deviceId: 'device-1',
+    );
+
+    test('upgrades to wss and carries the token in the canonical ApiKey query',
+        () {
+      expect(uri.scheme, 'wss');
+      expect(uri.path, '/socket');
+      expect(uri.queryParameters['ApiKey'], _token);
+      expect(uri.queryParameters['deviceId'], 'device-1');
+      // Same JF12 rationale as the stream/download URLs: the socket handshake
+      // authenticates through the same path, so it must use ApiKey too.
+      expect(uri.queryParameters.containsKey('api_key'), isFalse);
     });
   });
 }

--- a/test/core/sources/jellyfin/jellyfin_item_dto_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_item_dto_test.dart
@@ -99,6 +99,28 @@ void main() {
       })!;
       expect(dto.hasPrimaryImage, isFalse);
     });
+
+    test('ImageTags as a list (not a map) means no primary image', () {
+      // JF12 shape drift: if ImageTags arrives as a list, hasPrimaryImage stays
+      // false and the track is still usable — only artwork degrades.
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'ImageTags': <dynamic>['Primary', 'Backdrop'],
+      })!;
+      expect(dto.hasPrimaryImage, isFalse);
+    });
+
+    test('ImageTags with a lowercase "primary" key means no primary image', () {
+      // The key is matched exactly; a renamed/recased key degrades to no
+      // artwork rather than guessing.
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'ImageTags': <String, dynamic>{'primary': 'abc'},
+      })!;
+      expect(dto.hasPrimaryImage, isFalse);
+    });
   });
 
   group('JellyfinItemDto.fromJson — wrong field types never throw', () {
@@ -138,6 +160,28 @@ void main() {
         'RunTimeTicks': 'not-a-number',
       })!;
       expect(dto.runTimeTicks, isNull);
+    });
+
+    test('an explicit null RunTimeTicks reads as null (no throw)', () {
+      // JF12 may send the field as JSON null rather than omitting it.
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'RunTimeTicks': null,
+      })!;
+      expect(dto.runTimeTicks, isNull);
+    });
+
+    test('a null ProductionYear and a numeric-string ChildCount coerce safely',
+        () {
+      final dto = JellyfinItemDto.fromJson(<String, dynamic>{
+        'Id': 't1',
+        'Name': 'One',
+        'ProductionYear': null,
+        'ChildCount': '12',
+      })!;
+      expect(dto.productionYear, isNull);
+      expect(dto.childCount, 12);
     });
 
     test('a floating-point RunTimeTicks is truncated to an int', () {

--- a/test/core/sources/jellyfin/jellyfin_music_source_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_music_source_test.dart
@@ -152,7 +152,7 @@ void main() {
       expect(uri!.path, '/Audio/t1/stream');
       expect(uri.queryParameters['static'], 'true');
       expect(uri.host, 'music.example.com');
-      expect(uri.queryParameters['api_key'], 'secret-token');
+      expect(uri.queryParameters['ApiKey'], 'secret-token');
       expect(uri.queryParameters['UserId'], 'user-1');
       expect(uri.queryParameters['DeviceId'], 'device-1');
       // The stream URL is probed before it is returned (and the probe sees the
@@ -309,7 +309,7 @@ void main() {
       expect(uri, isNotNull);
       expect(uri!.path, '/Items/t1/Download');
       expect(uri.host, 'music.example.com');
-      expect(uri.queryParameters['api_key'], 'secret-token');
+      expect(uri.queryParameters['ApiKey'], 'secret-token');
       // The track's own uri stays the token-free jellyfin id.
       expect(track.uri, 'jellyfin:t1');
     });

--- a/test/core/sources/jellyfin/jellyfin_remote_command_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_remote_command_test.dart
@@ -92,7 +92,7 @@ void main() {
   });
 
   group('JellyfinEndpoints control endpoints', () {
-    test('controlSocket builds a wss URL with api_key and deviceId', () {
+    test('controlSocket builds a wss URL with ApiKey and deviceId', () {
       final Uri uri = JellyfinEndpoints.controlSocket(
         'https://music.example.com',
         accessToken: 'tok',
@@ -101,7 +101,7 @@ void main() {
       expect(uri.scheme, 'wss');
       expect(uri.host, 'music.example.com');
       expect(uri.path, '/socket');
-      expect(uri.queryParameters['api_key'], 'tok');
+      expect(uri.queryParameters['ApiKey'], 'tok');
       expect(uri.queryParameters['deviceId'], 'dev-1');
     });
 

--- a/test/core/sources/jellyfin/jellyfin_server_capabilities_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_server_capabilities_test.dart
@@ -25,6 +25,32 @@ void main() {
       );
     });
 
+    test('parses Jellyfin 12 release and pre-release strings', () {
+      expect(JellyfinServerVersion.tryParse('12.0'),
+          const JellyfinServerVersion(12, 0, 0));
+      expect(JellyfinServerVersion.tryParse('12.0.0'),
+          const JellyfinServerVersion(12, 0, 0));
+      expect(JellyfinServerVersion.tryParse('12.0-rc'),
+          const JellyfinServerVersion(12, 0, 0));
+      expect(JellyfinServerVersion.tryParse('12.0.0-rc1'),
+          const JellyfinServerVersion(12, 0, 0));
+      expect(JellyfinServerVersion.tryParse('12.1.0'),
+          const JellyfinServerVersion(12, 1, 0));
+    });
+
+    test('ignores a 4th version segment and a rich build suffix', () {
+      expect(JellyfinServerVersion.tryParse('12.0.0.1'),
+          const JellyfinServerVersion(12, 0, 0));
+      expect(JellyfinServerVersion.tryParse('12.0.0-rc1+build.123'),
+          const JellyfinServerVersion(12, 0, 0));
+    });
+
+    test('a bare major with no minor is not parsed (stays unknown)', () {
+      // Standard Jellyfin always reports major.minor.patch; a lone "12" has no
+      // recognizable minor, so it is treated as unparseable rather than guessed.
+      expect(JellyfinServerVersion.tryParse('12'), isNull);
+    });
+
     test('returns null for an unparseable string', () {
       expect(JellyfinServerVersion.tryParse('unknown'), isNull);
       expect(JellyfinServerVersion.tryParse(''), isNull);
@@ -69,6 +95,42 @@ void main() {
           jellyfinServerSupportFor('10.9.11'), JellyfinServerSupport.supported);
       expect(
           jellyfinServerSupportFor('10.10.0'), JellyfinServerSupport.supported);
+    });
+
+    test('the tested 10.10/10.11 line is supported', () {
+      expect(
+          jellyfinServerSupportFor('10.10.0'), JellyfinServerSupport.supported);
+      expect(jellyfinServerSupportFor('10.11.11'),
+          JellyfinServerSupport.supported);
+    });
+
+    test('a newer major (Jellyfin 12+) is forward-tolerant, not blocked', () {
+      for (final String v in <String>[
+        '12.0',
+        '12.0.0',
+        '12.0-rc',
+        '12.0.0-rc1',
+        '12.1.0',
+      ]) {
+        expect(
+          jellyfinServerSupportFor(v),
+          JellyfinServerSupport.newerUntested,
+          reason: '$v should classify as newerUntested',
+        );
+      }
+    });
+
+    test('the forward boundary keys off the tested major', () {
+      // At or below the tested major stays supported; above it flips to
+      // newerUntested — guarding the kMaximumTestedJellyfinMajor boundary.
+      expect(
+        jellyfinServerSupportFor('$kMaximumTestedJellyfinMajor.99.99'),
+        JellyfinServerSupport.supported,
+      );
+      expect(
+        jellyfinServerSupportFor('${kMaximumTestedJellyfinMajor + 1}.0.0'),
+        JellyfinServerSupport.newerUntested,
+      );
     });
 
     test('a version at the tested minimum is supported', () {

--- a/test/core/sources/jellyfin/jellyfin_server_info_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_server_info_test.dart
@@ -45,6 +45,43 @@ void main() {
       );
     });
 
+    test('returns null (clean fail) when a required field is the wrong type',
+        () {
+      // A server that sends Version or ServerName as a number reads as "not a
+      // Jellyfin server" rather than throwing a TypeError on an `as String`.
+      expect(
+        JellyfinServerInfo.fromJson(<String, dynamic>{
+          'ServerName': 'Home',
+          'Version': 12,
+        }),
+        isNull,
+      );
+      expect(
+        JellyfinServerInfo.fromJson(<String, dynamic>{
+          'ServerName': 99,
+          'Version': '12.0.0',
+        }),
+        isNull,
+      );
+    });
+
+    test('degrades retyped optional fields to null, still parsing', () {
+      final JellyfinServerInfo? info =
+          JellyfinServerInfo.fromJson(<String, dynamic>{
+        'ServerName': 'Home',
+        'Version': '12.0.0',
+        'Id': 123,
+        'ProductName': <String, dynamic>{'weird': true},
+        'OperatingSystem': <dynamic>[],
+      });
+      expect(info, isNotNull);
+      expect(info!.serverName, 'Home');
+      expect(info.version, '12.0.0');
+      expect(info.id, isNull);
+      expect(info.productName, isNull);
+      expect(info.operatingSystem, isNull);
+    });
+
     test('exposes parsed version and support classification', () {
       const JellyfinServerInfo current =
           JellyfinServerInfo(serverName: 'Home', version: '10.9.11');
@@ -59,6 +96,12 @@ void main() {
           JellyfinServerInfo(serverName: 'Weird', version: 'custom-build');
       expect(weird.parsedVersion, isNull);
       expect(weird.support, JellyfinServerSupport.unknown);
+
+      // A Jellyfin 12 release candidate parses and is flagged forward-tolerant.
+      const JellyfinServerInfo newer =
+          JellyfinServerInfo(serverName: 'Next', version: '12.0.0-rc1');
+      expect(newer.parsedVersion, const JellyfinServerVersion(12, 0, 0));
+      expect(newer.support, JellyfinServerSupport.newerUntested);
     });
   });
 }

--- a/test/core/sources/jellyfin/jellyfin_track_mapper_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_track_mapper_test.dart
@@ -37,7 +37,7 @@ void main() {
       const item = JellyfinItemDto(id: 'abc', name: 'X');
       final track = JellyfinTrackMapper.toTrack(item, baseUrl: _baseUrl);
       expect(track.uri, isNot(contains('http')));
-      expect(track.uri, isNot(contains('api_key')));
+      expect(track.uri, isNot(contains('ApiKey')));
     });
 
     test('falls back to the first listed artist when no album artist', () {


### PR DESCRIPTION
## Goal

Make Linthra behave like a conservative, Debian-style client across Jellyfin versions: stable, backward-compatible, forward-tolerant, and safe. Jellyfin 12 RCs are appearing (the next release after 10.11 — there is no 11), so this prepares Linthra for **12.x** without breaking **10.10/10.11** users.

A separate follow-up to #253 (which made library sync tolerant and resilient). This builds a thin layer on top — it does **not** redo #253's work.

## The one behavioral change: `api_key` → `ApiKey` on media URLs

This is the headline, and it's the thing that actually keeps playback working on Jellyfin 12.

- Jellyfin 12 disables `EnableLegacyAuthorization` **by default**. Verified against Jellyfin's own [`AuthorizationContext`](https://github.com/jellyfin/jellyfin/blob/master/Jellyfin.Server.Implementations/Security/AuthorizationContext.cs): the lowercase **`api_key`** query parameter and the `X-Emby-*` headers are only read when that flag is on, while the PascalCase **`ApiKey`** query parameter is read **unconditionally** — on the 10.x line (it's read *first*, with a "TODO deprecate `api_key`" comment) **and** on master/12.
- Linthra builds every media URL — stream, download, and the remote-control WebSocket — with the token in the query (the audio engine can't set a header). On a stock Jellyfin 12 server those `api_key` URLs would arrive **unauthenticated → 401**, breaking playback/downloads/socket even though the JSON API (which already uses the modern `MediaBrowser` Authorization header) keeps working.
- Fix: switch the single `JellyfinEndpoints.apiKeyParam` constant `'api_key'` → `'ApiKey'`. Backward-compatible (10.8+ read `ApiKey`) and forward-compatible (12 reads it unconditionally). **No version branching.**

## Hardening & diagnostics (no request-shape changes)

- **Tolerant parsing for every wire DTO.** The coercing helpers proven on `JellyfinItemDto` (#253) are hoisted and applied to `JellyfinServerInfo`, `JellyfinAuthResult`, `JellyfinPlaylistDto`, `JellyfinPlaylistEntry`, and the lyrics parser — replacing the remaining raw `as` casts. A missing / renamed / null / retyped field now fails *cleanly* (a clear "not a Jellyfin server" / sign-in error, or a skipped entry) instead of throwing a `TypeError` that aborted parsing.
- **Forward-tolerant version classification.** Adds a diagnostic-only `JellyfinServerSupport.newerUntested` band and `kMaximumTestedJellyfinMajor`, so a Jellyfin 12+ server is flagged *"newer than tested"* (a calm settings note + a diagnostics line) instead of being silently shown as a plain `supported` green check. Never blocks, never branches requests.

## What was audited

All Jellyfin endpoints and field assumptions were audited: system info, session/auth verification, item/album/artist listing, artwork/stream/download URLs, playlists, favourites, playback reporting, and the control socket. Endpoints remain on stable Jellyfin API paths; optional fields (`Album`, `AlbumArtist`, `Artists`, `RunTimeTicks`, `ImageTags`, `ProductionYear`, `ChildCount`, `TotalRecordCount`) are all read tolerantly, and the existing guarantees hold: music stays visible on partial/failed sync, the catalog is never wiped, and sign-out is never forced unless auth is actually invalid (gated on a `/Users/Me` 401/403).

## Tests

- Version strings: `10.10.x`, `10.11.11`, `12.0`, `12.0.0`, `12.0-rc`, `12.0.0-rc1`, 4-segment, `+build` suffix, bare-major, and weird/unknown — plus the new `newerUntested` classification band and boundary.
- Retyped / null / missing fields are non-fatal across the server-info, auth, item, and playlist DTOs; `ImageTags` shape drift degrades artwork without losing the track; explicit `Items: null` reads as empty; malformed playlists/entries are skipped, keeping the good ones.
- The `ApiKey` switch on stream/download/socket URLs (and that the legacy `api_key` is no longer the carrier); the cache-key denylist still refuses an `ApiKey`-tokenized URI; diagnostics carry the new label and remain secret-free.

## Docs

`docs/jellyfin-compatibility.md` now documents the four-band support model, the `ApiKey` / legacy-auth change, and a new **"Stable API contract assumptions"** section (401/403 = auth, `StartIndex`/`Limit`, `Items`/`TotalRecordCount`, stable paths, the deprecated favourites path form) — the single place to check if a future Jellyfin release moves something.

## Out of scope (untouched)

Plex, Subsonic/Navidrome, launcher icons, audio focus, Backup/Restore, Linthra Connect, donations, versioning. **No new dependencies.**

## Manual QA (recommended before merge)

- [ ] Jellyfin **10.11.11** (regression): sync, playback, artwork, playlists/favourites.
- [ ] Jellyfin **12 RC** in a *separate* test container (not the main server first): confirm playback, offline download, and the control socket work over `ApiKey`; music stays visible after a partial/failed sync; diagnostics show the `newer than tested` label and contain no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5VYj4XSrkbCyFw5M5weA7)_