### PR TITLE
fix(release): make v0.1.11 publisher runnable

### DIFF
--- a/.github/workflows/publish-v0.1.11.yml
+++ b/.github/workflows/publish-v0.1.11.yml
@@ -3,6 +3,7 @@ name: Publish Linthra v0.1.11
 # One-time publisher for the already-reviewed v0.1.11 release commit.
 # Remove this workflow after the tag, Release, and signed assets are verified.
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -20,7 +21,7 @@ jobs:
       RELEASE_TAG: v0.1.11
       RELEASE_NAME: Linthra v0.1.11
       TARGET_SHA: 379bcd2841b36d0ea78b12cc64435f619e6e5ccd
-      RELEASE_NOTES_PATH: ${{ runner.temp }}/linthra-v0.1.11-release-notes.md
+      RELEASE_NOTES_PATH: /tmp/linthra-v0.1.11-release-notes.md
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the one-time v0.1.11 publisher before it creates any tag or Release.

The initial workflow used `runner.temp` in job-level environment configuration, before a runner context was available, so GitHub did not start it. This change:

- uses a fixed `/tmp` release-notes path;
- adds `workflow_dispatch` as a manual fallback;
- keeps the immutable target commit, annotated-tag verification, stable Release creation, and explicit signed-build dispatch unchanged.

After this is green and merged, the push to `main` will run the corrected publisher.