### PR TITLE
ci: open weekly update PRs for GitHub Actions and Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot opens update PRs and stops there. Nothing here merges itself —
+# a human reviews every PR and decides what lands (issue #362).
+#
+# Dependabot PRs run the normal CI: ci.yml triggers on `pull_request` with no
+# branch filter, and both it and rust-core.yml declare `permissions:
+# contents: read` and use no secrets, which is exactly the context a Dependabot
+# PR gets. No dedicated token is needed here — the CI_FIXER_GITHUB_TOKEN
+# pattern in flutter-ci-fixer.yml exists because a *workflow* pushing with the
+# default GITHUB_TOKEN cannot retrigger CI. Dependabot is not a workflow, so
+# that limitation does not apply to it.
+version: 2
+
+updates:
+  # Action pins live in two places in this repo: .github/workflows/*.yml and the
+  # composite action at .github/actions/setup-flutter (which owns the only
+  # subosito/flutter-action pin). Both directories are listed so neither drifts
+  # unwatched.
+  #
+  # The single "*" group means one PR bumps a given action everywhere at once.
+  # test/tooling/toolchain_pins_test.dart fails when the same action is pinned
+  # to two different refs across .github/, so a per-directory split would open
+  # PRs that are red by construction. Grouping also keeps this to one review a
+  # week instead of one per action.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/setup-flutter"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+
+  # The Rust search core (native/linthra_core). Cargo.lock currently resolves to
+  # linthra_core and nothing else, so this finds no updates today; it is here so
+  # the first real dependency is covered from the moment it is added.
+  # rust-core.yml already runs fmt, clippy, tests and the 200k benchmark on
+  # native/linthra_core/**, so a Cargo PR gets the real checks. The lockfile is
+  # committed for the reproducible F-Droid build (#330), which is why updates
+  # have to arrive as a reviewable PR rather than a silent resolve.
+  - package-ecosystem: "cargo"
+    directory: "/native/linthra_core"
+    schedule:
+      interval: "weekly"
+    groups:
+      cargo:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,15 @@ updates:
   # subosito/flutter-action pin). Both directories are listed so neither drifts
   # unwatched.
   #
-  # The single "*" group means one PR bumps a given action everywhere at once.
-  # test/tooling/toolchain_pins_test.dart fails when the same action is pinned
-  # to two different refs across .github/, so a per-directory split would open
-  # PRs that are red by construction. Grouping also keeps this to one review a
-  # week instead of one per action.
+  # group-by: dependency-name is what makes the two directories safe. Without
+  # it a grouped multi-directory update opens one PR per directory, so an action
+  # used in both a workflow and the composite action would move in two separate
+  # PRs — and test/tooling/toolchain_pins_test.dart fails the moment the same
+  # action is pinned to two different refs across .github/. Both PRs would be
+  # red by construction. With it, each action gets one PR that updates every
+  # directory at once, so a ref can never be half-applied. The cost is a PR per
+  # action instead of one combined PR, which is the right trade against a
+  # guardrail that exists precisely to catch split refs.
   - package-ecosystem: "github-actions"
     directories:
       - "/"
@@ -31,6 +35,7 @@ updates:
       github-actions:
         patterns:
           - "*"
+        group-by: dependency-name
     commit-message:
       prefix: "ci"
 

--- a/.github/workflows/flutter-ci-fixer.yml
+++ b/.github/workflows/flutter-ci-fixer.yml
@@ -81,6 +81,16 @@ jobs:
             exit 0
           fi
 
+          # A Dependabot update that breaks CI has to stay broken. The red is
+          # the whole signal — it says this bump needs a human — and a repair
+          # commit would paper over which update broke what. This runs before
+          # the credential check and both Codex attempts, so no repair is ever
+          # generated for these branches, let alone published.
+          if [[ "$head_branch" == dependabot/* ]]; then
+            echo "Skipping Dependabot branch $head_branch; update PRs stay red for review."
+            exit 0
+          fi
+
           # Only normal CI runs are repair candidates. A repair published with
           # the dedicated token triggers normal push/pull_request CI again; if
           # that new CI fails on a codex/ci-fix-* branch it is rejected below.
@@ -347,7 +357,11 @@ jobs:
   publish:
     name: Publish validated Flutter fix
     needs: fix
-    if: ${{ needs.fix.outputs.ready == 'true' }}
+    # The Dependabot check in the fix job already stops a repair being built,
+    # so target_branch can never be a dependabot/ branch here. Restated anyway:
+    # this is the last gate before a commit is pushed, and "never publish onto
+    # an update PR" is worth enforcing where the push actually happens.
+    if: ${{ needs.fix.outputs.ready == 'true' && !startsWith(needs.fix.outputs.target_branch, 'dependabot/') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
PR 2 for #362. Adds `.github/dependabot.yml` and closes two safety gaps in `flutter-ci-fixer.yml`.

## What triggers a PR, and when

Dependabot runs on GitHub's side on a **weekly** schedule (no time pinned, so GitHub picks a consistent slot). It opens a PR only when a pinned version is actually behind. Two ecosystems:

| Ecosystem | Where it looks | Opens a PR when |
|---|---|---|
| `github-actions` | `.github/workflows/*.yml` and `.github/actions/setup-flutter` | a pinned action has a newer release |
| `cargo` | `native/linthra_core` | a crate in `Cargo.lock` has a newer version |

**Nothing auto-merges.** Dependabot only opens PRs — there is no auto-merge workflow, no `gh pr merge`, no automerge label. A human reviews and merges, per the rule in #362.

## Two directories, and why `group-by` is required

Action refs live in two places in this repo, not one. `.github/workflows/*.yml` holds 15 `actions/checkout@v5` pins and friends, but `.github/actions/setup-flutter/action.yml` owns the **only** `subosito/flutter-action@v2` pin. A config pointed at `/` alone would leave the composite action unwatched forever.

Listing both directories is not sufficient on its own. A grouped multi-directory update opens **one PR per directory** by default, so an action used in both a workflow and the composite action would be bumped in two separate PRs. `test/tooling/toolchain_pins_test.dart` (added in #363) fails the moment the same action carries two different refs across `.github/` — so both of those PRs would be red by construction, each one half-applying the bump.

`group-by: dependency-name` inverts that: one PR per action, spanning every directory, so a ref can never be half-applied. The cost is a PR per action rather than one combined PR — the right trade against a guardrail that exists precisely to catch split refs.

No action currently appears in both directories, so this changes nothing today. It matters the first time someone adds, say, `actions/checkout` to the composite action — at which point the wrong config would fail silently in the form of two permanently-red PRs.

## The CI fixer must not repair Dependabot PRs

If a Dependabot update breaks CI, the red **is** the deliverable — it says this bump needs a human. A repair commit would paper over which update broke what. `flutter-ci-fixer.yml` triggers on `workflow_run` when CI completes and would otherwise have treated a failed Dependabot run as an ordinary repair candidate.

Two gates, both explicit:

- **`fix` job** — the run-resolution step now bails on `dependabot/*`, alongside the existing fork and event-type checks. This sits before the Codex credential check and both repair attempts, so nothing is ever generated for those branches.
- **`publish` job** — its `if:` also requires the target branch not to start with `dependabot/`. Unreachable given the first gate, but this is the last point before a commit is pushed, and "never publish onto an update PR" is worth enforcing where the push happens.

Previously the only thing standing in the way was the protected-path guard, which forbids `^\.github/` and so would have aborted an Actions bump repair incidentally. That guard does **not** cover `native/`, so a Cargo PR had no protection at all. Both are now covered by branch name regardless of which files the update touched.

## Token / secret setup: none needed

#362 asked to reuse the dedicated-token pattern so update PRs actually run CI. Having traced it, **that pattern does not apply to Dependabot, and no new secret is required.**

The `CI_FIXER_GITHUB_TOKEN` in `flutter-ci-fixer.yml` exists because a *workflow* pushing with the default `GITHUB_TOKEN` cannot retrigger CI — GitHub suppresses that to prevent recursive runs. Dependabot is not a workflow; it is a first-party service, and its PRs raise `pull_request` events normally.

The checks then have to survive Dependabot's restricted context (read-only `GITHUB_TOKEN`, no access to regular repo secrets). Both relevant workflows already do:

- **`ci.yml`** — `on: pull_request` with no branch filter, `permissions: contents: read`, and no secrets at all. Its own comment says *"No secrets are used, so these checks run identically on fork PRs"* — a Dependabot PR is the same situation.
- **`rust-core.yml`** — `on: pull_request` with `paths: native/linthra_core/**`, which a Cargo PR matches. Also `contents: read`, also no secrets.

So if a Dependabot PR shows no checks, that is a bug to investigate, not a missing secret. **No repository or Dependabot secret needs to be created.**

## On the Cargo half of #362

The task framing for this PR said Linthra has no Rust project and that Cargo should be treated as not applicable. **That is not the case** — `native/linthra_core` is a real crate (`linthra_core`, added in #321, lockfile committed in #330 specifically for reproducible F-Droid builds) with its own `rust-core.yml` running fmt, clippy, tests and the 200k benchmark. It likely just doesn't show up in the repo's language breakdown next to the Dart and C++. Flagged and confirmed before writing anything, so Cargo is **included** here as #362 originally specified, not skipped.

Worth setting expectations: `Cargo.lock` currently resolves to `linthra_core` and nothing else — zero external crates — so this entry will find no updates today. It is wired up now so the first real dependency is covered the moment it lands.

## What Dependabot can touch

- `.github/workflows/*.yml`
- `.github/actions/setup-flutter/action.yml`
- `native/linthra_core/Cargo.toml`, `native/linthra_core/Cargo.lock`

The last three are wider than a strict workflows-only reading, and follow directly from covering the composite action and Cargo. Structurally out of reach either way: `metadata/`, `fastlane/`, the app version, application code, test code, release notes, signing files, licenses.

## Testing

- `.github/dependabot.yml` validates clean against SchemaStore's `dependabot-2.0.json` (Draft-07, `additionalProperties: false`), including `group-by`, whose only permitted value there is `dependency-name`.
- `flutter-ci-fixer.yml` parses; both jobs intact; the `dependabot/*` check lands at the run-resolution step, ahead of the credential check and both Codex steps.
- `./scripts/check_secrets.sh` passes.
- `toolchain_pins_test.dart` runs inside `Flutter checks`, and its `_scannedDirs` includes `.github`, so it inspects both changed files. The added lines introduce no `uses:` pin and no Flutter/Gradle/AGP/Kotlin/JDK version string.
- No app code, tests, or F-Droid metadata touched.

## Not in this PR

Dart/Flutter package updates (PR 3), the Flutter SDK checker (PR 4), and Gradle/AGP/Kotlin (PR 5) stay for their own PRs.