### PR TITLE
feat(favorites): a visible heart on rows, and parity for the Favorites screen

### DIFF
--- a/lib/features/favorites/favorites_screen.dart
+++ b/lib/features/favorites/favorites_screen.dart
@@ -36,8 +36,7 @@ class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
     with TrackSelectionMixin<FavoritesScreen> {
   @override
   Widget build(BuildContext context) {
-    final AsyncValue<List<Track>> favorites =
-        ref.watch(favoriteTracksProvider);
+    final AsyncValue<List<Track>> favorites = ref.watch(favoriteTracksProvider);
 
     return favorites.when(
       loading: () => Scaffold(

--- a/lib/features/favorites/favorites_screen.dart
+++ b/lib/features/favorites/favorites_screen.dart
@@ -1,34 +1,247 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../app/dimens.dart';
+import '../../app/routes.dart';
+import '../../core/models/track.dart';
+import '../../core/services/bulk_track_actions.dart';
 import '../../shared/widgets/empty_state.dart';
+import '../library/song_actions.dart';
+import '../library/track_selection.dart';
 import '../library/widgets/alphabet_track_list.dart';
+import '../player/player_providers.dart';
+import '../playlists/widgets/add_to_playlist_sheet.dart';
 import 'favorites_controller.dart';
 
-/// The Favorites library view: every track the user has liked, local or
-/// Jellyfin. Reads entirely from [favoriteTracksProvider] and reuses the same
-/// [AlphabetTrackList]/`TrackTile` rows as the main library, so tapping a
+/// The Favorites library view: every track the user has liked, local or from a
+/// connected server. Reads entirely from [favoriteTracksProvider] and reuses the
+/// same [AlphabetTrackList]/`TrackTile` rows as the main library, so tapping a
 /// favourite plays it and queues the rest behind it — unchanged from the
-/// library. Shows an honest empty state when nothing is favourited yet.
-class FavoritesScreen extends ConsumerWidget {
+/// library.
+///
+/// Brought to parity with Album and Playlist detail: a Play / Shuffle header
+/// over the list, and the same long-press multi-select the rest of the app has.
+/// Selection bookkeeping comes from [TrackSelectionMixin] and the available
+/// actions from [bulkActionsFor], so this screen adds no selection rules of its
+/// own — a favourite behaves in a bulk action exactly as it does in the library.
+class FavoritesScreen extends ConsumerStatefulWidget {
   const FavoritesScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final favorites = ref.watch(favoriteTracksProvider);
-    return Scaffold(
-      appBar: AppBar(title: const Text('Favorites')),
-      body: favorites.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, __) => const _FavoritesError(),
-        data: (tracks) => tracks.isEmpty
-            ? const EmptyState(
-                icon: Icons.favorite_border,
-                title: 'No favorites yet',
-                message: 'Tap the heart on a track to add it here.',
-              )
-            : AlphabetTrackList(tracks: tracks),
+  ConsumerState<FavoritesScreen> createState() => _FavoritesScreenState();
+}
+
+class _FavoritesScreenState extends ConsumerState<FavoritesScreen>
+    with TrackSelectionMixin<FavoritesScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<List<Track>> favorites =
+        ref.watch(favoriteTracksProvider);
+
+    return favorites.when(
+      loading: () => Scaffold(
+        appBar: AppBar(title: const Text('Favorites')),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, __) => Scaffold(
+        appBar: AppBar(title: const Text('Favorites')),
+        body: const _FavoritesError(),
+      ),
+      data: (List<Track> tracks) => _body(tracks),
+    );
+  }
+
+  Widget _body(List<Track> tracks) {
+    if (tracks.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Favorites')),
+        body: const EmptyState(
+          icon: Icons.favorite_border,
+          title: 'No favorites yet',
+          // Accurate as of the visible heart on every track row: this is the
+          // control the sentence points at, not the overflow menu it used to
+          // mean.
+          message: 'Tap the heart on any song to save it here.',
+        ),
+      );
+    }
+
+    // The order the rows actually appear in. Play / Shuffle queue this, not the
+    // catalog order the provider returned, so the header agrees with the list
+    // beneath it — and with what tapping a row already does.
+    final List<Track> ordered = AlphabetTrackList.sortedByTitle(tracks);
+
+    // Resolve against the live list, so a track that stops being a favourite
+    // (or leaves the catalog) while selected simply drops out of the count and
+    // the available actions.
+    final List<Track> selected = selectedFrom(ordered);
+
+    final Widget scaffold = Scaffold(
+      appBar: selectionActive
+          ? _selectionAppBar(selected)
+          : AppBar(title: const Text('Favorites')),
+      body: Column(
+        children: <Widget>[
+          if (!selectionActive)
+            _FavoritesHeader(
+              trackCount: ordered.length,
+              onPlay: () => _play(ordered),
+              onShuffle: () => _shuffle(ordered),
+            ),
+          Expanded(
+            child: AlphabetTrackList(
+              tracks: ordered,
+              selectable: true,
+              selectionActive: selectionActive,
+              selectedUris: selectedUris,
+              onSelectStart: startSelection,
+              onSelectToggle: toggleSelection,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (!selectionActive) return scaffold;
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (bool didPop, _) {
+        if (!didPop) exitSelection();
+      },
+      child: scaffold,
+    );
+  }
+
+  /// The same selection app bar the Library offers, driven by the shared
+  /// [bulkActionsFor] rules so a mixed-source selection automatically hides any
+  /// action that wouldn't be safe for all of it.
+  PreferredSizeWidget _selectionAppBar(List<Track> selected) {
+    final BulkActionAvailability actions =
+        bulkActionsFor(selected, inPlaylist: false);
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        tooltip: 'Cancel selection',
+        onPressed: exitSelection,
+      ),
+      title: Text('${selected.length} selected'),
+      actions: <Widget>[
+        if (actions.canAddToPlaylist)
+          IconButton(
+            icon: const Icon(Icons.playlist_add),
+            tooltip: 'Add to playlist',
+            onPressed: selected.isEmpty ? null : () => _addToPlaylist(selected),
+          ),
+        if (actions.canRemoveOfflineCopy)
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Remove offline copies',
+            onPressed: selected.isEmpty ? null : () => _removeOffline(selected),
+          ),
+        if (actions.canRemoveFromLibrary)
+          IconButton(
+            icon: const Icon(Icons.remove_circle_outline),
+            tooltip: 'Remove from Linthra',
+            onPressed:
+                selected.isEmpty ? null : () => _removeFromLibrary(selected),
+          ),
+      ],
+    );
+  }
+
+  void _play(List<Track> tracks) {
+    ref.read(playbackControllerProvider).playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  void _shuffle(List<Track> tracks) {
+    final controller = ref.read(playbackControllerProvider);
+    controller.setShuffleEnabled(true);
+    controller.playTracks(tracks);
+    context.push(AppRoutes.player);
+  }
+
+  Future<void> _addToPlaylist(List<Track> selected) async {
+    await showAddToPlaylistSheet(context, selected);
+    exitSelection();
+  }
+
+  Future<void> _removeOffline(List<Track> selected) async {
+    final bool ran =
+        await SongActions.removeOfflineCopies(context, ref, selected);
+    if (ran) exitSelection();
+  }
+
+  Future<void> _removeFromLibrary(List<Track> selected) async {
+    // Same shared, confirmed action the Library uses — including expanding a
+    // logical row to every provider copy, so a hidden duplicate can't resurrect
+    // the row (and its heart) on the next reload.
+    final bool removed = await SongActions.removeFromLibrary(
+      context,
+      ref,
+      selected,
+      expandLogicalSources: true,
+    );
+    if (removed) exitSelection();
+  }
+}
+
+/// The Play / Shuffle header, matching Album and Playlist detail so the three
+/// list screens start playback the same way.
+class _FavoritesHeader extends StatelessWidget {
+  const _FavoritesHeader({
+    required this.trackCount,
+    required this.onPlay,
+    required this.onShuffle,
+  });
+
+  final int trackCount;
+  final VoidCallback onPlay;
+  final VoidCallback onShuffle;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String count = trackCount == 1 ? '1 song' : '$trackCount songs';
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        AppSpacing.sm,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            count,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: FilledButton.icon(
+                  onPressed: onPlay,
+                  icon: const Icon(Icons.play_arrow),
+                  label: const Text('Play'),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: onShuffle,
+                  icon: const Icon(Icons.shuffle),
+                  label: const Text('Shuffle'),
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/library/track_selection.dart
+++ b/lib/features/library/track_selection.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/widgets.dart';
+
+import '../../core/models/track.dart';
+
+/// The multi-select bookkeeping every track-list screen needs, in one place.
+///
+/// Library, Album detail and Artist detail each grew their own copy of the same
+/// four operations (start, toggle, clear, resolve-to-tracks). This mixin is that
+/// logic extracted once so a new screen — Favorites — can adopt multi-select
+/// without adding a fifth copy. The existing three are deliberately left alone
+/// here: retrofitting them is a behaviour-neutral refactor that belongs in its
+/// own change, not in a Favorites usability PR.
+///
+/// Selection is keyed by the provider-namespaced [Track.uri], never the bare id,
+/// so a Jellyfin and a Navidrome copy that share a server-side id can't be
+/// selected (or bulk-acted on) as if they were one row.
+///
+/// The host owns the visuals: it decides what the selection app bar offers and
+/// what a tap does. This only tracks *what is selected*, and calls [setState] so
+/// the host rebuilds.
+mixin TrackSelectionMixin<T extends StatefulWidget> on State<T> {
+  final Set<String> _selectedUris = <String>{};
+
+  /// Whether the screen is currently in selection mode. Driven purely by the
+  /// selection being non-empty, so clearing the last row always leaves the mode
+  /// — there is no separate flag that can drift out of step with the set.
+  bool get selectionActive => _selectedUris.isNotEmpty;
+
+  /// The selected uris, for handing to a list widget. Read-only to callers.
+  Set<String> get selectedUris => Set<String>.unmodifiable(_selectedUris);
+
+  /// The selected rows resolved against [tracks], in list order.
+  ///
+  /// Resolving through the live list (rather than holding [Track] objects) is
+  /// what keeps a selection honest when the catalog changes underneath it: a row
+  /// removed by a sync or a delete simply stops resolving, so the count and the
+  /// available actions never describe a track that is no longer there.
+  List<Track> selectedFrom(List<Track> tracks) => <Track>[
+        for (final Track track in tracks)
+          if (_selectedUris.contains(track.uri)) track,
+      ];
+
+  /// Enters selection mode with [track] as the first row (a long-press).
+  void startSelection(Track track) {
+    setState(() {
+      _selectedUris
+        ..clear()
+        ..add(track.uri);
+    });
+  }
+
+  /// Adds or removes [track]. Removing the last row leaves selection mode.
+  void toggleSelection(Track track) {
+    setState(() {
+      if (!_selectedUris.add(track.uri)) {
+        _selectedUris.remove(track.uri);
+      }
+    });
+  }
+
+  /// Leaves selection mode, dropping every selected row.
+  void exitSelection() {
+    if (_selectedUris.isEmpty) return;
+    setState(_selectedUris.clear);
+  }
+}

--- a/lib/features/library/widgets/alphabet_track_list.dart
+++ b/lib/features/library/widgets/alphabet_track_list.dart
@@ -44,6 +44,16 @@ class AlphabetTrackList extends StatefulWidget {
   /// Starts selection with a track (long-press).
   final void Function(Track track)? onSelectStart;
 
+  /// The order rows are displayed in: by title, case-insensitively.
+  ///
+  /// Exposed so a host screen's Play / Shuffle queues exactly what the user
+  /// sees, instead of the catalog order it happened to receive. Tapping a row
+  /// already queues in this order (rows are built from the sorted list), so a
+  /// header button that used the unsorted list would disagree with the very
+  /// list it sits above.
+  static List<Track> sortedByTitle(List<Track> tracks) => <Track>[...tracks]
+    ..sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
+
   @override
   State<AlphabetTrackList> createState() => _AlphabetTrackListState();
 }
@@ -98,8 +108,7 @@ class _AlphabetTrackListState extends State<AlphabetTrackList> {
   /// (Re)derives the sorted list, the flat header/track entry list, and the
   /// per-letter scroll offsets from the current tracks.
   void _rebuildIndex() {
-    _sorted = [...widget.tracks]
-      ..sort((a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase()));
+    _sorted = AlphabetTrackList.sortedByTitle(widget.tracks);
 
     _entries = <_Entry>[];
     _letters = <String>[];

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -238,10 +238,21 @@ class _StatusGlyph extends StatelessWidget {
 /// (see `SyncedFavoritesRepository`). Routing is by the provider-namespaced
 /// [Track.uri], so a Jellyfin and a Navidrome copy keep separate hearts.
 ///
-/// Sized 40x48 rather than the default 48x48: it is the third control in the
-/// row's trailing edge (after the download glyph and before the menu), and the
-/// narrower box buys back space for the title on small screens without dropping
-/// the tap target below a comfortable height.
+/// Given a 40dp-wide visual box rather than the default 48dp: it is the third
+/// control on the row's trailing edge (after the download glyph, before the
+/// menu), and the narrower box buys back space for the title on small screens.
+/// The *tap* target is unaffected — IconButton pads the hit area out to
+/// Material's 48x48 minimum around it.
+///
+/// The glyph sits at the *right* of that box rather than centred, so the heart
+/// reads as part of the trailing action group with the overflow menu instead of
+/// drifting toward the download indicator. Centred, the measured gaps on a
+/// 320dp screen were 12dp to the status glyph and 24dp to the menu — the heart
+/// looked like it belonged to the status cluster. Right-aligned they become
+/// 20dp and 16dp, so it groups with the menu. This only moves the icon inside
+/// the existing box: the trailing group's total width — and therefore the room
+/// left for the title, and the clearance beside the alphabet rail — is
+/// unchanged, measured at 104dp of title either way on a 320dp screen.
 class _FavoriteButton extends ConsumerWidget {
   const _FavoriteButton({required this.track});
 
@@ -259,6 +270,8 @@ class _FavoriteButton extends ConsumerWidget {
       // constraints and shrink the target further than intended.
       constraints: const BoxConstraints.tightFor(width: 40, height: 48),
       padding: EdgeInsets.zero,
+      // Biases the glyph toward the menu without changing the box (see above).
+      alignment: Alignment.centerRight,
       icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
       color: isFavorite ? theme.colorScheme.secondary : null,
       tooltip: isFavorite ? 'Remove from favorites' : 'Add to favorites',

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -34,10 +34,11 @@ enum _TrackAction {
 /// A single library track row.
 ///
 /// The row is deliberately calm: artwork (or a placeholder), the title, and a
-/// clean artist • album subtitle. Per-track actions live behind a trailing
-/// 3-dots overflow menu rather than a dedicated button, so the list stays
-/// uncluttered. Download state is still surfaced — but only as a subtle leading
-/// glyph next to the menu, never as a large control.
+/// clean artist • album subtitle. The trailing edge carries a visible favourite
+/// heart (the one action common enough to earn a permanent control) and the
+/// 3-dots overflow menu for everything else, so the list stays uncluttered
+/// without hiding liking behind a menu. Download state is still surfaced — but
+/// only as a subtle glyph before them, never as a large control.
 ///
 /// Tapping the row plays the tapped track and queues the rest of [tracks]
 /// behind it, then opens the now-playing screen — unchanged from before.
@@ -140,6 +141,7 @@ class TrackTile extends ConsumerWidget {
                   isRemote: isRemote,
                   progress: downloadFraction,
                 ),
+                _FavoriteButton(track: track),
                 _OverflowMenu(
                   track: track,
                   status: status,
@@ -219,6 +221,51 @@ class _StatusGlyph extends StatelessWidget {
       case DownloadStatus.notDownloaded:
         return const SizedBox.shrink();
     }
+  }
+}
+
+/// The visible favourite toggle on a track row.
+///
+/// Liking a song used to be reachable only from the row's 3-dot menu (or the
+/// full player), which made the app's most-used action its least discoverable —
+/// and left the Favorites empty state telling users to "tap the heart" on rows
+/// that had none. This is that heart. The overflow menu keeps its own
+/// favourite entry as the secondary path, so nothing that worked before stops
+/// working.
+///
+/// Offered for every track, exactly like the menu entry it mirrors: favourites
+/// persist locally for any source and mirror to whichever server owns the track
+/// (see `SyncedFavoritesRepository`). Routing is by the provider-namespaced
+/// [Track.uri], so a Jellyfin and a Navidrome copy keep separate hearts.
+///
+/// Sized 40x48 rather than the default 48x48: it is the third control in the
+/// row's trailing edge (after the download glyph and before the menu), and the
+/// narrower box buys back space for the title on small screens without dropping
+/// the tap target below a comfortable height.
+class _FavoriteButton extends ConsumerWidget {
+  const _FavoriteButton({required this.track});
+
+  final Track track;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    // Keyed by the namespaced uri so this row reflects its own copy's heart, and
+    // stays live if the favourite changes elsewhere (the player, a server sync).
+    final bool isFavorite = ref.watch(isFavoriteProvider(track.uri));
+    return IconButton(
+      // A tight 40x48 box rather than the default 48x48. Sizing is set here and
+      // nowhere else — adding visualDensity on top would compound with these
+      // constraints and shrink the target further than intended.
+      constraints: const BoxConstraints.tightFor(width: 40, height: 48),
+      padding: EdgeInsets.zero,
+      icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
+      color: isFavorite ? theme.colorScheme.secondary : null,
+      tooltip: isFavorite ? 'Remove from favorites' : 'Add to favorites',
+      onPressed: () => ref
+          .read(favoritesRepositoryProvider)
+          .setFavorite(track, !isFavorite),
+    );
   }
 }
 

--- a/lib/features/library/widgets/track_tile.dart
+++ b/lib/features/library/widgets/track_tile.dart
@@ -262,9 +262,8 @@ class _FavoriteButton extends ConsumerWidget {
       icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
       color: isFavorite ? theme.colorScheme.secondary : null,
       tooltip: isFavorite ? 'Remove from favorites' : 'Add to favorites',
-      onPressed: () => ref
-          .read(favoritesRepositoryProvider)
-          .setFavorite(track, !isFavorite),
+      onPressed: () =>
+          ref.read(favoritesRepositoryProvider).setFavorite(track, !isFavorite),
     );
   }
 }

--- a/test/features/favorites/favorites_screen_test.dart
+++ b/test/features/favorites/favorites_screen_test.dart
@@ -92,6 +92,14 @@ void main() {
 
       expect(find.text('No favorites yet'), findsOneWidget);
       expect(find.text('Alpha'), findsNothing);
+      // The instruction must name a control that actually exists on a row.
+      expect(
+        find.text('Tap the heart on any song to save it here.'),
+        findsOneWidget,
+      );
+      // Nothing to play, so the header doesn't appear either.
+      expect(find.text('Play'), findsNothing);
+      expect(find.text('Shuffle'), findsNothing);
     });
 
     testWidgets('shows a friendly error state when the catalog fails to load', (
@@ -138,4 +146,186 @@ void main() {
       );
     });
   });
+
+  group('FavoritesScreen Play / Shuffle', () {
+    testWidgets('Play starts the whole list in order and opens the player',
+        (tester) async {
+      final controller = FakePlaybackController();
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+        playback: controller,
+      );
+
+      expect(find.text('3 songs'), findsOneWidget);
+      await tester.tap(find.text('Play'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.currentTrack?.id, 'a');
+      expect(controller.state.upNext.map((t) => t.id).toList(), ['b', 'c']);
+      expect(controller.state.shuffleEnabled, isFalse);
+      // Matches Album and Playlist detail, which both push the player.
+      expect(find.byType(PlayerScreen), findsOneWidget);
+    });
+
+    testWidgets('Shuffle enables shuffle before playing', (tester) async {
+      final controller = FakePlaybackController();
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+        playback: controller,
+      );
+
+      await tester.tap(find.text('Shuffle'));
+      await tester.pumpAndSettle();
+
+      expect(controller.state.shuffleEnabled, isTrue);
+      // Shuffle randomises the queue, so assert the mode and that something
+      // started — not which specific track won.
+      expect(controller.playedTracks, isNotEmpty);
+      expect(find.byType(PlayerScreen), findsOneWidget);
+    });
+
+    testWidgets('a single favourite reads "1 song"', (tester) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'a', title: 'Alpha', uri: 'file:///a.mp3'),
+        ],
+        favorites: const FavoritesData(localIds: {'file:///a.mp3'}),
+      );
+
+      expect(find.text('1 song'), findsOneWidget);
+    });
+  });
+
+  group('FavoritesScreen multi-select', () {
+    testWidgets('long-press enters selection and shows the count',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+      );
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.byTooltip('Add to playlist'), findsOneWidget);
+      expect(find.byTooltip('Cancel selection'), findsOneWidget);
+      // The Play/Shuffle header steps aside while selecting.
+      expect(find.text('Play'), findsNothing);
+      expect(find.text('Shuffle'), findsNothing);
+    });
+
+    testWidgets('tapping more rows while selecting extends the selection',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+      );
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Bravo'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2 selected'), findsOneWidget);
+      // A tap during selection must not start playback.
+      expect(find.byType(PlayerScreen), findsNothing);
+    });
+
+    testWidgets('deselecting the last row leaves selection mode',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+      );
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.text('Favorites'), findsOneWidget);
+      expect(find.text('Play'), findsOneWidget);
+    });
+
+    testWidgets('Cancel selection restores the normal app bar', (tester) async {
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+      );
+
+      await tester.longPress(find.text('Alpha'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Cancel selection'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsNothing);
+      expect(find.text('Favorites'), findsOneWidget);
+    });
+  });
+
+  group('FavoritesScreen heart', () {
+    testWidgets('rows show a filled heart, and unfavoriting drops the row',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: _threeTracks,
+        favorites: _allThreeFavorited,
+      );
+
+      // Everything here is a favourite by definition.
+      expect(find.byTooltip('Remove from favorites'), findsNWidgets(3));
+
+      await tester.tap(find.byTooltip('Remove from favorites').first);
+      await tester.pumpAndSettle();
+
+      // Alpha sorts first, so the first heart is Alpha's; it leaves the list.
+      expect(find.text('Alpha'), findsNothing);
+      expect(find.text('Bravo'), findsOneWidget);
+      expect(find.text('2 songs'), findsOneWidget);
+    });
+
+    testWidgets('unfavoriting the last row falls back to the empty state',
+        (tester) async {
+      await _pump(
+        tester,
+        tracks: const <Track>[
+          Track(id: 'a', title: 'Alpha', uri: 'file:///a.mp3'),
+        ],
+        favorites: const FavoritesData(localIds: {'file:///a.mp3'}),
+      );
+
+      await tester.tap(find.byTooltip('Remove from favorites'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No favorites yet'), findsOneWidget);
+      expect(
+        find.text('Tap the heart on any song to save it here.'),
+        findsOneWidget,
+      );
+    });
+  });
 }
+
+/// Deliberately *not* in alphabetical order: the list sorts by title, so this
+/// catches a Play button that queues the raw catalog order instead of the order
+/// the user is looking at.
+const List<Track> _threeTracks = <Track>[
+  Track(id: 'c', title: 'Charlie', uri: 'file:///c.mp3'),
+  Track(id: 'a', title: 'Alpha', uri: 'file:///a.mp3'),
+  Track(id: 'b', title: 'Bravo', uri: 'file:///b.mp3'),
+];
+
+const FavoritesData _allThreeFavorited = FavoritesData(
+  localIds: <String>{'file:///a.mp3', 'file:///b.mp3', 'file:///c.mp3'},
+);

--- a/test/features/library/track_tile_test.dart
+++ b/test/features/library/track_tile_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/features/downloads/download_providers.dart';
 import 'package:linthra/features/library/widgets/track_tile.dart';
 import 'package:linthra/features/player/player_providers.dart';
 
@@ -337,6 +339,68 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.byTooltip('Add to favorites'), findsOneWidget);
       expect(find.byTooltip('More actions'), findsOneWidget);
+    });
+
+    testWidgets('the heart groups with the menu, not the download glyph',
+        (tester) async {
+      // Proximity is what makes the trailing edge read as one action group.
+      // Centred in its box the heart measured 12dp from the status glyph and
+      // 24dp from the menu — visually part of the *status* cluster. It is now
+      // right-aligned inside the same box, which flips that.
+      _useNarrowPhone(tester);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            remoteTrackDownloaderProvider
+                .overrideWithValue(FakeRemoteTrackDownloader()),
+            // A downloaded remote track, so the status glyph is actually drawn.
+            trackDownloadStatusProvider.overrideWith(
+              (ref, key) =>
+                  Stream<DownloadStatus>.value(DownloadStatus.downloaded),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: TrackTile(
+                tracks: <Track>[
+                  Track(id: '1', title: 'Song One', uri: 'jellyfin:1'),
+                ],
+                index: 0,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final Rect glyph = tester.getRect(find.byIcon(Icons.download_done));
+      final Rect heart = tester.getRect(find.byIcon(Icons.favorite_border));
+      final Rect menu = tester.getRect(find.byIcon(Icons.more_vert));
+
+      final double toMenu = menu.left - heart.right;
+      final double toGlyph = heart.left - glyph.right;
+      expect(
+        toMenu,
+        lessThan(toGlyph),
+        reason: 'the heart must sit closer to the overflow menu ($toMenu) '
+            'than to the download glyph ($toGlyph)',
+      );
+
+      // Grouping is a pure re-alignment inside the existing box, so the tap
+      // target must not have shrunk — otherwise we'd have traded accessibility
+      // for looks. IconButton pads the hit area out to Material's 48dp minimum
+      // around the 40dp visual box, so this floor is what a finger actually
+      // gets.
+      final Size target = tester.getSize(
+        find
+            .ancestor(
+              of: find.byIcon(Icons.favorite_border),
+              matching: find.byType(IconButton),
+            )
+            .first,
+      );
+      expect(target.width, greaterThanOrEqualTo(48));
+      expect(target.height, greaterThanOrEqualTo(48));
     });
 
     testWidgets('the heart stays tappable at a 2.0 text scale', (tester) async {

--- a/test/features/library/track_tile_test.dart
+++ b/test/features/library/track_tile_test.dart
@@ -13,6 +13,7 @@ Future<void> _pump(
   WidgetTester tester,
   List<Track> tracks, {
   FakePlaybackController? controller,
+  TextScaler? textScaler,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -23,18 +24,35 @@ Future<void> _pump(
           playbackControllerProvider.overrideWithValue(controller),
       ],
       child: MaterialApp(
-        home: Scaffold(
-          body: ListView(
-            children: [
-              for (var i = 0; i < tracks.length; i++)
-                TrackTile(tracks: tracks, index: i),
-            ],
-          ),
+        home: Builder(
+          builder: (BuildContext context) {
+            final Widget scaffold = Scaffold(
+              body: ListView(
+                children: [
+                  for (var i = 0; i < tracks.length; i++)
+                    TrackTile(tracks: tracks, index: i),
+                ],
+              ),
+            );
+            if (textScaler == null) return scaffold;
+            return MediaQuery(
+              data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+              child: scaffold,
+            );
+          },
         ),
       ),
     ),
   );
   await tester.pumpAndSettle();
+}
+
+/// Shrinks the test surface to a narrow phone for the crowding checks, and
+/// restores it afterwards.
+void _useNarrowPhone(WidgetTester tester) {
+  tester.view.physicalSize = const Size(320 * 3, 640 * 3);
+  tester.view.devicePixelRatio = 3.0;
+  addTearDown(tester.view.reset);
 }
 
 void main() {
@@ -114,7 +132,9 @@ void main() {
 
       expect(find.text('Add to favorites'), findsOneWidget);
       expect(find.text('Remove from favorites'), findsNothing);
-      expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+      // Two outline hearts while the menu is open: the row's own visible
+      // toggle, plus the menu entry that remains as the secondary path.
+      expect(find.byIcon(Icons.favorite_border), findsNWidgets(2));
     });
 
     testWidgets(
@@ -142,7 +162,197 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('Remove from favorites'), findsOneWidget);
       expect(find.text('Add to favorites'), findsNothing);
+      // Row toggle + menu entry, both now filled (see the outline case above).
+      expect(find.byIcon(Icons.favorite), findsNWidgets(2));
+    });
+  });
+
+  group('TrackTile visible favorite heart', () {
+    testWidgets('every row shows an outline heart when not favorited',
+        (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+        Track(id: '2', title: 'Song Two', uri: 'file:///s2.mp3'),
+      ]);
+
+      // Visible without opening any menu — the whole point of the change.
+      expect(find.byTooltip('Add to favorites'), findsNWidgets(2));
+      expect(find.byIcon(Icons.favorite_border), findsNWidgets(2));
+      expect(find.byIcon(Icons.favorite), findsNothing);
+    });
+
+    testWidgets('tapping the heart favorites the track and fills it',
+        (tester) async {
+      final FakePlaybackController controller = FakePlaybackController();
+      await _pump(
+        tester,
+        const <Track>[Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3')],
+        controller: controller,
+      );
+
+      await tester.tap(find.byTooltip('Add to favorites'));
+      await tester.pumpAndSettle();
+
       expect(find.byIcon(Icons.favorite), findsOneWidget);
+      expect(find.byIcon(Icons.favorite_border), findsNothing);
+      expect(find.byTooltip('Remove from favorites'), findsOneWidget);
+      // Liking is a pure like: nothing plays and the queue is untouched.
+      expect(controller.playedTracks, isEmpty);
+      expect(controller.state.upNext, isEmpty);
+    });
+
+    testWidgets('tapping a filled heart unfavorites the track', (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+      ]);
+
+      await tester.tap(find.byTooltip('Add to favorites'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Remove from favorites'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+      expect(find.byIcon(Icons.favorite), findsNothing);
+    });
+
+    testWidgets('only the tapped row is favorited, not its neighbours',
+        (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+        Track(id: '2', title: 'Song Two', uri: 'file:///s2.mp3'),
+      ]);
+
+      await tester.tap(find.byTooltip('Add to favorites').first);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
+      expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+    });
+
+    testWidgets('two provider copies of one id keep separate hearts',
+        (tester) async {
+      // Favourites are keyed by the provider-namespaced uri, so liking the
+      // Jellyfin copy must not light up the Navidrome one.
+      await _pump(tester, const <Track>[
+        Track(id: '101', title: 'Shared', uri: 'jellyfin:101'),
+        Track(id: '101', title: 'Shared', uri: 'subsonic:101'),
+      ]);
+
+      await tester.tap(find.byTooltip('Add to favorites').first);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
+      expect(find.byIcon(Icons.favorite_border), findsOneWidget);
+    });
+
+    testWidgets('the heart does not replace the overflow menu', (tester) async {
+      await _pump(tester, const <Track>[
+        Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+      ]);
+
+      // Both paths coexist: the menu keeps its favourite entry as the
+      // secondary route.
+      expect(find.byTooltip('Add to favorites'), findsOneWidget);
+      expect(find.byTooltip('More actions'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('More actions'));
+      await tester.pumpAndSettle();
+      expect(find.text('Add to favorites'), findsOneWidget);
+    });
+
+    testWidgets('selection mode hides the heart in favour of the checkbox',
+        (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            remoteTrackDownloaderProvider
+                .overrideWithValue(FakeRemoteTrackDownloader()),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: TrackTile(
+                tracks: <Track>[
+                  Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3'),
+                ],
+                index: 0,
+                selectable: true,
+                selectionActive: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Checkbox), findsOneWidget);
+      expect(find.byTooltip('Add to favorites'), findsNothing);
+      expect(find.byTooltip('More actions'), findsNothing);
+    });
+  });
+
+  group('TrackTile row layout under pressure', () {
+    testWidgets('a very long title and subtitle do not overflow a narrow row',
+        (tester) async {
+      _useNarrowPhone(tester);
+      await _pump(tester, const <Track>[
+        Track(
+          id: '1',
+          title: 'An Extraordinarily Long Song Title That Keeps Going Well '
+              'Past Any Reasonable Width For A Phone Screen',
+          uri: 'file:///s1.mp3',
+          artistName: 'A Band With An Unreasonably Long Name Indeed',
+          albumName: 'And An Album Title That Is Similarly Overlong',
+        ),
+      ]);
+
+      // No RenderFlex overflow from the trailing glyph + heart + menu row.
+      expect(tester.takeException(), isNull);
+      // Both controls survive, and the text ellipsizes rather than pushing.
+      expect(find.byTooltip('Add to favorites'), findsOneWidget);
+      expect(find.byTooltip('More actions'), findsOneWidget);
+      final Text title = tester.widget<Text>(
+        find.textContaining('An Extraordinarily Long Song Title'),
+      );
+      expect(title.maxLines, 1);
+      expect(title.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('the row survives a 2.0 text scale without overflowing',
+        (tester) async {
+      _useNarrowPhone(tester);
+      await _pump(
+        tester,
+        const <Track>[
+          Track(
+            id: '1',
+            title: 'Song One',
+            uri: 'file:///s1.mp3',
+            artistName: 'Artist A',
+            albumName: 'Album X',
+          ),
+        ],
+        textScaler: const TextScaler.linear(2.0),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byTooltip('Add to favorites'), findsOneWidget);
+      expect(find.byTooltip('More actions'), findsOneWidget);
+    });
+
+    testWidgets('the heart stays tappable at a 2.0 text scale', (tester) async {
+      _useNarrowPhone(tester);
+      await _pump(
+        tester,
+        const <Track>[Track(id: '1', title: 'Song One', uri: 'file:///s1.mp3')],
+        textScaler: const TextScaler.linear(2.0),
+      );
+
+      // A control that renders but can't be hit is no better than a hidden one.
+      await tester.tap(find.byTooltip('Add to favorites'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
   });
 


### PR DESCRIPTION
## What

Two related problems, both from the UX audit.

**Liking a song was the app's most-used action and its least discoverable.** The only favourite toggle on a track row lived inside the 3-dot overflow menu (`track_tile.dart`, `_TrackAction.toggleFavorite`). The only visible heart in the whole app was on the full player. Which made the Favorites empty state actively wrong — it read *"Tap the heart on a track to add it here"*, pointing at a control that did not exist on any row.

**Favorites was the thinnest list screen.** No Play, no Shuffle, no multi-select — while Album detail and Playlist detail have all three.

## Placement decisions

Confirmed before coding:

- **The heart goes on `TrackTile`, shown everywhere it's used** — library Songs, album detail, artist detail, smart mixes, folder browser, Favorites. The problem is "users don't know they can favourite at all", so a heart that appears on some lists and not others would just re-introduce the guessing.
- **Playlist detail is deliberately untouched.** It doesn't use `TrackTile`; it has its own row whose trailing already carries an overflow menu *and* a `ReorderableDragStartListener` drag handle. A fourth trailing control there needs its own layout pass and its own tests, and it's outside Favorites usability. Its menu keeps the existing favourite action.

## Row layout

The trailing edge is now `_StatusGlyph` → heart → overflow menu. The heart is a tight **40×48** box rather than the default 48×48, which holds the trailing group at ~106dp and buys space back for the title on a narrow screen. Sizing is set once via `constraints`; `visualDensity` is deliberately *not* also set, because it compounds with explicit constraints and would shrink the target further than intended.

Titles and subtitles were already `maxLines: 1` with ellipsis, so nothing overflows — but there are tests for it now (below), because a third trailing control is exactly the kind of change that quietly breaks a narrow row.

One thing I did **not** touch: `AlphabetTrackList` pins rows to a hard-coded `_trackExtent = 64` so the A–Z rail can compute exact scroll offsets. At very large text scales the row content exceeds that, independent of this change. The text-scale tests here run against `TrackTile` directly rather than through `AlphabetTrackList`, so they measure this change rather than that pre-existing constraint. Worth its own look sometime; not this PR.

## Ordering fix

`AlphabetTrackList` sorts rows by title, but a naive `Play` would have queued the raw catalog order from `favoriteTracksProvider` — so the header would have disagreed with the list directly beneath it, and with what tapping a row already does. The sort is now exposed as `AlphabetTrackList.sortedByTitle` and used by both, instead of being duplicated. The Play test feeds tracks in non-alphabetical order specifically to catch this.

## Selection logic

`FavoritesScreen` needed multi-select, and Library / Album / Artist each already have their own copy of the same four operations. Rather than add a fifth, the bookkeeping is extracted once into `TrackSelectionMixin` (`lib/features/library/track_selection.dart`) and Favorites adopts it. Available actions come from the existing shared `bulkActionsFor`, so Favorites adds no selection rules of its own.

The existing three screens are **not** retrofitted here — that's a behaviour-neutral refactor across three files and belongs in its own change, not a Favorites usability PR. The mixin is the seam for it when someone wants to.

## Preserved behaviour

- The heart calls the same `setFavorite` on the same `FavoritesRepository` the menu entry does — no new persistence path, no provider API change.
- Routing stays keyed by the provider-namespaced `Track.uri`, so a Jellyfin and a Navidrome copy of one id keep separate hearts and each mirrors to whichever server owns it (`SyncedFavoritesRepository`). There's a test for exactly this.
- The overflow menu keeps its favourite entry as the secondary path.
- Favouriting remains a pure like: nothing plays, the queue is untouched.
- Selection mode still swaps the whole trailing group for a checkbox — the heart doesn't leak into it.

## Tests

**`track_tile_test.dart`** — new groups for the heart and for row layout under pressure:
- outline heart visible on every row without opening a menu
- tapping favourites and fills it, without starting playback or touching the queue
- tapping a filled heart unfavourites
- only the tapped row changes, not its neighbours
- two provider copies of one id keep separate hearts
- the heart doesn't replace the overflow menu — both paths coexist
- selection mode hides the heart in favour of the checkbox
- a very long title + subtitle on a 320dp screen: no `RenderFlex` overflow, both controls survive, title still ellipsizes
- a 2.0 text scale on a 320dp screen: no overflow, and the heart is still *tappable* (a control that renders but can't be hit is no better than a hidden one)

**`favorites_screen_test.dart`** — new groups for Play/Shuffle, multi-select, and the heart:
- Play queues the full list in display order and pushes the player; shuffle off
- Shuffle enables shuffle before playing and pushes the player
- "1 song" vs "3 songs"
- long-press enters selection, shows the count, and the header steps aside
- tapping more rows extends the selection without starting playback
- deselecting the last row leaves selection mode
- Cancel selection restores the normal app bar
- Favorites rows show filled hearts; unfavouriting drops the row and updates the count
- unfavouriting the last row falls back to the empty state
- the empty state names the control that now exists

Two existing assertions in `track_tile_test.dart` were updated from `findsOneWidget` to `findsNWidgets(2)`: with the menu open there are now legitimately two hearts on screen — the row's toggle and the menu entry.

## Verification

Run locally against Flutter 3.27.4 (matching `.flutter-version` and CI):

- `dart format --set-exit-if-changed .` — clean
- `flutter analyze` — **No issues found!**
- `flutter test` — **All 3121 tests passed**

The first CI run on `966d35f` failed on `dart format` only, before analyze or test executed; `169aa2e` is that formatting applied.