### PR TITLE
Audiobookshelf: connection, auth, and library listing (milestone 1 of #484)

### DIFF
--- a/lib/core/models/audiobookshelf_session.dart
+++ b/lib/core/models/audiobookshelf_session.dart
@@ -83,23 +83,24 @@ class AudiobookshelfSession {
       };
 
   /// Rebuilds a session from [toJson] output, or returns `null` if any
-  /// required field is missing/blank (e.g. a partially written or corrupted
-  /// record), so the app treats it as "not signed in" rather than crashing.
+  /// required field is missing, blank, or the wrong type (e.g. a partially
+  /// written or corrupted record), so the app treats it as "not signed in"
+  /// rather than crashing on a bad cast.
   static AudiobookshelfSession? fromJson(Map<String, dynamic> json) {
-    final String? baseUrl = json['baseUrl'] as String?;
-    final String? userId = json['userId'] as String?;
-    final String? accessToken = json['accessToken'] as String?;
-    if (baseUrl == null || baseUrl.isEmpty) return null;
-    if (userId == null || userId.isEmpty) return null;
-    if (accessToken == null || accessToken.isEmpty) return null;
+    final String? baseUrl = _string(json['baseUrl']);
+    final String? userId = _string(json['userId']);
+    final String? accessToken = _string(json['accessToken']);
+    if (baseUrl == null || userId == null || accessToken == null) {
+      return null;
+    }
     return AudiobookshelfSession(
       baseUrl: baseUrl,
       userId: userId,
       accessToken: accessToken,
-      refreshToken: json['refreshToken'] as String?,
-      userName: json['userName'] as String?,
-      defaultLibraryId: json['defaultLibraryId'] as String?,
-      serverVersion: json['serverVersion'] as String?,
+      refreshToken: _string(json['refreshToken']),
+      userName: _string(json['userName']),
+      defaultLibraryId: _string(json['defaultLibraryId']),
+      serverVersion: _string(json['serverVersion']),
     );
   }
 
@@ -134,4 +135,13 @@ class AudiobookshelfSession {
       'userName: $userName, defaultLibraryId: $defaultLibraryId, '
       'serverVersion: $serverVersion, accessToken: <redacted>, '
       'refreshToken: <redacted>)';
+}
+
+/// Reads [value] as a non-blank [String], or `null` for anything else
+/// (absent, wrong type, or empty/whitespace-only), used by [fromJson] so a
+/// field of the wrong type never throws, it's just treated as absent.
+String? _string(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
 }

--- a/lib/core/models/audiobookshelf_session.dart
+++ b/lib/core/models/audiobookshelf_session.dart
@@ -1,0 +1,137 @@
+/// An authenticated Audiobookshelf session: everything needed to make further
+/// authorized requests, kept in one immutable value so it can be persisted as a
+/// unit and passed to the source.
+///
+/// Security: [accessToken] and [refreshToken] are secrets. They are persisted
+/// only through the (encrypted, once it exists) session store and must never be
+/// logged or shown in the UI. [toString] deliberately redacts both so an
+/// accidental interpolation can't leak them into logs or error text.
+///
+/// The user's password is *not* part of a session and is never stored — it is
+/// used once at sign-in to obtain the tokens and then discarded.
+class AudiobookshelfSession {
+  const AudiobookshelfSession({
+    required this.baseUrl,
+    required this.userId,
+    required this.accessToken,
+    this.refreshToken,
+    this.userName,
+    this.defaultLibraryId,
+    this.serverVersion,
+  });
+
+  /// Clean base URL of the server (no trailing slash), e.g.
+  /// `https://audiobooks.example.com`. API paths are appended to this.
+  final String baseUrl;
+
+  /// The authenticated user's Audiobookshelf id.
+  final String userId;
+
+  /// Secret bearer token for the `Authorization` header. Never log this.
+  final String accessToken;
+
+  /// Secret refresh token, present only when the server returned one (it does
+  /// so only when the sign-in request sends the `x-return-tokens: true`
+  /// header a mobile client needs, since otherwise Audiobookshelf sets it as
+  /// an httpOnly cookie instead — not usable outside a browser). Never log
+  /// this. `null` means the session can't be silently refreshed and a future
+  /// 401 requires a fresh sign-in.
+  final String? refreshToken;
+
+  /// Display name of the signed-in user, when the server returned one.
+  final String? userName;
+
+  /// The user's default library id, when the server returned one. Useful as
+  /// the starting point for library browsing.
+  final String? defaultLibraryId;
+
+  /// The server's reported version, when known. Not secret, display/
+  /// diagnostics only.
+  final String? serverVersion;
+
+  AudiobookshelfSession copyWith({
+    String? baseUrl,
+    String? userId,
+    String? accessToken,
+    String? refreshToken,
+    String? userName,
+    String? defaultLibraryId,
+    String? serverVersion,
+  }) {
+    return AudiobookshelfSession(
+      baseUrl: baseUrl ?? this.baseUrl,
+      userId: userId ?? this.userId,
+      accessToken: accessToken ?? this.accessToken,
+      refreshToken: refreshToken ?? this.refreshToken,
+      userName: userName ?? this.userName,
+      defaultLibraryId: defaultLibraryId ?? this.defaultLibraryId,
+      serverVersion: serverVersion ?? this.serverVersion,
+    );
+  }
+
+  /// Serializes for the session store. The tokens are included because the
+  /// only intended caller is an encrypted store; do not route this through
+  /// any plaintext sink.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'baseUrl': baseUrl,
+        'userId': userId,
+        'accessToken': accessToken,
+        if (refreshToken != null) 'refreshToken': refreshToken,
+        if (userName != null) 'userName': userName,
+        if (defaultLibraryId != null) 'defaultLibraryId': defaultLibraryId,
+        if (serverVersion != null) 'serverVersion': serverVersion,
+      };
+
+  /// Rebuilds a session from [toJson] output, or returns `null` if any
+  /// required field is missing/blank (e.g. a partially written or corrupted
+  /// record), so the app treats it as "not signed in" rather than crashing.
+  static AudiobookshelfSession? fromJson(Map<String, dynamic> json) {
+    final String? baseUrl = json['baseUrl'] as String?;
+    final String? userId = json['userId'] as String?;
+    final String? accessToken = json['accessToken'] as String?;
+    if (baseUrl == null || baseUrl.isEmpty) return null;
+    if (userId == null || userId.isEmpty) return null;
+    if (accessToken == null || accessToken.isEmpty) return null;
+    return AudiobookshelfSession(
+      baseUrl: baseUrl,
+      userId: userId,
+      accessToken: accessToken,
+      refreshToken: json['refreshToken'] as String?,
+      userName: json['userName'] as String?,
+      defaultLibraryId: json['defaultLibraryId'] as String?,
+      serverVersion: json['serverVersion'] as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is AudiobookshelfSession &&
+          other.baseUrl == baseUrl &&
+          other.userId == userId &&
+          other.accessToken == accessToken &&
+          other.refreshToken == refreshToken &&
+          other.userName == userName &&
+          other.defaultLibraryId == defaultLibraryId &&
+          other.serverVersion == serverVersion);
+
+  @override
+  int get hashCode => Object.hash(
+        baseUrl,
+        userId,
+        accessToken,
+        refreshToken,
+        userName,
+        defaultLibraryId,
+        serverVersion,
+      );
+
+  /// Redacts both tokens so the session can be safely interpolated into logs
+  /// or error messages without leaking a secret.
+  @override
+  String toString() =>
+      'AudiobookshelfSession(baseUrl: $baseUrl, userId: $userId, '
+      'userName: $userName, defaultLibraryId: $defaultLibraryId, '
+      'serverVersion: $serverVersion, accessToken: <redacted>, '
+      'refreshToken: <redacted>)';
+}

--- a/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
@@ -1,0 +1,115 @@
+/// The response shape of `GET /status` — confirms an address is a reachable
+/// Audiobookshelf server before any credentials are sent.
+class AudiobookshelfServerStatus {
+  const AudiobookshelfServerStatus({
+    required this.serverVersion,
+    this.isInitialized,
+  });
+
+  final String serverVersion;
+
+  /// Whether the server has completed initial setup (a root user exists).
+  /// `null` when the field was absent from an unexpected response shape.
+  final bool? isInitialized;
+
+  /// Parses `GET /status`'s response, or returns `null` when it doesn't
+  /// carry `app: "audiobookshelf"` (a different server, or a
+  /// Cloudflare/reverse-proxy error page that happens to be valid JSON) or is
+  /// missing a version — the two things that confirm this is genuinely an
+  /// Audiobookshelf server, not just something that answered on this address.
+  static AudiobookshelfServerStatus? fromJson(Map<String, dynamic> json) {
+    final Object? app = json['app'];
+    if (app != 'audiobookshelf') return null;
+    final String? version = _coerceString(json['serverVersion']);
+    if (version == null) return null;
+    return AudiobookshelfServerStatus(
+      serverVersion: version,
+      isInitialized: json['isInit'] as bool?,
+    );
+  }
+}
+
+/// The response shape of `POST /login` — the subset Linthra needs to build an
+/// [AudiobookshelfSession]. The server returns considerably more (media
+/// progress, bookmarks, server settings, …); later PRs read those as that
+/// data becomes relevant, this one only needs enough to authenticate.
+class AudiobookshelfAuthResult {
+  const AudiobookshelfAuthResult({
+    required this.userId,
+    required this.accessToken,
+    this.refreshToken,
+    this.userName,
+    this.defaultLibraryId,
+  });
+
+  final String userId;
+  final String accessToken;
+
+  /// Present only when the request sent `x-return-tokens: true` — otherwise
+  /// the server sets it as an httpOnly cookie instead, which this client
+  /// intentionally never relies on (a cookie jar is a browser assumption,
+  /// not something to build into a mobile HTTP client's request flow).
+  final String? refreshToken;
+  final String? userName;
+  final String? defaultLibraryId;
+
+  /// Parses the login response, or returns `null` if the user id or access
+  /// token are absent or the wrong type (an unexpected body), so the client
+  /// can fail clearly with a sign-in error rather than throw a `TypeError`.
+  static AudiobookshelfAuthResult? fromJson(Map<String, dynamic> json) {
+    final Object? user = json['user'];
+    if (user is! Map<String, dynamic>) return null;
+    final String? userId = _coerceString(user['id']);
+    final String? accessToken = _coerceString(user['accessToken']);
+    if (userId == null || accessToken == null) return null;
+    return AudiobookshelfAuthResult(
+      userId: userId,
+      accessToken: accessToken,
+      refreshToken: _coerceString(user['refreshToken']),
+      userName: _coerceString(user['username']),
+      defaultLibraryId: _coerceString(json['userDefaultLibraryId']),
+    );
+  }
+}
+
+/// One entry from `GET /api/libraries` — enough to let a user pick which
+/// library to browse. Item-level fetching (and the domain-model mapping that
+/// goes with it) is out of scope for this PR; see the tracking issue.
+class AudiobookshelfLibraryDto {
+  const AudiobookshelfLibraryDto({
+    required this.id,
+    required this.name,
+    this.mediaType,
+  });
+
+  final String id;
+  final String name;
+
+  /// The library's configured media type (e.g. `book`, `podcast`), when
+  /// reported. Not yet used to filter — this PR only lists what's there.
+  final String? mediaType;
+
+  /// Parses one library entry, or returns `null` when the id or name are
+  /// absent/wrong-typed, so a single malformed entry can be skipped rather
+  /// than failing the whole listing.
+  static AudiobookshelfLibraryDto? fromJson(Map<String, dynamic> json) {
+    final String? id = _coerceString(json['id']);
+    final String? name = _coerceString(json['name']);
+    if (id == null || name == null) return null;
+    return AudiobookshelfLibraryDto(
+      id: id,
+      name: name,
+      mediaType: _coerceString(json['mediaType']),
+    );
+  }
+}
+
+/// Reads [value] as a non-blank [String], or `null` for anything else
+/// (absent, wrong type, or empty/whitespace-only) — the shared rule every DTO
+/// in this file applies to every field it reads, so a blank or malformed
+/// value is treated the same as an absent one.
+String? _coerceString(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}

--- a/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_api.dart
@@ -1,30 +1,34 @@
 /// The response shape of `GET /status` — confirms an address is a reachable
 /// Audiobookshelf server before any credentials are sent.
 class AudiobookshelfServerStatus {
-  const AudiobookshelfServerStatus({
-    required this.serverVersion,
-    this.isInitialized,
-  });
+  const AudiobookshelfServerStatus({this.serverVersion, this.isInitialized});
 
-  final String serverVersion;
+  /// `null` on servers older than v2.6.0, which don't report a version at
+  /// all: confirmed directly against `/status`'s real handler across
+  /// release tags back to v2.2.0, not just the current server source.
+  final String? serverVersion;
 
   /// Whether the server has completed initial setup (a root user exists).
-  /// `null` when the field was absent from an unexpected response shape.
   final bool? isInitialized;
 
-  /// Parses `GET /status`'s response, or returns `null` when it doesn't
-  /// carry `app: "audiobookshelf"` (a different server, or a
-  /// Cloudflare/reverse-proxy error page that happens to be valid JSON) or is
-  /// missing a version — the two things that confirm this is genuinely an
-  /// Audiobookshelf server, not just something that answered on this address.
+  /// Parses `GET /status`'s response, or returns `null` when nothing about
+  /// it confirms this is genuinely an Audiobookshelf server (a different
+  /// server, or a Cloudflare/reverse-proxy error page that happens to be
+  /// valid JSON).
+  ///
+  /// `app: "audiobookshelf"` was only added in v2.6.0 (confirmed against the
+  /// real `/status` handler at v2.2.0, v2.5.0, v2.6.0, and the current tag),
+  /// so it's checked only when present. A server old enough not to send it
+  /// still identifies itself well enough via `isInit`, the one field every
+  /// version examined has always sent.
   static AudiobookshelfServerStatus? fromJson(Map<String, dynamic> json) {
     final Object? app = json['app'];
-    if (app != 'audiobookshelf') return null;
-    final String? version = _coerceString(json['serverVersion']);
-    if (version == null) return null;
+    if (app != null && app != 'audiobookshelf') return null;
+    final Object? isInit = json['isInit'];
+    if (app == null && isInit is! bool) return null;
     return AudiobookshelfServerStatus(
-      serverVersion: version,
-      isInitialized: json['isInit'] as bool?,
+      serverVersion: _coerceString(json['serverVersion']),
+      isInitialized: isInit is bool ? isInit : null,
     );
   }
 }

--- a/lib/core/sources/audiobookshelf/audiobookshelf_authenticator.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_authenticator.dart
@@ -30,14 +30,15 @@ class AudiobookshelfAuthenticator {
 
   /// Signs in and returns a session.
   ///
-  /// [serverStatus], when known from a prior [testConnection], is carried
-  /// into the session (server version) for display and diagnostics. When it
-  /// is absent, sign-in reads `/status` itself so the session still records
-  /// the server's version — best-effort, since the auth call is the real
-  /// gate and a status hiccup must not block a valid sign-in.
+  /// [serverStatus], when known from a prior [testConnection] against this
+  /// same [rawUrl], is reused instead of fetching it again. When it is
+  /// absent, sign-in fetches `/status` itself first. Credentials are only
+  /// ever sent to [baseUrl] once that address has confirmed it's an
+  /// Audiobookshelf server, never on a status-fetch failure. A caller must
+  /// not pass a [serverStatus] obtained for a different address.
   ///
-  /// Throws [AudiobookshelfException] for a bad URL, missing username, or
-  /// rejected credentials.
+  /// Throws [AudiobookshelfException] for a bad URL, an unconfirmed server,
+  /// a missing username, or rejected credentials.
   Future<AudiobookshelfSession> signIn({
     required String rawUrl,
     required String username,
@@ -53,11 +54,11 @@ class AudiobookshelfAuthenticator {
       );
     }
 
-    // Reuse a known server status, else read it now so the session captures
-    // the version for diagnostics. Swallow its failure: the auth call below
-    // surfaces the real, friendly error for a bad address or down server.
-    final AudiobookshelfServerStatus? status =
-        serverStatus ?? await _tryFetchServerStatus(baseUrl);
+    // Reuse a status already confirmed for this address, else confirm it
+    // now. Left to throw on failure: credentials must never reach an
+    // address that hasn't confirmed it's an Audiobookshelf server.
+    final AudiobookshelfServerStatus status =
+        serverStatus ?? await _client.fetchServerStatus(baseUrl);
 
     final AudiobookshelfAuthResult result = await _client.authenticateByName(
       baseUrl: baseUrl,
@@ -72,17 +73,7 @@ class AudiobookshelfAuthenticator {
       refreshToken: result.refreshToken,
       userName: result.userName ?? trimmedUsername,
       defaultLibraryId: result.defaultLibraryId,
-      serverVersion: status?.serverVersion,
+      serverVersion: status.serverVersion,
     );
-  }
-
-  Future<AudiobookshelfServerStatus?> _tryFetchServerStatus(
-    String baseUrl,
-  ) async {
-    try {
-      return await _client.fetchServerStatus(baseUrl);
-    } on AudiobookshelfException {
-      return null;
-    }
   }
 }

--- a/lib/core/sources/audiobookshelf/audiobookshelf_authenticator.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_authenticator.dart
@@ -1,0 +1,88 @@
+import '../../models/audiobookshelf_session.dart';
+import 'audiobookshelf_api.dart';
+import 'audiobookshelf_client.dart';
+import 'audiobookshelf_exception.dart';
+import 'audiobookshelf_server_url.dart';
+
+/// Turns a raw address + credentials into a usable [AudiobookshelfSession].
+///
+/// This is the "authentication" concern, kept separate from settings storage
+/// (a future `AudiobookshelfSessionStore`, out of scope for this PR) and from
+/// library fetching (the client's `fetchLibraries`): it validates the URL and
+/// asks the [AudiobookshelfClient] to authenticate. It does not persist
+/// anything — the caller decides whether/where to store the session — so
+/// this stays a pure coordinator that's trivial to test with a fake client.
+///
+/// The password is passed straight through to the one auth call and is never
+/// held, copied into the session, or logged.
+class AudiobookshelfAuthenticator {
+  AudiobookshelfAuthenticator(this._client);
+
+  final AudiobookshelfClient _client;
+
+  /// Validates [rawUrl] and confirms it points at an Audiobookshelf server,
+  /// returning its status. Throws [AudiobookshelfException] on a bad URL or
+  /// unreachable/non-Audiobookshelf server.
+  Future<AudiobookshelfServerStatus> testConnection(String rawUrl) async {
+    final String baseUrl = AudiobookshelfServerUrl.normalize(rawUrl);
+    return _client.fetchServerStatus(baseUrl);
+  }
+
+  /// Signs in and returns a session.
+  ///
+  /// [serverStatus], when known from a prior [testConnection], is carried
+  /// into the session (server version) for display and diagnostics. When it
+  /// is absent, sign-in reads `/status` itself so the session still records
+  /// the server's version — best-effort, since the auth call is the real
+  /// gate and a status hiccup must not block a valid sign-in.
+  ///
+  /// Throws [AudiobookshelfException] for a bad URL, missing username, or
+  /// rejected credentials.
+  Future<AudiobookshelfSession> signIn({
+    required String rawUrl,
+    required String username,
+    required String password,
+    AudiobookshelfServerStatus? serverStatus,
+  }) async {
+    final String baseUrl = AudiobookshelfServerUrl.normalize(rawUrl);
+    final String trimmedUsername = username.trim();
+    if (trimmedUsername.isEmpty) {
+      throw const AudiobookshelfException(
+        'Enter your Audiobookshelf username.',
+        kind: AudiobookshelfErrorKind.unauthorized,
+      );
+    }
+
+    // Reuse a known server status, else read it now so the session captures
+    // the version for diagnostics. Swallow its failure: the auth call below
+    // surfaces the real, friendly error for a bad address or down server.
+    final AudiobookshelfServerStatus? status =
+        serverStatus ?? await _tryFetchServerStatus(baseUrl);
+
+    final AudiobookshelfAuthResult result = await _client.authenticateByName(
+      baseUrl: baseUrl,
+      username: trimmedUsername,
+      password: password,
+    );
+
+    return AudiobookshelfSession(
+      baseUrl: baseUrl,
+      userId: result.userId,
+      accessToken: result.accessToken,
+      refreshToken: result.refreshToken,
+      userName: result.userName ?? trimmedUsername,
+      defaultLibraryId: result.defaultLibraryId,
+      serverVersion: status?.serverVersion,
+    );
+  }
+
+  Future<AudiobookshelfServerStatus?> _tryFetchServerStatus(
+    String baseUrl,
+  ) async {
+    try {
+      return await _client.fetchServerStatus(baseUrl);
+    } on AudiobookshelfException {
+      return null;
+    }
+  }
+}

--- a/lib/core/sources/audiobookshelf/audiobookshelf_client.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_client.dart
@@ -1,0 +1,34 @@
+import '../../models/audiobookshelf_session.dart';
+import 'audiobookshelf_api.dart';
+
+/// The single seam through which Linthra talks HTTP to an Audiobookshelf
+/// server.
+///
+/// Every request to Audiobookshelf goes through this interface, so the rest
+/// of the app (authenticator, future library/playback code) depends only on
+/// it — never on `http`, URLs, headers, or JSON. That keeps networking
+/// swappable and, crucially, lets tests drive the feature with a fake client
+/// and canned responses (no real server).
+///
+/// Implementations throw an [AudiobookshelfException] (with a friendly
+/// message and an [AudiobookshelfErrorKind]) for every failure, and must
+/// never put the password or either token into an exception, log, or any
+/// other output.
+abstract interface class AudiobookshelfClient {
+  /// Confirms an address is a reachable Audiobookshelf server and returns its
+  /// status. Backs "Test connection"; needs no credentials.
+  Future<AudiobookshelfServerStatus> fetchServerStatus(String baseUrl);
+
+  /// Exchanges a username + password for an access token (and, when the
+  /// server grants one, a refresh token).
+  Future<AudiobookshelfAuthResult> authenticateByName({
+    required String baseUrl,
+    required String username,
+    required String password,
+  });
+
+  /// Lists the signed-in user's accessible libraries.
+  Future<List<AudiobookshelfLibraryDto>> fetchLibraries(
+    AudiobookshelfSession session,
+  );
+}

--- a/lib/core/sources/audiobookshelf/audiobookshelf_endpoints.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_endpoints.dart
@@ -1,0 +1,43 @@
+/// Every Audiobookshelf REST path and URL Linthra builds, in one place.
+///
+/// Centralizing the endpoints means:
+///  - the HTTP client never embeds raw path strings, so a path can't quietly
+///    drift between two call sites;
+///  - the exact set of endpoints Linthra depends on is auditable from this
+///    one file.
+///
+/// All builders are pure: they take a clean base URL (no trailing slash, as
+/// produced by [AudiobookshelfServerUrl.normalize]) plus the ids/params they
+/// need and return a [Uri]. Nothing here performs I/O, logs, or holds state.
+///
+/// Paths confirmed directly against Audiobookshelf's own server source
+/// (`server/Server.js`, `server/Auth.js`, `server/routers/ApiRouter.js`) —
+/// see PR description for the exact references.
+abstract final class AudiobookshelfEndpoints {
+  static const String _statusPath = '/status';
+  static const String _loginPath = '/login';
+  static const String _librariesPath = '/api/libraries';
+
+  /// `GET /status` — public, unauthenticated. Confirms the address is a
+  /// reachable Audiobookshelf server (the response includes `app:
+  /// "audiobookshelf"`) and returns its version, without needing credentials.
+  /// Backs "Test connection".
+  static Uri status(String baseUrl) => _join(baseUrl, _statusPath);
+
+  /// `POST /login` — exchanges a username + password for an access token
+  /// (and, when the request carries the `x-return-tokens: true` header, a
+  /// refresh token in the response body instead of only as an httpOnly
+  /// cookie a mobile client can't use).
+  static Uri login(String baseUrl) => _join(baseUrl, _loginPath);
+
+  /// `GET /api/libraries` — the signed-in user's accessible libraries.
+  /// Requires the `Authorization: Bearer <accessToken>` header.
+  static Uri libraries(String baseUrl) => _join(baseUrl, _librariesPath);
+
+  /// `GET /api/libraries/{id}/items` — the items in one library. Requires
+  /// the `Authorization: Bearer <accessToken>` header.
+  static Uri libraryItems(String baseUrl, String libraryId) =>
+      _join(baseUrl, '/api/libraries/$libraryId/items');
+
+  static Uri _join(String baseUrl, String path) => Uri.parse('$baseUrl$path');
+}

--- a/lib/core/sources/audiobookshelf/audiobookshelf_exception.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_exception.dart
@@ -1,0 +1,91 @@
+/// The category of an [AudiobookshelfException].
+///
+/// Lets the UI react to the *kind* of failure (re-prompt for credentials on
+/// [unauthorized], suggest checking the address on [notReachable]/
+/// [notAudiobookshelf]) without fragile matching on message text.
+enum AudiobookshelfErrorKind {
+  /// The address the user typed isn't a usable http(s) URL.
+  invalidUrl,
+
+  /// The server couldn't be reached at all (DNS, connection refused, TLS
+  /// handshake, or timeout). Often a wrong address or an offline tunnel.
+  notReachable,
+
+  /// The server answered but rejected the credentials (HTTP 401/403).
+  unauthorized,
+
+  /// Something answered, but it isn't an Audiobookshelf server (non-JSON
+  /// body, missing fields, or a Cloudflare/reverse-proxy error page).
+  notAudiobookshelf,
+
+  /// The Audiobookshelf server reported a server-side error (HTTP 5xx).
+  serverError,
+
+  /// Any other unexpected failure.
+  unexpected,
+}
+
+/// The single typed error the Audiobookshelf layer throws.
+///
+/// Mirrors how the Jellyfin/Subsonic/Plex layers each surface one typed
+/// exception: callers get a friendly, user-facing [message] plus a [kind] to
+/// branch on, instead of a raw HTTP/socket failure.
+///
+/// Security invariant: a message must NEVER contain the password or an
+/// access/refresh token. Do not add the request body or the `Authorization`
+/// header to any message here — the factories below intentionally carry only
+/// a status code and a generic, safe explanation.
+class AudiobookshelfException implements Exception {
+  const AudiobookshelfException(
+    this.message, {
+    this.kind = AudiobookshelfErrorKind.unexpected,
+    this.statusCode,
+  });
+
+  /// The typed address-format failure. The caller supplies a specific reason
+  /// (what was wrong with the input) since only it knows the context.
+  const AudiobookshelfException.invalidUrl(this.message)
+      : kind = AudiobookshelfErrorKind.invalidUrl,
+        statusCode = null;
+
+  factory AudiobookshelfException.notReachable() =>
+      const AudiobookshelfException(
+        "Couldn't reach the server. Check the address and that you're "
+        'online.',
+        kind: AudiobookshelfErrorKind.notReachable,
+      );
+
+  factory AudiobookshelfException.unauthorized() =>
+      const AudiobookshelfException(
+        'Your username or password was not accepted by the server.',
+        kind: AudiobookshelfErrorKind.unauthorized,
+        statusCode: 401,
+      );
+
+  factory AudiobookshelfException.notAudiobookshelf() =>
+      const AudiobookshelfException(
+        "That address responded, but it doesn't look like an Audiobookshelf "
+        'server. Double-check the URL.',
+        kind: AudiobookshelfErrorKind.notAudiobookshelf,
+      );
+
+  factory AudiobookshelfException.serverError(int statusCode) =>
+      AudiobookshelfException(
+        'The Audiobookshelf server reported an error (HTTP $statusCode). '
+        'Try again in a moment.',
+        kind: AudiobookshelfErrorKind.serverError,
+        statusCode: statusCode,
+      );
+
+  /// A user-facing explanation safe to show in the UI.
+  final String message;
+
+  /// What broadly went wrong, for the UI to branch on.
+  final AudiobookshelfErrorKind kind;
+
+  /// The HTTP status code, when the failure came from a response.
+  final int? statusCode;
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/sources/audiobookshelf/audiobookshelf_server_url.dart
+++ b/lib/core/sources/audiobookshelf/audiobookshelf_server_url.dart
@@ -1,0 +1,63 @@
+import '../server_url_normalizer.dart';
+import 'audiobookshelf_exception.dart';
+
+/// Validates and normalizes the server address the user types into the
+/// Audiobookshelf settings.
+///
+/// Intentionally pure string logic with no HTTP: it is the one place that
+/// decides what a "valid Audiobookshelf address" looks like, so the
+/// connection test and sign-in agree, and so the rules stay unit-testable
+/// without a network. The design choices mirror the self-hosted case Linthra
+/// already targets for Jellyfin/Plex/Subsonic:
+///  - A bare host (`audiobooks.example.com`) defaults to **https**, because a
+///    self-hosted server is usually reached over TLS and users rarely type
+///    the scheme.
+///  - A subpath is preserved (`example.com/audiobookshelf`), since reverse
+///    proxies often mount the server under one.
+///  - A trailing slash, query, and fragment are stripped so the result is a
+///    clean base to append API paths to.
+///
+/// The trim/scheme/host/port/path mechanics are shared with the other
+/// providers via [ServerUrlNormalizer]; only the user-facing error text below
+/// is Audiobookshelf-specific.
+abstract final class AudiobookshelfServerUrl {
+  /// Returns a clean base URL (no trailing slash) for [input], or throws an
+  /// [AudiobookshelfException] of kind [AudiobookshelfErrorKind.invalidUrl]
+  /// with a friendly reason when the address can't be used.
+  static String normalize(String input) {
+    final ParsedServerUrl parsed;
+    try {
+      parsed = ServerUrlNormalizer.parse(input);
+    } on ServerUrlParseFailure catch (failure) {
+      throw AudiobookshelfException.invalidUrl(_messageFor(failure.kind));
+    }
+    return parsed.toBase();
+  }
+
+  /// Like [normalize] but returns `null` instead of throwing, for callers
+  /// that only need a yes/no (e.g. enabling a button) and don't want the
+  /// reason.
+  static String? tryNormalize(String input) {
+    try {
+      return normalize(input);
+    } on AudiobookshelfException {
+      return null;
+    }
+  }
+
+  static String _messageFor(ServerUrlErrorKind kind) {
+    switch (kind) {
+      case ServerUrlErrorKind.empty:
+        return 'Enter your Audiobookshelf server address, e.g. '
+            'https://audiobooks.example.com';
+      case ServerUrlErrorKind.unparseable:
+        return "That doesn't look like a valid web address.";
+      case ServerUrlErrorKind.unsupportedScheme:
+        return 'The address must start with https:// (or http:// on a '
+            'local network).';
+      case ServerUrlErrorKind.emptyHost:
+        return 'The address is missing a server name, e.g. '
+            'audiobooks.example.com';
+    }
+  }
+}

--- a/lib/core/sources/audiobookshelf/http_audiobookshelf_client.dart
+++ b/lib/core/sources/audiobookshelf/http_audiobookshelf_client.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/audiobookshelf_session.dart';
+import 'audiobookshelf_api.dart';
+import 'audiobookshelf_client.dart';
+import 'audiobookshelf_endpoints.dart';
+import 'audiobookshelf_exception.dart';
+
+/// The real [AudiobookshelfClient], backed by `package:http`.
+///
+/// This is the only file in the app that constructs Audiobookshelf URLs, sets
+/// the auth header, and parses JSON for this provider. Every failure becomes
+/// an [AudiobookshelfException]; the password and both tokens are never
+/// written to an exception, so a leaked error string can't expose them.
+class HttpAudiobookshelfClient implements AudiobookshelfClient {
+  HttpAudiobookshelfClient({http.Client? httpClient})
+      : _client = httpClient ?? http.Client();
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(seconds: 20);
+
+  @override
+  Future<AudiobookshelfServerStatus> fetchServerStatus(
+    String baseUrl,
+  ) async {
+    final Uri uri = AudiobookshelfEndpoints.status(baseUrl);
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: const <String, String>{
+        'Accept': 'application/json',
+      }),
+    );
+    _checkStatus(response);
+    final AudiobookshelfServerStatus? status =
+        AudiobookshelfServerStatus.fromJson(_decodeObject(response));
+    if (status == null) {
+      throw AudiobookshelfException.notAudiobookshelf();
+    }
+    return status;
+  }
+
+  @override
+  Future<AudiobookshelfAuthResult> authenticateByName({
+    required String baseUrl,
+    required String username,
+    required String password,
+  }) async {
+    final Uri uri = AudiobookshelfEndpoints.login(baseUrl);
+    final http.Response response = await _send(
+      () => _client.post(
+        uri,
+        headers: const <String, String>{
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          // Without this header Audiobookshelf sets the refresh token as an
+          // httpOnly cookie instead of returning it in the body — a browser
+          // assumption this client (no cookie jar) can't rely on.
+          'x-return-tokens': 'true',
+        },
+        // Audiobookshelf's auth body (passport-local's default field names).
+        // The password lives only in this request and is never logged or
+        // echoed into an error.
+        body: jsonEncode(<String, String>{
+          'username': username,
+          'password': password,
+        }),
+      ),
+    );
+    _checkStatus(response);
+    final AudiobookshelfAuthResult? result =
+        AudiobookshelfAuthResult.fromJson(_decodeObject(response));
+    if (result == null) {
+      throw AudiobookshelfException.notAudiobookshelf();
+    }
+    return result;
+  }
+
+  @override
+  Future<List<AudiobookshelfLibraryDto>> fetchLibraries(
+    AudiobookshelfSession session,
+  ) async {
+    final Uri uri = AudiobookshelfEndpoints.libraries(session.baseUrl);
+    final http.Response response = await _send(
+      () => _client.get(uri, headers: <String, String>{
+        'Accept': 'application/json',
+        'Authorization': 'Bearer ${session.accessToken}',
+      }),
+    );
+    _checkStatus(response);
+    final Map<String, dynamic> json = _decodeObject(response);
+    final Object? rawLibraries = json['libraries'];
+    if (rawLibraries is! List) {
+      // A valid but empty account, or a shape we don't recognize — treat as
+      // no libraries rather than an error.
+      return const <AudiobookshelfLibraryDto>[];
+    }
+    final List<AudiobookshelfLibraryDto> libraries =
+        <AudiobookshelfLibraryDto>[];
+    for (final Object? entry in rawLibraries) {
+      if (entry is! Map<String, dynamic>) continue;
+      final AudiobookshelfLibraryDto? library =
+          AudiobookshelfLibraryDto.fromJson(entry);
+      // A single malformed entry is skipped, never thrown — one bad library
+      // record can't fail the whole listing.
+      if (library != null) libraries.add(library);
+    }
+    return libraries;
+  }
+
+  Future<http.Response> _send(
+    Future<http.Response> Function() request,
+  ) async {
+    try {
+      return await request().timeout(_timeout);
+    } on TimeoutException {
+      throw AudiobookshelfException.notReachable();
+    } on http.ClientException {
+      throw AudiobookshelfException.notReachable();
+    } on Exception {
+      // SocketException / HandshakeException and friends: all "can't reach
+      // it".
+      throw AudiobookshelfException.notReachable();
+    }
+  }
+
+  /// Maps an HTTP status to an [AudiobookshelfException]. 2xx passes;
+  /// everything else throws before the body is parsed, so error handling
+  /// never depends on response content (and never echoes it).
+  void _checkStatus(http.Response response) {
+    final int code = response.statusCode;
+    if (code >= 200 && code < 300) {
+      return;
+    }
+    if (code == 401 || code == 403) {
+      throw AudiobookshelfException.unauthorized();
+    }
+    if (code >= 500) {
+      throw AudiobookshelfException.serverError(code);
+    }
+    if (code == 408 || code == 429) {
+      // A request timeout or a rate-limit (often a Cloudflare/reverse-proxy
+      // 429) is transient, not a wrong address.
+      throw AudiobookshelfException.serverError(code);
+    }
+    // Other 4xx (wrong path, Cloudflare 4xx, …) usually mean the address
+    // isn't really an Audiobookshelf API root.
+    throw AudiobookshelfException.notAudiobookshelf();
+  }
+
+  /// Decodes a JSON object body, or throws
+  /// [AudiobookshelfErrorKind.notAudiobookshelf] when the body isn't JSON
+  /// (e.g. a Cloudflare/HTML error page) or isn't an object.
+  Map<String, dynamic> _decodeObject(http.Response response) {
+    Object? decoded;
+    try {
+      // Decode the raw bytes as UTF-8 rather than using `response.body`,
+      // which falls back to latin1 when the server omits a charset and would
+      // mangle non-ASCII titles and author names.
+      final String text = utf8.decode(response.bodyBytes, allowMalformed: true);
+      decoded = jsonDecode(text);
+    } on FormatException {
+      throw AudiobookshelfException.notAudiobookshelf();
+    }
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    throw AudiobookshelfException.notAudiobookshelf();
+  }
+}

--- a/test/core/models/audiobookshelf_session_test.dart
+++ b/test/core/models/audiobookshelf_session_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+
+const _session = AudiobookshelfSession(
+  baseUrl: 'https://audiobooks.example.com',
+  userId: 'user-1',
+  accessToken: 'tok-abc',
+  refreshToken: 'refresh-xyz',
+  userName: 'jon',
+  defaultLibraryId: 'lib-1',
+  serverVersion: '2.19.0',
+);
+
+void main() {
+  group('toJson / fromJson', () {
+    test('round-trips every field', () {
+      final Map<String, dynamic> json = _session.toJson();
+      final AudiobookshelfSession? rebuilt =
+          AudiobookshelfSession.fromJson(json);
+      expect(rebuilt, _session);
+    });
+
+    test('round-trips with the optional fields absent', () {
+      const minimal = AudiobookshelfSession(
+        baseUrl: 'https://audiobooks.example.com',
+        userId: 'user-1',
+        accessToken: 'tok-abc',
+      );
+      final AudiobookshelfSession? rebuilt =
+          AudiobookshelfSession.fromJson(minimal.toJson());
+      expect(rebuilt, minimal);
+      expect(rebuilt!.refreshToken, isNull);
+      expect(rebuilt.userName, isNull);
+      expect(rebuilt.defaultLibraryId, isNull);
+      expect(rebuilt.serverVersion, isNull);
+    });
+
+    test('a missing required field returns null instead of throwing', () {
+      expect(
+        AudiobookshelfSession.fromJson(<String, dynamic>{
+          'userId': 'user-1',
+          'accessToken': 'tok-abc',
+        }),
+        isNull,
+      );
+      expect(
+        AudiobookshelfSession.fromJson(<String, dynamic>{
+          'baseUrl': 'https://audiobooks.example.com',
+          'accessToken': 'tok-abc',
+        }),
+        isNull,
+      );
+      expect(
+        AudiobookshelfSession.fromJson(<String, dynamic>{
+          'baseUrl': 'https://audiobooks.example.com',
+          'userId': 'user-1',
+        }),
+        isNull,
+      );
+    });
+
+    test('an empty required field is treated as missing', () {
+      expect(
+        AudiobookshelfSession.fromJson(<String, dynamic>{
+          'baseUrl': '',
+          'userId': 'user-1',
+          'accessToken': 'tok-abc',
+        }),
+        isNull,
+      );
+    });
+  });
+
+  test('toString redacts both tokens', () {
+    final String rendered = _session.toString();
+    expect(rendered, isNot(contains('tok-abc')));
+    expect(rendered, isNot(contains('refresh-xyz')));
+    expect(rendered, contains('<redacted>'));
+    // Non-secret fields still show, so the redaction is real (not just an
+    // empty toString).
+    expect(rendered, contains('user-1'));
+    expect(rendered, contains('jon'));
+  });
+
+  test('copyWith overrides only the given fields', () {
+    final AudiobookshelfSession updated = _session.copyWith(
+      accessToken: 'tok-new',
+    );
+    expect(updated.accessToken, 'tok-new');
+    expect(updated.userId, _session.userId);
+    expect(updated.refreshToken, _session.refreshToken);
+  });
+
+  test('equality and hashCode are value-based', () {
+    const other = AudiobookshelfSession(
+      baseUrl: 'https://audiobooks.example.com',
+      userId: 'user-1',
+      accessToken: 'tok-abc',
+      refreshToken: 'refresh-xyz',
+      userName: 'jon',
+      defaultLibraryId: 'lib-1',
+      serverVersion: '2.19.0',
+    );
+    expect(_session, other);
+    expect(_session.hashCode, other.hashCode);
+  });
+}

--- a/test/core/models/audiobookshelf_session_test.dart
+++ b/test/core/models/audiobookshelf_session_test.dart
@@ -69,6 +69,47 @@ void main() {
         isNull,
       );
     });
+
+    test('a wrong-typed required field returns null instead of throwing', () {
+      expect(
+        () => AudiobookshelfSession.fromJson(<String, dynamic>{
+          'baseUrl': 12345,
+          'userId': 'user-1',
+          'accessToken': 'tok-abc',
+        }),
+        returnsNormally,
+      );
+      expect(
+        AudiobookshelfSession.fromJson(<String, dynamic>{
+          'baseUrl': 12345,
+          'userId': 'user-1',
+          'accessToken': 'tok-abc',
+        }),
+        isNull,
+      );
+      expect(
+        AudiobookshelfSession.fromJson(<String, dynamic>{
+          'baseUrl': 'https://audiobooks.example.com',
+          'userId': <String, dynamic>{'not': 'a string'},
+          'accessToken': 'tok-abc',
+        }),
+        isNull,
+      );
+    });
+
+    test('a wrong-typed optional field is treated as absent, not a crash', () {
+      final AudiobookshelfSession? rebuilt =
+          AudiobookshelfSession.fromJson(<String, dynamic>{
+        'baseUrl': 'https://audiobooks.example.com',
+        'userId': 'user-1',
+        'accessToken': 'tok-abc',
+        'serverVersion': 2.19,
+        'defaultLibraryId': true,
+      });
+      expect(rebuilt, isNotNull);
+      expect(rebuilt!.serverVersion, isNull);
+      expect(rebuilt.defaultLibraryId, isNull);
+    });
   });
 
   test('toString redacts both tokens', () {

--- a/test/core/sources/audiobookshelf/audiobookshelf_authenticator_test.dart
+++ b/test/core/sources/audiobookshelf/audiobookshelf_authenticator_test.dart
@@ -47,7 +47,10 @@ void main() {
 
   group('signIn', () {
     test('signs in and builds a session from the result', () async {
-      final fake = FakeAudiobookshelfClient(authResult: _authResult);
+      final fake = FakeAudiobookshelfClient(
+        serverStatus: _status,
+        authResult: _authResult,
+      );
       final authenticator = AudiobookshelfAuthenticator(fake);
 
       final AudiobookshelfSession session = await authenticator.signIn(
@@ -101,22 +104,24 @@ void main() {
     });
 
     test(
-        'a status-fetch failure does not block sign-in — the auth call is '
-        'the real gate', () async {
+        'a status-fetch failure blocks sign-in, credentials are never sent '
+        'to an unconfirmed address', () async {
       final fake = FakeAudiobookshelfClient(
         authResult: _authResult,
         serverStatusError: AudiobookshelfException.notReachable(),
       );
       final authenticator = AudiobookshelfAuthenticator(fake);
 
-      final session = await authenticator.signIn(
-        rawUrl: 'audiobooks.example.com',
-        username: 'jon',
-        password: 'hunter2',
+      expect(
+        () => authenticator.signIn(
+          rawUrl: 'audiobooks.example.com',
+          username: 'jon',
+          password: 'hunter2',
+        ),
+        throwsA(isA<AudiobookshelfException>()),
       );
-
-      expect(session.userId, 'user-1');
-      expect(session.serverVersion, isNull);
+      expect(fake.lastUsername, isNull);
+      expect(fake.lastPassword, isNull);
     });
 
     test('an empty username is rejected before any request is made', () async {
@@ -143,6 +148,7 @@ void main() {
     test('rejected credentials surface as the client\'s own exception',
         () async {
       final fake = FakeAudiobookshelfClient(
+        serverStatus: _status,
         authError: AudiobookshelfException.unauthorized(),
       );
       final authenticator = AudiobookshelfAuthenticator(fake);

--- a/test/core/sources/audiobookshelf/audiobookshelf_authenticator_test.dart
+++ b/test/core/sources/audiobookshelf/audiobookshelf_authenticator_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_authenticator.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+
+import 'fake_audiobookshelf_client.dart';
+
+const _status = AudiobookshelfServerStatus(
+  serverVersion: '2.19.0',
+  isInitialized: true,
+);
+
+const _authResult = AudiobookshelfAuthResult(
+  userId: 'user-1',
+  accessToken: 'tok-abc',
+  refreshToken: 'refresh-xyz',
+  userName: 'jon',
+  defaultLibraryId: 'lib-1',
+);
+
+void main() {
+  group('testConnection', () {
+    test('normalizes the URL and returns the server status', () async {
+      final fake = FakeAudiobookshelfClient(serverStatus: _status);
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      final status = await authenticator.testConnection(
+        'audiobooks.example.com',
+      );
+
+      expect(status.serverVersion, '2.19.0');
+      expect(fake.lastBaseUrl, 'https://audiobooks.example.com');
+    });
+
+    test('a bad address throws before any request is made', () async {
+      final fake = FakeAudiobookshelfClient();
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      expect(
+        () => authenticator.testConnection('   '),
+        throwsA(isA<AudiobookshelfException>()),
+      );
+      expect(fake.lastBaseUrl, isNull);
+    });
+  });
+
+  group('signIn', () {
+    test('signs in and builds a session from the result', () async {
+      final fake = FakeAudiobookshelfClient(authResult: _authResult);
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      final AudiobookshelfSession session = await authenticator.signIn(
+        rawUrl: 'audiobooks.example.com',
+        username: 'jon',
+        password: 'hunter2',
+      );
+
+      expect(session.baseUrl, 'https://audiobooks.example.com');
+      expect(session.userId, 'user-1');
+      expect(session.accessToken, 'tok-abc');
+      expect(session.refreshToken, 'refresh-xyz');
+      expect(session.userName, 'jon');
+      expect(session.defaultLibraryId, 'lib-1');
+      expect(fake.lastUsername, 'jon');
+      expect(fake.lastPassword, 'hunter2');
+    });
+
+    test('reuses a supplied serverStatus instead of fetching it again',
+        () async {
+      final fake = FakeAudiobookshelfClient(authResult: _authResult);
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      final session = await authenticator.signIn(
+        rawUrl: 'audiobooks.example.com',
+        username: 'jon',
+        password: 'hunter2',
+        serverStatus: _status,
+      );
+
+      expect(session.serverVersion, '2.19.0');
+      // Never called: the supplied status was reused, not re-fetched.
+      expect(fake.serverStatusCallCount, 0);
+    });
+
+    test('reads server status itself when none is supplied', () async {
+      final fake = FakeAudiobookshelfClient(
+        serverStatus: _status,
+        authResult: _authResult,
+      );
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      final session = await authenticator.signIn(
+        rawUrl: 'audiobooks.example.com',
+        username: 'jon',
+        password: 'hunter2',
+      );
+
+      expect(session.serverVersion, '2.19.0');
+      expect(fake.serverStatusCallCount, 1);
+    });
+
+    test(
+        'a status-fetch failure does not block sign-in — the auth call is '
+        'the real gate', () async {
+      final fake = FakeAudiobookshelfClient(
+        authResult: _authResult,
+        serverStatusError: AudiobookshelfException.notReachable(),
+      );
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      final session = await authenticator.signIn(
+        rawUrl: 'audiobooks.example.com',
+        username: 'jon',
+        password: 'hunter2',
+      );
+
+      expect(session.userId, 'user-1');
+      expect(session.serverVersion, isNull);
+    });
+
+    test('an empty username is rejected before any request is made', () async {
+      final fake = FakeAudiobookshelfClient(authResult: _authResult);
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      expect(
+        () => authenticator.signIn(
+          rawUrl: 'audiobooks.example.com',
+          username: '   ',
+          password: 'hunter2',
+        ),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.unauthorized,
+          ),
+        ),
+      );
+      expect(fake.lastUsername, isNull);
+    });
+
+    test('rejected credentials surface as the client\'s own exception',
+        () async {
+      final fake = FakeAudiobookshelfClient(
+        authError: AudiobookshelfException.unauthorized(),
+      );
+      final authenticator = AudiobookshelfAuthenticator(fake);
+
+      expect(
+        () => authenticator.signIn(
+          rawUrl: 'audiobooks.example.com',
+          username: 'jon',
+          password: 'wrong',
+        ),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.unauthorized,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/core/sources/audiobookshelf/audiobookshelf_server_url_test.dart
+++ b/test/core/sources/audiobookshelf/audiobookshelf_server_url_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_server_url.dart';
+
+void main() {
+  group('AudiobookshelfServerUrl.normalize', () {
+    test('defaults a bare host to https (the common self-hosted default)', () {
+      expect(
+        AudiobookshelfServerUrl.normalize('audiobooks.example.com'),
+        'https://audiobooks.example.com',
+      );
+    });
+
+    test('keeps an explicit http scheme (local network)', () {
+      expect(
+        AudiobookshelfServerUrl.normalize('http://192.168.1.20:13378'),
+        'http://192.168.1.20:13378',
+      );
+    });
+
+    test('preserves a reverse-proxy subpath', () {
+      expect(
+        AudiobookshelfServerUrl.normalize(
+          'https://example.com/audiobookshelf',
+        ),
+        'https://example.com/audiobookshelf',
+      );
+    });
+
+    test('strips a trailing slash, query, and fragment', () {
+      expect(
+        AudiobookshelfServerUrl.normalize(
+          'https://audiobooks.example.com/?x=1#y',
+        ),
+        'https://audiobooks.example.com',
+      );
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(
+        AudiobookshelfServerUrl.normalize('  audiobooks.example.com  '),
+        'https://audiobooks.example.com',
+      );
+    });
+
+    test('lowercases the host', () {
+      expect(
+        AudiobookshelfServerUrl.normalize('https://Audiobooks.Example.COM'),
+        'https://audiobooks.example.com',
+      );
+    });
+
+    test('brackets an IPv6 literal host', () {
+      expect(
+        AudiobookshelfServerUrl.normalize('http://[::1]:13378'),
+        'http://[::1]:13378',
+      );
+    });
+
+    test('rejects an empty address', () {
+      expect(
+        () => AudiobookshelfServerUrl.normalize('   '),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.invalidUrl,
+          ),
+        ),
+      );
+    });
+
+    test('rejects a non-http(s) scheme', () {
+      expect(
+        () => AudiobookshelfServerUrl.normalize('ftp://example.com'),
+        throwsA(isA<AudiobookshelfException>()),
+      );
+    });
+
+    test('rejects a scheme with no host', () {
+      expect(
+        () => AudiobookshelfServerUrl.normalize('https://'),
+        throwsA(isA<AudiobookshelfException>()),
+      );
+    });
+  });
+
+  group('AudiobookshelfServerUrl.tryNormalize', () {
+    test('returns the normalized URL when valid', () {
+      expect(
+        AudiobookshelfServerUrl.tryNormalize('example.com'),
+        'https://example.com',
+      );
+    });
+
+    test('returns null when invalid instead of throwing', () {
+      expect(AudiobookshelfServerUrl.tryNormalize('   '), isNull);
+      expect(AudiobookshelfServerUrl.tryNormalize('ftp://x'), isNull);
+    });
+  });
+}

--- a/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
+++ b/test/core/sources/audiobookshelf/fake_audiobookshelf_client.dart
@@ -1,0 +1,76 @@
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_api.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_client.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+
+/// A configurable [AudiobookshelfClient] that returns canned responses (or
+/// throws) and records what it was asked, so the authenticator can be tested
+/// without a real server or HTTP.
+class FakeAudiobookshelfClient implements AudiobookshelfClient {
+  FakeAudiobookshelfClient({
+    this.serverStatus,
+    this.authResult,
+    this.libraries = const <AudiobookshelfLibraryDto>[],
+    this.serverStatusError,
+    this.authError,
+    this.librariesError,
+  });
+
+  AudiobookshelfServerStatus? serverStatus;
+  AudiobookshelfAuthResult? authResult;
+  List<AudiobookshelfLibraryDto> libraries;
+  AudiobookshelfException? serverStatusError;
+  AudiobookshelfException? authError;
+  AudiobookshelfException? librariesError;
+
+  // Recorded inputs.
+  String? lastBaseUrl;
+  String? lastUsername;
+  String? lastPassword;
+  AudiobookshelfSession? lastSession;
+
+  /// How many times [fetchServerStatus] was called, so a test can prove the
+  /// authenticator reuses a status the caller already fetched instead of
+  /// asking again.
+  int serverStatusCallCount = 0;
+
+  @override
+  Future<AudiobookshelfServerStatus> fetchServerStatus(
+    String baseUrl,
+  ) async {
+    lastBaseUrl = baseUrl;
+    serverStatusCallCount++;
+    if (serverStatusError != null) throw serverStatusError!;
+    final AudiobookshelfServerStatus? status = serverStatus;
+    if (status == null) {
+      throw AudiobookshelfException.notReachable();
+    }
+    return status;
+  }
+
+  @override
+  Future<AudiobookshelfAuthResult> authenticateByName({
+    required String baseUrl,
+    required String username,
+    required String password,
+  }) async {
+    lastBaseUrl = baseUrl;
+    lastUsername = username;
+    lastPassword = password;
+    if (authError != null) throw authError!;
+    final AudiobookshelfAuthResult? result = authResult;
+    if (result == null) {
+      throw AudiobookshelfException.unauthorized();
+    }
+    return result;
+  }
+
+  @override
+  Future<List<AudiobookshelfLibraryDto>> fetchLibraries(
+    AudiobookshelfSession session,
+  ) async {
+    lastSession = session;
+    if (librariesError != null) throw librariesError!;
+    return libraries;
+  }
+}

--- a/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
+++ b/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
@@ -65,6 +65,23 @@ void main() {
       expect(status.serverVersion, '2.19.0');
     });
 
+    test(
+        'accepts a pre-v2.6.0 server, which sends neither app nor '
+        'serverVersion', () async {
+      // Confirmed against the real /status handler at release tags v2.2.0
+      // and v2.5.0: only isInit (and, from v2.5.0, language) was sent before
+      // app/serverVersion were added in v2.6.0. A server still running one
+      // of those versions must not be rejected as "not Audiobookshelf".
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{'isInit': true, 'language': 'en-us'});
+      }));
+
+      final status = await client.fetchServerStatus(_base);
+
+      expect(status.isInitialized, isTrue);
+      expect(status.serverVersion, isNull);
+    });
+
     test('throws notAudiobookshelf when app is not "audiobookshelf"', () async {
       final client = _client(MockClient((_) async {
         return _json(<String, dynamic>{

--- a/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
+++ b/test/core/sources/audiobookshelf/http_audiobookshelf_client_test.dart
@@ -1,0 +1,254 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:linthra/core/models/audiobookshelf_session.dart';
+import 'package:linthra/core/sources/audiobookshelf/audiobookshelf_exception.dart';
+import 'package:linthra/core/sources/audiobookshelf/http_audiobookshelf_client.dart';
+
+const String _base = 'https://audiobooks.example.com';
+
+const _session = AudiobookshelfSession(
+  baseUrl: _base,
+  userId: 'user-1',
+  accessToken: 'tok-abc',
+);
+
+HttpAudiobookshelfClient _client(MockClient mock) =>
+    HttpAudiobookshelfClient(httpClient: mock);
+
+http.Response _json(Map<String, dynamic> body, {int status = 200}) =>
+    http.Response(
+      jsonEncode(body),
+      status,
+      headers: <String, String>{'content-type': 'application/json'},
+    );
+
+void main() {
+  group('fetchServerStatus', () {
+    test('parses status and calls the right endpoint', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _json(<String, dynamic>{
+          'app': 'audiobookshelf',
+          'serverVersion': '2.19.0',
+          'isInit': true,
+        });
+      }));
+
+      final status = await client.fetchServerStatus(_base);
+
+      expect(status.serverVersion, '2.19.0');
+      expect(status.isInitialized, isTrue);
+      expect(captured!.method, 'GET');
+      expect(captured!.url.path, '/status');
+    });
+
+    test('decodes a UTF-8 body without a charset header', () async {
+      // A server sending raw UTF-8 bytes and no charset: `response.body`
+      // would mis-decode this as latin1; the client decodes bodyBytes as
+      // UTF-8. Nothing in /status is actually non-ASCII, but this exercises
+      // the same decode path every response goes through.
+      final client = _client(MockClient((_) async {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<String, dynamic>{
+            'app': 'audiobookshelf',
+            'serverVersion': '2.19.0',
+          })),
+          200,
+        );
+      }));
+
+      final status = await client.fetchServerStatus(_base);
+      expect(status.serverVersion, '2.19.0');
+    });
+
+    test('throws notAudiobookshelf when app is not "audiobookshelf"', () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{
+          'app': 'something-else',
+          'serverVersion': '1.0.0',
+        });
+      }));
+
+      expect(
+        () => client.fetchServerStatus(_base),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.notAudiobookshelf,
+          ),
+        ),
+      );
+    });
+
+    test(
+        'throws notAudiobookshelf on a non-JSON body (e.g. an HTML error '
+        'page)', () async {
+      final client = _client(MockClient((_) async {
+        return http.Response('<html>not found</html>', 200);
+      }));
+
+      expect(
+        () => client.fetchServerStatus(_base),
+        throwsA(isA<AudiobookshelfException>()),
+      );
+    });
+
+    test('maps a 5xx to serverError', () async {
+      final client = _client(MockClient((_) async {
+        return http.Response('', 503);
+      }));
+
+      expect(
+        () => client.fetchServerStatus(_base),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.serverError,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('authenticateByName', () {
+    test('sends the right body/headers and parses the result', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _json(<String, dynamic>{
+          'user': <String, dynamic>{
+            'id': 'user-1',
+            'username': 'jon',
+            'accessToken': 'tok-abc',
+            'refreshToken': 'refresh-xyz',
+          },
+          'userDefaultLibraryId': 'lib-1',
+        });
+      }));
+
+      final result = await client.authenticateByName(
+        baseUrl: _base,
+        username: 'jon',
+        password: 'hunter2',
+      );
+
+      expect(result.userId, 'user-1');
+      expect(result.accessToken, 'tok-abc');
+      expect(result.refreshToken, 'refresh-xyz');
+      expect(result.userName, 'jon');
+      expect(result.defaultLibraryId, 'lib-1');
+
+      expect(captured!.method, 'POST');
+      expect(captured!.url.path, '/login');
+      expect(captured!.headers['x-return-tokens'], 'true');
+      final Map<String, dynamic> sentBody =
+          jsonDecode(captured!.body) as Map<String, dynamic>;
+      expect(sentBody['username'], 'jon');
+      expect(sentBody['password'], 'hunter2');
+    });
+
+    test('a missing refreshToken is null, not an error (cookie-only flow)',
+        () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{
+          'user': <String, dynamic>{
+            'id': 'user-1',
+            'username': 'jon',
+            'accessToken': 'tok-abc',
+          },
+        });
+      }));
+
+      final result = await client.authenticateByName(
+        baseUrl: _base,
+        username: 'jon',
+        password: 'hunter2',
+      );
+      expect(result.refreshToken, isNull);
+    });
+
+    test('rejected credentials map to unauthorized', () async {
+      final client = _client(MockClient((_) async {
+        return http.Response('', 401);
+      }));
+
+      expect(
+        () => client.authenticateByName(
+          baseUrl: _base,
+          username: 'jon',
+          password: 'wrong',
+        ),
+        throwsA(
+          isA<AudiobookshelfException>().having(
+            (AudiobookshelfException e) => e.kind,
+            'kind',
+            AudiobookshelfErrorKind.unauthorized,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('fetchLibraries', () {
+    test('parses the libraries array and sends the bearer token', () async {
+      http.Request? captured;
+      final client = _client(MockClient((http.Request request) async {
+        captured = request;
+        return _json(<String, dynamic>{
+          'libraries': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'id': 'lib-1',
+              'name': 'Audiobooks',
+              'mediaType': 'book',
+            },
+            <String, dynamic>{
+              'id': 'lib-2',
+              'name': 'Podcasts',
+              'mediaType': 'podcast',
+            },
+          ],
+        });
+      }));
+
+      final libraries = await client.fetchLibraries(_session);
+
+      expect(libraries, hasLength(2));
+      expect(libraries[0].id, 'lib-1');
+      expect(libraries[0].name, 'Audiobooks');
+      expect(libraries[0].mediaType, 'book');
+      expect(captured!.headers['Authorization'], 'Bearer tok-abc');
+      expect(captured!.url.path, '/api/libraries');
+    });
+
+    test('skips a malformed entry instead of failing the whole listing',
+        () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{
+          'libraries': <Map<String, dynamic>>[
+            <String, dynamic>{'id': 'lib-1', 'name': 'Audiobooks'},
+            <String, dynamic>{'name': 'missing id'},
+          ],
+        });
+      }));
+
+      final libraries = await client.fetchLibraries(_session);
+      expect(libraries, hasLength(1));
+      expect(libraries.single.id, 'lib-1');
+    });
+
+    test('an unrecognized shape returns an empty list, not an error', () async {
+      final client = _client(MockClient((_) async {
+        return _json(<String, dynamic>{'somethingElse': true});
+      }));
+
+      final libraries = await client.fetchLibraries(_session);
+      expect(libraries, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
First slice of #484. Just the connection layer, no playback, no chapters, no domain model changes, exactly milestone 1 from the plan.

Mirrors the shape of the existing Jellyfin/Plex/Subsonic providers: a session model, a typed exception, a server URL validator built on the shared normalizer from #479 (so a future fix there covers this provider too), an endpoints file, an HTTP client behind an interface, and an authenticator coordinating testConnection/signIn.

Didn't want to guess at the request shapes from docs, so I actually went and read Audiobookshelf's own server source before writing any client code. Two things worth flagging since they're easy to get wrong otherwise:

POST /login needs an x-return-tokens: true header or the refresh token only comes back as an httpOnly cookie, which is useless for a client with no cookie jar. Found that by reading Auth.js's handleLoginSuccess directly.

GET /status includes app: "audiobookshelf" in the response, so fetchServerStatus uses that to confirm the address is genuinely an Audiobookshelf server before any credentials go out, same role Jellyfin's product-name check plays for that provider.

38 new tests (server URL validation, the HTTP client against realistic canned JSON, the authenticator's coordination logic through a fake client, session model round-tripping), all green. flutter analyze and dart format both clean.