### PR TITLE
ci: open weekly Flutter SDK update PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ name: CI
 #   * secret-scan         — offline scan for committed secrets / private data.
 #   * release-bump-guard  — release/* PRs only: the bump must be version-only.
 #   * dependency-guard    — deps/* PRs only: the update must be lockfile-only.
-#   * toolchain-guard     — toolchain/* PRs only: the update must be pin-only.
+#   * toolchain-guard     — toolchain/flutter-sdk only: the bump must be
+#                           pin-only.
 on:
   push:
     branches: [main]
@@ -117,13 +118,15 @@ jobs:
   toolchain-guard:
     name: Toolchain update touches only the pin
     runs-on: ubuntu-latest
-    # Only meaningful for the PRs the "Flutter SDK updates" workflow opens (it
-    # pushes the toolchain/flutter-sdk branch). The updater already refuses to
-    # commit anything but .flutter-version; re-checking here covers what happens
-    # to the branch afterwards — an "I'll just migrate the deprecated API while
-    # I'm here" commit pushed onto the SDK PR is exactly the change that must
-    # not ride along, because that migration is a human's separate PR.
-    if: ${{ startsWith(github.head_ref, 'toolchain/') }}
+    # Only the one branch the "Flutter SDK updates" workflow pushes. The
+    # updater already refuses to commit anything but .flutter-version;
+    # re-checking here covers what happens to the branch afterwards — an "I'll
+    # just migrate the deprecated API while I'm here" commit pushed onto the
+    # SDK PR is exactly the change that must not ride along, because that
+    # migration is a human's separate PR. Matched exactly, not by prefix: a
+    # human's toolchain/* PR is an ordinary PR and must not inherit the
+    # pin-only rule.
+    if: ${{ github.head_ref == 'toolchain/flutter-sdk' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ name: CI
 #   * secret-scan         — offline scan for committed secrets / private data.
 #   * release-bump-guard  — release/* PRs only: the bump must be version-only.
 #   * dependency-guard    — deps/* PRs only: the update must be lockfile-only.
+#   * toolchain-guard     — toolchain/* PRs only: the update must be pin-only.
 on:
   push:
     branches: [main]
@@ -103,11 +104,39 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Local twin: scripts/check_dependency_update_files.sh.
+      # Local twin: scripts/check_dependency_update_files.sh. --kind defaults to
+      # dart-packages, whose allowlist is pubspec.lock and nothing else.
       - name: Check changed files
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           git diff --name-only "$BASE_SHA" HEAD \
-            | ./scripts/check_dependency_update_files.sh
+            | ./scripts/check_dependency_update_files.sh --kind dart-packages
+
+  toolchain-guard:
+    name: Toolchain update touches only the pin
+    runs-on: ubuntu-latest
+    # Only meaningful for the PRs the "Flutter SDK updates" workflow opens (it
+    # pushes the toolchain/flutter-sdk branch). The updater already refuses to
+    # commit anything but .flutter-version; re-checking here covers what happens
+    # to the branch afterwards — an "I'll just migrate the deprecated API while
+    # I'm here" commit pushed onto the SDK PR is exactly the change that must
+    # not ride along, because that migration is a human's separate PR.
+    if: ${{ startsWith(github.head_ref, 'toolchain/') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Same script as the dependency guard, with the SDK updater's narrower
+      # allowlist: .flutter-version, and nothing else — not even pubspec.lock,
+      # which only a human may re-resolve.
+      - name: Check changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          git diff --name-only "$BASE_SHA" HEAD \
+            | ./scripts/check_dependency_update_files.sh --kind flutter-sdk

--- a/.github/workflows/flutter-ci-fixer.yml
+++ b/.github/workflows/flutter-ci-fixer.yml
@@ -92,8 +92,17 @@ jobs:
           # (.github/workflows/dart-dependency-updates.yml), whose PRs must stay
           # lockfile-only — a repair commit would put application code into a PR
           # that is guarded to contain nothing but pubspec.lock.
-          if [[ "$head_branch" == dependabot/* || "$head_branch" == deps/* ]]; then
-            echo "Skipping dependency update branch $head_branch; update PRs stay red for review."
+          #
+          # toolchain/* covers the Flutter SDK updater
+          # (.github/workflows/flutter-sdk-updates.yml). It matters most there:
+          # a new SDK goes red precisely when it deprecates an API Linthra uses,
+          # and "repair the application code until the checks pass" is the
+          # migration itself — a human decision, in a human's PR. Those PRs are
+          # guarded to contain nothing but .flutter-version, so a repair commit
+          # could not land on them anyway.
+          if [[ "$head_branch" == dependabot/* || "$head_branch" == deps/* \
+                || "$head_branch" == toolchain/* ]]; then
+            echo "Skipping dependency/toolchain update branch $head_branch; update PRs stay red for review."
             exit 0
           fi
 
@@ -363,14 +372,16 @@ jobs:
   publish:
     name: Publish validated Flutter fix
     needs: fix
-    # The dependency-branch check in the fix job already stops a repair being
-    # built, so target_branch can never be dependabot/ or deps/ here. Restated
-    # anyway: this is the last gate before a commit is pushed, and "never
-    # publish onto an update PR" is worth enforcing where the push happens.
+    # The update-branch check in the fix job already stops a repair being built,
+    # so target_branch can never be dependabot/, deps/ or toolchain/ here.
+    # Restated anyway: this is the last gate before a commit is pushed, and
+    # "never publish onto an update PR" is worth enforcing where the push
+    # happens.
     if: >-
       ${{ needs.fix.outputs.ready == 'true'
       && !startsWith(needs.fix.outputs.target_branch, 'dependabot/')
-      && !startsWith(needs.fix.outputs.target_branch, 'deps/') }}
+      && !startsWith(needs.fix.outputs.target_branch, 'deps/')
+      && !startsWith(needs.fix.outputs.target_branch, 'toolchain/') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/flutter-sdk-updates.yml
+++ b/.github/workflows/flutter-sdk-updates.yml
@@ -1,0 +1,414 @@
+name: Flutter SDK updates
+
+# Weekly check of the official Flutter stable channel against the SDK pinned in
+# .flutter-version, prepared as one reviewable draft PR (#362).
+#
+# Nothing here merges, and nothing here migrates code. The workflow's whole job
+# is to say "a newer stable SDK exists; here is the one-line pin change; here is
+# what CI thinks of it" and then stop. If the new SDK deprecates an API Linthra
+# uses, or makes the committed lockfile fail its enforced resolve, the PR goes
+# red and stays red until a human does the migration in their own PR. That red
+# is the deliverable, not a bug.
+#
+# Detection lives in scripts/check_flutter_sdk_update.py, not in this file, so
+# the version comparison can be tested offline against fixture manifests
+# (test/tooling/flutter_sdk_update_guardrails_test.dart). The script reads the
+# official release manifest from the same flutter_infra_release bucket
+# scripts/setup_flutter.sh installs the pinned SDK from, filters it to the
+# stable channel, and classifies the gap as patch, minor or major.
+#
+# patch / minor -> this workflow opens or updates the draft PR below.
+# major         -> no PR and no pin change; it opens or updates an issue
+#                  instead, because a major SDK migration touches application
+#                  APIs and the F-Droid build in ways CI cannot judge.
+#
+# See docs/dependency-updates.md.
+on:
+  schedule:
+    # Mondays, early UTC — the same weekly cadence as the other updaters, a few
+    # minutes after the Dart package run so the two never contend.
+    - cron: "41 4 * * 1"
+  workflow_dispatch:
+
+# A manual run is the scheduled run: same detection, same safety checks, same
+# publication path. The only difference is what started it.
+concurrency:
+  group: flutter-sdk-updates
+  cancel-in-progress: false
+
+# Read-only by default. The publication job below keeps this and routes its
+# writes through the dedicated token instead, because a push or PR made with
+# GITHUB_TOKEN does not trigger the PR's normal CI — and an update PR that runs
+# no checks is a broken updater.
+permissions:
+  contents: read
+
+env:
+  UPDATE_BRANCH: toolchain/flutter-sdk
+  COMMIT_SUBJECT_PREFIX: "chore(toolchain): update Flutter SDK to "
+
+jobs:
+  check:
+    name: Check the stable channel
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.check.outputs.status }}
+      current: ${{ steps.check.outputs.current }}
+      latest: ${{ steps.check.outputs.latest }}
+      latest_release_date: ${{ steps.check.outputs.latest_release_date }}
+      latest_archive: ${{ steps.check.outputs.latest_archive }}
+      latest_hash: ${{ steps.check.outputs.latest_hash }}
+      stable_confirmed: ${{ steps.check.outputs.stable_confirmed }}
+      source: ${{ steps.check.outputs.source }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      # Local twin: python3 scripts/check_flutter_sdk_update.py. Reads
+      # .flutter-version, fetches the official stable release manifest and
+      # classifies. Exits non-zero on anything it cannot trust — a malformed
+      # pin, a manifest it cannot parse, or a "newest stable" that is behind
+      # the pin — rather than guessing a target.
+      - name: Classify the pinned SDK against stable
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_flutter_sdk_update.py \
+            --github-output "$GITHUB_OUTPUT" | tee "$RUNNER_TEMP/check.txt"
+
+      - name: Summarise
+        shell: bash
+        env:
+          STATUS: ${{ steps.check.outputs.status }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Flutter stable check"
+            echo
+            echo '```text'
+            cat "$RUNNER_TEMP/check.txt"
+            echo '```'
+            if [[ "$STATUS" == "up-to-date" ]]; then
+              echo
+              echo "Nothing to do."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # patch / minor -> one reusable draft PR that changes the pin and nothing else
+  # ---------------------------------------------------------------------------
+  sdk-pr:
+    name: Open or update the draft SDK PR
+    needs: check
+    if: ${{ needs.check.outputs.status == 'patch' || needs.check.outputs.status == 'minor' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Fails the run rather than opening a PR that no CI would ever look at.
+      # This step lives in this job on purpose: a week with no update never
+      # reaches it, so a missing token cannot fail a no-op run.
+      - name: Require workflow-triggering publication token
+        env:
+          PUBLISH_TOKEN: ${{ secrets.DEPENDENCY_UPDATE_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "$PUBLISH_TOKEN" ]]; then
+            echo "::error::DEPENDENCY_UPDATE_TOKEN is required to publish the SDK update PR so it runs normal CI. See docs/dependency-updates.md."
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Open or update the draft SDK update PR
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDENCY_UPDATE_TOKEN }}
+          STATUS: ${{ needs.check.outputs.status }}
+          CURRENT: ${{ needs.check.outputs.current }}
+          LATEST: ${{ needs.check.outputs.latest }}
+          RELEASE_DATE: ${{ needs.check.outputs.latest_release_date }}
+          RELEASE_ARCHIVE: ${{ needs.check.outputs.latest_archive }}
+          RELEASE_HASH: ${{ needs.check.outputs.latest_hash }}
+          STABLE_CONFIRMED: ${{ needs.check.outputs.stable_confirmed }}
+          MANIFEST_SOURCE: ${{ needs.check.outputs.source }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The detection job already refused to continue on anything it could
+          # not trust, so reaching here without a confirmed stable target would
+          # mean the outputs were tampered with between jobs.
+          if [[ "$STABLE_CONFIRMED" != "true" ]]; then
+            echo "::error::The target $LATEST was not confirmed on the stable channel; refusing to open a PR."
+            exit 1
+          fi
+
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          subject="${COMMIT_SUBJECT_PREFIX}${LATEST}"
+
+          # Reuse the one update branch instead of opening a new PR every week.
+          remote_sha="$(git ls-remote origin "refs/heads/$UPDATE_BRANCH" | cut -f1)"
+          branch_exists=false
+          branch_matches_target=false
+
+          if [[ -n "$remote_sha" ]]; then
+            branch_exists=true
+            git fetch --no-tags origin "+refs/heads/$UPDATE_BRANCH:refs/remotes/origin/$UPDATE_BRANCH"
+
+            # Refuse to overwrite work this workflow did not create. The branch
+            # is expected to hold nothing but this workflow's own pin commits;
+            # if someone pushed a migration onto it, that is a human's PR now
+            # and a force-push would silently delete it.
+            foreign=""
+            while IFS='|' read -r author subject_line; do
+              [[ -n "$author$subject_line" ]] || continue
+              if [[ "$author" == "github-actions[bot]" \
+                    && "$subject_line" == "$COMMIT_SUBJECT_PREFIX"* ]]; then
+                continue
+              fi
+              foreign+="$author|$subject_line"$'\n'
+            done < <(git log --format='%an|%s' "HEAD..origin/$UPDATE_BRANCH")
+
+            if [[ -n "$foreign" ]]; then
+              {
+                echo "### Update skipped"
+                echo
+                echo "\`$UPDATE_BRANCH\` carries commits this workflow did not write:"
+                echo
+                echo '```text'
+                printf '%s' "$foreign"
+                echo '```'
+                echo
+                echo "Refusing to force-push over them. Merge or close the open PR first."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::$UPDATE_BRANCH has commits from someone else; not publishing."
+              exit 0
+            fi
+
+            branch_version="$(git show "origin/$UPDATE_BRANCH:.flutter-version" 2>/dev/null | tr -d '[:space:]' || true)"
+            if [[ -z "$branch_version" ]]; then
+              echo "::error::$UPDATE_BRANCH has no readable .flutter-version; refusing to force-push over it."
+              exit 1
+            fi
+
+            if [[ "$branch_version" == "$LATEST" ]]; then
+              branch_matches_target=true
+            else
+              # The open PR must only ever move forwards. If its pin is already
+              # ahead of the target the manifest just gave us, something is
+              # wrong with the data, not with the branch.
+              if ! python3 scripts/check_flutter_sdk_update.py \
+                    --current "$branch_version" --latest "$LATEST" --quiet; then
+                echo "::error::$UPDATE_BRANCH already proposes $branch_version, which is not older than $LATEST. Refusing to rewind the open PR."
+                exit 1
+              fi
+            fi
+          fi
+
+          # The one file this updater may write. scripts/check_dependency_update_files.sh
+          # re-checks that below, and ci.yml re-checks it again against the real
+          # PR diff for any toolchain/ branch.
+          if [[ "$branch_matches_target" == "true" ]]; then
+            echo "The open PR already proposes $LATEST; not pushing again." >> "$GITHUB_STEP_SUMMARY"
+          else
+            git checkout -B "$UPDATE_BRANCH"
+            printf '%s\n' "$LATEST" > .flutter-version
+            git diff --name-only | ./scripts/check_dependency_update_files.sh --kind flutter-sdk
+            git add .flutter-version
+            git commit -m "$subject"
+
+            if [[ "$branch_exists" == "true" ]]; then
+              git push --force-with-lease="$UPDATE_BRANCH:$remote_sha" origin "$UPDATE_BRANCH"
+            else
+              git push -u origin "$UPDATE_BRANCH"
+            fi
+          fi
+
+          body="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "Automatic Flutter SDK update — **$STATUS** release on the stable channel."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Currently pinned | \`$CURRENT\` |"
+            echo "| Proposed | \`$LATEST\` |"
+            echo "| Kind | $STATUS |"
+            echo "| Released | ${RELEASE_DATE:-unknown} |"
+            echo "| Stable channel | confirmed — \`$LATEST\` is published on stable |"
+            echo
+            echo "Confirmed against the official release manifest:"
+            echo
+            echo "- source: \`$MANIFEST_SOURCE\`"
+            echo "- archive: \`${RELEASE_ARCHIVE:-unknown}\`"
+            echo "- commit: \`${RELEASE_HASH:-unknown}\`"
+            echo
+            echo "That is the same \`flutter_infra_release\` bucket \`scripts/setup_flutter.sh\`"
+            echo "downloads from, so this version is installable by the pinned setup path."
+            echo
+            echo "### What changed here"
+            echo
+            echo "One file:"
+            echo
+            echo '```text'
+            echo ".flutter-version"
+            echo '```'
+            echo
+            echo "No application code, test code, \`pubspec.yaml\`, \`pubspec.lock\`, app"
+            echo "version, F-Droid metadata, Fastlane file, release note, signing file,"
+            echo "license, Gradle, AGP, Kotlin or JDK setting was touched, and no deprecated"
+            echo "API was migrated. \`scripts/check_dependency_update_files.sh --kind flutter-sdk\`"
+            echo "enforces that here and again in CI against this PR's real diff."
+            echo
+            echo "### This PR may be red, and that is fine"
+            echo
+            echo "A new SDK can deprecate an API Linthra uses, reformat with a newer Dart,"
+            echo "or make the committed lockfile fail CI's lockfile-enforced dependency"
+            echo "install. Any of those turns this PR red. That is the finding — it says the"
+            echo "upgrade needs a migration — not a fault in the PR. **Do the migration in a"
+            echo "separate PR.** Do not push fixes onto this branch: the file guard rejects"
+            echo "them, and the next scheduled run refuses to force-push over commits it did"
+            echo "not write. The Flutter CI fixer is kept off \`toolchain/\` branches for the"
+            echo "same reason."
+            echo
+            echo "### Before merging"
+            echo
+            echo "- [ ] CI is green, or every failure is understood and handled elsewhere."
+            echo "- [ ] The lockfile still resolves under the new SDK. \`pubspec.lock\` records"
+            echo "      the SDK line it was resolved against, so a minor bump can need a"
+            echo "      lockfile refresh — which belongs in its own PR, not this one."
+            echo "- [ ] **F-Droid / reproducibility:** the F-Droid recipe and the build"
+            echo "      environment read this same pin, so the new SDK has to be available"
+            echo "      and reproducible there too. Re-read \`docs/fdroid-build-recipe.md\`"
+            echo "      and the reproducibility notes, and update them if the bump changes"
+            echo "      what a builder must install."
+            echo "- [ ] A human reviewed and merged this. Nothing here auto-merges, ever."
+            echo
+            echo "Opened by [\`flutter-sdk-updates.yml\`](.github/workflows/flutter-sdk-updates.yml)"
+            echo "for issue #362. See [docs/dependency-updates.md](docs/dependency-updates.md)."
+            echo
+            echo "Reproduce the detection locally:"
+            echo
+            echo '```bash'
+            echo 'python3 scripts/check_flutter_sdk_update.py'
+            echo '```'
+          } > "$body"
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$UPDATE_BRANCH" \
+            --state open --json number --jq '.[0].number // empty')"
+
+          if [[ -n "$existing" ]]; then
+            # --title/--body only; leave the draft/ready state alone so a
+            # reviewer who marked the PR ready does not get it flipped back.
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --title "$subject" --body-file "$body"
+            echo "Updated PR #$existing ($CURRENT -> $LATEST)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh pr create --repo "$GITHUB_REPOSITORY" --draft \
+              --base main --head "$UPDATE_BRANCH" \
+              --title "$subject" --body-file "$body")"
+            echo "Opened $url ($CURRENT -> $LATEST)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # major -> an issue, no branch, no commit, no pin change
+  # ---------------------------------------------------------------------------
+  major-issue:
+    name: File the major migration issue
+    needs: check
+    if: ${{ needs.check.outputs.status == 'major' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The only write this workflow's own GITHUB_TOKEN ever gets, and only in
+      # the job that files the issue. An issue needs no CI, so it needs none of
+      # the dedicated publication token's reach.
+      issues: write
+    steps:
+      - name: Open or update the major migration issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT: ${{ needs.check.outputs.current }}
+          LATEST: ${{ needs.check.outputs.latest }}
+          RELEASE_DATE: ${{ needs.check.outputs.latest_release_date }}
+          MANIFEST_SOURCE: ${{ needs.check.outputs.source }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          major="${LATEST%%.*}"
+          title="Flutter ${major}.x is available — major SDK migration (manual)"
+
+          body="$RUNNER_TEMP/issue-body.md"
+          {
+            echo "A new **major** Flutter release is on the stable channel."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Currently pinned | \`$CURRENT\` |"
+            echo "| New stable major | \`$LATEST\` |"
+            echo "| Released | ${RELEASE_DATE:-unknown} |"
+            echo "| Source | \`$MANIFEST_SOURCE\` |"
+            echo
+            echo "### No PR was opened, on purpose"
+            echo
+            echo "\`.flutter-version\` has **not** been changed and no commit was made."
+            echo "Patch and minor SDK updates get an automatic draft PR; a major does not,"
+            echo "because a major migration is not a one-line pin change (#362)."
+            echo
+            echo "### Why this stays manual"
+            echo
+            echo "- **Application APIs.** A major SDK removes what earlier releases only"
+            echo "  deprecated. Working through that is a code change with design decisions"
+            echo "  in it, and this repo's automation never migrates application code."
+            echo "- **The dependency graph.** The committed \`pubspec.lock\` is resolved"
+            echo "  against the pinned SDK and records the SDK line it was resolved with, so"
+            echo "  a major bump usually forces a re-resolve — and possibly constraint"
+            echo "  changes in \`pubspec.yaml\`, which no bot here may write."
+            echo "- **F-Droid and reproducibility.** The F-Droid recipe and build"
+            echo "  environment install this same pin. A major bump can change what the"
+            echo "  builder must provide and whether the build still reproduces, and CI"
+            echo "  cannot prove either. See \`docs/fdroid-build-recipe.md\` and the"
+            echo "  reproducibility notes."
+            echo "- **The Android toolchain.** A major SDK often expects a different"
+            echo "  Gradle/AGP/Kotlin/JDK combination, which is its own review."
+            echo
+            echo "### Suggested route"
+            echo
+            echo "Do the migration in a normal human PR: bump the pin, refresh the"
+            echo "lockfile with the new SDK, fix the API breaks, re-check the F-Droid"
+            echo "recipe and reproducibility notes, and let normal CI judge it."
+            echo
+            echo "Filed by [\`flutter-sdk-updates.yml\`](.github/workflows/flutter-sdk-updates.yml)"
+            echo "for issue #362. This issue is updated in place on later runs rather than"
+            echo "refiled, so the weekly check will not spam duplicates."
+          } > "$body"
+
+          # Dedupe on the exact title, which is stable for the whole major line:
+          # a later release within the same major edits this issue instead of
+          # opening another, and a genuinely new major gets a new title. Listed
+          # rather than searched, so a freshly filed issue is found on the next
+          # run without waiting for the search index.
+          existing="$(TITLE="$title" gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --limit 200 --json number,title \
+            --jq 'map(select(.title == env.TITLE))[0].number // empty')"
+
+          if [[ -n "$existing" ]]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file "$body"
+            echo "Updated issue #$existing ($CURRENT -> $LATEST)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --body-file "$body")"
+            echo "Filed $url ($CURRENT -> $LATEST)." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -5,16 +5,18 @@ when something can move. It never merges anything. The bot's job is to say
 *"here is an update, and here is what CI thinks of it"*; deciding what happens
 next is a human's (issue #362).
 
-Three ecosystems are covered, by two different mechanisms:
+Four things are covered, by three different mechanisms:
 
-| Ecosystem | Handled by | Cadence |
-| --- | --- | --- |
-| GitHub Actions | Dependabot — [`.github/dependabot.yml`](../.github/dependabot.yml) | weekly |
-| Cargo (`native/linthra_core`) | Dependabot — same file | weekly |
-| Dart / Flutter packages | [`dart-dependency-updates.yml`](../.github/workflows/dart-dependency-updates.yml) | weekly |
+| What | Handled by | Cadence | Outcome |
+| --- | --- | --- | --- |
+| GitHub Actions | Dependabot — [`.github/dependabot.yml`](../.github/dependabot.yml) | weekly | PR |
+| Cargo (`native/linthra_core`) | Dependabot — same file | weekly | PR |
+| Dart / Flutter packages | [`dart-dependency-updates.yml`](../.github/workflows/dart-dependency-updates.yml) | weekly | draft PR |
+| Flutter SDK | [`flutter-sdk-updates.yml`](../.github/workflows/flutter-sdk-updates.yml) | weekly | draft PR, or an issue for a major |
 
-Toolchain updates — the Flutter SDK itself, Gradle, AGP, Kotlin, the JDK — are
-not automated yet. They are separate phases of the same issue.
+The rest of the toolchain — Gradle, AGP, Kotlin and the JDK — is not automated
+yet. Those are a separate phase of the same issue, and until then a bump to any
+of them is something a human notices and opens by hand.
 
 ## Dart / Flutter packages
 
@@ -184,3 +186,197 @@ Pass `--output-dir DIR` to also write the Markdown summary and the raw
   refuses to force-push over commits it did not write.
 - Merge manually when it is green and you are happy with it. Nothing
   auto-merges, by design.
+
+## Flutter SDK
+
+### Where the pin lives
+
+`.flutter-version`, at the repository root, holds one bare stable version and
+nothing else. It is the single source of truth for the SDK: CI installs from it
+through [`.github/actions/setup-flutter`](../.github/actions/setup-flutter/action.yml),
+contributors install from it through `scripts/setup_flutter.sh`, the Dart
+package updater resolves the lockfile with it, and the F-Droid recipe reads the
+same file. `test/tooling/toolchain_pins_test.dart` fails if a workflow or a
+document starts naming a version instead of reading this one.
+
+A Flutter SDK update is therefore a one-line change — and that is exactly what
+the updater is allowed to write.
+
+### Where the release information comes from
+
+The official Flutter release manifest:
+
+```text
+https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json
+```
+
+That is the machine-readable index behind Flutter's own archive page, served
+from the same `flutter_infra_release` bucket `scripts/setup_flutter.sh` already
+downloads the pinned SDK from. So a version this checker proposes is by
+construction a version the pinned setup path can install. No third-party
+version API, no scraped web page, no `git ls-remote` against the SDK repo.
+
+The manifest lists every release on every channel. A release is a candidate
+here only if all three hold:
+
+1. its `channel` is exactly `stable` — beta, dev and master are ignored, and so
+   are the `-0.N.pre` builds that ride the beta channel;
+2. its `version` is a bare `MAJOR.MINOR.PATCH` — this drops the historical
+   `v1.12.13+hotfix.9`-style stable tags, the only stable rows that are not
+   plain triples;
+3. its `archive` lives under `stable/`.
+
+The newest candidate is the one with the highest `(major, minor, patch)`, not
+the first row in the array — a hotfix on an older line can be published after a
+newer line already exists. The manifest's own `current_release.stable` pointer
+is resolved as a cross-check and any disagreement is reported, but the highest
+version wins either way, so the answer never depends on array order.
+
+### What it does
+
+Once a week (and on demand from **Actions → Flutter SDK updates → Run
+workflow**) the workflow compares the pin against that manifest. A manual run is
+the scheduled run: same detection, same classification, same safety checks.
+
+| Gap between pin and newest stable | Result |
+| --- | --- |
+| none | nothing happens, no PR, no issue |
+| newer patch, same major and minor | draft PR |
+| newer minor, same major | draft PR |
+| newer major | **issue**, and nothing else |
+
+The comparison lives in `scripts/check_flutter_sdk_update.py`, not in the
+workflow YAML, so it can be tested offline against fixture manifests
+(`test/tooling/flutter_sdk_update_guardrails_test.dart`). It uses no
+third-party semantic-version package; three integers and a tuple comparison are
+the whole algorithm.
+
+It fails loudly rather than guessing. A pin it cannot parse, a manifest it
+cannot parse, a manifest with no usable stable release, or a "newest stable"
+that is *older* than the pin all stop the run with a non-zero exit. In
+particular the updater never proposes a downgrade.
+
+Run it yourself:
+
+```bash
+python3 scripts/check_flutter_sdk_update.py
+python3 scripts/check_flutter_sdk_update.py --json
+```
+
+It reads two things and writes nothing.
+
+### Patch and minor: one draft PR
+
+The workflow keeps a single reusable branch:
+
+```text
+toolchain/flutter-sdk
+```
+
+A deliberately separate namespace from `deps/`, so it inherits none of the Dart
+package updater's rules; each branch namespace has its own allowlist. Repeated
+runs update that one PR rather than opening a new one every Monday, and a run
+whose target is already on the branch pushes nothing at all.
+
+The PR body states the currently pinned version, the proposed version, whether
+the gap is a patch or a minor, and the manifest entry (archive, commit,
+release date) that confirms the target really is published on the stable
+channel.
+
+### What the bot may touch
+
+Exactly one file:
+
+```text
+.flutter-version
+```
+
+Notably **not** `pubspec.lock`. A new SDK can require the lockfile to be
+re-resolved, but that resolution is what the reproducible F-Droid build depends
+on ([release-process.md](./release-process.md) §7), so it is a human's decision
+in a human's PR — not something an SDK bump drags along.
+
+`scripts/check_dependency_update_files.sh` owns the list. It takes an explicit
+`--kind`, because the two updaters have deliberately different reach:
+
+| `--kind` | Branch | May write |
+| --- | --- | --- |
+| `dart-packages` (default) | `deps/` | `pubspec.lock` |
+| `flutter-sdk` | `toolchain/` | `.flutter-version` |
+
+Neither kind can write the other's file. And as with the Dart updater, the
+guard runs twice: once inside the workflow before a commit exists, and again in
+CI against the **real PR diff** for any `toolchain/` branch — so a commit
+pushed onto the update PR afterwards is caught too. An automatic SDK update
+never changes application code, test code, dependency constraints, the app
+version, F-Droid metadata, Fastlane files, release notes, signing files or
+licenses, and it never migrates a deprecated API.
+
+### Normal CI runs on it, and red is the point
+
+The PR is published with the dedicated token, so GitHub triggers the repository's
+normal `pull_request` checks on it exactly like any other PR — format, analyze,
+test, the lockfile-enforced dependency install, the secret scan, and the
+`toolchain/` file guard.
+
+A new SDK can deprecate an API Linthra uses, reformat the codebase with a newer
+Dart, or make the committed lockfile fail its enforced resolve. Any of those
+turns the PR red, and **that is the finding**: the bump needs a migration. The
+migration is a separate, human PR. Do not push it onto the update branch — the
+file guard rejects it, and the next scheduled run refuses to force-push over
+commits it did not write.
+
+So the Flutter CI fixer is kept away from this branch too. It skips
+`toolchain/*` exactly the way it skips `dependabot/*` and `deps/*`: while
+resolving the failed run, before any repair is generated, and again in the
+publish job where the push would happen. "Repair the application code until the
+checks pass" *is* the migration, and it is not a bot's call.
+
+Nothing auto-merges. There is no merge command anywhere in the workflow, and a
+test asserts that stays true.
+
+### Major releases get an issue, not a PR
+
+A new major stable release produces no branch, no commit and no change to
+`.flutter-version`. The workflow opens — or updates, so the weekly run does not
+refile it — one issue explaining that a major migration is available, which
+version it is, and why it is intentionally manual:
+
+- **Application APIs.** A major removes what earlier releases only deprecated.
+- **The dependency graph.** The lockfile almost certainly has to be re-resolved,
+  possibly with constraint changes in `pubspec.yaml` that no bot may write.
+- **F-Droid and reproducibility.** The recipe and the build environment install
+  this same pin; a major bump can change what a builder must provide and whether
+  the build still reproduces, and CI cannot prove either.
+- **The Android toolchain.** A major SDK often expects a different
+  Gradle/AGP/Kotlin/JDK combination, which is its own review.
+
+### Reviewing an SDK update PR
+
+- Confirm the proposed version against the manifest details in the PR body.
+- Check CI. Red is informative; work out whether it is an API deprecation, a
+  formatting change from the newer Dart, or a lockfile that needs re-resolving.
+- Do any migration in a separate PR, and refresh `pubspec.lock` with the new SDK
+  there as well — the F-Droid build resolves from the committed lockfile.
+- Re-read [`fdroid-build-recipe.md`](./fdroid-build-recipe.md) and the
+  reproducibility notes, and update them if the bump changes what a builder must
+  install.
+- Merge manually when you are happy with it. Nothing auto-merges, by design.
+
+### One-time setup
+
+The same repository Actions secret the Dart package updater uses:
+
+- `DEPENDENCY_UPDATE_TOKEN` — a dedicated fine-grained token with **Contents:
+  read/write** and **Pull requests: read/write** on this repository.
+
+There is deliberately no second credential. A PR opened with the workflow's
+default `GITHUB_TOKEN` triggers no checks, and an update PR that runs no CI is a
+broken updater — so the workflow fails loudly rather than opening one. It only
+asks for the token in the job that publishes, so a week with no update (or a
+major, which files an issue) never touches it.
+
+The major-update path needs no token at all: it uses the workflow's own
+`GITHUB_TOKEN` with `issues: write`, granted in that one job. An issue runs no
+CI, so it needs none of the publication token's reach. Everything else in the
+workflow stays `contents: read`.

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -302,12 +302,14 @@ in a human's PR — not something an SDK bump drags along.
 | `--kind` | Branch | May write |
 | --- | --- | --- |
 | `dart-packages` (default) | `deps/` | `pubspec.lock` |
-| `flutter-sdk` | `toolchain/` | `.flutter-version` |
+| `flutter-sdk` | `toolchain/flutter-sdk` | `.flutter-version` |
 
 Neither kind can write the other's file. And as with the Dart updater, the
 guard runs twice: once inside the workflow before a commit exists, and again in
-CI against the **real PR diff** for any `toolchain/` branch — so a commit
-pushed onto the update PR afterwards is caught too. An automatic SDK update
+CI against the **real PR diff** for the `toolchain/flutter-sdk` branch — so a
+commit pushed onto the update PR afterwards is caught too. CI matches that
+branch exactly, not by `toolchain/` prefix: a human's own toolchain PR is an
+ordinary PR and is not held to the pin-only rule. An automatic SDK update
 never changes application code, test code, dependency constraints, the app
 version, F-Droid metadata, Fastlane files, release notes, signing files or
 licenses, and it never migrates a deprecated API.
@@ -317,7 +319,7 @@ licenses, and it never migrates a deprecated API.
 The PR is published with the dedicated token, so GitHub triggers the repository's
 normal `pull_request` checks on it exactly like any other PR — format, analyze,
 test, the lockfile-enforced dependency install, the secret scan, and the
-`toolchain/` file guard.
+`toolchain/flutter-sdk` file guard.
 
 A new SDK can deprecate an API Linthra uses, reformat the codebase with a newer
 Dart, or make the committed lockfile fail its enforced resolve. Any of those

--- a/scripts/check_dependency_update_files.sh
+++ b/scripts/check_dependency_update_files.sh
@@ -1,49 +1,98 @@
 #!/usr/bin/env bash
 #
-# check_dependency_update_files.sh — assert an automatic Dart/Flutter package
-# update only touches the one file such an update is allowed to touch.
+# check_dependency_update_files.sh — assert an automatic update only touches
+# the files that kind of update is allowed to touch.
 #
-# The "Dart dependency updates" workflow (and its local twin
-# scripts/update_dart_dependencies.sh) re-resolves the dependency graph with the
-# pinned Flutter SDK and writes the result to exactly one file:
+# Linthra runs two automatic updaters (issue #362), and each one writes exactly
+# one file:
 #
-#   * pubspec.lock                                (the resolved dependency set)
+#   --kind dart-packages   pubspec.lock       the resolved dependency set
+#                          .github/workflows/dart-dependency-updates.yml
+#                          scripts/update_dart_dependencies.sh
 #
-# Nothing else. In particular an automatic update must never rewrite the
-# constraints in pubspec.yaml, never touch application or test code to make a
-# new package version compile, and never go near the release surface — F-Droid
-# metadata, Fastlane, release notes, signing material, licenses or the app
-# version. Those are the changes a human decides on, in a PR they wrote.
+#   --kind flutter-sdk     .flutter-version   the pinned Flutter SDK
+#                          .github/workflows/flutter-sdk-updates.yml
 #
-# `flutter pub upgrade` already behaves that way: it resolves inside the
-# existing constraints and only rewrites the lockfile. This guard is the check
-# that the behaviour actually held, so the bot cannot quietly grow a wider
-# blast radius than it was designed for.
+# The kinds are deliberately separate allowlists rather than one union. A
+# lockfile refresh has no business editing the toolchain pin, and an SDK bump
+# has no business re-resolving the lockfile — that second resolution is a
+# human's call, because the committed pubspec.lock is what the reproducible
+# F-Droid build resolves from (docs/release-process.md §7). Sharing one list
+# would silently give each updater the other's reach.
+#
+# Nothing else is allowed in either kind. In particular an automatic update
+# must never rewrite the constraints in pubspec.yaml, never touch application
+# or test code to make a new version compile, and never go near the release
+# surface — F-Droid metadata, Fastlane, release notes, signing material,
+# licenses or the app version. Those are the changes a human decides on, in a
+# PR they wrote.
+#
+# The updaters already behave that way by construction (`flutter pub upgrade`
+# only rewrites the lockfile; the SDK updater writes one version string). This
+# guard is the check that the behaviour actually held, so a bot cannot quietly
+# grow a wider blast radius than it was designed for.
 #
 # It is used in two places, deliberately:
 #
 #   1. In the updater itself, before a commit is created at all.
-#   2. In CI, on every `deps/` PR, so the boundary is re-checked against the
-#      real PR diff — including anything pushed onto the branch afterwards.
+#   2. In CI, on every `deps/` and `toolchain/` PR, so the boundary is
+#      re-checked against the real PR diff — including anything pushed onto the
+#      branch afterwards.
 #
 # Usage:
 #
 #   # Explicit list (one path per line) on stdin:
 #   git diff --name-only <base>..HEAD | scripts/check_dependency_update_files.sh
+#   git diff --name-only <base>..HEAD \
+#     | scripts/check_dependency_update_files.sh --kind flutter-sdk
 #
 #   # Or as arguments:
 #   scripts/check_dependency_update_files.sh pubspec.lock
+#   scripts/check_dependency_update_files.sh --kind flutter-sdk .flutter-version
+#
+# --kind defaults to dart-packages, the updater that came first.
 #
 # Read-only, no network, no secrets. Sibling guard:
 # scripts/check_release_bump_files.sh does the same job for release/ PRs.
 
 set -uo pipefail
 
+kind="dart-packages"
+
 # Collect candidate paths from arguments, else from stdin.
 paths=()
-if [ "$#" -gt 0 ]; then
-  paths=("$@")
-else
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --kind)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --kind needs a value (dart-packages or flutter-sdk)." >&2
+        exit 1
+      fi
+      kind="$2"
+      shift 2 ;;
+    --kind=*)
+      kind="${1#--kind=}"
+      shift ;;
+    *)
+      paths+=("$1")
+      shift ;;
+  esac
+done
+
+# The allowlist for this kind, and the sentence explaining what the updater is.
+case "$kind" in
+  dart-packages)
+    allowed=("pubspec.lock")
+    what="Dart/Flutter package update" ;;
+  flutter-sdk)
+    allowed=(".flutter-version")
+    what="Flutter SDK update" ;;
+  *)
+    echo "ERROR: unknown --kind '$kind' (expected dart-packages or flutter-sdk)." >&2
+    exit 1 ;;
+esac
+
+if [ "${#paths[@]}" -eq 0 ]; then
   while IFS= read -r line; do
     [ -n "$line" ] && paths+=("$line")
   done
@@ -54,14 +103,13 @@ if [ "${#paths[@]}" -eq 0 ]; then
   exit 0
 fi
 
-# Returns 0 if the given path is allowed in an automatic dependency update.
+# Returns 0 if the given path is allowed for this kind of automatic update.
 is_allowed() {
-  case "$1" in
-    pubspec.lock)
-      return 0 ;;
-    *)
-      return 1 ;;
-  esac
+  local candidate="$1" entry
+  for entry in "${allowed[@]}"; do
+    [ "$candidate" = "$entry" ] && return 0
+  done
+  return 1
 }
 
 offenders=()
@@ -70,25 +118,27 @@ for p in "${paths[@]}"; do
 done
 
 if [ "${#offenders[@]}" -eq 0 ]; then
-  echo "OK: dependency update touches only pubspec.lock (${#paths[@]} file(s))."
+  echo "OK: $what touches only ${allowed[*]} (${#paths[@]} file(s))."
   exit 0
 fi
 
 {
-  echo "ERROR: this looks like an automatic dependency update, but it changes"
+  echo "ERROR: this looks like an automatic $what, but it changes"
   echo "files outside the allowed set:"
   echo
   for p in "${offenders[@]}"; do
     echo "  - $p"
   done
   echo
-  echo "An automatic Dart/Flutter package update may only rewrite:"
-  echo "  - pubspec.lock"
+  echo "An automatic $what may only rewrite:"
+  for p in "${allowed[@]}"; do
+    echo "  - $p"
+  done
   echo
   echo "It must not change dependency constraints (pubspec.yaml), application"
   echo "or test code, the app version, F-Droid metadata, Fastlane files,"
-  echo "release notes, signing files or licenses. If this update genuinely"
-  echo "needs one of those, it is not an automatic update — a human should"
-  echo "open that PR and explain the change."
+  echo "release notes, signing files or licenses — nor the file the *other*"
+  echo "updater owns. If this update genuinely needs one of those, it is not an"
+  echo "automatic update — a human should open that PR and explain the change."
 } >&2
 exit 1

--- a/scripts/check_flutter_sdk_update.py
+++ b/scripts/check_flutter_sdk_update.py
@@ -49,7 +49,9 @@ A release is a candidate only if all three hold:
      `v1.12.13+hotfix.9` / `v1.5.4-hotfix.2` style entries, which are the only
      stable rows that are not plain triples and are all far below any version
      this repo could be pinned to;
-  3. `archive`, when present, lives under `stable/`.
+  3. `archive` is a non-empty string under `stable/` — a row with no archive,
+     or one pointing outside `stable/`, names nothing the pinned setup path
+     could install, so it is not a version to propose.
 
 The newest candidate is the one with the highest (major, minor, patch). The
 manifest's own `current_release.stable` hash is resolved too and reported as
@@ -273,9 +275,14 @@ def stable_releases(manifest: Dict[str, Any]) -> StableSet:
             skipped.append(str(error))
             continue
         archive = release.get("archive")
-        if isinstance(archive, str) and not archive.startswith(_ARCHIVE_PREFIX):
-            # A stable row whose archive is not under stable/ contradicts
-            # itself. Never a candidate, and worth surfacing.
+        if not isinstance(archive, str) or not archive.startswith(
+            _ARCHIVE_PREFIX
+        ):
+            # A stable row must name the archive that `scripts/setup_flutter.sh`
+            # would download, and it must live under stable/. Missing, null,
+            # empty or pointing elsewhere all contradict the channel claim, so
+            # none of them is a candidate — a version we cannot confirm is
+            # installable is not one to propose. Worth surfacing.
             notes.append(
                 f"entry #{index} claims channel {_STABLE_CHANNEL} but its "
                 f"archive is not under {_ARCHIVE_PREFIX}: {archive!r}"

--- a/scripts/check_flutter_sdk_update.py
+++ b/scripts/check_flutter_sdk_update.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""check_flutter_sdk_update.py — is a newer Flutter stable SDK available?
+
+This is the detection half of the Flutter SDK updater (issue #362). It answers
+one question and stops there:
+
+    Is the SDK pinned in .flutter-version still the newest stable Flutter, and
+    if not, is the gap a patch, a minor or a major?
+
+It changes nothing. It writes no file in the repository, creates no commit and
+talks to no part of GitHub. Publishing is
+.github/workflows/flutter-sdk-updates.yml's job; this script only classifies,
+so the classification can be tested offline against fixtures
+(test/tooling/flutter_sdk_update_guardrails_test.dart) instead of being buried
+in YAML.
+
+Where the release data comes from
+---------------------------------
+
+The official Flutter release manifest:
+
+    https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json
+
+That is the same `flutter_infra_release` bucket the archive page publishes and
+the same one scripts/setup_flutter.sh downloads the pinned SDK from, so the
+version this script proposes is by construction a version the setup path can
+actually install. No third-party API, no scraped page, no HTML.
+
+The manifest looks like:
+
+    {
+      "base_url": "...",
+      "current_release": {"stable": "<hash>", "beta": "...", "dev": "..."},
+      "releases": [
+        {"hash": "...", "channel": "stable", "version": "...",
+         "archive": "stable/linux/flutter_linux_<version>-stable.tar.xz", ...},
+        ...
+      ]
+    }
+
+Which release counts as "the newest stable"
+-------------------------------------------
+
+A release is a candidate only if all three hold:
+
+  1. `channel` is exactly "stable" — beta, dev and master are ignored, and so
+     are the `-0.N.pre` pre-release builds that ride the beta channel;
+  2. `version` is a bare `MAJOR.MINOR.PATCH` — this drops the historical
+     `v1.12.13+hotfix.9` / `v1.5.4-hotfix.2` style entries, which are the only
+     stable rows that are not plain triples and are all far below any version
+     this repo could be pinned to;
+  3. `archive`, when present, lives under `stable/`.
+
+The newest candidate is the one with the highest (major, minor, patch). The
+manifest's own `current_release.stable` hash is resolved too and reported as
+`pointer_version`, purely as a cross-check: if it disagrees with the highest
+candidate the disagreement is printed, and the highest version still wins, so
+the answer never depends on how the array happens to be ordered.
+
+Classification
+--------------
+
+    CURRENT == LATEST                       -> up-to-date
+    same major, same minor, higher patch    -> patch
+    same major, higher minor                -> minor
+    higher major                            -> major
+
+Anything else is an error, not a guess. A malformed pin, a malformed manifest,
+a manifest with no usable stable release, or a LATEST that is *older* than
+CURRENT all exit 2 with a message. In particular the updater must never
+propose a downgrade, so "the newest stable is behind our pin" is a hard
+failure rather than a silent no-op.
+
+Usage
+-----
+
+    # The scheduled check: read .flutter-version, fetch the official manifest.
+    python3 scripts/check_flutter_sdk_update.py
+
+    # Offline, against a saved manifest, for a specific pin:
+    python3 scripts/check_flutter_sdk_update.py \\
+        --current 1.2.3 --releases-file /path/to/releases_linux.json
+
+    # Classify two versions directly, with no manifest at all. The workflow
+    # uses this to compare the version already on its update branch against
+    # the version it is about to propose.
+    python3 scripts/check_flutter_sdk_update.py --current 1.2.3 --latest 1.2.4
+
+    # Machine-readable output for the workflow.
+    python3 scripts/check_flutter_sdk_update.py --github-output "$GITHUB_OUTPUT"
+    python3 scripts/check_flutter_sdk_update.py --json
+
+Exit status: 0 when a classification was produced (including "up-to-date"),
+2 when the input could not be trusted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# The official manifest. Linux is the right list for CI and for
+# scripts/setup_flutter.sh's default platform; the version/channel data in the
+# macOS and Windows manifests is the same set of releases.
+DEFAULT_RELEASES_URL = (
+    "https://storage.googleapis.com/flutter_infra_release/releases/"
+    "releases_linux.json"
+)
+
+# A stable Flutter version is a bare triple. Nothing else is accepted, from the
+# manifest or from .flutter-version — test/tooling/toolchain_pins_test.dart
+# already enforces the same shape on the pin file.
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+_STABLE_CHANNEL = "stable"
+_ARCHIVE_PREFIX = "stable/"
+
+_FETCH_TIMEOUT_SECONDS = 30
+
+STATUS_UP_TO_DATE = "up-to-date"
+STATUS_PATCH = "patch"
+STATUS_MINOR = "minor"
+STATUS_MAJOR = "major"
+
+
+class CheckError(Exception):
+    """Input that cannot be trusted. Always fatal — never worked around."""
+
+
+Version = Tuple[int, int, int]
+
+
+def parse_version(text: Any, what: str) -> Version:
+    """Parse a bare MAJOR.MINOR.PATCH string, or raise CheckError."""
+    if not isinstance(text, str):
+        raise CheckError(f"{what} is not a string: {text!r}")
+    stripped = text.strip()
+    if not stripped:
+        raise CheckError(f"{what} is empty")
+    match = _VERSION_RE.match(stripped)
+    if match is None:
+        raise CheckError(
+            f"{what} is not a bare MAJOR.MINOR.PATCH version: {stripped!r}"
+        )
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def format_version(version: Version) -> str:
+    return "{}.{}.{}".format(*version)
+
+
+def classify(current: Version, latest: Version) -> str:
+    """Classify the gap between the pinned and the newest stable version.
+
+    Raises CheckError when `latest` is older than `current`: an automatic
+    update must never propose a downgrade, and a manifest that says the newest
+    stable is behind our pin is data we do not understand.
+    """
+    if latest == current:
+        return STATUS_UP_TO_DATE
+    if latest < current:
+        raise CheckError(
+            "the newest stable release ({}) is older than the pinned version "
+            "({}). Refusing to propose a downgrade — check "
+            ".flutter-version and the release manifest.".format(
+                format_version(latest), format_version(current)
+            )
+        )
+    if latest[0] > current[0]:
+        return STATUS_MAJOR
+    if latest[1] > current[1]:
+        return STATUS_MINOR
+    return STATUS_PATCH
+
+
+def read_pin(repo_root: Path) -> str:
+    """Read the Flutter pin, the repository's source of truth."""
+    pin_file = repo_root / ".flutter-version"
+    if not pin_file.is_file():
+        raise CheckError(f"missing {pin_file} (the pinned Flutter version)")
+    return pin_file.read_text(encoding="utf-8").strip()
+
+
+def load_manifest(
+    releases_file: Optional[str], releases_url: str
+) -> Dict[str, Any]:
+    """Load the release manifest from a file or the official URL."""
+    if releases_file is not None:
+        path = Path(releases_file)
+        if not path.is_file():
+            raise CheckError(f"release manifest not found: {path}")
+        raw = path.read_text(encoding="utf-8")
+        origin = str(path)
+    else:
+        if not releases_url.startswith("https://"):
+            raise CheckError(
+                f"refusing to fetch the release manifest over {releases_url!r}"
+                " — https is required"
+            )
+        try:
+            with urllib.request.urlopen(
+                releases_url, timeout=_FETCH_TIMEOUT_SECONDS
+            ) as response:
+                raw = response.read().decode("utf-8")
+        except Exception as error:  # network, TLS, HTTP status, decoding
+            raise CheckError(
+                f"could not fetch the Flutter release manifest from "
+                f"{releases_url}: {error}"
+            ) from error
+        origin = releases_url
+
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise CheckError(f"{origin} is not valid JSON: {error}") from error
+    if not isinstance(manifest, dict):
+        raise CheckError(f"{origin} is not a JSON object")
+    manifest["_origin"] = origin
+    return manifest
+
+
+class StableSet:
+    """The stable releases a manifest offers, and what was left out of them."""
+
+    def __init__(
+        self,
+        candidates: List[Tuple[Version, Dict[str, Any]]],
+        skipped: List[str],
+        notes: List[str],
+    ) -> None:
+        self.candidates = candidates
+        # Entries correctly left out by the channel/shape filter. Routine —
+        # every manifest has some — so they are counted, not shouted about.
+        self.skipped = skipped
+        # Things that were *not* expected and a human may want to look at.
+        self.notes = notes
+
+
+def stable_releases(manifest: Dict[str, Any]) -> StableSet:
+    """Return the usable stable releases.
+
+    Filtering entries out is normal: every beta/dev build, and the handful of
+    legacy `+hotfix.N` stable tags that are not comparable triples. A
+    *structurally* wrong manifest is not normal, and raises instead.
+    """
+    origin = manifest.get("_origin", "the release manifest")
+    releases = manifest.get("releases")
+    if not isinstance(releases, list):
+        raise CheckError(f"{origin} has no `releases` array")
+    if not releases:
+        raise CheckError(f"{origin} lists no releases at all")
+
+    candidates: List[Tuple[Version, Dict[str, Any]]] = []
+    skipped: List[str] = []
+    notes: List[str] = []
+    for index, release in enumerate(releases):
+        if not isinstance(release, dict):
+            raise CheckError(
+                f"{origin} entry #{index} is not an object: {release!r}"
+            )
+        channel = release.get("channel")
+        version_text = release.get("version")
+        if channel != _STABLE_CHANNEL:
+            continue
+        try:
+            version = parse_version(version_text, f"entry #{index}")
+        except CheckError as error:
+            skipped.append(str(error))
+            continue
+        archive = release.get("archive")
+        if isinstance(archive, str) and not archive.startswith(_ARCHIVE_PREFIX):
+            # A stable row whose archive is not under stable/ contradicts
+            # itself. Never a candidate, and worth surfacing.
+            notes.append(
+                f"entry #{index} claims channel {_STABLE_CHANNEL} but its "
+                f"archive is not under {_ARCHIVE_PREFIX}: {archive!r}"
+            )
+            continue
+        candidates.append((version, release))
+
+    if not candidates:
+        raise CheckError(
+            f"{origin} contains no usable `{_STABLE_CHANNEL}` release "
+            "(nothing matched channel + MAJOR.MINOR.PATCH + stable archive)"
+        )
+    return StableSet(candidates, skipped, notes)
+
+
+def newest_stable(
+    stable: StableSet, manifest: Dict[str, Any]
+) -> Tuple[Version, Dict[str, Any], str]:
+    """The highest-versioned stable release.
+
+    Returns `(version, release, pointer_version)`, where `pointer_version` is
+    the version `current_release.stable` resolves to, or `""` when it resolves
+    to nothing. Any disagreement is appended to `stable.notes`.
+    """
+    # max() on the (major, minor, patch) tuple; ties keep the first entry, so
+    # the result never depends on the array's order.
+    version, release = max(stable.candidates, key=lambda item: item[0])
+
+    # Cross-check against the manifest's own stable pointer. It is advisory:
+    # the highest version wins either way, but a disagreement is worth seeing.
+    current_release = manifest.get("current_release")
+    pointer_version = ""
+    if isinstance(current_release, dict):
+        pointer_hash = current_release.get(_STABLE_CHANNEL)
+        if isinstance(pointer_hash, str) and pointer_hash:
+            for candidate_version, candidate in stable.candidates:
+                if candidate.get("hash") == pointer_hash:
+                    pointer_version = format_version(candidate_version)
+                    break
+            if not pointer_version:
+                stable.notes.append(
+                    "current_release.stable points at hash "
+                    f"{pointer_hash}, which is not a usable stable release"
+                )
+            elif pointer_version != format_version(version):
+                stable.notes.append(
+                    f"current_release.stable points at {pointer_version} but "
+                    f"{format_version(version)} is the highest stable version; "
+                    "using the highest version"
+                )
+    return version, release, pointer_version
+
+
+def newest_in_major(stable: StableSet, major: int) -> str:
+    """Highest stable version sharing `major`, or "" — informational only."""
+    same = [version for version, _ in stable.candidates if version[0] == major]
+    return format_version(max(same)) if same else ""
+
+
+def build_result(args: argparse.Namespace, repo_root: Path) -> Dict[str, str]:
+    if args.current is not None:
+        current = parse_version(args.current, "--current")
+    else:
+        current = parse_version(read_pin(repo_root), ".flutter-version")
+
+    if args.latest is not None:
+        # Classification only: no manifest is consulted, so nothing here can
+        # claim the target was confirmed to exist on the stable channel.
+        latest = parse_version(args.latest, "--latest")
+        return {
+            "status": classify(current, latest),
+            "current": format_version(current),
+            "latest": format_version(latest),
+            "stable_confirmed": "false",
+            "source": "--latest",
+            "latest_hash": "",
+            "latest_release_date": "",
+            "latest_archive": "",
+            "latest_in_current_major": "",
+            "pointer_version": "",
+            "stable_releases_considered": "0",
+            "notes": "",
+        }
+
+    manifest = load_manifest(args.releases_file, args.releases_url)
+    stable = stable_releases(manifest)
+    latest, release, pointer = newest_stable(stable, manifest)
+    status = classify(current, latest)
+    return {
+        "status": status,
+        "current": format_version(current),
+        "latest": format_version(latest),
+        # The target came out of the stable-channel filter above, so reaching
+        # here *is* the confirmation that it exists on Flutter stable.
+        "stable_confirmed": "true",
+        "source": str(manifest.get("_origin", "")),
+        "latest_hash": str(release.get("hash") or ""),
+        "latest_release_date": str(release.get("release_date") or ""),
+        "latest_archive": str(release.get("archive") or ""),
+        "latest_in_current_major": newest_in_major(stable, current[0]),
+        "pointer_version": pointer,
+        "stable_releases_considered": str(len(stable.candidates)),
+        "notes": " | ".join(stable.notes),
+    }
+
+
+def report(result: Dict[str, str]) -> None:
+    status = result["status"]
+    if status == STATUS_UP_TO_DATE:
+        print(
+            f"Up to date: the pinned {result['current']} is the newest "
+            "release on the stable channel."
+        )
+    else:
+        print(
+            f"A {status} stable SDK update is available: "
+            f"{result['current']} -> {result['latest']}"
+        )
+        if result["latest_release_date"]:
+            print(f"  released: {result['latest_release_date']}")
+        if result["latest_archive"]:
+            print(f"  archive:  {result['latest_archive']}")
+    if result["stable_releases_considered"] != "0":
+        print(
+            f"  considered {result['stable_releases_considered']} stable "
+            f"release(s) from {result['source']}"
+        )
+    if result["notes"]:
+        for note in result["notes"].split(" | "):
+            print(f"  note: {note}")
+
+
+def write_github_output(path: str, result: Dict[str, str]) -> None:
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in result.items():
+            if "\n" in value:
+                raise CheckError(f"output {key} contains a newline: {value!r}")
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect a newer Flutter stable SDK than the pinned one.",
+    )
+    parser.add_argument(
+        "--current",
+        help="Version to compare against (default: read .flutter-version).",
+    )
+    parser.add_argument(
+        "--latest",
+        help="Classify against this version directly, consulting no manifest.",
+    )
+    parser.add_argument(
+        "--releases-file",
+        help="Read the release manifest from this file instead of the network.",
+    )
+    parser.add_argument(
+        "--releases-url",
+        default=DEFAULT_RELEASES_URL,
+        help="Official release manifest URL (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Repository root holding .flutter-version (default: this checkout).",
+    )
+    parser.add_argument(
+        "--github-output",
+        help="Append key=value lines for GitHub Actions to this file.",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Print the result as JSON."
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress the human-readable report."
+    )
+    args = parser.parse_args(argv)
+
+    if args.latest is not None and args.releases_file is not None:
+        parser.error("--latest and --releases-file are mutually exclusive")
+
+    repo_root = (
+        Path(args.repo_root)
+        if args.repo_root
+        else Path(__file__).resolve().parent.parent
+    )
+
+    try:
+        result = build_result(args, repo_root)
+        if args.github_output:
+            write_github_output(args.github_output, result)
+    except CheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    elif not args.quiet:
+        report(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/tooling/dependency_update_guardrails_test.dart
+++ b/test/tooling/dependency_update_guardrails_test.dart
@@ -236,14 +236,19 @@ void main() {
 
   group('the CI fixer leaves dependency updates alone', () {
     test('the fix job skips deps/ branches alongside dependabot/', () {
-      expect(
-        fixer,
-        contains(
-            r'if [[ "$head_branch" == dependabot/* || "$head_branch" == deps/* ]]; then'),
-        reason: 'A dependency update that breaks CI must stay broken — the red '
-            'is the signal. The skip has to happen while resolving the run, '
-            'before any repair is generated.',
-      );
+      // Matched per prefix rather than as one literal line, so extending the
+      // condition for another updater's namespace (toolchain/, covered by
+      // test/tooling/flutter_sdk_update_guardrails_test.dart) cannot silently
+      // drop one of the prefixes already protected here.
+      for (final String prefix in <String>['dependabot/', 'deps/']) {
+        expect(
+          fixer,
+          contains('"\$head_branch" == $prefix*'),
+          reason: 'A dependency update that breaks CI must stay broken — the '
+              'red is the signal. The skip has to happen while resolving the '
+              'run, before any repair is generated. Missing: $prefix',
+        );
+      }
     });
 
     test('the publish job restates the skip where the push happens', () {

--- a/test/tooling/flutter_sdk_update_guardrails_test.dart
+++ b/test/tooling/flutter_sdk_update_guardrails_test.dart
@@ -260,6 +260,70 @@ void main() {
       expect(r.value('notes'), contains('archive is not under stable/'));
     });
 
+    // A row that names no archive at all is no more installable than one
+    // pointing outside stable/, so the three shapes below are refused for the
+    // same reason. Each claims stable at a version far above the pin, so a
+    // regression that lets one through surfaces immediately as `latest`.
+    for (final MapEntry<String, Map<String, dynamic>> broken
+        in <String, Map<String, dynamic>>{
+      'a missing archive': _release('7.0.0')..remove('archive'),
+      'a null archive': _release('7.0.1')..['archive'] = null,
+      'an empty archive': _release('7.0.2')..['archive'] = '',
+    }.entries) {
+      test('a stable row with ${broken.key} is refused', () {
+        final _Result r = _check(
+          checker,
+          current: '1.2.3',
+          stable: <String>['1.2.4'],
+          extra: <Map<String, dynamic>>[broken.value],
+        );
+        expect(r.exitCode, 0, reason: r.describe());
+        expect(r.value('latest'), '1.2.4',
+            reason: 'A stable row naming no archive under stable/ cannot be '
+                'confirmed installable by the pinned setup path, so it must '
+                'never be proposed.');
+        expect(r.value('notes'), contains('archive is not under stable/'));
+      });
+    }
+
+    test('a stable row under stable/ is still a candidate', () {
+      // The other half of the rule: tightening it must not start rejecting
+      // the ordinary rows the manifest is made of.
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.2.4'],
+        extra: <Map<String, dynamic>>[
+          _release('7.0.0',
+              archive: 'stable/linux/flutter_linux_7.0.0-stable.tar.xz'),
+        ],
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '7.0.0');
+      expect(r.value('latest_archive'),
+          'stable/linux/flutter_linux_7.0.0-stable.tar.xz');
+    });
+
+    test('a manifest whose only stable rows lack an archive is an error', () {
+      // Fail-safe: no usable candidate is a hard error, not a silent
+      // "up-to-date" that would hide a stalled updater.
+      final _Result r = _runWithManifest(
+        checker,
+        const JsonEncoder.withIndent('  ').convert(<String, dynamic>{
+          'base_url':
+              'https://storage.googleapis.com/flutter_infra_release/releases',
+          'current_release': <String, String>{'stable': 'hash-stable-1.2.4'},
+          'releases': <Map<String, dynamic>>[
+            _release('1.2.4')..remove('archive'),
+            _release('1.3.0')..['archive'] = null,
+          ],
+        }),
+        <String>['--current', '1.2.3', '--json'],
+      );
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('no usable `stable` release'));
+    });
+
     test('reaching a target at all is the stable-channel confirmation', () {
       final _Result r =
           _check(checker, current: '1.2.3', stable: <String>['1.3.0']);
@@ -779,11 +843,15 @@ void main() {
   // The boundary is re-checked on the PR itself, and the fixer stays away.
   // ---------------------------------------------------------------------------
   group('the boundary is re-checked on the PR itself', () {
-    test('ci.yml guards toolchain/ PRs with the same script', () {
-      expect(ci, contains("startsWith(github.head_ref, 'toolchain/')"),
+    test('ci.yml guards the SDK update branch with the same script', () {
+      expect(ci, contains("github.head_ref == 'toolchain/flutter-sdk'"),
           reason: 'CI must run the pin-only guard on SDK update PRs — against '
               'the real PR diff, not just the files the updater thinks it '
               'changed.');
+      expect(ci.contains("startsWith(github.head_ref, 'toolchain/')"), isFalse,
+          reason: 'The guard must match the updater\'s branch exactly. A '
+              'prefix match would force every future human toolchain/* PR to '
+              'touch nothing but .flutter-version.');
       expect(
           ci,
           contains(

--- a/test/tooling/flutter_sdk_update_guardrails_test.dart
+++ b/test/tooling/flutter_sdk_update_guardrails_test.dart
@@ -1,0 +1,1011 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Guardrails for the automatic Flutter SDK updater (issue #362).
+///
+/// The updater is allowed to do exactly one thing: notice that the official
+/// stable channel has moved past `.flutter-version` and propose the new number.
+/// Everything else about it is a safety boundary —
+///
+///   * it follows the *stable* channel only, and only bare `MAJOR.MINOR.PATCH`
+///     releases published under a `stable/` archive;
+///   * it classifies the gap as patch, minor or major, and fails loudly on data
+///     it cannot trust rather than guessing a target;
+///   * it never proposes a downgrade;
+///   * a patch or minor opens one reusable draft PR that changes
+///     `.flutter-version` and nothing else — not application code, not tests,
+///     not `pubspec.lock`, not the release surface;
+///   * a major changes nothing at all and files an issue instead;
+///   * it never merges, and the PR it opens runs the normal CI;
+///   * the Flutter CI fixer leaves its branch alone, so an SDK bump that needs
+///     an API migration stays red for a human.
+///
+/// Those boundaries are the whole value of the updater, so they are tests
+/// rather than review notes. Every case here is offline: the classification
+/// tests feed fixture release manifests to the checker instead of touching the
+/// network, and nothing in this suite changes Linthra's actual Flutter pin.
+///
+/// Sibling coverage: test/tooling/dependency_update_guardrails_test.dart does
+/// the same for the Dart package updater (and holds the line that *its*
+/// allowlist stays `pubspec.lock`-only), and
+/// test/tooling/toolchain_pins_test.dart pins the toolchain versions.
+void main() {
+  final String root = _repoRoot();
+
+  final String checker = p.join(root, 'scripts', 'check_flutter_sdk_update.py');
+  final String guardScript =
+      p.join(root, 'scripts', 'check_dependency_update_files.sh');
+  late final String workflow =
+      _read(root, p.join('.github', 'workflows', 'flutter-sdk-updates.yml'));
+  late final String ci = _read(root, p.join('.github', 'workflows', 'ci.yml'));
+  late final String fixer =
+      _read(root, p.join('.github', 'workflows', 'flutter-ci-fixer.yml'));
+  late final String docs = _read(root, p.join('docs', 'dependency-updates.md'));
+
+  setUpAll(() {
+    expect(File(checker).existsSync(), isTrue,
+        reason: 'The update checker is missing: $checker');
+    final ProcessResult python =
+        Process.runSync('python3', <String>['--version']);
+    expect(python.exitCode, 0,
+        reason: 'python3 is not on PATH; the SDK update checker requires it.');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Classification. CURRENT comes from .flutter-version (or --current); LATEST
+  // is the newest usable stable release in the manifest.
+  // ---------------------------------------------------------------------------
+  group('classifying the gap between the pin and stable', () {
+    test('the same version is no update', () {
+      final _Result r = _check(checker, current: '1.2.3', stable: <String>[
+        '1.2.3',
+        '1.2.2',
+        '1.1.9',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'up-to-date');
+      expect(r.value('latest'), '1.2.3');
+    });
+
+    test('a newer patch on the same minor is a patch update', () {
+      final _Result r = _check(checker, current: '1.2.3', stable: <String>[
+        '1.2.4',
+        '1.2.3',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'patch');
+      expect(r.value('latest'), '1.2.4');
+    });
+
+    test('a newer minor on the same major is a minor update', () {
+      final _Result r = _check(checker, current: '1.2.3', stable: <String>[
+        '1.3.0',
+        '1.2.9',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'minor');
+      expect(r.value('latest'), '1.3.0');
+    });
+
+    test('a minor jump of several lines is still a minor update', () {
+      // The real case this updater was written for: the pin sits on one stable
+      // line and the channel has already moved two lines past it.
+      final _Result r = _check(checker, current: '1.2.3', stable: <String>[
+        '1.5.0',
+        '1.2.9',
+        '1.2.3',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'minor');
+      expect(r.value('latest'), '1.5.0');
+    });
+
+    test('a newer major is a major update', () {
+      final _Result r = _check(checker, current: '1.2.3', stable: <String>[
+        '2.0.0',
+        '1.2.9',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'major');
+      expect(r.value('latest'), '2.0.0');
+    });
+
+    test('a major update still reports the newest release on the old major',
+        () {
+      // The workflow files an issue and changes nothing for a major, so the
+      // maintainer should still be able to see what the current line is on.
+      final _Result r = _check(checker, current: '1.2.3', stable: <String>[
+        '2.0.0',
+        '1.2.9',
+      ]);
+      expect(r.status, 'major');
+      expect(r.value('latest_in_current_major'), '1.2.9');
+    });
+
+    test('the highest version wins regardless of manifest order', () {
+      // A hotfix on an older line can be published after a newer line exists,
+      // so "first entry in the array" is not a safe answer.
+      for (final List<String> order in <List<String>>[
+        <String>['1.2.9', '1.5.0', '1.4.0'],
+        <String>['1.4.0', '1.2.9', '1.5.0'],
+        <String>['1.5.0', '1.4.0', '1.2.9'],
+      ]) {
+        final _Result r = _check(checker, current: '1.2.3', stable: order);
+        expect(r.exitCode, 0, reason: r.describe());
+        expect(r.value('latest'), '1.5.0',
+            reason: 'Order ${order.join(', ')} chose ${r.value('latest')}.');
+      }
+    });
+
+    test('--latest classifies two versions with no manifest at all', () {
+      // The workflow uses this to compare the version already on its update
+      // branch against the version it is about to propose.
+      const Map<String, String> expected = <String, String>{
+        '1.2.3': 'up-to-date',
+        '1.2.4': 'patch',
+        '1.3.0': 'minor',
+        '2.0.0': 'major',
+      };
+      expected.forEach((String latest, String status) {
+        final _Result r = _run(checker, <String>[
+          '--current',
+          '1.2.3',
+          '--latest',
+          latest,
+          '--json',
+        ]);
+        expect(r.exitCode, 0, reason: r.describe());
+        expect(r.status, status);
+        // Nothing was checked against the channel, and it must not claim it was.
+        expect(r.value('stable_confirmed'), 'false');
+      });
+    });
+
+    test('the pin file is what is read when --current is omitted', () {
+      final String pin =
+          File(p.join(root, '.flutter-version')).readAsStringSync().trim();
+      final _Result r = _run(
+          checker, <String>['--latest', pin, '--json', '--repo-root', root]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('current'), pin,
+          reason: 'The checker must read .flutter-version as CURRENT.');
+      expect(r.status, 'up-to-date');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Release selection: stable only, and only releases shaped like releases.
+  // ---------------------------------------------------------------------------
+  group('following the stable channel and nothing else', () {
+    test('a higher beta release never becomes the target', () {
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.2.4'],
+        extra: <Map<String, dynamic>>[
+          _release('9.9.9', channel: 'beta', archive: 'beta/linux/x.tar.xz'),
+          _release('1.3.0', channel: 'beta', archive: 'beta/linux/x.tar.xz'),
+        ],
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '1.2.4',
+          reason: 'A beta release must never be proposed as a stable update.');
+      expect(r.status, 'patch');
+    });
+
+    test('dev and master releases are ignored too', () {
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.2.4'],
+        extra: <Map<String, dynamic>>[
+          _release('8.0.0', channel: 'dev', archive: 'dev/linux/x.tar.xz'),
+          _release('9.0.0',
+              channel: 'master', archive: 'master/linux/x.tar.xz'),
+        ],
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '1.2.4');
+    });
+
+    test('a pre-release version on the stable channel is skipped', () {
+      // `-0.N.pre` builds are how Flutter labels pre-releases; a stable row
+      // carrying one is not a version this updater can pin to.
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.2.4'],
+        extra: <Map<String, dynamic>>[
+          _release('1.9.0-0.1.pre'),
+          _release('1.8.0-hotfix.2'),
+        ],
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '1.2.4');
+    });
+
+    test('legacy `v`-prefixed and `+hotfix` stable tags are skipped', () {
+      // The official manifest still carries these from the 1.x era. They are
+      // not comparable triples, and they are all far below any usable pin.
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.2.4'],
+        extra: <Map<String, dynamic>>[
+          _release('v1.12.13+hotfix.9'),
+          _release('v1.2.1'),
+        ],
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '1.2.4');
+    });
+
+    test('a stable row whose archive is not under stable/ is refused', () {
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.2.4'],
+        extra: <Map<String, dynamic>>[
+          _release('7.0.0',
+              archive: 'beta/linux/flutter_linux_7.0.0-beta.tar.xz'),
+        ],
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '1.2.4',
+          reason: 'A row that claims stable but ships a non-stable archive '
+              'contradicts itself and must not be selected.');
+      expect(r.value('notes'), contains('archive is not under stable/'));
+    });
+
+    test('reaching a target at all is the stable-channel confirmation', () {
+      final _Result r =
+          _check(checker, current: '1.2.3', stable: <String>['1.3.0']);
+      expect(r.value('stable_confirmed'), 'true');
+      expect(r.value('latest_archive'), contains('stable/'));
+      expect(r.value('latest_hash'), isNotEmpty);
+    });
+
+    test('the manifest stable pointer is cross-checked, not obeyed blindly',
+        () {
+      // If current_release.stable lags the highest published stable version,
+      // the higher version still wins — and the disagreement is reported.
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: <String>['1.5.0', '1.4.0'],
+        stableHashFor: '1.4.0',
+      );
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.value('latest'), '1.5.0');
+      expect(r.value('pointer_version'), '1.4.0');
+      expect(r.value('notes'), contains('using the highest version'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failing loudly. Every case here must exit non-zero — never "no update".
+  // ---------------------------------------------------------------------------
+  group('untrustworthy data fails loudly instead of guessing', () {
+    test('the checker never proposes a downgrade', () {
+      final _Result r = _check(checker, current: '2.0.0', stable: <String>[
+        '1.9.9',
+        '1.9.8',
+      ]);
+      expect(r.exitCode, isNot(0),
+          reason: 'A stable channel behind our pin must fail, not silently '
+              'report "up to date".\n${r.describe()}');
+      expect(r.stderr, contains('downgrade'));
+    });
+
+    test('a downgrade is refused in --latest mode too', () {
+      final _Result r = _run(checker,
+          <String>['--current', '1.3.0', '--latest', '1.2.9', '--json']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('downgrade'));
+    });
+
+    for (final String bad in <String>[
+      '1.2',
+      '1',
+      '',
+      'v1.2.3',
+      '1.2.3-hotfix.1',
+      '1.2.3.4',
+      'stable',
+      '1.2.x',
+    ]) {
+      test('a malformed pin (${bad.isEmpty ? '<empty>' : bad}) is rejected',
+          () {
+        final _Result r =
+            _check(checker, current: bad, stable: <String>['9.9.9']);
+        expect(r.exitCode, isNot(0),
+            reason: 'A pin the checker cannot parse must stop the run.\n'
+                '${r.describe()}');
+        expect(r.stderr, contains('--current'));
+      });
+    }
+
+    test('a malformed --latest is rejected', () {
+      final _Result r =
+          _run(checker, <String>['--current', '1.2.3', '--latest', '1.3']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('--latest'));
+    });
+
+    test('a manifest that is not JSON is rejected', () {
+      final _Result r = _runWithManifest(
+          checker, 'not json at all', <String>['--current', '1.2.3', '--json']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('not valid JSON'));
+    });
+
+    test('a manifest that is not an object is rejected', () {
+      final _Result r = _runWithManifest(
+          checker, '[]', <String>['--current', '1.2.3', '--json']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('not a JSON object'));
+    });
+
+    test('a manifest with no releases array is rejected', () {
+      final _Result r = _runWithManifest(checker, '{"current_release": {}}',
+          <String>['--current', '1.2.3', '--json']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('releases'));
+    });
+
+    test('an empty releases array is rejected', () {
+      final _Result r = _runWithManifest(checker, '{"releases": []}',
+          <String>['--current', '1.2.3', '--json']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('no releases'));
+    });
+
+    test('a release entry that is not an object is rejected', () {
+      final _Result r = _runWithManifest(checker, '{"releases": ["3.0.0"]}',
+          <String>['--current', '1.2.3', '--json']);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('not an object'));
+    });
+
+    test('a manifest with no usable stable release is rejected', () {
+      final _Result r = _check(
+        checker,
+        current: '1.2.3',
+        stable: const <String>[],
+        extra: <Map<String, dynamic>>[
+          _release('1.9.0', channel: 'beta', archive: 'beta/linux/x.tar.xz'),
+        ],
+      );
+      expect(r.exitCode, isNot(0),
+          reason: 'No stable release means no answer, not "up to date".\n'
+              '${r.describe()}');
+      expect(r.stderr, contains('no usable'));
+    });
+
+    test('a missing manifest file is rejected', () {
+      final _Result r = _run(checker, <String>[
+        '--current',
+        '1.2.3',
+        '--releases-file',
+        p.join(root, 'does-not-exist.json'),
+      ]);
+      expect(r.exitCode, isNot(0), reason: r.describe());
+      expect(r.stderr, contains('not found'));
+    });
+
+    test('a non-https manifest URL is refused', () {
+      final _Result r = _run(checker, <String>[
+        '--current',
+        '1.2.3',
+        '--releases-url',
+        'http://example.com/releases.json',
+      ]);
+      expect(r.exitCode, isNot(0),
+          reason:
+              'The release manifest must come over https.\n${r.describe()}');
+      expect(r.stderr, contains('https'));
+    });
+  });
+
+  group('the checker reports itself to the workflow', () {
+    test('--github-output writes plain key=value lines', () {
+      final Directory tmp = Directory.systemTemp.createTempSync('sdk-out');
+      addTearDown(() => tmp.deleteSync(recursive: true));
+      final String out = p.join(tmp.path, 'out.txt');
+      final _Result r = _run(checker, <String>[
+        '--current',
+        '1.2.3',
+        '--latest',
+        '1.3.0',
+        '--github-output',
+        out,
+        '--quiet',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      final Map<String, String> parsed = <String, String>{
+        for (final String line in File(out).readAsLinesSync())
+          if (line.contains('=')) line.split('=').first: line.split('=').last,
+      };
+      expect(parsed['status'], 'minor');
+      expect(parsed['current'], '1.2.3');
+      expect(parsed['latest'], '1.3.0');
+    });
+
+    test('the checker never writes the pin file itself', () {
+      // Detection and publication are separate on purpose: the script only
+      // classifies, so nothing it does can move the repo's pin.
+      final String source = File(checker).readAsStringSync();
+      for (final String forbidden in <String>[
+        'write_text',
+        'git commit',
+        'git push',
+        'gh pr create',
+        'gh issue create',
+      ]) {
+        expect(source.contains(forbidden), isFalse,
+            reason: 'scripts/check_flutter_sdk_update.py contains '
+                '`$forbidden`. It may only read and classify; publishing '
+                'belongs to the workflow.');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The file allowlist. A bot PR on the SDK branch may carry one file.
+  // ---------------------------------------------------------------------------
+  group('the allowlist guard admits only the Flutter pin', () {
+    test('.flutter-version alone passes', () {
+      final ProcessResult r =
+          _runGuard(guardScript, 'flutter-sdk', <String>['.flutter-version']);
+      expect(r.exitCode, 0, reason: 'stdout: ${r.stdout}\nstderr: ${r.stderr}');
+    });
+
+    test('an empty change set passes', () {
+      final ProcessResult r =
+          _runGuard(guardScript, 'flutter-sdk', const <String>[]);
+      expect(r.exitCode, 0, reason: 'stdout: ${r.stdout}\nstderr: ${r.stderr}');
+    });
+
+    // One case per rule the issue spells out. If someone widens the allowlist,
+    // the specific protection they removed is named in the failure.
+    const Map<String, String> forbidden = <String, String>{
+      'pubspec.lock': 'the resolved dependency set (a human re-resolves it)',
+      'pubspec.yaml': 'dependency constraints and the Dart SDK constraint',
+      'lib/main.dart': 'application code',
+      'lib/core/app_info.dart': 'the in-app version',
+      'test/core/app_info_version_test.dart': 'test code',
+      'metadata/io.github.thezupzup.linthra.yml': 'F-Droid metadata',
+      'fastlane/metadata/android/en-US/changelogs/201999.txt': 'Fastlane files',
+      'docs/release-notes/v0.2.1.md': 'release notes',
+      'android/key.properties': 'signing configuration',
+      'android/app/linthra-release.jks': 'signing material',
+      'LICENSE': 'the license',
+      '.java-version': 'the JDK pin',
+      'android/settings.gradle': 'the AGP and Kotlin pins',
+      'android/gradle/wrapper/gradle-wrapper.properties': 'the Gradle pin',
+      '.github/workflows/ci.yml': 'CI configuration',
+      'scripts/check_dependency_update_files.sh': 'the guard itself',
+    };
+
+    forbidden.forEach((String path, String why) {
+      test('$path is rejected — $why', () {
+        final ProcessResult r = _runGuard(
+            guardScript, 'flutter-sdk', <String>['.flutter-version', path]);
+        expect(r.exitCode, isNot(0),
+            reason: 'An automatic Flutter SDK update must not change $why.\n'
+                'stdout: ${r.stdout}');
+        expect(r.stderr, contains(path),
+            reason: 'The rejection should name the offending path.');
+      });
+    });
+
+    test('the two update kinds cannot reach into each other', () {
+      // The Dart updater owns pubspec.lock; the SDK updater owns
+      // .flutter-version. Neither allowlist may grow the other's file.
+      final ProcessResult sdkTouchingLock =
+          _runGuard(guardScript, 'flutter-sdk', <String>['pubspec.lock']);
+      expect(sdkTouchingLock.exitCode, isNot(0),
+          reason: 'An SDK bump must not re-resolve the lockfile; that is a '
+              'human decision, because the committed lockfile is what the '
+              'reproducible F-Droid build resolves from.');
+
+      final ProcessResult dartTouchingPin =
+          _runGuard(guardScript, 'dart-packages', <String>['.flutter-version']);
+      expect(dartTouchingPin.exitCode, isNot(0),
+          reason: 'A package update must not move the toolchain pin.');
+    });
+
+    test('the Dart updater is still lockfile-only, by default and by name', () {
+      // The --kind option must not have loosened the original guard: with no
+      // --kind at all, and with --kind dart-packages, the answer is the same.
+      for (final List<String> argv in <List<String>>[
+        <String>['pubspec.lock'],
+        <String>['--kind', 'dart-packages', 'pubspec.lock'],
+      ]) {
+        final ProcessResult ok = Process.runSync(
+            'bash',
+            <String>[
+              guardScript,
+              ...argv,
+            ],
+            stdoutEncoding: const SystemEncoding(),
+            stderrEncoding: const SystemEncoding());
+        expect(ok.exitCode, 0, reason: 'stderr: ${ok.stderr}');
+      }
+      for (final String path in <String>[
+        '.flutter-version',
+        'lib/main.dart',
+        'pubspec.yaml',
+      ]) {
+        final ProcessResult bad = Process.runSync(
+            'bash', <String>[guardScript, 'pubspec.lock', path],
+            stdoutEncoding: const SystemEncoding(),
+            stderrEncoding: const SystemEncoding());
+        expect(bad.exitCode, isNot(0),
+            reason: 'The default (dart-packages) allowlist must still reject '
+                '$path.');
+      }
+    });
+
+    test('an unknown kind fails instead of allowing everything', () {
+      final ProcessResult r =
+          _runGuard(guardScript, 'anything-goes', <String>['lib/main.dart']);
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('unknown --kind'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The workflow.
+  // ---------------------------------------------------------------------------
+  group('the update workflow stays inside its boundaries', () {
+    test('it runs weekly and can be dispatched by hand', () {
+      expect(workflow, contains('schedule:'));
+      expect(workflow, contains('cron:'));
+      expect(workflow, contains('workflow_dispatch:'),
+          reason: 'A manual run must be possible, using the same logic.');
+    });
+
+    test('detection is delegated to the testable script', () {
+      expect(workflow, contains('scripts/check_flutter_sdk_update.py'),
+          reason: 'The version comparison must not live in YAML, where it '
+              'cannot be tested offline.');
+    });
+
+    test('it uses a toolchain branch, not the Dart package namespace', () {
+      expect(workflow, contains('UPDATE_BRANCH: toolchain/flutter-sdk'),
+          reason: 'A `deps/` branch would inherit the Dart updater\'s '
+              'lockfile-only allowlist, which is the wrong rule for an SDK '
+              'bump.');
+      expect(workflow.contains('UPDATE_BRANCH: deps/'), isFalse);
+    });
+
+    test('its own GITHUB_TOKEN is read-only at the top level', () {
+      expect(workflow, contains('permissions:\n  contents: read'),
+          reason: 'Writes must be opted into per job, not granted globally.');
+    });
+
+    test('it never merges anything', () {
+      for (final String forbidden in <String>[
+        'gh pr merge',
+        '--auto',
+        '--admin',
+        '--squash',
+        '--rebase',
+        'enable_pr_auto_merge',
+      ]) {
+        expect(workflow.contains(forbidden), isFalse,
+            reason: 'The update workflow contains `$forbidden`. Nothing may '
+                'ever merge into main automatically (#362).');
+      }
+    });
+
+    test('it never migrates application code', () {
+      // No SDK, no analyzer, no formatter, no test run, no code generation:
+      // this workflow has no way to "fix" the repo even if it wanted to.
+      for (final String forbidden in <String>[
+        'setup-flutter',
+        'dart format',
+        'codex',
+        'build_runner',
+      ]) {
+        expect(workflow.contains(forbidden), isFalse,
+            reason: 'The SDK updater must not run `$forbidden`. A bump that '
+                'breaks application code stays red for a human.');
+      }
+    });
+  });
+
+  group('the patch/minor PR job', () {
+    late final String job = _jobSection(workflow, 'sdk-pr');
+
+    test('it runs only for patch and minor updates', () {
+      expect(job, contains("needs.check.outputs.status == 'patch'"));
+      expect(job, contains("needs.check.outputs.status == 'minor'"));
+      expect(job.contains("status == 'major'"), isFalse,
+          reason: 'A major must not reach the PR path.');
+    });
+
+    test('it publishes with the dedicated token so the PR runs normal CI', () {
+      // A push or PR made with GITHUB_TOKEN does not trigger workflows, and an
+      // update PR that runs no checks is a broken updater (#362).
+      expect(job, contains(r'secrets.DEPENDENCY_UPDATE_TOKEN'),
+          reason: 'Reuse the existing publication secret rather than opening '
+              'a PR that no CI would look at.');
+      expect(job.contains(r'GH_TOKEN: ${{ github.token }}'), isFalse,
+          reason: 'github.token cannot retrigger CI on the PR it opens.');
+    });
+
+    test('a missing token fails the run instead of opening an unchecked PR',
+        () {
+      expect(job, contains('DEPENDENCY_UPDATE_TOKEN is required'));
+      expect(job, contains('exit 1'));
+    });
+
+    test('a run with no update never reaches the token check', () {
+      // The requirement is a pair: fail loudly when publishing is needed, and
+      // never fail a quiet week for want of a secret. Gating the whole job on
+      // the classification is what delivers the second half.
+      final String check = _jobSection(workflow, 'check');
+      expect(check.contains('DEPENDENCY_UPDATE_TOKEN'), isFalse,
+          reason: 'The detection job must not require the publication token; '
+              'a week with no update must not fail.');
+    });
+
+    test('the PR is a draft against main', () {
+      expect(job, contains('gh pr create'));
+      expect(job, contains('--draft'),
+          reason: 'SDK update PRs open as drafts for review.');
+      expect(job, contains('--base main'));
+    });
+
+    test('it reuses one PR instead of opening duplicates every week', () {
+      expect(job, contains('--state open --json number'),
+          reason: 'The workflow must look for an existing open PR on the '
+              'update branch and edit it rather than open another.');
+      expect(job, contains('gh pr edit'));
+    });
+
+    test('it refuses to force-push over commits it did not write', () {
+      expect(job, contains('--force-with-lease'),
+          reason: 'A plain force push could drop a concurrent update.');
+      expect(job, contains('foreign'),
+          reason: 'The workflow must detect commits on the update branch that '
+              'it did not author and stop instead of overwriting them.');
+      expect(job, contains(r'"$author" == "github-actions[bot]"'),
+          reason: 'Ownership is decided by author *and* subject, so a human '
+              'commit on the branch is always foreign.');
+    });
+
+    test('it will not rewind its own branch to an older version', () {
+      expect(job, contains('Refusing to rewind the open PR'),
+          reason: 'If the branch already proposes something newer than the '
+              'manifest just offered, the data is wrong — stop.');
+    });
+
+    test('it re-checks its own blast radius before committing', () {
+      expect(
+          job, contains('check_dependency_update_files.sh --kind flutter-sdk'),
+          reason: 'The updater must verify the changed files before a commit '
+              'exists, exactly as the Dart updater does.');
+    });
+
+    test('it writes the pin and nothing else', () {
+      expect(job, contains('> .flutter-version'),
+          reason: 'The whole change is one version string in one file.');
+      expect(job, contains('git add .flutter-version'));
+      expect(job.contains('git add -A'), isFalse);
+      expect(job.contains('git add .\n'), isFalse);
+      expect(job.contains('git add pubspec'), isFalse);
+    });
+
+    test('the PR body carries everything a reviewer needs', () {
+      for (final String required in <String>[
+        'Currently pinned',
+        'Proposed',
+        'Stable channel',
+        'confirmed',
+        'may be red',
+        'F-Droid',
+        'reproducib',
+        'auto-merge',
+        '#362',
+      ]) {
+        expect(job, contains(required),
+            reason: 'The PR body must mention "$required".');
+      }
+    });
+  });
+
+  group('the major update job', () {
+    late final String job = _jobSection(workflow, 'major-issue');
+
+    test('it runs only for a major update', () {
+      expect(job, contains("needs.check.outputs.status == 'major'"));
+    });
+
+    test('it files an issue and opens no PR', () {
+      expect(job, contains('gh issue create'));
+      expect(job, contains('gh issue edit'));
+      expect(job.contains('gh pr create'), isFalse,
+          reason: 'A major Flutter release must never produce an SDK bump PR.');
+    });
+
+    test('it makes no commit and does not touch the pin', () {
+      for (final String forbidden in <String>[
+        'git commit',
+        'git push',
+        'git checkout -B',
+        '> .flutter-version',
+      ]) {
+        expect(job.contains(forbidden), isFalse,
+            reason: 'The major path runs `$forbidden`. A major update must '
+                'change nothing in the repository (#362).');
+      }
+    });
+
+    test('it needs no publication token, only permission to file an issue', () {
+      expect(job, contains('issues: write'));
+      expect(job.contains('DEPENDENCY_UPDATE_TOKEN'), isFalse,
+          reason: 'An issue needs no CI, so it needs none of the publication '
+              'token\'s reach.');
+    });
+
+    test('it updates the open issue instead of refiling every week', () {
+      expect(job, contains('select(.title == env.TITLE)'),
+          reason: 'The weekly run must find its own issue by title and edit '
+              'it, or the maintainer gets a duplicate every Monday.');
+    });
+
+    test('the issue body explains why this stays manual', () {
+      for (final String required in <String>[
+        'Currently pinned',
+        'New stable major',
+        'manual',
+        'F-Droid',
+        'reproduc',
+        '#362',
+      ]) {
+        expect(job, contains(required),
+            reason: 'The issue body must mention "$required".');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The boundary is re-checked on the PR itself, and the fixer stays away.
+  // ---------------------------------------------------------------------------
+  group('the boundary is re-checked on the PR itself', () {
+    test('ci.yml guards toolchain/ PRs with the same script', () {
+      expect(ci, contains("startsWith(github.head_ref, 'toolchain/')"),
+          reason: 'CI must run the pin-only guard on SDK update PRs — against '
+              'the real PR diff, not just the files the updater thinks it '
+              'changed.');
+      expect(
+          ci,
+          contains(
+              './scripts/check_dependency_update_files.sh --kind flutter-sdk'),
+          reason:
+              'The PR-side guard must be the same script the updater uses.');
+    });
+
+    test('ci.yml still guards deps/ PRs as lockfile-only', () {
+      expect(ci, contains("startsWith(github.head_ref, 'deps/')"));
+      expect(
+          ci,
+          contains(
+              './scripts/check_dependency_update_files.sh --kind dart-packages'),
+          reason: 'Adding the toolchain guard must not weaken the Dart one.');
+    });
+
+    test('CI runs on every PR, so an SDK PR is never unchecked', () {
+      expect(ci, contains('pull_request:'));
+      expect(ci.contains('pull_request:\n    branches'), isFalse,
+          reason: 'A branch filter on pull_request would let an update PR '
+              'merge without the normal checks.');
+    });
+  });
+
+  group('the CI fixer leaves the toolchain branch alone', () {
+    test('the fix job skips toolchain/ alongside dependabot/ and deps/', () {
+      for (final String prefix in <String>[
+        'dependabot/',
+        'deps/',
+        'toolchain/',
+      ]) {
+        expect(
+          fixer,
+          contains('"\$head_branch" == $prefix*'),
+          reason: 'An SDK update that breaks CI must stay broken — the red is '
+              'the signal, and "repair the code until it passes" is the '
+              'migration itself. The skip has to happen while resolving the '
+              'run, before any repair is generated. Missing: $prefix',
+        );
+      }
+    });
+
+    test('the publish job restates the skip where the push happens', () {
+      for (final String prefix in <String>[
+        'dependabot/',
+        'deps/',
+        'toolchain/',
+      ]) {
+        expect(
+          fixer,
+          contains("!startsWith(needs.fix.outputs.target_branch, '$prefix')"),
+          reason: 'The last gate before a commit is pushed must also refuse '
+              '$prefix branches.',
+        );
+      }
+    });
+
+    test('the fixer still refuses to touch the pin in any PR', () {
+      expect(fixer, contains(r'\.flutter-version$'),
+          reason: 'The protected-path guard must keep .flutter-version out of '
+              'every agent patch, not just the ones on toolchain/ branches.');
+    });
+  });
+
+  group('the documentation describes what actually happens', () {
+    test('it no longer claims Flutter SDK updates are unautomated', () {
+      expect(
+          docs.contains('the Flutter SDK itself, Gradle, AGP, Kotlin'), isFalse,
+          reason: 'docs/dependency-updates.md still groups the Flutter SDK '
+              'with the toolchains that are not automated yet.');
+    });
+
+    test('it documents the pieces a maintainer needs', () {
+      for (final String required in <String>[
+        '.flutter-version',
+        'flutter-sdk-updates.yml',
+        'toolchain/flutter-sdk',
+        'check_flutter_sdk_update.py',
+        'flutter_infra_release',
+        'DEPENDENCY_UPDATE_TOKEN',
+        'F-Droid',
+      ]) {
+        expect(docs, contains(required),
+            reason: 'docs/dependency-updates.md must mention "$required".');
+      }
+    });
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Fixtures and helpers.
+// -----------------------------------------------------------------------------
+
+/// A release entry shaped like the official manifest's.
+Map<String, dynamic> _release(
+  String version, {
+  String channel = 'stable',
+  String? archive,
+}) =>
+    <String, dynamic>{
+      'hash': 'hash-$channel-$version',
+      'channel': channel,
+      'version': version,
+      'dart_sdk_version': '3.0.0',
+      'dart_sdk_arch': 'x64',
+      'release_date': '2026-01-01T00:00:00.000000Z',
+      'archive':
+          archive ?? '$channel/linux/flutter_linux_$version-$channel.tar.xz',
+      'sha256': 'sha-$version',
+    };
+
+/// Runs the checker against a synthesised manifest. No network is involved.
+_Result _check(
+  String checker, {
+  required String current,
+  required List<String> stable,
+  List<Map<String, dynamic>> extra = const <Map<String, dynamic>>[],
+  String? stableHashFor,
+}) {
+  final List<Map<String, dynamic>> releases = <Map<String, dynamic>>[
+    for (final String version in stable) _release(version),
+    ...extra,
+  ];
+  final String pointer =
+      stableHashFor ?? (stable.isNotEmpty ? stable.first : '');
+  final Map<String, dynamic> manifest = <String, dynamic>{
+    'base_url': 'https://storage.googleapis.com/flutter_infra_release/releases',
+    'current_release': <String, String>{
+      'stable': pointer.isEmpty ? '' : 'hash-stable-$pointer',
+      'beta': 'hash-beta-unused',
+      'dev': 'hash-dev-unused',
+    },
+    'releases': releases,
+  };
+  return _runWithManifest(
+    checker,
+    const JsonEncoder.withIndent('  ').convert(manifest),
+    <String>['--current', current, '--json'],
+  );
+}
+
+_Result _runWithManifest(String checker, String manifest, List<String> args) {
+  final Directory tmp = Directory.systemTemp.createTempSync('flutter-releases');
+  try {
+    final File file = File(p.join(tmp.path, 'releases_linux.json'))
+      ..writeAsStringSync(manifest);
+    return _run(checker, <String>[...args, '--releases-file', file.path]);
+  } finally {
+    tmp.deleteSync(recursive: true);
+  }
+}
+
+_Result _run(String checker, List<String> args) {
+  final ProcessResult r = Process.runSync(
+    'python3',
+    <String>[checker, ...args],
+    stdoutEncoding: const SystemEncoding(),
+    stderrEncoding: const SystemEncoding(),
+  );
+  return _Result(r.exitCode, r.stdout.toString(), r.stderr.toString());
+}
+
+ProcessResult _runGuard(String script, String kind, List<String> paths) =>
+    Process.runSync(
+      'bash',
+      <String>[script, '--kind', kind, ...paths],
+      stdoutEncoding: const SystemEncoding(),
+      stderrEncoding: const SystemEncoding(),
+    );
+
+class _Result {
+  _Result(this.exitCode, this.stdout, this.stderr);
+
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+
+  Map<String, dynamic> get json => jsonDecode(stdout) as Map<String, dynamic>;
+
+  String get status => value('status');
+
+  String value(String key) => (json[key] ?? '').toString();
+
+  String describe() => 'exit: $exitCode\nstdout:\n$stdout\nstderr:\n$stderr';
+}
+
+/// The text of one top-level job in a workflow file.
+///
+/// Job-scoped assertions matter here: "the workflow mentions the publication
+/// token somewhere" would pass even if the wrong job used it.
+String _jobSection(String workflow, String job) {
+  final RegExp header = RegExp('^  $job:\$', multiLine: true);
+  final RegExpMatch? start = header.firstMatch(workflow);
+  if (start == null) fail('Workflow has no job named "$job".');
+  final RegExp nextJob = RegExp(r'^  [a-z][\w-]*:$', multiLine: true);
+  for (final RegExpMatch m in nextJob.allMatches(workflow)) {
+    if (m.start > start.start) {
+      return workflow.substring(start.start, m.start);
+    }
+  }
+  return workflow.substring(start.start);
+}
+
+String _read(String root, String relativePath) {
+  final File f = File(p.join(root, relativePath));
+  expect(f.existsSync(), isTrue,
+      reason: 'Expected file is missing: $relativePath');
+  return f.readAsStringSync();
+}
+
+String _repoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, '.github')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}


### PR DESCRIPTION
Phase 4 of #362 — the Flutter SDK update checker. Phases 1–3 (#363, #364, #370) are merged; Gradle/AGP/Kotlin are deliberately **not** in this PR, they are phase 5.

Linthra now watches the official Flutter stable channel weekly and says *"there's a newer SDK, here's the PR"*. Nothing merges, and nothing migrates code.

## Behaviour

| Gap between `.flutter-version` and newest stable | Result |
| --- | --- |
| none | nothing at all — no PR, no issue |
| newer patch | draft PR on `toolchain/flutter-sdk` |
| newer minor | draft PR on `toolchain/flutter-sdk` |
| newer major | **issue**, no branch, no commit, no pin change |

## Where the release data comes from

The official Flutter release manifest:

```text
https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json
```

The machine-readable index behind Flutter's own archive page, served from the same `flutter_infra_release` bucket `scripts/setup_flutter.sh` already downloads the pinned SDK from — so a version this proposes is by construction one the pinned setup path can install. No third-party API, no scraped page.

A release is a candidate only if it is on the `stable` channel **and** its version is a bare `MAJOR.MINOR.PATCH` **and** its `archive` is a string under `stable/`. That drops every beta `-0.N.pre` build and the legacy `v1.x+hotfix.N` tags. A row with no archive at all — missing, null or empty — is dropped for the same reason a row pointing outside `stable/` is: it names nothing the pinned setup path could install, so it is not a version to propose. The **highest** surviving candidate wins, not the first array entry — a hotfix on an older line can be published after a newer line already exists. The manifest's own `current_release.stable` pointer is resolved as a cross-check and any disagreement reported.

## Detection is a script, not YAML

`scripts/check_flutter_sdk_update.py` — stdlib only, no third-party semantic-version package (three ints and a tuple compare). It reads two things and writes nothing; publishing belongs to the workflow. Runnable locally:

```bash
python3 scripts/check_flutter_sdk_update.py --json
```

It fails loudly rather than guessing. An unparseable pin, an unparseable manifest, a manifest with no usable stable release, or a "newest stable" that is *older* than the pin all exit non-zero. **It never proposes a downgrade.**

## Safety

- **Allowlist.** `scripts/check_dependency_update_files.sh` grows an explicit `--kind`. The default stays `dart-packages` → `pubspec.lock`, byte-for-byte the same rule as before; `flutter-sdk` → `.flutter-version` only. **Neither kind can write the other's file** — an SDK bump must not re-resolve the lockfile the reproducible F-Droid build depends on; that stays a human's decision. `ci.yml` runs the guard against the **real PR diff** for the `toolchain/flutter-sdk` head, alongside the existing `deps/` job. That branch is matched exactly, not by `toolchain/` prefix, so a human's own toolchain PR stays an ordinary PR and is not held to the pin-only rule.
- **Bot-branch ownership.** Mirrors the Dart updater: `--force-with-lease`, a per-commit author+subject check that refuses to force-push over anything the workflow did not write, and a version comparison that refuses to rewind the open PR to an older target. A run whose target is already on the branch pushes nothing.
- **No duplicates.** One reusable branch and one reusable PR; the major path finds its own issue by exact title and edits it.
- **Normal CI.** Published with the existing `DEPENDENCY_UPDATE_TOKEN`, so GitHub triggers the repo's normal `pull_request` checks. The token check lives in the publishing job, so a quiet week never fails for want of a secret. The major path needs no token — just `issues: write`, scoped to that one job.
- **CI fixer.** Now skips `toolchain/*` alongside `dependabot/*` and `deps/*`, in both the resolve step and the publish gate. A bump that breaks application code is *supposed* to stay red: "repair the code until the checks pass" is the migration itself.
- **No auto-merge.** No merge command anywhere, and a test asserts that stays true.

## Files changed

| File | |
| --- | --- |
| `scripts/check_flutter_sdk_update.py` | new — detection and classification |
| `.github/workflows/flutter-sdk-updates.yml` | new — weekly + `workflow_dispatch`, three jobs |
| `scripts/check_dependency_update_files.sh` | `--kind dart-packages\|flutter-sdk` |
| `.github/workflows/ci.yml` | new `toolchain-guard` job |
| `.github/workflows/flutter-ci-fixer.yml` | skip `toolchain/*` in both gates |
| `test/tooling/flutter_sdk_update_guardrails_test.dart` | new — 94 cases |
| `test/tooling/dependency_update_guardrails_test.dart` | fixer assertion matched per prefix |
| `docs/dependency-updates.md` | new **Flutter SDK** section |

Linthra's actual pin is untouched.

## Verification

`dart format` · `flutter analyze` (clean) · `flutter test` (**3320 passed**) · `./scripts/check_secrets.sh` · YAML parse of every workflow · `bash -n` on every script.

Classification was proven against fixture manifests (patch / minor / major / same / malformed / beta-filtering / downgrade / every shape of missing archive) without touching the real pin, and the workflow's branch-safety bash was rehearsed against a scratch repo: fresh branch → idempotent re-run → forward force-push → refused rewind → refused force-push over a human commit → CI-side guard rejecting app code on the branch.

## Setup needed

None beyond the existing `DEPENDENCY_UPDATE_TOKEN` (Contents + Pull requests, read/write). No second credential.