### PR TITLE
ci: check Gradle, AGP and Kotlin updates weekly

### DIFF
--- a/.github/workflows/android-toolchain-update-tests.yml
+++ b/.github/workflows/android-toolchain-update-tests.yml
@@ -1,0 +1,58 @@
+name: Android toolchain updater tests
+
+# Unit tests for the Python behind the Gradle / AGP / Kotlin updater (#362).
+#
+# The end-to-end guardrails live in
+# test/tooling/android_toolchain_update_guardrails_test.dart and run in ci.yml's
+# ordinary Flutter checks job on every PR. These are the layer below: the pin
+# patterns, the two upstream parsers and the classification, exercised directly
+# rather than through a subprocess. They need Python and nothing else, so they
+# run here instead of paying for an SDK install.
+#
+# Path-filtered, because they only ever fail when one of these files moves.
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/android-toolchain-updates.yml"
+      - ".github/workflows/android-toolchain-update-tests.yml"
+      - "scripts/toolchain_pins.py"
+      - "scripts/check_android_toolchain_update.py"
+      - "scripts/set_android_toolchain_pin.py"
+      - "scripts/check_toolchain_pin_diff.py"
+      - "scripts/check_dependency_update_files.sh"
+      - "test/tooling/android_toolchain_update_test.py"
+      - "android/settings.gradle"
+      - "android/gradle/wrapper/gradle-wrapper.properties"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/android-toolchain-updates.yml"
+      - ".github/workflows/android-toolchain-update-tests.yml"
+      - "scripts/toolchain_pins.py"
+      - "scripts/check_android_toolchain_update.py"
+      - "scripts/set_android_toolchain_pin.py"
+      - "scripts/check_toolchain_pin_diff.py"
+      - "scripts/check_dependency_update_files.sh"
+      - "test/tooling/android_toolchain_update_test.py"
+      - "android/settings.gradle"
+      - "android/gradle/wrapper/gradle-wrapper.properties"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Toolchain updater tooling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # Offline: fixture release indexes and throwaway directories, no network.
+      - name: Run tests
+        run: python3 test/tooling/android_toolchain_update_test.py

--- a/.github/workflows/android-toolchain-updates.yml
+++ b/.github/workflows/android-toolchain-updates.yml
@@ -1,0 +1,492 @@
+name: Android toolchain updates
+
+# Weekly check of the official Gradle, Android Gradle Plugin and Kotlin Gradle
+# plugin release indexes against the versions this repository pins (#362, the
+# fifth and final phase).
+#
+# Nothing here merges, and nothing here migrates code. The workflow's whole job
+# is to say "a newer release exists on the line we already ship; here is the
+# one-line pin change; here is what CI thinks of it" and then stop. If the new
+# toolchain breaks the Android build, the PR goes red and stays red until a
+# human does the migration in their own PR. That red is the deliverable, not a
+# bug.
+#
+# Detection lives in scripts/check_android_toolchain_update.py, not in this
+# file, so the version comparison can be tested offline against fixture indexes
+# (test/tooling/android_toolchain_update_guardrails_test.dart and
+# test/tooling/android_toolchain_update_test.py).
+#
+# The two questions it answers per tool are deliberately independent:
+#
+#   newest release still on the pinned major -> this workflow opens or updates
+#                                               that tool's draft PR
+#   a newer major exists                     -> no PR and no pin change; it
+#                                               opens or updates an issue
+#
+# Both can be true in the same week, and when they are, both happen. A new
+# major must never hide the later patch releases on the line Linthra actually
+# ships.
+#
+# One reusable branch and one reusable draft PR per tool:
+#
+#   toolchain/gradle  android/gradle/wrapper/gradle-wrapper.properties
+#   toolchain/agp     android/settings.gradle  (com.android.application only)
+#   toolchain/kotlin  android/settings.gradle  (org.jetbrains.kotlin.android only)
+#
+# The last two share a file, so a filename allowlist is not a boundary between
+# them. scripts/check_toolchain_pin_diff.py is — it compares the file's real
+# before/after text and rejects any change outside the single version string
+# that updater owns, comments included. It runs here before a commit exists,
+# and again in ci.yml against the real PR diff.
+#
+# See docs/dependency-updates.md.
+on:
+  schedule:
+    # Mondays, early UTC — the same weekly cadence as the other updaters, a few
+    # minutes after the Flutter SDK run so the two never contend.
+    - cron: "53 4 * * 1"
+  workflow_dispatch:
+
+# A manual run is the scheduled run: same detection, same safety checks, same
+# publication path. The only difference is what started it.
+concurrency:
+  group: android-toolchain-updates
+  cancel-in-progress: false
+
+# Read-only by default. The publication job below keeps this and routes its
+# writes through the dedicated token instead, because a push or PR made with
+# GITHUB_TOKEN does not trigger the PR's normal CI — and an update PR that runs
+# no checks is a broken updater.
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check the upstream release indexes
+    runs-on: ubuntu-latest
+    outputs:
+      # The full per-tool classification, as compact JSON keyed by tool. The
+      # publication jobs read their own entry out of it rather than having the
+      # check job fan out one output per tool per field.
+      results: ${{ steps.check.outputs.results }}
+      # The tools that have a newer release on their current major line, and
+      # the tools that have a newer major. A tool can appear in both.
+      pr_tools: ${{ steps.check.outputs.pr_tools }}
+      issue_tools: ${{ steps.check.outputs.issue_tools }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      # Local twin: python3 scripts/check_android_toolchain_update.py. Reads
+      # the three pin files, fetches the three official release indexes and
+      # classifies. Exits non-zero on anything it cannot trust — a malformed
+      # pin, an index it cannot parse, an index with no release on our own
+      # major line, or a "newest release" that is behind the pin — rather than
+      # guessing a target. One tool failing stops the whole run: publishing off
+      # a half-understood picture is exactly what this is meant to prevent.
+      - name: Classify the pinned toolchain against upstream
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_android_toolchain_update.py \
+            --github-output "$GITHUB_OUTPUT" | tee "$RUNNER_TEMP/check.txt"
+
+      - name: Summarise
+        shell: bash
+        env:
+          PR_TOOLS: ${{ steps.check.outputs.pr_tools }}
+          ISSUE_TOOLS: ${{ steps.check.outputs.issue_tools }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Android toolchain check"
+            echo
+            echo '```text'
+            cat "$RUNNER_TEMP/check.txt"
+            echo '```'
+            if [[ "$PR_TOOLS" == "[]" && "$ISSUE_TOOLS" == "[]" ]]; then
+              echo
+              echo "Nothing to do."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # A newer release on the pinned major -> one reusable draft PR per tool that
+  # changes that tool's version and nothing else.
+  # ---------------------------------------------------------------------------
+  toolchain-pr:
+    name: Draft PR for ${{ matrix.tool }}
+    needs: check
+    if: ${{ needs.check.outputs.pr_tools != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      # Each tool owns its own branch and its own PR, so one tool's failure
+      # must not cancel the others' updates.
+      fail-fast: false
+      matrix:
+        tool: ${{ fromJSON(needs.check.outputs.pr_tools) }}
+    env:
+      TOOL: ${{ matrix.tool }}
+      UPDATE_BRANCH: toolchain/${{ matrix.tool }}
+      LABEL: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].label }}
+      PIN_FILE: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].pin_file }}
+      CURRENT: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].current }}
+      TARGET: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].latest_in_current_major }}
+      STATUS: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].status }}
+      SOURCE: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].source }}
+      STABLE_CONFIRMED: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].stable_confirmed }}
+      MAJOR_STATUS: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].major_status }}
+      MAJOR_LATEST: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].major_latest }}
+    steps:
+      # Fails the run rather than opening a PR that no CI would ever look at.
+      # This step lives in this job on purpose: a week with no update never
+      # reaches it, so a missing token cannot fail a quiet run.
+      - name: Require workflow-triggering publication token
+        env:
+          PUBLISH_TOKEN: ${{ secrets.DEPENDENCY_UPDATE_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "$PUBLISH_TOKEN" ]]; then
+            echo "::error::DEPENDENCY_UPDATE_TOKEN is required to publish the $LABEL update PR so it runs normal CI. See docs/dependency-updates.md."
+            exit 1
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Open or update the draft toolchain PR
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDENCY_UPDATE_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The detection job already refused to continue on anything it could
+          # not trust, so reaching here without a confirmed release would mean
+          # the outputs were tampered with between jobs.
+          if [[ "$STABLE_CONFIRMED" != "true" ]]; then
+            echo "::error::The target $TARGET was not confirmed as a published $LABEL release; refusing to open a PR."
+            exit 1
+          fi
+          if [[ "${TARGET%%.*}" != "${CURRENT%%.*}" ]]; then
+            echo "::error::$TARGET is not on the pinned major line ($CURRENT). A major upgrade never gets a PR."
+            exit 1
+          fi
+
+          gh auth setup-git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          subject_prefix="chore(toolchain): update $LABEL to "
+          subject="${subject_prefix}${TARGET}"
+
+          # Reuse the one update branch instead of opening a new PR every week.
+          remote_sha="$(git ls-remote origin "refs/heads/$UPDATE_BRANCH" | cut -f1)"
+          branch_exists=false
+          branch_matches_target=false
+
+          if [[ -n "$remote_sha" ]]; then
+            branch_exists=true
+            git fetch --no-tags origin "+refs/heads/$UPDATE_BRANCH:refs/remotes/origin/$UPDATE_BRANCH"
+
+            # Refuse to overwrite work this workflow did not create. The branch
+            # is expected to hold nothing but this workflow's own pin commits
+            # for this one tool; if someone pushed a migration onto it, that is
+            # a human's PR now and a force-push would silently delete it.
+            foreign=""
+            while IFS='|' read -r author subject_line; do
+              [[ -n "$author$subject_line" ]] || continue
+              if [[ "$author" == "github-actions[bot]" \
+                    && "$subject_line" == "$subject_prefix"* ]]; then
+                continue
+              fi
+              foreign+="$author|$subject_line"$'\n'
+            done < <(git log --format='%an|%s' "HEAD..origin/$UPDATE_BRANCH")
+
+            if [[ -n "$foreign" ]]; then
+              {
+                echo "### $LABEL update skipped"
+                echo
+                echo "\`$UPDATE_BRANCH\` carries commits this workflow did not write:"
+                echo
+                echo '```text'
+                printf '%s' "$foreign"
+                echo '```'
+                echo
+                echo "Refusing to force-push over them. Merge or close the open PR first."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::warning::$UPDATE_BRANCH has commits from someone else; not publishing."
+              exit 0
+            fi
+
+            git show "origin/$UPDATE_BRANCH:$PIN_FILE" > "$RUNNER_TEMP/branch-pin-file"
+            branch_version="$(python3 scripts/toolchain_pins.py \
+              --tool "$TOOL" --file "$RUNNER_TEMP/branch-pin-file")"
+            if [[ -z "$branch_version" ]]; then
+              echo "::error::$UPDATE_BRANCH has no readable $LABEL pin in $PIN_FILE; refusing to force-push over it."
+              exit 1
+            fi
+
+            if [[ "$branch_version" == "$TARGET" ]]; then
+              branch_matches_target=true
+            else
+              # The open PR must only ever move forwards. If its pin is already
+              # ahead of the target upstream just gave us, something is wrong
+              # with the data, not with the branch.
+              if ! python3 scripts/check_android_toolchain_update.py \
+                    --tool "$TOOL" --current "$branch_version" \
+                    --latest "$TARGET" --quiet; then
+                echo "::error::$UPDATE_BRANCH already proposes $branch_version, which is not older than $TARGET. Refusing to rewind the open PR."
+                exit 1
+              fi
+            fi
+          fi
+
+          if [[ "$branch_matches_target" == "true" ]]; then
+            echo "The open $LABEL PR already proposes $TARGET; not pushing again." >> "$GITHUB_STEP_SUMMARY"
+          else
+            git checkout -B "$UPDATE_BRANCH"
+
+            # One version string, in one file, aimed by content rather than by
+            # filename — AGP and Kotlin share android/settings.gradle.
+            python3 scripts/set_android_toolchain_pin.py \
+              --tool "$TOOL" --version "$TARGET"
+
+            # Two guards, before a commit exists. The first bounds which files
+            # moved; the second bounds what changed inside the one that did.
+            # ci.yml runs both again against the real PR diff.
+            git diff --name-only | ./scripts/check_dependency_update_files.sh --kind "$TOOL"
+            python3 scripts/check_toolchain_pin_diff.py --kind "$TOOL" --base HEAD
+
+            git add -- "$PIN_FILE"
+            git commit -m "$subject"
+
+            if [[ "$branch_exists" == "true" ]]; then
+              git push --force-with-lease="$UPDATE_BRANCH:$remote_sha" origin "$UPDATE_BRANCH"
+            else
+              git push -u origin "$UPDATE_BRANCH"
+            fi
+          fi
+
+          body="$RUNNER_TEMP/pr-body.md"
+          {
+            echo "Automatic $LABEL update — **$STATUS** release on the currently pinned major line."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Currently pinned | \`$CURRENT\` |"
+            echo "| Proposed | \`$TARGET\` |"
+            echo "| Kind | $STATUS |"
+            echo "| Stable | confirmed — \`$TARGET\` is a published final release |"
+            echo "| Source | \`$SOURCE\` |"
+            echo
+            echo "That index is the one Gradle itself resolves this plugin or distribution"
+            echo "from, so the proposed version is installable by construction. Prereleases"
+            echo "(alpha, beta, RC, milestone, preview, nightly, snapshot) are never"
+            echo "candidates."
+            if [[ "$MAJOR_STATUS" == "available" ]]; then
+              echo
+              echo "> A newer **major** ($MAJOR_LATEST) also exists. It is deliberately not part of"
+              echo "> this PR — a major upgrade is a manual migration and gets its own issue."
+            fi
+            echo
+            echo "### What changed here"
+            echo
+            echo "One version string, in one file:"
+            echo
+            echo '```text'
+            echo "$PIN_FILE"
+            echo '```'
+            echo
+            echo "No application code, test code, \`pubspec.yaml\`, \`pubspec.lock\`,"
+            echo "\`.flutter-version\`, \`.java-version\`, app version, F-Droid metadata,"
+            echo "Fastlane file, release note, signing file, license, unrelated workflow or"
+            echo "doc was touched — and no *other* toolchain pin was touched either."
+            echo "\`scripts/check_dependency_update_files.sh --kind $TOOL\` bounds which files"
+            echo "moved, and \`scripts/check_toolchain_pin_diff.py --kind $TOOL\` bounds what"
+            echo "changed inside them: it puts the old version back and requires the file to"
+            echo "be byte-identical to its previous contents, so a comment rewrite or a"
+            echo "second pin in the same file is rejected. Both run here and again in CI"
+            echo "against this PR's real diff."
+            echo
+            echo "### This PR may be red, and that is fine"
+            echo
+            echo "A newer build tool can change defaults, tighten a deprecation or need a"
+            echo "different configuration. Any of that turns this PR red. That is the"
+            echo "finding — it says the upgrade needs work — not a fault in the PR. **Do the"
+            echo "migration in a separate PR.** Do not push fixes onto this branch: the"
+            echo "guards reject them, and the next scheduled run refuses to force-push over"
+            echo "commits it did not write. The Flutter CI fixer is kept off \`toolchain/\`"
+            echo "branches for the same reason."
+            echo
+            echo "### Before merging"
+            echo
+            echo "- [ ] CI is green, or every failure is understood and handled elsewhere."
+            echo "- [ ] **Flutter compatibility:** the Flutter version in \`.flutter-version\`"
+            echo "      ships its own Android build logic and supports a range of build"
+            echo "      tooling. Confirm the proposed version is inside that range rather"
+            echo "      than merely newer."
+            echo "- [ ] **F-Droid / reproducibility:** the F-Droid builder resolves this"
+            echo "      toolchain offline from these same files, so the proposed version has"
+            echo "      to be available and reproducible there too. Re-read"
+            echo "      \`docs/fdroid-build-recipe.md\` and the reproducibility notes, and"
+            echo "      update them if the bump changes what a builder must install."
+            echo "- [ ] A human reviewed and merged this. Nothing here auto-merges, ever."
+            echo
+            echo "Opened by [\`android-toolchain-updates.yml\`](.github/workflows/android-toolchain-updates.yml)"
+            echo "for issue #362. See [docs/dependency-updates.md](docs/dependency-updates.md)."
+            echo
+            echo "Reproduce the detection locally:"
+            echo
+            echo '```bash'
+            echo "python3 scripts/check_android_toolchain_update.py --tool $TOOL"
+            echo '```'
+          } > "$body"
+
+          existing="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$UPDATE_BRANCH" \
+            --state open --json number --jq '.[0].number // empty')"
+
+          if [[ -n "$existing" ]]; then
+            # --title/--body only; leave the draft/ready state alone so a
+            # reviewer who marked the PR ready does not get it flipped back.
+            gh pr edit "$existing" --repo "$GITHUB_REPOSITORY" \
+              --title "$subject" --body-file "$body"
+            echo "Updated PR #$existing ($LABEL $CURRENT -> $TARGET)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh pr create --repo "$GITHUB_REPOSITORY" --draft \
+              --base main --head "$UPDATE_BRANCH" \
+              --title "$subject" --body-file "$body")"
+            echo "Opened $url ($LABEL $CURRENT -> $TARGET)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # ---------------------------------------------------------------------------
+  # A newer major -> an issue, no branch, no commit, no pin change.
+  # ---------------------------------------------------------------------------
+  major-issue:
+    name: Major upgrade issue for ${{ matrix.tool }}
+    needs: check
+    if: ${{ needs.check.outputs.issue_tools != '[]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The only write this workflow's own GITHUB_TOKEN ever gets, and only in
+      # the job that files the issue. An issue needs no CI, so it needs none of
+      # the dedicated publication token's reach.
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: ${{ fromJSON(needs.check.outputs.issue_tools) }}
+    env:
+      TOOL: ${{ matrix.tool }}
+      LABEL: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].label }}
+      PIN_FILE: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].pin_file }}
+      CURRENT: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].current }}
+      NEWEST: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].latest }}
+      NEWEST_IN_MAJOR: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].latest_in_current_major }}
+      SOURCE: ${{ fromJSON(needs.check.outputs.results)[matrix.tool].source }}
+    steps:
+      # Deliberately no checkout: this path has nothing to read from the
+      # repository and must not be able to write to it.
+      - name: Open or update the major upgrade issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          major="${NEWEST%%.*}"
+          title="$LABEL ${major}.x is available — major upgrade (manual)"
+
+          body="$RUNNER_TEMP/issue-body.md"
+          {
+            echo "A new **major** $LABEL release is available."
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Currently pinned | \`$CURRENT\` |"
+            echo "| Newest stable | \`$NEWEST\` |"
+            echo "| Newest stable on the pinned major | \`$NEWEST_IN_MAJOR\` |"
+            echo "| Pinned in | \`$PIN_FILE\` |"
+            echo "| Source | \`$SOURCE\` |"
+            echo
+            echo "### No PR was opened, on purpose"
+            echo
+            echo "\`$PIN_FILE\` has **not** been changed and no commit was made. Patch and"
+            echo "minor updates *within the pinned major* get an automatic draft PR; a major"
+            echo "does not, because a major upgrade is not a one-line pin change (#362)."
+            echo
+            echo "The two are tracked separately: if the newest release on the pinned major"
+            echo "is ahead of what is pinned, that update still gets its own ordinary draft"
+            echo "PR this week. A new major never blocks it."
+            if [[ "$TOOL" == "agp" ]]; then
+              echo
+              echo "### Read this one carefully"
+              echo
+              echo "Linthra's F-Droid release still builds its per-ABI \`versionCode\`s by"
+              echo "iterating \`applicationVariants\` in \`android/app/build.gradle\`. That is"
+              echo "legacy Android DSL behaviour, and the next AGP major removes the API it"
+              echo "depends on. Bumping this pin without first porting that logic does not"
+              echo "produce a build failure so much as a **wrong \`versionCode\` scheme** —"
+              echo "which is the one thing an F-Droid release cannot get wrong, because"
+              echo "published version codes can never be reused or walked back."
+              echo
+              echo "Treat the variant/versionCode port as the actual work item here. The"
+              echo "version bump is the easy part."
+            fi
+            echo
+            echo "### Why this stays manual"
+            echo
+            echo "- **Flutter compatibility.** Flutter ships its own Gradle plugin and"
+            echo "  supports a bounded range of build tooling. The SDK pinned in"
+            echo "  \`.flutter-version\` decides what this project may actually use, and"
+            echo "  \"newer\" is not the same as \"supported\"."
+            echo "- **The Android build itself.** A major here changes defaults, removes"
+            echo "  deprecated DSL and can alter what ends up in the APK. That is a review,"
+            echo "  not a version bump."
+            echo "- **F-Droid and reproducibility.** The F-Droid builder resolves this"
+            echo "  toolchain offline from the files in this repository. A major upgrade can"
+            echo "  change what the builder must provide and whether the build still"
+            echo "  reproduces, and CI cannot prove either. See"
+            echo "  \`docs/fdroid-build-recipe.md\` and the reproducibility notes."
+            echo "- **The rest of the toolchain.** Gradle, AGP, Kotlin and the JDK move as a"
+            echo "  compatible set; one of them crossing a major usually drags the others."
+            echo
+            echo "### Suggested route"
+            echo
+            echo "Do the upgrade in a normal human PR: check Flutter's supported range"
+            echo "first, bump the pin, port whatever the major removed, re-check the"
+            echo "F-Droid recipe and reproducibility notes, and let normal CI judge it."
+            echo
+            echo "Filed by [\`android-toolchain-updates.yml\`](.github/workflows/android-toolchain-updates.yml)"
+            echo "for issue #362. This issue is updated in place on later runs rather than"
+            echo "refiled, so the weekly check will not spam duplicates."
+          } > "$body"
+
+          # Dedupe on the exact title, which is stable for the whole major line:
+          # a later release within the same major edits this issue instead of
+          # opening another, and a genuinely new major gets a new title. Listed
+          # rather than searched, so a freshly filed issue is found on the next
+          # run without waiting for the search index.
+          existing="$(TITLE="$title" gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --limit 200 --json number,title \
+            --jq 'map(select(.title == env.TITLE))[0].number // empty')"
+
+          if [[ -n "$existing" ]]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file "$body"
+            echo "Updated issue #$existing ($LABEL $CURRENT -> $NEWEST)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" --body-file "$body")"
+            echo "Filed $url ($LABEL $CURRENT -> $NEWEST)." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ name: CI
 #   * dependency-guard    — deps/* PRs only: the update must be lockfile-only.
 #   * toolchain-guard     — toolchain/flutter-sdk only: the bump must be
 #                           pin-only.
+#   * android-toolchain-guard — the three automatic Gradle/AGP/Kotlin branches
+#                           only: the bump must be one version string.
 on:
   push:
     branches: [main]
@@ -143,3 +145,42 @@ jobs:
           set -euo pipefail
           git diff --name-only "$BASE_SHA" HEAD \
             | ./scripts/check_dependency_update_files.sh --kind flutter-sdk
+
+  android-toolchain-guard:
+    name: Android toolchain update touches only its own pin
+    runs-on: ubuntu-latest
+    # Only the three branches the "Android toolchain updates" workflow pushes,
+    # each matched exactly. A broad `toolchain/*` rule would be wrong twice
+    # over: it would hold every future human toolchain PR to the pin-only rule,
+    # and it could not tell which of the three pins the PR is allowed to move.
+    if: >-
+      ${{ github.head_ref == 'toolchain/gradle'
+      || github.head_ref == 'toolchain/agp'
+      || github.head_ref == 'toolchain/kotlin' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Two guards, the same two the updater ran before committing — but here
+      # against the real PR diff, so anything pushed onto the branch afterwards
+      # is caught too.
+      #
+      # The second one is the interesting half. AGP and Kotlin are pinned in
+      # the *same file*, so "only android/settings.gradle changed" says nothing
+      # about which of the two moved. check_toolchain_pin_diff.py answers that
+      # by putting the old version back into the new file and requiring the
+      # result to be byte-identical to the old one: a Kotlin edit riding along
+      # in an AGP PR, or a reworded comment, cannot survive that.
+      - name: Check changed files and their contents
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          kind="${HEAD_REF#toolchain/}"
+          git diff --name-only "$BASE_SHA" HEAD \
+            | ./scripts/check_dependency_update_files.sh --kind "$kind"
+          python3 scripts/check_toolchain_pin_diff.py \
+            --kind "$kind" --base "$BASE_SHA" --head HEAD

--- a/.github/workflows/flutter-ci-fixer.yml
+++ b/.github/workflows/flutter-ci-fixer.yml
@@ -94,7 +94,9 @@ jobs:
           # that is guarded to contain nothing but pubspec.lock.
           #
           # toolchain/* covers the Flutter SDK updater
-          # (.github/workflows/flutter-sdk-updates.yml). It matters most there:
+          # (.github/workflows/flutter-sdk-updates.yml) and the Gradle/AGP/
+          # Kotlin updater (.github/workflows/android-toolchain-updates.yml).
+          # It matters most there:
           # a new SDK goes red precisely when it deprecates an API Linthra uses,
           # and "repair the application code until the checks pass" is the
           # migration itself — a human decision, in a human's PR. Those PRs are
@@ -341,7 +343,7 @@ jobs:
           # Protect repository policy/configuration, release/store metadata,
           # licensing notices at any depth, toolchain/version files, and signing
           # material. The agent may repair application/test code only.
-          forbidden='(^|/)(LICENSE($|\.)|COPYING($|\.)|NOTICE($|\.))|^(\.github/|metadata/|pubspec\.yaml$|\.flutter-version$|\.java-version$|fastlane/|docs/release-notes/|scripts/check_secrets\.sh$|analysis_options\.yaml$)|(^|/)(key\.properties|[^/]*\.(jks|keystore))$'
+          forbidden='(^|/)(LICENSE($|\.)|COPYING($|\.)|NOTICE($|\.))|^(\.github/|metadata/|pubspec\.yaml$|\.flutter-version$|\.java-version$|android/settings\.gradle$|android/gradle/wrapper/gradle-wrapper\.properties$|fastlane/|docs/release-notes/|scripts/check_secrets\.sh$|analysis_options\.yaml$)|(^|/)(key\.properties|[^/]*\.(jks|keystore))$'
           for path in "${changed[@]}"; do
             if [[ "$path" =~ $forbidden ]]; then
               echo "::error::Agent touched protected path: $path"

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,8 +19,17 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     // Stay on AGP 8.x while Flutter 3.44 still supports the legacy Android DSL
-    // used by Linthra's F-Droid per-ABI versionCode hook. AGP 8.10 supports
-    // API 36 and remains compatible with the external Kotlin Gradle plugin.
+    // used by Linthra's F-Droid per-ABI versionCode hook: the applicationVariants
+    // iteration in app/build.gradle has no supported equivalent in AGP 9, so
+    // crossing that major is a migration a human does deliberately, not a pin
+    // bump. Within 8.x the plugin supports the compileSdk this app targets and
+    // stays compatible with the external Kotlin Gradle plugin below.
+    //
+    // The two versions on the next lines are updated automatically, one at a
+    // time and only within their current major, by
+    // .github/workflows/android-toolchain-updates.yml. Keep explanatory prose
+    // above this point and out of those lines — the updater is guarded to
+    // rewrite the version string and nothing else, comments included.
     id "com.android.application" version "8.10.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.21" apply false
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,12 +18,16 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    // Stay on AGP 8.x while Flutter 3.44 still supports the legacy Android DSL
-    // used by Linthra's F-Droid per-ABI versionCode hook: the applicationVariants
-    // iteration in app/build.gradle has no supported equivalent in AGP 9, so
-    // crossing that major is a migration a human does deliberately, not a pin
-    // bump. Within 8.x the plugin supports the compileSdk this app targets and
-    // stays compatible with the external Kotlin Gradle plugin below.
+    // Stay on AGP 8.x for now. Linthra's F-Droid per-ABI versionCode logic
+    // currently relies on the legacy applicationVariants hook in
+    // app/build.gradle, and AGP 9 removes normal access to that legacy variant
+    // API. Android's guidance is to move such logic to the supported
+    // androidComponents Variant API (onVariants), noting that not every old API
+    // has a direct replacement — so crossing to AGP 9 means deliberately
+    // migrating that hook and then verifying the F-Droid versionCode behaviour,
+    // not just moving the version below. Within 8.x the plugin supports the
+    // compileSdk this app targets and stays compatible with the external Kotlin
+    // Gradle plugin below.
     //
     // The two versions on the next lines are updated automatically, one at a
     // time and only within their current major, by

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -5,7 +5,7 @@ when something can move. It never merges anything. The bot's job is to say
 *"here is an update, and here is what CI thinks of it"*; deciding what happens
 next is a human's (issue #362).
 
-Four things are covered, by three different mechanisms:
+Seven things are covered, by four different mechanisms:
 
 | What | Handled by | Cadence | Outcome |
 | --- | --- | --- | --- |
@@ -13,10 +13,45 @@ Four things are covered, by three different mechanisms:
 | Cargo (`native/linthra_core`) | Dependabot — same file | weekly | PR |
 | Dart / Flutter packages | [`dart-dependency-updates.yml`](../.github/workflows/dart-dependency-updates.yml) | weekly | draft PR |
 | Flutter SDK | [`flutter-sdk-updates.yml`](../.github/workflows/flutter-sdk-updates.yml) | weekly | draft PR, or an issue for a major |
+| Gradle | [`android-toolchain-updates.yml`](../.github/workflows/android-toolchain-updates.yml) | weekly | draft PR, and/or an issue for a major |
+| Android Gradle Plugin | same file | weekly | draft PR, and/or an issue for a major |
+| Kotlin Gradle plugin | same file | weekly | draft PR, and/or an issue for a major |
 
-The rest of the toolchain — Gradle, AGP, Kotlin and the JDK — is not automated
-yet. Those are a separate phase of the same issue, and until then a bump to any
-of them is something a human notices and opens by hand.
+The JDK is deliberately not on that list. `.java-version` is what CI, the local
+setup and the F-Droid builder all install, and a JDK change ripples through the
+whole Android build at once — issue #362 lists it under the upgrades that stay
+manual, and it still is.
+
+## How this was built
+
+Issue #362 was delivered in five phases, in this order:
+
+| Phase | PR | What it added |
+| --- | --- | --- |
+| 1 | #363 | One source of truth per toolchain pin, plus the guardrail tests that stop docs and workflows drifting from them |
+| 2 | #364 | Dependabot for GitHub Actions and Cargo |
+| 3 | #370 | The Dart/Flutter package updater, resolving with Linthra's pinned SDK |
+| 4 | #373 | The Flutter SDK update checker |
+| 5 | this one | Gradle, AGP and Kotlin update checking |
+
+Every phase reuses the same safety model rather than inventing its own, and the
+later ones tightened it where the earlier ones had been too loose — #373's
+switch from a `toolchain/*` prefix match to an exact branch match is the clearest
+example, and phase 5 keeps that rule.
+
+The shared rules, in one place:
+
+- **Nothing ever merges automatically.** No workflow here contains a merge
+  command, and tests assert that stays true.
+- **Nothing migrates code.** A bot may move a version; making the repository
+  work at that version is a human's PR.
+- **Red is the finding, not a failure.** An update PR that fails CI has told you
+  something useful.
+- **Each updater has a tiny, explicit allowlist**, checked twice: inside the
+  updater before a commit exists, and again in CI against the real PR diff.
+- **Update PRs run normal CI**, which is why publication uses a dedicated token
+  rather than the workflow's own `GITHUB_TOKEN`.
+- **Majors get an issue, never a PR.**
 
 ## Dart / Flutter packages
 
@@ -382,3 +417,268 @@ The major-update path needs no token at all: it uses the workflow's own
 `GITHUB_TOKEN` with `issues: write`, granted in that one job. An issue runs no
 CI, so it needs none of the publication token's reach. Everything else in the
 workflow stays `contents: read`.
+
+## Gradle, AGP and Kotlin
+
+The fifth and last phase of #362, and the one with a sharp edge in it: two of
+these three versions live in the **same file**.
+
+### Where the pins live
+
+```text
+android/gradle/wrapper/gradle-wrapper.properties   the Gradle distribution
+android/settings.gradle                            AGP and the Kotlin plugin
+```
+
+`test/tooling/toolchain_pins_test.dart` already requires each of those to be an
+exact `MAJOR.MINOR.PATCH` — the F-Droid build resolves them offline from these
+files, so a range or a `+` wildcard is not allowed. That means every update here
+is, like the Flutter SDK one, a single version string.
+
+### Where the release information comes from
+
+Official, machine-readable and first-party, one index per tool. No HTML is
+fetched or scraped, and no third-party version API is consulted.
+
+| Tool | Index |
+| --- | --- |
+| Gradle | `https://services.gradle.org/versions/all` |
+| AGP | `https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/maven-metadata.xml` |
+| Kotlin | `https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/maven-metadata.xml` |
+
+Each of those is the index Gradle itself would resolve the pin from:
+`services.gradle.org` is the host in `distributionUrl`, and the two
+`maven-metadata.xml` files describe the artifacts the `com.android.application`
+and `org.jetbrains.kotlin.android` plugin ids resolve to — served by the
+`google()` and `mavenCentral()` repositories already declared in
+`android/settings.gradle`'s `pluginManagement` block. So a version this checker
+proposes is one this project can actually resolve, by construction.
+
+### Which releases count
+
+A release is a candidate only if it is a bare `MAJOR.MINOR.PATCH`. That single
+rule does the prerelease filtering structurally rather than by trying to
+enumerate every marker upstream might invent: `-alpha01`, `-beta02`, `-rc01`,
+`-RC`, `-Beta1`, `-milestone-1`, `-preview`, `-eap-1`, `-dev-123`, `-M1` and
+`-SNAPSHOT` builds all carry a suffix and are therefore not triples. It also
+excludes Gradle's historical two-component tags, which a pin file may not hold.
+
+On top of that:
+
+- a Gradle entry must be `final`, must not be `broken`, a snapshot, a nightly, a
+  release-nightly, an active RC or a milestone for another release, and must
+  download from `https://services.gradle.org/distributions/`. Those flags are
+  upstream's own statement about the build, which is better evidence than
+  anything guessable from a version string;
+- Maven metadata must declare the group and artifact that was asked for, so a
+  redirect or a typo cannot make the updater start tracking someone else's
+  numbers. Its `<latest>` and `<release>` pointers are *ignored* — Kotlin's
+  `<release>` routinely names an `-RC` build — and the version list is filtered
+  instead.
+
+### Two answers, kept apart
+
+This is the part worth reading twice. For each tool the checker reports two
+independent things:
+
+- **the newest release still on the pinned major** — the only version an
+  automatic PR may ever propose;
+- **the newest release overall**, and whether that is on a newer major.
+
+Both can be true in the same week, and when they are, both happen. If a pin is
+on the 8.x line and upstream publishes both a newer 8.x and a first 9.x release,
+the newer 8.x still gets its ordinary draft PR *and* the 9.x independently gets
+a major-upgrade issue. Collapsing the two into one "how far behind are we"
+number is exactly how a new major would silently swallow every later patch on
+the line Linthra actually ships.
+
+| Situation | Result |
+| --- | --- |
+| pinned version is the newest on its major, no newer major | nothing happens |
+| newer patch or minor on the pinned major | draft PR |
+| newer major, pin already newest on its own major | **issue**, and nothing else |
+| newer patch or minor **and** a newer major | draft PR *and* an issue |
+
+The comparison lives in `scripts/check_android_toolchain_update.py`, not in the
+workflow YAML, so it can be tested offline against fixture indexes
+(`test/tooling/android_toolchain_update_guardrails_test.dart` end to end, and
+`test/tooling/android_toolchain_update_test.py` for the parsers). It uses no
+third-party semantic-version package; three integers and a tuple comparison are
+the whole algorithm.
+
+It fails loudly rather than guessing, and a failure stops the whole run rather
+than letting two tools publish while a third is misread. A pin it cannot parse,
+an index it cannot parse, an index that is not the document it should be, an
+index with no usable release, an index that lists nothing at all on the pinned
+major line, or a "newest release" that is *older* than the pin all exit
+non-zero. In particular the updater never proposes a downgrade.
+
+Run it yourself:
+
+```bash
+python3 scripts/check_android_toolchain_update.py
+python3 scripts/check_android_toolchain_update.py --tool kotlin --json
+```
+
+It reads files and writes nothing.
+
+### One draft PR per tool
+
+Three reusable branches, one reusable draft PR each:
+
+```text
+toolchain/gradle
+toolchain/agp
+toolchain/kotlin
+```
+
+Repeated runs update those PRs rather than opening a new one every Monday, and a
+run whose target is already on the branch pushes nothing at all. Each tool has
+its own commit subject prefix, so a commit belonging to one tool is *foreign* on
+another's branch and the updater will not force-push over it.
+
+### What the bot may touch, and why a filename is not enough
+
+Each updater owns one file:
+
+| Branch | May write |
+| --- | --- |
+| `toolchain/gradle` | `android/gradle/wrapper/gradle-wrapper.properties` |
+| `toolchain/agp` | `android/settings.gradle` |
+| `toolchain/kotlin` | `android/settings.gradle` |
+
+Look at the last two rows. **AGP and Kotlin are pinned in the same file**, so
+"only `android/settings.gradle` changed" says nothing about *which* of the two
+moved. A filename allowlist is satisfied by an AGP PR that also quietly bumps
+Kotlin, or reword the comment above both. That is not a boundary.
+
+So there are two guards, and they run together:
+
+1. `scripts/check_dependency_update_files.sh --kind gradle|agp|kotlin` bounds
+   **which files** moved. It is the same script the Dart and Flutter SDK
+   updaters use, with three more deliberately separate allowlists.
+2. `scripts/check_toolchain_pin_diff.py --kind gradle|agp|kotlin` bounds **what
+   changed inside them**. It finds the tool's own version in the previous and
+   the new text, puts the *old* version back into the new text, and requires the
+   result to be byte-identical to the old file.
+
+That second check is the interesting one, because it needs no list of things to
+watch out for. Everything outside the one captured version — the other plugin's
+version, comments, whitespace, ordering, the other wrapper properties, the
+distribution flavour — is protected by construction: putting the old version
+back could not possibly reproduce the old file if anything else had moved. It
+also rejects a target that is not a bare triple, a downgrade, and any change
+that crosses a major.
+
+Both guards run twice: inside the workflow before a commit exists, and again in
+CI against the **real PR diff**, so a commit pushed onto an update PR afterwards
+is caught too.
+
+CI matches the three automatic branches **exactly**, never by `toolchain/`
+prefix. A prefix rule would be wrong twice over: it would hold every future
+human `toolchain/*` PR to the pin-only rule, and it could not tell which of the
+three pins a given PR is allowed to move. #373 deliberately fixed the first half
+of that problem for the Flutter SDK branch; this phase keeps the rule and adds
+the second half.
+
+An automatic toolchain update therefore never changes application code, test
+code, `pubspec.yaml`, `pubspec.lock`, `.flutter-version`, `.java-version`,
+`metadata/`, `fastlane/`, the app version or versionCode, release notes, signing
+files, licenses, or unrelated workflows and docs. AGP cannot change Kotlin,
+Kotlin cannot change AGP, and Gradle cannot change either.
+
+The write itself is `scripts/set_android_toolchain_pin.py`, which is the only
+script in the repository allowed to move one of these pins. It refuses a
+downgrade, a major, a non-triple version and a no-op rewrite, and it reads the
+file back afterwards. It shares `scripts/toolchain_pins.py` with the guard on
+purpose: if the writer's idea of "the AGP version" ever drifted from the guard's,
+the guard would be checking something the writer never touches.
+
+### Normal CI runs on it, and red is the point
+
+These PRs are published with the dedicated token, so GitHub triggers the
+repository's normal `pull_request` checks on them exactly like any other PR.
+
+A newer build tool can change a default, tighten a deprecation or need
+configuration this project does not have yet. Any of that turns the PR red, and
+**that is the finding**. The migration is a separate, human PR. Do not push it
+onto the update branch — the guards reject it, and the next scheduled run
+refuses to force-push over commits it did not write.
+
+So the Flutter CI fixer is kept away from these branches too. It already skips
+`toolchain/*` the way it skips `dependabot/*` and `deps/*`, both while resolving
+the failed run and again in the publish job, and that now covers all four
+toolchain branches. Its protected-path guard also refuses to let an agent patch
+touch `android/settings.gradle` or `gradle-wrapper.properties` in *any* PR:
+"repair the build by moving a build-tool version" is never the fix.
+
+Nothing auto-merges. There is no merge command anywhere in the workflow, and a
+test asserts that stays true.
+
+### Major releases get an issue, not a PR
+
+A new major produces no branch, no commit and no pin change. The workflow opens
+— or updates, so the weekly run does not refile it — one issue per tool, titled
+for the whole major line so a later release within that major edits it in place.
+
+The issue states the currently pinned version, the newest stable version, the
+newest stable version still available on the pinned major, the upstream index it
+came from, and why the upgrade is manual:
+
+- **Flutter compatibility.** Flutter ships its own Gradle plugin and supports a
+  bounded range of build tooling. The SDK in `.flutter-version` decides what this
+  project may use, and "newer" is not the same as "supported".
+- **The Android build itself.** A major changes defaults, removes deprecated DSL
+  and can alter what ends up in the APK.
+- **F-Droid and reproducibility.** The F-Droid builder resolves this toolchain
+  offline from these files. A major can change what a builder must provide and
+  whether the build still reproduces, and CI cannot prove either. See
+  [`fdroid-build-recipe.md`](./fdroid-build-recipe.md) and the reproducibility
+  notes.
+- **The rest of the toolchain.** Gradle, AGP, Kotlin and the JDK move as a
+  compatible set.
+
+The AGP issue carries an extra warning, and it is the most important sentence in
+this whole document: Linthra's F-Droid release still builds its per-ABI
+`versionCode`s by iterating `applicationVariants` in `android/app/build.gradle`.
+That is legacy Android DSL, and the next AGP major removes the API it depends
+on. Bumping that pin without first porting the logic does not necessarily
+produce a build failure — it can produce a **wrong `versionCode` scheme**, which
+is the one thing an F-Droid release cannot get wrong, because published version
+codes can never be reused or walked back. The port is the work item; the version
+bump is the easy part.
+
+### Reviewing a toolchain update PR
+
+- Confirm the proposed version against the index details in the PR body.
+- Check that the Flutter SDK in `.flutter-version` actually supports it. Newer
+  is not the same as supported.
+- Check CI. Red is informative; work out what the new version changed.
+- Do any migration in a separate PR.
+- Re-read [`fdroid-build-recipe.md`](./fdroid-build-recipe.md) and the
+  reproducibility notes, and update them if the bump changes what a builder must
+  install.
+- Merge manually when you are happy with it. Nothing auto-merges, by design.
+
+### One-time setup
+
+The same repository Actions secret the other two updaters use, and no second
+credential:
+
+- `DEPENDENCY_UPDATE_TOKEN` — a dedicated fine-grained token with **Contents:
+  read/write** and **Pull requests: read/write** on this repository.
+
+The token is only required in the job that publishes a PR, so a week with
+nothing to propose never touches it — and neither does the major path, which
+uses the workflow's own `GITHUB_TOKEN` with `issues: write` granted in that one
+job. Everything else in the workflow stays `contents: read`.
+
+### Running the tests
+
+```bash
+flutter test test/tooling/android_toolchain_update_guardrails_test.dart
+python3 test/tooling/android_toolchain_update_test.py
+```
+
+Both are fully offline: fixture release indexes, throwaway git repositories, and
+no network access at all.

--- a/scripts/check_android_toolchain_update.py
+++ b/scripts/check_android_toolchain_update.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""check_android_toolchain_update.py — are newer Gradle / AGP / Kotlin releases
+available than the ones Linthra pins?
+
+This is the detection half of the Android toolchain updater (issue #362, the
+fifth and last phase). It answers one question per tool and stops there:
+
+    Is the version pinned in the repository still the newest stable release in
+    its own major line — and, separately, has a newer major line appeared?
+
+It changes nothing. It writes no file in the repository, creates no commit and
+talks to no part of GitHub. Publishing is
+.github/workflows/android-toolchain-updates.yml's job; this script only
+classifies, so the classification can be tested offline against fixtures
+(test/tooling/android_toolchain_update_guardrails_test.dart and
+test/tooling/android_toolchain_update_test.py) instead of being buried in YAML.
+
+The two answers are deliberately independent
+--------------------------------------------
+
+For each tool the script reports *both*:
+
+  * `latest_in_current_major` — the newest stable release that still shares the
+    pinned major. This is the only version an automatic PR may ever propose.
+  * `latest` — the newest stable release overall, and `major_status` when that
+    release is on a newer major than the pin.
+
+Keeping them apart is the point. If the pin is on 8.x and upstream has both a
+newer 8.x and a 9.0.0, the newer 8.x still deserves its ordinary draft PR, and
+the 9.0.0 independently deserves its own migration issue. Collapsing the two
+into a single "how far behind are we" number is what would make a new major
+silently swallow every later patch on the line we actually ship.
+
+Where the release data comes from
+---------------------------------
+
+Official, machine-readable, first-party. No HTML is fetched or scraped, and no
+third-party version API is consulted.
+
+  gradle   https://services.gradle.org/versions/all
+
+           Gradle's own release index, served by the same services.gradle.org
+           that android/gradle/wrapper/gradle-wrapper.properties downloads the
+           distribution from. Each entry carries explicit `final`, `snapshot`,
+           `nightly`, `releaseNightly`, `activeRc`, `rcFor`, `milestoneFor` and
+           `broken` flags, so "is this a finished release" is upstream's own
+           statement rather than something inferred from a version string.
+
+  agp      https://dl.google.com/dl/android/maven2/
+             com/android/tools/build/gradle/maven-metadata.xml
+
+           Maven metadata for the Android Gradle Plugin on Google's Maven
+           repository. That is the artifact the `com.android.application`
+           plugin id resolves to, served by the `google()` repository already
+           declared in android/settings.gradle's pluginManagement block.
+
+  kotlin   https://repo1.maven.org/maven2/
+             org/jetbrains/kotlin/kotlin-gradle-plugin/maven-metadata.xml
+
+           Maven metadata for the Kotlin Gradle plugin on Maven Central — the
+           artifact the `org.jetbrains.kotlin.android` plugin id resolves to,
+           served by the `mavenCentral()` repository in the same block.
+
+So in each case the index consulted here is the index Gradle itself would
+resolve the pin from, which is what makes a proposed version installable by
+construction rather than by hope.
+
+Which releases count
+--------------------
+
+A release is a candidate only if it is a bare `MAJOR.MINOR.PATCH`. That is the
+shape test/tooling/toolchain_pins_test.dart requires of all three pin files, so
+it is the only shape an automatic update may write into one. It also does the
+prerelease filtering structurally: `8.13.0-alpha01`, `2.4.20-RC`,
+`2.2.20-Beta1`, `9.0.0-milestone-1`, `-rc-1`, `-SNAPSHOT` and every other
+non-final build carries a suffix and is therefore not a triple. Gradle's
+historical two-component tags are excluded by the same rule — a pin file may
+not hold one.
+
+On top of that, Gradle entries must be `final`, not `broken`, not a snapshot /
+nightly / release-nightly / active RC / milestone, and must download from
+`https://services.gradle.org/distributions/`. Maven metadata must actually
+declare the group and artifact that was asked for.
+
+Failing safe
+------------
+
+Anything that cannot be trusted is an error, not a guess, and an error stops
+the whole run rather than letting two tools publish while a third is broken:
+
+  * a pin that is not a bare triple;
+  * an index that is not valid JSON / XML, or is not the document it should be;
+  * an index with no usable stable release at all;
+  * an index whose newest release is *older* than the pin — an automatic update
+    must never propose a downgrade, so that is a hard failure, not a no-op;
+  * an index that lists no release at all on the pinned major line, which means
+    it is not describing the tool we think it is.
+
+Classification, per tool, against the newest release in the pinned major:
+
+    CURRENT == LATEST-IN-MAJOR                 -> up-to-date
+    same major, same minor, higher patch       -> patch
+    same major, higher minor                   -> minor
+
+and separately, `major_status` is `available` when the newest release overall
+is on a higher major. A major never produces a pin change here or anywhere
+downstream.
+
+Usage
+-----
+
+    # The scheduled check: read all three pins, fetch all three indexes.
+    python3 scripts/check_android_toolchain_update.py
+
+    # One tool, offline, against saved index data:
+    python3 scripts/check_android_toolchain_update.py --tool gradle \\
+        --current 1.2.3 --versions-file /path/to/versions.json
+
+    # All three, offline (repeatable, TOOL=PATH form):
+    python3 scripts/check_android_toolchain_update.py \\
+        --versions-file gradle=/tmp/g.json --versions-file agp=/tmp/a.xml \\
+        --versions-file kotlin=/tmp/k.xml
+
+    # Classify two versions directly, consulting no index at all. The workflow
+    # uses this to compare the version already on an update branch against the
+    # version it is about to propose.
+    python3 scripts/check_android_toolchain_update.py --tool agp \\
+        --current 1.2.3 --latest 1.2.4
+
+    # Machine-readable output for the workflow.
+    python3 scripts/check_android_toolchain_update.py --github-output "$GITHUB_OUTPUT"
+    python3 scripts/check_android_toolchain_update.py --json
+
+Exit status: 0 when every requested tool was classified (including
+"up-to-date"), 2 when any input could not be trusted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from toolchain_pins import (
+    TOOL_NAMES,
+    CheckError,
+    Version,
+    format_version,
+    looks_like_prerelease,
+    parse_version,
+    read_pin,
+    tool,
+    try_version,
+)
+
+_FETCH_TIMEOUT_SECONDS = 30
+
+# An index this size is already far past anything upstream publishes; refusing
+# to read further is cheaper than trusting a body that grew unexpectedly.
+_MAX_INDEX_BYTES = 16 * 1024 * 1024
+
+STATUS_UP_TO_DATE = "up-to-date"
+STATUS_PATCH = "patch"
+STATUS_MINOR = "minor"
+STATUS_MAJOR = "major"
+
+MAJOR_NONE = "none"
+MAJOR_AVAILABLE = "available"
+
+_GRADLE_DISTRIBUTION_PREFIX = "https://services.gradle.org/distributions/"
+
+# The upstream index for each tool. `format` selects the parser below.
+SOURCES: Dict[str, Dict[str, str]] = {
+    "gradle": {
+        "url": "https://services.gradle.org/versions/all",
+        "format": "gradle-versions",
+    },
+    "agp": {
+        "url": (
+            "https://dl.google.com/dl/android/maven2/"
+            "com/android/tools/build/gradle/maven-metadata.xml"
+        ),
+        "format": "maven-metadata",
+        "group_id": "com.android.tools.build",
+        "artifact_id": "gradle",
+    },
+    "kotlin": {
+        "url": (
+            "https://repo1.maven.org/maven2/"
+            "org/jetbrains/kotlin/kotlin-gradle-plugin/maven-metadata.xml"
+        ),
+        "format": "maven-metadata",
+        "group_id": "org.jetbrains.kotlin",
+        "artifact_id": "kotlin-gradle-plugin",
+    },
+}
+
+
+class Candidates:
+    """The stable releases an index offers, and what was left out of them."""
+
+    def __init__(self) -> None:
+        self.versions: List[Version] = []
+        # Rejected because they are recognisably prereleases. Routine — every
+        # index is full of them — so they are counted, not shouted about.
+        self.prereleases = 0
+        # Rejected for any other reason: a legacy two-component tag, a build
+        # marked broken, a distribution served from somewhere unexpected.
+        self.malformed = 0
+        # Things that were *not* expected and a human may want to look at.
+        self.notes: List[str] = []
+
+
+# -----------------------------------------------------------------------------
+# Fetching
+# -----------------------------------------------------------------------------
+
+
+def load_index(url: str, path: Optional[str]) -> Tuple[str, str]:
+    """Return `(raw_text, origin)` for an index, from a file or over https."""
+    if path is not None:
+        file = Path(path)
+        if not file.is_file():
+            raise CheckError(f"release index not found: {file}")
+        return file.read_text(encoding="utf-8"), str(file)
+
+    if not url.startswith("https://"):
+        raise CheckError(
+            f"refusing to fetch a release index over {url!r} — https is required"
+        )
+    try:
+        with urllib.request.urlopen(url, timeout=_FETCH_TIMEOUT_SECONDS) as response:
+            raw = response.read(_MAX_INDEX_BYTES + 1)
+    except Exception as error:  # network, TLS, HTTP status
+        raise CheckError(f"could not fetch the release index from {url}: {error}") from error
+    if len(raw) > _MAX_INDEX_BYTES:
+        raise CheckError(
+            f"{url} returned more than {_MAX_INDEX_BYTES} bytes; refusing to parse it"
+        )
+    try:
+        return raw.decode("utf-8"), url
+    except UnicodeDecodeError as error:
+        raise CheckError(f"{url} is not valid UTF-8: {error}") from error
+
+
+# -----------------------------------------------------------------------------
+# Parsers
+# -----------------------------------------------------------------------------
+
+
+def parse_gradle_versions(raw: str, origin: str) -> Candidates:
+    """Candidates from Gradle's own release index.
+
+    Upstream states outright whether a build is finished, so that statement is
+    what gets trusted: `final` must be exactly true, and every "this is not a
+    release" flag must be clear. The version shape is checked as well, which is
+    what drops the historical two-component tags (`8.14`) — a pin file may only
+    hold a bare triple.
+    """
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise CheckError(f"{origin} is not valid JSON: {error}") from error
+    if not isinstance(payload, list):
+        raise CheckError(f"{origin} is not a JSON array of releases")
+    if not payload:
+        raise CheckError(f"{origin} lists no releases at all")
+
+    found = Candidates()
+    for index, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            raise CheckError(f"{origin} entry #{index} is not an object: {entry!r}")
+
+        version_text = entry.get("version")
+
+        # Upstream's own verdict first. Everything that is not a finished
+        # release — snapshots, nightlies, RCs, milestones — says so here.
+        #
+        # Which bucket a skipped row lands in is reporting only, and for Gradle
+        # the flags are a better witness than the version string: a
+        # release-nightly's version is a bare timestamp with no marker in it,
+        # but the row itself says plainly what it is.
+        if entry.get("final") is not True:
+            flagged = any(
+                entry.get(flag)
+                for flag in (
+                    "snapshot",
+                    "nightly",
+                    "releaseNightly",
+                    "activeRc",
+                    "rcFor",
+                    "milestoneFor",
+                )
+            )
+            if flagged or looks_like_prerelease(version_text):
+                found.prereleases += 1
+            else:
+                found.malformed += 1
+            continue
+
+        # `final` is claimed. Every other flag has to agree with it; one that
+        # does not means the row contradicts itself, and a self-contradictory
+        # row is not something to propose a pin change from.
+        contradiction = next(
+            (
+                flag
+                for flag in (
+                    "snapshot",
+                    "nightly",
+                    "releaseNightly",
+                    "activeRc",
+                    "broken",
+                    "rcFor",
+                    "milestoneFor",
+                )
+                if entry.get(flag)
+            ),
+            None,
+        )
+        if contradiction is not None:
+            found.notes.append(
+                f"entry #{index} ({version_text!r}) claims final but "
+                f"{contradiction} is set"
+            )
+            found.malformed += 1
+            continue
+
+        version = try_version(version_text)
+        if version is None:
+            if looks_like_prerelease(version_text):
+                found.prereleases += 1
+            else:
+                found.malformed += 1
+            continue
+
+        download = entry.get("downloadUrl")
+        if not isinstance(download, str) or not download.startswith(
+            _GRADLE_DISTRIBUTION_PREFIX
+        ):
+            # A final release must be downloadable from the distribution host
+            # the wrapper points at. A row that is not names nothing this
+            # repository could install, so it is not a version to propose — and
+            # it contradicts the `final` claim, so say so rather than counting
+            # it quietly.
+            found.notes.append(
+                f"entry #{index} ({version_text!r}) claims final but its "
+                f"downloadUrl is not under {_GRADLE_DISTRIBUTION_PREFIX}: "
+                f"{download!r}"
+            )
+            found.malformed += 1
+            continue
+
+        found.versions.append(version)
+
+    return found
+
+
+def parse_maven_metadata(
+    raw: str, origin: str, group_id: str, artifact_id: str
+) -> Candidates:
+    """Candidates from a Maven `maven-metadata.xml`.
+
+    `<latest>` and `<release>` are deliberately ignored: both routinely name a
+    prerelease (Kotlin's `<release>` has pointed at an `-RC` build), so the
+    version list is filtered here instead of trusting a pointer.
+    """
+    # ElementTree resolves entities, so a document declaring any is refused
+    # before it is parsed rather than being handed to the parser to expand.
+    lowered = raw.lower()
+    for hostile in ("<!doctype", "<!entity"):
+        if hostile in lowered:
+            raise CheckError(
+                f"{origin} contains a {hostile[2:]} declaration; refusing to parse it"
+            )
+
+    try:
+        root = ElementTree.fromstring(raw)
+    except ElementTree.ParseError as error:
+        raise CheckError(f"{origin} is not valid XML: {error}") from error
+    if root.tag != "metadata":
+        raise CheckError(f"{origin} is not Maven metadata (root is <{root.tag}>)")
+
+    for field, expected in (("groupId", group_id), ("artifactId", artifact_id)):
+        node = root.find(field)
+        actual = None if node is None else (node.text or "").strip()
+        if actual != expected:
+            raise CheckError(
+                f"{origin} describes {field} {actual!r}, not {expected!r}; "
+                "refusing to read versions out of the wrong artifact"
+            )
+
+    versions_node = root.find("versioning/versions")
+    if versions_node is None:
+        raise CheckError(f"{origin} has no <versioning><versions> element")
+
+    entries = list(versions_node.findall("version"))
+    if not entries:
+        raise CheckError(f"{origin} lists no versions at all")
+
+    found = Candidates()
+    for entry in entries:
+        text = (entry.text or "").strip()
+        version = try_version(text)
+        if version is None:
+            if looks_like_prerelease(text):
+                found.prereleases += 1
+            else:
+                found.malformed += 1
+            continue
+        found.versions.append(version)
+    return found
+
+
+def candidates_for(name: str, raw: str, origin: str) -> Candidates:
+    source = SOURCES[name]
+    if source["format"] == "gradle-versions":
+        found = parse_gradle_versions(raw, origin)
+    else:
+        found = parse_maven_metadata(
+            raw, origin, source["group_id"], source["artifact_id"]
+        )
+    if not found.versions:
+        raise CheckError(
+            f"{origin} contains no usable stable release for {tool(name).label} "
+            "(nothing matched a bare MAJOR.MINOR.PATCH release)"
+        )
+    return found
+
+
+# -----------------------------------------------------------------------------
+# Classification
+# -----------------------------------------------------------------------------
+
+
+def classify(current: Version, latest: Version) -> str:
+    """Classify the gap between a pinned and a candidate version.
+
+    Raises CheckError when `latest` is older than `current`: an automatic
+    update must never propose a downgrade, and an index that says the newest
+    release is behind our pin is data we do not understand.
+    """
+    if latest == current:
+        return STATUS_UP_TO_DATE
+    if latest < current:
+        raise CheckError(
+            "the newest stable release ({}) is older than the pinned version "
+            "({}). Refusing to propose a downgrade — check the pin and the "
+            "upstream release index.".format(
+                format_version(latest), format_version(current)
+            )
+        )
+    if latest[0] > current[0]:
+        return STATUS_MAJOR
+    if latest[1] > current[1]:
+        return STATUS_MINOR
+    return STATUS_PATCH
+
+
+def evaluate(name: str, current: Version, found: Candidates, origin: str) -> Dict[str, str]:
+    """Everything the workflow needs to know about one tool."""
+    t = tool(name)
+
+    latest = max(found.versions)
+    if latest < current:
+        raise CheckError(
+            "{}: the newest stable release ({}) is older than the pinned "
+            "version ({}). Refusing to propose a downgrade.".format(
+                t.label, format_version(latest), format_version(current)
+            )
+        )
+
+    in_major = [v for v in found.versions if v[0] == current[0]]
+    if not in_major:
+        # Our own major line is missing from the index entirely. That is not a
+        # tool that dropped a line — it is an index that is not describing the
+        # tool we think it is, and acting on it would be acting on data we
+        # cannot read.
+        raise CheckError(
+            "{}: {} lists no stable release on the pinned major line ({}.x). "
+            "Refusing to act on an index that does not describe the pinned "
+            "tool.".format(t.label, origin, current[0])
+        )
+
+    newest_in_major = max(in_major)
+    status = classify(current, newest_in_major)
+
+    notes = list(found.notes)
+    if current not in found.versions:
+        # Advisory: the pin still classifies fine against its own major line,
+        # but an index that has never heard of the version we ship is worth a
+        # human's eye.
+        notes.append(
+            f"the pinned version {format_version(current)} is not listed in "
+            f"{origin}"
+        )
+
+    major_available = latest[0] > current[0]
+    return {
+        "tool": name,
+        "label": t.label,
+        "pin_file": t.pin_file,
+        "source": origin,
+        "current": format_version(current),
+        "status": status,
+        "latest_in_current_major": format_version(newest_in_major),
+        "latest": format_version(latest),
+        "major_status": MAJOR_AVAILABLE if major_available else MAJOR_NONE,
+        "major_latest": format_version(latest) if major_available else "",
+        # The target came out of the stable filter above, so reaching here *is*
+        # the confirmation that it is a published final release.
+        "stable_confirmed": "true",
+        "releases_considered": str(len(found.versions)),
+        "prereleases_skipped": str(found.prereleases),
+        "malformed_skipped": str(found.malformed),
+        "notes": " | ".join(notes),
+    }
+
+
+# -----------------------------------------------------------------------------
+# Driving it
+# -----------------------------------------------------------------------------
+
+
+def parse_versions_files(values: List[str], tools: List[str]) -> Dict[str, str]:
+    """Resolve `--versions-file` arguments to `{tool: path}`."""
+    mapping: Dict[str, str] = {}
+    for value in values:
+        name, separator, path = value.partition("=")
+        if not separator:
+            if len(tools) != 1:
+                raise CheckError(
+                    "--versions-file needs the TOOL=PATH form unless exactly "
+                    "one --tool was given"
+                )
+            mapping[tools[0]] = value
+            continue
+        if name not in SOURCES:
+            raise CheckError(
+                f"--versions-file names unknown tool {name!r} "
+                f"(expected one of {', '.join(TOOL_NAMES)})"
+            )
+        mapping[name] = path
+    return mapping
+
+
+def build_results(args: argparse.Namespace, repo_root: Path) -> Dict[str, Dict[str, str]]:
+    tools: List[str] = [args.tool] if args.tool else list(TOOL_NAMES)
+
+    if args.current is not None and len(tools) != 1:
+        raise CheckError("--current applies to a single --tool")
+    if args.latest is not None and len(tools) != 1:
+        raise CheckError("--latest applies to a single --tool")
+
+    files = parse_versions_files(args.versions_file, tools)
+
+    results: Dict[str, Dict[str, str]] = {}
+    for name in tools:
+        t = tool(name)
+        current_text = args.current if args.current is not None else read_pin(repo_root, name)
+        current = parse_version(
+            current_text,
+            "--current" if args.current is not None else t.pin_file,
+        )
+
+        if args.latest is not None:
+            # Classification only: no index is consulted, so nothing here may
+            # claim the target was confirmed to be a published release.
+            latest = parse_version(args.latest, "--latest")
+            status = classify(current, latest)
+            results[name] = {
+                "tool": name,
+                "label": t.label,
+                "pin_file": t.pin_file,
+                "source": "--latest",
+                "current": format_version(current),
+                "status": status,
+                "latest_in_current_major": (
+                    format_version(latest) if latest[0] == current[0] else ""
+                ),
+                "latest": format_version(latest),
+                "major_status": (
+                    MAJOR_AVAILABLE if latest[0] > current[0] else MAJOR_NONE
+                ),
+                "major_latest": (
+                    format_version(latest) if latest[0] > current[0] else ""
+                ),
+                "stable_confirmed": "false",
+                "releases_considered": "0",
+                "prereleases_skipped": "0",
+                "malformed_skipped": "0",
+                "notes": "",
+            }
+            continue
+
+        raw, origin = load_index(SOURCES[name]["url"], files.get(name))
+        found = candidates_for(name, raw, origin)
+        results[name] = evaluate(name, current, found, origin)
+
+    return results
+
+
+def needs_pr(result: Dict[str, str]) -> bool:
+    return result["status"] in (STATUS_PATCH, STATUS_MINOR)
+
+
+def needs_issue(result: Dict[str, str]) -> bool:
+    return result["major_status"] == MAJOR_AVAILABLE
+
+
+def report(results: Dict[str, Dict[str, str]]) -> None:
+    for result in results.values():
+        label = result["label"]
+        if result["status"] == STATUS_UP_TO_DATE:
+            print(
+                f"{label}: up to date on {result['current']} — the newest "
+                f"release in the current major line."
+            )
+        else:
+            print(
+                f"{label}: a {result['status']} update is available: "
+                f"{result['current']} -> {result['latest_in_current_major']}"
+            )
+        if result["major_status"] == MAJOR_AVAILABLE:
+            print(
+                f"  a newer major exists: {result['major_latest']} — issue "
+                "only, never an automatic pin change"
+            )
+        if result["releases_considered"] != "0":
+            print(
+                f"  considered {result['releases_considered']} stable "
+                f"release(s) from {result['source']}"
+            )
+            print(
+                f"  skipped {result['prereleases_skipped']} prerelease(s) and "
+                f"{result['malformed_skipped']} unusable version string(s)"
+            )
+        if result["notes"]:
+            for note in result["notes"].split(" | "):
+                print(f"  note: {note}")
+
+
+def write_github_output(path: str, results: Dict[str, Dict[str, str]]) -> None:
+    compact = json.dumps(results, separators=(",", ":"), sort_keys=True)
+    pr_tools = json.dumps(
+        [name for name, r in results.items() if needs_pr(r)], separators=(",", ":")
+    )
+    issue_tools = json.dumps(
+        [name for name, r in results.items() if needs_issue(r)], separators=(",", ":")
+    )
+    for value in (compact, pr_tools, issue_tools):
+        if "\n" in value:
+            raise CheckError(f"output contains a newline: {value!r}")
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"results={compact}\n")
+        handle.write(f"pr_tools={pr_tools}\n")
+        handle.write(f"issue_tools={issue_tools}\n")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect newer stable Gradle / AGP / Kotlin releases than the "
+            "pinned ones."
+        ),
+    )
+    parser.add_argument(
+        "--tool",
+        choices=TOOL_NAMES,
+        help="Check only this tool (default: all three).",
+    )
+    parser.add_argument(
+        "--current",
+        help="Version to compare against (default: read the pin file).",
+    )
+    parser.add_argument(
+        "--latest",
+        help="Classify against this version directly, consulting no index.",
+    )
+    parser.add_argument(
+        "--versions-file",
+        action="append",
+        default=[],
+        metavar="[TOOL=]PATH",
+        help="Read a release index from this file instead of the network.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Repository root holding the pin files (default: this checkout).",
+    )
+    parser.add_argument(
+        "--github-output",
+        help="Append key=value lines for GitHub Actions to this file.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON.")
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress the human-readable report."
+    )
+    args = parser.parse_args(argv)
+
+    if args.latest is not None and args.versions_file:
+        parser.error("--latest and --versions-file are mutually exclusive")
+
+    repo_root = (
+        Path(args.repo_root)
+        if args.repo_root
+        else Path(__file__).resolve().parent.parent
+    )
+
+    try:
+        results = build_results(args, repo_root)
+        if args.github_output:
+            write_github_output(args.github_output, results)
+    except CheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    elif not args.quiet:
+        report(results)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_dependency_update_files.sh
+++ b/scripts/check_dependency_update_files.sh
@@ -3,8 +3,8 @@
 # check_dependency_update_files.sh — assert an automatic update only touches
 # the files that kind of update is allowed to touch.
 #
-# Linthra runs two automatic updaters (issue #362), and each one writes exactly
-# one file:
+# Linthra runs several automatic updaters (issue #362), and each one writes
+# exactly one file:
 #
 #   --kind dart-packages   pubspec.lock       the resolved dependency set
 #                          .github/workflows/dart-dependency-updates.yml
@@ -13,12 +13,25 @@
 #   --kind flutter-sdk     .flutter-version   the pinned Flutter SDK
 #                          .github/workflows/flutter-sdk-updates.yml
 #
+#   --kind gradle          android/gradle/wrapper/gradle-wrapper.properties
+#   --kind agp             android/settings.gradle
+#   --kind kotlin          android/settings.gradle
+#                          .github/workflows/android-toolchain-updates.yml
+#
 # The kinds are deliberately separate allowlists rather than one union. A
 # lockfile refresh has no business editing the toolchain pin, and an SDK bump
 # has no business re-resolving the lockfile — that second resolution is a
 # human's call, because the committed pubspec.lock is what the reproducible
 # F-Droid build resolves from (docs/release-process.md §7). Sharing one list
 # would silently give each updater the other's reach.
+#
+# Note the last two kinds: the AGP and Kotlin pins live in the *same file*, so
+# for those two a filename is not a boundary at all — this guard can only say
+# "settings.gradle changed", not "the AGP updater left Kotlin alone". That
+# second question is answered by scripts/check_toolchain_pin_diff.py, which
+# compares the file's real before/after text and rejects any change outside the
+# one version string the updater owns. The two run together, here and in CI:
+# this one bounds *which files*, that one bounds *what inside them*.
 #
 # Nothing else is allowed in either kind. In particular an automatic update
 # must never rewrite the constraints in pubspec.yaml, never touch application
@@ -49,6 +62,7 @@
 #   # Or as arguments:
 #   scripts/check_dependency_update_files.sh pubspec.lock
 #   scripts/check_dependency_update_files.sh --kind flutter-sdk .flutter-version
+#   scripts/check_dependency_update_files.sh --kind agp android/settings.gradle
 #
 # --kind defaults to dart-packages, the updater that came first.
 #
@@ -58,6 +72,7 @@
 set -uo pipefail
 
 kind="dart-packages"
+kinds="dart-packages, flutter-sdk, gradle, agp or kotlin"
 
 # Collect candidate paths from arguments, else from stdin.
 paths=()
@@ -65,7 +80,7 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --kind)
       if [ "$#" -lt 2 ]; then
-        echo "ERROR: --kind needs a value (dart-packages or flutter-sdk)." >&2
+        echo "ERROR: --kind needs a value ($kinds)." >&2
         exit 1
       fi
       kind="$2"
@@ -87,8 +102,19 @@ case "$kind" in
   flutter-sdk)
     allowed=(".flutter-version")
     what="Flutter SDK update" ;;
+  gradle)
+    allowed=("android/gradle/wrapper/gradle-wrapper.properties")
+    what="Gradle update" ;;
+  agp)
+    # Same file as kotlin below, on purpose — and exactly why this guard is not
+    # the whole story for these two. See scripts/check_toolchain_pin_diff.py.
+    allowed=("android/settings.gradle")
+    what="Android Gradle Plugin update" ;;
+  kotlin)
+    allowed=("android/settings.gradle")
+    what="Kotlin Gradle plugin update" ;;
   *)
-    echo "ERROR: unknown --kind '$kind' (expected dart-packages or flutter-sdk)." >&2
+    echo "ERROR: unknown --kind '$kind' (expected $kinds)." >&2
     exit 1 ;;
 esac
 

--- a/scripts/check_toolchain_pin_diff.py
+++ b/scripts/check_toolchain_pin_diff.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""check_toolchain_pin_diff.py — prove an automatic toolchain update changed
+one version number and nothing else.
+
+The content-aware half of the Android toolchain guard (issue #362, PR 5).
+scripts/check_dependency_update_files.sh answers "which files moved"; this
+script answers the question a filename cannot:
+
+    android/settings.gradle holds *two* pins. Did the AGP updater move the AGP
+    version — or did it also, quietly, move Kotlin's, or reword the comment
+    above them?
+
+A filename allowlist says "settings.gradle changed" and is satisfied. That is
+not good enough for two independent updaters sharing one file, so the boundary
+between them is checked against the file's actual before/after text.
+
+How the proof works
+-------------------
+
+Not by reading the diff and hoping the interesting hunk was spotted. Instead:
+
+    1. Find the tool's own version in the *before* text and in the *after*
+       text. Exactly one match in each; zero or several is a refusal.
+    2. Take the *after* text and put the *before* version back into it.
+    3. Require the result to equal the *before* text byte for byte.
+
+If anything else moved — the other plugin's version, a comment, whitespace, an
+unrelated property, a reordered line — step 3 fails, because putting the old
+version back could not possibly reproduce the old file. There is no list of
+"things to watch out for" to keep up to date; everything outside that one
+capture group is protected by construction.
+
+On top of that the version itself has to be sane: a bare `MAJOR.MINOR.PATCH`,
+strictly newer than before, and on the same major. An automatic update never
+proposes a downgrade and never crosses a major.
+
+In git mode the changed-file set is checked too, so this one command is enough
+to reject an update branch that also touched application code, tests,
+`pubspec.yaml`, F-Droid metadata, Fastlane files, release notes, signing
+material or a license.
+
+Usage
+-----
+
+    # Against the working tree, before the updater commits anything:
+    python3 scripts/check_toolchain_pin_diff.py --kind agp --base HEAD
+
+    # Against a real PR diff, in CI:
+    python3 scripts/check_toolchain_pin_diff.py --kind agp \\
+        --base "$BASE_SHA" --head HEAD
+
+    # Against two files, with no git repository at all (how the tests drive it):
+    python3 scripts/check_toolchain_pin_diff.py --kind agp \\
+        --before-file old.gradle --after-file new.gradle
+
+Read-only, no network, no secrets. Exit status: 0 the change is within the
+boundary, 2 it is not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from toolchain_pins import (
+    TOOL_NAMES,
+    CheckError,
+    find_pin,
+    format_version,
+    other_tools_in,
+    parse_version,
+    replace_pin,
+    tool,
+)
+
+
+def git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise CheckError(
+            "git {} failed: {}".format(" ".join(args), result.stderr.strip())
+        )
+    return result.stdout
+
+
+def changed_files(repo_root: Path, base: str, head: Optional[str]) -> List[str]:
+    args = ["diff", "--name-only", base]
+    if head is not None:
+        args.append(head)
+    return [line for line in git(repo_root, *args).splitlines() if line.strip()]
+
+
+def read_at(repo_root: Path, ref: Optional[str], path: str) -> str:
+    """The contents of `path` at `ref`, or in the working tree when ref is None."""
+    if ref is None:
+        file = repo_root / path
+        if not file.is_file():
+            raise CheckError(f"missing {path} in the working tree")
+        return file.read_text(encoding="utf-8")
+    return git(repo_root, "show", f"{ref}:{path}")
+
+
+def check_content(kind: str, before: str, after: str, origin: str) -> str:
+    """The heart of the guard. Returns a one-line summary, or raises."""
+    t = tool(kind)
+
+    before_text = find_pin(before, kind, f"{origin} (before)")
+    after_text = find_pin(after, kind, f"{origin} (after)")
+
+    if before == after:
+        return f"{t.label}: {origin} is unchanged."
+
+    # Named separately from the byte comparison below purely for the error
+    # message. "the AGP update also moved the Kotlin pin" is a far more useful
+    # failure than "something outside the AGP version changed".
+    for other in other_tools_in(kind):
+        other_before = find_pin(before, other, f"{origin} (before)")
+        other_after = find_pin(after, other, f"{origin} (after)")
+        if other_before != other_after:
+            raise CheckError(
+                f"this is an automatic {t.label} update, but it also moves the "
+                f"{tool(other).label} pin in {origin} "
+                f"({other_before} -> {other_after}). The two updaters share "
+                "this file and must never write each other's version — that "
+                "upgrade belongs in its own PR."
+            )
+
+    # Put the old version back. If the result is not the old file, something
+    # outside this tool's version changed.
+    restored = replace_pin(after, kind, before_text)
+    if restored != before:
+        raise CheckError(
+            f"this is an automatic {t.label} update, but {origin} differs from "
+            "its previous contents by more than "
+            f"{t.describe}. An automatic update may rewrite that one version "
+            "string and nothing else — not comments, not whitespace, not any "
+            "other setting in the same file."
+        )
+
+    before_version = parse_version(before_text, f"{origin} (before)")
+    after_version = parse_version(after_text, f"{origin} (after)")
+
+    if after_version < before_version:
+        raise CheckError(
+            f"refusing a downgrade of {t.label}: "
+            f"{format_version(before_version)} -> {format_version(after_version)}. "
+            "An automatic update never proposes a downgrade."
+        )
+    if after_version[0] != before_version[0]:
+        raise CheckError(
+            f"this {t.label} change crosses a major version: "
+            f"{format_version(before_version)} -> {format_version(after_version)}. "
+            "A major toolchain upgrade is a manual migration (#362) and gets "
+            "an issue, never an automatic pin change."
+        )
+
+    return (
+        f"OK: automatic {t.label} update moves {format_version(before_version)} "
+        f"-> {format_version(after_version)} in {origin}, and changes nothing else."
+    )
+
+
+def check_git(repo_root: Path, kind: str, base: str, head: Optional[str]) -> str:
+    t = tool(kind)
+    paths = changed_files(repo_root, base, head)
+    if not paths:
+        return f"{t.label}: no files changed; nothing to check."
+
+    offenders = [path for path in paths if path != t.pin_file]
+    if offenders:
+        raise CheckError(
+            "this looks like an automatic {} update, but it changes files "
+            "outside the one it owns:\n{}\n\nAn automatic {} update may only "
+            "rewrite:\n  - {}\n\nIt must not touch application or test code, "
+            "pubspec.yaml, pubspec.lock, the app version, F-Droid metadata, "
+            "Fastlane files, release notes, signing material, licenses, or "
+            "another tool's pin.".format(
+                t.label,
+                "\n".join(f"  - {path}" for path in offenders),
+                t.label,
+                t.pin_file,
+            )
+        )
+
+    return check_content(
+        kind,
+        read_at(repo_root, base, t.pin_file),
+        read_at(repo_root, head, t.pin_file),
+        t.pin_file,
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Assert an automatic toolchain update rewrote one version string "
+            "and nothing else."
+        ),
+    )
+    parser.add_argument("--kind", required=True, choices=TOOL_NAMES)
+    parser.add_argument(
+        "--base", help="Compare against this git ref (the PR base, or HEAD)."
+    )
+    parser.add_argument(
+        "--head",
+        help="The other side of the comparison (default: the working tree).",
+    )
+    parser.add_argument("--before-file", help="File holding the previous contents.")
+    parser.add_argument("--after-file", help="File holding the new contents.")
+    parser.add_argument(
+        "--repo-root",
+        help="Repository root for git mode (default: this checkout).",
+    )
+    args = parser.parse_args(argv)
+
+    file_mode = args.before_file is not None or args.after_file is not None
+    if file_mode:
+        if args.base is not None or args.head is not None:
+            parser.error("--before-file/--after-file cannot be combined with --base/--head")
+        if args.before_file is None or args.after_file is None:
+            parser.error("--before-file and --after-file must be given together")
+    elif args.base is None:
+        parser.error("give either --base (git mode) or --before-file/--after-file")
+
+    try:
+        if file_mode:
+            before = Path(args.before_file)
+            after = Path(args.after_file)
+            for file in (before, after):
+                if not file.is_file():
+                    raise CheckError(f"no such file: {file}")
+            summary = check_content(
+                args.kind,
+                before.read_text(encoding="utf-8"),
+                after.read_text(encoding="utf-8"),
+                tool(args.kind).pin_file,
+            )
+        else:
+            repo_root = (
+                Path(args.repo_root)
+                if args.repo_root
+                else Path(__file__).resolve().parent.parent
+            )
+            summary = check_git(repo_root, args.kind, args.base, args.head)
+    except CheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/set_android_toolchain_pin.py
+++ b/scripts/set_android_toolchain_pin.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""set_android_toolchain_pin.py — move exactly one Android toolchain pin.
+
+The write half of the Android toolchain updater (issue #362, PR 5). It is the
+only script in this repository allowed to change the Gradle, AGP or Kotlin pin,
+and the change it makes is deliberately tiny: one version string, in one file,
+found by the shared pattern in scripts/toolchain_pins.py, with every other byte
+of the file carried through untouched.
+
+    python3 scripts/set_android_toolchain_pin.py --tool agp --version 1.2.3
+
+Doing this in Python rather than with `sed` in the workflow is not ceremony.
+`agp` and `kotlin` live in the *same file*, so the edit has to be aimed by
+content, not by filename — and the aiming has to be the same aiming
+scripts/check_toolchain_pin_diff.py verifies afterwards, or the guard would be
+checking something the writer never touches. Sharing one module is what makes
+those two agree.
+
+What it refuses
+---------------
+
+  * a version that is not a bare MAJOR.MINOR.PATCH;
+  * a version that is not strictly newer than the pin — an automatic update
+    never proposes a downgrade, and re-writing the same value is a no-op the
+    caller should have skipped;
+  * a version on a different major — Gradle, AGP and Kotlin majors are all
+    manual migrations, and no automatic path may cross one;
+  * a pin file that does not contain exactly one place to make the edit.
+
+After writing it reads the file back and confirms the pin is what was asked
+for, so the run fails here rather than producing a commit nobody checked.
+
+Exit status: 0 written, 2 refused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from toolchain_pins import (
+    TOOL_NAMES,
+    CheckError,
+    find_pin,
+    format_version,
+    parse_version,
+    read_pin_file,
+    replace_pin,
+    tool,
+)
+
+
+def apply(repo_root: Path, name: str, version_text: str) -> str:
+    t = tool(name)
+    target = parse_version(version_text, "--version")
+
+    before = read_pin_file(repo_root, name)
+    current_text = find_pin(before, name, t.pin_file)
+    current = parse_version(current_text, f"{t.pin_file} ({t.label})")
+
+    if target == current:
+        raise CheckError(
+            f"{t.label} is already pinned to {format_version(current)}; "
+            "nothing to write"
+        )
+    if target < current:
+        raise CheckError(
+            f"refusing to move {t.label} from {format_version(current)} back "
+            f"to {format_version(target)} — an automatic update never proposes "
+            "a downgrade"
+        )
+    if target[0] != current[0]:
+        raise CheckError(
+            f"refusing to move {t.label} from {format_version(current)} to "
+            f"{format_version(target)}: that crosses a major version. A "
+            "major toolchain upgrade is a manual migration (#362) and gets an "
+            "issue, never an automatic pin change."
+        )
+
+    after = replace_pin(before, name, format_version(target))
+    if after == before:
+        raise CheckError(f"rewriting {t.pin_file} produced no change")
+
+    path = repo_root / t.pin_file
+    path.write_text(after, encoding="utf-8")
+
+    # Read it back rather than trusting the write: the guard downstream is
+    # worth more if this step has already proven the file says what we meant.
+    written = find_pin(path.read_text(encoding="utf-8"), name, t.pin_file)
+    if written != format_version(target):
+        raise CheckError(
+            f"{t.pin_file} reads back as {written!r} after writing "
+            f"{format_version(target)!r}"
+        )
+    return (
+        f"{t.label}: {format_version(current)} -> {format_version(target)} "
+        f"in {t.pin_file}"
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Set one Android toolchain pin to a newer version.",
+    )
+    parser.add_argument("--tool", required=True, choices=TOOL_NAMES)
+    parser.add_argument("--version", required=True, help="The new version.")
+    parser.add_argument(
+        "--repo-root",
+        help="Repository root holding the pin files (default: this checkout).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = (
+        Path(args.repo_root)
+        if args.repo_root
+        else Path(__file__).resolve().parent.parent
+    )
+
+    try:
+        print(apply(repo_root, args.tool, args.version))
+    except CheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/toolchain_pins.py
+++ b/scripts/toolchain_pins.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""toolchain_pins.py — where Linthra's Android toolchain pins live, and how to
+read, compare and rewrite exactly one of them.
+
+This is the shared core behind the three Android toolchain scripts (issue
+#362, PR 5):
+
+    scripts/check_android_toolchain_update.py   detect      (reads upstream)
+    scripts/set_android_toolchain_pin.py        write       (one pin, in place)
+    scripts/check_toolchain_pin_diff.py         guard       (verifies a diff)
+
+They share this module on purpose. The detector, the writer and the guard must
+agree byte-for-byte on *what a pin is* — if the guard's idea of "the AGP
+version" ever drifted from the writer's, the guard would be checking something
+the writer never touches, and the safety story would be theatre.
+
+The pins
+--------
+
+    gradle   android/gradle/wrapper/gradle-wrapper.properties
+             the version inside distributionUrl
+
+    agp      android/settings.gradle
+             the version of the `com.android.application` plugin
+
+    kotlin   android/settings.gradle
+             the version of the `org.jetbrains.kotlin.android` plugin
+
+Note that `agp` and `kotlin` share one file. That is the whole reason this
+module exists as more than a table of filenames: a filename allowlist cannot
+tell an AGP bump from a Kotlin bump, so the boundary between those two updaters
+has to be expressed in terms of file *content*. Each tool's regex captures its
+own version and nothing else, `replace_pin` rewrites only that capture, and
+scripts/check_toolchain_pin_diff.py proves — against the real before/after text
+— that everything outside that one capture is unchanged.
+
+Versions
+--------
+
+A pin is a bare `MAJOR.MINOR.PATCH`. That is the shape
+test/tooling/toolchain_pins_test.dart already requires of all three pin files,
+so it is also the only shape an automatic update may propose. Upstream rows
+that are not bare triples — Gradle's historical two-component tags, every
+`-alpha`/`-beta`/`-RC`/`-Beta1` plugin build — are simply not candidates. That
+one rule does most of the prerelease filtering for free, structurally, rather
+than by trying to enumerate every marker upstream might invent.
+
+CLI
+---
+
+The one thing this module does from the command line is *read* a pin out of a
+file, which the update workflow needs when it inspects the file already sitting
+on an update branch:
+
+    git show "origin/toolchain/agp:android/settings.gradle" > /tmp/pinfile
+    python3 scripts/toolchain_pins.py --tool agp --file /tmp/pinfile
+
+It prints the version and exits 0, or explains itself and exits 2. It never
+writes anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# A pin, and every version an automatic update may propose, is a bare triple.
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+# Markers that make an upstream version string a prerelease. Nothing is decided
+# by this list — the bare-triple rule above already rejects every one of these,
+# because they all carry a suffix. It exists so the checker can *report* "these
+# rows were skipped because they are prereleases" separately from "these rows
+# were skipped because they were malformed", which is a genuinely useful
+# distinction when reading a run's log.
+_PRERELEASE_RE = re.compile(
+    r"(?i)(alpha|beta|[-.]rc\b|[-.]rc\d|milestone|preview|nightly|snapshot"
+    r"|eap|-dev\b|[-.]m\d+\b)"
+)
+
+Version = Tuple[int, int, int]
+
+
+class CheckError(Exception):
+    """Input that cannot be trusted. Always fatal — never worked around."""
+
+
+class Tool:
+    """One pinned tool: where its version lives, and how to find it there."""
+
+    def __init__(
+        self,
+        name: str,
+        label: str,
+        pin_file: str,
+        pattern: re.Pattern[str],
+        describe: str,
+    ) -> None:
+        self.name = name
+        self.label = label
+        self.pin_file = pin_file
+        # Three groups: everything before the version, the version, everything
+        # after. Rewriting group 2 and re-joining is the only edit ever made.
+        self.pattern = pattern
+        self.describe = describe
+
+
+TOOLS: Dict[str, Tool] = {
+    "gradle": Tool(
+        name="gradle",
+        label="Gradle",
+        pin_file="android/gradle/wrapper/gradle-wrapper.properties",
+        # Anchored to the start of the distributionUrl line, and stopping at
+        # the distribution filename's extension. distributionBase,
+        # distributionPath, zipStoreBase and zipStorePath are not matched at
+        # all, so an updater that touched one of them would fail the diff
+        # guard.
+        #
+        # Note that the match ends at `.zip` rather than at the end of the
+        # line. Everything a pattern matches but does not capture is dropped by
+        # `replace_pin`, so an ungrouped `\s*$` here would silently eat the
+        # file's trailing newline — which is precisely the kind of "changed
+        # something else" the guard exists to reject.
+        pattern=re.compile(
+            r"(?m)^(distributionUrl=\S*?/gradle-)(\d+\.\d+\.\d+)(-(?:all|bin)\.zip)"
+        ),
+        describe="the Gradle version in the wrapper's distributionUrl",
+    ),
+    "agp": Tool(
+        name="agp",
+        label="Android Gradle Plugin",
+        pin_file="android/settings.gradle",
+        pattern=re.compile(
+            r'(id\s+"com\.android\.application"\s+version\s+")([^"]+)(")'
+        ),
+        describe='the version of the "com.android.application" plugin',
+    ),
+    "kotlin": Tool(
+        name="kotlin",
+        label="Kotlin Gradle plugin",
+        pin_file="android/settings.gradle",
+        pattern=re.compile(
+            r'(id\s+"org\.jetbrains\.kotlin\.android"\s+version\s+")([^"]+)(")'
+        ),
+        describe='the version of the "org.jetbrains.kotlin.android" plugin',
+    ),
+}
+
+TOOL_NAMES: List[str] = list(TOOLS)
+
+
+def tool(name: str) -> Tool:
+    try:
+        return TOOLS[name]
+    except KeyError:
+        raise CheckError(
+            f"unknown tool {name!r} (expected one of {', '.join(TOOL_NAMES)})"
+        ) from None
+
+
+# -----------------------------------------------------------------------------
+# Versions
+# -----------------------------------------------------------------------------
+
+
+def parse_version(text: object, what: str) -> Version:
+    """Parse a bare MAJOR.MINOR.PATCH string, or raise CheckError."""
+    if not isinstance(text, str):
+        raise CheckError(f"{what} is not a string: {text!r}")
+    stripped = text.strip()
+    if not stripped:
+        raise CheckError(f"{what} is empty")
+    match = _VERSION_RE.match(stripped)
+    if match is None:
+        raise CheckError(
+            f"{what} is not a bare MAJOR.MINOR.PATCH version: {stripped!r}"
+        )
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def try_version(text: object) -> Optional[Version]:
+    """Parse a candidate from upstream, or return None if it is not a triple.
+
+    Used where a non-triple is *expected and fine* — an upstream index lists
+    prereleases and legacy tags alongside the releases we care about. Anywhere a
+    version has to be trustworthy (a pin, a CLI argument, a target) use
+    `parse_version`, which raises instead.
+    """
+    try:
+        return parse_version(text, "version")
+    except CheckError:
+        return None
+
+
+def looks_like_prerelease(text: object) -> bool:
+    """True when a rejected version string is recognisably a prerelease."""
+    return isinstance(text, str) and _PRERELEASE_RE.search(text) is not None
+
+
+def format_version(version: Version) -> str:
+    return "{}.{}.{}".format(*version)
+
+
+# -----------------------------------------------------------------------------
+# Reading, and rewriting, one pin
+# -----------------------------------------------------------------------------
+
+
+def find_pin(text: str, name: str, origin: str = "the pin file") -> str:
+    """The version `name` pins in `text`.
+
+    Exactly one match is required. Zero means the file no longer looks the way
+    this module thinks it does, and more than one means an edit could not be
+    aimed unambiguously — both are refusals, not guesses.
+    """
+    t = tool(name)
+    matches = t.pattern.findall(text)
+    if not matches:
+        raise CheckError(
+            f"{origin} does not contain {t.describe}; refusing to guess "
+            f"where {t.label}'s version lives"
+        )
+    if len(matches) > 1:
+        found = ", ".join(sorted({m[1] for m in matches}))
+        raise CheckError(
+            f"{origin} contains {len(matches)} matches for {t.describe} "
+            f"({found}); refusing to edit an ambiguous pin"
+        )
+    return matches[0][1]
+
+
+def replace_pin(text: str, name: str, version: str) -> str:
+    """`text` with `name`'s pin set to `version`, and nothing else changed.
+
+    Only capture group 2 of the tool's pattern is rewritten, so every byte
+    outside the version — comments, other plugins, other properties, ordering,
+    trailing whitespace — is carried through untouched by construction.
+    """
+    t = tool(name)
+    find_pin(text, name)  # raises unless there is exactly one place to edit
+    return t.pattern.sub(
+        lambda m: f"{m.group(1)}{version}{m.group(3)}", text, count=1
+    )
+
+
+def read_pin_file(repo_root: Path, name: str) -> str:
+    path = repo_root / tool(name).pin_file
+    if not path.is_file():
+        raise CheckError(f"missing {path} (a toolchain source of truth)")
+    return path.read_text(encoding="utf-8")
+
+
+def read_pin(repo_root: Path, name: str) -> str:
+    """The version `name` is pinned to in this checkout."""
+    return find_pin(read_pin_file(repo_root, name), name, tool(name).pin_file)
+
+
+def other_tools_in(name: str) -> List[str]:
+    """The other tools pinned in the same file as `name`.
+
+    `agp` and `kotlin` answer each other here; `gradle` answers nothing. This is
+    what lets the diff guard say "the AGP updater moved the Kotlin pin" instead
+    of the vaguer "something else in the file changed".
+    """
+    pin_file = tool(name).pin_file
+    return [
+        other
+        for other in TOOL_NAMES
+        if other != name and TOOLS[other].pin_file == pin_file
+    ]
+
+
+# -----------------------------------------------------------------------------
+# CLI: read one pin out of one file.
+# -----------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Print the version one file pins for one toolchain tool.",
+    )
+    parser.add_argument("--tool", required=True, choices=TOOL_NAMES)
+    parser.add_argument(
+        "--file",
+        help="Read this file instead of the pin file in --repo-root.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Repository root holding the pin files (default: this checkout).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.file:
+            path = Path(args.file)
+            if not path.is_file():
+                raise CheckError(f"no such file: {path}")
+            print(find_pin(path.read_text(encoding="utf-8"), args.tool, str(path)))
+        else:
+            root = (
+                Path(args.repo_root)
+                if args.repo_root
+                else Path(__file__).resolve().parent.parent
+            )
+            print(read_pin(root, args.tool))
+    except CheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/tooling/android_toolchain_update_guardrails_test.dart
+++ b/test/tooling/android_toolchain_update_guardrails_test.dart
@@ -1,0 +1,1914 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+/// Guardrails for the automatic Gradle / AGP / Kotlin updater (issue #362, the
+/// fifth and last phase).
+///
+/// The updater is allowed to do exactly one thing per tool: notice that a newer
+/// stable release exists *on the major line this repository already ships* and
+/// propose that one version number. Everything else about it is a safety
+/// boundary —
+///
+///   * it reads official, machine-readable, first-party release indexes, and
+///     only bare `MAJOR.MINOR.PATCH` releases from them — never a prerelease;
+///   * it treats "newest on our major" and "newest overall" as two independent
+///     answers, so a new major can never hide a later patch on the line we
+///     ship, and a later patch can never smuggle in a major;
+///   * it fails loudly on data it cannot trust rather than guessing a target,
+///     and it never proposes a downgrade;
+///   * each tool gets one reusable draft PR on its own exactly-named branch,
+///     changing one version string and nothing else;
+///   * a major changes nothing at all and files an issue instead;
+///   * it never merges, and the PRs it opens run the normal CI;
+///   * the Flutter CI fixer leaves its branches alone, so a toolchain bump that
+///     needs a migration stays red for a human.
+///
+/// The sharp edge here, and the reason this suite exists separately from the
+/// Flutter SDK one: **AGP and Kotlin are pinned in the same file.** A filename
+/// allowlist cannot tell those two updaters apart, so the boundary between them
+/// is enforced against the file's real before/after content, and that enforcement
+/// is tested against this repository's actual `android/settings.gradle`.
+///
+/// Every case here is offline: the classification tests feed fixture release
+/// indexes to the checker instead of touching the network, and nothing in this
+/// suite changes Linthra's actual toolchain pins.
+///
+/// Sibling coverage: test/tooling/flutter_sdk_update_guardrails_test.dart and
+/// test/tooling/dependency_update_guardrails_test.dart do the same for the
+/// Flutter SDK and Dart package updaters, and
+/// test/tooling/toolchain_pins_test.dart pins the versions themselves.
+/// test/tooling/android_toolchain_update_test.py unit-tests the parsers this
+/// suite drives end to end.
+void main() {
+  final String root = _repoRoot();
+
+  final String checker =
+      p.join(root, 'scripts', 'check_android_toolchain_update.py');
+  final String diffGuard =
+      p.join(root, 'scripts', 'check_toolchain_pin_diff.py');
+  final String writer = p.join(root, 'scripts', 'set_android_toolchain_pin.py');
+  final String fileGuard =
+      p.join(root, 'scripts', 'check_dependency_update_files.sh');
+
+  late final String workflow = _read(
+      root, p.join('.github', 'workflows', 'android-toolchain-updates.yml'));
+  late final String ci = _read(root, p.join('.github', 'workflows', 'ci.yml'));
+  late final String fixer =
+      _read(root, p.join('.github', 'workflows', 'flutter-ci-fixer.yml'));
+  late final String docs = _read(root, p.join('docs', 'dependency-updates.md'));
+
+  // The repository's real pin files. Using these rather than a synthetic
+  // snippet means the content guard is tested against the thing it actually
+  // guards, comments and all.
+  late final String settingsGradle =
+      _read(root, p.join('android', 'settings.gradle'));
+  late final String wrapperProperties = _read(root,
+      p.join('android', 'gradle', 'wrapper', 'gradle-wrapper.properties'));
+
+  setUpAll(() {
+    for (final String script in <String>[checker, diffGuard, writer]) {
+      expect(File(script).existsSync(), isTrue,
+          reason: 'Missing toolchain updater script: $script');
+    }
+    final ProcessResult python =
+        Process.runSync('python3', <String>['--version']);
+    expect(python.exitCode, 0,
+        reason: 'python3 is not on PATH; the toolchain checker requires it.');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Classification. CURRENT comes from the pin file (or --current); the two
+  // answers are the newest release on the pinned major and the newest overall.
+  // ---------------------------------------------------------------------------
+  group('classifying the gap between a pin and upstream', () {
+    test('the same version is no update', () {
+      for (final String tool in _tools) {
+        final _Tool r =
+            _check(checker, tool: tool, current: '8.2.3', versions: <String>[
+          '8.2.3',
+          '8.2.2',
+          '8.1.9',
+        ]);
+        expect(r.exitCode, 0, reason: r.describe());
+        expect(r.status, 'up-to-date', reason: 'tool: $tool');
+        expect(r.value('latest_in_current_major'), '8.2.3');
+        expect(r.value('major_status'), 'none');
+      }
+    });
+
+    test('a newer patch on the same minor is a patch update', () {
+      final _Tool r = _check(checker,
+          tool: 'gradle',
+          current: '8.2.3',
+          versions: <String>['8.2.4', '8.2.3']);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'patch');
+      expect(r.value('latest_in_current_major'), '8.2.4');
+    });
+
+    test('a newer minor on the same major is a minor update', () {
+      final _Tool r = _check(checker,
+          tool: 'agp', current: '8.2.3', versions: <String>['8.3.0', '8.2.9']);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'minor');
+      expect(r.value('latest_in_current_major'), '8.3.0');
+    });
+
+    test('a minor jump of several lines is still a minor update', () {
+      final _Tool r = _check(checker,
+          tool: 'kotlin',
+          current: '2.2.21',
+          versions: <String>['2.5.0', '2.2.30', '2.2.21']);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'minor');
+      expect(r.value('latest_in_current_major'), '2.5.0');
+    });
+
+    test('a newer major asks for an issue, never a pin change', () {
+      for (final String tool in _tools) {
+        final _Tool r =
+            _check(checker, tool: tool, current: '8.2.3', versions: <String>[
+          '9.0.0',
+          '8.2.3',
+        ]);
+        expect(r.exitCode, 0, reason: r.describe());
+        // The PR path is driven by `status`, which stays inside the pinned
+        // major. Nothing about a major can reach it.
+        expect(r.status, 'up-to-date', reason: 'tool: $tool');
+        expect(r.value('major_status'), 'available');
+        expect(r.value('major_latest'), '9.0.0');
+        expect(r.value('latest_in_current_major'), '8.2.3');
+      }
+    });
+
+    test('a patch on the current major and a newer major are reported together',
+        () {
+      // The requirement this updater exists for: being on 8.x with both 8.15.0
+      // and 9.0.0 published must produce *both* a draft PR for 8.15.0 and a
+      // major-upgrade issue for 9.0.0. Neither may swallow the other.
+      final _Tool r =
+          _check(checker, tool: 'gradle', current: '8.14.5', versions: <String>[
+        '9.0.0',
+        '8.15.0',
+        '8.14.5',
+      ]);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'minor',
+          reason: 'The newer 8.x release must still be proposed.');
+      expect(r.value('latest_in_current_major'), '8.15.0');
+      expect(r.value('major_status'), 'available');
+      expect(r.value('major_latest'), '9.0.0');
+      expect(r.value('latest'), '9.0.0');
+    });
+
+    test('a newer major never becomes the proposed version', () {
+      // The strongest form of the rule: whatever else happens, the version the
+      // PR path would write is on the pinned major line.
+      for (final List<String> versions in <List<String>>[
+        <String>['9.0.0', '8.2.3'],
+        <String>['9.9.9', '8.2.4', '8.2.3'],
+        <String>['10.0.0', '9.0.0', '8.3.0'],
+      ]) {
+        final _Tool r =
+            _check(checker, tool: 'agp', current: '8.2.3', versions: versions);
+        expect(r.exitCode, 0, reason: r.describe());
+        expect(r.value('latest_in_current_major').startsWith('8.'), isTrue,
+            reason: 'Proposed ${r.value('latest_in_current_major')} from '
+                '${versions.join(', ')}.');
+      }
+    });
+
+    test('the workflow matrices route each answer to the right job', () {
+      // pr_tools and issue_tools are what the workflow actually branches on,
+      // so they are asserted directly rather than inferred from the statuses.
+      final Directory tmp =
+          Directory.systemTemp.createTempSync('toolchain-outputs');
+      try {
+        final File outputs = File(p.join(tmp.path, 'github-output'));
+        final _Run run = _run(checker, <String>[
+          '--tool',
+          'gradle',
+          '--current',
+          '8.14.5',
+          '--versions-file',
+          _writeGradleIndex(tmp, <String>['9.0.0', '8.15.0', '8.14.5']),
+          '--github-output',
+          outputs.path,
+          '--quiet',
+        ]);
+        expect(run.exitCode, 0, reason: run.describe());
+        final String written = outputs.readAsStringSync();
+        expect(written, contains('pr_tools=["gradle"]'),
+            reason: 'A newer release on the pinned major must open a PR.');
+        expect(written, contains('issue_tools=["gradle"]'),
+            reason: 'A newer major must file an issue in the same run.');
+      } finally {
+        tmp.deleteSync(recursive: true);
+      }
+    });
+
+    test('nothing to do produces two empty matrices', () {
+      final Directory tmp =
+          Directory.systemTemp.createTempSync('toolchain-outputs');
+      try {
+        final File outputs = File(p.join(tmp.path, 'github-output'));
+        final _Run run = _run(checker, <String>[
+          '--tool',
+          'gradle',
+          '--current',
+          '8.14.5',
+          '--versions-file',
+          _writeGradleIndex(tmp, <String>['8.14.5', '8.14.4']),
+          '--github-output',
+          outputs.path,
+          '--quiet',
+        ]);
+        expect(run.exitCode, 0, reason: run.describe());
+        expect(outputs.readAsStringSync(), contains('pr_tools=[]'));
+        expect(outputs.readAsStringSync(), contains('issue_tools=[]'));
+      } finally {
+        tmp.deleteSync(recursive: true);
+      }
+    });
+
+    test('the highest version wins regardless of upstream ordering', () {
+      // Gradle's own index really does list a hotfix on an older line after a
+      // newer line, so "first entry" is not a safe answer for any of them.
+      for (final List<String> order in <List<String>>[
+        <String>['8.2.9', '8.5.0', '8.4.0'],
+        <String>['8.4.0', '8.2.9', '8.5.0'],
+        <String>['8.5.0', '8.4.0', '8.2.9'],
+      ]) {
+        for (final String tool in _tools) {
+          final _Tool r =
+              _check(checker, tool: tool, current: '8.2.3', versions: order);
+          expect(r.exitCode, 0, reason: r.describe());
+          expect(r.value('latest_in_current_major'), '8.5.0',
+              reason: '$tool with order ${order.join(', ')} chose '
+                  '${r.value('latest_in_current_major')}.');
+        }
+      }
+    });
+
+    test('the pin file is what is read when --current is omitted', () {
+      for (final String tool in _tools) {
+        final _Run run = _run(
+            checker, <String>['--tool', tool, '--latest', '99.0.0', '--json']);
+        expect(run.exitCode, 0, reason: run.describe());
+        final Map<String, dynamic> result = (jsonDecode(run.stdout)
+            as Map<String, dynamic>)[tool] as Map<String, dynamic>;
+        expect(result['current'], matches(RegExp(r'^\d+\.\d+\.\d+$')),
+            reason: '$tool must read its pin from ${result['pin_file']}.');
+      }
+    });
+
+    test('--latest classifies two versions with no index at all', () {
+      // The workflow uses this to compare the version already on an update
+      // branch against the version it is about to propose.
+      const Map<String, String> expected = <String, String>{
+        '8.2.3': 'up-to-date',
+        '8.2.4': 'patch',
+        '8.3.0': 'minor',
+        '9.0.0': 'major',
+      };
+      expected.forEach((String latest, String status) {
+        final _Run run = _run(checker, <String>[
+          '--tool',
+          'gradle',
+          '--current',
+          '8.2.3',
+          '--latest',
+          latest,
+          '--json',
+        ]);
+        expect(run.exitCode, 0, reason: run.describe());
+        final Map<String, dynamic> result = (jsonDecode(run.stdout)
+            as Map<String, dynamic>)['gradle'] as Map<String, dynamic>;
+        expect(result['status'], status);
+        expect(result['stable_confirmed'], 'false',
+            reason: 'No index was consulted, so nothing may claim the target '
+                'was confirmed published.');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Stable releases only.
+  // ---------------------------------------------------------------------------
+  group('following final releases and nothing else', () {
+    test('Gradle release candidates and milestones never become the target',
+        () {
+      final _Run run = _runWithIndex(
+        checker,
+        'gradle',
+        '8.2.3',
+        _gradleIndex(<String>[
+          '8.2.3'
+        ], extra: <Map<String, dynamic>>[
+          _gradleEntry('8.3.0-rc-1', isFinal: false, activeRc: true),
+          _gradleEntry('8.4.0-milestone-1',
+              isFinal: false, milestoneFor: '8.4.0'),
+        ]),
+      );
+      expect(run.exitCode, 0, reason: run.describe());
+      expect(run.tool('gradle').value('latest_in_current_major'), '8.2.3');
+      expect(run.tool('gradle').value('prereleases_skipped'), '2');
+    });
+
+    test('Gradle snapshots and nightlies are ignored', () {
+      final _Run run = _runWithIndex(
+        checker,
+        'gradle',
+        '8.2.3',
+        _gradleIndex(<String>[
+          '8.2.3'
+        ], extra: <Map<String, dynamic>>[
+          _gradleEntry('8.9.0-20260101000000+0000',
+              isFinal: false, snapshot: true),
+          _gradleEntry('8.9.0-20260102000000+0000',
+              isFinal: false, releaseNightly: true),
+        ]),
+      );
+      expect(run.exitCode, 0, reason: run.describe());
+      expect(run.tool('gradle').value('latest_in_current_major'), '8.2.3');
+    });
+
+    test('a Gradle entry that claims final but contradicts itself is refused',
+        () {
+      for (final Map<String, dynamic> contradiction in <Map<String, dynamic>>[
+        <String, dynamic>{'broken': true},
+        <String, dynamic>{'snapshot': true},
+        <String, dynamic>{'nightly': true},
+        <String, dynamic>{'activeRc': true},
+        <String, dynamic>{'rcFor': '8.9.0'},
+        <String, dynamic>{'milestoneFor': '8.9.0'},
+      ]) {
+        final Map<String, dynamic> entry = _gradleEntry('8.9.0');
+        entry.addAll(contradiction);
+        final _Run run = _runWithIndex(
+            checker,
+            'gradle',
+            '8.2.3',
+            _gradleIndex(<String>['8.2.3'],
+                extra: <Map<String, dynamic>>[entry]));
+        expect(run.exitCode, 0, reason: run.describe());
+        expect(run.tool('gradle').value('latest_in_current_major'), '8.2.3',
+            reason:
+                'A final release contradicted by ${contradiction.keys.first} '
+                'must not be proposed.');
+        expect(run.tool('gradle').value('notes'), contains('claims final'));
+      }
+    });
+
+    test('a Gradle release served from an unexpected host is refused', () {
+      final _Run run = _runWithIndex(
+        checker,
+        'gradle',
+        '8.2.3',
+        _gradleIndex(<String>[
+          '8.2.3'
+        ], extra: <Map<String, dynamic>>[
+          _gradleEntry('8.9.0',
+              downloadUrl: 'https://example.invalid/gradle-8.9.0-bin.zip'),
+        ]),
+      );
+      expect(run.exitCode, 0, reason: run.describe());
+      expect(run.tool('gradle').value('latest_in_current_major'), '8.2.3',
+          reason: 'A version this repository could not download from the '
+              'wrapper distribution host is not a version to propose.');
+      expect(run.tool('gradle').value('notes'), contains('downloadUrl'));
+    });
+
+    test("Gradle's historical two-component tags are not candidates", () {
+      // `8.14` is a real Gradle release, but a pin file may only hold a bare
+      // triple (test/tooling/toolchain_pins_test.dart), so it is not a version
+      // an automatic update may write.
+      final _Run run = _runWithIndex(
+        checker,
+        'gradle',
+        '8.2.3',
+        _gradleIndex(<String>['8.2.3'],
+            extra: <Map<String, dynamic>>[_gradleEntry('8.14')]),
+      );
+      expect(run.exitCode, 0, reason: run.describe());
+      expect(run.tool('gradle').value('latest_in_current_major'), '8.2.3');
+      expect(run.tool('gradle').value('malformed_skipped'), '1');
+    });
+
+    test('Maven prereleases of every flavour are ignored', () {
+      for (final String tool in <String>['agp', 'kotlin']) {
+        final _Tool r =
+            _check(checker, tool: tool, current: '8.2.3', versions: <String>[
+          '8.2.3',
+          '8.3.0-alpha01',
+          '8.3.0-beta02',
+          '8.3.0-rc01',
+          '8.3.0-RC',
+          '8.3.0-Beta1',
+          '8.3.0-M1',
+          '8.3.0-SNAPSHOT',
+          '8.3.0-eap-1',
+          '8.3.0-dev-123',
+          '8.3.0-preview',
+        ]);
+        expect(r.exitCode, 0, reason: r.describe());
+        expect(r.value('latest_in_current_major'), '8.2.3',
+            reason: '$tool proposed a prerelease.');
+        expect(int.parse(r.value('prereleases_skipped')), 10,
+            reason: '$tool did not recognise every prerelease flavour.');
+      }
+    });
+
+    test('Maven <latest> and <release> pointers are not obeyed', () {
+      // Kotlin's own metadata routinely names an -RC build in <release>.
+      final String metadata = _mavenMetadata(
+        'org.jetbrains.kotlin',
+        'kotlin-gradle-plugin',
+        <String>['2.2.21', '2.3.0-RC'],
+        latest: '2.3.0-RC',
+        release: '2.3.0-RC',
+      );
+      final _Run run = _runWithIndex(checker, 'kotlin', '2.2.21', metadata);
+      expect(run.exitCode, 0, reason: run.describe());
+      expect(run.tool('kotlin').value('latest_in_current_major'), '2.2.21');
+      expect(run.tool('kotlin').status, 'up-to-date');
+    });
+
+    test('reaching a target at all is the confirmation it is published', () {
+      final _Tool r = _check(checker,
+          tool: 'kotlin',
+          current: '2.2.21',
+          versions: <String>['2.2.30', '2.2.21']);
+      expect(r.value('stable_confirmed'), 'true');
+      expect(r.value('releases_considered'), '2');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Untrustworthy data.
+  // ---------------------------------------------------------------------------
+  group('untrustworthy data fails loudly instead of guessing', () {
+    test('the checker never proposes a downgrade', () {
+      for (final String tool in _tools) {
+        final _Tool r =
+            _check(checker, tool: tool, current: '8.9.9', versions: <String>[
+          '8.2.3',
+          '8.1.0',
+        ]);
+        expect(r.exitCode, 2, reason: r.describe());
+        expect(r.stderr, contains('downgrade'), reason: 'tool: $tool');
+      }
+    });
+
+    test('a downgrade is refused in --latest mode too', () {
+      final _Run run = _run(checker, <String>[
+        '--tool',
+        'agp',
+        '--current',
+        '8.2.3',
+        '--latest',
+        '8.2.2',
+      ]);
+      expect(run.exitCode, 2, reason: run.describe());
+      expect(run.stderr, contains('downgrade'));
+    });
+
+    const List<String> badVersions = <String>[
+      '',
+      'latest',
+      '8',
+      '8.2',
+      '8.2.3.4',
+      'v8.2.3',
+      '8.2.3-rc1',
+      '../../etc/passwd',
+    ];
+
+    for (final String bad in badVersions) {
+      test(
+          'a malformed --current (${bad.isEmpty ? '<empty>' : bad}) is rejected',
+          () {
+        final _Run run = _run(checker, <String>[
+          '--tool',
+          'gradle',
+          '--current',
+          bad,
+          '--latest',
+          '9.9.9'
+        ]);
+        expect(run.exitCode, 2, reason: run.describe());
+      });
+    }
+
+    test('a malformed --latest is rejected', () {
+      final _Run run = _run(checker, <String>[
+        '--tool',
+        'gradle',
+        '--current',
+        '8.2.3',
+        '--latest',
+        'newest',
+      ]);
+      expect(run.exitCode, 2, reason: run.describe());
+    });
+
+    // Upstream payloads that are structurally wrong, rather than merely full of
+    // versions we do not want.
+    final Map<String, String> brokenGradle = <String, String>{
+      'not JSON at all': '{{{',
+      'a JSON object instead of an array': '{"versions": []}',
+      'an empty array': '[]',
+      'an array of strings': '["8.2.3"]',
+      'an array with a null entry': '[null]',
+    };
+    brokenGradle.forEach((String why, String payload) {
+      test('a Gradle index that is $why is rejected', () {
+        final _Run run = _runWithIndex(checker, 'gradle', '8.2.3', payload);
+        expect(run.exitCode, 2, reason: run.describe());
+      });
+    });
+
+    final Map<String, String> brokenMaven = <String, String>{
+      'not XML at all': 'this is not xml',
+      'rooted somewhere else': '<html><body>nothing to see</body></html>',
+      'missing the versions element':
+          '<metadata><groupId>org.jetbrains.kotlin</groupId>'
+              '<artifactId>kotlin-gradle-plugin</artifactId></metadata>',
+      'empty of versions': '<metadata><groupId>org.jetbrains.kotlin</groupId>'
+          '<artifactId>kotlin-gradle-plugin</artifactId>'
+          '<versioning><versions></versions></versioning></metadata>',
+    };
+    brokenMaven.forEach((String why, String payload) {
+      test('Maven metadata that is $why is rejected', () {
+        final _Run run = _runWithIndex(checker, 'kotlin', '2.2.21', payload);
+        expect(run.exitCode, 2, reason: run.describe());
+      });
+    });
+
+    test('metadata for a different artifact is refused', () {
+      // A redirect or a copy-paste error in the URL must not silently make the
+      // updater track someone else's version numbers.
+      final _Run run = _runWithIndex(
+        checker,
+        'kotlin',
+        '2.2.21',
+        _mavenMetadata('com.example', 'something-else', <String>['9.9.9']),
+      );
+      expect(run.exitCode, 2, reason: run.describe());
+      expect(run.stderr, contains('wrong artifact'));
+    });
+
+    test('metadata declaring entities is refused before it is parsed', () {
+      final _Run run = _runWithIndex(
+        checker,
+        'kotlin',
+        '2.2.21',
+        '<!DOCTYPE metadata [<!ENTITY a "b">]>\n'
+            '${_mavenMetadata('org.jetbrains.kotlin', 'kotlin-gradle-plugin', <String>[
+              '2.2.21'
+            ])}',
+      );
+      expect(run.exitCode, 2, reason: run.describe());
+      expect(run.stderr, contains('refusing to parse'));
+    });
+
+    test('an index with no usable release at all is rejected', () {
+      final _Run run = _runWithIndex(
+        checker,
+        'agp',
+        '8.2.3',
+        _mavenMetadata('com.android.tools.build', 'gradle',
+            <String>['8.3.0-alpha01', '8.3.0-rc01']),
+      );
+      expect(run.exitCode, 2, reason: run.describe());
+      expect(run.stderr, contains('no usable stable release'));
+    });
+
+    test('an index that never mentions our own major line is rejected', () {
+      // Not "the tool dropped a line" — an index that has no 8.x at all is not
+      // describing the tool we think it is, and acting on it would be acting
+      // on data we cannot read.
+      final _Run run = _runWithIndex(
+          checker,
+          'agp',
+          '8.2.3',
+          _mavenMetadata(
+              'com.android.tools.build', 'gradle', <String>['9.1.0']));
+      expect(run.exitCode, 2, reason: run.describe());
+      expect(run.stderr, contains('pinned major line'));
+    });
+
+    test('a missing index file is rejected', () {
+      final _Run run = _run(checker, <String>[
+        '--tool',
+        'gradle',
+        '--current',
+        '8.2.3',
+        '--versions-file',
+        p.join(Directory.systemTemp.path, 'definitely-not-here.json'),
+      ]);
+      expect(run.exitCode, 2, reason: run.describe());
+    });
+
+    test('a pin that is unknown upstream is reported but still classified', () {
+      // Advisory rather than fatal: the classification against the major line
+      // is still sound, but a human should know the index has never heard of
+      // the version we ship.
+      final _Tool r = _check(checker,
+          tool: 'kotlin',
+          current: '2.2.21',
+          versions: <String>['2.2.30', '2.2.20']);
+      expect(r.exitCode, 0, reason: r.describe());
+      expect(r.status, 'patch');
+      expect(r.value('notes'), contains('not listed'));
+    });
+
+    test('the checker never writes anything itself', () {
+      // Detection and publication are separate on purpose: the script only
+      // classifies, so nothing it does can move a pin.
+      final String source = File(checker).readAsStringSync();
+      for (final String forbidden in <String>[
+        'write_text',
+        'git commit',
+        'git push',
+        'gh pr create',
+        'gh issue create',
+      ]) {
+        expect(source.contains(forbidden), isFalse,
+            reason: 'scripts/check_android_toolchain_update.py contains '
+                '`$forbidden`. It may only read and classify; publishing '
+                'belongs to the workflow.');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The file allowlist. Which files an automatic update may move at all.
+  // ---------------------------------------------------------------------------
+  group('the allowlist guard admits only each tool\'s own pin file', () {
+    const Map<String, String> ownFile = <String, String>{
+      'gradle': 'android/gradle/wrapper/gradle-wrapper.properties',
+      'agp': 'android/settings.gradle',
+      'kotlin': 'android/settings.gradle',
+    };
+
+    ownFile.forEach((String kind, String path) {
+      test('$kind accepts $path alone', () {
+        final ProcessResult r = _runFileGuard(fileGuard, kind, <String>[path]);
+        expect(r.exitCode, 0,
+            reason: 'stdout: ${r.stdout}\nstderr: ${r.stderr}');
+      });
+    });
+
+    test('an empty change set passes for every kind', () {
+      for (final String kind in _tools) {
+        final ProcessResult r =
+            _runFileGuard(fileGuard, kind, const <String>[]);
+        expect(r.exitCode, 0, reason: 'kind: $kind, stderr: ${r.stderr}');
+      }
+    });
+
+    // One case per rule the issue spells out. If someone widens an allowlist,
+    // the specific protection they removed is named in the failure.
+    const Map<String, String> forbidden = <String, String>{
+      'lib/main.dart': 'application code',
+      'lib/core/app_info.dart': 'the in-app version',
+      'test/core/app_info_version_test.dart': 'test code',
+      'pubspec.yaml': 'dependency constraints',
+      'pubspec.lock': 'the resolved dependency set',
+      '.flutter-version': 'the Flutter SDK pin',
+      '.java-version': 'the JDK pin',
+      'metadata/io.github.thezupzup.linthra.yml': 'F-Droid metadata',
+      'fastlane/metadata/android/en-US/changelogs/201999.txt': 'Fastlane files',
+      'docs/release-notes/v0.2.1.md': 'release notes',
+      'android/key.properties': 'signing configuration',
+      'android/app/linthra-release.jks': 'signing material',
+      'android/app/build.gradle': 'the app module build logic',
+      'LICENSE': 'the license',
+      '.github/workflows/ci.yml': 'CI configuration',
+      'docs/dependency-updates.md': 'documentation',
+      'scripts/check_dependency_update_files.sh': 'the guard itself',
+    };
+
+    forbidden.forEach((String path, String why) {
+      test('$path is rejected for every automatic toolchain kind — $why', () {
+        for (final String kind in _tools) {
+          final ProcessResult r =
+              _runFileGuard(fileGuard, kind, <String>[ownFile[kind]!, path]);
+          expect(r.exitCode, isNot(0),
+              reason: 'An automatic $kind update must not change $why.\n'
+                  'stdout: ${r.stdout}');
+          expect(r.stderr, contains(path),
+              reason: 'The rejection should name the offending path.');
+        }
+      });
+    });
+
+    test('Gradle cannot reach the file AGP and Kotlin share, or vice versa',
+        () {
+      expect(
+          _runFileGuard(
+                  fileGuard, 'gradle', <String>['android/settings.gradle'])
+              .exitCode,
+          isNot(0),
+          reason: 'A Gradle wrapper bump must not touch the plugin pins.');
+      for (final String kind in <String>['agp', 'kotlin']) {
+        expect(
+            _runFileGuard(fileGuard, kind, <String>[
+              'android/gradle/wrapper/gradle-wrapper.properties'
+            ]).exitCode,
+            isNot(0),
+            reason: 'A $kind bump must not touch the Gradle wrapper.');
+      }
+    });
+
+    test('the earlier updaters keep their own narrower reach', () {
+      // Adding three kinds must not have turned the allowlists into one union.
+      for (final MapEntry<String, String> pair in <String, String>{
+        'dart-packages': 'pubspec.lock',
+        'flutter-sdk': '.flutter-version',
+      }.entries) {
+        expect(
+            _runFileGuard(fileGuard, pair.key, <String>[pair.value]).exitCode,
+            0,
+            reason: '${pair.key} must still accept ${pair.value}.');
+        for (final String path in <String>[
+          'android/settings.gradle',
+          'android/gradle/wrapper/gradle-wrapper.properties',
+        ]) {
+          expect(_runFileGuard(fileGuard, pair.key, <String>[path]).exitCode,
+              isNot(0),
+              reason: '${pair.key} must not be able to write $path.');
+        }
+      }
+      for (final String kind in _tools) {
+        for (final String path in <String>[
+          'pubspec.lock',
+          '.flutter-version'
+        ]) {
+          expect(
+              _runFileGuard(fileGuard, kind, <String>[path]).exitCode, isNot(0),
+              reason: '$kind must not be able to write $path.');
+        }
+      }
+    });
+
+    test('an unknown kind fails instead of allowing everything', () {
+      final ProcessResult r =
+          _runFileGuard(fileGuard, 'anything-goes', <String>['lib/main.dart']);
+      expect(r.exitCode, isNot(0));
+      expect(r.stderr, contains('unknown --kind'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The content guard. This is the part a filename cannot do, tested against
+  // the repository's real pin files.
+  // ---------------------------------------------------------------------------
+  group('the content guard bounds what changed inside the file', () {
+    test('a plain AGP bump is accepted', () {
+      final _Run r = _runDiffGuard(diffGuard, 'agp', settingsGradle,
+          _bumpAgp(settingsGradle, '9999.1.2'));
+      expect(r.exitCode, 2, reason: 'sanity: that target crosses a major');
+
+      final _Run ok = _runDiffGuard(diffGuard, 'agp', settingsGradle,
+          _bumpAgp(settingsGradle, _bumpPatch(_agpPin(settingsGradle))));
+      expect(ok.exitCode, 0, reason: ok.describe());
+      expect(ok.stdout, contains('changes nothing else'));
+    });
+
+    test('a plain Kotlin bump is accepted', () {
+      final _Run ok = _runDiffGuard(diffGuard, 'kotlin', settingsGradle,
+          _bumpKotlin(settingsGradle, _bumpPatch(_kotlinPin(settingsGradle))));
+      expect(ok.exitCode, 0, reason: ok.describe());
+    });
+
+    test('a plain Gradle bump is accepted', () {
+      final _Run ok = _runDiffGuard(
+          diffGuard,
+          'gradle',
+          wrapperProperties,
+          _bumpGradle(
+              wrapperProperties, _bumpPatch(_gradlePin(wrapperProperties))));
+      expect(ok.exitCode, 0, reason: ok.describe());
+    });
+
+    test('the AGP updater cannot alter the Kotlin pin', () {
+      final String after = _bumpKotlin(
+        _bumpAgp(settingsGradle, _bumpPatch(_agpPin(settingsGradle))),
+        _bumpPatch(_kotlinPin(settingsGradle)),
+      );
+      final _Run r = _runDiffGuard(diffGuard, 'agp', settingsGradle, after);
+      expect(r.exitCode, 2, reason: r.describe());
+      expect(r.stderr, contains('Kotlin Gradle plugin'),
+          reason: 'The failure must name what was moved that should not have '
+              'been — the two pins share android/settings.gradle, so this is '
+              'the case a filename allowlist cannot catch.');
+    });
+
+    test('the Kotlin updater cannot alter the AGP pin', () {
+      final String after = _bumpAgp(
+        _bumpKotlin(settingsGradle, _bumpPatch(_kotlinPin(settingsGradle))),
+        _bumpPatch(_agpPin(settingsGradle)),
+      );
+      final _Run r = _runDiffGuard(diffGuard, 'kotlin', settingsGradle, after);
+      expect(r.exitCode, 2, reason: r.describe());
+      expect(r.stderr, contains('Android Gradle Plugin'));
+    });
+
+    test('neither updater may rewrite a comment or unrelated content', () {
+      final String bumped =
+          _bumpAgp(settingsGradle, _bumpPatch(_agpPin(settingsGradle)));
+      for (final String tampered in <String>[
+        // A reworded comment.
+        bumped.replaceFirst('// Stay on AGP 8.x', '// Anything goes now'),
+        // A deleted comment line.
+        bumped.replaceFirst(RegExp(r'^\s*//.*\n', multiLine: true), ''),
+        // An extra plugin.
+        bumped.replaceFirst(
+            'include ":app"', 'include ":app"\ninclude ":evil"'),
+        // A whitespace-only change.
+        '$bumped\n',
+        // A different repository in pluginManagement.
+        bumped.replaceFirst('mavenCentral()', 'maven { url "https://evil" }'),
+      ]) {
+        final _Run r =
+            _runDiffGuard(diffGuard, 'agp', settingsGradle, tampered);
+        expect(r.exitCode, 2,
+            reason: 'An automatic update may rewrite one version string and '
+                'nothing else.\n${r.describe()}');
+        expect(r.stderr, contains('more than'));
+      }
+    });
+
+    test('the Gradle updater may not rewrite the other wrapper properties', () {
+      final String bumped = _bumpGradle(
+          wrapperProperties, _bumpPatch(_gradlePin(wrapperProperties)));
+      for (final String tampered in <String>[
+        bumped.replaceFirst('distributionPath=', 'distributionPath=x'),
+        bumped.replaceFirst('zipStorePath=', 'zipStorePath=x'),
+        bumped.replaceFirst('distributionBase=GRADLE_USER_HOME',
+            'distributionBase=SOMEWHERE_ELSE'),
+        '$bumped\nnetworkTimeout=10000\n',
+        // The distribution flavour is not the updater's to change either.
+        bumped.replaceFirst('-all.zip', '-bin.zip'),
+      ]) {
+        final _Run r =
+            _runDiffGuard(diffGuard, 'gradle', wrapperProperties, tampered);
+        expect(r.exitCode, 2, reason: r.describe());
+      }
+    });
+
+    test('a downgrade is refused by the guard as well as by the checker', () {
+      final String older = _bumpAgp(settingsGradle, '8.0.0');
+      final _Run r = _runDiffGuard(diffGuard, 'agp', older, settingsGradle);
+      expect(r.exitCode, 0, reason: 'sanity: forwards is fine');
+
+      final _Run back = _runDiffGuard(diffGuard, 'agp', settingsGradle, older);
+      expect(back.exitCode, 2, reason: back.describe());
+      expect(back.stderr, contains('downgrade'));
+    });
+
+    test('crossing a major is refused by the guard', () {
+      for (final MapEntry<String, String> pair in <String, String>{
+        'agp': _bumpAgp(settingsGradle, '9.0.0'),
+        'kotlin': _bumpKotlin(settingsGradle, '3.0.0'),
+      }.entries) {
+        final _Run r =
+            _runDiffGuard(diffGuard, pair.key, settingsGradle, pair.value);
+        expect(r.exitCode, 2, reason: r.describe());
+        expect(r.stderr, contains('major'));
+      }
+      final _Run gradle = _runDiffGuard(diffGuard, 'gradle', wrapperProperties,
+          _bumpGradle(wrapperProperties, '9.0.0'));
+      expect(gradle.exitCode, 2, reason: gradle.describe());
+    });
+
+    test('a prerelease target is refused by the guard', () {
+      final _Run r = _runDiffGuard(diffGuard, 'kotlin', settingsGradle,
+          _bumpKotlin(settingsGradle, '2.9.0-RC2'));
+      expect(r.exitCode, 2, reason: r.describe());
+    });
+
+    test('a file with no recognisable pin is refused, not guessed at', () {
+      final _Run r = _runDiffGuard(
+          diffGuard, 'agp', 'plugins {\n}\n', 'plugins {\n  // nothing\n}\n');
+      expect(r.exitCode, 2, reason: r.describe());
+      expect(r.stderr, contains('refusing to guess'));
+    });
+
+    test('an ambiguous file with two matching pins is refused', () {
+      final String doubled = settingsGradle.replaceFirstMapped(
+        _agpRe,
+        (Match m) => '${m[0]}\n'
+            '    id "com.android.application" version "8.0.0" apply false',
+      );
+      final _Run r = _runDiffGuard(diffGuard, 'agp', doubled, doubled);
+      expect(r.exitCode, 2, reason: r.describe());
+      expect(r.stderr, contains('ambiguous'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The writer.
+  // ---------------------------------------------------------------------------
+  group('the writer moves one version and refuses the rest', () {
+    test('it writes the pin and leaves the rest of the file byte-identical',
+        () {
+      for (final String tool in _tools) {
+        final _Sandbox sandbox = _Sandbox(root);
+        try {
+          final String before = sandbox.pinFileText(tool);
+          final String current = sandbox.pin(tool);
+          final String target = _bumpPatch(current);
+          final _Run write = _run(writer, <String>[
+            '--tool',
+            tool,
+            '--version',
+            target,
+            '--repo-root',
+            sandbox.path,
+          ]);
+          expect(write.exitCode, 0, reason: write.describe());
+          expect(sandbox.pin(tool), target);
+
+          // The strongest statement available: putting the old version back
+          // reproduces the previous file exactly.
+          final _Run guard =
+              _runDiffGuard(diffGuard, tool, before, sandbox.pinFileText(tool));
+          expect(guard.exitCode, 0, reason: '$tool: ${guard.describe()}');
+        } finally {
+          sandbox.dispose();
+        }
+      }
+    });
+
+    test('an automatic AGP write leaves the Kotlin pin alone, and vice versa',
+        () {
+      for (final MapEntry<String, String> pair in <String, String>{
+        'agp': 'kotlin',
+        'kotlin': 'agp',
+      }.entries) {
+        final _Sandbox sandbox = _Sandbox(root);
+        try {
+          final String otherBefore = sandbox.pin(pair.value);
+          final _Run write = _run(writer, <String>[
+            '--tool',
+            pair.key,
+            '--version',
+            _bumpPatch(sandbox.pin(pair.key)),
+            '--repo-root',
+            sandbox.path,
+          ]);
+          expect(write.exitCode, 0, reason: write.describe());
+          expect(sandbox.pin(pair.value), otherBefore,
+              reason: '${pair.key} moved ${pair.value} in the shared file.');
+        } finally {
+          sandbox.dispose();
+        }
+      }
+    });
+
+    test('rerunning with the same version is refused, so reruns are quiet', () {
+      final _Sandbox sandbox = _Sandbox(root);
+      try {
+        final _Run write = _run(writer, <String>[
+          '--tool',
+          'kotlin',
+          '--version',
+          sandbox.pin('kotlin'),
+          '--repo-root',
+          sandbox.path,
+        ]);
+        expect(write.exitCode, 2, reason: write.describe());
+        expect(write.stderr, contains('already pinned'));
+      } finally {
+        sandbox.dispose();
+      }
+    });
+
+    test('a downgrade, a major and a malformed version are all refused', () {
+      const Map<String, String> refusals = <String, String>{
+        '8.0.0': 'downgrade',
+        '9.0.0': 'major',
+        '8.99': 'MAJOR.MINOR.PATCH',
+        '8.99.0-rc1': 'MAJOR.MINOR.PATCH',
+      };
+      refusals.forEach((String version, String expected) {
+        final _Sandbox sandbox = _Sandbox(root);
+        try {
+          final _Run write = _run(writer, <String>[
+            '--tool',
+            'agp',
+            '--version',
+            version,
+            '--repo-root',
+            sandbox.path,
+          ]);
+          expect(write.exitCode, 2, reason: write.describe());
+          expect(write.stderr, contains(expected));
+          expect(sandbox.pinFileText('agp'),
+              _read(root, p.join('android', 'settings.gradle')),
+              reason: 'A refused write must leave the file untouched.');
+        } finally {
+          sandbox.dispose();
+        }
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // End to end, against a real git repository.
+  // ---------------------------------------------------------------------------
+  group('an update branch, checked the way CI checks it', () {
+    test('the guards accept a clean single-tool update and reject the rest',
+        () {
+      for (final String tool in _tools) {
+        final _GitSandbox sandbox = _GitSandbox(root);
+        try {
+          final _Run write = _run(writer, <String>[
+            '--tool',
+            tool,
+            '--version',
+            _bumpPatch(sandbox.pin(tool)),
+            '--repo-root',
+            sandbox.path,
+          ]);
+          expect(write.exitCode, 0, reason: write.describe());
+
+          expect(sandbox.fileGuard(fileGuard, tool).exitCode, 0,
+              reason: '$tool: the file guard rejected its own pin file.');
+          final _Run content = sandbox.contentGuard(diffGuard, tool);
+          expect(content.exitCode, 0, reason: '$tool: ${content.describe()}');
+        } finally {
+          sandbox.dispose();
+        }
+      }
+    });
+
+    test('an update that also touches app, release or signing files is caught',
+        () {
+      for (final String extra in <String>[
+        'lib/main.dart',
+        'pubspec.yaml',
+        'pubspec.lock',
+        '.flutter-version',
+        '.java-version',
+        'metadata/io.github.thezupzup.linthra.yml',
+        'fastlane/metadata/android/en-US/changelogs/201999.txt',
+        'docs/release-notes/v0.2.1.md',
+        'android/key.properties',
+        'LICENSE',
+        '.github/workflows/ci.yml',
+      ]) {
+        final _GitSandbox sandbox = _GitSandbox(root);
+        try {
+          _run(writer, <String>[
+            '--tool',
+            'agp',
+            '--version',
+            _bumpPatch(sandbox.pin('agp')),
+            '--repo-root',
+            sandbox.path,
+          ]);
+          sandbox.touch(extra);
+
+          expect(sandbox.fileGuard(fileGuard, 'agp').exitCode, isNot(0),
+              reason: 'The file guard let $extra ride along on an AGP update.');
+          final _Run content = sandbox.contentGuard(diffGuard, 'agp');
+          expect(content.exitCode, isNot(0),
+              reason: 'The content guard let $extra ride along.\n'
+                  '${content.describe()}');
+          expect(content.stderr, contains(extra));
+        } finally {
+          sandbox.dispose();
+        }
+      }
+    });
+
+    test('an AGP branch that also moves Kotlin is caught by the content guard',
+        () {
+      // The case the whole content guard exists for: the file allowlist is
+      // *satisfied* here, because only android/settings.gradle changed.
+      final _GitSandbox sandbox = _GitSandbox(root);
+      try {
+        _run(writer, <String>[
+          '--tool',
+          'agp',
+          '--version',
+          _bumpPatch(sandbox.pin('agp')),
+          '--repo-root',
+          sandbox.path,
+        ]);
+        _run(writer, <String>[
+          '--tool',
+          'kotlin',
+          '--version',
+          _bumpPatch(sandbox.pin('kotlin')),
+          '--repo-root',
+          sandbox.path,
+        ]);
+
+        expect(sandbox.fileGuard(fileGuard, 'agp').exitCode, 0,
+            reason: 'Only settings.gradle changed, so the filename allowlist '
+                'is happy — which is exactly the blind spot.');
+        final _Run content = sandbox.contentGuard(diffGuard, 'agp');
+        expect(content.exitCode, isNot(0), reason: content.describe());
+        expect(content.stderr, contains('Kotlin Gradle plugin'));
+      } finally {
+        sandbox.dispose();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The workflow.
+  // ---------------------------------------------------------------------------
+  group('the update workflow stays inside its boundaries', () {
+    test('it runs weekly and can be dispatched by hand', () {
+      expect(workflow, contains('schedule:'));
+      expect(workflow, contains('cron:'));
+      expect(workflow, contains('workflow_dispatch:'),
+          reason: 'A manual run must be possible, using the same logic.');
+    });
+
+    test('detection is delegated to the testable script', () {
+      expect(workflow, contains('scripts/check_android_toolchain_update.py'),
+          reason: 'The version comparison must not live in YAML, where it '
+              'cannot be tested offline.');
+    });
+
+    test('it uses the three toolchain branches, exactly named', () {
+      expect(workflow, contains(r'UPDATE_BRANCH: toolchain/${{ matrix.tool }}'),
+          reason: 'Each tool needs its own reusable branch.');
+      expect(workflow.contains('UPDATE_BRANCH: deps/'), isFalse,
+          reason: 'A deps/ branch would inherit the Dart updater\'s '
+              'lockfile-only allowlist.');
+      expect(workflow.contains('toolchain/flutter-sdk'), isFalse,
+          reason: 'This updater must not publish onto the SDK updater\'s '
+              'branch.');
+    });
+
+    test('its own GITHUB_TOKEN is read-only at the top level', () {
+      expect(workflow, contains('permissions:\n  contents: read'),
+          reason: 'Writes must be opted into per job, not granted globally.');
+    });
+
+    test('it never merges anything', () {
+      for (final String forbidden in <String>[
+        'gh pr merge',
+        '--auto',
+        '--admin',
+        '--squash',
+        '--rebase',
+        'enable_pr_auto_merge',
+      ]) {
+        expect(workflow.contains(forbidden), isFalse,
+            reason: 'The update workflow contains `$forbidden`. Nothing may '
+                'ever merge into main automatically (#362).');
+      }
+    });
+
+    test('it never migrates anything', () {
+      // No SDK, no Gradle, no analyzer, no formatter, no code generation: this
+      // workflow has no way to "fix" the repo even if it wanted to.
+      for (final String forbidden in <String>[
+        'setup-flutter',
+        'setup-java',
+        'dart format',
+        'gradlew',
+        'codex',
+        'build_runner',
+      ]) {
+        expect(workflow.contains(forbidden), isFalse,
+            reason: 'The toolchain updater must not run `$forbidden`. A bump '
+                'that breaks the build stays red for a human.');
+      }
+    });
+  });
+
+  group('the draft PR job', () {
+    late final String job = _jobSection(workflow, 'toolchain-pr');
+
+    test('it fans out over the tools that have an in-major update', () {
+      expect(job, contains('fromJSON(needs.check.outputs.pr_tools)'));
+      expect(job, contains("needs.check.outputs.pr_tools != '[]'"),
+          reason: 'A week with nothing to publish must not start this job.');
+    });
+
+    test('it proposes the newest release on the pinned major, never the newest',
+        () {
+      expect(job, contains('latest_in_current_major'),
+          reason: 'The PR target must come from the current major line.');
+      expect(job.contains(r'results)[matrix.tool].latest }}'), isFalse,
+          reason: 'The overall newest release must never become the PR target '
+              '— that is how a major would sneak into a pin.');
+    });
+
+    test('it refuses a target that is not on the pinned major', () {
+      expect(job, contains(r'"${TARGET%%.*}" != "${CURRENT%%.*}"'),
+          reason: 'A last-line check that the target shares the pinned major, '
+              'in case the job inputs were tampered with.');
+    });
+
+    test('it publishes with the dedicated token so the PR runs normal CI', () {
+      expect(job, contains(r'secrets.DEPENDENCY_UPDATE_TOKEN'),
+          reason: 'Reuse the existing publication secret rather than opening '
+              'a PR that no CI would look at.');
+      expect(job.contains(r'GH_TOKEN: ${{ github.token }}'), isFalse,
+          reason: 'github.token cannot retrigger CI on the PR it opens.');
+    });
+
+    test('a missing token fails the run instead of opening an unchecked PR',
+        () {
+      expect(job, contains('DEPENDENCY_UPDATE_TOKEN is required'));
+      expect(job, contains('exit 1'));
+    });
+
+    test('a run with nothing to publish never reaches the token check', () {
+      // The requirement is a pair: fail loudly when publishing is needed, and
+      // never fail a quiet week for want of a secret.
+      final String check = _jobSection(workflow, 'check');
+      expect(check.contains('DEPENDENCY_UPDATE_TOKEN'), isFalse,
+          reason: 'The detection job must not require the publication token; '
+              'a week with no update must not fail.');
+      final String issueJob = _jobSection(workflow, 'major-issue');
+      expect(issueJob.contains('DEPENDENCY_UPDATE_TOKEN'), isFalse,
+          reason: 'A major files an issue, which needs no CI and no token.');
+    });
+
+    test('the PR is a draft against main', () {
+      expect(job, contains('gh pr create'));
+      expect(job, contains('--draft'));
+      expect(job, contains('--base main'));
+    });
+
+    test('it reuses one PR per tool instead of opening duplicates every week',
+        () {
+      expect(job, contains('--head "\$UPDATE_BRANCH"'),
+          reason: 'The existing-PR lookup has to be scoped to this tool\'s '
+              'branch, or the three tools would fight over one PR.');
+      expect(job, contains('--state open --json number'));
+      expect(job, contains('gh pr edit'));
+    });
+
+    test('a rerun with the same target pushes nothing at all', () {
+      expect(job, contains('branch_matches_target'));
+      expect(job, contains('already proposes'),
+          reason: 'Repeated runs must be idempotent: same target, no new '
+              'commit, no force-push.');
+    });
+
+    test('it refuses to force-push over commits it did not write', () {
+      expect(job, contains('--force-with-lease'),
+          reason: 'A plain force push could drop a concurrent update.');
+      expect(job, contains('foreign'));
+      expect(job, contains(r'"$author" == "github-actions[bot]"'),
+          reason: 'Ownership is decided by author *and* subject, so a human '
+              'commit on the branch is always foreign.');
+      expect(job, contains(r'"$subject_line" == "$subject_prefix"*'),
+          reason: 'The subject prefix is per tool, so a Kotlin commit on the '
+              'AGP branch is foreign too.');
+    });
+
+    test('it will not rewind its own branch to an older version', () {
+      expect(job, contains('Refusing to rewind the open PR'));
+    });
+
+    test('it re-checks its own blast radius before committing', () {
+      expect(job, contains(r'check_dependency_update_files.sh --kind "$TOOL"'),
+          reason: 'Which files moved, checked before a commit exists.');
+      expect(job,
+          contains(r'check_toolchain_pin_diff.py --kind "$TOOL" --base HEAD'),
+          reason: 'What changed inside them, checked before a commit exists — '
+              'this is the half a filename cannot do.');
+    });
+
+    test('it stages one file and never the whole tree', () {
+      expect(job, contains(r'git add -- "$PIN_FILE"'));
+      expect(job.contains('git add -A'), isFalse);
+      expect(job.contains('git add .\n'), isFalse);
+    });
+
+    test('the PR body carries everything a reviewer needs', () {
+      for (final String required in <String>[
+        'Currently pinned',
+        'Proposed',
+        'Source',
+        'confirmed',
+        'Prereleases',
+        'may be red',
+        'Flutter compatibility',
+        'F-Droid',
+        'reproducib',
+        'auto-merges',
+        '#362',
+      ]) {
+        expect(job, contains(required),
+            reason: 'The PR body must mention "$required".');
+      }
+    });
+  });
+
+  group('the major upgrade job', () {
+    late final String job = _jobSection(workflow, 'major-issue');
+
+    test('it fans out over the tools that have a newer major', () {
+      expect(job, contains('fromJSON(needs.check.outputs.issue_tools)'));
+      expect(job, contains("needs.check.outputs.issue_tools != '[]'"));
+    });
+
+    test('it files an issue and opens no PR', () {
+      expect(job, contains('gh issue create'));
+      expect(job, contains('gh issue edit'));
+      expect(job.contains('gh pr create'), isFalse,
+          reason: 'A major release must never produce a pin-bump PR.');
+    });
+
+    test('it changes no repository file, and cannot', () {
+      for (final String forbidden in <String>[
+        'git commit',
+        'git push',
+        'git checkout',
+        'actions/checkout',
+        'set_android_toolchain_pin',
+      ]) {
+        expect(job.contains(forbidden), isFalse,
+            reason: 'The major path runs `$forbidden`. A major update must '
+                'change nothing in the repository (#362). It does not even '
+                'check the repository out.');
+      }
+    });
+
+    test('it needs no publication token, only permission to file an issue', () {
+      expect(job, contains('issues: write'));
+      expect(job, contains('contents: read'));
+      expect(job.contains('DEPENDENCY_UPDATE_TOKEN'), isFalse);
+    });
+
+    test('it updates the open issue instead of refiling every week', () {
+      expect(job, contains('select(.title == env.TITLE)'),
+          reason: 'The weekly run must find its own issue by title and edit '
+              'it, or the maintainer gets a duplicate every Monday.');
+      expect(job, contains(r'title="$LABEL ${major}.x is available'),
+          reason: 'The title has to be stable for a whole major line, and '
+              'distinct per tool, or the three would collide.');
+    });
+
+    test('the issue body says what a maintainer needs to decide', () {
+      for (final String required in <String>[
+        'Currently pinned',
+        'Newest stable',
+        'Newest stable on the pinned major',
+        'Source',
+        'stays manual',
+        'Flutter compatibility',
+        'F-Droid',
+        'reproduc',
+        '#362',
+      ]) {
+        expect(job, contains(required),
+            reason: 'The issue body must mention "$required".');
+      }
+    });
+
+    test('an AGP major warns about the legacy variant/versionCode behaviour',
+        () {
+      expect(job, contains(r'"$TOOL" == "agp"'),
+          reason: 'The AGP major issue needs its own warning.');
+      for (final String required in <String>[
+        'applicationVariants',
+        'versionCode',
+        'F-Droid',
+      ]) {
+        expect(job, contains(required),
+            reason: 'The AGP major warning must mention "$required": Linthra '
+                'still builds per-ABI version codes from the legacy variant '
+                'API, and published version codes can never be reused.');
+      }
+    });
+
+    test('it says a newer major does not block the in-major update', () {
+      expect(job, contains('tracked separately'),
+          reason: 'The issue should make clear that the ordinary draft PR for '
+              'the pinned major line still happens.');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The boundary is re-checked on the PR itself, and the fixer stays away.
+  // ---------------------------------------------------------------------------
+  group('the boundary is re-checked on the PR itself', () {
+    test('ci.yml matches the three automatic branches exactly', () {
+      for (final String branch in <String>[
+        'toolchain/gradle',
+        'toolchain/agp',
+        'toolchain/kotlin',
+      ]) {
+        expect(ci, contains("github.head_ref == '$branch'"),
+            reason: 'CI must guard $branch against the real PR diff.');
+      }
+      expect(ci.contains("startsWith(github.head_ref, 'toolchain/')"), isFalse,
+          reason: 'A prefix match would hold every future human toolchain/* PR '
+              'to the pin-only rule, and could not tell which of the three '
+              'pins the PR is allowed to move. #373 fixed exactly this for the '
+              'Flutter SDK branch; do not reintroduce it.');
+    });
+
+    test('ci.yml runs both guards, the same two the updater ran', () {
+      expect(
+          ci,
+          contains(
+              r'./scripts/check_dependency_update_files.sh --kind "$kind"'));
+      expect(ci, contains('scripts/check_toolchain_pin_diff.py'));
+      expect(ci, contains(r'--kind "$kind" --base "$BASE_SHA" --head HEAD'),
+          reason: 'The content guard must run against the PR\'s real diff, not '
+              'against the working tree.');
+    });
+
+    test('the guard kind is derived from the branch, so it cannot be widened',
+        () {
+      expect(ci, contains(r'kind="${HEAD_REF#toolchain/}"'),
+          reason: 'toolchain/agp must be checked as an AGP update and nothing '
+              'else — the branch name is what decides which pin may move.');
+    });
+
+    test('the earlier guards still run on their own branches', () {
+      expect(ci, contains("startsWith(github.head_ref, 'deps/')"));
+      expect(ci, contains("github.head_ref == 'toolchain/flutter-sdk'"));
+      expect(ci, contains('--kind dart-packages'));
+      expect(ci, contains('--kind flutter-sdk'));
+    });
+
+    test('CI runs on every PR, so a toolchain PR is never unchecked', () {
+      expect(ci, contains('pull_request:'));
+      expect(ci.contains('pull_request:\n    branches'), isFalse);
+    });
+  });
+
+  group('the CI fixer leaves the toolchain branches alone', () {
+    test('the fix job still skips toolchain/ alongside dependabot/ and deps/',
+        () {
+      // Regression cover for #373's behaviour now that three more branches
+      // live under toolchain/.
+      for (final String prefix in <String>[
+        'dependabot/',
+        'deps/',
+        'toolchain/',
+      ]) {
+        expect(fixer, contains('"\$head_branch" == $prefix*'),
+            reason: 'A toolchain update that breaks CI must stay broken — the '
+                'red is the signal. Missing: $prefix');
+      }
+    });
+
+    test('the publish job restates the skip where the push happens', () {
+      expect(
+          fixer,
+          contains(
+              "!startsWith(needs.fix.outputs.target_branch, 'toolchain/')"),
+          reason: 'The last gate before a commit is pushed must also refuse '
+              'toolchain/ branches.');
+    });
+
+    test('the fixer may not touch a toolchain pin in any PR', () {
+      // Not just on toolchain/ branches: the agent must never repair CI by
+      // moving a build-tool version, wherever it is working.
+      for (final String protected in <String>[
+        r'\.flutter-version$',
+        r'\.java-version$',
+        r'android/settings\.gradle$',
+        r'android/gradle/wrapper/gradle-wrapper\.properties$',
+      ]) {
+        expect(fixer, contains(protected),
+            reason: 'The protected-path guard must keep $protected out of '
+                'every agent patch.');
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Documentation.
+  // ---------------------------------------------------------------------------
+  group('the documentation describes what actually happens', () {
+    test('it no longer claims the Android toolchain is unautomated', () {
+      expect(
+          docs.contains(
+              'The rest of the toolchain — Gradle, AGP, Kotlin and the JDK — is not automated'),
+          isFalse,
+          reason: 'docs/dependency-updates.md still says Gradle, AGP and '
+              'Kotlin are handled by hand.');
+    });
+
+    test('it documents the pieces a maintainer needs', () {
+      for (final String required in <String>[
+        'android-toolchain-updates.yml',
+        'check_android_toolchain_update.py',
+        'check_toolchain_pin_diff.py',
+        'set_android_toolchain_pin.py',
+        'toolchain/gradle',
+        'toolchain/agp',
+        'toolchain/kotlin',
+        'services.gradle.org/versions/all',
+        'maven-metadata.xml',
+        'DEPENDENCY_UPDATE_TOKEN',
+        'applicationVariants',
+        'F-Droid',
+      ]) {
+        expect(docs, contains(required),
+            reason: 'docs/dependency-updates.md must mention "$required".');
+      }
+    });
+
+    test('it describes all five phases of #362', () {
+      for (final String required in <String>[
+        '#363',
+        '#364',
+        '#370',
+        '#373',
+        '#362',
+      ]) {
+        expect(docs, contains(required),
+            reason: 'docs/dependency-updates.md must reference $required so '
+                'the five phases are all accounted for.');
+      }
+    });
+
+    test('it still documents the earlier updaters', () {
+      for (final String required in <String>[
+        'pubspec.lock',
+        '.flutter-version',
+        'flutter-sdk-updates.yml',
+        'dart-dependency-updates.yml',
+        'dependabot.yml',
+      ]) {
+        expect(docs, contains(required),
+            reason: 'Phase 5 must not have dropped the earlier phases from '
+                'the documentation. Missing: $required');
+      }
+    });
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Fixtures and helpers.
+// -----------------------------------------------------------------------------
+
+const List<String> _tools = <String>['gradle', 'agp', 'kotlin'];
+
+/// The group/artifact each Maven-backed tool's metadata must declare.
+const Map<String, List<String>> _mavenCoordinates = <String, List<String>>{
+  'agp': <String>['com.android.tools.build', 'gradle'],
+  'kotlin': <String>['org.jetbrains.kotlin', 'kotlin-gradle-plugin'],
+};
+
+/// A release entry shaped like Gradle's own release index.
+Map<String, dynamic> _gradleEntry(
+  String version, {
+  bool isFinal = true,
+  bool snapshot = false,
+  bool nightly = false,
+  bool releaseNightly = false,
+  bool activeRc = false,
+  bool broken = false,
+  String rcFor = '',
+  String milestoneFor = '',
+  String? downloadUrl,
+}) =>
+    <String, dynamic>{
+      'version': version,
+      'buildTime': '20260101000000+0000',
+      'commitId': 'commit-$version',
+      'current': false,
+      'snapshot': snapshot,
+      'nightly': nightly,
+      'releaseNightly': releaseNightly,
+      'activeRc': activeRc,
+      'rcFor': rcFor,
+      'milestoneFor': milestoneFor,
+      'broken': broken,
+      'downloadUrl': downloadUrl ??
+          'https://services.gradle.org/distributions/gradle-$version-bin.zip',
+      'checksumUrl':
+          'https://services.gradle.org/distributions/gradle-$version-bin.zip.sha256',
+      'released': true,
+      'final': isFinal,
+    };
+
+String _gradleIndex(
+  List<String> finalVersions, {
+  List<Map<String, dynamic>> extra = const <Map<String, dynamic>>[],
+}) =>
+    const JsonEncoder.withIndent('  ').convert(<Map<String, dynamic>>[
+      for (final String version in finalVersions) _gradleEntry(version),
+      ...extra,
+    ]);
+
+String _mavenMetadata(
+  String groupId,
+  String artifactId,
+  List<String> versions, {
+  String? latest,
+  String? release,
+}) =>
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<metadata>\n'
+    '  <groupId>$groupId</groupId>\n'
+    '  <artifactId>$artifactId</artifactId>\n'
+    '  <versioning>\n'
+    '    <latest>${latest ?? versions.last}</latest>\n'
+    '    <release>${release ?? versions.last}</release>\n'
+    '    <versions>\n'
+    '${versions.map((String v) => '      <version>$v</version>').join('\n')}\n'
+    '    </versions>\n'
+    '  </versioning>\n'
+    '</metadata>\n';
+
+/// The index text a tool would fetch, holding exactly [versions] as releases.
+String _indexFor(String tool, List<String> versions) {
+  if (tool == 'gradle') return _gradleIndex(versions);
+  final List<String> coordinates = _mavenCoordinates[tool]!;
+  return _mavenMetadata(coordinates[0], coordinates[1], versions);
+}
+
+String _writeGradleIndex(Directory dir, List<String> versions) {
+  final File file = File(p.join(dir.path, 'gradle-versions.json'))
+    ..writeAsStringSync(_gradleIndex(versions));
+  return file.path;
+}
+
+/// Runs the checker for one tool against a synthesised index. No network.
+_Tool _check(
+  String checker, {
+  required String tool,
+  required String current,
+  required List<String> versions,
+}) =>
+    _runWithIndex(checker, tool, current, _indexFor(tool, versions)).tool(tool);
+
+_Run _runWithIndex(String checker, String tool, String current, String index) {
+  final Directory tmp = Directory.systemTemp.createTempSync('toolchain-index');
+  try {
+    final File file = File(p.join(tmp.path, 'index'))..writeAsStringSync(index);
+    return _run(checker, <String>[
+      '--tool',
+      tool,
+      '--current',
+      current,
+      '--versions-file',
+      file.path,
+      '--json',
+    ]);
+  } finally {
+    tmp.deleteSync(recursive: true);
+  }
+}
+
+_Run _run(String script, List<String> args) {
+  final ProcessResult r = Process.runSync(
+    'python3',
+    <String>[script, ...args],
+    stdoutEncoding: const SystemEncoding(),
+    stderrEncoding: const SystemEncoding(),
+  );
+  return _Run(r.exitCode, r.stdout.toString(), r.stderr.toString());
+}
+
+ProcessResult _runFileGuard(String script, String kind, List<String> paths) =>
+    Process.runSync(
+      'bash',
+      <String>[script, '--kind', kind, ...paths],
+      stdoutEncoding: const SystemEncoding(),
+      stderrEncoding: const SystemEncoding(),
+    );
+
+/// Runs the content guard over two in-memory versions of a pin file.
+_Run _runDiffGuard(String script, String kind, String before, String after) {
+  final Directory tmp = Directory.systemTemp.createTempSync('toolchain-diff');
+  try {
+    final File beforeFile = File(p.join(tmp.path, 'before'))
+      ..writeAsStringSync(before);
+    final File afterFile = File(p.join(tmp.path, 'after'))
+      ..writeAsStringSync(after);
+    return _run(script, <String>[
+      '--kind',
+      kind,
+      '--before-file',
+      beforeFile.path,
+      '--after-file',
+      afterFile.path,
+    ]);
+  } finally {
+    tmp.deleteSync(recursive: true);
+  }
+}
+
+// Pin readers and rewriters used to build fixtures out of the repository's real
+// files. They are deliberately independent of scripts/toolchain_pins.py — a
+// test that reused the implementation could not catch the implementation being
+// wrong.
+final RegExp _agpRe =
+    RegExp(r'(id\s+"com\.android\.application"\s+version\s+")([^"]+)(")');
+final RegExp _kotlinRe =
+    RegExp(r'(id\s+"org\.jetbrains\.kotlin\.android"\s+version\s+")([^"]+)(")');
+final RegExp _gradleRe =
+    RegExp(r'(distributionUrl=\S*?/gradle-)([^-]+)(-(?:all|bin)\.zip)');
+
+String _agpPin(String text) => _agpRe.firstMatch(text)!.group(2)!;
+String _kotlinPin(String text) => _kotlinRe.firstMatch(text)!.group(2)!;
+String _gradlePin(String text) => _gradleRe.firstMatch(text)!.group(2)!;
+
+String _bumpAgp(String text, String version) =>
+    text.replaceFirstMapped(_agpRe, (Match m) => '${m[1]}$version${m[3]}');
+String _bumpKotlin(String text, String version) =>
+    text.replaceFirstMapped(_kotlinRe, (Match m) => '${m[1]}$version${m[3]}');
+String _bumpGradle(String text, String version) =>
+    text.replaceFirstMapped(_gradleRe, (Match m) => '${m[1]}$version${m[3]}');
+
+/// `1.2.3` -> `1.2.4`. Keeps fixtures on the pinned major without hardcoding
+/// a version number that would go stale the moment a pin moves.
+String _bumpPatch(String version) {
+  final List<String> parts = version.split('.');
+  return '${parts[0]}.${parts[1]}.${int.parse(parts[2]) + 1}';
+}
+
+/// A throwaway copy of the repository's pin files, so a write test can run the
+/// real writer without touching the checkout.
+class _Sandbox {
+  _Sandbox(String root)
+      : _dir = Directory.systemTemp.createTempSync('toolchain-sandbox') {
+    Directory(p.join(path, 'android', 'gradle', 'wrapper'))
+        .createSync(recursive: true);
+    for (final String relative in <String>[
+      p.join('android', 'settings.gradle'),
+      p.join('android', 'gradle', 'wrapper', 'gradle-wrapper.properties'),
+    ]) {
+      File(p.join(path, relative))
+          .writeAsStringSync(File(p.join(root, relative)).readAsStringSync());
+    }
+  }
+
+  final Directory _dir;
+
+  String get path => _dir.path;
+
+  String pinFileText(String tool) => File(p.join(
+          path,
+          tool == 'gradle'
+              ? p.join(
+                  'android', 'gradle', 'wrapper', 'gradle-wrapper.properties')
+              : p.join('android', 'settings.gradle')))
+      .readAsStringSync();
+
+  String pin(String tool) {
+    final String text = pinFileText(tool);
+    switch (tool) {
+      case 'gradle':
+        return _gradlePin(text);
+      case 'agp':
+        return _agpPin(text);
+      default:
+        return _kotlinPin(text);
+    }
+  }
+
+  void dispose() => _dir.deleteSync(recursive: true);
+}
+
+/// A sandbox that is also a git repository, so the guards can be run the way
+/// CI runs them: against a real diff.
+class _GitSandbox extends _Sandbox {
+  _GitSandbox(super.root) {
+    _git(<String>['init', '-q', '.']);
+    _git(<String>['add', '-A']);
+    _git(<String>[
+      '-c',
+      'user.email=guardrails@example.invalid',
+      '-c',
+      'user.name=guardrails',
+      'commit',
+      '-qm',
+      'fixture',
+    ]);
+  }
+
+  ProcessResult _git(List<String> args) => Process.runSync(
+        'git',
+        <String>['-C', path, ...args],
+        stdoutEncoding: const SystemEncoding(),
+        stderrEncoding: const SystemEncoding(),
+      );
+
+  /// Creates (or appends to) a file the automatic update has no business in.
+  void touch(String relative) {
+    final File file = File(p.join(path, relative));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync('# added by a guardrail test\n',
+        mode: FileMode.append);
+  }
+
+  ProcessResult fileGuard(String script, String kind) {
+    final ProcessResult diff = _git(<String>['diff', '--name-only', 'HEAD']);
+    final List<String> paths = diff.stdout
+        .toString()
+        .split('\n')
+        .where((String line) => line.trim().isNotEmpty)
+        .toList();
+    // Untracked files never show up in `git diff`, so add them first — the
+    // updater's own pipeline runs against an index, not a bare working tree.
+    final ProcessResult untracked =
+        _git(<String>['ls-files', '--others', '--exclude-standard']);
+    paths.addAll(untracked.stdout
+        .toString()
+        .split('\n')
+        .where((String line) => line.trim().isNotEmpty));
+    return Process.runSync(
+      'bash',
+      <String>[script, '--kind', kind, ...paths],
+      stdoutEncoding: const SystemEncoding(),
+      stderrEncoding: const SystemEncoding(),
+    );
+  }
+
+  _Run contentGuard(String script, String kind) {
+    _git(<String>['add', '-A']);
+    return _run(script, <String>[
+      '--kind',
+      kind,
+      '--base',
+      'HEAD',
+      '--repo-root',
+      path,
+    ]);
+  }
+}
+
+class _Run {
+  _Run(this.exitCode, this.stdout, this.stderr);
+
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+
+  _Tool tool(String name) {
+    if (exitCode != 0) return _Tool(exitCode, stdout, stderr, null);
+    final Map<String, dynamic> parsed =
+        jsonDecode(stdout) as Map<String, dynamic>;
+    return _Tool(
+        exitCode, stdout, stderr, parsed[name] as Map<String, dynamic>?);
+  }
+
+  String describe() => 'exit: $exitCode\nstdout:\n$stdout\nstderr:\n$stderr';
+}
+
+class _Tool extends _Run {
+  _Tool(super.exitCode, super.stdout, super.stderr, this._result);
+
+  final Map<String, dynamic>? _result;
+
+  String get status => value('status');
+
+  String value(String key) => (_result?[key] ?? '').toString();
+}
+
+/// The text of one top-level job in a workflow file.
+///
+/// Job-scoped assertions matter here: "the workflow mentions the publication
+/// token somewhere" would pass even if the wrong job used it.
+String _jobSection(String workflow, String job) {
+  final RegExp header = RegExp('^  $job:\$', multiLine: true);
+  final RegExpMatch? start = header.firstMatch(workflow);
+  if (start == null) fail('Workflow has no job named "$job".');
+  final RegExp nextJob = RegExp(r'^  [a-z][\w-]*:$', multiLine: true);
+  for (final RegExpMatch m in nextJob.allMatches(workflow)) {
+    if (m.start > start.start) {
+      return workflow.substring(start.start, m.start);
+    }
+  }
+  return workflow.substring(start.start);
+}
+
+String _read(String root, String relativePath) {
+  final File f = File(p.join(root, relativePath));
+  expect(f.existsSync(), isTrue,
+      reason: 'Expected file is missing: $relativePath');
+  return f.readAsStringSync();
+}
+
+String _repoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, '.github')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}

--- a/test/tooling/android_toolchain_update_test.py
+++ b/test/tooling/android_toolchain_update_test.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Unit tests for the Android toolchain updater's Python internals (#362, PR 5).
+
+    python3 test/tooling/android_toolchain_update_test.py
+
+These sit one level below
+test/tooling/android_toolchain_update_guardrails_test.dart, which drives the
+same scripts end to end as subprocesses and also holds the workflow, CI and
+documentation to their promises. This file pokes at the parts that are easiest
+to get subtly wrong and hardest to see from outside:
+
+  * the pin patterns, including that rewriting one leaves every other byte of
+    the file alone — the property the whole AGP/Kotlin separation rests on;
+  * the upstream parsers, including the prerelease and self-contradiction
+    filters;
+  * the classification, including that "newest on our major" and "newest
+    overall" stay independent.
+
+Everything is offline. No network, no git, no repository writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+# The scripts import each other by module name the way they do when run from
+# scripts/, so that directory has to be importable here too.
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pins = _load("toolchain_pins", "toolchain_pins.py")
+checker = _load("check_android_toolchain_update", "check_android_toolchain_update.py")
+guard = _load("check_toolchain_pin_diff", "check_toolchain_pin_diff.py")
+writer = _load("set_android_toolchain_pin", "set_android_toolchain_pin.py")
+
+SETTINGS_GRADLE = (ROOT / "android" / "settings.gradle").read_text(encoding="utf-8")
+WRAPPER_PROPERTIES = (
+    ROOT / "android" / "gradle" / "wrapper" / "gradle-wrapper.properties"
+).read_text(encoding="utf-8")
+
+
+def gradle_entry(version, **overrides):
+    entry = {
+        "version": version,
+        "buildTime": "20260101000000+0000",
+        "current": False,
+        "snapshot": False,
+        "nightly": False,
+        "releaseNightly": False,
+        "activeRc": False,
+        "rcFor": "",
+        "milestoneFor": "",
+        "broken": False,
+        "downloadUrl": (
+            f"https://services.gradle.org/distributions/gradle-{version}-bin.zip"
+        ),
+        "final": True,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def gradle_index(*entries):
+    return json.dumps(list(entries))
+
+
+def maven_metadata(group_id, artifact_id, versions, latest=None, release=None):
+    body = "\n".join(f"      <version>{v}</version>" for v in versions)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<metadata>\n"
+        f"  <groupId>{group_id}</groupId>\n"
+        f"  <artifactId>{artifact_id}</artifactId>\n"
+        "  <versioning>\n"
+        f"    <latest>{latest or versions[-1]}</latest>\n"
+        f"    <release>{release or versions[-1]}</release>\n"
+        "    <versions>\n"
+        f"{body}\n"
+        "    </versions>\n"
+        "  </versioning>\n"
+        "</metadata>\n"
+    )
+
+
+class VersionParsing(unittest.TestCase):
+    def test_bare_triples_parse(self):
+        self.assertEqual(pins.parse_version("8.14.5", "x"), (8, 14, 5))
+        self.assertEqual(pins.parse_version("  2.2.21 ", "x"), (2, 2, 21))
+        self.assertEqual(pins.format_version((8, 14, 5)), "8.14.5")
+
+    def test_anything_else_is_refused(self):
+        for bad in [
+            "",
+            "   ",
+            "8",
+            "8.14",
+            "8.14.5.1",
+            "v8.14.5",
+            "8.14.5-rc1",
+            "latest",
+            "8.14.x",
+            None,
+            8.14,
+            ["8", "14", "5"],
+        ]:
+            with self.subTest(bad=bad):
+                with self.assertRaises(pins.CheckError):
+                    pins.parse_version(bad, "x")
+                self.assertIsNone(pins.try_version(bad))
+
+    def test_two_component_gradle_tags_are_not_pins(self):
+        # `8.14` is a real Gradle release, but a pin file may only hold a bare
+        # triple, so it is never a version an automatic update may write.
+        self.assertIsNone(pins.try_version("8.14"))
+
+    def test_prereleases_are_recognisable(self):
+        for text in [
+            "8.3.0-alpha01",
+            "8.3.0-beta02",
+            "8.3.0-rc01",
+            "2.4.20-RC",
+            "2.2.20-Beta1",
+            "9.0.0-milestone-1",
+            "9.7.1-20260814014720+0000-SNAPSHOT",
+            "1.9.0-eap-1",
+            "2.0.0-dev-123",
+            "8.0.0-preview",
+            "1.0.0-M1",
+        ]:
+            with self.subTest(text=text):
+                self.assertTrue(pins.looks_like_prerelease(text))
+
+    def test_final_versions_are_not_mistaken_for_prereleases(self):
+        for text in ["8.14.5", "2.2.21", "9.0.0", "10.20.30"]:
+            with self.subTest(text=text):
+                self.assertFalse(pins.looks_like_prerelease(text))
+
+
+class PinPatterns(unittest.TestCase):
+    def test_each_pin_is_found_in_the_real_file(self):
+        self.assertEqual(
+            pins.find_pin(WRAPPER_PROPERTIES, "gradle"),
+            pins.find_pin(WRAPPER_PROPERTIES, "gradle"),
+        )
+        for tool in ("agp", "kotlin"):
+            version = pins.find_pin(SETTINGS_GRADLE, tool)
+            self.assertRegex(version, r"^\d+\.\d+\.\d+$")
+
+    def test_agp_and_kotlin_read_different_versions_from_one_file(self):
+        self.assertNotEqual(
+            pins.find_pin(SETTINGS_GRADLE, "agp"),
+            pins.find_pin(SETTINGS_GRADLE, "kotlin"),
+        )
+
+    def test_replacing_a_pin_changes_only_that_pin(self):
+        for tool, text in (
+            ("gradle", WRAPPER_PROPERTIES),
+            ("agp", SETTINGS_GRADLE),
+            ("kotlin", SETTINGS_GRADLE),
+        ):
+            with self.subTest(tool=tool):
+                original = pins.find_pin(text, tool)
+                changed = pins.replace_pin(text, tool, "9999.888.777")
+                self.assertEqual(pins.find_pin(changed, tool), "9999.888.777")
+                # Everything else, including the other pin in the same file
+                # and the file's trailing newline, must survive untouched.
+                for other in pins.other_tools_in(tool):
+                    self.assertEqual(
+                        pins.find_pin(changed, other), pins.find_pin(text, other)
+                    )
+                self.assertEqual(pins.replace_pin(changed, tool, original), text)
+
+    def test_replacing_a_pin_preserves_the_trailing_newline(self):
+        # Regression: an ungrouped `\s*$` in the Gradle pattern used to swallow
+        # the file's final newline, which is a real, invisible diff.
+        changed = pins.replace_pin(WRAPPER_PROPERTIES, "gradle", "9.9.9")
+        self.assertTrue(WRAPPER_PROPERTIES.endswith("\n"))
+        self.assertTrue(changed.endswith("\n"))
+        self.assertEqual(len(changed.splitlines()), len(WRAPPER_PROPERTIES.splitlines()))
+
+    def test_a_missing_pin_is_refused_rather_than_guessed(self):
+        with self.assertRaises(pins.CheckError):
+            pins.find_pin("plugins {\n}\n", "agp")
+
+    def test_an_ambiguous_pin_is_refused(self):
+        doubled = SETTINGS_GRADLE + (
+            '\nplugins {\n    id "com.android.application" version "1.0.0" apply false\n}\n'
+        )
+        with self.assertRaises(pins.CheckError):
+            pins.find_pin(doubled, "agp")
+
+    def test_the_gradle_pattern_ignores_the_other_wrapper_properties(self):
+        for line in (
+            "distributionBase=GRADLE_USER_HOME",
+            "distributionPath=wrapper/dists",
+            "zipStoreBase=GRADLE_USER_HOME",
+            "zipStorePath=wrapper/dists",
+        ):
+            self.assertIn(line, pins.replace_pin(WRAPPER_PROPERTIES, "gradle", "9.9.9"))
+
+    def test_only_agp_and_kotlin_share_a_file(self):
+        self.assertEqual(pins.other_tools_in("agp"), ["kotlin"])
+        self.assertEqual(pins.other_tools_in("kotlin"), ["agp"])
+        self.assertEqual(pins.other_tools_in("gradle"), [])
+
+    def test_an_unknown_tool_is_refused(self):
+        with self.assertRaises(pins.CheckError):
+            pins.tool("everything")
+
+
+class GradleIndexParsing(unittest.TestCase):
+    def parse(self, raw):
+        return checker.parse_gradle_versions(raw, "fixture")
+
+    def test_final_releases_are_candidates(self):
+        found = self.parse(gradle_index(gradle_entry("8.14.5"), gradle_entry("9.0.0")))
+        self.assertEqual(sorted(found.versions), [(8, 14, 5), (9, 0, 0)])
+
+    def test_non_final_builds_are_skipped(self):
+        found = self.parse(
+            gradle_index(
+                gradle_entry("8.14.5"),
+                gradle_entry("9.1.0-rc-1", final=False, activeRc=True),
+                gradle_entry(
+                    "9.2.0-20260101000000+0000", final=False, releaseNightly=True
+                ),
+            )
+        )
+        self.assertEqual(found.versions, [(8, 14, 5)])
+        self.assertEqual(found.prereleases, 2)
+
+    def test_a_row_that_contradicts_its_own_final_flag_is_refused(self):
+        for flag, value in [
+            ("broken", True),
+            ("snapshot", True),
+            ("nightly", True),
+            ("releaseNightly", True),
+            ("activeRc", True),
+            ("rcFor", "9.9.9"),
+            ("milestoneFor", "9.9.9"),
+        ]:
+            with self.subTest(flag=flag):
+                found = self.parse(
+                    gradle_index(
+                        gradle_entry("8.14.5"), gradle_entry("9.9.9", **{flag: value})
+                    )
+                )
+                self.assertEqual(found.versions, [(8, 14, 5)])
+                self.assertTrue(any("claims final" in n for n in found.notes))
+
+    def test_a_release_from_an_unexpected_host_is_refused(self):
+        found = self.parse(
+            gradle_index(
+                gradle_entry("8.14.5"),
+                gradle_entry("9.9.9", downloadUrl="https://example.invalid/g.zip"),
+                gradle_entry("9.9.8", downloadUrl=None),
+            )
+        )
+        self.assertEqual(found.versions, [(8, 14, 5)])
+        self.assertEqual(len(found.notes), 2)
+
+    def test_structurally_wrong_payloads_raise(self):
+        for raw in ["{{{", '{"releases": []}', "[]", '["8.14.5"]', "[null]"]:
+            with self.subTest(raw=raw):
+                with self.assertRaises(pins.CheckError):
+                    self.parse(raw)
+
+
+class MavenMetadataParsing(unittest.TestCase):
+    def parse(self, raw, group="org.jetbrains.kotlin", artifact="kotlin-gradle-plugin"):
+        return checker.parse_maven_metadata(raw, "fixture", group, artifact)
+
+    def test_stable_versions_are_candidates(self):
+        found = self.parse(
+            maven_metadata(
+                "org.jetbrains.kotlin",
+                "kotlin-gradle-plugin",
+                ["2.2.21", "2.3.0-RC", "2.3.0"],
+            )
+        )
+        self.assertEqual(sorted(found.versions), [(2, 2, 21), (2, 3, 0)])
+        self.assertEqual(found.prereleases, 1)
+
+    def test_the_latest_and_release_pointers_are_ignored(self):
+        # Kotlin's own metadata has pointed <release> at an -RC build.
+        found = self.parse(
+            maven_metadata(
+                "org.jetbrains.kotlin",
+                "kotlin-gradle-plugin",
+                ["2.2.21", "2.3.0-RC"],
+                latest="2.3.0-RC",
+                release="2.3.0-RC",
+            )
+        )
+        self.assertEqual(found.versions, [(2, 2, 21)])
+
+    def test_metadata_for_another_artifact_is_refused(self):
+        with self.assertRaises(pins.CheckError):
+            self.parse(maven_metadata("com.example", "other", ["9.9.9"]))
+
+    def test_entity_declarations_are_refused_before_parsing(self):
+        raw = '<!DOCTYPE metadata [<!ENTITY a "b">]>\n' + maven_metadata(
+            "org.jetbrains.kotlin", "kotlin-gradle-plugin", ["2.2.21"]
+        )
+        with self.assertRaises(pins.CheckError) as caught:
+            self.parse(raw)
+        self.assertIn("refusing to parse", str(caught.exception))
+
+    def test_structurally_wrong_payloads_raise(self):
+        for raw in [
+            "not xml",
+            "<html><body>nope</body></html>",
+            "<metadata><groupId>org.jetbrains.kotlin</groupId>"
+            "<artifactId>kotlin-gradle-plugin</artifactId></metadata>",
+            "<metadata><groupId>org.jetbrains.kotlin</groupId>"
+            "<artifactId>kotlin-gradle-plugin</artifactId>"
+            "<versioning><versions></versions></versioning></metadata>",
+        ]:
+            with self.subTest(raw=raw[:40]):
+                with self.assertRaises(pins.CheckError):
+                    self.parse(raw)
+
+
+class Classification(unittest.TestCase):
+    def test_the_four_outcomes(self):
+        self.assertEqual(checker.classify((8, 2, 3), (8, 2, 3)), "up-to-date")
+        self.assertEqual(checker.classify((8, 2, 3), (8, 2, 4)), "patch")
+        self.assertEqual(checker.classify((8, 2, 3), (8, 3, 0)), "minor")
+        self.assertEqual(checker.classify((8, 2, 3), (9, 0, 0)), "major")
+
+    def test_a_downgrade_is_never_classified(self):
+        for older in [(8, 2, 2), (8, 1, 9), (7, 9, 9)]:
+            with self.subTest(older=older):
+                with self.assertRaises(pins.CheckError):
+                    checker.classify((8, 2, 3), older)
+
+    def evaluate(self, current, versions, tool="gradle"):
+        found = checker.Candidates()
+        found.versions = [pins.parse_version(v, "fixture") for v in versions]
+        return checker.evaluate(
+            tool, pins.parse_version(current, "current"), found, "fixture"
+        )
+
+    def test_the_two_answers_are_independent(self):
+        result = self.evaluate("8.14.5", ["9.0.0", "8.15.0", "8.14.5"])
+        self.assertEqual(result["status"], "minor")
+        self.assertEqual(result["latest_in_current_major"], "8.15.0")
+        self.assertEqual(result["major_status"], "available")
+        self.assertEqual(result["major_latest"], "9.0.0")
+        self.assertTrue(checker.needs_pr(result))
+        self.assertTrue(checker.needs_issue(result))
+
+    def test_a_newer_major_alone_asks_only_for_an_issue(self):
+        result = self.evaluate("8.14.5", ["9.0.0", "8.14.5"])
+        self.assertEqual(result["status"], "up-to-date")
+        self.assertFalse(checker.needs_pr(result))
+        self.assertTrue(checker.needs_issue(result))
+
+    def test_nothing_new_asks_for_nothing(self):
+        result = self.evaluate("8.14.5", ["8.14.5", "8.14.4"])
+        self.assertFalse(checker.needs_pr(result))
+        self.assertFalse(checker.needs_issue(result))
+
+    def test_upstream_ordering_never_decides(self):
+        for order in [
+            ["8.2.9", "8.5.0", "8.4.0"],
+            ["8.5.0", "8.4.0", "8.2.9"],
+            ["8.4.0", "8.2.9", "8.5.0"],
+        ]:
+            with self.subTest(order=order):
+                self.assertEqual(
+                    self.evaluate("8.2.3", order)["latest_in_current_major"], "8.5.0"
+                )
+
+    def test_an_index_without_our_major_line_is_refused(self):
+        with self.assertRaises(pins.CheckError) as caught:
+            self.evaluate("8.14.5", ["9.0.0", "9.1.0"])
+        self.assertIn("pinned major line", str(caught.exception))
+
+    def test_an_index_behind_our_pin_is_refused(self):
+        with self.assertRaises(pins.CheckError):
+            self.evaluate("8.14.5", ["8.14.4", "8.13.0"])
+
+    def test_a_pin_upstream_has_never_heard_of_is_noted_not_fatal(self):
+        result = self.evaluate("8.14.5", ["8.15.0", "8.14.4"])
+        self.assertEqual(result["status"], "minor")
+        self.assertIn("not listed", result["notes"])
+
+
+class ContentGuard(unittest.TestCase):
+    def bump(self, text, tool, version):
+        return pins.replace_pin(text, tool, version)
+
+    def test_a_clean_single_pin_change_is_accepted(self):
+        for tool, text in (
+            ("gradle", WRAPPER_PROPERTIES),
+            ("agp", SETTINGS_GRADLE),
+            ("kotlin", SETTINGS_GRADLE),
+        ):
+            with self.subTest(tool=tool):
+                current = pins.parse_version(pins.find_pin(text, tool), "pin")
+                newer = pins.format_version((current[0], current[1], current[2] + 1))
+                summary = guard.check_content(
+                    tool, text, self.bump(text, tool, newer), "fixture"
+                )
+                self.assertIn("changes nothing else", summary)
+
+    def test_agp_may_not_move_kotlin_and_kotlin_may_not_move_agp(self):
+        for mover, victim in (("agp", "kotlin"), ("kotlin", "agp")):
+            with self.subTest(mover=mover):
+                after = self.bump(
+                    self.bump(SETTINGS_GRADLE, mover, "8.99.99"), victim, "7.77.77"
+                )
+                with self.assertRaises(pins.CheckError) as caught:
+                    guard.check_content(mover, SETTINGS_GRADLE, after, "fixture")
+                self.assertIn(pins.tool(victim).label, str(caught.exception))
+
+    def test_a_reworded_comment_is_rejected(self):
+        current = pins.find_pin(SETTINGS_GRADLE, "agp")
+        newer = pins.format_version(
+            (
+                pins.parse_version(current, "pin")[0],
+                pins.parse_version(current, "pin")[1],
+                pins.parse_version(current, "pin")[2] + 1,
+            )
+        )
+        after = self.bump(SETTINGS_GRADLE, "agp", newer).replace(
+            "// Stay on AGP 8.x", "// Whatever"
+        )
+        with self.assertRaises(pins.CheckError) as caught:
+            guard.check_content("agp", SETTINGS_GRADLE, after, "fixture")
+        self.assertIn("more than", str(caught.exception))
+
+    def test_a_downgrade_and_a_major_are_both_rejected(self):
+        for target, expected in (("8.0.0", "downgrade"), ("9.0.0", "major")):
+            with self.subTest(target=target):
+                after = self.bump(SETTINGS_GRADLE, "agp", target)
+                with self.assertRaises(pins.CheckError) as caught:
+                    guard.check_content("agp", SETTINGS_GRADLE, after, "fixture")
+                self.assertIn(expected, str(caught.exception))
+
+    def test_a_prerelease_target_is_rejected(self):
+        after = self.bump(SETTINGS_GRADLE, "kotlin", "2.9.0-RC2")
+        with self.assertRaises(pins.CheckError):
+            guard.check_content("kotlin", SETTINGS_GRADLE, after, "fixture")
+
+    def test_an_unchanged_file_is_not_an_error(self):
+        summary = guard.check_content(
+            "agp", SETTINGS_GRADLE, SETTINGS_GRADLE, "fixture"
+        )
+        self.assertIn("unchanged", summary)
+
+
+class Writer(unittest.TestCase):
+    def sandbox(self, tmp):
+        """A throwaway copy of the repository's real pin files."""
+        root = Path(tmp)
+        (root / "android" / "gradle" / "wrapper").mkdir(parents=True)
+        (root / "android" / "settings.gradle").write_text(
+            SETTINGS_GRADLE, encoding="utf-8"
+        )
+        (root / "android" / "gradle" / "wrapper" / "gradle-wrapper.properties").write_text(
+            WRAPPER_PROPERTIES, encoding="utf-8"
+        )
+        return root
+
+    def test_it_writes_one_pin_and_nothing_else(self):
+        for tool in pins.TOOL_NAMES:
+            with self.subTest(tool=tool), tempfile.TemporaryDirectory() as tmp:
+                root = self.sandbox(tmp)
+                before = pins.read_pin_file(root, tool)
+                current = pins.parse_version(pins.find_pin(before, tool), "pin")
+                newer = pins.format_version((current[0], current[1], current[2] + 1))
+
+                writer.apply(root, tool, newer)
+
+                after = pins.read_pin_file(root, tool)
+                self.assertEqual(pins.find_pin(after, tool), newer)
+                self.assertIn(
+                    "changes nothing else",
+                    guard.check_content(tool, before, after, "fixture"),
+                )
+
+    def test_it_refuses_a_rerun_a_downgrade_a_major_and_a_prerelease(self):
+        for version, expected in (
+            (pins.find_pin(SETTINGS_GRADLE, "agp"), "already pinned"),
+            ("8.0.0", "downgrade"),
+            ("9.0.0", "major"),
+            ("8.99.0-rc1", "MAJOR.MINOR.PATCH"),
+        ):
+            with self.subTest(version=version), tempfile.TemporaryDirectory() as tmp:
+                root = self.sandbox(tmp)
+                with self.assertRaises(pins.CheckError) as caught:
+                    writer.apply(root, "agp", version)
+                self.assertIn(expected, str(caught.exception))
+                # A refusal must leave the file exactly as it was.
+                self.assertEqual(pins.read_pin_file(root, "agp"), SETTINGS_GRADLE)
+
+
+class NoNetworkInTheseTests(unittest.TestCase):
+    def test_every_configured_source_is_https_and_first_party(self):
+        allowed_hosts = (
+            "https://services.gradle.org/",
+            "https://dl.google.com/",
+            "https://repo1.maven.org/",
+        )
+        for name, source in checker.SOURCES.items():
+            with self.subTest(tool=name):
+                self.assertTrue(
+                    source["url"].startswith(allowed_hosts),
+                    f"{name} reads from {source['url']}, which is not a "
+                    "first-party release index.",
+                )
+                self.assertNotIn(".html", source["url"])
+
+    def test_a_non_https_index_is_refused(self):
+        with self.assertRaises(pins.CheckError):
+            checker.load_index("http://example.invalid/index.json", None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This is phase 5 of #362, the last one on the plan in that issue. Once a week Linthra now looks at the official release index for Gradle, the Android Gradle Plugin and the Kotlin Gradle plugin, and tells us what has moved.

**This PR does not bump any pin.** Gradle stays where it is, AGP stays where it is, Kotlin stays where it is. It only adds the checking machinery.

## What it does

For each of the three tools the checker answers two questions, and keeps them apart on purpose:

- what is the newest release **still on the major line we already ship**?
- has a **newer major** appeared?

The first one can open a draft PR. The second one only ever opens an issue.

The reason for splitting them is that collapsing them into one "how far behind are we" number is how a new major would quietly swallow every later patch on the line we actually build with. If we are on 8.x and upstream ships both a newer 8.x and a first 9.x, we get the ordinary draft PR for the 8.x release *and* a separate migration issue for 9.x, in the same run.

| Situation | Result |
| --- | --- |
| nothing new | nothing happens |
| newer patch/minor on our major | draft PR |
| newer major, our line already current | issue only |
| both | draft PR *and* an issue |

Three reusable branches, one reusable draft PR each: `toolchain/gradle`, `toolchain/agp`, `toolchain/kotlin`. Reruns update the existing PR instead of opening another, and a run whose target is already on the branch pushes nothing at all. Nothing auto-merges.

## Where the versions come from

First-party, machine-readable, no HTML anywhere:

| Tool | Index |
| --- | --- |
| Gradle | `services.gradle.org/versions/all` |
| AGP | Google Maven metadata for `com.android.tools.build:gradle` |
| Kotlin | Maven Central metadata for `org.jetbrains.kotlin:kotlin-gradle-plugin` |

Each of those is the index Gradle itself resolves the pin from — the host in `distributionUrl`, and the artifacts the `com.android.application` and `org.jetbrains.kotlin.android` plugin ids resolve to through the `google()` and `mavenCentral()` repositories already declared in `android/settings.gradle`. So anything proposed is resolvable by construction.

Only bare `MAJOR.MINOR.PATCH` releases are candidates, which throws out every prerelease structurally rather than by trying to list every marker upstream might invent — alpha, beta, rc, RC, Beta1, milestone, preview, eap, dev, M1, SNAPSHOT all carry a suffix. Gradle entries additionally have to be `final`, not broken, not a snapshot/nightly/RC/milestone, and served from the distribution host. Maven metadata has to declare the group and artifact we asked for, and its `latest` and `release` pointer elements are ignored — Kotlin's `release` pointer regularly names an `-RC` build — so the version list gets filtered instead.

Anything it cannot trust is a hard failure, not a guess: an unreadable pin, an unreadable index, an index that lists nothing at all on our own major line, or a "newest release" that is behind our pin. It never proposes a downgrade.

## The part that needed actual thought

AGP and Kotlin are pinned in **the same file**. A filename allowlist is completely satisfied by an AGP PR that also quietly bumps Kotlin, or reworded the comment above both. So there are two guards now:

1. `check_dependency_update_files.sh --kind gradle|agp|kotlin` — which files moved. Same script the other updaters use, three more separate allowlists.
2. `check_toolchain_pin_diff.py --kind gradle|agp|kotlin` — what changed inside them.

The second one works by putting the *old* version back into the *new* file and requiring the result to be byte-identical to the old file. That needs no list of things to watch out for: if anything else moved — the other plugin's version, a comment, whitespace, `zipStorePath`, the `-all` vs `-bin` flavour — putting the old version back cannot reproduce the old file. It also rejects a non-triple target, a downgrade and anything crossing a major.

Both run inside the updater before a commit exists, and again in CI against the real PR diff. CI matches the three automatic branches **exactly**, never by `toolchain/` prefix — #373 fixed that for the SDK branch and a prefix rule would be even worse here, since it could not tell which of the three pins a given PR is allowed to move.

So AGP cannot change Kotlin, Kotlin cannot change AGP, Gradle cannot change either, and none of them can go near application code, tests, `pubspec.yaml`, `pubspec.lock`, `.flutter-version`, `.java-version`, `metadata/`, `fastlane/`, the app version, release notes, signing files, licenses or unrelated workflows and docs.

## Majors

An issue, never a PR, never a file change. It states the pinned version, the newest stable, the newest stable still on our major, the index it came from, and why the upgrade is manual — Flutter's supported range, the Android build itself, F-Droid and reproducibility, and the fact that these four move as a set.

The AGP one carries an extra warning, and it is the important one: our F-Droid release still builds per-ABI `versionCode`s from the legacy `applicationVariants` hook, AGP 9 removes normal access to that legacy variant API, and getting the migration wrong does not necessarily fail the build — it can produce a **wrong versionCode scheme**, which is the one thing an F-Droid release can never walk back. The port to the supported `androidComponents` Variant API is the work item; the version bump is the easy part.

## Other bits

- Rewrote the AGP comment in `android/settings.gradle` so it explains the 8.x constraint without naming a minor the updater would then have to rewrite. Second commit corrects its wording on AGP 9: the legacy `applicationVariants` hook needs a deliberate migration to `androidComponents` / `onVariants` and re-verification of the F-Droid versionCode behaviour, rather than having "no supported equivalent".
- Added the two Gradle pin files to the CI fixer's protected paths. It already skips `toolchain/*` branches — which now covers all four — but "repair CI by moving a build-tool version" should never be an option anywhere.
- Publication reuses `DEPENDENCY_UPDATE_TOKEN`, only in the job that actually publishes, so a quiet week never needs it. The major path uses the workflow's own token with `issues: write` and nothing else.

## Languages

Python for the checker, the writer and the content guard — parsing two upstream formats and doing exact-text comparison is what it is good at, and it is unit-testable offline. Bash stays where it already was for the file allowlist. YAML for the workflow, Groovy/properties untouched apart from the one comment. Nothing was rewritten into Dart for uniformity.

## Tests

`test/tooling/android_toolchain_update_guardrails_test.dart` (130 tests) drives the real scripts end to end against fixture indexes and throwaway git repositories, and holds the workflow, CI and docs to their promises. `test/tooling/android_toolchain_update_test.py` (43 tests) covers the parsers, the pin patterns and the classification directly.

Between them: no update, patch, minor, major, patch-plus-major together, ordering independence, prereleases, malformed versions, malformed upstream data, empty release sets, refused downgrades, exact branch matching, duplicate PR/issue prevention, idempotent reruns, foreign commits, branch rewinds, the token being required exactly when publishing and not otherwise, all three file guards, both content guards, AGP↔Kotlin isolation, app/F-Droid/release/signing files being unreachable, and no merge command anywhere. Everything is offline and deterministic.

One of those tests earned its keep during development: the content guard caught the Gradle pattern silently eating the file's trailing newline, which is exactly the kind of invisible extra change it exists to stop.

## Checks run

`dart format --set-exit-if-changed .`, `flutter analyze`, full `flutter test` (3461 passing), `./scripts/check_secrets.sh`, YAML parse over every workflow, `bash -n` over the shell scripts and over every workflow `run:` block, `python3 -m py_compile`, and both new test suites.

Merging this completes the five phases planned in #362. Leaving that issue open here — it should be closed on merge, not from inside the PR.
