### PR TITLE
Stop the lyrics placeholder asking for a negative height

### DIFF
--- a/lib/features/player/widgets/lyrics_view.dart
+++ b/lib/features/player/widgets/lyrics_view.dart
@@ -71,13 +71,19 @@ class _LyricsPlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
+        // Room left once the scroll view's own padding is taken out. Floored at
+        // zero: a stage squeezed below that padding — a short landscape window,
+        // or Now Playing's fixed controls eating the height at a large text
+        // scale — would otherwise ask for a negative minimum, which is not a
+        // valid BoxConstraints and throws during layout.
+        final double available = constraints.maxHeight.isFinite
+            ? constraints.maxHeight - AppSpacing.md
+            : 0;
         return SingleChildScrollView(
           padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
           child: ConstrainedBox(
             constraints: BoxConstraints(
-              minHeight: constraints.maxHeight.isFinite
-                  ? constraints.maxHeight - AppSpacing.md
-                  : 0,
+              minHeight: available > 0 ? available : 0,
             ),
             child: EmptyState(
               icon: Icons.lyrics_outlined,

--- a/test/features/player/lyrics_experience_test.dart
+++ b/test/features/player/lyrics_experience_test.dart
@@ -13,6 +13,7 @@ import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/player_screen.dart';
 import 'package:linthra/features/player/widgets/album_artwork.dart';
 import 'package:linthra/features/player/widgets/lyrics/lyric_line_tile.dart';
+import 'package:linthra/features/player/widgets/lyrics_view.dart';
 
 import 'fake_playback_controller.dart';
 
@@ -630,6 +631,31 @@ void main() {
         find.text('line two'),
       );
       expect(line.size.height, greaterThan(30));
+    });
+
+    testWidgets('the empty state survives a stage squeezed to almost nothing',
+        (tester) async {
+      // Now Playing's fixed controls can leave the stage shorter than the
+      // placeholder's own padding — a short landscape window, or a large text
+      // scale. Asking for a negative minimum height is not valid
+      // BoxConstraints and throws during layout, so the floor has to hold.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            lyricsServiceProvider.overrideWithValue(_FakeLyricsService(null)),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(height: 8, width: 300, child: LyricsView()),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('the empty state scrolls rather than clipping at a huge scale',


### PR DESCRIPTION
Follow-up to #333. Codex flagged this on that PR, but the fix landed after it was merged, so it needs its own change — the bug is on `main` now.

## The bug

`_LyricsPlaceholder` (the empty and error states) reserves its scroll view's own padding out of the height it is given:

```dart
minHeight: constraints.maxHeight.isFinite
    ? constraints.maxHeight - AppSpacing.md   // 16
    : 0,
```

When the lyrics stage is shorter than that padding, the subtraction goes negative. A `BoxConstraints` with a negative minimum is not valid, so laying the placeholder out throws rather than showing it.

The stage is an `Expanded` under Now Playing's fixed metadata/transport/action chrome, and a flex child floors at zero rather than going negative — so a short landscape window, or a large text scale squeezing the chrome, gets there. That means it can throw exactly when a track has no lyrics, which is the common case for a local library.

Reproduced directly by pumping the lyrics panel in an 8px-tall box:

```
BoxConstraints has a negative minimum height.
BoxConstraints(0.0<=w<=Infinity, -8.0<=h<=Infinity; NOT NORMALIZED)
```

## The fix

Floor it at zero, with the reasoning in a comment so it doesn't get "simplified" back. A test pins it by rendering the panel in an 8px box and asserting no exception — it fails without the floor.

Full suite green on top of `main`; `flutter analyze` and `dart format` clean.

## Note on branch history

The original branch was auto-deleted when #333 merged. Per the repo's merged-PR convention this restarts from the current `main` and carries only the follow-up commit, so this is a new PR rather than a reopen of #333.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZs1dUyyaMd7g1ksApZbum)_