### PR TITLE
chore(release): prepare v0.1.12

### DIFF
--- a/docs/release-notes/v0.1.12.md
+++ b/docs/release-notes/v0.1.12.md
@@ -1,0 +1,69 @@
+# Linthra v0.1.12 — release notes
+
+**Linthra is an Android music player for local files and self-hosted music
+servers.** v0.1.12 is a focused **clean-reinstall and Android data-safety
+release**. It prevents Android from restoring an obsolete Linthra catalog and
+settings after the app has been uninstalled, while leaving normal in-place
+updates completely unchanged.
+
+- **Version:** `0.1.12` (`versionName`), `versionCode` `112999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** MPL-2.0
+
+## What's new
+
+### Clean reinstalls
+
+- **No more restored ghost tracks.** After uninstalling and reinstalling Linthra,
+  Android no longer restores an old SQLite catalog containing songs that may no
+  longer be reachable.
+- **No stale folder references.** Removed local-folder URIs and expired Android
+  Storage Access Framework grants are not resurrected on a fresh installation.
+- **Clean debug-to-stable switching.** Uninstalling a debug APK and then
+  installing the stable build now starts with a clean Linthra library instead
+  of silently importing the previous test state.
+- **No stale server or preference state.** Linthra's private databases,
+  SharedPreferences, files, and device-protected storage are excluded from
+  Android backup restore.
+
+### Updates still preserve everything
+
+- **Normal app updates are unaffected.** Installing v0.1.12 over an existing
+  Linthra installation keeps accounts, settings, playlists, catalog, cache, and
+  other private app data.
+- **No database migration.** The existing Drift schema and stored catalog remain
+  unchanged during an update.
+- **No user action required.** Existing users can update normally from their
+  current installation source.
+
+## Technical summary
+
+- Android Backup is disabled explicitly for debug, profile, and release builds.
+- Android 11-and-lower full-backup rules exclude every private storage domain.
+- Android 12+ data-extraction rules exclude the same state from both cloud backup
+  and device-to-device transfer.
+- Regression tests require every Android build type to retain the no-restore
+  policy and verify all private storage domains remain excluded.
+- Implemented in PR #300.
+
+## Verification completed
+
+- Dart formatting passed.
+- Flutter analysis and the complete test suite passed.
+- Android debug APK compilation passed with the merged manifests and backup
+  rules.
+- The privacy scan and GitHub Sponsor simulation passed.
+
+## Upgrade and distribution notes
+
+- Updating in place preserves the current Linthra installation and its data.
+- Uninstalling the app still removes its private data as expected; a subsequent
+  installation now starts clean instead of receiving an Android-restored copy.
+- Do not mix GitHub and F-Droid install sources because their APKs use different
+  signing keys and cannot update one another.
+- F-Droid will detect the stable `v0.1.12` tag and build from source using its own
+  signing key.
+
+No ads, no tracking, no analytics, no telemetry. Linthra plays music you already
+own or that your own server provides.

--- a/fastlane/metadata/android/en-US/changelogs/112999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/112999.txt
@@ -1,0 +1,7 @@
+Linthra 0.1.12 — clean reinstalls and safer Android data handling.
+
+- Reinstalling Linthra no longer restores stale songs, settings, server state, or inaccessible folder references.
+- Switching from a debug APK to stable now starts with a clean library after uninstall.
+- Normal in-place updates still keep accounts, playlists, settings, catalog, and cache.
+- Android cloud backup and device transfer now exclude Linthra's rebuildable private state.
+- No ads, tracking, analytics, or telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.11';
+  static const String _devVersionName = '0.1.12';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.11+111999
+version: 0.1.12+112999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
Prepares Linthra v0.1.12 as a focused clean-reinstall and Android data-safety release.

Release contents:

- bump `pubspec.yaml` to `0.1.12+112999`;
- keep `AppInfo` in lockstep at `0.1.12`;
- add the F-Droid changelog `112999.txt`;
- add the official v0.1.12 release notes.

The underlying fix is PR #300: Android no longer restores stale songs, preferences, server state, or inaccessible local-folder references after uninstall/reinstall or device migration. Normal in-place updates keep existing accounts, settings, playlists, catalog, and cache unchanged.

No dependency, database-schema, or functional code change is included in this release bump PR.