### PR TITLE
Give the play/pause button a proper button role

### DIFF
--- a/lib/features/player/widgets/playback_controls.dart
+++ b/lib/features/player/widgets/playback_controls.dart
@@ -151,35 +151,44 @@ class _PlayPauseButton extends StatelessWidget {
 
     return Tooltip(
       message: playing ? 'Pause' : 'Play',
-      child: Container(
-        width: 72,
-        height: 72,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: <Color>[gradientTop, gradientBottom],
-          ),
-          boxShadow: <BoxShadow>[
-            BoxShadow(
-              color: colorScheme.secondary.withValues(alpha: 0.45),
-              blurRadius: 24,
-              spreadRadius: -4,
-              offset: const Offset(0, 8),
+      // Hand-built from Container/InkWell rather than IconButton (for the
+      // brand gradient + glow), so unlike the transport row's other buttons
+      // it doesn't get a button role or enabled state for free -- Tooltip
+      // only contributes the label. Declared explicitly here so screen
+      // readers announce this the same way as every other control.
+      child: Semantics(
+        button: true,
+        enabled: onTap != null,
+        child: Container(
+          width: 72,
+          height: 72,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: <Color>[gradientTop, gradientBottom],
             ),
-          ],
-        ),
-        child: Material(
-          type: MaterialType.transparency,
-          shape: const CircleBorder(),
-          clipBehavior: Clip.antiAlias,
-          child: InkWell(
-            onTap: onTap,
-            child: Center(
-              child: loading
-                  ? _loadingIcon(onAccent)
-                  : _playIcon(playing, onAccent),
+            boxShadow: <BoxShadow>[
+              BoxShadow(
+                color: colorScheme.secondary.withValues(alpha: 0.45),
+                blurRadius: 24,
+                spreadRadius: -4,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: Material(
+            type: MaterialType.transparency,
+            shape: const CircleBorder(),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: onTap,
+              child: Center(
+                child: loading
+                    ? _loadingIcon(onAccent)
+                    : _playIcon(playing, onAccent),
+              ),
             ),
           ),
         ),

--- a/test/features/player/now_playing_talkback_test.dart
+++ b/test/features/player/now_playing_talkback_test.dart
@@ -86,7 +86,10 @@ void main() {
         tester.getSemantics(playFinder),
         matchesSemantics(
           tooltip: 'Play',
+          isButton: true,
           isFocusable: true,
+          isEnabled: true,
+          hasEnabledState: true,
           hasTapAction: true,
           hasFocusAction: true,
         ),
@@ -111,7 +114,10 @@ void main() {
         tester.getSemantics(pauseFinder),
         matchesSemantics(
           tooltip: 'Pause',
+          isButton: true,
           isFocusable: true,
+          isEnabled: true,
+          hasEnabledState: true,
           hasTapAction: true,
           hasFocusAction: true,
         ),


### PR DESCRIPTION
Part of #460, not the whole thing. Scoping this to just the transport row since that's what the issue lists first and it's a clean chunk to review on its own. Sidebar nav, track rows, dialogs, and server management are separate follow ups, didn't touch any of that here.

Shuffle, repeat, next, and previous all go through IconButton, so they get a button role and enabled state for free. Play/pause is hand built from Container and InkWell instead, for the brand gradient and glow, and Tooltip only ever gave it a label. A screen reader user got a name for the control but it never got announced as an actual button the way every other transport control does.

There's already a talkback test for this exact button, and it quietly leaves out isButton for Play/Pause while asserting it for everything else in the same file. Strengthened it first to check for isButton/isEnabled/hasEnabledState the same way the other buttons already do, confirmed that fails against the unfixed widget with exactly those three flags missing, then fixed it by wrapping the button in Semantics(button: true, enabled: onTap != null), which merges straight into the semantics node Tooltip already creates.

flutter analyze and dart format both clean. Ran the full player test directory against this branch and against a clean checkout of main, same 3 unrelated failures in playback_resolution_test.dart and source_routing_test.dart either way, nothing new from this change.