### PR TITLE
fix(android): prevent stale data restore after reinstall

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,11 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- Keep debug installs subject to the same no-restore policy as release.
+         Updating in place still preserves all app data. -->
+    <application
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules" />
 </manifest>

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android 11 and lower. Linthra can rebuild its catalog from the user's
+     selected sources, so restoring an old database or preferences after an
+     uninstall would create stale tracks, folder URIs, and account state. -->
+<full-backup-content>
+    <exclude domain="root" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
+    <exclude domain="device_root" path="." />
+    <exclude domain="device_file" path="." />
+    <exclude domain="device_database" path="." />
+    <exclude domain="device_sharedpref" path="." />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android 12 and higher. Exclude the same private state from both cloud
+     restore and device-to-device transfer. This does not affect in-place app
+     updates, which keep the existing application data directory. -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,11 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- Keep profile installs subject to the same no-restore policy as release.
+         Updating in place still preserves all app data. -->
+    <application
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules" />
 </manifest>

--- a/android/app/src/release/AndroidManifest.xml
+++ b/android/app/src/release/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--
+      A normal in-place app update keeps Linthra's private data. These settings
+      only stop Android Backup / device-transfer restore from resurrecting a
+      stale catalog, server configuration, or folder URI after uninstalling and
+      reinstalling the app.
+    -->
+    <application
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules" />
+</manifest>

--- a/test/app/android_backup_policy_test.dart
+++ b/test/app/android_backup_policy_test.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const List<String> _buildTypes = <String>[
+  'debug',
+  'profile',
+  'release',
+];
+
+const List<String> _backupDomains = <String>[
+  'root',
+  'file',
+  'database',
+  'sharedpref',
+  'external',
+  'device_root',
+  'device_file',
+  'device_database',
+  'device_sharedpref',
+];
+
+String _xmlSection(String xml, String tag) {
+  final int start = xml.indexOf('<$tag>');
+  final int end = xml.indexOf('</$tag>');
+  expect(start, greaterThanOrEqualTo(0), reason: 'Missing <$tag> section.');
+  expect(end, greaterThan(start), reason: 'Missing </$tag> section.');
+  return xml.substring(start, end);
+}
+
+void main() {
+  group('Android backup and restore policy', () {
+    test('every build type disables restore without affecting app updates', () {
+      for (final String buildType in _buildTypes) {
+        final String manifest = File(
+          'android/app/src/$buildType/AndroidManifest.xml',
+        ).readAsStringSync();
+
+        expect(
+          manifest,
+          contains('android:allowBackup="false"'),
+          reason: '$buildType must not restore stale app data after reinstall.',
+        );
+        expect(
+          manifest,
+          contains('android:fullBackupContent="@xml/backup_rules"'),
+          reason: '$buildType must bind the Android 11-and-lower rules.',
+        );
+        expect(
+          manifest,
+          contains(
+            'android:dataExtractionRules="@xml/data_extraction_rules"',
+          ),
+          reason: '$buildType must bind the Android 12+ rules.',
+        );
+      }
+    });
+
+    test('legacy backup excludes every private storage domain', () {
+      final String rules = File(
+        'android/app/src/main/res/xml/backup_rules.xml',
+      ).readAsStringSync();
+
+      for (final String domain in _backupDomains) {
+        expect(
+          rules,
+          contains('<exclude domain="$domain" path="." />'),
+          reason: 'Legacy backup must exclude the $domain domain.',
+        );
+      }
+    });
+
+    test('Android 12+ excludes all data from cloud and device transfer', () {
+      final String rules = File(
+        'android/app/src/main/res/xml/data_extraction_rules.xml',
+      ).readAsStringSync();
+      final String cloudBackup = _xmlSection(rules, 'cloud-backup');
+      final String deviceTransfer = _xmlSection(rules, 'device-transfer');
+
+      for (final String domain in _backupDomains) {
+        final String exclusion = '<exclude domain="$domain" path="." />';
+        expect(
+          cloudBackup,
+          contains(exclusion),
+          reason: 'Cloud backup must exclude the $domain domain.',
+        );
+        expect(
+          deviceTransfer,
+          contains(exclusion),
+          reason: 'Device transfer must exclude the $domain domain.',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
Prevents Android from restoring Linthra's old catalog and preferences after the app is uninstalled and reinstalled.

What changes:

- disables Android Backup for debug, profile, and release builds;
- adds Android 11-and-lower full-backup exclusions;
- adds Android 12+ cloud-backup and device-transfer exclusions;
- excludes databases, SharedPreferences, app files, external app files, and device-protected storage;
- adds regression tests that require every build type to keep this policy.

A normal in-place update is unaffected: Android keeps the existing Linthra data directory, accounts, settings, playlists, catalog, and cache. The policy only applies when Android would otherwise restore copied data after uninstall/reinstall or device migration.

This avoids ghost tracks and stale folder permissions when switching from a debug APK to a stable install after uninstalling.