### PR TITLE
chore(release): prepare 0.1.8 visual polish and Jellyfin stability release

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Linthra is built to respect the people who use it:
 
 ## Roadmap
 
-The phased **[product roadmap](./docs/roadmap.md)** — v0.1.7 stabilization →
+The phased **[product roadmap](./docs/roadmap.md)** — v0.1.8 stabilization →
 Backup/Restore → optional Linthra Connect → Linthra Desktop — has the direction and
 its one guiding rule: **Linthra works on its own; Linthra Connect is optional** (no
 Docker, no account, no desktop dependency, no required pairing). The feature-level

--- a/docs/release-notes/v0.1.8.md
+++ b/docs/release-notes/v0.1.8.md
@@ -1,0 +1,97 @@
+# Linthra v0.1.8 — release notes
+
+**Linthra is a modern, local-first, privacy-focused music player for people who
+own their music.** v0.1.8 is a **visual polish & Jellyfin stability release**.
+It adds no new features — it makes Jellyfin sync more forgiving, makes the
+appearance themes do what they say, and restores the Classic look to the
+Linthra identity.
+
+- **Version:** `0.1.8` (`versionName`), `versionCode` `108999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+- **Get it:** Available from the
+  [GitHub Releases page](https://github.com/TheZupZup/Linthra/releases) first
+  (signed APKs); [Obtainium](https://github.com/ImranR98/Obtainium) can track
+  this repository for updates. The
+  [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/) build
+  follows after F-Droid's reproducible-build review.
+
+## What's new
+
+### Jellyfin
+
+- **More tolerant, more resilient sync.** Jellyfin music sync handles
+  hiccups more gracefully and fails less often.
+- **Your music stays visible.** If a Jellyfin sync fails for a moment, your
+  existing music is no longer cleared out — it stays put until the next
+  successful sync.
+- **Jellyfin 12 ready.** Compatibility preparation via the modern `ApiKey`
+  media URLs, so streaming keeps working as servers update.
+
+### Appearance & themes
+
+- **Real launcher-icon switching.** Choosing an icon in Appearance settings now
+  actually changes the Android launcher icon.
+- **Themes retint the app.** App icon & branding choices now retint the in-app
+  accent/theme, so the icon you pick and the colours you see agree.
+- **Classic restored to the Linthra identity:** black surfaces, orange
+  energy/actions, and purple identity details.
+- **Available themes:** Classic, Neon, Gold, Black & White.
+
+## Support note
+
+- Linthra remains **free and open source**, and **works on its own**.
+- The Support / donation screen stays **optional** and **cosmetic / support-only**.
+- **No gating, no telemetry, no billing SDK, and no required account.**
+- **No core feature is locked behind donation.**
+
+The repository shows a **Sponsor** button (GitHub Sponsors). It points at the
+same handle as the in-app **Settings → About → Support Linthra** screen, and is
+entirely voluntary — see [docs/SUPPORT.md](../SUPPORT.md).
+
+## Technical summary
+
+- **Jellyfin sync tolerance & resilience**
+  ([PR #253](https://github.com/TheZupZup/Linthra/pull/253)): sync is more
+  forgiving of transient failures and no longer drops the existing library when
+  a refresh fails temporarily.
+- **Jellyfin 12 compatibility layer**
+  ([PR #254](https://github.com/TheZupZup/Linthra/pull/254)): media URLs use the
+  modern `ApiKey` scheme.
+- **Real Android launcher-icon switching from Appearance settings**
+  ([PR #251](https://github.com/TheZupZup/Linthra/pull/251)).
+- **Accent themes from branding variants**
+  ([PR #255](https://github.com/TheZupZup/Linthra/pull/255)): the chosen app
+  icon / branding variant retints the in-app accent/theme.
+- **Classic theme identity restored**
+  ([PR #257](https://github.com/TheZupZup/Linthra/pull/257)): black surfaces,
+  orange energy/actions, purple identity details.
+
+No provider, sync, playback, or theme behaviour changes beyond the merged work
+above — this is a version bump, changelog, and release-notes change only.
+
+## Manual QA checklist (Pixel / Android)
+
+- [ ] Install the debug APK on a Pixel / Android device.
+- [ ] Confirm the Play Protect warning appears (expected **only** for a
+      sideloaded debug build) and the app installs and launches.
+- [ ] Verify each theme renders: **Classic**, **Neon**, **Gold**,
+      **Black & White**.
+- [ ] Verify launcher-icon switching from Appearance settings actually changes
+      the home-screen icon.
+- [ ] Verify Jellyfin sync and playback work, and that existing music stays
+      visible if a sync fails temporarily.
+- [ ] Verify background playback and the media notification.
+- [ ] Verify no unexpected permissions are requested.
+
+## Upgrade notes
+
+- **Nothing to do.** Upgrading keeps your existing settings and library.
+- **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
+  key, while the F-Droid build is signed with F-Droid's key; the two can't
+  update each other. Stick with one source.
+
+No ads, no tracking, no analytics, no telemetry. No Spotify, stream-ripping, or
+DRM-bypass claims — Linthra plays music you already own or that your own server
+provides.

--- a/docs/release-notes/v0.1.8.md
+++ b/docs/release-notes/v0.1.8.md
@@ -2,9 +2,10 @@
 
 **Linthra is a modern, local-first, privacy-focused music player for people who
 own their music.** v0.1.8 is a **visual polish & Jellyfin stability release**.
-It adds no new features — it makes Jellyfin sync more forgiving, makes the
-appearance themes do what they say, and restores the Classic look to the
-Linthra identity.
+It makes Jellyfin sync more forgiving, makes the appearance themes do what they
+say, and restores the Classic look to the Linthra identity. The only new
+feature is a small, optional **Community card** in Settings — quiet links and a
+share action, with no ads, tracking, account, or locked features.
 
 - **Version:** `0.1.8` (`versionName`), `versionCode` `108999`
 - **Platform:** Android
@@ -39,6 +40,19 @@ Linthra identity.
   energy/actions, and purple identity details.
 - **Available themes:** Classic, Neon, Gold, Black & White.
 
+### Community & sharing
+
+- **Added an optional Community card in Settings → About.** From it you can:
+  - **Join r/Linthra** (the community subreddit),
+  - **Open GitHub** (the project repository),
+  - **Open the latest release** page,
+  - **Share Linthra** using the native Android share sheet.
+- **Optional and quiet by design:** no ads, no tracking, no telemetry, no forced
+  account, **no Reddit login requirement**, and no locked features. Joining,
+  GitHub, and the latest release just open public web pages in your browser;
+  "Share Linthra" opens the system share sheet. Nothing is sent on its own and
+  nothing is required — every core feature works whether or not you ever tap it.
+
 ## Support note
 
 - Linthra remains **free and open source**, and **works on its own**.
@@ -67,6 +81,10 @@ entirely voluntary — see [docs/SUPPORT.md](../SUPPORT.md).
 - **Classic theme identity restored**
   ([PR #257](https://github.com/TheZupZup/Linthra/pull/257)): black surfaces,
   orange energy/actions, purple identity details.
+- **Community & share links in Settings → About**
+  ([PR #259](https://github.com/TheZupZup/Linthra/pull/259)): optional links to
+  join r/Linthra, open GitHub, view the latest release, and share Linthra via
+  the system share sheet — no account, login, or tracking.
 
 No provider, sync, playback, or theme behaviour changes beyond the merged work
 above — this is a version bump, changelog, and release-notes change only.
@@ -83,7 +101,11 @@ above — this is a version bump, changelog, and release-notes change only.
 - [ ] Verify Jellyfin sync and playback work, and that existing music stays
       visible if a sync fails temporarily.
 - [ ] Verify background playback and the media notification.
-- [ ] Verify no unexpected permissions are requested.
+- [ ] Verify the **Settings → About** community links open (Join the community,
+      GitHub, Latest release) and that **Share Linthra** opens the system share
+      sheet.
+- [ ] Verify no unexpected permissions are requested (the share sheet needs
+      none).
 
 ## Upgrade notes
 

--- a/fastlane/metadata/android/en-US/changelogs/108999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/108999.txt
@@ -1,6 +1,6 @@
 Linthra 0.1.8 — visual polish & Jellyfin stability.
 
-A polish and stability release. No new features.
+A polish and stability release, plus optional community links.
 
 Jellyfin:
 - Music sync is more tolerant and resilient, with fewer failures.
@@ -14,6 +14,12 @@ Appearance:
 - Classic theme restored to the Linthra identity: black surfaces, orange
   energy/actions, purple identity details.
 - Themes: Classic, Neon, Gold, Black & White.
+
+Community (optional):
+- New Community card in Settings: join r/Linthra, open GitHub, view the
+  latest release, and share Linthra via the system share sheet.
+- Optional and quiet: no ads, no tracking, no telemetry, no forced
+  account, no Reddit login, no locked features.
 
 Notes:
 - Linthra remains free and open source, and works on its own.

--- a/fastlane/metadata/android/en-US/changelogs/108999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/108999.txt
@@ -1,0 +1,23 @@
+Linthra 0.1.8 — visual polish & Jellyfin stability.
+
+A polish and stability release. No new features.
+
+Jellyfin:
+- Music sync is more tolerant and resilient, with fewer failures.
+- Your existing music stays visible if a Jellyfin sync fails for a
+  moment, instead of disappearing.
+- Jellyfin 12 compatibility preparation via modern "ApiKey" media URLs.
+
+Appearance:
+- The Android launcher icon now really switches from Appearance settings.
+- App icon & branding themes retint the in-app accent/theme.
+- Classic theme restored to the Linthra identity: black surfaces, orange
+  energy/actions, purple identity details.
+- Themes: Classic, Neon, Gold, Black & White.
+
+Notes:
+- Linthra remains free and open source, and works on its own.
+- The Support screen stays optional and cosmetic — no gating, no
+  telemetry, no billing SDK, no required account.
+
+No ads. No tracking. No locked features.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -38,4 +38,34 @@ abstract final class AppInfo {
   /// without recompiling the suite with a dart-define.
   static String resolveVersion(String defined, String devFallback) =>
       defined.isEmpty ? devFallback : defined;
+
+  /// The release channel shown in Settings → About, **derived from [version]**
+  /// so it always matches what shipped instead of a hand-maintained label. A
+  /// stable release (no pre-release suffix, e.g. `0.1.8`) reads `Stable`; a
+  /// pre-release reads its tier. This replaces the old hardcoded `Alpha`, so the
+  /// stable `0.1.8` build never presents itself as alpha.
+  static String get releaseChannel => channelForVersion(version);
+
+  /// Pure mapping from a [versionName] (e.g. `0.1.8` or `0.1.8-alpha.2`) to its
+  /// human-facing channel: `Stable` when there is no pre-release suffix, else
+  /// the tier (`Alpha` / `Beta` / `Release candidate`). The suffixes mirror the
+  /// release tags `tool/version_from_tag.dart` accepts. Exposed so the rule is
+  /// unit-testable without a build.
+  static String channelForVersion(String versionName) {
+    final int dash = versionName.indexOf('-');
+    if (dash == -1) {
+      return 'Stable';
+    }
+    final String suffix = versionName.substring(dash + 1);
+    if (suffix.startsWith('alpha')) {
+      return 'Alpha';
+    }
+    if (suffix.startsWith('beta')) {
+      return 'Beta';
+    }
+    if (suffix.startsWith('rc')) {
+      return 'Release candidate';
+    }
+    return 'Stable';
+  }
 }

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.7';
+  static const String _devVersionName = '0.1.8';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,12 +20,12 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Plex tracks can now be downloaded for offline playback.',
-    'Cached tracks play from your device, and fall back to streaming if a '
-        'file is missing or unreadable.',
-    'Offline downloads are now written atomically, so an interrupted '
-        "download can't leave a broken file.",
-    'Reproducible per-ABI release builds for F-Droid.',
+    'Jellyfin sync is more tolerant and resilient.',
+    'Existing music stays visible if a Jellyfin sync fails temporarily.',
+    'Jellyfin 12 compatibility preparation.',
+    'Launcher icon switching now works from Appearance settings.',
+    'App themes now retint the in-app accent/theme.',
+    'Added optional Community links and Share Linthra in Settings.',
   ];
 
   @override

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -177,10 +177,13 @@ class _BuildInfoCard extends StatelessWidget {
             value: AppInfo.version,
           ),
           const Divider(height: 0),
-          const _InfoRow(
+          // Derived from AppInfo.version (the single source of truth) rather
+          // than hardcoded, so the stable 0.1.8 build reads "Stable" and a
+          // future pre-release reads its tier — never a stale "Alpha".
+          _InfoRow(
             icon: Icons.flag_outlined,
             label: 'Release channel',
-            value: 'Alpha',
+            value: AppInfo.releaseChannel,
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.7+107999
+version: 0.1.8+108999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/test/core/app_info_version_test.dart
+++ b/test/core/app_info_version_test.dart
@@ -101,6 +101,31 @@ void main() {
     });
   });
 
+  group('AppInfo.releaseChannel', () {
+    test('a stable versionName (no suffix) reads "Stable"', () {
+      expect(AppInfo.channelForVersion('0.1.8'), 'Stable');
+      expect(AppInfo.channelForVersion('1.2.3'), 'Stable');
+    });
+
+    test('a pre-release versionName reads its tier', () {
+      expect(AppInfo.channelForVersion('0.1.8-alpha.2'), 'Alpha');
+      expect(AppInfo.channelForVersion('0.1.8-beta.1'), 'Beta');
+      expect(AppInfo.channelForVersion('0.1.8-rc.1'), 'Release candidate');
+    });
+
+    test('the shipped 0.1.8 build resolves to a stable channel', () {
+      // 0.1.8 is cut as a stable release, so Settings → About must read
+      // "Stable" — not the old hardcoded "Alpha". This is intentionally coupled
+      // to pubspec.yaml's version (like the drift tests above); cutting a
+      // pre-release here would flip it to that tier.
+      expect(AppInfo.releaseChannel, 'Stable');
+      expect(
+        AppInfo.releaseChannel,
+        AppInfo.channelForVersion(AppInfo.version),
+      );
+    });
+  });
+
   test('diagnostics report carries the effective app version', () {
     // Settings ▸ Diagnostics and "Report a bug" both render the version through
     // AppDiagnostics.report(appVersion: AppInfo.version); confirm the effective

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -86,6 +86,12 @@ void main() {
       expect(find.text(AppInfo.name), findsOneWidget);
       // The running version is shown verbatim.
       expect(find.text(AppInfo.version), findsOneWidget);
+      // The release channel is derived from the version: 0.1.8 is stable, so it
+      // must read "Stable" and never the old hardcoded "Alpha".
+      expect(find.text('Release channel'), findsOneWidget);
+      expect(find.text(AppInfo.releaseChannel), findsOneWidget);
+      expect(find.text('Stable'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
       expect(find.text('Source code'), findsOneWidget);
       expect(find.text('Releases'), findsOneWidget);
       expect(find.text('License (MPL-2.0)'), findsOneWidget);


### PR DESCRIPTION
## Summary

Release-prep PR for **Linthra 0.1.8** — the next stable release after 0.1.7. This is a **version bump + changelog + release-notes change only**. No new runtime features live in this PR, and no provider/sync/playback/theme behavior changes beyond what is already merged on `main`.

- Bump `pubspec.yaml` `0.1.7+107999` → **`0.1.8+108999`** (stable rank `999`; `108999` is the canonical encoding of `0.1.8` from `tool/version_from_tag.dart`: `1·100_000 + 8·1_000 + 999`).
- Bump `lib/core/app_info.dart` `_devVersionName` `0.1.7` → `0.1.8` (kept in lockstep with `pubspec.yaml` per `test/core/app_info_version_test.dart`).
- Add Fastlane changelog `fastlane/metadata/android/en-US/changelogs/108999.txt`.
- Add `docs/release-notes/v0.1.8.md` (GitHub Releases / Obtainium), including the Pixel/Android manual QA checklist.
- Update the README roadmap line to `v0.1.8 stabilization`.

This branch is **rebased on the latest `main`**, which now includes **#259 (community & share links)**, so the 0.1.8 build it produces contains that feature and the notes describe it accurately. F-Droid metadata is intentionally left untouched (`AutoUpdateMode: Version` auto-detects the version from `pubspec.yaml`).

## Release highlights (all already merged into `main`)

- Jellyfin music sync is more tolerant and resilient (#253).
- Existing music stays visible if a Jellyfin sync fails temporarily (#253).
- Jellyfin 12 compatibility preparation via modern `ApiKey` media URLs (#254).
- Real Android launcher-icon switching from Appearance settings (#251).
- App icon & branding themes now retint the in-app accent/theme (#255).
- Classic theme restored to the Linthra identity: black surfaces, orange energy/actions, purple identity details (#257).
- **Optional Community card in Settings → About (#259):** join r/Linthra, open GitHub, view the latest release, and share Linthra via the native Android share sheet — no ads, tracking, telemetry, forced account, Reddit login, or locked features.
- Themes available: Classic, Neon, Gold, Black & White.
- Support/donation screen remains optional, cosmetic/support-only — no gating, telemetry, billing SDK, or required account.

## Release notes wording

Linthra remains free and open source. Linthra works on its own. Linthra Connect is optional. No ads. No tracking. No locked features. No Spotify / stream-ripping / DRM-bypass claims.

## Not touched in this PR

Jellyfin/Plex/Subsonic/Navidrome logic · audio focus/playback logic · Backup/Restore logic · Linthra Connect logic · donations logic · Android permissions/manifest (the only Android-facing change is the version bump).

## Manual QA checklist (Pixel / Android)

- [ ] Install the debug APK.
- [ ] Confirm the Play Protect warning is expected **only** for sideloaded debug builds; app installs and launches.
- [ ] Verify themes render: Classic, Neon, Gold, Black & White.
- [ ] Verify launcher-icon switching from Appearance settings.
- [ ] Verify Jellyfin sync/playback (existing music stays visible if a sync fails temporarily).
- [ ] Verify background playback / media notification.
- [ ] Verify the Settings → About community links open (Join the community, GitHub, Latest release) and **Share Linthra** opens the system share sheet.
- [ ] Verify no unexpected permissions (the share sheet needs none).

## CI / APK

- All checks green on the latest commit (`a36ffe2`): **Flutter checks** (format/analyze/test, incl. the version-drift guard), **Secret & privacy scan**, **Build debug APK**.
- The **`linthra-debug-apk`** artifact built from this branch includes **both** the version bump (`0.1.8+108999`) and the #259 community/share links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)