### PR TITLE
feat(library): add favorite toggle to track overflow menus

### DIFF
--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -7,7 +7,9 @@ import '../../../core/models/track.dart';
 import '../../../core/repositories/download_repository.dart';
 import '../../../core/repositories/download_store.dart';
 import '../../../data/repositories/download_repository_provider.dart';
+import '../../../data/repositories/favorites_repository_provider.dart';
 import '../../downloads/download_providers.dart';
+import '../../player/favorites_providers.dart';
 import '../../player/now_playing.dart';
 import '../../player/player_providers.dart';
 import '../../player/widgets/track_artwork.dart';
@@ -18,6 +20,7 @@ import '../song_actions.dart';
 /// offered is context-aware: it depends on whether the track is remote and on
 /// its current [DownloadStatus] (see `_OverflowMenu._menuItems`).
 enum _TrackAction {
+  toggleFavorite,
   playNext,
   addToQueue,
   addToPlaylist,
@@ -235,19 +238,28 @@ class _OverflowMenu extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Keyed by the provider-namespaced uri, so local/Jellyfin/Subsonic copies
+    // each reflect their own heart. Watched here so the menu label/icon stay
+    // live if the favourite state changes while the row is on screen.
+    final bool isFavorite = ref.watch(isFavoriteProvider(track.uri));
     return PopupMenuButton<_TrackAction>(
       icon: const Icon(Icons.more_vert),
       tooltip: 'More actions',
       onSelected: (action) => _run(context, ref, action),
-      itemBuilder: (context) => _menuItems(),
+      itemBuilder: (context) => _menuItems(isFavorite),
     );
   }
 
   /// Context-aware action list. Offline actions are gated on [isRemote]; the
-  /// rest depend on the track's [DownloadStatus]. The queue, add-to-playlist,
-  /// and remove-from-Linthra actions are always available.
-  List<PopupMenuEntry<_TrackAction>> _menuItems() {
+  /// rest depend on the track's [DownloadStatus]. The favourite toggle, queue,
+  /// add-to-playlist, and remove-from-Linthra actions are always available.
+  List<PopupMenuEntry<_TrackAction>> _menuItems(bool isFavorite) {
     final items = <PopupMenuEntry<_TrackAction>>[
+      _item(
+        _TrackAction.toggleFavorite,
+        isFavorite ? Icons.favorite : Icons.favorite_border,
+        isFavorite ? 'Remove from favorites' : 'Add to favorites',
+      ),
       _item(_TrackAction.playNext, Icons.queue_music, 'Play next'),
       _item(_TrackAction.addToQueue, Icons.add_to_queue, 'Add to queue'),
       _item(_TrackAction.addToPlaylist, Icons.playlist_add, 'Add to playlist'),
@@ -295,6 +307,16 @@ class _OverflowMenu extends ConsumerWidget {
     _TrackAction action,
   ) async {
     switch (action) {
+      case _TrackAction.toggleFavorite:
+        // Like/unlike without touching playback or the queue. Re-read the
+        // current state so the toggle is correct even if the heart changed
+        // after the menu opened, and hand the real [Track] to the repository so
+        // its uri routes local/Jellyfin/Subsonic favourites (and the Subsonic
+        // sync push) correctly.
+        final bool isFavorite = ref.read(isFavoriteProvider(track.uri));
+        await ref
+            .read(favoritesRepositoryProvider)
+            .setFavorite(track, !isFavorite);
       case _TrackAction.playNext:
         ref.read(playbackControllerProvider).playNext(track);
       case _TrackAction.addToQueue:

--- a/lib/features/playlists/playlist_detail_screen.dart
+++ b/lib/features/playlists/playlist_detail_screen.dart
@@ -7,10 +7,12 @@ import '../../app/routes.dart';
 import '../../core/models/playlist.dart';
 import '../../core/models/track.dart';
 import '../../core/services/bulk_track_actions.dart';
+import '../../data/repositories/favorites_repository_provider.dart';
 import '../../data/repositories/playlist_repository_provider.dart';
 import '../../shared/widgets/confirm_dialog.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../library/song_actions.dart';
+import '../player/favorites_providers.dart';
 import '../player/now_playing.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
@@ -235,6 +237,8 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     final Track track = tracks[index];
     final NowPlayingRowState? nowPlaying =
         ref.watch(nowPlayingProvider.select((n) => n.stateForRow(track)));
+    // Keyed by the provider-namespaced uri so each source's heart is its own.
+    final bool isFavorite = ref.watch(isFavoriteProvider(track.uri));
     return ListTile(
       key: ValueKey<String>(track.uri),
       leading: TrackArtwork(
@@ -251,8 +255,20 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
             icon: const Icon(Icons.more_vert),
             tooltip: 'Track actions',
             onSelected: (a) => _runRow(playlist, track, a),
-            itemBuilder: (context) => const <PopupMenuEntry<_RowAction>>[
+            itemBuilder: (context) => <PopupMenuEntry<_RowAction>>[
               PopupMenuItem<_RowAction>(
+                value: _RowAction.toggleFavorite,
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(
+                    isFavorite ? Icons.favorite : Icons.favorite_border,
+                  ),
+                  title: Text(
+                    isFavorite ? 'Remove from favorites' : 'Add to favorites',
+                  ),
+                ),
+              ),
+              const PopupMenuItem<_RowAction>(
                 value: _RowAction.playNext,
                 child: ListTile(
                   contentPadding: EdgeInsets.zero,
@@ -260,7 +276,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                   title: Text('Play next'),
                 ),
               ),
-              PopupMenuItem<_RowAction>(
+              const PopupMenuItem<_RowAction>(
                 value: _RowAction.addToQueue,
                 child: ListTile(
                   contentPadding: EdgeInsets.zero,
@@ -268,7 +284,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                   title: Text('Add to queue'),
                 ),
               ),
-              PopupMenuItem<_RowAction>(
+              const PopupMenuItem<_RowAction>(
                 value: _RowAction.addToPlaylist,
                 child: ListTile(
                   contentPadding: EdgeInsets.zero,
@@ -276,7 +292,7 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
                   title: Text('Add to playlist'),
                 ),
               ),
-              PopupMenuItem<_RowAction>(
+              const PopupMenuItem<_RowAction>(
                 value: _RowAction.removeFromPlaylist,
                 child: ListTile(
                   contentPadding: EdgeInsets.zero,
@@ -407,6 +423,15 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
     _RowAction action,
   ) async {
     switch (action) {
+      case _RowAction.toggleFavorite:
+        // Like/unlike from the playlist row without touching playback or the
+        // queue. Re-read the current state so the toggle is correct even if the
+        // heart changed after the menu opened; the real [Track] uri routes the
+        // favourite to the right source (and its Subsonic sync push).
+        final bool isFavorite = ref.read(isFavoriteProvider(track.uri));
+        await ref
+            .read(favoritesRepositoryProvider)
+            .setFavorite(track, !isFavorite);
       case _RowAction.playNext:
         ref.read(playbackControllerProvider).playNext(track);
       case _RowAction.addToQueue:
@@ -527,7 +552,13 @@ class _PlaylistDetailScreenState extends ConsumerState<PlaylistDetailScreen> {
 
 enum _DetailMenuAction { rename, delete }
 
-enum _RowAction { playNext, addToQueue, addToPlaylist, removeFromPlaylist }
+enum _RowAction {
+  toggleFavorite,
+  playNext,
+  addToQueue,
+  addToPlaylist,
+  removeFromPlaylist,
+}
 
 class _Header extends StatelessWidget {
   const _Header({required this.onPlay, required this.onShuffle});

--- a/test/features/library/track_tile_test.dart
+++ b/test/features/library/track_tile_test.dart
@@ -4,15 +4,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/features/library/widgets/track_tile.dart';
+import 'package:linthra/features/player/player_providers.dart';
 
+import '../player/fake_playback_controller.dart';
 import 'fake_remote_track_downloader.dart';
 
-Future<void> _pump(WidgetTester tester, List<Track> tracks) async {
+Future<void> _pump(
+  WidgetTester tester,
+  List<Track> tracks, {
+  FakePlaybackController? controller,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         remoteTrackDownloaderProvider
             .overrideWithValue(FakeRemoteTrackDownloader()),
+        if (controller != null)
+          playbackControllerProvider.overrideWithValue(controller),
       ],
       child: MaterialApp(
         home: Scaffold(
@@ -92,6 +100,49 @@ void main() {
 
       expect(find.text('Play next'), findsOneWidget);
       expect(find.text('Add to queue'), findsOneWidget);
+    });
+
+    testWidgets(
+        'overflow menu offers Add to favorites with an outline heart when not '
+        'favorited', (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+      ]);
+
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to favorites'), findsOneWidget);
+      expect(find.text('Remove from favorites'), findsNothing);
+      expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+    });
+
+    testWidgets(
+        'choosing Add to favorites likes the track and flips to a filled-heart '
+        'Remove — without starting playback or changing the queue',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      await _pump(
+        tester,
+        const <Track>[Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3')],
+        controller: controller,
+      );
+
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Add to favorites'));
+      await tester.pumpAndSettle();
+
+      // Favoriting is a pure like: no track played, no queue change.
+      expect(controller.playedTracks, isEmpty);
+      expect(controller.state.upNext, isEmpty);
+
+      // Reopening the menu now shows the filled-heart "Remove from favorites".
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+      expect(find.text('Remove from favorites'), findsOneWidget);
+      expect(find.text('Add to favorites'), findsNothing);
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
     });
   });
 

--- a/test/features/playlists/playlist_detail_screen_test.dart
+++ b/test/features/playlists/playlist_detail_screen_test.dart
@@ -102,6 +102,29 @@ void main() {
     expect(find.text('player-screen'), findsOneWidget);
   });
 
+  testWidgets(
+      'track row menu toggles favorite without playing or changing the queue',
+      (tester) async {
+    final FakePlaybackController controller = FakePlaybackController();
+    await _pump(tester, store: await _seededStore(), controller: controller);
+
+    await tester.tap(find.byTooltip('Track actions').first);
+    await tester.pumpAndSettle();
+    expect(find.text('Add to favorites'), findsOneWidget);
+
+    await tester.tap(find.text('Add to favorites'));
+    await tester.pumpAndSettle();
+
+    // Favoriting is a pure like: no playback, no queue change.
+    expect(controller.playedTracks, isEmpty);
+    expect(controller.state.upNext, isEmpty);
+
+    // Reopening the row's menu now offers the filled-heart remove action.
+    await tester.tap(find.byTooltip('Track actions').first);
+    await tester.pumpAndSettle();
+    expect(find.text('Remove from favorites'), findsOneWidget);
+  });
+
   testWidgets('long-press enters selection mode and shows the count',
       (tester) async {
     await _pump(


### PR DESCRIPTION
## What

Adds an **Add to favorites** / **Remove from favorites** action to every track-level overflow menu in the library UI, so a song can be liked/unliked straight from a list — without starting playback.

- Shows **Add to favorites** with an outline heart (`favorite_border`) when the track isn't favorited.
- Shows **Remove from favorites** with a filled heart (`favorite`) when it already is.
- The action **never starts playback and never touches the queue** — it only toggles the heart.

## Where

Two overflow menus cover every requested surface:

| Menu | Screens it covers |
| --- | --- |
| `TrackTile._OverflowMenu` (shared) | Songs list, Album detail, Artist detail, Search result track rows, Favorites, Smart-mix detail |
| `PlaylistDetailScreen._trackRow` | Playlist track rows |

Album- and playlist-level overflow menus (e.g. rename/delete a playlist) are intentionally left unchanged — this is track-level favorites only.

## How

- Watches `isFavoriteProvider(track.uri)` to pick the label + heart icon, keyed by the provider-namespaced `Track.uri` so local / Jellyfin / Subsonic copies each reflect their own heart.
- Toggles through the existing `FavoritesRepository.setFavorite(track, !isFavorite)` — the same call `NowPlayingActions` already uses. Passing the real `Track` means its `uri` routes the favourite to the right source, including the Subsonic/Navidrome server sync path added in #264.
- Re-reads the current favourite state at action time so the toggle is correct even if the heart changed while the menu was open.

## Tests

- `track_tile_test.dart`: the menu offers "Add to favorites" with an outline heart when not favorited; choosing it likes the track and flips to a filled-heart "Remove from favorites", asserting no playback started and the queue is unchanged.
- `playlist_detail_screen_test.dart`: the playlist row menu toggles favorite without playing or changing the queue.

## Out of scope

No changes to playback, playlist sync, provider login, auto-sync, or Now Playing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH7ZJfDqBWtAXwzwtwHWWv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LH7ZJfDqBWtAXwzwtwHWWv)_