### PR TITLE
Give lyrics a proper home on Now Playing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,16 @@ the widgets hold no playback logic of their own.
   Missing lyrics are `null` (the calm "no lyrics" state), never an error;
   lookups run on demand off the playback path; failures are logged by type
   only through the secret-free `LyricsDiagnostics`.
+
+  Presentation is a separate layer under `features/player/widgets/lyrics/`, and
+  the split is deliberate: the timing→emphasis rule is a pure function
+  (`core/models/lyric_focus.dart`), the viewport owns scrolling and follow
+  behaviour, `LyricLineTile` owns how one line looks, `SyncedLyricLine` owns
+  how a timed line reacts to the active index, and `LyricsBackdrop` owns the
+  background treatment. No widget derives timing for itself, and the model and
+  the wire format are untouched by any of it. Lyrics are shown in place on Now
+  Playing — the artwork hero swaps for the lyrics panel — so the transport
+  controls stay exactly where they are.
 - **Cast** drives real Chromecast through `CastService`; see [cast.md](cast.md).
 
 ## Android folder selection (SAF)

--- a/docs/battery.md
+++ b/docs/battery.md
@@ -78,11 +78,24 @@ tick:
 - **Mini-player & now-playing screen** select just the fields they show; only the
   thin progress line and the controls follow the position, not the artwork and
   text around them. See `lib/features/player/mini_player.dart`.
-- **Synced lyrics** select the *active line index* (not the raw position), so the
-  highlighted-line list rebuilds only when the line actually changes — a handful
-  of times per song rather than four times a second for the whole track. The
-  sync still moves exactly on each line boundary. See
-  `lib/features/player/widgets/lyrics_view.dart`.
+- **Synced lyrics** select the *active line index* (not the raw position), so a
+  position tick that stays inside the current line costs one cheap scan and no
+  rebuild at all — a handful of real changes per song rather than four times a
+  second for the whole track. The sync still moves exactly on each line
+  boundary. The viewport then **listens** to that index rather than watching it,
+  publishing it on a `ValueNotifier` that each row subscribes to, so a genuine
+  line change repaints only the rows whose emphasis actually moved — the old and
+  new active lines and their neighbours — and never rebuilds the list itself.
+  The only motion is a one-shot scroll to the new line plus the per-row style
+  transition, both skipped under reduced motion; nothing animates continuously.
+  See `lib/features/player/widgets/lyrics/lyrics_viewport.dart` and
+  `lib/features/player/widgets/lyrics/synced_lyric_line.dart`.
+- **The lyrics panel paints no artwork of its own.** It veils the Now Playing
+  backdrop that is already on screen instead of decoding and blurring a second
+  copy of the cover, and its edge fades are plain gradient rectangles rather
+  than a `ShaderMask` (which would force a `saveLayer` over the whole scrolling
+  list every frame). See
+  `lib/features/player/widgets/lyrics/lyrics_backdrop.dart`.
 - **Queue sheet** selects only the queue identity (current + up-next + history),
   so the open sheet doesn't rebuild on position ticks while you browse it. See
   `lib/features/player/widgets/queue_sheet.dart`.
@@ -205,6 +218,7 @@ Battery work is only safe if it's measurable. Useful levers:
   rebuild stats to confirm the now-playing surfaces aren't rebuilding on every
   position tick. The throttling above is covered by tests
   (`test/features/player/lyrics_highlight_throttle_test.dart`,
+  `test/features/player/lyrics_experience_test.dart`,
   `test/features/player/queue_sheet_throttle_test.dart`,
   `test/shared/widgets/now_playing_indicator_test.dart`) so a regression that
   reintroduces per-tick rebuilds fails CI.

--- a/docs/codebase-tour.md
+++ b/docs/codebase-tour.md
@@ -54,6 +54,8 @@ class is bound to its interface, and where tests swap in fakes.
 | Background playback / lock screen / Android Auto | `lib/core/services/linthra_audio_handler.dart`, `media_browser_tree.dart` |
 | Turning a track into a playable URL | `lib/core/services/playable_uri_resolver.dart` + the resolvers beside it |
 | Cast / Chromecast | `lib/core/services/cast/` and `lib/features/player/cast/` |
+| Lyrics (fetching & parsing) | `lib/core/services/lyrics_resolver.dart`, `lyrics_text_parser.dart` |
+| Lyrics (how they look) | `lib/features/player/widgets/lyrics/` + `lib/core/models/lyric_focus.dart` |
 | Local-files provider | `lib/core/sources/local/` |
 | Jellyfin provider | `lib/core/sources/jellyfin/` |
 | Navidrome / Subsonic provider | `lib/core/sources/subsonic/` |

--- a/lib/core/models/lyric_focus.dart
+++ b/lib/core/models/lyric_focus.dart
@@ -1,0 +1,47 @@
+/// How much visual weight a lyric line carries relative to the line playing
+/// right now.
+///
+/// This is the *whole* of the "which line is emphasised how much" rule, kept as
+/// plain data so it can be reasoned about (and tested) without a widget tree, a
+/// painter, or a playback controller. Presentation widgets map an emphasis onto
+/// type, colour, and opacity; they never derive it themselves.
+enum LyricEmphasis {
+  /// The line playing right now — the one the eye should land on.
+  active,
+
+  /// Immediately before or after the active line: clearly readable, plainly
+  /// secondary.
+  adjacent,
+
+  /// Two lines out. Still legible, visibly receded.
+  near,
+
+  /// Everything further away, fading into the backdrop.
+  distant,
+
+  /// Lyrics with no timing at all. Every line reads the same, because there is
+  /// no honest way to say which one is playing.
+  untimed,
+}
+
+/// The emphasis the line at [index] should carry when [activeIndex] is playing.
+///
+/// [activeIndex] is exactly what `Lyrics.activeLineIndex` returns, including its
+/// `-1` for "no line has started yet" (an instrumental intro, or plain lyrics).
+/// In that case every line comes back as [LyricEmphasis.near]: uniformly calm,
+/// with nothing highlighted, rather than guessing at a line that isn't playing.
+///
+/// The fade is symmetric — a line two ahead recedes as much as a line two back.
+/// Distance is the only input, so this stays a pure function of the two indices.
+LyricEmphasis lyricEmphasisFor({
+  required int index,
+  required int activeIndex,
+}) {
+  if (activeIndex < 0) return LyricEmphasis.near;
+  return switch ((index - activeIndex).abs()) {
+    0 => LyricEmphasis.active,
+    1 => LyricEmphasis.adjacent,
+    2 => LyricEmphasis.near,
+    _ => LyricEmphasis.distant,
+  };
+}

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -9,6 +9,8 @@ import 'cast/cast_button.dart';
 import 'cast/cast_providers.dart';
 import 'player_providers.dart';
 import 'widgets/album_artwork.dart';
+import 'widgets/lyrics/lyrics_backdrop.dart';
+import 'widgets/lyrics_view.dart';
 import 'widgets/now_playing_actions.dart';
 import 'widgets/now_playing_background.dart';
 import 'widgets/playback_controls.dart';
@@ -115,16 +117,30 @@ class _EmptyNowPlaying extends StatelessWidget {
   }
 }
 
-class _NowPlaying extends StatelessWidget {
+class _NowPlaying extends StatefulWidget {
   const _NowPlaying({required this.track});
 
   final Track track;
 
   @override
+  State<_NowPlaying> createState() => _NowPlayingState();
+}
+
+class _NowPlayingState extends State<_NowPlaying> {
+  /// Whether the stage is showing lyrics instead of the cover.
+  ///
+  /// Deliberately kept across track changes: someone reading along wants the
+  /// next song's lyrics too, not the artwork back. It is a plain toggle rather
+  /// than a gesture, so it can't collide with the existing swipe-to-dismiss or
+  /// with dragging the seek bar.
+  bool _showLyrics = false;
+
+  @override
   Widget build(BuildContext context) {
+    final Track track = widget.track;
     // A tighter side margin lets the artwork breathe wider and gives the
     // transport controls more room to spread, while the generous gaps below
-    // group the screen into three calm bands: artwork · metadata · controls.
+    // group the screen into three calm bands: stage · metadata · controls.
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppSpacing.md,
@@ -134,50 +150,158 @@ class _NowPlaying extends StatelessWidget {
       ),
       child: Column(
         children: [
-          Expanded(
-            child: Center(
-              child: ConstrainedBox(
-                // Cap the hero on tablets/foldables so it stays a square cover,
-                // not an oversized panel; phones use the full width.
-                constraints: const BoxConstraints(maxWidth: 480),
-                child: AspectRatio(
-                  aspectRatio: 1,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(AppRadii.lg),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.4),
-                          blurRadius: 40,
-                          spreadRadius: -12,
-                          offset: const Offset(0, 20),
-                        ),
-                      ],
-                    ),
-                    child: AlbumArtwork(
-                      artworkUri: track.artworkUri,
-                      borderRadius: BorderRadius.circular(AppRadii.lg),
-                    ),
-                  ),
-                ),
-              ),
+          Expanded(child: _Stage(track: track, showLyrics: _showLyrics)),
+          // Lyrics need the height more than the gap does; the artwork keeps
+          // its generous breathing room.
+          SizedBox(height: _showLyrics ? AppSpacing.md : AppSpacing.xl),
+          // In lyrics mode the three-line metadata block collapses to a single
+          // quiet line, handing the difference to the lyrics above without
+          // losing track of what is playing.
+          if (_showLyrics)
+            _CompactTrackLine(
+              title: track.title,
+              artistName: track.artistName,
+            )
+          else
+            TrackMetadata(
+              title: track.title,
+              artistName: track.artistName,
+              albumName: track.albumName,
             ),
-          ),
-          const SizedBox(height: AppSpacing.xl),
-          TrackMetadata(
-            title: track.title,
-            artistName: track.artistName,
-            albumName: track.albumName,
-          ),
-          const SizedBox(height: AppSpacing.lg),
+          SizedBox(height: _showLyrics ? AppSpacing.md : AppSpacing.lg),
           // The only part of the screen that follows the live, high-frequency
-          // playback state — kept separate so the artwork, metadata, and the
-          // blurred background above never rebuild on a position tick.
+          // playback state — kept separate so the stage, metadata, and the
+          // blurred background above never rebuild on a position tick. It stays
+          // exactly where it is in both modes, so play/pause, skip, and seek are
+          // never further away for reading lyrics.
           const _LiveControls(),
           const SizedBox(height: AppSpacing.md),
-          NowPlayingActions(track: track),
+          NowPlayingActions(
+            track: track,
+            lyricsVisible: _showLyrics,
+            onToggleLyrics: () => setState(() => _showLyrics = !_showLyrics),
+          ),
         ],
       ),
+    );
+  }
+}
+
+/// The hero area of Now Playing: the album cover, or the lyrics in its place.
+///
+/// Both fill the same box, so switching modes moves nothing below it. The
+/// crossfade is a single one-shot transition — the only motion here — and is
+/// skipped outright under reduced motion.
+class _Stage extends StatelessWidget {
+  const _Stage({required this.track, required this.showLyrics});
+
+  final Track track;
+  final bool showLyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: MediaQuery.disableAnimationsOf(context)
+          ? Duration.zero
+          : const Duration(milliseconds: 260),
+      child: showLyrics
+          // SizedBox.expand so the lyrics panel takes the whole stage rather
+          // than sizing itself to its (unbounded) scrolling content.
+          ? const SizedBox.expand(
+              key: ValueKey<String>('lyrics-stage'),
+              child: LyricsBackdrop(child: LyricsView()),
+            )
+          : SizedBox.expand(
+              key: const ValueKey<String>('artwork-stage'),
+              child: _ArtworkHero(artworkUri: track.artworkUri),
+            ),
+    );
+  }
+}
+
+/// The album cover, capped and lifted off the backdrop by a soft shadow.
+class _ArtworkHero extends StatelessWidget {
+  const _ArtworkHero({required this.artworkUri});
+
+  final Uri? artworkUri;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        // Cap the hero on tablets/foldables so it stays a square cover, not an
+        // oversized panel; phones use the full width.
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: AspectRatio(
+          aspectRatio: 1,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(AppRadii.lg),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.4),
+                  blurRadius: 40,
+                  spreadRadius: -12,
+                  offset: const Offset(0, 20),
+                ),
+              ],
+            ),
+            child: AlbumArtwork(
+              artworkUri: artworkUri,
+              borderRadius: BorderRadius.circular(AppRadii.lg),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Title and artist on one quiet line, shown in place of the full metadata
+/// block while the lyrics have the stage.
+class _CompactTrackLine extends StatelessWidget {
+  const _CompactTrackLine({required this.title, this.artistName});
+
+  final String title;
+  final String? artistName;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String? artist = artistName;
+    final bool hasArtist = artist != null && artist.isNotEmpty;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Flexible(
+          child: Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        if (hasArtist) ...[
+          Text(
+            ' · ',
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ),
+          Flexible(
+            child: Text(
+              artist,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ],
     );
   }
 }

--- a/lib/features/player/widgets/lyrics/lyric_line_tile.dart
+++ b/lib/features/player/widgets/lyrics/lyric_line_tile.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+
+import '../../../../app/dimens.dart';
+import '../../../../core/models/lyric_focus.dart';
+
+/// One line of lyrics, styled for its [emphasis].
+///
+/// The single place a [LyricEmphasis] becomes type, colour, and weight — used by
+/// both the synced and the plain viewport, so a timed and an untimed line share
+/// their metrics and only differ where they genuinely should.
+///
+/// Every colour is read from the [ColorScheme], so the tile retints with the
+/// user's branding theme and works in light and dark without a hard-coded value.
+/// The active line is never distinguished by colour *alone*: it is also larger
+/// and heavier, carries an accent marker in the gutter, and reports itself as
+/// selected to screen readers.
+class LyricLineTile extends StatelessWidget {
+  const LyricLineTile({
+    required this.text,
+    required this.emphasis,
+    this.onTap,
+    super.key,
+  });
+
+  /// The line's text. May be empty — a deliberate blank between stanzas, which
+  /// keeps its vertical rhythm rather than collapsing.
+  final String text;
+
+  final LyricEmphasis emphasis;
+
+  /// Seeks playback to this line, for a timed line the user can jump to. Null
+  /// leaves the line inert (plain lyrics, or a timed set's untimed leftovers),
+  /// and the tile then claims no tap target and no button semantics.
+  final VoidCallback? onTap;
+
+  /// The smallest comfortable height for a seekable line. Lyric rows are short
+  /// text, so left alone they would be well under the accessible minimum.
+  static const double minTapTargetHeight = 48;
+
+  /// Width reserved for the active-line marker on *timed* lyrics. Held even
+  /// when the marker isn't drawn, so the text never reflows as the active line
+  /// moves.
+  static const double _markerGutter = 16;
+
+  static const double _markerWidth = 3;
+  static const double _markerHeight = 16;
+
+  /// How long a line takes to settle into its new emphasis. Long enough to read
+  /// as a transition, short enough that a quick run of lines doesn't smear.
+  static const Duration transition = Duration(milliseconds: 220);
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool reduceMotion = MediaQuery.disableAnimationsOf(context);
+    final Duration duration = reduceMotion ? Duration.zero : transition;
+    final bool isBlank = text.trim().isEmpty;
+
+    Widget line = Row(
+      children: <Widget>[
+        // Plain lyrics have no active line, so they get no gutter at all and
+        // sit flush — the layout itself says "nothing here is highlighted".
+        if (emphasis != LyricEmphasis.untimed)
+          _ActiveMarker(
+            active: emphasis == LyricEmphasis.active,
+            duration: duration,
+          ),
+        Expanded(
+          child: AnimatedDefaultTextStyle(
+            duration: duration,
+            curve: Curves.easeOut,
+            style: styleFor(theme, emphasis),
+            child: Text(isBlank ? ' ' : text),
+          ),
+        ),
+      ],
+    );
+
+    line = Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: AppSpacing.sm,
+      ),
+      child: line,
+    );
+
+    if (onTap == null) {
+      // A blank stanza gap is spacing, not content: it would otherwise be read
+      // out as an empty item between two lines.
+      return isBlank ? ExcludeSemantics(child: line) : line;
+    }
+
+    return MergeSemantics(
+      child: Semantics(
+        // Screen readers get the same "this is the line playing" signal the eye
+        // does, rather than inferring it from a colour they never see.
+        selected: emphasis == LyricEmphasis.active,
+        button: true,
+        hint: 'Play from this line',
+        child: Material(
+          // Transparent so the artwork backdrop shows through; present so the
+          // tap still lands an ink ripple wherever the tile is hosted.
+          type: MaterialType.transparency,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(AppRadii.sm),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: minTapTargetHeight),
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: line,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The text style for [emphasis], derived entirely from [theme].
+  ///
+  /// The progression is opacity *and* weight, not opacity alone, so the active
+  /// line stays dominant even where a bright cover pushes the contrast around.
+  /// Sizes come from the text theme, so the user's text scaling multiplies them
+  /// rather than fighting a fixed value.
+  static TextStyle styleFor(ThemeData theme, LyricEmphasis emphasis) {
+    final ColorScheme colors = theme.colorScheme;
+    final TextStyle base = theme.textTheme.titleMedium ?? const TextStyle();
+    switch (emphasis) {
+      case LyricEmphasis.active:
+        return base.copyWith(
+          color: colors.onSurface,
+          fontSize: (base.fontSize ?? 16) * 1.25,
+          fontWeight: FontWeight.w700,
+          height: 1.3,
+          letterSpacing: -0.2,
+        );
+      case LyricEmphasis.adjacent:
+        return base.copyWith(
+          color: colors.onSurface.withValues(alpha: 0.62),
+          fontWeight: FontWeight.w500,
+          height: 1.35,
+        );
+      case LyricEmphasis.near:
+        return base.copyWith(
+          color: colors.onSurface.withValues(alpha: 0.42),
+          fontWeight: FontWeight.w500,
+          height: 1.35,
+        );
+      case LyricEmphasis.distant:
+        return base.copyWith(
+          color: colors.onSurface.withValues(alpha: 0.26),
+          fontWeight: FontWeight.w500,
+          height: 1.35,
+        );
+      case LyricEmphasis.untimed:
+        // Plain lyrics are a reading surface, not a following one: one calm
+        // weight, near-full contrast, and generous leading.
+        return (theme.textTheme.bodyLarge ?? base).copyWith(
+          color: colors.onSurface.withValues(alpha: 0.86),
+          height: 1.7,
+        );
+    }
+  }
+}
+
+/// The small accent pill marking the active line.
+///
+/// It is a *redundant* cue — the line is already larger and heavier — which is
+/// what lets the active state survive a user who can't distinguish the colours.
+/// Its gutter is reserved whether or not it is drawn, so the lines never shift
+/// sideways as the marker moves down the song.
+class _ActiveMarker extends StatelessWidget {
+  const _ActiveMarker({required this.active, required this.duration});
+
+  final bool active;
+  final Duration duration;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: LyricLineTile._markerGutter,
+      child: Center(
+        child: AnimatedOpacity(
+          // Cross-fades with the text restyle above, so the two read as one
+          // change rather than two. Zero-duration under reduced motion.
+          duration: duration,
+          curve: Curves.easeOut,
+          opacity: active ? 1 : 0,
+          child: Container(
+            width: LyricLineTile._markerWidth,
+            height: LyricLineTile._markerHeight,
+            decoration: BoxDecoration(
+              // The brand's energy accent — the same token the progress line
+              // and play button use — so the highlight reads as Linthra's.
+              color: colors.secondary,
+              borderRadius: BorderRadius.circular(AppRadii.pill),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/lyrics/lyric_line_tile.dart
+++ b/lib/features/player/widgets/lyrics/lyric_line_tile.dart
@@ -31,6 +31,8 @@ class LyricLineTile extends StatelessWidget {
   /// Seeks playback to this line, for a timed line the user can jump to. Null
   /// leaves the line inert (plain lyrics, or a timed set's untimed leftovers),
   /// and the tile then claims no tap target and no button semantics.
+  ///
+  /// Ignored for a blank line even when one is supplied — see [build].
   final VoidCallback? onTap;
 
   /// The smallest comfortable height for a seekable line. Lyric rows are short
@@ -54,7 +56,14 @@ class LyricLineTile extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final bool reduceMotion = MediaQuery.disableAnimationsOf(context);
     final Duration duration = reduceMotion ? Duration.zero : transition;
+    // A blank line is stanza rhythm, not content — and an `.lrc` can legally
+    // give one a timestamp (`[00:10.00]` with nothing after it), which
+    // LyricsTextParser preserves. Such a row must stay pure spacing: seeking to
+    // it would offer an unlabelled button with a "Play from this line" hint, and
+    // marking it would float an accent pill beside nothing. So blankness, not
+    // just the absence of a timestamp, decides whether a line is interactive.
     final bool isBlank = text.trim().isEmpty;
+    final VoidCallback? onTapLine = isBlank ? null : onTap;
 
     Widget line = Row(
       children: <Widget>[
@@ -62,7 +71,7 @@ class LyricLineTile extends StatelessWidget {
         // sit flush — the layout itself says "nothing here is highlighted".
         if (emphasis != LyricEmphasis.untimed)
           _ActiveMarker(
-            active: emphasis == LyricEmphasis.active,
+            active: !isBlank && emphasis == LyricEmphasis.active,
             duration: duration,
           ),
         Expanded(
@@ -84,7 +93,7 @@ class LyricLineTile extends StatelessWidget {
       child: line,
     );
 
-    if (onTap == null) {
+    if (onTapLine == null) {
       // A blank stanza gap is spacing, not content: it would otherwise be read
       // out as an empty item between two lines.
       return isBlank ? ExcludeSemantics(child: line) : line;
@@ -102,7 +111,7 @@ class LyricLineTile extends StatelessWidget {
           // tap still lands an ink ripple wherever the tile is hosted.
           type: MaterialType.transparency,
           child: InkWell(
-            onTap: onTap,
+            onTap: onTapLine,
             borderRadius: BorderRadius.circular(AppRadii.sm),
             child: ConstrainedBox(
               constraints: const BoxConstraints(minHeight: minTapTargetHeight),

--- a/lib/features/player/widgets/lyrics/lyrics_backdrop.dart
+++ b/lib/features/player/widgets/lyrics/lyrics_backdrop.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../../../../app/dimens.dart';
+import '../now_playing_background.dart';
+
+/// The background treatment behind the lyrics surface.
+///
+/// It deliberately paints **no artwork of its own.** Now Playing already renders
+/// [NowPlayingBackground] — one heavily blurred, dimmed copy of the current
+/// cover, held on its own retained compositing layer — directly behind this
+/// panel. Decoding and blurring a second copy would double the most expensive
+/// paint on the screen to produce a picture the user is already looking at. So
+/// this lays a calm veil over that existing backdrop instead: the artwork still
+/// tints and blurs through, and the lyrics get a guaranteed contrast floor over
+/// a washed-out cover as much as a near-black one.
+///
+/// Both the veil and the edge fades come from the [ColorScheme], so the panel
+/// retints with the branding theme and reads correctly in light and dark. The
+/// fades are plain gradient rectangles rather than a `ShaderMask`: a mask would
+/// force a `saveLayer` over the whole scrolling list every frame, which is
+/// exactly the cost a lower-end phone can least afford here.
+class LyricsBackdrop extends StatelessWidget {
+  const LyricsBackdrop({required this.child, super.key});
+
+  final Widget child;
+
+  /// How far the lines dissolve into the backdrop at the top and bottom edges.
+  static const double _fadeExtent = 44;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+    // A light theme's surface *is* the bright end of its ramp, so it needs to
+    // sit heavier over the artwork to hold the same readability a dark theme
+    // gets for less.
+    final double veil = theme.brightness == Brightness.dark ? 0.55 : 0.74;
+    final Color veilColor = colors.surface.withValues(alpha: veil);
+
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: veilColor,
+        borderRadius: BorderRadius.circular(AppRadii.lg),
+        border: Border.all(
+          color: colors.onSurface.withValues(alpha: 0.06),
+        ),
+      ),
+      child: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          child,
+          _EdgeFade(color: veilColor, alignment: Alignment.topCenter),
+          _EdgeFade(color: veilColor, alignment: Alignment.bottomCenter),
+        ],
+      ),
+    );
+  }
+}
+
+/// A soft dissolve at one end of the scrolling lyrics, so lines arrive and
+/// leave rather than being cut off by a hard edge.
+class _EdgeFade extends StatelessWidget {
+  const _EdgeFade({required this.color, required this.alignment});
+
+  final Color color;
+
+  /// [Alignment.topCenter] or [Alignment.bottomCenter].
+  final Alignment alignment;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isTop = alignment == Alignment.topCenter;
+    return Positioned(
+      top: isTop ? 0 : null,
+      bottom: isTop ? null : 0,
+      left: 0,
+      right: 0,
+      height: LyricsBackdrop._fadeExtent,
+      // Decoration only — it must never swallow a tap meant for the line
+      // sitting under it.
+      child: IgnorePointer(
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: isTop ? Alignment.topCenter : Alignment.bottomCenter,
+              end: isTop ? Alignment.bottomCenter : Alignment.topCenter,
+              colors: <Color>[color, color.withValues(alpha: 0)],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/lyrics/lyrics_viewport.dart
+++ b/lib/features/player/widgets/lyrics/lyrics_viewport.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../app/dimens.dart';
@@ -98,6 +99,14 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
   /// and last lines can reach the active position like any other.
   static const double _edgePaddingFraction = 0.4;
 
+  /// How many estimate-and-settle passes a jump to an unbuilt row gets before
+  /// it gives up. Each pass builds a new band of rows and so measures better
+  /// than the last; this only stops a pathological list from walking forever.
+  static const int _maxEstimatePasses = 5;
+
+  /// How close an estimate has to land to count as "nowhere left to go".
+  static const double _estimateEpsilon = 0.5;
+
   final ScrollController _scroll = ScrollController();
 
   /// The active line index the rows subscribe to.
@@ -107,6 +116,10 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
   List<GlobalKey> _keys = const <GlobalKey>[];
 
   DateTime? _lastManualScroll;
+
+  /// The blank space the list reserves at each end, cached from layout so an
+  /// offset estimate can subtract it. It is padding, not rows.
+  double _edgePadding = 0;
 
   @override
   void initState() {
@@ -181,10 +194,12 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
   /// A row that is currently laid out can be measured directly. A row that
   /// isn't — after a long seek, or a jump from a tapped line, the target can sit
   /// far outside the built window — has no render object for `ensureVisible` to
-  /// measure, and that call would silently do nothing. So the scroll is first
-  /// estimated from the list's own extent to bring the row into the build
-  /// window, then refined once on the next frame when the real row exists.
-  void _centre(int index, {bool allowEstimate = true}) {
+  /// measure, and that call would silently do nothing. So the scroll is walked
+  /// toward it by estimate: each jump builds a new band of rows, which gives a
+  /// better estimate for the next pass, until the target itself is laid out and
+  /// can be revealed exactly. [pass] bounds that walk so it can always
+  /// terminate.
+  void _centre(int index, {int pass = 0}) {
     if (!mounted || index < 0 || index >= _keys.length) return;
     if (!_scroll.hasClients) return;
 
@@ -203,23 +218,91 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
       return;
     }
 
-    if (!allowEstimate || _keys.isEmpty) return;
+    if (pass >= _maxEstimatePasses) return;
+    final double? estimate = _estimateOffsetFor(index);
+    if (estimate == null) return;
     final ScrollPosition position = _scroll.position;
-    final double totalExtent =
-        position.maxScrollExtent + position.viewportDimension;
-    if (totalExtent <= 0) return;
-    final double rowExtent = totalExtent / _keys.length;
-    final double target = rowExtent * index +
-        rowExtent / 2 -
-        position.viewportDimension * _activeLineAlignment;
-    _scroll.jumpTo(
-      target.clamp(position.minScrollExtent, position.maxScrollExtent),
+    final double target = estimate.clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
     );
-    // One refinement pass only, so a line that stubbornly refuses to lay out
-    // can never spin this into a loop.
+    // Already as close as this list can get and the row still isn't built:
+    // another identical jump would only spin the walk.
+    if ((target - position.pixels).abs() < _estimateEpsilon) return;
+    _scroll.jumpTo(target);
     WidgetsBinding.instance.addPostFrameCallback(
-      (_) => _centre(index, allowEstimate: false),
+      (_) => _centre(index, pass: pass + 1),
     );
+  }
+
+  /// The scroll offset that would put row [index] at [_activeLineAlignment],
+  /// or null when the list has no geometry to reason about yet.
+  ///
+  /// Prefers *measured* anchors. Whatever rows are laid out right now report
+  /// their real reveal offsets, and the slope between the outermost two is a
+  /// per-row extent that already accounts for however those lines wrapped —
+  /// far better than assuming every row in the song is the same height.
+  ///
+  /// Only with nothing measurable does it fall back to dividing the content
+  /// evenly, and even then it subtracts the two edge paddings first: they are
+  /// blank space, not rows, and counting them would inflate every row and push
+  /// the jump further off with each index.
+  double? _estimateOffsetFor(int index) {
+    if (_keys.isEmpty || !_scroll.hasClients) return null;
+
+    int? firstIndex;
+    double? firstOffset;
+    int? lastIndex;
+    double? lastOffset;
+    for (int i = 0; i < _keys.length; i++) {
+      final BuildContext? lineContext = _keys[i].currentContext;
+      if (lineContext == null) continue;
+      final double? offset = _revealOffsetOf(lineContext);
+      if (offset == null) continue;
+      firstIndex ??= i;
+      firstOffset ??= offset;
+      lastIndex = i;
+      lastOffset = offset;
+    }
+
+    if (firstIndex != null && lastIndex != null && lastIndex != firstIndex) {
+      final double perRow =
+          (lastOffset! - firstOffset!) / (lastIndex - firstIndex);
+      return firstOffset + (index - firstIndex) * perRow;
+    }
+    if (firstIndex != null) {
+      // A single anchor still fixes the *origin*; only the slope is assumed.
+      return firstOffset! + (index - firstIndex) * _uniformRowExtent();
+    }
+
+    final double rowExtent = _uniformRowExtent();
+    if (rowExtent <= 0) return null;
+    return _edgePadding +
+        rowExtent * index +
+        rowExtent / 2 -
+        _scroll.position.viewportDimension * _activeLineAlignment;
+  }
+
+  /// The average height of a row, with the list's blank edge padding removed.
+  double _uniformRowExtent() {
+    final ScrollPosition position = _scroll.position;
+    final double content =
+        position.maxScrollExtent + position.viewportDimension;
+    final double rows = content - _edgePadding * 2;
+    if (rows <= 0 || _keys.isEmpty) return 0;
+    return rows / _keys.length;
+  }
+
+  /// The scroll offset that would reveal [lineContext]'s row at the active
+  /// position — the same measurement `ensureVisible` makes, read directly so it
+  /// can serve as an anchor.
+  double? _revealOffsetOf(BuildContext lineContext) {
+    final RenderObject? box = lineContext.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return null;
+    final RenderAbstractViewport? viewport =
+        RenderAbstractViewport.maybeOf(box);
+    if (viewport == null) return null;
+    return viewport.getOffsetToReveal(box, _activeLineAlignment).offset;
   }
 
   @override
@@ -249,6 +332,9 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
           final double edgePadding = constraints.maxHeight.isFinite
               ? constraints.maxHeight * _edgePaddingFraction
               : AppSpacing.xl;
+          // Cached, not state: a layout constant the offset estimate needs, and
+          // writing it changes nothing that would need a rebuild.
+          _edgePadding = edgePadding;
           return NotificationListener<ScrollStartNotification>(
             // dragDetails is set only when a finger started the scroll, so the
             // view's own animated centring never counts as the user taking over.

--- a/lib/features/player/widgets/lyrics/lyrics_viewport.dart
+++ b/lib/features/player/widgets/lyrics/lyrics_viewport.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../app/dimens.dart';
+import '../../../../core/models/lyric_focus.dart';
+import '../../../../core/models/lyrics.dart';
+import '../../../../core/models/playback_state.dart';
+import '../../player_providers.dart';
+import 'lyric_line_tile.dart';
+import 'synced_lyric_line.dart';
+
+/// The widest a column of lyrics gets, whatever the screen. Long lines are
+/// tiring to read edge-to-edge on a tablet or an unfolded foldable, so the text
+/// stays a comfortable measure and centres in the space instead of stretching.
+const double _maxLineWidth = 620;
+
+/// Wraps a lyrics list in that measure. Applied once around the scroll view
+/// rather than per row, so a long song pays for it exactly once.
+Widget _withReadableWidth(Widget child) {
+  return Center(
+    child: ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: _maxLineWidth),
+      child: child,
+    ),
+  );
+}
+
+/// Plain, untimed lyrics: a calm reading surface.
+///
+/// Deliberately inert — no highlighting, no auto-scroll, no invented timings,
+/// because there is nothing to sync to. What makes it feel considered instead of
+/// dumped is typography: generous leading, a capped measure, and room to breathe
+/// at both ends.
+class PlainLyricsViewport extends StatelessWidget {
+  const PlainLyricsViewport({required this.lyrics, super.key});
+
+  final Lyrics lyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    return _withReadableWidth(
+      ListView.builder(
+        key: const Key('plain-lyrics'),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.lg,
+        ),
+        itemCount: lyrics.lines.length,
+        itemBuilder: (BuildContext context, int index) => LyricLineTile(
+          text: lyrics.lines[index].text,
+          emphasis: LyricEmphasis.untimed,
+        ),
+      ),
+    );
+  }
+}
+
+/// Timed lyrics: the active line held near the middle of the viewport, with the
+/// lines around it fading progressively away from it.
+///
+/// Two things keep this cheap on a low-end phone:
+///
+///  * The active line index is **listened to, not watched**. The ~4 Hz position
+///    stream is reduced to a line index inside a `select`, exactly as before, so
+///    a tick that stays within a line costs one scan and nothing else. But the
+///    result is pushed into a [ValueNotifier] rather than rebuilding this
+///    widget, so even a real line change never rebuilds the list — only the
+///    individual [SyncedLyricLine]s whose emphasis moved (see that class).
+///  * The only motion is a one-shot scroll when the line changes, plus the
+///    per-row style transition. Nothing animates continuously, and both are
+///    skipped outright under [MediaQueryData.disableAnimations].
+class SyncedLyricsViewport extends ConsumerStatefulWidget {
+  const SyncedLyricsViewport({required this.lyrics, super.key});
+
+  final Lyrics lyrics;
+
+  @override
+  ConsumerState<SyncedLyricsViewport> createState() =>
+      _SyncedLyricsViewportState();
+}
+
+class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
+  /// How long the scroll to a newly active line takes.
+  static const Duration _scrollDuration = Duration(milliseconds: 420);
+
+  /// How long auto-following stands down after the user scrolls by hand, so
+  /// reading ahead isn't yanked back to the playing line mid-sentence. It
+  /// resumes on the next line change after this, with no timer in between.
+  static const Duration _followPause = Duration(seconds: 5);
+
+  /// Where in the viewport the active line settles. Slightly above true centre
+  /// reads better: it leaves more of what is coming than of what has gone.
+  static const double _activeLineAlignment = 0.42;
+
+  /// Share of the viewport left blank above and below the lyrics, so the first
+  /// and last lines can reach the active position like any other.
+  static const double _edgePaddingFraction = 0.4;
+
+  final ScrollController _scroll = ScrollController();
+
+  /// The active line index the rows subscribe to.
+  final ValueNotifier<int> _activeLine = ValueNotifier<int>(-1);
+
+  /// One key per line, used to centre a line once it is laid out.
+  List<GlobalKey> _keys = const <GlobalKey>[];
+
+  DateTime? _lastManualScroll;
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuildKeys();
+    _activeLine.value = _activeLineNow();
+    // Opening mid-song should land on the current line, not at the top.
+    _scheduleCentre(_activeLine.value);
+  }
+
+  @override
+  void didUpdateWidget(SyncedLyricsViewport oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new track's lyrics: drop the old keys, re-derive the active line, and
+    // forget that the user was scrolling the *previous* song by hand.
+    if (widget.lyrics != oldWidget.lyrics) {
+      _rebuildKeys();
+      _lastManualScroll = null;
+      _activeLine.value = _activeLineNow();
+      if (_scroll.hasClients) _scroll.jumpTo(0);
+      _scheduleCentre(_activeLine.value);
+    }
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    _activeLine.dispose();
+    super.dispose();
+  }
+
+  void _rebuildKeys() {
+    _keys = List<GlobalKey>.generate(
+      widget.lyrics.lines.length,
+      (_) => GlobalKey(),
+    );
+  }
+
+  /// The active line for the position playback is at right now.
+  ///
+  /// Falls back to the controller's synchronous state until the first stream
+  /// event arrives, mirroring the rest of the player UI, so opening lyrics
+  /// mid-playback highlights immediately instead of starting from -1.
+  int _activeLineNow() {
+    final PlaybackState state = ref.read(playbackStateProvider).valueOrNull ??
+        ref.read(playbackControllerProvider).state;
+    return widget.lyrics.activeLineIndex(state.position);
+  }
+
+  void _onActiveLineChanged(int next) {
+    if (_activeLine.value == next) return;
+    _activeLine.value = next;
+    _scheduleCentre(next);
+  }
+
+  /// Whether auto-following is standing down because the user just scrolled.
+  bool get _isFollowPaused {
+    final DateTime? last = _lastManualScroll;
+    return last != null && DateTime.now().difference(last) < _followPause;
+  }
+
+  void _scheduleCentre(int index) {
+    if (index < 0 || index >= _keys.length) return;
+    if (_isFollowPaused) return;
+    // After the frame that lays the new emphasis out, so the row is measured at
+    // the size it will actually be.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _centre(index));
+  }
+
+  /// Brings the line at [index] to [_activeLineAlignment].
+  ///
+  /// A row that is currently laid out can be measured directly. A row that
+  /// isn't — after a long seek, or a jump from a tapped line, the target can sit
+  /// far outside the built window — has no render object for `ensureVisible` to
+  /// measure, and that call would silently do nothing. So the scroll is first
+  /// estimated from the list's own extent to bring the row into the build
+  /// window, then refined once on the next frame when the real row exists.
+  void _centre(int index, {bool allowEstimate = true}) {
+    if (!mounted || index < 0 || index >= _keys.length) return;
+    if (!_scroll.hasClients) return;
+
+    final BuildContext? lineContext = _keys[index].currentContext;
+    if (lineContext != null) {
+      unawaited(
+        Scrollable.ensureVisible(
+          lineContext,
+          alignment: _activeLineAlignment,
+          duration: MediaQuery.disableAnimationsOf(context)
+              ? Duration.zero
+              : _scrollDuration,
+          curve: Curves.easeOutCubic,
+        ),
+      );
+      return;
+    }
+
+    if (!allowEstimate || _keys.isEmpty) return;
+    final ScrollPosition position = _scroll.position;
+    final double totalExtent =
+        position.maxScrollExtent + position.viewportDimension;
+    if (totalExtent <= 0) return;
+    final double rowExtent = totalExtent / _keys.length;
+    final double target = rowExtent * index +
+        rowExtent / 2 -
+        position.viewportDimension * _activeLineAlignment;
+    _scroll.jumpTo(
+      target.clamp(position.minScrollExtent, position.maxScrollExtent),
+    );
+    // One refinement pass only, so a line that stubbornly refuses to lay out
+    // can never spin this into a loop.
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _centre(index, allowEstimate: false),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Lyrics lyrics = widget.lyrics;
+    final Duration fallback =
+        ref.read(playbackControllerProvider).state.position;
+
+    // Listen rather than watch. The select still collapses the ~4 Hz position
+    // stream down to a line index — the battery contract the throttle test
+    // pins — but the result lands in a notifier the rows read, so neither this
+    // widget nor the list below it rebuilds when the line changes.
+    ref.listen<int>(
+      playbackStateProvider.select(
+        (AsyncValue<PlaybackState> state) => lyrics.activeLineIndex(
+          state.valueOrNull?.position ?? fallback,
+        ),
+      ),
+      (int? previous, int next) => _onActiveLineChanged(next),
+    );
+
+    return _withReadableWidth(
+      LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          // Blank space at both ends so the opening and closing lines can sit
+          // where every other active line does.
+          final double edgePadding = constraints.maxHeight.isFinite
+              ? constraints.maxHeight * _edgePaddingFraction
+              : AppSpacing.xl;
+          return NotificationListener<ScrollStartNotification>(
+            // dragDetails is set only when a finger started the scroll, so the
+            // view's own animated centring never counts as the user taking over.
+            onNotification: (ScrollStartNotification notification) {
+              if (notification.dragDetails != null) {
+                _lastManualScroll = DateTime.now();
+              }
+              return false;
+            },
+            child: ListView.builder(
+              key: const Key('synced-lyrics'),
+              controller: _scroll,
+              padding: EdgeInsets.fromLTRB(
+                AppSpacing.md,
+                edgePadding,
+                AppSpacing.md,
+                edgePadding,
+              ),
+              itemCount: lyrics.lines.length,
+              itemBuilder: (BuildContext context, int index) {
+                final LyricLine line = lyrics.lines[index];
+                final Duration? start = line.start;
+                return KeyedSubtree(
+                  key: _keys[index],
+                  child: SyncedLyricLine(
+                    activeLine: _activeLine,
+                    index: index,
+                    text: line.text,
+                    // Tapping a timed line jumps there through the controller,
+                    // so it seeks whichever output is live — local or cast.
+                    onSeek: start == null
+                        ? null
+                        : () =>
+                            ref.read(playbackControllerProvider).seek(start),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/player/widgets/lyrics/synced_lyric_line.dart
+++ b/lib/features/player/widgets/lyrics/synced_lyric_line.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../core/models/lyric_focus.dart';
+import 'lyric_line_tile.dart';
+
+/// A timed lyric line that follows the active line on its own.
+///
+/// This is the piece that keeps the synced view cheap. The viewport publishes
+/// the active line index as a [ValueListenable] instead of rebuilding through
+/// it, and each row subscribes directly — then repaints **only when its own
+/// [LyricEmphasis] changes**. Crossing a line boundary therefore touches the
+/// handful of rows whose emphasis actually moved (the old and new active lines
+/// and their neighbours), not every row the list happens to have built, and the
+/// list itself is never rebuilt at all.
+///
+/// It holds no timing logic: the index arrives ready-made from the playback
+/// position, and [lyricEmphasisFor] turns it into emphasis.
+class SyncedLyricLine extends StatefulWidget {
+  const SyncedLyricLine({
+    required this.activeLine,
+    required this.index,
+    required this.text,
+    this.onSeek,
+    super.key,
+  });
+
+  /// The index of the line playing right now, as published by the viewport.
+  final ValueListenable<int> activeLine;
+
+  /// This line's position in the lyrics.
+  final int index;
+
+  final String text;
+
+  /// Seeks playback to this line's timestamp. Null for a line with no
+  /// timestamp, which then isn't tappable.
+  final VoidCallback? onSeek;
+
+  @override
+  State<SyncedLyricLine> createState() => _SyncedLyricLineState();
+}
+
+class _SyncedLyricLineState extends State<SyncedLyricLine> {
+  late LyricEmphasis _emphasis = _emphasisNow();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.activeLine.addListener(_onActiveLineChanged);
+  }
+
+  @override
+  void didUpdateWidget(SyncedLyricLine oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.activeLine != widget.activeLine) {
+      oldWidget.activeLine.removeListener(_onActiveLineChanged);
+      widget.activeLine.addListener(_onActiveLineChanged);
+    }
+    // A recycled row now standing in for a different line (or a different
+    // song's notifier) must re-derive its emphasis rather than keep the old
+    // one. No setState — a rebuild is already under way.
+    if (oldWidget.index != widget.index ||
+        oldWidget.activeLine != widget.activeLine) {
+      _emphasis = _emphasisNow();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.activeLine.removeListener(_onActiveLineChanged);
+    super.dispose();
+  }
+
+  LyricEmphasis _emphasisNow() => lyricEmphasisFor(
+        index: widget.index,
+        activeIndex: widget.activeLine.value,
+      );
+
+  void _onActiveLineChanged() {
+    final LyricEmphasis next = _emphasisNow();
+    // The guard is the point: most line changes leave most rows' emphasis
+    // untouched, and those rows must not repaint.
+    if (next == _emphasis) return;
+    setState(() => _emphasis = next);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LyricLineTile(
+      text: widget.text,
+      emphasis: _emphasis,
+      onTap: widget.onSeek,
+    );
+  }
+}

--- a/lib/features/player/widgets/lyrics_view.dart
+++ b/lib/features/player/widgets/lyrics_view.dart
@@ -5,17 +5,20 @@ import '../../../app/dimens.dart';
 import '../../../core/models/lyrics.dart';
 import '../../../shared/widgets/empty_state.dart';
 import '../lyrics_providers.dart';
-import '../player_providers.dart';
+import 'lyrics/lyrics_viewport.dart';
 
 /// The lyrics experience shown from Now Playing.
 ///
-/// It follows the *currently playing* track (via [currentTrackLyricsProvider]),
-/// so skipping reloads the lines in place and the previous song's text never
-/// lingers. Three shapes:
+/// A thin orchestrator: it picks which of four shapes to show and hands the work
+/// to a dedicated widget. It follows the *currently playing* track (via
+/// [currentTrackLyricsProvider]), so skipping reloads the lines in place and the
+/// previous song's text never lingers.
+///
 ///  - no lyrics → a calm "No lyrics available yet." placeholder;
-///  - plain lyrics (no timestamps) → a static, readable list, no highlighting;
-///  - timed lyrics → a smooth synced view that highlights the current line and
-///    auto-scrolls as playback moves.
+///  - plain lyrics (no timestamps) → [PlainLyricsViewport], a static readable
+///    column with no highlighting and no invented timings;
+///  - timed lyrics → [SyncedLyricsViewport], which holds the active line near
+///    the middle of the view and fades the lines around it.
 ///
 /// Critically, it only *reads* playback state — opening it never starts or
 /// restarts playback. Because it follows the unified [playbackStateProvider]
@@ -29,196 +32,61 @@ class LyricsView extends ConsumerWidget {
     final AsyncValue<Lyrics?> lyrics = ref.watch(currentTrackLyricsProvider);
 
     return lyrics.when(
-      loading: () => const Padding(
-        padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
-        child: Center(child: CircularProgressIndicator()),
-      ),
+      loading: () => const Center(child: CircularProgressIndicator()),
       // Never surface raw error text (it can carry transport detail); show one
       // calm, friendly line instead.
-      error: (_, __) => const Padding(
-        padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
-        child: EmptyState(
-          icon: Icons.lyrics_outlined,
-          title: "Couldn't load lyrics",
-          message: 'Check your connection and try again.',
-        ),
+      error: (_, __) => const _LyricsPlaceholder(
+        title: "Couldn't load lyrics",
+        message: 'Check your connection and try again.',
       ),
-      data: (value) {
+      data: (Lyrics? value) {
         if (value == null || value.isEmpty) {
-          return const Padding(
-            padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
-            child: EmptyState(
-              icon: Icons.lyrics_outlined,
-              title: 'No lyrics available yet.',
-              message: "They'll appear here when your server has them.",
-            ),
+          return const _LyricsPlaceholder(
+            title: 'No lyrics available yet.',
+            message: "They'll appear here when your server has them.",
           );
         }
         return value.isSynced
-            ? _SyncedLyrics(lyrics: value)
-            : _PlainLyrics(lyrics: value);
+            ? SyncedLyricsViewport(lyrics: value)
+            : PlainLyricsViewport(lyrics: value);
       },
     );
   }
 }
 
-/// Static lyrics with no timing: a plain, readable, scrollable list.
-class _PlainLyrics extends StatelessWidget {
-  const _PlainLyrics({required this.lyrics});
+/// The "nothing to show" states, centred in the lyrics panel.
+///
+/// Scrollable rather than fixed: the panel is a fraction of Now Playing rather
+/// than a full sheet, and at a large text scale — or on a short screen — the
+/// placeholder can be taller than the space it is given. Letting it scroll keeps
+/// it fully readable instead of clipping the message off the bottom, while the
+/// minimum height keeps it optically centred whenever it does fit.
+class _LyricsPlaceholder extends StatelessWidget {
+  const _LyricsPlaceholder({required this.title, required this.message});
 
-  final Lyrics lyrics;
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    return ListView.builder(
-      key: const Key('plain-lyrics'),
-      padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-      itemCount: lyrics.lines.length,
-      itemBuilder: (context, index) {
-        final String text = lyrics.lines[index].text;
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-          // A blank line keeps its vertical rhythm rather than collapsing.
-          child: Text(
-            text.isEmpty ? ' ' : text,
-            style: theme.textTheme.bodyLarge,
-          ),
-        );
-      },
-    );
-  }
-}
-
-/// Timed lyrics: highlights the line active at the current playback position and
-/// auto-scrolls to keep it centred, with neighbouring lines softly dimmed.
-class _SyncedLyrics extends ConsumerStatefulWidget {
-  const _SyncedLyrics({required this.lyrics});
-
-  final Lyrics lyrics;
-
-  @override
-  ConsumerState<_SyncedLyrics> createState() => _SyncedLyricsState();
-}
-
-class _SyncedLyricsState extends ConsumerState<_SyncedLyrics> {
-  final ScrollController _scroll = ScrollController();
-  List<GlobalKey> _keys = const <GlobalKey>[];
-  int _activeIndex = -1;
-
-  @override
-  void initState() {
-    super.initState();
-    _rebuildKeys();
-  }
-
-  @override
-  void didUpdateWidget(_SyncedLyrics oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // A new track's lyrics: reset keys and the highlight so nothing stale shows.
-    if (widget.lyrics != oldWidget.lyrics) {
-      _rebuildKeys();
-      _activeIndex = -1;
-    }
-  }
-
-  void _rebuildKeys() {
-    _keys = List<GlobalKey>.generate(
-      widget.lyrics.lines.length,
-      (_) => GlobalKey(),
-    );
-  }
-
-  @override
-  void dispose() {
-    _scroll.dispose();
-    super.dispose();
-  }
-
-  /// The lyric line active at the current playback position.
-  ///
-  /// Battery: the active-line index is computed *inside* the provider
-  /// [select], so this widget rebuilds only when the highlighted line actually
-  /// changes (a handful of times per song) — not on every ~4 Hz position tick.
-  /// The whole synced list (with its per-line [AnimatedDefaultTextStyle]s) would
-  /// otherwise rebuild four times a second for the entire length of a track. The
-  /// per-tick cost is now just one cheap [Lyrics.activeLineIndex] scan with no
-  /// rebuild while the line is unchanged. Falls back to the controller's latest
-  /// position until the first stream event arrives, mirroring the rest of the
-  /// player UI. Reads only — never triggers playback.
-  int _activeLine() {
-    final Lyrics lyrics = widget.lyrics;
-    final Duration fallback =
-        ref.read(playbackControllerProvider).state.position;
-    return ref.watch(
-      playbackStateProvider.select(
-        (s) => lyrics.activeLineIndex(s.valueOrNull?.position ?? fallback),
-      ),
-    );
-  }
+  final String title;
+  final String message;
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final int active = _activeLine();
-
-    if (active != _activeIndex) {
-      _activeIndex = active;
-      _scheduleScrollTo(active);
-    }
-
-    return ListView.builder(
-      key: const Key('synced-lyrics'),
-      controller: _scroll,
-      // Generous vertical padding so the first and last lines can sit centred.
-      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xl),
-      itemCount: widget.lyrics.lines.length,
-      itemBuilder: (context, index) {
-        final LyricLine line = widget.lyrics.lines[index];
-        final bool isActive = index == active;
-        final Color color = isActive
-            ? theme.colorScheme.secondary
-            : theme.colorScheme.onSurface.withValues(alpha: 0.4);
-        return Padding(
-          key: _keys[index],
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return SingleChildScrollView(
           padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            // Tap a timed line to jump there — routed through the controller, so
-            // it seeks whichever output is active (local or cast).
-            onTap: line.start == null
-                ? null
-                : () => ref.read(playbackControllerProvider).seek(line.start!),
-            child: AnimatedDefaultTextStyle(
-              duration: const Duration(milliseconds: 220),
-              curve: Curves.easeOut,
-              style:
-                  (theme.textTheme.titleMedium ?? const TextStyle()).copyWith(
-                color: color,
-                fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
-                height: 1.35,
-              ),
-              child: Text(line.text.isEmpty ? ' ' : line.text),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: constraints.maxHeight.isFinite
+                  ? constraints.maxHeight - AppSpacing.md
+                  : 0,
+            ),
+            child: EmptyState(
+              icon: Icons.lyrics_outlined,
+              title: title,
+              message: message,
             ),
           ),
         );
       },
     );
-  }
-
-  /// Smoothly centres the active line. Guarded so it only runs once per change
-  /// and only while the line is laid out.
-  void _scheduleScrollTo(int index) {
-    if (index < 0 || index >= _keys.length) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final BuildContext? ctx = _keys[index].currentContext;
-      if (ctx == null) return;
-      Scrollable.ensureVisible(
-        ctx,
-        alignment: 0.5,
-        duration: const Duration(milliseconds: 360),
-        curve: Curves.easeInOut,
-      );
-    });
   }
 }

--- a/lib/features/player/widgets/now_playing_actions.dart
+++ b/lib/features/player/widgets/now_playing_actions.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../app/dimens.dart';
 import '../../../core/models/playback_state.dart';
 import '../../../core/models/track.dart';
 import '../../../data/repositories/favorites_repository_provider.dart';
@@ -10,7 +9,6 @@ import '../favorites_providers.dart';
 import '../now_playing_favorite_target.dart';
 import '../player_providers.dart';
 import '../sleep_timer_controller.dart';
-import 'lyrics_view.dart';
 import 'queue_sheet.dart';
 import 'sleep_timer_sheet.dart';
 
@@ -19,14 +17,27 @@ import 'sleep_timer_sheet.dart';
 ///
 /// They're live: favorite toggles a heart synced through the
 /// [FavoritesRepository] (to Jellyfin for remote tracks, on-device for local
-/// ones), queue opens the up-next list, lyrics fetches the track's lyrics from
-/// the source — falling back to an honest "no lyrics" state when there are none
-/// (or for a local track / when signed out) — and the sleep timer (a moon that
-/// lights up while a countdown is running) opens the delay picker.
+/// ones), queue opens the up-next list, lyrics switches the screen into its
+/// lyrics-focused mode, and the sleep timer (a moon that lights up while a
+/// countdown is running) opens the delay picker.
 class NowPlayingActions extends ConsumerWidget {
-  const NowPlayingActions({super.key, required this.track});
+  const NowPlayingActions({
+    super.key,
+    required this.track,
+    this.lyricsVisible = false,
+    this.onToggleLyrics,
+  });
 
   final Track track;
+
+  /// Whether the screen is currently showing lyrics instead of the artwork, so
+  /// the lyrics button can read as the toggle it is.
+  final bool lyricsVisible;
+
+  /// Switches the lyrics-focused mode on and off. Null on surfaces that host
+  /// the action row without a lyrics area, which leaves the button inert rather
+  /// than opening something the caller didn't ask for.
+  final VoidCallback? onToggleLyrics;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -84,10 +95,13 @@ class NowPlayingActions extends ConsumerWidget {
         ),
         IconButton(
           iconSize: 22,
-          onPressed: () => _openLyrics(context),
-          icon: const Icon(Icons.lyrics_outlined),
-          color: muted,
-          tooltip: 'Lyrics',
+          onPressed: onToggleLyrics,
+          icon: Icon(
+            lyricsVisible ? Icons.lyrics : Icons.lyrics_outlined,
+          ),
+          color: lyricsVisible ? theme.colorScheme.primary : muted,
+          isSelected: lyricsVisible,
+          tooltip: lyricsVisible ? 'Hide lyrics' : 'Lyrics',
         ),
         IconButton(
           iconSize: 22,
@@ -105,56 +119,5 @@ class NowPlayingActions extends ConsumerWidget {
 
   void _openQueue(BuildContext context) {
     showQueueSheet(context);
-  }
-
-  void _openLyrics(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      isScrollControlled: true,
-      builder: (_) => const _LyricsSheet(),
-    );
-  }
-}
-
-/// The lyrics sheet: a tall, premium synced-lyrics panel. It follows the
-/// *currently playing* track rather than a captured one, so skipping updates the
-/// lines in place; the heavy lifting (loading / empty / plain / synced
-/// highlighting + auto-scroll) lives in [LyricsView]. Opening it only reads
-/// playback state — it never starts or restarts playback.
-class _LyricsSheet extends StatelessWidget {
-  const _LyricsSheet();
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-
-    return SafeArea(
-      child: SizedBox(
-        height: MediaQuery.sizeOf(context).height * 0.85,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            0,
-            AppSpacing.lg,
-            AppSpacing.lg,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Row(
-                children: [
-                  Icon(Icons.lyrics_outlined, color: theme.colorScheme.primary),
-                  const SizedBox(width: AppSpacing.sm),
-                  Text('Lyrics', style: theme.textTheme.titleMedium),
-                ],
-              ),
-              const SizedBox(height: AppSpacing.sm),
-              const Expanded(child: LyricsView()),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/test/core/models/lyric_focus_test.dart
+++ b/test/core/models/lyric_focus_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/lyric_focus.dart';
+
+void main() {
+  group('lyricEmphasisFor', () {
+    test('the playing line is the active one', () {
+      expect(
+        lyricEmphasisFor(index: 4, activeIndex: 4),
+        LyricEmphasis.active,
+      );
+    });
+
+    test('emphasis falls off progressively either side of the active line', () {
+      const int active = 10;
+      expect(
+        lyricEmphasisFor(index: active, activeIndex: active),
+        LyricEmphasis.active,
+      );
+      expect(
+        lyricEmphasisFor(index: active + 1, activeIndex: active),
+        LyricEmphasis.adjacent,
+      );
+      expect(
+        lyricEmphasisFor(index: active + 2, activeIndex: active),
+        LyricEmphasis.near,
+      );
+      expect(
+        lyricEmphasisFor(index: active + 3, activeIndex: active),
+        LyricEmphasis.distant,
+      );
+      expect(
+        lyricEmphasisFor(index: active + 40, activeIndex: active),
+        LyricEmphasis.distant,
+      );
+    });
+
+    test('the fade is symmetric: sung lines recede like upcoming ones', () {
+      const int active = 10;
+      for (int distance = 0; distance <= 4; distance++) {
+        expect(
+          lyricEmphasisFor(index: active - distance, activeIndex: active),
+          lyricEmphasisFor(index: active + distance, activeIndex: active),
+          reason: 'distance $distance must read the same either side',
+        );
+      }
+    });
+
+    test('before the first timed line nothing is highlighted', () {
+      // Lyrics.activeLineIndex reports -1 during an instrumental intro. Every
+      // line must then read the same — inventing an "active" line would be a
+      // lie about where playback is.
+      for (final int index in <int>[0, 1, 2, 9]) {
+        expect(
+          lyricEmphasisFor(index: index, activeIndex: -1),
+          LyricEmphasis.near,
+        );
+      }
+    });
+  });
+}

--- a/test/features/player/lyrics_experience_test.dart
+++ b/test/features/player/lyrics_experience_test.dart
@@ -46,6 +46,15 @@ const _synced = Lyrics(lines: <LyricLine>[
   LyricLine(text: 'line seven', start: Duration(seconds: 60)),
 ]);
 
+/// A timed set with an interior *timestamped blank* line — what
+/// `LyricsTextParser` produces for a bare `[00:10.00]` tag in an `.lrc`, kept
+/// for stanza rhythm.
+const _syncedWithGap = Lyrics(lines: <LyricLine>[
+  LyricLine(text: 'before the gap', start: Duration.zero),
+  LyricLine(text: '', start: Duration(seconds: 10)),
+  LyricLine(text: 'after the gap', start: Duration(seconds: 20)),
+]);
+
 const _plain = Lyrics(lines: <LyricLine>[
   LyricLine(text: 'plain one'),
   LyricLine(text: 'plain two'),
@@ -314,6 +323,56 @@ void main() {
         ),
       );
       expect(target.height, greaterThanOrEqualTo(48.0));
+    });
+
+    testWidgets('a timestamped blank line stays pure spacing', (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          // 12s: the blank line at 10s is the active one.
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _syncedWithGap,
+      );
+      await _openLyrics(tester);
+
+      final Finder blank = find.byWidgetPredicate(
+        (Widget w) => w is LyricLineTile && w.text.trim().isEmpty,
+      );
+      expect(blank, findsOneWidget);
+
+      // No tap target: seeking to a stanza gap would offer an unlabelled button.
+      expect(
+        find.descendant(of: blank, matching: find.byType(InkWell)),
+        findsNothing,
+      );
+      // And nothing for a screen reader to land on.
+      expect(
+        find.descendant(of: blank, matching: find.byType(ExcludeSemantics)),
+        findsOneWidget,
+      );
+      // Even though it is the active line, no accent pill floats beside the
+      // empty row.
+      final Iterable<AnimatedOpacity> markers =
+          tester.widgetList<AnimatedOpacity>(
+        find.descendant(of: blank, matching: find.byType(AnimatedOpacity)),
+      );
+      expect(markers, isNotEmpty);
+      for (final AnimatedOpacity marker in markers) {
+        expect(marker.opacity, 0.0);
+      }
+
+      // The real lines around it are still perfectly seekable.
+      expect(
+        find.descendant(
+          of: find.ancestor(
+            of: find.text('after the gap'),
+            matching: find.byType(LyricLineTile),
+          ),
+          matching: find.byType(InkWell),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('plain lyrics are not seekable', (tester) async {

--- a/test/features/player/lyrics_experience_test.dart
+++ b/test/features/player/lyrics_experience_test.dart
@@ -1,0 +1,592 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/app/brand_theme.dart';
+import 'package:linthra/app/theme.dart';
+import 'package:linthra/core/models/lyrics.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/lyrics_service.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+import 'package:linthra/features/player/player_screen.dart';
+import 'package:linthra/features/player/widgets/album_artwork.dart';
+import 'package:linthra/features/player/widgets/lyrics/lyric_line_tile.dart';
+
+import 'fake_playback_controller.dart';
+
+/// A lyrics backend returning one canned set for the test track.
+class _FakeLyricsService implements LyricsService {
+  _FakeLyricsService(this._lyrics);
+
+  final Lyrics? _lyrics;
+
+  @override
+  Future<Lyrics?> lyricsFor(Track track) async => _lyrics;
+}
+
+const _track = Track(
+  id: 'a',
+  title: 'Song A',
+  uri: 'jellyfin:a',
+  artistName: 'Artist A',
+  albumName: 'Album A',
+);
+
+/// Enough lines that the fade band (active ± 2) doesn't cover the whole song,
+/// so "distant" is genuinely reachable.
+const _synced = Lyrics(lines: <LyricLine>[
+  LyricLine(text: 'line one', start: Duration.zero),
+  LyricLine(text: 'line two', start: Duration(seconds: 10)),
+  LyricLine(text: 'line three', start: Duration(seconds: 20)),
+  LyricLine(text: 'line four', start: Duration(seconds: 30)),
+  LyricLine(text: 'line five', start: Duration(seconds: 40)),
+  LyricLine(text: 'line six', start: Duration(seconds: 50)),
+  LyricLine(text: 'line seven', start: Duration(seconds: 60)),
+]);
+
+const _plain = Lyrics(lines: <LyricLine>[
+  LyricLine(text: 'plain one'),
+  LyricLine(text: 'plain two'),
+  LyricLine(text: 'plain three'),
+]);
+
+PlaybackState _playingAt(Duration position) => PlaybackState(
+      status: PlaybackStatus.playing,
+      currentTrack: _track,
+      position: position,
+      duration: const Duration(seconds: 90),
+    );
+
+/// The style the synced view applied to [text]: the [AnimatedDefaultTextStyle]
+/// that *directly* wraps this line's [Text] (Material wraps plenty of others).
+AnimatedDefaultTextStyle _wrapperOf(WidgetTester tester, String text) {
+  final Iterable<AnimatedDefaultTextStyle> candidates =
+      tester.widgetList<AnimatedDefaultTextStyle>(
+    find.ancestor(
+      of: find.text(text),
+      matching: find.byType(AnimatedDefaultTextStyle),
+    ),
+  );
+  for (final AnimatedDefaultTextStyle wrapper in candidates) {
+    final Widget child = wrapper.child;
+    if (child is Text && child.data == text) return wrapper;
+  }
+  return candidates.first;
+}
+
+TextStyle _styleOf(WidgetTester tester, String text) =>
+    _wrapperOf(tester, text).style;
+
+double _opacityOf(WidgetTester tester, String text) =>
+    _styleOf(tester, text).color!.a;
+
+/// Gives the test a tall window, so a whole song's worth of lines is on screen
+/// at once (and so Now Playing's fixed chrome fits at a large text scale).
+void _useTallWindow(WidgetTester tester, {double height = 1600}) {
+  tester.view.physicalSize = Size(900, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<void> _pumpPlayer(
+  WidgetTester tester, {
+  required FakePlaybackController controller,
+  Lyrics? lyrics,
+  bool disableAnimations = false,
+  TextScaler textScaler = TextScaler.noScaling,
+  ThemeData? theme,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        playbackControllerProvider.overrideWithValue(controller),
+        lyricsServiceProvider.overrideWithValue(_FakeLyricsService(lyrics)),
+      ],
+      child: MaterialApp(
+        theme: theme,
+        home: Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(
+              disableAnimations: disableAnimations,
+              textScaler: textScaler,
+            ),
+            child: const PlayerScreen(),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openLyrics(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Lyrics'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('lyrics-focused mode', () {
+    testWidgets('the lyrics button swaps the artwork for the lyrics',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: _synced,
+      );
+
+      // Artwork owns the stage until lyrics are asked for.
+      expect(find.byType(AlbumArtwork), findsOneWidget);
+      expect(find.byKey(const Key('synced-lyrics')), findsNothing);
+
+      await _openLyrics(tester);
+
+      expect(find.byKey(const Key('synced-lyrics')), findsOneWidget);
+      expect(find.byType(AlbumArtwork), findsNothing);
+    });
+
+    testWidgets('playback controls stay reachable while lyrics are showing',
+        (tester) async {
+      final controller =
+          FakePlaybackController(initial: _playingAt(Duration.zero));
+      await _pumpPlayer(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+
+      // The whole transport row is still on screen, and still drives playback.
+      expect(find.byTooltip('Pause'), findsOneWidget);
+      expect(find.byTooltip('Next'), findsOneWidget);
+      expect(find.byTooltip('Previous'), findsOneWidget);
+      await tester.tap(find.byTooltip('Pause'));
+      expect(controller.pauseCount, 1);
+
+      // And what is playing is still named, in the compact line.
+      expect(find.text('Song A'), findsOneWidget);
+      expect(find.text('Artist A'), findsOneWidget);
+    });
+
+    testWidgets('the toggle returns the artwork', (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+      expect(find.byKey(const Key('synced-lyrics')), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Hide lyrics'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlbumArtwork), findsOneWidget);
+      expect(find.byKey(const Key('synced-lyrics')), findsNothing);
+    });
+  });
+
+  group('synced lyrics presentation', () {
+    testWidgets('the active line is visually dominant', (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+
+      // 12s lands on "line two" (10s..20s).
+      final TextStyle active = _styleOf(tester, 'line two');
+      final TextStyle neighbour = _styleOf(tester, 'line one');
+
+      expect(active.fontWeight, FontWeight.w700);
+      expect(neighbour.fontWeight, FontWeight.w500);
+      // Larger, fully opaque, and a different colour — dominance is carried by
+      // size and weight too, never by colour alone.
+      expect(active.fontSize, greaterThan(neighbour.fontSize!));
+      expect(active.color!.a, 1.0);
+      expect(active.color, isNot(neighbour.color));
+    });
+
+    testWidgets('surrounding lines fade progressively, not uniformly',
+        (tester) async {
+      // Tall enough that the whole fade band is built and measurable at once.
+      _useTallWindow(tester);
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+
+      // "line two" is active, so three/four/five step further away from it.
+      final double adjacent = _opacityOf(tester, 'line three');
+      final double near = _opacityOf(tester, 'line four');
+      final double distant = _opacityOf(tester, 'line five');
+
+      expect(_opacityOf(tester, 'line two'), greaterThan(adjacent));
+      expect(adjacent, greaterThan(near));
+      expect(near, greaterThan(distant));
+    });
+
+    testWidgets('the highlight follows the position across a line boundary',
+        (tester) async {
+      final controller = FakePlaybackController(
+        initial: _playingAt(const Duration(seconds: 12)),
+      );
+      await _pumpPlayer(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w700);
+
+      controller.emit(_playingAt(const Duration(seconds: 22)));
+      await tester.pumpAndSettle();
+
+      expect(_styleOf(tester, 'line three').fontWeight, FontWeight.w700);
+      expect(_styleOf(tester, 'line two').fontWeight, FontWeight.w500);
+    });
+
+    testWidgets('the active line is kept near the middle of the viewport',
+        (tester) async {
+      final controller =
+          FakePlaybackController(initial: _playingAt(Duration.zero));
+      await _pumpPlayer(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+
+      final Rect viewport = tester.getRect(
+        find.byKey(const Key('synced-lyrics')),
+      );
+
+      // Walk the song and check the active line never drifts out toward an
+      // edge — the whole point of the auto-follow.
+      for (final ({int seconds, String text}) step
+          in <({int seconds, String text})>[
+        (seconds: 20, text: 'line three'),
+        (seconds: 40, text: 'line five'),
+        (seconds: 60, text: 'line seven'),
+      ]) {
+        controller.emit(_playingAt(Duration(seconds: step.seconds)));
+        await tester.pumpAndSettle();
+
+        final Rect line = tester.getRect(find.text(step.text));
+        expect(
+          line.center.dy,
+          greaterThan(viewport.top + viewport.height * 0.15),
+          reason: '${step.text} drifted off the top of the viewport',
+        );
+        expect(
+          line.center.dy,
+          lessThan(viewport.bottom - viewport.height * 0.15),
+          reason: '${step.text} drifted off the bottom of the viewport',
+        );
+      }
+    });
+  });
+
+  group('seeking from a lyric line', () {
+    testWidgets('tapping a timed line seeks through the PlaybackController',
+        (tester) async {
+      final controller =
+          FakePlaybackController(initial: _playingAt(Duration.zero));
+      await _pumpPlayer(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+
+      await tester.tap(find.text('line three'));
+      await tester.pumpAndSettle();
+
+      // Routed through the controller — never straight at the audio engine —
+      // so it seeks whichever output is live.
+      expect(controller.seeks, <Duration>[const Duration(seconds: 20)]);
+    });
+
+    testWidgets('a seekable line is a comfortably large touch target',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+
+      final Size target = tester.getSize(
+        find.ancestor(
+          of: find.text('line three'),
+          matching: find.byType(InkWell),
+        ),
+      );
+      expect(target.height, greaterThanOrEqualTo(48.0));
+    });
+
+    testWidgets('plain lyrics are not seekable', (tester) async {
+      final controller =
+          FakePlaybackController(initial: _playingAt(Duration.zero));
+      await _pumpPlayer(tester, controller: controller, lyrics: _plain);
+      await _openLyrics(tester);
+
+      await tester.tap(find.text('plain two'));
+      await tester.pumpAndSettle();
+
+      // No timestamps means nothing honest to seek to.
+      expect(controller.seeks, isEmpty);
+    });
+  });
+
+  group('unsynced and missing lyrics', () {
+    testWidgets('plain lyrics render with no highlighting at all',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _plain,
+      );
+      await _openLyrics(tester);
+
+      expect(find.byKey(const Key('plain-lyrics')), findsOneWidget);
+      expect(find.byKey(const Key('synced-lyrics')), findsNothing);
+
+      // Every line reads identically: no fake "current line" despite playback
+      // being well underway.
+      final TextStyle first = _styleOf(tester, 'plain one');
+      expect(_styleOf(tester, 'plain two'), first);
+      expect(_styleOf(tester, 'plain three'), first);
+    });
+
+    testWidgets('plain lyrics keep a readable measure on a wide screen',
+        (tester) async {
+      tester.view.physicalSize = const Size(2400, 1600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: _plain,
+      );
+      await _openLyrics(tester);
+
+      final Size list = tester.getSize(find.byKey(const Key('plain-lyrics')));
+      expect(list.width, lessThanOrEqualTo(620.0));
+    });
+
+    testWidgets('a track with no lyrics shows the calm empty state',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: null,
+      );
+      await _openLyrics(tester);
+
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+      expect(find.byKey(const Key('synced-lyrics')), findsNothing);
+      expect(find.byKey(const Key('plain-lyrics')), findsNothing);
+    });
+
+    testWidgets('an empty lyrics document shows the empty state too',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: const Lyrics(lines: <LyricLine>[]),
+      );
+      await _openLyrics(tester);
+
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+    });
+  });
+
+  group('accessibility', () {
+    testWidgets('reduced motion removes the line transition and the scroll',
+        (tester) async {
+      final controller = FakePlaybackController(
+        initial: _playingAt(const Duration(seconds: 12)),
+      );
+      await _pumpPlayer(
+        tester,
+        controller: controller,
+        lyrics: _synced,
+        disableAnimations: true,
+      );
+      await _openLyrics(tester);
+
+      // Each lyric line's own style wrapper — not Material's internal ones,
+      // which carry their own theme-change duration and aren't ours to assert.
+      for (final String text in <String>[
+        'line one',
+        'line two',
+        'line three'
+      ]) {
+        expect(_wrapperOf(tester, text).duration, Duration.zero);
+      }
+      // The accent marker fades on the same (zero) schedule.
+      final Iterable<AnimatedOpacity> markers =
+          tester.widgetList<AnimatedOpacity>(
+        find.descendant(
+          of: find.byType(LyricLineTile),
+          matching: find.byType(AnimatedOpacity),
+        ),
+      );
+      expect(markers, isNotEmpty);
+      for (final AnimatedOpacity marker in markers) {
+        expect(marker.duration, Duration.zero);
+      }
+
+      // Crossing a boundary still lands the highlight, and lands it *whole*:
+      // one frame to deliver the position and one to rebuild the rows, with no
+      // interpolation left in flight. Mid-animation this would still read w500.
+      controller.emit(_playingAt(const Duration(seconds: 22)));
+      await tester.pump();
+      await tester.pump();
+      expect(_styleOf(tester, 'line three').fontWeight, FontWeight.w700);
+    });
+
+    testWidgets('the active line reports itself as selected to screen readers',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+
+      // Emphasis must not be colour-only: the active line is announced as
+      // selected, and every timed line as something you can act on.
+      expect(
+        tester.getSemantics(find.text('line two')),
+        matchesSemantics(
+          label: 'line two',
+          hint: 'Play from this line',
+          isSelected: true,
+          isButton: true,
+          isFocusable: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+      expect(
+        tester.getSemantics(find.text('line three')),
+        matchesSemantics(
+          label: 'line three',
+          hint: 'Play from this line',
+          isButton: true,
+          isFocusable: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+
+      // Disposed in the body: the framework verifies outstanding handles before
+      // tearDowns run.
+      handle.dispose();
+    });
+
+    testWidgets('lyrics stay readable and unclipped at a large text scale',
+        (tester) async {
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _synced,
+        textScaler: const TextScaler.linear(2.0),
+      );
+      await _openLyrics(tester);
+
+      // No overflow anywhere in the tree (the harness turns one into a failure
+      // via the exception below), and the lines really did grow.
+      expect(tester.takeException(), isNull);
+      expect(find.text('line two'), findsOneWidget);
+
+      final RenderBox line = tester.renderObject<RenderBox>(
+        find.text('line two'),
+      );
+      expect(line.size.height, greaterThan(30));
+    });
+
+    testWidgets('the empty state scrolls rather than clipping at a huge scale',
+        (tester) async {
+      // Now Playing's fixed chrome (metadata, transport, actions) does not
+      // itself fit an 800x600 window at 3x — that is true of the artwork mode
+      // too and is out of scope here. The window is sized so the panel, not the
+      // chrome, is what this test measures.
+      _useTallWindow(tester);
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(initial: _playingAt(Duration.zero)),
+        lyrics: null,
+        textScaler: const TextScaler.linear(3.0),
+      );
+      await _openLyrics(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('No lyrics available yet.'), findsOneWidget);
+    });
+  });
+
+  group('theming', () {
+    for (final ({String name, ThemeData theme}) variant
+        in <({String name, ThemeData theme})>[
+      (name: 'dark', theme: AppTheme.dark(BrandPalettes.classic)),
+      (name: 'light', theme: AppTheme.light(BrandPalettes.classicLight)),
+    ]) {
+      testWidgets('lyrics take their colours from the ${variant.name} scheme',
+          (tester) async {
+        await _pumpPlayer(
+          tester,
+          controller: FakePlaybackController(
+            initial: _playingAt(const Duration(seconds: 12)),
+          ),
+          lyrics: _synced,
+          theme: variant.theme,
+        );
+        await _openLyrics(tester);
+
+        final ColorScheme colors = variant.theme.colorScheme;
+        final TextStyle active = _styleOf(tester, 'line two');
+
+        // The dominant line is the scheme's own foreground at full strength,
+        // so it reads over any cover in either brightness.
+        expect(active.color, colors.onSurface);
+        // And the receding lines are that same foreground, just quieter — no
+        // hard-coded greys.
+        final Color faded = _styleOf(tester, 'line one').color!;
+        expect(faded.a, lessThan(1.0));
+        expect(
+          faded.withValues(alpha: 1.0),
+          colors.onSurface.withValues(alpha: 1.0),
+        );
+      });
+    }
+
+    testWidgets('the active-line marker uses the brand accent', (tester) async {
+      final ThemeData theme = AppTheme.dark(BrandPalettes.classic);
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _synced,
+        theme: theme,
+      );
+      await _openLyrics(tester);
+
+      // The redundant, non-colour-only cue next to the active line is drawn in
+      // the same accent the progress line and play button use.
+      final Iterable<Container> markers = tester.widgetList<Container>(
+        find.descendant(
+          of: find.byType(LyricLineTile),
+          matching: find.byType(Container),
+        ),
+      );
+      expect(
+        markers.map((Container c) => (c.decoration as BoxDecoration?)?.color),
+        contains(theme.colorScheme.secondary),
+      );
+    });
+  });
+}

--- a/test/features/player/lyrics_experience_test.dart
+++ b/test/features/player/lyrics_experience_test.dart
@@ -55,6 +55,20 @@ const _syncedWithGap = Lyrics(lines: <LyricLine>[
   LyricLine(text: 'after the gap', start: Duration(seconds: 20)),
 ]);
 
+/// A long song whose lines wrap to very different heights, so no single
+/// per-row extent describes the list. Line `i` starts at `i` seconds.
+Lyrics _unevenLyrics({int count = 60}) {
+  return Lyrics(
+    lines: List<LyricLine>.generate(count, (int i) {
+      // Every third line is a long one that wraps over several rows.
+      final String text = i % 3 == 0
+          ? 'line $i ${'and it carries on well past the end of the line ' * 4}'
+          : 'line $i';
+      return LyricLine(text: text, start: Duration(seconds: i));
+    }),
+  );
+}
+
 const _plain = Lyrics(lines: <LyricLine>[
   LyricLine(text: 'plain one'),
   LyricLine(text: 'plain two'),
@@ -288,6 +302,57 @@ void main() {
           reason: '${step.text} drifted off the bottom of the viewport',
         );
       }
+    });
+  });
+
+  group('following across a long seek', () {
+    testWidgets('a jump far down an uneven song still lands the active line',
+        (tester) async {
+      // Uneven wrapped heights mean a single averaged row extent describes the
+      // list badly; the target row also starts far outside the built window, so
+      // ensureVisible alone has nothing to measure.
+      final Lyrics lyrics = _unevenLyrics();
+      final controller =
+          FakePlaybackController(initial: _playingAt(Duration.zero));
+      await _pumpPlayer(tester, controller: controller, lyrics: lyrics);
+      await _openLyrics(tester);
+
+      const String target = 'line 52';
+      expect(find.textContaining(target), findsNothing);
+
+      controller.emit(_playingAt(const Duration(seconds: 52)));
+      await tester.pumpAndSettle();
+
+      // Built, on screen, and actually near the active position — not merely
+      // scrolled somewhere in its general direction.
+      final Finder line = find.textContaining(target);
+      expect(line, findsOneWidget);
+      final Rect viewport =
+          tester.getRect(find.byKey(const Key('synced-lyrics')));
+      final Rect rect = tester.getRect(line);
+      expect(rect.center.dy, greaterThan(viewport.top));
+      expect(rect.center.dy, lessThan(viewport.bottom));
+    });
+
+    testWidgets('jumping back up to the opening line lands too',
+        (tester) async {
+      final Lyrics lyrics = _unevenLyrics();
+      final controller = FakePlaybackController(
+        initial: _playingAt(const Duration(seconds: 52)),
+      );
+      await _pumpPlayer(tester, controller: controller, lyrics: lyrics);
+      await _openLyrics(tester);
+
+      controller.emit(_playingAt(Duration.zero));
+      await tester.pumpAndSettle();
+
+      final Finder line = find.textContaining('line 0 ');
+      expect(line, findsOneWidget);
+      final Rect viewport =
+          tester.getRect(find.byKey(const Key('synced-lyrics')));
+      final Rect rect = tester.getRect(line);
+      expect(rect.center.dy, greaterThan(viewport.top));
+      expect(rect.center.dy, lessThan(viewport.bottom));
     });
   });
 


### PR DESCRIPTION
Lyrics worked, but they didn't feel like part of the app. A bottom sheet, one bold line, and every other line dimmed to the same `0.4` — honest, but plain. This reworks the presentation and leaves everything below it alone.

**No change to the lyrics data model, the wire format, or how lyrics are fetched.** `Lyrics` / `LyricLine`, `LyricsService`, `LyricsResolver`, the per-provider `LyricsProvider`s and `LyricsTextParser` are all untouched. No new dependency.

## What changed

**Synced lyrics.** The active line is held near the middle of the viewport, and the lines around it fade progressively instead of all sitting at one opacity. The active line is dominant by size and weight as well as colour, and carries a small accent marker in a reserved gutter (so nothing reflows as it moves down the song). Tapping a timed line still seeks through the existing `PlaybackController`, so it follows whichever output is live — local or Cast.

**Plain lyrics.** Still deliberately inert — no fake highlighting, no invented timestamps — but with the typography to look intentional: generous leading, a 620px measure so they don't stretch edge-to-edge on a tablet, and room to breathe at both ends.

**Lyrics-focused mode.** The panel now lives in place on Now Playing rather than in a sheet. The artwork hero swaps for the lyrics and the three-line metadata block collapses to one quiet line; the progress bar, the transport row, and the action row stay exactly where they were, so play/pause and skip are never further away for reading along. It's a button toggle, not a gesture, so it can't collide with swipe-to-dismiss or with dragging the seek bar.

**Visuals.** The backdrop reuses the artwork system already on screen — `NowPlayingBackground`'s blurred, dimmed cover — and lays a theme-derived veil over it for a readability floor, heavier in light mode where `surface` is the bright end of the ramp. Every foreground colour comes from `ColorScheme`; there are no hard-coded colours in the new widgets.

## Structure

The old `lyrics_view.dart` was doing all of it. Split into pieces with one job each:

| | |
| --- | --- |
| `core/models/lyric_focus.dart` | which line is emphasised how much — a pure function |
| `lyrics/lyrics_viewport.dart` | scrolling, centring, follow behaviour |
| `lyrics/lyric_line_tile.dart` | how one line looks |
| `lyrics/synced_lyric_line.dart` | how a timed line reacts to the active index |
| `lyrics/lyrics_backdrop.dart` | the background treatment |

`lyrics_view.dart` is now just the loading / error / empty / plain / synced switch. No widget derives timing for itself, and there's no painter involved.

## Performance

The existing battery contract is kept: the active-line index is still selected from the ~4 Hz position stream, so a tick that stays inside the current line costs one cheap scan and no rebuild. `lyrics_highlight_throttle_test.dart` still passes unchanged.

On top of that, the viewport now **listens** to that index rather than watching it, publishing it on a `ValueNotifier` that each row subscribes to. A row calls `setState` only when *its own* emphasis changes, so crossing a line boundary repaints the handful of rows that actually moved instead of every row the list had built — and the list itself is never rebuilt.

The backdrop paints no artwork of its own (no second decode, no second full-screen blur), and its edge fades are plain gradient rectangles rather than a `ShaderMask`, which would force a `saveLayer` over the whole scrolling list every frame. Nothing animates continuously; the only motion is the one-shot scroll and the per-row style transition. No network calls, no telemetry.

## Bug fix

Centring used `Scrollable.ensureVisible` on a per-line `GlobalKey`, which silently does nothing when the target row isn't laid out. After a long seek the active line could land outside the built window and simply stay off-screen. It now estimates the offset from the list's own extent first, then refines once on the next frame when the real row exists — with a single refinement pass, so it can't loop.

Auto-follow also stands down for 5s after a finger-initiated scroll (detected via `ScrollStartNotification.dragDetails`, so the view's own animated centring never counts), instead of yanking you back mid-sentence.

## Accessibility

- 48dp minimum touch target on seekable lines.
- The active line reports `selected: true` to screen readers, and timed lines are buttons with a "Play from this line" hint — emphasis is never colour-only, in the UI or in semantics.
- Both the line transition and the auto-scroll collapse to zero duration under `MediaQuery.disableAnimations`, as do the stage crossfade and the marker fade.
- Sizes come from the text theme, so text scaling multiplies them; the empty state scrolls rather than clipping when it outgrows the panel.

## Tests

`test/core/models/lyric_focus_test.dart` and `test/features/player/lyrics_experience_test.dart` — 25 new tests covering active-line selection, progressive fade, follow-on-boundary, the active line staying near centre across a song, tap-to-seek reaching the controller, touch target size, plain lyrics not being seekable, the unsynced fallback, missing and empty lyrics, reduced motion, large text scaling, and the light and dark schemes.

Full suite passes (3155 tests); `flutter analyze` and `dart format` are clean.

One thing worth flagging: Now Playing's fixed chrome doesn't fit an 800×600 window at a 3× text scale. I checked, and that's pre-existing — artwork mode overflows by the identical 91px on `main` — so it's out of scope here, but it's real and probably worth its own change.

## On language choice

Per the multi-language guidance, I looked at whether any of this belonged in `linthra_core` rather than Dart. My read is no, and the reasoning is about the workload:

- Parsing runs **once per track**, off the playback path, over ~30–120 lines.
- The timeline lookup is ~120 comparisons at 4 Hz — under 500 ops/second. An FFI round-trip four times a second would cost more in marshalling than the scan it replaced.
- `linthra_core` is deliberately not yet wired to Flutter (no `dart:ffi` in `lib/`, no cargo step in Gradle). Wiring it here would put a cargo/NDK cross-compile into the F-Droid source-build path, which today needs NDK+CMake only for SQLite — a real reproducibility cost for no measurable gain.

I also deliberately left `Lyrics.activeLineIndex` as a linear scan rather than converting it to a binary search: `Lyrics` has a `const` constructor so it can't cache a lookup table, and the scan isn't a bottleneck.

The case that **would** genuinely belong in Rust is searching lyrics *across* a large library — "find the song with this line" over 200k tracks is the same inverted-index problem `linthra_core` already solves, and it should sit next to the existing search index behind the same future FFI boundary. That's a separate piece of work, not this one.

## Not included

Draft, and not for merge yet — I'd like eyes on the emphasis curve and the veil alphas on real covers before this goes in. Worth checking on a device: how the fade band reads on a very long song, and whether the light-theme veil is heavy enough over a bright cover.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZs1dUyyaMd7g1ksApZbum)_