### PR TITLE
feat(library): show albums in a responsive grid

### DIFF
--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -22,7 +22,7 @@ import 'library_state.dart';
 import 'selected_folder_controller.dart';
 import 'song_actions.dart';
 import 'unified_library_providers.dart';
-import 'widgets/album_tile.dart';
+import 'widgets/album_grid.dart';
 import 'widgets/alphabet_track_list.dart';
 import 'widgets/artist_tile.dart';
 import 'widgets/folder_browser_tab.dart';
@@ -256,16 +256,10 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         message: 'You can still browse the connected server from Folders.',
       );
     }
-    return ListView.builder(
-      key: const Key('library_album_list'),
-      itemCount: filtered.length,
-      itemBuilder: (context, index) {
-        final Album album = filtered[index];
-        return AlbumTile(
-          album: album,
-          onTap: () => context.push(AppRoutes.albumDetailPath(album.id)),
-        );
-      },
+    return AlbumGrid(
+      albums: filtered,
+      onOpen: (Album album) =>
+          context.push(AppRoutes.albumDetailPath(album.id)),
     );
   }
 

--- a/lib/features/library/widgets/album_grid.dart
+++ b/lib/features/library/widgets/album_grid.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/models/album.dart';
+import 'album_grid_card.dart';
+
+/// Narrowest a card may get before the grid drops a column. Two cards plus the
+/// gutters still fit comfortably on the narrowest phones we support, which is
+/// why [albumGridColumnCount] never returns fewer than [_minColumns].
+const double _minCardWidth = 200;
+
+/// Phones (and anything narrower than two comfortable cards) get exactly two
+/// columns; the cap keeps covers from turning into thumbnails on a desktop
+/// window that is very wide.
+const int _minColumns = 2;
+const int _maxColumns = 6;
+
+/// Columns for [width] logical pixels of *content* width — the space left for
+/// the cards themselves, gutters included, after the grid's own padding.
+///
+/// Two on a phone, and an extra column only once there is genuinely room for
+/// another card at [_minCardWidth]. Pure so the breakpoints can be tested
+/// without pumping a widget.
+int albumGridColumnCount(double width) {
+  if (!width.isFinite || width <= 0) return _minColumns;
+  final int fits = (width / _minCardWidth).floor();
+  return fits.clamp(_minColumns, _maxColumns);
+}
+
+/// The Albums tab body: a responsive grid of [AlbumGridCard]s.
+///
+/// Every cell is sized as a square cover plus the room its two labels need at
+/// the current text scale ([AlbumGridCard.labelExtent]), so cards stay aligned
+/// and the artwork stays square whatever the column count.
+class AlbumGrid extends StatelessWidget {
+  const AlbumGrid({required this.albums, required this.onOpen, super.key});
+
+  final List<Album> albums;
+  final void Function(Album album) onOpen;
+
+  static const double _gutter = AppSpacing.md;
+
+  @override
+  Widget build(BuildContext context) {
+    final double labelExtent = AlbumGridCard.labelExtent(context);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double content = constraints.maxWidth - _gutter * 2;
+        final int columns = albumGridColumnCount(content);
+        final double cardWidth = (content - _gutter * (columns - 1)) / columns;
+        return GridView.builder(
+          key: const Key('library_album_grid'),
+          padding: const EdgeInsets.all(_gutter),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: columns,
+            crossAxisSpacing: _gutter,
+            mainAxisSpacing: AppSpacing.lg,
+            mainAxisExtent: cardWidth + labelExtent,
+          ),
+          itemCount: albums.length,
+          itemBuilder: (BuildContext context, int index) {
+            final Album album = albums[index];
+            return AlbumGridCard(
+              album: album,
+              onTap: () => onOpen(album),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/features/library/widgets/album_grid_card.dart
+++ b/lib/features/library/widgets/album_grid_card.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../app/dimens.dart';
+import '../../../core/catalog/library_grouping.dart';
+import '../../../core/models/album.dart';
+import '../../../core/models/track.dart';
+import '../../player/widgets/album_artwork.dart';
+import '../../playlists/widgets/add_to_playlist_sheet.dart';
+import '../unified_library_providers.dart';
+
+/// One card in the Albums grid: square cover, title, artist.
+///
+/// Same gestures as the list row it replaces — a tap opens the album, a
+/// long-press sends every album track through the shared bulk playlist flow —
+/// so muscle memory and the existing safeguards both carry over.
+///
+/// The card expects a bounded height (the grid gives every cell a fixed
+/// [AlbumGridCard.labelExtent] above the square artwork). The artwork is
+/// [Flexible], so it shrinks rather than overflowing if a cell ever ends up
+/// shorter than the text needs.
+class AlbumGridCard extends ConsumerWidget {
+  const AlbumGridCard({required this.album, this.onTap, super.key});
+
+  final Album album;
+  final VoidCallback? onTap;
+
+  /// Line-height multiplier applied to both labels. Pinned here (rather than
+  /// left to the theme's per-style default) so [labelExtent] can reserve the
+  /// exact space the text will occupy at any text scale.
+  static const double _lineHeight = 1.3;
+  static const double _titleFallbackSize = 14;
+  static const double _artistFallbackSize = 12;
+
+  /// Height the two text lines need below the artwork: title (up to two lines)
+  /// plus artist (one line), including the gaps around them.
+  ///
+  /// The grid adds this to the square artwork's side to size each cell, so the
+  /// labels keep their room when the user scales text up.
+  static double labelExtent(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final TextScaler scaler = MediaQuery.textScalerOf(context);
+    final double title = _scaledLine(
+      scaler,
+      theme.textTheme.titleSmall?.fontSize ?? _titleFallbackSize,
+    );
+    final double artist = _scaledLine(
+      scaler,
+      theme.textTheme.bodySmall?.fontSize ?? _artistFallbackSize,
+    );
+    return AppSpacing.sm + title * 2 + AppSpacing.xs + artist;
+  }
+
+  static double _scaledLine(TextScaler scaler, double fontSize) =>
+      scaler.scale(fontSize) * _lineHeight;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    // One semantics node per card, so a screen reader announces
+    // "<title>, <artist>" as a single tappable target instead of two labels.
+    return MergeSemantics(
+      child: InkWell(
+        borderRadius: const BorderRadius.all(Radius.circular(AppRadii.md)),
+        onTap: onTap,
+        onLongPress: () => _addAllToPlaylist(context, ref),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Flexible(
+              child: AspectRatio(
+                aspectRatio: 1,
+                child: AlbumArtwork(artworkUri: album.artworkUri),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              album.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                height: _lineHeight,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              album.artistName?.isNotEmpty == true
+                  ? album.artistName!
+                  : kUnknownArtist,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                height: _lineHeight,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _addAllToPlaylist(BuildContext context, WidgetRef ref) {
+    final List<Track> tracks = tracksForAlbum(
+      ref.read(libraryUnifiedTracksProvider),
+      album.id,
+    );
+    if (tracks.isNotEmpty) {
+      showAddToPlaylistSheet(context, tracks);
+    }
+  }
+}

--- a/test/features/library/album_grid_test.dart
+++ b/test/features/library/album_grid_test.dart
@@ -1,0 +1,352 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:linthra/app/routes.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/features/library/album_detail_screen.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/library/widgets/album_grid.dart';
+import 'package:linthra/features/library/widgets/album_grid_card.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/widgets/album_artwork.dart';
+
+import '../player/fake_playback_controller.dart';
+import 'fake_music_library_repository.dart';
+
+// No artworkUri anywhere, so these widget tests never reach for the network:
+// every cover falls back to the placeholder, which is also the "album without
+// artwork" case exercised below.
+const List<Track> _tracks = <Track>[
+  Track(
+    id: '1',
+    title: 'Alpha',
+    uri: 'jellyfin:1',
+    artistName: 'Daft Punk',
+    albumName: 'Discovery',
+  ),
+  Track(
+    id: '2',
+    title: 'Beta',
+    uri: 'jellyfin:2',
+    artistName: 'Daft Punk',
+    albumName: 'Discovery',
+  ),
+  Track(
+    id: '3',
+    title: 'Gamma',
+    uri: 'jellyfin:3',
+    artistName: 'Adele',
+    albumName: '25',
+  ),
+];
+
+/// Six albums, enough rows to tell two columns from three or four.
+List<Track> _manyAlbums() => <Track>[
+      for (int i = 0; i < 6; i++)
+        Track(
+          id: 'many-$i',
+          title: 'Song $i',
+          uri: 'jellyfin:many-$i',
+          artistName: 'Artist $i',
+          albumName: 'Album $i',
+        ),
+    ];
+
+GoRouter _router() {
+  return GoRouter(
+    initialLocation: AppRoutes.library,
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.library,
+        builder: (_, __) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/library/album/:id',
+        builder: (_, GoRouterState s) =>
+            AlbumDetailScreen(albumId: s.pathParameters['id']!),
+      ),
+    ],
+  );
+}
+
+/// Pumps the Library at a given logical screen size and lands on Albums.
+Future<void> _pumpAlbums(
+  WidgetTester tester, {
+  List<Track>? tracks,
+  Size size = const Size(390, 844), // a typical phone
+}) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = size;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        musicLibraryRepositoryProvider.overrideWithValue(
+          FakeMusicLibraryRepository(tracks: tracks ?? _tracks),
+        ),
+        playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+      ],
+      child: MaterialApp.router(routerConfig: _router()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Albums'));
+  await tester.pumpAndSettle();
+}
+
+/// On-screen rectangles of every laid-out album card.
+List<Rect> _cardRects(WidgetTester tester) {
+  return tester.elementList(find.byType(AlbumGridCard)).map((Element e) {
+    final RenderBox box = e.renderObject! as RenderBox;
+    return box.localToGlobal(Offset.zero) & box.size;
+  }).toList();
+}
+
+/// The cards sharing the topmost row, left to right.
+List<Rect> _firstRow(WidgetTester tester) {
+  final List<Rect> rects = _cardRects(tester);
+  final double top = rects
+      .map((Rect r) => r.top)
+      .reduce((double a, double b) => a < b ? a : b);
+  return <Rect>[
+    for (final Rect r in rects)
+      if (r.top == top) r,
+  ]..sort((Rect a, Rect b) => a.left.compareTo(b.left));
+}
+
+void main() {
+  group('albumGridColumnCount', () {
+    test('a phone-width content box gets exactly two columns', () {
+      expect(albumGridColumnCount(328), 2); // 360dp phone, minus padding
+      expect(albumGridColumnCount(358), 2); // 390dp phone, minus padding
+      expect(albumGridColumnCount(398), 2); // 430dp phone, minus padding
+    });
+
+    test('a third column only lands once there is room for one', () {
+      expect(albumGridColumnCount(560), 2);
+      expect(albumGridColumnCount(600), 3);
+      expect(albumGridColumnCount(800), 4);
+    });
+
+    test('columns are capped so covers never shrink to thumbnails', () {
+      expect(albumGridColumnCount(4000), 6);
+    });
+
+    test('a degenerate width still renders two columns', () {
+      expect(albumGridColumnCount(0), 2);
+      expect(albumGridColumnCount(-10), 2);
+      expect(albumGridColumnCount(double.infinity), 2);
+    });
+  });
+
+  group('Albums grid', () {
+    testWidgets('albums render as grid cards, not list rows', (tester) async {
+      await _pumpAlbums(tester);
+
+      expect(find.byKey(const Key('library_album_grid')), findsOneWidget);
+      expect(find.byType(GridView), findsOneWidget);
+      expect(find.byType(AlbumGridCard), findsNWidgets(2));
+      expect(find.text('Discovery'), findsOneWidget);
+      expect(find.text('25'), findsOneWidget);
+      expect(find.text('Daft Punk'), findsOneWidget);
+      expect(find.text('Adele'), findsOneWidget);
+    });
+
+    testWidgets('two cards fit side by side on a typical phone width',
+        (tester) async {
+      await _pumpAlbums(tester, tracks: _manyAlbums());
+
+      final List<Rect> row = _firstRow(tester);
+      expect(row.length, 2);
+
+      // Both cards are on screen, side by side, and each is wide enough to read.
+      expect(row.first.left, lessThan(row.last.left));
+      expect(row.last.right, lessThanOrEqualTo(390));
+      expect(row.first.width, greaterThan(120));
+    });
+
+    testWidgets('artwork stays square', (tester) async {
+      await _pumpAlbums(tester);
+
+      final Rect art = tester.getRect(
+        find
+            .descendant(
+              of: find.byType(AlbumGridCard),
+              matching: find.byType(AlbumArtwork),
+            )
+            .first,
+      );
+      expect(art.width, closeTo(art.height, 0.5));
+    });
+
+    testWidgets('a wide window gets more columns than a phone', (tester) async {
+      await _pumpAlbums(
+        tester,
+        tracks: _manyAlbums(),
+        size: const Size(1280, 900),
+      );
+
+      expect(_firstRow(tester).length, greaterThan(2));
+    });
+
+    testWidgets('tapping a card opens that album', (tester) async {
+      await _pumpAlbums(tester);
+
+      await tester.tap(find.text('Discovery'));
+      await tester.pumpAndSettle();
+
+      // On the album detail screen, showing only Discovery's tracks.
+      expect(find.text('Play'), findsOneWidget);
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+      expect(find.text('Gamma'), findsNothing);
+    });
+
+    testWidgets('tapping the other card opens the other album', (tester) async {
+      await _pumpAlbums(tester);
+
+      await tester.tap(find.text('25'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Gamma'), findsOneWidget);
+      expect(find.text('Alpha'), findsNothing);
+    });
+
+    testWidgets(
+        'long-pressing a card still offers the whole album to a '
+        'playlist', (tester) async {
+      await _pumpAlbums(tester);
+
+      await tester.longPress(find.text('Discovery'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add 2 songs to playlist'), findsOneWidget);
+      expect(find.text('New playlist'), findsOneWidget);
+    });
+
+    testWidgets('search still filters the grid', (tester) async {
+      await _pumpAlbums(tester);
+
+      await tester.enterText(
+        find.byKey(const Key('library_search_field')),
+        'adele',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlbumGridCard), findsOneWidget);
+      expect(find.text('25'), findsOneWidget);
+      expect(find.text('Discovery'), findsNothing);
+    });
+
+    testWidgets('a query with no matches still shows the empty state',
+        (tester) async {
+      await _pumpAlbums(tester);
+
+      await tester.enterText(
+        find.byKey(const Key('library_search_field')),
+        'zzzzz',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('No results found.'), findsOneWidget);
+      expect(find.byType(AlbumGridCard), findsNothing);
+    });
+
+    testWidgets('a long title and artist are clipped, never overflowing',
+        (tester) async {
+      await _pumpAlbums(
+        tester,
+        tracks: const <Track>[
+          Track(
+            id: 'long',
+            title: 'Song',
+            uri: 'jellyfin:long',
+            artistName: 'An Extremely Long Recording Artist Name That Will Not '
+                'Fit On One Line Of A Grid Card',
+            albumName: 'An Extraordinarily Long Album Title That Runs Well '
+                'Past Two Lines Of Any Reasonable Grid Card',
+          ),
+        ],
+      );
+
+      // A RenderFlex/paragraph overflow surfaces as a pumped exception.
+      expect(tester.takeException(), isNull);
+
+      final Finder card = find.byType(AlbumGridCard);
+      final Text title = tester.widget<Text>(
+        find.descendant(of: card, matching: find.textContaining('Album Title')),
+      );
+      expect(title.maxLines, 2);
+      expect(title.overflow, TextOverflow.ellipsis);
+
+      final Text artist = tester.widget<Text>(
+        find.descendant(of: card, matching: find.textContaining('Artist Name')),
+      );
+      expect(artist.maxLines, 1);
+      expect(artist.overflow, TextOverflow.ellipsis);
+
+      // The card still sits inside the viewport, text and all.
+      expect(tester.getRect(card).bottom, lessThanOrEqualTo(844));
+    });
+
+    testWidgets('scaled-up text does not overflow a card', (tester) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(390, 844);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            musicLibraryRepositoryProvider.overrideWithValue(
+              FakeMusicLibraryRepository(tracks: _tracks),
+            ),
+            playlistStoreProvider.overrideWithValue(InMemoryPlaylistStore()),
+            playbackControllerProvider
+                .overrideWithValue(FakePlaybackController()),
+          ],
+          child: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+            child: MaterialApp.router(routerConfig: _router()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Albums'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(AlbumGridCard), findsNWidgets(2));
+    });
+
+    testWidgets('albums without artwork render the placeholder safely',
+        (tester) async {
+      await _pumpAlbums(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.descendant(
+          of: find.byType(AlbumGridCard),
+          matching: find.byIcon(Icons.music_note),
+        ),
+        findsNWidgets(2),
+      );
+    });
+
+    testWidgets('a card reads as one item to a screen reader', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpAlbums(tester);
+
+      expect(
+        find.bySemanticsLabel(RegExp(r'Discovery\s*\n?\s*Daft Punk')),
+        findsOneWidget,
+      );
+      handle.dispose();
+    });
+  });
+}

--- a/test/features/library/library_browse_test.dart
+++ b/test/features/library/library_browse_test.dart
@@ -7,7 +7,7 @@ import 'package:linthra/data/repositories/in_memory_playlist_store.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
 import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/features/library/library_screen.dart';
-import 'package:linthra/features/library/widgets/album_tile.dart';
+import 'package:linthra/features/library/widgets/album_grid_card.dart';
 import 'package:linthra/features/library/widgets/artist_tile.dart';
 import 'package:linthra/features/player/player_providers.dart';
 
@@ -164,16 +164,17 @@ void main() {
       expect(find.text('Gamma'), findsOneWidget);
     });
 
-    testWidgets('the Albums tab renders grouped albums with title/artist/count',
+    testWidgets('the Albums tab renders grouped albums with title and artist',
         (tester) async {
       await _pump(tester);
       await tester.tap(find.text('Albums'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(AlbumTile), findsNWidgets(2));
+      expect(find.byType(AlbumGridCard), findsNWidgets(2));
       expect(find.text('Discovery'), findsOneWidget);
       expect(find.text('25'), findsOneWidget);
-      expect(find.text('Daft Punk • 2 songs'), findsOneWidget);
+      expect(find.text('Daft Punk'), findsOneWidget);
+      expect(find.text('Adele'), findsOneWidget);
     });
 
     testWidgets('long-pressing an album opens its bulk playlist sheet',


### PR DESCRIPTION
## What

The Albums tab listed one album per full-width row, with the cover reduced to a 48px thumbnail. Covers are how people recognise an album, so this replaces the `ListView` of `AlbumTile`s with a responsive grid of cover-first cards.

- **Two columns on a phone**, with an extra column only once there is genuinely room for another card at a readable width (large foldables, tablets, desktop windows), capped at six so covers never shrink to thumbnails.
- **Each card**: square artwork, title below it (max two lines, ellipsised), artist under that (max one line, ellipsised).
- **Gestures unchanged**: tap opens the album detail screen, long-press sends every album track through the existing bulk playlist flow.
- **Untouched**: search filtering, empty states (`No results found.` / no-albums), routing, and the Artists and Songs tabs. `AlbumTile` stays as-is — the artist detail screen still uses it, where a list row is the right shape.

## How

- `lib/features/library/widgets/album_grid_card.dart` — the card. Artwork goes through the existing `AlbumArtwork`, so a missing or unloadable cover degrades to the shared placeholder. Spacing, radii, colours, and text styles come from `AppSpacing` / `AppRadii` / the theme's `textTheme` and `colorScheme`. `MergeSemantics` makes each card one node, so a screen reader announces "&lt;title&gt;, &lt;artist&gt;" as a single target instead of two labels.
- `lib/features/library/widgets/album_grid.dart` — the grid. `albumGridColumnCount(width)` is a pure function (min 2, +1 per 200dp of card room, max 6) so the breakpoints are testable without pumping a widget.
- Each cell's `mainAxisExtent` is the square cover plus exactly the height the two labels need **at the current text scale** (`AlbumGridCard.labelExtent`), so cards stay aligned and nothing overflows when the user scales text up. The artwork is `Flexible`, so it shrinks rather than overflowing if a cell is ever shorter than the text needs.

## Tests

New `test/features/library/album_grid_test.dart` (17 tests) covers: albums render in a grid; two cards fit side by side at 390dp; artwork stays square; a wide window gets more than two columns; tapping each card opens the right album (through a real `GoRouter`); long-press still offers the whole album to a playlist; search filtering and the no-results state still work; long titles/artist names are clipped rather than overflowing; 2x text scale does not overflow; albums without artwork render the placeholder safely; a card reads as one semantics node. Plus unit tests for the column-count breakpoints.

`test/features/library/library_browse_test.dart` updated for the new Albums tab structure (cards, artist on its own line). Full suite green: 3018 tests, `flutter analyze` clean, `dart format` applied.

No version bump, no unrelated cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RuZ5BsqaRJPF4bN5Q5hX64)_