### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](./LICENSE)
 [![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
+[![Platform: Linux](https://img.shields.io/badge/platform-Linux-FCC624.svg)](#install)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Latest release: v0.2.1](https://img.shields.io/badge/release-v0.2.1-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
+[![Latest release: v0.2.2](https://img.shields.io/badge/release-v0.2.2-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 [![Community: r/Linthra](https://img.shields.io/badge/community-r%2FLinthra-FF9F43.svg)](https://reddit.com/r/Linthra)
 
@@ -14,10 +15,11 @@
 
 ### Your music, your server.
 
-**Linthra is an open-source Android music player for people who keep their music
-on their own devices or self-hosted servers.** It plays local files and streams
-from your own Jellyfin, Navidrome / Subsonic, or Plex server. No ads, no
-tracking, no account.
+**Linthra is an open-source music player for people who keep their music on
+their own devices or self-hosted servers.** Android is the mature mobile target,
+and native Linux desktop support is now available for early testing. Linthra
+plays local files and streams from your own Jellyfin, Navidrome / Subsonic, or
+Plex server. No ads, no tracking, no account.
 
 ## Features
 
@@ -73,15 +75,17 @@ with no account, the F-Droid build is yours, free, for good.
 
 New versions land on
 [GitHub Releases](https://github.com/thezupzup/linthra/releases) first, as
-signed APKs. The current stable is v0.2.1. Linthra is also on
+signed Android APKs and, starting with v0.2.2, a native Linux x64 archive. The
+current stable is v0.2.2. Linthra is also on
 [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/); F-Droid
 builds may arrive a bit later while their build and review process runs. Not on
 Google Play yet.
 
-> **Don't mix install sources.** GitHub APKs and F-Droid builds are signed with
-> different keys and can't update each other. Pick one and stick with it.
+> **Don't mix Android install sources.** GitHub APKs and F-Droid builds are
+> signed with different keys and can't update each other. Pick one and stick
+> with it.
 
-To install from GitHub Releases and get updates, use
+To install from GitHub Releases and get Android updates, use
 [Obtainium](https://github.com/ImranR98/Obtainium):
 
 1. Install Obtainium.
@@ -93,6 +97,11 @@ To install from GitHub Releases and get updates, use
 Or download the `.apk` from the
 [latest release](https://github.com/thezupzup/linthra/releases/latest) and open
 it on your phone.
+
+For Linux, download `Linthra-v0.2.2-linux-x64.tar.gz` from the same GitHub
+Release. This is the native bundle, not a Flatpak yet; required runtime packages
+and native development instructions are in
+[docs/linux-desktop.md](./docs/linux-desktop.md).
 
 Notes:
 
@@ -134,9 +143,10 @@ help is needed. To support development, see
 
 ## Roadmap
 
-See [docs/roadmap.md](./docs/roadmap.md). In short: stabilize 0.1.x, then
-backup/restore, then the optional Linthra Connect and a desktop app. Linthra
-always works on its own: no Docker, no account, no required pairing.
+See [docs/roadmap.md](./docs/roadmap.md). In short: keep Android stable, deepen
+the native Linux desktop experience, and finish Flatpak/Flathub packaging while
+continuing backup/restore and optional Linthra Connect work. Linthra always
+works on its own: no Docker, no account, no required pairing.
 
 ## Documentation
 

--- a/docs/release-notes/v0.2.2.md
+++ b/docs/release-notes/v0.2.2.md
@@ -1,0 +1,46 @@
+# Linthra v0.2.2
+
+Linthra 0.2.2 is a feature and stability release for Android, with the first official native Linux release path alongside it.
+
+## What's new
+
+- **Now Playing feels smoother.** The playback progress control now uses Linthra's wavy seek bar, with a stable seek handoff so the marker does not snap back while the player catches up.
+- **Synced lyrics got a full presentation pass.** The active line follows cleanly in-place on Now Playing, surrounding lines use progressive emphasis, and the layout stays stable while the active line changes.
+- **Artwork survives restarts.** Remote artwork can be kept in Linthra's managed disk cache instead of being downloaded again every time the app opens.
+- **Automatic song precaching is optional.** It can be disabled independently; normal streaming and explicit/manual downloads keep working.
+- **Linux now has real native playback.** Linthra can build and run as a native Flutter Linux app using the Linux media backend, and official releases can publish an x64 Linux bundle from GitHub Actions.
+
+## Stability and accessibility
+
+This release also includes fixes around seek acknowledgement, short lyrics layouts, timed-lyrics geometry, reduced-motion behavior, keyboard/screen-reader semantics in the updated player controls, and stronger Linux lifecycle/build validation.
+
+## Android and F-Droid
+
+Android remains a first-class target and the normal F-Droid source-build path stays separate from GitHub release signing.
+
+The canonical Android version for this release is:
+
+- versionName: `0.2.2`
+- base versionCode: `202999`
+
+F-Droid's split-ABI build keeps Linthra's established `base * 10 + ABI rank` scheme:
+
+- armeabi-v7a: `2029991`
+- arm64-v8a: `2029992`
+- x86_64: `2029993`
+
+The release tooling now preserves that transformed F-Droid `CurrentVersionCode` instead of accidentally writing the untransformed base code. The committed `pubspec.lock`, Rust `Cargo.lock`, per-ABI Gradle override, and canonical GitHub per-ABI asset names remain part of the reproducible-build guardrails.
+
+F-Droid builds from source and can appear later than the GitHub Release while its own update/build/review pipeline runs.
+
+## Linux download
+
+The GitHub Release workflow can attach:
+
+`Linthra-v0.2.2-linux-x64.tar.gz`
+
+This is the native Flutter Linux bundle, not the future Flatpak. It may still require the Linux runtime libraries documented in `docs/linux-desktop.md`. Flatpak/Flathub packaging and deeper desktop integration such as MPRIS remain separate roadmap work.
+
+## Upgrade notes
+
+No migration step is required. Existing Android installs keep their library/settings data during a normal same-source update. As always, GitHub APKs and F-Droid packages are signed by different keys, so do not switch install sources on top of an existing installation.

--- a/fastlane/metadata/android/en-US/changelogs/202999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/202999.txt
@@ -1,0 +1,6 @@
+Linthra 0.2.2
+
+- Redesigns synced lyrics and improves the Now Playing seek experience.
+- Keeps remote artwork cached across restarts.
+- Adds a switch to disable automatic song precaching without disabling streaming or manual downloads.
+- Includes playback/lyrics stability fixes and the new Linux desktop foundation.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.2.1';
+  static const String _devVersionName = '0.2.2';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,9 +20,9 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Fixes source-build compatibility for F-Droid after the v0.2.0 release.',
-    'The Rust core now ships with a committed dependency lockfile for reproducible builds.',
-    'No playback, library, or server behavior changed in this maintenance update.',
+    'Now Playing has a smoother wavy seek bar and a redesigned synced-lyrics experience.',
+    'Remote artwork is cached on disk so covers can survive restarts without being downloaded again.',
+    'Automatic song precaching can now be disabled while normal streaming and manual downloads keep working.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.2.1+201999
+version: 0.2.2+202999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepare the clean v0.2.2 release diff from current `main`.

- bump `pubspec.yaml` to `0.2.2+202999`
- update `AppInfo` to `0.2.2`
- refresh the in-app What's new card
- add the Fastlane changelog for versionCode `202999`
- add full v0.2.2 release notes
- update README release/install text for v0.2.2 and the first native Linux x64 release archive

## F-Droid

**Merge #472 before publishing v0.2.2.** That focused PR fixes the release-bump helper so F-Droid `CurrentVersionCode` follows Linthra's existing split-ABI `VercodeOperation` contract.

The actual Android/F-Droid build inputs in this release stay on the established scheme:

- base: `202999`
- armeabi-v7a: `2029991`
- arm64-v8a: `2029992`
- x86_64: `2029993`

This PR does not touch `pubspec.lock`, Rust `Cargo.lock`, Android signing, the F-Droid build recipe, Gradle's per-ABI override, or the canonical per-ABI GitHub asset names.

## v0.2.2 highlights

- redesigned synced lyrics and smoother seek handoff
- persistent remote artwork cache
- automatic song precaching can be disabled independently of streaming/manual downloads
- native Linux playback foundation and official Linux x64 release archive path

## Release sequence

1. Merge #472 after its CI is green.
2. Let this PR's full CI go green and merge it.
3. Publish with `/publish-stable v0.2.2`.
4. The stable publisher must verify the signed Android assets and `Linthra-v0.2.2-linux-x64.tar.gz`.
5. F-Droid can then discover/build the immutable `v0.2.2` source tag through its normal update path.

No tag or GitHub Release is created by this PR.