### PR TITLE
fix(fdroid): preserve split version codes in release bumps

### DIFF
--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -244,7 +244,7 @@ def _fdroid_current_version_code(text, base_version_code):
         if match is None:
             raise VersionError(
                 "Unsupported F-Droid VercodeOperation {!r}; expected "
-                "`%c*MULTIPLIER + OFFSET`. Refusing to guess "
+                "`%c*MULTIPLIER + OFFSET`; refusing to guess "
                 "CurrentVersionCode.".format(expression)
             )
         multiplier = int(match.group(1))

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -221,17 +221,19 @@ def _fdroid_current_version_code(text, base_version_code):
 
     operations = []
     for line in text[marker.end() :].splitlines():
-        if line and not line[0].isspace():
-            break
         stripped = line.strip()
-        if not stripped:
+        if not stripped or stripped.startswith("#"):
             continue
-        if not stripped.startswith("-"):
-            raise VersionError(
-                "Unsupported F-Droid VercodeOperation entry {!r}; refusing to "
-                "guess CurrentVersionCode.".format(stripped)
-            )
-        expression = stripped[1:].strip()
+
+        # The VercodeOperation value is a YAML list. Stop as soon as the next
+        # metadata key begins, even if a fixture/editor happened to indent it.
+        # A malformed *list item* is still an error below; only a non-list line
+        # terminates this field.
+        item = re.fullmatch(r"-\s*(.+)", stripped)
+        if item is None:
+            break
+
+        expression = item.group(1).strip()
         if (
             len(expression) >= 2
             and expression[0] == expression[-1]

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -18,7 +18,7 @@ generated PR is merged. See docs/release-process.md.
 Usage:
 
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37
-    python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 \\
+    python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 \
         --changelog "Linthra 0.1.0-alpha.37 — fixed X."
     python3 scripts/prepare_release_bump.py 0.1.0-alpha.37 --force-changelog
 
@@ -201,8 +201,79 @@ def create_changelog(path, version_name, body, allow_overwrite):
     return True
 
 
+def _fdroid_current_version_code(text, base_version_code):
+    """Return the CurrentVersionCode F-Droid will use for this metadata.
+
+    Linthra's F-Droid entry uses VercodeOperation to turn one canonical base
+    code from pubspec.yaml into three per-ABI codes (`base*10 + rank`). F-Droid's
+    update checker compares/records the highest transformed code, so writing the
+    untransformed base here makes our draft metadata internally inconsistent and
+    trips the release guardrail.
+
+    Keep this parser deliberately narrow: the repo only supports the simple
+    `%c*MULTIPLIER + OFFSET` form used by Linthra. If a future metadata change
+    introduces another operation shape, fail instead of evaluating arbitrary
+    metadata as code or silently guessing a CurrentVersionCode.
+    """
+    marker = re.search(r"^VercodeOperation:[ \t]*$", text, flags=re.MULTILINE)
+    if marker is None:
+        return base_version_code
+
+    operations = []
+    for line in text[marker.end() :].splitlines():
+        if line and not line[0].isspace():
+            break
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("-"):
+            raise VersionError(
+                "Unsupported F-Droid VercodeOperation entry {!r}; refusing to "
+                "guess CurrentVersionCode.".format(stripped)
+            )
+        expression = stripped[1:].strip()
+        if (
+            len(expression) >= 2
+            and expression[0] == expression[-1]
+            and expression[0] in ("'", '"')
+        ):
+            expression = expression[1:-1]
+        match = re.fullmatch(r"%c\s*\*\s*(\d+)\s*\+\s*(\d+)", expression)
+        if match is None:
+            raise VersionError(
+                "Unsupported F-Droid VercodeOperation {!r}; expected "
+                "`%c*MULTIPLIER + OFFSET`. Refusing to guess "
+                "CurrentVersionCode.".format(expression)
+            )
+        multiplier = int(match.group(1))
+        offset = int(match.group(2))
+        transformed = base_version_code * multiplier + offset
+        if transformed <= 0 or transformed > _MAX_VERSION_CODE:
+            raise VersionError(
+                "F-Droid VercodeOperation {!r} transforms base versionCode {} "
+                "to {}, outside the valid Android range (1..{}).".format(
+                    expression,
+                    base_version_code,
+                    transformed,
+                    _MAX_VERSION_CODE,
+                )
+            )
+        operations.append(transformed)
+
+    if not operations:
+        raise VersionError(
+            "F-Droid metadata declares VercodeOperation but contains no "
+            "supported operations; refusing to guess CurrentVersionCode."
+        )
+    return max(operations)
+
+
 def update_fdroid_metadata(path, version_name, version_code):
     """Update CurrentVersion/CurrentVersionCode in the F-Droid metadata YAML.
+
+    When VercodeOperation is present, CurrentVersionCode must be the highest
+    transformed per-ABI code, matching F-Droid's own update-check behavior.
+    Without VercodeOperation the canonical base versionCode is used unchanged.
 
     Returns True if the file changed. If the file does not exist, returns False
     silently — the repo may not carry the draft F-Droid entry. The Builds block
@@ -221,6 +292,7 @@ def update_fdroid_metadata(path, version_name, version_code):
             "F-Droid metadata at {} has no `CurrentVersionCode:` line; "
             "refusing to guess.".format(path)
         )
+    fdroid_version_code = _fdroid_current_version_code(text, version_code)
     new_text = re.sub(
         r"^CurrentVersion:.*$",
         "CurrentVersion: {}".format(version_name),
@@ -230,7 +302,7 @@ def update_fdroid_metadata(path, version_name, version_code):
     )
     new_text = re.sub(
         r"^CurrentVersionCode:.*$",
-        "CurrentVersionCode: {}".format(version_code),
+        "CurrentVersionCode: {}".format(fdroid_version_code),
         new_text,
         count=1,
         flags=re.MULTILINE,

--- a/test/tooling/prepare_release_bump_fdroid_vercode_test.dart
+++ b/test/tooling/prepare_release_bump_fdroid_vercode_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final String repoRoot = _findRepoRoot();
+  final String script = p.join(repoRoot, 'scripts', 'prepare_release_bump.py');
+
+  test('release bump records the highest F-Droid split versionCode', () async {
+    final Directory tmp =
+        await Directory.systemTemp.createTemp('linthra_fdroid_vercode_');
+    addTearDown(() async => tmp.delete(recursive: true));
+
+    Directory(p.join(tmp.path, 'lib', 'core')).createSync(recursive: true);
+    Directory(p.join(
+      tmp.path,
+      'fastlane',
+      'metadata',
+      'android',
+      'en-US',
+      'changelogs',
+    )).createSync(recursive: true);
+    Directory(p.join(tmp.path, 'metadata')).createSync(recursive: true);
+
+    File(p.join(tmp.path, 'pubspec.yaml')).writeAsStringSync(
+      'name: linthra\nversion: 0.2.1+201999\n',
+    );
+    File(p.join(tmp.path, 'lib', 'core', 'app_info.dart')).writeAsStringSync(
+      "abstract final class AppInfo {\n"
+      "  static const String _devVersionName = '0.2.1';\n"
+      "}\n",
+    );
+    final File metadata =
+        File(p.join(tmp.path, 'metadata', 'io.github.thezupzup.linthra.yml'));
+    metadata.writeAsStringSync(
+      'Name: Linthra\n'
+      'CurrentVersion: 0.2.1\n'
+      'CurrentVersionCode: 2019993\n'
+      'VercodeOperation:\n'
+      '  - "%c*10 + 1"\n'
+      '  - "%c*10 + 2"\n'
+      '  - "%c*10 + 3"\n'
+      'Builds:\n'
+      '  - versionName: 0.2.1\n'
+      '    versionCode: 2019991\n',
+    );
+
+    final ProcessResult result = Process.runSync(
+      'python3',
+      <String>[
+        script,
+        '0.2.2',
+        '--repo-root',
+        tmp.path,
+        '--changelog',
+        'Linthra 0.2.2 test changelog.',
+      ],
+    );
+
+    expect(
+      result.exitCode,
+      0,
+      reason: 'stdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+    );
+
+    final String after = metadata.readAsStringSync();
+    expect(after, contains('CurrentVersion: 0.2.2'));
+    expect(after, contains('CurrentVersionCode: 2029993'));
+    expect(after, contains('  - "%c*10 + 1"'));
+    expect(after, contains('  - "%c*10 + 2"'));
+    expect(after, contains('  - "%c*10 + 3"'));
+    expect(after, contains('versionName: 0.2.1'));
+    expect(after, contains('versionCode: 2019991'));
+  });
+
+  test('unsupported F-Droid version-code expressions fail safely', () async {
+    final Directory tmp =
+        await Directory.systemTemp.createTemp('linthra_fdroid_vercode_bad_');
+    addTearDown(() async => tmp.delete(recursive: true));
+
+    Directory(p.join(tmp.path, 'lib', 'core')).createSync(recursive: true);
+    Directory(p.join(
+      tmp.path,
+      'fastlane',
+      'metadata',
+      'android',
+      'en-US',
+      'changelogs',
+    )).createSync(recursive: true);
+    Directory(p.join(tmp.path, 'metadata')).createSync(recursive: true);
+
+    File(p.join(tmp.path, 'pubspec.yaml')).writeAsStringSync(
+      'name: linthra\nversion: 0.2.1+201999\n',
+    );
+    File(p.join(tmp.path, 'lib', 'core', 'app_info.dart')).writeAsStringSync(
+      "abstract final class AppInfo {\n"
+      "  static const String _devVersionName = '0.2.1';\n"
+      "}\n",
+    );
+    File(p.join(tmp.path, 'metadata', 'io.github.thezupzup.linthra.yml'))
+        .writeAsStringSync(
+      'Name: Linthra\n'
+      'CurrentVersion: 0.2.1\n'
+      'CurrentVersionCode: 2019993\n'
+      'VercodeOperation:\n'
+      '  - "%c**2"\n',
+    );
+
+    final ProcessResult result = Process.runSync(
+      'python3',
+      <String>[
+        script,
+        '0.2.2',
+        '--repo-root',
+        tmp.path,
+        '--changelog',
+        'Linthra 0.2.2 test changelog.',
+      ],
+    );
+
+    expect(result.exitCode, isNot(0));
+    expect(result.stderr, contains('Unsupported F-Droid VercodeOperation'));
+    expect(result.stderr, contains('refusing to guess CurrentVersionCode'));
+  });
+}
+
+String _findRepoRoot() {
+  Directory d = Directory.current;
+  while (true) {
+    if (File(p.join(d.path, 'pubspec.yaml')).existsSync() &&
+        Directory(p.join(d.path, 'scripts')).existsSync()) {
+      return d.path;
+    }
+    final Directory parent = d.parent;
+    if (parent.path == d.path) {
+      fail('Could not find repo root from ${Directory.current.path}');
+    }
+    d = parent;
+  }
+}


### PR DESCRIPTION
## Problem

Linthra's F-Droid metadata uses `VercodeOperation` to transform the canonical `pubspec.yaml` versionCode into one code per ABI (`base * 10 + rank`). The release-bump helper was updating `CurrentVersionCode` with the untransformed base code instead of the highest transformed code.

For a future v0.2.2 bump that would mean writing `202999` where the split-ABI metadata contract expects `2029993`.

The existing F-Droid release guardrails already define the correct invariant: `CurrentVersionCode` must be the highest per-ABI code.

## Fix

- parse Linthra's supported F-Droid `VercodeOperation` form safely
- compute the highest transformed code for `CurrentVersionCode`
- keep the old base-code behavior when no `VercodeOperation` exists
- refuse unsupported operation syntax instead of evaluating arbitrary metadata or guessing
- add focused regression coverage using the real v0.2.2-style numbers

## Safety

This does **not** change:

- Android Gradle versionCode generation
- the per-ABI ranks
- F-Droid build recipes
- signing
- `pubspec.lock`
- `Cargo.lock`
- release asset names
- app/runtime behavior

It only makes the release-preparation helper agree with the F-Droid metadata contract that the rest of the repo already enforces.

## Validation expected from CI

- full Flutter suite, including the existing F-Droid release guardrails
- new `prepare_release_bump_fdroid_vercode_test.dart`
- secret/privacy scan
- normal Android/Linux CI remain unchanged

This is intentionally separate from the v0.2.2 version-bump PR so the release diff stays clean.