### PR TITLE
docs: make contributing guide more personal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,40 @@
 # Contributing to Linthra
 
-Hey thanks for being here. Linthra is a self-hosted Android music player, and
-this is a great time to get involved. Small changes can still shape the project
-in a real way.
+Hey, thanks for checking out Linthra.
 
-**You do not need to know Dart or Flutter to contribute to Linthra.** Testing the
-app, improving docs, reporting bugs, or working in one of the native/tooling
-areas are all real contributions.
+The project is still growing, so even a small contribution can make a real
+difference. Code is welcome, but testing the app, reporting bugs, improving docs,
+or helping with tooling is useful too.
 
-If you're not sure where to start, check the
-[issue tracker](https://github.com/TheZupZup/Linthra/issues). Issues tagged
-**`good first issue`** are intentionally kept approachable, and **`help wanted`**
-shows where an extra pair of hands would help most.
+You also don't need to know Dart or Flutter. Linthra has a few different areas,
+so if you know Kotlin, Rust, C++, Python, SQL, or just want to test things, there
+is probably something you can help with.
 
-## Pick the language you know
+If you don't know where to start, check the
+[issue tracker](https://github.com/TheZupZup/Linthra/issues). `good first issue`
+is a good place to start, and `help wanted` means I would really appreciate an
+extra pair of hands there.
 
-Linthra uses different languages where they have a real technical job. Pick the
-area that matches what you already know:
+## Pick the area you know
+
+I don't want languages in the repo just for the GitHub stats. Each one should
+have a real reason to be there.
 
 | Language | Good place to contribute |
 | --- | --- |
-| **Dart / Flutter** | UI, player orchestration, providers, onboarding, app logic |
+| **Dart / Flutter** | UI, player logic, providers, onboarding, app features |
 | **Kotlin** | Android APIs, SAF/MediaStore, media session, Android Auto, platform channels |
-| **Rust** | large-library indexing/search and future 100k–200k-track primitives |
-| **C++** | realtime audio DSP, EQ/limiting, future audio analysis and SIMD |
-| **Python** | releases, developer tooling, fixtures, benchmarks, validation |
-| **SQL** | SQLite indexes/query plans and very-large-library performance |
+| **Rust** | large-library indexing/search and performance-heavy core work |
+| **C++** | realtime audio DSP, EQ, limiting, audio processing |
+| **Python** | developer tooling, fixtures, benchmarks, validation |
+| **SQL** | SQLite indexes, query plans and large-library performance |
 
-The detailed map and boundaries are in
-[Contributing by language](./docs/language-areas.md). A language should only be
-used when it has a real technical role in the project.
+There is a more detailed map in
+[Contributing by language](./docs/language-areas.md).
 
 ## Setting up the project
 
-For Dart/Flutter/Android work, the normal setup is:
+For normal Dart/Flutter/Android work, start with:
 
 ```bash
 ./scripts/setup_flutter.sh
@@ -44,95 +45,102 @@ For Dart/Flutter/Android work, the normal setup is:
 `verify_android.sh` runs the main Flutter checks and can build a debug APK when
 an Android SDK is available.
 
-Full setup details and troubleshooting are in
-[docs/development.md](./docs/development.md). The
-[codebase tour](./docs/codebase-tour.md) is useful if you want a map of where
-features live before changing anything.
+More setup details are in [docs/development.md](./docs/development.md), and the
+[codebase tour](./docs/codebase-tour.md) is useful if you want to see where
+things live before touching the code.
 
-Native/tooling areas have their own focused commands and CI:
+For the other areas:
 
 - `native/linthra_core/` uses Cargo.
 - `native/linthra_audio/` uses CMake.
-- `tools/large_library/` contains Python/SQLite tooling for large-library work.
+- `tools/large_library/` contains the Python and SQLite large-library tooling.
 
-## Picking something to work on
+## Before you start
 
-- Comment on an issue before starting so two people don't unknowingly do the
-  same work.
-- Keep independent problems in separate issues when they can be fixed
-  separately. It makes them easier to understand, review, assign, and close.
-- If several problems are really one bug or one flow, one issue with a short
-  checklist is fine.
-- Opening a small PR for something not yet tracked is okay too — just explain
-  what changed and why.
+If there is already an issue for what you want to fix, leave a comment first.
+It helps avoid two people doing the same work without knowing it.
+
+If you find several unrelated problems, I prefer separate small issues when they
+can be fixed separately. They are easier to understand, review, assign, and
+close that way.
+
+If a few problems are really the same bug or the same flow, one issue with a
+small checklist is completely fine.
+
+You can also open a small PR for something that does not already have an issue.
+Just explain what you changed and why.
 
 ## Pull requests
 
-- **Keep PRs small and focused.** One change per PR is much easier to review and
-  merge than a big bundle.
-- **Write a clear description** with what changed and why. Link the issue it
-  closes when there is one.
-- **Add tests when it makes sense**, especially for bug fixes and new logic.
-- **No unrelated changes.** Don't reformat or refactor nearby code unless it is
-  part of the same job.
-- Run the relevant verification command before pushing.
+Please keep PRs focused. One job per PR is much easier for me to review and much
+easier for someone else to understand later.
+
+A good PR should:
+
+- explain what changed and why
+- link the issue it fixes when there is one
+- add tests when the change needs them
+- avoid unrelated refactors or formatting changes
+- run the relevant checks before pushing
+
+I am completely fine asking for a small correction during review. That is normal
+and it does not mean the contribution is bad. If something looks good, I want to
+get it merged.
 
 ## Code style
 
-Nothing exotic — just code that's easy to read and maintain:
+I mostly care that the code stays easy to understand and maintain.
 
-- **Readable over clever.** Clear names and straightforward control flow win.
-- **Modular.** Keep files and functions focused.
-- **No premature abstraction.** Add a shared layer when there is a real reason
-  for it, not just because two lines look similar.
-- **Comment the why, not the what.** Explain non-obvious decisions rather than
-  narrating obvious code.
+- Prefer clear code over clever code.
+- Keep files and functions focused.
+- Don't create abstractions before there is a real reason for them.
+- Comments should explain why something is weird or important, not repeat what
+  the code already says.
 
-## Privacy & security
+## Privacy and security
 
-A few rules are non-negotiable:
+These rules matter a lot for Linthra:
 
-- **Never log tokens, passwords, or secrets.**
-- **Don't persist authenticated URLs.** Stream URLs must not end up in logs,
-  diagnostics, or long-term storage.
-- **Keep credentials encrypted at rest.**
-- **No telemetry or phoning home.** Nothing should leave the device unless the
-  user explicitly chooses it.
+- Never log tokens, passwords, or secrets.
+- Don't save authenticated stream URLs in logs, diagnostics, or long-term
+  storage.
+- Keep credentials encrypted at rest.
+- No telemetry or phoning home unless the user explicitly chooses it.
 
-If a change touches authentication, streaming, diagnostics, or stored
-credentials, mention the security impact in the PR description so it is easy to
-review.
+If your change touches authentication, streaming, diagnostics, or stored
+credentials, mention it in the PR so I know to review that part carefully.
 
 ## Testing
 
-Some behaviour only shows up properly on a real phone, server, Cast receiver, or
-Android Auto setup. If your PR touches one of those areas and you can test it on
-real hardware, please say what you tested in the PR.
+Some bugs only show up on real hardware. If your change touches a real music
+server, Cast, Android Auto, offline playback, or something device-specific and
+you can test it for real, please say what you tested in the PR.
 
 The [manual QA checklist](./docs/manual-test-checklist.md) covers the important
-paths. For bug reports, **Settings → Report a bug** can build a secret-free
-report you can review before opening an issue.
+paths. You can also use **Settings → Report a bug** to build a secret-free report
+before opening an issue.
 
-## Supporting contributors
+## About contributor funding
 
-Linthra is open source and contributions are currently voluntary, but I don't
-want the project to grow while pretending the people helping build it don't
-matter.
+Right now, contributing to Linthra is voluntary and I can't promise payment for
+a PR.
 
-If Linthra eventually receives enough recurring donations or sponsorships to
-make it sustainable, I plan to create a public contributor sponsorship program
-and share part of that funding with people who meaningfully help the project.
+But I also don't want Linthra to become successful one day while I keep all the
+support for myself and other people are helping me build it.
 
-The exact system would be designed transparently when we actually reach that
-point, because I want it to stay fair and sustainable for everyone.
+If Linthra starts receiving enough recurring donations or sponsorships, my plan
+is to open a public contributor sponsorship page and put part of that money back
+toward the people who help the project.
 
-For now I can't promise payment for a contribution, but if Linthra becomes
-financially successful, my goal is not to keep all of that support for myself
-while other people are helping build it.
+I don't have a formula for that yet because the money does not exist yet. If we
+get there, I want to figure it out openly and keep it fair.
+
+Basically, if Linthra grows because people help me, I want the people who helped
+it grow to be part of that success too.
 
 ## License
 
-Linthra is [MPL-2.0](./LICENSE). By contributing, you agree your contributions
-are licensed under the same terms.
+Linthra is [MPL-2.0](./LICENSE). By contributing, you agree that your
+contribution is licensed under the same terms.
 
-Thanks again — see you in the issues.
+Thanks for helping Linthra. Even a small fix is appreciated.


### PR DESCRIPTION
Small follow-up to make `CONTRIBUTING.md` sound more natural and personal while keeping the same contributor rules and funding idea.

- simpler wording
- more first-person voice
- less formal phrasing
- keeps setup, issue, PR, security, testing and license guidance
- keeps the future contributor funding idea without promising payment today