### PR TITLE
fix(onboarding): keep the welcome laying out in a short viewport

### DIFF
--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -213,101 +213,113 @@ class _WelcomePage extends StatelessWidget {
       ),
     );
 
-    return SingleChildScrollView(
-      key: const PageStorageKey<String>('welcome-scroll'),
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.lg,
-        vertical: AppSpacing.xl,
-      ),
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          minHeight: MediaQuery.sizeOf(context).height -
-              MediaQuery.paddingOf(context).vertical -
-              (AppSpacing.xl * 2),
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            _Entrance(
-              controller: motion,
-              begin: 0,
-              end: .55,
-              travel: 14,
-              child: Center(
-                child: ScaleTransition(
-                  scale: logoScale,
-                  child: const SelectedLinthraLogoMark(size: 96),
+    // The welcome fills its box so the column can sit optically centred, but
+    // it stays scrollable once the copy outgrows a short viewport. The height
+    // comes from the box we were actually handed — SafeArea has already taken
+    // the system insets off it — rather than from the raw screen size, and it
+    // is clamped at zero: subtracting the padding must never be able to hand
+    // ConstrainedBox a negative (non-normalized) minimum.
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double minHeight = constraints.hasBoundedHeight
+            ? (constraints.maxHeight - (AppSpacing.xl * 2))
+                .clamp(0.0, double.infinity)
+            : 0.0;
+
+        return SingleChildScrollView(
+          key: const PageStorageKey<String>('welcome-scroll'),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.lg,
+            vertical: AppSpacing.xl,
+          ),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: minHeight),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                _Entrance(
+                  controller: motion,
+                  begin: 0,
+                  end: .55,
+                  travel: 14,
+                  child: Center(
+                    child: ScaleTransition(
+                      scale: logoScale,
+                      child: const SelectedLinthraLogoMark(size: 96),
+                    ),
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.xl),
-            _Entrance(
-              controller: motion,
-              begin: .18,
-              end: .7,
-              child: Text(
-                replay ? 'Welcome back to Linthra' : 'Welcome to Linthra',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.headlineMedium?.copyWith(
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: -.7,
+                const SizedBox(height: AppSpacing.xl),
+                _Entrance(
+                  controller: motion,
+                  begin: .18,
+                  end: .7,
+                  child: Text(
+                    replay ? 'Welcome back to Linthra' : 'Welcome to Linthra',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: -.7,
+                    ),
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            _Entrance(
-              controller: motion,
-              begin: .3,
-              end: .8,
-              child: Text(
-                'Your music. Your servers. Your choice.',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.titleMedium?.copyWith(color: muted),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            _Entrance(
-              controller: motion,
-              begin: .4,
-              end: .88,
-              child: Text(
-                'Linthra brings local music, Jellyfin, Navidrome / Subsonic and '
-                'Plex into one private, open-source library.',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodyLarge?.copyWith(
-                  color: muted,
-                  height: 1.45,
+                const SizedBox(height: AppSpacing.sm),
+                _Entrance(
+                  controller: motion,
+                  begin: .3,
+                  end: .8,
+                  child: Text(
+                    'Your music. Your servers. Your choice.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.titleMedium?.copyWith(color: muted),
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.xl),
-            _Entrance(
-              controller: motion,
-              begin: .55,
-              end: 1,
-              child: FilledButton.icon(
-                onPressed: onStart,
-                icon: const Icon(Icons.arrow_forward_rounded),
-                label: Text(replay ? 'Explore music sources' : 'Get started'),
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(54),
+                const SizedBox(height: AppSpacing.lg),
+                _Entrance(
+                  controller: motion,
+                  begin: .4,
+                  end: .88,
+                  child: Text(
+                    'Linthra brings local music, Jellyfin, Navidrome / Subsonic and '
+                    'Plex into one private, open-source library.',
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: muted,
+                      height: 1.45,
+                    ),
+                  ),
                 ),
-              ),
+                const SizedBox(height: AppSpacing.xl),
+                _Entrance(
+                  controller: motion,
+                  begin: .55,
+                  end: 1,
+                  child: FilledButton.icon(
+                    onPressed: onStart,
+                    icon: const Icon(Icons.arrow_forward_rounded),
+                    label:
+                        Text(replay ? 'Explore music sources' : 'Get started'),
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(54),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                _Entrance(
+                  controller: motion,
+                  begin: .64,
+                  end: 1,
+                  child: TextButton(
+                    onPressed: onSkip,
+                    child: Text(replay ? 'Done' : 'Skip for now'),
+                  ),
+                ),
+              ],
             ),
-            const SizedBox(height: AppSpacing.sm),
-            _Entrance(
-              controller: motion,
-              begin: .64,
-              end: 1,
-              child: TextButton(
-                onPressed: onSkip,
-                child: Text(replay ? 'Done' : 'Skip for now'),
-              ),
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/features/onboarding/onboarding_screen_test.dart
+++ b/test/features/onboarding/onboarding_screen_test.dart
@@ -6,11 +6,16 @@ import 'package:linthra/features/onboarding/onboarding_screen.dart';
 void main() {
   testWidgets('welcome moves into the music-source chooser', (tester) async {
     await tester.pumpWidget(
-      const ProviderScope(
+      ProviderScope(
         child: MaterialApp(
-          home: MediaQuery(
-            data: MediaQueryData(disableAnimations: true),
-            child: OnboardingScreen(),
+          // Turn animations off so the tour settles in a single pump, but keep
+          // the surrounding metrics: building MediaQueryData from scratch would
+          // describe a zero-size screen, which is a viewport no device has.
+          home: Builder(
+            builder: (BuildContext context) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(disableAnimations: true),
+              child: const OnboardingScreen(),
+            ),
           ),
         ),
       ),
@@ -27,5 +32,32 @@ void main() {
     expect(find.text('Jellyfin'), findsOneWidget);
     expect(find.text('Navidrome / Subsonic'), findsOneWidget);
     expect(find.text('Plex'), findsOneWidget);
+  });
+
+  testWidgets('welcome survives a viewport shorter than its own padding',
+      (tester) async {
+    // A split-screen window — or any embedding that reports a viewport smaller
+    // than the page's vertical padding — used to drive the welcome's minimum
+    // height negative, and a non-normalized BoxConstraints asserts on build.
+    // The page must lay out and stay readable instead.
+    tester.view.physicalSize = const Size(400, 40);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(disableAnimations: true),
+              child: const OnboardingScreen(),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Welcome to Linthra'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Fixes the red **Flutter checks** job on `main` ([run 31242679401](https://github.com/TheZupZup/Linthra/actions/runs/31242679401), commit e2777fb / #320). That run was `3107 tests passed, 1 failed`; the other two CI jobs were green.

## The failure

`test/features/onboarding/onboarding_screen_test.dart` → *welcome moves into the music-source chooser*:

```
BoxConstraints has a negative minimum height.
The offending constraints were:
  BoxConstraints(0.0<=w<=Infinity, -64.0<=h<=Infinity; NOT NORMALIZED)
  _WelcomePage.build (onboarding_screen.dart:222)
```

The assertion killed the build, so nothing rendered and the follow-on expectation reported `Found 0 widgets with text "Welcome to Linthra"`.

## Root cause

`_WelcomePage` sized itself from the raw screen height:

```dart
minHeight: MediaQuery.sizeOf(context).height
    - MediaQuery.paddingOf(context).vertical
    - (AppSpacing.xl * 2),   // 64
```

Nothing kept that subtraction above zero. A non-normalized `BoxConstraints` asserts during build, so any viewport shorter than the page's own 64px of vertical padding takes the whole first-run screen down.

Two separate defects lined up to make it fail in CI:

1. **Production** — the height arithmetic is unguarded. This is the real bug.
2. **Test** — the test built `MediaQueryData(disableAnimations: true)` from scratch. A fresh `MediaQueryData` reports `Size.zero`, a viewport no device has, which drove the expression to `0 - 0 - 64 = -64` and matches the logged constraint exactly.

It is the only subtraction of its kind in `lib/` — the other four `MediaQuery.sizeOf(...).height` uses all multiply (`* 0.85`, `* 0.7`, `* 0.6`), so they cannot go negative.

## The fix

- Take the height from the box the page is **actually given**, via `LayoutBuilder`. It sits under the `SafeArea` that has already removed the system insets, so the separate padding subtraction is gone, and the result is clamped at zero. An unbounded height falls back to `0` rather than an infinite minimum.
- The test now copies the ambient metrics (`MediaQuery.of(context).copyWith(disableAnimations: true)`) instead of fabricating a zero-size screen.
- Added a regression test that pumps the page into a viewport shorter than its padding — this pins the production defect independently of how any test sets up its `MediaQuery`.

The centred-but-scrollable layout is unchanged on real viewports; the diff looks large only because the `Column` re-indented under the new builder.

## Verification

Run locally on the same toolchain CI pins (Flutter 3.27.4 / Dart 3.6.2), all four checks:

| Check | Result |
|---|---|
| `flutter pub get --enforce-lockfile` | ✅ no lockfile drift |
| `dart format --set-exit-if-changed .` | ✅ `805 files (0 changed)` |
| `flutter analyze` | ✅ `No issues found!` |
| `flutter test` | ✅ `+3109: All tests passed!` |
| `./scripts/check_secrets.sh` | ✅ passed |

3109 = the 3108 from the failing run, plus the new regression test.

The regression test was confirmed to catch the bug rather than merely pass alongside it: with the production change stashed it fails with `BoxConstraints(0.0<=w<=Infinity, -24.0<=h<=Infinity; NOT NORMALIZED)`. Worth noting the test-side change alone would have turned CI green while leaving the production bug latent — hence both.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPvMPT9vcAiQ92HNNhRip6)_