### PR TITLE
Share one server URL normalizer across providers

### DIFF
--- a/lib/core/sources/jellyfin/jellyfin_server_url.dart
+++ b/lib/core/sources/jellyfin/jellyfin_server_url.dart
@@ -1,3 +1,4 @@
+import '../server_url_normalizer.dart';
 import 'jellyfin_exception.dart';
 
 /// Validates and normalizes the server address the user types into settings.
@@ -15,53 +16,22 @@ import 'jellyfin_exception.dart';
 ///    often mount Jellyfin under one.
 ///  - A trailing slash, query, and fragment are stripped so the result is a
 ///    clean base to which API paths can be appended.
+///
+/// The trim/scheme/host/port/path mechanics are shared with the other
+/// providers via [ServerUrlNormalizer]; only the user-facing error text
+/// below is Jellyfin-specific.
 abstract final class JellyfinServerUrl {
   /// Returns a clean base URL (no trailing slash) for [input], or throws a
   /// [JellyfinException] of kind [JellyfinErrorKind.invalidUrl] with a friendly
   /// reason when the address can't be used.
   static String normalize(String input) {
-    final String trimmed = input.trim();
-    if (trimmed.isEmpty) {
-      throw const JellyfinException.invalidUrl(
-        'Enter your Jellyfin server address, e.g. https://music.example.com',
-      );
+    final ParsedServerUrl parsed;
+    try {
+      parsed = ServerUrlNormalizer.parse(input);
+    } on ServerUrlParseFailure catch (failure) {
+      throw JellyfinException.invalidUrl(_messageFor(failure.kind));
     }
-
-    // No scheme typed → assume https (the Cloudflare-proxied default).
-    final String withScheme =
-        trimmed.contains('://') ? trimmed : 'https://$trimmed';
-
-    final Uri? uri = Uri.tryParse(withScheme);
-    if (uri == null) {
-      throw const JellyfinException.invalidUrl(
-        "That doesn't look like a valid web address.",
-      );
-    }
-
-    final String scheme = uri.scheme.toLowerCase();
-    if (scheme != 'http' && scheme != 'https') {
-      throw const JellyfinException.invalidUrl(
-        'The address must start with https:// (or http:// on a local network).',
-      );
-    }
-
-    if (uri.host.isEmpty) {
-      throw const JellyfinException.invalidUrl(
-        'The address is missing a server name, e.g. music.example.com',
-      );
-    }
-
-    final StringBuffer base = StringBuffer()
-      ..write(scheme)
-      ..write('://')
-      ..write(uri.host);
-    if (uri.hasPort) {
-      base
-        ..write(':')
-        ..write(uri.port);
-    }
-    base.write(_trimTrailingSlashes(uri.path));
-    return base.toString();
+    return parsed.toBase();
   }
 
   /// Like [normalize] but returns `null` instead of throwing, for callers that
@@ -74,11 +44,16 @@ abstract final class JellyfinServerUrl {
     }
   }
 
-  static String _trimTrailingSlashes(String path) {
-    int end = path.length;
-    while (end > 0 && path[end - 1] == '/') {
-      end--;
+  static String _messageFor(ServerUrlErrorKind kind) {
+    switch (kind) {
+      case ServerUrlErrorKind.empty:
+        return 'Enter your Jellyfin server address, e.g. https://music.example.com';
+      case ServerUrlErrorKind.unparseable:
+        return "That doesn't look like a valid web address.";
+      case ServerUrlErrorKind.unsupportedScheme:
+        return 'The address must start with https:// (or http:// on a local network).';
+      case ServerUrlErrorKind.emptyHost:
+        return 'The address is missing a server name, e.g. music.example.com';
     }
-    return path.substring(0, end);
   }
 }

--- a/lib/core/sources/plex/plex_server_url.dart
+++ b/lib/core/sources/plex/plex_server_url.dart
@@ -1,3 +1,4 @@
+import '../server_url_normalizer.dart';
 import 'plex_exception.dart';
 
 /// Validates and normalizes the server address the user types into the Plex
@@ -16,53 +17,22 @@ import 'plex_exception.dart';
 ///    mount PMS under one; the API paths append to whatever base survives here.
 ///  - A trailing slash, query, and fragment are stripped so the result is a
 ///    clean base to append to (the endpoint builders concatenate paths directly).
+///
+/// The trim/scheme/host/port/path mechanics are shared with the other
+/// providers via [ServerUrlNormalizer]; only the user-facing error text
+/// below is Plex-specific.
 abstract final class PlexServerUrl {
   /// Returns a clean base URL (no trailing slash) for [input], or throws a
   /// [PlexException] of kind [PlexErrorKind.invalidUrl] with a friendly reason
   /// when the address can't be used.
   static String normalize(String input) {
-    final String trimmed = input.trim();
-    if (trimmed.isEmpty) {
-      throw const PlexException.invalidUrl(
-        'Enter your Plex server address, e.g. http://192.168.1.10:32400',
-      );
+    final ParsedServerUrl parsed;
+    try {
+      parsed = ServerUrlNormalizer.parse(input);
+    } on ServerUrlParseFailure catch (failure) {
+      throw PlexException.invalidUrl(_messageFor(failure.kind));
     }
-
-    // No scheme typed → assume https (the common remote default).
-    final String withScheme =
-        trimmed.contains('://') ? trimmed : 'https://$trimmed';
-
-    final Uri? uri = Uri.tryParse(withScheme);
-    if (uri == null) {
-      throw const PlexException.invalidUrl(
-        "That doesn't look like a valid web address.",
-      );
-    }
-
-    final String scheme = uri.scheme.toLowerCase();
-    if (scheme != 'http' && scheme != 'https') {
-      throw const PlexException.invalidUrl(
-        'The address must start with https:// (or http:// on a local network).',
-      );
-    }
-
-    if (uri.host.isEmpty) {
-      throw const PlexException.invalidUrl(
-        'The address is missing a server name, e.g. 192.168.1.10:32400',
-      );
-    }
-
-    final StringBuffer base = StringBuffer()
-      ..write(scheme)
-      ..write('://')
-      ..write(uri.host);
-    if (uri.hasPort) {
-      base
-        ..write(':')
-        ..write(uri.port);
-    }
-    base.write(_trimTrailingSlashes(uri.path));
-    return base.toString();
+    return parsed.toBase();
   }
 
   /// Like [normalize] but returns `null` instead of throwing, for callers that
@@ -75,11 +45,16 @@ abstract final class PlexServerUrl {
     }
   }
 
-  static String _trimTrailingSlashes(String path) {
-    int end = path.length;
-    while (end > 0 && path[end - 1] == '/') {
-      end--;
+  static String _messageFor(ServerUrlErrorKind kind) {
+    switch (kind) {
+      case ServerUrlErrorKind.empty:
+        return 'Enter your Plex server address, e.g. http://192.168.1.10:32400';
+      case ServerUrlErrorKind.unparseable:
+        return "That doesn't look like a valid web address.";
+      case ServerUrlErrorKind.unsupportedScheme:
+        return 'The address must start with https:// (or http:// on a local network).';
+      case ServerUrlErrorKind.emptyHost:
+        return 'The address is missing a server name, e.g. 192.168.1.10:32400';
     }
-    return path.substring(0, end);
   }
 }

--- a/lib/core/sources/server_url_normalizer.dart
+++ b/lib/core/sources/server_url_normalizer.dart
@@ -1,0 +1,118 @@
+/// Why [ServerUrlNormalizer.parse] rejected an address, without owning the
+/// user-facing message -- each provider phrases these slightly differently,
+/// and only the provider knows which of its own exception types to throw.
+enum ServerUrlErrorKind {
+  /// The input was empty (after trimming).
+  empty,
+
+  /// The input, with a default scheme applied if none was typed, still
+  /// isn't parseable as a URL at all.
+  unparseable,
+
+  /// The URL parsed, but its scheme isn't http or https.
+  unsupportedScheme,
+
+  /// The URL parsed with an http(s) scheme but no host.
+  emptyHost,
+}
+
+/// Thrown internally by [ServerUrlNormalizer.parse] so each provider can
+/// catch it and translate [kind] into its own typed exception and message.
+/// Never meant to escape a provider's own `normalize()`.
+class ServerUrlParseFailure implements Exception {
+  const ServerUrlParseFailure(this.kind);
+
+  final ServerUrlErrorKind kind;
+}
+
+/// The validated pieces of a normalized server URL, before any
+/// provider-specific path post-processing (e.g. Subsonic's `/rest`
+/// stripping).
+class ParsedServerUrl {
+  const ParsedServerUrl({
+    required this.scheme,
+    required this.host,
+    required this.port,
+    required this.path,
+  });
+
+  final String scheme;
+  final String host;
+  final int? port;
+
+  /// Trailing slashes already trimmed; query and fragment already dropped
+  /// ([Uri] parsing drops those from `.path` itself).
+  final String path;
+
+  /// Rebuilds the clean base URL: `scheme://host[:port][path]`, no
+  /// trailing slash. [pathOverride] lets a provider substitute a
+  /// further-processed path (Subsonic's `/rest` stripping) without
+  /// re-deriving scheme/host/port.
+  String toBase({String? pathOverride}) {
+    final StringBuffer buffer = StringBuffer()
+      ..write(scheme)
+      ..write('://')
+      ..write(host);
+    if (port != null) {
+      buffer
+        ..write(':')
+        ..write(port);
+    }
+    buffer.write(pathOverride ?? path);
+    return buffer.toString();
+  }
+}
+
+/// Shared trim/scheme/host/port/path normalization used by every
+/// self-hosted server address field (Jellyfin, Plex, Subsonic/Navidrome).
+/// Extracted so a networking fix only needs to land once instead of being
+/// repeated -- and possibly forgotten -- in each provider's own copy of
+/// this logic. Provider-specific behaviour (custom error messages,
+/// Subsonic's `/rest` suffix stripping) stays in each provider's own
+/// `*ServerUrl.normalize()`, which uses this as a thin shared core.
+abstract final class ServerUrlNormalizer {
+  /// Parses and validates [input], defaulting to https when no scheme is
+  /// typed. Throws [ServerUrlParseFailure] (never a provider exception)
+  /// when [input] can't be used -- callers translate
+  /// [ServerUrlParseFailure.kind] into their own typed, user-facing
+  /// exception.
+  static ParsedServerUrl parse(String input) {
+    final String trimmed = input.trim();
+    if (trimmed.isEmpty) {
+      throw const ServerUrlParseFailure(ServerUrlErrorKind.empty);
+    }
+
+    // No scheme typed -> assume https (the common self-hosted/remote default).
+    final String withScheme =
+        trimmed.contains('://') ? trimmed : 'https://$trimmed';
+
+    final Uri? uri = Uri.tryParse(withScheme);
+    if (uri == null) {
+      throw const ServerUrlParseFailure(ServerUrlErrorKind.unparseable);
+    }
+
+    final String scheme = uri.scheme.toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      throw const ServerUrlParseFailure(ServerUrlErrorKind.unsupportedScheme);
+    }
+
+    if (uri.host.isEmpty) {
+      throw const ServerUrlParseFailure(ServerUrlErrorKind.emptyHost);
+    }
+
+    return ParsedServerUrl(
+      scheme: scheme,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+      path: _trimTrailingSlashes(uri.path),
+    );
+  }
+
+  static String _trimTrailingSlashes(String path) {
+    int end = path.length;
+    while (end > 0 && path[end - 1] == '/') {
+      end--;
+    }
+    return path.substring(0, end);
+  }
+}

--- a/lib/core/sources/subsonic/subsonic_server_url.dart
+++ b/lib/core/sources/subsonic/subsonic_server_url.dart
@@ -1,3 +1,4 @@
+import '../server_url_normalizer.dart';
 import 'subsonic_exception.dart';
 
 /// Validates and normalizes the server address the user types into the
@@ -20,53 +21,22 @@ import 'subsonic_exception.dart';
 ///    (`http://host:4533/rest`) still gets a clean root — Linthra appends
 ///    `/rest/<method>.view` itself, so a kept `/rest` would double it into
 ///    `/rest/rest/ping.view`.
+///
+/// The trim/scheme/host/port/path mechanics are shared with the other
+/// providers via [ServerUrlNormalizer]; the `/rest` stripping above and the
+/// user-facing error text below stay Subsonic-specific.
 abstract final class SubsonicServerUrl {
   /// Returns a clean base URL (no trailing slash) for [input], or throws a
   /// [SubsonicException] of kind [SubsonicErrorKind.invalidUrl] with a friendly
   /// reason when the address can't be used.
   static String normalize(String input) {
-    final String trimmed = input.trim();
-    if (trimmed.isEmpty) {
-      throw const SubsonicException.invalidUrl(
-        'Enter your server address, e.g. https://music.example.com',
-      );
+    final ParsedServerUrl parsed;
+    try {
+      parsed = ServerUrlNormalizer.parse(input);
+    } on ServerUrlParseFailure catch (failure) {
+      throw SubsonicException.invalidUrl(_messageFor(failure.kind));
     }
-
-    // No scheme typed → assume https (the common self-hosted default).
-    final String withScheme =
-        trimmed.contains('://') ? trimmed : 'https://$trimmed';
-
-    final Uri? uri = Uri.tryParse(withScheme);
-    if (uri == null) {
-      throw const SubsonicException.invalidUrl(
-        "That doesn't look like a valid web address.",
-      );
-    }
-
-    final String scheme = uri.scheme.toLowerCase();
-    if (scheme != 'http' && scheme != 'https') {
-      throw const SubsonicException.invalidUrl(
-        'The address must start with https:// (or http:// on a local network).',
-      );
-    }
-
-    if (uri.host.isEmpty) {
-      throw const SubsonicException.invalidUrl(
-        'The address is missing a server name, e.g. music.example.com',
-      );
-    }
-
-    final StringBuffer base = StringBuffer()
-      ..write(scheme)
-      ..write('://')
-      ..write(uri.host);
-    if (uri.hasPort) {
-      base
-        ..write(':')
-        ..write(uri.port);
-    }
-    base.write(_stripRestSuffix(_trimTrailingSlashes(uri.path)));
-    return base.toString();
+    return parsed.toBase(pathOverride: _stripRestSuffix(parsed.path));
   }
 
   /// Like [normalize] but returns `null` instead of throwing, for callers that
@@ -79,12 +49,17 @@ abstract final class SubsonicServerUrl {
     }
   }
 
-  static String _trimTrailingSlashes(String path) {
-    int end = path.length;
-    while (end > 0 && path[end - 1] == '/') {
-      end--;
+  static String _messageFor(ServerUrlErrorKind kind) {
+    switch (kind) {
+      case ServerUrlErrorKind.empty:
+        return 'Enter your server address, e.g. https://music.example.com';
+      case ServerUrlErrorKind.unparseable:
+        return "That doesn't look like a valid web address.";
+      case ServerUrlErrorKind.unsupportedScheme:
+        return 'The address must start with https:// (or http:// on a local network).';
+      case ServerUrlErrorKind.emptyHost:
+        return 'The address is missing a server name, e.g. music.example.com';
     }
-    return path.substring(0, end);
   }
 
   /// Drops a trailing `/rest` segment (the Subsonic API mount) from an otherwise

--- a/test/core/sources/plex/plex_server_url_test.dart
+++ b/test/core/sources/plex/plex_server_url_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/plex/plex_exception.dart';
+import 'package:linthra/core/sources/plex/plex_server_url.dart';
+
+void main() {
+  group('PlexServerUrl.normalize', () {
+    test('defaults a bare host to https (the remote-server case)', () {
+      expect(
+        PlexServerUrl.normalize('plex.example.com'),
+        'https://plex.example.com',
+      );
+    });
+
+    test('keeps an explicit http scheme and port (LAN server)', () {
+      expect(
+        PlexServerUrl.normalize('http://192.168.1.10:32400'),
+        'http://192.168.1.10:32400',
+      );
+    });
+
+    test('preserves a reverse-proxy subpath', () {
+      expect(
+        PlexServerUrl.normalize('https://example.com/plex'),
+        'https://example.com/plex',
+      );
+    });
+
+    test('strips a trailing slash, query, and fragment', () {
+      expect(
+        PlexServerUrl.normalize('https://example.com/plex/?x=1#y'),
+        'https://example.com/plex',
+      );
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(
+        PlexServerUrl.normalize('  plex.example.com  '),
+        'https://plex.example.com',
+      );
+    });
+
+    test('lowercases the host', () {
+      expect(
+        PlexServerUrl.normalize('https://Plex.Example.COM'),
+        'https://plex.example.com',
+      );
+    });
+
+    test('rejects an empty address', () {
+      expect(
+        () => PlexServerUrl.normalize('   '),
+        throwsA(
+          isA<PlexException>().having(
+            (PlexException e) => e.kind,
+            'kind',
+            PlexErrorKind.invalidUrl,
+          ),
+        ),
+      );
+    });
+
+    test('rejects a non-http(s) scheme', () {
+      expect(
+        () => PlexServerUrl.normalize('ftp://example.com'),
+        throwsA(isA<PlexException>()),
+      );
+    });
+
+    test('rejects a scheme with no host', () {
+      expect(
+        () => PlexServerUrl.normalize('https://'),
+        throwsA(isA<PlexException>()),
+      );
+    });
+  });
+
+  group('PlexServerUrl.tryNormalize', () {
+    test('returns the normalized URL when valid', () {
+      expect(
+        PlexServerUrl.tryNormalize('192.168.1.10:32400'),
+        'https://192.168.1.10:32400',
+      );
+    });
+
+    test('returns null when invalid instead of throwing', () {
+      expect(PlexServerUrl.tryNormalize('   '), isNull);
+      expect(PlexServerUrl.tryNormalize('ftp://x'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #350.

## What this does

Jellyfin, Plex, and Subsonic/Navidrome each had their own near-identical copy of the trim / default-scheme / parse / validate / rebuild logic for server addresses. Pulls the shared mechanics into `ServerUrlNormalizer.parse()` in `lib/core/sources/server_url_normalizer.dart`, returning a `ParsedServerUrl` (scheme/host/port/path plus a `toBase()` rebuilder) or throwing a `ServerUrlParseFailure` carrying an error kind.

Each provider's `normalize()` is now a thin adapter: call the shared parser, translate the failure kind into its own typed exception with its own message text, and build the final URL. Subsonic still does its own `/rest`-suffix stripping on top, unchanged, exactly where the issue asked for it to stay.

## What this doesn't do

No behavioural change. Every existing provider-specific error message is preserved verbatim, and `toBase()` rebuilds the URL exactly the way each provider's old inline code did — including the not-yet-fixed IPv6-literal-host bug, left alone here on purpose. That's a separate, focused follow-up PR (#348) stacked on this branch, since the issue itself notes IPv6 is easiest to fix once this lands.

## Testing

- All existing Jellyfin and Subsonic normalizer tests pass unchanged.
- Added `test/core/sources/plex/plex_server_url_test.dart` — Plex had no normalizer test coverage at all before this, so the refactor had nothing local to check it against for that provider. 9 new tests mirroring the existing Jellyfin/Subsonic style.
- `flutter analyze` clean on all four changed files.
- Full `flutter test` run against a clean checkout of `main` to confirm a handful of pre-existing failures elsewhere (an offline-cache resolver test, some CI/tooling guardrail tests) are unrelated to this change, not introduced by it.