### PR TITLE
ci: open weekly Dart package update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,17 @@
 # Dependabot opens update PRs and stops there. Nothing here merges itself —
 # a human reviews every PR and decides what lands (issue #362).
 #
+# Dart packages are deliberately NOT here. Dependabot supports the pub
+# ecosystem, but it resolves with its own bare Dart SDK and installs no Flutter,
+# while pubspec.lock has to be resolved with the SDK pinned in .flutter-version
+# for the reproducible F-Droid build — and pub has no `lockfile-only` versioning
+# strategy, so every option it offers (widen / increase / increase-if-necessary)
+# rewrites the constraints in pubspec.yaml, which an automatic update must never
+# do. .github/workflows/dart-dependency-updates.yml handles pub instead; adding
+# a `pub` entry here fails
+# test/tooling/dependency_update_guardrails_test.dart so the two cannot end up
+# fighting over the same lockfile. See docs/dependency-updates.md.
+#
 # Dependabot PRs run the normal CI: ci.yml triggers on `pull_request` with no
 # branch filter, and both it and rust-core.yml declare `permissions:
 # contents: read` and use no secrets, which is exactly the context a Dependabot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
 # Quality, security, and release-hygiene checks on every PR and on pushes to
-# main. Three independent jobs run in parallel:
+# main. Four independent jobs run in parallel:
 #   * flutter             — format, analyze, test, lockfile-enforced pub get.
 #   * secret-scan         — offline scan for committed secrets / private data.
 #   * release-bump-guard  — release/* PRs only: the bump must be version-only.
+#   * dependency-guard    — deps/* PRs only: the update must be lockfile-only.
 on:
   push:
     branches: [main]
@@ -86,3 +87,27 @@ jobs:
           set -euo pipefail
           git diff --name-only "$BASE_SHA" HEAD \
             | ./scripts/check_release_bump_files.sh
+
+  dependency-guard:
+    name: Dependency update touches only the lockfile
+    runs-on: ubuntu-latest
+    # Only meaningful for the PRs the "Dart dependency updates" workflow opens
+    # (it pushes the deps/dart-packages branch). The updater already refuses to
+    # commit anything but pubspec.lock; re-checking here covers what happens to
+    # the branch afterwards — a well-meaning "just fix the test" commit pushed
+    # onto the update PR is exactly the change that must not ride along.
+    if: ${{ startsWith(github.head_ref, 'deps/') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # Local twin: scripts/check_dependency_update_files.sh.
+      - name: Check changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA" HEAD \
+            | ./scripts/check_dependency_update_files.sh

--- a/.github/workflows/dart-dependency-updates.yml
+++ b/.github/workflows/dart-dependency-updates.yml
@@ -1,0 +1,243 @@
+name: Dart dependency updates
+
+# Weekly check for Dart/Flutter package updates that fit inside the constraints
+# already written in pubspec.yaml, prepared as one reviewable draft PR (#362).
+#
+# Nothing here merges. The workflow's whole job is to say "these packages can
+# move; here is the lockfile; here is what CI thinks of it" and then stop.
+#
+# Why this is not Dependabot. Dependabot does support the pub ecosystem, but it
+# cannot meet two of Linthra's requirements:
+#
+#   * It resolves with its own bare Dart SDK and installs no Flutter at all,
+#     while pubspec.lock has to be resolved with the SDK pinned in
+#     .flutter-version — the reproducible F-Droid build resolves from that
+#     committed lockfile (docs/release-process.md §7). The difference is not
+#     theoretical: a resolution with the pinned SDK writes `flutter: ">=3.44.0"`
+#     into the lockfile's `sdks:` block, which a Flutter-less resolver cannot
+#     arrive at.
+#   * pub has no `versioning-strategy: lockfile-only`. Its three strategies
+#     (widen / increase / increase-if-necessary) all rewrite the constraints in
+#     pubspec.yaml, and an automatic update must never do that.
+#
+# So Dependabot keeps GitHub Actions and Cargo (.github/dependabot.yml) and this
+# workflow keeps pub. See docs/dependency-updates.md.
+on:
+  schedule:
+    # Mondays, early UTC — same weekly cadence as the Dependabot ecosystems.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+# One update at a time: the runs share a branch, and a second run force-pushing
+# underneath the first would be the only way this workflow could lose work.
+concurrency:
+  group: dart-dependency-updates
+  cancel-in-progress: false
+
+# The job's own GITHUB_TOKEN stays read-only. Every write goes through the
+# dedicated publication token in the publish step, because a push or PR made
+# with GITHUB_TOKEN does not trigger the PR's normal CI — and an update PR that
+# runs no checks is a broken updater.
+permissions:
+  contents: read
+
+env:
+  UPDATE_BRANCH: deps/dart-packages
+  COMMIT_SUBJECT: "chore(deps): update Dart packages within current constraints"
+
+jobs:
+  update:
+    name: Resolve and prepare update PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      # The pinned SDK, from .flutter-version. This is the reason the workflow
+      # exists at all, so it is the first thing that happens.
+      - name: Set up Flutter
+        uses: ./.github/actions/setup-flutter
+
+      # Local twin: ./scripts/update_dart_dependencies.sh. Runs
+      # `flutter pub upgrade` (which resolves inside the existing constraints
+      # and only rewrites pubspec.lock), asserts nothing outside pubspec.lock
+      # moved, and re-checks the result with `flutter pub get --enforce-lockfile`.
+      # Exit 3 means everything is already at the newest allowed version.
+      - name: Resolve updates with the pinned SDK
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Kept outside the checkout: the updater refuses to continue if
+          # anything but pubspec.lock changed, and its own report is not a
+          # repository change. Exported for the publish step.
+          REPORT_DIR="$RUNNER_TEMP/dep-update"
+          echo "REPORT_DIR=$REPORT_DIR" >> "$GITHUB_ENV"
+
+          status=0
+          ./scripts/update_dart_dependencies.sh --output-dir "$REPORT_DIR" || status=$?
+          case "$status" in
+            0) echo "changed=true" >> "$GITHUB_OUTPUT" ;;
+            3) echo "changed=false" >> "$GITHUB_OUTPUT"
+               echo "No Dart package updates are available inside the current constraints." >> "$GITHUB_STEP_SUMMARY" ;;
+            *) exit "$status" ;;
+          esac
+
+      # The Flutter checks CI runs, minus the lockfile step the script already
+      # did. These are informational: a dependency that needs application
+      # changes must still reach a human as a red PR, so a failure here is
+      # recorded in the PR body rather than swallowing the update.
+      - name: Verify formatting
+        id: format
+        if: ${{ steps.resolve.outputs.changed == 'true' }}
+        continue-on-error: true
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze
+        id: analyze
+        if: ${{ steps.resolve.outputs.changed == 'true' }}
+        continue-on-error: true
+        run: flutter analyze
+
+      - name: Run tests
+        id: test
+        if: ${{ steps.resolve.outputs.changed == 'true' }}
+        continue-on-error: true
+        run: flutter test
+
+      - name: Require workflow-triggering publication token
+        if: ${{ steps.resolve.outputs.changed == 'true' }}
+        env:
+          PUBLISH_TOKEN: ${{ secrets.DEPENDENCY_UPDATE_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "$PUBLISH_TOKEN" ]]; then
+            echo "::error::DEPENDENCY_UPDATE_TOKEN is required to publish the update PR so it runs normal CI. See docs/dependency-updates.md."
+            exit 1
+          fi
+
+      - name: Open or update the draft dependency PR
+        if: ${{ steps.resolve.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDENCY_UPDATE_TOKEN }}
+          FORMAT_OUTCOME: ${{ steps.format.outcome }}
+          ANALYZE_OUTCOME: ${{ steps.analyze.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Reuse the one update branch instead of opening a new PR every week.
+          remote_sha="$(git ls-remote origin "refs/heads/$UPDATE_BRANCH" | cut -f1)"
+
+          if [[ -n "$remote_sha" ]]; then
+            git fetch --no-tags origin "+refs/heads/$UPDATE_BRANCH:refs/remotes/origin/$UPDATE_BRANCH"
+
+            # Refuse to overwrite work this workflow did not create. The branch
+            # is expected to hold nothing but this workflow's own commit; if
+            # someone pushed a fix onto it, that is a human's PR now and a
+            # force-push would silently delete it.
+            foreign="$(git log --format='%an|%s' "HEAD..origin/$UPDATE_BRANCH" \
+              | grep -vxF "github-actions[bot]|$COMMIT_SUBJECT" || true)"
+            if [[ -n "$foreign" ]]; then
+              {
+                echo "### Update skipped"
+                echo
+                echo "\`$UPDATE_BRANCH\` carries commits this workflow did not write:"
+                echo
+                echo '```text'
+                echo "$foreign"
+                echo '```'
+                echo
+                echo "Refusing to force-push over them. Merge or close the open PR first."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::$UPDATE_BRANCH has commits from someone else; not publishing."
+              exit 0
+            fi
+
+            # Nothing new since the last run: leave the open PR exactly as it is
+            # rather than force-pushing an identical tree and re-notifying.
+            if git show "origin/$UPDATE_BRANCH:pubspec.lock" 2>/dev/null | diff -q - pubspec.lock >/dev/null 2>&1; then
+              echo "The open update PR already carries this lockfile; nothing to push." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+          fi
+
+          git checkout -B "$UPDATE_BRANCH"
+          git add pubspec.lock
+          git commit -m "$COMMIT_SUBJECT"
+
+          if [[ -n "$remote_sha" ]]; then
+            git push --force-with-lease="$UPDATE_BRANCH:$remote_sha" origin "$UPDATE_BRANCH"
+          else
+            git push -u origin "$UPDATE_BRANCH"
+          fi
+
+          # Report the checks rather than gate on them: a dependency that needs
+          # application changes is exactly the signal this PR exists to deliver.
+          verdict() {
+            case "$1" in
+              success) printf 'passed' ;;
+              *)       printf '**failed**' ;;
+            esac
+          }
+
+          {
+            echo "Weekly Dart/Flutter package refresh, resolved with the Flutter SDK"
+            echo "pinned in \`.flutter-version\`."
+            echo
+            echo "Only \`pubspec.lock\` changed. No constraint in \`pubspec.yaml\` was"
+            echo "touched, so no direct dependency crossed a major version, and no"
+            echo "application code, test, F-Droid metadata, Fastlane file, release note,"
+            echo "signing file, license or app version was modified."
+            echo
+            cat "$REPORT_DIR/summary.md"
+            echo
+            echo "### Checks run before this PR was opened"
+            echo
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| \`flutter pub get --enforce-lockfile\` | passed |"
+            echo "| \`dart format --set-exit-if-changed .\` | $(verdict "$FORMAT_OUTCOME") |"
+            echo "| \`flutter analyze\` | $(verdict "$ANALYZE_OUTCOME") |"
+            echo "| \`flutter test\` | $(verdict "$TEST_OUTCOME") |"
+            echo
+            echo "A failure above is not a bug in this PR — it means an update needs"
+            echo "application changes, and that is a decision for a human. The PR is"
+            echo "left red on purpose; the CI fixer is kept off this branch."
+            echo
+            echo "Reproduce locally:"
+            echo
+            echo '```bash'
+            echo './scripts/setup_flutter.sh'
+            echo 'export PATH="$PWD/.tool/flutter/bin:$PATH"'
+            echo './scripts/update_dart_dependencies.sh'
+            echo '```'
+            echo
+            echo "See [docs/dependency-updates.md](docs/dependency-updates.md)."
+          } > "$REPORT_DIR/pr-body.md"
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$UPDATE_BRANCH" \
+            --state open --json number --jq '.[0].number // empty')"
+
+          if [[ -n "$existing" ]]; then
+            # --body-file only; leave the draft/ready state alone so a reviewer
+            # who marked the PR ready does not get it flipped back.
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file "$REPORT_DIR/pr-body.md"
+            echo "Updated PR #$existing." >> "$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh pr create --repo "$GITHUB_REPOSITORY" --draft \
+              --base main --head "$UPDATE_BRANCH" \
+              --title "chore(deps): update Dart packages within current constraints" \
+              --body-file "$REPORT_DIR/pr-body.md")"
+            echo "Opened $url" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/flutter-ci-fixer.yml
+++ b/.github/workflows/flutter-ci-fixer.yml
@@ -81,13 +81,19 @@ jobs:
             exit 0
           fi
 
-          # A Dependabot update that breaks CI has to stay broken. The red is
+          # A dependency update that breaks CI has to stay broken. The red is
           # the whole signal — it says this bump needs a human — and a repair
           # commit would paper over which update broke what. This runs before
           # the credential check and both Codex attempts, so no repair is ever
           # generated for these branches, let alone published.
-          if [[ "$head_branch" == dependabot/* ]]; then
-            echo "Skipping Dependabot branch $head_branch; update PRs stay red for review."
+          #
+          # dependabot/* covers GitHub Actions and Cargo (.github/dependabot.yml);
+          # deps/* covers the Dart/Flutter package updater
+          # (.github/workflows/dart-dependency-updates.yml), whose PRs must stay
+          # lockfile-only — a repair commit would put application code into a PR
+          # that is guarded to contain nothing but pubspec.lock.
+          if [[ "$head_branch" == dependabot/* || "$head_branch" == deps/* ]]; then
+            echo "Skipping dependency update branch $head_branch; update PRs stay red for review."
             exit 0
           fi
 
@@ -357,11 +363,14 @@ jobs:
   publish:
     name: Publish validated Flutter fix
     needs: fix
-    # The Dependabot check in the fix job already stops a repair being built,
-    # so target_branch can never be a dependabot/ branch here. Restated anyway:
-    # this is the last gate before a commit is pushed, and "never publish onto
-    # an update PR" is worth enforcing where the push actually happens.
-    if: ${{ needs.fix.outputs.ready == 'true' && !startsWith(needs.fix.outputs.target_branch, 'dependabot/') }}
+    # The dependency-branch check in the fix job already stops a repair being
+    # built, so target_branch can never be dependabot/ or deps/ here. Restated
+    # anyway: this is the last gate before a commit is pushed, and "never
+    # publish onto an update PR" is worth enforcing where the push happens.
+    if: >-
+      ${{ needs.fix.outputs.ready == 'true'
+      && !startsWith(needs.fix.outputs.target_branch, 'dependabot/')
+      && !startsWith(needs.fix.outputs.target_branch, 'deps/') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,5 +44,6 @@ The full index of Linthra's docs. New to the project? Start with the
 | Reporting a bug | [reporting-bugs.md](./reporting-bugs.md) |
 | Manual QA checklist | [manual-test-checklist.md](./manual-test-checklist.md) |
 | Release process & signing | [release-process.md](./release-process.md) · [signing](./release-signing.md) |
+| Dependency update bots | [dependency-updates.md](./dependency-updates.md) |
 | F-Droid readiness | [fdroid-readiness.md](./fdroid-readiness.md) |
 | Google Play readiness | [play-store-readiness.md](./play-store-readiness.md) |

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,186 @@
+# Dependency updates
+
+Linthra checks its own dependencies on a schedule and prepares a pull request
+when something can move. It never merges anything. The bot's job is to say
+*"here is an update, and here is what CI thinks of it"*; deciding what happens
+next is a human's (issue #362).
+
+Three ecosystems are covered, by two different mechanisms:
+
+| Ecosystem | Handled by | Cadence |
+| --- | --- | --- |
+| GitHub Actions | Dependabot — [`.github/dependabot.yml`](../.github/dependabot.yml) | weekly |
+| Cargo (`native/linthra_core`) | Dependabot — same file | weekly |
+| Dart / Flutter packages | [`dart-dependency-updates.yml`](../.github/workflows/dart-dependency-updates.yml) | weekly |
+
+Toolchain updates — the Flutter SDK itself, Gradle, AGP, Kotlin, the JDK — are
+not automated yet. They are separate phases of the same issue.
+
+## Dart / Flutter packages
+
+### What it does
+
+Once a week (and on demand from **Actions → Dart dependency updates → Run
+workflow**) the workflow checks out `main`, installs the pinned Flutter SDK and
+runs:
+
+```bash
+flutter pub upgrade
+```
+
+That resolves every dependency to the newest version the constraints already in
+`pubspec.yaml` allow, and writes the result to `pubspec.lock` — nothing else. If
+the lockfile does not change, the run stops there and no PR is opened.
+
+If it does change, the workflow:
+
+1. asserts that `pubspec.lock` is the only file that moved,
+2. re-checks the result with `flutter pub get --enforce-lockfile`,
+3. runs `dart format`, `flutter analyze` and `flutter test`,
+4. opens — or updates — a single draft PR on the `deps/dart-packages` branch.
+
+Step 3 is reported, not enforced. A dependency that needs application changes
+produces a red PR on purpose; see [Red PRs are the point](#red-prs-are-the-point).
+
+### Why `flutter pub upgrade`, and not `--major-versions=false`
+
+There is no `--major-versions=false`. `--major-versions` is a non-negatable
+flag, and giving it a value fails outright:
+
+```console
+$ flutter pub upgrade --major-versions=false
+Flag option "--major-versions" should not be given a value.
+$ echo $?
+64
+```
+
+The flag also does the opposite of what an automatic update wants: it *rewrites
+the constraints in `pubspec.yaml`* so that majors can be pulled in. Plain
+`flutter pub upgrade` is already the "newest compatible versions, no constraint
+edits" command — `just_audio: ^0.9.42` cannot resolve to `0.10.0`, and
+`permission_handler: ^11.3.1` cannot resolve to `12.0.0`. The rule is enforced
+by the caret ranges a human wrote, which is exactly where that decision belongs.
+
+One honest caveat: `pubspec.yaml` does not constrain *transitive* packages, so a
+lockfile refresh can move them across major versions — the analyzer / build /
+`source_gen` chain behind `drift_dev` is the usual example. That is what a
+lockfile refresh is. It stays bounded by the pinned SDK and by what the direct
+constraints admit, and it is a large part of why this ends in a reviewed PR
+instead of a silent commit.
+
+### Why not Dependabot
+
+Dependabot does support the `pub` ecosystem, and using it would have been less
+code. It cannot meet two of Linthra's requirements:
+
+- **The pinned SDK.** Dependabot's pub updater resolves with its own bare Dart
+  SDK and installs no Flutter at all. `pubspec.lock` is committed so the F-Droid
+  build resolves the same dependency set we tested
+  ([release-process.md](./release-process.md) §7), which means the lockfile has
+  to come from the SDK in `.flutter-version`. The difference is not theoretical:
+  resolving with the pinned SDK writes an `sdks:` block into the lockfile that
+  names the Flutter line it was resolved against, which a Flutter-less resolver
+  cannot produce.
+- **Constraints must not move.** pub has no `lockfile-only` versioning strategy.
+  All three strategies it offers — `widen`, `increase`, `increase-if-necessary`
+  — rewrite the constraints in `pubspec.yaml`.
+
+Dependabot keeps GitHub Actions and Cargo, where neither problem exists.
+`test/tooling/dependency_update_guardrails_test.dart` fails if a `pub` ecosystem
+is ever added to `.github/dependabot.yml`, so the two cannot start fighting over
+the same lockfile.
+
+### What the bot may touch
+
+Exactly one file:
+
+```text
+pubspec.lock
+```
+
+Anything else fails the run before a commit exists.
+`scripts/check_dependency_update_files.sh` owns that list, and it runs twice:
+once inside the updater, and again in CI against the real PR diff for any
+`deps/` branch — so a "just fix the failing test" commit pushed onto the update
+PR afterwards is caught too.
+
+In particular an automatic update never changes dependency constraints,
+application code, test code, the app version, F-Droid metadata, Fastlane files,
+release notes, signing files or licenses.
+
+### Packages that deserve a closer look
+
+The PR body calls these out by name when they move, because the Flutter checks
+job cannot fully judge them — it does not build an APK, and it does not
+regenerate the committed Drift output:
+
+| Package(s) | Why |
+| --- | --- |
+| `just_audio`, `audio_service`, `audio_session` | Platform plugins behind playback, the media session and audio focus. Only a real Android build and a device exercise them. |
+| `drift`, `drift_dev`, `sqlparser` | `drift_dev` generates the committed `*.g.dart`. If the generator's output changes, regeneration is an application change — run **Generate Drift files**, in its own PR. |
+| `sqlite3`, `sqlite3_flutter_libs` | The native SQLite engine shipped in the APK; relevant to reproducibility. |
+| `flutter_secure_storage` | Android Keystore-backed token storage. |
+| `permission_handler` | Runtime `POST_NOTIFICATIONS` request. |
+| `file_picker` | Native folder chooser. |
+| `cast`, `bonsoir` | Chromecast transport and mDNS discovery, both F-Droid-safe by choice. |
+
+This is a list of things to *read carefully*, not a resolution rule. Nothing
+here needs special grouping: `pub upgrade` re-resolves the whole graph as one
+consistent set, so packages that must move together already do, and a version
+that would break a co-dependency is simply never selected.
+
+### Red PRs are the point
+
+If the update needs application changes, the PR stays red. That is the finding,
+not a failure of the bot — the Flutter 3.44.7 upgrade is the worked example of
+why blind auto-updates are not wanted here.
+
+So the Flutter CI fixer is kept away from these branches. It skips `deps/*`
+exactly the way it skips `dependabot/*`: while resolving the failed run, before
+any repair is generated, and again in the publish job where the push would
+happen. A repair commit would both hide which bump broke what and put
+application code into a PR that is guarded to contain nothing but the lockfile.
+
+### One-time setup
+
+The workflow needs one repository Actions secret:
+
+- `DEPENDENCY_UPDATE_TOKEN` — a dedicated fine-grained token with **Contents:
+  read/write** and **Pull requests: read/write** on this repository.
+
+This is the same pattern as `CI_FIXER_GITHUB_TOKEN` in
+[flutter-ci-fixer.md](./flutter-ci-fixer.md), and for the same reason: a push or
+a PR made with the workflow's default `GITHUB_TOKEN` does not trigger further
+workflows, so the PR would open with no checks on it. An update PR that runs no
+CI is a broken updater, so the workflow fails loudly rather than opening one —
+but only when there is actually an update to publish. A week with no updates
+never touches the token.
+
+The job's own `GITHUB_TOKEN` stays `contents: read`.
+
+### Reproducing it locally
+
+The workflow runs the same script a contributor can:
+
+```bash
+./scripts/setup_flutter.sh
+export PATH="$PWD/.tool/flutter/bin:$PATH"
+./scripts/update_dart_dependencies.sh
+```
+
+It refuses to run against a Flutter that is not the pinned one, refuses to run
+on a dirty tree (so every changed file is attributable to the run), and commits
+nothing. Exit codes: `0` updated, `3` already up to date, `1` a guard failed.
+
+Pass `--output-dir DIR` to also write the Markdown summary and the raw
+`pub upgrade` log the workflow puts in the PR body.
+
+### Reviewing an update PR
+
+- Read the package list in the PR body, and the "needs a closer look" section.
+- Check CI. Red is informative; work out *which* bump caused it.
+- If it needs code changes, do that in a separate PR. Do not push the fix onto
+  the update branch — the CI guard rejects it, and the next scheduled run
+  refuses to force-push over commits it did not write.
+- Merge manually when it is green and you are happy with it. Nothing
+  auto-merges, by design.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -597,6 +597,8 @@ consume our signed artifacts:
 | Secret & privacy scan on PRs & `main` | **Automatic** (`ci.yml`, job `secret-scan`; runs `scripts/check_secrets.sh` — offline, no secrets). |
 | Fastlane changelog exists for the current `versionCode` | **Automatic** on PRs & `main` (`flutter test` ▸ `test/tooling/release_changelog_test.dart`). |
 | Release-bump PR touches only version files | **Automatic** on `release/*` PRs only (`ci.yml`, job `release-bump-guard`; `scripts/check_release_bump_files.sh`). |
+| Dart/Flutter package updates inside the current constraints | **Automatic PR only** (weekly `dart-dependency-updates.yml`); resolves with the pinned SDK, changes only `pubspec.lock`, opens a **draft** PR and never merges. See [dependency-updates.md](./dependency-updates.md). |
+| Dependency-update PR touches only `pubspec.lock` | **Automatic** on `deps/*` PRs only (`ci.yml`, job `dependency-guard`; `scripts/check_dependency_update_files.sh`). |
 | Debug APK build + build-output verification | Manual (`workflow_dispatch`) + on PRs (`android-debug-apk.yml`; a "Verify build output exists" step rejects a missing/empty APK). |
 | Release APK/AAB build | **Manual** (`workflow_dispatch`) **and automatic on `v*` tags** (`android-release-build.yml`). |
 | Preparing the version-bump PR (pubspec, in-app mirror, Fastlane changelog, F-Droid `CurrentVersion`) | **Manual** (`workflow_dispatch`, `prepare-release-bump.yml`); opens a draft PR but never tags, builds, or publishes. The same edits are reproducible locally with `scripts/prepare_release_bump.py`. |
@@ -620,6 +622,8 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
 | `ci.yml` · `flutter` — format, analyze, test, `pub get --enforce-lockfile` | ✅ | ✅ | — | — |
 | `ci.yml` · `secret-scan` — `scripts/check_secrets.sh` | ✅ | ✅ | — | — |
 | `ci.yml` · `release-bump-guard` — `scripts/check_release_bump_files.sh` | ✅ (only `release/*` branches) | — | — | — |
+| `ci.yml` · `dependency-guard` — `scripts/check_dependency_update_files.sh` | ✅ (only `deps/*` branches) | — | — | — |
+| `dart-dependency-updates.yml` — open/update the draft Dart package PR | — | — | — | ✅ (also weekly on a schedule) |
 | `android-debug-apk.yml` — build debug APK + verify output | ✅ | — | — | ✅ |
 | `android-release-build.yml` — release APK/AAB, tag↔pubspec preflight, attach | — | — | ✅ | ✅ |
 | `prepare-release-bump.yml` — open the version-bump PR | — | — | — | ✅ |
@@ -627,7 +631,7 @@ Release, writes production notes, signs a store build, or submits to F-Droid.
 
 The `flutter` job also runs the whole `test/` suite, which includes the
 release-safety guardrail tests below — so those gate every PR, not just release
-PRs. Nothing in `ci.yml` uses a secret, so all three jobs run identically on
+PRs. Nothing in `ci.yml` uses a secret, so all four jobs run identically on
 fork PRs.
 
 ### What the guardrails catch (and how to run them locally)

--- a/scripts/check_dependency_update_files.sh
+++ b/scripts/check_dependency_update_files.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# check_dependency_update_files.sh — assert an automatic Dart/Flutter package
+# update only touches the one file such an update is allowed to touch.
+#
+# The "Dart dependency updates" workflow (and its local twin
+# scripts/update_dart_dependencies.sh) re-resolves the dependency graph with the
+# pinned Flutter SDK and writes the result to exactly one file:
+#
+#   * pubspec.lock                                (the resolved dependency set)
+#
+# Nothing else. In particular an automatic update must never rewrite the
+# constraints in pubspec.yaml, never touch application or test code to make a
+# new package version compile, and never go near the release surface — F-Droid
+# metadata, Fastlane, release notes, signing material, licenses or the app
+# version. Those are the changes a human decides on, in a PR they wrote.
+#
+# `flutter pub upgrade` already behaves that way: it resolves inside the
+# existing constraints and only rewrites the lockfile. This guard is the check
+# that the behaviour actually held, so the bot cannot quietly grow a wider
+# blast radius than it was designed for.
+#
+# It is used in two places, deliberately:
+#
+#   1. In the updater itself, before a commit is created at all.
+#   2. In CI, on every `deps/` PR, so the boundary is re-checked against the
+#      real PR diff — including anything pushed onto the branch afterwards.
+#
+# Usage:
+#
+#   # Explicit list (one path per line) on stdin:
+#   git diff --name-only <base>..HEAD | scripts/check_dependency_update_files.sh
+#
+#   # Or as arguments:
+#   scripts/check_dependency_update_files.sh pubspec.lock
+#
+# Read-only, no network, no secrets. Sibling guard:
+# scripts/check_release_bump_files.sh does the same job for release/ PRs.
+
+set -uo pipefail
+
+# Collect candidate paths from arguments, else from stdin.
+paths=()
+if [ "$#" -gt 0 ]; then
+  paths=("$@")
+else
+  while IFS= read -r line; do
+    [ -n "$line" ] && paths+=("$line")
+  done
+fi
+
+if [ "${#paths[@]}" -eq 0 ]; then
+  echo "No changed files provided; nothing to check."
+  exit 0
+fi
+
+# Returns 0 if the given path is allowed in an automatic dependency update.
+is_allowed() {
+  case "$1" in
+    pubspec.lock)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+offenders=()
+for p in "${paths[@]}"; do
+  is_allowed "$p" || offenders+=("$p")
+done
+
+if [ "${#offenders[@]}" -eq 0 ]; then
+  echo "OK: dependency update touches only pubspec.lock (${#paths[@]} file(s))."
+  exit 0
+fi
+
+{
+  echo "ERROR: this looks like an automatic dependency update, but it changes"
+  echo "files outside the allowed set:"
+  echo
+  for p in "${offenders[@]}"; do
+    echo "  - $p"
+  done
+  echo
+  echo "An automatic Dart/Flutter package update may only rewrite:"
+  echo "  - pubspec.lock"
+  echo
+  echo "It must not change dependency constraints (pubspec.yaml), application"
+  echo "or test code, the app version, F-Droid metadata, Fastlane files,"
+  echo "release notes, signing files or licenses. If this update genuinely"
+  echo "needs one of those, it is not an automatic update — a human should"
+  echo "open that PR and explain the change."
+} >&2
+exit 1

--- a/scripts/update_dart_dependencies.sh
+++ b/scripts/update_dart_dependencies.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# update_dart_dependencies.sh — re-resolve Linthra's Dart/Flutter packages with
+# the pinned Flutter SDK and leave a validated pubspec.lock behind.
+#
+# This is the local twin of the "Dart dependency updates" workflow. Running it
+# by hand produces exactly the lockfile that workflow would commit, which is the
+# point: the reproducible F-Droid build resolves from the committed pubspec.lock
+# (docs/release-process.md §7), so the lockfile has to come from the SDK this
+# repo is actually pinned to and not from whatever Dart happens to be on PATH.
+#
+#   ./scripts/setup_flutter.sh                    # install the pinned SDK
+#   export PATH="$PWD/.tool/flutter/bin:$PATH"
+#   ./scripts/update_dart_dependencies.sh
+#
+# What it runs, and why that command:
+#
+#   flutter pub upgrade
+#
+# `pub upgrade` re-resolves every dependency to the newest version the existing
+# constraints in pubspec.yaml already allow, and writes only pubspec.lock. That
+# is the whole "compatible updates, no constraint changes" behaviour by
+# construction — `^0.9.42` cannot resolve to 0.10.0, `^11.3.1` cannot resolve to
+# 12.0.0. Note that `--major-versions=false` does NOT exist: `--major-versions`
+# is a non-negatable flag, and passing it a value fails with
+#   Flag option "--major-versions" should not be given a value.
+# (exit 64). The flag's actual job is the opposite of what we want here — it
+# rewrites the constraints in pubspec.yaml so majors can be pulled in. Plain
+# `pub upgrade` is the "no majors, no constraint edits" command.
+#
+# Transitive packages are a deliberate exception: pubspec.yaml does not
+# constrain them, so a lockfile refresh can and does move them across major
+# versions (the analyzer/build/source_gen chain behind drift_dev, for example).
+# That is what a lockfile refresh is. It is bounded by the pinned SDK and by
+# what the direct constraints admit, and it is exactly why this ends in a
+# reviewed PR that runs the normal checks instead of a silent commit.
+#
+# Exit codes:
+#
+#   0  pubspec.lock was updated and passed every guard
+#   3  already up to date — nothing changed, nothing to do
+#   1  a guard failed, or the run could not complete
+#
+# Options:
+#
+#   --output-dir DIR   Write summary.md (a Markdown report of what moved) and
+#                      upgrade.log (the raw `pub upgrade` output) into DIR.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION_FILE="$REPO_ROOT/.flutter-version"
+LOCKFILE="pubspec.lock"
+
+# Packages worth calling out by name when they move. Not a resolution rule —
+# pub already resolves the graph as one consistent set, so nothing here needs
+# artificial grouping. These are the ones whose bump CI cannot fully judge:
+# native/plugin code that only a real Android build exercises, the code
+# generator behind the committed *.g.dart files, and the SQLite engine the
+# reproducible F-Droid build ships.
+WATCHED=(
+  just_audio just_audio_platform_interface
+  audio_service audio_service_platform_interface
+  audio_session
+  drift drift_dev sqlparser
+  sqlite3 sqlite3_flutter_libs
+  flutter_secure_storage
+  permission_handler
+  file_picker
+  cast bonsoir
+)
+
+output_dir=""
+
+info() { printf '==> %s\n' "$*"; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output-dir)
+      [ "$#" -ge 2 ] || die "--output-dir needs a directory"
+      output_dir="$2"
+      shift 2 ;;
+    --output-dir=*)
+      output_dir="${1#--output-dir=}"
+      shift ;;
+    -h|--help)
+      sed -n '2,/^set -uo/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//; $d'
+      exit 0 ;;
+    *)
+      die "unknown argument: $1" ;;
+  esac
+done
+
+cd "$REPO_ROOT" || die "cannot enter $REPO_ROOT"
+
+if [ -n "$output_dir" ]; then
+  mkdir -p "$output_dir" || die "cannot create $output_dir"
+  output_dir="$(cd "$output_dir" && pwd)"
+fi
+
+# --- 1. resolve with the pinned SDK, or not at all --------------------------
+
+command -v flutter >/dev/null 2>&1 \
+  || die "flutter is not on PATH. Run ./scripts/setup_flutter.sh first, then
+       export PATH=\"$REPO_ROOT/.tool/flutter/bin:\$PATH\""
+
+[ -f "$VERSION_FILE" ] || die "missing $VERSION_FILE (the pinned Flutter version)"
+required="$(tr -d '[:space:]' < "$VERSION_FILE")"
+[ -n "$required" ] || die "$VERSION_FILE is empty"
+
+actual="$(flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][0-9.]*\).*/\1/p' | head -1)"
+[ -n "$actual" ] || die "could not read the version of the Flutter on PATH"
+
+if [ "$actual" != "$required" ]; then
+  die "Flutter on PATH is $actual but this repo is pinned to $required.
+       The committed lockfile has to be resolved with the pinned SDK — a
+       different SDK resolves a different set and quietly breaks the
+       reproducible F-Droid build. Run ./scripts/setup_flutter.sh."
+fi
+info "Resolving with the pinned Flutter $actual"
+
+# --- 2. refuse to work on a dirty tree --------------------------------------
+
+# Every guard below asks "what did this script change?", and git is what answers
+# it — so a checkout is a hard requirement, not a nicety.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+  || die "$REPO_ROOT is not a git working tree; the changed-file guard cannot run."
+
+# The honest answer only exists when nothing else was already changed.
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  git status --short --untracked-files=no >&2
+  die "the working tree has uncommitted changes. Commit or stash them first —
+       this script has to be able to attribute every changed file to itself."
+fi
+
+# --- 3. upgrade inside the existing constraints -----------------------------
+
+upgrade_log="$(mktemp "${TMPDIR:-/tmp}/pub-upgrade.XXXXXX")"
+trap 'rm -f "$upgrade_log"' EXIT
+
+info "flutter pub upgrade"
+if ! flutter pub upgrade 2>&1 | tee "$upgrade_log"; then
+  die "flutter pub upgrade failed; see the output above."
+fi
+
+# --- 4. nothing changed? then there is nothing to do ------------------------
+
+# The report directory is this script's own output, not a repository change,
+# so drop it when it was pointed somewhere inside the checkout.
+out_rel=""
+if [ -n "$output_dir" ]; then
+  case "$output_dir/" in
+    "$REPO_ROOT"/*) out_rel="${output_dir#"$REPO_ROOT"/}" ;;
+  esac
+fi
+
+changed=""
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  if [ -n "$out_rel" ]; then
+    case "$path" in
+      "$out_rel"|"$out_rel"/*) continue ;;
+    esac
+  fi
+  changed="${changed}${path}"$'\n'
+done < <(git status --porcelain --untracked-files=normal | sed 's/^...//')
+changed="${changed%$'\n'}"
+
+if [ -z "$changed" ]; then
+  info "pubspec.lock is already at the newest versions the constraints allow."
+  [ -n "$output_dir" ] && cp "$upgrade_log" "$output_dir/upgrade.log"
+  exit 3
+fi
+
+# --- 5. only pubspec.lock may have moved ------------------------------------
+
+info "Checking the changed files against the allowlist"
+if ! printf '%s\n' "$changed" | "$SCRIPT_DIR/check_dependency_update_files.sh"; then
+  die "the upgrade changed files an automatic update is not allowed to change.
+       Nothing has been committed. Inspect the diff and handle it by hand."
+fi
+
+# --- 6. the lockfile must satisfy the unchanged constraints -----------------
+
+# The same command ci.yml runs. If a lockfile we just generated cannot satisfy
+# --enforce-lockfile, the artifact itself is broken, so stop here rather than
+# opening a PR that is red for a reason nobody needs to review.
+info "flutter pub get --enforce-lockfile"
+flutter pub get --enforce-lockfile \
+  || die "the freshly resolved lockfile fails --enforce-lockfile. This is a bug
+       in the resolution, not a dependency that needs review; not proceeding."
+
+# --- 7. report what moved ---------------------------------------------------
+
+# `pub upgrade` already prints the moves; "> name new (was old)" is a change,
+# "+ name" an addition, "- name" a removal. Reuse that rather than re-deriving
+# it from the lockfile diff.
+moves="$(grep -E '^[>+-] [a-z0-9_]+ ' "$upgrade_log" || true)"
+moved_names="$(printf '%s\n' "$moves" | awk '{print $2}' | sort -u)"
+
+watched_hits=()
+for pkg in "${WATCHED[@]}"; do
+  if printf '%s\n' "$moved_names" | grep -qx "$pkg"; then
+    watched_hits+=("$pkg")
+  fi
+done
+
+count="$(printf '%s\n' "$moves" | grep -c . || true)"
+info "$count package(s) changed in $LOCKFILE"
+if [ "${#watched_hits[@]}" -gt 0 ]; then
+  info "Native/codegen packages moved: ${watched_hits[*]}"
+fi
+
+if [ -n "$output_dir" ]; then
+  cp "$upgrade_log" "$output_dir/upgrade.log"
+  {
+    echo "### Resolved with Flutter $required"
+    echo
+    echo "\`flutter pub upgrade\` — inside the existing \`pubspec.yaml\` constraints,"
+    echo "so no constraint changed and no direct dependency crossed a major version."
+    echo
+    if [ "${#watched_hits[@]}" -gt 0 ]; then
+      echo "### Needs a closer look"
+      echo
+      echo "These moved, and the Flutter checks job cannot fully judge them — it"
+      echo "does not build an APK, and it does not regenerate the committed Drift"
+      echo "output:"
+      echo
+      for pkg in "${watched_hits[@]}"; do
+        echo "- \`$pkg\`"
+      done
+      echo
+    fi
+    echo "### Package changes"
+    echo
+    echo '```text'
+    printf '%s\n' "$moves"
+    echo '```'
+  } > "$output_dir/summary.md"
+  info "Wrote $output_dir/summary.md"
+fi
+
+info "Done. $LOCKFILE is updated and validated; nothing has been committed."
+exit 0

--- a/test/tooling/dependency_update_guardrails_test.dart
+++ b/test/tooling/dependency_update_guardrails_test.dart
@@ -1,0 +1,305 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Guardrails for the automatic Dart/Flutter package updater (issue #362).
+///
+/// The updater is allowed to do exactly one thing: re-resolve the dependency
+/// graph with the pinned Flutter SDK and rewrite `pubspec.lock`. Everything
+/// else about it is a safety boundary —
+///
+///   * it resolves with the SDK from `.flutter-version`, because the
+///     reproducible F-Droid build resolves from the committed lockfile;
+///   * it never edits the constraints in `pubspec.yaml`, so no direct
+///     dependency can cross a major version;
+///   * it never touches application code, tests, the app version, F-Droid
+///     metadata, Fastlane files, release notes, signing material or licenses;
+///   * it never merges, and the PR it opens runs the normal CI;
+///   * the Flutter CI fixer leaves its branches alone, so an update that needs
+///     application changes stays red for a human.
+///
+/// Those boundaries are the whole value of the updater, so they are tests
+/// rather than review notes. This suite reads files and shells out to the
+/// offline guard script; it never resolves dependencies or touches the network.
+///
+/// Sibling coverage: test/tooling/toolchain_pins_test.dart pins the toolchain
+/// versions, test/tooling/fdroid_release_guardrails_test.dart pins the release
+/// plumbing (including that `pubspec.lock` stays tracked at all).
+void main() {
+  final String root = _repoRoot();
+
+  final String guardScript =
+      p.join(root, 'scripts', 'check_dependency_update_files.sh');
+  late final String updater =
+      _read(root, p.join('scripts', 'update_dart_dependencies.sh'));
+  late final String workflow = _read(
+      root, p.join('.github', 'workflows', 'dart-dependency-updates.yml'));
+  late final String ci = _read(root, p.join('.github', 'workflows', 'ci.yml'));
+  late final String fixer =
+      _read(root, p.join('.github', 'workflows', 'flutter-ci-fixer.yml'));
+
+  group('the allowlist guard admits only the lockfile', () {
+    test('pubspec.lock alone passes', () {
+      final ProcessResult r = _runGuard(guardScript, <String>['pubspec.lock']);
+      expect(r.exitCode, 0, reason: 'stdout: ${r.stdout}\nstderr: ${r.stderr}');
+    });
+
+    test('an empty change set passes', () {
+      final ProcessResult r = _runGuard(guardScript, const <String>[]);
+      expect(r.exitCode, 0, reason: 'stdout: ${r.stdout}\nstderr: ${r.stderr}');
+    });
+
+    // One case per rule the issue spells out. If someone widens the allowlist,
+    // the specific protection they removed is named in the failure.
+    const Map<String, String> forbidden = <String, String>{
+      'pubspec.yaml': 'dependency constraints (would allow a major upgrade)',
+      'lib/main.dart': 'application code',
+      'lib/core/app_info.dart': 'the in-app version',
+      'test/core/app_info_version_test.dart': 'test code',
+      'metadata/io.github.thezupzup.linthra.yml': 'F-Droid metadata',
+      'fastlane/metadata/android/en-US/changelogs/201999.txt': 'Fastlane files',
+      'docs/release-notes/v0.2.1.md': 'release notes',
+      'android/key.properties': 'signing configuration',
+      'android/app/linthra-release.jks': 'signing material',
+      'LICENSE': 'the license',
+      '.flutter-version': 'the Flutter pin',
+      '.github/workflows/ci.yml': 'CI configuration',
+      'scripts/check_dependency_update_files.sh': 'the guard itself',
+    };
+
+    forbidden.forEach((String path, String why) {
+      test('$path is rejected — $why', () {
+        final ProcessResult r =
+            _runGuard(guardScript, <String>['pubspec.lock', path]);
+        expect(r.exitCode, isNot(0),
+            reason: 'An automatic dependency update must not change $why.\n'
+                'stdout: ${r.stdout}');
+        expect(r.stderr, contains(path),
+            reason: 'The rejection should name the offending path.');
+      });
+    });
+  });
+
+  group('the updater resolves the way the lockfile requires', () {
+    test('it runs plain `flutter pub upgrade`', () {
+      expect(updater, contains('flutter pub upgrade'),
+          reason: 'The updater must re-resolve inside the existing '
+              'constraints with `flutter pub upgrade`.');
+    });
+
+    test('it never passes --major-versions or --tighten', () {
+      // Both rewrite pubspec.yaml. `--major-versions` additionally has no
+      // negated form: `--major-versions=false` fails with
+      // 'Flag option "--major-versions" should not be given a value.' (exit 64),
+      // so "upgrade but not majors" is plain `pub upgrade`, not a flag.
+      for (final String flag in <String>['--major-versions', '--tighten']) {
+        for (final String line in updater.split('\n')) {
+          if (line.trimLeft().startsWith('#')) continue;
+          expect(line.contains(flag), isFalse,
+              reason: 'scripts/update_dart_dependencies.sh runs $flag in:\n'
+                  '  $line\n'
+                  'That flag edits the constraints in pubspec.yaml, which an '
+                  'automatic update must never do.');
+        }
+      }
+    });
+
+    test('it refuses to resolve with an SDK other than the pinned one', () {
+      expect(updater, contains('.flutter-version'),
+          reason: 'The updater must read the pinned Flutter version.');
+      expect(updater, contains(r'if [ "$actual" != "$required" ]; then'),
+          reason: 'The updater must compare the Flutter on PATH against '
+              '.flutter-version and stop when they differ — a lockfile '
+              'resolved with a different SDK breaks the F-Droid build.');
+    });
+
+    test('it re-checks the result with --enforce-lockfile', () {
+      expect(updater, contains('flutter pub get --enforce-lockfile'),
+          reason: 'The generated lockfile must satisfy the same check ci.yml '
+              'runs before it can become a PR.');
+    });
+
+    test('it pipes the changed files through the allowlist guard', () {
+      expect(updater, contains('check_dependency_update_files.sh'),
+          reason: 'The updater must verify its own blast radius before '
+              'anything is committed.');
+    });
+
+    test('it commits nothing itself', () {
+      for (final String forbidden in <String>[
+        'git commit',
+        'git push',
+        'gh pr create',
+      ]) {
+        expect(updater.contains(forbidden), isFalse,
+            reason: 'scripts/update_dart_dependencies.sh runs `$forbidden`. '
+                'The script only prepares and validates the lockfile; '
+                'publishing belongs to the workflow.');
+      }
+    });
+  });
+
+  group('the update workflow stays inside its boundaries', () {
+    test('it runs on a schedule and can be dispatched by hand', () {
+      expect(workflow, contains('schedule:'));
+      expect(workflow, contains('cron:'));
+      expect(workflow, contains('workflow_dispatch:'));
+    });
+
+    test('it delegates resolution to the shared script', () {
+      expect(workflow, contains('./scripts/update_dart_dependencies.sh'),
+          reason: 'The workflow and the local twin must run the same code.');
+    });
+
+    test('it installs Flutter through the pinned setup action', () {
+      expect(workflow, contains('uses: ./.github/actions/setup-flutter'),
+          reason: 'Resolution has to use the pinned SDK.');
+    });
+
+    test('its own GITHUB_TOKEN is read-only', () {
+      expect(workflow, contains('permissions:\n  contents: read'),
+          reason: 'Writes must go through the dedicated publication token, '
+              'not an elevated GITHUB_TOKEN.');
+    });
+
+    test('it publishes with a dedicated token so the PR runs normal CI', () {
+      // A push or PR made with GITHUB_TOKEN does not trigger workflows, and an
+      // update PR that runs no checks is a broken updater (#362).
+      expect(workflow, contains(r'secrets.DEPENDENCY_UPDATE_TOKEN'),
+          reason: 'The PR must be created with a token that retriggers CI.');
+      expect(workflow.contains('GH_TOKEN: \${{ github.token }}'), isFalse,
+          reason: 'github.token cannot retrigger CI on the PR it opens.');
+    });
+
+    test('the PR is a draft against main', () {
+      expect(workflow, contains('gh pr create'));
+      expect(workflow, contains('--draft'),
+          reason: 'Update PRs open as drafts for review.');
+      expect(workflow, contains('--base main'));
+    });
+
+    test('it reuses one branch instead of opening duplicates', () {
+      expect(workflow, contains('UPDATE_BRANCH: deps/dart-packages'));
+      expect(workflow, contains('--state open --json number'),
+          reason: 'The workflow must look for an existing open PR on the '
+              'update branch and edit it rather than open another.');
+    });
+
+    test('it refuses to force-push over commits it did not write', () {
+      expect(workflow, contains('--force-with-lease'),
+          reason: 'A plain force push could drop a concurrent update.');
+      expect(workflow, contains('foreign='),
+          reason: 'The workflow must detect commits on the update branch that '
+              'it did not author and stop instead of overwriting them.');
+    });
+
+    test('it never merges anything', () {
+      for (final String forbidden in <String>[
+        'gh pr merge',
+        '--auto',
+        '--admin',
+        '--squash',
+        '--rebase',
+      ]) {
+        expect(workflow.contains(forbidden), isFalse,
+            reason: 'The update workflow contains `$forbidden`. Nothing may '
+                'ever merge into main automatically (#362).');
+      }
+    });
+
+    test('a failing check does not block the PR from opening', () {
+      // The red PR is the deliverable when an update needs application
+      // changes, so format/analyze/test are reported, not gated on.
+      expect('continue-on-error: true'.allMatches(workflow).length, 3,
+          reason: 'dart format, flutter analyze and flutter test must each run '
+              'without failing the job, so the update still reaches a human.');
+    });
+  });
+
+  group('the boundary is re-checked on the PR itself', () {
+    test('ci.yml guards deps/ PRs with the same script', () {
+      expect(ci, contains("startsWith(github.head_ref, 'deps/')"),
+          reason: 'CI must run the lockfile-only guard on update PRs.');
+      expect(ci, contains('./scripts/check_dependency_update_files.sh'),
+          reason:
+              'The PR-side guard must be the same script the updater uses.');
+    });
+
+    test('CI runs on every PR, so an update PR is never unchecked', () {
+      expect(ci, contains('pull_request:'));
+      expect(ci.contains('pull_request:\n    branches'), isFalse,
+          reason: 'A branch filter on pull_request would let an update PR '
+              'merge without the normal checks.');
+    });
+  });
+
+  group('the CI fixer leaves dependency updates alone', () {
+    test('the fix job skips deps/ branches alongside dependabot/', () {
+      expect(
+        fixer,
+        contains(
+            r'if [[ "$head_branch" == dependabot/* || "$head_branch" == deps/* ]]; then'),
+        reason: 'A dependency update that breaks CI must stay broken — the red '
+            'is the signal. The skip has to happen while resolving the run, '
+            'before any repair is generated.',
+      );
+    });
+
+    test('the publish job restates the skip where the push happens', () {
+      expect(
+        fixer,
+        contains("!startsWith(needs.fix.outputs.target_branch, 'dependabot/')"),
+      );
+      expect(
+        fixer,
+        contains("!startsWith(needs.fix.outputs.target_branch, 'deps/')"),
+        reason: 'The last gate before a commit is pushed must also refuse '
+            'dependency update branches.',
+      );
+    });
+  });
+
+  group('pub is not left to Dependabot', () {
+    test('.github/dependabot.yml declares no pub ecosystem', () {
+      final String dependabot =
+          _read(root, p.join('.github', 'dependabot.yml'));
+      expect(dependabot.contains('package-ecosystem: "pub"'), isFalse,
+          reason: 'Dependabot cannot meet Linthra\'s pub requirements: it '
+              'resolves with its own Dart SDK and installs no Flutter, and '
+              'every pub versioning-strategy it offers (widen / increase / '
+              'increase-if-necessary) rewrites the constraints in '
+              'pubspec.yaml. Dart packages are handled by '
+              '.github/workflows/dart-dependency-updates.yml.');
+    });
+  });
+}
+
+ProcessResult _runGuard(String script, List<String> paths) => Process.runSync(
+      'bash',
+      <String>[script, ...paths],
+      stdoutEncoding: const SystemEncoding(),
+      stderrEncoding: const SystemEncoding(),
+    );
+
+String _read(String root, String relativePath) {
+  final File f = File(p.join(root, relativePath));
+  expect(f.existsSync(), isTrue,
+      reason: 'Expected file is missing: $relativePath');
+  return f.readAsStringSync();
+}
+
+String _repoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, '.github')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}


### PR DESCRIPTION
Adds the Dart/Flutter package updater — the third phase of #362, after the pin cleanup and the Dependabot config.

Once a week the workflow checks out `main`, installs the Flutter SDK pinned in `.flutter-version`, and re-resolves the dependency graph. If `pubspec.lock` does not change, it stops. If it does, it opens or updates a single draft PR that contains nothing but the lockfile.

## I looked at Dependabot first

It does support pub, and using it would have been less code. Two things rule it out:

- Its pub updater resolves with its own bare Dart SDK and installs no Flutter at all. Our lockfile is committed so the F-Droid build resolves the set we tested, so it has to come from the pinned SDK. This is not theoretical — resolving with Flutter 3.44.7 writes `flutter: ">=3.44.0"` into the lockfile's `sdks:` block, which a Flutter-less resolver cannot arrive at.
- pub has no `lockfile-only` versioning strategy. All three it offers (`widen`, `increase`, `increase-if-necessary`) rewrite the constraints in `pubspec.yaml`.

Dependabot keeps GitHub Actions and Cargo, where neither problem exists. A guardrail test fails if a `pub` entry is ever added to `dependabot.yml`, so the two can't end up fighting over the same lockfile.

## About `--major-versions=false`

It doesn't exist. `--major-versions` is a non-negatable flag and passing it a value fails:

```console
$ flutter pub upgrade --major-versions=false
Flag option "--major-versions" should not be given a value.   # exit 64
```

The flag also does the opposite of what we want — its whole job is rewriting `pubspec.yaml` so majors *can* be pulled in. Plain `flutter pub upgrade` is already the "newest compatible, no constraint edits" command: the carets a human wrote are what keep `just_audio: ^0.9.42` off `0.10.x` and `permission_handler: ^11.3.1` off `12.x`.

One honest caveat, in the docs too: `pubspec.yaml` doesn't constrain *transitive* packages, so a lockfile refresh does move them across majors — on today's tree, the analyzer/build/`source_gen` chain behind `drift_dev`. That's what a lockfile refresh is. It stays bounded by the pinned SDK and by what the direct constraints admit, and it's a large part of why this ends in a reviewed PR.

## Safety boundaries

The allowlist is one file: `pubspec.lock`. `scripts/check_dependency_update_files.sh` owns it and runs twice — inside the updater before a commit exists, and again in CI on any `deps/` PR against the real diff, so a "just fix the failing test" commit pushed onto the update branch afterwards is caught too.

Resolution lives in `scripts/update_dart_dependencies.sh` so the lockfile is reproducible by hand. It refuses to run against a Flutter that isn't the pinned one, refuses a dirty tree (so every changed file is attributable to the run), and commits nothing.

`dart format`, `flutter analyze` and `flutter test` run before the PR opens and are reported in its body rather than gated on — an update that needs application changes should arrive as a red PR. So the CI fixer now skips `deps/*` exactly the way it skips `dependabot/*`, in both the fix and publish jobs.

Nothing merges. The PR is a draft, and the workflow contains no merge call at all.

## No special grouping

I checked whether `just_audio`/`audio_service`/`audio_session`, `drift`/`drift_dev`, `sqlite3_flutter_libs` and the Cast packages need to move together. They don't need anything special: `pub upgrade` re-resolves the whole graph as one consistent set, so a version that would break a co-dependency is never selected. They're called out by name in the PR body instead, because CI doesn't build an APK and doesn't regenerate the committed Drift output — those are the bumps worth reading carefully.

## Setup

One new secret, `DEPENDENCY_UPDATE_TOKEN` (Contents + Pull requests, read/write). Same reason as `CI_FIXER_GITHUB_TOKEN`: a PR opened with the default `GITHUB_TOKEN` runs no checks. The workflow fails loudly if it's missing, but only when there's actually an update to publish.

## Verified

Ran the real thing against the current tree with Flutter 3.44.7: `flutter pub upgrade` moves 70 packages, touches only `pubspec.lock`, and `pub get --enforce-lockfile`, format, analyze and the full suite all pass on the result. Also exercised the updater's exit paths (updated / nothing to do / dirty tree / wrong SDK / non-repo) and simulated the publish step against a local origin — first run creates the draft PR, an unchanged lockfile pushes nothing, a newer one force-pushes and edits the existing PR instead of opening a second, and a human commit on the branch makes it refuse rather than overwrite.

Flutter SDK, Gradle/AGP/Kotlin and major dependency migrations are still later phases.

Part of #362

---
_Generated by [Claude Code](https://claude.ai/code/session_015o8qofh2ug3PKbubVAgA2c)_