### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](./LICENSE)
 [![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
+[![Platform: Linux](https://img.shields.io/badge/platform-Linux-FCC624.svg)](#install)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Latest release: v0.2.1](https://img.shields.io/badge/release-v0.2.1-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
+[![Latest release: v0.2.2](https://img.shields.io/badge/release-v0.2.2-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 [![Community: r/Linthra](https://img.shields.io/badge/community-r%2FLinthra-FF9F43.svg)](https://reddit.com/r/Linthra)
 
@@ -14,10 +15,11 @@
 
 ### Your music, your server.
 
-**Linthra is an open-source Android music player for people who keep their music
-on their own devices or self-hosted servers.** It plays local files and streams
-from your own Jellyfin, Navidrome / Subsonic, or Plex server. No ads, no
-tracking, no account.
+**Linthra is an open-source music player for people who keep their music on
+their own devices or self-hosted servers.** Android is the mature mobile target,
+and native Linux desktop support is now available for early testing. Linthra
+plays local files and streams from your own Jellyfin, Navidrome / Subsonic, or
+Plex server. No ads, no tracking, no account.
 
 ## Features
 
@@ -73,15 +75,17 @@ with no account, the F-Droid build is yours, free, for good.
 
 New versions land on
 [GitHub Releases](https://github.com/thezupzup/linthra/releases) first, as
-signed APKs. The current stable is v0.2.1. Linthra is also on
+signed Android APKs and, starting with v0.2.2, a native Linux x64 archive. The
+current stable is v0.2.2. Linthra is also on
 [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/); F-Droid
 builds may arrive a bit later while their build and review process runs. Not on
 Google Play yet.
 
-> **Don't mix install sources.** GitHub APKs and F-Droid builds are signed with
-> different keys and can't update each other. Pick one and stick with it.
+> **Don't mix Android install sources.** GitHub APKs and F-Droid builds are
+> signed with different keys and can't update each other. Pick one and stick
+> with it.
 
-To install from GitHub Releases and get updates, use
+To install from GitHub Releases and get Android updates, use
 [Obtainium](https://github.com/ImranR98/Obtainium):
 
 1. Install Obtainium.
@@ -93,6 +97,11 @@ To install from GitHub Releases and get updates, use
 Or download the `.apk` from the
 [latest release](https://github.com/thezupzup/linthra/releases/latest) and open
 it on your phone.
+
+For Linux, download `Linthra-v0.2.2-linux-x64.tar.gz` from the same GitHub
+Release. This is the native bundle, not a Flatpak yet; required runtime packages
+and native development instructions are in
+[docs/linux-desktop.md](./docs/linux-desktop.md).
 
 Notes:
 
@@ -134,9 +143,10 @@ help is needed. To support development, see
 
 ## Roadmap
 
-See [docs/roadmap.md](./docs/roadmap.md). In short: stabilize 0.1.x, then
-backup/restore, then the optional Linthra Connect and a desktop app. Linthra
-always works on its own: no Docker, no account, no required pairing.
+See [docs/roadmap.md](./docs/roadmap.md). In short: keep Android stable, deepen
+the native Linux desktop experience, and finish Flatpak/Flathub packaging while
+continuing backup/restore and optional Linthra Connect work. Linthra always
+works on its own: no Docker, no account, no required pairing.
 
 ## Documentation
 

--- a/docs/release-notes/v0.2.2.md
+++ b/docs/release-notes/v0.2.2.md
@@ -1,0 +1,46 @@
+# Linthra v0.2.2
+
+Linthra 0.2.2 is a feature and stability release for Android, with the first official native Linux release path alongside it.
+
+## What's new
+
+- **Now Playing feels smoother.** The playback progress control now uses Linthra's wavy seek bar, with a stable seek handoff so the marker does not snap back while the player catches up.
+- **Synced lyrics got a full presentation pass.** The active line follows cleanly in-place on Now Playing, surrounding lines use progressive emphasis, and the layout stays stable while the active line changes.
+- **Artwork survives restarts.** Remote artwork can be kept in Linthra's managed disk cache instead of being downloaded again every time the app opens.
+- **Automatic song precaching is optional.** It can be disabled independently; normal streaming and explicit/manual downloads keep working.
+- **Linux now has real native playback.** Linthra can build and run as a native Flutter Linux app using the Linux media backend, and official releases can publish an x64 Linux bundle from GitHub Actions.
+
+## Stability and accessibility
+
+This release also includes fixes around seek acknowledgement, short lyrics layouts, timed-lyrics geometry, reduced-motion behavior, keyboard/screen-reader semantics in the updated player controls, and stronger Linux lifecycle/build validation.
+
+## Android and F-Droid
+
+Android remains a first-class target and the normal F-Droid source-build path stays separate from GitHub release signing.
+
+The canonical Android version for this release is:
+
+- versionName: `0.2.2`
+- base versionCode: `202999`
+
+F-Droid's split-ABI build keeps Linthra's established `base * 10 + ABI rank` scheme:
+
+- armeabi-v7a: `2029991`
+- arm64-v8a: `2029992`
+- x86_64: `2029993`
+
+The release tooling now preserves that transformed F-Droid `CurrentVersionCode` instead of accidentally writing the untransformed base code. The committed `pubspec.lock`, Rust `Cargo.lock`, per-ABI Gradle override, and canonical GitHub per-ABI asset names remain part of the reproducible-build guardrails.
+
+F-Droid builds from source and can appear later than the GitHub Release while its own update/build/review pipeline runs.
+
+## Linux download
+
+The GitHub Release workflow can attach:
+
+`Linthra-v0.2.2-linux-x64.tar.gz`
+
+This is the native Flutter Linux bundle, not the future Flatpak. It may still require the Linux runtime libraries documented in `docs/linux-desktop.md`. Flatpak/Flathub packaging and deeper desktop integration such as MPRIS remain separate roadmap work.
+
+## Upgrade notes
+
+No migration step is required. Existing Android installs keep their library/settings data during a normal same-source update. As always, GitHub APKs and F-Droid packages are signed by different keys, so do not switch install sources on top of an existing installation.

--- a/fastlane/metadata/android/en-US/changelogs/202999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/202999.txt
@@ -1,0 +1,6 @@
+Linthra 0.2.2
+
+- Redesigns synced lyrics and improves the Now Playing seek experience.
+- Keeps remote artwork cached across restarts.
+- Adds a switch to disable automatic song precaching without disabling streaming or manual downloads.
+- Includes playback/lyrics stability fixes and the new Linux desktop foundation.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.2.1';
+  static const String _devVersionName = '0.2.2';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,9 +20,9 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Fixes source-build compatibility for F-Droid after the v0.2.0 release.',
-    'The Rust core now ships with a committed dependency lockfile for reproducible builds.',
-    'No playback, library, or server behavior changed in this maintenance update.',
+    'Now Playing has a smoother wavy seek bar and a redesigned synced-lyrics experience.',
+    'Remote artwork is cached on disk so covers can survive restarts without being downloaded again.',
+    'Automatic song precaching can now be disabled while normal streaming and manual downloads keep working.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.2.1+201999
+version: 0.2.2+202999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -18,7 +18,7 @@ generated PR is merged. See docs/release-process.md.
 Usage:
 
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37
-    python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 \\
+    python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 \
         --changelog "Linthra 0.1.0-alpha.37 — fixed X."
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --force-changelog
 
@@ -201,8 +201,79 @@ def create_changelog(path, version_name, body, allow_overwrite):
     return True
 
 
+def _fdroid_current_version_code(text, base_version_code):
+    """Return the CurrentVersionCode F-Droid will use for this metadata.
+
+    Linthra's F-Droid entry uses VercodeOperation to turn one canonical base
+    code from pubspec.yaml into three per-ABI codes (`base*10 + rank`). F-Droid's
+    update checker compares/records the highest transformed code, so writing the
+    untransformed base here makes our draft metadata internally inconsistent and
+    trips the release guardrail.
+
+    Keep this parser deliberately narrow: the repo only supports the simple
+    `%c*MULTIPLIER + OFFSET` form used by Linthra. If a future metadata change
+    introduces another operation shape, fail instead of evaluating arbitrary
+    metadata as code or silently guessing a CurrentVersionCode.
+    """
+    marker = re.search(r"^VercodeOperation:[ \t]*$", text, flags=re.MULTILINE)
+    if marker is None:
+        return base_version_code
+
+    operations = []
+    for line in text[marker.end() :].splitlines():
+        if line and not line[0].isspace():
+            break
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("-"):
+            raise VersionError(
+                "Unsupported F-Droid VercodeOperation entry {!r}; refusing to "
+                "guess CurrentVersionCode.".format(stripped)
+            )
+        expression = stripped[1:].strip()
+        if (
+            len(expression) >= 2
+            and expression[0] == expression[-1]
+            and expression[0] in ("'", '"')
+        ):
+            expression = expression[1:-1]
+        match = re.fullmatch(r"%c\s*\*\s*(\d+)\s*\+\s*(\d+)", expression)
+        if match is None:
+            raise VersionError(
+                "Unsupported F-Droid VercodeOperation {!r}; expected "
+                "`%c*MULTIPLIER + OFFSET`. Refusing to guess "
+                "CurrentVersionCode.".format(expression)
+            )
+        multiplier = int(match.group(1))
+        offset = int(match.group(2))
+        transformed = base_version_code * multiplier + offset
+        if transformed <= 0 or transformed > _MAX_VERSION_CODE:
+            raise VersionError(
+                "F-Droid VercodeOperation {!r} transforms base versionCode {} "
+                "to {}, outside the valid Android range (1..{}).".format(
+                    expression,
+                    base_version_code,
+                    transformed,
+                    _MAX_VERSION_CODE,
+                )
+            )
+        operations.append(transformed)
+
+    if not operations:
+        raise VersionError(
+            "F-Droid metadata declares VercodeOperation but contains no "
+            "supported operations; refusing to guess CurrentVersionCode."
+        )
+    return max(operations)
+
+
 def update_fdroid_metadata(path, version_name, version_code):
     """Update CurrentVersion/CurrentVersionCode in the F-Droid metadata YAML.
+
+    When VercodeOperation is present, CurrentVersionCode must be the highest
+    transformed per-ABI code, matching F-Droid's own update-check behavior.
+    Without VercodeOperation the canonical base versionCode is used unchanged.
 
     Returns True if the file changed. If the file does not exist, returns False
     silently — the repo may not carry the draft F-Droid entry. The Builds block
@@ -221,6 +292,7 @@ def update_fdroid_metadata(path, version_name, version_code):
             "F-Droid metadata at {} has no `CurrentVersionCode:` line; "
             "refusing to guess.".format(path)
         )
+    fdroid_version_code = _fdroid_current_version_code(text, version_code)
     new_text = re.sub(
         r"^CurrentVersion:.*$",
         "CurrentVersion: {}".format(version_name),
@@ -230,7 +302,7 @@ def update_fdroid_metadata(path, version_name, version_code):
     )
     new_text = re.sub(
         r"^CurrentVersionCode:.*$",
-        "CurrentVersionCode: {}".format(version_code),
+        "CurrentVersionCode: {}".format(fdroid_version_code),
         new_text,
         count=1,
         flags=re.MULTILINE,

--- a/test/tooling/prepare_release_bump_fdroid_vercode_test.dart
+++ b/test/tooling/prepare_release_bump_fdroid_vercode_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final String repoRoot = _findRepoRoot();
+  final String script = p.join(repoRoot, 'scripts', 'prepare_release_bump.py');
+
+  test('release bump records the highest F-Droid split versionCode', () async {
+    final Directory tmp =
+        await Directory.systemTemp.createTemp('linthra_fdroid_vercode_');
+    addTearDown(() async => tmp.delete(recursive: true));
+
+    Directory(p.join(tmp.path, 'lib', 'core')).createSync(recursive: true);
+    Directory(p.join(
+      tmp.path,
+      'fastlane',
+      'metadata',
+      'android',
+      'en-US',
+      'changelogs',
+    )).createSync(recursive: true);
+    Directory(p.join(tmp.path, 'metadata')).createSync(recursive: true);
+
+    File(p.join(tmp.path, 'pubspec.yaml')).writeAsStringSync(
+      'name: linthra\nversion: 0.2.1+201999\n',
+    );
+    File(p.join(tmp.path, 'lib', 'core', 'app_info.dart')).writeAsStringSync(
+      "abstract final class AppInfo {\n"
+      "  static const String _devVersionName = '0.2.1';\n"
+      "}\n",
+    );
+    final File metadata =
+        File(p.join(tmp.path, 'metadata', 'io.github.thezupzup.linthra.yml'));
+    metadata.writeAsStringSync(
+      'Name: Linthra\n'
+      'CurrentVersion: 0.2.1\n'
+      'CurrentVersionCode: 2019993\n'
+      'VercodeOperation:\n'
+      '  - "%c*10 + 1"\n'
+      '  - "%c*10 + 2"\n'
+      '  - "%c*10 + 3"\n'
+      'Builds:\n'
+      '  - versionName: 0.2.1\n'
+      '    versionCode: 2019991\n',
+    );
+
+    final ProcessResult result = Process.runSync(
+      'python3',
+      <String>[
+        script,
+        '0.2.2',
+        '--repo-root',
+        tmp.path,
+        '--changelog',
+        'Linthra 0.2.2 test changelog.',
+      ],
+    );
+
+    expect(
+      result.exitCode,
+      0,
+      reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+    );
+
+    final String after = metadata.readAsStringSync();
+    expect(after, contains('CurrentVersion: 0.2.2'));
+    expect(after, contains('CurrentVersionCode: 2029993'));
+    expect(after, contains('  - "%c*10 + 1"'));
+    expect(after, contains('  - "%c*10 + 2"'));
+    expect(after, contains('  - "%c*10 + 3"'));
+    expect(after, contains('versionName: 0.2.1'));
+    expect(after, contains('versionCode: 2019991'));
+  });
+
+  test('unsupported F-Droid version-code expressions fail safely', () async {
+    final Directory tmp =
+        await Directory.systemTemp.createTemp('linthra_fdroid_vercode_bad_');
+    addTearDown(() async => tmp.delete(recursive: true));
+
+    Directory(p.join(tmp.path, 'lib', 'core')).createSync(recursive: true);
+    Directory(p.join(
+      tmp.path,
+      'fastlane',
+      'metadata',
+      'android',
+      'en-US',
+      'changelogs',
+    )).createSync(recursive: true);
+    Directory(p.join(tmp.path, 'metadata')).createSync(recursive: true);
+
+    File(p.join(tmp.path, 'pubspec.yaml')).writeAsStringSync(
+      'name: linthra\nversion: 0.2.1+201999\n',
+    );
+    File(p.join(tmp.path, 'lib', 'core', 'app_info.dart')).writeAsStringSync(
+      "abstract final class AppInfo {\n"
+      "  static const String _devVersionName = '0.2.1';\n"
+      "}\n",
+    );
+    File(p.join(tmp.path, 'metadata', 'io.github.thezupzup.linthra.yml'))
+        .writeAsStringSync(
+      'Name: Linthra\n'
+      'CurrentVersion: 0.2.1\n'
+      'CurrentVersionCode: 2019993\n'
+      'VercodeOperation:\n'
+      '  - "%c**2"\n',
+    );
+
+    final ProcessResult result = Process.runSync(
+      'python3',
+      <String>[
+        script,
+        '0.2.2',
+        '--repo-root',
+        tmp.path,
+        '--changelog',
+        'Linthra 0.2.2 test changelog.',
+      ],
+    );
+
+    expect(result.exitCode, isNot(0));
+    expect(result.stderr, contains('Unsupported F-Droid VercodeOperation'));
+    expect(result.stderr, contains('refusing to guess CurrentVersionCode'));
+  });
+}
+
+String _findRepoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, 'scripts')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}


### PR DESCRIPTION
## Summary

Prepare Linthra v0.2.2 from the current `main` while keeping the Android/F-Droid release path explicit and guarded.

- bump `pubspec.yaml` to `0.2.2+202999`
- update the in-app version and What's new card
- add the Fastlane changelog and full v0.2.2 release notes
- update the README for v0.2.2 and the first native Linux x64 release archive
- harden `prepare_release_bump.py` so F-Droid `CurrentVersionCode` respects Linthra's per-ABI `VercodeOperation`
- add a regression test for the F-Droid split version-code calculation

## F-Droid safety

The Android base versionCode remains `202999`. Linthra's existing per-ABI rule stays unchanged:

- armeabi-v7a → `2029991`
- arm64-v8a → `2029992`
- x86_64 → `2029993`

The release-bump helper previously wrote the untransformed base code into local F-Droid `CurrentVersionCode` even when `VercodeOperation` was present. This PR makes it compute the same highest transformed code the metadata contract expects, while refusing unsupported operation syntax rather than evaluating arbitrary metadata or guessing.

No Android signing configuration, F-Droid build recipe, per-ABI Gradle override, `pubspec.lock`, Rust `Cargo.lock`, application ID, or canonical GitHub per-ABI asset name is changed.

## User-facing v0.2.2 highlights

- redesigned synced lyrics and smoother seek handoff
- persistent remote artwork cache
- automatic song precaching can be disabled independently of normal streaming/manual downloads
- native Linux playback foundation and GitHub Linux x64 release archive

## Release target

After CI is green and this PR is merged:

- tag: `v0.2.2`
- versionName: `0.2.2`
- base versionCode: `202999`
- stable publishing should use the existing `/publish-stable v0.2.2` flow

That publisher now waits for both signed Android release assets and the Linux archive before reporting the release as verified.

## Required checks before merge

Please do **not** merge until the normal CI is green, especially:

- `flutter pub get --enforce-lockfile`
- formatting / analyze / full Flutter tests
- F-Droid release guardrails
- the new release-bump F-Droid version-code test
- Android build/release checks that exercise the unchanged per-ABI contract
- Linux desktop build

No tag or GitHub Release is created by this PR.