### PR TITLE
feat(linux): add native desktop build foundation

### DIFF
--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -1,0 +1,127 @@
+name: Linux desktop build
+
+# Keeps the native Linux target building. Linthra's Android CI is unchanged and
+# stays the gate it already is; this runs alongside it so an Android-shaped
+# change that quietly breaks the desktop build — a new plugin with no Linux
+# implementation, a service that initialises eagerly, an edit that regenerates
+# the linux/ runner from the Flutter template — fails on the PR that made it
+# rather than the next time someone tries to package a release.
+#
+# It builds the real application, not a stripped-down probe: analyze and the
+# full test suite run against the same checkout, then `flutter build linux
+# --release` produces the bundle a developer would run.
+#
+# Flatpak packaging is separate, later work (issue #376, PR 5). Nothing here
+# assumes it.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Read-only: the job only inspects the checkout and builds it. No secrets, so it
+# runs identically on fork PRs.
+permissions:
+  contents: read
+
+jobs:
+  build-linux:
+    name: Build Linux desktop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # The native toolchain `flutter build linux` shells out to. Kept as an
+      # explicit list rather than a meta-package so it is obvious what the
+      # desktop build actually needs, and so it stays comparable with the
+      # Fedora package list in docs/linux-desktop.md:
+      #
+      #   clang / cmake / ninja-build / pkg-config — the build itself
+      #   libgtk-3-dev                             — the Flutter Linux embedder
+      #   liblzma-dev, libstdc++-12-dev            — Flutter tool prerequisites
+      #   libsecret-1-dev                          — flutter_secure_storage_linux,
+      #                                              i.e. encrypted credential
+      #                                              storage. Not optional: the
+      #                                              plugin fails to build
+      #                                              without it, and Linthra
+      #                                              never falls back to
+      #                                              plaintext credentials.
+      - name: Install Linux build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libgtk-3-dev \
+            liblzma-dev \
+            libstdc++-12-dev \
+            libsecret-1-dev
+
+      # Installs the version pinned in .flutter-version, the same action every
+      # other workflow uses.
+      - name: Set up Flutter
+        uses: ./.github/actions/setup-flutter
+
+      - name: Enable Linux desktop
+        run: flutter config --enable-linux-desktop
+
+      # Same lockfile-enforced resolution as the Android jobs: the desktop build
+      # must use the exact committed dependency set, not a fresh resolution that
+      # could pull a different plugin version onto one platform only.
+      - name: Install dependencies (lockfile-enforced)
+        run: flutter pub get --enforce-lockfile
+
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
+
+      # Identity and build-hygiene guard for the committed runner: the GTK
+      # application id still matches Android's applicationId, the window title
+      # still matches AppInfo.name, and the offline SQLite seam is still wired.
+      # Cheap, and it catches a `flutter create` regeneration that the build
+      # itself would happily accept.
+      - name: Check Linux runner configuration
+        run: python3 scripts/check_linux_runner.py
+
+      - name: Test the Linux runner tooling
+        run: python3 test/tooling/check_linux_runner_test.py
+
+      # Release mode, because that is the build that has to work for packaging
+      # and it exercises the AOT path a debug build skips.
+      - name: Build Linux application
+        run: flutter build linux --release
+
+      # A build that "succeeds" without producing a runnable bundle is the
+      # failure mode worth catching explicitly — mirrors the APK size check in
+      # the Android debug workflow.
+      - name: Verify build output exists
+        run: |
+          set -euo pipefail
+          bundle="build/linux/x64/release/bundle"
+          binary="$bundle/linthra"
+          for required in "$binary" "$bundle/lib/libflutter_linux_gtk.so" "$bundle/data/flutter_assets"; do
+            if [ ! -e "$required" ]; then
+              echo "::error::Expected Linux build output missing: $required"
+              exit 1
+            fi
+          done
+          if [ ! -x "$binary" ]; then
+            echo "::error::$binary is not executable."
+            exit 1
+          fi
+          echo "Linux bundle present at $bundle."
+
+      - name: Upload Linux bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: linthra-linux-x64
+          path: build/linux/x64/release/bundle
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,12 @@
 .packages
 build/
 
-# The android/ platform scaffold is committed. Other native platforms
-# (linux/, windows/, …) are still generated locally via `flutter create .`
-# until we decide to commit them.
+# The android/ and linux/ platform scaffolds are committed — both are real
+# build targets with CI behind them, and linux/ carries Linthra's own edits
+# (window identity, the offline SQLite seam) that a regeneration would drop.
+# linux/flutter/ephemeral is per-build output and is excluded by linux/.gitignore.
+# Any other native platform (windows/, macos/, …) is still generated locally via
+# `flutter create .`; there is no target for them yet.
 
 # IDE
 .idea/

--- a/.metadata
+++ b/.metadata
@@ -18,6 +18,9 @@ migration:
     - platform: android
       create_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
       base_revision: d8a9f9a52e5af486f80d932e838ee93861ffd863
+    - platform: linux
+      create_revision: 84fc5cbb223bc12f83d65b647ff8a56caf779ffd
+      base_revision: 84fc5cbb223bc12f83d65b647ff8a56caf779ffd
 
   # User provided section
 
@@ -28,3 +31,8 @@ migration:
   unmanaged_files:
     - 'lib/main.dart'
     - 'ios/Runner.xcodeproj/project.pbxproj'
+    # Linthra owns these two: the window identity/metadata and the offline
+    # SQLite seam. A template migration must not restore the generated
+    # versions. scripts/check_linux_runner.py catches it if one ever does.
+    - 'linux/CMakeLists.txt'
+    - 'linux/runner/my_application.cc'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,11 @@ For the other areas:
 
 - `native/linthra_core/` uses Cargo.
 - `native/linthra_audio/` uses CMake.
+- `linux/` is the native Linux desktop runner (C++/GTK/CMake). Its setup —
+  required distribution packages, how to run Linthra on Linux from source, and
+  what is still unsupported there — is in
+  [docs/linux-desktop.md](./docs/linux-desktop.md); `./scripts/verify_linux.sh`
+  is the desktop twin of `verify_android.sh`.
 - `tools/large_library/` contains the Python and SQLite large-library tooling.
 
 ## Before you start

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | --- | --- |
 | Contributing & setup | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Development, build & CI | [development.md](./development.md) |
+| Linux desktop build (experimental) | [linux-desktop.md](./linux-desktop.md) |
 | Codebase tour (where everything lives) | [codebase-tour.md](./codebase-tour.md) |
 | Architecture & extension points | [architecture.md](./architecture.md) |
 | Where to help (contributor roadmap) | [contributor-roadmap.md](./contributor-roadmap.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,8 +20,18 @@ possible without rewriting the UI.
 
 ## Target platforms
 
-Android first, Linux desktop later, and possibly Windows — all from one Flutter
-codebase.
+Android and Linux desktop, from one Flutter codebase; possibly Windows later.
+
+Android is the platform Linthra ships on. The native Linux target builds and
+launches, and is deliberately incomplete — playback and the desktop UX are still
+being built out. What each platform does and does not have is in
+[linux-desktop.md](linux-desktop.md).
+
+Platform differences live behind interfaces, never in widgets. `HostPlatform`
+(`core/platform/host_platform.dart`) is the platform expressed as a value, so
+every selection rule is a plain, testable decision instead of a `dart:io` read
+that only ever resolves one way on a given machine; `hostPlatformProvider` is
+the same value for provider-level selection.
 
 ## Tech stack
 
@@ -104,6 +114,12 @@ lib/
 - **`DownloadRepository`** (`core/repositories/`) — enforces the user-initiated,
   mobile-data-respecting download policy in one place. See
   [offline-cache.md](offline-cache.md).
+- **`MediaSessionBinding`** (`core/services/media_session_binding.dart`) — the
+  platform media session (notification, lock screen, Android Auto), separated
+  from playback itself. Android attaches the `audio_service` session;
+  a platform with none gets an inert binding, so `audio_service` is never
+  initialised where it has no implementation. MPRIS becomes a third
+  implementation of this interface rather than a branch inside startup.
 
 ## The single playback seam (local + cast)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,9 +1,15 @@
 # Development
 
-Linthra is a standard Flutter app. The **Android** platform scaffold (`android/`)
-is committed, so no `flutter create` step is needed. Other native platform
-folders (`linux/`, …) are generated locally when you need them, so the repo stays
-focused on the cross-platform Dart code.
+Linthra is a standard Flutter app. The **Android** (`android/`) and **Linux**
+(`linux/`) platform scaffolds are both committed, so no `flutter create` step is
+needed for either. Any other native platform folder (`windows/`, `macos/`, …)
+would be generated locally, and none is a target today.
+
+> Building for the Linux desktop? Start with
+> [linux-desktop.md](linux-desktop.md) — required native packages, how to run
+> from source, and what is intentionally unsupported so far (playback, most of
+> all). Android is the platform Linthra ships on; Linux is not production-ready
+> yet.
 
 > New to the code itself? The [codebase tour](codebase-tour.md) maps where each
 > feature lives and how the pieces fit together.
@@ -57,6 +63,10 @@ Flutter would be used, and whether an Android SDK is present.
 The verification script auto-detects `.tool/flutter`, so you don't have to
 update `PATH` just to run it.
 
+`scripts/verify_linux.sh` is the desktop twin: the same shared checks plus the
+Linux runner configuration check and `flutter build linux --release`. See
+[linux-desktop.md](linux-desktop.md).
+
 ### What `verify_android.sh` does
 
 Runs, in CI order, and exits non-zero if any real check fails:
@@ -91,21 +101,28 @@ flutter pub get
 # 2. Run on a connected Android device or emulator
 flutter run
 
-# (Optional) generate scaffolding for another platform, e.g. Linux desktop:
-flutter create --platforms=linux .
+# Or run the native Linux desktop build (see linux-desktop.md for the
+# native packages it needs first):
+flutter run -d linux
 ```
 
-> `flutter create` may regenerate template files such as `main.dart`. If
-> prompted, keep the existing versions in this repo.
+> Do **not** re-run `flutter create` to "refresh" a platform folder. It
+> regenerates template files — `lib/main.dart`, and for Linux the window
+> identity and the offline SQLite seam in `linux/` — over Linthra's own edits.
+> `.metadata` lists those files as unmanaged and
+> `scripts/check_linux_runner.py` fails if they are ever reverted.
 
 ## What is intentionally not committed
 
-The repo holds source and the committed `android/` scaffold only — the
-toolchain is installed per-environment:
+The repo holds source and the committed `android/` and `linux/` scaffolds only
+— the toolchain is installed per-environment:
 
 - **The Flutter SDK** — downloaded into the git-ignored `.tool/flutter`.
 - **The Android SDK** — provided by your machine/CI, never vendored here.
-- **Dart/Flutter caches and build output** — `.dart_tool/`, `build/`, etc.
+- **Dart/Flutter caches and build output** — `.dart_tool/`, `build/`,
+  `linux/flutter/ephemeral/`, etc.
+- **The Linux native toolchain** (clang/cmake/ninja/GTK/libsecret) — installed
+  from your distribution; see [linux-desktop.md](linux-desktop.md).
 
 CI installs Flutter via the `subosito/flutter-action` GitHub Action rather than
 these scripts, but reads the **same** `.flutter-version` file to decide which
@@ -125,6 +142,9 @@ do not.
   APK build is skipped and verification still passes if analyze/format/tests
   pass. Install the Android SDK and set `ANDROID_HOME` to enable
   `flutter build apk --debug`.
+- **Linux build dependencies missing** — `./scripts/verify_linux.sh` names the
+  packages it could not find and skips only the build step;
+  [linux-desktop.md](linux-desktop.md) lists them per distribution.
 - **`dart format` mismatch** — run `dart format .` to apply the formatter, then
   commit the result. CI uses `--set-exit-if-changed`, so unformatted code fails.
   Make sure you're on the pinned Flutter — a newer Dart can reformat differently.

--- a/docs/language-areas.md
+++ b/docs/language-areas.md
@@ -8,6 +8,7 @@ Linthra is a Flutter app, but the project is deliberately becoming polyglot wher
 | Kotlin | Android platform integration, SAF/MediaStore, media session, Android Auto, system channels | `android/app/src/main/kotlin/` |
 | Rust | large-library indexing/search, future grouping and duplicate primitives | `native/linthra_core/` |
 | C++ | realtime audio DSP, EQ/limiting, future audio analysis and SIMD work | `native/linthra_audio/` |
+| C++ / CMake (GTK) | the native Linux desktop runner: window identity and metadata, GTK application setup, native build configuration | `linux/` |
 | Python | release tooling, large-library fixtures, benchmarks, validation | `scripts/`, `tool/`, `tools/` |
 | SQL | SQLite schema/index/query performance for very large catalogs | `tools/large_library/schema.sql` and Drift/database work |
 
@@ -27,9 +28,15 @@ Choose Kotlin when Android itself is the feature. Linthra already has native cha
 
 `linthra_audio` owns realtime signal processing. The callback must stay bounded, allocation-free and lock-free. EQ, limiter behaviour, SIMD, channel layouts and loudness/peak analysis are useful C++ contribution areas. The current core is intentionally separated from the `just_audio` mobile binding so DSP math can be reviewed independently from Android playback plumbing.
 
+## C++ / CMake / GTK — the Linux runner
+
+`linux/` is the native entry point of the desktop app: a small GTK application that creates the window, sets Linthra's identity, and hands off to the Flutter engine. It is C++ because that is what the Flutter Linux embedder is; there is no Dart alternative for this layer.
+
+Keep it small. Anything that could live in Dart should — the runner exists to create a correct window and get out of the way, not to hold product logic. Its build configuration (`linux/CMakeLists.txt`) is also where native-dependency decisions land, such as the SQLite pre-fetch seam that keeps the build possible with no network. See [linux-desktop.md](linux-desktop.md).
+
 ## Python / tooling
 
-Python should remove repetitive maintainer work or create useful developer fixtures. Linthra already uses Python in release/branding tooling; `tools/large_library/` adds deterministic 200k-track SQLite generation and query benchmarks using only the standard library.
+Python should remove repetitive maintainer work or create useful developer fixtures. Linthra already uses Python in release/branding tooling; `tools/large_library/` adds deterministic 200k-track SQLite generation and query benchmarks using only the standard library. `scripts/check_linux_runner.py` is a good shape to copy: a config invariant that no compiler would catch, checked against its real sources of truth, with unit tests beside it.
 
 ## SQL / database performance
 

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -1,0 +1,227 @@
+# Linux desktop
+
+Linthra has a native Flutter Linux target. This page is how to build and run it,
+what works today, and what deliberately does not yet.
+
+> **Linux is not production-ready.** This is the first milestone of
+> [issue #376](https://github.com/TheZupZup/Linthra/issues/376): the app
+> compiles, launches, and renders in a real desktop window. **There is no audio
+> playback on Linux yet** — that is the next piece of work. Android is
+> unaffected and remains the platform Linthra actually ships on.
+
+## What exists after this milestone
+
+* `linux/` is committed, like `android/`. No `flutter create` step.
+* `flutter build linux` produces a runnable bundle.
+* The window carries Linthra's real identity: application id
+  `io.github.thezupzup.linthra` (the same reverse-DNS id as the Android build),
+  window title `Linthra`, a 1180×780 default size and a 420×600 minimum.
+* Every shared layer is the same code Android runs: domain models, providers,
+  repositories, routing, theming, the local scanner, and the Jellyfin /
+  Navidrome / Subsonic / Plex integrations.
+* Server credentials persist in **encrypted** storage on Linux, through the
+  desktop Secret Service (see [Secure storage](#secure-storage)).
+* CI builds the Linux target on every PR
+  ([`linux-desktop-build.yml`](../.github/workflows/linux-desktop-build.yml)).
+
+## Required packages
+
+The Flutter Linux toolchain plus the two libraries Linthra's own plugins need.
+
+### Fedora / Fedora Kinoite
+
+```bash
+sudo dnf install \
+  clang cmake ninja-build pkgconf-pkg-config \
+  gtk3-devel xz-devel libsecret-devel
+```
+
+On **Kinoite** (and any rpm-ostree system) do development work inside a
+toolbox rather than layering packages onto the host image:
+
+```bash
+toolbox create linthra
+toolbox enter linthra
+# then run the dnf command above inside the toolbox
+```
+
+### Debian / Ubuntu
+
+```bash
+sudo apt install \
+  clang cmake ninja-build pkg-config \
+  libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev
+```
+
+### Arch
+
+```bash
+sudo pacman -S --needed clang cmake ninja pkgconf gtk3 xz libsecret
+```
+
+### What each one is for
+
+| Package | Needed by |
+| --- | --- |
+| `clang`, `cmake`, `ninja`, `pkg-config` | the Flutter Linux build itself |
+| GTK 3 development headers | the Flutter Linux embedder |
+| `liblzma` / `xz` development headers | Flutter tool prerequisite |
+| **libsecret development headers** | `flutter_secure_storage_linux` — encrypted credential storage. Not optional: without it the plugin does not build, and Linthra never falls back to plaintext credentials. |
+
+At **runtime** the app additionally wants a Secret Service provider
+(`gnome-keyring` on GNOME, `kwallet` with its Secret Service interface on KDE).
+Both are present on a standard Fedora Workstation or Kinoite install.
+
+## Building and running from source
+
+```bash
+./scripts/setup_flutter.sh                       # the pinned Flutter (no sudo)
+export PATH="$PWD/.tool/flutter/bin:$PATH"
+
+flutter config --enable-linux-desktop
+flutter pub get --enforce-lockfile
+flutter run -d linux                             # or: flutter build linux --release
+```
+
+A release build lands in `build/linux/x64/release/bundle/`; run
+`./build/linux/x64/release/bundle/linthra`.
+
+To run the same checks CI runs:
+
+```bash
+./scripts/verify_linux.sh
+```
+
+That does `pub get --enforce-lockfile`, `dart format --set-exit-if-changed`,
+`flutter analyze`, `flutter test`, the runner configuration check, and
+`flutter build linux --release`. It skips only the build if the native packages
+above are missing, and says which ones. `scripts/verify_android.sh` is
+unchanged and still the Android twin.
+
+### Building without a network
+
+`sqlite3_flutter_libs` compiles SQLite into the app so the Drift catalog runs on
+the same engine and the same compile flags Android uses. On Linux its CMake
+downloads the SQLite amalgamation from `sqlite.org` while *configuring* the
+build. That is fine on a normal machine and impossible in a sandboxed or
+air-gapped build — including `flatpak-builder`, which builds with networking
+disabled.
+
+`linux/CMakeLists.txt` therefore honours `LINTHRA_SQLITE3_SOURCE_DIR`: point it
+at an already-unpacked amalgamation (a directory containing `sqlite3.c`) and
+nothing is downloaded.
+
+```bash
+LINTHRA_SQLITE3_SOURCE_DIR=/path/to/sqlite-autoconf-XXXXXXX \
+  flutter build linux --release
+```
+
+It works through CMake's own `FETCHCONTENT_SOURCE_DIR_<NAME>` hook, so the
+plugin is neither patched nor vendored — leave the variable unset and the build
+is byte-for-byte the upstream one. `scripts/check_linux_runner.py` fails if the
+seam is ever removed, because losing it breaks nothing on a machine with a
+network and would only surface at packaging time.
+
+## Secure storage
+
+`flutter_secure_storage` publishes a real Linux implementation
+(`flutter_secure_storage_linux`), and Linthra uses it unchanged. On Linux it
+stores through **libsecret**, i.e. the freedesktop Secret Service — the same
+place your other desktop apps keep credentials — instead of Android's Keystore.
+Jellyfin, Subsonic/Navidrome and Plex sessions are encrypted at rest on Linux
+exactly as they are on Android.
+
+Two runtime facts worth knowing:
+
+* A Secret Service provider must be running and **unlocked**. On a normal
+  desktop session the login keyring is unlocked at login and nothing is asked of
+  you. On a bare window manager with no keyring daemon, reads and writes fail —
+  Linthra treats that as "not signed in" and keeps running. It never writes
+  credentials anywhere else.
+* Credential storage was not weakened to make Linux work, and there is no
+  plaintext fallback on any platform.
+
+## What is intentionally unsupported on Linux right now
+
+| Area | State | Why |
+| --- | --- | --- |
+| **Audio playback** | **Unsupported** | `just_audio` publishes no Linux implementation. `localPlaybackControllerProvider` builds `UnsupportedPlaybackController` on desktop, which answers any request to play with one explicit error instead of reaching a plugin that is not there. Next PR of #376. |
+| Media session / MPRIS | Unsupported | `audio_service` is Android/iOS only. `PlatformMediaSessionBinding` returns the inert binding on Linux, so `audio_service` is never initialised there. MPRIS is later desktop work. |
+| Android Auto | Android-only, by design | It is an Android platform integration, not a Linthra feature. |
+| Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls arrive with MPRIS. |
+| Android audio focus | Android-only, by design | `JustAudioPlaybackController` already scopes its focus handling to Android/iOS. |
+| SAF (`content://` folders) | Android-only, by design | Linux picks a real filesystem path. The scanner's desktop path is the one that runs. |
+| Local tag/artwork reading | Unsupported | `UnsupportedLocalMetadataReader` on every filesystem scan, Android included. Tracks fall back to filename/folder derivation. A real desktop reader is later work in #376. |
+| Chromecast | Android/iOS only | Already gated in `cast_providers.dart`; Linux keeps the honest "cast unavailable" service. |
+| Share sheet, launcher-icon switching | Android-only, by design | No desktop equivalent; the UI simply omits them. |
+| Desktop layout, keyboard shortcuts, media keys | Not started | The existing layout renders in the window and is usable for development. The desktop UX pass is later work in #376. |
+
+Nothing in that table is faked. Each one is an explicit implementation behind an
+existing interface, so it is visible in the code and covered by tests.
+
+## How platform selection works
+
+Linthra picks platform implementations behind interfaces, never with a
+`Platform.isLinux` check inside a widget. Two pieces make that testable:
+
+* **`HostPlatform`** (`lib/core/platform/host_platform.dart`) — the platform as
+  a value rather than a `dart:io` read. Production uses `HostPlatform.current`;
+  tests pass `HostPlatform.android` or `HostPlatform.linux`, so *both* branches
+  of every seam can be asserted from one machine.
+* **`hostPlatformProvider`** (`lib/data/repositories/host_platform_provider.dart`)
+  — the same value for provider-level selection, overridable in a
+  `ProviderContainer`.
+
+The seams that branch on it:
+
+| Seam | Android | Linux |
+| --- | --- | --- |
+| `PlatformMediaSessionBinding` | `audio_service` session | inert, never touches `audio_service` |
+| `localPlaybackControllerProvider` | `JustAudioPlaybackController` | `UnsupportedPlaybackController` |
+| `PlatformFolderPickerService` | SAF tree picker | `file_picker` filesystem chooser |
+| `PlatformAudioFileScanner` | SAF content-resolver walk | `dart:io` walk |
+| `safDocumentListerProvider` | native content resolver | unsupported |
+| `safPermissionProbeProvider` | native grant probe | unsupported |
+| `localLyricsReaderProvider` | SAF sibling document | filesystem sibling |
+| `PlatformShareService` | `ACTION_SEND` | no-op |
+| `PlatformLauncherIconService` | `<activity-alias>` toggle | no-op |
+
+Adding a platform-specific behaviour means adding a row here, not a check in a
+widget.
+
+## Guardrails
+
+* `scripts/check_linux_runner.py` — the committed runner still matches the app's
+  identity (`APPLICATION_ID` = Android's `applicationId`, `BINARY_NAME` =
+  the package name, window title = `AppInfo.name`), the window metrics are
+  sane, the offline SQLite seam is wired, and nothing under `linux/` hardcodes
+  an absolute host path. Tests: `test/tooling/check_linux_runner_test.py`.
+* `test/app/linux_startup_test.dart` — every provider `main()` reads before the
+  first frame constructs on a Linux host, with no Android MethodChannel
+  binding among them.
+* `test/features/library/library_platform_bindings_test.dart` and
+  `test/features/player/playback_platform_binding_test.dart` — each seam picks
+  the Android implementation on Android and the desktop one on Linux.
+
+`linux/CMakeLists.txt` and `linux/runner/my_application.cc` are listed as
+`unmanaged_files` in `.metadata`, so `flutter migrate` leaves Linthra's edits
+alone. If someone re-runs `flutter create --platforms=linux .` anyway, the
+checker above is what catches the reverted title and the lost SQLite seam.
+
+## Where this is going
+
+The Linux distribution target is **Flathub**. A locally installable Flatpak on
+Fedora Kinoite is a validation step on the way, not the destination. Flatpak
+packaging — manifest, desktop file, icons, AppStream metadata, sandbox
+permissions — is later work in #376 and is not part of this milestone.
+
+Decisions already taken with that destination in mind:
+
+* one reverse-DNS application id shared with Android, stable and
+  Flathub-shaped (`io.github.thezupzup.linthra`);
+* no build-time dependency on host filesystem paths (enforced by the checker);
+* no runtime downloading of anything that belongs in the build;
+* the SQLite escape hatch above, so a network-isolated build is already
+  possible;
+* every platform integration behind an interface, so a sandboxed portal-based
+  implementation can be slotted in without touching feature code.

--- a/lib/core/platform/host_platform.dart
+++ b/lib/core/platform/host_platform.dart
@@ -1,0 +1,93 @@
+import 'dart:io' show Platform;
+
+/// The operating system Linthra is running on, as far as platform *selection*
+/// is concerned.
+///
+/// Linthra has always chosen its platform implementations with `Platform.isX`
+/// read straight from `dart:io`. That works in the app and is untestable off the
+/// host OS: a unit test running on Linux can assert that the desktop branch was
+/// taken, but it can never assert that Android still picks the Android one —
+/// exactly the regression that would go unnoticed once a second platform
+/// exists.
+///
+/// [HostPlatform] is the same decision expressed as a value, so the selection
+/// rule can be exercised for *both* platforms on one machine. Production code
+/// keeps using [HostPlatform.current], which reads `dart:io` once at startup and
+/// is unchanged behaviour; tests pass [HostPlatform.android] or
+/// [HostPlatform.linux] directly.
+///
+/// This is deliberately a small, closed enum rather than a wrapper around every
+/// `Platform` member: it exists to answer "which implementation should I build",
+/// not to abstract the OS.
+enum HostPlatform {
+  android,
+  ios,
+  linux,
+  macOS,
+  windows,
+
+  /// Anything else `dart:io` reports (fuchsia, or a future value). Treated as a
+  /// non-Android, non-desktop platform: every seam falls back to its safest
+  /// implementation.
+  other;
+
+  /// The platform this process is actually running on.
+  ///
+  /// Read from `dart:io` once, at first use. `Platform.operatingSystem` is a
+  /// build-time constant on every target Linthra ships, so this is a cheap
+  /// lookup, not a syscall per call site.
+  static final HostPlatform current = fromOperatingSystem(
+    Platform.operatingSystem,
+  );
+
+  /// Maps a `Platform.operatingSystem` string onto a [HostPlatform].
+  ///
+  /// Exposed so the mapping itself is unit-testable without spoofing the host
+  /// OS, and so a future embedder string can be handled explicitly rather than
+  /// silently landing in the wrong branch.
+  static HostPlatform fromOperatingSystem(String operatingSystem) {
+    switch (operatingSystem) {
+      case 'android':
+        return HostPlatform.android;
+      case 'ios':
+        return HostPlatform.ios;
+      case 'linux':
+        return HostPlatform.linux;
+      case 'macos':
+        return HostPlatform.macOS;
+      case 'windows':
+        return HostPlatform.windows;
+      default:
+        return HostPlatform.other;
+    }
+  }
+
+  /// Whether this is Android — the platform that owns SAF, the media
+  /// notification, Android Auto, and the native MethodChannels.
+  bool get isAndroid => this == HostPlatform.android;
+
+  /// Whether this is a desktop platform (Linux today; macOS and Windows are not
+  /// targets yet but must not be misread as mobile if someone builds them).
+  bool get isDesktop =>
+      this == HostPlatform.linux ||
+      this == HostPlatform.macOS ||
+      this == HostPlatform.windows;
+
+  /// A stable, secret-free label for diagnostics and logs.
+  String get label {
+    switch (this) {
+      case HostPlatform.android:
+        return 'android';
+      case HostPlatform.ios:
+        return 'ios';
+      case HostPlatform.linux:
+        return 'linux';
+      case HostPlatform.macOS:
+        return 'macos';
+      case HostPlatform.windows:
+        return 'windows';
+      case HostPlatform.other:
+        return 'other';
+    }
+  }
+}

--- a/lib/core/services/media_session_binding.dart
+++ b/lib/core/services/media_session_binding.dart
@@ -1,0 +1,150 @@
+import '../platform/host_platform.dart';
+import '../repositories/download_repository.dart';
+import '../repositories/favorites_repository.dart';
+import '../repositories/music_library_repository.dart';
+import '../repositories/playlist_repository.dart';
+import 'linthra_audio_handler.dart';
+import 'media_artwork_source.dart';
+import 'playback_controller.dart';
+
+/// Attaches Linthra's playback to the platform's media session — the thing that
+/// draws the notification / lock-screen controls and answers Android Auto.
+///
+/// The session is a *platform integration*, not a playback engine: whether one
+/// exists says nothing about whether audio can play. Android has one
+/// (`audio_service`, behind [LinthraAudioHandler]); Linux has none yet, and
+/// MPRIS — the desktop equivalent — is a later PR.
+///
+/// The seam exists so startup can ask for a session without knowing which
+/// platform it is on, and so the Android-only plugin is never *touched* on a
+/// platform that has no implementation for it. Calling into `audio_service` off
+/// Android does not merely fail; it fails after `AudioService.init` has already
+/// half-configured its statics (it builds a cache manager and installs handler
+/// callbacks before the first platform call throws), which is the kind of
+/// half-initialised state that is easy to trip over later.
+abstract interface class MediaSessionBinding {
+  /// Whether this platform has a media session Linthra can attach to. Read by
+  /// diagnostics; startup does not need to branch on it.
+  bool get isSupported;
+
+  /// Attaches the session, returning whether one is now live.
+  ///
+  /// Best-effort and never throws: a platform without the native setup (or a
+  /// test host with no bindings) reports `false` and the app carries on. The
+  /// repositories are what Android Auto browses; they are ignored where there
+  /// is no session.
+  Future<bool> attach(
+    PlaybackController controller,
+    MusicLibraryRepository library, {
+    PlaylistRepository? playlists,
+    FavoritesRepository? favorites,
+    DownloadRepository? downloads,
+    MediaArtworkSource? artwork,
+  });
+}
+
+/// The Android media session, backed by `audio_service`.
+///
+/// A thin wrapper over [connectMediaSession] so the `audio_service` import stays
+/// confined to [LinthraAudioHandler]'s file and this one line of routing.
+class AudioServiceMediaSessionBinding implements MediaSessionBinding {
+  const AudioServiceMediaSessionBinding();
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<bool> attach(
+    PlaybackController controller,
+    MusicLibraryRepository library, {
+    PlaylistRepository? playlists,
+    FavoritesRepository? favorites,
+    DownloadRepository? downloads,
+    MediaArtworkSource? artwork,
+  }) async {
+    final LinthraAudioHandler? handler = await connectMediaSession(
+      controller,
+      library,
+      playlists: playlists,
+      favorites: favorites,
+      downloads: downloads,
+      artwork: artwork,
+    );
+    return handler != null;
+  }
+}
+
+/// The explicit "this platform has no media session" binding.
+///
+/// Used on Linux (and every other desktop) until MPRIS lands. It is deliberately
+/// a real, named class rather than a silent `if`: an inert session is a fact
+/// about the platform that diagnostics can report and tests can assert on, and
+/// it makes the missing desktop integration visible in the code instead of
+/// implied by its absence.
+class UnsupportedMediaSessionBinding implements MediaSessionBinding {
+  const UnsupportedMediaSessionBinding();
+
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<bool> attach(
+    PlaybackController controller,
+    MusicLibraryRepository library, {
+    PlaylistRepository? playlists,
+    FavoritesRepository? favorites,
+    DownloadRepository? downloads,
+    MediaArtworkSource? artwork,
+  }) async =>
+      false;
+}
+
+/// The default [MediaSessionBinding]: the real `audio_service` session on
+/// Android, an inert one everywhere else.
+///
+/// This is the one place that knows about the platform split, mirroring
+/// `PlatformShareService` and `PlatformFolderPickerService`. The Android
+/// delegate is only ever *reached* on Android, so `audio_service` cannot
+/// initialise on a platform that has no implementation for it.
+class PlatformMediaSessionBinding implements MediaSessionBinding {
+  const PlatformMediaSessionBinding({
+    HostPlatform? host,
+    MediaSessionBinding androidBinding =
+        const AudioServiceMediaSessionBinding(),
+    MediaSessionBinding fallbackBinding =
+        const UnsupportedMediaSessionBinding(),
+  })  : _host = host,
+        _androidBinding = androidBinding,
+        _fallbackBinding = fallbackBinding;
+
+  // Null means "read the real host". Resolved lazily rather than in the
+  // initialiser list so the class stays const-constructible.
+  final HostPlatform? _host;
+  final MediaSessionBinding _androidBinding;
+  final MediaSessionBinding _fallbackBinding;
+
+  MediaSessionBinding get _delegate => (_host ?? HostPlatform.current).isAndroid
+      ? _androidBinding
+      : _fallbackBinding;
+
+  @override
+  bool get isSupported => _delegate.isSupported;
+
+  @override
+  Future<bool> attach(
+    PlaybackController controller,
+    MusicLibraryRepository library, {
+    PlaylistRepository? playlists,
+    FavoritesRepository? favorites,
+    DownloadRepository? downloads,
+    MediaArtworkSource? artwork,
+  }) =>
+      _delegate.attach(
+        controller,
+        library,
+        playlists: playlists,
+        favorites: favorites,
+        downloads: downloads,
+        artwork: artwork,
+      );
+}

--- a/lib/core/services/platform_folder_picker_service.dart
+++ b/lib/core/services/platform_folder_picker_service.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import '../platform/host_platform.dart';
 import 'file_picker_folder_picker_service.dart';
 import 'folder_picker_service.dart';
 import 'method_channel_saf_folder_picker.dart';
@@ -15,17 +14,23 @@ import 'method_channel_saf_folder_picker.dart';
 /// platform split, mirroring [PlatformAudioFileScanner] on the scan side.
 class PlatformFolderPickerService implements FolderPickerService {
   const PlatformFolderPickerService({
+    HostPlatform? host,
     FolderPickerService androidPicker = const MethodChannelSafFolderPicker(),
     FolderPickerService fallbackPicker = const FilePickerFolderPickerService(),
-  })  : _androidPicker = androidPicker,
+  })  : _host = host,
+        _androidPicker = androidPicker,
         _fallbackPicker = fallbackPicker;
 
+  /// The platform to route for. Null means "ask the real host", which is what
+  /// the app always does; tests pass a value so both branches are reachable
+  /// from one machine.
+  final HostPlatform? _host;
   final FolderPickerService _androidPicker;
   final FolderPickerService _fallbackPicker;
 
   @override
   Future<String?> pickFolder() {
-    if (Platform.isAndroid) {
+    if ((_host ?? HostPlatform.current).isAndroid) {
       return _androidPicker.pickFolder();
     }
     return _fallbackPicker.pickFolder();

--- a/lib/core/services/platform_launcher_icon_service.dart
+++ b/lib/core/services/platform_launcher_icon_service.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import '../platform/host_platform.dart';
 import 'android_launcher_icon_service.dart';
 import 'launcher_icon_service.dart';
 import 'noop_launcher_icon_service.dart';
@@ -14,16 +13,22 @@ import 'noop_launcher_icon_service.dart';
 /// and the in-app branding selection still applies.
 class PlatformLauncherIconService implements LauncherIconService {
   const PlatformLauncherIconService({
+    HostPlatform? host,
     LauncherIconService androidService = const AndroidLauncherIconService(),
     LauncherIconService fallbackService = const NoopLauncherIconService(),
-  })  : _androidService = androidService,
+  })  : _host = host,
+        _androidService = androidService,
         _fallbackService = fallbackService;
 
+  /// The platform to route for; null reads the real host. See
+  /// [PlatformFolderPickerService] for why this is injectable.
+  final HostPlatform? _host;
   final LauncherIconService _androidService;
   final LauncherIconService _fallbackService;
 
-  LauncherIconService get _delegate =>
-      Platform.isAndroid ? _androidService : _fallbackService;
+  LauncherIconService get _delegate => (_host ?? HostPlatform.current).isAndroid
+      ? _androidService
+      : _fallbackService;
 
   @override
   bool get isSupported => _delegate.isSupported;

--- a/lib/core/services/platform_playback_support.dart
+++ b/lib/core/services/platform_playback_support.dart
@@ -1,0 +1,18 @@
+import '../platform/host_platform.dart';
+
+/// Which platforms have an on-device audio engine Linthra can drive.
+///
+/// One named rule instead of a `Platform.isAndroid` sprinkled through the
+/// provider graph, so "does this build have audio?" has exactly one answer that
+/// both the app and the tests read.
+///
+/// The rule follows the engine, not the product plan: `just_audio` — the package
+/// `JustAudioPlaybackController` wraps — publishes Android and iOS
+/// implementations and no Linux one. Desktop therefore gets
+/// `UnsupportedPlaybackController` until a real desktop backend is wired in,
+/// which is the next piece of Linux work.
+abstract final class PlatformPlaybackSupport {
+  /// Whether `just_audio` can actually play audio on [host].
+  static bool hasOnDeviceEngine(HostPlatform host) =>
+      host == HostPlatform.android || host == HostPlatform.ios;
+}

--- a/lib/core/services/platform_share_service.dart
+++ b/lib/core/services/platform_share_service.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import '../platform/host_platform.dart';
 import 'android_share_service.dart';
 import 'noop_share_service.dart';
 import 'share_service.dart';
@@ -14,16 +13,22 @@ import 'share_service.dart';
 /// page simply omits the "Share Linthra" entry.
 class PlatformShareService implements ShareService {
   const PlatformShareService({
+    HostPlatform? host,
     ShareService androidService = const AndroidShareService(),
     ShareService fallbackService = const NoopShareService(),
-  })  : _androidService = androidService,
+  })  : _host = host,
+        _androidService = androidService,
         _fallbackService = fallbackService;
 
+  /// The platform to route for; null reads the real host. See
+  /// [PlatformFolderPickerService] for why this is injectable.
+  final HostPlatform? _host;
   final ShareService _androidService;
   final ShareService _fallbackService;
 
-  ShareService get _delegate =>
-      Platform.isAndroid ? _androidService : _fallbackService;
+  ShareService get _delegate => (_host ?? HostPlatform.current).isAndroid
+      ? _androidService
+      : _fallbackService;
 
   @override
   bool get isSupported => _delegate.isSupported;

--- a/lib/core/services/unsupported_playback_controller.dart
+++ b/lib/core/services/unsupported_playback_controller.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+
+import '../models/playback_state.dart';
+import '../models/repeat_mode.dart';
+import '../models/track.dart';
+import 'local_playback_controller.dart';
+
+/// The on-device engine for a platform that does not have one yet.
+///
+/// Linthra's audio engine is `just_audio`, and `just_audio` ships no Linux
+/// implementation. Rather than let the app reach a plugin that isn't there —
+/// where a tap on a song produces a `MissingPluginException` from somewhere deep
+/// in the engine, or worse, silence with no explanation — the desktop build gets
+/// this: a controller that satisfies the whole [LocalPlaybackController]
+/// contract and answers every playback request with one clear, deliberate error.
+///
+/// It is a placeholder with an expiry date. Linux audio playback is the next
+/// piece of desktop work; when a real desktop backend lands, this class is
+/// deleted and the platform selection in `localPlaybackControllerProvider`
+/// points at that backend instead. Nothing else has to change, because the UI
+/// only ever knew [PlaybackController].
+///
+/// What it deliberately does *not* do is pretend. It keeps no queue, reports no
+/// position, and never claims [PlaybackStatus.playing] — a fake queue that never
+/// plays is harder to reason about than an honest failure, and it would let a
+/// broken desktop build look healthy in a screenshot.
+class UnsupportedPlaybackController implements LocalPlaybackController {
+  UnsupportedPlaybackController({String? reason})
+      : _reason = reason ?? defaultReason;
+
+  /// The message surfaced on the now-playing screen when a track is requested.
+  /// Deliberately plain and user-facing: someone running the desktop build
+  /// should learn *why* nothing played, not see a stack trace.
+  static const String defaultReason =
+      'Audio playback is not available on this platform yet.';
+
+  final String _reason;
+  final StreamController<PlaybackState> _states =
+      StreamController<PlaybackState>.broadcast();
+
+  PlaybackState _state = PlaybackState.idle;
+  bool _disposed = false;
+
+  @override
+  PlaybackState get state => _state;
+
+  @override
+  Stream<PlaybackState> get stateStream => _states.stream;
+
+  /// Why playback is unavailable. Read by tests and, later, by diagnostics.
+  String get reason => _reason;
+
+  // Any request to *make sound* lands here: remember which track was asked for
+  // (so the UI can name it) and publish the explicit failure.
+  void _refuse(Track? track) {
+    _emit(PlaybackState(
+      status: PlaybackStatus.error,
+      currentTrack: track ?? _state.currentTrack,
+      errorMessage: _reason,
+      shuffleEnabled: _state.shuffleEnabled,
+      repeatMode: _state.repeatMode,
+    ));
+  }
+
+  void _emit(PlaybackState next) {
+    if (_disposed) return;
+    _state = next;
+    _states.add(next);
+  }
+
+  @override
+  Future<void> playTrack(Track track) async => _refuse(track);
+
+  @override
+  Future<void> playTracks(List<Track> tracks, {int startIndex = 0}) async {
+    final bool inRange = startIndex >= 0 && startIndex < tracks.length;
+    _refuse(inRange ? tracks[startIndex] : null);
+  }
+
+  @override
+  void playNext(Track track) => _refuse(track);
+
+  @override
+  void addToQueue(Track track) => _refuse(track);
+
+  @override
+  Future<void> play() async => _refuse(null);
+
+  @override
+  Future<void> playFromQueue(int upNextIndex) async => _refuse(null);
+
+  @override
+  Future<void> playFromHistory(int previousIndex) async => _refuse(null);
+
+  @override
+  Future<void> skipToNext() async => _refuse(null);
+
+  @override
+  Future<void> skipToPrevious() async => _refuse(null);
+
+  // Everything below either has no audio to act on or is a mode the UI may set
+  // before anything plays. These stay quiet no-ops so the settings and queue
+  // screens behave normally instead of erroring at rest.
+
+  @override
+  void removeFromQueue(int upNextIndex) {}
+
+  @override
+  void reorderQueue(int oldIndex, int newIndex) {}
+
+  @override
+  void clearQueue() {}
+
+  @override
+  void setShuffleEnabled(bool enabled) {
+    _emit(PlaybackState(
+      status: _state.status,
+      currentTrack: _state.currentTrack,
+      errorMessage: _state.errorMessage,
+      shuffleEnabled: enabled,
+      repeatMode: _state.repeatMode,
+    ));
+  }
+
+  @override
+  void setRepeatMode(RepeatMode mode) {
+    _emit(PlaybackState(
+      status: _state.status,
+      currentTrack: _state.currentTrack,
+      errorMessage: _state.errorMessage,
+      shuffleEnabled: _state.shuffleEnabled,
+      repeatMode: mode,
+    ));
+  }
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> seek(Duration position) async {}
+
+  @override
+  Future<void> stop() async => _emit(PlaybackState.idle);
+
+  // --- LocalPlaybackController: the cast-handoff and engine-lifecycle half ---
+  //
+  // There is no engine to silence or restore, so these are inert. `isSuspended`
+  // stays false: reporting "suspended" would tell the cast controller a local
+  // engine is being held back, which is not what is happening.
+
+  @override
+  bool get isSuspended => false;
+
+  @override
+  Future<void> suspend() async {}
+
+  @override
+  Future<void> resume({Duration at = Duration.zero, bool play = false}) async {}
+
+  @override
+  Future<void> restartQueue() async {}
+
+  @override
+  void setVolumeNormalizationEnabled(bool enabled) {}
+
+  @override
+  void onAppForegrounded() {}
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _states.close();
+  }
+}

--- a/lib/data/repositories/host_platform_provider.dart
+++ b/lib/data/repositories/host_platform_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/platform/host_platform.dart';
+
+/// The platform the app believes it is running on, for every provider that has
+/// to choose a platform-specific implementation.
+///
+/// Defaults to the real host, so the running app behaves exactly as it did when
+/// each of those providers read `Platform.isAndroid` itself. Its reason for
+/// existing is the other direction: a test can override it and assert that the
+/// Android bindings are still chosen on Android and that a desktop build gets
+/// the desktop ones — on a single machine, without the assertion quietly
+/// becoming "whatever this CI runner happens to be".
+final hostPlatformProvider = Provider<HostPlatform>((ref) {
+  return HostPlatform.current;
+});

--- a/lib/features/library/library_providers.dart
+++ b/lib/features/library/library_providers.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/services/folder_picker_service.dart';
@@ -10,6 +8,7 @@ import '../../core/sources/local/method_channel_saf_document_lister.dart';
 import '../../core/sources/local/method_channel_saf_permission_probe.dart';
 import '../../core/sources/local/saf_document_lister.dart';
 import '../../core/sources/local/saf_permission_probe.dart';
+import '../../data/repositories/host_platform_provider.dart';
 
 /// The storage seam the library scan uses to discover audio files.
 ///
@@ -38,7 +37,7 @@ final folderPickerServiceProvider = Provider<FolderPickerService>((ref) {
 /// elsewhere (desktop, tests) the unsupported binding makes a content-URI scan
 /// fall back to filesystem path resolution. Tests override it with a fake.
 final safDocumentListerProvider = Provider<SafDocumentLister>((ref) {
-  return Platform.isAndroid
+  return ref.watch(hostPlatformProvider).isAndroid
       ? const MethodChannelSafDocumentLister()
       : const UnsupportedSafDocumentLister();
 });
@@ -49,7 +48,7 @@ final safDocumentListerProvider = Provider<SafDocumentLister>((ref) {
 /// elsewhere (desktop, tests) the unsupported binding reports `null` so the
 /// persisted-permission line is simply omitted. Tests override it with a fake.
 final safPermissionProbeProvider = Provider<SafPermissionProbe>((ref) {
-  return Platform.isAndroid
+  return ref.watch(hostPlatformProvider).isAndroid
       ? const MethodChannelSafPermissionProbe()
       : const UnsupportedSafPermissionProbe();
 });

--- a/lib/features/player/lyrics_providers.dart
+++ b/lib/features/player/lyrics_providers.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/lyrics.dart';
@@ -14,6 +12,7 @@ import '../../core/services/subsonic_lyrics_provider.dart';
 import '../../core/sources/local/io_local_lyrics_reader.dart';
 import '../../core/sources/local/local_lyrics_reader.dart';
 import '../../core/sources/local/method_channel_saf_lyrics_reader.dart';
+import '../../data/repositories/host_platform_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
 import '../settings/jellyfin/jellyfin_settings_providers.dart';
 import '../settings/plex/plex_settings_controller.dart';
@@ -76,7 +75,7 @@ final currentTrackLyricsProvider =
 /// [lyricsServiceProvider] directly, so this is only exercised in a real app
 /// build.
 final localLyricsReaderProvider = Provider<LocalLyricsReader>((ref) {
-  return Platform.isAndroid
+  return ref.watch(hostPlatformProvider).isAndroid
       ? const MethodChannelSafLyricsReader()
       : const IoLocalLyricsReader();
 });

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -3,11 +3,13 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/playback_state.dart';
+import '../../core/platform/host_platform.dart';
 import '../../core/services/active_playback_controller.dart';
 import '../../core/services/just_audio_playback_controller.dart';
 import '../../core/services/local_playable_uri_resolver.dart';
 import '../../core/services/local_playback_controller.dart';
 import '../../core/services/offline_first_playable_uri_resolver.dart';
+import '../../core/services/platform_playback_support.dart';
 import '../../core/services/playable_uri_resolver.dart';
 import '../../core/services/playback_candidate_source.dart';
 import '../../core/services/playback_controller.dart';
@@ -25,6 +27,7 @@ import '../../core/services/routing_playable_uri_resolver.dart';
 import '../../core/services/routing_server_playback_reporter.dart';
 import '../../core/services/server_playback_reporter.dart';
 import '../../core/services/smart_precache_service.dart';
+import '../../core/services/unsupported_playback_controller.dart';
 import '../../core/sources/jellyfin/jellyfin_account_fingerprint.dart';
 import '../../core/sources/jellyfin/jellyfin_playable_uri_resolver.dart';
 import '../../core/sources/jellyfin/jellyfin_playback_reporter.dart';
@@ -36,6 +39,7 @@ import '../../core/sources/subsonic/subsonic_account_fingerprint.dart';
 import '../../core/sources/subsonic/subsonic_playable_uri_resolver.dart';
 import '../../core/sources/subsonic/subsonic_playback_reporter.dart';
 import '../../data/repositories/download_repository_provider.dart';
+import '../../data/repositories/host_platform_provider.dart';
 import '../../data/repositories/play_history_repository_provider.dart';
 import '../../data/repositories/remote_cache_index_provider.dart';
 import '../settings/jellyfin/jellyfin_settings_controller.dart';
@@ -202,6 +206,22 @@ final playbackCandidateSourceProvider = Provider<PlaybackCandidateSource>(
 
 final localPlaybackControllerProvider =
     Provider<LocalPlaybackController>((ref) {
+  // Platforms without a `just_audio` implementation get the explicit
+  // unsupported engine instead. This is the only branch: everything downstream —
+  // the routing controller, the queue UI, smart pre-cache, playback reporting —
+  // keeps talking to a LocalPlaybackController and is unaware which one it got.
+  //
+  // Building the `just_audio` controller on such a platform is what has to be
+  // avoided, not just calling it: its constructor creates an AudioPlayer, which
+  // is the plugin-backed object that does not exist there.
+  final HostPlatform host = ref.watch(hostPlatformProvider);
+  if (!PlatformPlaybackSupport.hasOnDeviceEngine(host)) {
+    final UnsupportedPlaybackController unsupported =
+        UnsupportedPlaybackController();
+    ref.onDispose(unsupported.dispose);
+    return unsupported;
+  }
+
   final controller = JustAudioPlaybackController(
     resolver: ref.read(playableUriResolverProvider),
     // Read once at construction; the candidate source itself reads the live

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'app/linthra_app.dart';
 import 'core/models/plex_session.dart';
 import 'core/models/subsonic_session.dart';
 import 'core/models/theme_mode_preference.dart';
-import 'core/services/linthra_audio_handler.dart';
+import 'core/services/media_session_binding.dart';
 import 'core/sources/plex/plex_artwork.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
 import 'data/repositories/app_icon_variant_store_provider.dart';
@@ -141,9 +141,11 @@ Future<void> main() async {
     ],
   );
 
-  // Attaching the session is best-effort: on a platform without the native
-  // audio_service setup it returns null and basic playback still works. The
-  // handler mirrors the controller and outlives this scope with the container.
+  // Attaching the session is best-effort and platform-routed: on a platform
+  // with no media session (Linux today — MPRIS is later desktop work) the
+  // binding is the inert one and `audio_service` is never initialised at all.
+  // On Android it attaches the real session; the handler mirrors the controller
+  // and outlives this scope with the container.
   // Passing the playlist + favourites + downloads repositories lets Android Auto
   // browse Playlists/Favorites/Offline (when the user has any) alongside
   // Songs/Albums/Artists/Queue — all read straight from the persisted stores, so
@@ -154,7 +156,7 @@ Future<void> main() async {
   // content:// — the handler reads it synchronously, never a credentialed
   // getCoverArt / X-Plex-Token cover URL. The covers are fetched and cached
   // ahead of time, off the playback path, by the prewarm service started below.
-  await connectMediaSession(
+  await const PlatformMediaSessionBinding().attach(
     container.read(playbackControllerProvider),
     container.read(musicLibraryRepositoryProvider),
     playlists: container.read(playlistRepositoryProvider),

--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,0 +1,166 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "linthra")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "io.github.thezupzup.linthra")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# === Bundled SQLite, without a build-time download ===
+#
+# `sqlite3_flutter_libs` compiles the SQLite amalgamation into the app so the
+# Drift catalog runs on the same engine, with the same compile flags (FTS5,
+# math functions, session/preupdate hooks), that Android already uses. On Linux
+# its own CMake pulls that amalgamation from sqlite.org with FetchContent at
+# *configure* time.
+#
+# That download is harmless on a developer machine with a network, and it is a
+# problem everywhere else: a sandboxed CI runner, an air-gapped build, and —
+# the one that matters for where Linthra is going — flatpak-builder, which runs
+# the build with networking disabled. Flathub expects every source to be
+# declared in the manifest and fetched up front.
+#
+# LINTHRA_SQLITE3_SOURCE_DIR is the seam for that. Point it at an already
+# unpacked amalgamation (a directory containing `sqlite3.c`) and the fetch is
+# satisfied locally. It works through CMake's own
+# FETCHCONTENT_SOURCE_DIR_<NAME> hook, so the plugin is never patched or
+# vendored: leave the variable unset and the build is byte-for-byte the
+# upstream one. See docs/linux-desktop.md.
+set(LINTHRA_SQLITE3_SOURCE_DIR "$ENV{LINTHRA_SQLITE3_SOURCE_DIR}" CACHE PATH
+  "Directory holding an already-unpacked SQLite amalgamation (sqlite3.c). \
+Set this to build without fetching SQLite from sqlite.org.")
+if(LINTHRA_SQLITE3_SOURCE_DIR)
+  if(NOT EXISTS "${LINTHRA_SQLITE3_SOURCE_DIR}/sqlite3.c")
+    message(FATAL_ERROR
+      "LINTHRA_SQLITE3_SOURCE_DIR is set to '${LINTHRA_SQLITE3_SOURCE_DIR}' "
+      "but there is no sqlite3.c there. It must point at an unpacked SQLite "
+      "amalgamation.")
+  endif()
+  # FORCE: the plugin's FetchContent_Declare runs later in this same configure,
+  # and only a cache entry that is already set wins over it.
+  set(FETCHCONTENT_SOURCE_DIR_SQLITE3 "${LINTHRA_SQLITE3_SOURCE_DIR}"
+    CACHE PATH "SQLite source supplied by Linthra." FORCE)
+  message(STATUS
+    "Linthra: using pre-fetched SQLite from ${LINTHRA_SQLITE3_SOURCE_DIR}")
+endif()
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/linux/flutter/CMakeLists.txt
+++ b/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,23 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
+  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+}

--- a/linux/flutter/generated_plugin_registrant.h
+++ b/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,26 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
+  sqlite3_flutter_libs
+  url_launcher_linux
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/linux/runner/main.cc
+++ b/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -1,0 +1,175 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+// The user-visible application name. Kept as one constant so the header bar,
+// the fallback title bar, and anything added later can never drift apart — and
+// so it stays greppable against the Dart-side `AppInfo.name` and the Android
+// `android:label`. scripts/check_linux_runner.py enforces that agreement.
+static constexpr const char* kApplicationName = "Linthra";
+
+// Opening window size on a desktop. Wide enough to feel like a desktop app
+// rather than a stretched phone, without pretending the desktop layout (a later
+// PR) already exists.
+static constexpr int kDefaultWindowWidth = 1180;
+static constexpr int kDefaultWindowHeight = 780;
+
+// The narrowest/shortest the window may be dragged. Roughly a large phone, the
+// shape the current shared layout is written for.
+static constexpr int kMinimumWindowWidth = 420;
+static constexpr int kMinimumWindowHeight = 600;
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, kApplicationName);
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, kApplicationName);
+  }
+
+  gtk_window_set_default_size(window, kDefaultWindowWidth,
+                              kDefaultWindowHeight);
+
+  // Floor the window at a size the current (phone-first) Flutter layout can
+  // still render without overflowing. Linthra's desktop layout lands in a later
+  // PR; until then this keeps a dragged-narrow window usable for development
+  // rather than letting it collapse into a wall of overflow errors.
+  GdkGeometry geometry;
+  geometry.min_width = kMinimumWindowWidth;
+  geometry.min_height = kMinimumWindowHeight;
+  gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/linux/runner/my_application.h
+++ b/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""check_linux_runner.py — hold the committed Linux runner to Linthra's identity.
+
+The `linux/` directory is Flutter template code that Linthra has edited. That
+combination rots quietly: `flutter create --platforms=linux .` regenerates those
+files from the template, and a regeneration silently restores the template's
+lowercase `"linthra"` window title, drops the window-size constants, and — the
+expensive one — drops the SQLite pre-fetch seam that lets the app build with no
+network. Nothing fails; the app still compiles. It just stops being Linthra, or
+stops building offline, and nobody notices until packaging.
+
+So the identity is asserted against its real sources of truth instead of being
+duplicated here:
+
+    application id  <- android/app/build.gradle (applicationId)
+    binary name     <- pubspec.yaml (name)
+    window title    <- lib/core/app_info.dart (AppInfo.name)
+
+Those three are what a desktop and, later, a Flathub listing key off. An app id
+that disagrees with Android's would mean two different identities for one
+product; a window title that disagrees with `AppInfo.name` would mean the title
+bar and the About screen disagree.
+
+It also checks two things that are about *how* the runner builds rather than
+what it is called:
+
+  * the SQLite pre-fetch seam (LINTHRA_SQLITE3_SOURCE_DIR) is still there, so a
+    network-isolated build — flatpak-builder included — stays possible;
+  * nothing under linux/ hardcodes an absolute host path, which would make the
+    build depend on one machine's filesystem.
+
+Usage
+-----
+
+    python3 scripts/check_linux_runner.py            # check this repository
+    python3 scripts/check_linux_runner.py --root DIR # check another checkout
+
+Read-only, offline, no dependencies beyond the standard library. Exit status: 0
+if the runner agrees with the app, 2 if it does not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Paths this script reads, all relative to the repository root.
+CMAKELISTS = Path("linux") / "CMakeLists.txt"
+MY_APPLICATION = Path("linux") / "runner" / "my_application.cc"
+PUBSPEC = Path("pubspec.yaml")
+APP_INFO = Path("lib") / "core" / "app_info.dart"
+BUILD_GRADLE = Path("android") / "app" / "build.gradle"
+
+# The CMake variable linux/CMakeLists.txt uses to accept an already-unpacked
+# SQLite amalgamation instead of downloading one. See docs/linux-desktop.md.
+SQLITE_SOURCE_VARIABLE = "LINTHRA_SQLITE3_SOURCE_DIR"
+
+# An absolute path baked into the native build would tie it to one machine.
+# `/` alone is far too common in CMake (every ${VAR}/sub path), so this looks
+# for a quoted or bare token that starts at a real filesystem root.
+ABSOLUTE_PATH_PATTERN = re.compile(
+    r'(?<![\w$/{])/(?:home|Users|root|opt|usr/local|tmp|var|mnt|media)/[\w./-]+'
+)
+
+
+class CheckError(Exception):
+    """A file could not be read or a required value could not be found."""
+
+
+def _read(root: Path, relative: Path) -> str:
+    path = root / relative
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CheckError(f"cannot read {relative}: {error}") from error
+
+
+def _extract(text: str, pattern: str, what: str, where: Path) -> str:
+    """Return the single capture group of `pattern` in `text`.
+
+    Requiring exactly one match is the point: a second `set(BINARY_NAME ...)`
+    or a second `static const char* kApplicationName` means the file no longer
+    has one answer, and picking the first would hide that.
+    """
+    matches = re.findall(pattern, text, flags=re.MULTILINE)
+    if not matches:
+        raise CheckError(f"{where}: could not find {what}")
+    if len(matches) > 1:
+        raise CheckError(f"{where}: found {len(matches)} definitions of {what}, expected 1")
+    return matches[0]
+
+
+def application_id(root: Path) -> str:
+    """The GTK application id the Linux runner registers under."""
+    return _extract(
+        _read(root, CMAKELISTS),
+        r'^set\(APPLICATION_ID\s+"([^"]+)"\)',
+        "APPLICATION_ID",
+        CMAKELISTS,
+    )
+
+
+def binary_name(root: Path) -> str:
+    """The on-disk name of the built executable."""
+    return _extract(
+        _read(root, CMAKELISTS),
+        r'^set\(BINARY_NAME\s+"([^"]+)"\)',
+        "BINARY_NAME",
+        CMAKELISTS,
+    )
+
+
+def window_title(root: Path) -> str:
+    """The user-visible name the runner puts in the title/header bar."""
+    return _extract(
+        _read(root, MY_APPLICATION),
+        r'kApplicationName\s*=\s*"([^"]+)"',
+        "kApplicationName",
+        MY_APPLICATION,
+    )
+
+
+def window_metric(root: Path, name: str) -> int:
+    """One of the runner's window-size constants."""
+    return int(
+        _extract(
+            _read(root, MY_APPLICATION),
+            rf"{name}\s*=\s*(\d+);",
+            name,
+            MY_APPLICATION,
+        )
+    )
+
+
+def android_application_id(root: Path) -> str:
+    """Android's applicationId — the identity Linux has to match."""
+    return _extract(
+        _read(root, BUILD_GRADLE),
+        r'^\s*applicationId\s*=\s*"([^"]+)"',
+        "applicationId",
+        BUILD_GRADLE,
+    )
+
+
+def pubspec_name(root: Path) -> str:
+    """The Dart package name, which is also the executable name."""
+    return _extract(_read(root, PUBSPEC), r"^name:\s*(\S+)", "name", PUBSPEC)
+
+
+def app_display_name(root: Path) -> str:
+    """`AppInfo.name` — the product name the app shows about itself."""
+    return _extract(
+        _read(root, APP_INFO),
+        r"static const String name\s*=\s*'([^']+)'",
+        "AppInfo.name",
+        APP_INFO,
+    )
+
+
+def absolute_paths_under_linux(root: Path) -> list[str]:
+    """Absolute host paths hardcoded in the committed Linux build files.
+
+    Only the files Linthra owns are scanned. `linux/flutter/ephemeral` is
+    generated per build and is not in git.
+    """
+    findings: list[str] = []
+    linux_dir = root / "linux"
+    for path in sorted(linux_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if "ephemeral" in path.relative_to(linux_dir).parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for match in ABSOLUTE_PATH_PATTERN.findall(line):
+                findings.append(f"{path.relative_to(root)}:{line_number}: {match}")
+    return findings
+
+
+def check(root: Path) -> list[str]:
+    """Return the problems found, empty when the runner is consistent."""
+    problems: list[str] = []
+
+    def compare(label: str, actual: str, expected: str, source: str) -> None:
+        if actual != expected:
+            problems.append(
+                f"{label} is {actual!r} but {source} says {expected!r}"
+            )
+
+    compare(
+        "linux/CMakeLists.txt APPLICATION_ID",
+        application_id(root),
+        android_application_id(root),
+        "android/app/build.gradle applicationId",
+    )
+    compare(
+        "linux/CMakeLists.txt BINARY_NAME",
+        binary_name(root),
+        pubspec_name(root),
+        "pubspec.yaml name",
+    )
+    compare(
+        "linux/runner/my_application.cc kApplicationName",
+        window_title(root),
+        app_display_name(root),
+        "lib/core/app_info.dart AppInfo.name",
+    )
+
+    # Window metrics: a minimum larger than the default would open the window
+    # already clamped, which reads as the app ignoring its own default.
+    minimum_width = window_metric(root, "kMinimumWindowWidth")
+    minimum_height = window_metric(root, "kMinimumWindowHeight")
+    default_width = window_metric(root, "kDefaultWindowWidth")
+    default_height = window_metric(root, "kDefaultWindowHeight")
+    if minimum_width > default_width or minimum_height > default_height:
+        problems.append(
+            f"minimum window size {minimum_width}x{minimum_height} exceeds the "
+            f"default {default_width}x{default_height}"
+        )
+    if minimum_width <= 0 or minimum_height <= 0:
+        problems.append("minimum window size must be positive")
+
+    # The offline-build seam. Losing it does not break any build that has a
+    # network, which is exactly why it needs a guard.
+    cmakelists = _read(root, CMAKELISTS)
+    if SQLITE_SOURCE_VARIABLE not in cmakelists:
+        problems.append(
+            f"{CMAKELISTS} no longer honours {SQLITE_SOURCE_VARIABLE}, so the "
+            "Linux build cannot be made to skip the SQLite download "
+            "(see docs/linux-desktop.md)"
+        )
+    elif "FETCHCONTENT_SOURCE_DIR_SQLITE3" not in cmakelists:
+        problems.append(
+            f"{CMAKELISTS} sets {SQLITE_SOURCE_VARIABLE} but never forwards it "
+            "to FETCHCONTENT_SOURCE_DIR_SQLITE3, so it has no effect"
+        )
+
+    for finding in absolute_paths_under_linux(root):
+        problems.append(f"absolute host path in the Linux build: {finding}")
+
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check the committed Linux runner against Linthra's identity."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root to check (default: this repository)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        problems = check(args.root)
+    except CheckError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    if problems:
+        print("Linux runner configuration problems:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 2
+
+    print("Linux runner configuration OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_linux.sh
+++ b/scripts/verify_linux.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# verify_linux.sh — run the Linux desktop checks locally, the way CI runs them.
+#
+# The twin of scripts/verify_android.sh, for the other platform. Order mirrors
+# .github/workflows/linux-build.yml:
+#
+#   flutter pub get --enforce-lockfile  ->  dart format (check)  ->
+#   flutter analyze  ->  flutter test  ->  Linux runner config check  ->
+#   flutter build linux --release
+#
+# The shared checks (format/analyze/test) are deliberately repeated here rather
+# than delegated: someone working on the desktop build should be able to run one
+# script and know whether they broke anything, without also remembering to run
+# the Android one.
+#
+# Native toolchain: `flutter build linux` needs clang, cmake, ninja, pkg-config
+# and the GTK 3 development headers, plus libsecret for encrypted credential
+# storage. They are checked up front and a missing one *skips* the build with a
+# clear message instead of failing the whole script — the same shape as
+# verify_android.sh skipping the APK when there is no Android SDK. See
+# docs/linux-desktop.md for the Fedora and Debian/Ubuntu package names.
+#
+# Flutter resolution: prefer the project-local SDK from setup_flutter.sh
+# (.tool/flutter), otherwise fall back to Flutter on PATH.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOCAL_FLUTTER_BIN="$REPO_ROOT/.tool/flutter/bin/flutter"
+
+info() { printf '\n==> %s\n' "$*"; }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+resolve_flutter() {
+  if [ -x "$LOCAL_FLUTTER_BIN" ]; then
+    FLUTTER="$LOCAL_FLUTTER_BIN"
+    PATH="$(dirname "$LOCAL_FLUTTER_BIN"):$PATH"
+    export PATH
+    info "Using project-local Flutter: $FLUTTER"
+  elif command -v flutter >/dev/null 2>&1; then
+    FLUTTER="$(command -v flutter)"
+    info "Using Flutter from PATH: $FLUTTER"
+  else
+    die "Flutter not found. Run ./scripts/setup_flutter.sh first."
+  fi
+  "$FLUTTER" --version | head -1 || true
+}
+
+# Report the native build prerequisites that are missing, one per line. Empty
+# output means the Linux build can run.
+missing_native_deps() {
+  local missing=()
+  local tool
+  for tool in clang cmake ninja pkg-config; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+  done
+  if command -v pkg-config >/dev/null 2>&1; then
+    pkg-config --exists gtk+-3.0 || missing+=("gtk+-3.0 development headers")
+    pkg-config --exists libsecret-1 || missing+=("libsecret-1 development headers")
+  fi
+  printf '%s\n' "${missing[@]+"${missing[@]}"}"
+}
+
+FAILED=()
+
+run_step() {
+  local label="$1"; shift
+  info "$label"
+  if "$@"; then
+    return 0
+  fi
+  warn "FAILED: $label"
+  FAILED+=("$label")
+  return 1
+}
+
+main() {
+  cd "$REPO_ROOT"
+  resolve_flutter
+
+  run_step "flutter pub get --enforce-lockfile" "$FLUTTER" pub get --enforce-lockfile
+  run_step "dart format --set-exit-if-changed ." dart format --set-exit-if-changed .
+  run_step "flutter analyze" "$FLUTTER" analyze
+  run_step "flutter test" "$FLUTTER" test
+
+  # Flutter-independent: the committed runner still matches the app's identity
+  # and can still build without a network. Cheap, so it runs before the build.
+  run_step "Linux runner configuration" python3 scripts/check_linux_runner.py
+  run_step "Linux runner tooling tests" python3 test/tooling/check_linux_runner_test.py
+
+  # Read line by line: a dependency name can contain spaces ("gtk+-3.0
+  # development headers"), so word splitting would mangle the report.
+  local missing=()
+  local dep
+  while IFS= read -r dep; do
+    [ -n "$dep" ] && missing+=("$dep")
+  done < <(missing_native_deps)
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    run_step "flutter build linux --release" "$FLUTTER" build linux --release
+  else
+    warn "Missing native Linux build dependencies:"
+    printf '  - %s\n' "${missing[@]}" >&2
+    warn "Skipping 'flutter build linux --release'. See docs/linux-desktop.md"
+    warn "for the packages to install. analyze/format/tests still ran above."
+  fi
+
+  if [ "${#FAILED[@]}" -gt 0 ]; then
+    info "Verification FAILED (${#FAILED[@]} step(s)):"
+    printf '  - %s\n' "${FAILED[@]}"
+    exit 1
+  fi
+
+  info "Verification passed."
+}
+
+main "$@"

--- a/test/app/linux_startup_test.dart
+++ b/test/app/linux_startup_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/media_session_binding.dart';
+import 'package:linthra/core/services/unsupported_playback_controller.dart';
+import 'package:linthra/data/repositories/download_repository_provider.dart';
+import 'package:linthra/data/repositories/favorites_repository_provider.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playlist_repository_provider.dart';
+import 'package:linthra/data/repositories/remote_cache_index_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+import 'package:linthra/features/player/media_artwork_providers.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+/// What `main()` builds before the first frame, on a Linux host.
+///
+/// `main()` itself cannot be called from a unit test — it runs the app — but the
+/// thing that would break a Linux launch is not `runApp`, it is the provider
+/// graph constructed above it: one eagerly-built Android-only service is enough
+/// to take the process down before a window exists. So this walks that same
+/// graph with the host pinned to Linux and asserts every read succeeds.
+///
+/// It is a smoke test on purpose. It does not assert behaviour of each service —
+/// their own suites do that — only that a Linux build can *construct* them.
+void main() {
+  ProviderContainer linuxContainer() {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        hostPlatformProvider.overrideWithValue(HostPlatform.linux),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  test('every provider main() reads before the first frame builds on Linux',
+      () {
+    final ProviderContainer container = linuxContainer();
+
+    // The order mirrors lib/main.dart.
+    expect(() {
+      container.read(playbackControllerProvider);
+      container.read(musicLibraryRepositoryProvider);
+      container.read(playlistRepositoryProvider);
+      container.read(favoritesRepositoryProvider);
+      container.read(downloadRepositoryProvider);
+      container.read(mediaArtworkCacheProvider);
+      container.read(mediaArtworkPrewarmServiceProvider);
+      container.read(smartPrecacheServiceProvider);
+      container.read(remotePrebufferServiceProvider);
+      container.read(remoteCacheIndexProvider);
+      container.read(playbackReportingServiceProvider);
+      container.read(remoteControlServiceProvider);
+      container.read(remoteControlActivatorProvider);
+      container.read(localPlaybackControllerProvider);
+    }, returnsNormally);
+  });
+
+  test('the library and lyrics seams build on Linux too', () {
+    final ProviderContainer container = linuxContainer();
+
+    expect(() {
+      container.read(audioFileScannerProvider);
+      container.read(folderPickerServiceProvider);
+      container.read(safDocumentListerProvider);
+      container.read(safPermissionProbeProvider);
+      container.read(localMetadataReaderProvider);
+      container.read(localLyricsReaderProvider);
+    }, returnsNormally);
+  });
+
+  test('the engine built for Linux is the unsupported one', () {
+    // The specific guard behind the smoke test above: "it constructed" would
+    // also be true if a future change quietly put `just_audio` back on Linux,
+    // where it constructs fine and then fails at the first tap.
+    expect(linuxContainer().read(localPlaybackControllerProvider),
+        isA<UnsupportedPlaybackController>());
+  });
+
+  test('the volume-normalization listener main() installs is safe to fire', () {
+    // main() pushes the persisted "Normalize volume" value onto the local
+    // engine immediately. On Linux that lands on the unsupported controller,
+    // which must absorb it rather than throw before the first frame.
+    final ProviderContainer container = linuxContainer();
+
+    expect(
+      () => container
+          .read(localPlaybackControllerProvider)
+          .setVolumeNormalizationEnabled(true),
+      returnsNormally,
+    );
+  });
+
+  test('startup asks for a media session and is told there is none', () async {
+    final ProviderContainer container = linuxContainer();
+    const binding = PlatformMediaSessionBinding(host: HostPlatform.linux);
+
+    final bool attached = await binding.attach(
+      container.read(playbackControllerProvider),
+      container.read(musicLibraryRepositoryProvider),
+      playlists: container.read(playlistRepositoryProvider),
+      favorites: container.read(favoritesRepositoryProvider),
+      downloads: container.read(downloadRepositoryProvider),
+      artwork: container.read(mediaArtworkCacheProvider),
+    );
+
+    expect(attached, isFalse);
+  });
+}

--- a/test/core/platform/host_platform_test.dart
+++ b/test/core/platform/host_platform_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+
+void main() {
+  group('HostPlatform.fromOperatingSystem', () {
+    test('maps every operating system dart:io reports', () {
+      expect(HostPlatform.fromOperatingSystem('android'), HostPlatform.android);
+      expect(HostPlatform.fromOperatingSystem('ios'), HostPlatform.ios);
+      expect(HostPlatform.fromOperatingSystem('linux'), HostPlatform.linux);
+      expect(HostPlatform.fromOperatingSystem('macos'), HostPlatform.macOS);
+      expect(HostPlatform.fromOperatingSystem('windows'), HostPlatform.windows);
+      expect(HostPlatform.fromOperatingSystem('fuchsia'), HostPlatform.other);
+    });
+
+    test('an unknown embedder falls into "other", never Android', () {
+      // The important half: a platform nobody has thought about must not be
+      // handed the Android bindings by accident. Every seam treats "other" the
+      // way it treats desktop — as "not Android".
+      expect(
+          HostPlatform.fromOperatingSystem('someFutureOs'), HostPlatform.other);
+      expect(HostPlatform.fromOperatingSystem('').isAndroid, isFalse);
+      expect(HostPlatform.fromOperatingSystem('Android').isAndroid, isFalse,
+          reason: 'dart:io reports lowercase; matching must stay exact');
+    });
+  });
+
+  group('classification', () {
+    test('only Android is Android', () {
+      expect(HostPlatform.android.isAndroid, isTrue);
+      for (final HostPlatform other in HostPlatform.values.where(
+        (HostPlatform p) => p != HostPlatform.android,
+      )) {
+        expect(other.isAndroid, isFalse,
+            reason: '${other.label} is not Android');
+      }
+    });
+
+    test('Linux, macOS and Windows are desktop; Android and iOS are not', () {
+      expect(HostPlatform.linux.isDesktop, isTrue);
+      expect(HostPlatform.macOS.isDesktop, isTrue);
+      expect(HostPlatform.windows.isDesktop, isTrue);
+      expect(HostPlatform.android.isDesktop, isFalse);
+      expect(HostPlatform.ios.isDesktop, isFalse);
+      expect(HostPlatform.other.isDesktop, isFalse);
+    });
+
+    test('labels are stable, lowercase and secret-free', () {
+      // Diagnostics embed these, so they must never grow into a device string.
+      for (final HostPlatform platform in HostPlatform.values) {
+        expect(platform.label, matches(RegExp(r'^[a-z]+$')));
+      }
+      expect(HostPlatform.macOS.label, 'macos');
+    });
+  });
+
+  group('HostPlatform.current', () {
+    test('agrees with dart:io on whatever host is running the suite', () {
+      // Not a tautology: it is the one assertion that the production default
+      // still reads the real OS rather than a hardcoded value.
+      expect(
+        HostPlatform.current,
+        HostPlatform.fromOperatingSystem(Platform.operatingSystem),
+      );
+      expect(HostPlatform.current.isAndroid, Platform.isAndroid);
+    });
+  });
+}

--- a/test/core/services/media_session_binding_test.dart
+++ b/test/core/services/media_session_binding_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/repositories/download_repository.dart';
+import 'package:linthra/core/repositories/favorites_repository.dart';
+import 'package:linthra/core/repositories/music_library_repository.dart';
+import 'package:linthra/core/repositories/playlist_repository.dart';
+import 'package:linthra/core/services/media_artwork_source.dart';
+import 'package:linthra/core/services/media_session_binding.dart';
+import 'package:linthra/core/services/playback_controller.dart';
+import 'package:linthra/data/repositories/in_memory_music_library_repository.dart';
+
+import '../../features/player/fake_playback_controller.dart';
+
+/// A binding that records whether it was reached at all.
+///
+/// The point of the platform split is not which value comes back — it is that
+/// the Android delegate is never *entered* on a platform where `audio_service`
+/// has no implementation, because entering it is what leaves the plugin's
+/// statics half-configured.
+class _RecordingBinding implements MediaSessionBinding {
+  _RecordingBinding({required this.isSupported, required this.result});
+
+  @override
+  final bool isSupported;
+  final bool result;
+  int attachCalls = 0;
+
+  @override
+  Future<bool> attach(
+    PlaybackController controller,
+    MusicLibraryRepository library, {
+    PlaylistRepository? playlists,
+    FavoritesRepository? favorites,
+    DownloadRepository? downloads,
+    MediaArtworkSource? artwork,
+  }) async {
+    attachCalls++;
+    return result;
+  }
+}
+
+void main() {
+  late FakePlaybackController controller;
+  late MusicLibraryRepository library;
+
+  setUp(() {
+    controller = FakePlaybackController();
+    library = InMemoryMusicLibraryRepository();
+  });
+
+  tearDown(() async {
+    await controller.dispose();
+  });
+
+  group('UnsupportedMediaSessionBinding', () {
+    test('reports no session and attaches nothing', () async {
+      const MediaSessionBinding binding = UnsupportedMediaSessionBinding();
+
+      expect(binding.isSupported, isFalse);
+      expect(await binding.attach(controller, library), isFalse);
+    });
+  });
+
+  group('PlatformMediaSessionBinding', () {
+    test('on Android, delegates to the audio_service binding', () async {
+      final android = _RecordingBinding(isSupported: true, result: true);
+      final fallback = _RecordingBinding(isSupported: false, result: false);
+      final binding = PlatformMediaSessionBinding(
+        host: HostPlatform.android,
+        androidBinding: android,
+        fallbackBinding: fallback,
+      );
+
+      expect(binding.isSupported, isTrue);
+      expect(await binding.attach(controller, library), isTrue);
+      expect(android.attachCalls, 1);
+      expect(fallback.attachCalls, 0);
+    });
+
+    test('on Linux, never enters the Android binding', () async {
+      final android = _RecordingBinding(isSupported: true, result: true);
+      final fallback = _RecordingBinding(isSupported: false, result: false);
+      final binding = PlatformMediaSessionBinding(
+        host: HostPlatform.linux,
+        androidBinding: android,
+        fallbackBinding: fallback,
+      );
+
+      expect(binding.isSupported, isFalse);
+      expect(await binding.attach(controller, library), isFalse);
+      expect(android.attachCalls, 0,
+          reason: 'audio_service must not initialise on a platform '
+              'that has no implementation for it');
+      expect(fallback.attachCalls, 1);
+    });
+
+    test('every non-Android platform routes to the fallback', () async {
+      for (final HostPlatform host in HostPlatform.values.where(
+        (HostPlatform p) => p != HostPlatform.android,
+      )) {
+        final android = _RecordingBinding(isSupported: true, result: true);
+        final binding = PlatformMediaSessionBinding(
+          host: host,
+          androidBinding: android,
+          fallbackBinding: _RecordingBinding(isSupported: false, result: false),
+        );
+
+        expect(await binding.attach(controller, library), isFalse,
+            reason: '${host.label} has no media session');
+        expect(android.attachCalls, 0,
+            reason: 'the Android binding was entered on ${host.label}');
+      }
+    });
+
+    test('the real default routes by the host the suite runs on', () async {
+      // No `host:` override, so this exercises the binding the app itself
+      // constructs. The unit host is never Android, so `audio_service` must not
+      // be touched — if it were, this call would throw or hang instead of
+      // returning false.
+      const binding = PlatformMediaSessionBinding();
+
+      expect(binding.isSupported, isFalse);
+      expect(await binding.attach(controller, library), isFalse);
+    });
+  });
+}

--- a/test/core/services/platform_folder_picker_service_test.dart
+++ b/test/core/services/platform_folder_picker_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
 import 'package:linthra/core/services/folder_picker_service.dart';
 import 'package:linthra/core/services/platform_folder_picker_service.dart';
 
@@ -38,6 +39,59 @@ void main() {
       expect(result, '/home/me/Music');
       expect(fallback.calls, 1);
       expect(android.calls, 0);
+    });
+
+    test('on Android, delegates to the SAF picker', () async {
+      // Asserted with an injected host rather than the real one, so the Android
+      // half of the split is covered from any machine — including the Linux CI
+      // runner, where it would otherwise be untestable.
+      final android = _RecordingPicker('content://tree/primary%3AMusic');
+      final fallback = _RecordingPicker('/home/me/Music');
+      final service = PlatformFolderPickerService(
+        host: HostPlatform.android,
+        androidPicker: android,
+        fallbackPicker: fallback,
+      );
+
+      final result = await service.pickFolder();
+
+      expect(result, 'content://tree/primary%3AMusic');
+      expect(android.calls, 1);
+      expect(fallback.calls, 0);
+    });
+
+    test('on Linux, delegates to the filesystem chooser', () async {
+      final android = _RecordingPicker('content://should-not-be-used');
+      final fallback = _RecordingPicker('/home/me/Music');
+      final service = PlatformFolderPickerService(
+        host: HostPlatform.linux,
+        androidPicker: android,
+        fallbackPicker: fallback,
+      );
+
+      expect(await service.pickFolder(), '/home/me/Music');
+      expect(android.calls, 0);
+      expect(fallback.calls, 1);
+    });
+
+    test('an explicit host never disagrees with the real host on this machine',
+        () async {
+      // Guards the injection itself: passing the actual platform must behave
+      // identically to passing nothing.
+      final android = _RecordingPicker('content://should-not-be-used');
+      final fallback = _RecordingPicker('/home/me/Music');
+
+      expect(
+        await PlatformFolderPickerService(
+          host: HostPlatform.current,
+          androidPicker: android,
+          fallbackPicker: fallback,
+        ).pickFolder(),
+        await PlatformFolderPickerService(
+          androidPicker: android,
+          fallbackPicker: fallback,
+        ).pickFolder(),
+      );
     });
   });
 }

--- a/test/core/services/platform_launcher_icon_service_test.dart
+++ b/test/core/services/platform_launcher_icon_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/launcher_icon_service.dart';
+import 'package:linthra/core/services/noop_launcher_icon_service.dart';
+import 'package:linthra/core/services/platform_launcher_icon_service.dart';
+
+/// Records the variant it was asked to apply, so the platform split can be
+/// asserted without touching the real `<activity-alias>` toggle.
+class _RecordingLauncherIconService implements LauncherIconService {
+  _RecordingLauncherIconService({required this.isSupported});
+
+  @override
+  final bool isSupported;
+  String? applied;
+
+  @override
+  Future<bool> applyVariant(String variantId) async {
+    applied = variantId;
+    return true;
+  }
+}
+
+void main() {
+  group('PlatformLauncherIconService', () {
+    test('on Android, switches the real launcher alias', () async {
+      final android = _RecordingLauncherIconService(isSupported: true);
+      final fallback = _RecordingLauncherIconService(isSupported: false);
+      final service = PlatformLauncherIconService(
+        host: HostPlatform.android,
+        androidService: android,
+        fallbackService: fallback,
+      );
+
+      expect(service.isSupported, isTrue);
+      await service.applyVariant('classic');
+      expect(android.applied, 'classic');
+      expect(fallback.applied, isNull);
+    });
+
+    test('on Linux, there is no launcher alias to switch', () async {
+      // The in-app branding choice still applies; only the desktop launcher
+      // entry is out of scope, and it must not reach the Android channel.
+      final android = _RecordingLauncherIconService(isSupported: true);
+      final fallback = _RecordingLauncherIconService(isSupported: false);
+      final service = PlatformLauncherIconService(
+        host: HostPlatform.linux,
+        androidService: android,
+        fallbackService: fallback,
+      );
+
+      expect(service.isSupported, isFalse);
+      await service.applyVariant('classic');
+      expect(android.applied, isNull);
+      expect(fallback.applied, 'classic');
+    });
+
+    test('the production default is inert on this (non-Android) host', () {
+      const service = PlatformLauncherIconService();
+
+      expect(service.isSupported, isFalse);
+      expect(const NoopLauncherIconService().isSupported, isFalse);
+    });
+  });
+}

--- a/test/core/services/share_service_test.dart
+++ b/test/core/services/share_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
 import 'package:linthra/core/services/android_share_service.dart';
 import 'package:linthra/core/services/noop_share_service.dart';
 import 'package:linthra/core/services/platform_share_service.dart';
@@ -69,6 +70,43 @@ void main() {
         expect(android.shared, isNull);
         expect(service.isSupported, isFalse);
       }
+    });
+
+    test('on Android, shares through the ACTION_SEND chooser', () async {
+      // Injected host, so the Android branch is covered from any machine
+      // rather than only when the suite happens to run on a device.
+      final _RecordingShareService android =
+          _RecordingShareService(isSupported: true);
+      final _RecordingShareService fallback =
+          _RecordingShareService(isSupported: false);
+      final ShareService service = PlatformShareService(
+        host: HostPlatform.android,
+        androidService: android,
+        fallbackService: fallback,
+      );
+
+      expect(service.isSupported, isTrue);
+      await service.share('invite');
+      expect(android.shared, 'invite');
+      expect(fallback.shared, isNull);
+    });
+
+    test('on Linux, sharing is unsupported and reaches no Android code',
+        () async {
+      final _RecordingShareService android =
+          _RecordingShareService(isSupported: true);
+      final _RecordingShareService fallback =
+          _RecordingShareService(isSupported: false);
+      final ShareService service = PlatformShareService(
+        host: HostPlatform.linux,
+        androidService: android,
+        fallbackService: fallback,
+      );
+
+      expect(service.isSupported, isFalse);
+      await service.share('invite');
+      expect(android.shared, isNull);
+      expect(fallback.shared, 'invite');
     });
   });
 }

--- a/test/core/services/unsupported_playback_controller_test.dart
+++ b/test/core/services/unsupported_playback_controller_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/unsupported_playback_controller.dart';
+
+Track _track(String id) => Track(
+      id: id,
+      title: 'Song $id',
+      uri: 'file:///music/$id.mp3',
+      artistName: 'Artist',
+      albumName: 'Album',
+      duration: const Duration(minutes: 3),
+    );
+
+void main() {
+  late UnsupportedPlaybackController controller;
+
+  setUp(() {
+    controller = UnsupportedPlaybackController();
+  });
+
+  tearDown(() async {
+    await controller.dispose();
+  });
+
+  test('starts idle and silent', () {
+    expect(controller.state.status, PlaybackStatus.idle);
+    expect(controller.state.currentTrack, isNull);
+    expect(controller.isSuspended, isFalse);
+  });
+
+  group('a request to play', () {
+    test('fails explicitly and names the track that was asked for', () async {
+      await controller.playTrack(_track('a'));
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.currentTrack?.id, 'a');
+      expect(controller.state.errorMessage,
+          UnsupportedPlaybackController.defaultReason);
+    });
+
+    test('never reports playing, buffering, or a position', () async {
+      await controller.playTracks(<Track>[_track('a'), _track('b')]);
+      await controller.play();
+      await controller.skipToNext();
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.position, Duration.zero);
+      expect(controller.state.duration, Duration.zero);
+    });
+
+    test('keeps no queue — the failure is not dressed up as playback',
+        () async {
+      await controller.playTracks(
+        <Track>[_track('a'), _track('b'), _track('c')],
+      );
+
+      expect(controller.state.upNext, isEmpty);
+      expect(controller.state.previous, isEmpty);
+      expect(controller.state.hasPrevious, isFalse);
+    });
+
+    test('playTracks reports the track at startIndex', () async {
+      await controller.playTracks(
+        <Track>[_track('a'), _track('b'), _track('c')],
+        startIndex: 2,
+      );
+
+      expect(controller.state.currentTrack?.id, 'c');
+    });
+
+    test('an out-of-range startIndex still fails cleanly', () async {
+      await controller.playTracks(<Track>[_track('a')], startIndex: 9);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.currentTrack, isNull);
+    });
+
+    test('the failure reaches listeners on the state stream', () async {
+      final Future<PlaybackState> next = controller.stateStream.first;
+
+      await controller.playTrack(_track('a'));
+
+      expect((await next).status, PlaybackStatus.error);
+    });
+
+    test('a custom reason is used verbatim', () async {
+      final custom = UnsupportedPlaybackController(reason: 'No audio here.');
+      addTearDown(custom.dispose);
+
+      await custom.playTrack(_track('a'));
+
+      expect(custom.reason, 'No audio here.');
+      expect(custom.state.errorMessage, 'No audio here.');
+    });
+  });
+
+  group('modes and transport that do not need audio', () {
+    test('shuffle and repeat are remembered without erroring', () {
+      controller.setShuffleEnabled(true);
+      controller.setRepeatMode(RepeatMode.all);
+
+      expect(controller.state.shuffleEnabled, isTrue);
+      expect(controller.state.repeatMode, RepeatMode.all);
+      expect(controller.state.status, PlaybackStatus.idle,
+          reason: 'setting a mode is not a request to play');
+    });
+
+    test('a mode set after a failure keeps the failure visible', () async {
+      await controller.playTrack(_track('a'));
+      controller.setRepeatMode(RepeatMode.one);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.errorMessage,
+          UnsupportedPlaybackController.defaultReason);
+      expect(controller.state.repeatMode, RepeatMode.one);
+    });
+
+    test('pause, seek and queue edits are quiet no-ops', () async {
+      await controller.pause();
+      await controller.seek(const Duration(seconds: 30));
+      controller.removeFromQueue(0);
+      controller.reorderQueue(0, 1);
+      controller.clearQueue();
+
+      expect(controller.state.status, PlaybackStatus.idle);
+    });
+
+    test('stop returns to idle, clearing the error', () async {
+      await controller.playTrack(_track('a'));
+      await controller.stop();
+
+      expect(controller.state.status, PlaybackStatus.idle);
+      expect(controller.state.errorMessage, isNull);
+    });
+  });
+
+  group('the cast-handoff half of LocalPlaybackController', () {
+    test('never claims to be suspending a local engine', () async {
+      await controller.suspend();
+      expect(controller.isSuspended, isFalse);
+
+      await controller.resume(at: const Duration(seconds: 10), play: true);
+      await controller.restartQueue();
+      controller.setVolumeNormalizationEnabled(true);
+      controller.onAppForegrounded();
+
+      expect(controller.state.status, PlaybackStatus.idle);
+    });
+  });
+
+  group('dispose', () {
+    test('is idempotent and stops emitting', () async {
+      await controller.dispose();
+      await controller.dispose();
+
+      // Post-dispose calls must not throw on a closed stream controller — app
+      // shutdown can race a last UI callback.
+      await controller.playTrack(_track('a'));
+      expect(controller.state.status, PlaybackStatus.idle);
+    });
+  });
+}

--- a/test/features/library/library_platform_bindings_test.dart
+++ b/test/features/library/library_platform_bindings_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/platform_folder_picker_service.dart';
+import 'package:linthra/core/sources/local/audio_file_scanner.dart';
+import 'package:linthra/core/sources/local/io_local_lyrics_reader.dart';
+import 'package:linthra/core/sources/local/local_metadata_reader.dart';
+import 'package:linthra/core/sources/local/method_channel_saf_document_lister.dart';
+import 'package:linthra/core/sources/local/method_channel_saf_lyrics_reader.dart';
+import 'package:linthra/core/sources/local/method_channel_saf_permission_probe.dart';
+import 'package:linthra/core/sources/local/saf_document_lister.dart';
+import 'package:linthra/core/sources/local/saf_permission_probe.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/features/library/library_providers.dart';
+import 'package:linthra/features/player/lyrics_providers.dart';
+
+ProviderContainer _containerFor(HostPlatform host) {
+  final container = ProviderContainer(
+    overrides: <Override>[hostPlatformProvider.overrideWithValue(host)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('Android keeps its native bindings', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = _containerFor(HostPlatform.android);
+    });
+
+    test('SAF traversal goes through the content resolver', () {
+      expect(container.read(safDocumentListerProvider),
+          isA<MethodChannelSafDocumentLister>());
+    });
+
+    test('the persisted-grant probe is the native one', () {
+      expect(container.read(safPermissionProbeProvider),
+          isA<MethodChannelSafPermissionProbe>());
+    });
+
+    test('sidecar lyrics are read as a SAF sibling document', () {
+      expect(container.read(localLyricsReaderProvider),
+          isA<MethodChannelSafLyricsReader>());
+    });
+  });
+
+  group('Linux gets the desktop/unsupported bindings', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = _containerFor(HostPlatform.linux);
+    });
+
+    test('no SAF traversal — the scan falls back to the filesystem walk', () {
+      // SAF is an Android content-resolver API. On Linux the binding must be
+      // the explicitly unsupported one so LocalMusicSource resolves the folder
+      // as a real path instead of calling a channel that does not exist.
+      expect(container.read(safDocumentListerProvider),
+          isA<UnsupportedSafDocumentLister>());
+    });
+
+    test('no persisted-grant probe — there are no SAF grants to hold', () {
+      expect(container.read(safPermissionProbeProvider),
+          isA<UnsupportedSafPermissionProbe>());
+    });
+
+    test('sidecar lyrics are read straight off the filesystem', () {
+      expect(container.read(localLyricsReaderProvider),
+          isA<IoLocalLyricsReader>());
+    });
+
+    test('none of the Android MethodChannel bindings are constructed', () {
+      // The bindings above are the ones that would otherwise reach a native
+      // channel on a platform with no Linthra plugin registered. Stated as one
+      // assertion because it is the actual startup requirement: nothing built
+      // for a Linux launch may be an Android channel client.
+      expect(container.read(safDocumentListerProvider),
+          isNot(isA<MethodChannelSafDocumentLister>()));
+      expect(container.read(safPermissionProbeProvider),
+          isNot(isA<MethodChannelSafPermissionProbe>()));
+      expect(container.read(localLyricsReaderProvider),
+          isNot(isA<MethodChannelSafLyricsReader>()));
+    });
+  });
+
+  group('bindings that are the same on both platforms', () {
+    test('the scanner stays the platform-routing one everywhere', () {
+      // PlatformAudioFileScanner already routes a content:// URI to SAF and a
+      // path to the dart:io walk. Linux only ever hands it paths, so the
+      // desktop build needs no separate scanner.
+      for (final HostPlatform host in <HostPlatform>[
+        HostPlatform.android,
+        HostPlatform.linux,
+      ]) {
+        expect(_containerFor(host).read(audioFileScannerProvider),
+            isA<PlatformAudioFileScanner>());
+      }
+    });
+
+    test('the folder picker stays the platform-routing one everywhere', () {
+      for (final HostPlatform host in <HostPlatform>[
+        HostPlatform.android,
+        HostPlatform.linux,
+      ]) {
+        expect(_containerFor(host).read(folderPickerServiceProvider),
+            isA<PlatformFolderPickerService>());
+      }
+    });
+
+    test('desktop tag reading is still the unsupported reader', () {
+      // Real Linux metadata extraction is later desktop work. Until then the
+      // mapper falls back to filename/folder derivation, on Linux exactly as it
+      // already does for a filesystem path on Android.
+      expect(
+          _containerFor(HostPlatform.linux).read(localMetadataReaderProvider),
+          isA<UnsupportedLocalMetadataReader>());
+    });
+  });
+}

--- a/test/features/player/playback_platform_binding_test.dart
+++ b/test/features/player/playback_platform_binding_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/local_playback_controller.dart';
+import 'package:linthra/core/services/platform_playback_support.dart';
+import 'package:linthra/core/services/unsupported_playback_controller.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+ProviderContainer _containerFor(HostPlatform host) {
+  final container = ProviderContainer(
+    overrides: <Override>[hostPlatformProvider.overrideWithValue(host)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('PlatformPlaybackSupport.hasOnDeviceEngine', () {
+    test('is true exactly where just_audio publishes an implementation', () {
+      expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.android),
+          isTrue);
+      expect(
+          PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.ios), isTrue);
+      expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.linux),
+          isFalse);
+      expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.macOS),
+          isFalse);
+      expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.windows),
+          isFalse);
+      expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.other),
+          isFalse);
+    });
+  });
+
+  group('localPlaybackControllerProvider', () {
+    test('on Android, still builds the just_audio engine', () {
+      // The Android regression guard: adding the desktop branch must not have
+      // moved Android onto the stub.
+      final ProviderContainer container = _containerFor(HostPlatform.android);
+
+      final LocalPlaybackController controller =
+          container.read(localPlaybackControllerProvider);
+
+      expect(controller, isA<JustAudioPlaybackController>());
+    });
+
+    test('on Linux, builds the explicit unsupported engine', () {
+      final ProviderContainer container = _containerFor(HostPlatform.linux);
+
+      final LocalPlaybackController controller =
+          container.read(localPlaybackControllerProvider);
+
+      expect(controller, isA<UnsupportedPlaybackController>());
+      expect(controller.state.status, PlaybackStatus.idle);
+    });
+
+    test('every desktop platform gets the unsupported engine', () {
+      for (final HostPlatform host in <HostPlatform>[
+        HostPlatform.linux,
+        HostPlatform.macOS,
+        HostPlatform.windows,
+        HostPlatform.other,
+      ]) {
+        expect(
+          _containerFor(host).read(localPlaybackControllerProvider),
+          isA<UnsupportedPlaybackController>(),
+          reason: '${host.label} has no just_audio implementation',
+        );
+      }
+    });
+
+    test('the Linux engine reports playback as unavailable, not broken',
+        () async {
+      final ProviderContainer container = _containerFor(HostPlatform.linux);
+      final LocalPlaybackController controller =
+          container.read(localPlaybackControllerProvider);
+
+      await controller.play();
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.errorMessage,
+          UnsupportedPlaybackController.defaultReason);
+    });
+  });
+
+  group('playbackControllerProvider', () {
+    test('routes through the same ActivePlaybackController on Linux', () {
+      // The UI depends on this provider, never on the engine. It has to build
+      // on a platform with no audio engine, otherwise the whole player feature
+      // fails to construct at startup.
+      final ProviderContainer container = _containerFor(HostPlatform.linux);
+
+      expect(
+        () => container.read(playbackControllerProvider),
+        returnsNormally,
+      );
+      expect(container.read(playbackControllerProvider).state.status,
+          PlaybackStatus.idle);
+    });
+  });
+}

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_linux_runner.py (#376, PR 1).
+
+    python3 test/tooling/check_linux_runner_test.py
+
+The checker's job is to notice when the committed Linux runner drifts from the
+app's identity — most plausibly because someone re-ran
+`flutter create --platforms=linux .` and the template overwrote it. So the tests
+are mostly "take a good checkout, break exactly one thing, expect it to be
+caught", built on a synthetic checkout rather than the real one: a fixture that
+can be broken is the only way to prove the checker fails when it should, and it
+keeps these tests from depending on Linthra's current version or app id.
+
+One test does run against the real repository, because "the checker passes on
+the actual runner" is the thing the CI job cares about.
+
+Everything is offline. No network, no git, no repository writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load("check_linux_runner", "check_linux_runner.py")
+
+
+APP_ID = "io.example.app"
+BINARY = "exampleapp"
+DISPLAY_NAME = "ExampleApp"
+
+CMAKELISTS = """\
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+set(BINARY_NAME "{binary}")
+set(APPLICATION_ID "{app_id}")
+
+set(LINTHRA_SQLITE3_SOURCE_DIR "$ENV{{LINTHRA_SQLITE3_SOURCE_DIR}}" CACHE PATH "")
+if(LINTHRA_SQLITE3_SOURCE_DIR)
+  set(FETCHCONTENT_SOURCE_DIR_SQLITE3 "${{LINTHRA_SQLITE3_SOURCE_DIR}}"
+    CACHE PATH "" FORCE)
+endif()
+
+include(flutter/generated_plugins.cmake)
+"""
+
+MY_APPLICATION = """\
+#include "my_application.h"
+
+static constexpr const char* kApplicationName = "{display_name}";
+static constexpr int kDefaultWindowWidth = 1180;
+static constexpr int kDefaultWindowHeight = 780;
+static constexpr int kMinimumWindowWidth = 420;
+static constexpr int kMinimumWindowHeight = 600;
+"""
+
+BUILD_GRADLE = """\
+android {{
+    namespace = "{app_id}"
+    defaultConfig {{
+        applicationId = "{app_id}"
+    }}
+}}
+"""
+
+PUBSPEC = """\
+name: {binary}
+description: An example.
+version: 1.2.3+10203
+"""
+
+APP_INFO = """\
+abstract final class AppInfo {{
+  static const String name = '{display_name}';
+  static const String tagline = 'Example.';
+}}
+"""
+
+
+def build_checkout(
+    directory: Path,
+    *,
+    cmakelists: str | None = None,
+    my_application: str | None = None,
+    build_gradle: str | None = None,
+    pubspec: str | None = None,
+    app_info: str | None = None,
+) -> Path:
+    """Write a minimal, internally consistent checkout the checker can read."""
+    (directory / "linux" / "runner").mkdir(parents=True, exist_ok=True)
+    (directory / "android" / "app").mkdir(parents=True, exist_ok=True)
+    (directory / "lib" / "core").mkdir(parents=True, exist_ok=True)
+
+    (directory / "linux" / "CMakeLists.txt").write_text(
+        cmakelists
+        if cmakelists is not None
+        else CMAKELISTS.format(binary=BINARY, app_id=APP_ID),
+        encoding="utf-8",
+    )
+    (directory / "linux" / "runner" / "my_application.cc").write_text(
+        my_application
+        if my_application is not None
+        else MY_APPLICATION.format(display_name=DISPLAY_NAME),
+        encoding="utf-8",
+    )
+    (directory / "android" / "app" / "build.gradle").write_text(
+        build_gradle
+        if build_gradle is not None
+        else BUILD_GRADLE.format(app_id=APP_ID),
+        encoding="utf-8",
+    )
+    (directory / "pubspec.yaml").write_text(
+        pubspec if pubspec is not None else PUBSPEC.format(binary=BINARY),
+        encoding="utf-8",
+    )
+    (directory / "lib" / "core" / "app_info.dart").write_text(
+        app_info
+        if app_info is not None
+        else APP_INFO.format(display_name=DISPLAY_NAME),
+        encoding="utf-8",
+    )
+    return directory
+
+
+class CheckoutCase(unittest.TestCase):
+    """Base class giving each test a fresh throwaway checkout."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+
+class ConsistentCheckoutTest(CheckoutCase):
+    def test_a_consistent_checkout_has_no_problems(self) -> None:
+        build_checkout(self.root)
+        self.assertEqual(checker.check(self.root), [])
+
+    def test_main_exits_zero(self) -> None:
+        build_checkout(self.root)
+        self.assertEqual(checker.main(["--root", str(self.root)]), 0)
+
+
+class IdentityDriftTest(CheckoutCase):
+    def test_application_id_must_match_android(self) -> None:
+        build_checkout(
+            self.root,
+            cmakelists=CMAKELISTS.format(binary=BINARY, app_id="com.example.other"),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("APPLICATION_ID", problems[0])
+        self.assertIn("com.example.other", problems[0])
+
+    def test_binary_name_must_match_the_package_name(self) -> None:
+        build_checkout(
+            self.root,
+            cmakelists=CMAKELISTS.format(binary="renamed", app_id=APP_ID),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("BINARY_NAME", problems[0])
+
+    def test_window_title_must_match_app_info(self) -> None:
+        # The regression a template regeneration actually causes: the title
+        # goes back to the lowercase package name.
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=BINARY),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("kApplicationName", problems[0])
+
+    def test_a_wholly_regenerated_runner_is_caught(self) -> None:
+        # The full template restoration: lowercase title, no size constants.
+        build_checkout(
+            self.root,
+            my_application='  gtk_window_set_title(window, "exampleapp");\n',
+        )
+        with self.assertRaises(checker.CheckError):
+            checker.check(self.root)
+
+    def test_several_problems_are_all_reported(self) -> None:
+        build_checkout(
+            self.root,
+            cmakelists=CMAKELISTS.format(binary="renamed", app_id="com.example.other"),
+            my_application=MY_APPLICATION.format(display_name="Other"),
+        )
+        self.assertEqual(len(checker.check(self.root)), 3)
+
+
+class WindowMetricsTest(CheckoutCase):
+    def test_minimum_may_not_exceed_the_default(self) -> None:
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+                "kMinimumWindowWidth = 420", "kMinimumWindowWidth = 2000"
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("minimum window size", problems[0])
+
+    def test_a_zero_minimum_is_rejected(self) -> None:
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME).replace(
+                "kMinimumWindowHeight = 600", "kMinimumWindowHeight = 0"
+            ),
+        )
+        self.assertIn("must be positive", " ".join(checker.check(self.root)))
+
+    def test_equal_minimum_and_default_is_allowed(self) -> None:
+        build_checkout(
+            self.root,
+            my_application=MY_APPLICATION.format(display_name=DISPLAY_NAME)
+            .replace("kMinimumWindowWidth = 420", "kMinimumWindowWidth = 1180")
+            .replace("kMinimumWindowHeight = 600", "kMinimumWindowHeight = 780"),
+        )
+        self.assertEqual(checker.check(self.root), [])
+
+
+class OfflineBuildSeamTest(CheckoutCase):
+    def test_losing_the_sqlite_seam_is_caught(self) -> None:
+        # This is the check that matters for packaging: without the seam the
+        # build still succeeds anywhere with a network, so nothing else notices.
+        build_checkout(
+            self.root,
+            cmakelists='set(BINARY_NAME "exampleapp")\nset(APPLICATION_ID "io.example.app")\n',
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("LINTHRA_SQLITE3_SOURCE_DIR", problems[0])
+
+    def test_a_seam_that_is_never_forwarded_is_caught(self) -> None:
+        # Declaring the variable and not wiring it to FetchContent would look
+        # right in a diff and do nothing.
+        build_checkout(
+            self.root,
+            cmakelists=(
+                'set(BINARY_NAME "exampleapp")\n'
+                'set(APPLICATION_ID "io.example.app")\n'
+                'set(LINTHRA_SQLITE3_SOURCE_DIR "" CACHE PATH "")\n'
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("never forwards it", problems[0])
+
+
+class AbsolutePathTest(CheckoutCase):
+    def test_a_hardcoded_host_path_is_caught(self) -> None:
+        build_checkout(self.root)
+        (self.root / "linux" / "CMakeLists.txt").write_text(
+            CMAKELISTS.format(binary=BINARY, app_id=APP_ID)
+            + 'include_directories("/home/dev/sqlite")\n',
+            encoding="utf-8",
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("absolute host path", problems[0])
+        self.assertIn("/home/dev/sqlite", problems[0])
+
+    def test_ordinary_cmake_variable_paths_are_not_flagged(self) -> None:
+        build_checkout(self.root)
+        (self.root / "linux" / "CMakeLists.txt").write_text(
+            CMAKELISTS.format(binary=BINARY, app_id=APP_ID)
+            + 'set(BUNDLE "${CMAKE_INSTALL_PREFIX}/data/flutter_assets")\n'
+            + 'set(RPATH "$ORIGIN/lib")\n',
+            encoding="utf-8",
+        )
+        self.assertEqual(checker.check(self.root), [])
+
+    def test_generated_ephemeral_files_are_ignored(self) -> None:
+        # linux/flutter/ephemeral is per-build output full of machine paths and
+        # is not in git; scanning it would fail on every developer's checkout.
+        build_checkout(self.root)
+        ephemeral = self.root / "linux" / "flutter" / "ephemeral"
+        ephemeral.mkdir(parents=True)
+        (ephemeral / "generated_config.cmake").write_text(
+            'set(FLUTTER_ROOT "/home/dev/flutter")\n', encoding="utf-8"
+        )
+        self.assertEqual(checker.check(self.root), [])
+
+
+class MissingFileTest(CheckoutCase):
+    def test_a_missing_runner_is_an_error_not_a_pass(self) -> None:
+        with self.assertRaises(checker.CheckError):
+            checker.check(self.root)
+
+    def test_main_reports_a_read_failure_as_exit_two(self) -> None:
+        self.assertEqual(checker.main(["--root", str(self.root)]), 2)
+
+
+class RealRepositoryTest(unittest.TestCase):
+    def test_the_committed_linux_runner_is_consistent(self) -> None:
+        self.assertEqual(checker.check(ROOT), [])
+
+    def test_the_runner_uses_the_android_application_id(self) -> None:
+        # Stated explicitly because it is the decision that matters for
+        # Flathub: one reverse-DNS id for the product on every platform.
+        self.assertEqual(
+            checker.application_id(ROOT), checker.android_application_id(ROOT)
+        )
+
+    def test_the_window_title_is_the_product_name(self) -> None:
+        self.assertEqual(checker.window_title(ROOT), checker.app_display_name(ROOT))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
PR 1 of #376. Adds the Flutter Linux target so Linthra compiles, launches and renders in a real native desktop window — and nothing else. Playback, the desktop UX pass and Flatpak packaging are separate PRs.

Android is untouched: no changes under `android/`, `fastlane/` or `metadata/`, no version bump, no signing or release changes, and the Android plugin registration is byte-identical (`audio_service`, `just_audio`, `permission_handler_android` and the rest are all still there).

## What now compiles and runs

`linux/` is committed alongside `android/`, so there is no `flutter create` step for either platform. `flutter build linux --release` produces a runnable bundle, and running it gives you Linthra's real onboarding screen in a GTK window — same domain models, providers, repositories, router, theme, scanner and Jellyfin/Navidrome/Subsonic/Plex code as Android.

Window identity is the app's own, not the template's: application id `io.github.thezupzup.linthra` (the same reverse-DNS id as the Android `applicationId`), title `Linthra`, 1180×780 default size with a 420×600 floor. The floor exists only so a dragged-narrow window stays usable while developing — the phone-first layout still renders as-is, and the desktop layout is later work.

## The one build-time decision worth reviewing

`sqlite3_flutter_libs` on Linux downloads the SQLite amalgamation from `sqlite.org` during CMake *configure*. That is invisible on a normal machine and fatal in a network-isolated build — which is exactly what `flatpak-builder` is.

`linux/CMakeLists.txt` therefore honours `LINTHRA_SQLITE3_SOURCE_DIR`: point it at an already-unpacked amalgamation and nothing is fetched. It works through CMake's own `FETCHCONTENT_SOURCE_DIR_<NAME>` hook, so the plugin is neither patched nor vendored, and leaving the variable unset gives the byte-for-byte upstream build. I kept the plugin rather than dropping to system SQLite so the Drift catalog keeps running on the same engine and the same compile flags (FTS5, math functions, session/preupdate hooks) as Android.

`scripts/check_linux_runner.py` fails if that seam is ever removed, because losing it breaks nothing anywhere with a network.

## What Android-only pieces were isolated

The seams that already existed were reused; the two new ones follow the same shape.

- **`MediaSessionBinding`** (new) separates the platform media session from playback. Android attaches the `audio_service` session; Linux gets an inert binding and `audio_service` is never entered there. That matters more than "it would fail anyway": `AudioService.init` builds a cache manager and installs handler callbacks *before* its first platform call throws, so calling it off Android leaves half-configured statics behind. MPRIS becomes a third implementation of this interface rather than a branch in `main()`.
- **`UnsupportedPlaybackController`** (new) is the desktop engine. `just_audio` publishes no Linux implementation, so `localPlaybackControllerProvider` builds this instead — and the important part is that the `just_audio` controller is never *constructed*, since its constructor creates the `AudioPlayer`.
- SAF traversal, the SAF grant probe and the sidecar lyrics reader now select through `hostPlatformProvider` instead of reading `Platform.isAndroid` inline. Same behaviour, now assertable for both platforms.
- The share sheet, launcher-icon switching, Android audio focus, `POST_NOTIFICATIONS` and Chromecast were already gated correctly and are unchanged.

Nothing is faked on Linux. Each unsupported case is a named class behind the existing interface, so it is visible in the code and covered by tests.

To make the Android half of every seam testable from a Linux machine, `HostPlatform` expresses the platform as a value rather than a `dart:io` read (`HostPlatform.current` in production, `HostPlatform.android`/`.linux` in tests). Without it, "Android still picks the Android implementation" is unassertable on any CI runner we have.

## What remains intentionally unsupported

| Area | State |
| --- | --- |
| **Audio playback** | **Unsupported** — PR 2. Any request to play answers with one explicit error instead of silence or a `MissingPluginException`. |
| Media session / MPRIS | Unsupported — later desktop work |
| Local tag/artwork reading | Unsupported — PR 3. Falls back to filename/folder derivation, as it already does for filesystem scans on Android. |
| Desktop layout, keyboard shortcuts, media keys | Not started — PR 4 |
| Android Auto, media notification, SAF, share sheet, launcher icons, Chromecast | Android-only by design |

## Credentials

`flutter_secure_storage` publishes a real Linux implementation and it is wired unchanged — sessions are encrypted through the desktop Secret Service (libsecret) instead of Android Keystore. Nothing was weakened and there is no plaintext fallback on any platform. `libsecret` development headers are a **required** build dependency for that reason, not an optional one; the runtime side (a running, unlocked keyring) is documented.

## Linux CI

New `linux-desktop-build.yml`, on the same triggers as `ci.yml`: installs the native toolchain, uses the pinned Flutter via the shared `./.github/actions/setup-flutter`, runs `pub get --enforce-lockfile` → `dart format` → `analyze` → the full test suite, checks the runner configuration, then builds and uploads a release bundle. It fails if the bundle is missing or the binary is not executable.

Android CI is unchanged and is still exactly as much of a gate as it was. This job runs alongside it so an Android-shaped change that breaks the desktop build — a new plugin with no Linux implementation, a service that initialises eagerly, a `flutter create` that reverts the runner — fails on the PR that caused it rather than at packaging time.

Locally, `scripts/verify_linux.sh` is the twin of `verify_android.sh` and skips only the build (naming the packages) when the native toolchain is missing.

## Tests

54 new Dart tests and 20 Python tests (3515 total Dart tests pass):

- each seam picks the Android implementation on Android and the desktop one on Linux;
- `audio_service` is never entered on any non-Android platform;
- the unsupported engine fails explicitly, keeps no queue and never claims to be playing;
- **every provider `main()` reads before the first frame constructs on a Linux host**, with no Android MethodChannel binding among them (`test/app/linux_startup_test.dart`) — this is the actual "will it launch" regression guard;
- the runner-config checker catches a regenerated runner, a lost SQLite seam and a hardcoded host path.

## Toward Flathub

Flatpak packaging is PR 5 and nothing here presumes it, but the decisions were made with Flathub as the destination: one stable reverse-DNS id shared with Android, no build-time dependency on host filesystem paths (enforced), nothing downloaded at app startup that belongs in the build, the SQLite escape hatch above so a no-network build already works, and every platform integration behind an interface so a portal-based implementation can be slotted in without touching feature code.

## Validation

Run against this branch: `dart format --set-exit-if-changed .`, `flutter analyze` (clean), full `flutter test` (3515 passed), `python3 test/tooling/check_linux_runner_test.py` (20 passed), `python3 scripts/check_linux_runner.py`, `./scripts/check_secrets.sh`, YAML parse of the new workflow, `flutter build linux --debug` and `--release`, and the release bundle launched headless under Xvfb — window present with the expected title, WM class and 1180×780 geometry, onboarding UI rendered, no Dart exceptions. `flutter pub get --enforce-lockfile` passes, so `pubspec.lock` is untouched.

Two things I could not run here: the Android debug APK build (no Android SDK in this environment, and `dl.google.com` is unreachable from it) — the unchanged Android workflows will cover it on this PR; and the SQLite fetch itself (`sqlite.org` is also unreachable), so both Linux builds were validated through the `LINTHRA_SQLITE3_SOURCE_DIR` path against a locally built amalgamation. CI, which has a network, exercises the default download path.

Not for merge yet.


---
_Generated by [Claude Code](https://claude.ai/code/session_012nCSyqeEuoqVjxMdLSrBnz)_