### PR TITLE
chore(fdroid): stage 0.1.10 metadata recipe

### DIFF
--- a/metadata/io.github.thezupzup.linthra.yml
+++ b/metadata/io.github.thezupzup.linthra.yml
@@ -364,14 +364,6 @@ Builds:
       - $$flutter$$/bin/flutter build apk --release --split-per-abi --target-platform="android-arm"
       - popd
       - mv $repo io.github.thezupzup.linthra
-    # Upstream-signed reference APK for this ABI on the matching GitHub Release.
-    # %v expands to the build's versionName (e.g. 0.1.8); there is no
-    # %a placeholder for ABI in F-Droid metadata, so the ABI slug is hardcoded
-    # per Build entry. The Android Release Build workflow uploads the per-ABI
-    # APK under exactly this name. (Per-Build `binary` overrides any top-level
-    # `Binaries`; see fdroidserver build.py: `url := build.binary or
-    # app.Binaries`.) Added in response to the F-Droid maintainer's feedback on
-    # MR !39329 ("add binary to every version").
     binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-armeabi-v7a-release-signed.apk
 
   - versionName: 0.1.8
@@ -444,7 +436,6 @@ Builds:
       - mv $repo io.github.thezupzup.linthra
     binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-x86_64-release-signed.apk
 
-
   - versionName: 0.1.9
     versionCode: 1099991
     commit: 31d022834b15d74799e3215a515a653028a9a6f7
@@ -478,14 +469,6 @@ Builds:
       - $$flutter$$/bin/flutter build apk --release --split-per-abi --target-platform="android-arm"
       - popd
       - mv $repo io.github.thezupzup.linthra
-    # Upstream-signed reference APK for this ABI on the matching GitHub Release.
-    # %v expands to the build's versionName (e.g. 0.1.9); there is no
-    # %a placeholder for ABI in F-Droid metadata, so the ABI slug is hardcoded
-    # per Build entry. The Android Release Build workflow uploads the per-ABI
-    # APK under exactly this name. (Per-Build `binary` overrides any top-level
-    # `Binaries`; see fdroidserver build.py: `url := build.binary or
-    # app.Binaries`.) Added in response to the F-Droid maintainer's feedback on
-    # MR !39329 ("add binary to every version").
     binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-armeabi-v7a-release-signed.apk
 
   - versionName: 0.1.9
@@ -557,6 +540,111 @@ Builds:
       - popd
       - mv $repo io.github.thezupzup.linthra
     binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-x86_64-release-signed.apk
+
+  - versionName: 0.1.10
+    versionCode: 1109991
+    commit: 7b5419373b95aa0e1b4ff9f08101b5ad05f7674d
+    sudo:
+      - mkdir -p /home/runner/work/Linthra
+      - chown -R vagrant /home/runner/work
+    output: build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
+    srclibs:
+      - flutter@stable
+    prebuild:
+      - flutterVersion=$(cat .flutter-version)
+      - '[[ $flutterVersion ]]'
+      - git -C $$flutter$$ checkout -f $flutterVersion
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
+      - popd
+      - mv $repo io.github.thezupzup.linthra
+    scandelete:
+      - .pub-cache
+    build:
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter build apk --release --split-per-abi --target-platform="android-arm"
+      - popd
+      - mv $repo io.github.thezupzup.linthra
+    binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-armeabi-v7a-release-signed.apk
+
+  - versionName: 0.1.10
+    versionCode: 1109992
+    commit: 7b5419373b95aa0e1b4ff9f08101b5ad05f7674d
+    sudo:
+      - mkdir -p /home/runner/work/Linthra
+      - chown -R vagrant /home/runner/work
+    output: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+    srclibs:
+      - flutter@stable
+    prebuild:
+      - flutterVersion=$(cat .flutter-version)
+      - '[[ $flutterVersion ]]'
+      - git -C $$flutter$$ checkout -f $flutterVersion
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
+      - popd
+      - mv $repo io.github.thezupzup.linthra
+    scandelete:
+      - .pub-cache
+    build:
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter build apk --release --split-per-abi --target-platform="android-arm64"
+      - popd
+      - mv $repo io.github.thezupzup.linthra
+    binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-arm64-v8a-release-signed.apk
+
+  - versionName: 0.1.10
+    versionCode: 1109993
+    commit: 7b5419373b95aa0e1b4ff9f08101b5ad05f7674d
+    sudo:
+      - mkdir -p /home/runner/work/Linthra
+      - chown -R vagrant /home/runner/work
+    output: build/app/outputs/flutter-apk/app-x86_64-release.apk
+    srclibs:
+      - flutter@stable
+    prebuild:
+      - flutterVersion=$(cat .flutter-version)
+      - '[[ $flutterVersion ]]'
+      - git -C $$flutter$$ checkout -f $flutterVersion
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter config --no-analytics
+      - $$flutter$$/bin/flutter pub get --enforce-lockfile
+      - popd
+      - mv $repo io.github.thezupzup.linthra
+    scandelete:
+      - .pub-cache
+    build:
+      - export repo=/home/runner/work/Linthra/Linthra
+      - cd ..
+      - mv io.github.thezupzup.linthra $repo
+      - pushd $repo
+      - export PUB_CACHE=$(pwd)/.pub-cache
+      - $$flutter$$/bin/flutter build apk --release --split-per-abi --target-platform="android-x64"
+      - popd
+      - mv $repo io.github.thezupzup.linthra
+    binary: https://github.com/TheZupZup/Linthra/releases/download/v%v/linthra-v%v-x86_64-release-signed.apk
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 VercodeOperation:
@@ -565,5 +653,5 @@ VercodeOperation:
   - "%c*10 + 3"
 UpdateCheckData: pubspec.yaml|version:\s*[^+]+\+(\d+)|.|version:\s*([^\+]+)\+
 
-CurrentVersion: 0.1.9
-CurrentVersionCode: 1099993
+CurrentVersion: 0.1.10
+CurrentVersionCode: 1109993


### PR DESCRIPTION
Stages the repository's F-Droid metadata mirror for **Linthra 0.1.10**.

## Added builds

All entries are pinned to the final release commit that `v0.1.10` must target:

`7b5419373b95aa0e1b4ff9f08101b5ad05f7674d`

- `armeabi-v7a`: versionCode `1109991`
- `arm64-v8a`: versionCode `1109992`
- `x86_64`: versionCode `1109993`

Each build keeps the canonical per-ABI output and GitHub Release `binary:` filename. The metadata also moves:

- `CurrentVersion` to `0.1.10`
- `CurrentVersionCode` to `1109993`

## Important: do not merge yet

This PR is intentionally a draft because `v0.1.10` and its signed GitHub Release assets do not exist yet. Before merging:

- [ ] Create stable GitHub Release/tag `v0.1.10` targeting exactly `7b5419373b95aa0e1b4ff9f08101b5ad05f7674d`.
- [ ] Confirm the Android Release Build succeeds.
- [ ] Confirm these assets exist:
  - `linthra-v0.1.10-release-signed.apk`
  - `linthra-v0.1.10-release-signed.aab`
  - `linthra-v0.1.10-armeabi-v7a-release-signed.apk`
  - `linthra-v0.1.10-arm64-v8a-release-signed.apk`
  - `linthra-v0.1.10-x86_64-release-signed.apk`
- [ ] Smoke-test the signed APK.
- [ ] Mark this PR ready and merge it.

F-Droid itself uses automatic tag detection and signs its own builds. This file is Linthra's in-repository mirror/guardrail and does not directly publish to the store.