### PR TITLE
ci: bump the last checkout pin in ci.yml to v7 (completes #365)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     if: ${{ startsWith(github.head_ref, 'deps/') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Targets #365's branch so the fix lands inside that PR and keeps it self-consistent.

## What was actually failing

Not `flutter analyze` — that step passes on #365's current head (`7912ebe`):

```
Analyzing Linthra...
No issues found! (ran in 14.6s)
```

The `Flutter checks` job fails one step later, in `flutter test`:

```
##[error]3225 tests passed, 1 failed.
```

The single failure is the pin guardrail, `test/tooling/toolchain_pins_test.dart:188`
("shared GitHub Actions are pinned consistently → each third-party action is used at
one ref across `.github/`"):

```
Expected: an object with length of <1>
  Actual: Set:['v7', 'v5']
   Which: has length of <2>
actions/checkout is pinned to v7 and v5 across .github/workflows/...
```

## Root cause

`.github/workflows/ci.yml:102` — the `Checkout` step of the `dependency-guard` job —
was still on `actions/checkout@v5`.

That job did not exist when Dependabot generated the bump (`25a5ce8`). It was added to
`ci.yml` later by #370 (`75e548a`), which introduced two fresh `@v5` checkout uses: one
in the new `.github/workflows/dart-dependency-updates.yml` and one in this new `ci.yml`
job. Merging main into the Dependabot branch (`4150745`) brought both onto the PR. The
follow-up commit `7912ebe` ("ci: keep checkout pin consistent") fixed the
`dart-dependency-updates.yml` reference but missed the `ci.yml` one, so `actions/checkout`
stayed split across two refs and the guardrail kept failing.

## Scope

This is specific to #365, not a pre-existing problem on `main`. On `main` all 17
`actions/checkout` uses are `@v5` — one ref, so the guardrail passes there, and CI on
`main` (`a2deeef`) is green. The mixed set only exists on the update branch, which is
exactly the drift the guardrail is designed to catch.

## Change

One line, `.github/workflows/ci.yml`:

```diff
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
```

Every `actions/checkout` use under `.github/` is now `@v7`, and every other third-party
action resolves to a single ref (`setup-java@v5`, `setup-python@v7`, `upload-artifact@v7`,
`download-artifact@v8`, `flutter-action@v2`, `rust-toolchain@stable`, `codex-action@v1`).

## Not changed

- No analyzer ignores, no `flutter analyze` weakening — analyze was already clean.
- `toolchain_pins_test.dart` and the other guardrails are untouched; the fix satisfies
  the guardrail rather than relaxing it.
- `flutter-ci-fixer.yml` still skips `dependabot/*` and `deps/*` branches, in both the
  `fix` job and the publish-job restatement.
- No application code touched; #365 stays a pure `actions/checkout` v5 → v7 update.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KwNeBwE7yhY66ngUwezA55)_