### PR TITLE
Index tracks.source_id so a source re-sync doesn't full-scan the catalog

### DIFF
--- a/lib/data/database/linthra_database.dart
+++ b/lib/data/database/linthra_database.dart
@@ -23,6 +23,10 @@ part 'linthra_database.g.dart';
 ///    one album (`library_grouping.dart`). Purely additive: existing rows keep
 ///    every value and read back with the new columns `null` until the next
 ///    source re-scan populates them.
+///  * **v4** — index on `tracks.source_id` (see `tracks_table.dart`), so a
+///    source re-sync's `DELETE ... WHERE source_id = ?` no longer scans the
+///    whole catalog to find the one source's rows. Purely additive: no rows
+///    or columns change.
 @DriftDatabase(tables: [Tracks])
 class LinthraDatabase extends _$LinthraDatabase {
   LinthraDatabase() : super(_openConnection());
@@ -32,7 +36,7 @@ class LinthraDatabase extends _$LinthraDatabase {
   LinthraDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 3;
+  int get schemaVersion => 4;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -48,6 +52,14 @@ class LinthraDatabase extends _$LinthraDatabase {
             await _migrateTracksKeyToUri(m);
           } else if (from < 3) {
             await _addAlbumGroupingColumns(m);
+          }
+          // Independent of the branches above: a v1 database rebuilt by
+          // _migrateTracksKeyToUri still needs the index added separately
+          // here, same as a v2 or v3 database does -- createTable never
+          // creates indexes declared on the table, and createAll() (the
+          // fresh-install path) is the only place that already includes it.
+          if (from < 4) {
+            await _addTracksSourceIdIndex(m);
           }
         },
       );
@@ -98,6 +110,19 @@ class LinthraDatabase extends _$LinthraDatabase {
       await m.addColumn(tracks, tracks.albumId);
       await m.addColumn(tracks, tracks.albumArtistName);
     });
+  }
+
+  /// v(1|2|3) → v4: add the index a fresh install already gets from
+  /// [Tracks]'s `@TableIndex` via `createAll()`. `createTable` (used by the
+  /// v1 → v2 rebuild above) only ever issues `CREATE TABLE`, never the
+  /// indexes declared on it, so every upgrade path needs this run
+  /// separately regardless of which version it started from.
+  ///
+  /// **Purely additive, and data is preserved.** An index changes lookup
+  /// performance, not row contents; no existing value is read, moved, or
+  /// dropped.
+  Future<void> _addTracksSourceIdIndex(Migrator m) async {
+    await m.createIndex(tracksSourceId);
   }
 }
 

--- a/lib/data/database/linthra_database.g.dart
+++ b/lib/data/database/linthra_database.g.dart
@@ -579,11 +579,13 @@ abstract class _$LinthraDatabase extends GeneratedDatabase {
   _$LinthraDatabase(QueryExecutor e) : super(e);
   $LinthraDatabaseManager get managers => $LinthraDatabaseManager(this);
   late final $TracksTable tracks = $TracksTable(this);
+  late final Index tracksSourceId = Index('tracks_source_id',
+      'CREATE INDEX tracks_source_id ON tracks (source_id)');
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [tracks];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [tracks, tracksSourceId];
 }
 
 typedef $$TracksTableCreateCompanionBuilder = TracksCompanion Function({

--- a/lib/data/database/tables/tracks_table.dart
+++ b/lib/data/database/tables/tracks_table.dart
@@ -20,6 +20,13 @@ import 'package:drift/drift.dart';
 /// coexist instead of silently overwriting each other under `insertOrReplace`.
 /// `id` is kept as a column because the per-provider server APIs (e.g. Jellyfin
 /// favourites/playlists) still address items by it.
+/// Sync replaces one source's rows at a time by deleting every row whose
+/// [Tracks.sourceId] matches (`DELETE FROM tracks WHERE source_id = ?`,
+/// see `upsertCatalog`). Without an index that lookup is a full scan of the
+/// whole catalog on every re-sync; a large library makes every sync
+/// noticeably slower for a delete that only ever touches one source's rows.
+/// Added in schema v4.
+@TableIndex(name: 'tracks_source_id', columns: {#sourceId})
 @DataClassName('TrackRow')
 class Tracks extends Table {
   TextColumn get id => text()();

--- a/test/data/database/linthra_database_migration_test.dart
+++ b/test/data/database/linthra_database_migration_test.dart
@@ -32,6 +32,57 @@ CREATE TABLE tracks (
 );
 ''';
 
+/// The exact `tracks` DDL as of schema v3 -- the v2 shape plus the nullable
+/// album-grouping columns, still with no index on `source_id`.
+const String _v3CreateTracks = '''
+CREATE TABLE tracks (
+  id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  uri TEXT NOT NULL,
+  artist_name TEXT NULL,
+  album_name TEXT NULL,
+  album_id TEXT NULL,
+  album_artist_name TEXT NULL,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  track_number INTEGER NULL,
+  artwork_uri TEXT NULL,
+  PRIMARY KEY (uri)
+);
+''';
+
+/// Opens a database whose underlying file is already at schema v3 with
+/// [seedStatements] inserted, then lets the real migration run on first use.
+Future<LinthraDatabase> _openMigratedFromV3(
+  List<String> seedStatements,
+) async {
+  final NativeDatabase executor = NativeDatabase.memory(
+    setup: (db) {
+      db.execute(_v3CreateTracks);
+      for (final String statement in seedStatements) {
+        db.execute(statement);
+      }
+      // Mark the file as schema v3 so drift runs onUpgrade(3 -> 4), not
+      // onCreate.
+      db.execute('PRAGMA user_version = 3;');
+    },
+  );
+  return LinthraDatabase.forTesting(executor);
+}
+
+/// Whether SQLite's own catalog reports an index on `tracks.source_id` --
+/// asserting the real effect of the migration (a usable index exists),
+/// rather than just that `createIndex` didn't throw.
+Future<bool> _hasSourceIdIndex(LinthraDatabase db) async {
+  final rows = await db
+      .customSelect(
+        "SELECT COUNT(*) AS c FROM sqlite_master WHERE type = 'index' "
+        "AND tbl_name = 'tracks' AND sql LIKE '%source_id%';",
+      )
+      .getSingle();
+  return (rows.data['c'] as int) > 0;
+}
+
 /// Opens a database whose underlying file is already at schema [version] with
 /// [seed] rows inserted, then lets the real migration run on first use.
 Future<LinthraDatabase> _openMigratedFromV2(
@@ -135,12 +186,109 @@ void main() {
       expect(await db.select(db.tracks).get(), hasLength(2));
     });
 
-    test('leaves the schema at v3', () async {
+    test('lands on the current schema version, not just v3', () async {
       db = await _openMigratedFromV2(<String>[]);
-      // Force the migration to run, then read the file's recorded version.
+      // A v2 database runs every subsequent onUpgrade branch in one pass
+      // (v2 -> v3 -> v4), landing on whatever the current version actually
+      // is -- not hardcoded to 4, so this doesn't go stale again the next
+      // time schemaVersion bumps.
       await db.select(db.tracks).get();
       final result = await db.customSelect('PRAGMA user_version;').getSingle();
-      expect(result.data.values.first, 3);
+      expect(result.data.values.first, db.schemaVersion);
+    });
+
+    test('also picks up the v4 index along the way', () async {
+      db = await _openMigratedFromV2(<String>[]);
+      await db.select(db.tracks).get();
+      expect(await _hasSourceIdIndex(db), isTrue);
+    });
+  });
+
+  group('v3 → v4 migration', () {
+    late LinthraDatabase db;
+
+    tearDown(() async => db.close());
+
+    test('preserves every existing row and all of its values', () async {
+      db = await _openMigratedFromV3(<String>[
+        "INSERT INTO tracks (id, source_id, title, uri, artist_name, "
+            "album_name, album_id, album_artist_name, duration_ms, "
+            "track_number, artwork_uri) VALUES "
+            "('t1', 'jellyfin', 'One', 'jellyfin:t1', 'Adele', '25', "
+            "'jellyfin:al-1', 'Adele', 180000, 1, "
+            "'https://media.example/a.jpg');",
+        "INSERT INTO tracks (id, source_id, title, uri, duration_ms) "
+            "VALUES ('t2', 'subsonic', 'Two', 'subsonic:t2', 240000);",
+      ]);
+
+      final List<TrackRow> rows = await db.select(db.tracks).get();
+      expect(rows, hasLength(2));
+
+      final TrackRow jellyfin =
+          rows.firstWhere((TrackRow r) => r.uri == 'jellyfin:t1');
+      expect(jellyfin.sourceId, 'jellyfin');
+      expect(jellyfin.albumId, 'jellyfin:al-1');
+      expect(jellyfin.albumArtistName, 'Adele');
+      expect(jellyfin.artworkUri, 'https://media.example/a.jpg');
+
+      final TrackRow subsonic =
+          rows.firstWhere((TrackRow r) => r.uri == 'subsonic:t2');
+      expect(subsonic.albumId, isNull);
+    });
+
+    test('adds a usable index on source_id', () async {
+      db = await _openMigratedFromV3(<String>[]);
+      // Force the migration to run.
+      await db.select(db.tracks).get();
+      expect(await _hasSourceIdIndex(db), isTrue);
+    });
+
+    test('a source-scoped delete still only removes that source\'s rows',
+        () async {
+      // Not a performance benchmark (an in-memory DB with two rows can't
+      // demonstrate that) -- this is the actual access pattern the index
+      // exists for (`_deleteSource` in drift_music_library_repository.dart),
+      // proving the migrated table still behaves correctly under it.
+      db = await _openMigratedFromV3(<String>[
+        "INSERT INTO tracks (id, source_id, title, uri, duration_ms) "
+            "VALUES ('t1', 'jellyfin', 'One', 'jellyfin:t1', 0);",
+        "INSERT INTO tracks (id, source_id, title, uri, duration_ms) "
+            "VALUES ('t2', 'subsonic', 'Two', 'subsonic:t2', 0);",
+      ]);
+
+      await (db.delete(db.tracks)..where((t) => t.sourceId.equals('jellyfin')))
+          .go();
+
+      final List<TrackRow> remaining = await db.select(db.tracks).get();
+      expect(remaining, hasLength(1));
+      expect(remaining.single.sourceId, 'subsonic');
+    });
+
+    test('leaves the schema at v4', () async {
+      db = await _openMigratedFromV3(<String>[]);
+      await db.select(db.tracks).get();
+      final result = await db.customSelect('PRAGMA user_version;').getSingle();
+      expect(result.data.values.first, 4);
+    });
+
+    test(
+        "the source-scoped delete's query plan actually uses the index, "
+        'not just that the index exists', () async {
+      // An unindexed lookup always needs a full SCAN; that half isn't worth
+      // proving. What actually matters: after migration, the same delete
+      // this issue is about (`_deleteSource` in
+      // drift_music_library_repository.dart) really does SEARCH via the new
+      // index instead, not just that CREATE INDEX succeeded somewhere.
+      db = await _openMigratedFromV3(<String>[]);
+      await db.select(db.tracks).get(); // force the migration to run
+      final plan = await db
+          .customSelect(
+            "EXPLAIN QUERY PLAN DELETE FROM tracks WHERE source_id = 'x';",
+          )
+          .get();
+      final String detail = plan.map((r) => r.data['detail']).join();
+      expect(detail, isNot(contains('SCAN tracks')));
+      expect(detail, contains('tracks_source_id'));
     });
   });
 
@@ -165,6 +313,18 @@ void main() {
       final TrackRow row = await db.select(db.tracks).getSingle();
       expect(row.albumId, 'plex:201');
       expect(row.albumArtistName, 'Kavinsky');
+    });
+
+    test('already has the source_id index, with no migration needed', () async {
+      final LinthraDatabase db =
+          LinthraDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+
+      // onCreate's createAll() includes every entity declared on the table,
+      // the index among them -- unlike an upgrade, which needs the explicit
+      // v3 -> v4 step because createTable alone does not.
+      await db.select(db.tracks).get();
+      expect(await _hasSourceIdIndex(db), isTrue);
     });
   });
 }


### PR DESCRIPTION
Closes #349.

A source re-sync deletes that source's rows first (_deleteSource in drift_music_library_repository.dart, DELETE FROM tracks WHERE source_id = ?), but nothing narrowed that lookup, so every sync scanned the whole tracks table just to find one source's rows. Checked this directly rather than assuming: the delete's own query plan now reads SEARCH tracks USING INDEX tracks_source_id instead of a scan.

Added the index via @TableIndex on the Tracks table, bumped schema to v4, added the migration for existing installs. One thing worth calling out: createTable (used by the old v1 to v2 rebuild) only ever issues CREATE TABLE, never the indexes declared on a table, confirmed that by reading Migrator's source rather than assuming it. So every upgrade path needs the index added as its own explicit step no matter which version someone's coming from, only createAll (the fresh install path) already includes it for free.

Migration tests build real pre-migration tables by hand and run the actual MigrationStrategy over them, same convention the existing v2 to v3 tests already use. They confirm existing rows and every value survive untouched, the index exists and is actually used by the query planner afterward, and a v1 database migrating straight through to v4 in one pass still picks up the index, not just a v3 database. The one pre-existing test that asserted the post-migration version now checks against db.schemaVersion instead of a hardcoded 3, so it doesn't go stale the next time schemaVersion bumps again.

flutter analyze clean, dart format clean, full test/data/database suite plus drift_music_library_repository/drift_repository_wiring/track_mapper all pass with no regressions. Also built a debug APK from this branch and ran it on a physical phone to confirm the app installs and runs fine with the new schema, not just in the test harness.