### PR TITLE
chore(release): prepare v0.1.15

### DIFF
--- a/docs/release-notes/v0.1.15.md
+++ b/docs/release-notes/v0.1.15.md
@@ -1,0 +1,32 @@
+# Linthra v0.1.15 — release notes
+
+**Linthra is an Android music player for local files and self-hosted music servers.** v0.1.15 is a focused player-interface stability release for Navidrome, Jellyfin, Plex, local music, offline cache, and casting.
+
+- **Version:** `0.1.15` (`versionName`), `versionCode` `115999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** MPL-2.0
+
+## What's new
+
+### A steadier Now Playing screen
+
+- The Now Playing screen no longer jumps when playback moves between source, buffering, cache, casting, and error indicators.
+- The fix applies to Navidrome/Subsonic, Jellyfin, Plex, local music, offline cache, and casting because they share the same player status area.
+- The status area now reserves one stable height, keeping track metadata, the progress bar, and transport controls in place.
+- Long playback errors stay on one line with an ellipsis instead of expanding the layout.
+
+### Better large-text support
+
+- The stable status area grows with the system text scale.
+- Larger accessibility text remains readable without overlapping or moving the controls.
+- A widget regression test verifies the transition from `Playing from Navidrome` to `Buffering…` to `Playing from Cache` without vertical movement.
+
+## Upgrade and distribution notes
+
+- Normal in-place updates preserve accounts, settings, playlists, catalog, favorites, and cache.
+- No playback routing, seeking, provider, cache, or streaming behavior changed in this release.
+- Do not mix GitHub and F-Droid installations because the APKs use different signing keys and cannot update one another.
+- F-Droid builds and signs its own APKs from the source tag; GitHub Release APKs are signed by the upstream project.
+
+No ads, no tracking, no analytics, no telemetry. Linthra plays music you already own or that your own server provides.

--- a/fastlane/metadata/android/en-US/changelogs/115999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/115999.txt
@@ -1,0 +1,4 @@
+Linthra 0.1.15
+
+- Keeps the Now Playing screen steady when Navidrome, Jellyfin, or Plex playback changes between streaming, buffering, cache, casting, and error states.
+- Improves playback-status accessibility at larger system text sizes without shifting the progress bar or controls.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.14';
+  static const String _devVersionName = '0.1.15';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,10 +20,9 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Compilation and collaboration albums now stay together after a library sync.',
-    'The Albums tab now uses a responsive cover grid with two columns on phones.',
-    'Linthra can follow your phone’s theme, or stay in Light or Dark mode.',
-    'First sync screens now correctly identify Jellyfin, Navidrome, and Plex.',
+    'The Now Playing screen no longer jumps when Navidrome, Jellyfin, or Plex playback changes status.',
+    'Streaming, buffering, cache, casting, and error indicators now share a stable layout.',
+    'Playback status stays readable with larger system text without moving the controls.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.14+114999
+version: 0.1.15+115999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepares the focused v0.1.15 player-interface stability release after #317.

- bumps `pubspec.yaml` to `0.1.15+115999`;
- keeps `AppInfo` in lockstep at `0.1.15`;
- refreshes the in-app What's new card;
- adds the F-Droid changelog for versionCode `115999`;
- adds the full v0.1.15 release notes.

## User-facing change

The Now Playing screen stays steady when Navidrome/Subsonic, Jellyfin, Plex, local, cache, casting, buffering, or error status indicators change. Larger system text remains supported without shifting the progress bar or controls.

## Validation

GitHub Actions should verify formatting, analysis, the full Flutter test suite, version consistency, Android debug compilation, and release lint checks before merge.

After this PR is merged, publish from the merged commit using the repository's owner-only stable release command:

`/publish-stable v0.1.15`