### PR TITLE
fix(android): trust user-installed CAs for HTTPS

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -53,8 +53,9 @@
          Navidrome/Subsonic or Jellyfin server on the local network (e.g.
          http://192.168.1.50:4533) can be reached. Android blocks cleartext by
          default on modern targets; see res/xml/network_security_config.xml for
-         the rationale. System certificate trust is unchanged, so self-signed
-         certificates are still rejected. -->
+         the rationale. HTTPS trusts system CAs plus user-installed CAs, so a
+         self-hosted server's private CA works once installed on the device;
+         certificates not anchored in either store are still rejected. -->
     <application
         android:label="Linthra"
         android:name="${applicationName}"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -13,10 +13,21 @@
     is permitted app-wide here. This is a deliberate connectivity choice for a
     self-hosted app; it adds no tracking and sends nothing to any third party.
     HTTPS is always preferred and is recommended for any server reachable from
-    outside the local network. The default (system) certificate trust anchors
-    are kept, so self-signed certificates are still rejected (the app surfaces a
-    clear "couldn't verify your server's certificate" message instead).
+    outside the local network.
+
+    For HTTPS, Linthra trusts the system CAs plus user-installed CAs (the ones
+    added under Settings > Security > Encryption & credentials > User
+    credentials). Self-hosted servers often use a private CA or self-signed
+    certificate; installing that CA on the device lets Linthra connect without
+    weakening TLS — certificate chains and hostnames are still fully verified,
+    and a certificate not anchored in either store is still rejected (the app
+    surfaces a clear "couldn't verify your server's certificate" message).
 -->
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true" />
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
 </network-security-config>

--- a/test/app/network_security_config_test.dart
+++ b/test/app/network_security_config_test.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// The network security config carries two deliberate choices for a self-hosted
+// app: cleartext http for LAN servers, and — issue #266 — HTTPS trust for
+// user-installed CAs, so a private-CA / self-signed Jellyfin or Navidrome
+// certificate works once its CA is installed on the device. Neither weakens
+// TLS: chains and hostnames are still verified by the platform, and a
+// certificate not anchored in the system or user store is still rejected.
+// These checks keep both choices from silently regressing.
+void main() {
+  group('android network security config', () {
+    late String config;
+
+    setUpAll(() {
+      config = File('android/app/src/main/res/xml/network_security_config.xml')
+          .readAsStringSync();
+    });
+
+    test('the manifest binds the config', () {
+      final String manifest =
+          File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+      expect(
+        manifest,
+        contains(
+            'android:networkSecurityConfig="@xml/network_security_config"'),
+      );
+    });
+
+    test('cleartext stays permitted for LAN http servers', () {
+      expect(config, contains('cleartextTrafficPermitted="true"'));
+    });
+
+    test('HTTPS trusts system CAs plus user-installed CAs (issue #266)', () {
+      // Both anchors must be listed: declaring only "user" would drop system
+      // trust; omitting "user" is Android's default and re-breaks private CAs.
+      expect(config, contains('<certificates src="system" />'));
+      expect(config, contains('<certificates src="user" />'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #266

## Problem

A self-hosted Jellyfin (or Navidrome) server using a private CA / self-signed certificate was rejected with a certificate error even after the user installed that CA into Android's **User credentials** (Trusted credentials → User) store. Since Android 7, apps only trust user-installed CAs if their network security config explicitly opts in — Linthra's config didn't, so only system CAs were trusted.

## Fix

Add explicit `<trust-anchors>` to the base config in `network_security_config.xml`, trusting both the **system** and **user** certificate stores:

```xml
<base-config cleartextTrafficPermitted="true">
    <trust-anchors>
        <certificates src="system" />
        <certificates src="user" />
    </trust-anchors>
</base-config>
```

This is a real trust-store fix, not a TLS bypass:

- No `badCertificateCallback`, no accept-all certificates.
- Hostname verification and chain validation are unchanged — the platform still fully verifies every connection.
- A certificate not anchored in either store is still rejected with the existing "couldn't verify your server's certificate" message.
- Cleartext support for LAN `http://` servers is unchanged.

## Also in this PR

- Updated the XML rationale comment (and the matching `AndroidManifest.xml` comment) to explain that Linthra trusts system CAs plus user-installed CAs for self-hosted servers.
- Added `test/app/network_security_config_test.dart`, following the existing pattern in `media_artwork_content_uri_test.dart` of guarding Android XML from Dart tests: it checks the manifest binds the config, cleartext stays permitted, and both `system` and `user` trust anchors are present.

## Testing

The reporter can grab the **Android Debug APK** artifact this PR's CI produces and test against their Jellyfin server with the user-installed CA (asked in #266).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CRt3vcz6kN9ThERs7EBDi

---
_Generated by [Claude Code](https://claude.ai/code/session_011CRt3vcz6kN9ThERs7EBDi)_