### PR TITLE
chore(release): prepare v0.1.11 — folder browsing & Android navigation

### DIFF
--- a/docs/release-notes/v0.1.11.md
+++ b/docs/release-notes/v0.1.11.md
@@ -1,0 +1,92 @@
+# Linthra v0.1.11 — release notes
+
+**Linthra is an Android music player for local files and self-hosted music
+servers.** v0.1.11 is a **folder-browsing and Android navigation release**. It
+adds a real server-folder view for Jellyfin and Navidrome/Subsonic and makes the
+Android system Back button follow Linthra's navigation before exiting the app.
+
+- **Version:** `0.1.11` (`versionName`), `versionCode` `111999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** [MPL-2.0](../../LICENSE)
+- **Get it:** Available from the
+  [GitHub Releases page](https://github.com/TheZupZup/Linthra/releases) first
+  (signed APKs); [Obtainium](https://github.com/ImranR98/Obtainium) can track
+  this repository for updates. The
+  [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/) build
+  follows after F-Droid detects the tag and completes its build process.
+
+## What's new
+
+### Browse by folder hierarchy
+
+- **New Folders tab.** Library now includes a Folders tab when a compatible
+  Jellyfin or Navidrome/Subsonic server is connected.
+- **Real server structure.** Browse the hierarchy exposed by the server instead
+  of relying only on Linthra's flat Songs, Albums, and Artists views.
+- **Direct playback.** Songs found inside a folder can be started immediately
+  using Linthra's existing playback queue and track actions.
+- **Separate connected sources.** Jellyfin and Navidrome/Subsonic roots are
+  shown independently when both are connected.
+- **Lightweight navigation.** Linthra requests one folder level at a time rather
+  than recursively downloading the complete directory tree.
+- **Friendly states.** Loading, empty-folder, error, and retry states are handled
+  inside the folder browser.
+
+### Android Back navigation
+
+- **Nested folders return correctly.** Android Back moves to the previous folder
+  before leaving the Folders tab.
+- **Detail screens return normally.** Album, artist, playlist, player, support,
+  and settings-detail screens return to their parent screen.
+- **Main tabs return to Library.** Back from the root of Playlists, Downloads,
+  or Settings returns to Library instead of closing Linthra immediately.
+- **Exit only from the true root.** Linthra closes normally only when Back is
+  pressed from the root of Library with no internal state left to dismiss.
+- **Existing tab history is preserved.** The independent navigation stack and
+  scroll position of each bottom-navigation tab remain intact.
+
+## Technical summary
+
+- **Provider-neutral folder capability**
+  ([PR #289](https://github.com/TheZupZup/Linthra/pull/289), closes
+  [#282](https://github.com/TheZupZup/Linthra/issues/282)): a small optional
+  folder-browsing contract lets supported providers expose root folders and one
+  immediate child level without changing the normal music-source interface.
+- **Jellyfin folder browser:** reads music roots from `/Library/MediaFolders`
+  and direct child folders/tracks from `/Items` with non-recursive requests.
+- **Navidrome/Subsonic folder browser:** reads music roots through
+  `getMusicFolders`, indexes through `getIndexes`, and nested directories through
+  `getMusicDirectory`.
+- **Credential-safe identifiers:** folder IDs stay opaque and never include an
+  authenticated URL, password, token, or other secret.
+- **Central Android Back handling**
+  ([PR #289](https://github.com/TheZupZup/Linthra/pull/289), closes
+  [#285](https://github.com/TheZupZup/Linthra/issues/285)): root and branch
+  navigators now cooperate so internal state is handled before the app exits.
+
+No dependency, Drift schema, account, playlist, download, cache, or media-library
+data migration is included in this release.
+
+## Manual QA completed
+
+- [x] Browse a real Jellyfin folder hierarchy.
+- [x] Open nested folders and start a song directly from Folders.
+- [x] Use Android Back to return through nested folders.
+- [x] Use Android Back across Linthra detail screens and main tabs.
+- [x] Exit normally from the Library root.
+- [x] Dart formatting, Flutter analysis, full tests, privacy scan, Android debug
+      build, and GitHub Sponsor simulation passed on the feature PR.
+
+## Upgrade and distribution notes
+
+- No settings reset or database migration is required.
+- **Don't mix install sources.** A GitHub-release APK is signed with Linthra's
+  key, while the F-Droid build is signed with F-Droid's key; the two cannot
+  update each other. Stay with one source.
+- F-Droid detects stable tags automatically and builds from source. The local
+  metadata mirror can be updated after tagging with the final tag commit SHA and
+  per-ABI version codes.
+
+No ads, no tracking, no analytics, no telemetry. Linthra plays music you already
+own or that your own server provides.

--- a/fastlane/metadata/android/en-US/changelogs/111999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/111999.txt
@@ -1,0 +1,6 @@
+Linthra 0.1.11 — folder browsing and Android navigation.
+
+- Browse Jellyfin and Navidrome/Subsonic through their real folder hierarchy from Library → Folders.
+- Open nested folders and start songs directly from the folder view.
+- Android Back now closes internal states, returns from detail screens, goes back to Library from other main tabs, and exits only from Library root.
+- No ads, tracking, analytics, or telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.10';
+  static const String _devVersionName = '0.1.11';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Choose Wi-Fi only, Save data, or Unlimited for downloads and smart pre-cache.',
-    'Metered Android connections are now detected instead of assumed to be Wi-Fi.',
-    'Add a whole album or artist, or selected songs, to a playlist.',
-    'The separate GitHub Sponsor edition can unlock a custom two-color palette.',
+    'Browse Jellyfin and Navidrome/Subsonic through their real folder hierarchy.',
+    'Open nested folders and start songs directly from the Folders tab.',
+    'Android Back now returns through Linthra before the app exits.',
+    'Folder browsing loads one level at a time for fast, lightweight navigation.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.10+110999
+version: 0.1.11+111999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepares the stable **Linthra v0.1.11** release after #289 landed on `main`.

## Version

- `pubspec.yaml`: `0.1.11+111999`
- in-app version: `0.1.11`
- planned tag: `v0.1.11`

## Release highlights

- Browse Jellyfin and Navidrome/Subsonic through their real folder hierarchy.
- Open nested folders and start tracks directly from Library → Folders.
- Android system Back now follows Linthra's internal navigation and exits only from Library's true root.
- Folder navigation loads one level at a time and keeps provider credentials out of folder identifiers.

## Release files

- Adds `docs/release-notes/v0.1.11.md`.
- Adds F-Droid changelog `111999.txt`.
- Refreshes the in-app What's new card.
- Keeps `pubspec.lock`, dependencies, Drift schema, and runtime permissions unchanged.

## Validation required before merge/tag

- [ ] Dart formatting
- [ ] Flutter analysis
- [ ] Full Flutter tests, including version-drift and F-Droid guardrails
- [ ] Secret & privacy scan
- [ ] Android debug build
- [ ] GitHub Sponsor simulation

After this PR is green and merged, create the stable `v0.1.11` tag from the merge commit and publish the GitHub Release using `docs/release-notes/v0.1.11.md`.