### PR TITLE
docs(readme): shorten README and move the docs index to docs/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ tracking, no account.
 - Chromecast, implemented in pure Dart. No Google Play Services needed.
 - Android Auto.
 - Queue, playlists and favorites. Playlists and hearts sync both ways with
-  Jellyfin and Navidrome, and work fine with no server at all.
-- Smart mixes (recently played, most played, never played, and so on), built
-  from listening data that never leaves the device.
+  Jellyfin and Navidrome, and also work without a server.
+- Smart mixes (recently played, most played, never played). Built from
+  listening data that stays on the device.
 - Background playback with lock-screen, Bluetooth and headset controls,
   shuffle, repeat, and synced lyrics.
 - Themes, and you can switch the actual launcher icon from settings.
@@ -42,7 +42,7 @@ Each of these has its own page in [the docs](./docs/README.md).
 
 | Now Playing | Library | Smart mixes |
 | --- | --- | --- |
-| ![Now Playing](fastlane/metadata/android/en-US/images/phoneScreenshots/01-now-playing-carefree.png) | ![Library — Albums](fastlane/metadata/android/en-US/images/phoneScreenshots/02-library-albums.png) | ![Smart mixes](fastlane/metadata/android/en-US/images/phoneScreenshots/04-smart-mixes.png) |
+| ![Now Playing](fastlane/metadata/android/en-US/images/phoneScreenshots/01-now-playing-carefree.png) | ![Library albums](fastlane/metadata/android/en-US/images/phoneScreenshots/02-library-albums.png) | ![Smart mixes](fastlane/metadata/android/en-US/images/phoneScreenshots/04-smart-mixes.png) |
 
 More in [`phoneScreenshots/`](fastlane/metadata/android/en-US/images/phoneScreenshots/).
 
@@ -58,9 +58,8 @@ Google Play yet.
 > **Don't mix install sources.** GitHub APKs and F-Droid builds are signed with
 > different keys and can't update each other. Pick one and stick with it.
 
-The nicest way to install from GitHub is
-[Obtainium](https://github.com/ImranR98/Obtainium), which also keeps you
-updated:
+To install from GitHub Releases and get updates, use
+[Obtainium](https://github.com/ImranR98/Obtainium):
 
 1. Install Obtainium.
 2. Tap **Add App** and paste the source URL:
@@ -68,11 +67,11 @@ updated:
 3. Install the latest release. Obtainium handles updates from then on. (Enable
    **"Include prereleases"** only if you want to test pre-release builds.)
 
-Or just download the `.apk` from the
+Or download the `.apk` from the
 [latest release](https://github.com/thezupzup/linthra/releases/latest) and open
 it on your phone.
 
-Two things worth knowing:
+Notes:
 
 - Android Auto only shows sideloaded media apps after a one-time developer
   toggle. See [docs/android-auto.md](./docs/android-auto.md).
@@ -83,41 +82,39 @@ Two things worth knowing:
 
 | Source | Status |
 | --- | --- |
-| **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) — [docs](./docs/local-music.md) |
-| **Jellyfin** | ✅ Stream, cache, cast, playlists & favorites — [docs](./docs/jellyfin.md) |
-| **Navidrome / Subsonic** | ✅ Stream, cache, cast, lyrics, playlists & favorites (two-way sync) — [docs](./docs/providers.md) |
-| **Plex** | ✅ Browse, stream & cache from your own Plex Media Server — [docs](./docs/plex.md) |
-| **WebDAV / NAS** | 🔜 Planned — same `MusicSource` seam |
+| **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) ([docs](./docs/local-music.md)) |
+| **Jellyfin** | ✅ Stream, cache, cast, playlists & favorites ([docs](./docs/jellyfin.md)) |
+| **Navidrome / Subsonic** | ✅ Stream, cache, cast, lyrics, playlists & favorites, two-way sync ([docs](./docs/providers.md)) |
+| **Plex** | ✅ Browse, stream & cache from your own Plex Media Server ([docs](./docs/plex.md)) |
+| **WebDAV / NAS** | 🔜 Planned, behind the same `MusicSource` interface |
 
 ## Privacy
 
-Nothing leaves your device unless you make it happen.
+Nothing leaves your device unless you send it yourself.
 
 - No telemetry, no analytics.
-- Bug reports are built locally and only go anywhere if you open the prefilled
-  issue yourself.
-- Downloads are always something you started.
+- Bug reports are built locally and only sent if you open the prefilled issue
+  yourself.
+- Downloads only happen when you start them.
 - Minimal permissions: playback and internet, no storage permission.
-- Your server password is used once to get a token and then discarded; the
-  token is stored encrypted and never logged.
+- The server password is used once to get a token, then discarded. The token
+  is stored encrypted and never logged.
 
-More in [PRIVACY.md](./PRIVACY.md) and the per-provider docs.
+Details are in [PRIVACY.md](./PRIVACY.md) and the provider docs.
 
 ## Contributing
 
-Testing against your own server, capturing screenshots, or fixing a confusing
-doc counts just as much as code. [CONTRIBUTING.md](./CONTRIBUTING.md) gets you
-set up in two commands, and the
-[contributor roadmap](./docs/contributor-roadmap.md) shows where help is most
-useful right now. If you'd like to support development, see
+Testing against your own server, screenshots, and doc fixes are useful
+contributions, not just code. [CONTRIBUTING.md](./CONTRIBUTING.md) covers
+setup. The [contributor roadmap](./docs/contributor-roadmap.md) lists where
+help is needed. To support development, see
 [docs/SUPPORT.md](./docs/SUPPORT.md).
 
 ## Roadmap
 
-See [docs/roadmap.md](./docs/roadmap.md). The short version: stabilize 0.1.x,
-then backup/restore, then the optional Linthra Connect and a desktop app. One
-rule holds through all of it: Linthra works on its own. No Docker, no account,
-no required pairing.
+See [docs/roadmap.md](./docs/roadmap.md). In short: stabilize 0.1.x, then
+backup/restore, then the optional Linthra Connect and a desktop app. Linthra
+always works on its own: no Docker, no account, no required pairing.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ tracking, no account.
   size limit and "Keep offline" pinning.
 - Chromecast, implemented in pure Dart. No Google Play Services needed.
 - Android Auto.
-- Queue, playlists and favourites. Playlists and hearts sync both ways with
+- Queue, playlists and favorites. Playlists and hearts sync both ways with
   Jellyfin and Navidrome, and work fine with no server at all.
 - Smart mixes (recently played, most played, never played, and so on), built
   from listening data that never leaves the device.
@@ -51,8 +51,9 @@ More in [`phoneScreenshots/`](fastlane/metadata/android/en-US/images/phoneScreen
 New versions land on
 [GitHub Releases](https://github.com/thezupzup/linthra/releases) first, as
 signed APKs. The current stable is v0.1.8. Linthra is also on
-[F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/), usually a
-bit behind while their build and review runs. Not on Google Play yet.
+[F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/); F-Droid
+builds may arrive a bit later while their build and review process runs. Not on
+Google Play yet.
 
 > **Don't mix install sources.** GitHub APKs and F-Droid builds are signed with
 > different keys and can't update each other. Pick one and stick with it.
@@ -83,19 +84,22 @@ Two things worth knowing:
 | Source | Status |
 | --- | --- |
 | **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) — [docs](./docs/local-music.md) |
-| **Jellyfin** | ✅ Stream, cache, cast, playlists & favourites — [docs](./docs/jellyfin.md) |
-| **Navidrome / Subsonic** | ✅ Stream, cache, cast, lyrics, playlists & favourites (two-way sync) — [docs](./docs/providers.md) |
+| **Jellyfin** | ✅ Stream, cache, cast, playlists & favorites — [docs](./docs/jellyfin.md) |
+| **Navidrome / Subsonic** | ✅ Stream, cache, cast, lyrics, playlists & favorites (two-way sync) — [docs](./docs/providers.md) |
 | **Plex** | ✅ Browse, stream & cache from your own Plex Media Server — [docs](./docs/plex.md) |
 | **WebDAV / NAS** | 🔜 Planned — same `MusicSource` seam |
 
 ## Privacy
 
-Nothing leaves your device unless you make it happen. There is no telemetry and
-no analytics; bug reports are built locally and only go anywhere if you open
-the prefilled issue yourself. Downloads are always something you started.
-Permissions are minimal: playback and internet, no storage permission. Your
-server password is used once to get a token and then discarded; the token is
-stored encrypted and never logged.
+Nothing leaves your device unless you make it happen.
+
+- No telemetry, no analytics.
+- Bug reports are built locally and only go anywhere if you open the prefilled
+  issue yourself.
+- Downloads are always something you started.
+- Minimal permissions: playback and internet, no storage permission.
+- Your server password is used once to get a token and then discarded; the
+  token is stored encrypted and never logged.
 
 More in [PRIVACY.md](./PRIVACY.md) and the per-provider docs.
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,17 @@ Play yet.
 > **Don't mix install sources:** GitHub APKs and F-Droid builds are signed with
 > different keys and can't update each other — pick one and stick with it.
 
-- **Obtainium** — [Obtainium](https://github.com/ImranR98/Obtainium) installs
-  straight from GitHub Releases and keeps Linthra updated: add
-  `https://github.com/thezupzup/linthra` as the source URL.
+**Obtainium (recommended)** — [Obtainium](https://github.com/ImranR98/Obtainium)
+installs straight from GitHub Releases and keeps Linthra updated:
+
+1. Install Obtainium.
+2. Tap **Add App** and paste the source URL:
+   `https://github.com/thezupzup/linthra`
+3. Install the latest release; Obtainium handles updates from then on. (Enable
+   **"Include prereleases"** only if you want to test pre-release builds.)
+
+Other options:
+
 - **Manual APK** — download the signed `.apk` from the
   [latest release](https://github.com/thezupzup/linthra/releases/latest) and
   open it on your phone.

--- a/README.md
+++ b/README.md
@@ -20,23 +20,23 @@ tracking, no account.
 
 ## Features
 
-- **Local library** — pick a folder, scan it, browse Songs / Albums / Artists
-  with search. No broad storage permission.
-- **Self-hosted streaming** — connect your own Jellyfin, Navidrome / Subsonic,
-  or Plex server. Streaming is the default; nothing downloads unless you ask.
-- **Smart offline cache** — download the tracks you want offline; Wi-Fi only by
-  default, with a size limit and "Keep offline" pinning.
-- **Cast / Chromecast** — pure-Dart Cast, no Google Play Services.
-- **Android Auto** — browse your library and play from the car screen.
-- **Queue, playlists & favourites** — full queue control, and playlists /
-  favourites sync two-way with Jellyfin and Navidrome / Subsonic.
-- **Smart mixes** — automatic collections (Recently played, Most played,
-  Favorites, …) built from on-device signals that stay on the device.
-- **Background playback** — lock-screen, Bluetooth, and headset controls, plus
-  shuffle / repeat and synced lyrics.
-- **Themes & icons** — retint the app and switch the real launcher icon.
+- Plays music from a folder on your phone. Uses the Android folder picker, so
+  it never asks for a broad storage permission.
+- Streams from your own Jellyfin, Navidrome / Subsonic, or Plex server.
+  Streaming is the default and nothing downloads unless you ask.
+- Offline cache: download the tracks you want, Wi-Fi only by default, with a
+  size limit and "Keep offline" pinning.
+- Chromecast, implemented in pure Dart. No Google Play Services needed.
+- Android Auto.
+- Queue, playlists and favourites. Playlists and hearts sync both ways with
+  Jellyfin and Navidrome, and work fine with no server at all.
+- Smart mixes (recently played, most played, never played, and so on), built
+  from listening data that never leaves the device.
+- Background playback with lock-screen, Bluetooth and headset controls,
+  shuffle, repeat, and synced lyrics.
+- Themes, and you can switch the actual launcher icon from settings.
 
-Every feature has a deep-dive in [the docs](./docs/README.md).
+Each of these has its own page in [the docs](./docs/README.md).
 
 ## Screenshots
 
@@ -48,33 +48,34 @@ More in [`phoneScreenshots/`](fastlane/metadata/android/en-US/images/phoneScreen
 
 ## Install
 
-**[GitHub Releases](https://github.com/thezupzup/linthra/releases)** is the
-source of truth for the latest builds — each release ships signed APKs, and the
-current stable is **v0.1.8**. Linthra is also on
-**[F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/)**, though
-F-Droid updates may arrive later while their build/review runs. Not on Google
-Play yet.
+New versions land on
+[GitHub Releases](https://github.com/thezupzup/linthra/releases) first, as
+signed APKs. The current stable is v0.1.8. Linthra is also on
+[F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/), usually a
+bit behind while their build and review runs. Not on Google Play yet.
 
-> **Don't mix install sources:** GitHub APKs and F-Droid builds are signed with
-> different keys and can't update each other — pick one and stick with it.
+> **Don't mix install sources.** GitHub APKs and F-Droid builds are signed with
+> different keys and can't update each other. Pick one and stick with it.
 
-**Obtainium (recommended)** — [Obtainium](https://github.com/ImranR98/Obtainium)
-installs straight from GitHub Releases and keeps Linthra updated:
+The nicest way to install from GitHub is
+[Obtainium](https://github.com/ImranR98/Obtainium), which also keeps you
+updated:
 
 1. Install Obtainium.
 2. Tap **Add App** and paste the source URL:
    `https://github.com/thezupzup/linthra`
-3. Install the latest release; Obtainium handles updates from then on. (Enable
+3. Install the latest release. Obtainium handles updates from then on. (Enable
    **"Include prereleases"** only if you want to test pre-release builds.)
 
-Other options:
+Or just download the `.apk` from the
+[latest release](https://github.com/thezupzup/linthra/releases/latest) and open
+it on your phone.
 
-- **Manual APK** — download the signed `.apk` from the
-  [latest release](https://github.com/thezupzup/linthra/releases/latest) and
-  open it on your phone.
-- **Android Auto?** Sideloaded media apps only appear after a one-time
-  "Unknown sources" toggle — see [docs/android-auto.md](./docs/android-auto.md).
-- **Build it yourself** — setup, build, and CI details are in
+Two things worth knowing:
+
+- Android Auto only shows sideloaded media apps after a one-time developer
+  toggle. See [docs/android-auto.md](./docs/android-auto.md).
+- Building from source is two commands. See
   [docs/development.md](./docs/development.md).
 
 ## Supported sources
@@ -89,35 +90,35 @@ Other options:
 
 ## Privacy
 
-- **No telemetry, no analytics, no phoning home** — nothing leaves your device
-  unless **you** choose to.
-- **No surprise downloads** — streaming is the default; downloads are always
-  user-initiated.
-- **Minimal permissions** — playback and internet; no broad storage permission.
-- **Your secrets stay safe** — the server password is used once to get a token,
-  then discarded; the token is encrypted at rest and never logged.
+Nothing leaves your device unless you make it happen. There is no telemetry and
+no analytics; bug reports are built locally and only go anywhere if you open
+the prefilled issue yourself. Downloads are always something you started.
+Permissions are minimal: playback and internet, no storage permission. Your
+server password is used once to get a token and then discarded; the token is
+stored encrypted and never logged.
 
-Details in [PRIVACY.md](./PRIVACY.md) and each provider's doc.
+More in [PRIVACY.md](./PRIVACY.md) and the per-provider docs.
 
 ## Contributing
 
-Linthra is small and friendly — testing against your own server, capturing
-screenshots, and fixing docs are all real contributions, no Flutter expertise
-required. Start with [CONTRIBUTING.md](./CONTRIBUTING.md); the
-[contributor roadmap](./docs/contributor-roadmap.md) shows where help matters
-most right now, and optional ways to support development are in
+Testing against your own server, capturing screenshots, or fixing a confusing
+doc counts just as much as code. [CONTRIBUTING.md](./CONTRIBUTING.md) gets you
+set up in two commands, and the
+[contributor roadmap](./docs/contributor-roadmap.md) shows where help is most
+useful right now. If you'd like to support development, see
 [docs/SUPPORT.md](./docs/SUPPORT.md).
 
 ## Roadmap
 
-The phased product direction — and its one guiding rule, **Linthra works on its
-own; Linthra Connect is optional** — lives in
-[docs/roadmap.md](./docs/roadmap.md), along with the honest gaps.
+See [docs/roadmap.md](./docs/roadmap.md). The short version: stabilize 0.1.x,
+then backup/restore, then the optional Linthra Connect and a desktop app. One
+rule holds through all of it: Linthra works on its own. No Docker, no account,
+no required pairing.
 
 ## Documentation
 
-The full index — setup, architecture, and a deep-dive per feature — is in
-[docs/README.md](./docs/README.md).
+Everything is indexed in [docs/README.md](./docs/README.md): setup,
+architecture, and a page per feature.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,239 +15,101 @@
 
 **Linthra is an open-source Android music player for people who keep their music
 on their own devices or self-hosted servers.** It plays local files and streams
-from your own Jellyfin or Navidrome / Subsonic server. No ads, no tracking, no
-account.
+from your own Jellyfin, Navidrome / Subsonic, or Plex server. No ads, no
+tracking, no account.
 
----
+## Features
 
-## 🎧 Why Linthra?
+- **Local library** — pick a folder, scan it, browse Songs / Albums / Artists
+  with search. No broad storage permission.
+- **Self-hosted streaming** — connect your own Jellyfin, Navidrome / Subsonic,
+  or Plex server. Streaming is the default; nothing downloads unless you ask.
+- **Smart offline cache** — download the tracks you want offline; Wi-Fi only by
+  default, with a size limit and "Keep offline" pinning.
+- **Cast / Chromecast** — pure-Dart Cast, no Google Play Services.
+- **Android Auto** — browse your library and play from the car screen.
+- **Queue, playlists & favourites** — full queue control, and playlists /
+  favourites sync two-way with Jellyfin and Navidrome / Subsonic.
+- **Smart mixes** — automatic collections (Recently played, Most played,
+  Favorites, …) built from on-device signals that stay on the device.
+- **Background playback** — lock-screen, Bluetooth, and headset controls, plus
+  shuffle / repeat and synced lyrics.
+- **Themes & icons** — retint the app and switch the real launcher icon.
 
-Point it at your Jellyfin / Navidrome / Subsonic server, or a folder of local
-files, and it plays from there.
+Every feature has a deep-dive in [the docs](./docs/README.md).
 
-Streaming is the default — nothing downloads unless you ask. Browsing stays fast
-because the app reads from a local catalog rather than the network, and nothing
-phones home: no telemetry, no ads, no account.
-
-If you self-host your music and want a straightforward Android player for it,
-give Linthra a try.
-
-## Status
-
-**Linthra 0.1.8 is the current stable release**, available from
-[GitHub Releases](https://github.com/thezupzup/linthra/releases/latest) as signed
-APKs. You can connect a real server, sync your library, stream, cache, cast, and
-drive it from Android Auto on a real phone. It still has honest, documented rough
-edges (see [Roadmap](#roadmap) and the per-feature docs), so it's a great time to
-jump in — small contributions land fast and shape where it goes.
-
-> **On F-Droid:** yes — Linthra is on
-> [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/), though
-> F-Droid updates may arrive later than GitHub Releases while F-Droid processes
-> their build/review. Linthra is **not on Google Play** yet.
-
-## 📸 Screenshots
-
-Real captures from a running build — Now Playing, your Library, and the
-auto-built Smart mixes:
+## Screenshots
 
 | Now Playing | Library | Smart mixes |
 | --- | --- | --- |
 | ![Now Playing](fastlane/metadata/android/en-US/images/phoneScreenshots/01-now-playing-carefree.png) | ![Library — Albums](fastlane/metadata/android/en-US/images/phoneScreenshots/02-library-albums.png) | ![Smart mixes](fastlane/metadata/android/en-US/images/phoneScreenshots/04-smart-mixes.png) |
 
-More are in [`phoneScreenshots/`](fastlane/metadata/android/en-US/images/phoneScreenshots/);
-the full set and capture notes are in [docs/listing-assets.md](./docs/listing-assets.md).
-The app icon and the feature-graphic banner (above) are generated from one source
-design — not mockups.
-
-## What works today
-
-- **Local library** — pick a folder (Storage Access Framework), scan it, browse
-  **Songs / Albums / Artists** with search. No broad storage permission.
-- **Self-hosted streaming** — connect your own **Jellyfin** or
-  **Navidrome / Subsonic** server: test, sign in, sync, and stream. Works over
-  HTTPS / Cloudflare-proxied domains.
-- **Plex** — connect your own **Plex Media Server**: browse, stream, and cache.
-  Plex support is available (one provider among several, not the default); some
-  server setups may still need testing.
-- **Smart offline cache** — tap to download the tracks you want offline; Wi-Fi
-  only by default, with a size limit and "Keep offline" pinning.
-- **Cast / Chromecast** — hand a stream off to a speaker or TV, with device
-  volume control and track metadata (title/artist/album/artwork) on the receiver.
-  Pure-Dart Cast, no Google Play Services. (App-name/logo branding on the receiver
-  needs a custom receiver app — see [docs/cast.md](./docs/cast.md).)
-- **Android Auto** — browse your Library, Queue, Playlists, and Favorites from
-  the car screen and tap to play.
-- **Queue / Up Next** — play next, add to queue, reorder, remove, and save the
-  queue as a playlist — without building a playlist first ([docs](./docs/queue.md)).
-- **Playlists & favourites** — create/edit/reorder/delete playlists; favourite
-  tracks. Both sync with **Jellyfin and Navidrome / Subsonic** where supported
-  (a server change shows up here, and your changes push back), while local-only
-  playlists and hearts work fully with no server at all.
-- **Smart mixes** — automatic, Made-by-Linthra collections (Recently added /
-  played, Most played, Favorites, Downloaded, Random, Never played) built from
-  on-device signals that stay on the device ([docs](./docs/smart-mixes.md)).
-- **Background playback** — media notification with lock-screen, Bluetooth, and
-  wired-headset controls, plus shuffle / repeat and synced lyrics.
-- **Appearance** — switch the real Android launcher icon and retint the app from
-  Appearance settings; themes **Classic / Neon / Gold / Black & White**.
-- **Optional community & sharing** — quiet links in **Settings → About** (join
-  [r/Linthra](https://reddit.com/r/Linthra), open GitHub or the latest release)
-  and an Android share-sheet action. No account, login, or tracking.
-
-Each feature has a deep-dive in [the docs](#documentation).
+More in [`phoneScreenshots/`](fastlane/metadata/android/en-US/images/phoneScreenshots/).
 
 ## Install
 
-> **GitHub Releases is the source of truth for the latest Linthra builds** —
-> **[github.com/thezupzup/linthra/releases](https://github.com/thezupzup/linthra/releases)**.
-> Each release ships **signed** APKs; the current stable build is **v0.1.8**. PR
-> and debug APKs are for testing only — not official releases. Linthra is also on
-> [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/), but
-> F-Droid updates may arrive later after their build/review process; Linthra isn't
-> on Google Play yet.
+**[GitHub Releases](https://github.com/thezupzup/linthra/releases)** is the
+source of truth for the latest builds — each release ships signed APKs, and the
+current stable is **v0.1.8**. Linthra is also on
+**[F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/)**, though
+F-Droid updates may arrive later while their build/review runs. Not on Google
+Play yet.
+
 > **Don't mix install sources:** GitHub APKs and F-Droid builds are signed with
 > different keys and can't update each other — pick one and stick with it.
 
-**Obtainium (recommended)** — [Obtainium](https://github.com/ImranR98/Obtainium)
-installs straight from GitHub Releases and keeps Linthra updated:
+- **Obtainium** — [Obtainium](https://github.com/ImranR98/Obtainium) installs
+  straight from GitHub Releases and keeps Linthra updated: add
+  `https://github.com/thezupzup/linthra` as the source URL.
+- **Manual APK** — download the signed `.apk` from the
+  [latest release](https://github.com/thezupzup/linthra/releases/latest) and
+  open it on your phone.
+- **Android Auto?** Sideloaded media apps only appear after a one-time
+  "Unknown sources" toggle — see [docs/android-auto.md](./docs/android-auto.md).
+- **Build it yourself** — setup, build, and CI details are in
+  [docs/development.md](./docs/development.md).
 
-1. Install Obtainium.
-2. Tap **Add App** and paste the source URL:
-   `https://github.com/thezupzup/linthra`
-3. Install the latest release; Obtainium handles updates from then on. (Enable
-   **"Include prereleases"** only if you want to test pre-release builds.)
-
-**Manual APK** — download the signed `.apk` from the
-[latest release](https://github.com/thezupzup/linthra/releases/latest), open it on
-your phone, and allow "install from unknown sources" if prompted.
-
-**Build it yourself** — `flutter pub get && flutter build apk --debug`. Full
-setup, CI builds, and release details are in
-[docs/development.md](./docs/development.md). In most environments, run
-`./scripts/setup_flutter.sh` then `./scripts/verify_android.sh` to get the
-pinned Flutter toolchain and run the same checks as CI.
-
-> **Using Android Auto?** Sideloaded media apps only appear after you enable
-> Android Auto's developer **"Unknown sources"** toggle — a one-time step,
-> detailed in [docs/android-auto.md](./docs/android-auto.md).
-
-## Ways to help
-
-Linthra is small and friendly — good first contributions are very welcome, and
-many don't need a single line of code:
-
-- **Test with your server** — does it work with your **Jellyfin**? Your
-  **Navidrome / Subsonic**? Tell us what broke.
-- **Try Cast** — connect a Chromecast / speaker / TV and report device
-  compatibility.
-- **Test Android Auto** — on a head unit or the Desktop Head Unit.
-- **Capture more screenshots** — Downloads with tracks, Android Auto, Cast, or a
-  tablet layout.
-- **Improve docs** — fix a confusing step, add a setup gotcha.
-- **Report bugs in one tap** — **Settings → Report a bug** builds a
-  **secret-free** report on your device (no tokens, no passwords); review it,
-  then copy it or open a prefilled GitHub issue.
-  ([how it works](./docs/reporting-bugs.md))
-- **Improve accessibility** — better screen-reader labels and TalkBack support.
-- **Polish UI/UX** — small refinements add up.
-- **Help future providers** — WebDAV / NAS support behind the same interface.
-- **Join the community** — say hi or share your setup at
-  [r/Linthra](https://reddit.com/r/Linthra) (optional, quiet, and no account is
-  needed to read it).
-
-New here? [CONTRIBUTING.md](./CONTRIBUTING.md) walks through setup in two
-commands, and the [contributor roadmap](./docs/contributor-roadmap.md) shows
-where help is most useful right now. The
-[issue tracker](https://github.com/thezupzup/linthra/issues) has tasks tagged
-`good first issue` and `help wanted`.
-
-Found Linthra useful? A **GitHub star** helps others discover it.
-
-**Support development (optional).** Linthra is free, with no ads and no
-tracking, and every core feature stays free. If you'd like to help fund
-development, testing devices, app-store costs, and long-term maintenance, the
-app has an in-app **Settings → About → Support Linthra** screen. The supporter
-model — and how Play Store billing will be added **only** in Play builds later,
-while F-Droid builds stay free of any proprietary billing dependency — is
-described in [docs/SUPPORT.md](./docs/SUPPORT.md).
-
-## Self-hosted sources
-
-Sources sit behind one interface, so the app treats them uniformly:
+## Supported sources
 
 | Source | Status |
 | --- | --- |
 | **Local files** | ✅ Scan a folder, play directly (SAF, no broad permission) — [docs](./docs/local-music.md) |
 | **Jellyfin** | ✅ Stream, cache, cast, playlists & favourites — [docs](./docs/jellyfin.md) |
 | **Navidrome / Subsonic** | ✅ Stream, cache, cast, lyrics, playlists & favourites (two-way sync) — [docs](./docs/providers.md) |
-| **Plex** | ✅ Browse, stream & cache from your own Plex Media Server (some setups may still need testing) — [docs](./docs/plex.md) |
+| **Plex** | ✅ Browse, stream & cache from your own Plex Media Server — [docs](./docs/plex.md) |
 | **WebDAV / NAS** | 🔜 Planned — same `MusicSource` seam |
 
 ## Privacy
 
-Linthra is built to respect the people who use it:
-
 - **No telemetry, no analytics, no phoning home** — nothing leaves your device
-  unless **you** choose to. Bug reports are built locally and never auto-sent;
-  "Open GitHub issue" only opens your browser to a prefilled, unsubmitted issue.
+  unless **you** choose to.
 - **No surprise downloads** — streaming is the default; downloads are always
-  user-initiated, Wi-Fi only unless you opt in to mobile data.
-- **Minimal permissions** — foreground-service + notification (playback) and
-  internet (your server). **No broad storage permission.**
+  user-initiated.
+- **Minimal permissions** — playback and internet; no broad storage permission.
 - **Your secrets stay safe** — the server password is used once to get a token,
-  then discarded; the token is encrypted at rest, never logged, and stream URLs
-  are minted only on demand. Token-handling details are in each provider's doc.
+  then discarded; the token is encrypted at rest and never logged.
+
+Details in [PRIVACY.md](./PRIVACY.md) and each provider's doc.
+
+## Contributing
+
+Linthra is small and friendly — testing against your own server, capturing
+screenshots, and fixing docs are all real contributions, no Flutter expertise
+required. Start with [CONTRIBUTING.md](./CONTRIBUTING.md); the
+[contributor roadmap](./docs/contributor-roadmap.md) shows where help matters
+most right now, and optional ways to support development are in
+[docs/SUPPORT.md](./docs/SUPPORT.md).
 
 ## Roadmap
 
-The phased **[product roadmap](./docs/roadmap.md)** — v0.1.8 stabilization →
-Backup/Restore → optional Linthra Connect → Linthra Desktop — has the direction and
-its one guiding rule: **Linthra works on its own; Linthra Connect is optional** (no
-Docker, no account, no desktop dependency, no required pairing). The feature-level
-view:
-
-**Next up:** local tag/metadata parsing + album artwork · album/playlist
-"download all" + background download manager · real connectivity detection for
-the Wi-Fi gate · WebDAV / NAS sources.
-
-**Later:** local-file lyrics (`.lrc`/tags), ReplayGain, MPRIS, Linux desktop,
-richer Android Auto and Cast.
-
-Honest gaps (no local tag parsing yet, single Jellyfin server, direct-play only,
-partial playlist sync, optimistic connectivity) are documented per feature.
+The phased product direction — and its one guiding rule, **Linthra works on its
+own; Linthra Connect is optional** — lives in
+[docs/roadmap.md](./docs/roadmap.md), along with the honest gaps.
 
 ## Documentation
 
-| Topic | Doc |
-| --- | --- |
-| Contributing & setup | [CONTRIBUTING.md](./CONTRIBUTING.md) |
-| Product roadmap (phased direction) | [docs/roadmap.md](./docs/roadmap.md) |
-| Where to help (contributor roadmap) | [docs/contributor-roadmap.md](./docs/contributor-roadmap.md) |
-| Backup & restore (file format) | [docs/backup-restore-format.md](./docs/backup-restore-format.md) |
-| Supporting Linthra (optional supporter model) | [docs/SUPPORT.md](./docs/SUPPORT.md) |
-| Codebase tour (where everything lives) | [docs/codebase-tour.md](./docs/codebase-tour.md) |
-| Architecture & extension points | [docs/architecture.md](./docs/architecture.md) |
-| Development, build & CI | [docs/development.md](./docs/development.md) |
-| Library browsing & search | [docs/library.md](./docs/library.md) |
-| Local music (on-device folders) | [docs/local-music.md](./docs/local-music.md) |
-| Music providers (overview) | [docs/providers.md](./docs/providers.md) |
-| Jellyfin setup | [docs/jellyfin.md](./docs/jellyfin.md) · [compatibility](./docs/jellyfin-compatibility.md) · [sync](./docs/jellyfin-sync.md) |
-| Streaming, buffering & recovery | [docs/streaming.md](./docs/streaming.md) |
-| Queue / Up Next | [docs/queue.md](./docs/queue.md) |
-| Offline cache & downloads | [docs/offline-cache.md](./docs/offline-cache.md) |
-| Battery usage | [docs/battery.md](./docs/battery.md) |
-| Cast / Chromecast | [docs/cast.md](./docs/cast.md) |
-| Remote control (drive Linthra from another app) | [docs/remote-control.md](./docs/remote-control.md) |
-| Android Auto | [docs/android-auto.md](./docs/android-auto.md) |
-| Reporting a bug | [docs/reporting-bugs.md](./docs/reporting-bugs.md) |
-| Playlists & safe removal | [docs/playlists-and-delete.md](./docs/playlists-and-delete.md) |
-| Smart mixes (automatic playlists) | [docs/smart-mixes.md](./docs/smart-mixes.md) |
-| App icon & branding (in-app + real Android launcher icon) | [docs/app-icon-branding.md](./docs/app-icon-branding.md) |
-| Manual QA checklist | [docs/manual-test-checklist.md](./docs/manual-test-checklist.md) |
-| Release process & signing | [docs/release-process.md](./docs/release-process.md) · [signing](./docs/release-signing.md) |
-| F-Droid readiness | [docs/fdroid-readiness.md](./docs/fdroid-readiness.md) |
-| Google Play readiness | [docs/play-store-readiness.md](./docs/play-store-readiness.md) |
+The full index — setup, architecture, and a deep-dive per feature — is in
+[docs/README.md](./docs/README.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# Linthra documentation
+
+The full index of Linthra's docs. New to the project? Start with the
+[main README](../README.md) for an overview, then
+[CONTRIBUTING.md](../CONTRIBUTING.md) for setup.
+
+## Getting started & contributing
+
+| Topic | Doc |
+| --- | --- |
+| Contributing & setup | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Development, build & CI | [development.md](./development.md) |
+| Codebase tour (where everything lives) | [codebase-tour.md](./codebase-tour.md) |
+| Architecture & extension points | [architecture.md](./architecture.md) |
+| Where to help (contributor roadmap) | [contributor-roadmap.md](./contributor-roadmap.md) |
+| Product roadmap (phased direction) | [roadmap.md](./roadmap.md) |
+| Supporting Linthra (optional supporter model) | [SUPPORT.md](./SUPPORT.md) |
+
+## Features
+
+| Topic | Doc |
+| --- | --- |
+| Library browsing & search | [library.md](./library.md) |
+| Local music (on-device folders) | [local-music.md](./local-music.md) |
+| Music providers (overview) | [providers.md](./providers.md) |
+| Jellyfin setup | [jellyfin.md](./jellyfin.md) · [compatibility](./jellyfin-compatibility.md) · [sync](./jellyfin-sync.md) |
+| Plex setup | [plex.md](./plex.md) |
+| Streaming, buffering & recovery | [streaming.md](./streaming.md) |
+| Queue / Up Next | [queue.md](./queue.md) |
+| Offline cache & downloads | [offline-cache.md](./offline-cache.md) |
+| Cast / Chromecast | [cast.md](./cast.md) |
+| Remote control (drive Linthra from another app) | [remote-control.md](./remote-control.md) |
+| Android Auto | [android-auto.md](./android-auto.md) |
+| Playlists & safe removal | [playlists-and-delete.md](./playlists-and-delete.md) |
+| Smart mixes (automatic playlists) | [smart-mixes.md](./smart-mixes.md) |
+| Backup & restore (file format) | [backup-restore-format.md](./backup-restore-format.md) |
+| Battery usage | [battery.md](./battery.md) |
+| App icon & branding (in-app + real Android launcher icon) | [app-icon-branding.md](./app-icon-branding.md) |
+
+## Quality & releases
+
+| Topic | Doc |
+| --- | --- |
+| Reporting a bug | [reporting-bugs.md](./reporting-bugs.md) |
+| Manual QA checklist | [manual-test-checklist.md](./manual-test-checklist.md) |
+| Release process & signing | [release-process.md](./release-process.md) · [signing](./release-signing.md) |
+| F-Droid readiness | [fdroid-readiness.md](./fdroid-readiness.md) |
+| Google Play readiness | [play-store-readiness.md](./play-store-readiness.md) |


### PR DESCRIPTION
## What

Trims the README from ~250 lines to ~120 so it's easier to scan, without losing any documentation from the repo.

- Replaced the long **"What works today"** section with a short **Features** list (one line per feature, deep-dives stay in the per-feature docs).
- Removed the **"Build it yourself"** details — the Install section now points to [docs/development.md](../blob/claude/linthra-readme-simplify-qbl0a4/docs/development.md), which already covers setup, CI, and the helper scripts.
- Replaced the long **"Ways to help"** section with a short **Contributing** section pointing to [CONTRIBUTING.md](../blob/claude/linthra-readme-simplify-qbl0a4/CONTRIBUTING.md), the contributor roadmap, and docs/SUPPORT.md.
- Replaced the **Roadmap** details with a two-line section pointing to [docs/roadmap.md](../blob/claude/linthra-readme-simplify-qbl0a4/docs/roadmap.md) (keeps the "Linthra works on its own; Linthra Connect is optional" rule visible).
- Moved the full documentation table to a new **[docs/README.md](../blob/claude/linthra-readme-simplify-qbl0a4/docs/README.md)** index, grouped into *Getting started & contributing*, *Features*, and *Quality & releases* — and added Plex to it (it was missing from the old table).

## What stayed in the README

- Badges, feature graphic, tagline, and intro.
- A compact **Install** section: GitHub Releases as source of truth, F-Droid, the don't-mix-signing-keys warning, Obtainium, and the Android Auto sideload note.
- The **Supported sources** table and a short **Privacy** section.
- Screenshots (with less surrounding prose).

## Notes

- The `#roadmap` and `#documentation` anchors are preserved, since `.github/ISSUE_TEMPLATE/feature_request.yml` and `docs/codebase-tour.md` link to them.
- All relative links in both files were checked to resolve.
- No documentation was deleted — everything removed from the README already exists in CONTRIBUTING.md or docs/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HF8RiYGWkscf2fteCfiXq

---
_Generated by [Claude Code](https://claude.ai/code/session_011HF8RiYGWkscf2fteCfiXq)_