### PR TITLE
chore(release): prepare v0.1.10 — mobile data controls & playlist tools

### DIFF
--- a/docs/release-notes/v0.1.10.md
+++ b/docs/release-notes/v0.1.10.md
@@ -1,0 +1,133 @@
+# Linthra v0.1.10 — release notes
+
+**Linthra is an Android music player for local files and self-hosted music
+servers.** v0.1.10 is a **mobile-data control and playlist workflow release**.
+It adds real Android metered-network detection, three clear mobile-data
+profiles, bulk album/artist playlist actions, song multi-selection, and an
+optional custom palette in the separate GitHub Sponsor edition.
+
+This release adds Android's normal `ACCESS_NETWORK_STATE` permission. It has no
+runtime prompt and is used only to classify the active connection as unmetered,
+metered, offline, or unknown. Linthra does not read an SSID, carrier identity,
+IP address, server URL, location, or credential through this feature.
+
+- **Version:** `0.1.10` (`versionName`), `versionCode` `110999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+- **Get it:** Available from the
+  [GitHub Releases page](https://github.com/TheZupZup/Linthra/releases) first
+  (signed APKs); [Obtainium](https://github.com/ImranR98/Obtainium) can track
+  this repository for updates. The
+  [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/) build
+  follows after F-Droid detects the tag and completes its build process.
+
+## What's new
+
+### Mobile-data profiles
+
+- **Wi-Fi only.** Before a new remote download or smart pre-cache starts,
+  Linthra requires an unmetered connection. LTE/5G and metered hotspots wait
+  instead of being treated as Wi-Fi.
+- **Save data.** User-requested downloads may use a metered connection, while
+  automatic smart pre-cache stays paused to avoid background consumption.
+- **Unlimited.** User-requested downloads and smart pre-cache may use metered
+  connections normally.
+- **Real Android metering.** Linthra now follows Android's active-network
+  capability instead of guessing from the transport name. This handles metered
+  Wi-Fi, unmetered cellular service, VPN default networks, offline state, and
+  unusual devices conservatively.
+- **Safe migration.** The previous mobile-data toggle migrates automatically:
+  disabled or absent becomes *Wi-Fi only*, while enabled becomes *Unlimited*.
+
+### Playlists
+
+- **Add an entire album or artist.** Long-press an album or artist row, or use
+  the visible action in its detail screen, to send every song to a playlist.
+- **Select several songs.** Long-press a song in Songs, album detail, or artist
+  detail, select the tracks you want, then add only that selection.
+- **One consistent playlist flow.** Existing playlists and newly created
+  playlists use the same duplicate-aware path and report added/skipped tracks.
+
+### Appearance and support
+
+- **Optional custom two-color palette.** The separate GitHub Sponsor edition
+  can unlock a custom Linthra identity and playback accent for an active GitHub
+  sponsorship of at least $3 USD/month.
+- **The free core is unchanged.** Classic, Neon, Gold, and Black & White remain
+  free everywhere. Playback, offline listening, local files, Jellyfin,
+  Navidrome/Subsonic, Plex, Cast, and Android Auto are not locked.
+- **F-Droid stays independent.** The F-Droid and ordinary canonical builds hide
+  the GitHub-dependent custom-palette unlock path and require no billing SDK.
+
+## Scope note
+
+v0.1.10 fixes the previous production placeholder that always reported Wi-Fi
+and protects the common case where a download or smart pre-cache is considered
+while the device is already on a metered connection. Guaranteed cancellation
+and automatic retry when the network changes during an already active transfer
+remain follow-up work in [#275](https://github.com/TheZupZup/Linthra/issues/275).
+The release does not claim that zero bytes can continue after every possible
+mid-transfer Wi-Fi-to-LTE handoff.
+
+## Technical summary
+
+- **Android metered-network detection and mobile-data profiles**
+  ([PR #284](https://github.com/TheZupZup/Linthra/pull/284), partially addresses
+  [#275](https://github.com/TheZupZup/Linthra/issues/275)): a small native
+  `ConnectivityManager` channel reports unmetered, metered, offline, or unknown;
+  Dart preferences expose Wi-Fi only, Save data, and Unlimited; smart pre-cache
+  pauses in Save data; legacy settings migrate without a database change.
+- **Bulk playlist actions and song multi-selection**
+  ([PR #280](https://github.com/TheZupZup/Linthra/pull/280), closes
+  [#279](https://github.com/TheZupZup/Linthra/issues/279)): album/artist row
+  gestures, detail-screen actions, and multi-select all reuse the existing
+  playlist sheet and mutation safeguards.
+- **Supporter custom palette and distribution boundary**
+  ([PR #277](https://github.com/TheZupZup/Linthra/pull/277), corrected by
+  [PR #278](https://github.com/TheZupZup/Linthra/pull/278)): local palette
+  persistence and accessible derived tones, with GitHub Sponsor verification
+  isolated to the dedicated Sponsor APK; F-Droid and ordinary builds keep all
+  core features and built-in themes without exposing the unlock UI.
+
+No dependency, Drift schema, provider account, playback-engine, or media-library
+data migration is included in this release preparation.
+
+## Manual QA checklist (Pixel / Android)
+
+- [ ] Upgrade from v0.1.9 and verify settings, servers, library, and downloads
+      remain available.
+- [ ] Select *Wi-Fi only* on Wi-Fi and verify a remote download and smart
+      pre-cache can start.
+- [ ] Move to LTE/5G, then verify a new remote download waits and smart
+      pre-cache does not start.
+- [ ] Select *Save data* on LTE/5G and verify an explicit download is allowed
+      while automatic smart pre-cache remains paused.
+- [ ] Select *Unlimited* on LTE/5G and verify explicit downloads and smart
+      pre-cache are allowed.
+- [ ] Restart the app after each profile choice and verify the selection remains.
+- [ ] Add all songs from an album and an artist to an existing playlist.
+- [ ] Multi-select songs and add only the selected tracks to a playlist.
+- [ ] Create a playlist from the shared sheet and verify duplicate reporting.
+- [ ] In the ordinary/F-Droid build, verify built-in themes remain available and
+      the GitHub Sponsor custom-palette unlock is hidden.
+- [ ] In the GitHub Sponsor build, verify the custom palette remains locked until
+      sponsor verification succeeds, then persists after restart.
+- [ ] Verify Jellyfin and Navidrome/Subsonic sign-in, sync, playback, downloads,
+      background playback, and the media notification.
+- [ ] Verify no new runtime permission prompt appears.
+
+## Upgrade and distribution notes
+
+- Existing mobile-data preferences migrate automatically; no manual reset is
+  required.
+- **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
+  key, while the F-Droid build is signed with F-Droid's key; the two cannot
+  update each other. Stay with one source.
+- F-Droid detects stable tags automatically and builds from source. The local
+  metadata mirror is updated after tagging because its build entries need the
+  final tag commit SHA and per-ABI version codes.
+
+No ads, no tracking, no analytics, no telemetry. No Spotify, stream-ripping, or
+DRM-bypass claims — Linthra plays music you already own or that your own server
+provides.

--- a/fastlane/metadata/android/en-US/changelogs/110999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/110999.txt
@@ -1,0 +1,17 @@
+Linthra 0.1.10 — mobile data controls & playlist tools.
+
+Mobile data:
+- Choose Wi-Fi only, Save data, or Unlimited for downloads and
+  smart pre-cache.
+- Linthra now reads Android's metered-network state instead of
+  assuming every connection is Wi-Fi.
+- Wi-Fi only keeps new remote downloads and smart pre-cache off
+  LTE/5G and metered hotspots.
+- Save data allows user-requested downloads while pausing automatic
+  smart pre-cache.
+
+Playlists:
+- Add every song from an album or artist to a playlist.
+- Long-press songs to select several and add only that selection.
+- The shared playlist flow still handles duplicates and lets you
+  create a playlist immediately.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.9';
+  static const String _devVersionName = '0.1.10';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'User-installed CA certificates are now trusted for HTTPS servers.',
-    'Playlists and favorites now sync two-way with Navidrome/Subsonic.',
-    'Changes made on your server now show up on their own.',
-    'Add or remove favorites straight from any track menu.',
+    'Choose Wi-Fi only, Save data, or Unlimited for downloads and smart pre-cache.',
+    'Metered Android connections are now detected instead of assumed to be Wi-Fi.',
+    'Add a whole album or artist, or selected songs, to a playlist.',
+    'The separate GitHub Sponsor edition can unlock a custom two-color palette.',
   ];
 
   @override

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Choose Wi-Fi only, Save data, or Unlimited for downloads and smart pre-cache.',
-    'Metered Android connections are now detected instead of assumed to be Wi-Fi.',
-    'Add a whole album or artist, or selected songs, to a playlist.',
-    'The separate GitHub Sponsor edition can unlock a custom two-color palette.',
+    'User-installed CA certificates are now trusted for HTTPS servers.',
+    'Playlists and favorites now sync two-way with Navidrome/Subsonic.',
+    'Changes made on your server now show up on their own.',
+    'Add or remove favorites straight from any track menu.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.9+109999
+version: 0.1.10+110999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
Prepares the **v0.1.10** stable release from the current `main` after #284. Release metadata and release notes only; no new runtime behavior beyond work already merged.

## What changed

- [x] Bumps `pubspec.yaml` to `0.1.10+110999`.
- [x] Updates `AppInfo._devVersionName` to `0.1.10` in lockstep.
- [x] Adds the F-Droid/Fastlane changelog at `fastlane/metadata/android/en-US/changelogs/110999.txt`.
- [x] Adds full release notes at `docs/release-notes/v0.1.10.md`.

The in-app **What's new** copy is intentionally isolated in #287 so this `release/*` branch satisfies the repository's version-only guard.

`110999` is the canonical stable versionCode for `0.1.10`. Split APK codes will be `1109991`, `1109992`, and `1109993` for armeabi-v7a, arm64-v8a, and x86_64.

## Release highlights

- Android metered-network detection and three mobile-data profiles: Wi-Fi only, Save data, and Unlimited (#284, partially addresses #275).
- Add every song from an album or artist to a playlist, plus song multi-selection (#280, closes #279).
- Optional custom two-color palette in the separate GitHub Sponsor edition, while every core feature and built-in theme remains free (#277, corrected by #278).

## Deliberately not touched

- `metadata/io.github.thezupzup.linthra.yml`: its v0.1.10 build entries need the final tag commit SHA, so this remains a post-tag follow-up.
- README/current-stable badges and `docs/index.html`: v0.1.9 remains the published stable release until the v0.1.10 tag and assets exist.
- Dependencies, Drift schema/generated code, release signing, and runtime feature code.
- Issue #275 remains open because guaranteed cancellation/retry across a mid-transfer network transition is follow-up work.

## Before tagging

- [ ] CI green on this PR, including version drift, release-branch file scope, and Fastlane changelog guards.
- [ ] Merge #287 and this PR into `main`; do not tag from either feature branch.
- [ ] Run `./scripts/release_preflight.sh v0.1.10` from updated `main` and confirm it reports `0.1.10+110999`.
- [ ] Confirm stable release-signing secrets are configured.
- [ ] Create the stable GitHub Release/tag `v0.1.10` targeting the merged `main` commit and use `docs/release-notes/v0.1.10.md` as the notes.
- [ ] Verify the universal APK/AAB and all three signed per-ABI APKs attach with the expected names.
- [ ] Smoke-test the signed APK.

## After tagging / F-Droid

- [ ] Update the repository's F-Droid metadata mirror with the full v0.1.10 tag commit SHA, per-ABI build entries, `CurrentVersion: 0.1.10`, and `CurrentVersionCode: 1109993`.
- [ ] Update README and web documentation to show v0.1.10 as current stable.
- [ ] Let F-Droid's automatic tag detection build and sign its own package; no direct store push is performed from this repository.
