### PR TITLE
feat(linux): add native audio playback

### DIFF
--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -39,6 +39,7 @@ jobs:
       #   clang / cmake / ninja-build / pkg-config — the build itself
       #   libgtk-3-dev                             — the Flutter Linux embedder
       #   liblzma-dev, libstdc++-12-dev            — Flutter tool prerequisites
+      #   xauth / xvfb                              — headless native smoke display
       #   libsecret-1-dev                          — flutter_secure_storage_linux,
       #                                              i.e. encrypted credential
       #                                              storage. Not optional: the
@@ -46,6 +47,8 @@ jobs:
       #                                              without it, and Linthra
       #                                              never falls back to
       #                                              plaintext credentials.
+      #   libmpv-dev                                — media_kit audio backend;
+      #                                              also supplies runtime libmpv
       - name: Install Linux build dependencies
         run: |
           set -euo pipefail
@@ -58,7 +61,10 @@ jobs:
             libgtk-3-dev \
             liblzma-dev \
             libstdc++-12-dev \
-            libsecret-1-dev
+            libsecret-1-dev \
+            libmpv-dev \
+            xauth \
+            xvfb
 
       # Installs the version pinned in .flutter-version, the same action every
       # other workflow uses.
@@ -93,6 +99,20 @@ jobs:
 
       - name: Test the Linux runner tooling
         run: python3 test/tooling/check_linux_runner_test.py
+
+      # A normal Flutter widget test cannot load the Linux plugin bundle, so
+      # this target runs in the real GTK runner and opens a silent local WAV
+      # through libmpv without starting playback. Two create/load/dispose cycles
+      # cover reinitialization.
+      - name: Build native audio lifecycle smoke
+        run: >-
+          flutter build linux --release
+          --target=tool/linux_audio_backend_smoke.dart
+
+      - name: Run native audio lifecycle smoke
+        run: >-
+          xvfb-run --auto-servernum
+          build/linux/x64/release/bundle/linthra
 
       # Release mode, because that is the build that has to work for packaging
       # and it exercises the AOT path a debug build skips.

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,8 +64,8 @@ The verification script auto-detects `.tool/flutter`, so you don't have to
 update `PATH` just to run it.
 
 `scripts/verify_linux.sh` is the desktop twin: the same shared checks plus the
-Linux runner configuration check and `flutter build linux --release`. See
-[linux-desktop.md](linux-desktop.md).
+Linux runner configuration check, the native audio lifecycle smoke test, and
+`flutter build linux --release`. See [linux-desktop.md](linux-desktop.md).
 
 ### What `verify_android.sh` does
 
@@ -142,8 +142,9 @@ do not.
   APK build is skipped and verification still passes if analyze/format/tests
   pass. Install the Android SDK and set `ANDROID_HOME` to enable
   `flutter build apk --debug`.
-- **Linux build dependencies missing** — `./scripts/verify_linux.sh` names the
-  packages it could not find and skips only the build step;
+- **Linux build/runtime dependencies missing** — `./scripts/verify_linux.sh`
+  names the packages (including the libmpv runtime) it could not find and
+  skips only the audio smoke test and the build step;
   [linux-desktop.md](linux-desktop.md) lists them per distribution.
 - **`dart format` mismatch** — run `dart format .` to apply the formatter, then
   commit the result. CI uses `--set-exit-if-changed`, so unformatted code fails.

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -3,11 +3,11 @@
 Linthra has a native Flutter Linux target. This page is how to build and run it,
 what works today, and what deliberately does not yet.
 
-> **Linux is not production-ready.** This is the first milestone of
+> **Linux is not production-ready.** This is the second milestone of
 > [issue #376](https://github.com/TheZupZup/Linthra/issues/376): the app
-> compiles, launches, and renders in a real desktop window. **There is no audio
-> playback on Linux yet** — that is the next piece of work. Android is
-> unaffected and remains the platform Linthra actually ships on.
+> compiles, launches, renders in a real desktop window, and plays local and
+> server audio. Desktop media controls and packaging are later milestones.
+> Android is unaffected and remains the platform Linthra actually ships on.
 
 ## What exists after this milestone
 
@@ -26,14 +26,14 @@ what works today, and what deliberately does not yet.
 
 ## Required packages
 
-The Flutter Linux toolchain plus the two libraries Linthra's own plugins need.
+The Flutter Linux toolchain plus the native libraries Linthra's plugins need.
 
 ### Fedora / Fedora Kinoite
 
 ```bash
 sudo dnf install \
   clang cmake ninja-build pkgconf-pkg-config \
-  gtk3-devel xz-devel libsecret-devel
+  gtk3-devel xz-devel libsecret-devel mpv-libs mpv-devel
 ```
 
 On **Kinoite** (and any rpm-ostree system) do development work inside a
@@ -50,13 +50,13 @@ toolbox enter linthra
 ```bash
 sudo apt install \
   clang cmake ninja-build pkg-config \
-  libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev
+  libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev libmpv-dev
 ```
 
 ### Arch
 
 ```bash
-sudo pacman -S --needed clang cmake ninja pkgconf gtk3 xz libsecret
+sudo pacman -S --needed clang cmake ninja pkgconf gtk3 xz libsecret mpv
 ```
 
 ### What each one is for
@@ -67,8 +67,9 @@ sudo pacman -S --needed clang cmake ninja pkgconf gtk3 xz libsecret
 | GTK 3 development headers | the Flutter Linux embedder |
 | `liblzma` / `xz` development headers | Flutter tool prerequisite |
 | **libsecret development headers** | `flutter_secure_storage_linux` — encrypted credential storage. Not optional: without it the plugin does not build, and Linthra never falls back to plaintext credentials. |
+| **libmpv** | `just_audio_media_kit` / `media_kit` — local and HTTP(S) audio decoding, seeking, timing, and output through PulseAudio or PipeWire. Ubuntu's `libmpv-dev`, Fedora's `mpv-libs` + `mpv-devel`, and Arch's `mpv` provide it. |
 
-At **runtime** the app additionally wants a Secret Service provider
+At **runtime** the app additionally needs libmpv and wants a Secret Service provider
 (`gnome-keyring` on GNOME, `kwallet` with its Secret Service interface on KDE).
 Both are present on a standard Fedora Workstation or Kinoite install.
 
@@ -141,11 +142,34 @@ Two runtime facts worth knowing:
 * Credential storage was not weakened to make Linux work, and there is no
   plaintext fallback on any platform.
 
-## What is intentionally unsupported on Linux right now
+## Audio playback
+
+Linux uses `just_audio_media_kit`, which implements the same `just_audio`
+platform contract as Android's engine but delegates decoding and output to
+media_kit/libmpv. This was chosen over a second, parallel playback stack because
+Linthra's existing `JustAudioPlaybackController` already owns the difficult
+parts: ordered playable candidates, offline-to-stream fallback, queue mutation,
+shuffle/repeat, completion, retries, position/duration state, ReplayGain, and
+safe errors. `LinuxPlaybackController` only registers the Linux implementation;
+Android still constructs `JustAudioPlaybackController` and therefore remains on
+ExoPlayer, `audio_service`, and its existing audio-focus behavior.
+
+The same resolved URI path handles regular filesystem files and direct or
+transcoded Jellyfin, Navidrome/Subsonic, and supported Plex HTTP(S) URLs. No
+source-specific player exists and credentials remain in the existing resolver.
+
+libmpv provides broad codec/container support and PulseAudio/PipeWire output.
+It is a native runtime dependency, not a binary downloaded when Linthra starts.
+The future Flatpak manifest must build or include libmpv as a declared module.
+`media_kit_libs_linux` normally offers an optional build-time mimalloc download;
+Linthra explicitly disables it in `linux/CMakeLists.txt`, so this backend adds no
+undeclared network access to an isolated `flatpak-builder` build.
+
+## Remaining Linux limitations
 
 | Area | State | Why |
 | --- | --- | --- |
-| **Audio playback** | **Unsupported** | `just_audio` publishes no Linux implementation. `localPlaybackControllerProvider` builds `UnsupportedPlaybackController` on desktop, which answers any request to play with one explicit error instead of reaching a plugin that is not there. Next PR of #376. |
+| **Audio playback** | Supported | media_kit/libmpv through `LinuxPlaybackController`; local files and resolved Jellyfin, Navidrome/Subsonic, and Plex HTTP(S) streams share one backend. |
 | Media session / MPRIS | Unsupported | `audio_service` is Android/iOS only. `PlatformMediaSessionBinding` returns the inert binding on Linux, so `audio_service` is never initialised there. MPRIS is later desktop work. |
 | Android Auto | Android-only, by design | It is an Android platform integration, not a Linthra feature. |
 | Media notification + `POST_NOTIFICATIONS` | Android-only, by design | There is no equivalent gate on Linux; desktop controls arrive with MPRIS. |
@@ -177,7 +201,7 @@ The seams that branch on it:
 | Seam | Android | Linux |
 | --- | --- | --- |
 | `PlatformMediaSessionBinding` | `audio_service` session | inert, never touches `audio_service` |
-| `localPlaybackControllerProvider` | `JustAudioPlaybackController` | `UnsupportedPlaybackController` |
+| `localPlaybackControllerProvider` | `JustAudioPlaybackController` (ExoPlayer) | `LinuxPlaybackController` (media_kit/libmpv) |
 | `PlatformFolderPickerService` | SAF tree picker | `file_picker` filesystem chooser |
 | `PlatformAudioFileScanner` | SAF content-resolver walk | `dart:io` walk |
 | `safDocumentListerProvider` | native content resolver | unsupported |

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -94,10 +94,14 @@ To run the same checks CI runs:
 ```
 
 That does `pub get --enforce-lockfile`, `dart format --set-exit-if-changed`,
-`flutter analyze`, `flutter test`, the runner configuration check, and
-`flutter build linux --release`. It skips only the build if the native packages
-above are missing, and says which ones. `scripts/verify_android.sh` is
-unchanged and still the Android twin.
+`flutter analyze`, `flutter test`, the runner configuration check, the same
+native audio lifecycle smoke CI runs (builds and runs
+`tool/linux_audio_backend_smoke.dart`), and `flutter build linux --release`.
+It skips the smoke test and the build if the native packages above are
+missing — including the libmpv *runtime* library, checked the same way
+media_kit loads it, since a Linux build succeeds without libmpv but can't play
+anything — and says which ones. `scripts/verify_android.sh` is unchanged and
+still the Android twin.
 
 ### Building without a network
 

--- a/lib/core/services/linux_playback_controller.dart
+++ b/lib/core/services/linux_playback_controller.dart
@@ -1,0 +1,78 @@
+import 'dart:math';
+
+import 'package:just_audio/just_audio.dart';
+import 'package:just_audio_media_kit/just_audio_media_kit.dart';
+
+import 'just_audio_playback_controller.dart';
+import 'local_playable_uri_resolver.dart';
+import 'playable_uri_resolver.dart';
+import 'playback_candidate_source.dart';
+
+typedef LinuxPlaybackBackendRegistration = void Function();
+
+/// Registers just_audio's Linux implementation once for this process.
+///
+/// Registration is synchronous, so the success flag cannot race another call
+/// in the same isolate. It is deliberately set after registration returns: if
+/// native setup throws, the next controller construction can retry.
+class LinuxPlaybackBackendInitializer {
+  LinuxPlaybackBackendInitializer({
+    LinuxPlaybackBackendRegistration? registerBackend,
+  }) : _registerBackend = registerBackend ?? _registerDefaultBackend;
+
+  final LinuxPlaybackBackendRegistration _registerBackend;
+  bool _initialized = false;
+
+  void ensureInitialized() {
+    if (_initialized) return;
+    _registerBackend();
+    _initialized = true;
+  }
+
+  static void _registerDefaultBackend() {
+    JustAudioMediaKit.title = 'Linthra';
+    JustAudioMediaKit.ensureInitialized(linux: true, windows: false);
+  }
+}
+
+/// Linux on-device playback backed by media_kit and the declared libmpv runtime.
+///
+/// The transport, queue, resolver fallback and completion behaviour deliberately
+/// stay in [JustAudioPlaybackController]. This class only registers the Linux
+/// federated implementation before that controller creates its [AudioPlayer].
+/// Android never constructs this type and therefore keeps just_audio's native
+/// ExoPlayer implementation and its existing audio-service/audio-focus path.
+class LinuxPlaybackController extends JustAudioPlaybackController {
+  static final LinuxPlaybackBackendInitializer _backendInitializer =
+      LinuxPlaybackBackendInitializer();
+
+  factory LinuxPlaybackController({
+    AudioPlayer? player,
+    PlayableUriResolver resolver = const LocalPlayableUriResolver(),
+    PlaybackCandidateSource candidates = const NoFallbackCandidateSource(),
+    PlayableUriResolver? streamingFallbackResolver,
+    Random? random,
+    TrackCompletionCallback? onTrackCompleted,
+  }) {
+    // Tests inject an AudioPlayer explicitly. The production path registers
+    // media_kit before the superclass can construct its AudioPlayer.
+    if (player == null) _backendInitializer.ensureInitialized();
+    return LinuxPlaybackController._(
+      player: player,
+      resolver: resolver,
+      candidates: candidates,
+      streamingFallbackResolver: streamingFallbackResolver,
+      random: random,
+      onTrackCompleted: onTrackCompleted,
+    );
+  }
+
+  LinuxPlaybackController._({
+    super.player,
+    required super.resolver,
+    required super.candidates,
+    super.streamingFallbackResolver,
+    super.random,
+    super.onTrackCompleted,
+  });
+}

--- a/lib/core/services/platform_playback_support.dart
+++ b/lib/core/services/platform_playback_support.dart
@@ -6,13 +6,13 @@ import '../platform/host_platform.dart';
 /// provider graph, so "does this build have audio?" has exactly one answer that
 /// both the app and the tests read.
 ///
-/// The rule follows the engine, not the product plan: `just_audio` — the package
-/// `JustAudioPlaybackController` wraps — publishes Android and iOS
-/// implementations and no Linux one. Desktop therefore gets
-/// `UnsupportedPlaybackController` until a real desktop backend is wired in,
-/// which is the next piece of Linux work.
+/// The rule follows the available engines, not the product plan: Android/iOS
+/// use just_audio's native implementations and Linux uses the media_kit/libmpv
+/// federated implementation. Other desktop platforms remain unsupported.
 abstract final class PlatformPlaybackSupport {
-  /// Whether `just_audio` can actually play audio on [host].
+  /// Whether Linthra can actually play on-device audio on [host].
   static bool hasOnDeviceEngine(HostPlatform host) =>
-      host == HostPlatform.android || host == HostPlatform.ios;
+      host == HostPlatform.android ||
+      host == HostPlatform.ios ||
+      host == HostPlatform.linux;
 }

--- a/lib/features/player/player_providers.dart
+++ b/lib/features/player/player_providers.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
 
 import '../../core/models/playback_state.dart';
 import '../../core/platform/host_platform.dart';
 import '../../core/services/active_playback_controller.dart';
 import '../../core/services/just_audio_playback_controller.dart';
+import '../../core/services/linux_playback_controller.dart';
 import '../../core/services/local_playable_uri_resolver.dart';
 import '../../core/services/local_playback_controller.dart';
 import '../../core/services/offline_first_playable_uri_resolver.dart';
@@ -204,9 +206,18 @@ final playbackCandidateSourceProvider = Provider<PlaybackCandidateSource>(
   (ref) => const NoFallbackCandidateSource(),
 );
 
+/// Test seam for Linux's native audio engine.
+///
+/// Production leaves this null so [LinuxPlaybackController] registers and
+/// creates media_kit/libmpv. Tests inject a channel-free [AudioPlayer] fake:
+/// `flutter test` intentionally does not assemble the native Linux bundle, so
+/// loading libmpv there would make otherwise deterministic unit tests depend on
+/// host packages or speakers.
+final linuxAudioPlayerProvider = Provider<AudioPlayer?>((ref) => null);
+
 final localPlaybackControllerProvider =
     Provider<LocalPlaybackController>((ref) {
-  // Platforms without a `just_audio` implementation get the explicit
+  // Platforms without an on-device implementation get the explicit
   // unsupported engine instead. This is the only branch: everything downstream —
   // the routing controller, the queue UI, smart pre-cache, playback reporting —
   // keeps talking to a LocalPlaybackController and is unaware which one it got.
@@ -222,25 +233,35 @@ final localPlaybackControllerProvider =
     return unsupported;
   }
 
-  final controller = JustAudioPlaybackController(
-    resolver: ref.read(playableUriResolverProvider),
-    // Read once at construction; the candidate source itself reads the live
-    // library lazily at play time, so the session-pinned engine still sees a
-    // fresh catalog (and default-source change) without being rebuilt.
-    candidates: ref.read(playbackCandidateSourceProvider),
-    // When a track's offline-cache file won't open (corrupt, or reclaimed after
-    // the existence check), fall back to streaming the *same* track — this
-    // resolver resolves past the offline cache (the offline-first resolver's own
-    // fallback), so even a single-source cached track recovers to its live
-    // stream rather than erroring.
-    streamingFallbackResolver: ref.read(remoteCacheResolverProvider),
-    // Record a completed play when a track reaches its end. Read lazily at
-    // completion time (not watched), so the play-history repository never ties
-    // into the engine's lifecycle. Only the track id is recorded; it stays
-    // on-device. Casting suspends the engine, so cast plays aren't counted.
-    onTrackCompleted: (track) => unawaited(
-        ref.read(playHistoryRepositoryProvider).recordCompletion(track)),
-  );
+  final controller = host == HostPlatform.linux
+      ? LinuxPlaybackController(
+          player: ref.read(linuxAudioPlayerProvider),
+          resolver: ref.read(playableUriResolverProvider),
+          candidates: ref.read(playbackCandidateSourceProvider),
+          streamingFallbackResolver: ref.read(remoteCacheResolverProvider),
+          onTrackCompleted: (track) => unawaited(
+            ref.read(playHistoryRepositoryProvider).recordCompletion(track),
+          ),
+        )
+      : JustAudioPlaybackController(
+          resolver: ref.read(playableUriResolverProvider),
+          // Read once at construction; the candidate source itself reads the live
+          // library lazily at play time, so the session-pinned engine still sees a
+          // fresh catalog (and default-source change) without being rebuilt.
+          candidates: ref.read(playbackCandidateSourceProvider),
+          // When a track's offline-cache file won't open (corrupt, or reclaimed after
+          // the existence check), fall back to streaming the *same* track — this
+          // resolver resolves past the offline cache (the offline-first resolver's own
+          // fallback), so even a single-source cached track recovers to its live
+          // stream rather than erroring.
+          streamingFallbackResolver: ref.read(remoteCacheResolverProvider),
+          // Record a completed play when a track reaches its end. Read lazily at
+          // completion time (not watched), so the play-history repository never ties
+          // into the engine's lifecycle. Only the track id is recorded; it stays
+          // on-device. Casting suspends the engine, so cast plays aren't counted.
+          onTrackCompleted: (track) => unawaited(
+              ref.read(playHistoryRepositoryProvider).recordCompletion(track)),
+        );
   ref.onDispose(controller.dispose);
   return controller;
 });

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -108,10 +108,33 @@ if(LINTHRA_SQLITE3_SOURCE_DIR)
     "Linthra: using pre-fetched SQLite from ${LINTHRA_SQLITE3_SOURCE_DIR}")
 endif()
 
+# media_kit_libs_linux otherwise downloads and compiles mimalloc while CMake is
+# building the app. Linthra does not need the optional allocator override, and
+# flatpak-builder is network-isolated, so disable it before generated plugin
+# CMake is included. Playback uses the declared system/Flatpak libmpv runtime.
+set(MIMALLOC_USE_STATIC_LIBS OFF CACHE BOOL
+  "Do not download media_kit's optional mimalloc allocator." FORCE)
+
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+
+# flutter_secure_storage_linux 1.2.3 bundles an older nlohmann json.hpp whose
+# literal-operator declarations trigger Clang's deprecated-literal-operator
+# warning. APPLY_STANDARD_SETTINGS promotes every warning to an error, so Clang
+# 22 cannot compile that otherwise-valid upstream plugin.
+#
+# flutter_secure_storage 10 fixes the header, but also rewrites Android secure
+# storage defaults and migration. Keep PR 2 from changing Android credentials:
+# preserve -Werror everywhere and demote only this diagnostic, only for this
+# plugin target. Remove this exception when the storage major is upgraded with
+# dedicated Android migration coverage.
+if(TARGET flutter_secure_storage_linux_plugin AND
+   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(flutter_secure_storage_linux_plugin PRIVATE
+    -Wno-error=deprecated-literal-operator)
+endif()
 
 # === Installation ===
 # By default, "installing" just makes a relocatable bundle in the build

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
@@ -14,6 +15,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) media_kit_libs_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitLibsLinuxPlugin");
+  media_kit_libs_linux_plugin_register_with_registrar(media_kit_libs_linux_registrar);
   g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
   sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  media_kit_libs_linux
   sqlite3_flutter_libs
   url_launcher_linux
 )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.7.1"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -496,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
   io:
     dependency: transitive
     description:
@@ -528,6 +544,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.46"
+  just_audio_media_kit:
+    dependency: "direct main"
+    description:
+      name: just_audio_media_kit
+      sha256: f3cf04c3a50339709e87e90b4e841eef4364ab4be2bdbac0c54cc48679f84d23
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   just_audio_platform_interface:
     dependency: transitive
     description:
@@ -600,6 +624,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  media_kit:
+    dependency: transitive
+    description:
+      name: media_kit
+      sha256: ae9e79597500c7ad6083a3c7b7b7544ddabfceacce7ae5c9709b0ec16a5d6643
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.6"
+  media_kit_libs_linux:
+    dependency: "direct main"
+    description:
+      name: media_kit_libs_linux
+      sha256: "2b473399a49ec94452c4d4ae51cfc0f6585074398d74216092bf3d54aac37ecf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   meta:
     dependency: transitive
     description:
@@ -760,6 +800,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   protobuf:
     dependency: transitive
     description:
@@ -808,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  safe_local_storage:
+    dependency: transitive
+    description:
+      name: safe_local_storage
+      sha256: "494b982d5edb71030650ea463d939670e91b232b588323dc75229d2c5f23e7b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.6"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1045,6 +1101,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  universal_platform:
+    dependency: transitive
+    description:
+      name: universal_platform
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  uri_parser:
+    dependency: transitive
+    description:
+      name: uri_parser
+      sha256: "051c62e5f693de98ca9f130ee707f8916e2266945565926be3ff20659f7853ce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,14 @@ dependencies:
   # services layer; the UI depends on the PlaybackController interface, never on
   # just_audio directly.
   just_audio: ^0.9.42
+  # Linux implementation of just_audio, backed by media_kit/libmpv. Keeping
+  # the federated adapter means Linux reuses Linthra's existing resolver,
+  # fallback, queue and completion controller while Android stays on ExoPlayer.
+  just_audio_media_kit: ^2.1.0
+  # Supplies media_kit's Linux native registration. libmpv is an explicit
+  # system/Flatpak runtime dependency; Linthra disables this package's optional
+  # mimalloc download in linux/CMakeLists.txt for network-isolated builds.
+  media_kit_libs_linux: ^1.2.1
   # Background playback + platform media session (notification, lock screen,
   # Android Auto). Used only by LinthraAudioHandler in the services layer, which
   # forwards session commands to PlaybackController and mirrors its state out.

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -24,6 +24,9 @@ bar and the About screen disagree.
 It also checks two things that are about *how* the runner builds rather than
 what it is called:
 
+  * the temporary Clang exception for flutter_secure_storage_linux stays
+    PRIVATE to that plugin target, so the legacy bundled header builds without
+    weakening -Werror for Linthra or any other plugin;
   * the SQLite pre-fetch seam (LINTHRA_SQLITE3_SOURCE_DIR) is still there, so a
     network-isolated build — flatpak-builder included — stays possible;
   * nothing under linux/ hardcodes an absolute host path, which would make the
@@ -56,6 +59,13 @@ BUILD_GRADLE = Path("android") / "app" / "build.gradle"
 # The CMake variable linux/CMakeLists.txt uses to accept an already-unpacked
 # SQLite amalgamation instead of downloading one. See docs/linux-desktop.md.
 SQLITE_SOURCE_VARIABLE = "LINTHRA_SQLITE3_SOURCE_DIR"
+
+SECURE_STORAGE_TARGET = "flutter_secure_storage_linux_plugin"
+SECURE_STORAGE_WARNING_EXCEPTION = "-Wno-error=deprecated-literal-operator"
+SECURE_STORAGE_SCOPED_EXCEPTION = re.compile(
+    rf"target_compile_options\(\s*{SECURE_STORAGE_TARGET}\s+PRIVATE\s+"
+    rf"{re.escape(SECURE_STORAGE_WARNING_EXCEPTION)}\s*\)"
+)
 
 # An absolute path baked into the native build would tie it to one machine.
 # `/` alone is far too common in CMake (every ${VAR}/sub path), so this looks
@@ -238,6 +248,22 @@ def check(root: Path) -> list[str]:
         problems.append(
             f"{CMAKELISTS} sets {SQLITE_SOURCE_VARIABLE} but never forwards it "
             "to FETCHCONTENT_SOURCE_DIR_SQLITE3, so it has no effect"
+        )
+
+    # Clang 22 diagnoses the old json.hpp bundled by
+    # flutter_secure_storage_linux 1.2.3. The exception must remain both unique
+    # and PRIVATE to that plugin; a directory/global suppression would weaken
+    # the runner's -Werror contract and hide unrelated warnings.
+    cmake_code = "\n".join(
+        line for line in cmakelists.splitlines() if not line.lstrip().startswith("#")
+    )
+    if (
+        cmake_code.count(SECURE_STORAGE_WARNING_EXCEPTION) != 1
+        or SECURE_STORAGE_SCOPED_EXCEPTION.search(cmake_code) is None
+    ):
+        problems.append(
+            "the deprecated-literal-operator exception must appear exactly "
+            f"once and be PRIVATE to {SECURE_STORAGE_TARGET}"
         )
 
     for finding in absolute_paths_under_linux(root):

--- a/scripts/verify_linux.sh
+++ b/scripts/verify_linux.sh
@@ -3,11 +3,11 @@
 # verify_linux.sh — run the Linux desktop checks locally, the way CI runs them.
 #
 # The twin of scripts/verify_android.sh, for the other platform. Order mirrors
-# .github/workflows/linux-build.yml:
+# .github/workflows/linux-desktop-build.yml:
 #
 #   flutter pub get --enforce-lockfile  ->  dart format (check)  ->
 #   flutter analyze  ->  flutter test  ->  Linux runner config check  ->
-#   flutter build linux --release
+#   native audio lifecycle smoke (build + run) -> flutter build linux --release
 #
 # The shared checks (format/analyze/test) are deliberately repeated here rather
 # than delegated: someone working on the desktop build should be able to run one
@@ -16,10 +16,14 @@
 #
 # Native toolchain: `flutter build linux` needs clang, cmake, ninja, pkg-config
 # and the GTK 3 development headers, plus libsecret for encrypted credential
-# storage. They are checked up front and a missing one *skips* the build with a
-# clear message instead of failing the whole script — the same shape as
-# verify_android.sh skipping the APK when there is no Android SDK. See
-# docs/linux-desktop.md for the Fedora and Debian/Ubuntu package names.
+# storage. `just_audio_media_kit`/media_kit additionally dlopen the libmpv
+# runtime at process startup (lib/core/services/linux_playback_controller.dart)
+# rather than link it at build time, so a build can "succeed" on a machine that
+# cannot actually play audio. All of these are checked up front and a missing
+# one *skips* the build and the audio smoke test with a clear message instead
+# of failing the whole script — the same shape as verify_android.sh skipping
+# the APK when there is no Android SDK. See docs/linux-desktop.md for the
+# Fedora, Debian/Ubuntu and Arch package names.
 #
 # Flutter resolution: prefer the project-local SDK from setup_flutter.sh
 # (.tool/flutter), otherwise fall back to Flutter on PATH.
@@ -50,8 +54,35 @@ resolve_flutter() {
   "$FLUTTER" --version | head -1 || true
 }
 
-# Report the native build prerequisites that are missing, one per line. Empty
-# output means the Linux build can run.
+# Whether the libmpv runtime that media_kit/just_audio_media_kit dlopen at
+# startup can actually be loaded. media_kit resolves it by trying
+# DynamicLibrary.open() against "libmpv.so", then "libmpv.so.2", then
+# "libmpv.so.1", in that order (media_kit's
+# lib/src/player/native/core/native_library.dart) — it is a runtime dlopen,
+# not a build-time link, so `flutter build linux` succeeds without it and a
+# pkg-config module name (which describes the *development* package, and
+# isn't consistently named across distributions) would not actually tell us
+# whether that dlopen will work. Probing with the same libc call media_kit
+# uses is the reliable check.
+libmpv_runtime_available() {
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - <<'PY'
+import ctypes
+import sys
+
+for name in ("libmpv.so", "libmpv.so.2", "libmpv.so.1"):
+    try:
+        ctypes.CDLL(name)
+    except OSError:
+        continue
+    else:
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+# Report the native build/runtime prerequisites that are missing, one per
+# line. Empty output means the Linux build and the audio smoke test can run.
 missing_native_deps() {
   local missing=()
   local tool
@@ -62,7 +93,24 @@ missing_native_deps() {
     pkg-config --exists gtk+-3.0 || missing+=("gtk+-3.0 development headers")
     pkg-config --exists libsecret-1 || missing+=("libsecret-1 development headers")
   fi
+  libmpv_runtime_available ||
+    missing+=("libmpv runtime (libmpv.so / libmpv.so.2 / libmpv.so.1)")
   printf '%s\n' "${missing[@]+"${missing[@]}"}"
+}
+
+# Mirrors the CI job's "Run native audio lifecycle smoke" step: run the bundle
+# that "Build native audio lifecycle smoke" just produced from
+# tool/linux_audio_backend_smoke.dart. CI always runs it under xvfb-run
+# because its runner is headless; locally, prefer xvfb-run when present so the
+# behaviour matches CI exactly, but fall back to running it directly, since a
+# developer's machine already has a real display CI doesn't.
+run_audio_smoke() {
+  local binary="$REPO_ROOT/build/linux/x64/release/bundle/linthra"
+  if command -v xvfb-run >/dev/null 2>&1; then
+    xvfb-run --auto-servernum "$binary"
+  else
+    "$binary"
+  fi
 }
 
 FAILED=()
@@ -101,12 +149,21 @@ main() {
   done < <(missing_native_deps)
 
   if [ "${#missing[@]}" -eq 0 ]; then
+    # A normal Flutter widget test cannot load the Linux plugin bundle, so
+    # this target runs in the real GTK runner and opens a silent local WAV
+    # through libmpv without starting playback — the same smoke CI runs.
+    run_step "Build native audio lifecycle smoke" \
+      "$FLUTTER" build linux --release \
+      --target=tool/linux_audio_backend_smoke.dart
+    run_step "Run native audio lifecycle smoke" run_audio_smoke
+
     run_step "flutter build linux --release" "$FLUTTER" build linux --release
   else
-    warn "Missing native Linux build dependencies:"
+    warn "Missing native Linux build/runtime dependencies:"
     printf '  - %s\n' "${missing[@]}" >&2
-    warn "Skipping 'flutter build linux --release'. See docs/linux-desktop.md"
-    warn "for the packages to install. analyze/format/tests still ran above."
+    warn "Skipping the native audio lifecycle smoke and"
+    warn "'flutter build linux --release'. See docs/linux-desktop.md for the"
+    warn "packages to install. analyze/format/tests still ran above."
   fi
 
   if [ "${#FAILED[@]}" -gt 0 ]; then

--- a/test/app/linux_startup_test.dart
+++ b/test/app/linux_startup_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/linux_playback_controller.dart';
 import 'package:linthra/core/services/media_session_binding.dart';
-import 'package:linthra/core/services/unsupported_playback_controller.dart';
 import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/data/repositories/favorites_repository_provider.dart';
 import 'package:linthra/data/repositories/host_platform_provider.dart';
@@ -13,6 +13,8 @@ import 'package:linthra/features/library/library_providers.dart';
 import 'package:linthra/features/player/lyrics_providers.dart';
 import 'package:linthra/features/player/media_artwork_providers.dart';
 import 'package:linthra/features/player/player_providers.dart';
+
+import '../support/fake_audio_player.dart';
 
 /// What `main()` builds before the first frame, on a Linux host.
 ///
@@ -29,6 +31,7 @@ void main() {
     final container = ProviderContainer(
       overrides: <Override>[
         hostPlatformProvider.overrideWithValue(HostPlatform.linux),
+        linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
       ],
     );
     addTearDown(container.dispose);
@@ -71,18 +74,15 @@ void main() {
     }, returnsNormally);
   });
 
-  test('the engine built for Linux is the unsupported one', () {
-    // The specific guard behind the smoke test above: "it constructed" would
-    // also be true if a future change quietly put `just_audio` back on Linux,
-    // where it constructs fine and then fails at the first tap.
+  test('the engine built for Linux is the real Linux controller', () {
     expect(linuxContainer().read(localPlaybackControllerProvider),
-        isA<UnsupportedPlaybackController>());
+        isA<LinuxPlaybackController>());
   });
 
   test('the volume-normalization listener main() installs is safe to fire', () {
     // main() pushes the persisted "Normalize volume" value onto the local
-    // engine immediately. On Linux that lands on the unsupported controller,
-    // which must absorb it rather than throw before the first frame.
+    // engine immediately. The Linux backend must accept it without throwing
+    // before the first frame.
     final ProviderContainer container = linuxContainer();
 
     expect(

--- a/test/core/services/linux_playback_controller_test.dart
+++ b/test/core/services/linux_playback_controller_test.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/linux_playback_controller.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+
+class _Engine extends Fake implements AudioPlayer {
+  final states = StreamController<PlayerState>.broadcast(sync: true);
+  final positions = StreamController<Duration>.broadcast(sync: true);
+  final durations = StreamController<Duration?>.broadcast(sync: true);
+  final events = StreamController<PlaybackEvent>.broadcast(sync: true);
+  final List<String> opened = <String>[];
+  final List<Duration> seeks = <Duration>[];
+  int plays = 0;
+  int pauses = 0;
+  int stops = 0;
+  int disposals = 0;
+  bool failOpen = false;
+
+  @override
+  Stream<PlayerState> get playerStateStream => states.stream;
+  @override
+  Stream<Duration> get positionStream => positions.stream;
+  @override
+  Stream<Duration?> get durationStream => durations.stream;
+  @override
+  Stream<PlaybackEvent> get playbackEventStream => events.stream;
+
+  @override
+  Future<Duration?> setUrl(String url,
+      {Map<String, String>? headers,
+      Duration? initialPosition,
+      bool preload = true,
+      dynamic tag}) async {
+    opened.add(url);
+    if (failOpen) throw Exception('native open failed with a secret URL');
+    return const Duration(minutes: 4);
+  }
+
+  @override
+  Future<void> play() async {
+    plays++;
+    states.add(PlayerState(true, ProcessingState.ready));
+  }
+
+  @override
+  Future<void> pause() async {
+    pauses++;
+    states.add(PlayerState(false, ProcessingState.ready));
+  }
+
+  @override
+  Future<void> stop() async => stops++;
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {
+    if (position != null) seeks.add(position);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> dispose() async => disposals++;
+
+  Future<void> close() async {
+    await states.close();
+    await positions.close();
+    await durations.close();
+    await events.close();
+  }
+}
+
+class _Resolver implements PlayableUriResolver {
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    if (track.uri.startsWith('/')) {
+      return ResolvedPlayable(Uri.file(track.uri), PlaybackSource.localFile);
+    }
+    return ResolvedPlayable(
+      Uri.parse('https://music.example/stream/${track.id}'),
+      PlaybackSource.streamingDirect,
+    );
+  }
+}
+
+Track _track(String id, String uri) => Track(id: id, title: id, uri: uri);
+
+void main() {
+  group('LinuxPlaybackBackendInitializer', () {
+    test('registers the backend exactly once after successful initialization',
+        () {
+      var registrations = 0;
+      final initializer = LinuxPlaybackBackendInitializer(
+        registerBackend: () => registrations++,
+      );
+
+      initializer.ensureInitialized();
+      initializer.ensureInitialized();
+
+      expect(registrations, 1);
+    });
+
+    test('allows a later attempt to retry after initialization throws', () {
+      var registrations = 0;
+      final initializer = LinuxPlaybackBackendInitializer(
+        registerBackend: () {
+          if (++registrations == 1) throw StateError('initialization failed');
+        },
+      );
+
+      expect(initializer.ensureInitialized, throwsStateError);
+      expect(initializer.ensureInitialized, returnsNormally);
+      expect(registrations, 2);
+    });
+  });
+  LinuxPlaybackController build(_Engine engine, {Random? random}) =>
+      LinuxPlaybackController(
+        player: engine,
+        resolver: _Resolver(),
+        random: random,
+      );
+
+  test('opens local files and remote resolver URLs through the same engine',
+      () async {
+    final engine = _Engine();
+    final controller = build(engine);
+    addTearDown(() async {
+      await controller.dispose();
+      await engine.close();
+    });
+
+    await controller.playTrack(_track('local', '/music/song.flac'));
+    await controller.playTrack(_track('remote', 'jellyfin:remote'));
+
+    expect(engine.opened, <String>[
+      Uri.file('/music/song.flac').toString(),
+      'https://music.example/stream/remote',
+    ]);
+    expect(controller.state.source, PlaybackSource.streamingDirect);
+    expect(controller.state.status, PlaybackStatus.playing);
+  });
+
+  test('play, pause, seek and stop delegate and keep state truthful', () async {
+    final engine = _Engine();
+    final controller = build(engine);
+    addTearDown(() async {
+      await controller.dispose();
+      await engine.close();
+    });
+
+    await controller.playTrack(_track('a', '/a.mp3'));
+    await controller.pause();
+    await controller.seek(const Duration(seconds: 37));
+    await controller.play();
+    await controller.stop();
+
+    expect(engine.pauses, 1);
+    expect(engine.seeks, <Duration>[const Duration(seconds: 37)]);
+    expect(engine.plays, 2);
+    expect(engine.stops, 1);
+    expect(controller.state.status, PlaybackStatus.idle);
+  });
+
+  test(
+      'queue replacement, next/previous and shuffle/repeat stay controller-owned',
+      () async {
+    final engine = _Engine();
+    final controller = build(engine, random: Random(7));
+    addTearDown(() async {
+      await controller.dispose();
+      await engine.close();
+    });
+    final tracks = <Track>[
+      _track('a', '/a.mp3'),
+      _track('b', '/b.mp3'),
+      _track('c', '/c.mp3'),
+    ];
+
+    await controller.playTracks(tracks);
+    await controller.skipToNext();
+    await controller.skipToPrevious();
+    controller.setShuffleEnabled(true);
+    controller.setRepeatMode(RepeatMode.all);
+
+    expect(controller.state.currentTrack, tracks.first);
+    expect(controller.state.shuffleEnabled, isTrue);
+    expect(controller.state.repeatMode, RepeatMode.all);
+    expect(controller.state.upNext, hasLength(2));
+  });
+
+  test('completion advances and a native open error never claims playing',
+      () async {
+    final engine = _Engine();
+    final controller = build(engine);
+    addTearDown(() async {
+      await controller.dispose();
+      await engine.close();
+    });
+    await controller.playTracks(<Track>[
+      _track('a', '/a.mp3'),
+      _track('b', '/b.mp3'),
+    ]);
+
+    engine.states.add(PlayerState(false, ProcessingState.completed));
+    await pumpEventQueue();
+    expect(controller.state.currentTrack?.id, 'b');
+
+    engine.failOpen = true;
+    await controller.playTrack(_track('broken', 'plex:broken'));
+    expect(controller.state.status, PlaybackStatus.error);
+    expect(controller.state.isPlaying, isFalse);
+    expect(controller.state.errorMessage, isNot(contains('music.example')));
+  });
+
+  test('dispose releases the engine and a fresh controller can play', () async {
+    final firstEngine = _Engine();
+    final first = build(firstEngine);
+    await first.dispose();
+    expect(firstEngine.disposals, 1);
+    await firstEngine.close();
+
+    final secondEngine = _Engine();
+    final second = build(secondEngine);
+    await second.playTrack(_track('again', '/again.ogg'));
+    expect(second.state.status, PlaybackStatus.playing);
+    await second.dispose();
+    await secondEngine.close();
+  });
+}

--- a/test/features/player/lyrics_experience_test.dart
+++ b/test/features/player/lyrics_experience_test.dart
@@ -16,6 +16,7 @@ import 'package:linthra/features/player/widgets/lyrics/lyric_line_tile.dart';
 import 'package:linthra/features/player/widgets/lyrics/lyrics_viewport.dart';
 import 'package:linthra/features/player/widgets/lyrics_view.dart';
 
+import '../../support/fake_audio_player.dart';
 import 'fake_playback_controller.dart';
 
 /// A lyrics backend returning one canned set for the test track.
@@ -772,6 +773,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: <Override>[
+            linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
             lyricsServiceProvider.overrideWithValue(_FakeLyricsService(null)),
           ],
           child: const MaterialApp(

--- a/test/features/player/now_playing_add_to_playlist_test.dart
+++ b/test/features/player/now_playing_add_to_playlist_test.dart
@@ -2,13 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/widgets/now_playing_actions.dart';
+
+import '../../support/fake_audio_player.dart';
 
 void main() {
   testWidgets('Now Playing actions include Add to playlist', (tester) async {
     await tester.pumpWidget(
-      const ProviderScope(
-        child: MaterialApp(
+      ProviderScope(
+        overrides: <Override>[
+          linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+        ],
+        child: const MaterialApp(
           home: Scaffold(
             body: NowPlayingActions(
               track: Track(id: '1', title: 'Song One', uri: 'jellyfin:1'),

--- a/test/features/player/playback_controller_lifecycle_test.dart
+++ b/test/features/player/playback_controller_lifecycle_test.dart
@@ -3,18 +3,24 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/features/player/player_providers.dart';
 
+import '../../support/fake_audio_player.dart';
+
 /// Locks in the playback-lifecycle guarantee from the alpha bug report: the
 /// single [PlaybackController] must be pinned for the app session, so navigating
 /// between tabs/screens and changing settings can never recreate or dispose it
 /// (which would dispose the live `AudioPlayer` and cut the music). These tests
-/// drive the *real* `playbackControllerProvider`; on a non-mobile test host the
-/// `just_audio` engine constructs without touching any platform channel.
+/// drive the *real* `playbackControllerProvider` with the Linux AudioPlayer
+/// seam explicitly replaced so unit tests never initialize native plugins.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('playback controller lifecycle', () {
     test('is read once and survives a resolver/locator rebuild', () {
-      final container = ProviderContainer();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+        ],
+      );
       addTearDown(container.dispose);
 
       final first = container.read(playbackControllerProvider);
@@ -36,7 +42,11 @@ void main() {
     });
 
     test('survives a download-store rebuild (e.g. a download completing)', () {
-      final container = ProviderContainer();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+        ],
+      );
       addTearDown(container.dispose);
 
       final first = container.read(playbackControllerProvider);
@@ -53,7 +63,11 @@ void main() {
     });
 
     test('the same instance backs the provider on every read', () {
-      final container = ProviderContainer();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+        ],
+      );
       addTearDown(container.dispose);
 
       final reads = List.generate(

--- a/test/features/player/playback_platform_binding_test.dart
+++ b/test/features/player/playback_platform_binding_test.dart
@@ -3,15 +3,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/platform/host_platform.dart';
 import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/linux_playback_controller.dart';
 import 'package:linthra/core/services/local_playback_controller.dart';
 import 'package:linthra/core/services/platform_playback_support.dart';
 import 'package:linthra/core/services/unsupported_playback_controller.dart';
 import 'package:linthra/data/repositories/host_platform_provider.dart';
 import 'package:linthra/features/player/player_providers.dart';
 
+import '../../support/fake_audio_player.dart';
+
 ProviderContainer _containerFor(HostPlatform host) {
   final container = ProviderContainer(
-    overrides: <Override>[hostPlatformProvider.overrideWithValue(host)],
+    overrides: <Override>[
+      hostPlatformProvider.overrideWithValue(host),
+      linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+    ],
   );
   addTearDown(container.dispose);
   return container;
@@ -19,13 +25,13 @@ ProviderContainer _containerFor(HostPlatform host) {
 
 void main() {
   group('PlatformPlaybackSupport.hasOnDeviceEngine', () {
-    test('is true exactly where just_audio publishes an implementation', () {
+    test('is true exactly where Linthra provides an implementation', () {
       expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.android),
           isTrue);
       expect(
           PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.ios), isTrue);
       expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.linux),
-          isFalse);
+          isTrue);
       expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.macOS),
           isFalse);
       expect(PlatformPlaybackSupport.hasOnDeviceEngine(HostPlatform.windows),
@@ -45,21 +51,21 @@ void main() {
           container.read(localPlaybackControllerProvider);
 
       expect(controller, isA<JustAudioPlaybackController>());
+      expect(controller, isNot(isA<LinuxPlaybackController>()));
     });
 
-    test('on Linux, builds the explicit unsupported engine', () {
+    test('on Linux, builds the media_kit-backed engine', () {
       final ProviderContainer container = _containerFor(HostPlatform.linux);
 
       final LocalPlaybackController controller =
           container.read(localPlaybackControllerProvider);
 
-      expect(controller, isA<UnsupportedPlaybackController>());
+      expect(controller, isA<LinuxPlaybackController>());
       expect(controller.state.status, PlaybackStatus.idle);
     });
 
-    test('every desktop platform gets the unsupported engine', () {
+    test('unsupported desktop platforms keep the unsupported engine', () {
       for (final HostPlatform host in <HostPlatform>[
-        HostPlatform.linux,
         HostPlatform.macOS,
         HostPlatform.windows,
         HostPlatform.other,
@@ -71,26 +77,12 @@ void main() {
         );
       }
     });
-
-    test('the Linux engine reports playback as unavailable, not broken',
-        () async {
-      final ProviderContainer container = _containerFor(HostPlatform.linux);
-      final LocalPlaybackController controller =
-          container.read(localPlaybackControllerProvider);
-
-      await controller.play();
-
-      expect(controller.state.status, PlaybackStatus.error);
-      expect(controller.state.errorMessage,
-          UnsupportedPlaybackController.defaultReason);
-    });
   });
 
   group('playbackControllerProvider', () {
     test('routes through the same ActivePlaybackController on Linux', () {
       // The UI depends on this provider, never on the engine. It has to build
-      // on a platform with no audio engine, otherwise the whole player feature
-      // fails to construct at startup.
+      // over the real Linux engine so the player feature constructs at startup.
       final ProviderContainer container = _containerFor(HostPlatform.linux);
 
       expect(

--- a/test/features/player/sleep_timer_sheet_test.dart
+++ b/test/features/player/sleep_timer_sheet_test.dart
@@ -4,9 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/track.dart';
+import 'package:linthra/features/player/player_providers.dart';
 import 'package:linthra/features/player/sleep_timer_controller.dart';
 import 'package:linthra/features/player/widgets/now_playing_actions.dart';
 import 'package:linthra/features/player/widgets/sleep_timer_sheet.dart';
+
+import '../../support/fake_audio_player.dart';
 
 /// An inert [Timer] that never fires, so arming the countdown in a widget test
 /// schedules no real timers (which would otherwise leave the test pending).
@@ -116,8 +119,11 @@ void main() {
     testWidgets('includes a Sleep timer action that opens the sheet',
         (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: <Override>[
+            linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+          ],
+          child: const MaterialApp(
             home: Scaffold(
               body: NowPlayingActions(
                 track: Track(id: '1', title: 'Song One', uri: 'jellyfin:1'),

--- a/test/support/fake_audio_player.dart
+++ b/test/support/fake_audio_player.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+
+/// Channel-free AudioPlayer used when a test intentionally builds Linux
+/// playback providers without exercising the native plugin bundle.
+class FakeAudioPlayer extends Fake implements AudioPlayer {
+  @override
+  Stream<PlayerState> get playerStateStream => const Stream.empty();
+
+  @override
+  Stream<Duration> get positionStream => const Stream.empty();
+
+  @override
+  Stream<Duration?> get durationStream => const Stream.empty();
+
+  @override
+  Stream<PlaybackEvent> get playbackEventStream => const Stream.empty();
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -61,6 +61,12 @@ if(LINTHRA_SQLITE3_SOURCE_DIR)
 endif()
 
 include(flutter/generated_plugins.cmake)
+
+if(TARGET flutter_secure_storage_linux_plugin AND
+   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(flutter_secure_storage_linux_plugin PRIVATE
+    -Wno-error=deprecated-literal-operator)
+endif()
 """
 
 MY_APPLICATION = """\
@@ -249,7 +255,7 @@ class OfflineBuildSeamTest(CheckoutCase):
             cmakelists='set(BINARY_NAME "exampleapp")\nset(APPLICATION_ID "io.example.app")\n',
         )
         problems = checker.check(self.root)
-        self.assertEqual(len(problems), 1)
+        self.assertEqual(len(problems), 2)
         self.assertIn("LINTHRA_SQLITE3_SOURCE_DIR", problems[0])
 
     def test_a_seam_that_is_never_forwarded_is_caught(self) -> None:
@@ -264,8 +270,43 @@ class OfflineBuildSeamTest(CheckoutCase):
             ),
         )
         problems = checker.check(self.root)
-        self.assertEqual(len(problems), 1)
+        self.assertEqual(len(problems), 2)
         self.assertIn("never forwards it", problems[0])
+
+
+class SecureStorageWarningScopeTest(CheckoutCase):
+    def test_losing_the_plugin_exception_is_caught(self) -> None:
+        cmakelists = CMAKELISTS.format(binary=BINARY, app_id=APP_ID).replace(
+            """\
+if(TARGET flutter_secure_storage_linux_plugin AND
+   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(flutter_secure_storage_linux_plugin PRIVATE
+    -Wno-error=deprecated-literal-operator)
+endif()
+""",
+            "",
+        )
+        build_checkout(self.root, cmakelists=cmakelists)
+
+        problems = checker.check(self.root)
+
+        self.assertEqual(len(problems), 1)
+        self.assertIn("deprecated-literal-operator", problems[0])
+
+    def test_a_global_exception_is_rejected(self) -> None:
+        cmakelists = CMAKELISTS.format(binary=BINARY, app_id=APP_ID).replace(
+            """\
+  target_compile_options(flutter_secure_storage_linux_plugin PRIVATE
+    -Wno-error=deprecated-literal-operator)
+""",
+            "  add_compile_options(-Wno-error=deprecated-literal-operator)\n",
+        )
+        build_checkout(self.root, cmakelists=cmakelists)
+
+        problems = checker.check(self.root)
+
+        self.assertEqual(len(problems), 1)
+        self.assertIn("PRIVATE", problems[0])
 
 
 class AbsolutePathTest(CheckoutCase):

--- a/tool/linux_audio_backend_smoke.dart
+++ b/tool/linux_audio_backend_smoke.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/linux_playback_controller.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final directory =
+      await Directory.systemTemp.createTemp('linthra_linux_audio_smoke_');
+  final audioFile = File('${directory.path}/silence.wav');
+  await audioFile.writeAsBytes(_silentWav(), flush: true);
+  var result = 0;
+
+  try {
+    await _exerciseLifecycle(audioFile.path);
+    await _exerciseLifecycle(audioFile.path);
+    stdout.writeln('Linux native audio lifecycle smoke passed.');
+  } catch (error, stackTrace) {
+    stderr.writeln('Linux native audio lifecycle smoke failed:');
+    stderr.writeln(error);
+    stderr.writeln(stackTrace);
+    result = 1;
+  } finally {
+    if (directory.existsSync()) {
+      await directory.delete(recursive: true);
+    }
+  }
+  exit(result);
+}
+
+Future<void> _exerciseLifecycle(String path) async {
+  final controller = LinuxPlaybackController();
+  try {
+    // Queue while suspended, then resume without autoplay. This loads the local
+    // WAV through the real just_audio_media_kit/libmpv backend but never asks
+    // the audio device to produce sound.
+    await controller.suspend();
+    await controller.playTrack(
+      Track(id: 'smoke', title: 'Silent smoke sample', uri: path),
+    );
+    await controller.resume(play: false);
+
+    if (controller.state.status == PlaybackStatus.error) {
+      throw StateError(
+        controller.state.errorMessage ?? 'The native backend rejected the WAV.',
+      );
+    }
+    if (controller.state.source != PlaybackSource.localFile) {
+      throw StateError('The native backend did not load the local WAV.');
+    }
+  } finally {
+    await controller.dispose();
+  }
+}
+
+Uint8List _silentWav() {
+  const sampleRate = 8000;
+  const channelCount = 1;
+  const bytesPerSample = 2;
+  const frameCount = 800;
+  const dataSize = frameCount * channelCount * bytesPerSample;
+  const headerSize = 44;
+  final bytes = ByteData(headerSize + dataSize);
+
+  void writeAscii(int offset, String value) {
+    for (var index = 0; index < value.length; index++) {
+      bytes.setUint8(offset + index, value.codeUnitAt(index));
+    }
+  }
+
+  writeAscii(0, 'RIFF');
+  bytes.setUint32(4, 36 + dataSize, Endian.little);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  bytes.setUint32(16, 16, Endian.little);
+  bytes.setUint16(20, 1, Endian.little);
+  bytes.setUint16(22, channelCount, Endian.little);
+  bytes.setUint32(24, sampleRate, Endian.little);
+  bytes.setUint32(
+    28,
+    sampleRate * channelCount * bytesPerSample,
+    Endian.little,
+  );
+  bytes.setUint16(32, channelCount * bytesPerSample, Endian.little);
+  bytes.setUint16(34, bytesPerSample * 8, Endian.little);
+  writeAscii(36, 'data');
+  bytes.setUint32(40, dataSize, Endian.little);
+
+  return bytes.buffer.asUint8List();
+}


### PR DESCRIPTION
Adds native Linux audio playback to Linthra using just_audio_media_kit, media_kit, and libmpv.

This keeps the existing PlaybackController architecture and adds a Linux-specific backend without changing Android playback behavior.

Validated locally on Fedora Kinoite 44 with Clang 22:

Linux release build succeeds
flutter_secure_storage_linux Clang 22 warning workaround is scoped to the plugin
Jellyfin streaming playback works with real audio output
Now Playing, playback progress, and lyrics work during Linux playback
Linux runner/tooling checks pass

Part of #376 Linux audio playback milestone.