### PR TITLE
style(theme): restore purple identity in Classic theme

### DIFF
--- a/lib/app/brand_theme.dart
+++ b/lib/app/brand_theme.dart
@@ -17,15 +17,18 @@ import 'colors.dart';
 /// whole registry ships in every build and is trivially unit-testable, mirroring
 /// the `AppIconVariant` catalog it parallels.
 ///
-/// Roles — black-first, one accent per theme: surfaces stay dark and a single
-/// accent colour carries everything coloured (Classic orange, Neon neon-blue,
-/// Gold gold, Black & White white):
+/// Roles — black-first: surfaces stay dark and colour carries identity and
+/// energy. Classic pairs the Linthra purple identity with a warm orange accent
+/// (black + orange + purple); the neutral themes (Neon neon-blue, Gold gold,
+/// Black & White white) stay a single accent that fills both roles:
 ///  - [primary]/[primaryBright]/[onPrimary] → the colour-scheme seed and the
-///    accent's text/icon tone for selected navigation, text buttons, input
-///    focus, and selected rows. [primaryBright] is the accessible-on-dark tone.
+///    identity tone for selected navigation, text buttons, input focus, and
+///    selected rows (Linthra purple for Classic). [primaryBright] is the
+///    accessible-on-dark tone.
 ///  - [accent]/[onAccent]        → `colorScheme.secondary`/`onSecondary` — the
-///    same accent on filled call-to-action buttons, progress, sliders, the play
-///    button, and small emphasis. Equal to [primary] for these themes.
+///    energy accent on filled call-to-action buttons, progress, sliders, the
+///    play button, and small emphasis (warm orange for Classic). Equal to
+///    [primary] for the single-accent neutral themes.
 ///  - [accentBright]             → `colorScheme.onSecondaryContainer` and the
 ///    play button's gradient top (via [LinthraAccents]).
 ///  - [accentDeep]               → the play button's gradient bottom (via
@@ -48,20 +51,21 @@ class BrandPalette {
   /// The matching [AppIconVariant.id]. Never shown to users.
   final String id;
 
-  /// The theme's single accent (orange for Classic): the colour-scheme seed and
-  /// the tint behind selected navigation and selected rows. Equal to [accent].
+  /// The theme's identity colour (Linthra purple for Classic): the colour-scheme
+  /// seed and the tint behind selected navigation and selected rows. Equal to
+  /// [accent] for the single-accent neutral themes.
   final Color primary;
 
   /// Text/icon colour on a [primary] fill (and the selected switch thumb).
   final Color onPrimary;
 
-  /// A brighter take on [primary] for the accent's text/icons/borders on the
+  /// A brighter take on [primary] for the identity text/icons/borders on the
   /// dark surfaces — selected navigation, text buttons, selected rows, input
   /// focus — where [primary] itself can fall short of the text-contrast bar.
   final Color primaryBright;
 
-  /// The accent (warm orange for Classic) on filled call-to-action buttons,
-  /// progress, sliders, the play button, and small emphasis. One per theme.
+  /// The energy accent (warm orange for Classic) on filled call-to-action
+  /// buttons, progress, sliders, the play button, and small emphasis.
   final Color accent;
 
   /// Lighter accent for the play button's gradient top and tonal foregrounds.
@@ -121,20 +125,24 @@ class LinthraAccents extends ThemeExtension<LinthraAccents> {
 /// The built-in brand palettes, one per [AppIconVariant], and the resolver the
 /// theme reads them through.
 ///
-/// Every theme is a single accent on the dark surfaces, with no second hue:
-/// [classic] is orange (reusing today's [AppColors] orange), [neon] neon
-/// cyan/blue, [gold] gold, and [blackWhite] pure black/white. Each sets
-/// [primary] equal to its [accent] so the whole UI reads as one accent on
-/// black; [primaryBright] is the accessible-on-dark tone for accent text/icons.
-/// Error/destructive colours are never themed.
+/// [classic] is the full Linthra identity — black surfaces, a warm orange
+/// energy accent, and a Linthra-purple [primary] for the identity details
+/// (selected navigation, text buttons, input focus, selected rows). The neutral
+/// themes are a single accent with no second hue: [neon] neon cyan/blue, [gold]
+/// gold, and [blackWhite] pure black/white, each setting [primary] equal to its
+/// [accent] so the whole UI reads as one accent on black. [primaryBright] is the
+/// accessible-on-dark tone for identity text/icons. Error/destructive colours
+/// are never themed.
 abstract final class BrandPalettes {
-  /// The default — black + orange: a single warm orange accent on the dark
-  /// surfaces. Also the fallback for an unknown/absent id (see [byId]).
+  /// The default — black + orange + purple: a warm orange energy accent with a
+  /// Linthra-purple identity ([primary]) for selected navigation, text buttons,
+  /// input focus, and selected rows on the dark surfaces. Also the fallback for
+  /// an unknown/absent id (see [byId]).
   static const BrandPalette classic = BrandPalette(
     id: 'classic',
-    primary: AppColors.accent,
-    onPrimary: AppColors.onAccent,
-    primaryBright: AppColors.accentBright,
+    primary: AppColors.brand,
+    onPrimary: Color(0xFFFFFFFF),
+    primaryBright: AppColors.brandBright,
     accent: AppColors.accent,
     accentBright: AppColors.accentBright,
     accentDeep: AppColors.accentDeep,

--- a/test/app/brand_theme_test.dart
+++ b/test/app/brand_theme_test.dart
@@ -46,22 +46,27 @@ void main() {
       }
     });
 
-    test('Classic is a black + orange palette built from AppColors', () {
-      // Classic uses Linthra's existing orange (AppColors.accent*) as its one
-      // accent: primary and accent are the same orange.
-      expect(BrandPalettes.classic.primary, AppColors.accent);
-      expect(BrandPalettes.classic.onPrimary, AppColors.onAccent);
-      expect(BrandPalettes.classic.primaryBright, AppColors.accentBright);
+    test('Classic is a black + orange + purple palette built from AppColors',
+        () {
+      // Classic pairs a Linthra-purple identity (primary) with Linthra's warm
+      // orange energy accent — the two are deliberately different hues.
+      expect(BrandPalettes.classic.primary, AppColors.brand);
+      expect(BrandPalettes.classic.primaryBright, AppColors.brandBright);
       expect(BrandPalettes.classic.accent, AppColors.accent);
       expect(BrandPalettes.classic.accentBright, AppColors.accentBright);
       expect(BrandPalettes.classic.accentDeep, AppColors.accentDeep);
       expect(BrandPalettes.classic.onAccent, AppColors.onAccent);
       expect(BrandPalettes.classic.accentContainer, AppColors.accentContainer);
+      // Identity and accent are distinct hues, not the same colour.
+      expect(BrandPalettes.classic.primary, isNot(AppColors.accent));
     });
 
-    test('every theme is a single accent (primary == accent)', () {
-      // No second hue: each variant's identity colour is its accent.
-      for (final BrandPalette p in BrandPalettes.all) {
+    test('the neutral themes are a single accent (primary == accent)', () {
+      // No second hue for Neon/Gold/Black & White: each variant's identity
+      // colour is its accent. Classic is excluded — it pairs purple + orange.
+      final Iterable<BrandPalette> neutral =
+          BrandPalettes.all.where((BrandPalette p) => p.id != 'classic');
+      for (final BrandPalette p in neutral) {
         expect(p.primary, p.accent, reason: '${p.id} primary == accent');
         expect(
           p.primaryBright,

--- a/test/app/theme_test.dart
+++ b/test/app/theme_test.dart
@@ -6,9 +6,10 @@ import 'package:linthra/app/theme.dart';
 
 void main() {
   group('AppTheme', () {
-    test('Classic dark theme is black + orange (one accent)', () {
+    test('Classic dark theme is black + orange + purple', () {
       final ThemeData theme = AppTheme.dark(BrandPalettes.classic);
-      expect(theme.colorScheme.primary, AppColors.accent);
+      // Identity (primary) is Linthra purple; the energy accent stays orange.
+      expect(theme.colorScheme.primary, AppColors.brand);
       expect(theme.colorScheme.secondary, AppColors.accent);
       expect(theme.colorScheme.onSecondary, AppColors.onAccent);
       expect(theme.colorScheme.error, AppColors.error);
@@ -64,12 +65,13 @@ void main() {
       expect(cta, AppColors.accent);
     });
 
-    test('Classic selected navigation uses the bright orange accent', () {
-      // Selected/active states carry the (accessible) bright accent tone.
+    test('Classic selected navigation uses the bright Linthra purple', () {
+      // Identity details — selected/active navigation — carry the (accessible)
+      // bright purple tone, distinct from the orange energy accent.
       final ThemeData theme = AppTheme.dark(BrandPalettes.classic);
       final IconThemeData? icon = theme.navigationBarTheme.iconTheme
           ?.resolve(<WidgetState>{WidgetState.selected});
-      expect(icon?.color, AppColors.accentBright);
+      expect(icon?.color, AppColors.brandBright);
     });
   });
 }


### PR DESCRIPTION
## Summary

Restores a clean Linthra identity for the **Classic** theme: **black** UI surfaces, **orange** for action/energy, and **purple** for Linthra identity details. This is *not* the old orange-depth experiment (see #256, which stays closed) — there are no gradients, shadows, `depthTint`, `accentDepth`, or rose/pink background tint.

The theme plumbing already routes `palette.primary` to the identity surfaces and `palette.accent` to the energy surfaces, so this is a one-palette change: Classic's `primary`/`primaryBright` flip from the orange accent to the existing `AppColors.brand`/`brandBright` violet, while every orange role is left untouched.

## Classic behavior

- **Orange (energy)** — filled CTA buttons (Sync / Connect), progress, sliders, and the play button stay orange (`colorScheme.secondary` / `LinthraAccents`).
- **Purple (identity)** — selected navigation, selected rows, text buttons, and input focus now use Linthra purple (`colorScheme.primary` / `primaryBright`).
- **Background** stays black/dark.
- Net feel: black + orange + purple, clean and intentional.

## Unchanged

- **Neon**, **Gold**, and **Black & White** palettes are untouched (still single-accent).
- Error/destructive colours are never themed.
- No provider / sync / playback / cache changes. No versioning changes.

## Changes

- `lib/app/brand_theme.dart` — Classic palette `primary`/`primaryBright`/`onPrimary` → Linthra purple; doc comments updated to describe the black + orange + purple roles.
- `test/app/brand_theme_test.dart` — Classic asserts purple `primary` + orange `accent` (distinct hues); the single-accent invariant now scopes to the neutral themes only.
- `test/app/theme_test.dart` — Classic `primary` asserts purple, CTA asserts orange, selected navigation asserts bright purple.

## Tests

- Classic primary is Linthra purple; accent remains Linthra orange.
- Classic CTA button remains orange; selected navigation uses bright purple.
- Neon, Gold, and Black & White remain unchanged.
- Error/destructive colours remain unchanged.

Small and cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RLaUYnLHeQrpwY7sjFPey)_