### PR TITLE
docs(site): update Linthra website for 0.1.8 and community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](./LICENSE)
 [![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)](#status)
+[![Latest release: v0.1.8](https://img.shields.io/badge/release-v0.1.8-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
+[![Community: r/Linthra](https://img.shields.io/badge/community-r%2FLinthra-FF9F43.svg)](https://reddit.com/r/Linthra)
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="75">](https://f-droid.org/packages/io.github.thezupzup.linthra/)
 
@@ -33,15 +34,17 @@ give Linthra a try.
 
 ## Status
 
-**Linthra is early alpha — but already usable for testing today.** You can
-connect a real server, sync your library, stream, cache, cast, and drive it from
-Android Auto on a real phone. It's not production-stable, it's **not on Google
-Play or F-Droid**, and it has honest, documented rough edges (see
-[Roadmap](#-roadmap) and the per-feature docs). That's exactly why it's a great
-time to jump in — small contributions land fast and shape where it goes.
+**Linthra 0.1.8 is the current stable release**, available from
+[GitHub Releases](https://github.com/thezupzup/linthra/releases/latest) as signed
+APKs. You can connect a real server, sync your library, stream, cache, cast, and
+drive it from Android Auto on a real phone. It still has honest, documented rough
+edges (see [Roadmap](#-roadmap) and the per-feature docs), so it's a great time to
+jump in — small contributions land fast and shape where it goes.
 
-> **On F-Droid:** not yet. Preparation is underway, but Linthra hasn't been
-> submitted and isn't on F-Droid — see [docs/fdroid-readiness.md](./docs/fdroid-readiness.md).
+> **On F-Droid:** not yet. The reproducible build is being prepared, and an
+> F-Droid build follows after F-Droid's review — see
+> [docs/fdroid-readiness.md](./docs/fdroid-readiness.md). Linthra is **not on
+> Google Play** yet either.
 
 ## 📸 Screenshots
 
@@ -64,6 +67,9 @@ design — not mockups.
 - **Self-hosted streaming** — connect your own **Jellyfin** or
   **Navidrome / Subsonic** server: test, sign in, sync, and stream. Works over
   HTTPS / Cloudflare-proxied domains.
+- **Plex** — connect your own **Plex Media Server**: browse, stream, and cache.
+  Plex support is available (one provider among several, not the default); some
+  server setups may still need testing.
 - **Smart offline cache** — tap to download the tracks you want offline; Wi-Fi
   only by default, with a size limit and "Keep offline" pinning.
 - **Cast / Chromecast** — hand a stream off to a speaker or TV, with device
@@ -81,14 +87,23 @@ design — not mockups.
   on-device signals that stay on the device ([docs](./docs/smart-mixes.md)).
 - **Background playback** — media notification with lock-screen, Bluetooth, and
   wired-headset controls, plus shuffle / repeat and synced lyrics.
+- **Appearance** — switch the real Android launcher icon and retint the app from
+  Appearance settings; themes **Classic / Neon / Gold / Black & White**.
+- **Optional community & sharing** — quiet links in **Settings → About** (join
+  [r/Linthra](https://reddit.com/r/Linthra), open GitHub or the latest release)
+  and an Android share-sheet action. No account, login, or tracking.
 
 Each feature has a deep-dive in [the docs](#-documentation).
 
 ## Install
 
-> Linthra is **not on Google Play or F-Droid**. It's distributed as a
-> sideloadable APK from **[GitHub Releases](https://github.com/thezupzup/linthra/releases)**.
-> Alpha releases are GitHub **pre-releases**.
+> **GitHub Releases is the official home for Linthra builds** —
+> **[github.com/thezupzup/linthra/releases](https://github.com/thezupzup/linthra/releases)**.
+> Each release ships **signed** APKs; the current stable build is **v0.1.8**. PR
+> and debug APKs are for testing only — not official releases. An F-Droid build
+> follows after F-Droid's review, and Linthra isn't on Google Play yet.
+> **Don't mix install sources:** GitHub APKs and F-Droid builds are signed with
+> different keys and can't update each other — pick one and stick with it.
 
 **Obtainium (recommended)** — [Obtainium](https://github.com/ImranR98/Obtainium)
 installs straight from GitHub Releases and keeps Linthra updated:
@@ -96,12 +111,12 @@ installs straight from GitHub Releases and keeps Linthra updated:
 1. Install Obtainium.
 2. Tap **Add App** and paste the source URL:
    `https://github.com/thezupzup/linthra`
-3. Enable **"Include prereleases"** — alpha builds are GitHub pre-releases.
-4. Install the latest release; Obtainium handles updates from then on.
+3. Install the latest release; Obtainium handles updates from then on. (Enable
+   **"Include prereleases"** only if you want to test pre-release builds.)
 
-**Manual APK** — download the `.apk` from the
-[latest release](https://github.com/thezupzup/linthra/releases), open it on your
-phone, and allow "install from unknown sources" if prompted.
+**Manual APK** — download the signed `.apk` from the
+[latest release](https://github.com/thezupzup/linthra/releases/latest), open it on
+your phone, and allow "install from unknown sources" if prompted.
 
 **Build it yourself** — `flutter pub get && flutter build apk --debug`. Full
 setup, CI builds, and release details are in
@@ -112,9 +127,6 @@ pinned Flutter toolchain and run the same checks as CI.
 > **Using Android Auto?** Sideloaded media apps only appear after you enable
 > Android Auto's developer **"Unknown sources"** toggle — a one-time step,
 > detailed in [docs/android-auto.md](./docs/android-auto.md).
->
-> **Heads up:** until release signing is provisioned, some alpha APKs may be
-> **debug-signed**; if a signature changes, you may need to reinstall.
 
 ## Ways to help
 
@@ -136,6 +148,9 @@ many don't need a single line of code:
 - **Improve accessibility** — better screen-reader labels and TalkBack support.
 - **Polish UI/UX** — small refinements add up.
 - **Help future providers** — WebDAV / NAS support behind the same interface.
+- **Join the community** — say hi or share your setup at
+  [r/Linthra](https://reddit.com/r/Linthra) (optional, quiet, and no account is
+  needed to read it).
 
 New here? [CONTRIBUTING.md](./CONTRIBUTING.md) walks through setup in two
 commands, and the [contributor roadmap](./docs/contributor-roadmap.md) shows
@@ -162,6 +177,7 @@ Sources sit behind one interface, so the app treats them uniformly:
 | **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) — [docs](./docs/local-music.md) |
 | **Jellyfin** | ✅ Stream, cache, cast, playlists & favourites — [docs](./docs/jellyfin.md) |
 | **Navidrome / Subsonic** | ✅ Stream, cache, cast (favourites & lyrics are follow-ups) — [docs](./docs/providers.md) |
+| **Plex** | ✅ Browse, stream & cache from your own Plex Media Server (some setups may still need testing) — [docs](./docs/plex.md) |
 | **WebDAV / NAS** | 🔜 Planned — same `MusicSource` seam |
 
 ## Privacy

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ drive it from Android Auto on a real phone. It still has honest, documented roug
 edges (see [Roadmap](#roadmap) and the per-feature docs), so it's a great time to
 jump in — small contributions land fast and shape where it goes.
 
-> **On F-Droid:** not yet. The reproducible build is being prepared, and an
-> F-Droid build follows after F-Droid's review — see
-> [docs/fdroid-readiness.md](./docs/fdroid-readiness.md). Linthra is **not on
-> Google Play** yet either.
+> **On F-Droid:** yes — Linthra is on
+> [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/), though
+> F-Droid updates may arrive later than GitHub Releases while F-Droid processes
+> their build/review. Linthra is **not on Google Play** yet.
 
 ## 📸 Screenshots
 
@@ -97,11 +97,13 @@ Each feature has a deep-dive in [the docs](#documentation).
 
 ## Install
 
-> **GitHub Releases is the official home for Linthra builds** —
+> **GitHub Releases is the source of truth for the latest Linthra builds** —
 > **[github.com/thezupzup/linthra/releases](https://github.com/thezupzup/linthra/releases)**.
 > Each release ships **signed** APKs; the current stable build is **v0.1.8**. PR
-> and debug APKs are for testing only — not official releases. An F-Droid build
-> follows after F-Droid's review, and Linthra isn't on Google Play yet.
+> and debug APKs are for testing only — not official releases. Linthra is also on
+> [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/), but
+> F-Droid updates may arrive later after their build/review process; Linthra isn't
+> on Google Play yet.
 > **Don't mix install sources:** GitHub APKs and F-Droid builds are signed with
 > different keys and can't update each other — pick one and stick with it.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ give Linthra a try.
 [GitHub Releases](https://github.com/thezupzup/linthra/releases/latest) as signed
 APKs. You can connect a real server, sync your library, stream, cache, cast, and
 drive it from Android Auto on a real phone. It still has honest, documented rough
-edges (see [Roadmap](#-roadmap) and the per-feature docs), so it's a great time to
+edges (see [Roadmap](#roadmap) and the per-feature docs), so it's a great time to
 jump in — small contributions land fast and shape where it goes.
 
 > **On F-Droid:** not yet. The reproducible build is being prepared, and an
@@ -93,7 +93,7 @@ design — not mockups.
   [r/Linthra](https://reddit.com/r/Linthra), open GitHub or the latest release)
   and an Android share-sheet action. No account, login, or tracking.
 
-Each feature has a deep-dive in [the docs](#-documentation).
+Each feature has a deep-dive in [the docs](#documentation).
 
 ## Install
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Linthra · Open-source music player for local &amp; self-hosted music</title>
-  <meta name="description" content="Linthra is an open-source Android music player for local libraries and self-hosted music servers like Jellyfin and Navidrome/Subsonic. No ads, no tracking, no account." />
+  <meta name="description" content="Linthra is an open-source Android music player for local libraries and self-hosted music servers like Jellyfin, Navidrome/Subsonic, and Plex. No ads, no tracking, no account." />
   <meta name="theme-color" content="#111018" />
   <meta name="color-scheme" content="dark" />
 
@@ -15,7 +15,7 @@
   <!-- Open Graph / social -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Linthra · Open-source music player for local &amp; self-hosted music" />
-  <meta property="og:description" content="An open-source Android music player for local libraries and self-hosted music servers like Jellyfin and Navidrome/Subsonic. No ads, no tracking, no account." />
+  <meta property="og:description" content="An open-source Android music player for local libraries and self-hosted music servers like Jellyfin, Navidrome/Subsonic, and Plex. No ads, no tracking, no account." />
   <meta property="og:image" content="assets/feature-graphic.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Linthra · Open-source music player for local &amp; self-hosted music" />
@@ -37,6 +37,7 @@
         <a href="#features">Features</a>
         <a href="#screenshots">Screenshots</a>
         <a href="#get">Get it</a>
+        <a href="#community">Community</a>
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub</a>
       </nav>
     </div>
@@ -49,38 +50,38 @@
         <img class="hero-logo" src="assets/linthra-icon.svg" alt="Linthra logo" width="104" height="104" />
         <p class="eyebrow">Open source · Android · Built in Canada 🇨🇦</p>
         <h1 class="hero-title">Linthra</h1>
-        <p class="tagline">Built for local and self-hosted music.</p>
+        <p class="tagline">Your music, beautifully yours.</p>
         <p class="hero-desc">
           Linthra plays the music you keep yourself: local files on your phone, or
-          your own Jellyfin and Navidrome / Subsonic server. It streams straight from
-          the source, with no ads and no account to sign up for.
+          your own Jellyfin, Navidrome / Subsonic, or Plex server. It streams
+          straight from the source, with no ads and no account to sign up for.
         </p>
 
         <div class="cta-row">
-          <a class="btn btn-primary" href="https://github.com/TheZupZup/Linthra" rel="noopener">
+          <a class="btn btn-primary" href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">
+            <svg class="btn-ico" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" d="M12 3v12m0 0 4-4m-4 4-4-4M5 17v2a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-2"/></svg>
+            Download the latest release
+          </a>
+          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra" rel="noopener">
             <svg class="btn-ico" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 .5A11.5 11.5 0 0 0 8.36 22.93c.57.1.78-.25.78-.55v-2c-3.2.7-3.88-1.36-3.88-1.36-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.69 5.4-5.26 5.69.41.36.78 1.06.78 2.14v3.17c0 .31.21.66.79.55A11.5 11.5 0 0 0 12 .5Z"/></svg>
             View on GitHub
-          </a>
-          <a class="btn btn-secondary" href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">
-            <svg class="btn-ico" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M5 20a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1zm2.3-13.9L6 4.2a.5.5 0 0 1 .84-.55l1.36 1.96a7.97 7.97 0 0 1 7.6 0l1.36-1.96A.5.5 0 0 1 18 4.2l-1.3 1.9A8 8 0 0 1 21 13H3a8 8 0 0 1 4.3-6.9M8.5 11a1 1 0 1 0 0-2 1 1 0 0 0 0 2m7 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2"/></svg>
-            AndroidFreeware
           </a>
         </div>
 
         <div class="cta-row cta-row-soon" aria-label="More ways to get Linthra">
-          <a class="chip chip-link" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
+          <a class="chip chip-link" href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra</a>
           <a class="chip chip-link" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
+          <span class="chip" aria-disabled="true">F-Droid <em>after review</em></span>
           <span class="chip" aria-disabled="true">Google&nbsp;Play <em>testing soon</em></span>
           <a class="chip chip-link" href="privacy.html">Privacy&nbsp;Policy</a>
         </div>
 
-        <p class="alpha-note">
-          <span class="badge-alpha">Early alpha</span>
-          but usable for testing today. Install from
-          <a href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
-          or sideload the APK from
-          <a href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">GitHub Releases</a>.
-          Not on Google Play yet.
+        <p class="release-note">
+          <span class="badge-release">Stable · v0.1.8</span>
+          The official signed builds come from
+          <a href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">GitHub Releases</a>.
+          An F-Droid build follows after F-Droid's review. PR and debug APKs are
+          for testing only — not official releases.
         </p>
       </div>
     </section>
@@ -91,10 +92,10 @@
         <h2 id="about-title" class="section-title">Your music, your server</h2>
         <p class="section-lead">
           Point Linthra at a folder of local files, or at your own Jellyfin /
-          Navidrome / Subsonic server, and it plays from there. Streaming is the
-          default, so nothing downloads until you ask for it. Browsing stays quick
-          because the app reads from a catalog it keeps on the device, instead of
-          hitting the network on every tap.
+          Navidrome / Subsonic / Plex server, and it plays from there. Streaming is
+          the default, so nothing downloads until you ask for it. Browsing stays
+          quick because the app reads from a catalog it keeps on the device, instead
+          of hitting the network on every tap.
         </p>
       </div>
     </section>
@@ -127,6 +128,13 @@
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 7h16v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1zM4 7l2-3h12l2 3M10 12h4"/></svg>
+            </span>
+            <h3>Plex support</h3>
+            <p>Plex support is available: connect your own Plex Media Server, browse your library, and stream and cache from it. Some server setups may still need testing.</p>
+          </li>
+          <li class="card">
+            <span class="card-ico" aria-hidden="true">
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M12 3a9 9 0 1 0 9 9M12 3v9l6-4"/><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" d="M16 3.5a9 9 0 0 1 4.5 4.5"/></svg>
             </span>
             <h3>Background playback</h3>
@@ -141,10 +149,31 @@
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M3 17a4 4 0 0 1 4 4M3 13a8 8 0 0 1 8 8M3 9V6a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-5M3 21h.01"/></svg>
+            </span>
+            <h3>Cast</h3>
+            <p>Hand a stream off to a Chromecast, speaker or TV, with device-volume control and track artwork on the receiver. Pure-Dart Cast — no Google Play Services.</p>
+          </li>
+          <li class="card">
+            <span class="card-ico" aria-hidden="true">
               <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M3 13l2-5a2 2 0 0 1 1.9-1.4h10.2A2 2 0 0 1 19 8l2 5v5a1 1 0 0 1-1 1h-1a1 1 0 0 1-1-1v-1H6v1a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1zM7 16h.01M17 16h.01"/></svg>
             </span>
             <h3>Android Auto</h3>
             <p>Browse your Library, Queue, Playlists and Favourites from the car screen and tap to play.</p>
+          </li>
+          <li class="card">
+            <span class="card-ico" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 7a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v2a2 2 0 0 1-2 2H8a2 2 0 0 0-2 2v1M16 7h2a2 2 0 0 1 2 2v1a2 2 0 0 1-2 2h-2M10 16h4v5a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1z"/></svg>
+            </span>
+            <h3>App icon &amp; themes</h3>
+            <p>Switch the real Android launcher icon and retint the app from Appearance settings. Themes — Classic, Neon, Gold, and Black &amp; White — restyle the in-app accent to match.</p>
+          </li>
+          <li class="card">
+            <span class="card-ico" aria-hidden="true">
+              <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5Z"/></svg>
+            </span>
+            <h3>Community &amp; sharing</h3>
+            <p>Optional, quiet links in Settings → About: join <a href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra</a>, open GitHub or the latest release, and share Linthra via the Android share sheet. No account or login required.</p>
           </li>
           <li class="card">
             <span class="card-ico" aria-hidden="true">
@@ -159,14 +188,6 @@
             </span>
             <h3>Open source</h3>
             <p>Built with Flutter and licensed under MPL-2.0, so anyone can read the code, build it, and send a patch. Bug reports are assembled on your device and never sent automatically.</p>
-          </li>
-          <li class="card card-soon">
-            <span class="card-badge">In development</span>
-            <span class="card-ico" aria-hidden="true">
-              <svg viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 7h16v11a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1zM4 7l2-3h12l2 3M10 12h4"/></svg>
-            </span>
-            <h3>Plex support</h3>
-            <p>Read-only support for your own Plex Media Server is in progress, built in small steps that are easy to review. It hasn’t shipped yet.</p>
           </li>
         </ul>
         <p class="muted-note">
@@ -215,47 +236,76 @@
       <div class="container narrow">
         <h2 id="get-title" class="section-title">Get Linthra</h2>
         <p class="section-lead">
-          Linthra is early alpha but usable for testing today. Install it from
-          F-Droid, grab an APK from GitHub Releases, or get it on AndroidFreeware or OpenAPK.
+          <strong>GitHub Releases is the official home for Linthra builds.</strong>
+          Every release ships signed APKs (and an Android App Bundle); the current
+          stable build is <strong>v0.1.8</strong>.
           <a href="https://github.com/ImranR98/Obtainium" rel="noopener">Obtainium</a>
           can install straight from GitHub Releases and keep it updated.
         </p>
         <div class="cta-row center">
-          <a class="btn btn-primary" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">Get it on F-Droid</a>
-          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">GitHub Releases</a>
+          <a class="btn btn-primary" href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">Download the latest release</a>
+          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">All releases &amp; changelog</a>
         </div>
         <div class="cta-row center">
-          <!-- Direct universal signed APK from the latest GitHub Release; bump the version on each release. -->
-          <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases/download/v0.1.5/linthra-v0.1.5-release-signed.apk" rel="noopener">Download APK (v0.1.5)</a>
-          <a class="btn btn-secondary" href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware</a>
-          <a class="btn btn-secondary" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
+          <a class="btn btn-secondary" href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware (mirror)</a>
+          <a class="btn btn-secondary" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK (mirror)</a>
         </div>
         <div class="store-grid">
+          <span class="store-item" aria-disabled="true">
+            <strong>F-Droid</strong>
+            <span>Coming after F-Droid's review</span>
+          </span>
           <span class="store-item" aria-disabled="true">
             <strong>Google Play</strong>
             <span>Testing track, coming soon</span>
           </span>
         </div>
+        <p class="muted-note">
+          <strong>GitHub Releases are the official builds.</strong> PR and debug
+          APKs are for testing only — not official releases. An F-Droid build
+          follows after F-Droid's review. Don't mix install sources: GitHub APKs
+          and F-Droid builds are signed with different keys, so they can't update
+          each other — pick one and stick with it.
+        </p>
         <p class="section-lead center">
           Need help or found a bug? Contact us at
-          <a href="mailto:support@linthra.ca">support@linthra.ca</a>.
-        </p>
-        <p class="muted-note">
-          Looking for older builds? See
-          <a href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">previous versions &amp; changelog</a>
-          on GitHub.
+          <a href="mailto:support@linthra.ca">support@linthra.ca</a>, or join the
+          community at <a href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra</a>.
         </p>
       </div>
     </section>
 
-    <!-- Privacy -->
+    <!-- Community -->
+    <section class="section" id="community" aria-labelledby="community-title">
+      <div class="container narrow">
+        <h2 id="community-title" class="section-title">Community</h2>
+        <p class="section-lead">
+          There's a small, optional community subreddit at
+          <a href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra</a> — a
+          calm place to share setups, ask questions, and follow along. It's quiet
+          and entirely optional: no Reddit login is needed to read it, and Linthra
+          never asks you to create an account.
+        </p>
+        <p class="center">
+          <a class="btn btn-secondary" href="https://reddit.com/r/Linthra" rel="noopener">Visit r/Linthra</a>
+        </p>
+      </div>
+    </section>
+
+    <!-- Privacy & principles -->
     <section class="section section-privacy" id="privacy" aria-labelledby="privacy-title">
       <div class="container narrow">
-        <h2 id="privacy-title" class="section-title">Privacy first</h2>
+        <h2 id="privacy-title" class="section-title">Free, private, and yours</h2>
         <p class="section-lead">
-          No ads. No trackers. No analytics or telemetry SDK. No account, and no
-          Linthra server. The app talks only to the music sources <strong>you</strong>
-          configure and to your own local files.
+          Linthra is free and open source. No ads. No tracking. No analytics. No
+          telemetry. No locked features, no forced account, and no required server.
+          The app talks only to the music sources <strong>you</strong> configure
+          and to your own local files.
+        </p>
+        <p class="section-lead">
+          <strong>Linthra works on its own; Linthra Connect is optional.</strong>
+          There's no Docker, no account, and no pairing to set up before you can
+          play your music.
         </p>
         <p class="center">
           <a class="btn btn-secondary" href="privacy.html">Read the Privacy Policy</a>
@@ -272,7 +322,8 @@
       </div>
       <nav class="footer-links" aria-label="Footer">
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub repository</a>
-        <a href="#get">Download</a>
+        <a href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">Download</a>
+        <a href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra community</a>
         <a href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware</a>
         <a href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
         <a href="privacy.html">Privacy Policy</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -70,18 +70,19 @@
 
         <div class="cta-row cta-row-soon" aria-label="More ways to get Linthra">
           <a class="chip chip-link" href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra</a>
+          <a class="chip chip-link" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>
           <a class="chip chip-link" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
-          <span class="chip" aria-disabled="true">F-Droid <em>after review</em></span>
           <span class="chip" aria-disabled="true">Google&nbsp;Play <em>testing soon</em></span>
           <a class="chip chip-link" href="privacy.html">Privacy&nbsp;Policy</a>
         </div>
 
         <p class="release-note">
           <span class="badge-release">Stable · v0.1.8</span>
-          The official signed builds come from
-          <a href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">GitHub Releases</a>.
-          An F-Droid build follows after F-Droid's review. PR and debug APKs are
-          for testing only — not official releases.
+          <a href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">GitHub Releases</a>
+          is the source of truth for the latest official builds. Linthra is also on
+          <a href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">F-Droid</a>,
+          which may lag behind while F-Droid processes updates. PR and debug APKs
+          are for testing only — not official releases.
         </p>
       </div>
     </section>
@@ -247,25 +248,23 @@
           <a class="btn btn-secondary" href="https://github.com/TheZupZup/Linthra/releases" rel="noopener">All releases &amp; changelog</a>
         </div>
         <div class="cta-row center">
+          <a class="btn btn-secondary" href="https://f-droid.org/packages/io.github.thezupzup.linthra/" rel="noopener">Get it on F-Droid</a>
           <a class="btn btn-secondary" href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware (mirror)</a>
           <a class="btn btn-secondary" href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK (mirror)</a>
         </div>
         <div class="store-grid">
-          <span class="store-item" aria-disabled="true">
-            <strong>F-Droid</strong>
-            <span>Coming after F-Droid's review</span>
-          </span>
           <span class="store-item" aria-disabled="true">
             <strong>Google Play</strong>
             <span>Testing track, coming soon</span>
           </span>
         </div>
         <p class="muted-note">
-          <strong>GitHub Releases are the official builds.</strong> PR and debug
-          APKs are for testing only — not official releases. An F-Droid build
-          follows after F-Droid's review. Don't mix install sources: GitHub APKs
-          and F-Droid builds are signed with different keys, so they can't update
-          each other — pick one and stick with it.
+          <strong>GitHub Releases are the source of truth for the latest official
+          builds.</strong> Linthra is also available on F-Droid, but F-Droid
+          updates may arrive later after their build/review process. PR and debug
+          APKs are for testing only — not official releases. Don't mix install
+          sources: GitHub APKs and F-Droid builds are signed with different keys,
+          so they can't update each other — pick one and stick with it.
         </p>
         <p class="section-lead center">
           Need help or found a bug? Contact us at

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -26,6 +26,7 @@
         <a href="index.html#features">Features</a>
         <a href="index.html#screenshots">Screenshots</a>
         <a href="index.html#get">Get it</a>
+        <a href="index.html#community">Community</a>
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub</a>
       </nav>
     </div>
@@ -194,7 +195,8 @@
       </div>
       <nav class="footer-links" aria-label="Footer">
         <a href="https://github.com/TheZupZup/Linthra" rel="noopener">GitHub repository</a>
-        <a href="index.html#get">Download</a>
+        <a href="https://github.com/TheZupZup/Linthra/releases/latest" rel="noopener">Download</a>
+        <a href="https://reddit.com/r/Linthra" rel="noopener">r/Linthra community</a>
         <a href="https://www.androidfreeware.net/download-linthra-apk.html" rel="noopener">AndroidFreeware</a>
         <a href="https://www.openapk.net/linthra/io.github.thezupzup.linthra/" rel="noopener">OpenAPK</a>
         <a href="privacy.html">Privacy Policy</a>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -251,13 +251,13 @@ h1, h2, h3 { line-height: 1.2; margin: 0; }
 }
 .chip-link:hover { border-color: var(--purple); text-decoration: none; color: var(--text); }
 
-.alpha-note {
+.release-note {
   margin-top: 28px;
   color: var(--muted);
   font-size: 0.92rem;
   max-width: 560px;
 }
-.badge-alpha {
+.badge-release {
   display: inline-block;
   margin-right: 8px;
   padding: 3px 10px;


### PR DESCRIPTION
## Summary

Updates the public Linthra website (`docs/`) and README so they match the **0.1.8** release and the new **r/Linthra** community. Documentation/site-only — no runtime, provider, sync, playback, permission, telemetry, or analytics changes. The diff against `main` is strictly `docs/index.html`, `docs/privacy.html`, `docs/styles.css`, and `README.md`.

## What changed (website / docs)

**Plex wording**
- Removed the "in development / hasn't shipped yet" framing.
- Plex is now presented as available ("Plex support is available… some server setups may still need testing"), as **one provider among several** — Jellyfin, Navidrome/Subsonic, Plex, and local music are all presented clearly. Not overpromised, not the default.

**Downloads → GitHub Releases as the source of truth**
- Primary CTA and download links point to `https://github.com/TheZupZup/Linthra/releases/latest`.
- Removed the pinned `v0.1.5` direct-APK link.
- States plainly: GitHub Releases are the source of truth for the latest official builds; **Linthra is also available on F-Droid, but F-Droid updates may arrive later after their build/review process**; PR/debug APKs are testing-only; don't mix install sources (GitHub APKs and F-Droid builds are signed with different keys).

**0.1.8 release info**
- Site now reflects the current **stable** release (no more "early alpha"), surfacing the 0.1.8 highlights: Jellyfin sync more tolerant/resilient with existing music kept if a sync fails temporarily, Jellyfin 12 compatibility prep, launcher-icon switching + theme retinting from Appearance, Classic theme identity (dark surfaces, orange actions, purple details), the optional Community card + Android share sheet, and `Stable` replacing `Alpha`.

**Community**
- `https://reddit.com/r/Linthra` added to the footer, a dedicated community section, a feature card, the get/support copy, and the README — optional and quiet, no Reddit login or account required.

**Feature list**
- Feature cards now cover: Jellyfin, Navidrome/Subsonic, Plex, local music, Android Auto, Cast, offline/cache, app icon & theme customization, and optional community/share links.

**Principles**
- The site states: free & open source; no ads, tracking, analytics, or telemetry; no locked features, forced account, or required server; Linthra works on its own and Linthra Connect is optional.

**Branding**
- Tagline "Your music, beautifully yours."; dark surfaces / orange actions / purple identity details; themes Classic, Neon, Gold, Black & White.

## Files
- `docs/index.html`, `docs/privacy.html`, `docs/styles.css`, `README.md`

## Testing
- Both HTML pages parse cleanly (balanced tags) and every in-page anchor resolves.
- Confirmed via the GitHub API that the latest release is genuinely `v0.1.8` with signed APKs/AAB, so `releases/latest` resolves to it.
- No stale "Plex experimental / in development", "early alpha", "not on F-Droid yet", or pinned-APK copy remains; no PR/debug APK is presented as an official download.
- `r/Linthra` links use the canonical `https://reddit.com/r/Linthra` (matches the in-app About screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)