### PR TITLE
feat(playlists): add all album or artist songs to a playlist

### DIFF
--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -32,8 +32,7 @@ class AlbumDetailScreen extends ConsumerStatefulWidget {
   final String albumId;
 
   @override
-  ConsumerState<AlbumDetailScreen> createState() =>
-      _AlbumDetailScreenState();
+  ConsumerState<AlbumDetailScreen> createState() => _AlbumDetailScreenState();
 }
 
 class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -24,13 +24,25 @@ import 'widgets/track_tile.dart';
 /// album*, never the whole library. Reuses [TrackTile], so per-track actions
 /// and download state look identical to the main library. The app-bar playlist
 /// action sends every album track through the shared bulk playlist flow.
-class AlbumDetailScreen extends ConsumerWidget {
+/// Long-pressing a track starts multi-select so any subset can use that same
+/// playlist flow.
+class AlbumDetailScreen extends ConsumerStatefulWidget {
   const AlbumDetailScreen({required this.albumId, super.key});
 
   final String albumId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AlbumDetailScreen> createState() =>
+      _AlbumDetailScreenState();
+}
+
+class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
+  final Set<String> _selectedUris = <String>{};
+
+  bool get _selecting => _selectedUris.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
     final LibraryState state = ref.watch(libraryControllerProvider);
 
     if (state.status == LibraryStatus.loading) {
@@ -47,13 +59,15 @@ class AlbumDetailScreen extends ConsumerWidget {
     // single bounded filter, is derived here.
     Album? album;
     for (final Album candidate in ref.watch(libraryAlbumsProvider)) {
-      if (candidate.id == albumId) {
+      if (candidate.id == widget.albumId) {
         album = candidate;
         break;
       }
     }
-    final List<Track> tracks =
-        tracksForAlbum(ref.watch(libraryUnifiedTracksProvider), albumId);
+    final List<Track> tracks = tracksForAlbum(
+      ref.watch(libraryUnifiedTracksProvider),
+      widget.albumId,
+    );
     if (album == null || tracks.isEmpty) {
       return Scaffold(
         appBar: AppBar(),
@@ -65,43 +79,119 @@ class AlbumDetailScreen extends ConsumerWidget {
       );
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(album.title, maxLines: 1, overflow: TextOverflow.ellipsis),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.playlist_add),
-            tooltip: 'Add all songs to playlist',
-            onPressed: () => showAddToPlaylistSheet(context, tracks),
-          ),
-        ],
-      ),
+    final List<Track> selected = <Track>[
+      for (final Track track in tracks)
+        if (_selectedUris.contains(track.uri)) track,
+    ];
+
+    final Widget scaffold = Scaffold(
+      appBar: _selecting
+          ? _selectionAppBar(selected)
+          : AppBar(
+              title: Text(
+                album.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              actions: <Widget>[
+                IconButton(
+                  icon: const Icon(Icons.playlist_add),
+                  tooltip: 'Add all songs to playlist',
+                  onPressed: () => showAddToPlaylistSheet(context, tracks),
+                ),
+              ],
+            ),
       body: CustomScrollView(
         slivers: <Widget>[
-          SliverToBoxAdapter(
-            child: _AlbumHeader(
-              album: album,
-              trackCount: tracks.length,
-              onPlay: () => _play(context, ref, tracks),
-              onShuffle: () => _shuffle(context, ref, tracks),
+          if (!_selecting)
+            SliverToBoxAdapter(
+              child: _AlbumHeader(
+                album: album,
+                trackCount: tracks.length,
+                onPlay: () => _play(context, tracks),
+                onShuffle: () => _shuffle(context, tracks),
+              ),
             ),
-          ),
           SliverList.builder(
             itemCount: tracks.length,
-            itemBuilder: (context, index) =>
-                TrackTile(tracks: tracks, index: index),
+            itemBuilder: (context, index) {
+              final Track track = tracks[index];
+              return TrackTile(
+                tracks: tracks,
+                index: index,
+                selectable: true,
+                selectionActive: _selecting,
+                selected: _selectedUris.contains(track.uri),
+                onSelectStart: () => _enterSelection(track),
+                onSelectToggle: () => _toggle(track),
+              );
+            },
           ),
         ],
       ),
     );
+
+    if (!_selecting) return scaffold;
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (!didPop) _exitSelection();
+      },
+      child: scaffold,
+    );
   }
 
-  void _play(BuildContext context, WidgetRef ref, List<Track> tracks) {
+  PreferredSizeWidget _selectionAppBar(List<Track> selected) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: 'Cancel selection',
+        onPressed: _exitSelection,
+      ),
+      title: Text('${selected.length} selected'),
+      actions: <Widget>[
+        IconButton(
+          icon: const Icon(Icons.playlist_add),
+          tooltip: 'Add to playlist',
+          onPressed: selected.isEmpty
+              ? null
+              : () => _addSelectedToPlaylist(selected),
+        ),
+      ],
+    );
+  }
+
+  void _enterSelection(Track track) {
+    setState(() {
+      _selectedUris
+        ..clear()
+        ..add(track.uri);
+    });
+  }
+
+  void _toggle(Track track) {
+    setState(() {
+      if (!_selectedUris.add(track.uri)) {
+        _selectedUris.remove(track.uri);
+      }
+    });
+  }
+
+  void _exitSelection() {
+    setState(_selectedUris.clear);
+  }
+
+  Future<void> _addSelectedToPlaylist(List<Track> selected) async {
+    await showAddToPlaylistSheet(context, selected);
+    if (mounted) _exitSelection();
+  }
+
+  void _play(BuildContext context, List<Track> tracks) {
     ref.read(playbackControllerProvider).playTracks(tracks);
     context.push(AppRoutes.player);
   }
 
-  void _shuffle(BuildContext context, WidgetRef ref, List<Track> tracks) {
+  void _shuffle(BuildContext context, List<Track> tracks) {
     final controller = ref.read(playbackControllerProvider);
     controller.setShuffleEnabled(true);
     controller.playTracks(tracks);

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -152,9 +152,8 @@ class _AlbumDetailScreenState extends ConsumerState<AlbumDetailScreen> {
         IconButton(
           icon: const Icon(Icons.playlist_add),
           tooltip: 'Add to playlist',
-          onPressed: selected.isEmpty
-              ? null
-              : () => _addSelectedToPlaylist(selected),
+          onPressed:
+              selected.isEmpty ? null : () => _addSelectedToPlaylist(selected),
         ),
       ],
     );

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -22,7 +22,8 @@ import 'widgets/track_tile.dart';
 /// Reads the same derived grouping the Albums tab uses, so it stays in sync
 /// with the catalog: tapping a track plays it and queues the rest of *this
 /// album*, never the whole library. Reuses [TrackTile], so per-track actions
-/// and download state look identical to the main library.
+/// and download state look identical to the main library. The app-bar playlist
+/// action sends every album track through the shared bulk playlist flow.
 class AlbumDetailScreen extends ConsumerWidget {
   const AlbumDetailScreen({required this.albumId, super.key});
 

--- a/lib/features/library/album_detail_screen.dart
+++ b/lib/features/library/album_detail_screen.dart
@@ -10,6 +10,7 @@ import '../../core/models/track.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
 import '../player/widgets/album_artwork.dart';
+import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
@@ -66,6 +67,13 @@ class AlbumDetailScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(album.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.playlist_add),
+            tooltip: 'Add all songs to playlist',
+            onPressed: () => showAddToPlaylistSheet(context, tracks),
+          ),
+        ],
       ),
       body: CustomScrollView(
         slivers: <Widget>[

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -26,14 +26,25 @@ import 'widgets/track_tile.dart';
 /// queues only this artist's tracks; tapping a single track queues the artist's
 /// tracks from that point. Reuses [TrackTile] and [AlbumTile] so rows match the
 /// rest of the library. Long-pressing one of the album rows opens the shared
-/// bulk playlist flow for that album.
-class ArtistDetailScreen extends ConsumerWidget {
+/// bulk playlist flow for that album. Long-pressing a track starts multi-select
+/// so any subset of the artist's songs can be added together.
+class ArtistDetailScreen extends ConsumerStatefulWidget {
   const ArtistDetailScreen({required this.artistId, super.key});
 
   final String artistId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ArtistDetailScreen> createState() =>
+      _ArtistDetailScreenState();
+}
+
+class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
+  final Set<String> _selectedUris = <String>{};
+
+  bool get _selecting => _selectedUris.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
     final LibraryState state = ref.watch(libraryControllerProvider);
 
     if (state.status == LibraryStatus.loading) {
@@ -49,13 +60,13 @@ class ArtistDetailScreen extends ConsumerWidget {
     // filters over the catalog, not another full grouping of it.
     Artist? artist;
     for (final Artist candidate in ref.watch(libraryArtistsProvider)) {
-      if (candidate.id == artistId) {
+      if (candidate.id == widget.artistId) {
         artist = candidate;
         break;
       }
     }
     final List<Track> songs = ref.watch(libraryUnifiedTracksProvider);
-    final List<Track> tracks = tracksForArtist(songs, artistId);
+    final List<Track> tracks = tracksForArtist(songs, widget.artistId);
     if (artist == null || tracks.isEmpty) {
       return Scaffold(
         appBar: AppBar(),
@@ -67,64 +78,140 @@ class ArtistDetailScreen extends ConsumerWidget {
       );
     }
 
-    final List<Album> albums = albumsForArtist(songs, artistId);
+    final List<Album> albums = albumsForArtist(songs, widget.artistId);
+    final List<Track> selected = <Track>[
+      for (final Track track in tracks)
+        if (_selectedUris.contains(track.uri)) track,
+    ];
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(artist.name, maxLines: 1, overflow: TextOverflow.ellipsis),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.playlist_add),
-            tooltip: 'Add all songs to playlist',
-            onPressed: () => showAddToPlaylistSheet(context, tracks),
-          ),
-        ],
-      ),
+    final Widget scaffold = Scaffold(
+      appBar: _selecting
+          ? _selectionAppBar(selected)
+          : AppBar(
+              title: Text(
+                artist.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              actions: <Widget>[
+                IconButton(
+                  icon: const Icon(Icons.playlist_add),
+                  tooltip: 'Add all songs to playlist',
+                  onPressed: () => showAddToPlaylistSheet(context, tracks),
+                ),
+              ],
+            ),
       body: CustomScrollView(
         slivers: <Widget>[
-          SliverToBoxAdapter(
-            child: _ArtistHeader(
-              artist: artist,
-              albumCount: albums.length,
-              trackCount: tracks.length,
-              onPlay: () => _play(context, ref, tracks),
-              onShuffle: () => _shuffle(context, ref, tracks),
+          if (!_selecting) ...<Widget>[
+            SliverToBoxAdapter(
+              child: _ArtistHeader(
+                artist: artist,
+                albumCount: albums.length,
+                trackCount: tracks.length,
+                onPlay: () => _play(context, tracks),
+                onShuffle: () => _shuffle(context, tracks),
+              ),
             ),
-          ),
-          if (albums.length > 1) ...<Widget>[
-            const SliverToBoxAdapter(child: _SectionHeader(label: 'Albums')),
-            SliverList.builder(
-              itemCount: albums.length,
-              itemBuilder: (context, index) {
-                final Album album = albums[index];
-                return AlbumTile(
-                  album: album,
-                  onTap: () => _openAlbum(context, album.id),
-                );
-              },
-            ),
+            if (albums.length > 1) ...<Widget>[
+              const SliverToBoxAdapter(child: _SectionHeader(label: 'Albums')),
+              SliverList.builder(
+                itemCount: albums.length,
+                itemBuilder: (context, index) {
+                  final Album album = albums[index];
+                  return AlbumTile(
+                    album: album,
+                    onTap: () => _openAlbum(context, album.id),
+                  );
+                },
+              ),
+            ],
+            const SliverToBoxAdapter(child: _SectionHeader(label: 'Songs')),
           ],
-          const SliverToBoxAdapter(child: _SectionHeader(label: 'Songs')),
           SliverList.builder(
             itemCount: tracks.length,
-            itemBuilder: (context, index) =>
-                TrackTile(tracks: tracks, index: index),
+            itemBuilder: (context, index) {
+              final Track track = tracks[index];
+              return TrackTile(
+                tracks: tracks,
+                index: index,
+                selectable: true,
+                selectionActive: _selecting,
+                selected: _selectedUris.contains(track.uri),
+                onSelectStart: () => _enterSelection(track),
+                onSelectToggle: () => _toggle(track),
+              );
+            },
           ),
         ],
       ),
     );
+
+    if (!_selecting) return scaffold;
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (!didPop) _exitSelection();
+      },
+      child: scaffold,
+    );
+  }
+
+  PreferredSizeWidget _selectionAppBar(List<Track> selected) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: 'Cancel selection',
+        onPressed: _exitSelection,
+      ),
+      title: Text('${selected.length} selected'),
+      actions: <Widget>[
+        IconButton(
+          icon: const Icon(Icons.playlist_add),
+          tooltip: 'Add to playlist',
+          onPressed: selected.isEmpty
+              ? null
+              : () => _addSelectedToPlaylist(selected),
+        ),
+      ],
+    );
+  }
+
+  void _enterSelection(Track track) {
+    setState(() {
+      _selectedUris
+        ..clear()
+        ..add(track.uri);
+    });
+  }
+
+  void _toggle(Track track) {
+    setState(() {
+      if (!_selectedUris.add(track.uri)) {
+        _selectedUris.remove(track.uri);
+      }
+    });
+  }
+
+  void _exitSelection() {
+    setState(_selectedUris.clear);
+  }
+
+  Future<void> _addSelectedToPlaylist(List<Track> selected) async {
+    await showAddToPlaylistSheet(context, selected);
+    if (mounted) _exitSelection();
   }
 
   void _openAlbum(BuildContext context, String albumId) {
     context.push(AppRoutes.albumDetailPath(albumId));
   }
 
-  void _play(BuildContext context, WidgetRef ref, List<Track> tracks) {
+  void _play(BuildContext context, List<Track> tracks) {
     ref.read(playbackControllerProvider).playTracks(tracks);
     context.push(AppRoutes.player);
   }
 
-  void _shuffle(BuildContext context, WidgetRef ref, List<Track> tracks) {
+  void _shuffle(BuildContext context, List<Track> tracks) {
     final controller = ref.read(playbackControllerProvider);
     controller.setShuffleEnabled(true);
     controller.playTracks(tracks);

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -11,6 +11,7 @@ import '../../core/models/track.dart';
 import '../../shared/widgets/artwork_image.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../player/player_providers.dart';
+import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_state.dart';
@@ -70,6 +71,13 @@ class ArtistDetailScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(artist.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.playlist_add),
+            tooltip: 'Add all songs to playlist',
+            onPressed: () => showAddToPlaylistSheet(context, tracks),
+          ),
+        ],
       ),
       body: CustomScrollView(
         slivers: <Widget>[

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -168,9 +168,8 @@ class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {
         IconButton(
           icon: const Icon(Icons.playlist_add),
           tooltip: 'Add to playlist',
-          onPressed: selected.isEmpty
-              ? null
-              : () => _addSelectedToPlaylist(selected),
+          onPressed:
+              selected.isEmpty ? null : () => _addSelectedToPlaylist(selected),
         ),
       ],
     );

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -25,7 +25,8 @@ import 'widgets/track_tile.dart';
 /// Reads the same derived grouping the Artists tab uses. Playing from here
 /// queues only this artist's tracks; tapping a single track queues the artist's
 /// tracks from that point. Reuses [TrackTile] and [AlbumTile] so rows match the
-/// rest of the library.
+/// rest of the library. Long-pressing one of the album rows opens the shared
+/// bulk playlist flow for that album.
 class ArtistDetailScreen extends ConsumerWidget {
   const ArtistDetailScreen({required this.artistId, super.key});
 

--- a/lib/features/library/artist_detail_screen.dart
+++ b/lib/features/library/artist_detail_screen.dart
@@ -34,8 +34,7 @@ class ArtistDetailScreen extends ConsumerStatefulWidget {
   final String artistId;
 
   @override
-  ConsumerState<ArtistDetailScreen> createState() =>
-      _ArtistDetailScreenState();
+  ConsumerState<ArtistDetailScreen> createState() => _ArtistDetailScreenState();
 }
 
 class _ArtistDetailScreenState extends ConsumerState<ArtistDetailScreen> {

--- a/lib/features/library/widgets/album_tile.dart
+++ b/lib/features/library/widgets/album_tile.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../app/dimens.dart';
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/album.dart';
+import '../../../core/models/track.dart';
 import '../../player/widgets/album_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
@@ -55,7 +56,7 @@ class AlbumTile extends ConsumerWidget {
   }
 
   void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
-    final tracks = tracksForAlbum(
+    final List<Track> tracks = tracksForAlbum(
       ref.read(libraryUnifiedTracksProvider),
       album.id,
     );

--- a/lib/features/library/widgets/album_tile.dart
+++ b/lib/features/library/widgets/album_tile.dart
@@ -9,13 +9,10 @@ import '../../player/widgets/album_artwork.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
 
-/// One row in the Albums list: cover (or the shared placeholder), album title,
-/// and an artist • track-count subtitle. Long titles/artists ellipsize so a row
-/// never overflows on a narrow phone.
+/// One row in the Albums list: cover, title, artist, and track count.
 ///
-/// A tap opens the album detail. A long-press opens the shared bulk playlist
-/// sheet with every track from this album, preserving album order and the
-/// existing duplicate/source safeguards in the playlist flow.
+/// A tap opens the album. A long-press sends every album track through the
+/// shared bulk playlist flow, preserving ordering and existing safeguards.
 class AlbumTile extends ConsumerWidget {
   const AlbumTile({required this.album, this.onTap, super.key});
 

--- a/lib/features/library/widgets/album_tile.dart
+++ b/lib/features/library/widgets/album_tile.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../app/dimens.dart';
+import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/album.dart';
 import '../../player/widgets/album_artwork.dart';
+import '../../playlists/widgets/add_to_playlist_sheet.dart';
+import '../unified_library_providers.dart';
 
 /// One row in the Albums list: cover (or the shared placeholder), album title,
 /// and an artist • track-count subtitle. Long titles/artists ellipsize so a row
 /// never overflows on a narrow phone.
-class AlbumTile extends StatelessWidget {
+///
+/// A tap opens the album detail. A long-press opens the shared bulk playlist
+/// sheet with every track from this album, preserving album order and the
+/// existing duplicate/source safeguards in the playlist flow.
+class AlbumTile extends ConsumerWidget {
   const AlbumTile({required this.album, this.onTap, super.key});
 
   final Album album;
   final VoidCallback? onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     return ListTile(
       leading: SizedBox.square(
@@ -42,7 +50,18 @@ class AlbumTile extends StatelessWidget {
       ),
       trailing: const Icon(Icons.chevron_right),
       onTap: onTap,
+      onLongPress: () => _addAllToPlaylist(context, ref),
     );
+  }
+
+  void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
+    final tracks = tracksForAlbum(
+      ref.read(libraryUnifiedTracksProvider),
+      album.id,
+    );
+    if (tracks.isNotEmpty) {
+      showAddToPlaylistSheet(context, tracks);
+    }
   }
 
   static String _subtitle(Album album) {

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -8,13 +8,10 @@ import '../../../shared/widgets/artwork_image.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
 
-/// One row in the Artists list: a circular avatar (artwork or a placeholder
-/// glyph), the artist name, and an album/track-count subtitle. Long names
-/// ellipsize so a row never overflows on a narrow phone.
+/// One row in the Artists list: avatar, name, album count, and track count.
 ///
-/// A tap opens the artist detail. A long-press opens the shared bulk playlist
-/// sheet with every track from this artist, preserving the existing
-/// duplicate/source safeguards in the playlist flow.
+/// A tap opens the artist. A long-press sends every artist track through the
+/// shared bulk playlist flow and its existing duplicate/source safeguards.
 class ArtistTile extends ConsumerWidget {
   const ArtistTile({required this.artist, this.onTap, super.key});
 
@@ -68,8 +65,7 @@ class ArtistTile extends ConsumerWidget {
   }
 }
 
-/// A circular artist avatar: the artwork when present, otherwise a calm tinted
-/// circle with a person glyph (the "optional avatar placeholder").
+/// A circular artist avatar: artwork when present, otherwise a tinted glyph.
 class _ArtistAvatar extends StatelessWidget {
   const _ArtistAvatar({required this.artworkUri});
 

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/artist.dart';
+import '../../../core/models/track.dart';
 import '../../../shared/widgets/artwork_image.dart';
 import '../../playlists/widgets/add_to_playlist_sheet.dart';
 import '../unified_library_providers.dart';
@@ -48,7 +49,7 @@ class ArtistTile extends ConsumerWidget {
   }
 
   void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
-    final tracks = tracksForArtist(
+    final List<Track> tracks = tracksForArtist(
       ref.read(libraryUnifiedTracksProvider),
       artist.id,
     );

--- a/lib/features/library/widgets/artist_tile.dart
+++ b/lib/features/library/widgets/artist_tile.dart
@@ -1,19 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/catalog/library_grouping.dart';
 import '../../../core/models/artist.dart';
 import '../../../shared/widgets/artwork_image.dart';
+import '../../playlists/widgets/add_to_playlist_sheet.dart';
+import '../unified_library_providers.dart';
 
 /// One row in the Artists list: a circular avatar (artwork or a placeholder
 /// glyph), the artist name, and an album/track-count subtitle. Long names
 /// ellipsize so a row never overflows on a narrow phone.
-class ArtistTile extends StatelessWidget {
+///
+/// A tap opens the artist detail. A long-press opens the shared bulk playlist
+/// sheet with every track from this artist, preserving the existing
+/// duplicate/source safeguards in the playlist flow.
+class ArtistTile extends ConsumerWidget {
   const ArtistTile({required this.artist, this.onTap, super.key});
 
   final Artist artist;
   final VoidCallback? onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     return ListTile(
       leading: _ArtistAvatar(artworkUri: artist.artworkUri),
@@ -35,7 +43,18 @@ class ArtistTile extends StatelessWidget {
       ),
       trailing: const Icon(Icons.chevron_right),
       onTap: onTap,
+      onLongPress: () => _addAllToPlaylist(context, ref),
     );
+  }
+
+  void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
+    final tracks = tracksForArtist(
+      ref.read(libraryUnifiedTracksProvider),
+      artist.id,
+    );
+    if (tracks.isNotEmpty) {
+      showAddToPlaylistSheet(context, tracks);
+    }
   }
 
   static String _subtitle(Artist artist) {

--- a/test/features/library/album_detail_screen_test.dart
+++ b/test/features/library/album_detail_screen_test.dart
@@ -133,7 +133,7 @@ void main() {
       expect(controller.state.upNext, isEmpty);
     });
 
-    testWidgets('adds every album track through the bulk playlist sheet',
+    testWidgets('adds every album track through the visible bulk action',
         (tester) async {
       await _pump(tester);
       await _openAlbum(tester, 'Discovery');

--- a/test/features/library/album_detail_screen_test.dart
+++ b/test/features/library/album_detail_screen_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linthra/app/routes.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/library/album_detail_screen.dart';
 import 'package:linthra/features/library/artist_detail_screen.dart';
 import 'package:linthra/features/library/library_screen.dart';
@@ -74,6 +76,7 @@ Future<FakePlaybackController> _pump(
       overrides: <Override>[
         musicLibraryRepositoryProvider
             .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
         playbackControllerProvider.overrideWithValue(controller),
       ],
       child: MaterialApp.router(routerConfig: _router()),
@@ -128,6 +131,18 @@ void main() {
       // Started at Beta; nothing after it on this album.
       expect(controller.state.currentTrack?.id, '2');
       expect(controller.state.upNext, isEmpty);
+    });
+
+    testWidgets('adds every album track through the bulk playlist sheet',
+        (tester) async {
+      await _pump(tester);
+      await _openAlbum(tester, 'Discovery');
+
+      await tester.tap(find.byTooltip('Add all songs to playlist'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
     });
 
     testWidgets('an album with missing metadata shows Unknown Album',

--- a/test/features/library/album_detail_screen_test.dart
+++ b/test/features/library/album_detail_screen_test.dart
@@ -145,6 +145,26 @@ void main() {
       expect(find.text('New playlist'), findsOneWidget);
     });
 
+    testWidgets('long-press selects multiple album tracks for a playlist',
+        (tester) async {
+      await _pump(tester);
+      await _openAlbum(tester, 'Discovery');
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+      expect(find.text('2 selected'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Add to playlist'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
+    });
+
     testWidgets('an album with missing metadata shows Unknown Album',
         (tester) async {
       await _pump(

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linthra/app/routes.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/library/album_detail_screen.dart';
 import 'package:linthra/features/library/artist_detail_screen.dart';
 import 'package:linthra/features/library/library_screen.dart';
@@ -75,6 +77,7 @@ Future<FakePlaybackController> _pump(
       overrides: <Override>[
         musicLibraryRepositoryProvider
             .overrideWithValue(FakeMusicLibraryRepository(tracks: tracks)),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
         playbackControllerProvider.overrideWithValue(controller),
       ],
       child: MaterialApp.router(routerConfig: _router()),
@@ -134,6 +137,18 @@ void main() {
       expect(find.text('Play'), findsOneWidget);
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsNothing);
+    });
+
+    testWidgets('adds every artist track through the bulk playlist sheet',
+        (tester) async {
+      await _pump(tester);
+      await _openArtist(tester, 'Daft Punk');
+
+      await tester.tap(find.byTooltip('Add all songs to playlist'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
     });
 
     testWidgets('an artist with missing metadata shows Unknown Artist',

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -104,11 +104,9 @@ void main() {
 
         expect(find.text('Play all'), findsOneWidget);
         expect(find.text('Shuffle all'), findsOneWidget);
-        // Albums section (the artist has two albums) and songs section.
         expect(find.text('Albums'), findsOneWidget);
         expect(find.text('Songs'), findsOneWidget);
         expect(find.byType(AlbumTile), findsNWidgets(2));
-        // This artist's tracks, not the other artist's.
         expect(find.text('Alpha'), findsOneWidget);
         expect(find.text('Beta'), findsOneWidget);
         expect(find.text('Gamma'), findsNothing);
@@ -122,7 +120,6 @@ void main() {
       await tester.tap(find.text('Play all'));
       await tester.pumpAndSettle();
 
-      // Two tracks by Daft Punk; album order puts Discovery before Homework.
       expect(controller.state.currentTrack?.id, '1');
       expect(controller.state.upNext.map((Track t) => t.id), <String>['2']);
     });
@@ -136,7 +133,6 @@ void main() {
         await tester.tap(find.text('Discovery'));
         await tester.pumpAndSettle();
 
-        // Now on the album detail: its Play action and only its track.
         expect(find.text('Play'), findsOneWidget);
         expect(find.text('Alpha'), findsOneWidget);
         expect(find.text('Beta'), findsNothing);

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -139,6 +139,19 @@ void main() {
       expect(find.text('Beta'), findsNothing);
     });
 
+    testWidgets('long-pressing an artist album adds only that album songs',
+        (tester) async {
+      await _pump(tester);
+      await _openArtist(tester, 'Daft Punk');
+
+      await tester.longPress(find.text('Discovery'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to playlist'), findsOneWidget);
+      expect(find.text('Add 2 songs to playlist'), findsNothing);
+      expect(find.text('New playlist'), findsOneWidget);
+    });
+
     testWidgets('adds every artist track through the bulk playlist sheet',
         (tester) async {
       await _pump(tester);

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -96,22 +96,24 @@ Future<void> _openArtist(WidgetTester tester, String name) async {
 
 void main() {
   group('ArtistDetailScreen', () {
-    testWidgets('tapping an artist opens detail listing albums and tracks',
-        (tester) async {
-      await _pump(tester);
-      await _openArtist(tester, 'Daft Punk');
+    testWidgets(
+      'tapping an artist opens detail listing albums and tracks',
+      (tester) async {
+        await _pump(tester);
+        await _openArtist(tester, 'Daft Punk');
 
-      expect(find.text('Play all'), findsOneWidget);
-      expect(find.text('Shuffle all'), findsOneWidget);
-      // Albums section (the artist has two albums) and songs section.
-      expect(find.text('Albums'), findsOneWidget);
-      expect(find.text('Songs'), findsOneWidget);
-      expect(find.byType(AlbumTile), findsNWidgets(2));
-      // This artist's tracks, not the other artist's.
-      expect(find.text('Alpha'), findsOneWidget);
-      expect(find.text('Beta'), findsOneWidget);
-      expect(find.text('Gamma'), findsNothing);
-    });
+        expect(find.text('Play all'), findsOneWidget);
+        expect(find.text('Shuffle all'), findsOneWidget);
+        // Albums section (the artist has two albums) and songs section.
+        expect(find.text('Albums'), findsOneWidget);
+        expect(find.text('Songs'), findsOneWidget);
+        expect(find.byType(AlbumTile), findsNWidgets(2));
+        // This artist's tracks, not the other artist's.
+        expect(find.text('Alpha'), findsOneWidget);
+        expect(find.text('Beta'), findsOneWidget);
+        expect(find.text('Gamma'), findsNothing);
+      },
+    );
 
     testWidgets('Play all queues the artist tracks', (tester) async {
       final FakePlaybackController controller = await _pump(tester);
@@ -125,44 +127,50 @@ void main() {
       expect(controller.state.upNext.map((Track t) => t.id), <String>['2']);
     });
 
-    testWidgets('tapping an album in the artist detail opens that album',
-        (tester) async {
-      await _pump(tester);
-      await _openArtist(tester, 'Daft Punk');
+    testWidgets(
+      'tapping an album in the artist detail opens that album',
+      (tester) async {
+        await _pump(tester);
+        await _openArtist(tester, 'Daft Punk');
 
-      await tester.tap(find.text('Discovery'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.text('Discovery'));
+        await tester.pumpAndSettle();
 
-      // Now on the album detail: its Play action and only its track.
-      expect(find.text('Play'), findsOneWidget);
-      expect(find.text('Alpha'), findsOneWidget);
-      expect(find.text('Beta'), findsNothing);
-    });
+        // Now on the album detail: its Play action and only its track.
+        expect(find.text('Play'), findsOneWidget);
+        expect(find.text('Alpha'), findsOneWidget);
+        expect(find.text('Beta'), findsNothing);
+      },
+    );
 
-    testWidgets('long-pressing an artist album adds only that album songs',
-        (tester) async {
-      await _pump(tester);
-      await _openArtist(tester, 'Daft Punk');
+    testWidgets(
+      'long-pressing an artist album adds only that album songs',
+      (tester) async {
+        await _pump(tester);
+        await _openArtist(tester, 'Daft Punk');
 
-      await tester.longPress(find.text('Discovery'));
-      await tester.pumpAndSettle();
+        await tester.longPress(find.text('Discovery'));
+        await tester.pumpAndSettle();
 
-      expect(find.text('Add to playlist'), findsOneWidget);
-      expect(find.text('Add 2 songs to playlist'), findsNothing);
-      expect(find.text('New playlist'), findsOneWidget);
-    });
+        expect(find.text('Add to playlist'), findsOneWidget);
+        expect(find.text('Add 2 songs to playlist'), findsNothing);
+        expect(find.text('New playlist'), findsOneWidget);
+      },
+    );
 
-    testWidgets('adds every artist track through the bulk playlist sheet',
-        (tester) async {
-      await _pump(tester);
-      await _openArtist(tester, 'Daft Punk');
+    testWidgets(
+      'adds every artist track through the bulk playlist sheet',
+      (tester) async {
+        await _pump(tester);
+        await _openArtist(tester, 'Daft Punk');
 
-      await tester.tap(find.byTooltip('Add all songs to playlist'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byTooltip('Add all songs to playlist'));
+        await tester.pumpAndSettle();
 
-      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
-      expect(find.text('New playlist'), findsOneWidget);
-    });
+        expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+        expect(find.text('New playlist'), findsOneWidget);
+      },
+    );
 
     testWidgets('an artist with missing metadata shows Unknown Artist',
         (tester) async {

--- a/test/features/library/artist_detail_screen_test.dart
+++ b/test/features/library/artist_detail_screen_test.dart
@@ -168,6 +168,26 @@ void main() {
       },
     );
 
+    testWidgets('long-press selects multiple artist tracks for a playlist',
+        (tester) async {
+      await _pump(tester);
+      await _openArtist(tester, 'Daft Punk');
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      await tester.tap(find.text('Beta'));
+      await tester.pumpAndSettle();
+      expect(find.text('2 selected'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Add to playlist'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
+    });
+
     testWidgets('an artist with missing metadata shows Unknown Artist',
         (tester) async {
       final FakePlaybackController controller = await _pump(

--- a/test/features/library/library_browse_test.dart
+++ b/test/features/library/library_browse_test.dart
@@ -181,7 +181,7 @@ void main() {
       expect(find.text('Daft Punk • 2 songs'), findsOneWidget);
     });
 
-    testWidgets('long-pressing an album adds all of its songs to a playlist',
+    testWidgets('long-pressing an album opens its bulk playlist sheet',
         (tester) async {
       await _pump(tester);
       await tester.tap(find.text('Albums'));
@@ -207,7 +207,7 @@ void main() {
       expect(find.text('1 album • 2 songs'), findsOneWidget);
     });
 
-    testWidgets('long-pressing an artist adds all of their songs to a playlist',
+    testWidgets('long-pressing an artist opens their bulk playlist sheet',
         (tester) async {
       await _pump(tester);
       await tester.tap(find.text('Artists'));

--- a/test/features/library/library_browse_test.dart
+++ b/test/features/library/library_browse_test.dart
@@ -90,7 +90,6 @@ void main() {
       await _pump(tester);
       await _enter(tester, 'adele');
 
-      // Only Gamma is by Adele.
       expect(find.text('Gamma'), findsOneWidget);
       expect(find.text('Alpha'), findsNothing);
     });
@@ -99,7 +98,6 @@ void main() {
       await _pump(tester);
       await _enter(tester, 'discovery');
 
-      // Alpha and Beta are both on Discovery; Gamma (album "25") is hidden.
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsOneWidget);
       expect(find.text('Gamma'), findsNothing);
@@ -139,7 +137,6 @@ void main() {
 
       await _enter(tester, 'gamma');
 
-      // Filtering the list started nothing and changed nothing about playback.
       expect(controller.playedTracks, isEmpty);
       expect(controller.playCount, 0);
       expect(controller.state.currentTrack?.id, '1');
@@ -153,7 +150,6 @@ void main() {
 
       expect(find.textContaining('api_key'), findsNothing);
       expect(find.textContaining('AccessToken'), findsNothing);
-      // The row shows friendly metadata, not the opaque uri.
       expect(find.text('Daft Punk • Discovery'), findsOneWidget);
     });
   });
@@ -177,7 +173,6 @@ void main() {
       expect(find.byType(AlbumTile), findsNWidgets(2));
       expect(find.text('Discovery'), findsOneWidget);
       expect(find.text('25'), findsOneWidget);
-      // Album row subtitle: artist + track count.
       expect(find.text('Daft Punk • 2 songs'), findsOneWidget);
     });
 
@@ -203,7 +198,6 @@ void main() {
       expect(find.byType(ArtistTile), findsNWidgets(2));
       expect(find.text('Daft Punk'), findsOneWidget);
       expect(find.text('Adele'), findsOneWidget);
-      // Artist row subtitle: album + track count.
       expect(find.text('1 album • 2 songs'), findsOneWidget);
     });
 
@@ -225,13 +219,11 @@ void main() {
       await _enter(tester, 'alpha');
       expect(find.text('Beta'), findsNothing);
 
-      // Move to Albums (clears the query), then back to Songs.
       await tester.tap(find.text('Albums'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Songs'));
       await tester.pumpAndSettle();
 
-      // The full song list is back — the query did not survive the switch.
       expect(find.text('Alpha'), findsOneWidget);
       expect(find.text('Beta'), findsOneWidget);
       expect(find.text('Gamma'), findsOneWidget);

--- a/test/features/library/library_browse_test.dart
+++ b/test/features/library/library_browse_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/library/library_screen.dart';
 import 'package:linthra/features/library/widgets/album_tile.dart';
 import 'package:linthra/features/library/widgets/artist_tile.dart';
@@ -49,6 +51,7 @@ Future<void> _pump(
         musicLibraryRepositoryProvider.overrideWithValue(
           FakeMusicLibraryRepository(tracks: tracks ?? _sampleTracks()),
         ),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
         if (playback != null)
           playbackControllerProvider.overrideWithValue(playback),
       ],
@@ -178,6 +181,19 @@ void main() {
       expect(find.text('Daft Punk • 2 songs'), findsOneWidget);
     });
 
+    testWidgets('long-pressing an album adds all of its songs to a playlist',
+        (tester) async {
+      await _pump(tester);
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('Discovery'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
+    });
+
     testWidgets('the Artists tab renders grouped artists with name/count',
         (tester) async {
       await _pump(tester);
@@ -189,6 +205,19 @@ void main() {
       expect(find.text('Adele'), findsOneWidget);
       // Artist row subtitle: album + track count.
       expect(find.text('1 album • 2 songs'), findsOneWidget);
+    });
+
+    testWidgets('long-pressing an artist adds all of their songs to a playlist',
+        (tester) async {
+      await _pump(tester);
+      await tester.tap(find.text('Artists'));
+      await tester.pumpAndSettle();
+
+      await tester.longPress(find.text('Daft Punk'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
     });
 
     testWidgets('switching tabs clears the active search', (tester) async {


### PR DESCRIPTION
## Summary

Adds complete bulk **Add all songs to playlist** support for albums, artists, and selected songs.

Closes #279.

## User experience

- Long-press an album row to open the playlist picker with every song from that album.
- Long-press an artist row to open the picker with every song from that artist.
- Album rows shown inside an artist detail page use the same long-press behavior.
- Album and artist detail screens expose a visible app-bar playlist action to add every song.
- Long-press a song in the Songs tab, an album detail, or an artist detail to start multi-select.
- Tap additional songs, then use the app-bar **Add to playlist** action to send only the selected tracks.
- Back or the close action exits selection without leaving the detail page.
- The shared sheet supports existing playlists and creating a new playlist.

## Existing safeguards reused

All entry points intentionally reuse `showAddToPlaylistSheet` instead of adding another playlist mutation path, preserving existing behavior for:

- duplicate tracks;
- local, Jellyfin, and Subsonic/Navidrome source compatibility;
- synced playlist writes;
- accurate added/skipped feedback;
- creating a playlist and adding the selection immediately.

## Tests

- Album and artist visible actions pass their complete track sets.
- Long-pressing an album or artist row opens the correctly sized bulk sheet.
- Long-pressing an album inside artist detail includes only that album.
- Album and artist detail tests select multiple songs and pass only that selection to the playlist sheet.
- Existing Songs-tab selection and playlist-sheet tests continue to cover multi-select, duplicate handling, and real added counts.

## Scope

One complete feature PR: visible bulk actions, album/artist long-press gestures, song multi-selection across browse and detail screens, shared playlist flow, and integration coverage. No playback, queue, download, provider, or database behavior is changed.