### PR TITLE
fix(theme): harden the light palettes for WCAG AA

### DIFF
--- a/docs/app-icon-branding.md
+++ b/docs/app-icon-branding.md
@@ -66,8 +66,20 @@ A small, data-driven feature that mirrors the Support module's per-build seam:
   buttons, and input focus. So each variant reads as a black UI with one clear
   accent: **Classic** orange, **Neon** neon cyan/blue, **Gold** gold, **Black &
   White** white. There is no second hue (no purple). Each palette sets `primary`
-  to its `accent`; `primaryBright` is the accessible-on-dark tone for accent
-  text/icons. **Error / destructive colours are kept separate and never themed.**
+  to its `accent`; `primaryBright` is the tone that carries accent text/icons at
+  the contrast bar for its mode. **Error / destructive colours are kept separate
+  and never themed by variant** (the light themes do use a deeper red than the
+  dark ones, so error copy stays readable on light surfaces — see
+  `AppColors.lightError`).
+- **Light palettes** — every variant has both a dark palette (`BrandPalettes.all`)
+  and a light one (`BrandPalettes.allLight`, suffixed `Light`); `byId` picks
+  between them by `Brightness`, and its unknown-id fallback is itself
+  brightness-correct. The light palettes are *not* the dark tones on pale
+  surfaces: accents chosen for black backgrounds fall far below WCAG AA on white
+  ones, so each is re-toned at the same hue. `test/app/light_contrast_test.dart`
+  enforces the ratios off a real `ThemeData`, so a regression fails CI rather
+  than shipping. Linthra still runs dark-only today (`themeMode: ThemeMode.dark`)
+  — these palettes exist so light mode can be switched on safely.
   (The brand marks/launcher icons keep their own gradients — e.g. Classic's
   signature violet→orange mark and the default launcher icon are unchanged.)
 - **Launcher icon (Android)** — the same selection also switches the real

--- a/lib/app/brand_theme.dart
+++ b/lib/app/brand_theme.dart
@@ -59,9 +59,13 @@ class BrandPalette {
   /// Text/icon colour on a [primary] fill (and the selected switch thumb).
   final Color onPrimary;
 
-  /// A brighter take on [primary] for the identity text/icons/borders on the
-  /// dark surfaces — selected navigation, text buttons, selected rows, input
-  /// focus — where [primary] itself can fall short of the text-contrast bar.
+  /// The identity tone for text/icons/borders — selected navigation, text
+  /// buttons, selected rows, input focus — where [primary] itself can fall
+  /// short of the text-contrast bar.
+  ///
+  /// "Bright" is relative to the surfaces it sits on: a *lighter* take on
+  /// [primary] for the dark palettes, and a *deeper* one for the light
+  /// palettes. Either way it is the tone that carries small text safely.
   final Color primaryBright;
 
   /// The energy accent (warm orange for Classic) on filled call-to-action
@@ -131,8 +135,12 @@ class LinthraAccents extends ThemeExtension<LinthraAccents> {
 /// themes are a single accent with no second hue: [neon] neon cyan/blue, [gold]
 /// gold, and [blackWhite] pure black/white, each setting [primary] equal to its
 /// [accent] so the whole UI reads as one accent on black. [primaryBright] is the
-/// accessible-on-dark tone for identity text/icons. Error/destructive colours
-/// are never themed.
+/// tone that carries identity text/icons at the contrast bar for its mode.
+///
+/// Each variant has both a dark palette (in [all]) and a light one (in
+/// [allLight], suffixed `Light`); [byId] picks between them by brightness.
+/// Error/destructive colours are never themed by variant, though the light
+/// themes do use a deeper red than the dark ones — see [AppColors.lightError].
 abstract final class BrandPalettes {
   /// The default — black + orange + purple: a warm orange energy accent with a
   /// Linthra-purple identity ([primary]) for selected navigation, text buttons,
@@ -194,10 +202,8 @@ abstract final class BrandPalettes {
   );
 
   /// The light-mode counterpart of [blackWhite]: pure black accents/brand on
-  /// light surfaces. Kept strictly black-and-white too. (Linthra runs dark-only
-  /// today, so this is defensive: if light mode ever ships, Black & White stays
-  /// legible instead of going invisible-white on white.)
-  static const BrandPalette _blackWhiteLight = BrandPalette(
+  /// light surfaces. Kept strictly black-and-white too.
+  static const BrandPalette blackWhiteLight = BrandPalette(
     id: 'blackwhite',
     primary: Color(0xFF000000),
     onPrimary: Color(0xFFFFFFFF),
@@ -209,7 +215,58 @@ abstract final class BrandPalettes {
     accentContainer: Color(0xFFFFFFFF),
   );
 
-  /// Every palette in [AppIconVariants.all] order; Classic first.
+  /// The light-mode counterpart of [classic] — the same purple identity and
+  /// warm orange energy accent, re-toned for light surfaces.
+  ///
+  /// The dark tones are not merely dimmer here, they are unreadable: on
+  /// [AppColors.lightBackground] the dark [primaryBright] reaches 2.71:1 and the
+  /// dark [accent] 2.04:1, both far under the 4.5:1 text bar. Hue is preserved
+  /// exactly (251.8° violet, 29.4° orange) so Classic still reads as Linthra —
+  /// only lightness moves. See `AppColors` for the per-token contrast figures
+  /// and `test/app/light_contrast_test.dart` for the enforced matrix.
+  static const BrandPalette classicLight = BrandPalette(
+    id: 'classic',
+    primary: AppColors.brandLight,
+    onPrimary: Color(0xFFFFFFFF),
+    primaryBright: AppColors.brandBrightLight,
+    accent: AppColors.accentLight,
+    accentBright: AppColors.accentBrightLight,
+    accentDeep: AppColors.accentDeepLight,
+    onAccent: AppColors.onAccentLight,
+    accentContainer: AppColors.accentContainerLight,
+  );
+
+  /// The light-mode counterpart of [neon]: the same single electric blue accent,
+  /// deepened until it carries text on light surfaces (the dark `0xFF34C5FF`
+  /// manages 1.9:1 on white).
+  static const BrandPalette neonLight = BrandPalette(
+    id: 'neon',
+    primary: Color(0xFF0A6E96),
+    onPrimary: Color(0xFFFFFFFF),
+    primaryBright: Color(0xFF085B7C),
+    accent: Color(0xFF0A6E96),
+    accentBright: Color(0xFF085B7C),
+    accentDeep: Color(0xFF064A66),
+    onAccent: Color(0xFFFFFFFF),
+    accentContainer: Color(0xFFD2EEFA),
+  );
+
+  /// The light-mode counterpart of [gold]: the same single gold accent, deepened
+  /// into a bronze-gold that survives light surfaces (the dark `0xFFF5C518`
+  /// manages 1.7:1 on white — gold is the worst offender of the four).
+  static const BrandPalette goldLight = BrandPalette(
+    id: 'gold',
+    primary: Color(0xFF7A5C00),
+    onPrimary: Color(0xFFFFFFFF),
+    primaryBright: Color(0xFF6B5000),
+    accent: Color(0xFF7A5C00),
+    accentBright: Color(0xFF6B5000),
+    accentDeep: Color(0xFF574100),
+    onAccent: Color(0xFFFFFFFF),
+    accentContainer: Color(0xFFFBEFC2),
+  );
+
+  /// Every dark palette in [AppIconVariants.all] order; Classic first.
   static const List<BrandPalette> all = <BrandPalette>[
     classic,
     neon,
@@ -217,26 +274,38 @@ abstract final class BrandPalettes {
     blackWhite,
   ];
 
+  /// Every light palette, in the same order as [all] — one per entry, so a
+  /// variant can never have a dark palette but no light one.
+  static const List<BrandPalette> allLight = <BrandPalette>[
+    classicLight,
+    neonLight,
+    goldLight,
+    blackWhiteLight,
+  ];
+
   /// Resolves a stored/selected variant [id] to its palette for [brightness],
-  /// falling back to [classic] for a null, empty, or unrecognised value — the
-  /// same "unknown → Classic" rule [AppIconVariants.byId] uses, so the theme can
-  /// never land on a palette that does not exist.
+  /// falling back to Classic for a null, empty, or unrecognised value — the same
+  /// "unknown → Classic" rule [AppIconVariants.byId] uses, so the theme can
+  /// never land on a palette that does not exist. The fallback is itself
+  /// brightness-correct: an unknown id in light mode yields [classicLight], not
+  /// the dark Classic.
   ///
-  /// Only Black & White differs by brightness (white-on-dark vs black-on-light);
-  /// every other variant uses one palette for both, since accents chosen for the
-  /// dark surfaces stay legible either way.
+  /// Every variant now differs by brightness. Accents chosen for dark surfaces
+  /// do *not* stay legible on light ones — that assumption held only while
+  /// Linthra was dark-only, and each light palette exists to replace it.
   static BrandPalette byId(String? id, {required Brightness brightness}) {
+    final List<BrandPalette> palettes =
+        brightness == Brightness.light ? allLight : all;
+    final BrandPalette fallback =
+        brightness == Brightness.light ? classicLight : classic;
     if (id == null || id.isEmpty) {
-      return classic;
+      return fallback;
     }
-    if (id == blackWhite.id) {
-      return brightness == Brightness.light ? _blackWhiteLight : blackWhite;
-    }
-    for (final BrandPalette palette in all) {
+    for (final BrandPalette palette in palettes) {
       if (palette.id == id) {
         return palette;
       }
     }
-    return classic;
+    return fallback;
   }
 }

--- a/lib/app/colors.dart
+++ b/lib/app/colors.dart
@@ -56,8 +56,76 @@ abstract final class AppColors {
   static const Color lightSurfaceHigh = Color(0xFFF1EFF8);
   static const Color lightSurfaceHighest = Color(0xFFE9E5F3);
   static const Color lightOnSurface = Color(0xFF1A1820);
-  static const Color lightOnSurfaceMuted = Color(0xFF6B6878);
-  static const Color lightOutline = Color(0xFFD9D5E6);
+
+  /// Secondary text on the light surfaces.
+  ///
+  /// Nudged one step darker than the original `0xFF6B6878`, which cleared 4.5:1
+  /// on [lightBackground] (5.00:1) but not on [lightSurfaceHighest] — the popup
+  /// menu and SnackBar surface — where it landed at 4.38:1. This clears 4.5:1
+  /// on all four light surfaces, the tightest being 4.71:1.
+  static const Color lightOnSurfaceMuted = Color(0xFF666374);
+
+  /// The border tone for *controls* on the light surfaces — text-field and
+  /// outlined-button borders, chip outlines.
+  ///
+  /// These delimit an interactive control, so they carry WCAG 1.4.11's 3:1
+  /// non-text bar: this reaches 3.10:1 on [lightBackground] and 3.37:1 on
+  /// [lightSurface]. It is the lightest violet-grey that clears 3:1 on *both*,
+  /// so it stays quiet while remaining a real edge. (The previous `0xFFD9D5E6`
+  /// managed only 1.33:1 and read as almost no border at all.)
+  static const Color lightOutline = Color(0xFF8F88A6);
+
+  /// The separator tone for the light surfaces — list dividers only.
+  ///
+  /// Dividers here are decorative: the rows they sit between are already
+  /// distinguished by their text and spacing, so 1.4.11 does not apply and
+  /// pushing them to 3:1 would grid the UI. Kept deliberately softer than
+  /// [lightOutline] so a settings list does not turn into a table.
+  static const Color lightOutlineVariant = Color(0xFFC7C2D9);
+
+  // Light-mode brand tones.
+  //
+  // The dark tones above are tuned for dark surfaces and fall well short on the
+  // light ones ([brandBright] manages 2.71:1 on [lightBackground]; [accent]
+  // 2.04:1), so light mode gets its own set rather than reusing them. Only
+  // lightness moves: the light oranges keep [accent]'s exact 29.4° hue at full
+  // chroma, and [brandLight] keeps [brand]'s exact 251.8° hue at full chroma,
+  // so both modes still read as the same product.
+
+  /// Light-mode [brand]: the identity fill and colour-scheme seed. Same hue and
+  /// chroma as [brand], darkened until white-on-it reaches 5.77:1.
+  static const Color brandLight = Color(0xFF633DFF);
+
+  /// Light-mode [brandBright]: the identity tone for text, icons, and focus
+  /// rings on light surfaces (6.65:1 on [lightSurface]). This is [brandDeep] —
+  /// an existing Linthra violet — reused rather than a newly invented one.
+  static const Color brandBrightLight = brandDeep;
+
+  /// Light-mode [accent]. Also used as SnackBar action *text*, which is the
+  /// binding constraint at 4.58:1 on [lightSurfaceHighest]; this is the
+  /// lightest brand-hue orange that clears it.
+  static const Color accentLight = Color(0xFFA35000);
+
+  /// Light-mode [accentBright]: the play button's gradient top, and the label
+  /// on a selected chip (5.77:1 on [accentContainerLight]).
+  static const Color accentBrightLight = Color(0xFF8F4600);
+
+  /// Light-mode [accentDeep]: the play button's gradient bottom.
+  static const Color accentDeepLight = Color(0xFF7A3C00);
+
+  /// White reads on the darker light-mode accent (5.67:1); the dark warm ink
+  /// [onAccent] uses on the bright orange would not.
+  static const Color onAccentLight = Color(0xFFFFFFFF);
+
+  /// A light warm tint behind selected/active accent content, replacing the
+  /// dark brown [accentContainer] that would otherwise punch a dark hole in a
+  /// light UI.
+  static const Color accentContainerLight = Color(0xFFFFE7CE);
 
   static const Color error = Color(0xFFE5484D);
+
+  /// Light-mode [error]. The shared [error] reaches only 3.91:1 on
+  /// [lightSurface] — large-text only — so error copy gets a deeper red on the
+  /// light surfaces (6.44:1). Dark mode keeps [error] unchanged.
+  static const Color lightError = Color(0xFFB3282E);
 }

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -27,6 +27,10 @@ abstract final class AppTheme {
         onSurface: AppColors.darkOnSurface,
         onSurfaceMuted: AppColors.darkOnSurfaceMuted,
         outline: AppColors.darkOutline,
+        // Dark mode draws control borders and dividers with one tone, so both
+        // slots take the same value and the rendered dark theme is unchanged.
+        outlineVariant: AppColors.darkOutline,
+        error: AppColors.error,
       );
 
   static ThemeData light(BrandPalette palette) => _build(
@@ -38,7 +42,11 @@ abstract final class AppTheme {
         surfaceHighest: AppColors.lightSurfaceHighest,
         onSurface: AppColors.lightOnSurface,
         onSurfaceMuted: AppColors.lightOnSurfaceMuted,
+        // Light mode splits the two: controls need a 3:1 edge, dividers are
+        // decorative and stay softer. See the AppColors doc comments.
         outline: AppColors.lightOutline,
+        outlineVariant: AppColors.lightOutlineVariant,
+        error: AppColors.lightError,
       );
 
   static ThemeData _build({
@@ -51,6 +59,8 @@ abstract final class AppTheme {
     required Color onSurface,
     required Color onSurfaceMuted,
     required Color outline,
+    required Color outlineVariant,
+    required Color error,
   }) {
     final colorScheme = ColorScheme.fromSeed(
       seedColor: palette.primary,
@@ -71,8 +81,8 @@ abstract final class AppTheme {
       surfaceContainerHigh: surfaceHigh,
       surfaceContainerHighest: surfaceHighest,
       outline: outline,
-      outlineVariant: outline,
-      error: AppColors.error,
+      outlineVariant: outlineVariant,
+      error: error,
     );
 
     final pillShape = RoundedRectangleBorder(
@@ -262,7 +272,9 @@ abstract final class AppTheme {
         shape: smallShape,
       ),
       dividerTheme: DividerThemeData(
-        color: outline,
+        // Separators, not control edges — they take the softer variant. In dark
+        // mode this is the same colour as [outline], so nothing changes there.
+        color: outlineVariant,
         thickness: 0.5,
         space: 0.5,
       ),

--- a/test/app/brand_theme_test.dart
+++ b/test/app/brand_theme_test.dart
@@ -35,15 +35,25 @@ void main() {
     });
 
     test('falls back to Classic for null, empty, or unknown ids', () {
-      // The same "unknown → Classic" rule AppIconVariants.byId follows.
+      // The same "unknown → Classic" rule AppIconVariants.byId follows. The
+      // fallback is brightness-correct: an unknown id in light mode must land
+      // on light Classic, not on the dark palette.
       for (final Brightness b in Brightness.values) {
-        expect(BrandPalettes.byId(null, brightness: b), BrandPalettes.classic);
-        expect(BrandPalettes.byId('', brightness: b), BrandPalettes.classic);
-        expect(
-          BrandPalettes.byId('does-not-exist', brightness: b),
-          BrandPalettes.classic,
-        );
+        final BrandPalette expected =
+            BrandPalettes.byId('classic', brightness: b);
+        expect(BrandPalettes.byId(null, brightness: b), expected);
+        expect(BrandPalettes.byId('', brightness: b), expected);
+        expect(BrandPalettes.byId('does-not-exist', brightness: b), expected);
       }
+      // And that fallback really is the mode-appropriate Classic.
+      expect(
+        BrandPalettes.byId(null, brightness: Brightness.dark),
+        BrandPalettes.classic,
+      );
+      expect(
+        BrandPalettes.byId(null, brightness: Brightness.light),
+        BrandPalettes.classicLight,
+      );
     });
 
     test('Classic is a black + orange + purple palette built from AppColors',
@@ -64,8 +74,12 @@ void main() {
     test('the neutral themes are a single accent (primary == accent)', () {
       // No second hue for Neon/Gold/Black & White: each variant's identity
       // colour is its accent. Classic is excluded — it pairs purple + orange.
-      final Iterable<BrandPalette> neutral =
-          BrandPalettes.all.where((BrandPalette p) => p.id != 'classic');
+      // Holds in both brightnesses, so the light palettes cannot quietly
+      // introduce a second hue the dark ones do not have.
+      final Iterable<BrandPalette> neutral = <BrandPalette>[
+        ...BrandPalettes.all,
+        ...BrandPalettes.allLight,
+      ].where((BrandPalette p) => p.id != 'classic');
       for (final BrandPalette p in neutral) {
         expect(p.primary, p.accent, reason: '${p.id} primary == accent');
         expect(
@@ -83,8 +97,13 @@ void main() {
 
     test('every palette keeps a legible accent/onAccent contrast', () {
       // onAccent rides on top of an accent fill (e.g. the play button glyph), so
-      // the two must stay clearly distinguishable for accessibility.
-      for (final BrandPalette p in BrandPalettes.all) {
+      // the two must stay clearly distinguishable for accessibility. Checked in
+      // both brightnesses; test/app/light_contrast_test.dart pins the light
+      // palettes to the stricter WCAG ratios.
+      for (final BrandPalette p in <BrandPalette>[
+        ...BrandPalettes.all,
+        ...BrandPalettes.allLight,
+      ]) {
         final double delta =
             (p.accent.computeLuminance() - p.onAccent.computeLuminance()).abs();
         expect(

--- a/test/app/light_contrast_test.dart
+++ b/test/app/light_contrast_test.dart
@@ -1,0 +1,368 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/colors.dart';
+import 'package:linthra/app/theme.dart';
+
+/// Contrast guardrails for the light themes.
+///
+/// Linthra still runs dark-only (`themeMode: ThemeMode.dark`), so nothing here
+/// is user-visible yet — that is exactly why it needs a test. The light themes
+/// were built alongside the dark ones and then never rendered, so their tones
+/// silently drifted out of the accessible range: before this suite, Classic's
+/// `primaryBright` carried text buttons at 2.71:1 and its `accent` carried
+/// SnackBar action text at 1.65:1.
+///
+/// Every expectation below is read off a real [ThemeData] rather than off the
+/// palette constants, so it fails both when a colour regresses *and* when a
+/// widget theme is rewired to the wrong slot.
+///
+/// WCAG 2.1 bars used:
+///  - 1.4.3 Contrast (Minimum): 4.5:1 for normal-size text/icons.
+///  - 1.4.11 Non-text Contrast: 3:1 for the boundary of an interactive control.
+void main() {
+  /// WCAG 2.1 relative-luminance contrast ratio, from 1.0 to 21.0.
+  ///
+  /// [Color.computeLuminance] is already WCAG relative luminance, so this is
+  /// just the ratio formula on top of it.
+  double contrast(Color a, Color b) {
+    final double la = a.computeLuminance();
+    final double lb = b.computeLuminance();
+    final double lighter = la > lb ? la : lb;
+    final double darker = la > lb ? lb : la;
+    return (lighter + 0.05) / (darker + 0.05);
+  }
+
+  void expectContrast(
+    Color foreground,
+    Color background, {
+    required double atLeast,
+    required String reason,
+  }) {
+    final double ratio = contrast(foreground, background);
+    expect(
+      ratio,
+      greaterThanOrEqualTo(atLeast),
+      reason: '$reason — got ${ratio.toStringAsFixed(2)}:1, '
+          'need ${atLeast.toStringAsFixed(1)}:1 '
+          '($foreground on $background)',
+    );
+  }
+
+  /// The four light surfaces a foreground can land on, by the theme slot that
+  /// carries it. Text buttons in particular appear on all of them.
+  List<({String name, Color color})> lightSurfacesOf(ThemeData theme) {
+    return <({String name, Color color})>[
+      (name: 'scaffold background', color: theme.scaffoldBackgroundColor),
+      (name: 'card / dialog / bottom sheet', color: theme.cardTheme.color!),
+      (name: 'popup menu', color: theme.popupMenuTheme.color!),
+      (name: 'navigation bar', color: theme.navigationBarTheme.backgroundColor!),
+    ];
+  }
+
+  Color? selectedNavIconColor(ThemeData theme) => theme
+      .navigationBarTheme.iconTheme
+      ?.resolve(<WidgetState>{WidgetState.selected})?.color;
+
+  Color? selectedNavLabelColor(ThemeData theme) => theme
+      .navigationBarTheme.labelTextStyle
+      ?.resolve(<WidgetState>{WidgetState.selected})?.color;
+
+  Color? textButtonColor(ThemeData theme) =>
+      theme.textButtonTheme.style?.foregroundColor?.resolve(<WidgetState>{});
+
+  /// Every variant, so a light palette can never ship untested.
+  final List<({String id, BrandPalette palette})> lightPalettes =
+      <({String id, BrandPalette palette})>[
+    (id: 'classic', palette: BrandPalettes.classicLight),
+    (id: 'neon', palette: BrandPalettes.neonLight),
+    (id: 'gold', palette: BrandPalettes.goldLight),
+    (id: 'blackwhite', palette: BrandPalettes.blackWhiteLight),
+  ];
+
+  group('light theme contrast', () {
+    for (final ({String id, BrandPalette palette}) variant in lightPalettes) {
+      group(variant.id, () {
+        final ThemeData theme = AppTheme.light(variant.palette);
+
+        test('body and secondary text clear 4.5:1 on every light surface', () {
+          for (final ({String name, Color color}) surface
+              in lightSurfacesOf(theme)) {
+            expectContrast(
+              theme.colorScheme.onSurface,
+              surface.color,
+              atLeast: 4.5,
+              reason: 'body text on ${surface.name}',
+            );
+            expectContrast(
+              theme.colorScheme.onSurfaceVariant,
+              surface.color,
+              atLeast: 4.5,
+              reason: 'secondary text on ${surface.name}',
+            );
+          }
+        });
+
+        test('text buttons clear 4.5:1 on every light surface', () {
+          // The regression that motivated this suite: the dark primaryBright
+          // reached only 2.37:1 on the popup-menu surface.
+          final Color? foreground = textButtonColor(theme);
+          expect(foreground, isNotNull);
+          for (final ({String name, Color color}) surface
+              in lightSurfacesOf(theme)) {
+            expectContrast(
+              foreground!,
+              surface.color,
+              atLeast: 4.5,
+              reason: 'text button label on ${surface.name}',
+            );
+          }
+        });
+
+        test('selected navigation icon and label clear 4.5:1', () {
+          final Color background = theme.navigationBarTheme.backgroundColor!;
+          expectContrast(
+            selectedNavIconColor(theme)!,
+            background,
+            atLeast: 4.5,
+            reason: 'selected navigation icon',
+          );
+          expectContrast(
+            selectedNavLabelColor(theme)!,
+            background,
+            atLeast: 4.5,
+            reason: 'selected navigation label',
+          );
+        });
+
+        test('unselected navigation icon and label clear 4.5:1', () {
+          final Color background = theme.navigationBarTheme.backgroundColor!;
+          final Color? icon = theme.navigationBarTheme.iconTheme
+              ?.resolve(<WidgetState>{})?.color;
+          final Color? label = theme.navigationBarTheme.labelTextStyle
+              ?.resolve(<WidgetState>{})?.color;
+          expectContrast(
+            icon!,
+            background,
+            atLeast: 4.5,
+            reason: 'unselected navigation icon',
+          );
+          expectContrast(
+            label!,
+            background,
+            atLeast: 4.5,
+            reason: 'unselected navigation label',
+          );
+        });
+
+        test('SnackBar action text clears 4.5:1 on the SnackBar', () {
+          // accent doubles as action-text colour, which is the tightest
+          // constraint on the light accent tone.
+          expectContrast(
+            theme.snackBarTheme.actionTextColor!,
+            theme.snackBarTheme.backgroundColor!,
+            atLeast: 4.5,
+            reason: 'SnackBar action text',
+          );
+          expectContrast(
+            theme.snackBarTheme.contentTextStyle!.color!,
+            theme.snackBarTheme.backgroundColor!,
+            atLeast: 4.5,
+            reason: 'SnackBar content text',
+          );
+        });
+
+        test('filled call-to-action label clears 4.5:1 on its fill', () {
+          final ButtonStyle? style = theme.filledButtonTheme.style;
+          expectContrast(
+            style!.foregroundColor!.resolve(<WidgetState>{})!,
+            style.backgroundColor!.resolve(<WidgetState>{})!,
+            atLeast: 4.5,
+            reason: 'filled button label on its accent fill',
+          );
+        });
+
+        test('selected chip label clears 4.5:1 on the selected chip', () {
+          expectContrast(
+            theme.chipTheme.secondaryLabelStyle!.color!,
+            theme.chipTheme.selectedColor!,
+            atLeast: 4.5,
+            reason: 'selected chip label',
+          );
+          expectContrast(
+            theme.chipTheme.labelStyle!.color!,
+            theme.chipTheme.backgroundColor!,
+            atLeast: 4.5,
+            reason: 'unselected chip label',
+          );
+        });
+
+        test('error colour clears 4.5:1 on every light surface', () {
+          for (final ({String name, Color color}) surface
+              in lightSurfacesOf(theme)) {
+            expectContrast(
+              theme.colorScheme.error,
+              surface.color,
+              atLeast: 4.5,
+              reason: 'error text on ${surface.name}',
+            );
+          }
+        });
+
+        test('control borders clear the 3:1 non-text bar', () {
+          // WCAG 1.4.11: these delimit interactive controls.
+          final OutlineInputBorder enabled =
+              theme.inputDecorationTheme.enabledBorder! as OutlineInputBorder;
+          final OutlineInputBorder focused =
+              theme.inputDecorationTheme.focusedBorder! as OutlineInputBorder;
+          final Color fill = theme.inputDecorationTheme.fillColor!;
+          expectContrast(
+            enabled.borderSide.color,
+            fill,
+            atLeast: 3.0,
+            reason: 'search / text field border',
+          );
+          expectContrast(
+            focused.borderSide.color,
+            fill,
+            atLeast: 3.0,
+            reason: 'focused text field border',
+          );
+          expectContrast(
+            theme.colorScheme.outline,
+            theme.scaffoldBackgroundColor,
+            atLeast: 3.0,
+            reason: 'outlined button / chip border',
+          );
+        });
+
+        test('the play button gradient stays visible on light surfaces', () {
+          final LinthraAccents accents = theme.extension<LinthraAccents>()!;
+          for (final ({String name, Color color}) surface
+              in lightSurfacesOf(theme)) {
+            expectContrast(
+              accents.accentBright,
+              surface.color,
+              atLeast: 3.0,
+              reason: 'play button gradient top on ${surface.name}',
+            );
+            expectContrast(
+              accents.accentDeep,
+              surface.color,
+              atLeast: 3.0,
+              reason: 'play button gradient bottom on ${surface.name}',
+            );
+          }
+        });
+
+        test('no palette tone is a dark slab on a light surface', () {
+          // accentContainer used to be a dark brown (0xFF3A2A16). Its own
+          // foreground contrast passed, so only a lightness check catches it:
+          // a container on a light theme must itself be light.
+          expect(
+            theme.colorScheme.secondaryContainer.computeLuminance(),
+            greaterThan(0.5),
+            reason: '${variant.id}: secondaryContainer must be a light tint, '
+                'not a dark block punched into the light UI',
+          );
+        });
+      });
+    }
+  });
+
+  group('light palette registry', () {
+    test('every variant resolves to a distinct light palette', () {
+      for (final ({String id, BrandPalette palette}) variant in lightPalettes) {
+        final BrandPalette resolved =
+            BrandPalettes.byId(variant.id, brightness: Brightness.light);
+        expect(resolved, same(variant.palette));
+        expect(resolved.id, variant.id);
+      }
+    });
+
+    test('light and dark palettes are genuinely different tones', () {
+      // Guards against a future variant being added to allLight by copying its
+      // dark entry — which is precisely the bug this PR fixes.
+      for (final ({String id, BrandPalette palette}) variant in lightPalettes) {
+        if (variant.id == 'blackwhite') {
+          continue; // Pure black/white by design; asserted in brand_theme_test.
+        }
+        final BrandPalette dark =
+            BrandPalettes.byId(variant.id, brightness: Brightness.dark);
+        expect(
+          variant.palette.accent,
+          isNot(dark.accent),
+          reason: '${variant.id}: light accent must be re-toned, not reused',
+        );
+        expect(
+          variant.palette.primaryBright,
+          isNot(dark.primaryBright),
+          reason: '${variant.id}: light primaryBright must be re-toned',
+        );
+      }
+    });
+
+    test('allLight covers exactly the same variants as all', () {
+      expect(
+        BrandPalettes.allLight.map((BrandPalette p) => p.id).toList(),
+        BrandPalettes.all.map((BrandPalette p) => p.id).toList(),
+      );
+    });
+
+    test('an unknown id falls back to Classic in the right brightness', () {
+      expect(
+        BrandPalettes.byId('does-not-exist', brightness: Brightness.light),
+        same(BrandPalettes.classicLight),
+      );
+      expect(
+        BrandPalettes.byId('does-not-exist', brightness: Brightness.dark),
+        same(BrandPalettes.classic),
+      );
+    });
+
+    test('Classic keeps its Linthra hues in light mode', () {
+      // "Accessible" must not mean "beige". Classic stays a violet identity
+      // paired with a warm orange energy accent — the same two hue families as
+      // dark mode, only re-toned for light surfaces.
+      final HSLColor violet = HSLColor.fromColor(BrandPalettes.classicLight.primary);
+      final HSLColor darkViolet = HSLColor.fromColor(BrandPalettes.classic.primary);
+      final HSLColor orange = HSLColor.fromColor(BrandPalettes.classicLight.accent);
+      final HSLColor darkOrange = HSLColor.fromColor(BrandPalettes.classic.accent);
+
+      expect(
+        (violet.hue - darkViolet.hue).abs(),
+        lessThan(2.0),
+        reason: 'light Classic primary must keep the Linthra violet hue',
+      );
+      expect(
+        (orange.hue - darkOrange.hue).abs(),
+        lessThan(2.0),
+        reason: 'light Classic accent must keep the Linthra orange hue',
+      );
+      // Still two different hues, as in dark mode.
+      expect((violet.hue - orange.hue).abs(), greaterThan(90));
+    });
+  });
+
+  group('dark theme is untouched by the light hardening', () {
+    // This PR must not change a single rendered dark pixel.
+    final ThemeData dark = AppTheme.dark(BrandPalettes.classic);
+
+    test('dark still uses one outline tone for borders and dividers', () {
+      expect(dark.colorScheme.outline, AppColors.darkOutline);
+      expect(dark.colorScheme.outlineVariant, AppColors.darkOutline);
+      expect(dark.dividerTheme.color, AppColors.darkOutline);
+    });
+
+    test('dark keeps the shared error red', () {
+      expect(dark.colorScheme.error, AppColors.error);
+    });
+
+    test('dark Classic keeps its original brand tones', () {
+      expect(dark.colorScheme.primary, AppColors.brand);
+      expect(dark.colorScheme.secondary, AppColors.accent);
+      expect(dark.colorScheme.onSecondary, AppColors.onAccent);
+      expect(dark.colorScheme.secondaryContainer, AppColors.accentContainer);
+    });
+  });
+}

--- a/test/app/light_contrast_test.dart
+++ b/test/app/light_contrast_test.dart
@@ -56,17 +56,20 @@ void main() {
       (name: 'scaffold background', color: theme.scaffoldBackgroundColor),
       (name: 'card / dialog / bottom sheet', color: theme.cardTheme.color!),
       (name: 'popup menu', color: theme.popupMenuTheme.color!),
-      (name: 'navigation bar', color: theme.navigationBarTheme.backgroundColor!),
+      (
+        name: 'navigation bar',
+        color: theme.navigationBarTheme.backgroundColor!
+      ),
     ];
   }
 
-  Color? selectedNavIconColor(ThemeData theme) => theme
-      .navigationBarTheme.iconTheme
-      ?.resolve(<WidgetState>{WidgetState.selected})?.color;
+  Color? selectedNavIconColor(ThemeData theme) =>
+      theme.navigationBarTheme.iconTheme
+          ?.resolve(<WidgetState>{WidgetState.selected})?.color;
 
-  Color? selectedNavLabelColor(ThemeData theme) => theme
-      .navigationBarTheme.labelTextStyle
-      ?.resolve(<WidgetState>{WidgetState.selected})?.color;
+  Color? selectedNavLabelColor(ThemeData theme) =>
+      theme.navigationBarTheme.labelTextStyle
+          ?.resolve(<WidgetState>{WidgetState.selected})?.color;
 
   Color? textButtonColor(ThemeData theme) =>
       theme.textButtonTheme.style?.foregroundColor?.resolve(<WidgetState>{});
@@ -324,10 +327,14 @@ void main() {
       // "Accessible" must not mean "beige". Classic stays a violet identity
       // paired with a warm orange energy accent — the same two hue families as
       // dark mode, only re-toned for light surfaces.
-      final HSLColor violet = HSLColor.fromColor(BrandPalettes.classicLight.primary);
-      final HSLColor darkViolet = HSLColor.fromColor(BrandPalettes.classic.primary);
-      final HSLColor orange = HSLColor.fromColor(BrandPalettes.classicLight.accent);
-      final HSLColor darkOrange = HSLColor.fromColor(BrandPalettes.classic.accent);
+      final HSLColor violet =
+          HSLColor.fromColor(BrandPalettes.classicLight.primary);
+      final HSLColor darkViolet =
+          HSLColor.fromColor(BrandPalettes.classic.primary);
+      final HSLColor orange =
+          HSLColor.fromColor(BrandPalettes.classicLight.accent);
+      final HSLColor darkOrange =
+          HSLColor.fromColor(BrandPalettes.classic.accent);
 
       expect(
         (violet.hue - darkViolet.hue).abs(),


### PR DESCRIPTION
PR 1 of 2 for system theme support. **No user-visible change** — `themeMode: ThemeMode.dark` is untouched, so this ships dark-only exactly as today. PR 2 adds the System/Light/Dark setting on top.

## Why this is separate

The light themes are already fully built and passed to `MaterialApp.router` (`theme:`), but `themeMode` pins the app to dark — so they have been constructed on every frame and never rendered. Nothing was checking them, and their tones drifted well out of the accessible range.

Landing the palette first means the follow-up switch cannot expose an unreadable UI to users who never opted in. If we flipped `ThemeMode.system` with these tones in place, every user on a light-mode phone would get invisible dividers and unreadable text buttons on first launch after update.

## What was actually broken

Measured against the light surfaces, before this change:

| Token | Role | Ratio | Bar |
|---|---|---|---|
| `primaryBright` | text buttons, selected nav, focus rings | 2.37–2.93:1 | 4.5 |
| `accent` | SnackBar action **text** | 1.65:1 | 4.5 |
| `accent` | slider active track | 1.88:1 | 3.0 |
| `lightOutline` | borders + dividers | 1.33:1 | 3.0 |
| `error` | error copy | 3.44:1 | 4.5 |
| `lightOnSurfaceMuted` | secondary text on popup menu | 4.38:1 | 4.5 |

Plus `accentContainer` was a dark brown (`0xFF3A2A16`) — it passed its own foreground check while punching a dark block into a light UI. The new lightness assertion is what catches that class of bug.

The muted-text one is worth calling out: it cleared 4.5:1 on the scaffold background (5.00:1) and only failed on the popup-menu/SnackBar surface. The test found it, I didn't.

## Approach

Every variant now has a light palette (`BrandPalettes.allLight`) instead of reusing the dark one, and `byId` picks by `Brightness` — including a brightness-correct unknown-id fallback.

**Hue is preserved exactly.** The light oranges keep the brand's 29.4° hue at full chroma; the light violet keeps 251.8°. Classic still reads as Linthra purple + warm orange, only re-toned for light surfaces — accessible was not allowed to mean beige. `brandBrightLight` is `brandDeep`, an existing Linthra violet, rather than a newly invented tone.

The outline token is split in two: controls get a real 3:1 edge (WCAG 1.4.11), dividers stay decorative and soft so light lists don't turn into tables.

### Classic light palette — for visual review

| Slot | Value | Note |
|---|---|---|
| `primary` | `#633DFF` | brand hue, full chroma, white-on-it 5.77:1 |
| `primaryBright` | `#5B3FD9` | = existing `brandDeep`, 6.65:1 on white |
| `accent` | `#A35000` | lightest brand-hue orange clearing SnackBar text |
| `accentBright` | `#8F4600` | gradient top / selected chip label |
| `accentDeep` | `#7A3C00` | gradient bottom |
| `onAccent` | `#FFFFFF` | the dark warm ink wouldn't read here |
| `accentContainer` | `#FFE7CE` | light warm tint |

Neon and Gold are also re-toned (dark Gold managed 1.7:1 on white — the worst of the four). Black & White already had a light counterpart and is unchanged.

## Dark mode is byte-identical

`AppTheme.dark` passes the same value to both outline slots and keeps the shared error red, so nothing dark renders differently. There's a dedicated test group asserting this rather than relying on review.

## Tests

New `test/app/light_contrast_test.dart` reads every expectation off a real `ThemeData` rather than off the palette constants, so it fails both when a colour regresses **and** when a widget theme is rewired to the wrong slot. Covers all four variants across body/secondary text, text buttons, selected + unselected nav, SnackBar, filled CTA, chips, errors, control borders, and the play-button gradient — on all four light surfaces.

- `flutter test` — 3070 passing
- `flutter analyze` — no issues

## Scope

No version bump. No `themeMode` change. No unrelated accessibility cleanup — the `alpha: 0.35`/`0.45` muted-text call sites in `artist_tile.dart`, `alphabet_track_list.dart`, and `artist_detail_screen.dart` fail today **in dark mode already**, so they're pre-existing and deliberately left for a separate PR.

One thing to flag: the custom-palette feature (`custom_brand_palette.dart`, supporter cosmetics) derives its own tones from user-chosen colours and is not covered by these guarantees. Out of scope here, worth a look before light mode ships.

## Review note

Values are numerically verified but **the look is a brand call, not just a contrast one** — light Classic is a deeper violet and a burnt-orange rather than the glowy dark-mode tones. Worth eyeballing in the APK before merge; the `android-debug-apk` workflow can build one, though light mode isn't reachable in-app until PR 2, so the palette needs checking via a temporary `ThemeMode.light` flip or a widget preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2zR428Jn65EY65f8uTyGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2zR428Jn65EY65f8uTyGk)_