### PR TITLE
chore(fdroid): track 0.1.8 in the F-Droid metadata recipe

### DIFF
--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -15,9 +15,9 @@ RepoType: git
 Repo: https://github.com/TheZupZup/Linthra.git
 
 Builds:
-  - versionName: 0.1.0-alpha.39
-    versionCode: 1000391
-    commit: 0c7ca8d1fe55576e869e3ecc5c1d43f2dbeda871
+  - versionName: 0.1.8
+    versionCode: 1089991
+    commit: d8484f449ba4871ab206842b21b0c42ea4b63a8d
     sudo:
       - mkdir -p /home/runner/work/Linthra
       - chown -R vagrant /home/runner/work
@@ -49,7 +49,7 @@ Builds:
       - popd
       - mv $repo io.github.thezupzup.linthra
     # Upstream-signed reference APK for this ABI on the matching GitHub Release.
-    # %v expands to the build's versionName (e.g. 0.1.0-alpha.39); there is no
+    # %v expands to the build's versionName (e.g. 0.1.8); there is no
     # %a placeholder for ABI in F-Droid metadata, so the ABI slug is hardcoded
     # per Build entry. The Android Release Build workflow uploads the per-ABI
     # APK under exactly this name. (Per-Build `binary` overrides any top-level
@@ -58,9 +58,9 @@ Builds:
     # MR !39329 ("add binary to every version").
     binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-armeabi-v7a-release-signed.apk
 
-  - versionName: 0.1.0-alpha.39
-    versionCode: 1000392
-    commit: 0c7ca8d1fe55576e869e3ecc5c1d43f2dbeda871
+  - versionName: 0.1.8
+    versionCode: 1089992
+    commit: d8484f449ba4871ab206842b21b0c42ea4b63a8d
     sudo:
       - mkdir -p /home/runner/work/Linthra
       - chown -R vagrant /home/runner/work
@@ -93,9 +93,9 @@ Builds:
       - mv $repo io.github.thezupzup.linthra
     binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-arm64-v8a-release-signed.apk
 
-  - versionName: 0.1.0-alpha.39
-    versionCode: 1000393
-    commit: 0c7ca8d1fe55576e869e3ecc5c1d43f2dbeda871
+  - versionName: 0.1.8
+    versionCode: 1089993
+    commit: d8484f449ba4871ab206842b21b0c42ea4b63a8d
     sudo:
       - mkdir -p /home/runner/work/Linthra
       - chown -R vagrant /home/runner/work
@@ -136,5 +136,5 @@ VercodeOperation:
   - "%c*10 + 3"
 UpdateCheckData: pubspec.yaml|version:\s*[^+]+\+(\d+)|.|version:\s*([^\+]+)\+
 
-CurrentVersion: 0.1.0-alpha.39
-CurrentVersionCode: 1000393
+CurrentVersion: 0.1.8
+CurrentVersionCode: 1089993


### PR DESCRIPTION
## Summary

Bring the tracked fdroiddata recipe mirror (`metadata/io.github.thezupzup.linthra.yml`) up to the current stable release **0.1.8 / versionCode 108999**. It was still pinned to the obsolete `0.1.0-alpha.39`. This is the smallest correct change: the three per‑ABI `Builds` entries and `CurrentVersion`/`CurrentVersionCode` only. Everything else (auto‑update wiring, per‑ABI scheme, `binary:` templates, `AllowedAPKSigningKeys`) is byte‑identical.

Scope guard: **F‑Droid metadata only.** No app runtime / provider / sync / playback / cache logic, no Android permissions, no telemetry/analytics/payment SDKs, no ads or feature gating.

## What changed (and why each line is needed)

| Line | Before → After | Why |
| --- | --- | --- |
| `versionName` ×3 | `0.1.0-alpha.39` → `0.1.8` | Track the current release; `%v` in each `binary:` URL expands to this. |
| `versionCode` ×3 | `1000391/2/3` → `1089991/2/3` | Per‑ABI code = `base*10 + rank` for base `108999` (armeabi‑v7a=1, arm64‑v8a=2, x86_64=3) — same rule as `android/app/build.gradle`'s `versionCodeOverride` and the `VercodeOperation` block. |
| `commit` ×3 | `0c7ca8d1…` → `d8484f449ba4871ab206842b21b0c42ea4b63a8d` | Full 40‑char SHA behind tag `v0.1.8` (`git rev-list -n 1 v0.1.8`), never the tag name — required by the guardrail test. |
| comment example | `(e.g. 0.1.0-alpha.39)` → `(e.g. 0.1.8)` | Keep the inline doc example current. |
| `CurrentVersion` | `0.1.0-alpha.39` → `0.1.8` | Suggested version. |
| `CurrentVersionCode` | `1000393` → `1089993` | Highest per‑ABI code (`108999*10+3`). |

Unchanged on purpose: `AllowedAPKSigningKeys`, `AutoUpdateMode: Version`, `UpdateCheckMode: Tags`, `VercodeOperation` (`%c*10 + 1/2/3`), `UpdateCheckData`, `output:` paths, `srclibs`, `prebuild`/`build`, and the `binary:` URL templates.

## Analysis against the review checklist

- **Current metadata state / tracked version** — mirror was stale at `0.1.0-alpha.39+1000393`; pubspec is `0.1.8+108999`. (The mirror is a reference draft; the live recipe is in fdroiddata on GitLab, which auto‑updates and is not edited from this repo.)
- **Is `AutoUpdateMode: Version` enough?** — Yes for *tracking*. `UpdateCheckMode: Tags` + `UpdateCheckData` read `versionName`/`versionCode` from `pubspec.yaml` at each `v*` tag; `VercodeOperation` fans the base code out into the three per‑ABI `Builds`. F‑Droid auto‑detects 0.1.8 and future tags — no manual fdroiddata entry is needed just to add a release.
- **Manual build entry needed?** — Only if the auto‑update MR is stuck, or if reproducibility fails and the maintainer applies the documented fallback (see below). If a manual entry is written, its content equals the three per‑ABI blocks in this diff.
- **Correct tag/commit?** — `v0.1.8` → `d8484f449ba4871ab206842b21b0c42ea4b63a8d` (matches the release tag and the release‑prep commit).
- **Correct output path?** — `build/app/outputs/flutter-apk/app-<abi>-release.apk`, exactly what `flutter build apk --release --split-per-abi` emits.
- **ABI‑split mismatch?** — None. The metadata explicitly supports the split via `VercodeOperation`; codes match `base*10+rank`; each `output:` and `binary:` ABI agree.
- **Flutter build commands correct for F‑Droid?** — Yes: `flutter pub get` (prebuild) then `flutter build apk --release --split-per-abi` (no `--build-name/--build-number`; version comes from `pubspec.yaml`).
- **Old alpha/version metadata?** — Updated: the alpha.39 pin is fully replaced by 0.1.8.

## Testing / build notes for the fdroiddata MR

The v0.1.8 GitHub Release publishes all referenced upstream‑signed artifacts, so every `binary:` URL (`v%v` → `v0.1.8`) resolves:
`linthra-v0.1.8-armeabi-v7a-release-signed.apk`, `…-arm64-v8a-…`, `…-x86_64-…`, plus the universal `.apk`/`.aab`. No debug or PR artifacts are referenced.

Before advancing the fdroiddata MR, run and require all three green:

```sh
fdroid build io.github.thezupzup.linthra:1089991   # armeabi-v7a
fdroid build io.github.thezupzup.linthra:1089992   # arm64-v8a  <- watch this one
fdroid build io.github.thezupzup.linthra:1089993   # x86_64
```

**Known reproducibility caveat (not introduced here):** per `docs/fdroid-reproducibility-arm64.md`, the 64‑bit splits can fail byte‑for‑byte signature copying when built in one multi‑ABI pass. The release CI now builds each ABI isolated with `--target-platform` to fix this; **0.1.8 must be the release that confirms it via a green `fdroid build`.** If the 64‑bit splits still aren't reproducible, apply the documented fallback in fdroiddata (drop `AllowedAPKSigningKeys` + the `binary:` lines so F‑Droid builds and signs the per‑ABI APKs itself). Either way F‑Droid ships one correct artifact per ABI.

## Public wording (verified accurate, unchanged)

`README.md` (Status/Install) and `docs/release-process.md` §5 already state, correctly: GitHub Releases are the source of truth for the latest official builds; F‑Droid is available but may lag; GitHub and F‑Droid APKs are signed with different keys and cannot cross‑update. No wording changes were needed.

## Verification

No Flutter/Dart toolchain in this environment, so `test/tooling/fdroid_release_guardrails_test.dart` was traced by hand against the new file — every assertion passes (per‑ABI `base*10+rank`, `CurrentVersionCode = base*10+3`, 40‑hex commit SHAs, canonical `binary:` URL shape, 1:1 name/code/output/binary alignment). CI runs it on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsN2WduR7YGQcSohFx76ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsN2WduR7YGQcSohFx76ye)_