### PR TITLE
fix(linux): avoid pipefail in release archive preview

### DIFF
--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -310,7 +310,13 @@ jobs:
           # path components beyond the single top-level Linthra-<tag>-linux-x64/
           # directory — never the build/linux/... or repo checkout hierarchy.
           tar -czf "$archive_file" "$archive_dir"
-          tar -tzf "$archive_file" | head -5
+          # Validate the complete archive, then preview a few entries without a
+          # `tar | head` pipeline. With `set -o pipefail`, `head` closing early
+          # makes GNU tar report a broken-pipe write error even when the archive
+          # itself is perfectly valid.
+          archive_list="$RUNNER_TEMP/linux-release-archive-list.txt"
+          tar -tzf "$archive_file" > "$archive_list"
+          head -5 "$archive_list"
 
           echo "archive_file=${archive_file}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Problem

The v0.2.2 Linux release build itself succeeded, including tests, native audio smoke, and the final Flutter Linux bundle. The release packaging job then failed after creating the tarball because it ran:

`tar -tzf "$archive_file" | head -5`

under `set -euo pipefail`. `head` exits after five lines, closes the pipe, and GNU tar reports `stdout: write error`, causing exit code 2 even though the archive is valid.

## Fix

- validate the complete tarball by writing `tar -tzf` output to a temporary file
- preview the first five entries from that file with `head`
- keep `set -euo pipefail` and all existing release validation/upload behavior unchanged

## Scope

One workflow file only. No Android, F-Droid, signing, app code, versioning, or release asset names are changed.

## Recovery for v0.2.2

After this is merged, manually dispatch `linux-desktop-build.yml` with `release_tag=v0.2.2`. The workflow checks out the immutable v0.2.2 tag for the actual app build and uses the fixed workflow logic from `main` to package and attach `Linthra-v0.2.2-linux-x64.tar.gz` to the already-existing GitHub Release.