### PR TITLE
Use XDG Music directory for Linux library defaults (#413)

### DIFF
--- a/lib/core/services/file_picker_folder_picker_service.dart
+++ b/lib/core/services/file_picker_folder_picker_service.dart
@@ -1,6 +1,7 @@
 import 'package:file_picker/file_picker.dart';
 
 import 'folder_picker_service.dart';
+import 'linux_music_directory.dart';
 
 /// A [FolderPickerService] backed by the `file_picker` plugin — the desktop
 /// (GTK/Win32) folder chooser.
@@ -13,12 +14,22 @@ import 'folder_picker_service.dart';
 /// which returns a `content://` tree URI with a persisted read grant, and uses
 /// this class only as the desktop fallback (where a filesystem path is correct).
 class FilePickerFolderPickerService implements FolderPickerService {
-  const FilePickerFolderPickerService();
+  const FilePickerFolderPickerService({
+    LinuxMusicDirectory suggestedDirectory = const LinuxMusicDirectory(),
+  }) : _suggestedDirectory = suggestedDirectory;
+
+  /// Resolves the folder the chooser should open to. Only ever suggests a
+  /// starting point — the user is free to navigate anywhere else — and only
+  /// ever resolves to something on Linux; every other desktop platform gets
+  /// `null`, i.e. the chooser's own default.
+  final LinuxMusicDirectory _suggestedDirectory;
 
   @override
-  Future<String?> pickFolder() {
+  Future<String?> pickFolder() async {
+    final String? initialDirectory = await _suggestedDirectory.resolve();
     return FilePicker.platform.getDirectoryPath(
       dialogTitle: 'Select your music folder',
+      initialDirectory: initialDirectory,
     );
   }
 }

--- a/lib/core/services/linux_music_directory.dart
+++ b/lib/core/services/linux_music_directory.dart
@@ -76,6 +76,13 @@ class LinuxMusicDirectory {
       return await file.readAsString();
     } on FileSystemException {
       return null;
+    } on FormatException {
+      // readAsString() decodes as UTF-8 and throws FormatException on invalid
+      // bytes. A corrupt/non-UTF-8 user-dirs.dirs is exactly the "can't be
+      // trusted" case this class otherwise fails safe on, so it's treated the
+      // same as a missing file rather than propagating and blocking the
+      // chooser from opening at all.
+      return null;
     }
   }
 

--- a/lib/core/services/linux_music_directory.dart
+++ b/lib/core/services/linux_music_directory.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../platform/host_platform.dart';
+import 'xdg_user_dirs.dart';
+
+/// Resolves the Linux XDG Music directory (`$XDG_MUSIC_DIR`) to *suggest* as
+/// the starting folder in the desktop folder chooser — this never scans a
+/// folder itself, and the user remains free to navigate anywhere else in the
+/// chooser.
+///
+/// Reads `user-dirs.dirs` the way `xdg-user-dirs-update` writes it (via
+/// [XdgUserDirs]) instead of assuming `~/Music`, so a localized or
+/// user-renamed Music directory (`~/Musique`, `~/My Music`, a directory with
+/// non-ASCII characters, ...) is suggested correctly. No shell is ever
+/// invoked — the config file is read and parsed as plain text.
+///
+/// Resolution fails safe to `null` — "suggest nothing, let the chooser fall
+/// back to its own default" — whenever the result can't be trusted: off
+/// Linux, no `$HOME` in the environment, no config file, no `XDG_MUSIC_DIR`
+/// entry, a value in a form `xdg-user-dirs` doesn't itself write, the entry
+/// disabled (pointing at `$HOME` itself — `xdg-user-dirs`'s own way of saying
+/// "no separate Music folder"), or a resolved directory that doesn't actually
+/// exist.
+class LinuxMusicDirectory {
+  const LinuxMusicDirectory();
+
+  /// Resolves the current user's Music directory, or `null` per the class doc
+  /// above.
+  ///
+  /// [host] and [environment] are injection points for tests, defaulting to
+  /// the real host platform and process environment; the running app never
+  /// passes them.
+  Future<String?> resolve({
+    HostPlatform? host,
+    Map<String, String>? environment,
+  }) async {
+    if ((host ?? HostPlatform.current) != HostPlatform.linux) {
+      return null;
+    }
+    final Map<String, String> env = environment ?? Platform.environment;
+    final String? home = _nonEmpty(env['HOME']);
+    if (home == null) {
+      return null;
+    }
+
+    final String configHome =
+        _nonEmpty(env['XDG_CONFIG_HOME']) ?? p.join(home, '.config');
+    final File userDirsFile = File(p.join(configHome, 'user-dirs.dirs'));
+
+    final String? contents = await _readIfExists(userDirsFile);
+    if (contents == null) {
+      return null;
+    }
+
+    final String? resolved =
+        XdgUserDirs.resolveMusicDirectory(contents, home: home);
+    if (resolved == null) {
+      return null;
+    }
+    // Disabled: xdg-user-dirs represents "no separate Music dir" by pointing
+    // the entry at $HOME itself. Suggesting the whole home directory as a
+    // music folder default would be worse than suggesting nothing.
+    if (p.equals(resolved, home)) {
+      return null;
+    }
+    if (!Directory(resolved).existsSync()) {
+      return null;
+    }
+    return resolved;
+  }
+
+  static Future<String?> _readIfExists(File file) async {
+    try {
+      return await file.readAsString();
+    } on FileSystemException {
+      return null;
+    }
+  }
+
+  static String? _nonEmpty(String? value) =>
+      value == null || value.isEmpty ? null : value;
+}

--- a/lib/core/services/xdg_user_dirs.dart
+++ b/lib/core/services/xdg_user_dirs.dart
@@ -1,0 +1,64 @@
+/// Parses the Linux XDG "user dirs" config format — `user-dirs.dirs`, as
+/// written by `xdg-user-dirs-update` — to resolve `XDG_MUSIC_DIR`, without
+/// ever invoking a shell.
+///
+/// The format `xdg-user-dirs-update` itself writes is a small set of
+/// `KEY="value"` lines, where `value` is either `$HOME/relative/path` or an
+/// absolute `/path`, e.g.:
+///
+/// ```text
+/// XDG_MUSIC_DIR="$HOME/Music"
+/// ```
+///
+/// This class only understands those two literal forms (see [_expand]), so it
+/// can resolve `$HOME` with a plain string substitution instead of a shell —
+/// a value like `XDG_MUSIC_DIR="$(rm -rf ~)"` is just unmatched text, never
+/// executed. Anything outside those two forms (an unquoted value, `~`
+/// shorthand, a missing key, a truncated line, ...) is treated as unusable and
+/// yields `null`; this class has no opinion on what "unusable" should fall
+/// back to — that's the resolver built on top of it (`LinuxMusicDirectory`).
+class XdgUserDirs {
+  const XdgUserDirs._();
+
+  static final RegExp _musicDirLine = RegExp(
+    r'^\s*XDG_MUSIC_DIR\s*=\s*"([^"]*)"\s*$',
+  );
+
+  /// Resolves `XDG_MUSIC_DIR` from the raw contents of a `user-dirs.dirs`
+  /// file. Returns the expanded absolute path, or `null` when the file has no
+  /// such entry, or the entry isn't in one of the two forms `xdg-user-dirs`
+  /// itself writes.
+  ///
+  /// [home] is substituted for the literal `$HOME` token; it is never read
+  /// from the environment by this class (see the resolver above it for that).
+  static String? resolveMusicDirectory(
+    String userDirsFileContents, {
+    required String home,
+  }) {
+    for (final String line
+        in userDirsFileContents.split(RegExp(r'\r\n|\r|\n'))) {
+      final RegExpMatch? match = _musicDirLine.firstMatch(line);
+      if (match == null) continue;
+      return _expand(match.group(1)!, home: home);
+    }
+    return null;
+  }
+
+  /// Expands the two value forms `xdg-user-dirs` writes with plain string
+  /// operations: `$HOME` alone (the "disabled" form — see
+  /// [LinuxMusicDirectory]), `$HOME/...`, and an absolute `/...` path. Any
+  /// other shape is rejected rather than guessed at.
+  static String? _expand(String rawValue, {required String home}) {
+    const String homeToken = r'$HOME';
+    if (rawValue == homeToken) {
+      return home;
+    }
+    if (rawValue.startsWith('$homeToken/')) {
+      return home + rawValue.substring(homeToken.length);
+    }
+    if (rawValue.startsWith('/')) {
+      return rawValue;
+    }
+    return null;
+  }
+}

--- a/test/core/services/linux_music_directory_test.dart
+++ b/test/core/services/linux_music_directory_test.dart
@@ -137,6 +137,35 @@ void main() {
     });
 
     test(
+        'falls back to null instead of throwing when user-dirs.dirs contains '
+        'malformed UTF-8', () async {
+      // File.readAsString() decodes as UTF-8 and throws FormatException on
+      // invalid bytes (e.g. a lone continuation byte). That must be treated
+      // like any other untrustworthy config, not propagate and prevent the
+      // folder picker from opening.
+      final Directory configDir = Directory(p.join(tempHome.path, '.config'))
+        ..createSync(recursive: true);
+      File(p.join(configDir.path, 'user-dirs.dirs')).writeAsBytesSync(
+        <int>[
+          0x58,
+          0x44,
+          0x47,
+          0x5F,
+          0xFF,
+          0xFE,
+          0x0A
+        ], // "XDG_" + invalid bytes
+      );
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+    });
+
+    test(
         'falls back to null when the entry is disabled (XDG_MUSIC_DIR="\$HOME")',
         () async {
       await writeUserDirs('XDG_MUSIC_DIR="\$HOME"');

--- a/test/core/services/linux_music_directory_test.dart
+++ b/test/core/services/linux_music_directory_test.dart
@@ -1,0 +1,285 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/core/services/linux_music_directory.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('LinuxMusicDirectory.resolve', () {
+    late Directory tempHome;
+    const resolver = LinuxMusicDirectory();
+
+    setUp(() {
+      tempHome = Directory.systemTemp.createTempSync('linthra-xdg-home-');
+    });
+
+    tearDown(() {
+      if (tempHome.existsSync()) {
+        tempHome.deleteSync(recursive: true);
+      }
+    });
+
+    /// Writes `~/.config/user-dirs.dirs` with [contents] and creates
+    /// [musicDirName] (when given) under the temp home so an existence check
+    /// finds a real directory, mirroring a genuine XDG setup.
+    Future<void> writeUserDirs(
+      String contents, {
+      String? musicDirName,
+    }) async {
+      final Directory configDir = Directory(p.join(tempHome.path, '.config'))
+        ..createSync(recursive: true);
+      File(p.join(configDir.path, 'user-dirs.dirs'))
+          .writeAsStringSync(contents);
+      if (musicDirName != null) {
+        Directory(p.join(tempHome.path, musicDirName)).createSync();
+      }
+    }
+
+    Map<String, String> envFor(
+      Directory home, {
+      String? xdgConfigHome,
+    }) {
+      return {
+        'HOME': home.path,
+        if (xdgConfigHome != null) 'XDG_CONFIG_HOME': xdgConfigHome,
+      };
+    }
+
+    test('resolves XDG_MUSIC_DIR="\$HOME/Music"', () async {
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/Music"',
+        musicDirName: 'Music',
+      );
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, p.join(tempHome.path, 'Music'));
+    });
+
+    test('resolves a localized directory such as "\$HOME/Musique"', () async {
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/Musique"',
+        musicDirName: 'Musique',
+      );
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, p.join(tempHome.path, 'Musique'));
+    });
+
+    test('resolves a directory containing spaces', () async {
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/My Music"',
+        musicDirName: 'My Music',
+      );
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, p.join(tempHome.path, 'My Music'));
+    });
+
+    test('resolves a directory containing non-ASCII characters', () async {
+      const dirName = 'Música 音楽';
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/$dirName"',
+        musicDirName: dirName,
+      );
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, p.join(tempHome.path, dirName));
+    });
+
+    test('falls back to null when user-dirs.dirs is missing', () async {
+      // No writeUserDirs() call — ~/.config/user-dirs.dirs doesn't exist.
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('falls back to null when XDG_MUSIC_DIR is missing from the file',
+        () async {
+      await writeUserDirs('XDG_DESKTOP_DIR="\$HOME/Desktop"');
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('falls back to null for a malformed value', () async {
+      await writeUserDirs(r'XDG_MUSIC_DIR=$HOME/Music'); // unquoted
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+    });
+
+    test(
+        'falls back to null when the entry is disabled (XDG_MUSIC_DIR="\$HOME")',
+        () async {
+      await writeUserDirs('XDG_MUSIC_DIR="\$HOME"');
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('falls back to null when the resolved directory does not exist',
+        () async {
+      // Entry present and well-formed, but nothing was created on disk for it.
+      await writeUserDirs('XDG_MUSIC_DIR="\$HOME/Music"');
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('falls back to null when \$HOME is not set', () async {
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/Music"',
+        musicDirName: 'Music',
+      );
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: const {},
+      );
+
+      expect(result, isNull);
+    });
+
+    test('honours XDG_CONFIG_HOME when set, instead of ~/.config', () async {
+      final Directory customConfigParent =
+          Directory.systemTemp.createTempSync('linthra-xdg-config-');
+      addTearDown(() {
+        if (customConfigParent.existsSync()) {
+          customConfigParent.deleteSync(recursive: true);
+        }
+      });
+      final String customConfigHome =
+          p.join(customConfigParent.path, 'xdg-config');
+      Directory(customConfigHome).createSync(recursive: true);
+      File(p.join(customConfigHome, 'user-dirs.dirs'))
+          .writeAsStringSync('XDG_MUSIC_DIR="\$HOME/Music"');
+      Directory(p.join(tempHome.path, 'Music')).createSync();
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome, xdgConfigHome: customConfigHome),
+      );
+
+      expect(result, p.join(tempHome.path, 'Music'));
+    });
+
+    test(
+        'ignores a stray ~/.config/user-dirs.dirs when XDG_CONFIG_HOME '
+        'points elsewhere', () async {
+      // ~/.config has a usable entry, but XDG_CONFIG_HOME redirects to a
+      // directory with no user-dirs.dirs at all — that redirection must win.
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/Music"',
+        musicDirName: 'Music',
+      );
+      final Directory emptyConfigParent =
+          Directory.systemTemp.createTempSync('linthra-xdg-empty-config-');
+      addTearDown(() {
+        if (emptyConfigParent.existsSync()) {
+          emptyConfigParent.deleteSync(recursive: true);
+        }
+      });
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome, xdgConfigHome: emptyConfigParent.path),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('never touches a shell or process to resolve the value', () async {
+      // No `Process` is ever started by the resolver; a value that looks like
+      // a shell command substitution just fails to match the supported forms
+      // and is rejected, rather than being executed.
+      final String marker =
+          p.join(tempHome.path, 'xdg-user-dirs-should-not-run');
+      await writeUserDirs('XDG_MUSIC_DIR="\$(touch $marker)"');
+
+      final result = await resolver.resolve(
+        host: HostPlatform.linux,
+        environment: envFor(tempHome),
+      );
+
+      expect(result, isNull);
+      expect(File(marker).existsSync(), isFalse);
+    });
+
+    for (final host in [
+      HostPlatform.android,
+      HostPlatform.macOS,
+      HostPlatform.windows,
+      HostPlatform.ios,
+      HostPlatform.other,
+    ]) {
+      test('is a no-op off Linux (${host.label})', () async {
+        await writeUserDirs(
+          'XDG_MUSIC_DIR="\$HOME/Music"',
+          musicDirName: 'Music',
+        );
+
+        final result = await resolver.resolve(
+          host: host,
+          environment: envFor(tempHome),
+        );
+
+        expect(result, isNull);
+      });
+    }
+
+    test(
+        'an explicit Linux host never disagrees with the real host on a '
+        'non-Linux test runner', () async {
+      // Guards the injection itself, mirroring the pattern used for
+      // PlatformFolderPickerService: passing the real platform must behave
+      // identically to passing nothing.
+      await writeUserDirs(
+        'XDG_MUSIC_DIR="\$HOME/Music"',
+        musicDirName: 'Music',
+      );
+      final env = envFor(tempHome);
+
+      final withExplicitHost =
+          await resolver.resolve(host: HostPlatform.current, environment: env);
+      final withDefaultHost = await resolver.resolve(environment: env);
+
+      expect(withExplicitHost, withDefaultHost);
+    });
+  });
+}

--- a/test/core/services/xdg_user_dirs_test.dart
+++ b/test/core/services/xdg_user_dirs_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/services/xdg_user_dirs.dart';
+
+void main() {
+  group('XdgUserDirs.resolveMusicDirectory', () {
+    const home = '/home/alex';
+
+    test('resolves the stock XDG_MUSIC_DIR="\$HOME/Music" entry', () {
+      const contents = '''
+# This file is written by xdg-user-dirs-update
+XDG_DESKTOP_DIR="\$HOME/Desktop"
+XDG_MUSIC_DIR="\$HOME/Music"
+XDG_PICTURES_DIR="\$HOME/Pictures"
+''';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/home/alex/Music',
+      );
+    });
+
+    test('resolves a localized directory name', () {
+      const contents = 'XDG_MUSIC_DIR="\$HOME/Musique"';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/home/alex/Musique',
+      );
+    });
+
+    test('resolves a directory name containing spaces', () {
+      const contents = 'XDG_MUSIC_DIR="\$HOME/My Music"';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/home/alex/My Music',
+      );
+    });
+
+    test('resolves a directory name containing non-ASCII characters', () {
+      const contents = 'XDG_MUSIC_DIR="\$HOME/Música 音楽"';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/home/alex/Música 音楽',
+      );
+    });
+
+    test('resolves an absolute-path value unchanged', () {
+      const contents = 'XDG_MUSIC_DIR="/mnt/music"';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/mnt/music',
+      );
+    });
+
+    test('resolves the disabled form (pointing at \$HOME itself)', () {
+      const contents = 'XDG_MUSIC_DIR="\$HOME"';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        home,
+      );
+    });
+
+    test('returns null when the file has no XDG_MUSIC_DIR entry', () {
+      const contents = '''
+XDG_DESKTOP_DIR="\$HOME/Desktop"
+XDG_DOWNLOAD_DIR="\$HOME/Downloads"
+''';
+      expect(XdgUserDirs.resolveMusicDirectory(contents, home: home), isNull);
+    });
+
+    test('returns null for an empty file', () {
+      expect(XdgUserDirs.resolveMusicDirectory('', home: home), isNull);
+    });
+
+    test('returns null for an unquoted value', () {
+      const contents = r'XDG_MUSIC_DIR=$HOME/Music';
+      expect(XdgUserDirs.resolveMusicDirectory(contents, home: home), isNull);
+    });
+
+    test('returns null for a value using ~ instead of \$HOME', () {
+      const contents = 'XDG_MUSIC_DIR="~/Music"';
+      expect(XdgUserDirs.resolveMusicDirectory(contents, home: home), isNull);
+    });
+
+    test('returns null for a truncated (unterminated-quote) line', () {
+      const contents = 'XDG_MUSIC_DIR="\$HOME/Music';
+      expect(XdgUserDirs.resolveMusicDirectory(contents, home: home), isNull);
+    });
+
+    test('returns null for a relative value with no \$HOME prefix', () {
+      const contents = 'XDG_MUSIC_DIR="Music"';
+      expect(XdgUserDirs.resolveMusicDirectory(contents, home: home), isNull);
+    });
+
+    // Regression guard for "no shell evaluation": a shell command substitution
+    // embedded in the value must be treated as ordinary unmatched text (and so
+    // rejected, since it isn't the documented `$HOME/...` or `/...` form), never
+    // executed or passed to a shell.
+    test('never evaluates shell content embedded in the value', () {
+      const contents = r'XDG_MUSIC_DIR="$(touch /tmp/xdg-user-dirs-pwned)"';
+      expect(XdgUserDirs.resolveMusicDirectory(contents, home: home), isNull);
+    });
+
+    test('is tolerant of surrounding whitespace and other entries', () {
+      const contents = '''
+XDG_DOWNLOAD_DIR="\$HOME/Downloads"
+   XDG_MUSIC_DIR="\$HOME/Music"
+XDG_VIDEOS_DIR="\$HOME/Videos"
+''';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/home/alex/Music',
+      );
+    });
+
+    test('handles Windows-style line endings', () {
+      const contents = 'XDG_DESKTOP_DIR="\$HOME/Desktop"\r\n'
+          'XDG_MUSIC_DIR="\$HOME/Music"\r\n';
+      expect(
+        XdgUserDirs.resolveMusicDirectory(contents, home: home),
+        '/home/alex/Music',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #413

Previously the desktop folder chooser opened with no suggested starting directory at all, so on Linux it fell back to whatever GTK/file_picker picks by default -- never the user's actual Music folder, and just as wrong for anyone who renamed or relocated it (~/Musique, ~/My Music, an XDG_MUSIC_DIR override, ...).

Adds a small, testable XDG/Linux path helper instead of hardcoding ~/Music:

- XdgUserDirs (pure, no I/O) parses the `user-dirs.dirs` config format xdg-user-dirs-update itself writes and expands the `$HOME` token with a plain string substitution -- never a shell -- so a value like `"$(rm -rf ~)"` is just unmatched text, never executed.
- LinuxMusicDirectory (I/O + platform gate, built on HostPlatform the same way PlatformFolderPickerService already is) resolves ~/.config/user-dirs.dirs (honouring XDG_CONFIG_HOME when set), reads XDG_MUSIC_DIR through XdgUserDirs, and fails safe to null -- off Linux, missing $HOME, missing/malformed config, the entry disabled (pointing at $HOME itself), or a resolved directory that doesn't exist.

FilePickerFolderPickerService now passes the resolved directory as file_picker's `initialDirectory` -- a suggested starting point only; the folder chooser still opens for every pick, and nothing is scanned until the user explicitly picks a folder. Android's SAF picker path is untouched.

Tests: XdgUserDirs and LinuxMusicDirectory cover the stock and localized entries, spaces, non-ASCII names, absolute-path values, missing config, missing entry, malformed/unquoted values, the disabled ($HOME) form, XDG_CONFIG_HOME vs. the ~/.config fallback, a shell-injection-shaped value never being executed, and every non-Linux HostPlatform staying a no-op.