### PR TITLE
fix: persist artwork cache and clarify song precaching (#356)

### DIFF
--- a/lib/core/services/artwork_disk_cache.dart
+++ b/lib/core/services/artwork_disk_cache.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Persists remote artwork bytes to a small, Linthra-managed disk cache keyed
+/// by the credential-free artwork identity ([artworkImageProvider]'s `Uri`
+/// argument), so a cover fetched once survives an app restart.
+///
+/// Why this exists: Flutter's built-in `ImageCache` is in-memory only and is
+/// dropped the moment the process ends, so every remote cover — Jellyfin's
+/// token-free image URL, or a resolved Subsonic/Plex reference — was otherwise
+/// re-fetched on *every* app launch (issue #356: "every time I open the app it
+/// has to re-download all images for everything"). This cache sits in front of
+/// the network fetch inside `artworkImageProvider`: a hit is read straight from
+/// disk (no network at all); a miss still loads exactly as it did before this
+/// cache existed and, in the background, fetches + writes the bytes so the
+/// *next* launch is a hit.
+///
+/// Distinct from `MediaArtworkCache` (which caches a small platform-loadable
+/// `content://` copy for the lock screen / Android Auto, in the OS-reclaimable
+/// temp directory): this cache backs the in-app UI — `artworkImageProvider`,
+/// the one seam every track row, album/artist tile, header, and mini-player
+/// loads art through — lives in the app-support directory (durable, not
+/// reclaimed under memory pressure), and is a plain, safe-to-delete folder of
+/// image files with no manifest to go stale.
+///
+/// Security / privacy:
+///  - The cache **key** — and therefore the on-disk file name — is a SHA-256
+///    hash of the *credential-free* artwork identity: a Jellyfin cover URL is
+///    already token-free by construction, and Subsonic/Plex covers are keyed by
+///    their opaque reference (`subsonic-cover:<id>`, `plex-thumb:<path>`)
+///    rather than any resolved, authenticated URL. Nothing that could carry a
+///    token or server address is ever part of a file name, and there is no
+///    index/manifest that could record one either.
+///  - The *authenticated* fetch URL a provider's `ArtworkReferenceResolver`
+///    produces exists only as a local inside [_warmNow], used once to fetch the
+///    bytes, and is never written to disk or logged.
+///  - A missing or corrupt (0-byte / unreadable) cache entry is always treated
+///    as a miss, never surfaced as an error — the caller falls back to a fresh
+///    fetch and, ultimately, its placeholder.
+class ArtworkDiskCache {
+  ArtworkDiskCache({
+    required Directory directory,
+    Uri Function(Uri key)? resolveFetchUrl,
+    Future<List<int>?> Function(Uri url)? fetch,
+    http.Client? httpClient,
+  })  : _directory = directory,
+        _resolveFetchUrl = resolveFetchUrl ?? _identity,
+        _httpClient = httpClient ?? http.Client() {
+    _fetch = fetch ?? _defaultFetch;
+  }
+
+  /// The app's persistent artwork-cache directory. Nothing is created yet —
+  /// [_warmNow] creates it lazily on first write. Call once at startup and pass
+  /// the result to the constructor; tests inject their own temp directory.
+  static Future<Directory> defaultDirectory() async {
+    final Directory base = await getApplicationSupportDirectory();
+    return Directory(p.join(base.path, 'artwork_cache'));
+  }
+
+  final Directory _directory;
+
+  /// Turns a credential-free key into the URL to fetch. Defaults to the
+  /// identity function (an already-loadable Jellyfin URL needs no resolving);
+  /// the app wires this to `artwork_image.dart`'s installed
+  /// `ArtworkReferenceResolver` so a Subsonic/Plex reference resolves with the
+  /// live session's credential at fetch time, never persisted.
+  final Uri Function(Uri key) _resolveFetchUrl;
+
+  final http.Client _httpClient;
+  late final Future<List<int>?> Function(Uri url) _fetch;
+
+  /// In-flight warms, keyed by the cache key's hash, so a burst of rebuilds for
+  /// the same reference (e.g. a scrolling list) share one fetch instead of
+  /// racing to write the same file — and so a caller (tests) can await the same
+  /// result rather than firing a second one.
+  final Map<String, Future<void>> _warming = <String, Future<void>>{};
+
+  static const Duration _timeout = Duration(seconds: 20);
+
+  File _fileFor(String hash) => File(p.join(_directory.path, '$hash.img'));
+
+  /// The cached file for [key] if a non-empty copy already exists on disk, or
+  /// `null` on a miss or a corrupt (0-byte / unreadable) entry. A cheap
+  /// synchronous stat, so `artworkImageProvider` can consult it while building
+  /// an `ImageProvider` with no `await`.
+  File? cachedFile(Uri key) {
+    final File file = _fileFor(_hash(key));
+    try {
+      if (file.lengthSync() > 0) return file;
+    } on FileSystemException {
+      // Missing, or an odd permissions error — either way, not a usable hit.
+    }
+    return null;
+  }
+
+  /// Fetches [key]'s bytes and writes them to the persistent cache, so the
+  /// *next* [cachedFile] call is a hit. Safe to call on every render: it
+  /// de-duplicates concurrent warms for the same key (returning the same
+  /// in-flight future) and re-checks the disk before fetching, so a real cache
+  /// hit never spends the network twice. Never throws — every failure (an
+  /// unresolvable reference, a network error, a non-image response, a write
+  /// failure) just leaves the entry to warm again on a later call.
+  Future<void> warm(Uri key) {
+    final String hash = _hash(key);
+    final Future<void>? inFlight = _warming[hash];
+    if (inFlight != null) return inFlight;
+    final Future<void> future = _runWarm(key, hash);
+    _warming[hash] = future;
+    return future;
+  }
+
+  // A plain try/finally wrapper rather than `_warmNow(...).whenComplete(...)`:
+  // chaining `whenComplete` onto a future whose last hop is a native file
+  // completion (as `_warmNow`'s is, via `File.rename`) has been observed to
+  // never resolve on some platforms/engines, silently stalling every future
+  // caller awaiting [warm]. try/finally reaches the same "always clean up the
+  // in-flight entry" guarantee without that combinator.
+  Future<void> _runWarm(Uri key, String hash) async {
+    try {
+      await _warmNow(key, hash);
+    } finally {
+      // `Map.remove` would return the removed Future itself here (the map's
+      // value type), which trips the unawaited-futures lint on a bare
+      // expression statement; removeWhere discards it via a bool predicate
+      // instead, with the exact same effect.
+      _warming.removeWhere((String k, Future<void> _) => k == hash);
+    }
+  }
+
+  Future<void> _warmNow(Uri key, String hash) async {
+    try {
+      final File file = _fileFor(hash);
+      if (await file.exists() && await file.length() > 0) return;
+      final Uri url = _resolveFetchUrl(key);
+      if (!url.isScheme('http') && !url.isScheme('https')) {
+        // An unresolved reference (e.g. signed out) resolves to itself, which
+        // is never fetchable — nothing to warm; a later render (signed back
+        // in) retries.
+        return;
+      }
+      final List<int>? bytes = await _fetch(url);
+      if (bytes == null || bytes.isEmpty) return;
+      if (!await _directory.exists()) {
+        await _directory.create(recursive: true);
+      }
+      // Write to a temp sibling then rename, so a crash mid-write can't leave a
+      // truncated image that would fail to decode until evicted.
+      final File tmp = File('${file.path}.tmp');
+      await tmp.writeAsBytes(bytes, flush: true);
+      await tmp.rename(file.path);
+    } catch (_) {
+      // Best-effort: leave it to retry on a later render.
+    }
+  }
+
+  /// A credential-free, filename-safe cache key: the SHA-256 of [key]'s string
+  /// form. [key] itself never carries a token (see class docs), so neither does
+  /// the hash — and hashing also keeps an odd reference from escaping the cache
+  /// directory.
+  static String _hash(Uri key) =>
+      sha256.convert(utf8.encode(key.toString())).toString();
+
+  static Uri _identity(Uri key) => key;
+
+  /// The default fetcher: a plain GET (over the reused [_httpClient]) that
+  /// returns the body bytes only for a 2xx image response. Any transport error,
+  /// non-2xx status, or non-image body yields `null`. The URL — which may carry
+  /// a credential — is never logged, even on error.
+  Future<List<int>?> _defaultFetch(Uri url) async {
+    try {
+      final http.Response response =
+          await _httpClient.get(url).timeout(_timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) return null;
+      final String contentType =
+          (response.headers['content-type'] ?? '').toLowerCase();
+      if (!contentType.startsWith('image/')) return null;
+      final List<int> bytes = response.bodyBytes;
+      return bytes.isEmpty ? null : bytes;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Releases the shared HTTP client. The on-disk cache is left intact — it is
+  /// durable and persists across restarts by design; call when the owning
+  /// container is torn down.
+  void dispose() => _httpClient.close();
+}

--- a/lib/features/settings/precache/precache_settings_section.dart
+++ b/lib/features/settings/precache/precache_settings_section.dart
@@ -56,6 +56,13 @@ class PrecacheSettingsSection extends ConsumerWidget {
             ),
             const SizedBox(height: AppSpacing.sm),
             Text(
+              'This is Linthra\'s automatic song cache. Turn it off to stop '
+              'Linthra fetching song data on its own — streaming still works, '
+              'and any song you explicitly download stays available offline.',
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
               'To keep a song for good, use "Keep offline" on a download — '
               'pinned tracks are protected and never removed automatically.',
               style: theme.textTheme.bodySmall?.copyWith(color: muted),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'app/linthra_app.dart';
 import 'core/models/plex_session.dart';
 import 'core/models/subsonic_session.dart';
 import 'core/models/theme_mode_preference.dart';
+import 'core/services/artwork_disk_cache.dart';
 import 'core/services/media_session_binding.dart';
 import 'core/sources/plex/plex_artwork.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
@@ -269,7 +270,7 @@ Future<void> main() async {
   // row keeps its placeholder) and anything else (Jellyfin and local covers)
   // loads directly.
   // Secret-free: only the resolved NetworkImage URL is built, never logged.
-  installArtworkReferenceResolver((Uri reference) {
+  Uri? resolveArtworkReference(Uri reference) {
     final SubsonicSession? subsonicSession =
         container.read(subsonicSettingsControllerProvider.notifier).session;
     if (subsonicSession != null) {
@@ -283,7 +284,25 @@ Future<void> main() async {
       if (resolved != null) return resolved;
     }
     return null;
-  });
+  }
+
+  installArtworkReferenceResolver(resolveArtworkReference);
+
+  // Persistent, credential-free artwork cache (issue #356): backs every
+  // artworkImageProvider render with a Linthra-managed disk cache under the
+  // app-support directory, so a cover fetched once doesn't need re-fetching on
+  // the next launch — Flutter's built-in image cache is memory-only and is
+  // dropped when the process ends. Shares the resolver above to mint a fetch
+  // URL for a Subsonic/Plex reference; an already-loadable Jellyfin URL needs
+  // no resolving (the resolver returns null for it, so the key is fetched
+  // as-is). Only the credential-free key ever reaches disk — see
+  // [ArtworkDiskCache]'s class docs.
+  installArtworkDiskCache(
+    ArtworkDiskCache(
+      directory: await ArtworkDiskCache.defaultDirectory(),
+      resolveFetchUrl: (Uri key) => resolveArtworkReference(key) ?? key,
+    ),
+  );
 
   // With the sessions loaded, pull the user's server favourites (Jellyfin and
   // Subsonic/Navidrome) so the heart reflects each server from the first frame.

--- a/lib/shared/widgets/artwork_image.dart
+++ b/lib/shared/widgets/artwork_image.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
+
+import '../../core/services/artwork_disk_cache.dart';
 
 /// Turns a credential-free artwork *reference* into a loadable URL at render
 /// time, or returns `null` for a [reference] it doesn't own.
@@ -26,6 +29,21 @@ void installArtworkReferenceResolver(ArtworkReferenceResolver? resolver) {
   _referenceResolver = resolver;
 }
 
+/// The app-level persistent artwork cache (see `main`), or `null` when none is
+/// installed — the default in tests, and briefly at app startup before the
+/// async install completes, where every render simply behaves exactly as it did
+/// before this cache existed (a fresh [NetworkImage] each time).
+ArtworkDiskCache? _diskCache;
+
+/// Installs the app-level [ArtworkDiskCache] (see `main`). Passing `null`
+/// clears it. Idempotent and global for the same reason as
+/// [installArtworkReferenceResolver]: [artworkImageProvider] is a plain
+/// function with no Riverpod scope, so the persistent-cache behaviour is taught
+/// to the one seam rather than threaded through every call site.
+void installArtworkDiskCache(ArtworkDiskCache? cache) {
+  _diskCache = cache;
+}
+
 /// Resolves an artwork [uri] to the right [ImageProvider] — the app's single
 /// artwork-resolver seam.
 ///
@@ -37,12 +55,16 @@ void installArtworkReferenceResolver(ArtworkReferenceResolver? resolver) {
 /// - A `file:` URI is embedded cover art Linthra extracted from a local audio
 ///   file into its own private cache; it loads straight from disk with a
 ///   [FileImage].
-/// - A credential-free *reference* (e.g. Subsonic's `subsonic-cover:<id>`) is
-///   handed to the installed [ArtworkReferenceResolver], which weaves in the
-///   live session's auth to produce a loadable URL; that URL is then loaded with
-///   a [NetworkImage].
-/// - Anything else is a server's plain http(s) image URL (Jellyfin builds a
-///   token-free primary-image URL), loaded with a [NetworkImage] unchanged.
+/// - Anything else — a server's plain http(s) image URL (Jellyfin builds a
+///   token-free primary-image URL), or a credential-free *reference* (e.g.
+///   Subsonic's `subsonic-cover:<id>`) — is first checked against the installed
+///   [ArtworkDiskCache] (issue #356): a hit loads straight from disk with a
+///   [FileImage], no network at all. A miss is handed to the installed
+///   [ArtworkReferenceResolver] (which weaves in the live session's auth to
+///   produce a loadable URL for a reference, or returns `null` for an
+///   already-loadable URL) and loaded with a [NetworkImage] exactly as before —
+///   and, in the background, fetched once more and written to the disk cache so
+///   the *next* render of the same cover is a hit.
 ///
 /// Sources with no cover at all — an untagged local file, or a Subsonic item the
 /// server reports no `coverArt` for — carry a null `artworkUri` and never reach
@@ -54,6 +76,16 @@ void installArtworkReferenceResolver(ArtworkReferenceResolver? resolver) {
 ImageProvider artworkImageProvider(Uri uri) {
   if (uri.isScheme('file')) {
     return FileImage(File(uri.toFilePath()));
+  }
+  final ArtworkDiskCache? cache = _diskCache;
+  if (cache != null) {
+    final File? cached = cache.cachedFile(uri);
+    if (cached != null) return FileImage(cached);
+    // A miss: warm the persistent cache in the background so a later render of
+    // this same cover (this session or the next launch) is a hit. Fire-and-
+    // forget and best-effort — never awaited, never blocks this render, and
+    // never throws (see [ArtworkDiskCache.warm]).
+    unawaited(cache.warm(uri));
   }
   final Uri? resolved = _referenceResolver?.call(uri);
   return NetworkImage((resolved ?? uri).toString());

--- a/test/core/services/artwork_disk_cache_test.dart
+++ b/test/core/services/artwork_disk_cache_test.dart
@@ -1,0 +1,209 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/artwork_disk_cache.dart';
+
+void main() {
+  group('ArtworkDiskCache', () {
+    late Directory dir;
+    late List<Uri> fetchedUrls;
+    late List<int>? Function(Uri url) fetch;
+
+    ArtworkDiskCache build({Uri Function(Uri key)? resolveFetchUrl}) {
+      return ArtworkDiskCache(
+        directory: dir,
+        resolveFetchUrl: resolveFetchUrl,
+        fetch: (Uri url) async {
+          fetchedUrls.add(url);
+          return fetch(url);
+        },
+      );
+    }
+
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp('artwork_disk_cache_test');
+      fetchedUrls = <Uri>[];
+      fetch = (Uri url) => <int>[1, 2, 3, 4];
+    });
+
+    tearDown(() async {
+      if (await dir.exists()) await dir.delete(recursive: true);
+    });
+
+    test('a miss returns null and fetches nothing on its own', () async {
+      final cache = build();
+      expect(cache.cachedFile(Uri.parse('https://server.example/cover.jpg')),
+          isNull);
+      expect(fetchedUrls, isEmpty);
+    });
+
+    test('cache miss fetches and stores the image', () async {
+      final cache = build();
+      final key = Uri.parse('https://server.example/cover.jpg');
+
+      await cache.warm(key);
+
+      expect(fetchedUrls, [key]);
+      final File? cached = cache.cachedFile(key);
+      expect(cached, isNotNull);
+      expect(await cached!.readAsBytes(), <int>[1, 2, 3, 4]);
+    });
+
+    test('a cache hit avoids a second network fetch', () async {
+      final cache = build();
+      final key = Uri.parse('https://server.example/cover.jpg');
+      await cache.warm(key);
+      expect(fetchedUrls, hasLength(1));
+
+      // A fresh instance over the same directory, so this is a genuine restart
+      // scenario, not just in-memory memoization.
+      final reopened = build();
+      final File? cached = reopened.cachedFile(key);
+      expect(cached, isNotNull);
+
+      // Warming again must not re-fetch: the file is already there.
+      await reopened.warm(key);
+      expect(fetchedUrls, hasLength(1));
+    });
+
+    test('concurrent warms of the same key share one fetch', () async {
+      final cache = build();
+      final key = Uri.parse('https://server.example/cover.jpg');
+
+      await Future.wait(<Future<void>>[
+        cache.warm(key),
+        cache.warm(key),
+        cache.warm(key),
+      ]);
+
+      expect(fetchedUrls, hasLength(1));
+    });
+
+    test('a missing cache entry refetches safely', () async {
+      final cache = build();
+      final key = Uri.parse('https://server.example/cover.jpg');
+      expect(cache.cachedFile(key), isNull);
+
+      await cache.warm(key);
+      expect(cache.cachedFile(key), isNotNull);
+    });
+
+    test('a corrupt (0-byte) cache entry is treated as a miss and refetched',
+        () async {
+      final cache = build();
+      final key = Uri.parse('https://server.example/cover.jpg');
+
+      // Simulate a truncated/corrupt prior write.
+      if (!await dir.exists()) await dir.create(recursive: true);
+      final File corrupt = File(
+        '${dir.path}/${_sha256Hex('https://server.example/cover.jpg')}.img',
+      );
+      await corrupt.writeAsBytes(<int>[]);
+
+      expect(cache.cachedFile(key), isNull);
+
+      await cache.warm(key);
+      final File? healed = cache.cachedFile(key);
+      expect(healed, isNotNull);
+      expect(await healed!.readAsBytes(), <int>[1, 2, 3, 4]);
+    });
+
+    test('a failed fetch caches nothing and never throws', () async {
+      fetch = (Uri url) => null;
+      final cache = build();
+      final key = Uri.parse('https://server.example/cover.jpg');
+
+      await cache.warm(key);
+
+      expect(cache.cachedFile(key), isNull);
+    });
+
+    test('an unresolved reference (e.g. signed out) is never fetched',
+        () async {
+      // resolveFetchUrl returns the reference itself (unresolved), which is
+      // not http(s) — the cache must skip fetching rather than attempt (and
+      // fail) an unsupported request.
+      final cache = build(resolveFetchUrl: (Uri key) => key);
+      final key = Uri.parse('subsonic-cover:al-123');
+
+      await cache.warm(key);
+
+      expect(fetchedUrls, isEmpty);
+      expect(cache.cachedFile(key), isNull);
+    });
+
+    test(
+        'no token or authenticated URL is persisted: the cache key and file '
+        'name are derived only from the credential-free reference', () async {
+      final key = Uri.parse('subsonic-cover:al-123');
+      final cache = build(
+        resolveFetchUrl: (Uri k) => Uri.parse(
+          'https://music.example.com/rest/getCoverArt.view'
+          '?id=al-123&u=alice&t=super-secret-token&s=salt',
+        ),
+      );
+
+      await cache.warm(key);
+
+      final File? cached = cache.cachedFile(key);
+      expect(cached, isNotNull);
+      // The file name is a hash of the credential-free key, never the URL.
+      expect(cached!.path, isNot(contains('super-secret-token')));
+      expect(cached.path, isNot(contains('getCoverArt')));
+      expect(cached.path, contains(_sha256Hex('subsonic-cover:al-123')));
+      // The bytes on disk are exactly the image, no URL text embedded.
+      expect(await cached.readAsBytes(), <int>[1, 2, 3, 4]);
+      // Nothing else was written to the directory (no manifest/index file).
+      final List<FileSystemEntity> entries = await dir.list().toList();
+      expect(entries, hasLength(1));
+    });
+
+    test(
+        'provider-specific references stay credential-free: the same '
+        'reference caches to the same file regardless of a rotated token',
+        () async {
+      String token = 'token-one';
+      final key = Uri.parse('plex-thumb:/library/metadata/1/thumb/1');
+      final cache = build(
+        resolveFetchUrl: (Uri k) => Uri.parse(
+          'https://plex.example.com${k.path}?X-Plex-Token=$token',
+        ),
+      );
+
+      await cache.warm(key);
+      final File? first = cache.cachedFile(key);
+      expect(first, isNotNull);
+      final String firstPath = first!.path;
+
+      // Force a re-fetch under a rotated token by deleting the cached file —
+      // the resulting file must land at the exact same, token-independent path.
+      await first.delete();
+      token = 'token-two';
+      await cache.warm(key);
+      final File? second = cache.cachedFile(key);
+      expect(second, isNotNull);
+      expect(second!.path, firstPath);
+    });
+  });
+}
+
+String _sha256Hex(String input) {
+  // Mirrors ArtworkDiskCache's private hashing without depending on it, so a
+  // change to the private implementation that keeps the *contract* (a stable,
+  // credential-free, content-addressed file name) doesn't need this test to
+  // reach into private state.
+  const String alphabet = '0123456789abcdef';
+  final List<int> bytes = _sha256(input);
+  final StringBuffer buffer = StringBuffer();
+  for (final int byte in bytes) {
+    buffer.write(alphabet[(byte >> 4) & 0xf]);
+    buffer.write(alphabet[byte & 0xf]);
+  }
+  return buffer.toString();
+}
+
+// Uses the same `crypto` package the production code uses, rather than a
+// local shim.
+List<int> _sha256(String input) => sha256.convert(utf8.encode(input)).bytes;

--- a/test/data/repositories/cache_download_repository_test.dart
+++ b/test/data/repositories/cache_download_repository_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/download_progress.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
 import 'package:linthra/core/models/track.dart';
 import 'package:linthra/core/repositories/download_repository.dart';
 import 'package:linthra/core/repositories/download_store.dart';
@@ -9,7 +11,10 @@ import 'package:linthra/core/repositories/offline_file_store.dart';
 import 'package:linthra/core/services/connectivity_service.dart';
 import 'package:linthra/core/services/download_scheduler.dart';
 import 'package:linthra/core/services/offline_cache_manager.dart';
+import 'package:linthra/core/services/offline_first_playable_uri_resolver.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
 import 'package:linthra/core/services/remote_track_downloader.dart';
+import 'package:linthra/core/services/smart_precache_service.dart';
 import 'package:linthra/data/repositories/cache_download_repository.dart';
 import 'package:linthra/data/repositories/in_memory_download_preferences.dart';
 import 'package:linthra/data/repositories/in_memory_download_store.dart';
@@ -112,6 +117,27 @@ class _SpyOfflineFileStore implements OfflineFileStore {
   Future<void> delete(String fileName) {
     deleted.add(fileName);
     return _inner.delete(fileName);
+  }
+}
+
+/// A streaming fallback that records the track it was asked to resolve and
+/// returns a canned "streaming direct" result — stands in for the real
+/// Jellyfin/Subsonic/Plex resolvers so [OfflineFirstPlayableUriResolver] can be
+/// exercised without a server (issue #356: streaming must still work when
+/// nothing is cached).
+class _RecordingStreamResolver implements PlayableUriResolver {
+  Track? resolved;
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    resolved = track;
+    return ResolvedPlayable(
+      Uri.parse('https://server.example/stream/${track.id}'),
+      PlaybackSource.streamingDirect,
+    );
   }
 }
 
@@ -1617,6 +1643,104 @@ void main() {
       expect(
           downloader.fetched.any((Track t) => t.uri == 'plex:want'), isFalse);
       expect((await repo.cacheSnapshot()).usedBytes, 4);
+    });
+  });
+
+  // Issue #356: "disable song cache". Automatic song caching has exactly one
+  // gate — DownloadPreferences.preloadEnabled — surfaced in Settings as
+  // "Pre-cache upcoming tracks" and consulted only by SmartPrecacheService
+  // (see its own tests for that unit-level guarantee). These tests close the
+  // loop end-to-end against a *real* repository: turning it off truly writes
+  // no bytes, streaming still resolves normally, and explicit downloads (which
+  // never consult this preference) are unaffected.
+  group('automatic song caching can be disabled (issue #356)', () {
+    late InMemoryDownloadStore store;
+    late InMemoryOfflineFileStore files;
+    late InMemoryDownloadPreferences preferences;
+    late _FakeConnectivity connectivity;
+    late _FakeRemoteDownloader downloader;
+
+    CacheDownloadRepository build() {
+      return CacheDownloadRepository(
+        store: store,
+        files: files,
+        downloader: downloader,
+        connectivity: connectivity,
+        preferences: preferences,
+      );
+    }
+
+    setUp(() {
+      store = InMemoryDownloadStore();
+      files = InMemoryOfflineFileStore();
+      preferences = InMemoryDownloadPreferences(preloadEnabled: false);
+      connectivity = _FakeConnectivity(NetworkStatus.wifi);
+      downloader = _FakeRemoteDownloader();
+    });
+
+    test(
+        'SmartPrecacheService caches nothing through a real repository when '
+        'preloadEnabled is off', () async {
+      final CacheDownloadRepository repo = build();
+      final StreamController<PlaybackState> states =
+          StreamController<PlaybackState>.broadcast();
+      final SmartPrecacheService service = SmartPrecacheService(
+        playbackStates: states.stream,
+        prefetcher: repo,
+        preferences: preferences,
+      );
+
+      states.add(const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: Track(id: 'now', title: 'now', uri: 'jellyfin:now'),
+        upNext: <Track>[
+          Track(id: 'next1', title: 'next1', uri: 'jellyfin:next1'),
+          Track(id: 'next2', title: 'next2', uri: 'jellyfin:next2'),
+        ],
+      ));
+      await _settle();
+      await _settle();
+
+      expect(downloader.fetchCount, 0);
+      expect((await repo.cacheSnapshot()).entries, isEmpty);
+      expect(await repo.downloadedTrackKeys(), isEmpty);
+
+      await service.dispose();
+      await states.close();
+    });
+
+    test('explicit downloads remain enabled when preloadEnabled is off',
+        () async {
+      final CacheDownloadRepository repo = build();
+
+      final DownloadRequestOutcome outcome =
+          await repo.requestDownload(_jellyfin('manual'));
+
+      expect(outcome, DownloadRequestOutcome.started);
+      expect(await repo.statusFor('manual'), DownloadStatus.downloaded);
+      expect(downloader.fetchCount, 1);
+    });
+
+    test(
+        'streaming still resolves via the fallback when nothing is cached '
+        '(song caching disabled)', () async {
+      // Nothing was ever downloaded or preloaded — store/files stay empty for
+      // this test, exactly what an all-session-long preloadEnabled:false user
+      // sees for a track they never explicitly downloaded.
+      final StoreCachedTrackLocator locator =
+          StoreCachedTrackLocator(store, files);
+      final _RecordingStreamResolver fallback = _RecordingStreamResolver();
+      final OfflineFirstPlayableUriResolver resolver =
+          OfflineFirstPlayableUriResolver(
+        locator: locator,
+        fallback: fallback,
+      );
+      final Track track = _jellyfin('unplayed');
+
+      final ResolvedPlayable resolved = await resolver.resolve(track);
+
+      expect(resolved.source, PlaybackSource.streamingDirect);
+      expect(fallback.resolved, track);
     });
   });
 }

--- a/test/shared/widgets/artwork_image_test.dart
+++ b/test/shared/widgets/artwork_image_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linthra/core/models/plex_session.dart';
 import 'package:linthra/core/models/subsonic_session.dart';
+import 'package:linthra/core/services/artwork_disk_cache.dart';
 import 'package:linthra/core/sources/plex/plex_artwork.dart';
 import 'package:linthra/core/sources/plex/plex_track_mapper.dart';
 import 'package:linthra/core/sources/subsonic/subsonic_artwork.dart';
@@ -17,9 +18,12 @@ const _subsonicSession = SubsonicSession(
 );
 
 void main() {
-  // The resolver is a process-global on the single artwork seam; always clear it
-  // so one test can't leak its hook into the next.
-  tearDown(() => installArtworkReferenceResolver(null));
+  // The resolver and the disk cache are process-globals on the single artwork
+  // seam; always clear them so one test can't leak its hook into the next.
+  tearDown(() {
+    installArtworkReferenceResolver(null);
+    installArtworkDiskCache(null);
+  });
 
   group('artworkImageProvider', () {
     test('loads a file:// cover from disk with a FileImage', () {
@@ -262,6 +266,124 @@ void main() {
         Uri.parse('file:///data/app/cache/linthra_local_artwork/abc.img'),
       );
       expect(fileProvider, isA<FileImage>());
+    });
+  });
+
+  // Issue #356: persistent artwork caching. No [ArtworkDiskCache] installed is
+  // covered by every group above (they never install one) — this group covers
+  // the seam's behaviour once one *is* installed.
+  group('artworkImageProvider with an installed disk cache', () {
+    late Directory dir;
+
+    setUp(() async {
+      dir = await Directory.systemTemp.createTemp('artwork_image_cache_test');
+    });
+
+    tearDown(() async {
+      if (await dir.exists()) await dir.delete(recursive: true);
+    });
+
+    test('a cache hit returns a FileImage — no NetworkImage, no resolver call',
+        () async {
+      bool resolverCalled = false;
+      installArtworkReferenceResolver((Uri ref) {
+        resolverCalled = true;
+        return Uri.parse('https://should-not-be-used.example');
+      });
+      final cache = ArtworkDiskCache(
+        directory: dir,
+        fetch: (Uri url) async => <int>[1, 2, 3],
+      );
+      installArtworkDiskCache(cache);
+      final key = Uri.parse('https://server.example/Items/1/Images/Primary');
+      await cache.warm(key);
+
+      final provider = artworkImageProvider(key);
+
+      expect(provider, isA<FileImage>());
+      expect(resolverCalled, isFalse);
+    });
+
+    test(
+        'a cache miss still returns a NetworkImage exactly as before, and '
+        'warms the cache in the background for next time', () async {
+      final cache = ArtworkDiskCache(
+        directory: dir,
+        fetch: (Uri url) async => <int>[1, 2, 3],
+      );
+      installArtworkDiskCache(cache);
+      final key = Uri.parse('https://server.example/Items/1/Images/Primary');
+
+      final provider = artworkImageProvider(key);
+
+      // The render itself is unaffected by the miss — same type, same URL as
+      // with no disk cache installed at all.
+      expect(provider, isA<NetworkImage>());
+      expect((provider as NetworkImage).url, key.toString());
+
+      // The background warm this call fired is fire-and-forget; warm() itself
+      // de-dupes concurrent calls for the same key, so awaiting it again here
+      // returns the exact in-flight future the provider started, letting the
+      // test wait for it deterministically instead of guessing event-loop
+      // turns.
+      await cache.warm(key);
+      final File? cached = cache.cachedFile(key);
+      expect(cached, isNotNull);
+      expect(artworkImageProvider(key), isA<FileImage>());
+    });
+
+    test('a corrupt cache entry falls back to a fresh NetworkImage fetch',
+        () async {
+      await dir.create(recursive: true);
+      final key = Uri.parse('https://server.example/Items/1/Images/Primary');
+      final File corrupt = File('${dir.path}/anything.img');
+      // A cache hit is only ever a file whose *hashed* name ArtworkDiskCache
+      // itself would produce; this stray/corrupt file must simply be ignored
+      // (a miss), never mistaken for this key's cache entry.
+      await corrupt.writeAsBytes(<int>[]);
+      installArtworkDiskCache(
+        ArtworkDiskCache(directory: dir, fetch: (Uri url) async => null),
+      );
+
+      final provider = artworkImageProvider(key);
+
+      expect(provider, isA<NetworkImage>());
+      expect((provider as NetworkImage).url, key.toString());
+    });
+
+    test(
+        'a Subsonic reference miss warms via the resolved (authenticated) '
+        'URL but caches under the credential-free reference', () async {
+      installArtworkReferenceResolver(
+        (Uri ref) => SubsonicArtwork.resolve(ref, _subsonicSession),
+      );
+      final List<Uri> fetchedUrls = <Uri>[];
+      final cache = ArtworkDiskCache(
+        directory: dir,
+        resolveFetchUrl: (Uri ref) =>
+            SubsonicArtwork.resolve(ref, _subsonicSession) ?? ref,
+        fetch: (Uri url) async {
+          fetchedUrls.add(url);
+          return <int>[1, 2, 3];
+        },
+      );
+      installArtworkDiskCache(cache);
+      final reference = SubsonicArtwork.reference('al-7');
+
+      artworkImageProvider(reference);
+      // Awaits the same in-flight warm the provider's fire-and-forget call
+      // started (warm() de-dupes by key), rather than guessing event-loop
+      // turns.
+      await cache.warm(reference);
+
+      // The fetch went out to the authenticated getCoverArt URL...
+      expect(fetchedUrls, hasLength(1));
+      expect(fetchedUrls.single.toString(), contains('getCoverArt'));
+      expect(fetchedUrls.single.toString(), contains('the-secret-token'));
+      // ...but the cache is keyed by the credential-free reference, so a later
+      // render of the *same reference* is a hit regardless of the token.
+      expect(cache.cachedFile(reference), isNotNull);
+      expect(artworkImageProvider(reference), isA<FileImage>());
     });
   });
 }


### PR DESCRIPTION
## Summary

- Persist remote artwork to disk so covers do not need to be re-downloaded on every app launch.
- Reuse the existing precache setting to control automatic song caching.
- Keep manual downloads and normal streaming unaffected.
- Avoid persisting authenticated artwork URLs or credentials.
- Add regression tests for artwork caching and song precaching behavior.

## Testing

- `flutter analyze` ✅
- `flutter test` ✅ — 3538 tests passed

Closes #356