### PR TITLE
Draw playback progress as a wavy line, not a flat slider

### DIFF
--- a/docs/battery.md
+++ b/docs/battery.md
@@ -64,6 +64,14 @@ tick:
   **honours the OS reduced-motion setting** (`MediaQuery.disableAnimations`) — a
   paused, off-screen, or reduce-motion indicator schedules no frames. See
   `lib/shared/widgets/now_playing_indicator.dart`.
+- **The wavy progress bar** (Now Playing and the mini-player's top edge) has
+  **no perpetual animation**: a wave that drifted forever would repaint the full
+  width of the bar every frame on the app's most-used screen. Its only motion is
+  a one-shot ~420 ms swell when playback starts or pauses — skipped entirely
+  under reduced motion — after which it schedules no frames and costs a single
+  polyline repaint per position tick, on its own `RepaintBoundary`. The
+  mini-player's copy never even swells. See
+  `lib/shared/widgets/wavy_progress_indicator.dart`.
 - **Track rows** watch a position-*independent* now-playing snapshot
   (`current track + isPlaying`), so they rebuild only on a track change or a
   play/pause flip — never on a position tick. See `lib/features/player/now_playing.dart`.

--- a/lib/features/player/mini_player.dart
+++ b/lib/features/player/mini_player.dart
@@ -8,6 +8,7 @@ import '../../core/models/playback_source.dart';
 import '../../core/models/playback_state.dart';
 import '../../core/models/track.dart';
 import '../../core/services/playback_source_label.dart';
+import '../../shared/widgets/wavy_progress_indicator.dart';
 import 'cast/cast_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
@@ -181,14 +182,26 @@ class _MiniSubtitle extends StatelessWidget {
   }
 }
 
-/// A 2.5dp accent line tracking playback progress across the mini-player's top
-/// edge. Sits at 0 (an empty track) when the duration is still unknown, so it
-/// never animates indeterminately or jumps.
+/// A slim accent line tracking playback progress across the mini-player's top
+/// edge, drawn as the same gentle wave the now-playing screen uses so the two
+/// surfaces read as one design. Sits at 0 (an empty track) when the duration is
+/// still unknown, so it never animates indeterminately or jumps.
+///
+/// Deliberately marker-less, and pinned at the full wave rather than following
+/// the play/pause swell the full player uses: at this size the wave is texture
+/// rather than a control, and this bar is on screen on every main tab — so it
+/// stays a plain repaint per position tick and adds no animation frames
+/// anywhere in the app. Tapping the mini-player opens the full player; it is
+/// not a seek surface, so it carries no slider semantics of its own.
 ///
 /// It watches the position/duration itself, so a position tick rebuilds only
 /// this thin line — not the artwork and text above it.
 class _MiniProgressBar extends ConsumerWidget {
   const _MiniProgressBar();
+
+  /// Enough room for the wave's peaks and stroke without meaningfully eating
+  /// into the 64dp bar's content row.
+  static const double _height = 6.0;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -200,11 +213,16 @@ class _MiniProgressBar extends ConsumerWidget {
     final double value = total > 0
         ? (state.position.inMilliseconds / total).clamp(0.0, 1.0)
         : 0.0;
-    return LinearProgressIndicator(
-      value: value,
-      minHeight: 2.5,
-      backgroundColor: theme.colorScheme.onSurface.withValues(alpha: 0.08),
-      color: theme.colorScheme.secondary,
+    return SizedBox(
+      height: _height,
+      child: WavyProgressIndicator(
+        value: value,
+        activeColor: theme.colorScheme.secondary,
+        inactiveColor: theme.colorScheme.onSurface.withValues(alpha: 0.08),
+        amplitude: 1.4,
+        wavelength: 26,
+        strokeWidth: 2,
+      ),
     );
   }
 }

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -201,6 +201,9 @@ class _LiveControls extends ConsumerWidget {
         PlaybackProgressBar(
           position: state.position,
           duration: state.duration,
+          // Drives the wave's slow drift: it flows while playing and holds
+          // still when paused, so a paused screen schedules no frames.
+          playing: state.isPlaying,
           onSeek: (position) =>
               ref.read(playbackControllerProvider).seek(position),
         ),

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -1,19 +1,41 @@
 import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
+import 'wavy_seek_bar.dart';
+
+/// How the seekable progress bar is drawn.
+enum PlaybackProgressStyle {
+  /// Linthra's own [WavySeekBar]: a soft serpentine line with a round marker.
+  wave,
+
+  /// The plain Material [Slider]. Kept as a first-class, tested path so a single
+  /// constant reverts the look if the wave ever proves problematic on a device.
+  slider,
+}
+
+/// The style [PlaybackProgressBar] uses unless a call site overrides it. Change
+/// this one value to move the whole app back to the Material slider.
+const PlaybackProgressStyle defaultPlaybackProgressStyle =
+    PlaybackProgressStyle.wave;
 
 /// Seekable progress bar showing the current position and total duration.
 ///
 /// Robust to an unknown duration (common at the very start of a stream or for a
-/// live source): when [duration] is zero the slider sits stable and disabled and
+/// live source): when [duration] is zero the bar sits stable and disabled and
 /// the total reads `--:--`, so the UI never breaks or jumps. While the user
-/// drags, the thumb and the elapsed label follow the finger; the actual
+/// drags, the marker and the elapsed label follow the finger; the actual
 /// [onSeek] fires once on release, so playback isn't spammed mid-drag.
+///
+/// The drag preview lives here rather than in either renderer, so both the wave
+/// and the slider stay interchangeable and the time labels follow the finger the
+/// same way in both.
 class PlaybackProgressBar extends StatefulWidget {
   const PlaybackProgressBar({
     required this.position,
     required this.duration,
     required this.onSeek,
+    this.playing = false,
+    this.style = defaultPlaybackProgressStyle,
     super.key,
   });
 
@@ -23,6 +45,13 @@ class PlaybackProgressBar extends StatefulWidget {
   /// Called with the target position when a seek completes. The bar still
   /// renders progress when this is null, just without seeking.
   final ValueChanged<Duration>? onSeek;
+
+  /// Whether playback is actively playing. Only the wave's slow drift uses this;
+  /// a paused bar holds still and schedules no frames.
+  final bool playing;
+
+  /// Which renderer to use. Defaults to [defaultPlaybackProgressStyle].
+  final PlaybackProgressStyle style;
 
   @override
   State<PlaybackProgressBar> createState() => _PlaybackProgressBarState();
@@ -49,8 +78,7 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
     final int posMs = hasDuration
         ? widget.position.inMilliseconds.clamp(0, totalMs).toInt()
         : 0;
-    final double sliderValue = _dragMs ?? posMs.toDouble();
-    final double elapsedMs = _dragMs ?? posMs.toDouble();
+    final double barValue = _dragMs ?? posMs.toDouble();
 
     final muted = theme.colorScheme.onSurfaceVariant;
     final labelStyle = theme.textTheme.labelSmall?.copyWith(
@@ -61,21 +89,31 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
 
     return Column(
       children: [
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 4,
-            overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
-            inactiveTrackColor:
-                theme.colorScheme.onSurface.withValues(alpha: 0.15),
-          ),
-          child: Slider(
-            value: sliderValue,
-            max: hasDuration ? totalMs.toDouble() : 1.0,
-            onChanged: canSeek ? _onChanged : null,
-            onChangeEnd: canSeek ? _onChangeEnd : null,
-          ),
-        ),
+        switch (widget.style) {
+          PlaybackProgressStyle.wave => WavySeekBar(
+              value: barValue,
+              max: hasDuration ? totalMs.toDouble() : 0.0,
+              onChanged: canSeek ? _onChanged : null,
+              onChangeEnd: canSeek ? _onChangeEnd : null,
+              semanticFormatter: _formatMs,
+              playing: widget.playing,
+            ),
+          PlaybackProgressStyle.slider => SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                trackHeight: 4,
+                overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+                thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+                inactiveTrackColor:
+                    theme.colorScheme.onSurface.withValues(alpha: 0.15),
+              ),
+              child: Slider(
+                value: barValue,
+                max: hasDuration ? totalMs.toDouble() : 1.0,
+                onChanged: canSeek ? _onChanged : null,
+                onChangeEnd: canSeek ? _onChangeEnd : null,
+              ),
+            ),
+        },
         // Snug under the track and aligned to its ends, so the times read as a
         // caption for the bar rather than a separate, floating row.
         Padding(
@@ -83,10 +121,7 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                _format(Duration(milliseconds: elapsedMs.round())),
-                style: labelStyle,
-              ),
+              Text(_formatMs(barValue), style: labelStyle),
               Text(
                 hasDuration ? _format(widget.duration) : '--:--',
                 style: labelStyle,
@@ -97,6 +132,9 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
       ],
     );
   }
+
+  static String _formatMs(double milliseconds) =>
+      _format(Duration(milliseconds: milliseconds.round()));
 
   /// `m:ss`, widening to `h:mm:ss` past an hour.
   static String _format(Duration d) {

--- a/lib/features/player/widgets/wavy_seek_bar.dart
+++ b/lib/features/player/widgets/wavy_seek_bar.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/wavy_progress_indicator.dart';
+
+/// A seekable playback position control drawn as a gentle wave.
+///
+/// The API deliberately mirrors [Slider] — [value], [max], [onChanged],
+/// [onChangeEnd] — so a call site can swap between the two with one line and no
+/// other changes. That is what makes falling back to the plain Material slider
+/// cheap if the wave ever misbehaves on a device (see `PlaybackProgressStyle`).
+///
+/// Replacing a real [Slider] means its built-in accessibility has to be replaced
+/// too, so this declares the slider role itself: screen readers announce the
+/// elapsed and total time and can seek with the increase/decrease actions,
+/// stepping by [_semanticStepFraction] of the track (never less than
+/// [_minSemanticStep], so a long song doesn't take a hundred taps to cross).
+class WavySeekBar extends StatelessWidget {
+  const WavySeekBar({
+    required this.value,
+    required this.max,
+    required this.onChanged,
+    required this.onChangeEnd,
+    required this.semanticFormatter,
+    this.playing = false,
+    super.key,
+  });
+
+  /// The current position in milliseconds, already reflecting an in-progress
+  /// drag when the parent is previewing one.
+  final double value;
+
+  /// The track length in milliseconds. Zero means the duration is not known
+  /// yet: the bar renders flat and empty rather than guessing.
+  final double max;
+
+  /// Called continuously while the user drags or taps, for a live preview.
+  /// Null disables interaction entirely.
+  final ValueChanged<double>? onChanged;
+
+  /// Called once when the gesture completes, with the position to seek to.
+  final ValueChanged<double>? onChangeEnd;
+
+  /// Renders a millisecond position as the `m:ss` text screen readers announce.
+  final String Function(double milliseconds) semanticFormatter;
+
+  /// Whether playback is actively playing. The wave rides at full amplitude
+  /// while it is, and eases down to a calmer, shallower wave when paused.
+  final bool playing;
+
+  /// Height of the touch target. The painted line is much thinner; the box is
+  /// sized for a comfortable, WCAG-sized target instead.
+  static const double _hitHeight = 44.0;
+
+  static const double _amplitude = 3.0;
+
+  /// Long enough that the line reads as a slow wave rather than a tight
+  /// squiggle at phone widths (roughly a dozen crests across a full track).
+  static const double _wavelength = 28.0;
+  static const double _strokeWidth = 3.0;
+  static const double _thumbRadius = 6.0;
+
+  /// One increase/decrease action moves this much of the track…
+  static const double _semanticStepFraction = 0.05;
+
+  /// …but never less than this, so short tracks still step sensibly.
+  static const Duration _minSemanticStep = Duration(seconds: 5);
+
+  bool get _enabled => max > 0 && onChanged != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final double fraction = max > 0 ? (value / max).clamp(0.0, 1.0) : 0.0;
+
+    final Widget bar = LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double width = constraints.maxWidth;
+
+        /// Maps a local touch x to a position in milliseconds, using the exact
+        /// inset the painter reserved for the marker so the point the user
+        /// touches is the point the marker lands on.
+        double positionAt(double dx) {
+          final double inset = WavyProgressIndicator.trackInset(
+            thumbRadius: _thumbRadius,
+            strokeWidth: _strokeWidth,
+          );
+          final double trackWidth = width - inset * 2;
+          if (trackWidth <= 0) return 0;
+          final double travelled =
+              Directionality.of(context) == TextDirection.rtl
+                  ? (width - inset) - dx
+                  : dx - inset;
+          return (travelled / trackWidth).clamp(0.0, 1.0) * max;
+        }
+
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: _enabled
+              ? (details) => onChanged!(positionAt(details.localPosition.dx))
+              : null,
+          onTapUp: _enabled
+              ? (details) =>
+                  onChangeEnd?.call(positionAt(details.localPosition.dx))
+              : null,
+          onHorizontalDragStart: _enabled
+              ? (details) => onChanged!(positionAt(details.localPosition.dx))
+              : null,
+          onHorizontalDragUpdate: _enabled
+              ? (details) => onChanged!(positionAt(details.localPosition.dx))
+              : null,
+          onHorizontalDragEnd:
+              _enabled ? (details) => onChangeEnd?.call(value) : null,
+          child: SizedBox(
+            height: _hitHeight,
+            width: double.infinity,
+            child: WavyProgressIndicator(
+              value: fraction,
+              activeColor: theme.colorScheme.secondary,
+              inactiveColor:
+                  theme.colorScheme.onSurface.withValues(alpha: 0.15),
+              amplitude: _amplitude,
+              wavelength: _wavelength,
+              strokeWidth: _strokeWidth,
+              // With no duration there is nothing to point at, so the marker is
+              // withheld rather than parked misleadingly at the start.
+              thumbRadius: max > 0 ? _thumbRadius : 0.0,
+              active: playing,
+            ),
+          ),
+        );
+      },
+    );
+
+    return _seekSemantics(child: bar);
+  }
+
+  /// Declares the slider role a real [Slider] would have provided, with the
+  /// spoken value and — when seeking is possible — the two seek actions.
+  Widget _seekSemantics({required Widget child}) {
+    if (!_enabled) {
+      return Semantics(
+        label: 'Playback position',
+        value: max > 0
+            ? '${semanticFormatter(value)} of ${semanticFormatter(max)}'
+            : 'Unknown',
+        readOnly: true,
+        container: true,
+        excludeSemantics: true,
+        child: child,
+      );
+    }
+
+    final double step = _semanticStep;
+    final double increased = (value + step).clamp(0.0, max);
+    final double decreased = (value - step).clamp(0.0, max);
+    return Semantics(
+      slider: true,
+      container: true,
+      excludeSemantics: true,
+      label: 'Playback position',
+      value: '${semanticFormatter(value)} of ${semanticFormatter(max)}',
+      increasedValue: '${semanticFormatter(increased)} of '
+          '${semanticFormatter(max)}',
+      decreasedValue: '${semanticFormatter(decreased)} of '
+          '${semanticFormatter(max)}',
+      onIncrease: () => onChangeEnd?.call(increased),
+      onDecrease: () => onChangeEnd?.call(decreased),
+      child: child,
+    );
+  }
+
+  double get _semanticStep {
+    final double proportional = max * _semanticStepFraction;
+    final double floor = _minSemanticStep.inMilliseconds.toDouble();
+    return proportional > floor ? proportional : floor;
+  }
+}

--- a/lib/shared/widgets/wavy_progress_indicator.dart
+++ b/lib/shared/widgets/wavy_progress_indicator.dart
@@ -1,0 +1,353 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Progress drawn along a gentle horizontal wave instead of a flat bar.
+///
+/// The elapsed part of the track is a soft serpentine line in [activeColor];
+/// the remainder is a calm straight line in [inactiveColor], with an optional
+/// round marker riding the boundary between them. The wave's amplitude eases to
+/// zero at both ends of the elapsed segment, so it grows out of — and settles
+/// back into — the flat line rather than looking cut off.
+///
+/// This widget is purely presentational: it knows about a [value] in `0..1` and
+/// nothing about playback, seeking, or `Duration`. That keeps it reusable for
+/// any "progress along a line" surface (the now-playing bar, the mini-player's
+/// top edge) and keeps the interaction and semantics with the caller — see
+/// `WavySeekBar` for the seekable, screen-reader-friendly wrapper.
+///
+/// **There is deliberately no perpetual animation here.** A wave that drifts
+/// forever would repaint the full width of the bar on every frame, on the
+/// screen users leave open the longest — the opposite of what a low-end phone
+/// wants, and something `docs/battery.md` rules out for the rest of the UI. The
+/// only motion is a one-shot ease when [active] flips: the wave swells to full
+/// [amplitude] while progress is advancing and settles back to a calmer,
+/// shallower wave at rest. That transition takes [transitionDuration], then the
+/// widget stops scheduling frames entirely, and it is skipped outright when the
+/// platform or user asks for reduced motion
+/// ([MediaQueryData.disableAnimations]). A bar whose [active] never changes —
+/// the mini-player's — costs exactly one paint per position tick.
+class WavyProgressIndicator extends StatefulWidget {
+  const WavyProgressIndicator({
+    required this.value,
+    required this.activeColor,
+    required this.inactiveColor,
+    this.thumbColor,
+    this.amplitude = 3.0,
+    this.wavelength = 20.0,
+    this.strokeWidth = 3.0,
+    this.thumbRadius = 0.0,
+    this.active = true,
+    this.transitionDuration = const Duration(milliseconds: 420),
+    super.key,
+  })  : assert(amplitude >= 0, 'amplitude must not be negative'),
+        assert(wavelength > 0, 'wavelength must be positive'),
+        assert(strokeWidth > 0, 'strokeWidth must be positive'),
+        assert(thumbRadius >= 0, 'thumbRadius must not be negative');
+
+  /// How far along the line the progress marker sits, from 0 to 1. Values
+  /// outside that range are clamped, and a NaN (an unknown duration divided
+  /// into itself) is treated as 0, so the line never renders garbage.
+  final double value;
+
+  /// The elapsed (wavy) part of the line. Linthra passes the warm "live" accent.
+  final Color activeColor;
+
+  /// The remaining (flat) part of the line.
+  final Color inactiveColor;
+
+  /// The marker's fill. Defaults to [activeColor]. Only drawn when
+  /// [thumbRadius] is greater than zero.
+  final Color? thumbColor;
+
+  /// Peak vertical deflection of the wave, in logical pixels. Small on purpose —
+  /// this is a texture, not a waveform.
+  final double amplitude;
+
+  /// The distance between two wave crests, in logical pixels.
+  final double wavelength;
+
+  /// Thickness of both the wavy and the flat line.
+  final double strokeWidth;
+
+  /// Radius of the progress marker; 0 draws no marker. The track is inset by
+  /// this much at both ends so the marker never clips at 0% or 100%.
+  final double thumbRadius;
+
+  /// Whether the wave sits at its full [amplitude]. Callers pass whether the
+  /// progress is actually advancing — for playback, whether it is playing.
+  ///
+  /// At rest the wave eases down to a shallower version of itself rather than
+  /// going flat, so the bar keeps its identity while still reading, at a glance,
+  /// as stopped.
+  final bool active;
+
+  /// How long the swell between the resting and the full wave takes. This is the
+  /// only animation the widget ever runs, and it runs once per flip of [active].
+  final Duration transitionDuration;
+
+  /// The horizontal padding the painter reserves at each end so a marker of
+  /// [thumbRadius] (or a line of [strokeWidth]) stays fully inside the box.
+  ///
+  /// Exposed so a caller mapping a touch position back to a fraction uses the
+  /// exact same geometry the painter drew with.
+  static double trackInset({
+    required double thumbRadius,
+    required double strokeWidth,
+  }) =>
+      math.max(thumbRadius, strokeWidth / 2);
+
+  @override
+  State<WavyProgressIndicator> createState() => _WavyProgressIndicatorState();
+}
+
+class _WavyProgressIndicatorState extends State<WavyProgressIndicator>
+    with SingleTickerProviderStateMixin {
+  /// How deep the wave stays at rest, as a fraction of [amplitude]. Shallow
+  /// enough to read as stopped, deep enough to still look like a wave.
+  static const double _restingScale = 0.4;
+
+  /// Drives the swell between [_restingScale] and 1. It starts *at* the value
+  /// matching the initial [active], so opening a screen never plays a
+  /// gratuitous entrance animation — only a genuine flip animates.
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: widget.transitionDuration,
+    value: widget.active ? 1.0 : 0.0,
+  );
+
+  late final Animation<double> _swell = _controller.drive(
+    Tween<double>(begin: _restingScale, end: 1.0)
+        .chain(CurveTween(curve: Curves.easeOutCubic)),
+  );
+
+  bool _reduceMotion = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _reduceMotion = MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    // A reduce-motion request mid-flight means the swell should just be over.
+    if (_reduceMotion && _controller.isAnimating) _settle();
+  }
+
+  @override
+  void didUpdateWidget(WavyProgressIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.transitionDuration != widget.transitionDuration) {
+      _controller.duration = widget.transitionDuration;
+    }
+    if (oldWidget.active != widget.active) {
+      if (_reduceMotion) {
+        _settle();
+      } else {
+        // A one-shot ease that finishes and stops: after it lands the widget
+        // schedules no further frames.
+        unawaited(
+          widget.active ? _controller.forward() : _controller.reverse(),
+        );
+      }
+    }
+  }
+
+  /// Jump straight to the target without animating.
+  void _settle() => _controller.value = widget.active ? 1.0 : 0.0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Its own layer, so a swelling wave never re-rasterizes what it is drawn
+    // over — on Now Playing that is the expensive blurred artwork backdrop.
+    return RepaintBoundary(
+      child: CustomPaint(
+        size: Size.infinite,
+        painter: _WavyProgressPainter(
+          swell: _swell,
+          value: widget.value,
+          activeColor: widget.activeColor,
+          inactiveColor: widget.inactiveColor,
+          thumbColor: widget.thumbColor ?? widget.activeColor,
+          amplitude: widget.amplitude,
+          wavelength: widget.wavelength,
+          strokeWidth: widget.strokeWidth,
+          thumbRadius: widget.thumbRadius,
+          textDirection: Directionality.of(context),
+        ),
+      ),
+    );
+  }
+}
+
+/// Draws the flat remainder, the wavy elapsed segment, and the marker.
+///
+/// [swell] is both the repaint signal and the multiplier on [amplitude], so the
+/// painter follows the swell transition without the widget rebuilding, and stops
+/// being asked to repaint the moment that transition lands.
+class _WavyProgressPainter extends CustomPainter {
+  _WavyProgressPainter({
+    required this.swell,
+    required this.value,
+    required this.activeColor,
+    required this.inactiveColor,
+    required this.thumbColor,
+    required this.amplitude,
+    required this.wavelength,
+    required this.strokeWidth,
+    required this.thumbRadius,
+    required this.textDirection,
+  }) : super(repaint: swell);
+
+  final Animation<double> swell;
+  final double value;
+  final Color activeColor;
+  final Color inactiveColor;
+  final Color thumbColor;
+  final double amplitude;
+  final double wavelength;
+  final double strokeWidth;
+  final double thumbRadius;
+  final TextDirection textDirection;
+
+  /// How far apart the polyline's points are, in logical pixels. Sampling a
+  /// straight polyline is far cheaper than fitting curves and, at this step
+  /// against a 3px stroke, is visually indistinguishable from a true sine —
+  /// which is what keeps this affordable on a low-end phone at 60 Hz.
+  static const double _sampleStep = 2.5;
+
+  /// The translucent ring behind the marker, as a multiple of [thumbRadius].
+  static const double _haloScale = 1.7;
+  static const double _haloAlpha = 0.22;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty) return;
+
+    final double inset = WavyProgressIndicator.trackInset(
+      thumbRadius: thumbRadius,
+      strokeWidth: strokeWidth,
+    );
+    final double trackWidth = size.width - inset * 2;
+    if (trackWidth <= 0) return;
+
+    final double centerY = size.height / 2;
+    final double fraction = _safeFraction(value);
+    final double elapsed = trackWidth * fraction;
+
+    // In RTL the line runs right-to-left, so progress grows from the right edge
+    // and the wave mirrors with it.
+    final bool rtl = textDirection == TextDirection.rtl;
+    final double origin = rtl ? size.width - inset : inset;
+    final double direction = rtl ? -1.0 : 1.0;
+    final double markerX = origin + direction * elapsed;
+
+    final Paint stroke = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..isAntiAlias = true;
+
+    // The remainder first, so the accent wave and marker sit on top of it.
+    if (elapsed < trackWidth) {
+      canvas.drawLine(
+        Offset(markerX, centerY),
+        Offset(origin + direction * trackWidth, centerY),
+        stroke..color = inactiveColor,
+      );
+    }
+
+    if (elapsed > 0) {
+      canvas.drawPath(
+        _wavePath(
+          origin: origin,
+          direction: direction,
+          length: elapsed,
+          centerY: centerY,
+        ),
+        stroke..color = activeColor,
+      );
+    }
+
+    if (thumbRadius > 0) {
+      final Paint fill = Paint()..isAntiAlias = true;
+      canvas.drawCircle(
+        Offset(markerX, centerY),
+        thumbRadius * _haloScale,
+        fill..color = thumbColor.withValues(alpha: _haloAlpha),
+      );
+      canvas.drawCircle(
+        Offset(markerX, centerY),
+        thumbRadius,
+        fill..color = thumbColor,
+      );
+    }
+  }
+
+  /// The elapsed segment as a sampled polyline, starting at [origin] and running
+  /// [length] pixels in [direction].
+  Path _wavePath({
+    required double origin,
+    required double direction,
+    required double length,
+    required double centerY,
+  }) {
+    final Path path = Path()..moveTo(origin, centerY);
+    // Ease the amplitude in and out over up to one wavelength at each end (or
+    // half the segment when it is shorter than that), so the wave emerges from
+    // and returns to the flat line instead of ending mid-crest under the marker.
+    final double taper = math.min(wavelength, length / 2);
+    for (double d = _sampleStep; d < length; d += _sampleStep) {
+      path.lineTo(
+        origin + direction * d,
+        centerY - _deflection(d, length, taper),
+      );
+    }
+    path.lineTo(
+      origin + direction * length,
+      centerY - _deflection(length, length, taper),
+    );
+    return path;
+  }
+
+  /// Vertical offset of the wave [d] pixels into a segment of [length], with the
+  /// amplitude ramped over [taper] pixels at each end and scaled by the current
+  /// [swell].
+  double _deflection(double d, double length, double taper) {
+    if (amplitude <= 0) return 0;
+    final double ramp =
+        taper <= 0 ? 1.0 : math.min(1.0, math.min(d, length - d) / taper);
+    // A cosine ease on the ramp keeps the transition from flat to wavy smooth
+    // rather than visibly kinked where the ramp ends.
+    final double eased = (1 - math.cos(ramp * math.pi)) / 2;
+    return amplitude *
+        swell.value *
+        eased *
+        math.sin(d / wavelength * 2 * math.pi);
+  }
+
+  /// [value] clamped to `0..1`, treating a non-finite value (an unknown
+  /// duration) as no progress rather than propagating a NaN into the path.
+  static double _safeFraction(double value) {
+    if (!value.isFinite) return 0;
+    return value.clamp(0.0, 1.0);
+  }
+
+  @override
+  bool shouldRepaint(_WavyProgressPainter oldDelegate) =>
+      oldDelegate.value != value ||
+      oldDelegate.activeColor != activeColor ||
+      oldDelegate.inactiveColor != inactiveColor ||
+      oldDelegate.thumbColor != thumbColor ||
+      oldDelegate.amplitude != amplitude ||
+      oldDelegate.wavelength != wavelength ||
+      oldDelegate.strokeWidth != strokeWidth ||
+      oldDelegate.thumbRadius != thumbRadius ||
+      oldDelegate.textDirection != textDirection ||
+      oldDelegate.swell != swell;
+}

--- a/test/features/player/playback_progress_bar_test.dart
+++ b/test/features/player/playback_progress_bar_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/features/player/widgets/playback_progress_bar.dart';
+import 'package:linthra/features/player/widgets/wavy_seek_bar.dart';
+
+/// The bar is pumped at a fixed 300dp so the tap/drag maths below are exact:
+/// the painter insets the track by the marker radius (6) at each end, leaving a
+/// 288dp travel, and the widget is centred in an 800dp-wide test window.
+const double _barWidth = 300;
+const Duration _total = Duration(minutes: 4);
+
+Future<List<Duration>> _pumpBar(
+  WidgetTester tester, {
+  Duration position = Duration.zero,
+  Duration duration = _total,
+  bool seekable = true,
+  bool playing = false,
+  PlaybackProgressStyle style = PlaybackProgressStyle.wave,
+}) async {
+  final List<Duration> seeks = <Duration>[];
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: _barWidth,
+            child: PlaybackProgressBar(
+              position: position,
+              duration: duration,
+              playing: playing,
+              style: style,
+              onSeek: seekable ? seeks.add : null,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  return seeks;
+}
+
+void main() {
+  group('PlaybackProgressBar (wave)', () {
+    testWidgets('is the default style', (tester) async {
+      await _pumpBar(tester);
+
+      expect(find.byType(WavySeekBar), findsOneWidget);
+      expect(find.byType(Slider), findsNothing);
+    });
+
+    testWidgets('renders the elapsed and total times', (tester) async {
+      await _pumpBar(tester, position: const Duration(seconds: 75));
+
+      expect(find.text('1:15'), findsOneWidget);
+      expect(find.text('4:00'), findsOneWidget);
+    });
+
+    testWidgets('reads --:-- and does not seek without a duration',
+        (tester) async {
+      final seeks = await _pumpBar(tester, duration: Duration.zero);
+
+      expect(find.text('--:--'), findsOneWidget);
+
+      await tester.tap(find.byType(WavySeekBar));
+      await tester.pump();
+      expect(seeks, isEmpty);
+    });
+
+    testWidgets('a tap seeks to the touched point', (tester) async {
+      final seeks = await _pumpBar(tester);
+
+      // The centre of the track is half of a four-minute song.
+      await tester.tap(find.byType(WavySeekBar));
+      await tester.pump();
+
+      expect(seeks, hasLength(1));
+      expect(seeks.single.inSeconds, closeTo(120, 1));
+    });
+
+    testWidgets('a drag previews the elapsed label and seeks once on release',
+        (tester) async {
+      final seeks = await _pumpBar(tester);
+
+      final Offset centre = tester.getCenter(find.byType(WavySeekBar));
+      final TestGesture gesture = await tester.startGesture(centre);
+      await tester.pump();
+      // Quarter of the 288dp travel is 25% of the song…
+      await gesture.moveTo(centre - const Offset(72, 0));
+      await tester.pump();
+
+      // …shown live in the label, with nothing committed yet.
+      expect(find.text('1:00'), findsOneWidget);
+      expect(seeks, isEmpty);
+
+      await gesture.up();
+      await tester.pump();
+
+      // Exactly one seek, at the released position.
+      expect(seeks, hasLength(1));
+      expect(seeks.single.inSeconds, closeTo(60, 1));
+    });
+
+    testWidgets('renders progress but never seeks with no onSeek handler',
+        (tester) async {
+      final seeks = await _pumpBar(
+        tester,
+        position: const Duration(minutes: 1),
+        seekable: false,
+      );
+
+      expect(find.text('1:00'), findsOneWidget);
+      await tester.tap(find.byType(WavySeekBar));
+      await tester.pump();
+      expect(seeks, isEmpty);
+    });
+
+    testWidgets('never animates perpetually, playing or paused',
+        (tester) async {
+      // The bar lives on the screen users leave open longest, so it must settle
+      // in both states — pumpAndSettle returning is the whole assertion.
+      await _pumpBar(tester, playing: true);
+      await tester.pumpAndSettle();
+      expect(tester.binding.hasScheduledFrame, isFalse);
+
+      await _pumpBar(tester, playing: false);
+      await tester.pumpAndSettle();
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
+  });
+
+  group('PlaybackProgressBar (wave) accessibility', () {
+    testWidgets('announces the position as a slider', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpBar(tester, position: const Duration(seconds: 75));
+
+      final SemanticsNode node = tester.getSemantics(find.byType(WavySeekBar));
+      expect(node.label, 'Playback position');
+      expect(node.value, '1:15 of 4:00');
+      expect(
+        node.hasFlag(SemanticsFlag.isSlider),
+        isTrue,
+        reason: 'replacing Slider must not drop the slider role',
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('increase and decrease seek by a step', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final seeks =
+          await _pumpBar(tester, position: const Duration(minutes: 1));
+
+      // 5% of a four-minute track is 12s, comfortably over the 5s floor.
+      tester.semantics.increase(find.semantics.byLabel('Playback position'));
+      await tester.pump();
+      expect(seeks.single, const Duration(seconds: 72));
+
+      seeks.clear();
+      tester.semantics.decrease(find.semantics.byLabel('Playback position'));
+      await tester.pump();
+      expect(seeks.single, const Duration(seconds: 48));
+
+      handle.dispose();
+    });
+
+    testWidgets('is read-only, not a slider, without a duration',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await _pumpBar(tester, duration: Duration.zero);
+
+      final SemanticsNode node = tester.getSemantics(find.byType(WavySeekBar));
+      expect(node.value, 'Unknown');
+      expect(node.hasFlag(SemanticsFlag.isSlider), isFalse);
+
+      handle.dispose();
+    });
+  });
+
+  group('PlaybackProgressBar (slider fallback)', () {
+    testWidgets('still renders a Material slider and seeks', (tester) async {
+      final seeks = await _pumpBar(
+        tester,
+        style: PlaybackProgressStyle.slider,
+      );
+
+      expect(find.byType(Slider), findsOneWidget);
+      expect(find.byType(WavySeekBar), findsNothing);
+
+      await tester.tap(find.byType(Slider));
+      await tester.pump();
+
+      expect(seeks, hasLength(1));
+      expect(seeks.single, greaterThan(Duration.zero));
+    });
+
+    testWidgets('shows the same labels as the wave', (tester) async {
+      await _pumpBar(
+        tester,
+        position: const Duration(seconds: 75),
+        style: PlaybackProgressStyle.slider,
+      );
+
+      expect(find.text('1:15'), findsOneWidget);
+      expect(find.text('4:00'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/player_screen.dart';
 import 'package:linthra/features/player/widgets/album_artwork.dart';
 import 'package:linthra/features/player/widgets/now_playing_background.dart';
+import 'package:linthra/features/player/widgets/wavy_seek_bar.dart';
 
 import 'fake_playback_controller.dart';
 
@@ -176,12 +177,12 @@ void main() {
       expect(next.onPressed, isNull);
     });
 
-    testWidgets('the slider seeks via the controller', (tester) async {
+    testWidgets('the progress bar seeks via the controller', (tester) async {
       final controller = _playing(duration: const Duration(minutes: 3));
       await _pumpScreen(tester, controller);
 
-      // Tapping the slider commits a seek to roughly its center.
-      await tester.tap(find.byType(Slider));
+      // Tapping the wavy progress bar commits a seek to roughly its center.
+      await tester.tap(find.byType(WavySeekBar));
       await tester.pumpAndSettle();
 
       expect(controller.seeks, isNotEmpty);

--- a/test/shared/widgets/wavy_progress_indicator_test.dart
+++ b/test/shared/widgets/wavy_progress_indicator_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/shared/widgets/wavy_progress_indicator.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required double value,
+  bool active = true,
+  bool reduceMotion = false,
+  double thumbRadius = 0,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (BuildContext context) => MediaQuery(
+          data:
+              MediaQuery.of(context).copyWith(disableAnimations: reduceMotion),
+          child: Directionality(
+            textDirection: textDirection,
+            child: Center(
+              child: SizedBox(
+                width: 300,
+                height: 44,
+                child: WavyProgressIndicator(
+                  value: value,
+                  activeColor: const Color(0xFFFF9F43),
+                  inactiveColor: const Color(0x26FFFFFF),
+                  thumbRadius: thumbRadius,
+                  active: active,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('WavyProgressIndicator', () {
+    testWidgets('renders at rest without scheduling frames', (tester) async {
+      await _pump(tester, value: 0.4);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WavyProgressIndicator), findsOneWidget);
+      // A static bar must not animate perpetually — this is what keeps the
+      // mini-player free on every screen.
+      expect(tester.binding.hasScheduledFrame, isFalse);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('does not animate on first build', (tester) async {
+      // Opening a screen should not replay an entrance swell — the wave is
+      // already at the amplitude matching its initial state.
+      await _pump(tester, value: 0.4);
+      await tester.pump();
+
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
+
+    testWidgets('swells once when active flips, then stops', (tester) async {
+      await _pump(tester, value: 0.4);
+      await tester.pumpAndSettle();
+
+      await _pump(tester, value: 0.4, active: false);
+      await tester.pump();
+      // The one-shot ease is running…
+      expect(tester.binding.hasScheduledFrame, isTrue);
+
+      // …and it lands, rather than looping forever. pumpAndSettle returning at
+      // all is the assertion: a perpetual animation would hang here.
+      await tester.pumpAndSettle();
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
+
+    testWidgets('snaps instead of easing when reduce-motion is requested',
+        (tester) async {
+      await _pump(tester, value: 0.4, reduceMotion: true);
+      await tester.pumpAndSettle();
+
+      await _pump(tester, value: 0.4, active: false, reduceMotion: true);
+      await tester.pump();
+
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
+
+    testWidgets('paints the extremes and out-of-range values safely',
+        (tester) async {
+      for (final double value in <double>[0.0, 1.0, -3.0, 4.2, double.nan]) {
+        await _pump(tester, value: value, thumbRadius: 6);
+        await tester.pumpAndSettle();
+        expect(
+          tester.takeException(),
+          isNull,
+          reason: 'value $value should paint without throwing',
+        );
+      }
+    });
+
+    testWidgets('paints in a right-to-left layout', (tester) async {
+      await _pump(
+        tester,
+        value: 0.5,
+        thumbRadius: 6,
+        textDirection: TextDirection.rtl,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('sits on its own repaint boundary', (tester) async {
+      await _pump(tester, value: 0.4);
+      await tester.pumpAndSettle();
+
+      // The bar must not force whatever it is drawn over (on Now Playing, the
+      // blurred artwork backdrop) to re-rasterize as it repaints.
+      expect(
+        find.descendant(
+          of: find.byType(WavyProgressIndicator),
+          matching: find.byType(RepaintBoundary),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('WavyProgressIndicator.trackInset', () {
+    test('reserves room for the marker when one is drawn', () {
+      expect(
+        WavyProgressIndicator.trackInset(thumbRadius: 6, strokeWidth: 3),
+        6,
+      );
+    });
+
+    test('falls back to half the stroke with no marker', () {
+      expect(
+        WavyProgressIndicator.trackInset(thumbRadius: 0, strokeWidth: 3),
+        1.5,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What changed

Now Playing's seek control and the mini-player's top edge now render progress along a gentle serpentine line instead of a flat track.

- The **elapsed** part is the wave, in the warm "live" accent (`colorScheme.secondary`, the slot the theme already reserves for progress).
- The **remainder** stays a calm straight line.
- A round **marker** with a soft halo rides the boundary between them.
- The wave's amplitude tapers to zero at both ends of the elapsed segment, so it grows out of — and settles back into — the flat line rather than ending mid-crest under the marker.

Playback behaviour is unchanged, no new dependencies, no network calls, no telemetry.

## Architecture

Three layers, so the visual is reusable and the fallback is one line:

| Layer | File | Job |
| --- | --- | --- |
| Presentation | `lib/shared/widgets/wavy_progress_indicator.dart` | A `value` in `0..1` plus colours. No `Duration`, no seeking, no playback — reusable for any "progress along a line" surface. |
| Interaction | `lib/features/player/widgets/wavy_seek_bar.dart` | Gestures + semantics. Mirrors `Slider`'s API (`value` / `max` / `onChanged` / `onChangeEnd`) so the two are interchangeable at a call site. |
| Composition | `lib/features/player/widgets/playback_progress_bar.dart` | Keeps its existing public API; picks a renderer and owns the drag preview so the time labels follow the finger identically either way. |

### Falling back to the Material slider

`PlaybackProgressStyle` is a real enum with both branches implemented and tested. Flipping `defaultPlaybackProgressStyle` back to `.slider` restores the previous bar everywhere — the old code path was kept intact rather than deleted, and `playback_progress_bar_test.dart` covers it so it can't rot.

## Performance

**There is deliberately no perpetual animation.** A wave drifting sideways looks lovely in isolation, but it repaints the full width of the bar every frame on the screen users leave open the longest — the opposite of what `docs/battery.md` asks of the rest of the UI, and the wrong trade on a low-end phone.

- The only motion is a **one-shot ~420 ms swell** when playback starts or pauses: full amplitude while playing, easing down to a shallower wave at rest. Then the widget stops scheduling frames entirely.
- Skipped outright under `MediaQuery.disableAnimations`, matching `NowPlayingIndicator`.
- No entrance animation — the controller starts *at* the value matching the initial state, so opening a screen doesn't replay a swell.
- The mini-player's copy never swells at all: one plain repaint per position tick, on every main tab.
- The painter is a **sampled polyline** (2.5 px steps, one `Path`, one `drawPath`) rather than per-frame curve fitting, and sits on its own `RepaintBoundary` so the expensive blurred Now Playing backdrop never re-rasterizes underneath it.

This is also why the existing suite caught the first cut: 27 tests hung on `pumpAndSettle` against a perpetual animation. Settling in both states is now an explicit assertion rather than an accident.

## Accessibility

Replacing a real `Slider` drops its built-in accessibility, so `WavySeekBar` declares the slider role itself:

- `Semantics(slider: true, …)` with the position spoken as `"1:15 of 4:00"`.
- Increase/decrease actions seek by 5% of the track, floored at 5 s so a long song doesn't take a hundred taps to cross.
- With no duration yet, it degrades to a read-only node announcing `Unknown` instead of pretending to be seekable.
- The touch target is a full **44dp** tall regardless of the thin painted line, and touch-to-position mapping shares the painter's inset constant, so the marker lands exactly where the finger did.
- RTL layouts mirror: progress grows from the right edge and the wave follows.

## Themes

Colours come entirely from `colorScheme`, so every brand palette and both light and dark work without new constants. Verified by rasterizing the widget in both themes; the light-mode deep orange and the dark-mode bright orange both read clearly against their surfaces. The inactive track keeps the previous slider's exact tone, so contrast is at parity with what shipped before — not changed either way by this PR.

## Tests

- `test/shared/widgets/wavy_progress_indicator_test.dart` — no frames at rest, one-shot swell that lands, reduce-motion snapping, the repaint boundary, and painting safely at `0` / `1` / out-of-range / `NaN` / RTL.
- `test/features/player/playback_progress_bar_test.dart` — tap-to-seek geometry, drag previewing the label and committing exactly once on release, the disabled and unknown-duration paths, the semantics above, and the slider fallback.
- `test/features/player/player_screen_test.dart` — the existing seek test now drives the wave bar.

`flutter analyze` clean, `dart format` clean, full suite green (3130 tests).

## Not done here

Real audio waveform extraction is explicitly out of scope — the wave is decorative texture, not a rendering of the audio.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ujuxfhcwSemDmPYtDZXLo)_