### PR TITLE
feat(rust): add large-library search core for v0.2.0

### DIFF
--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -1,0 +1,38 @@
+name: Rust library core
+
+on:
+  pull_request:
+    paths:
+      - 'native/linthra_core/**'
+      - '.github/workflows/rust-core.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'native/linthra_core/**'
+      - '.github/workflows/rust-core.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  rust-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path native/linthra_core/Cargo.toml -- --check
+
+      - name: Clippy
+        run: cargo clippy --manifest-path native/linthra_core/Cargo.toml --all-targets -- -D warnings
+
+      - name: Unit tests
+        run: cargo test --manifest-path native/linthra_core/Cargo.toml
+
+      - name: 200k-track regression benchmark
+        run: cargo run --release --manifest-path native/linthra_core/Cargo.toml --bin benchmark_200k

--- a/native/linthra_core/Cargo.toml
+++ b/native/linthra_core/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "linthra_core"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+description = "High-performance library indexing and search core for Linthra"
+publish = false
+
+[lib]
+name = "linthra_core"
+path = "src/lib.rs"
+
+[[bin]]
+name = "benchmark_200k"
+path = "src/bin/benchmark_200k.rs"
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+panic = "abort"

--- a/native/linthra_core/README.md
+++ b/native/linthra_core/README.md
@@ -1,0 +1,27 @@
+# linthra_core (Rust)
+
+`linthra_core` is Linthra's high-performance library engine. Its first job is to make searching very large catalogs predictable without making Flutter walk 100,000–200,000 track objects for every keystroke.
+
+## Current scope
+
+- dependency-free Rust core
+- immutable inverted index
+- title / artist / album / album-artist / provider tokens
+- prefix search with AND semantics across query terms
+- deterministic ranking
+- synthetic 200,000-track regression benchmark
+
+The crate is intentionally **not wired into Flutter yet**. The core is being benchmarked and stabilized behind a small API first; the later FFI binding can then be reviewed independently without mixing Android packaging risk into the indexing algorithm.
+
+## Run it
+
+```bash
+cargo test --manifest-path native/linthra_core/Cargo.toml
+cargo run --release --manifest-path native/linthra_core/Cargo.toml --bin benchmark_200k
+```
+
+The benchmark uses a generous 50 ms average-query regression ceiling so shared CI runners stay reliable. It is a guard against accidentally turning search into an O(full catalog) operation, not a claim that every device will have identical timings.
+
+## Good contribution areas
+
+Rust contributors can work here without knowing Flutter. Useful next steps include Unicode-aware normalization, compact index serialization, incremental index updates, cross-provider duplicate candidates, album grouping primitives, memory benchmarks, and the eventual stable Dart/Flutter FFI boundary.

--- a/native/linthra_core/src/bin/benchmark_200k.rs
+++ b/native/linthra_core/src/bin/benchmark_200k.rs
@@ -1,0 +1,70 @@
+use std::time::{Duration, Instant};
+
+use linthra_core::{LibraryIndex, TrackRecord};
+
+const TRACK_COUNT: usize = 200_000;
+const SEARCH_ITERATIONS: usize = 500;
+
+fn main() {
+    let tracks = synthetic_library(TRACK_COUNT);
+
+    let build_started = Instant::now();
+    let index = LibraryIndex::build(tracks);
+    let build_elapsed = build_started.elapsed();
+
+    let queries = [
+        "artist 421 track 199421",
+        "album 311 artist 731",
+        "navidrome track 150000",
+        "jellyfin album 42",
+        "local artist 11",
+    ];
+
+    let search_started = Instant::now();
+    let mut hit_count = 0usize;
+    for iteration in 0..SEARCH_ITERATIONS {
+        let query = queries[iteration % queries.len()];
+        hit_count += index.search(query, 50).len();
+    }
+    let search_elapsed = search_started.elapsed();
+    let average = search_elapsed / SEARCH_ITERATIONS as u32;
+
+    println!("Linthra large-library benchmark");
+    println!("tracks: {TRACK_COUNT}");
+    println!("index build: {} ms", build_elapsed.as_millis());
+    println!(
+        "{SEARCH_ITERATIONS} searches: {} ms (avg {} µs)",
+        search_elapsed.as_millis(),
+        average.as_micros()
+    );
+    println!("total returned hits: {hit_count}");
+
+    // This is a regression smoke threshold, not a marketing benchmark. It is
+    // deliberately generous enough for shared CI runners while still catching
+    // an accidental O(catalog × query) implementation.
+    assert!(
+        average < Duration::from_millis(50),
+        "average search exceeded the 50 ms large-library budget: {average:?}"
+    );
+}
+
+fn synthetic_library(count: usize) -> Vec<TrackRecord> {
+    (0..count)
+        .map(|index| {
+            let provider = match index % 4 {
+                0 => "local",
+                1 => "jellyfin",
+                2 => "navidrome",
+                _ => "plex",
+            };
+            TrackRecord::new(
+                format!("track-{index}"),
+                format!("Track {index} Midnight Signal"),
+                format!("Artist {}", index % 1_500),
+                format!("Album {}", index % 2_500),
+                Some(format!("Artist {}", index % 1_500)),
+                provider,
+            )
+        })
+        .collect()
+}

--- a/native/linthra_core/src/lib.rs
+++ b/native/linthra_core/src/lib.rs
@@ -90,7 +90,8 @@ impl LibraryIndex {
 
     /// Searches using AND semantics across query terms and prefix semantics
     /// within each term. Results are ranked by field importance and exact-token
-    /// matches, then deterministically by title/id for stable UI ordering.
+    /// matches, then deterministically by title/id/provider/index for stable UI
+    /// ordering even when providers expose otherwise-identical copies.
     pub fn search(&self, query: &str, limit: usize) -> Vec<SearchHit<'_>> {
         if limit == 0 || self.tracks.is_empty() {
             return Vec::new();
@@ -101,10 +102,31 @@ impl LibraryIndex {
             return Vec::new();
         }
 
+        // Evaluate the rarest query token first. A common token such as
+        // "album" can have a posting for every track in a 200k catalog; making
+        // a 200k-entry HashMap for that before seeing a selective token such as
+        // "199421" wastes both CPU and memory. Counting posting lengths is
+        // cheap, then subsequent common terms only retain scores for candidates
+        // that already survived the selective terms.
+        let mut planned_terms: Vec<(String, usize)> = terms
+            .into_iter()
+            .map(|term| {
+                let estimated_postings = self.estimated_postings(&term);
+                (term, estimated_postings)
+            })
+            .collect();
+        if planned_terms.iter().any(|(_, count)| *count == 0) {
+            return Vec::new();
+        }
+        planned_terms.sort_unstable_by_key(|(_, count)| *count);
+
         let mut candidates: Option<HashMap<usize, u32>> = None;
 
-        for term in terms {
-            let mut best_for_term: HashMap<usize, u16> = HashMap::new();
+        for (term, _) in planned_terms {
+            let mut best_for_term: HashMap<usize, u16> = match &candidates {
+                Some(current) => HashMap::with_capacity(current.len()),
+                None => HashMap::new(),
+            };
 
             for (token, token_postings) in self.postings.range(term.clone()..) {
                 if !token.starts_with(&term) {
@@ -112,6 +134,14 @@ impl LibraryIndex {
                 }
                 let exact_bonus: u16 = if token == &term { 3 } else { 0 };
                 for posting in token_postings {
+                    // After the first (most selective) term, never materialize
+                    // scores for tracks that have already been eliminated.
+                    if let Some(current) = &candidates {
+                        if !current.contains_key(&posting.track_index) {
+                            continue;
+                        }
+                    }
+
                     let score = posting.weight.saturating_add(exact_bonus);
                     best_for_term
                         .entry(posting.track_index)
@@ -160,6 +190,12 @@ impl LibraryIndex {
                         .id
                         .cmp(&self.tracks[*right_index].id)
                 })
+                .then_with(|| {
+                    self.tracks[*left_index]
+                        .provider
+                        .cmp(&self.tracks[*right_index].provider)
+                })
+                .then_with(|| left_index.cmp(right_index))
         });
         ranked.truncate(limit);
 
@@ -170,6 +206,17 @@ impl LibraryIndex {
                 score,
             })
             .collect()
+    }
+
+    fn estimated_postings(&self, term: &str) -> usize {
+        let mut count = 0usize;
+        for (token, token_postings) in self.postings.range(term.to_owned()..) {
+            if !token.starts_with(term) {
+                break;
+            }
+            count = count.saturating_add(token_postings.len());
+        }
+        count
     }
 }
 
@@ -260,5 +307,32 @@ mod tests {
         let hits = index.search("jellyfin battery", 10);
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].track.id, "2");
+    }
+
+    #[test]
+    fn identical_title_and_id_records_have_a_total_provider_order() {
+        let index = LibraryIndex::build(vec![
+            TrackRecord::new(
+                "same-id",
+                "Same Song",
+                "Same Artist",
+                "Same Album",
+                None,
+                "plex",
+            ),
+            TrackRecord::new(
+                "same-id",
+                "Same Song",
+                "Same Artist",
+                "Same Album",
+                None,
+                "jellyfin",
+            ),
+        ]);
+
+        let hits = index.search("same song", 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].track.provider, "jellyfin");
+        assert_eq!(hits[1].track.provider, "plex");
     }
 }

--- a/native/linthra_core/src/lib.rs
+++ b/native/linthra_core/src/lib.rs
@@ -155,7 +155,11 @@ impl LibraryIndex {
                         .title
                         .cmp(&self.tracks[*right_index].title)
                 })
-                .then_with(|| self.tracks[*left_index].id.cmp(&self.tracks[*right_index].id))
+                .then_with(|| {
+                    self.tracks[*left_index]
+                        .id
+                        .cmp(&self.tracks[*right_index].id)
+                })
         });
         ranked.truncate(limit);
 
@@ -179,10 +183,10 @@ fn index_field(
     // outrank another track merely because a token is repeated in its metadata.
     let unique: HashSet<String> = normalized_tokens(value).into_iter().collect();
     for token in unique {
-        postings
-            .entry(token)
-            .or_default()
-            .push(Posting { track_index, weight });
+        postings.entry(token).or_default().push(Posting {
+            track_index,
+            weight,
+        });
     }
 }
 

--- a/native/linthra_core/src/lib.rs
+++ b/native/linthra_core/src/lib.rs
@@ -1,0 +1,260 @@
+//! High-performance, dependency-free library primitives for Linthra.
+//!
+//! The first responsibility of this crate is intentionally narrow: index and
+//! search very large music libraries without asking Flutter to walk hundreds of
+//! thousands of Dart objects for every query. The public API is platform-neutral
+//! so Android/iOS/desktop bindings can be added later without changing the core.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrackRecord {
+    pub id: String,
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub album_artist: Option<String>,
+    pub provider: String,
+}
+
+impl TrackRecord {
+    pub fn new(
+        id: impl Into<String>,
+        title: impl Into<String>,
+        artist: impl Into<String>,
+        album: impl Into<String>,
+        album_artist: Option<String>,
+        provider: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            artist: artist.into(),
+            album: album.into(),
+            album_artist,
+            provider: provider.into(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Posting {
+    track_index: usize,
+    weight: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearchHit<'a> {
+    pub track: &'a TrackRecord,
+    pub score: u32,
+}
+
+/// Immutable inverted index designed for fast repeated searches.
+///
+/// Tokens live in a BTreeMap rather than a HashMap because the ordered keyspace
+/// makes prefix lookup (`metal` → `metallica`) logarithmic to enter and linear
+/// only in the number of matching tokens. Query work therefore scales with the
+/// relevant postings, not the full catalog size.
+pub struct LibraryIndex {
+    tracks: Vec<TrackRecord>,
+    postings: BTreeMap<String, Vec<Posting>>,
+}
+
+impl LibraryIndex {
+    pub fn build(tracks: Vec<TrackRecord>) -> Self {
+        let mut postings: BTreeMap<String, Vec<Posting>> = BTreeMap::new();
+
+        for (track_index, track) in tracks.iter().enumerate() {
+            index_field(&mut postings, track_index, &track.title, 12);
+            index_field(&mut postings, track_index, &track.artist, 8);
+            index_field(&mut postings, track_index, &track.album, 5);
+            if let Some(album_artist) = &track.album_artist {
+                index_field(&mut postings, track_index, album_artist, 6);
+            }
+            // Provider is intentionally searchable at a low weight. It makes
+            // diagnostics/power-user searches useful without outranking music
+            // metadata (e.g. "navidrome halo").
+            index_field(&mut postings, track_index, &track.provider, 2);
+        }
+
+        Self { tracks, postings }
+    }
+
+    pub fn len(&self) -> usize {
+        self.tracks.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tracks.is_empty()
+    }
+
+    /// Searches using AND semantics across query terms and prefix semantics
+    /// within each term. Results are ranked by field importance and exact-token
+    /// matches, then deterministically by title/id for stable UI ordering.
+    pub fn search(&self, query: &str, limit: usize) -> Vec<SearchHit<'_>> {
+        if limit == 0 || self.tracks.is_empty() {
+            return Vec::new();
+        }
+
+        let terms = normalized_tokens(query);
+        if terms.is_empty() {
+            return Vec::new();
+        }
+
+        let mut candidates: Option<HashMap<usize, u32>> = None;
+
+        for term in terms {
+            let mut best_for_term: HashMap<usize, u16> = HashMap::new();
+
+            for (token, token_postings) in self.postings.range(term.clone()..) {
+                if !token.starts_with(&term) {
+                    break;
+                }
+                let exact_bonus: u16 = if token == &term { 3 } else { 0 };
+                for posting in token_postings {
+                    let score = posting.weight.saturating_add(exact_bonus);
+                    best_for_term
+                        .entry(posting.track_index)
+                        .and_modify(|best| *best = (*best).max(score))
+                        .or_insert(score);
+                }
+            }
+
+            if best_for_term.is_empty() {
+                return Vec::new();
+            }
+
+            candidates = Some(match candidates {
+                None => best_for_term
+                    .into_iter()
+                    .map(|(index, score)| (index, u32::from(score)))
+                    .collect(),
+                Some(mut current) => {
+                    current.retain(|index, total| {
+                        if let Some(score) = best_for_term.get(index) {
+                            *total += u32::from(*score);
+                            true
+                        } else {
+                            false
+                        }
+                    });
+                    if current.is_empty() {
+                        return Vec::new();
+                    }
+                    current
+                }
+            });
+        }
+
+        let mut ranked: Vec<(usize, u32)> = candidates.unwrap_or_default().into_iter().collect();
+        ranked.sort_unstable_by(|(left_index, left_score), (right_index, right_score)| {
+            right_score
+                .cmp(left_score)
+                .then_with(|| {
+                    self.tracks[*left_index]
+                        .title
+                        .cmp(&self.tracks[*right_index].title)
+                })
+                .then_with(|| self.tracks[*left_index].id.cmp(&self.tracks[*right_index].id))
+        });
+        ranked.truncate(limit);
+
+        ranked
+            .into_iter()
+            .map(|(track_index, score)| SearchHit {
+                track: &self.tracks[track_index],
+                score,
+            })
+            .collect()
+    }
+}
+
+fn index_field(
+    postings: &mut BTreeMap<String, Vec<Posting>>,
+    track_index: usize,
+    value: &str,
+    weight: u16,
+) {
+    // Deduplicate within one field so "Very Very Good" does not artificially
+    // outrank another track merely because a token is repeated in its metadata.
+    let unique: HashSet<String> = normalized_tokens(value).into_iter().collect();
+    for token in unique {
+        postings
+            .entry(token)
+            .or_default()
+            .push(Posting { track_index, weight });
+    }
+}
+
+fn normalized_tokens(value: &str) -> Vec<String> {
+    value
+        .split(|character: char| !character.is_alphanumeric())
+        .filter(|part| !part.is_empty())
+        .map(|part| part.to_lowercase())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LibraryIndex, TrackRecord};
+
+    fn fixture() -> LibraryIndex {
+        LibraryIndex::build(vec![
+            TrackRecord::new(
+                "1",
+                "Master of Puppets",
+                "Metallica",
+                "Master of Puppets",
+                Some("Metallica".into()),
+                "navidrome",
+            ),
+            TrackRecord::new(
+                "2",
+                "Battery",
+                "Metallica",
+                "Master of Puppets",
+                Some("Metallica".into()),
+                "jellyfin",
+            ),
+            TrackRecord::new(
+                "3",
+                "Master Blaster",
+                "Stevie Wonder",
+                "Hotter than July",
+                None,
+                "local",
+            ),
+        ])
+    }
+
+    #[test]
+    fn exact_multi_term_search_prefers_title_and_artist() {
+        let index = fixture();
+        let hits = index.search("metallica master", 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].track.id, "1");
+    }
+
+    #[test]
+    fn prefix_search_does_not_scan_for_an_exact_full_word() {
+        let index = fixture();
+        let hits = index.search("met mast", 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].track.id, "1");
+    }
+
+    #[test]
+    fn query_terms_have_and_semantics() {
+        let index = fixture();
+        let hits = index.search("stevie puppets", 10);
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn provider_can_be_used_as_a_low_weight_filter_term() {
+        let index = fixture();
+        let hits = index.search("jellyfin battery", 10);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].track.id, "2");
+    }
+}


### PR DESCRIPTION
## Why Rust here

Linthra should stay responsive for users with 100k–200k tracks without making Flutter scan the whole Dart catalog for every search keystroke. This introduces a real Rust contribution area with a narrow performance responsibility rather than adding Rust for the language badge.

## What ships in this PR

- new `native/linthra_core` Rust crate with no third-party runtime dependencies
- immutable inverted index for title, artist, album, album artist, and provider metadata
- prefix matching and AND semantics across query terms
- deterministic weighted ranking
- unit coverage for exact/prefix/provider searches
- synthetic 200,000-track benchmark with a generous 50 ms average-query regression ceiling
- dedicated Rust CI for fmt, clippy, tests, and the 200k benchmark
- contributor-facing README for the Rust area

## Deliberate boundary

This PR does **not** wire Rust into Flutter yet. The indexing/search core gets a stable, benchmarked API first; FFI/mobile packaging can then land as a separate review without hiding algorithm changes inside Android build-system work.

That keeps the current Dart/Drift library path untouched while giving Rust contributors a useful, testable part of Linthra immediately.