### PR TITLE
fix(library): make the first-sync empty state provider-aware

### DIFF
--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -13,12 +13,12 @@ import '../../core/services/bulk_track_actions.dart';
 import '../../core/sources/local/folder_location.dart';
 import '../../shared/widgets/empty_state.dart';
 import '../playlists/widgets/add_to_playlist_sheet.dart';
-import '../settings/jellyfin/jellyfin_sync_controller.dart';
 import 'folder_browser_providers.dart';
 import 'library_browse_providers.dart';
 import 'library_controller.dart';
 import 'library_search.dart';
 import 'library_state.dart';
+import 'library_sync_activity.dart';
 import 'selected_folder_controller.dart';
 import 'song_actions.dart';
 import 'unified_library_providers.dart';
@@ -103,12 +103,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         ref.watch(folderBrowsableSourcesProvider).isNotEmpty;
     final AsyncValue<String?> selectedFolder =
         ref.watch(selectedFolderControllerProvider);
-    // While the first Jellyfin sync is running, an empty catalog should read as
+    // While a first library sync is running, an empty catalog should read as
     // "filling up", not "nothing here" — so the library never looks broken
-    // during onboarding.
-    final bool jellyfinSyncing = ref.watch(
-      jellyfinSyncControllerProvider.select((s) => s.isSyncing),
-    );
+    // during onboarding. Covers every server source, not just Jellyfin: Plex
+    // exposes no folder hierarchy, so before this a scanning Plex library fell
+    // through to the local-folder prompt.
+    final List<String> syncingSources = ref.watch(syncingSourceNamesProvider);
 
     // Drop any selected rows no longer in the catalog (e.g. after a removal) so
     // the count and actions stay accurate. Keyed by the provider-namespaced uri,
@@ -150,8 +150,8 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
         bottom: browsing ? _tabBar() : null,
       ),
       body: browsing
-          ? _browseBody(songs)
-          : _statusBody(state, selectedFolder.valueOrNull, jellyfinSyncing),
+          ? _browseBody(songs, syncingSources)
+          : _statusBody(state, selectedFolder.valueOrNull, syncingSources),
     );
   }
 
@@ -177,7 +177,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   Widget _statusBody(
     LibraryState state,
     String? selectedFolder,
-    bool jellyfinSyncing,
+    List<String> syncingSources,
   ) {
     switch (state.status) {
       case LibraryStatus.loading:
@@ -188,11 +188,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
           onRetry: () => ref.read(libraryControllerProvider.notifier).refresh(),
         );
       case LibraryStatus.loaded:
-        // A first Jellyfin sync in flight takes precedence over the folder-pick
-        // prompt: tell the user their library is on its way rather than implying
-        // it's empty.
-        if (jellyfinSyncing) {
-          return const _LibrarySyncing();
+        // A first sync in flight — from any connected server — takes precedence
+        // over the folder-pick prompt: tell the user their library is on its way
+        // rather than implying it's empty, or (for Plex, which has no folder
+        // hierarchy to fall back on) asking them for a folder they don't want.
+        final String? headline = syncingHeadline(syncingSources);
+        if (headline != null) {
+          return _LibrarySyncing(headline: headline);
         }
         return _LibraryEmpty(
           selectedFolder: selectedFolder,
@@ -205,8 +207,13 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
   /// Catalog search + four browse tabs. Folders performs its own hierarchical
   /// navigation, so the flat-catalog search field is hidden on that tab.
-  Widget _browseBody(List<Track> songs) {
+  Widget _browseBody(List<Track> songs, List<String> syncingSources) {
     final bool foldersTab = _tabController.index == 3;
+    // A connected folder-capable server (Jellyfin, Navidrome/Subsonic) shows the
+    // tabs the moment it connects, so its *first* sync lands here rather than in
+    // [_statusBody]. Pass the syncing sources down so the catalog tabs say
+    // "still filling" instead of "nothing in the synced catalog".
+    final String? syncHeadline = syncingHeadline(syncingSources);
     return Column(
       children: <Widget>[
         if (!foldersTab)
@@ -219,9 +226,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
           child: TabBarView(
             controller: _tabController,
             children: <Widget>[
-              _songsTab(songs),
-              _albumsTab(),
-              _artistsTab(),
+              _songsTab(songs, syncHeadline),
+              _albumsTab(syncHeadline),
+              _artistsTab(syncHeadline),
               const FolderBrowserTab(),
             ],
           ),
@@ -232,10 +239,11 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
 
   // --- Tabs -------------------------------------------------------------
 
-  Widget _songsTab(List<Track> songs) {
+  Widget _songsTab(List<Track> songs, String? syncHeadline) {
     final List<Track> filtered = _filteredSongs(songs);
     if (filtered.isEmpty) {
       if (_query.isNotEmpty) return const _NoResults();
+      if (syncHeadline != null) return _CatalogFilling(headline: syncHeadline);
       return const EmptyState(
         icon: Icons.music_note_outlined,
         title: 'No songs in the synced catalog',
@@ -245,11 +253,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     return _songsList(filtered);
   }
 
-  Widget _albumsTab() {
+  Widget _albumsTab(String? syncHeadline) {
     final List<Album> filtered =
         filterAlbums(ref.watch(libraryAlbumsProvider), _query);
     if (filtered.isEmpty) {
       if (_query.isNotEmpty) return const _NoResults();
+      if (syncHeadline != null) return _CatalogFilling(headline: syncHeadline);
       return const EmptyState(
         icon: Icons.album_outlined,
         title: 'No albums in the synced catalog',
@@ -263,11 +272,12 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
     );
   }
 
-  Widget _artistsTab() {
+  Widget _artistsTab(String? syncHeadline) {
     final List<Artist> filtered =
         filterArtists(ref.watch(libraryArtistsProvider), _query);
     if (filtered.isEmpty) {
       if (_query.isNotEmpty) return const _NoResults();
+      if (syncHeadline != null) return _CatalogFilling(headline: syncHeadline);
       return const EmptyState(
         icon: Icons.person_outline,
         title: 'No artists in the synced catalog',
@@ -404,6 +414,27 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   }
 }
 
+/// The catalog-tab counterpart to [_LibrarySyncing], for the case where a
+/// folder-capable server is connected (so the tabs are already showing) but its
+/// first sync hasn't landed any tracks yet. Says the catalog is still filling
+/// rather than that it is empty, and still points at Folders — which *is*
+/// browseable right now, ahead of the sync.
+class _CatalogFilling extends StatelessWidget {
+  const _CatalogFilling({required this.headline});
+
+  final String headline;
+
+  @override
+  Widget build(BuildContext context) {
+    return EmptyState(
+      icon: Icons.sync_outlined,
+      title: headline,
+      message: 'Your songs will appear here as soon as they’re in. '
+          'You can browse the connected server from Folders meanwhile.',
+    );
+  }
+}
+
 /// The "no search matches" state, shown when a query filters every row out of
 /// the active tab. Deliberately friendly and identical across tabs.
 class _NoResults extends StatelessWidget {
@@ -419,11 +450,16 @@ class _NoResults extends StatelessWidget {
   }
 }
 
-/// Shown when the catalog is still empty but a first Jellyfin sync is running,
+/// Shown when the catalog is still empty but a first library sync is running,
 /// so onboarding reads as "your library is on its way" rather than "nothing
 /// here". Replaced automatically once the synced tracks land.
+///
+/// [headline] names the syncing source when exactly one is running and stays
+/// general when several are — see `syncingHeadline`.
 class _LibrarySyncing extends StatelessWidget {
-  const _LibrarySyncing();
+  const _LibrarySyncing({required this.headline});
+
+  final String headline;
 
   @override
   Widget build(BuildContext context) {
@@ -440,7 +476,7 @@ class _LibrarySyncing extends StatelessWidget {
             ),
             const SizedBox(height: AppSpacing.md),
             Text(
-              'Your Jellyfin library is syncing',
+              headline,
               style: theme.textTheme.titleMedium,
               textAlign: TextAlign.center,
             ),

--- a/lib/features/library/library_sync_activity.dart
+++ b/lib/features/library/library_sync_activity.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/sources/music_provider.dart';
+import '../settings/jellyfin/jellyfin_sync_controller.dart';
+import '../settings/plex/plex_sync_controller.dart';
+import '../settings/subsonic/subsonic_sync_controller.dart';
+
+/// The display names of every music source whose library sync is running right
+/// now, in a stable order (Jellyfin, Navidrome/Subsonic, Plex).
+///
+/// The Library screen uses this to tell a filling-up catalog apart from an
+/// empty one, so a first sync never reads as "you have no music" — and, for
+/// Plex, never as the local-folder prompt (Plex exposes no folder hierarchy, so
+/// before this the screen fell all the way through to "No music folder
+/// selected" while the library was actively scanning).
+///
+/// It reads the three existing sync controllers and nothing else: no provider
+/// API changes, no new state. Each is `select`ed down to its own boolean, so a
+/// sync's status *message* changing mid-run never rebuilds the Library.
+///
+/// Scope note: every provider's state exposes "a sync is running", not "the
+/// *first* sync is running" — that distinction lives in the controllers' own
+/// auto-sync fingerprints and isn't reachable from a state object. The Library
+/// only consults this while its catalog is still empty, which makes the two
+/// equivalent in practice: a re-sync of a library that already has tracks never
+/// reaches these call sites.
+final syncingSourceNamesProvider = Provider<List<String>>((ref) {
+  final bool jellyfin = ref.watch(
+    jellyfinSyncControllerProvider.select((state) => state.isSyncing),
+  );
+  final bool subsonic = ref.watch(
+    subsonicSyncControllerProvider.select((state) => state.isSyncing),
+  );
+  // Plex's `isSyncing` spans both of its phases — scanning the server and
+  // writing the results — which is exactly the window the catalog is empty in.
+  final bool plex = ref.watch(
+    plexSyncControllerProvider.select((state) => state.isSyncing),
+  );
+
+  return <String>[
+    if (jellyfin) MusicProviders.jellyfin.displayName,
+    if (subsonic) MusicProviders.subsonic.displayName,
+    if (plex) MusicProviders.plex.displayName,
+  ];
+});
+
+/// The headline for a catalog that is filling up, given the sources currently
+/// syncing. Named per-provider when exactly one is running ("Your Jellyfin
+/// library is syncing") and kept general when several are, so the line is
+/// always true without listing servers.
+///
+/// Returns null when nothing is syncing, so callers can fall through to their
+/// normal empty state.
+String? syncingHeadline(List<String> sourceNames) {
+  if (sourceNames.isEmpty) return null;
+  if (sourceNames.length == 1) {
+    return 'Your ${sourceNames.single} library is syncing';
+  }
+  return 'Your libraries are syncing';
+}

--- a/test/features/library/library_sync_state_test.dart
+++ b/test/features/library/library_sync_state_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/music_folder.dart';
+import 'package:linthra/core/services/folder_browsable_music_source.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/features/library/folder_browser_providers.dart';
+import 'package:linthra/features/library/library_screen.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_controller.dart';
+import 'package:linthra/features/settings/jellyfin/jellyfin_sync_state.dart';
+import 'package:linthra/features/settings/plex/plex_sync_controller.dart';
+import 'package:linthra/features/settings/plex/plex_sync_state.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_sync_controller.dart';
+import 'package:linthra/features/settings/subsonic/subsonic_sync_state.dart';
+
+import 'fake_music_library_repository.dart';
+
+/// Each provider's sync controller pinned to a fixed state, so a test can put
+/// the Library in the exact "first sync in flight" moment.
+class _FixedJellyfinSync extends JellyfinSyncController {
+  _FixedJellyfinSync(this._fixed);
+  final JellyfinSyncState _fixed;
+  @override
+  JellyfinSyncState build() => _fixed;
+}
+
+class _FixedSubsonicSync extends SubsonicSyncController {
+  _FixedSubsonicSync(this._fixed);
+  final SubsonicSyncState _fixed;
+  @override
+  SubsonicSyncState build() => _fixed;
+}
+
+class _FixedPlexSync extends PlexSyncController {
+  _FixedPlexSync(this._fixed);
+  final PlexSyncState _fixed;
+  @override
+  PlexSyncState build() => _fixed;
+}
+
+/// A folder-browsable source that never gets asked for anything: the Library
+/// only needs it to be *present* for the browse tabs to appear, which is what
+/// puts a syncing Navidrome/Subsonic on the tab path rather than the
+/// folder-pick path.
+class _StubFolderSource implements FolderBrowsableMusicSource {
+  @override
+  String get id => 'subsonic';
+
+  @override
+  String get displayName => 'Navidrome / Subsonic';
+
+  @override
+  Future<List<MusicFolder>> fetchRootFolders() async => const <MusicFolder>[];
+
+  @override
+  Future<MusicFolderListing> fetchFolder(String folderId) async =>
+      MusicFolderListing.empty;
+}
+
+Future<void> _pumpLibrary(
+  WidgetTester tester, {
+  JellyfinSyncState jellyfin = const JellyfinSyncState(),
+  SubsonicSyncState subsonic = const SubsonicSyncState(),
+  PlexSyncState plex = const PlexSyncState(),
+  bool hasFolderSources = false,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        // An empty catalog — the case onboarding starts from.
+        musicLibraryRepositoryProvider
+            .overrideWithValue(FakeMusicLibraryRepository()),
+        jellyfinSyncControllerProvider
+            .overrideWith(() => _FixedJellyfinSync(jellyfin)),
+        subsonicSyncControllerProvider
+            .overrideWith(() => _FixedSubsonicSync(subsonic)),
+        plexSyncControllerProvider.overrideWith(() => _FixedPlexSync(plex)),
+        folderBrowsableSourcesProvider.overrideWithValue(
+          hasFolderSources
+              ? <FolderBrowsableMusicSource>[_StubFolderSource()]
+              : const <FolderBrowsableMusicSource>[],
+        ),
+      ],
+      child: const MaterialApp(home: LibraryScreen()),
+    ),
+  );
+  // Let the (empty) catalog load resolve. Don't pumpAndSettle: a syncing state
+  // shows an endless progress spinner.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  group('Library first-sync state is provider-aware', () {
+    testWidgets('Plex: a scanning library never asks for a local folder',
+        (tester) async {
+      // The regression this whole change exists for. Plex exposes no folder
+      // hierarchy, so before the fix an empty catalog + a scanning Plex library
+      // fell straight through to "No music folder selected".
+      await _pumpLibrary(tester, plex: const PlexSyncState.scanning());
+
+      expect(find.text('Your Plex library is syncing'), findsOneWidget);
+      expect(find.text('No music folder selected'), findsNothing);
+      expect(find.text('Select a folder'), findsNothing);
+    });
+
+    testWidgets('Plex: the write phase counts as syncing too', (tester) async {
+      // Plex writes in batches, so `syncing` (saving) is just as much part of
+      // the first-run window as `scanning` (reading).
+      await _pumpLibrary(
+        tester,
+        plex: const PlexSyncState.syncing(trackCount: 400),
+      );
+
+      expect(find.text('Your Plex library is syncing'), findsOneWidget);
+      expect(find.text('No music folder selected'), findsNothing);
+    });
+
+    testWidgets('Jellyfin: names the source', (tester) async {
+      await _pumpLibrary(tester, jellyfin: const JellyfinSyncState.syncing());
+
+      expect(find.text('Your Jellyfin library is syncing'), findsOneWidget);
+      expect(find.text('No music folder selected'), findsNothing);
+    });
+
+    testWidgets(
+        'Subsonic: the catalog tabs read as filling, not empty, while syncing',
+        (tester) async {
+      // A connected Navidrome/Subsonic is folder-browsable, so the tabs show
+      // immediately and the first sync lands on the Songs tab rather than the
+      // folder-pick prompt. It must not claim the catalog is empty.
+      await _pumpLibrary(
+        tester,
+        subsonic: const SubsonicSyncState.syncing(),
+        hasFolderSources: true,
+      );
+
+      // findsWidgets, not findsOneWidget: TabBarView may keep a neighbouring
+      // catalog tab alive, and every catalog tab shows the same headline.
+      expect(
+        find.text('Your Navidrome / Subsonic library is syncing'),
+        findsWidgets,
+      );
+      expect(find.text('No songs in the synced catalog'), findsNothing);
+      expect(find.text('No music folder selected'), findsNothing);
+      // Folder browsing is genuinely available ahead of the sync, so the tabs
+      // and the pointer to Folders both stay.
+      expect(find.byKey(const Key('library_tabs')), findsOneWidget);
+      expect(find.textContaining('Folders'), findsWidgets);
+    });
+
+    testWidgets('several sources syncing at once stay general', (tester) async {
+      await _pumpLibrary(
+        tester,
+        jellyfin: const JellyfinSyncState.syncing(),
+        plex: const PlexSyncState.scanning(),
+      );
+
+      // Naming one server would be wrong and listing both is noise.
+      expect(find.text('Your libraries are syncing'), findsOneWidget);
+      expect(find.text('Your Jellyfin library is syncing'), findsNothing);
+      expect(find.text('No music folder selected'), findsNothing);
+    });
+
+    testWidgets('local-only: nothing syncing still prompts for a folder',
+        (tester) async {
+      await _pumpLibrary(tester);
+
+      // The pre-existing behaviour, unchanged: no server sync in flight and an
+      // empty catalog is a genuine "pick a folder" moment.
+      expect(find.text('No music folder selected'), findsOneWidget);
+      expect(find.text('Select a folder'), findsOneWidget);
+      expect(find.textContaining('is syncing'), findsNothing);
+      expect(find.text('Your libraries are syncing'), findsNothing);
+    });
+
+    testWidgets('a finished sync falls back to the normal empty state',
+        (tester) async {
+      // Success/error/idle are all "not syncing" — the screen must go back to
+      // its ordinary empty state rather than pinning a spinner.
+      await _pumpLibrary(
+        tester,
+        jellyfin: const JellyfinSyncState.error('Something went wrong.'),
+        plex: const PlexSyncState.done(trackCount: 0, message: 'Nothing here.'),
+      );
+
+      expect(find.text('No music folder selected'), findsOneWidget);
+      expect(find.textContaining('is syncing'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## What

The Library screen only consulted the **Jellyfin** sync controller when deciding whether an empty catalog meant "still filling up" or "you have no music". That single-provider assumption produced two bad onboarding moments:

**Plex — the worst case.** `folderBrowsableSourcesProvider` only ever contains Jellyfin and Subsonic, so a Plex-only user has no folder sources. With an empty catalog and `jellyfinSyncing == false`, the screen fell all the way through to `_LibraryEmpty` and showed:

> **No music folder selected** — Choose a folder on your device to scan for music.

…while their Plex library was actively scanning. Not a weak empty state — a wrong one, pointing at a feature they didn't ask for.

**Navidrome/Subsonic.** A connected Subsonic server *is* folder-browsable, so `browsing` flips on and the first sync lands on the browse tabs instead. Those tabs said "No songs in the synced catalog" at exactly the moment the catalog was filling.

## How

New `lib/features/library/library_sync_activity.dart`:

- `syncingSourceNamesProvider` — reads the three existing sync controllers and returns the display names of whichever are syncing. Each controller is `select`ed down to its own boolean, so a status *message* changing mid-sync never rebuilds the Library.
- `syncingHeadline(...)` — names the source when exactly one is syncing ("Your Plex library is syncing") and stays general when several are ("Your libraries are syncing"). Returns `null` when nothing is syncing, so callers fall through to their normal empty state.

`library_screen.dart` consults it in both places an empty catalog can surface:

- `_statusBody` → `_LibrarySyncing` now covers all three server sources, not just Jellyfin. This is the fix for the Plex prompt.
- The Songs / Albums / Artists tabs → a new `_CatalogFilling` state when the slice is empty *and* a sync is running. This is the fix for the Subsonic path. It still points at Folders, which genuinely is browseable ahead of the sync.

Plex's `isSyncing` deliberately spans both its phases (`scanning` the server and `syncing`/writing the batches), which is exactly the window where the catalog is empty.

## Scope

- No provider APIs change. No new sync state is introduced. This only reads what the controllers already expose.
- Once a sync finishes — success, error, or idle — every screen falls back to exactly its previous behaviour.
- A local-only install (nothing connected, nothing syncing) still gets the folder prompt, unchanged.
- No version bump, no unrelated cleanup.

## A note on "initial" sync

The brief asked for *initial* sync. Worth being explicit that none of the three state models can express that:

- `JellyfinSyncState`, `SubsonicSyncState` and `PlexSyncState` all expose only "a sync is running" (`isSyncing`). None carries a "this is the first one" flag.
- For Jellyfin and Subsonic the first-sync knowledge lives in the controllers' auto-sync fingerprint stores (`JellyfinAutoSyncStore` / `SubsonicAutoSyncStore`), consulted inside `autoSyncIfNeeded()` and never reflected back into state. Reading it from the UI would mean an async store read on every Library build.
- **Plex has neither.** There is no `PlexAutoSyncStore` and no `autoSyncIfNeeded()` — sync is kicked by `syncAfterSelectionChange()` from the settings controller. Plex has a *content signature* cache (`PlexSyncCacheStore`) but that answers "did anything change?", not "is this the first sync?".

Rather than add a first-sync flag to three state objects and invent one for Plex, this gates on "a sync is running" **and only consults it while the catalog is still empty**. That makes the two equivalent in practice: a re-sync of a library that already has tracks never reaches these call sites, because a non-empty catalog renders content instead. If a first-sync distinction is ever genuinely needed elsewhere, that's the architectural change to discuss on its own — it shouldn't ride along here.

## Tests

`test/features/library/library_sync_state_test.dart` — seven cases:

- Plex scanning → names Plex, never shows the folder prompt (the regression this exists for)
- Plex writing (`syncing` phase) → same, so the whole window is covered
- Jellyfin syncing → names Jellyfin
- Subsonic syncing with folder sources present → catalog tabs read as filling, tabs and the Folders pointer both stay
- Two sources at once → stays general, names neither
- Local-only, nothing syncing → folder prompt unchanged
- Finished sync (error + done) → falls back to the normal empty state rather than pinning a spinner

The existing `library_jellyfin_syncing_test.dart` passes unchanged — Jellyfin-only copy is identical to before.

CI is green on `a156b33`: **Flutter checks** (analyze + test) passed, along with the secret/privacy scan, the debug APK build, and both simulated lock-state validations.