### PR TITLE
feat(theme): follow the phone's light/dark setting

### DIFF
--- a/docs/app-icon-branding.md
+++ b/docs/app-icon-branding.md
@@ -78,8 +78,20 @@ A small, data-driven feature that mirrors the Support module's per-build seam:
   surfaces: accents chosen for black backgrounds fall far below WCAG AA on white
   ones, so each is re-toned at the same hue. `test/app/light_contrast_test.dart`
   enforces the ratios off a real `ThemeData`, so a regression fails CI rather
-  than shipping. Linthra still runs dark-only today (`themeMode: ThemeMode.dark`)
-  — these palettes exist so light mode can be switched on safely.
+  than shipping. These palettes are what makes the light theme safe to reach.
+- **Theme mode (System / Light / Dark)** — `ThemeModeController`
+  (`lib/features/appearance/theme_mode_controller.dart`) holds the choice and
+  persists it through `ThemeModeStore`; `LinthraApp` watches it, so a change
+  repaints every screen at once. The default is `ThemeMode.system`, which also
+  makes `MaterialApp` re-render when the phone flips light/dark while Linthra is
+  open — no listener of our own. `main` awaits `readStoredThemeMode()` *before*
+  `runApp` and seeds `initialThemeModeProvider` with the result, so the first
+  frame is already correct; loading it asynchronously afterwards would make
+  someone who picked Light on a dark phone watch the app flash dark and flip.
+  That seeding is also why the controller has no async load of its own, which
+  removes the race where a stored value lands after the user has already tapped
+  a different option. A read or write that throws falls back to "follow the
+  phone" rather than taking startup down.
   (The brand marks/launcher icons keep their own gradients — e.g. Classic's
   signature violet→orange mark and the default launcher icon are unchanged.)
 - **Launcher icon (Android)** — the same selection also switches the real

--- a/lib/app/colors.dart
+++ b/lib/app/colors.dart
@@ -7,8 +7,10 @@ import 'package:flutter/material.dart';
 /// accent reserved for things that are *live* — the playing / selected / active
 /// states and playback progress. Keeping orange scarce is what makes it read as
 /// energy rather than decoration, and it's what separates Linthra from a calm
-/// productivity app. Dark mode is the primary experience; the light palette
-/// mirrors it so both feel like the same product.
+/// productivity app. Dark is the signature look, but Linthra follows the
+/// phone's light/dark setting by default, so both modes are first-class: the
+/// light palette re-tones the same two hues rather than mirroring the dark
+/// tones, which would not survive on pale surfaces.
 abstract final class AppColors {
   // Brand violet — the primary identity.
   /// The core brand colour: app identity, primary buttons, structural accents.

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -8,6 +8,7 @@ import '../core/services/stability_diagnostics.dart';
 import '../features/appearance/app_icon_controller.dart';
 import '../features/appearance/custom_brand_palette.dart';
 import '../features/appearance/custom_theme_controller.dart';
+import '../features/appearance/theme_mode_controller.dart';
 import '../features/library/remote_library_refresher.dart';
 import '../features/player/player_providers.dart';
 import '../features/support/support_actions_provider.dart';
@@ -25,8 +26,10 @@ final notificationPermissionProvider = Provider<NotificationPermission>((ref) {
   return const PermissionHandlerNotificationPermission();
 });
 
-/// Root widget. Dark mode is the primary experience; the light theme follows
-/// the system setting when the user opts out of dark.
+/// Root widget. Linthra follows the phone's light/dark setting by default; the
+/// user can pin Light or Dark in Settings → Appearance, and that choice is read
+/// from storage before the first frame (see `readStoredThemeMode`) so launching
+/// never flashes the wrong theme.
 ///
 /// On first build it asks for the notification permission once, after the first
 /// frame, so the Android 13+ `POST_NOTIFICATIONS` prompt has an attached
@@ -100,6 +103,7 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
   @override
   Widget build(BuildContext context) {
     final router = ref.watch(appRouterProvider);
+    final themeMode = ref.watch(themeModeControllerProvider);
     final variant = ref.watch(appIconControllerProvider);
     final customTheme = ref.watch(customThemeControllerProvider);
     final distribution = ref.watch(supportDistributionProvider);
@@ -120,7 +124,10 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(paletteFor(Brightness.light)),
       darkTheme: AppTheme.dark(paletteFor(Brightness.dark)),
-      themeMode: ThemeMode.dark,
+      // Watching the controller means a change repaints every screen at once.
+      // ThemeMode.system additionally makes MaterialApp rebuild when the phone
+      // flips light/dark while Linthra is open — no listener of our own needed.
+      themeMode: themeMode.materialThemeMode,
       routerConfig: router,
     );
   }

--- a/lib/core/models/theme_mode_preference.dart
+++ b/lib/core/models/theme_mode_preference.dart
@@ -1,0 +1,48 @@
+/// The user's theme-mode choice, as persisted.
+///
+/// Deliberately Flutter-free (like `CustomThemeSettings`) so a lightweight
+/// key/value store can persist it as one short string. The mapping onto
+/// Material's `ThemeMode` lives with the appearance feature that renders it.
+///
+/// The stored value is a non-secret display preference: no account, server,
+/// library, or playback data is involved.
+enum ThemeModePreference {
+  /// Follow the phone's light/dark setting. The default, and what most people
+  /// expect from an app that offers the choice at all.
+  system('system'),
+
+  /// Always light, regardless of the phone.
+  light('light'),
+
+  /// Always dark, regardless of the phone. What Linthra did unconditionally
+  /// before this preference existed.
+  dark('dark');
+
+  const ThemeModePreference(this.storageId);
+
+  /// The stable string written to storage. Never shown to users, and never
+  /// renamed — a stored value must keep resolving across app updates.
+  final String storageId;
+
+  /// What an absent, empty, or unrecognised stored value resolves to.
+  ///
+  /// Following the phone is the safe landing spot: it is the documented
+  /// default, and it is what a first-run install gets.
+  static const ThemeModePreference fallback = ThemeModePreference.system;
+
+  /// Resolves a stored [storageId] back to its preference, falling back to
+  /// [fallback] for anything unrecognised — the same "unknown → default" rule
+  /// the branding variants use, so a corrupted or downgraded preference can
+  /// never leave the app without a theme mode.
+  static ThemeModePreference fromStorageId(String? storageId) {
+    if (storageId == null || storageId.isEmpty) {
+      return fallback;
+    }
+    for (final ThemeModePreference preference in values) {
+      if (preference.storageId == storageId) {
+        return preference;
+      }
+    }
+    return fallback;
+  }
+}

--- a/lib/core/repositories/theme_mode_store.dart
+++ b/lib/core/repositories/theme_mode_store.dart
@@ -1,0 +1,14 @@
+import '../models/theme_mode_preference.dart';
+
+/// Persists the user's System / Light / Dark choice.
+///
+/// The value is a non-secret display preference only. No account, server,
+/// library, or playback data is stored here.
+abstract interface class ThemeModeStore {
+  /// Returns the stored preference, or `null` when the user has never chosen
+  /// one — which the caller resolves to [ThemeModePreference.fallback].
+  Future<ThemeModePreference?> read();
+
+  /// Persists [preference].
+  Future<void> write(ThemeModePreference preference);
+}

--- a/lib/data/repositories/in_memory_theme_mode_store.dart
+++ b/lib/data/repositories/in_memory_theme_mode_store.dart
@@ -1,0 +1,20 @@
+import '../../core/models/theme_mode_preference.dart';
+import '../../core/repositories/theme_mode_store.dart';
+
+/// Test-friendly [ThemeModeStore] that keeps one value in memory.
+class InMemoryThemeModeStore implements ThemeModeStore {
+  InMemoryThemeModeStore([this._preference]);
+
+  ThemeModePreference? _preference;
+
+  /// The last written value, for assertions.
+  ThemeModePreference? get preference => _preference;
+
+  @override
+  Future<ThemeModePreference?> read() async => _preference;
+
+  @override
+  Future<void> write(ThemeModePreference preference) async {
+    _preference = preference;
+  }
+}

--- a/lib/data/repositories/shared_preferences_theme_mode_store.dart
+++ b/lib/data/repositories/shared_preferences_theme_mode_store.dart
@@ -1,0 +1,29 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/theme_mode_preference.dart';
+import '../../core/repositories/theme_mode_store.dart';
+
+/// Persists the theme-mode choice as a single non-secret string.
+class SharedPreferencesThemeModeStore implements ThemeModeStore {
+  const SharedPreferencesThemeModeStore();
+
+  static const String _key = 'theme_mode_v1';
+
+  @override
+  Future<ThemeModePreference?> read() async {
+    final SharedPreferences preferences = await SharedPreferences.getInstance();
+    final String? stored = preferences.getString(_key);
+    if (stored == null) {
+      return null;
+    }
+    // An unrecognised value (a downgrade, or a hand-edited preference file)
+    // resolves to the default rather than throwing.
+    return ThemeModePreference.fromStorageId(stored);
+  }
+
+  @override
+  Future<void> write(ThemeModePreference preference) async {
+    final SharedPreferences preferences = await SharedPreferences.getInstance();
+    await preferences.setString(_key, preference.storageId);
+  }
+}

--- a/lib/data/repositories/theme_mode_store_provider.dart
+++ b/lib/data/repositories/theme_mode_store_provider.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/theme_mode_preference.dart';
+import '../../core/repositories/theme_mode_store.dart';
+import 'in_memory_theme_mode_store.dart';
+import 'shared_preferences_theme_mode_store.dart';
+
+/// The single [ThemeModeStore] the app reads/writes the System/Light/Dark
+/// choice through.
+///
+/// Defaults to the in-memory implementation so widget and unit tests stay free
+/// of platform plugins. The running app overrides this with
+/// [sharedPreferencesThemeModeStoreOverride] so the choice persists across
+/// restarts.
+final themeModeStoreProvider = Provider<ThemeModeStore>((ref) {
+  return InMemoryThemeModeStore();
+});
+
+/// Production binding: persists the theme mode via `shared_preferences`.
+/// Applied in `main`.
+final sharedPreferencesThemeModeStoreOverride =
+    themeModeStoreProvider.overrideWithValue(
+  const SharedPreferencesThemeModeStore(),
+);
+
+/// Reads the stored theme mode before the first frame is built.
+///
+/// `main` awaits this and seeds `initialThemeModeProvider` with the result, so
+/// the very first frame already renders in the user's chosen mode. Loading it
+/// asynchronously *after* startup would work too, but a user who picked Light
+/// on a dark phone would watch the app flash dark and then flip — the exact
+/// glitch this preference is supposed to remove.
+///
+/// Defensive by design: a store that throws (a plugin hiccup, unreadable
+/// preferences) resolves to [ThemeModePreference.fallback] rather than taking
+/// startup down. A theme preference must never be able to stop the app booting.
+Future<ThemeModePreference> readStoredThemeMode([
+  ThemeModeStore store = const SharedPreferencesThemeModeStore(),
+]) async {
+  try {
+    return await store.read() ?? ThemeModePreference.fallback;
+  } catch (_) {
+    return ThemeModePreference.fallback;
+  }
+}

--- a/lib/features/appearance/appearance_settings_screen.dart
+++ b/lib/features/appearance/appearance_settings_screen.dart
@@ -9,6 +9,7 @@ import 'app_icon_controller.dart';
 import 'app_icon_variant.dart';
 import 'custom_theme_card.dart';
 import 'linthra_logo_mark.dart';
+import 'theme_mode_card.dart';
 
 /// "App icon & branding" — reached from Settings → Appearance.
 ///
@@ -35,6 +36,8 @@ class AppearanceSettingsScreen extends ConsumerWidget {
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
         children: <Widget>[
+          const ThemeModeCard(),
+          const SizedBox(height: AppSpacing.lg),
           _IntroCard(showCustomPalette: showCustomPalette),
           const SizedBox(height: AppSpacing.md),
           _VariantGrid(

--- a/lib/features/appearance/theme_mode_card.dart
+++ b/lib/features/appearance/theme_mode_card.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/dimens.dart';
+import '../../core/models/theme_mode_preference.dart';
+import 'theme_mode_controller.dart';
+
+/// The System / Light / Dark picker, shown at the top of Settings → Appearance.
+///
+/// Sits above the icon/branding picker because it is the coarser choice: which
+/// surfaces the app paints on, before which accent paints them.
+class ThemeModeCard extends ConsumerWidget {
+  const ThemeModeCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final ThemeModePreference selected = ref.watch(themeModeControllerProvider);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Icon(
+                  Icons.contrast_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Text(
+                    'Appearance',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              selected == ThemeModePreference.system
+                  ? 'Linthra follows your phone’s light/dark setting.'
+                  : 'Linthra always uses the ${selected.label.toLowerCase()} '
+                      'theme, whatever your phone is set to.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            // SegmentedButton gives the three options one clear selected state
+            // and the right semantics for screen readers for free.
+            SizedBox(
+              width: double.infinity,
+              child: SegmentedButton<ThemeModePreference>(
+                segments: <ButtonSegment<ThemeModePreference>>[
+                  for (final ThemeModePreference preference
+                      in ThemeModePreference.values)
+                    ButtonSegment<ThemeModePreference>(
+                      value: preference,
+                      label: Text(preference.label),
+                      icon: Icon(preference.icon),
+                      tooltip: preference.label,
+                    ),
+                ],
+                selected: <ThemeModePreference>{selected},
+                showSelectedIcon: false,
+                onSelectionChanged: (Set<ThemeModePreference> selection) {
+                  ref
+                      .read(themeModeControllerProvider.notifier)
+                      .select(selection.first);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/appearance/theme_mode_controller.dart
+++ b/lib/features/appearance/theme_mode_controller.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/theme_mode_preference.dart';
+import '../../data/repositories/theme_mode_store_provider.dart';
+
+/// The theme mode the controller starts from on its very first build.
+///
+/// Defaults to following the phone. `main` overrides it with the value read
+/// from storage *before* `runApp`, so the first frame is already correct and
+/// there is no dark-then-light flash on launch.
+///
+/// This seam is why the controller has no async load of its own: the value is
+/// known before any frame exists, which also removes the race where a stored
+/// value lands after the user has already tapped a different option.
+final initialThemeModeProvider = Provider<ThemeModePreference>((ref) {
+  return ThemeModePreference.fallback;
+});
+
+/// Holds the user's System / Light / Dark choice and persists every change.
+class ThemeModeController extends Notifier<ThemeModePreference> {
+  @override
+  ThemeModePreference build() => ref.read(initialThemeModeProvider);
+
+  /// Applies [preference] immediately and persists it best-effort.
+  ///
+  /// The UI updates from [state] rather than from the write completing, so the
+  /// theme switches on tap even if storage is slow or unavailable.
+  Future<void> select(ThemeModePreference preference) async {
+    if (preference == state) {
+      return;
+    }
+    state = preference;
+    try {
+      await ref.read(themeModeStoreProvider).write(preference);
+    } catch (_) {
+      // A failed preference write must never surface as an error or undo the
+      // user's visible choice; it just will not survive the next restart.
+    }
+  }
+}
+
+/// The app's theme mode. `LinthraApp` watches this, so a change repaints every
+/// screen at once.
+final themeModeControllerProvider =
+    NotifierProvider<ThemeModeController, ThemeModePreference>(
+  ThemeModeController.new,
+);
+
+/// Maps the persisted preference onto Material's [ThemeMode].
+///
+/// Kept out of the model itself so `ThemeModePreference` stays Flutter-free and
+/// storable by a plain key/value store.
+extension ThemeModePreferenceMaterial on ThemeModePreference {
+  ThemeMode get materialThemeMode => switch (this) {
+        ThemeModePreference.system => ThemeMode.system,
+        ThemeModePreference.light => ThemeMode.light,
+        ThemeModePreference.dark => ThemeMode.dark,
+      };
+
+  /// The user-facing option label.
+  String get label => switch (this) {
+        ThemeModePreference.system => 'System',
+        ThemeModePreference.light => 'Light',
+        ThemeModePreference.dark => 'Dark',
+      };
+
+  /// The icon shown beside [label] in the picker.
+  IconData get icon => switch (this) {
+        ThemeModePreference.system => Icons.brightness_auto_outlined,
+        ThemeModePreference.light => Icons.light_mode_outlined,
+        ThemeModePreference.dark => Icons.dark_mode_outlined,
+      };
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app/linthra_app.dart';
 import 'core/models/plex_session.dart';
 import 'core/models/subsonic_session.dart';
+import 'core/models/theme_mode_preference.dart';
 import 'core/services/linthra_audio_handler.dart';
 import 'core/sources/plex/plex_artwork.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
@@ -30,6 +31,8 @@ import 'data/repositories/selected_music_folder_repository_provider.dart';
 import 'data/repositories/share_service_provider.dart';
 import 'data/repositories/subsonic_auto_sync_store_provider.dart';
 import 'data/repositories/subsonic_session_store_provider.dart';
+import 'data/repositories/theme_mode_store_provider.dart';
+import 'features/appearance/theme_mode_controller.dart';
 import 'features/downloads/download_providers.dart';
 import 'features/library/playback_candidates_provider.dart';
 import 'features/player/cast/cast_providers.dart';
@@ -45,6 +48,14 @@ import 'shared/widgets/artwork_image.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Read the saved theme mode *before* the container exists, so the very first
+  // frame already paints in the user's chosen mode. Loading it after startup
+  // would make someone who picked Light on a dark phone watch the app flash
+  // dark and then flip. This is the one preference worth blocking startup on,
+  // and only barely: it is a single string read, and it fails soft to
+  // "follow the phone" rather than throwing.
+  final ThemeModePreference storedThemeMode = await readStoredThemeMode();
 
   // One container backs the whole app so the *same* PlaybackController and
   // MusicLibraryRepository instances drive both the UI (through providers) and
@@ -112,6 +123,10 @@ Future<void> main() async {
       // Persist the user's chosen in-app branding variant (Settings →
       // Appearance). A single non-secret variant id; purely cosmetic.
       sharedPreferencesAppIconVariantStoreOverride,
+      // Persist the System / Light / Dark choice, and seed the controller with
+      // the value already read above so the first frame is correct.
+      sharedPreferencesThemeModeStoreOverride,
+      initialThemeModeProvider.overrideWithValue(storedThemeMode),
       // Switch the real Android launcher icon to match that choice (a no-op off
       // Android); toggles <activity-alias> entries, never touching playback.
       platformLauncherIconServiceOverride,

--- a/test/app/light_contrast_test.dart
+++ b/test/app/light_contrast_test.dart
@@ -6,12 +6,15 @@ import 'package:linthra/app/theme.dart';
 
 /// Contrast guardrails for the light themes.
 ///
-/// Linthra still runs dark-only (`themeMode: ThemeMode.dark`), so nothing here
-/// is user-visible yet — that is exactly why it needs a test. The light themes
-/// were built alongside the dark ones and then never rendered, so their tones
+/// These ratios are now user-visible: Linthra follows the phone's light/dark
+/// setting by default, and the light themes render for real.
+///
+/// They did not used to be. The light themes were built alongside the dark ones
+/// and then never rendered — the app pinned `ThemeMode.dark` — so their tones
 /// silently drifted out of the accessible range: before this suite, Classic's
 /// `primaryBright` carried text buttons at 2.71:1 and its `accent` carried
-/// SnackBar action text at 1.65:1.
+/// SnackBar action text at 1.65:1. That is what this suite exists to prevent
+/// recurring now that the tones are on screen.
 ///
 /// Every expectation below is read off a real [ThemeData] rather than off the
 /// palette constants, so it fails both when a colour regresses *and* when a

--- a/test/app/theme_mode_test.dart
+++ b/test/app/theme_mode_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/linthra_app.dart';
+import 'package:linthra/core/models/theme_mode_preference.dart';
+import 'package:linthra/data/repositories/in_memory_theme_mode_store.dart';
+import 'package:linthra/data/repositories/theme_mode_store_provider.dart';
+import 'package:linthra/features/appearance/theme_mode_controller.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../features/player/fake_playback_controller.dart';
+
+/// End-to-end theme-mode behaviour, driven through the real [LinthraApp] so the
+/// wiring (controller → `MaterialApp.themeMode`) is covered, not just the
+/// controller in isolation.
+void main() {
+  /// The brightness Linthra is *actually rendering*, read from the resolved
+  /// theme inside the app rather than from the `themeMode` we passed in.
+  Brightness renderedBrightness(WidgetTester tester) {
+    final BuildContext context = tester.element(find.byType(Navigator).first);
+    return Theme.of(context).brightness;
+  }
+
+  Future<ProviderContainer> pumpApp(
+    WidgetTester tester, {
+    ThemeModePreference? seed,
+    InMemoryThemeModeStore? store,
+  }) async {
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(FakePlaybackController()),
+        if (store != null) themeModeStoreProvider.overrideWithValue(store),
+        if (seed != null) initialThemeModeProvider.overrideWithValue(seed),
+      ],
+    );
+    addTearDown(container.dispose);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const LinthraApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  /// Sets the phone's light/dark setting for this test.
+  void setPhoneBrightness(WidgetTester tester, Brightness brightness) {
+    tester.platformDispatcher.platformBrightnessTestValue = brightness;
+    addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);
+  }
+
+  group('theme mode follows the phone by default', () {
+    testWidgets('defaults to ThemeMode.system', (tester) async {
+      setPhoneBrightness(tester, Brightness.dark);
+      await pumpApp(tester);
+
+      expect(
+        tester.widget<MaterialApp>(find.byType(MaterialApp)).themeMode,
+        ThemeMode.system,
+      );
+    });
+
+    testWidgets('renders light on a light phone', (tester) async {
+      setPhoneBrightness(tester, Brightness.light);
+      await pumpApp(tester);
+
+      expect(renderedBrightness(tester), Brightness.light);
+    });
+
+    testWidgets('renders dark on a dark phone', (tester) async {
+      setPhoneBrightness(tester, Brightness.dark);
+      await pumpApp(tester);
+
+      expect(renderedBrightness(tester), Brightness.dark);
+    });
+
+    testWidgets('flips live when the phone theme changes while open',
+        (tester) async {
+      // The "update immediately" requirement: no relaunch, no navigation, no
+      // listener of our own — just the OS setting changing under a running app.
+      setPhoneBrightness(tester, Brightness.light);
+      await pumpApp(tester);
+      expect(renderedBrightness(tester), Brightness.light);
+
+      setPhoneBrightness(tester, Brightness.dark);
+      await tester.pumpAndSettle();
+      expect(renderedBrightness(tester), Brightness.dark);
+
+      // And back again, so this is a live binding rather than a one-way latch.
+      setPhoneBrightness(tester, Brightness.light);
+      await tester.pumpAndSettle();
+      expect(renderedBrightness(tester), Brightness.light);
+    });
+  });
+
+  group('an explicit choice overrides the phone', () {
+    testWidgets('Light stays light on a dark phone', (tester) async {
+      setPhoneBrightness(tester, Brightness.dark);
+      await pumpApp(tester, seed: ThemeModePreference.light);
+
+      expect(renderedBrightness(tester), Brightness.light);
+    });
+
+    testWidgets('Dark stays dark on a light phone', (tester) async {
+      setPhoneBrightness(tester, Brightness.light);
+      await pumpApp(tester, seed: ThemeModePreference.dark);
+
+      expect(renderedBrightness(tester), Brightness.dark);
+    });
+
+    testWidgets('a pinned mode ignores a live phone theme change',
+        (tester) async {
+      setPhoneBrightness(tester, Brightness.light);
+      await pumpApp(tester, seed: ThemeModePreference.dark);
+      expect(renderedBrightness(tester), Brightness.dark);
+
+      setPhoneBrightness(tester, Brightness.dark);
+      await tester.pumpAndSettle();
+      expect(renderedBrightness(tester), Brightness.dark);
+
+      setPhoneBrightness(tester, Brightness.light);
+      await tester.pumpAndSettle();
+      expect(
+        renderedBrightness(tester),
+        Brightness.dark,
+        reason: 'pinning Dark must survive the phone flipping to light',
+      );
+    });
+  });
+
+  group('the stored choice is applied without a flash', () {
+    testWidgets('the seeded preference is live on the very first frame',
+        (tester) async {
+      // Seeded the way main does: read from storage before runApp. The
+      // assertion is that the *first* pump already renders light on a dark
+      // phone — no intermediate dark frame to flash through.
+      setPhoneBrightness(tester, Brightness.dark);
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          playbackControllerProvider
+              .overrideWithValue(FakePlaybackController()),
+          initialThemeModeProvider.overrideWithValue(ThemeModePreference.light),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const LinthraApp(),
+        ),
+      );
+
+      expect(
+        tester.widget<MaterialApp>(find.byType(MaterialApp)).themeMode,
+        ThemeMode.light,
+        reason: 'the stored mode must be applied before the first frame, '
+            'not loaded asynchronously afterwards',
+      );
+    });
+
+    testWidgets('changing the mode at runtime repaints the app',
+        (tester) async {
+      final InMemoryThemeModeStore store = InMemoryThemeModeStore();
+      setPhoneBrightness(tester, Brightness.dark);
+      final ProviderContainer container = await pumpApp(tester, store: store);
+      expect(renderedBrightness(tester), Brightness.dark);
+
+      await container
+          .read(themeModeControllerProvider.notifier)
+          .select(ThemeModePreference.light);
+      await tester.pumpAndSettle();
+
+      expect(renderedBrightness(tester), Brightness.light);
+      expect(store.preference, ThemeModePreference.light);
+    });
+  });
+}

--- a/test/features/appearance/appearance_settings_screen_test.dart
+++ b/test/features/appearance/appearance_settings_screen_test.dart
@@ -2,15 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/custom_theme_settings.dart';
+import 'package:linthra/core/models/theme_mode_preference.dart';
 import 'package:linthra/data/repositories/app_icon_variant_store_provider.dart';
 import 'package:linthra/data/repositories/custom_theme_store_provider.dart';
 import 'package:linthra/data/repositories/in_memory_app_icon_variant_store.dart';
 import 'package:linthra/data/repositories/in_memory_custom_theme_store.dart';
+import 'package:linthra/data/repositories/in_memory_theme_mode_store.dart';
+import 'package:linthra/data/repositories/theme_mode_store_provider.dart';
 import 'package:linthra/features/appearance/app_icon_controller.dart';
 import 'package:linthra/features/appearance/app_icon_variant.dart';
 import 'package:linthra/features/appearance/appearance_settings_screen.dart';
 import 'package:linthra/features/appearance/custom_theme_controller.dart';
 import 'package:linthra/features/appearance/linthra_logo_mark.dart';
+import 'package:linthra/features/appearance/theme_mode_controller.dart';
 import 'package:linthra/features/settings/hub/about_screen.dart';
 import 'package:linthra/features/support/support_actions_provider.dart';
 import 'package:linthra/features/support/supporter_entitlement.dart';
@@ -146,6 +150,49 @@ void main() {
       expect(find.textContaining('active monthly GitHub Sponsors'),
           findsOneWidget);
       expect(find.byKey(const Key('custom-theme-enabled')), findsNothing);
+    });
+
+    testWidgets('offers System, Light, and Dark, starting on System',
+        (tester) async {
+      final ProviderContainer container = await pump(tester);
+
+      for (final ThemeModePreference preference in ThemeModePreference.values) {
+        expect(
+          find.text(preference.label),
+          findsOneWidget,
+          reason: '${preference.label} must be offered',
+        );
+      }
+      expect(
+        container.read(themeModeControllerProvider),
+        ThemeModePreference.system,
+      );
+      expect(find.textContaining('follows your phone'), findsOneWidget);
+    });
+
+    testWidgets('picking Light selects and persists it', (tester) async {
+      final ProviderContainer container = await pump(tester);
+
+      await tester.tap(find.text('Light'));
+      await tester.pumpAndSettle();
+
+      expect(
+        container.read(themeModeControllerProvider),
+        ThemeModePreference.light,
+      );
+      expect(
+        container.read(themeModeStoreProvider),
+        isA<InMemoryThemeModeStore>().having(
+          (InMemoryThemeModeStore store) => store.preference,
+          'persisted preference',
+          ThemeModePreference.light,
+        ),
+      );
+      // The blurb switches away from the "follows your phone" wording once a
+      // mode is pinned, so the card always states what is actually happening.
+      expect(find.textContaining('follows your phone'), findsNothing);
+      expect(
+          find.textContaining('always uses the light theme'), findsOneWidget);
     });
   });
 

--- a/test/features/appearance/theme_mode_controller_test.dart
+++ b/test/features/appearance/theme_mode_controller_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/theme_mode_preference.dart';
+import 'package:linthra/core/repositories/theme_mode_store.dart';
+import 'package:linthra/data/repositories/in_memory_theme_mode_store.dart';
+import 'package:linthra/data/repositories/theme_mode_store_provider.dart';
+import 'package:linthra/features/appearance/theme_mode_controller.dart';
+
+/// A store whose reads and writes always fail, standing in for a plugin hiccup
+/// or unreadable preferences.
+class _ThrowingThemeModeStore implements ThemeModeStore {
+  @override
+  Future<ThemeModePreference?> read() async => throw StateError('read failed');
+
+  @override
+  Future<void> write(ThemeModePreference preference) async =>
+      throw StateError('write failed');
+}
+
+void main() {
+  group('ThemeModePreference', () {
+    test('defaults to following the phone', () {
+      expect(ThemeModePreference.fallback, ThemeModePreference.system);
+    });
+
+    test('round-trips every value through its storage id', () {
+      for (final ThemeModePreference preference in ThemeModePreference.values) {
+        expect(
+          ThemeModePreference.fromStorageId(preference.storageId),
+          preference,
+          reason: '${preference.name} must survive a storage round-trip',
+        );
+      }
+    });
+
+    test('storage ids are stable strings, not enum indices', () {
+      // Indices would silently remap if the enum is ever reordered, turning a
+      // stored "light" into "dark" on update.
+      expect(ThemeModePreference.system.storageId, 'system');
+      expect(ThemeModePreference.light.storageId, 'light');
+      expect(ThemeModePreference.dark.storageId, 'dark');
+    });
+
+    test('an unknown, empty, or absent id falls back to system', () {
+      expect(
+          ThemeModePreference.fromStorageId(null), ThemeModePreference.system);
+      expect(ThemeModePreference.fromStorageId(''), ThemeModePreference.system);
+      expect(
+        ThemeModePreference.fromStorageId('sepia'),
+        ThemeModePreference.system,
+      );
+    });
+
+    test('maps onto the matching Material ThemeMode', () {
+      expect(ThemeModePreference.system.materialThemeMode, ThemeMode.system);
+      expect(ThemeModePreference.light.materialThemeMode, ThemeMode.light);
+      expect(ThemeModePreference.dark.materialThemeMode, ThemeMode.dark);
+    });
+  });
+
+  group('ThemeModeController', () {
+    ProviderContainer containerWith({
+      ThemeModeStore? store,
+      ThemeModePreference? seed,
+    }) {
+      final ProviderContainer container = ProviderContainer(
+        overrides: <Override>[
+          if (store != null) themeModeStoreProvider.overrideWithValue(store),
+          if (seed != null) initialThemeModeProvider.overrideWithValue(seed),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('starts on system when nothing has been seeded', () {
+      final ProviderContainer container = containerWith();
+      expect(
+        container.read(themeModeControllerProvider),
+        ThemeModePreference.system,
+      );
+    });
+
+    test('starts on the seeded preference, with no async load', () {
+      // The seed is what main reads from storage before runApp. Reading the
+      // controller synchronously — without pumping — is the assertion that
+      // matters: the first frame is already correct, so there is no flash.
+      final ProviderContainer container =
+          containerWith(seed: ThemeModePreference.light);
+      expect(
+        container.read(themeModeControllerProvider),
+        ThemeModePreference.light,
+      );
+    });
+
+    test('selecting a mode updates state and persists it', () async {
+      final InMemoryThemeModeStore store = InMemoryThemeModeStore();
+      final ProviderContainer container = containerWith(store: store);
+
+      await container
+          .read(themeModeControllerProvider.notifier)
+          .select(ThemeModePreference.dark);
+
+      expect(
+        container.read(themeModeControllerProvider),
+        ThemeModePreference.dark,
+      );
+      expect(store.preference, ThemeModePreference.dark);
+    });
+
+    test('the persisted choice is what a later launch seeds from', () async {
+      // The full restart path: write through one container, read it back the
+      // way main does, and seed a fresh container with the result.
+      final InMemoryThemeModeStore store = InMemoryThemeModeStore();
+      await containerWith(store: store)
+          .read(themeModeControllerProvider.notifier)
+          .select(ThemeModePreference.light);
+
+      final ProviderContainer relaunched = containerWith(
+        store: store,
+        seed: await readStoredThemeMode(store),
+      );
+
+      expect(
+        relaunched.read(themeModeControllerProvider),
+        ThemeModePreference.light,
+      );
+    });
+
+    test('re-selecting the current mode does not rewrite storage', () async {
+      final InMemoryThemeModeStore store =
+          InMemoryThemeModeStore(ThemeModePreference.dark);
+      final ProviderContainer container = containerWith(
+        store: store,
+        seed: ThemeModePreference.dark,
+      );
+
+      await container
+          .read(themeModeControllerProvider.notifier)
+          .select(ThemeModePreference.dark);
+
+      expect(store.preference, ThemeModePreference.dark);
+    });
+
+    test('a failing write never undoes the visible choice', () async {
+      final ProviderContainer container =
+          containerWith(store: _ThrowingThemeModeStore());
+
+      await container
+          .read(themeModeControllerProvider.notifier)
+          .select(ThemeModePreference.light);
+
+      expect(
+        container.read(themeModeControllerProvider),
+        ThemeModePreference.light,
+      );
+    });
+  });
+
+  group('readStoredThemeMode', () {
+    test('returns the stored preference', () async {
+      expect(
+        await readStoredThemeMode(
+          InMemoryThemeModeStore(ThemeModePreference.dark),
+        ),
+        ThemeModePreference.dark,
+      );
+    });
+
+    test('falls back to system when nothing is stored', () async {
+      expect(
+        await readStoredThemeMode(InMemoryThemeModeStore()),
+        ThemeModePreference.system,
+      );
+    });
+
+    test('a throwing store never takes startup down', () async {
+      // main awaits this before runApp, so it must not be able to throw.
+      expect(
+        await readStoredThemeMode(_ThrowingThemeModeStore()),
+        ThemeModePreference.system,
+      );
+    });
+  });
+}


### PR DESCRIPTION
PR 2 of 2 for system theme support, on top of #308. Adds the System / Light / Dark choice and defaults to following the phone.

This is the user-visible half — #308 made the light palettes accessible while the app was still pinned to dark, so switching light mode on here cannot expose an unreadable UI.

## What changes for users

Linthra now follows the phone's light/dark setting out of the box. Settings → Appearance gains a System / Light / Dark picker at the top of the screen, above the icon/branding picker — it's the coarser choice (which surfaces the app paints on, before which accent paints them). The choice survives restarts.

Anyone who wants the old behaviour picks **Dark** once.

## How it's built

`ThemeModeController` holds the choice; `LinthraApp` watches it, so a change repaints every screen at once. Persistence goes through a `ThemeModeStore`, mirroring the existing app-icon-variant store: in-memory by default so tests stay free of platform plugins, with the `shared_preferences` binding applied in `main`.

**Live system changes are free.** `ThemeMode.system` already makes `MaterialApp` re-render when the phone flips while the app is open, so there's no listener of our own to get wrong. The test asserts it flips *both* ways rather than latching once.

**No launch flash.** `main` awaits `readStoredThemeMode()` before `runApp` and seeds `initialThemeModeProvider` with the result, so the first frame is already correct. Loading it asynchronously afterwards would make someone who picked Light on a dark phone watch the app flash dark and then flip — the exact glitch this preference is meant to remove. `main` already awaits other setup before `runApp`, so this adds one string read, not a new startup phase.

That seeding is also why the controller has **no async load of its own**. Beyond the flash, an async load introduces a race: a stored value landing after the user has already tapped a different option would silently overwrite their choice. Seeding removes the race by construction rather than guarding it with a flag.

**Failure is soft throughout.** A store that throws on read falls back to following the phone rather than taking startup down — a theme preference must never be able to stop the app booting. A failed write never undoes the user's visible choice; it just won't survive the next restart.

**Storage is a stable string, not an enum index.** Reordering the enum later can't turn a stored `"light"` into `"dark"` on update. Unknown values fall back to system, the same "unknown → default" rule the branding variants use.

## Tests

`test/app/theme_mode_test.dart` drives the real `LinthraApp` and reads the **actually rendered** brightness (`Theme.of(context).brightness`) rather than the `themeMode` we passed in, so the wiring is covered, not just the controller:

- defaults to `ThemeMode.system`; renders light on a light phone, dark on a dark one
- flips live when the phone theme changes mid-session, and flips back
- a pinned mode ignores the phone flipping, in both directions
- the seeded preference is live on the **first** pump — the no-flash assertion
- changing the mode at runtime repaints the app and persists

`test/features/appearance/theme_mode_controller_test.dart` covers the storage round-trip, the stable-id guarantee, unknown/empty/absent fallbacks, the full write → read-back → reseed restart path, and both failure modes (throwing read, throwing write).

The appearance screen test covers the picker appearing, defaulting to System, and persisting a pick.

- `flutter test` — all passing
- `flutter analyze` — no issues
- `dart format` — clean

## Scope

No version bump. No unrelated cleanup. Two doc comments were corrected because this PR falsifies them: the "Linthra still runs dark-only" line I added in #308, and `AppColors`' "dark mode is the primary experience".

## Review notes

**This is where you can finally see #308's palette.** Install the debug APK, then Settings → Appearance → Light. No temporary commit needed, which is what you asked for.

Two things I'd flag rather than fix here:

- **Status bar icons.** There's no `SystemUiOverlayStyle` anywhere in `lib/`. Flutter's M3 `AppBar` derives it from the app bar background, which is set per-brightness, so it should be right — but "should" is doing work. Worth checking on-device in light mode; if the status bar icons come out wrong, setting it explicitly in `appBarTheme` is a small follow-up.
- **Supporter custom palettes.** `custom_brand_palette.dart` derives tones from user-chosen colours and isn't covered by #308's contrast guarantees. A user-picked pale accent in light mode can still be unreadable. Now that light mode is reachable, this is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2zR428Jn65EY65f8uTyGk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2zR428Jn65EY65f8uTyGk)_