### PR TITLE
chore(release): prepare v0.1.9 — HTTPS trust fix & sync improvements

### DIFF
--- a/docs/release-notes/v0.1.9.md
+++ b/docs/release-notes/v0.1.9.md
@@ -1,0 +1,131 @@
+# Linthra v0.1.9 — release notes
+
+**Linthra is a modern, local-first, privacy-focused music player for people who
+own their music.** v0.1.9 is a **connectivity fix & sync improvement release**.
+It makes self-hosted HTTPS servers that use a user-installed CA certificate
+work on Android, brings two-way playlist & favorites sync to
+Navidrome/Subsonic, and lets you favorite or unfavorite any track straight from
+its menu. No new permissions, no behavior changes beyond the merged work below.
+
+- **Version:** `0.1.9` (`versionName`), `versionCode` `109999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+- **Get it:** Available from the
+  [GitHub Releases page](https://github.com/TheZupZup/Linthra/releases) first
+  (signed APKs); [Obtainium](https://github.com/ImranR98/Obtainium) can track
+  this repository for updates. The
+  [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/) build
+  follows after F-Droid's build process runs.
+
+## What's new
+
+### HTTPS & certificates
+
+- **User-installed CA certificates are now trusted for HTTPS.** Since
+  Android 7, apps only trust user-installed CA certificates when they opt in —
+  so a self-hosted Jellyfin or Navidrome server behind a private CA or
+  self-signed certificate was rejected even after you installed the CA on the
+  device. Linthra now trusts the system store **and** the user store: install
+  your CA under *Settings → Security → Encryption & credentials → User
+  credentials* and the server just connects. TLS is not weakened — certificate
+  chains and hostnames are still fully verified, and a certificate not anchored
+  in either store is still rejected with the clear "couldn't verify your
+  server's certificate" message. Plain-HTTP LAN servers are unchanged.
+  (Fixes [#266](https://github.com/TheZupZup/Linthra/issues/266).)
+
+### Navidrome / Subsonic
+
+- **Two-way playlist & favorites sync.** Playlists and hearts now mirror both
+  ways with your Navidrome/Subsonic server, behind the same sync seam Jellyfin
+  uses.
+- **Reliable hearts.** A favorite that fails while offline (or mid-hiccup) is
+  queued and retried on the next refresh — never silently reverted.
+- **No manual syncing.** Changes made on the server are picked up automatically
+  on app resume and screen opens, throttled so it stays battery-friendly, and
+  the first sync starts on its own after sign-in.
+- **Non-destructive throughout.** Local-only playlists are untouched and remote
+  deletes only happen behind an explicit confirmation.
+
+### Library
+
+- **Favorite from any track menu.** Every track-level overflow menu — Songs
+  list, album and artist detail, search results, Favorites, smart-mix detail,
+  and playlist detail — now has an *Add to favorites* / *Remove from favorites*
+  action, so you can like or unlike a song without starting playback. It routes
+  through the same favorites store as the heart on Now Playing, including the
+  Navidrome/Subsonic sync path.
+
+### Docs
+
+- **Shorter README.** The README is now a scannable overview; the full
+  documentation index moved to [docs/README.md](../README.md).
+
+## Support note
+
+- Linthra remains **free and open source**, and **works on its own**.
+- The Support / donation screen stays **optional** and **cosmetic / support-only**.
+- **No gating, no telemetry, no billing SDK, and no required account.**
+- **No core feature is locked behind donation.**
+
+The repository shows a **Sponsor** button (GitHub Sponsors). It points at the
+same handle as the in-app **Settings → About → Support Linthra** screen, and is
+entirely voluntary — see [docs/SUPPORT.md](../SUPPORT.md).
+
+## Technical summary
+
+- **Android user-installed CA trust for HTTPS**
+  ([PR #269](https://github.com/TheZupZup/Linthra/pull/269), fixes
+  [#266](https://github.com/TheZupZup/Linthra/issues/266)): the network
+  security config adds `trust-anchors` for the `system` and `user` certificate
+  stores; chains and hostnames stay fully verified, cleartext support for LAN
+  servers is unchanged, and a guard test pins the config.
+- **Navidrome/Subsonic playlist & favorites sync**
+  ([PR #264](https://github.com/TheZupZup/Linthra/pull/264)): Subsonic
+  `star`/`unstar`/`getStarred2` and playlist CRUD behind a provider-agnostic
+  gateway seam shared with Jellyfin; queued/retried hearts, throttled
+  auto-refresh, automatic first sync after sign-in.
+- **Favorite toggle in track overflow menus**
+  ([PR #265](https://github.com/TheZupZup/Linthra/pull/265)): shared TrackTile
+  menu and playlist-detail row menu toggle through the existing
+  FavoritesRepository; never starts playback or modifies the queue.
+- **README & docs index cleanup**
+  ([PR #267](https://github.com/TheZupZup/Linthra/pull/267),
+  [PR #268](https://github.com/TheZupZup/Linthra/pull/268)): shorter README,
+  documentation table moved to `docs/README.md`, wording pass.
+
+No provider, sync, playback, or theme behaviour changes beyond the merged work
+above — this is a version bump, changelog, and release-notes change only.
+
+## Manual QA checklist (Pixel / Android)
+
+- [ ] Install the debug APK on a Pixel / Android device.
+- [ ] Confirm the Play Protect warning appears (expected **only** for a
+      sideloaded debug build) and the app installs and launches.
+- [ ] HTTPS with a private CA: install the CA on the device (*Settings →
+      Security → Encryption & credentials*), connect to a Jellyfin or
+      Navidrome server behind it, and verify sign-in, sync, and playback work.
+- [ ] HTTPS with an untrusted certificate (CA **not** installed): verify the
+      clear "couldn't verify your server's certificate" message still appears.
+- [ ] Plain-HTTP LAN server: verify connecting still works (unchanged).
+- [ ] Navidrome: favorite/unfavorite and create/edit a playlist on the server
+      and in the app; verify both directions sync without a manual refresh.
+- [ ] Toggle a favorite while offline; verify it is retried and not reverted
+      once the server is reachable again.
+- [ ] Verify *Add to favorites* / *Remove from favorites* appears in the track
+      overflow menus (Songs list, album detail, playlist detail) and toggles
+      the heart without starting playback.
+- [ ] Verify Jellyfin sync and playback still work.
+- [ ] Verify background playback and the media notification.
+- [ ] Verify no unexpected permissions are requested.
+
+## Upgrade notes
+
+- **Nothing to do.** Upgrading keeps your existing settings and library.
+- **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
+  key, while the F-Droid build is signed with F-Droid's key; the two can't
+  update each other. Stick with one source.
+
+No ads, no tracking, no analytics, no telemetry. No Spotify, stream-ripping, or
+DRM-bypass claims — Linthra plays music you already own or that your own server
+provides.

--- a/docs/release-notes/v0.1.9.md
+++ b/docs/release-notes/v0.1.9.md
@@ -1,11 +1,11 @@
 # Linthra v0.1.9 — release notes
 
-**Linthra is a modern, local-first, privacy-focused music player for people who
-own their music.** v0.1.9 is a **connectivity fix & sync improvement release**.
-It makes self-hosted HTTPS servers that use a user-installed CA certificate
-work on Android, brings two-way playlist & favorites sync to
-Navidrome/Subsonic, and lets you favorite or unfavorite any track straight from
-its menu. No new permissions, no behavior changes beyond the merged work below.
+**Linthra is an Android music player for local files and self-hosted music
+servers.** v0.1.9 is a **connectivity fix & sync improvement release**. It
+makes self-hosted HTTPS servers that use a user-installed CA certificate work
+on Android, brings two-way playlist & favorites sync to Navidrome/Subsonic,
+and lets you favorite or unfavorite any track straight from its menu. No new
+permissions, no behavior changes beyond the merged work below.
 
 - **Version:** `0.1.9` (`versionName`), `versionCode` `109999`
 - **Platform:** Android

--- a/fastlane/metadata/android/en-US/changelogs/109999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/109999.txt
@@ -1,0 +1,24 @@
+Linthra 0.1.9 — HTTPS trust fix & sync improvements.
+
+A small update for self-hosted HTTPS servers, Navidrome/Subsonic sync,
+and favorites.
+
+Connections:
+- HTTPS servers using a user-installed CA certificate now connect.
+  Install your private CA on the device and Jellyfin or Navidrome
+  servers behind it just work — certificate chains and hostnames are
+  still fully verified.
+
+Navidrome / Subsonic:
+- Playlists and favorites now sync two-way with the server.
+- Favorites are reliable: a failed or offline change is queued and
+  retried instead of being silently reverted.
+- Changes made on the server are picked up automatically — no manual
+  sync needed.
+- The first sync starts on its own after sign-in.
+
+Library:
+- Add or remove favorites straight from any track menu, without
+  starting playback.
+
+No ads. No tracking. No locked features.

--- a/fastlane/metadata/android/en-US/changelogs/109999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/109999.txt
@@ -20,5 +20,3 @@ Navidrome / Subsonic:
 Library:
 - Add or remove favorites straight from any track menu, without
   starting playback.
-
-No ads. No tracking. No locked features.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.8';
+  static const String _devVersionName = '0.1.9';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,12 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Jellyfin sync is more tolerant and resilient.',
-    'Existing music stays visible if a Jellyfin sync fails temporarily.',
-    'Jellyfin 12 compatibility preparation.',
-    'Launcher icon switching now works from Appearance settings.',
-    'App themes now retint the in-app accent/theme.',
-    'Added optional Community links and Share Linthra in Settings.',
+    'User-installed CA certificates are now trusted for HTTPS servers.',
+    'Playlists and favorites now sync two-way with Navidrome/Subsonic.',
+    'Changes made on your server now show up on their own.',
+    'Add or remove favorites straight from any track menu.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.8+108999
+version: 0.1.9+109999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
Prepares the **v0.1.9** patch release after the TLS/user-CA fix. Release metadata only — no runtime behavior changes beyond what is already merged on `main`, and no signing changes.

## What changed

- [x] **Version bump to `0.1.9+109999`** — `pubspec.yaml` and `lib/core/app_info.dart` (`_devVersionName`) together, as the drift test requires. `109999` is the canonical stable encoding of `0.1.9` (`tool/version_from_tag.dart`); verified locally with `./scripts/release_preflight.sh v0.1.9` → OK.
- [x] **In-app "What's new"** (`lib/features/settings/about/whats_new_section.dart`) — four short, user-facing bullets: user-installed CA trust, Navidrome/Subsonic two-way playlist & favorites sync, automatic server-change pickup, favorites from track menus. No PR numbers in the UI, matching the existing style.
- [x] **Fastlane changelog** `fastlane/metadata/android/en-US/changelogs/109999.txt` — the F-Droid "What's New" (required by `test/tooling/release_changelog_test.dart`).
- [x] **Release notes** `docs/release-notes/v0.1.9.md` — follows the v0.1.8 template: what's new, technical summary with PR links ([#269](https://github.com/TheZupZup/Linthra/pull/269) fixes [#266](https://github.com/TheZupZup/Linthra/issues/266), [#264](https://github.com/TheZupZup/Linthra/pull/264), [#265](https://github.com/TheZupZup/Linthra/pull/265), [#267](https://github.com/TheZupZup/Linthra/pull/267)/[#268](https://github.com/TheZupZup/Linthra/pull/268)), manual QA checklist (including private-CA / untrusted-cert / plain-HTTP scenarios), and upgrade notes.

### Release highlights covered

- Android user-installed CA certificates are now trusted for HTTPS self-hosted servers (Jellyfin/Navidrome) — fixes #266 via PR #269; chains and hostnames still fully verified.
- Navidrome/Subsonic two-way playlist & favorites sync, queued/retried hearts, automatic refresh (#264).
- Favorite/unfavorite in every track overflow menu (#265).
- Shorter README and docs index moved to `docs/README.md` (#267, #268).

### Deliberately not touched

- **`metadata/io.github.thezupzup.linthra.yml` (F-Droid recipe mirror)** — matches the 0.1.8 flow (#258 → #262/#263 after tagging): its `Builds` entries and `CurrentVersionCode` need the v0.1.9 **tag commit SHA** and the per-ABI code (`1099993`), which only exist after this PR is merged and tagged. The guardrail tests explicitly allow `pubspec.yaml` to be ahead of it. (Note: `scripts/prepare_release_bump.py` would set `CurrentVersionCode` to the base code `109999`, which the per-ABI guardrail test now rejects — another reason it's left for the post-tag mirror update.)
- **README badge / "current stable" line and `docs/index.html`** — still say v0.1.8, which stays true until the tag and Release assets exist; updated post-release for 0.1.8 (#261) and listed below.
- **Release signing** — unchanged.

*Heads-up:* `scripts/check_release_bump_files.sh` (CI-gated only on `release/*` branches, so not run here) would flag `whats_new_section.dart`; the 0.1.8 prep PR (#258) included the same in-app update, so this follows precedent.

## Still to do before tagging v0.1.9 (after merging this PR)

- [ ] CI green on this PR (format, analyze, tests — includes the version-drift, canonical-versionCode, and Fastlane-changelog guards).
- [ ] Merge this PR into `main` — **do not tag before it is merged**.
- [ ] `git checkout main && git pull`, then `./scripts/release_preflight.sh v0.1.9` (expects `OK: v0.1.9 matches pubspec.yaml version 0.1.9+109999`).
- [ ] Confirm the `LINTHRA_*` release-signing secrets are configured — a stable tag **fails fast** without them.
- [ ] Create the GitHub **Release** on new tag `v0.1.9` targeting `main` (stable releases are never auto-created); paste the notes from `docs/release-notes/v0.1.9.md`. Alternatively push the annotated tag first, then create the Release and re-run the workflow.
- [ ] Watch **Android Release Build** on the tag and verify all five assets attach by exact name: `linthra-v0.1.9-{armeabi-v7a,arm64-v8a,x86_64}-release-signed.apk` + universal `.apk`/`.aab` — F-Droid's `binary:` URLs resolve only once they exist.
- [ ] Install and smoke-test per the QA checklist in `docs/release-notes/v0.1.9.md` (especially the user-CA scenario from #266).

## After tagging (follow-up PRs, matching the 0.1.8 flow)

- [ ] Update the F-Droid recipe mirror `metadata/io.github.thezupzup.linthra.yml`: per-ABI `Builds` entries at `git rev-list -n 1 v0.1.9`, versionCodes `1099991/1099992/1099993`, `CurrentVersion: 0.1.9`, `CurrentVersionCode: 1099993` (fdroiddata itself auto-detects via `AutoUpdateMode: Version` — no manual fdroiddata edit expected).
- [ ] Update README (release badge + "current stable is v0.1.9") and `docs/index.html` (stable badge + download text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tgLUcRPDts3CcKdQEGgT8

---
_Generated by [Claude Code](https://claude.ai/code/session_011tgLUcRPDts3CcKdQEGgT8)_