### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](./LICENSE)
 [![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Latest release: v0.1.15](https://img.shields.io/badge/release-v0.1.15-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
+[![Latest release: v0.2.0](https://img.shields.io/badge/release-v0.2.0-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 [![Community: r/Linthra](https://img.shields.io/badge/community-r%2FLinthra-FF9F43.svg)](https://reddit.com/r/Linthra)
 
@@ -71,7 +71,7 @@ More in [`phoneScreenshots/`](fastlane/metadata/android/en-US/images/phoneScreen
 
 New versions land on
 [GitHub Releases](https://github.com/thezupzup/linthra/releases) first, as
-signed APKs. The current stable is v0.1.15. Linthra is also on
+signed APKs. The current stable is v0.2.0. Linthra is also on
 [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/); F-Droid
 builds may arrive a bit later while their build and review process runs. Not on
 Google Play yet.

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -1,0 +1,49 @@
+# Linthra v0.2.0 — release notes
+
+**Linthra is an Android music player for local files and self-hosted music servers.** v0.2.0 introduces a proper first-run experience for new installs and expands the project foundations for future performance work and broader open-source contributions.
+
+- **Version:** `0.2.0` (`versionName`), `versionCode` `200999`
+- **Platform:** Android
+- **Application ID:** `io.github.thezupzup.linthra`
+- **License:** MPL-2.0
+
+## What's new
+
+### A real first-run welcome
+
+- New installs now open a guided welcome instead of dropping directly into an empty library.
+- The source chooser helps users start with local music, Jellyfin, Navidrome / Subsonic, or Plex.
+- Notification permission is deferred until the welcome has completed so first launch stays focused on setup.
+- The welcome can be replayed later from Settings.
+
+### Existing installs stay out of the way
+
+- Linthra now records onboarding completion and detects Android install history during startup.
+- Existing users upgrading from an earlier version continue into the normal app instead of being treated like a fresh install.
+- The startup state is resolved before the router is built, preventing a temporary jump into the wrong screen.
+
+### More resilient onboarding UI
+
+- The welcome layout now uses the actual SafeArea constraints and handles very short viewports without producing invalid layout constraints.
+- Regression coverage protects first-run routing, upgrade classification, onboarding persistence, and short-screen layout behavior.
+
+## Project foundations for v0.2.x
+
+This release also opens more of Linthra to contributors working outside Dart while keeping these components deliberately separate from the shipped playback path until they are ready to be integrated.
+
+- A Rust `linthra_core` prototype provides a deterministic large-library search index and a 200k-track benchmark.
+- A native C++ audio DSP project defines an allocation-free processing chain, stable C ABI, EQ/preamp/limiter tests, and a realtime-safety benchmark.
+- Python and SQL tooling can generate and benchmark a deterministic 200k-track SQLite library.
+- CI now validates the Rust core, C++ DSP work, and large-library SQL benchmark independently.
+- Contributor documentation maps real areas where Dart, Kotlin, Rust, C++, Python, and SQL can be used in Linthra.
+
+These native and tooling projects are foundations for future work; v0.2.0 does not claim that Rust search or the C++ DSP chain has replaced the current Flutter playback/search implementation yet.
+
+## Upgrade and distribution notes
+
+- Normal in-place updates preserve accounts, settings, playlists, catalog, favorites, and cache.
+- Existing installs should bypass the new first-run welcome automatically.
+- Do not mix GitHub and F-Droid installations because the APKs use different signing keys and cannot update one another.
+- F-Droid builds and signs its own APKs from the source tag; GitHub Release APKs are signed by the upstream project.
+
+No ads, no tracking, no analytics, no telemetry. Linthra plays music you already own or that your own server provides.

--- a/fastlane/metadata/android/en-US/changelogs/200999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/200999.txt
@@ -1,0 +1,5 @@
+Linthra 0.2.0
+
+- Adds a guided first-run welcome that helps new users choose local music, Jellyfin, Navidrome / Subsonic, or Plex.
+- Keeps existing installs out of the welcome during upgrades and lets the tour be replayed later from Settings.
+- Improves first-run layout resilience on short screens.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.1.15';
+  static const String _devVersionName = '0.2.0';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,9 +20,9 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'The Now Playing screen no longer jumps when Navidrome, Jellyfin, or Plex playback changes status.',
-    'Streaming, buffering, cache, casting, and error indicators now share a stable layout.',
-    'Playback status stays readable with larger system text without moving the controls.',
+    'New installs now start with a guided welcome that helps you choose local music or a self-hosted server.',
+    'Existing installs are detected during upgrades so the new welcome does not interrupt normal updates.',
+    'The welcome tour can be replayed later from Settings whenever you want to add or revisit a music source.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.1.15+115999
+version: 0.2.0+200999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepare Linthra v0.2.0 for a stable release.

- bump `pubspec.yaml` to `0.2.0+200999`
- update the in-app version to `0.2.0`
- refresh the in-app What's new section for the first-run welcome
- add the F-Droid changelog for versionCode `200999`
- add full v0.2.0 release notes
- update the README release badge and current stable version

## Release focus

v0.2.0 ships the new first-run onboarding and source chooser while preserving the normal upgrade path for existing installs. It also includes the new Rust, C++, Python, and SQL project foundations as contributor/performance infrastructure; the release notes intentionally do not claim those native prototypes are already wired into the shipped playback or search paths.

## Distribution

Target tag after merge: `v0.2.0`.

F-Droid will build from the source tag using versionCode `200999`; GitHub Release builds remain handled by the existing stable-release workflow.