### PR TITLE
fix(player): keep status changes from shifting the UI

### DIFF
--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -225,10 +225,12 @@ class _StatusSlot extends StatelessWidget {
     final scaler = MediaQuery.textScalerOf(context);
     final labelStyle = theme.textTheme.labelLarge;
     final bodyStyle = theme.textTheme.bodyMedium;
-    final labelHeight = scaler.scale(labelStyle?.fontSize ?? 14) *
-        (labelStyle?.height ?? 1.2);
-    final bodyHeight = scaler.scale(bodyStyle?.fontSize ?? 14) *
-        (bodyStyle?.height ?? 1.2);
+    final labelFontSize = labelStyle?.fontSize ?? 14.0;
+    final bodyFontSize = bodyStyle?.fontSize ?? 14.0;
+    final labelLineHeight = labelStyle?.height ?? 1.2;
+    final bodyLineHeight = bodyStyle?.height ?? 1.2;
+    final labelHeight = scaler.scale(labelFontSize) * labelLineHeight;
+    final bodyHeight = scaler.scale(bodyFontSize) * bodyLineHeight;
     final textHeight = labelHeight > bodyHeight ? labelHeight : bodyHeight;
     final preferredHeight = textHeight + AppSpacing.xs;
     final slotHeight = preferredHeight > 24 ? preferredHeight : 24.0;

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -196,13 +196,7 @@ class _LiveControls extends ConsumerWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        // Every source/buffering/casting/error state shares one fixed-height
-        // slot. Their icon and text metrics differ slightly, but the progress
-        // bar and transport controls must never move when the state changes.
-        SizedBox(
-          height: 24,
-          child: Center(child: _SourceOrError(state: state)),
-        ),
+        _StatusSlot(child: _SourceOrError(state: state)),
         const SizedBox(height: AppSpacing.md),
         PlaybackProgressBar(
           position: state.position,
@@ -213,6 +207,36 @@ class _LiveControls extends ConsumerWidget {
         const SizedBox(height: AppSpacing.sm),
         PlaybackControls(state: state),
       ],
+    );
+  }
+}
+
+/// A stable status area that still grows enough for the user's text scale.
+/// Every source/buffering/casting/error state uses the same computed height, so
+/// switching states cannot move the artwork or metadata above the controls.
+class _StatusSlot extends StatelessWidget {
+  const _StatusSlot({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scaler = MediaQuery.textScalerOf(context);
+    final labelStyle = theme.textTheme.labelLarge;
+    final bodyStyle = theme.textTheme.bodyMedium;
+    final labelHeight = scaler.scale(labelStyle?.fontSize ?? 14) *
+        (labelStyle?.height ?? 1.2);
+    final bodyHeight = scaler.scale(bodyStyle?.fontSize ?? 14) *
+        (bodyStyle?.height ?? 1.2);
+    final textHeight = labelHeight > bodyHeight ? labelHeight : bodyHeight;
+    final preferredHeight = textHeight + AppSpacing.xs;
+    final slotHeight = preferredHeight > 24 ? preferredHeight : 24.0;
+
+    return SizedBox(
+      key: const ValueKey('player-status-slot'),
+      height: slotHeight,
+      child: Center(child: child),
     );
   }
 }
@@ -260,9 +284,7 @@ class _SourceOrError extends ConsumerWidget {
     }
     final source = state.source;
     if (source == null) {
-      // Reserve the inline chip's height so the column doesn't shift when the
-      // source resolves a beat after the track loads.
-      return const SizedBox(height: 22);
+      return const SizedBox.shrink();
     }
     return PlaybackSourceChip(
       source: source,

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -196,7 +196,13 @@ class _LiveControls extends ConsumerWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _SourceOrError(state: state),
+        // Every source/buffering/casting/error state shares one fixed-height
+        // slot. Their icon and text metrics differ slightly, but the progress
+        // bar and transport controls must never move when the state changes.
+        SizedBox(
+          height: 24,
+          child: Center(child: _SourceOrError(state: state)),
+        ),
         const SizedBox(height: AppSpacing.md),
         PlaybackProgressBar(
           position: state.position,
@@ -243,6 +249,8 @@ class _SourceOrError extends ConsumerWidget {
           color: theme.colorScheme.error,
         ),
         textAlign: TextAlign.center,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
       );
     }
     // A mid-stream re-buffer: a calm "Buffering…" hint rather than the source

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -44,6 +44,14 @@ Future<void> _pumpPlayer(
   await tester.pumpAndSettle();
 }
 
+Future<void> _pumpStreamUpdate(WidgetTester tester) async {
+  // The playback stream can publish after the first frame. Pump one more
+  // bounded frame rather than using pumpAndSettle: the buffering spinner is a
+  // continuous animation and would otherwise keep the test waiting forever.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 16));
+}
+
 FakePlaybackController _streamingController() {
   return FakePlaybackController(
     initial: const PlaybackState(
@@ -72,7 +80,7 @@ void main() {
         position: Duration(minutes: 2),
       ),
     );
-    await tester.pump();
+    await _pumpStreamUpdate(tester);
 
     expect(find.text('Buffering…'), findsOneWidget);
     expect(
@@ -89,7 +97,7 @@ void main() {
         position: Duration(minutes: 2),
       ),
     );
-    await tester.pump();
+    await _pumpStreamUpdate(tester);
 
     expect(find.text('Playing from Cache'), findsOneWidget);
     expect(

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -19,33 +19,49 @@ const _track = Track(
 
 Future<void> _pumpPlayer(
   WidgetTester tester,
-  FakePlaybackController controller,
-) async {
+  FakePlaybackController controller, {
+  TextScaler? textScaler,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         playbackControllerProvider.overrideWithValue(controller),
       ],
-      child: const MaterialApp(home: PlayerScreen()),
+      child: MaterialApp(
+        builder: (context, child) {
+          final mediaQuery = MediaQuery.of(context);
+          return MediaQuery(
+            data: mediaQuery.copyWith(
+              textScaler: textScaler ?? mediaQuery.textScaler,
+            ),
+            child: child!,
+          );
+        },
+        home: const PlayerScreen(),
+      ),
     ),
   );
   await tester.pumpAndSettle();
 }
 
+FakePlaybackController _streamingController() {
+  return FakePlaybackController(
+    initial: const PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+      source: PlaybackSource.streamingDirect,
+      duration: Duration(minutes: 4),
+    ),
+  );
+}
+
 void main() {
-  testWidgets('status changes do not move the progress controls', (tester) async {
-    final controller = FakePlaybackController(
-      initial: const PlaybackState(
-        status: PlaybackStatus.playing,
-        currentTrack: _track,
-        source: PlaybackSource.streamingDirect,
-        duration: Duration(minutes: 4),
-      ),
-    );
+  testWidgets('status changes do not move the track metadata', (tester) async {
+    final controller = _streamingController();
     await _pumpPlayer(tester, controller);
 
-    final slider = find.byType(Slider);
-    final directStreamY = tester.getTopLeft(slider).dy;
+    final title = find.text('Remote song');
+    final directStreamY = tester.getTopLeft(title).dy;
     expect(find.text('Playing from Navidrome'), findsOneWidget);
 
     controller.emit(
@@ -60,7 +76,7 @@ void main() {
 
     expect(find.text('Buffering…'), findsOneWidget);
     expect(
-      tester.getTopLeft(slider).dy,
+      tester.getTopLeft(title).dy,
       moreOrLessEquals(directStreamY, epsilon: 0.01),
     );
 
@@ -77,8 +93,22 @@ void main() {
 
     expect(find.text('Playing from Cache'), findsOneWidget);
     expect(
-      tester.getTopLeft(slider).dy,
+      tester.getTopLeft(title).dy,
       moreOrLessEquals(directStreamY, epsilon: 0.01),
     );
+  });
+
+  testWidgets('status slot grows with the system text scale', (tester) async {
+    await _pumpPlayer(
+      tester,
+      _streamingController(),
+      textScaler: TextScaler.linear(2),
+    );
+
+    final statusSlot = find.byKey(const ValueKey('player-status-slot'));
+    expect(statusSlot, findsOneWidget);
+    expect(tester.getSize(statusSlot).height, greaterThan(24));
+    expect(find.text('Playing from Navidrome'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+
+import 'fake_playback_controller.dart';
+
+const _track = Track(
+  id: 'remote-1',
+  title: 'Remote song',
+  uri: 'subsonic:remote-1',
+  artistName: 'Artist',
+  albumName: 'Album',
+);
+
+Future<void> _pumpPlayer(
+  WidgetTester tester,
+  FakePlaybackController controller,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        playbackControllerProvider.overrideWithValue(controller),
+      ],
+      child: const MaterialApp(home: PlayerScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('status changes do not move the progress controls', (tester) async {
+    final controller = FakePlaybackController(
+      initial: const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: _track,
+        source: PlaybackSource.streamingDirect,
+        duration: Duration(minutes: 4),
+      ),
+    );
+    await _pumpPlayer(tester, controller);
+
+    final slider = find.byType(Slider);
+    final directStreamY = tester.getTopLeft(slider).dy;
+    expect(find.text('Playing from Navidrome'), findsOneWidget);
+
+    controller.emit(
+      const PlaybackState(
+        status: PlaybackStatus.buffering,
+        currentTrack: _track,
+        duration: Duration(minutes: 4),
+        position: Duration(minutes: 2),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Buffering…'), findsOneWidget);
+    expect(
+      tester.getTopLeft(slider).dy,
+      moreOrLessEquals(directStreamY, epsilon: 0.01),
+    );
+
+    controller.emit(
+      const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: _track,
+        source: PlaybackSource.offlineCache,
+        duration: Duration(minutes: 4),
+        position: Duration(minutes: 2),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Playing from Cache'), findsOneWidget);
+    expect(
+      tester.getTopLeft(slider).dy,
+      moreOrLessEquals(directStreamY, epsilon: 0.01),
+    );
+  });
+}

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -102,7 +102,7 @@ void main() {
     await _pumpPlayer(
       tester,
       _streamingController(),
-      textScaler: TextScaler.linear(2),
+      textScaler: const TextScaler.linear(2),
     );
 
     final statusSlot = find.byKey(const ValueKey('player-status-slot'));


### PR DESCRIPTION
## Summary

Fixes the full player layout jumping when playback moves between streaming, buffering, and cache states.

- reserves one fixed-height slot for the source, buffering, casting, and error indicators;
- centers every indicator inside that slot so their different icon and text metrics cannot move the progress bar or transport controls;
- keeps long playback errors on one line with an ellipsis instead of allowing the status area to grow;
- adds a widget regression test that transitions from `Playing from Navidrome` to `Buffering…` to `Playing from Cache` and asserts the slider stays at the same vertical position.

No playback, seeking, provider, cache, or streaming behavior changes.

Closes #315

## Validation

The focused widget regression test is included in this PR. GitHub Actions will run formatting, analysis, the full Flutter test suite, Android debug compilation, and release lint validation.