### PR TITLE
fix(android): unblock release builds with valid backup rules

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -1,8 +1,7 @@
 name: Android Debug APK
 
-# Builds an unsigned debug APK for manual on-device testing.
-# This is for testing only: it does not sign release builds, create
-# GitHub releases, or publish anything.
+# Builds an unsigned debug APK for manual on-device testing and validates the
+# Android release lint path used by stable APK/AAB builds.
 on:
   workflow_dispatch:
   pull_request:
@@ -47,6 +46,13 @@ jobs:
 
       - name: Build debug APK
         run: flutter build apk --debug
+
+      # A debug APK does not execute lintVitalRelease. Run that task explicitly
+      # so invalid release-only Android resources fail on the PR instead of
+      # breaking a stable tag after it has already been created.
+      - name: Validate release Android lint
+        working-directory: android
+        run: ./gradlew lintVitalRelease
 
       # Fail fast if the build produced no usable artifact. The upload step
       # below also guards with if-no-files-found: error, but checking here gives

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Android 11 and lower. Linthra can rebuild its catalog from the user's
      selected sources, so restoring an old database or preferences after an
-     uninstall would create stale tracks, folder URIs, and account state. -->
+     uninstall would create stale tracks, folder URIs, and account state.
+
+     Keep this file to the five storage domains accepted by the Android lint
+     schema used by Linthra's release toolchain. android:allowBackup="false"
+     remains the primary no-restore guard for every build type. -->
 <full-backup-content>
     <exclude domain="root" path="." />
     <exclude domain="file" path="." />
     <exclude domain="database" path="." />
     <exclude domain="sharedpref" path="." />
     <exclude domain="external" path="." />
-    <exclude domain="device_root" path="." />
-    <exclude domain="device_file" path="." />
-    <exclude domain="device_database" path="." />
-    <exclude domain="device_sharedpref" path="." />
 </full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Android 12 and higher. Exclude the same private state from both cloud
      restore and device-to-device transfer. This does not affect in-place app
-     updates, which keep the existing application data directory. -->
+     updates, which keep the existing application data directory.
+
+     Keep this file to the five storage domains accepted by the Android lint
+     schema used by Linthra's release toolchain. android:allowBackup="false"
+     remains the primary no-restore guard for every build type. -->
 <data-extraction-rules>
     <cloud-backup>
         <exclude domain="root" path="." />
@@ -9,10 +13,6 @@
         <exclude domain="database" path="." />
         <exclude domain="sharedpref" path="." />
         <exclude domain="external" path="." />
-        <exclude domain="device_root" path="." />
-        <exclude domain="device_file" path="." />
-        <exclude domain="device_database" path="." />
-        <exclude domain="device_sharedpref" path="." />
     </cloud-backup>
     <device-transfer>
         <exclude domain="root" path="." />
@@ -20,9 +20,5 @@
         <exclude domain="database" path="." />
         <exclude domain="sharedpref" path="." />
         <exclude domain="external" path="." />
-        <exclude domain="device_root" path="." />
-        <exclude domain="device_file" path="." />
-        <exclude domain="device_database" path="." />
-        <exclude domain="device_sharedpref" path="." />
     </device-transfer>
 </data-extraction-rules>

--- a/test/app/android_backup_policy_test.dart
+++ b/test/app/android_backup_policy_test.dart
@@ -70,7 +70,8 @@ void main() {
       expect(
         rules,
         isNot(contains('domain="device_')),
-        reason: 'Device-protected domains break lintVitalRelease in the pinned toolchain.',
+        reason:
+            'Device-protected domains break lintVitalRelease in the pinned toolchain.',
       );
     });
 
@@ -97,7 +98,8 @@ void main() {
       expect(
         rules,
         isNot(contains('domain="device_')),
-        reason: 'Device-protected domains break lintVitalRelease in the pinned toolchain.',
+        reason:
+            'Device-protected domains break lintVitalRelease in the pinned toolchain.',
       );
     });
   });

--- a/test/app/android_backup_policy_test.dart
+++ b/test/app/android_backup_policy_test.dart
@@ -8,16 +8,15 @@ const List<String> _buildTypes = <String>[
   'release',
 ];
 
-const List<String> _backupDomains = <String>[
+// These are the storage domains accepted by the Android lint schema used by
+// Linthra's pinned release toolchain. Device-protected storage domains are not
+// used by Linthra and previously caused lintVitalRelease to reject the build.
+const List<String> _supportedBackupDomains = <String>[
   'root',
   'file',
   'database',
   'sharedpref',
   'external',
-  'device_root',
-  'device_file',
-  'device_database',
-  'device_sharedpref',
 ];
 
 String _xmlSection(String xml, String tag) {
@@ -56,28 +55,33 @@ void main() {
       }
     });
 
-    test('legacy backup excludes every private storage domain', () {
+    test('legacy backup excludes every supported private storage domain', () {
       final String rules = File(
         'android/app/src/main/res/xml/backup_rules.xml',
       ).readAsStringSync();
 
-      for (final String domain in _backupDomains) {
+      for (final String domain in _supportedBackupDomains) {
         expect(
           rules,
           contains('<exclude domain="$domain" path="." />'),
           reason: 'Legacy backup must exclude the $domain domain.',
         );
       }
+      expect(
+        rules,
+        isNot(contains('domain="device_')),
+        reason: 'Device-protected domains break lintVitalRelease in the pinned toolchain.',
+      );
     });
 
-    test('Android 12+ excludes all data from cloud and device transfer', () {
+    test('Android 12+ excludes all supported data from cloud and transfer', () {
       final String rules = File(
         'android/app/src/main/res/xml/data_extraction_rules.xml',
       ).readAsStringSync();
       final String cloudBackup = _xmlSection(rules, 'cloud-backup');
       final String deviceTransfer = _xmlSection(rules, 'device-transfer');
 
-      for (final String domain in _backupDomains) {
+      for (final String domain in _supportedBackupDomains) {
         final String exclusion = '<exclude domain="$domain" path="." />';
         expect(
           cloudBackup,
@@ -90,6 +94,11 @@ void main() {
           reason: 'Device transfer must exclude the $domain domain.',
         );
       }
+      expect(
+        rules,
+        isNot(contains('domain="device_')),
+        reason: 'Device-protected domains break lintVitalRelease in the pinned toolchain.',
+      );
     });
   });
 }


### PR DESCRIPTION
Fixes the v0.1.12 release-build failure reported by `lintVitalRelease`.

Cause:

- the backup rule files included `device_root`, `device_file`, `device_database`, and `device_sharedpref` domains;
- Linthra's pinned Android lint schema rejects those domains during release builds, even though debug APK builds do not execute the same check;
- `assembleRelease` therefore stopped before producing any APK or AAB.

Changes:

- keep both backup XML files to the five domains accepted by the pinned release toolchain: `root`, `file`, `database`, `sharedpref`, and `external`;
- retain `android:allowBackup="false"` as the primary no-restore guard for debug, profile, and release builds;
- update the regression test and explicitly forbid reintroducing `device_*` domains;
- run `./gradlew lintVitalRelease` in the Android PR workflow so release-only Android resource errors are caught before a stable tag is created.

Normal in-place updates remain unaffected and keep all Linthra data. Uninstall/reinstall still starts clean.

Because `v0.1.12` is already an immutable tag on the failed source commit, this fix should ship as v0.1.13. The planned two-column album grid can follow in v0.1.14.