### PR TITLE
chore(about): refresh What's new for v0.1.10

### DIFF
--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'User-installed CA certificates are now trusted for HTTPS servers.',
-    'Playlists and favorites now sync two-way with Navidrome/Subsonic.',
-    'Changes made on your server now show up on their own.',
-    'Add or remove favorites straight from any track menu.',
+    'Choose Wi-Fi only, Save data, or Unlimited for downloads and smart pre-cache.',
+    'Metered Android connections are now detected instead of assumed to be Wi-Fi.',
+    'Add a whole album or artist, or selected songs, to a playlist.',
+    'The separate GitHub Sponsor edition can unlock a custom two-color palette.',
   ];
 
   @override


### PR DESCRIPTION
Updates the in-app **What's new** card for the upcoming v0.1.10 release.

## Highlights shown in-app

- Wi-Fi only, Save data, and Unlimited mobile-data profiles.
- Real Android metered-network detection.
- Bulk album/artist playlist actions and song multi-selection.
- Optional custom two-color palette in the separate GitHub Sponsor edition.

This is deliberately separate from the `release/0.1.10` bump PR because Linthra's release-branch guard allows only version, changelog, metadata, and release-note files on `release/*` branches.

No version, dependency, runtime behavior, F-Droid metadata, or signing changes are included here. Merge this and #286 before creating tag `v0.1.10`.