### PR TITLE
fix(player): stabilise seek handoff and timed-lyric geometry

### DIFF
--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -323,6 +323,11 @@ class _LiveControls extends ConsumerWidget {
         _StatusSlot(child: _SourceOrError(state: state)),
         const SizedBox(height: AppSpacing.md),
         PlaybackProgressBar(
+          // Identity is the track, so a track change disposes the bar's state
+          // — including a seek it is still holding optimistically — rather than
+          // carrying it onto the new song. Duration alone can't do that: two
+          // tracks can be exactly as long as each other.
+          key: ValueKey<String?>(state.currentTrack?.id),
           position: state.position,
           duration: state.duration,
           // Drives the wave's slow drift: it flows while playing and holds

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -326,8 +326,10 @@ class _LiveControls extends ConsumerWidget {
           // Identity is the track, so a track change disposes the bar's state
           // — including a seek it is still holding optimistically — rather than
           // carrying it onto the new song. Duration alone can't do that: two
-          // tracks can be exactly as long as each other.
-          key: ValueKey<String?>(state.currentTrack?.id),
+          // tracks can be exactly as long as each other. The uri is what Track
+          // itself calls identity (see its == ): bare ids collide across
+          // providers, the provider-namespaced uri does not.
+          key: ValueKey<String?>(state.currentTrack?.uri),
           position: state.position,
           duration: state.duration,
           // Drives the wave's slow drift: it flows while playing and holds

--- a/lib/features/player/widgets/lyrics/lyric_line_tile.dart
+++ b/lib/features/player/widgets/lyrics/lyric_line_tile.dart
@@ -11,9 +11,9 @@ import '../../../../core/models/lyric_focus.dart';
 ///
 /// Every colour is read from the [ColorScheme], so the tile retints with the
 /// user's branding theme and works in light and dark without a hard-coded value.
-/// The active line is never distinguished by colour *alone*: it is also larger
-/// and heavier, carries an accent marker in the gutter, and reports itself as
-/// selected to screen readers.
+/// The active line is never distinguished by colour *alone*: it is also heavier,
+/// carries an accent marker in the gutter, and reports itself as selected to
+/// screen readers.
 class LyricLineTile extends StatelessWidget {
   const LyricLineTile({
     required this.text,
@@ -126,10 +126,22 @@ class LyricLineTile extends StatelessWidget {
     );
   }
 
+  /// The line height every *timed* emphasis shares. Auto-follow animates the
+  /// list to the active line while the rows are restyling, so any metric that
+  /// differs between emphases changes row geometry mid-scroll and the target
+  /// slides out from under the animation. Holding leading — and size, below —
+  /// constant is what makes the follow land where it aimed.
+  static const double _timedHeight = 1.35;
+
   /// The text style for [emphasis], derived entirely from [theme].
   ///
-  /// The progression is opacity *and* weight, not opacity alone, so the active
-  /// line stays dominant even where a bright cover pushes the contrast around.
+  /// Emphasis is carried by opacity *and* weight, not opacity alone, so the
+  /// active line stays dominant even where a bright cover pushes the contrast
+  /// around — and, with the marker and the selected semantics, survives a user
+  /// who can't distinguish the colours. It is deliberately *not* carried by
+  /// size: every timed state shares one font size and one line height, so a line
+  /// occupies exactly the same space whether or not it is the one playing.
+  ///
   /// Sizes come from the text theme, so the user's text scaling multiplies them
   /// rather than fighting a fixed value.
   static TextStyle styleFor(ThemeData theme, LyricEmphasis emphasis) {
@@ -139,28 +151,26 @@ class LyricLineTile extends StatelessWidget {
       case LyricEmphasis.active:
         return base.copyWith(
           color: colors.onSurface,
-          fontSize: (base.fontSize ?? 16) * 1.25,
           fontWeight: FontWeight.w700,
-          height: 1.3,
-          letterSpacing: -0.2,
+          height: _timedHeight,
         );
       case LyricEmphasis.adjacent:
         return base.copyWith(
           color: colors.onSurface.withValues(alpha: 0.62),
           fontWeight: FontWeight.w500,
-          height: 1.35,
+          height: _timedHeight,
         );
       case LyricEmphasis.near:
         return base.copyWith(
           color: colors.onSurface.withValues(alpha: 0.42),
           fontWeight: FontWeight.w500,
-          height: 1.35,
+          height: _timedHeight,
         );
       case LyricEmphasis.distant:
         return base.copyWith(
           color: colors.onSurface.withValues(alpha: 0.26),
           fontWeight: FontWeight.w500,
-          height: 1.35,
+          height: _timedHeight,
         );
       case LyricEmphasis.untimed:
         // Plain lyrics are a reading surface, not a following one: one calm
@@ -175,7 +185,7 @@ class LyricLineTile extends StatelessWidget {
 
 /// The small accent pill marking the active line.
 ///
-/// It is a *redundant* cue — the line is already larger and heavier — which is
+/// It is a *redundant* cue — the line is already heavier and brighter — which is
 /// what lets the active state survive a user who can't distinguish the colours.
 /// Its gutter is reserved whether or not it is drawn, so the lines never shift
 /// sideways as the marker moves down the song.

--- a/lib/features/player/widgets/lyrics/lyrics_viewport.dart
+++ b/lib/features/player/widgets/lyrics/lyrics_viewport.dart
@@ -77,15 +77,25 @@ class SyncedLyricsViewport extends ConsumerStatefulWidget {
 
   final Lyrics lyrics;
 
+  /// How long the one-shot scroll to a newly active line takes.
+  ///
+  /// Short enough that the line is settled well before the next one starts, and
+  /// paired with a curve that eases *in* as well as out: the follow no longer
+  /// lurches off the mark the instant a line changes, which was the abrupt part.
+  /// It is one animation per line change and nothing in between — the view
+  /// schedules no frames while a line is simply playing.
+  static const Duration scrollDuration = Duration(milliseconds: 350);
+
+  /// The curve of that scroll. Symmetric easing, so the movement starts and
+  /// stops as gently as it travels.
+  static const Curve scrollCurve = Curves.easeInOutCubic;
+
   @override
   ConsumerState<SyncedLyricsViewport> createState() =>
       _SyncedLyricsViewportState();
 }
 
 class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
-  /// How long the scroll to a newly active line takes.
-  static const Duration _scrollDuration = Duration(milliseconds: 420);
-
   /// How long auto-following stands down after the user scrolls by hand, so
   /// reading ahead isn't yanked back to the playing line mid-sentence. It
   /// resumes on the next line change after this, with no timer in between.
@@ -184,8 +194,10 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
   void _scheduleCentre(int index) {
     if (index < 0 || index >= _keys.length) return;
     if (_isFollowPaused) return;
-    // After the frame that lays the new emphasis out, so the row is measured at
-    // the size it will actually be.
+    // After the frame that lays the new active line out, so the row is measured
+    // once it exists. Its emphasis no longer changes its metrics (see
+    // LyricLineTile.styleFor), so what is measured here is what the scroll will
+    // still be aiming at when it arrives.
     WidgetsBinding.instance.addPostFrameCallback((_) => _centre(index));
   }
 
@@ -211,8 +223,8 @@ class _SyncedLyricsViewportState extends ConsumerState<SyncedLyricsViewport> {
           alignment: _activeLineAlignment,
           duration: MediaQuery.disableAnimationsOf(context)
               ? Duration.zero
-              : _scrollDuration,
-          curve: Curves.easeOutCubic,
+              : SyncedLyricsViewport.scrollDuration,
+          curve: SyncedLyricsViewport.scrollCurve,
         ),
       );
       return;

--- a/lib/features/player/widgets/playback_progress_bar.dart
+++ b/lib/features/player/widgets/playback_progress_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../../../app/dimens.dart';
@@ -26,6 +28,14 @@ const PlaybackProgressStyle defaultPlaybackProgressStyle =
 /// drags, the marker and the elapsed label follow the finger; the actual
 /// [onSeek] fires once on release, so playback isn't spammed mid-drag.
 ///
+/// Release then *holds* that target until playback reports it. [position] comes
+/// from a stream deliberately coalesced to ~250 ms for battery, so it keeps
+/// reporting the pre-seek position for a moment after the seek is issued;
+/// showing it again the instant the finger lifts snaps the marker back to where
+/// the drag started and only then jumps forward. The bar stays optimistic
+/// across that gap instead — bounded by [seekAckTimeout], so a seek that never
+/// lands can't pin the marker somewhere playback isn't.
+///
 /// The drag preview lives here rather than in either renderer, so both the wave
 /// and the slider stay interchangeable and the time labels follow the finger the
 /// same way in both.
@@ -53,6 +63,20 @@ class PlaybackProgressBar extends StatefulWidget {
   /// Which renderer to use. Defaults to [defaultPlaybackProgressStyle].
   final PlaybackProgressStyle style;
 
+  /// How close [position] has to land to a released seek target before the bar
+  /// hands the display back to it.
+  ///
+  /// The position stream is coalesced to ~250 ms, so the first tick that
+  /// reflects a seek can already sit a flush — plus whatever the engine rounds
+  /// to — past the target. This is that budget with headroom, and still far
+  /// below a difference the eye would read as a jump.
+  static const Duration seekAckTolerance = Duration(milliseconds: 750);
+
+  /// The longest an unacknowledged seek target is held. A seek can simply fail
+  /// (a dead source, a position the engine refuses), and the bar must fall back
+  /// to the truth rather than lie indefinitely.
+  static const Duration seekAckTimeout = Duration(seconds: 3);
+
   @override
   State<PlaybackProgressBar> createState() => _PlaybackProgressBarState();
 }
@@ -61,11 +85,74 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
   /// The in-progress drag position in milliseconds, or null when not dragging.
   double? _dragMs;
 
-  void _onChanged(double value) => setState(() => _dragMs = value);
+  /// The position the last completed gesture seeked to, in milliseconds, shown
+  /// in place of [PlaybackProgressBar.position] until playback acknowledges it.
+  /// Null once acknowledged, superseded, or timed out.
+  double? _pendingSeekMs;
+
+  /// Fires if that acknowledgement never comes — the bound on the optimism.
+  Timer? _pendingSeekExpiry;
+
+  @override
+  void didUpdateWidget(PlaybackProgressBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A different duration means a different source is loaded, and a target
+    // measured against the previous track is meaningless against this one.
+    if (widget.duration != oldWidget.duration) {
+      _clearPendingSeek();
+      return;
+    }
+    if (widget.position != oldWidget.position) _settlePendingSeek();
+  }
+
+  @override
+  void dispose() {
+    _pendingSeekExpiry?.cancel();
+    super.dispose();
+  }
+
+  /// Hands the display back to the authoritative position once it has reached
+  /// the pending target.
+  ///
+  /// No `setState`: this only runs from [didUpdateWidget], where the rebuild
+  /// that delivered the new position is already under way.
+  void _settlePendingSeek() {
+    final double? target = _pendingSeekMs;
+    if (target == null) return;
+    final double delta = (widget.position.inMilliseconds - target).abs();
+    if (delta > PlaybackProgressBar.seekAckTolerance.inMilliseconds) return;
+    _clearPendingSeek();
+  }
+
+  void _clearPendingSeek() {
+    _pendingSeekMs = null;
+    _pendingSeekExpiry?.cancel();
+    _pendingSeekExpiry = null;
+  }
+
+  void _onChanged(double value) {
+    setState(() {
+      // A fresh gesture supersedes the previous target outright: the finger is
+      // the most current intent there is.
+      _clearPendingSeek();
+      _dragMs = value;
+    });
+  }
 
   void _onChangeEnd(double value) {
     widget.onSeek?.call(Duration(milliseconds: value.round()));
-    setState(() => _dragMs = null);
+    _pendingSeekExpiry?.cancel();
+    _pendingSeekExpiry = Timer(
+      PlaybackProgressBar.seekAckTimeout,
+      () {
+        if (!mounted) return;
+        setState(_clearPendingSeek);
+      },
+    );
+    setState(() {
+      _dragMs = null;
+      _pendingSeekMs = value;
+    });
   }
 
   @override
@@ -78,7 +165,12 @@ class _PlaybackProgressBarState extends State<PlaybackProgressBar> {
     final int posMs = hasDuration
         ? widget.position.inMilliseconds.clamp(0, totalMs).toInt()
         : 0;
-    final double barValue = _dragMs ?? posMs.toDouble();
+    // The finger first, then a seek playback hasn't caught up with, then the
+    // truth. Each is only ever the *most current* thing known about where
+    // playback is meant to be.
+    final double barValue = _dragMs ??
+        _pendingSeekMs?.clamp(0, totalMs.toDouble()) ??
+        posMs.toDouble();
 
     final muted = theme.colorScheme.onSurfaceVariant;
     final labelStyle = theme.textTheme.labelSmall?.copyWith(

--- a/test/features/player/lyrics_experience_test.dart
+++ b/test/features/player/lyrics_experience_test.dart
@@ -13,6 +13,7 @@ import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/player_screen.dart';
 import 'package:linthra/features/player/widgets/album_artwork.dart';
 import 'package:linthra/features/player/widgets/lyrics/lyric_line_tile.dart';
+import 'package:linthra/features/player/widgets/lyrics/lyrics_viewport.dart';
 import 'package:linthra/features/player/widgets/lyrics_view.dart';
 
 import 'fake_playback_controller.dart';
@@ -105,6 +106,25 @@ TextStyle _styleOf(WidgetTester tester, String text) =>
 
 double _opacityOf(WidgetTester tester, String text) =>
     _styleOf(tester, text).color!.a;
+
+/// The whole row [text] is rendered in.
+Finder _tileOf(String text) => find.ancestor(
+      of: find.text(text),
+      matching: find.byType(LyricLineTile),
+    );
+
+/// How visible that row's accent marker is — the non-colour, non-typographic
+/// cue for the active line.
+double _markerOpacityOf(WidgetTester tester, String text) {
+  return tester
+      .widget<AnimatedOpacity>(
+        find.descendant(
+          of: _tileOf(text),
+          matching: find.byType(AnimatedOpacity),
+        ),
+      )
+      .opacity;
+}
 
 /// Gives the test a tall window, so a whole song's worth of lines is on screen
 /// at once (and so Now Playing's fixed chrome fits at a large text scale).
@@ -223,11 +243,117 @@ void main() {
 
       expect(active.fontWeight, FontWeight.w700);
       expect(neighbour.fontWeight, FontWeight.w500);
-      // Larger, fully opaque, and a different colour — dominance is carried by
-      // size and weight too, never by colour alone.
-      expect(active.fontSize, greaterThan(neighbour.fontSize!));
+      // Heavier, fully opaque, and a different colour — dominance is carried by
+      // weight too, never by colour alone.
       expect(active.color!.a, 1.0);
       expect(active.color, isNot(neighbour.color));
+      // …and by the accent marker beside it, the cue that survives a reader who
+      // can see neither the weight nor the colour.
+      expect(_markerOpacityOf(tester, 'line two'), 1.0);
+      expect(_markerOpacityOf(tester, 'line one'), 0.0);
+    });
+
+    testWidgets('emphasis never changes a timed line\'s metrics',
+        (tester) async {
+      _useTallWindow(tester);
+      await _pumpPlayer(
+        tester,
+        controller: FakePlaybackController(
+          initial: _playingAt(const Duration(seconds: 12)),
+        ),
+        lyrics: _synced,
+      );
+      await _openLyrics(tester);
+
+      // Auto-follow animates the list while the rows restyle, so a size or
+      // leading that moved with emphasis would change row geometry underneath
+      // the scroll. Every timed state has to lay out identically.
+      final TextStyle active = _styleOf(tester, 'line two');
+      for (final String other in <String>[
+        'line one', // adjacent
+        'line four', // near
+        'line five', // distant
+      ]) {
+        final TextStyle style = _styleOf(tester, other);
+        expect(style.fontSize, active.fontSize, reason: '$other font size');
+        expect(style.height, active.height, reason: '$other line height');
+        expect(
+          style.letterSpacing,
+          active.letterSpacing,
+          reason: '$other letter spacing',
+        );
+      }
+    });
+
+    testWidgets('a line keeps its exact height as it becomes active',
+        (tester) async {
+      _useTallWindow(tester);
+      final controller = FakePlaybackController(
+        initial: _playingAt(const Duration(seconds: 12)),
+      );
+      await _pumpPlayer(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+
+      // Measured while it is merely adjacent…
+      final Size text = tester.getSize(find.text('line three'));
+      final Size row = tester.getSize(_tileOf('line three'));
+
+      controller.emit(_playingAt(const Duration(seconds: 22)));
+      await tester.pumpAndSettle();
+      expect(_styleOf(tester, 'line three').fontWeight, FontWeight.w700);
+
+      // …and unchanged now that it is the line playing. The whole row, marker
+      // gutter and all, keeps exactly the space it had.
+      expect(tester.getSize(find.text('line three')), text);
+      expect(tester.getSize(_tileOf('line three')), row);
+    });
+
+    testWidgets('auto-follow is one short transition, not a running animation',
+        (tester) async {
+      final controller = FakePlaybackController(
+        initial: _playingAt(const Duration(seconds: 12)),
+      );
+      await _pumpPlayer(tester, controller: controller, lyrics: _synced);
+      await _openLyrics(tester);
+
+      // Short enough to be over before the next line, eased at both ends so it
+      // neither lurches off the mark nor arrives abruptly.
+      expect(
+        SyncedLyricsViewport.scrollDuration.inMilliseconds,
+        inInclusiveRange(340, 360),
+      );
+      expect(SyncedLyricsViewport.scrollCurve, Curves.easeInOutCubic);
+
+      final ScrollableState list = tester.state<ScrollableState>(
+        find.descendant(
+          of: find.byKey(const Key('synced-lyrics')),
+          matching: find.byType(Scrollable),
+        ),
+      );
+      final double start = list.position.pixels;
+
+      controller.emit(_playingAt(const Duration(seconds: 22)));
+      // The change reaches the viewport through the position stream and is
+      // measured in a post-frame callback, so the scroll starts a few frames
+      // later rather than on the emit itself.
+      double midway = start;
+      for (int i = 0; i < 5 && midway == start; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        midway = list.position.pixels;
+      }
+
+      // Part way there: the follow travels, it does not jump.
+      expect(midway, greaterThan(start), reason: 'auto-follow never started');
+
+      // And it arrives within its own duration.
+      await tester.pump(SyncedLyricsViewport.scrollDuration);
+      final double settled = list.position.pixels;
+      expect(settled, greaterThan(midway));
+
+      // Nothing is left running: a line that is simply playing costs no frames.
+      await tester.pumpAndSettle();
+      expect(list.position.pixels, settled);
+      expect(tester.binding.hasScheduledFrame, isFalse);
     });
 
     testWidgets('surrounding lines fade progressively, not uniformly',

--- a/test/features/player/now_playing_talkback_test.dart
+++ b/test/features/player/now_playing_talkback_test.dart
@@ -362,11 +362,15 @@ void main() {
       expect(controller.seeks, isNotEmpty);
       expect(controller.seeks.last.inSeconds, 72);
 
-      // Perform semantic decrease action
-      // Decreased position: 60s - 12s = 48s (0:48).
+      // Perform semantic decrease action.
+      // A step moves from the value just announced, not from a position the
+      // ~250ms-coalesced stream has yet to report: the bar holds the seek it
+      // just issued, so 1:12 - 12s is 1:00 (and stepping up then down returns
+      // where it started rather than jumping to 0:48).
+      expect(tester.getSemantics(seekFinder).value, '1:12 of 4:00');
       tester.semantics.decrease(find.semantics.byLabel('Playback position'));
       await tester.pumpAndSettle();
-      expect(controller.seeks.last.inSeconds, 48);
+      expect(controller.seeks.last.inSeconds, 60);
 
       handle.dispose();
     });

--- a/test/features/player/playback_progress_bar_test.dart
+++ b/test/features/player/playback_progress_bar_test.dart
@@ -10,6 +10,11 @@ import 'package:linthra/features/player/widgets/wavy_seek_bar.dart';
 const double _barWidth = 300;
 const Duration _total = Duration(minutes: 4);
 
+/// Pumps the bar, returning the list every seek lands in.
+///
+/// Passing [seeks] back in re-pumps the *same* bar with a new [position] — the
+/// widget type and location are unchanged, so the element and its state survive
+/// and the bar sees the update exactly as it would from a position tick.
 Future<List<Duration>> _pumpBar(
   WidgetTester tester, {
   Duration position = Duration.zero,
@@ -17,8 +22,9 @@ Future<List<Duration>> _pumpBar(
   bool seekable = true,
   bool playing = false,
   PlaybackProgressStyle style = PlaybackProgressStyle.wave,
+  List<Duration>? seeks,
 }) async {
-  final List<Duration> seeks = <Duration>[];
+  seeks ??= <Duration>[];
   await tester.pumpWidget(
     MaterialApp(
       home: Scaffold(
@@ -31,6 +37,9 @@ Future<List<Duration>> _pumpBar(
               playing: playing,
               style: style,
               onSeek: seekable ? seeks.add : null,
+              // Keyed so a re-pump with a new position updates this bar rather
+              // than replacing it — the state under test has to survive.
+              key: const Key('progress-bar'),
             ),
           ),
         ),
@@ -39,6 +48,20 @@ Future<List<Duration>> _pumpBar(
   );
   await tester.pump();
   return seeks;
+}
+
+/// Drags the wave to [fraction] of the track and lifts the finger, returning
+/// after the frame that release produced.
+Future<void> _dragTo(WidgetTester tester, double fraction) async {
+  // The painter insets the box by the marker radius (6) at each end.
+  const double travel = _barWidth - 12;
+  final Offset centre = tester.getCenter(find.byType(WavySeekBar));
+  final TestGesture gesture = await tester.startGesture(centre);
+  await tester.pump();
+  await gesture.moveTo(centre + Offset((fraction - 0.5) * travel, 0));
+  await tester.pump();
+  await gesture.up();
+  await tester.pump();
 }
 
 void main() {
@@ -130,6 +153,136 @@ void main() {
     });
   });
 
+  group('PlaybackProgressBar seek handoff', () {
+    // The position stream is coalesced to ~250 ms for battery, so for a moment
+    // after a seek it still reports where playback *was*. These tests pin the
+    // handoff across that gap: the released target holds the display until the
+    // authoritative position reaches it, so the marker never snaps backwards
+    // and then forward again.
+
+    testWidgets('releasing a drag does not snap back to the old position',
+        (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await _pumpBar(tester, seeks: seeks);
+
+      await _dragTo(tester, 0.25);
+
+      // Released at a quarter of a four-minute song.
+      expect(seeks, hasLength(1));
+      expect(seeks.single.inSeconds, closeTo(60, 1));
+      expect(find.text('1:00'), findsOneWidget);
+      expect(find.text('0:00'), findsNothing);
+
+      // The next ticks still carry the pre-seek position — the seek has not
+      // reached playbackStateProvider yet. The bar must not show it.
+      for (final Duration stale in <Duration>[
+        const Duration(milliseconds: 250),
+        const Duration(milliseconds: 500),
+      ]) {
+        await _pumpBar(tester, position: stale, seeks: seeks);
+        expect(find.text('1:00'), findsOneWidget);
+        expect(find.text('0:00'), findsNothing);
+      }
+    });
+
+    testWidgets('normal position updates take over once playback catches up',
+        (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await _pumpBar(tester, seeks: seeks);
+      await _dragTo(tester, 0.25);
+      await _pumpBar(tester, position: Duration.zero, seeks: seeks);
+      expect(find.text('1:00'), findsOneWidget);
+
+      // The seek lands: the first authoritative position at the target hands
+      // the display straight back.
+      await _pumpBar(
+        tester,
+        position: const Duration(seconds: 60, milliseconds: 120),
+        seeks: seeks,
+      );
+      await _pumpBar(tester,
+          position: const Duration(seconds: 63), seeks: seeks);
+      expect(find.text('1:03'), findsOneWidget);
+
+      // Including an update that moves *backwards*, which a still-pinned bar
+      // would have swallowed.
+      await _pumpBar(tester,
+          position: const Duration(seconds: 30), seeks: seeks);
+      expect(find.text('0:30'), findsOneWidget);
+    });
+
+    testWidgets('a drag still seeks exactly once, however long the hold lasts',
+        (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await _pumpBar(tester, seeks: seeks);
+
+      await _dragTo(tester, 0.75);
+
+      for (final int seconds in <int>[0, 1, 180, 181]) {
+        await _pumpBar(
+          tester,
+          position: Duration(seconds: seconds),
+          seeks: seeks,
+        );
+      }
+
+      expect(seeks, hasLength(1));
+      expect(seeks.single.inSeconds, closeTo(180, 1));
+    });
+
+    testWidgets('a seek that never lands releases the bar after the timeout',
+        (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await _pumpBar(tester, seeks: seeks);
+      await _dragTo(tester, 0.25);
+
+      // Playback carries on where it was: the seek failed. The bar holds the
+      // optimistic target only while the bound allows.
+      await _pumpBar(tester,
+          position: const Duration(seconds: 1), seeks: seeks);
+      expect(find.text('1:00'), findsOneWidget);
+
+      await tester.pump(
+        PlaybackProgressBar.seekAckTimeout + const Duration(milliseconds: 1),
+      );
+      await tester.pump();
+
+      expect(find.text('0:01'), findsOneWidget);
+      expect(find.text('1:00'), findsNothing);
+    });
+
+    testWidgets('a new drag supersedes the held target', (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await _pumpBar(tester, seeks: seeks);
+      await _dragTo(tester, 0.25);
+      expect(find.text('1:00'), findsOneWidget);
+
+      // Second thoughts, before the first seek was ever reported.
+      await _dragTo(tester, 0.75);
+
+      expect(find.text('3:00'), findsOneWidget);
+      expect(seeks, hasLength(2));
+    });
+
+    testWidgets('a new track drops a target measured against the old one',
+        (tester) async {
+      final List<Duration> seeks = <Duration>[];
+      await _pumpBar(tester, seeks: seeks);
+      await _dragTo(tester, 0.25);
+      expect(find.text('1:00'), findsOneWidget);
+
+      await _pumpBar(
+        tester,
+        position: const Duration(seconds: 3),
+        duration: const Duration(minutes: 5),
+        seeks: seeks,
+      );
+
+      expect(find.text('0:03'), findsOneWidget);
+      expect(find.text('5:00'), findsOneWidget);
+    });
+  });
+
   group('PlaybackProgressBar (wave) accessibility', () {
     testWidgets('announces the position as a slider', (tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
@@ -158,9 +311,37 @@ void main() {
       expect(seeks.single, const Duration(seconds: 72));
 
       seeks.clear();
+      // A step lands on the announced value, not on a position the coalesced
+      // stream has yet to report: stepping down from 1:12 returns to 1:00,
+      // rather than stepping down from a stale 1:00 and jumping to 0:48.
+      expect(
+        tester.getSemantics(find.byType(WavySeekBar)).value,
+        '1:12 of 4:00',
+      );
       tester.semantics.decrease(find.semantics.byLabel('Playback position'));
       await tester.pump();
-      expect(seeks.single, const Duration(seconds: 48));
+      expect(seeks.single, const Duration(seconds: 60));
+
+      handle.dispose();
+    });
+
+    testWidgets('a step away from a stale position still lands where announced',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      final seeks =
+          await _pumpBar(tester, position: const Duration(minutes: 1));
+
+      // Two increases in quick succession, before either is reported: the
+      // second must build on the first rather than repeat it.
+      tester.semantics.increase(find.semantics.byLabel('Playback position'));
+      await tester.pump();
+      tester.semantics.increase(find.semantics.byLabel('Playback position'));
+      await tester.pump();
+
+      expect(
+        seeks,
+        <Duration>[const Duration(seconds: 72), const Duration(seconds: 84)],
+      );
 
       handle.dispose();
     });

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -189,6 +189,39 @@ void main() {
       expect(controller.seeks.first, greaterThan(Duration.zero));
     });
 
+    testWidgets('a track change drops a seek the previous track was holding',
+        (tester) async {
+      // Two songs of exactly the same length — so nothing about the *shape* of
+      // the playback state changes when the track does, and only the bar's
+      // identity can tell them apart.
+      const Duration sameLength = Duration(minutes: 3);
+      final controller = _playing(duration: sameLength);
+      await _pumpScreen(tester, controller);
+
+      // Seek into the middle of song one. The bar holds that target while the
+      // ~250ms-coalesced position stream catches up.
+      await tester.tap(find.byType(WavySeekBar));
+      await tester.pumpAndSettle();
+      expect(controller.seeks, hasLength(1));
+      expect(find.text('1:30'), findsOneWidget);
+
+      // Song two starts from the beginning before that ever happened.
+      controller.emit(
+        const PlaybackState(
+          status: PlaybackStatus.playing,
+          currentTrack: Track(id: '2', title: 'Song Two', uri: '/2.mp3'),
+          source: PlaybackSource.localFile,
+          duration: sameLength,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // A position from the previous song must not ride along into this one.
+      expect(find.text('0:00'), findsOneWidget);
+      expect(find.text('1:30'), findsNothing);
+      expect(controller.seeks, hasLength(1));
+    });
+
     testWidgets('the queue button opens up-next', (tester) async {
       final controller = _playing(
         upNext: const <Track>[

--- a/test/features/player/player_screen_test.dart
+++ b/test/features/player/player_screen_test.dart
@@ -191,10 +191,20 @@ void main() {
 
     testWidgets('a track change drops a seek the previous track was holding',
         (tester) async {
-      // Two songs of exactly the same length — so nothing about the *shape* of
-      // the playback state changes when the track does, and only the bar's
-      // identity can tell them apart.
+      // The two songs are as alike as the playback state can make them: exactly
+      // the same length, and the same *bare* id — which is legal, because ids
+      // are only unique within a provider (see `Track.==`). Nothing but the
+      // provider-namespaced uri separates them, so nothing but the uri can tell
+      // the bar it is looking at a different song.
       const Duration sameLength = Duration(minutes: 3);
+      const Track songTwo = Track(
+        id: '1',
+        title: 'Song Two',
+        uri: 'jellyfin:1',
+      );
+      expect(songTwo.id, _localTrack.id);
+      expect(songTwo.uri, isNot(_localTrack.uri));
+
       final controller = _playing(duration: sameLength);
       await _pumpScreen(tester, controller);
 
@@ -209,8 +219,8 @@ void main() {
       controller.emit(
         const PlaybackState(
           status: PlaybackStatus.playing,
-          currentTrack: Track(id: '2', title: 'Song Two', uri: '/2.mp3'),
-          source: PlaybackSource.localFile,
+          currentTrack: songTwo,
+          source: PlaybackSource.streamingDirect,
           duration: sameLength,
         ),
       );


### PR DESCRIPTION
Two small stability fixes on Now Playing, both about something moving when it shouldn't. No redesign, no new perpetual animation, and the ~250 ms position coalescing stays exactly as it is.

## 1. Playback progress: the seek handoff

**Root cause.** `PlaybackProgressBar._onChangeEnd()` cleared its drag preview (`_dragMs = null`) in the same breath as calling `onSeek`. The position it then falls back to comes from `playbackStateProvider`, fed by `JustAudioPlaybackController`'s deliberately coalesced `_positionFlushInterval` (250 ms). So for up to a flush after release, the bar re-rendered the *pre-seek* position: the marker snapped back to where the drag started and only then jumped forward.

**Fix.** An optimistic pending-seek position:

- dragging still shows the drag preview, and `onSeek` still fires exactly once on release;
- the released target keeps being displayed after the drag ends;
- it is cleared when the authoritative position reaches it (`seekAckTolerance`, 750 ms — the coalescing flush plus headroom for engine rounding);
- bounded by `seekAckTimeout` (3 s), so a seek that never lands can't pin the UI;
- stale state is dropped when a new gesture supersedes it, when a new source loads, and on dispose.

The precedence is finger → unacknowledged seek → authoritative position. No ticker, no perpetual animation — one cancellable one-shot timer that exists only while a seek is outstanding.

**Track identity.** Dropping the target on a duration change is not enough on its own: two tracks can be exactly as long as each other, and then nothing about the playback state distinguishes them. The bar is therefore keyed in `_LiveControls` by the current track's **`uri`** — what `Track` itself defines identity by (its `==` and `hashCode` use `uri` alone, because bare ids only have to be unique within a provider). A track change disposes the bar's state, pending seek included, whatever the two durations happen to be and whatever ids two providers happen to reuse.

One behaviour consequence, in the accessibility path: a semantic increase/decrease now steps from the value just announced rather than from a position the coalesced stream has yet to report. `increase` then `decrease` returns to where it started (1:00 → 1:12 → 1:00) instead of stepping off a stale value and landing at 0:48, and two quick increases accumulate (1:12, 1:24) instead of both issuing the same seek. Two existing assertions encoded the old arithmetic and were updated.

## 2. Synced lyrics: row geometry

**Root cause.** `LyricLineTile.styleFor` gave `LyricEmphasis.active` a different font size (`× 1.25`), leading (`1.3` vs `1.35`) and letter spacing (`-0.2`) from every other timed state. `AnimatedDefaultTextStyle` animated that over 220 ms **while** the viewport was animating `Scrollable.ensureVisible` for 420 ms — so the rows changed height under the in-flight scroll and the follow landed off the target it measured.

**Fix.** Every timed emphasis now shares one font size and one line height (`_timedHeight`), with letter spacing left alone too, so a line occupies exactly the same space whether or not it is playing. Active indication is unchanged in strength: full-opacity `onSurface`, `w700` against `w500`, the accent marker in the gutter, and `selected: true` semantics. `LyricEmphasis.untimed` (plain lyrics) keeps its own `bodyLarge` typography and generous leading. Sizes still come from the text theme, so text scaling multiplies them as before.

The auto-follow transition is now a one-shot 350 ms `Curves.easeInOutCubic` (was 420 ms `easeOutCubic`), exposed as `SyncedLyricsViewport.scrollDuration` / `scrollCurve`. Easing in as well as out removes the lurch at the start of the movement.

Untouched: the `ValueNotifier` active-line optimisation (the viewport listens rather than watches, so only affected `SyncedLyricLine` rows rebuild and the list never does), the reduced-motion zero-duration paths, and the 5 s manual-scroll follow pause.

## Files changed

- `lib/features/player/widgets/playback_progress_bar.dart`
- `lib/features/player/player_screen.dart`
- `lib/features/player/widgets/lyrics/lyric_line_tile.dart`
- `lib/features/player/widgets/lyrics/lyrics_viewport.dart`
- `test/features/player/playback_progress_bar_test.dart`
- `test/features/player/player_screen_test.dart`
- `test/features/player/lyrics_experience_test.dart`
- `test/features/player/now_playing_talkback_test.dart`

`wavy_seek_bar.dart` needed no change — the Slider-mirroring API and the slider semantics already carry the corrected value through unchanged.

## Tests

Added (progress bar), a new `seek handoff` group:

- releasing a drag does not snap back to the old position (and does not while stale ticks keep arriving);
- normal position updates take over once playback catches up, including a subsequent backwards update;
- a drag still seeks exactly once, however long the hold lasts;
- a seek that never lands releases the bar after the timeout;
- a new drag supersedes the held target;
- a new track drops a target measured against the old one;
- a semantic step away from a stale position lands where announced.

Added (Now Playing wiring): a track change drops a seek the previous track was holding — song two is exactly as long as song one **and carries the same bare `id`**, differing only in `uri`, which is the case neither a duration comparison nor an id-keyed widget can catch. Verified to fail both without the key and with an id-based one.

Added (lyrics):

- emphasis never changes a timed line's metrics (size, leading, letter spacing equal across active/adjacent/near/distant);
- a line keeps its exact rendered height — text box and whole row — as it becomes active;
- auto-follow is one short transition: it travels rather than jumps, arrives within its own duration, and leaves no frames scheduled.

Updated: "the active line is visually dominant" now asserts weight, full opacity, a distinct colour and the accent marker instead of a larger font size; the two semantic-step assertions described above.

No throttle or battery test was weakened — `lyrics_highlight_throttle_test.dart`, `queue_sheet_throttle_test.dart` and the "never animates perpetually" assertions are untouched and passing.

## Commands run

- `dart format --set-exit-if-changed .` — clean
- `flutter analyze` — **No issues found**, nothing suppressed
- `./scripts/check_secrets.sh` — passed
- `flutter test` (full suite) — **3237 passing**

## Tradeoffs

- **Ack by tolerance, not by identity.** The controller reports a position, not "your seek landed", so acknowledgement is `|position − target| ≤ 750 ms`. A seek shorter than that tolerance is acknowledged by the pre-seek position itself — harmless, since the discrepancy is below what the eye resolves, and it just restores today's behaviour for that case.
- **Keying by track uri rebuilds the bar on every track change.** That is the point, and it costs one widget subtree rebuild at a moment the whole screen is changing anyway.
- **Duration change also clears the pending target.** Right for a source change; a stream that revises its own duration mid-track would drop the optimism early and fall back to the authoritative position — the pre-existing behaviour, not a new failure mode.
- **Active lines are less loud than before.** Losing the 1.25× size is the point of the change, but it is a real visual reduction; weight, opacity and the marker carry it now.
- **Font weight still affects text width**, so a line sitting exactly on a wrap boundary could in principle re-wrap when it goes bold. Keeping weight as the indicator was a requirement; removing the size and letter-spacing deltas leaves that as the only remaining geometric variable.
