### PR TITLE
Make the DSP tests actually fail in Release

### DIFF
--- a/.github/workflows/cpp-audio-dsp.yml
+++ b/.github/workflows/cpp-audio-dsp.yml
@@ -17,16 +17,31 @@ permissions:
 jobs:
   audio-dsp:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Release is what ships, so it runs the realtime budget too.
+          - build_type: Release
+            ctest_args: ''
+          # Debug is a second opinion on the DSP expectations. The realtime
+          # budget is skipped here because an unoptimized build says nothing
+          # useful about the performance of the build users actually get.
+          - build_type: Debug
+            ctest_args: '--exclude-regex linthra_audio_realtime_budget'
+    name: audio-dsp (${{ matrix.build_type }})
     steps:
       - uses: actions/checkout@v4
 
       - name: Configure
         run: >-
           cmake -S native/linthra_audio -B build/linthra_audio
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
       - name: Build
         run: cmake --build build/linthra_audio --parallel
 
-      - name: Unit and realtime tests
-        run: ctest --test-dir build/linthra_audio --output-on-failure
+      - name: Run tests
+        run: >-
+          ctest --test-dir build/linthra_audio --output-on-failure
+          ${{ matrix.ctest_args }}

--- a/native/linthra_audio/tests/dsp_test.cpp
+++ b/native/linthra_audio/tests/dsp_test.cpp
@@ -2,14 +2,38 @@
 #include "linthra_audio/linthra_audio.h"
 
 #include <array>
-#include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <iostream>
 
 namespace {
+
+int failures = 0;
+
 bool near(float left, float right, float tolerance = 1.0e-4F) {
     return std::abs(left - right) <= tolerance;
 }
+
+// These tests used to use assert(), but CI builds this target in Release and
+// Release defines NDEBUG, which expands assert() to nothing. Every expectation
+// below was being compiled out, so the binary exited 0 without checking any DSP
+// behaviour at all.
+//
+// check() is ordinary code, so it runs in every build type. It records the
+// failure instead of aborting, which lets one run report every broken
+// expectation rather than only the first, and main() reports the count to CTest
+// through its exit status.
+void check(bool condition, const char* expression, const char* file, int line) {
+    if (condition) {
+        return;
+    }
+    std::cerr << file << ':' << line << ": CHECK failed: " << expression << '\n';
+    ++failures;
+}
+
 }  // namespace
+
+#define CHECK(condition) check((condition), #condition, __FILE__, __LINE__)
 
 int main() {
     using linthra::audio::DspChain;
@@ -24,7 +48,7 @@ int main() {
     const auto original = clean;
     bypass.process(clean.data(), 3, 2);
     for (std::size_t index = 0; index < clean.size(); ++index) {
-        assert(near(clean[index], original[index]));
+        CHECK(near(clean[index], original[index]));
     }
 
     // Preamp is deterministic and clip-free when the limiter is off.
@@ -35,8 +59,8 @@ int main() {
     preamp.configure(preamp_config);
     std::array<float, 2> preamp_frame{1.0F, -1.0F};
     preamp.process(preamp_frame.data(), 1, 2);
-    assert(near(preamp_frame[0], 0.501187F, 1.0e-3F));
-    assert(near(preamp_frame[1], -0.501187F, 1.0e-3F));
+    CHECK(near(preamp_frame[0], 0.501187F, 1.0e-3F));
+    CHECK(near(preamp_frame[1], -0.501187F, 1.0e-3F));
 
     // The stereo-linked limiter applies one gain to both channels. This avoids
     // pulling a loud channel down independently and shifting the stereo image.
@@ -48,8 +72,8 @@ int main() {
     std::array<float, 2> hot_frame{2.0F, 1.0F};
     limiter.process(hot_frame.data(), 1, 2);
     const float threshold = std::pow(10.0F, -0.3F / 20.0F);
-    assert(std::abs(hot_frame[0]) <= threshold + 1.0e-4F);
-    assert(near(hot_frame[0] / hot_frame[1], 2.0F, 1.0e-3F));
+    CHECK(std::abs(hot_frame[0]) <= threshold + 1.0e-4F);
+    CHECK(near(hot_frame[0] / hot_frame[1], 2.0F, 1.0e-3F));
 
     // A peaking band should alter an impulse response without producing NaN or
     // infinity. Exact coefficients are implementation detail; stability is the
@@ -65,27 +89,35 @@ int main() {
     equalizer.process(impulse.data(), impulse.size(), 1);
     bool changed = false;
     for (std::size_t index = 0; index < impulse.size(); ++index) {
-        assert(std::isfinite(impulse[index]));
+        CHECK(std::isfinite(impulse[index]));
         if (!near(impulse[index], index == 0 ? 0.5F : 0.0F)) {
             changed = true;
         }
     }
-    assert(changed);
+    CHECK(changed);
 
     // Smoke-test the C ABI that a future JNI/FFI layer will call.
     LinthraAudioDsp* c_dsp = linthra_audio_create(48'000.0F);
-    assert(c_dsp != nullptr);
-    LinthraAudioConfig c_config{};
-    c_config.limiter_enabled = 0;
-    c_config.preamp_db = 0.0F;
-    c_config.limiter_threshold_db = -0.3F;
-    c_config.limiter_release_ms = 80.0F;
-    linthra_audio_configure(c_dsp, &c_config);
-    std::array<float, 2> c_samples{0.2F, -0.2F};
-    linthra_audio_process(c_dsp, c_samples.data(), 1, 2);
-    assert(near(c_samples[0], 0.2F));
-    assert(near(c_samples[1], -0.2F));
-    linthra_audio_destroy(c_dsp);
+    CHECK(c_dsp != nullptr);
+    // The C entry points ignore a null handle, which would leave the samples
+    // untouched and make the checks below pass for the wrong reason.
+    if (c_dsp != nullptr) {
+        LinthraAudioConfig c_config{};
+        c_config.limiter_enabled = 0;
+        c_config.preamp_db = 0.0F;
+        c_config.limiter_threshold_db = -0.3F;
+        c_config.limiter_release_ms = 80.0F;
+        linthra_audio_configure(c_dsp, &c_config);
+        std::array<float, 2> c_samples{0.2F, -0.2F};
+        linthra_audio_process(c_dsp, c_samples.data(), 1, 2);
+        CHECK(near(c_samples[0], 0.2F));
+        CHECK(near(c_samples[1], -0.2F));
+        linthra_audio_destroy(c_dsp);
+    }
 
+    if (failures != 0) {
+        std::cerr << failures << " DSP check(s) failed\n";
+        return 1;
+    }
     return 0;
 }


### PR DESCRIPTION
Fixes #345

## What was wrong

`native/linthra_audio/tests/dsp_test.cpp` checked all of its expectations with `assert()`, and the workflow configures the target with `-DCMAKE_BUILD_TYPE=Release`.

CMake's Release flags are `-O3 -DNDEBUG`, and `assert()` expands to nothing under `NDEBUG`. Every DSP expectation was being compiled out. The test binary ran, did no checking, and exited 0.

This wasn't theoretical. The Release binary on `main` contains **zero** references to `__assert_fail`:

```
$ grep -m1 CXX_FLAGS CMakeFiles/linthra_audio_tests.dir/flags.make
CXX_FLAGS = -O3 -DNDEBUG -std=c++17
$ nm -C linthra_audio_tests | grep -c assert_fail
0
```

I then pointed the bypass test at a value the DSP never produces (`999.0F` instead of the untouched input) and ran it exactly as CI does:

```
$ ctest --test-dir build/linthra_audio --output-on-failure -R linthra_audio_tests
1/1 Test #1: linthra_audio_tests ..............   Passed    0.01 sec
100% tests passed, 0 tests failed out of 1
>>> ctest exit code: 0
```

A knowingly false test passed green. The same break in Debug aborted with exit 8, which is what confirms the whole difference was `NDEBUG`.

## Why Release made the old checks unsafe

`assert()` is a debugging aid, not a test assertion — the standard requires it to be a no-op when `NDEBUG` is defined. Any build that turns on optimization the normal way turns the checks off, so the one configuration we actually gated merges on was the one configuration doing no verification. The suite could only have caught a regression on a developer's Debug build.

## What changed

**`native/linthra_audio/tests/dsp_test.cpp`**

A small `CHECK` helper replaces `assert()`. It's ordinary code with no `NDEBUG` dependency, so the expectations run in every build type:

```cpp
void check(bool condition, const char* expression, const char* file, int line) {
    if (condition) {
        return;
    }
    std::cerr << file << ':' << line << ": CHECK failed: " << expression << '\n';
    ++failures;
}

#define CHECK(condition) check((condition), #condition, __FILE__, __LINE__)
```

It counts failures instead of aborting, so one run reports every broken expectation with file and line rather than stopping at the first, and `main()` returns non-zero so CTest fails. No testing framework added — the helper is about 10 lines at the top of the file it serves.

The 10 expectations are otherwise unchanged: same conditions, same tolerances, same comments. One behavioural fix beyond the mechanical swap — the C ABI smoke test is now guarded on a non-null handle. The C entry points ignore a null handle, so without the guard the two checks after it would leave the samples untouched and pass for the wrong reason.

**`.github/workflows/cpp-audio-dsp.yml`**

Added a Debug configuration alongside Release as a second opinion on the DSP expectations. The realtime budget stays Release-only: an unoptimized build says nothing useful about the performance of the build users actually get, and holding it to a realtime budget on a shared runner invites a spurious red. Debug measured ~8x slower locally (401 ms vs 51 ms for the same 60 s of audio), so it would be measuring the wrong thing even where it passes.

`CMakeLists.txt` needed no change — once the checks are real code, the existing `add_test` entries already propagate the exit status.

## How I verified a failing check now fails CI

Re-broke the *same* expectation that passed silently before, and rebuilt in Release:

```
$ ctest --test-dir build/linthra_audio --output-on-failure -R linthra_audio_tests
.../dsp_test.cpp:51: CHECK failed: near(clean[index], 999.0F)
  ... (6 occurrences, one per sample)
6 DSP check(s) failed

0% tests passed, 1 tests failed out of 1
The following tests FAILED:
	  1 - linthra_audio_tests (Failed)
>>> ctest exit code: 8
```

Release now fails, with the failing expression and line. Debug fails the same way (exit 8). I also confirmed the expectations are physically present in the optimized binary — `strings` on the Release build lists each one (`near(clean[index], original[index])`, `std::abs(hot_frame[0]) <= threshold + 1.0e-4F`, `c_dsp != nullptr`, …), where before there was nothing.

The correct expectation was restored before committing; the diff contains no `999.0F`.

## Commands run

```bash
# Release — matches the CI job
cmake -S native/linthra_audio -B build/rel -DCMAKE_BUILD_TYPE=Release
cmake --build build/rel --parallel
ctest --test-dir build/rel --output-on-failure

# Debug — the new CI job
cmake -S native/linthra_audio -B build/dbg -DCMAKE_BUILD_TYPE=Debug
cmake --build build/dbg --parallel
ctest --test-dir build/dbg --output-on-failure \
  --exclude-regex linthra_audio_realtime_budget

# Benchmark, unchanged
./build/rel/linthra_audio_benchmark
```

Results: Release 2/2 passed, Debug 1/1 passed, both builds clean under `-Wall -Wextra -Wpedantic -Werror`. Benchmark output preserved:

```
Processed 60 seconds of 48 kHz stereo / 5-band EQ + limiter in 49 ms (0.000821616x realtime)
```

CI on this PR confirms it end to end: `audio-dsp (Release)` ran 2/2 tests, `audio-dsp (Debug)` ran 1/1, both green.

## Scope

Only the test file and the workflow are touched — no source file under `src/` or `include/` is in the diff. DSP algorithms, limiter behaviour, EQ behaviour and the Android playback integration are untouched, and the realtime path stays allocation-free and lock-free because nothing in it changed. Nothing here overlaps #337 or #342; this only makes the existing test infrastructure trustworthy so those can be built on it.
