### PR TITLE
docs(tooling): open v0.2.0 to more contributor languages

### DIFF
--- a/.github/workflows/large-library-sql.yml
+++ b/.github/workflows/large-library-sql.yml
@@ -1,0 +1,34 @@
+name: Large-library SQL
+
+on:
+  pull_request:
+    paths:
+      - 'tools/large_library/**'
+      - '.github/workflows/large-library-sql.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/large_library/**'
+      - '.github/workflows/large-library-sql.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  sqlite-200k:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate 200k-track catalog
+        run: >-
+          python3 tools/large_library/generate_sqlite_fixture.py
+          --output /tmp/linthra-200k.sqlite
+          --tracks 200000
+
+      - name: Benchmark indexed queries
+        run: >-
+          python3 tools/large_library/benchmark_sqlite.py
+          --database /tmp/linthra-200k.sqlite
+          --iterations 200
+          --max-average-ms 50

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,36 @@ Hey — thanks for being here. Linthra is a self-hosted Android music player, an
 it's early alpha, which is honestly the best time to get involved: small changes
 land fast and genuinely shape where the project goes.
 
-You don't need to be a Flutter expert to help. Testing the app against your own
-server, capturing a screenshot, or fixing a confusing line in the docs are all
-real, useful contributions. If you're not sure where to start, the
+**You do not need to know Dart or Flutter to contribute to Linthra.** Testing the
+app against your own server, improving docs, or working in one of the native /
+tooling areas are all real contributions. If you're not sure where to start, the
 [contributor roadmap](./docs/contributor-roadmap.md) lays out where help matters
 most right now.
+
+## Pick the language you know
+
+Linthra uses different languages where they have a real technical job. Pick the
+part that matches what you already know:
+
+| Language | Good place to contribute |
+| --- | --- |
+| **Dart / Flutter** | UI, player orchestration, providers, onboarding, app logic |
+| **Kotlin** | Android APIs, SAF/MediaStore, media session, Android Auto, platform channels |
+| **Rust** | large-library indexing/search and future 100k–200k-track primitives |
+| **C++** | realtime audio DSP, EQ/limiting, future audio analysis and SIMD |
+| **Python** | releases, developer tooling, fixtures, benchmarks, validation |
+| **SQL** | SQLite indexes/query plans and very-large-library performance |
+
+The detailed map, constraints, and suggested contribution areas are in
+[Contributing by language](./docs/language-areas.md). A language is never added
+just to make the GitHub language bar more colourful — every area needs a real
+owner, useful tests/benchmarks, and a small boundary to the rest of the app.
 
 ## Setting up the project
 
 Linthra is a standard Flutter app with a committed Android scaffold, so there's
-no `flutter create` step. In most environments you only need two commands:
+no `flutter create` step. For Dart/Flutter/Android work, in most environments you
+only need two commands:
 
 ```bash
 ./scripts/setup_flutter.sh    # installs the pinned Flutter (no sudo, cached locally)
@@ -26,6 +46,10 @@ downloads the pinned version into the git-ignored `.tool/flutter`.
 `flutter test`, and an APK build (only if an Android SDK is present). Full
 details, troubleshooting, and the manual path are in
 [docs/development.md](./docs/development.md).
+
+Native/tooling areas have their own small commands and CI. In particular,
+`native/linthra_core/` uses Cargo, `native/linthra_audio/` uses CMake, and
+`tools/large_library/` uses only Python's standard library plus SQLite.
 
 ## Finding your way around the code
 
@@ -56,6 +80,10 @@ A few that don't go too deep into the codebase:
 - Add or improve **accessibility labels** so screen readers announce controls
   clearly.
 - Polish an **empty state** so a blank screen explains what to do next.
+- **Rust:** improve large-library normalization/search tests or benchmark memory.
+- **C++:** add DSP response tests or improve realtime benchmark coverage.
+- **Python / SQL:** add a representative 200k-track query and prove its index
+  with `EXPLAIN QUERY PLAN`.
 
 ## Pull requests
 
@@ -65,8 +93,9 @@ A few that don't go too deep into the codebase:
 - **Add tests when it makes sense** — bug fixes and new logic especially.
 - **No unrelated changes.** Resist the urge to reformat or refactor nearby code
   in the same PR; open a separate one if it's worth doing.
-- Run `./scripts/verify_android.sh` (or the CI commands) before pushing — CI runs
-  `dart format --set-exit-if-changed`, so unformatted code will fail.
+- Run the relevant verification command before pushing. Flutter CI runs
+  `dart format --set-exit-if-changed`; native/tooling areas have focused CI in
+  `.github/workflows/`.
 
 ## Code style
 

--- a/docs/language-areas.md
+++ b/docs/language-areas.md
@@ -1,0 +1,40 @@
+# Contributing by language
+
+Linthra is a Flutter app, but the project is deliberately becoming polyglot where a language has a real technical job. You do **not** need to learn Dart before you can make a meaningful contribution.
+
+| Language | Owns / improves | Main area |
+| --- | --- | --- |
+| Dart / Flutter | UI, playback orchestration, providers, onboarding, cross-platform app logic | `lib/`, `test/` |
+| Kotlin | Android platform integration, SAF/MediaStore, media session, Android Auto, system channels | `android/app/src/main/kotlin/` |
+| Rust | large-library indexing/search, future grouping and duplicate primitives | `native/linthra_core/` |
+| C++ | realtime audio DSP, EQ/limiting, future audio analysis and SIMD work | `native/linthra_audio/` |
+| Python | release tooling, large-library fixtures, benchmarks, validation | `scripts/`, `tool/`, `tools/` |
+| SQL | SQLite schema/index/query performance for very large catalogs | `tools/large_library/schema.sql` and Drift/database work |
+
+## Dart / Flutter
+
+Choose Dart when the change is visible app behaviour: screens, navigation, source/provider flows, player state, caching policy, settings, or tests around those features. Flutter remains the product shell and orchestration layer.
+
+## Kotlin / Android
+
+Choose Kotlin when Android itself is the feature. Linthra already has native channels for scoped-storage scanning, launcher icons, sharing, connectivity, display refresh rate and media artwork. Android Auto/media-session work belongs here when it needs Android APIs rather than Flutter widgets.
+
+## Rust / large libraries
+
+`linthra_core` targets the work that becomes expensive at 100,000–200,000 tracks. Its first responsibility is indexed search with a synthetic 200k regression benchmark. Good follow-up areas include compact index persistence, incremental updates, duplicate candidates, grouping primitives, memory profiling and the eventual stable Flutter FFI boundary.
+
+## C++ / audio DSP
+
+`linthra_audio` owns realtime signal processing. The callback must stay bounded, allocation-free and lock-free. EQ, limiter behaviour, SIMD, channel layouts and loudness/peak analysis are useful C++ contribution areas. The current core is intentionally separated from the `just_audio` mobile binding so DSP math can be reviewed independently from Android playback plumbing.
+
+## Python / tooling
+
+Python should remove repetitive maintainer work or create useful developer fixtures. Linthra already uses Python in release/branding tooling; `tools/large_library/` adds deterministic 200k-track SQLite generation and query benchmarks using only the standard library.
+
+## SQL / database performance
+
+SQL matters when a query that feels instant at 5,000 tracks becomes obvious at 200,000. Contributions should include the query plan and a representative fixture/benchmark when possible. Avoid adding indexes speculatively: each index costs storage and write time, so keep ones that serve measured access patterns.
+
+## Cross-language rule
+
+A language does not enter Linthra just to appear in GitHub's language bar. New native/tooling code should have a clear owner, tests or benchmarks, a small boundary to the rest of the app, and a reason it is better suited to that job than the existing layer.

--- a/tools/large_library/README.md
+++ b/tools/large_library/README.md
@@ -1,0 +1,20 @@
+# Large-library tooling (Python + SQL)
+
+This directory gives Python/SQL contributors a deterministic way to work on Linthra's 100k–200k-track behaviour without needing a personal music server or a huge real library.
+
+Generate a 200k-track SQLite fixture:
+
+```bash
+python3 tools/large_library/generate_sqlite_fixture.py \
+  --output /tmp/linthra-200k.sqlite \
+  --tracks 200000
+```
+
+Run representative indexed-query benchmarks:
+
+```bash
+python3 tools/large_library/benchmark_sqlite.py \
+  --database /tmp/linthra-200k.sqlite
+```
+
+The scripts use only Python's standard library. `schema.sql` is a performance sandbox shaped like the fields Linthra cares about; it is **not** a replacement for the Drift production schema. A useful SQL contribution should show the access pattern it improves and, where practical, the `EXPLAIN QUERY PLAN` result that proves the intended index is used.

--- a/tools/large_library/benchmark_sqlite.py
+++ b/tools/large_library/benchmark_sqlite.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Regression benchmark for Linthra-shaped SQLite queries at large scale."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import statistics
+import time
+from pathlib import Path
+
+QUERIES: tuple[tuple[str, str, tuple[object, ...]], ...] = (
+    (
+        "title prefix",
+        "SELECT id, title FROM tracks WHERE normalized_title LIKE ? LIMIT 50",
+        ("track 199%",),
+    ),
+    (
+        "artist exact",
+        "SELECT id, title FROM tracks WHERE normalized_artist = ? LIMIT 100",
+        ("artist 421",),
+    ),
+    (
+        "provider album",
+        "SELECT id, title FROM tracks WHERE provider = ? AND album_id = ? LIMIT 100",
+        ("navidrome", "navidrome:album:311"),
+    ),
+    (
+        "recently added",
+        "SELECT id, title FROM tracks ORDER BY date_added DESC LIMIT 50",
+        (),
+    ),
+)
+
+
+def query_plan(connection: sqlite3.Connection, sql: str, params: tuple[object, ...]) -> str:
+    rows = connection.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+    return " | ".join(str(row[3]) for row in rows)
+
+
+def benchmark(
+    connection: sqlite3.Connection,
+    sql: str,
+    params: tuple[object, ...],
+    iterations: int,
+) -> tuple[float, float]:
+    samples_ms: list[float] = []
+    for _ in range(iterations):
+        started = time.perf_counter_ns()
+        connection.execute(sql, params).fetchall()
+        samples_ms.append((time.perf_counter_ns() - started) / 1_000_000)
+    return statistics.mean(samples_ms), statistics.quantiles(samples_ms, n=20)[18]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--database", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--max-average-ms", type=float, default=50.0)
+    args = parser.parse_args()
+
+    connection = sqlite3.connect(f"file:{args.database}?mode=ro", uri=True)
+    connection.execute("PRAGMA case_sensitive_like = ON")
+    try:
+        count = connection.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        print(f"catalog: {count:,} tracks")
+
+        failed = False
+        for name, sql, params in QUERIES:
+            plan = query_plan(connection, sql, params)
+            average_ms, p95_ms = benchmark(connection, sql, params, args.iterations)
+            print(
+                f"{name:16} avg={average_ms:8.3f} ms "
+                f"p95={p95_ms:8.3f} ms plan={plan}"
+            )
+
+            # Every benchmark query has a matching index in schema.sql. A full
+            # table scan is therefore a schema/query regression, even if a fast
+            # CI machine happens to hide it in wall-clock timing.
+            if "SCAN tracks" in plan and "USING INDEX" not in plan:
+                print(f"ERROR: {name} fell back to a full table scan")
+                failed = True
+            if average_ms > args.max_average_ms:
+                print(
+                    f"ERROR: {name} exceeded the {args.max_average_ms:.1f} ms "
+                    "average-query budget"
+                )
+                failed = True
+
+        if failed:
+            raise SystemExit(1)
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/large_library/generate_sqlite_fixture.py
+++ b/tools/large_library/generate_sqlite_fixture.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Generate a deterministic Linthra-shaped SQLite catalog for performance work."""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SCHEMA = ROOT / "schema.sql"
+
+
+def normalized(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def row(index: int) -> tuple[object, ...]:
+    providers = ("local", "jellyfin", "navidrome", "plex")
+    provider = providers[index % len(providers)]
+    artist_number = index % 1_500
+    album_number = index % 2_500
+    artist = f"Artist {artist_number}"
+    album = f"Album {album_number}"
+    title = f"Track {index} Midnight Signal"
+    album_artist = "Various Artists" if index % 29 == 0 else artist
+    album_id = f"{provider}:album:{album_number}"
+    return (
+        index + 1,
+        provider,
+        f"{provider}-track-{index}",
+        title,
+        normalized(title),
+        artist,
+        normalized(artist),
+        album,
+        normalized(album),
+        album_artist,
+        normalized(album_artist),
+        album_id,
+        1_700_000_000 + index,
+    )
+
+
+def generate(output: Path, track_count: int, batch_size: int = 5_000) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        output.unlink()
+
+    started = time.perf_counter()
+    connection = sqlite3.connect(output)
+    try:
+        connection.executescript(SCHEMA.read_text(encoding="utf-8"))
+        insert = """
+            INSERT INTO tracks (
+                id, provider, provider_track_id, title, normalized_title,
+                artist_name, normalized_artist, album_name, normalized_album,
+                album_artist_name, normalized_album_artist, album_id, date_added
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+        for start in range(0, track_count, batch_size):
+            stop = min(start + batch_size, track_count)
+            connection.executemany(insert, (row(index) for index in range(start, stop)))
+        connection.commit()
+    finally:
+        connection.close()
+
+    elapsed = time.perf_counter() - started
+    size_mb = output.stat().st_size / (1024 * 1024)
+    print(
+        f"generated {track_count:,} tracks in {elapsed:.2f}s "
+        f"({size_mb:.1f} MiB): {output}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--tracks", type=int, default=200_000)
+    args = parser.parse_args()
+    if args.tracks <= 0:
+        parser.error("--tracks must be positive")
+    generate(args.output, args.tracks)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/large_library/schema.sql
+++ b/tools/large_library/schema.sql
@@ -1,0 +1,41 @@
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA temp_store = MEMORY;
+PRAGMA case_sensitive_like = ON;
+
+CREATE TABLE IF NOT EXISTS tracks (
+    id INTEGER PRIMARY KEY,
+    provider TEXT NOT NULL,
+    provider_track_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    normalized_title TEXT NOT NULL,
+    artist_name TEXT NOT NULL,
+    normalized_artist TEXT NOT NULL,
+    album_name TEXT NOT NULL,
+    normalized_album TEXT NOT NULL,
+    album_artist_name TEXT,
+    normalized_album_artist TEXT,
+    album_id TEXT,
+    date_added INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tracks_provider_identity
+    ON tracks(provider, provider_track_id);
+
+CREATE INDEX IF NOT EXISTS idx_tracks_title
+    ON tracks(normalized_title);
+
+CREATE INDEX IF NOT EXISTS idx_tracks_artist
+    ON tracks(normalized_artist);
+
+CREATE INDEX IF NOT EXISTS idx_tracks_album
+    ON tracks(normalized_album);
+
+CREATE INDEX IF NOT EXISTS idx_tracks_album_artist
+    ON tracks(normalized_album_artist);
+
+CREATE INDEX IF NOT EXISTS idx_tracks_provider_album
+    ON tracks(provider, album_id);
+
+CREATE INDEX IF NOT EXISTS idx_tracks_recent
+    ON tracks(date_added DESC);


### PR DESCRIPTION
## Goal

Make it immediately obvious that contributors do not need to know Dart to help Linthra, while giving Python/SQL contributors a real performance workflow rather than documentation-only language mentions.

## What changes

- adds a prominent language map to `CONTRIBUTING.md`
- documents real ownership areas for Dart/Flutter, Kotlin, Rust, C++, Python, and SQL
- adds `docs/language-areas.md` with boundaries and suggested work by language
- adds a Python standard-library tool that generates a deterministic 200,000-track SQLite fixture
- adds an indexed SQL benchmark schema for large-library work
- benchmarks representative title/artist/provider-album/recent queries and inspects `EXPLAIN QUERY PLAN`
- adds CI to catch accidental full-table scans or major query regressions at 200k tracks

## Relationship to the native PRs

This documentation names the v0.2.0 Rust and C++ areas introduced by #321 and #322. It is best merged after (or alongside) those PRs so every documented path exists on `main`.

The SQL schema in `tools/large_library/` is explicitly a performance sandbox, not a replacement for Linthra's production Drift schema.