### PR TITLE
chore(release): prepare v0.1.13 with F-Droid build fix

### DIFF
--- a/docs/release-notes/v0.1.13.md
+++ b/docs/release-notes/v0.1.13.md
@@ -1,0 +1,40 @@
+# Linthra v0.1.13 — release notes
+
+**Linthra is an Android music player for local files and self-hosted music servers.** v0.1.13 is a focused **F-Droid release reliability fix**. It carries forward the clean-reinstall protection intended for v0.1.12 while correcting the Android release-only lint failure that prevented that version from producing release artifacts.
+
+- **Version:** `0.1.13` (`versionName`), `versionCode` `113999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** MPL-2.0
+
+## What's new
+
+### F-Droid release build fixed
+
+- **Release builds work again.** Linthra's Android backup-rule XML now uses only the storage domains accepted by the pinned Android lint schema.
+- **v0.1.12 failure addressed.** The previous tag failed during `lintVitalRelease` before an APK or AAB could be produced; v0.1.13 includes the corrected rules from PR #304.
+- **Earlier detection in CI.** Pull requests now run `./gradlew lintVitalRelease`, catching release-only Android resource failures before a stable tag is created.
+
+### Clean reinstall behavior preserved
+
+- **Uninstall and reinstall starts clean.** Android backup and device transfer remain blocked from restoring obsolete Linthra databases, settings, server state, and inaccessible folder references.
+- **Normal updates preserve data.** Installing v0.1.13 over an existing installation keeps accounts, playlists, settings, catalog, and cache.
+- **No database migration or feature change.** This release is intentionally limited to release reliability and the already-planned clean-reinstall protection.
+
+## Technical summary
+
+- Removed unsupported `device_root`, `device_file`, `device_database`, and `device_sharedpref` domains from Android backup-rule resources.
+- Retained the supported `root`, `file`, `database`, `sharedpref`, and `external` exclusions.
+- Retained `android:allowBackup="false"` as the primary no-restore guard for debug, profile, and release builds.
+- Strengthened regression coverage so unsupported `device_*` domains cannot be reintroduced silently.
+- Added `lintVitalRelease` to the Android pull-request workflow.
+- Implemented in PR #304.
+
+## Upgrade and distribution notes
+
+- Existing users should update normally; app data is preserved during an in-place update.
+- Users who uninstall Linthra before reinstalling receive a clean library rather than Android-restored stale state.
+- Do not mix GitHub and F-Droid install sources because their APKs use different signing keys and cannot update one another.
+- F-Droid can detect the stable `v0.1.13` tag and build it from source using its own signing key.
+
+No ads, no tracking, no analytics, no telemetry. Linthra plays music you already own or that your own server provides.

--- a/fastlane/metadata/android/en-US/changelogs/113999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/113999.txt
@@ -1,0 +1,7 @@
+Linthra 0.1.13 — F-Droid release build reliability fix.
+
+- Fixed the Android release-only lint failure that prevented v0.1.12 from building on F-Droid.
+- Backup rules now use only storage domains accepted by Linthra's pinned Android toolchain.
+- Release CI now runs lintVitalRelease so similar F-Droid-breaking resource errors are caught before tagging.
+- Clean reinstall protection remains enabled, while normal in-place updates continue to preserve app data.
+- No ads, tracking, analytics, or telemetry.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.12';
+  static const String _devVersionName = '0.1.13';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.12+112999
+version: 0.1.13+113999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Linthra v0.1.13

Prepares **only v0.1.13** as a focused recovery release for the failed v0.1.12 build.

### Included

- Bumps `pubspec.yaml` to `0.1.13+113999`.
- Bumps the in-app version to `0.1.13`.
- Includes the Android/F-Droid release-build fix already merged in PR #304.
- Adds the F-Droid/fastlane “What’s New” entry at `113999.txt`.
- Adds complete GitHub release notes for v0.1.13.
- Explicitly documents that normal in-place updates preserve user data.
- Explicitly documents the new `lintVitalRelease` CI protection.

### Intentionally excluded

- No two-column album grid.
- No new UI or playback feature.
- No unrelated dependency or behavior change.

The album-grid work remains planned for v0.1.14.

### Required checks before tagging

- Flutter analysis and tests.
- Version consistency tests.
- Android debug compilation.
- `./gradlew lintVitalRelease`.
- Android release build artifacts.

After CI is green and this PR is merged, create the immutable tag `v0.1.13` from `main`.