### PR TITLE
ci: announce stable releases on Reddit

### DIFF
--- a/.github/workflows/reddit-release-announcement-tests.yml
+++ b/.github/workflows/reddit-release-announcement-tests.yml
@@ -1,0 +1,40 @@
+name: Reddit release announcement tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/reddit-release-announcement.yml"
+      - ".github/workflows/reddit-release-announcement-tests.yml"
+      - "scripts/reddit_release_announcement.py"
+      - "scripts/reddit_release_voice.json"
+      - "scripts/post_reddit_release.py"
+      - "test/tooling/reddit_release_announcement_test.py"
+      - "docs/reddit-release-announcements.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/reddit-release-announcement.yml"
+      - ".github/workflows/reddit-release-announcement-tests.yml"
+      - "scripts/reddit_release_announcement.py"
+      - "scripts/reddit_release_voice.json"
+      - "scripts/post_reddit_release.py"
+      - "test/tooling/reddit_release_announcement_test.py"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Reddit announcement tooling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Run tests
+        run: python3 test/tooling/reddit_release_announcement_test.py

--- a/.github/workflows/reddit-release-announcement.yml
+++ b/.github/workflows/reddit-release-announcement.yml
@@ -1,0 +1,137 @@
+name: Reddit release announcement
+
+# A stable GitHub Release is already the maintainer's publish decision. This
+# workflow only mirrors that announcement to r/Linthra; it never creates,
+# edits, rolls back, or blocks the release itself.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Stable release tag to preview, e.g. v0.2.2. Manual runs never post."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reddit-release-${{ github.event.release.tag_name || inputs.release_tag || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Build Reddit preview
+    runs-on: ubuntu-latest
+    # A prerelease can also emit a published event. It is deliberately not
+    # announced. Manual runs are allowed through so the generator can validate
+    # the requested tag and show the exact post without publishing it.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.release.draft == false &&
+           github.event.release.prerelease == false) }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Load release metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            jq '.release' "${GITHUB_EVENT_PATH}" > release.json
+          else
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+              > release.json
+          fi
+
+      - name: Generate Reddit post
+        run: |
+          set -euo pipefail
+          python3 scripts/reddit_release_announcement.py \
+            --release-json release.json \
+            --voice-config scripts/reddit_release_voice.json \
+            --output-dir reddit-preview
+
+      - name: Show exact preview
+        run: |
+          {
+            echo "## Reddit release preview"
+            echo
+            echo "**Title**"
+            echo
+            cat reddit-preview/title.txt
+            echo
+            echo "**Body**"
+            echo
+            cat reddit-preview/body.md
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              echo
+              echo "> Preview only — manual runs cannot publish to Reddit."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload prepared announcement
+        if: ${{ github.event_name == 'release' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: reddit-release-announcement
+          path: reddit-preview/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish to r/Linthra
+    needs: prepare
+    runs-on: ubuntu-latest
+    # This is intentionally unreachable from workflow_dispatch. A manual run is
+    # always a preview; only GitHub's stable release event can publish.
+    if: >-
+      ${{ github.event_name == 'release' &&
+          needs.prepare.result == 'success' &&
+          vars.REDDIT_RELEASE_ANNOUNCEMENTS_ENABLED == 'true' }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Download prepared announcement
+        uses: actions/download-artifact@v8
+        with:
+          name: reddit-release-announcement
+          path: reddit-preview
+
+      - name: Publish once
+        env:
+          REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+          REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
+          REDDIT_REFRESH_TOKEN: ${{ secrets.REDDIT_REFRESH_TOKEN }}
+          REDDIT_USER_AGENT: "linux:io.github.thezupzup.linthra.releases:v1 (by /u/TheZupZup)"
+        run: |
+          set -euo pipefail
+
+          release_url="$(jq -r '.release_url' reddit-preview/announcement.json)"
+          subreddit="$(jq -r '.subreddit' reddit-preview/announcement.json)"
+
+          python3 scripts/post_reddit_release.py \
+            --title-file reddit-preview/title.txt \
+            --body-file reddit-preview/body.md \
+            --release-url "${release_url}" \
+            --subreddit "${subreddit}"

--- a/docs/reddit-release-announcements.md
+++ b/docs/reddit-release-announcements.md
@@ -1,0 +1,163 @@
+# Reddit release announcements
+
+Linthra can turn a published stable GitHub Release into one short post in
+`r/Linthra`.
+
+The GitHub Release stays the source of truth. Reddit is only an announcement:
+if Reddit is unavailable, the release remains published and nothing is rolled
+back.
+
+## What triggers it
+
+`.github/workflows/reddit-release-announcement.yml` listens for GitHub's
+`release: published` event.
+
+It skips draft and prerelease releases. A tag, a merge, or editing an existing
+release does not publish anything to Reddit.
+
+Manual runs are preview-only. From **Actions → Reddit release announcement →
+Run workflow**, enter a stable release tag and the workflow puts the exact title
+and body in the job summary. A manual run has no path to the publish job.
+
+## What the post sounds like
+
+`scripts/reddit_release_announcement.py` reads the GitHub Release body and keeps
+the post deliberately small:
+
+- a short maintainer-style intro;
+- at most five bullets, preferring `What's new` or `Highlights`;
+- a thank-you;
+- the GitHub Release URL;
+- a short F-Droid follow-up.
+
+The wording lives in `scripts/reddit_release_voice.json`, so changing the voice
+later does not require editing the workflow.
+
+There is no AI/LLM call in CI. The release notes are already human-written; the
+script only trims and formats them.
+
+## Reddit access in 2026
+
+Reddit's current help documentation says the Data API is for **approved
+developers** and requires OAuth. Reddit also directs developers to its Developer
+Platform first and provides a Data Access Request path for bots/apps that are
+not supported there.
+
+This workflow uses the OAuth Data API because GitHub Actions is an external
+service and the job needs to submit a normal text post. Reddit's Developer
+Platform external endpoints are a limited-access feature too, so moving this
+automation to Devvit would not remove the approval/setup step.
+
+Before enabling live posting:
+
+1. Request/confirm non-commercial Reddit Data API access for this use case.
+   Describe it plainly: one maintainer-owned bot that posts Linthra release
+   announcements to the Linthra community.
+2. Register the OAuth client Reddit gives/approves for the app.
+3. Authorize the Reddit account that will make the posts with **permanent**
+   access and the minimum scopes used here: `read` and `submit`.
+4. Keep the resulting refresh token. The workflow exchanges it for a short-lived
+   access token on each release; it never stores a Reddit password.
+
+Reddit's live API documents `/api/submit` for creating self-posts. OAuth API
+requests are made through `oauth.reddit.com`, with a descriptive User-Agent.
+
+Useful official references:
+
+- https://support.reddithelp.com/hc/en-us/articles/14945211791892-Developer-Platform-Accessing-Reddit-Data
+- https://support.reddithelp.com/hc/en-us/articles/16160319875092-Reddit-Data-API-Wiki
+- https://www.reddit.com/dev/api/
+- https://redditinc.com/policies/developer-terms
+- https://redditinc.com/policies/data-api-terms
+
+## GitHub setup
+
+Create these repository **Actions secrets**:
+
+- `REDDIT_CLIENT_ID`
+- `REDDIT_CLIENT_SECRET`
+- `REDDIT_REFRESH_TOKEN`
+
+Then create this repository **Actions variable**:
+
+- `REDDIT_RELEASE_ANNOUNCEMENTS_ENABLED` = `true`
+
+The variable is the kill switch. Until it is exactly `true`, stable releases
+still build a preview but the Reddit publish job is skipped.
+
+Do not put a Reddit password in GitHub.
+
+The refresh token must have the `read` and `submit` scopes:
+
+- `submit` creates the text post;
+- `read` lets the workflow check recent `r/Linthra` posts before publishing, so
+  rerunning a workflow does not create a duplicate.
+
+## Duplicate protection
+
+Every generated post includes the GitHub Release URL.
+
+Before submitting, `scripts/post_reddit_release.py` reads the newest posts in
+`r/Linthra` and looks for that exact release URL in the self-post body. If it is
+already there, the script exits successfully without creating another post.
+
+The workflow also uses a per-release GitHub Actions concurrency group, so two
+runs for the same release do not publish at the same time.
+
+This makes the normal recovery path simple: if a Reddit job fails, fix the
+credential/API problem and rerun that failed workflow. If Reddit actually
+created the post before the failure, the duplicate check finds it.
+
+## Failure behavior
+
+A Reddit failure can make the announcement workflow red, but it cannot:
+
+- unpublish or delete the GitHub Release;
+- delete a tag;
+- change app/F-Droid metadata;
+- merge anything;
+- create a retry loop.
+
+The posting script does not print OAuth tokens, client secrets, or refresh
+tokens. HTTP error bodies from the OAuth exchange are deliberately not echoed to
+Actions logs.
+
+## Disable it
+
+Set `REDDIT_RELEASE_ANNOUNCEMENTS_ENABLED` to anything other than `true`, or
+disable the workflow in GitHub Actions.
+
+Preview mode continues to work even while live posting is disabled.
+
+## Local preview
+
+Save a GitHub Release JSON payload and run:
+
+```bash
+python3 scripts/reddit_release_announcement.py \
+  --release-json release.json \
+  --voice-config scripts/reddit_release_voice.json \
+  --output-dir /tmp/linthra-reddit
+```
+
+Then inspect:
+
+```text
+/tmp/linthra-reddit/title.txt
+/tmp/linthra-reddit/body.md
+```
+
+The generator uses only Python's standard library and makes no network request.
+
+## Tests
+
+Run:
+
+```bash
+python3 test/tooling/reddit_release_announcement_test.py
+```
+
+The tests cover stable/prerelease filtering, empty and very long release notes,
+the bullet limit, Markdown cleanup, conservative Reddit length limits, secret
+isolation, duplicate detection, missing credentials, and the fact that manual
+workflow runs cannot reach the publisher.

--- a/scripts/post_reddit_release.py
+++ b/scripts/post_reddit_release.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Publish one Linthra release announcement through Reddit's OAuth Data API."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
+OAUTH_BASE = "https://oauth.reddit.com"
+DEFAULT_USER_AGENT = (
+    "linux:io.github.thezupzup.linthra.releases:v1 (by /u/TheZupZup)"
+)
+
+
+class RedditPublishError(RuntimeError):
+    """A publish failure that is safe to report without exposing credentials."""
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RedditPublishError(f"missing required environment variable {name}")
+    return value
+
+
+def _request_json(
+    request: urllib.request.Request, *, context: str
+) -> dict[str, Any]:
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        # Do not print the body: auth failures can include request details and
+        # there is no reason to risk reflecting credentials into Actions logs.
+        raise RedditPublishError(
+            f"{context} failed with HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RedditPublishError(f"{context} failed: {exc.reason}") from exc
+
+    try:
+        decoded = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RedditPublishError(f"{context} returned invalid JSON") from exc
+    if not isinstance(decoded, dict):
+        raise RedditPublishError(f"{context} returned an unexpected response")
+    return decoded
+
+
+def exchange_refresh_token(
+    client_id: str, client_secret: str, refresh_token: str, user_agent: str
+) -> str:
+    credentials = base64.b64encode(
+        f"{client_id}:{client_secret}".encode("utf-8")
+    ).decode("ascii")
+    data = urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        TOKEN_URL,
+        data=data,
+        headers={
+            "Authorization": f"Basic {credentials}",
+            "User-Agent": user_agent,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    payload = _request_json(request, context="Reddit OAuth token exchange")
+    token = payload.get("access_token")
+    if not isinstance(token, str) or not token:
+        raise RedditPublishError("Reddit OAuth token exchange returned no access token")
+    return token
+
+
+def find_existing_announcement(
+    access_token: str,
+    user_agent: str,
+    subreddit: str,
+    release_url: str,
+) -> str | None:
+    query = urllib.parse.urlencode({"limit": 100, "raw_json": 1})
+    request = urllib.request.Request(
+        f"{OAUTH_BASE}/r/{urllib.parse.quote(subreddit)}/new?{query}",
+        headers={
+            "Authorization": f"bearer {access_token}",
+            "User-Agent": user_agent,
+        },
+    )
+    payload = _request_json(request, context="Reddit duplicate check")
+    children = payload.get("data", {}).get("children", [])
+    if not isinstance(children, list):
+        raise RedditPublishError("Reddit duplicate check returned an unexpected listing")
+
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        data = child.get("data")
+        if not isinstance(data, dict):
+            continue
+        selftext = data.get("selftext")
+        if isinstance(selftext, str) and release_url in selftext:
+            permalink = data.get("permalink")
+            if isinstance(permalink, str) and permalink:
+                return f"https://www.reddit.com{permalink}"
+            return "already announced"
+    return None
+
+
+def submit_post(
+    access_token: str,
+    user_agent: str,
+    subreddit: str,
+    title: str,
+    body: str,
+) -> str:
+    data = urllib.parse.urlencode(
+        {
+            "api_type": "json",
+            "kind": "self",
+            "sr": subreddit,
+            "title": title,
+            "text": body,
+            "sendreplies": "true",
+            "resubmit": "true",
+            "raw_json": "1",
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{OAUTH_BASE}/api/submit",
+        data=data,
+        headers={
+            "Authorization": f"bearer {access_token}",
+            "User-Agent": user_agent,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    payload = _request_json(request, context="Reddit post submission")
+    json_result = payload.get("json")
+    if not isinstance(json_result, dict):
+        raise RedditPublishError("Reddit post submission returned no json result")
+
+    errors = json_result.get("errors")
+    if isinstance(errors, list) and errors:
+        safe_errors = []
+        for item in errors:
+            if isinstance(item, list) and len(item) >= 2:
+                safe_errors.append(f"{item[0]}: {item[1]}")
+            else:
+                safe_errors.append("unknown Reddit API error")
+        raise RedditPublishError(
+            "Reddit rejected the post: " + "; ".join(safe_errors)
+        )
+
+    data_result = json_result.get("data")
+    if not isinstance(data_result, dict):
+        raise RedditPublishError("Reddit post submission returned no post data")
+    url = data_result.get("url")
+    if not isinstance(url, str) or not url.startswith("http"):
+        raise RedditPublishError("Reddit post submission returned no post URL")
+    return url
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--title-file", type=Path, required=True)
+    parser.add_argument("--body-file", type=Path, required=True)
+    parser.add_argument("--release-url", required=True)
+    parser.add_argument("--subreddit", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        title = args.title_file.read_text(encoding="utf-8").strip()
+        body = args.body_file.read_text(encoding="utf-8").strip()
+        if not title or not body:
+            raise RedditPublishError("generated Reddit title/body is empty")
+
+        client_id = _required_env("REDDIT_CLIENT_ID")
+        client_secret = _required_env("REDDIT_CLIENT_SECRET")
+        refresh_token = _required_env("REDDIT_REFRESH_TOKEN")
+        user_agent = os.environ.get("REDDIT_USER_AGENT", DEFAULT_USER_AGENT).strip()
+        if not user_agent:
+            raise RedditPublishError("REDDIT_USER_AGENT must not be empty")
+
+        token = exchange_refresh_token(
+            client_id, client_secret, refresh_token, user_agent
+        )
+        existing = find_existing_announcement(
+            token, user_agent, args.subreddit, args.release_url
+        )
+        if existing is not None:
+            print(f"Reddit announcement already exists: {existing}")
+            return 0
+
+        url = submit_post(token, user_agent, args.subreddit, title, body)
+        print(f"Reddit announcement published: {url}")
+        return 0
+    except (OSError, RedditPublishError) as exc:
+        print(f"reddit publish: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reddit_release_announcement.py
+++ b/scripts/reddit_release_announcement.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Build a short, human Reddit announcement from a GitHub Release payload."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+STABLE_TAG_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+BULLET_RE = re.compile(r"^\s*[-*]\s+(.+?)\s*$")
+HEADING_RE = re.compile(r"^\s*(#{1,6})\s+(.+?)\s*$")
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+INLINE_CODE_RE = re.compile(r"`([^`]+)`")
+BOLD_RE = re.compile(r"\*\*([^*]+)\*\*")
+ITALIC_RE = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)")
+MAX_TITLE_CHARS = 300
+MAX_BODY_CHARS = 10_000
+
+DEFAULT_VOICE = {
+    "subreddit": "Linthra",
+    "max_bullets": 5,
+    "patch_intro": (
+        "Small update this time, but there are a few things in here "
+        "I'm really happy with."
+    ),
+    "feature_intro": (
+        "New Linthra update is out, and there are a few things in this one "
+        "I'm really happy with."
+    ),
+    "bullet_lead": "I focused mostly on:",
+    "empty_release_note": (
+        "I kept this one simple — the full details are in the GitHub release."
+    ),
+    "closing": (
+        "Thanks to everyone testing Linthra and reporting the weird little bugs 😅"
+    ),
+    "fdroid": "F-Droid will follow once the new build makes its way through their side.",
+}
+
+
+class AnnouncementError(ValueError):
+    """Raised when a release cannot safely produce an announcement."""
+
+
+def load_voice(path: Path | None) -> dict[str, Any]:
+    voice = dict(DEFAULT_VOICE)
+    if path is None:
+        return voice
+    with path.open(encoding="utf-8") as handle:
+        custom = json.load(handle)
+    if not isinstance(custom, dict):
+        raise AnnouncementError("voice config must be a JSON object")
+    voice.update(custom)
+    max_bullets = voice.get("max_bullets")
+    if not isinstance(max_bullets, int) or not 1 <= max_bullets <= 10:
+        raise AnnouncementError("voice config max_bullets must be an integer from 1 to 10")
+    return voice
+
+
+def parse_stable_version(tag: str) -> tuple[int, int, int]:
+    match = STABLE_TAG_RE.fullmatch(tag.strip())
+    if match is None:
+        raise AnnouncementError(
+            f"release tag {tag!r} is not a stable MAJOR.MINOR.PATCH tag"
+        )
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def release_is_announceable(release: dict[str, Any]) -> bool:
+    if release.get("draft") is True or release.get("prerelease") is True:
+        return False
+    if not release.get("published_at"):
+        return False
+    tag = release.get("tag_name")
+    return isinstance(tag, str) and STABLE_TAG_RE.fullmatch(tag.strip()) is not None
+
+
+def clean_markdown(text: str) -> str:
+    value = text.strip()
+    value = MARKDOWN_LINK_RE.sub(r"\1", value)
+    value = INLINE_CODE_RE.sub(r"\1", value)
+    value = BOLD_RE.sub(r"\1", value)
+    value = ITALIC_RE.sub(r"\1", value)
+    value = value.replace("\\_", "_")
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def preferred_section(body: str) -> tuple[list[str], bool]:
+    """Return the What's new/Highlights section when one exists."""
+    lines = body.splitlines()
+    start: int | None = None
+    start_level: int | None = None
+
+    for index, raw in enumerate(lines):
+        match = HEADING_RE.match(raw)
+        if match is None:
+            continue
+        title = clean_markdown(match.group(2)).lower().replace("’", "'")
+        if title in {"what's new", "whats new", "highlights", "what is new"}:
+            start = index + 1
+            start_level = len(match.group(1))
+            break
+
+    if start is None:
+        return lines, False
+
+    selected: list[str] = []
+    for raw in lines[start:]:
+        match = HEADING_RE.match(raw)
+        if match is not None and len(match.group(1)) <= (start_level or 6):
+            break
+        selected.append(raw)
+    return selected, True
+
+
+def _collect_bullets(lines: list[str], max_bullets: int) -> list[str]:
+    bullets: list[str] = []
+    skip_prefixes = (
+        "version:",
+        "versionname",
+        "versioncode",
+        "platform:",
+        "application id:",
+        "license:",
+    )
+    for raw in lines:
+        match = BULLET_RE.match(raw)
+        if match is None:
+            continue
+        item = clean_markdown(match.group(1))
+        if not item or item.lower().startswith(skip_prefixes):
+            continue
+        if len(item) > 180:
+            item = item[:177].rstrip(" ,.;:-") + "…"
+        if item not in bullets:
+            bullets.append(item)
+        if len(bullets) >= max_bullets:
+            break
+    return bullets
+
+
+def extract_bullets(body: str, max_bullets: int) -> list[str]:
+    section, found_preferred = preferred_section(body)
+    bullets = _collect_bullets(section, max_bullets)
+    if bullets or found_preferred:
+        return bullets
+    return _collect_bullets(body.splitlines(), max_bullets)
+
+
+def _normalise_tag(tag: str) -> str:
+    tag = tag.strip()
+    return tag if tag.startswith("v") else f"v{tag}"
+
+
+def build_announcement(
+    release: dict[str, Any], voice: dict[str, Any]
+) -> dict[str, str]:
+    if not release_is_announceable(release):
+        raise AnnouncementError(
+            "release is a draft, prerelease, unpublished, or unstable tag"
+        )
+
+    raw_tag = str(release["tag_name"])
+    _, _, patch = parse_stable_version(raw_tag)
+    tag = _normalise_tag(raw_tag)
+
+    release_url = release.get("html_url")
+    if not isinstance(release_url, str) or not release_url.startswith("https://"):
+        raise AnnouncementError("release html_url is missing or invalid")
+
+    title = f"Linthra {tag} is out 🎵"
+    if len(title) > MAX_TITLE_CHARS:
+        raise AnnouncementError("generated Reddit title exceeds the safe title limit")
+
+    body_text = release.get("body")
+    if not isinstance(body_text, str):
+        body_text = ""
+
+    bullets = extract_bullets(body_text, int(voice["max_bullets"]))
+    intro_key = "patch_intro" if patch > 0 else "feature_intro"
+
+    parts = [str(voice[intro_key]).strip()]
+    if bullets:
+        parts.extend(
+            [
+                str(voice["bullet_lead"]).strip(),
+                "\n".join(f"- {item}" for item in bullets),
+            ]
+        )
+    else:
+        parts.append(str(voice["empty_release_note"]).strip())
+
+    parts.extend(
+        [
+            str(voice["closing"]).strip(),
+            f"GitHub release:\n{release_url}",
+            str(voice["fdroid"]).strip(),
+        ]
+    )
+    body = "\n\n".join(part for part in parts if part)
+
+    if len(body) > MAX_BODY_CHARS:
+        raise AnnouncementError(
+            f"generated Reddit body exceeds the conservative "
+            f"{MAX_BODY_CHARS}-character limit"
+        )
+
+    return {
+        "tag": tag,
+        "title": title,
+        "body": body,
+        "release_url": release_url,
+        "subreddit": str(voice["subreddit"]),
+    }
+
+
+def write_outputs(announcement: dict[str, str], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "title.txt").write_text(
+        announcement["title"] + "\n", encoding="utf-8"
+    )
+    (output_dir / "body.md").write_text(
+        announcement["body"] + "\n", encoding="utf-8"
+    )
+    (output_dir / "announcement.json").write_text(
+        json.dumps(announcement, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--release-json", type=Path, required=True)
+    parser.add_argument("--voice-config", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--json", action="store_true", help="print JSON to stdout")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        with args.release_json.open(encoding="utf-8") as handle:
+            release = json.load(handle)
+        if not isinstance(release, dict):
+            raise AnnouncementError("release payload must be a JSON object")
+        voice = load_voice(args.voice_config)
+        announcement = build_announcement(release, voice)
+        if args.output_dir:
+            write_outputs(announcement, args.output_dir)
+        if args.json:
+            print(json.dumps(announcement, ensure_ascii=False))
+        return 0
+    except (OSError, json.JSONDecodeError, AnnouncementError) as exc:
+        print(f"reddit announcement: {exc}", file=sys.stderr)
+        if isinstance(exc, AnnouncementError) and str(exc).startswith(
+            "release is a draft"
+        ):
+            return 3
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reddit_release_voice.json
+++ b/scripts/reddit_release_voice.json
@@ -1,0 +1,10 @@
+{
+  "subreddit": "Linthra",
+  "max_bullets": 5,
+  "patch_intro": "Small update this time, but there are a few things in here I'm really happy with.",
+  "feature_intro": "New Linthra update is out, and there are a few things in this one I'm really happy with.",
+  "bullet_lead": "I focused mostly on:",
+  "empty_release_note": "I kept this one simple — the full details are in the GitHub release.",
+  "closing": "Thanks to everyone testing Linthra and reporting the weird little bugs 😅",
+  "fdroid": "F-Droid will follow once the new build makes its way through their side."
+}

--- a/test/tooling/reddit_release_announcement_test.py
+++ b/test/tooling/reddit_release_announcement_test.py
@@ -1,0 +1,207 @@
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+announcement = _load_module(
+    "reddit_release_announcement",
+    ROOT / "scripts" / "reddit_release_announcement.py",
+)
+poster = _load_module(
+    "post_reddit_release",
+    ROOT / "scripts" / "post_reddit_release.py",
+)
+
+
+def _release(**overrides):
+    data = {
+        "tag_name": "v0.2.2",
+        "name": "Linthra v0.2.2",
+        "html_url": "https://github.com/TheZupZup/Linthra/releases/tag/v0.2.2",
+        "body": (
+            "# Linthra v0.2.2\n\n"
+            "## What's new\n\n"
+            "- **Smoother lyrics** while following timed lines.\n"
+            "- The `seek bar` no longer jumps backwards after a seek.\n"
+            "- [Dependency updates](https://example.invalid) are easier to review.\n"
+        ),
+        "draft": False,
+        "prerelease": False,
+        "published_at": "2026-08-14T12:00:00Z",
+    }
+    data.update(overrides)
+    return data
+
+
+class AnnouncementTests(unittest.TestCase):
+    def setUp(self):
+        self.voice = announcement.load_voice(
+            ROOT / "scripts" / "reddit_release_voice.json"
+        )
+
+    def test_stable_published_release_produces_post(self):
+        result = announcement.build_announcement(_release(), self.voice)
+        self.assertEqual(result["title"], "Linthra v0.2.2 is out 🎵")
+        self.assertIn("Smoother lyrics", result["body"])
+        self.assertIn(result["release_url"], result["body"])
+
+    def test_prerelease_is_rejected(self):
+        with self.assertRaises(announcement.AnnouncementError):
+            announcement.build_announcement(
+                _release(tag_name="v0.2.3-beta.1", prerelease=True), self.voice
+            )
+
+    def test_draft_is_rejected(self):
+        with self.assertRaises(announcement.AnnouncementError):
+            announcement.build_announcement(_release(draft=True), self.voice)
+
+    def test_empty_release_body_is_still_sensible(self):
+        result = announcement.build_announcement(_release(body=""), self.voice)
+        self.assertIn("full details are in the GitHub release", result["body"])
+        self.assertIn(result["release_url"], result["body"])
+
+    def test_maximum_bullet_count_is_respected(self):
+        body = "## What's new\n\n" + "\n".join(
+            f"- change number {index}" for index in range(1, 20)
+        )
+        result = announcement.build_announcement(_release(body=body), self.voice)
+        bullets = [line for line in result["body"].splitlines() if line.startswith("- ")]
+        self.assertEqual(len(bullets), self.voice["max_bullets"])
+
+    def test_long_release_notes_are_shortened(self):
+        long_item = "x" * 500
+        result = announcement.build_announcement(
+            _release(body=f"## What's new\n\n- {long_item}"), self.voice
+        )
+        bullet = next(
+            line for line in result["body"].splitlines() if line.startswith("- ")
+        )
+        self.assertLessEqual(len(bullet), 182)
+        self.assertTrue(bullet.endswith("…"))
+        self.assertLess(len(result["body"]), announcement.MAX_BODY_CHARS)
+
+    def test_markdown_is_cleaned_without_breaking_reddit_formatting(self):
+        result = announcement.build_announcement(_release(), self.voice)
+        self.assertNotIn("**Smoother lyrics**", result["body"])
+        self.assertNotIn("`seek bar`", result["body"])
+        self.assertNotIn("](https://example.invalid)", result["body"])
+        self.assertIn("- Smoother lyrics while following timed lines.", result["body"])
+        self.assertIn("- The seek bar no longer jumps backwards after a seek.", result["body"])
+
+    def test_secrets_never_enter_generated_output(self):
+        secret_values = {
+            "REDDIT_CLIENT_ID": "client-secret-marker",
+            "REDDIT_CLIENT_SECRET": "client-secret-value-marker",
+            "REDDIT_REFRESH_TOKEN": "refresh-token-marker",
+        }
+        with mock.patch.dict(os.environ, secret_values, clear=False):
+            result = announcement.build_announcement(_release(), self.voice)
+        serialized = json.dumps(result)
+        for value in secret_values.values():
+            self.assertNotIn(value, serialized)
+
+    def test_title_and_body_stay_inside_conservative_limits(self):
+        result = announcement.build_announcement(_release(), self.voice)
+        self.assertLessEqual(len(result["title"]), announcement.MAX_TITLE_CHARS)
+        self.assertLessEqual(len(result["body"]), announcement.MAX_BODY_CHARS)
+
+    def test_cli_writes_preview_files_without_network(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            release_path = tmp_path / "release.json"
+            output = tmp_path / "out"
+            release_path.write_text(json.dumps(_release()), encoding="utf-8")
+            code = announcement.main(
+                [
+                    "--release-json",
+                    str(release_path),
+                    "--voice-config",
+                    str(ROOT / "scripts" / "reddit_release_voice.json"),
+                    "--output-dir",
+                    str(output),
+                ]
+            )
+            self.assertEqual(code, 0)
+            self.assertTrue((output / "title.txt").exists())
+            self.assertTrue((output / "body.md").exists())
+            self.assertTrue((output / "announcement.json").exists())
+
+
+class PostingSafetyTests(unittest.TestCase):
+    def test_duplicate_release_url_skips_submission(self):
+        listing = {
+            "data": {
+                "children": [
+                    {
+                        "data": {
+                            "selftext": (
+                                "GitHub release:\n"
+                                "https://github.com/TheZupZup/Linthra/releases/tag/v0.2.2"
+                            ),
+                            "permalink": "/r/Linthra/comments/example/release/",
+                        }
+                    }
+                ]
+            }
+        }
+        with mock.patch.object(poster, "_request_json", return_value=listing):
+            found = poster.find_existing_announcement(
+                "access",
+                "agent",
+                "Linthra",
+                "https://github.com/TheZupZup/Linthra/releases/tag/v0.2.2",
+            )
+        self.assertEqual(
+            found, "https://www.reddit.com/r/Linthra/comments/example/release/"
+        )
+
+    def test_missing_credentials_fail_before_any_network_call(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "title").write_text("Title", encoding="utf-8")
+            (tmp_path / "body").write_text("Body", encoding="utf-8")
+            with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+                poster.urllib.request, "urlopen"
+            ) as urlopen:
+                code = poster.main(
+                    [
+                        "--title-file",
+                        str(tmp_path / "title"),
+                        "--body-file",
+                        str(tmp_path / "body"),
+                        "--release-url",
+                        "https://github.com/TheZupZup/Linthra/releases/tag/v0.2.2",
+                        "--subreddit",
+                        "Linthra",
+                    ]
+                )
+            self.assertEqual(code, 1)
+            urlopen.assert_not_called()
+
+    def test_manual_workflow_is_preview_only(self):
+        workflow = (
+            ROOT / ".github" / "workflows" / "reddit-release-announcement.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("github.event_name == 'release'", workflow)
+        self.assertNotIn("workflow_dispatch' &&", workflow)
+        self.assertNotIn("gh release delete", workflow)
+        self.assertNotIn("gh pr merge", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a small release-announcement workflow for r/Linthra.

When a real stable GitHub Release is published, the workflow builds a short Reddit post from the human-written release notes. It keeps the tone simple/personal, caps the post at five useful bullets, links back to the release, and never calls an AI API.

A few safety things are deliberate:
- draft/prerelease releases are ignored
- manual runs are preview-only and show the exact post in the Actions summary
- live posting is disabled until `REDDIT_RELEASE_ANNOUNCEMENTS_ENABLED=true`
- reruns check recent r/Linthra posts for the same GitHub release URL before submitting
- Reddit failures cannot roll back/delete a GitHub Release or tag
- credentials stay in Actions secrets and the workflow uses a refresh token, not a Reddit password

Reddit's current docs say Data API access is for approved developers and requires OAuth, so there is one manual setup step before this can post live. The docs in this PR explain the three secrets, the enable variable, and the required `read` + `submit` scopes.

I also added a tiny Python test workflow. The generator/publisher are stdlib-only, and the local suite covers stable/prerelease filtering, empty/long notes, bullet limits, Markdown cleanup, secret isolation, duplicate handling, and the preview-only manual path.

No app code, release metadata, F-Droid files, or versions are changed.