### PR TITLE
feat(settings): add Linthra community and share links

### DIFF
--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/MainActivity.kt
@@ -27,6 +27,10 @@ class MainActivity : AudioServiceActivity() {
     // the application context (not this activity) so it never leaks the activity.
     private val launcherIconChannel by lazy { LauncherIconChannel(applicationContext) }
 
+    // Opens the system share sheet. Bound to this activity because the chooser
+    // must launch from an activity context, not the application context.
+    private val shareChannel by lazy { ShareChannel(this) }
+
     override fun onResume() {
         super.onResume()
         displayRefreshRate.onResume()
@@ -102,6 +106,16 @@ class MainActivity : AudioServiceActivity() {
             LauncherIconChannel.CHANNEL,
         ).setMethodCallHandler { call, result ->
             launcherIconChannel.handle(call, result)
+        }
+
+        // Share sheet: hand the system a short invite via ACTION_SEND
+        // (ShareChannel). Separate channel from SAF and the launcher icon so
+        // each stays small and auditable.
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            ShareChannel.CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            shareChannel.handle(call, result)
         }
     }
 

--- a/android/app/src/main/kotlin/io/github/thezupzup/linthra/ShareChannel.kt
+++ b/android/app/src/main/kotlin/io/github/thezupzup/linthra/ShareChannel.kt
@@ -1,0 +1,51 @@
+package io.github.thezupzup.linthra
+
+import android.app.Activity
+import android.content.Intent
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+
+// Opens the Android system share sheet for a short piece of text. Fires a plain
+// ACTION_SEND intent wrapped in a chooser — the standard AOSP share sheet, no
+// Google Play Services and no permission required. The text is the only thing
+// it touches; there is no recipient, account, or tracking.
+//
+// Bound to the hosting Activity (the chooser must launch from an activity
+// context, not the application context). The Dart side (AndroidShareService)
+// mirrors the channel name and the "shareText" method.
+class ShareChannel(private val activity: Activity) {
+    fun handle(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "shareText" -> {
+                val text = call.argument<String>("text")
+                if (text.isNullOrEmpty()) {
+                    result.error("bad_args", "text is required", null)
+                } else {
+                    shareText(text, result)
+                }
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun shareText(text: String, result: MethodChannel.Result) {
+        try {
+            val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, text)
+            }
+            // Wrap in a chooser so the user always sees the full share sheet
+            // rather than a remembered default target.
+            activity.startActivity(Intent.createChooser(sendIntent, null))
+            result.success(true)
+        } catch (e: Exception) {
+            // No app to handle the share, or no activity to host the chooser.
+            // The Dart side treats any failure as "not shared".
+            result.error("share_failed", e.message, null)
+        }
+    }
+
+    companion object {
+        const val CHANNEL = "io.github.thezupzup.linthra/share"
+    }
+}

--- a/lib/core/services/android_share_service.dart
+++ b/lib/core/services/android_share_service.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'share_service.dart';
+
+/// A [ShareService] that opens the Android system share sheet through a native
+/// method channel.
+///
+/// The native handler (`ShareChannel.kt`) fires a plain `ACTION_SEND` intent
+/// wrapped in a chooser — the standard AOSP share sheet, no Google Play
+/// Services and no permission required. The text is the only thing crossing the
+/// channel; there is no recipient, account, or tracking.
+///
+/// Off Android — or when the native handler isn't registered — every call is a
+/// safe no-op returning `false`, mirroring how [AndroidLauncherIconService]
+/// degrades, so callers never have to guard the platform split.
+class AndroidShareService implements ShareService {
+  const AndroidShareService();
+
+  // Mirrors ShareChannel.kt's CHANNEL name.
+  static const MethodChannel _channel =
+      MethodChannel('io.github.thezupzup.linthra/share');
+
+  @override
+  bool get isSupported => Platform.isAndroid;
+
+  @override
+  Future<bool> share(String text) async {
+    if (!Platform.isAndroid) {
+      return false;
+    }
+    try {
+      final bool? ok = await _channel.invokeMethod<bool>(
+        'shareText',
+        <String, String>{'text': text},
+      );
+      return ok ?? false;
+    } on MissingPluginException {
+      // Native handler not registered (shouldn't happen on a real build); let
+      // the caller carry on without surfacing an error.
+      return false;
+    } on PlatformException {
+      // No activity to host the chooser, or the system declined; treat as "not
+      // shared" rather than surfacing a raw platform error into the UI.
+      return false;
+    }
+  }
+}

--- a/lib/core/services/noop_share_service.dart
+++ b/lib/core/services/noop_share_service.dart
@@ -1,0 +1,18 @@
+import 'share_service.dart';
+
+/// A [ShareService] that does nothing.
+///
+/// It is the default provider binding (so unit/widget tests stay free of
+/// platform channels) and the fallback on every non-Android platform, where
+/// there is no native share sheet wired up. [isSupported] is `false` and
+/// [share] is a no-op returning `false`, so the About page simply hides the
+/// "Share Linthra" entry and the rest of the page is unaffected.
+class NoopShareService implements ShareService {
+  const NoopShareService();
+
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<bool> share(String text) async => false;
+}

--- a/lib/core/services/platform_share_service.dart
+++ b/lib/core/services/platform_share_service.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'android_share_service.dart';
+import 'noop_share_service.dart';
+import 'share_service.dart';
+
+/// The default [ShareService]: the real share sheet on Android, a safe no-op
+/// everywhere else.
+///
+/// This is the one place that knows about the platform split, mirroring
+/// [PlatformLauncherIconService]. On Android it delegates to
+/// [AndroidShareService] (the `ACTION_SEND` chooser); on every other platform
+/// it uses [NoopShareService] so the feature is ignored safely and the About
+/// page simply omits the "Share Linthra" entry.
+class PlatformShareService implements ShareService {
+  const PlatformShareService({
+    ShareService androidService = const AndroidShareService(),
+    ShareService fallbackService = const NoopShareService(),
+  })  : _androidService = androidService,
+        _fallbackService = fallbackService;
+
+  final ShareService _androidService;
+  final ShareService _fallbackService;
+
+  ShareService get _delegate =>
+      Platform.isAndroid ? _androidService : _fallbackService;
+
+  @override
+  bool get isSupported => _delegate.isSupported;
+
+  @override
+  Future<bool> share(String text) => _delegate.share(text);
+}

--- a/lib/core/services/share_service.dart
+++ b/lib/core/services/share_service.dart
@@ -1,0 +1,25 @@
+/// Hands a short piece of text to the platform's native share sheet.
+///
+/// This is the seam the About page's "Share Linthra" action drives so a tap
+/// opens the system share sheet (Android `ACTION_SEND`) with an invite the user
+/// can send wherever they like. It is intentionally tiny and best-effort,
+/// mirroring [LauncherIconService]: implementations must never throw into the
+/// UI, and on a platform or device without a share sheet the no-op binding
+/// ([isSupported] == false) keeps the rest of the page working unchanged.
+///
+/// It carries no recipient, no account, and no tracking — only the text the
+/// caller passes. Every share is an explicit user tap; nothing is sent on its
+/// own.
+abstract interface class ShareService {
+  /// Whether a native share sheet is available here. `false` off Android (and
+  /// in tests), so the UI can hide the "Share Linthra" entry rather than offer
+  /// an action that can't run.
+  bool get isSupported;
+
+  /// Opens the system share sheet for [text].
+  ///
+  /// Returns `true` when the sheet was presented, `false` otherwise.
+  /// Implementations must swallow platform errors and return `false` rather
+  /// than throwing, so a failed or unsupported share can never break the page.
+  Future<bool> share(String text);
+}

--- a/lib/data/repositories/share_service_provider.dart
+++ b/lib/data/repositories/share_service_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/noop_share_service.dart';
+import '../../core/services/platform_share_service.dart';
+import '../../core/services/share_service.dart';
+
+/// The single [ShareService] the app opens the native share sheet through.
+///
+/// Defaults to the no-op implementation so widget and unit tests stay free of
+/// platform channels (and non-Android hosts ignore the feature). The running
+/// app overrides this with [platformShareServiceOverride] so "Share Linthra"
+/// actually opens the system share sheet on Android. Mirrors the
+/// [launcherIconServiceProvider] seam.
+final shareServiceProvider = Provider<ShareService>((ref) {
+  return const NoopShareService();
+});
+
+/// Production binding: the real Android share sheet, a safe no-op elsewhere.
+/// Applied in `main`.
+final platformShareServiceOverride =
+    shareServiceProvider.overrideWithValue(const PlatformShareService());

--- a/lib/features/settings/hub/about_screen.dart
+++ b/lib/features/settings/hub/about_screen.dart
@@ -6,6 +6,7 @@ import '../../../app/dimens.dart';
 import '../../../app/external_link_launcher_provider.dart';
 import '../../../app/routes.dart';
 import '../../../core/app_info.dart';
+import '../../../data/repositories/share_service_provider.dart';
 import '../../appearance/selected_logo_mark.dart';
 import '../../support/support_actions_provider.dart';
 import '../about/support_section.dart';
@@ -28,6 +29,21 @@ class AboutScreen extends ConsumerWidget {
   static const String _licenseUrl =
       'https://github.com/thezupzup/linthra/blob/main/LICENSE';
 
+  // Community & sharing links. Plain public pages opened in the browser, plus a
+  // native share sheet — no account, login, or tracking. These are an optional
+  // invitation, never a gate; every core feature works whether or not they are
+  // ever tapped.
+  static const String _communityUrl = 'https://reddit.com/r/Linthra';
+  static const String _githubUrl = 'https://github.com/TheZupZup/Linthra';
+  static const String _latestReleaseUrl =
+      'https://github.com/TheZupZup/Linthra/releases/latest';
+
+  /// The invite handed to the system share sheet — the app's name, what it is,
+  /// and its public GitHub page. No tracking parameters, nothing personal.
+  static const String _shareMessage =
+      'Linthra — a free, open-source, local-first music player. '
+      'https://github.com/TheZupZup/Linthra';
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // The "Support Linthra" entry hides itself in a links-disabled build
@@ -35,6 +51,10 @@ class AboutScreen extends ConsumerWidget {
     // links has no entry point. It is the only support-aware bit of this page;
     // everything else (help/contact, links) is unaffected.
     final bool showSupport = ref.watch(supportLinksEnabledProvider);
+    // "Share Linthra" only appears where a native share sheet exists (Android);
+    // off it, the row is simply omitted rather than offering an action that
+    // can't run.
+    final bool canShare = ref.watch(shareServiceProvider).isSupported;
     return SettingsDetailScaffold(
       title: 'About',
       children: <Widget>[
@@ -52,6 +72,13 @@ class AboutScreen extends ConsumerWidget {
         ],
         const SupportSection(),
         const SizedBox(height: AppSpacing.md),
+        _CommunityCard(
+          onJoinCommunity: () => _open(context, ref, _communityUrl),
+          onShare: canShare ? () => _share(context, ref) : null,
+          onOpenGitHub: () => _open(context, ref, _githubUrl),
+          onOpenLatestRelease: () => _open(context, ref, _latestReleaseUrl),
+        ),
+        const SizedBox(height: AppSpacing.md),
         _LinksCard(
           onOpenRepo: () => _open(context, ref, _repoUrl),
           onOpenReleases: () => _open(context, ref, _releasesUrl),
@@ -59,6 +86,21 @@ class AboutScreen extends ConsumerWidget {
         ),
       ],
     );
+  }
+
+  /// Opens the system share sheet with the Linthra invite, falling back to a
+  /// snackbar if the platform can't present it (the service never throws). The
+  /// messenger is captured before the await so we don't touch [context] across
+  /// an async gap.
+  Future<void> _share(BuildContext context, WidgetRef ref) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool shared =
+        await ref.read(shareServiceProvider).share(_shareMessage);
+    if (!shared) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text("Couldn't open the share sheet.")),
+      );
+    }
   }
 
   /// Opens [url] in the browser, falling back to a snackbar if the platform
@@ -206,6 +248,64 @@ class _SupportLinthraCard extends StatelessWidget {
   }
 }
 
+/// Optional community & sharing links.
+///
+/// Joining the community, opening GitHub, and viewing the latest release open
+/// public pages in the browser; "Share Linthra" hands the system share sheet a
+/// short invite. Everything here is voluntary and quiet — no popups, no account
+/// or login, no tracking — an invitation, never a gate. The "Share Linthra" row
+/// is shown only when [onShare] is non-null (a device with a native share
+/// sheet); otherwise it is omitted.
+class _CommunityCard extends StatelessWidget {
+  const _CommunityCard({
+    required this.onJoinCommunity,
+    required this.onShare,
+    required this.onOpenGitHub,
+    required this.onOpenLatestRelease,
+  });
+
+  final VoidCallback onJoinCommunity;
+  final VoidCallback? onShare;
+  final VoidCallback onOpenGitHub;
+  final VoidCallback onOpenLatestRelease;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: <Widget>[
+          _LinkRow(
+            icon: Icons.forum_outlined,
+            label: 'Join the community',
+            onTap: onJoinCommunity,
+          ),
+          if (onShare != null) ...<Widget>[
+            const Divider(height: 0),
+            _LinkRow(
+              icon: Icons.share_outlined,
+              label: 'Share Linthra',
+              trailingIcon: Icons.ios_share,
+              onTap: onShare!,
+            ),
+          ],
+          const Divider(height: 0),
+          _LinkRow(
+            icon: Icons.code_outlined,
+            label: 'GitHub',
+            onTap: onOpenGitHub,
+          ),
+          const Divider(height: 0),
+          _LinkRow(
+            icon: Icons.new_releases_outlined,
+            label: 'Latest release',
+            onTap: onOpenLatestRelease,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 /// External project links, each opening in the browser.
 class _LinksCard extends StatelessWidget {
   const _LinksCard({
@@ -246,17 +346,22 @@ class _LinksCard extends StatelessWidget {
   }
 }
 
-/// A single tappable link row inside the links card.
+/// A single tappable link row inside a links card.
+///
+/// Defaults to the "open in browser" affordance; rows that do something else
+/// (e.g. open the share sheet) pass their own [trailingIcon].
 class _LinkRow extends StatelessWidget {
   const _LinkRow({
     required this.icon,
     required this.label,
     required this.onTap,
+    this.trailingIcon = Icons.open_in_new,
   });
 
   final IconData icon;
   final String label;
   final VoidCallback onTap;
+  final IconData trailingIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -265,7 +370,7 @@ class _LinkRow extends StatelessWidget {
     return ListTile(
       leading: Icon(icon, color: theme.colorScheme.primary),
       title: Text(label),
-      trailing: Icon(Icons.open_in_new, size: 18, color: muted),
+      trailing: Icon(trailingIcon, size: 18, color: muted),
       onTap: onTap,
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,6 +27,7 @@ import 'data/repositories/plex_sync_cache_store_provider.dart';
 import 'data/repositories/preferred_source_store_provider.dart';
 import 'data/repositories/remote_cache_index_provider.dart';
 import 'data/repositories/selected_music_folder_repository_provider.dart';
+import 'data/repositories/share_service_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
 import 'features/downloads/download_providers.dart';
 import 'features/library/playback_candidates_provider.dart';
@@ -111,6 +112,9 @@ Future<void> main() async {
       // Switch the real Android launcher icon to match that choice (a no-op off
       // Android); toggles <activity-alias> entries, never touching playback.
       platformLauncherIconServiceOverride,
+      // Open the native Android share sheet for the "Share Linthra" action (a
+      // no-op off Android); fires a plain ACTION_SEND, no permission required.
+      platformShareServiceOverride,
       // Lyrics from whichever source owns the track: a signed-in Jellyfin or
       // Subsonic/Navidrome server, or a sidecar .lrc/.txt next to a local file.
       lyricsServiceOverride,

--- a/test/core/services/share_service_test.dart
+++ b/test/core/services/share_service_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/android_share_service.dart';
+import 'package:linthra/core/services/noop_share_service.dart';
+import 'package:linthra/core/services/platform_share_service.dart';
+import 'package:linthra/core/services/share_service.dart';
+
+/// A [ShareService] that records the text it was asked to share, so the
+/// platform-split delegation can be proven without a real channel.
+class _RecordingShareService implements ShareService {
+  _RecordingShareService({this.isSupported = true});
+
+  @override
+  final bool isSupported;
+  String? shared;
+
+  @override
+  Future<bool> share(String text) async {
+    shared = text;
+    return true;
+  }
+}
+
+void main() {
+  group('NoopShareService', () {
+    test('is unsupported and never shares', () async {
+      const ShareService service = NoopShareService();
+      expect(service.isSupported, isFalse);
+      expect(await service.share('anything'), isFalse);
+    });
+  });
+
+  group('AndroidShareService', () {
+    test('is a safe no-op off Android (no channel call, returns false)',
+        () async {
+      // The unit suite runs on the host platform (not Android), so the service
+      // must short-circuit before touching the method channel and report the
+      // share as not done rather than throwing.
+      const ShareService service = AndroidShareService();
+      expect(service.isSupported, Platform.isAndroid);
+      if (!Platform.isAndroid) {
+        expect(await service.share('hello'), isFalse);
+      }
+    });
+  });
+
+  group('PlatformShareService', () {
+    test('delegates to the right binding for the host platform', () async {
+      final _RecordingShareService android =
+          _RecordingShareService(isSupported: true);
+      final _RecordingShareService fallback =
+          _RecordingShareService(isSupported: false);
+      final ShareService service = PlatformShareService(
+        androidService: android,
+        fallbackService: fallback,
+      );
+
+      await service.share('invite');
+
+      if (Platform.isAndroid) {
+        expect(android.shared, 'invite');
+        expect(fallback.shared, isNull);
+        expect(service.isSupported, isTrue);
+      } else {
+        // Every non-Android host uses the no-op fallback, so the feature is
+        // ignored safely and the About page omits the "Share Linthra" row.
+        expect(fallback.shared, 'invite');
+        expect(android.shared, isNull);
+        expect(service.isSupported, isFalse);
+      }
+    });
+  });
+}

--- a/test/features/settings/hub/about_screen_test.dart
+++ b/test/features/settings/hub/about_screen_test.dart
@@ -6,6 +6,8 @@ import 'package:linthra/app/external_link_launcher_provider.dart';
 import 'package:linthra/app/routes.dart';
 import 'package:linthra/core/app_info.dart';
 import 'package:linthra/core/services/external_link_launcher.dart';
+import 'package:linthra/core/services/share_service.dart';
+import 'package:linthra/data/repositories/share_service_provider.dart';
 import 'package:linthra/features/settings/about/whats_new_section.dart';
 import 'package:linthra/features/settings/hub/about_screen.dart';
 import 'package:linthra/features/support/support_actions_provider.dart';
@@ -23,14 +25,43 @@ class _FakeLinkLauncher implements ExternalLinkLauncher {
   }
 }
 
-Future<_FakeLinkLauncher> _pump(
+class _FakeShareService implements ShareService {
+  _FakeShareService({this.isSupported = true, this.result = true});
+
+  @override
+  final bool isSupported;
+  final bool result;
+  String? shared;
+
+  @override
+  Future<bool> share(String text) async {
+    shared = text;
+    return result;
+  }
+}
+
+/// The fakes wired into a pumped About screen, returned together so a test can
+/// assert against either the browser launcher or the share sheet.
+class _Fakes {
+  _Fakes(this.launcher, this.share);
+
+  final _FakeLinkLauncher launcher;
+  final _FakeShareService share;
+}
+
+Future<_Fakes> _pump(
   WidgetTester tester, {
   bool launchResult = true,
+  bool shareSupported = true,
+  bool shareResult = true,
 }) async {
   final _FakeLinkLauncher launcher = _FakeLinkLauncher(result: launchResult);
-  // A tall surface so every card (brand, build info, support, and links) is laid
-  // out and hittable — a ListView only builds the rows it can show.
-  tester.view.physicalSize = const Size(1000, 2000);
+  final _FakeShareService share =
+      _FakeShareService(isSupported: shareSupported, result: shareResult);
+  // A tall surface so every card (brand, build info, support, community, and
+  // links) is laid out and hittable — a ListView only builds the rows it can
+  // show.
+  tester.view.physicalSize = const Size(1000, 2400);
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
   addTearDown(tester.view.resetDevicePixelRatio);
@@ -38,12 +69,13 @@ Future<_FakeLinkLauncher> _pump(
     ProviderScope(
       overrides: <Override>[
         externalLinkLauncherProvider.overrideWithValue(launcher),
+        shareServiceProvider.overrideWithValue(share),
       ],
       child: const MaterialApp(home: AboutScreen()),
     ),
   );
   await tester.pumpAndSettle();
-  return launcher;
+  return _Fakes(launcher, share);
 }
 
 void main() {
@@ -90,13 +122,74 @@ void main() {
     });
 
     testWidgets('tapping "Source code" opens the repository', (tester) async {
-      final launcher = await _pump(tester);
+      final _Fakes fakes = await _pump(tester);
 
       await tester.tap(find.text('Source code'));
       await tester.pumpAndSettle();
 
+      expect(fakes.launcher.opened,
+          Uri.parse('https://github.com/thezupzup/linthra'));
+    });
+
+    testWidgets('shows the community rows and opens each link', (tester) async {
+      final _Fakes fakes = await _pump(tester);
+
+      expect(find.text('Join the community'), findsOneWidget);
+      expect(find.text('GitHub'), findsOneWidget);
+      expect(find.text('Latest release'), findsOneWidget);
+
+      await tester.tap(find.text('Join the community'));
+      await tester.pumpAndSettle();
+      expect(fakes.launcher.opened, Uri.parse('https://reddit.com/r/Linthra'));
+
+      await tester.tap(find.text('GitHub'));
+      await tester.pumpAndSettle();
+      expect(fakes.launcher.opened,
+          Uri.parse('https://github.com/TheZupZup/Linthra'));
+
+      await tester.tap(find.text('Latest release'));
+      await tester.pumpAndSettle();
+      expect(fakes.launcher.opened,
+          Uri.parse('https://github.com/TheZupZup/Linthra/releases/latest'));
+    });
+
+    testWidgets('shows "Share Linthra" and shares via the share sheet',
+        (tester) async {
+      final _Fakes fakes = await _pump(tester);
+
+      expect(find.text('Share Linthra'), findsOneWidget);
+
+      await tester.tap(find.text('Share Linthra'));
+      await tester.pumpAndSettle();
+
+      expect(fakes.share.shared, isNotNull);
+      expect(fakes.share.shared, contains('Linthra'));
       expect(
-          launcher.opened, Uri.parse('https://github.com/thezupzup/linthra'));
+        fakes.share.shared,
+        contains('https://github.com/TheZupZup/Linthra'),
+      );
+    });
+
+    testWidgets('hides "Share Linthra" when no share sheet is available',
+        (tester) async {
+      // Off Android (or any host without a native share sheet) the row is
+      // omitted rather than offering an action that can't run.
+      await _pump(tester, shareSupported: false);
+
+      expect(find.text('Share Linthra'), findsNothing);
+      // The browser-based community rows are unaffected.
+      expect(find.text('Join the community'), findsOneWidget);
+      expect(find.text('GitHub'), findsOneWidget);
+    });
+
+    testWidgets('shows a snackbar when the share sheet cannot open',
+        (tester) async {
+      await _pump(tester, shareResult: false);
+
+      await tester.tap(find.text('Share Linthra'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Couldn't open the share sheet."), findsOneWidget);
     });
 
     testWidgets('shows a snackbar when a link cannot be opened',


### PR DESCRIPTION
## Summary

Adds an optional **Community** card to **Settings → About** with four quiet, voluntary entries:

| Entry | Action |
|-------|--------|
| **Join the community** | Opens `https://reddit.com/r/Linthra` in the browser |
| **Share Linthra** | Opens the **native Android share sheet** (`ACTION_SEND` chooser) with a short invite |
| **GitHub** | Opens `https://github.com/TheZupZup/Linthra` |
| **Latest release** | Opens `https://github.com/TheZupZup/Linthra/releases/latest` |

The browser links reuse the existing `ExternalLinkLauncher` seam (the same one the "Report a bug" and project-links flows use). The share sheet is wired through a **new `ShareService` seam**, mirroring the existing `LauncherIconService` pattern:

- `lib/core/services/share_service.dart` — interface
- `lib/core/services/noop_share_service.dart` — default (tests / non-Android)
- `lib/core/services/android_share_service.dart` — `MethodChannel` → `ACTION_SEND`
- `lib/core/services/platform_share_service.dart` — Android-vs-noop split
- `lib/data/repositories/share_service_provider.dart` — provider + production override
- `android/.../ShareChannel.kt` + registration in `MainActivity.kt`

Because the default binding is the no-op, widget/unit tests stay plugin-free, and on any host without a native share sheet the **"Share Linthra" row is simply omitted** rather than offering an action that can't run.

## Quiet & optional — by construction

- No popups, no notifications.
- No account, no login, **no Reddit login requirement** (it just opens a public URL in the browser).
- No tracking, no telemetry, no analytics, no ads.
- No donation gating, no feature locking — an invitation, never a gate; every core feature works whether or not these are ever tapped.
- The share text carries no tracking parameters and nothing personal — just the app name and its public GitHub page.

## Not touched

- No provider / sync / playback / cache code.
- **No new dependency** (uses the existing `MethodChannel` pattern and `url_launcher` seam).
- **No Android permission or manifest change** — `ACTION_SEND` via `Intent.createChooser` needs neither a permission nor a `<queries>` entry.
- No versioning changes (this is a feature PR, separate from the 0.1.8 release-prep PR #258).

## Tests

- `test/features/settings/hub/about_screen_test.dart` — community rows render and open the right URLs; "Share Linthra" invokes the share service; the row is hidden when no share sheet is available; snackbar fallback when the sheet can't open.
- `test/core/services/share_service_test.dart` — no-op behavior, safe off-Android no-op for the Android impl, and platform-split delegation.

## QA

CI (format / analyze / test) and the Android Debug APK build run on this PR. Manual smoke on a Pixel: open **Settings → About**, tap each community link (browser opens), tap **Share Linthra** (system share sheet appears), confirm no new permission prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDK29DjZ6EgQYjy8oi4EDm)_