### PR TITLE
ci(release): add manual stable publish fallback

### DIFF
--- a/.github/workflows/publish-stable-release.yml
+++ b/.github/workflows/publish-stable-release.yml
@@ -3,6 +3,16 @@ name: Publish stable release
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Stable tag to publish (for example v0.1.15)
+        required: true
+        type: string
+      pr_number:
+        description: Merged release PR number
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,15 +22,18 @@ permissions:
 jobs:
   publish:
     if: >-
-      github.event.issue.pull_request &&
-      github.event.comment.user.login == github.repository_owner &&
-      startsWith(github.event.comment.body, '/publish-stable v')
+      (github.event_name == 'workflow_dispatch' &&
+       github.actor == github.repository_owner) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.user.login == github.repository_owner &&
+       startsWith(github.event.comment.body, '/publish-stable v'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       GH_TOKEN: ${{ github.token }}
-      COMMAND_BODY: ${{ github.event.comment.body }}
-      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMAND_BODY: ${{ github.event_name == 'workflow_dispatch' && format('/publish-stable {0}', inputs.release_tag) || github.event.comment.body }}
+      PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.issue.number }}
     steps:
       - name: Resolve merged release commit and requested tag
         id: release


### PR DESCRIPTION
## Summary

Adds a manual fallback to the stable release publisher while keeping the existing owner-only `/publish-stable vX.Y.Z` PR-comment flow.

- adds `workflow_dispatch` inputs for the stable tag and merged release PR number;
- keeps the same validation, immutable-tag protection, signed Android build, and asset verification;
- restricts manual publishing to the repository owner;
- lets a release proceed even when GitHub fails to deliver the `issue_comment` trigger.

## Why

Both exact `/publish-stable v0.1.15` comments on merged PR #318 were accepted by GitHub, but no tag or release was created. The workflow file exists on `main`, so a manual owner-only fallback prevents the release process from being blocked by the comment event.

## After merge

Open **Actions → Publish stable release → Run workflow** and use:

- `release_tag`: `v0.1.15`
- `pr_number`: `318`
