### PR TITLE
chore(release): publish v0.1.11

### DIFF
--- a/.github/workflows/publish-v0.1.11.yml
+++ b/.github/workflows/publish-v0.1.11.yml
@@ -1,0 +1,121 @@
+name: Publish Linthra v0.1.11
+
+# One-time publisher for the already-reviewed v0.1.11 release commit.
+# Remove this workflow after the tag, Release, and signed assets are verified.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/publish-v0.1.11.yml
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: v0.1.11
+      RELEASE_NAME: Linthra v0.1.11
+      TARGET_SHA: 379bcd2841b36d0ea78b12cc64435f619e6e5ccd
+      RELEASE_NOTES_PATH: ${{ runner.temp }}/linthra-v0.1.11-release-notes.md
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify the immutable release target
+        shell: bash
+        run: |
+          set -euo pipefail
+          git cat-file -e "${TARGET_SHA}^{commit}"
+          test "$(git show "${TARGET_SHA}:pubspec.yaml" | sed -n 's/^version: //p')" = "0.1.11+111999"
+          git show "${TARGET_SHA}:lib/core/app_info.dart" \
+            | grep -Fq "static const String _devVersionName = '0.1.11';"
+          git show "${TARGET_SHA}:docs/release-notes/v0.1.11.md" \
+            > "${RELEASE_NOTES_PATH}"
+
+      - name: Create annotated tag and GitHub Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.RELEASE_TAG;
+            const target = process.env.TARGET_SHA;
+
+            let tagRef;
+            try {
+              tagRef = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${tag}`,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            if (tagRef) {
+              const existingTag = await github.rest.git.getTag({
+                owner,
+                repo,
+                tag_sha: tagRef.data.object.sha,
+              });
+              if (
+                existingTag.data.object.type !== 'commit' ||
+                existingTag.data.object.sha !== target
+              ) {
+                core.setFailed(
+                  `${tag} already exists but does not point to ${target}.`,
+                );
+                return;
+              }
+              core.info(`${tag} already exists on the expected commit.`);
+            } else {
+              const annotatedTag = await github.rest.git.createTag({
+                owner,
+                repo,
+                tag,
+                message: 'Linthra v0.1.11 — folder browsing & Android navigation',
+                object: target,
+                type: 'commit',
+              });
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/tags/${tag}`,
+                sha: annotatedTag.data.sha,
+              });
+              core.info(`Created annotated tag ${tag} on ${target}.`);
+            }
+
+            try {
+              const existingRelease = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag,
+              });
+              core.info(
+                `Release already exists: ${existingRelease.data.html_url}`,
+              );
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              const body = fs.readFileSync(
+                process.env.RELEASE_NOTES_PATH,
+                'utf8',
+              );
+              const release = await github.rest.repos.createRelease({
+                owner,
+                repo,
+                tag_name: tag,
+                name: process.env.RELEASE_NAME,
+                body,
+                draft: false,
+                prerelease: false,
+              });
+              core.info(`Published ${release.data.html_url}`);
+            }

--- a/.github/workflows/publish-v0.1.11.yml
+++ b/.github/workflows/publish-v0.1.11.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   publish:
@@ -37,7 +38,7 @@ jobs:
           git show "${TARGET_SHA}:docs/release-notes/v0.1.11.md" \
             > "${RELEASE_NOTES_PATH}"
 
-      - name: Create annotated tag and GitHub Release
+      - name: Create tag, publish Release, and start signed build
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -119,3 +120,15 @@ jobs:
               });
               core.info(`Published ${release.data.html_url}`);
             }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'android-release-build.yml',
+              ref: 'main',
+              inputs: {
+                signed: 'true',
+                release_tag: tag,
+              },
+            });
+            core.info(`Started the signed Android release build for ${tag}.`);


### PR DESCRIPTION
## Summary

Adds a one-time publisher for the already-reviewed and merged **Linthra v0.1.11** release.

## Immutable release target

- Commit: `379bcd2841b36d0ea78b12cc64435f619e6e5ccd`
- Version: `0.1.11+111999`
- Tag: `v0.1.11`
- Release notes: `docs/release-notes/v0.1.11.md` from that exact commit

## What the workflow does

1. Verifies the target commit exists and contains the exact expected version in both `pubspec.yaml` and `AppInfo`.
2. Creates an annotated `v0.1.11` tag pointing to that immutable release commit.
3. Publishes the stable GitHub Release using the reviewed release notes.
4. Explicitly dispatches `android-release-build.yml` with `signed: true` and `release_tag: v0.1.11`, so the signed universal APK, per-ABI APKs, and AAB are attached even though GitHub suppresses workflow chaining from `GITHUB_TOKEN` tag creation.
5. Refuses to move or replace an existing tag that points somewhere else.

## Cleanup

This workflow is intentionally temporary. Remove `.github/workflows/publish-v0.1.11.yml` after the tag, Release, and signed assets are verified.