### PR TITLE
fix(release): allow owner comment to trigger v0.1.11 build

### DIFF
--- a/.github/workflows/publish-v0.1.11.yml
+++ b/.github/workflows/publish-v0.1.11.yml
@@ -3,6 +3,8 @@ name: Publish Linthra v0.1.11 signed assets
 # Temporary one-time runner. Remove after the five v0.1.11 assets are verified.
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
   push:
     branches:
       - main
@@ -16,6 +18,11 @@ permissions:
 
 jobs:
   publish-assets:
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.number == 293 &&
+       github.event.comment.body == '/publish-v0.1.11' &&
+       github.event.comment.user.login == github.repository_owner)
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:


### PR DESCRIPTION
Adds an explicit owner-only command trigger to the temporary v0.1.11 publisher.

After this PR is merged, the workflow runs when the repository owner posts the exact comment `/publish-v0.1.11` on PR #293. All other comments, users, and issues are ignored.

The existing publication flow remains unchanged:

- launch the official `android-release-build.yml` with `signed=true` and `release_tag=v0.1.11`;
- capture and follow the exact run;
- attach the universal APK, three per-ABI APKs, and AAB to the existing stable Release;
- verify all five canonical public asset names;
- post either a final verification receipt or the failed log tail in PR #293.

This avoids relying on push-triggered workflow chaining from automated merges. The temporary workflow will be removed after the release assets are verified.