### PR TITLE
chore(about): refresh what's new for 0.1.11

### DIFF
--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Choose Wi-Fi only, Save data, or Unlimited for downloads and smart pre-cache.',
-    'Metered Android connections are now detected instead of assumed to be Wi-Fi.',
-    'Add a whole album or artist, or selected songs, to a playlist.',
-    'The separate GitHub Sponsor edition can unlock a custom two-color palette.',
+    'Browse Jellyfin and Navidrome/Subsonic through their real folder hierarchy.',
+    'Open nested folders and start songs directly from the Folders tab.',
+    'Android Back now returns through Linthra before the app exits.',
+    'Folder browsing loads one level at a time for fast, lightweight navigation.',
   ];
 
   @override


### PR DESCRIPTION
Refreshes the in-app About → What's new card for the upcoming 0.1.11 release.

Highlights:
- Jellyfin and Navidrome/Subsonic folder hierarchy browsing
- direct playback from the Folders tab
- consistent Android system Back behavior
- lightweight one-level-at-a-time folder loading

This is intentionally separate from the version-bump PR so the release guard keeps #290 version-only.