### PR TITLE
Make self-hosted server URLs work with IPv6 literals

### DIFF
--- a/lib/core/sources/server_url_normalizer.dart
+++ b/lib/core/sources/server_url_normalizer.dart
@@ -37,12 +37,24 @@ class ParsedServerUrl {
   });
 
   final String scheme;
+
+  /// As reported by [Uri.host]. For an IPv6 literal this has no brackets
+  /// (e.g. `::1`, not `[::1]`) -- that's how Dart's own URI parsing
+  /// reports it. Use [hostForUrl], not this field directly, when
+  /// rebuilding a URL string.
   final String host;
+
   final int? port;
 
   /// Trailing slashes already trimmed; query and fragment already dropped
   /// ([Uri] parsing drops those from `.path` itself).
   final String path;
+
+  /// [host], bracketed when it's an IPv6 literal -- safe to drop straight
+  /// into a rebuilt URL string. An IPv6 literal is the only kind of host
+  /// [Uri.host] ever reports containing a colon (a bare DNS hostname or
+  /// IPv4 address never does), so that's a reliable and cheap check.
+  String get hostForUrl => host.contains(':') ? '[$host]' : host;
 
   /// Rebuilds the clean base URL: `scheme://host[:port][path]`, no
   /// trailing slash. [pathOverride] lets a provider substitute a
@@ -52,7 +64,7 @@ class ParsedServerUrl {
     final StringBuffer buffer = StringBuffer()
       ..write(scheme)
       ..write('://')
-      ..write(host);
+      ..write(hostForUrl);
     if (port != null) {
       buffer
         ..write(':')

--- a/test/core/sources/jellyfin/jellyfin_server_url_test.dart
+++ b/test/core/sources/jellyfin/jellyfin_server_url_test.dart
@@ -60,6 +60,23 @@ void main() {
       );
     });
 
+    test('brackets an IPv6 literal host and stays parseable', () {
+      final String result = JellyfinServerUrl.normalize('https://[::1]:8096');
+      expect(result, 'https://[::1]:8096');
+
+      final Uri? reparsed = Uri.tryParse(result);
+      expect(reparsed, isNotNull);
+      expect(reparsed!.host, '::1');
+      expect(reparsed.port, 8096);
+    });
+
+    test('brackets a full IPv6 literal host with a subpath', () {
+      expect(
+        JellyfinServerUrl.normalize('https://[2001:db8::1]/jellyfin'),
+        'https://[2001:db8::1]/jellyfin',
+      );
+    });
+
     test('rejects an empty address', () {
       expect(
         () => JellyfinServerUrl.normalize('   '),

--- a/test/core/sources/plex/plex_server_url_test.dart
+++ b/test/core/sources/plex/plex_server_url_test.dart
@@ -46,6 +46,16 @@ void main() {
       );
     });
 
+    test('brackets an IPv6 literal host and stays parseable', () {
+      final String result = PlexServerUrl.normalize('http://[::1]:32400');
+      expect(result, 'http://[::1]:32400');
+
+      final Uri? reparsed = Uri.tryParse(result);
+      expect(reparsed, isNotNull);
+      expect(reparsed!.host, '::1');
+      expect(reparsed.port, 32400);
+    });
+
     test('rejects an empty address', () {
       expect(
         () => PlexServerUrl.normalize('   '),

--- a/test/core/sources/subsonic/subsonic_server_url_test.dart
+++ b/test/core/sources/subsonic/subsonic_server_url_test.dart
@@ -84,6 +84,23 @@ void main() {
       );
     });
 
+    test('brackets an IPv6 literal host and stays parseable', () {
+      final String result = SubsonicServerUrl.normalize('http://[::1]:4533');
+      expect(result, 'http://[::1]:4533');
+
+      final Uri? reparsed = Uri.tryParse(result);
+      expect(reparsed, isNotNull);
+      expect(reparsed!.host, '::1');
+      expect(reparsed.port, 4533);
+    });
+
+    test('brackets an IPv6 host while still stripping a pasted /rest', () {
+      expect(
+        SubsonicServerUrl.normalize('http://[::1]:4533/rest'),
+        'http://[::1]:4533',
+      );
+    });
+
     test('rejects an empty address', () {
       expect(
         () => SubsonicServerUrl.normalize('   '),


### PR DESCRIPTION
Closes #348. Stacked on #479 (the shared-normalizer refactor) -- this is the fix the issue says becomes a single small change once that one lands, so please review/merge #479 first.

## What this fixes

`Uri.host` reports an IPv6 literal without its brackets (`::1`, not `[::1]`), so the normalizers were rebuilding an address as `scheme://::1:port`. That string is unparseable -- nothing can tell where the address ends and the port begins anymore. Confirmed empirically: `Uri.tryParse('https://::1:8096')` returns `null`. Anyone running Jellyfin/Plex/Navidrome on an IPv6-only server would hit this immediately.

## Testing (added first, confirmed failing pre-fix)

- One `https://[::1]:port` case per provider (Jellyfin, Plex, Subsonic)
- A full (non-loopback) IPv6 address with a subpath for Jellyfin
- A combined case for Subsonic: an IPv6 host plus a pasted `/rest` suffix, to make sure the two fixes compose correctly

All five fail against pre-fix code (verified before writing the fix), all five pass after it. Full existing suite stays green.

## Fix

`ParsedServerUrl.hostForUrl` brackets the host when it contains a colon -- the one thing that reliably marks an IPv6 literal, since a bare DNS hostname or IPv4 address never contains one. `toBase()` now writes that instead of the raw host. Because this lives in the shared normalizer from #479, one change fixes all three providers at once, which is exactly why the issue suggested landing the refactor first.