### PR TITLE
fix : handle Linux server disappearance during playback.

### DIFF
--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -126,6 +126,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// recovers without ever looping forever on a real outage/expiry.
   static const int _maxStreamRetries = 1;
 
+  /// How long a mid-stream re-buffer may persist before it is treated as a dead
+  /// stream. Prevents an unreachable server from leaving the UI stuck on
+  /// "Buffering…" when the engine never surfaces an error. Set shorter in tests.
+  static const Duration _defaultMidStreamBufferingTimeout =
+      Duration(seconds: 30);
+
   final AudioPlayer _player;
   final PlayableUriResolver _resolver;
 
@@ -242,6 +248,21 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   // failure. Reset when a fresh track loads and when playback reaches `playing`,
   // so each track (and each successful stretch) gets its own one-retry budget.
   int _retriesForCurrent = 0;
+
+  /// Whether a mid-stream recovery (bounded retry or sibling fallback) is
+  /// already running. Set synchronously before the async work starts so a
+  /// concurrent watchdog timeout and engine error cannot both drive recovery.
+  bool _streamRecoveryInFlight = false;
+
+  /// Fires when a mid-stream [PlaybackStatus.buffering] outlasts
+  /// [midStreamBufferingTimeout], turning a silent stall into a recoverable
+  /// failure. Null when not buffering.
+  Timer? _bufferingWatchdog;
+
+  /// How long mid-stream buffering may last before [_onBufferingTimeout]
+  /// runs. Never changed in production; tests set this to keep runs fast.
+  @visibleForTesting
+  Duration midStreamBufferingTimeout = _defaultMidStreamBufferingTimeout;
 
   // Guards against overlapping playback transitions. Every action that changes
   // what's playing — skip to next/previous, jump within the queue or history,
@@ -648,7 +669,20 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // unaffected.
     if (status == PlaybackStatus.idle) return;
     // Playback is healthy again: give a later, independent drop a fresh retry.
-    if (status == PlaybackStatus.playing) _retriesForCurrent = 0;
+    // Do not reset while a mid-stream recovery is still loading — a stale
+    // ready/playing event from setUrl must not refill the retry budget mid-attempt.
+    if (status == PlaybackStatus.playing) {
+      if (!_streamRecoveryInFlight) {
+        _retriesForCurrent = 0;
+      }
+      _cancelBufferingWatchdog();
+    }
+    if (status == PlaybackStatus.buffering &&
+        _state.status == PlaybackStatus.playing) {
+      // A mid-stream re-buffer on a track that was playing: arm the watchdog so
+      // a server that vanishes without an engine error can't hang forever.
+      _armBufferingWatchdog();
+    }
     // When a track finishes, what happens next depends on the repeat mode.
     if (status == PlaybackStatus.completed) {
       _onCompleted();
@@ -659,39 +693,167 @@ class JustAudioPlaybackController implements LocalPlaybackController {
 
   /// Recovers from an engine error that happens **while streaming**. A transient
   /// drop gets one bounded retry that re-resolves and reloads at the preserved
-  /// position; an auth/format failure (or an exhausted retry) shows a friendly,
-  /// secret-free message. The raw [error] (which can carry a tokenized URL) is
-  /// never logged or surfaced — only its classification is used.
+  /// position; when that is exhausted, sibling source candidates are tried once
+  /// at the same position. An auth/format failure (or an exhausted fallback)
+  /// shows a friendly, secret-free message. The raw [error] (which can carry a
+  /// tokenized URL) is never logged or surfaced — only its classification is
+  /// used.
   void _onEngineError(Object error, StackTrace _) {
-    // A cast receiver owns the audio while suspended: never touch local
-    // playback, so a local engine glitch can't pull output back from the
-    // receiver or start duplicate audio.
     if (_suspended) return;
-    // Only recover from a failure that happens once we're actually streaming; an
-    // initial-load failure is handled where setUrl is awaited (with its own
-    // friendly message), so we don't fight it here.
     if (_state.status != PlaybackStatus.playing &&
         _state.status != PlaybackStatus.buffering) {
       return;
     }
+    _handleStreamFailure(classifyEngineError(error));
+  }
+
+  /// Shared recovery for a classified mid-stream failure (from the engine or
+  /// from a buffering watchdog timeout when the server never answers).
+  ///
+  /// Coalesces concurrent triggers: only one recovery runs at a time. A second
+  /// failure that arrives while retry/fallback is already in flight is ignored
+  /// so it cannot start a duplicate `_playCurrent` or candidate pass.
+  void _handleStreamFailure(StreamInterruption interruption) {
+    unawaited(_beginStreamRecovery(interruption));
+  }
+
+  /// Runs the single shared mid-stream recovery path. Returns immediately when
+  /// another recovery is already in flight (or when there is nothing to recover).
+  Future<void> _beginStreamRecovery(StreamInterruption interruption) async {
+    if (_suspended) return;
+    if (_streamRecoveryInFlight) return;
     final Track? track = _queue.current;
     if (track == null) return;
 
-    final StreamInterruption interruption = classifyEngineError(error);
-    // Secret-free breadcrumb: only the classified *kind*, never the raw error
-    // (which can echo a tokenized stream URL).
+    // Claim the gate before any await so a racing engine error / watchdog
+    // timeout cannot start a second recovery.
+    _streamRecoveryInFlight = true;
+    _cancelBufferingWatchdog();
     StabilityDiagnostics.playbackError(interruption.kind.name);
-    if (interruption.retryable && _retriesForCurrent < _maxStreamRetries) {
-      _retriesForCurrent++;
-      // Re-resolve and reload at the preserved position. The resolver re-checks
-      // the session/server, so a real expiry/outage surfaces a precise friendly
-      // error while a transient blip simply recovers. setUrl replaces the
-      // source, so there is no duplicate playback and no jump to the start.
-      unawaited(_playCurrent(startAt: _state.position, isRetry: true));
+    try {
+      if (interruption.retryable && _retriesForCurrent < _maxStreamRetries) {
+        _retriesForCurrent++;
+        await _playCurrent(startAt: _state.position, isRetry: true);
+        return;
+      }
+      await _tryRemainingCandidatesOrError(track, interruption.message);
+    } finally {
+      _streamRecoveryInFlight = false;
+      // Recovery may finish while the UI is still on buffering (setUrl/play
+      // issued, engine quiet). Re-arm so that hang cannot outlive the bound;
+      // [_streamRecoveryInFlight] is clear, so a later timeout can run. No-ops
+      // when we already left buffering (playing / error / loading).
+      _armBufferingWatchdogIfBuffering();
+    }
+  }
+
+  /// Arms a one-shot watchdog while the engine is mid-stream buffering. If it
+  /// fires, the stall is treated like a server that stopped responding.
+  void _armBufferingWatchdog() {
+    _cancelBufferingWatchdog();
+    _bufferingWatchdog = Timer(midStreamBufferingTimeout, _onBufferingTimeout);
+  }
+
+  /// Arms the buffering watchdog only when status is already mid-stream
+  /// buffering — never for initial [PlaybackStatus.loading].
+  void _armBufferingWatchdogIfBuffering() {
+    if (_state.status != PlaybackStatus.buffering) return;
+    _armBufferingWatchdog();
+  }
+
+  void _cancelBufferingWatchdog() {
+    _bufferingWatchdog?.cancel();
+    _bufferingWatchdog = null;
+  }
+
+  void _onBufferingTimeout() {
+    _bufferingWatchdog = null;
+    if (_suspended) return;
+    if (_state.status != PlaybackStatus.buffering) return;
+    if (_queue.current == null) return;
+    _handleStreamFailure(
+      const StreamInterruption(
+        StreamInterruptionKind.serverUnreachable,
+        "Couldn't reach your music server. Check your connection and try again.",
+        retryable: true,
+      ),
+    );
+  }
+
+  /// After a mid-stream retry budget is spent, tries any sibling source copies
+  /// not yet attempted for the current track, then emits an error.
+  Future<void> _tryRemainingCandidatesOrError(
+    Track track,
+    String message,
+  ) async {
+    final Track? current = _queue.current;
+    final List<Track> candidates = _candidates.candidatesFor(track);
+    final int playedIndex = current == null
+        ? -1
+        : candidates.indexWhere((Track t) => t.uri == current.uri);
+    final List<Track> remaining =
+        playedIndex < 0 || playedIndex + 1 >= candidates.length
+            ? const <Track>[]
+            : candidates.sublist(playedIndex + 1);
+
+    if (remaining.isEmpty) {
+      _emitError(track, message);
       return;
     }
-    _emitError(track, interruption.message);
+
+    final int generation = ++_playbackGeneration;
+    final Duration startAt = _state.position;
+    _emit(_state.copyWith(status: PlaybackStatus.buffering));
+    // Controller-driven mid-stream buffering (not playing→buffering): still
+    // bound the hang so fallback cannot wait forever without an engine error.
+    _armBufferingWatchdog();
+
+    final ({Track track, ResolvedPlayable resolved})? outcome;
+    try {
+      outcome = await _loadFirstWorkingCandidate(remaining, generation);
+    } on PlaybackResolutionException catch (error) {
+      if (generation != _playbackGeneration) return;
+      _emitError(track, error.message);
+      return;
+    }
+
+    if (outcome == null || generation != _playbackGeneration) return;
+
+    final Track played = outcome.track;
+    final bool swappedProvider = played.uri != track.uri;
+    if (swappedProvider) _queue = _queue.replaceCurrent(played);
+    _emit(
+      _state.copyWith(
+        currentTrack: played,
+        source: outcome.resolved.source,
+        upNext: _queue.upNext,
+        previous: _queue.history,
+        hasPrevious: _queue.hasPrevious,
+      ),
+      force: swappedProvider,
+    );
+    await _applyVolume();
+    if (startAt > Duration.zero) await _player.seek(startAt);
+    if (generation != _playbackGeneration) return;
+    unawaited(_player.play());
   }
+
+  /// Drives [_handleStreamFailure] from a test without a platform engine error.
+  @visibleForTesting
+  void handleStreamFailureForTesting(StreamInterruption interruption) =>
+      _handleStreamFailure(interruption);
+
+  /// Like [handleStreamFailureForTesting], but awaits the shared recovery path
+  /// so tests can chain failures deterministically after each attempt finishes.
+  @visibleForTesting
+  Future<void> handleStreamFailureForTestingAsync(
+    StreamInterruption interruption,
+  ) =>
+      _beginStreamRecovery(interruption);
+
+  /// Drives [_onBufferingTimeout] from a test without waiting on a timer.
+  @visibleForTesting
+  void onBufferingTimeoutForTesting() => _onBufferingTimeout();
 
   /// Maps the engine's (playing, processingState) pair to a [PlaybackStatus].
   ///
@@ -974,6 +1136,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // A fresh load (or retry) establishes a new position baseline; drop any
     // coalesced tick from the previous source so it can't flush onto it.
     _resetPositionFlush();
+    _cancelBufferingWatchdog();
 
     // A fresh (non-retry) load starts a new track or a deliberate (re)play, so
     // reset the mid-stream recovery budget. A retry must keep its counter.
@@ -1002,6 +1165,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
       // visible and show a calm buffering state, rather than blanking to a fresh
       // load (which would look like the track jumped back to the start).
       _emit(_state.copyWith(status: PlaybackStatus.buffering));
+      // Bound this recovery buffering: playing→buffering is not observed here.
+      _armBufferingWatchdog();
     } else {
       // Reset position/duration up front so the UI doesn't show the previous
       // track's progress while the new one loads.
@@ -1212,6 +1377,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// Emits an error state for [track] carrying a friendly [message], preserving
   /// the queue context so the UI keeps showing the right track and up-next.
   void _emitError(Track track, String message) {
+    _cancelBufferingWatchdog();
     _emit(PlaybackState(
       status: PlaybackStatus.error,
       currentTrack: track,
@@ -1265,6 +1431,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     _resumeAfterTransientLoss = false;
     _supersedeFocusTransport();
     _restoreDuckedVolume();
+    // After a server outage the engine may be in error with no loaded source.
+    // Re-resolve at the preserved position so a returned server (or a sibling
+    // copy) can recover without rebuilding the queue.
+    if (_state.status == PlaybackStatus.error && _queue.current != null) {
+      _retriesForCurrent = 0;
+      await _playCurrent(startAt: _state.position);
+      return;
+    }
     // play()'s future completes when playback ends, so we don't await it.
     unawaited(_player.play());
   }
@@ -1313,6 +1487,7 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   @override
   Future<void> dispose() async {
     _resetPositionFlush();
+    _cancelBufferingWatchdog();
     _cancelPendingFocusPause();
     await _interruptionSub?.cancel();
     await _becomingNoisySub?.cancel();

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -403,14 +405,40 @@ class _SourceOrError extends ConsumerWidget {
     }
 
     if (state.status == PlaybackStatus.error) {
-      return Text(
-        state.errorMessage ?? "Couldn't play this track",
-        style: theme.textTheme.bodyMedium?.copyWith(
-          color: theme.colorScheme.error,
-        ),
-        textAlign: TextAlign.center,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              state.errorMessage ?? "Couldn't play this track",
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (state.currentTrack != null) ...[
+            const SizedBox(width: AppSpacing.xs),
+            TextButton(
+              onPressed: () =>
+                  unawaited(ref.read(playbackControllerProvider).play()),
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: Text(
+                'Retry',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
+        ],
       );
     }
     // A mid-stream re-buffer: a calm "Buffering…" hint rather than the source

--- a/test/core/services/just_audio_playback_controller_stream_recovery_test.dart
+++ b/test/core/services/just_audio_playback_controller_stream_recovery_test.dart
@@ -1,0 +1,497 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/playback_candidate_source.dart';
+import 'package:linthra/core/services/stream_interruption.dart';
+
+/// Fake engine with controllable state and error streams for mid-stream recovery
+/// tests. No platform channel is touched.
+class _ControllablePlayer extends Fake implements AudioPlayer {
+  _ControllablePlayer();
+
+  final StreamController<PlayerState> _playerStateController =
+      StreamController<PlayerState>.broadcast();
+  final StreamController<PlaybackEvent> _playbackEventController =
+      StreamController<PlaybackEvent>.broadcast();
+
+  final List<String> setUrlCalls = <String>[];
+  int playCalls = 0;
+
+  /// URIs whose [setUrl] should throw.
+  Set<String> failUrls = <String>{};
+
+  /// When true, every [setUrl] after the first successful one throws, simulating
+  /// a server that dies mid-playback on retry.
+  bool failAfterFirstSuccess = false;
+  bool _hadSuccessfulSetUrl = false;
+
+  @override
+  Stream<PlayerState> get playerStateStream => _playerStateController.stream;
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream<Duration?>.empty();
+  @override
+  Stream<PlaybackEvent> get playbackEventStream =>
+      _playbackEventController.stream;
+
+  void emitState(PlayerState state) => _playerStateController.add(state);
+
+  void emitError(Object error) =>
+      _playbackEventController.addError(error, StackTrace.empty);
+
+  @override
+  Future<Duration?> setUrl(
+    String url, {
+    Map<String, String>? headers,
+    Duration? initialPosition,
+    bool preload = true,
+    dynamic tag,
+  }) async {
+    setUrlCalls.add(url);
+    final bool shouldFail = failUrls.contains(url) ||
+        (failAfterFirstSuccess && _hadSuccessfulSetUrl);
+    if (shouldFail) {
+      throw Exception('engine could not open source');
+    }
+    _hadSuccessfulSetUrl = true;
+    return const Duration(minutes: 3);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> play() async => playCalls++;
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {}
+  @override
+  Future<void> dispose() async {
+    await _playerStateController.close();
+    await _playbackEventController.close();
+  }
+}
+
+/// Resolver that can flip between reachable and unreachable per uri, modelling a
+/// server that disappears and later returns. Never echoes secrets in messages.
+class _FlappingResolver implements PlayableUriResolver {
+  _FlappingResolver({
+    required this.reachable,
+    this.token = 'SECRET-TOKEN',
+  });
+
+  final Set<String> reachable;
+  final String token;
+  final List<String> calls = <String>[];
+  int _counter = 0;
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    calls.add(track.uri);
+    if (!reachable.contains(track.uri)) {
+      throw const PlaybackResolutionException(
+        "Couldn't reach your music server.",
+        kind: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+    }
+    _counter++;
+    return ResolvedPlayable(
+      Uri.parse('https://server.example/stream/${track.uri}'
+          '?n=$_counter&api_key=$token'),
+      PlaybackSource.streamingDirect,
+    );
+  }
+}
+
+Track _track(String id, String uri) => Track(
+      id: id,
+      title: 'Song',
+      uri: uri,
+      artistName: 'Artist',
+      albumName: 'Album',
+      duration: const Duration(minutes: 3),
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final Track jelly = _track('j', 'jellyfin:j');
+  final Track sub = _track('s', 'subsonic:s');
+  final Track next = _track('n', 'jellyfin:n');
+
+  JustAudioPlaybackController build({
+    required _ControllablePlayer player,
+    required PlayableUriResolver resolver,
+    Map<String, List<Track>> candidates = const <String, List<Track>>{},
+  }) {
+    final controller = JustAudioPlaybackController(
+      player: player,
+      resolver: resolver,
+      candidates: MapPlaybackCandidateSource(() => candidates),
+    )..midStreamBufferingTimeout = Duration.zero;
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  group('mid-stream server disappearance', () {
+    Future<void> startPlaying(
+      JustAudioPlaybackController controller,
+      _ControllablePlayer player,
+    ) async {
+      await controller.playTracks(<Track>[jelly]);
+      player.emitState(PlayerState(true, ProcessingState.ready));
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+    }
+
+    test('a transient drop gets one bounded retry', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(player: player, resolver: resolver);
+
+      await startPlaying(controller, player);
+      expect(resolver.calls, <String>['jellyfin:j']);
+
+      controller.handleStreamFailureForTesting(
+        classifyEngineError(Exception('Connection reset while reading')),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
+      expect(player.setUrlCalls.length, 2);
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+    });
+
+    test('concurrent mid-stream failures start only one recovery', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(player: player, resolver: resolver);
+
+      await startPlaying(controller, player);
+      expect(resolver.calls, <String>['jellyfin:j']);
+
+      // Watchdog + engine error racing: both enter the shared path, but the
+      // in-flight gate must admit only one bounded retry.
+      const StreamInterruption failure = StreamInterruption(
+        StreamInterruptionKind.serverUnreachable,
+        "Couldn't reach your music server. Check your connection and try again.",
+        retryable: true,
+      );
+      controller.handleStreamFailureForTesting(failure);
+      controller.handleStreamFailureForTesting(failure);
+      controller.onBufferingTimeoutForTesting();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
+      expect(player.setUrlCalls.length, 2);
+    });
+
+    test('retry exhaustion falls back to a sibling source copy', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(
+        reachable: <String>{'jellyfin:j', 'subsonic:s'},
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+      // Avoid the post-recovery zero-timeout re-arm firing between the two
+      // deliberate failure injections (build() defaults to Duration.zero).
+      controller.midStreamBufferingTimeout = const Duration(hours: 1);
+
+      await controller.playTracks(<Track>[jelly, next]);
+      // Drive status through the controller only — avoid a parallel player-state
+      // stream event that can arrive after recovery and refill the retry budget.
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      expect(resolver.calls, <String>['jellyfin:j']);
+
+      // First retryable failure → consumes the one bounded retry on the same
+      // source (still jellyfin).
+      await controller.handleStreamFailureForTestingAsync(
+        const StreamInterruption(
+          StreamInterruptionKind.networkDropped,
+          'The connection dropped while streaming. Reconnecting…',
+          retryable: true,
+        ),
+      );
+      expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
+
+      // Second retryable failure → budget exhausted → remaining sibling.
+      await controller.handleStreamFailureForTestingAsync(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+
+      expect(controller.state.currentTrack?.uri, 'subsonic:s');
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+      expect(controller.state.upNext.map((Track t) => t.uri).toList(),
+          <String>['jellyfin:n']);
+      expect(
+          resolver.calls, <String>['jellyfin:j', 'jellyfin:j', 'subsonic:s']);
+      expect(player.setUrlCalls.length, 3);
+    });
+
+    test('persistent disappearance surfaces error and preserves the queue',
+        () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      player.emitState(PlayerState(true, ProcessingState.ready));
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      resolver.reachable.remove('jellyfin:j');
+      await controller.handleStreamFailureForTestingAsync(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+      await controller.handleStreamFailureForTestingAsync(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+
+      final PlaybackState s = controller.state;
+      expect(s.status, PlaybackStatus.error);
+      expect(s.currentTrack?.uri, 'jellyfin:j');
+      expect(s.upNext.map((Track t) => t.uri).toList(), <String>['jellyfin:n']);
+      expect(s.errorMessage, isNot(contains('SECRET')));
+      expect(s.errorMessage, isNot(contains('http')));
+      // Bounded: each candidate is probed at most a handful of times — never loops.
+      expect(resolver.calls.length, lessThanOrEqualTo(6));
+      expect(
+        resolver.calls.where((String u) => u == 'subsonic:s').length,
+        greaterThanOrEqualTo(1),
+      );
+    });
+
+    test('a non-retryable auth failure skips retry and tries fallback',
+        () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(
+        reachable: <String>{'subsonic:s'},
+      );
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      player.emitState(PlayerState(true, ProcessingState.ready));
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.handleStreamFailureForTesting(
+        const StreamInterruption(
+          StreamInterruptionKind.sessionExpired,
+          'Your session expired. Sign in again to keep streaming.',
+          retryable: false,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.currentTrack?.uri, 'subsonic:s');
+      expect(resolver.calls, <String>['jellyfin:j', 'subsonic:s']);
+    });
+  });
+
+  group('buffering watchdog', () {
+    test('prolonged mid-stream buffering is treated as server unreachable',
+        () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      controller
+          .handleEngineState(PlayerState(true, ProcessingState.buffering));
+
+      resolver.reachable.remove('jellyfin:j');
+      controller.onBufferingTimeoutForTesting();
+      await Future<void>.delayed(Duration.zero);
+      controller.onBufferingTimeoutForTesting();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(resolver.calls.length, lessThanOrEqualTo(2));
+    });
+
+    test('controller-driven recovery buffering cannot hang past the watchdog',
+        () async {
+      // After a mid-stream retry reloads successfully, status stays buffering
+      // until the engine reports playing. With no engine events, the recovery
+      // path re-arms the watchdog; a timeout must reach a terminal error
+      // instead of hanging forever.
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      expect(resolver.calls, <String>['jellyfin:j']);
+
+      await controller.handleStreamFailureForTestingAsync(
+        const StreamInterruption(
+          StreamInterruptionKind.networkDropped,
+          'The connection dropped while streaming. Reconnecting…',
+          retryable: true,
+        ),
+      );
+      // Retry loaded (second resolve) but we never emit playing.
+      expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
+      expect(controller.state.status, PlaybackStatus.buffering);
+
+      // Same escape the re-armed watchdog uses: budget already spent → error.
+      controller.onBufferingTimeoutForTesting();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+      // No further resolve hammering after the bounded escape.
+      expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
+    });
+  });
+
+  group('manual recovery after outage', () {
+    test('play() from error re-resolves when the server returns', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{});
+      final controller = build(player: player, resolver: resolver);
+
+      await controller.playTracks(<Track>[jelly]);
+      expect(controller.state.status, PlaybackStatus.error);
+
+      resolver.reachable.add('jellyfin:j');
+      await controller.play();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+      expect(controller.state.currentTrack?.uri, 'jellyfin:j');
+      expect(resolver.calls.length, 2);
+    });
+  });
+
+  group('fake-server resolver integration', () {
+    test('server-down then up models disappearance and recovery', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+
+      resolver.reachable.remove('jellyfin:j');
+      controller.handleStreamFailureForTesting(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      controller.handleStreamFailureForTesting(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, PlaybackStatus.error);
+
+      resolver.reachable.add('jellyfin:j');
+      await controller.play();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+      expect(resolver.calls.last, 'jellyfin:j');
+    });
+
+    test('fallback uses the existing candidate policy when primary stays down',
+        () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'subsonic:s'});
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: <String, List<Track>>{
+          'jellyfin:j': <Track>[jelly, sub],
+        },
+      );
+
+      await controller.playTracks(<Track>[jelly]);
+      player.emitState(PlayerState(true, ProcessingState.ready));
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      controller.handleStreamFailureForTesting(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+      controller.handleStreamFailureForTesting(
+        const StreamInterruption(
+          StreamInterruptionKind.serverUnreachable,
+          "Couldn't reach your music server. Check your connection and try again.",
+          retryable: true,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.currentTrack?.uri, 'subsonic:s');
+      expect(
+        resolver.calls.where((String u) => u == 'subsonic:s').length,
+        greaterThanOrEqualTo(1),
+      );
+    });
+  });
+}

--- a/test/core/services/just_audio_playback_controller_stream_recovery_test.dart
+++ b/test/core/services/just_audio_playback_controller_stream_recovery_test.dart
@@ -86,11 +86,9 @@ class _ControllablePlayer extends Fake implements AudioPlayer {
 class _FlappingResolver implements PlayableUriResolver {
   _FlappingResolver({
     required this.reachable,
-    this.token = 'SECRET-TOKEN',
   });
 
   final Set<String> reachable;
-  final String token;
   final List<String> calls = <String>[];
   int _counter = 0;
 
@@ -109,7 +107,7 @@ class _FlappingResolver implements PlayableUriResolver {
     _counter++;
     return ResolvedPlayable(
       Uri.parse('https://server.example/stream/${track.uri}'
-          '?n=$_counter&api_key=$token'),
+          '?n=$_counter'),
       PlaybackSource.streamingDirect,
     );
   }

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -119,4 +119,23 @@ void main() {
     expect(find.text('Playing from Navidrome'), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('an error shows a Retry control that re-triggers play', (
+    tester,
+  ) async {
+    final controller = FakePlaybackController(
+      initial: const PlaybackState(
+        status: PlaybackStatus.error,
+        currentTrack: _track,
+        errorMessage: "Couldn't reach your music server.",
+      ),
+    );
+    await _pumpPlayer(tester, controller);
+
+    expect(find.text('Retry'), findsOneWidget);
+    await tester.tap(find.text('Retry'));
+    await tester.pump();
+
+    expect(controller.playCount, 1);
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #468

Handles the case where a configured self-hosted server disappears during Linux playback.

The implementation extends the existing playback recovery flow without adding provider-specific logic or a separate retry system.

## What changed

- Added bounded mid-stream recovery for network/server failures.
- Added a single in-flight recovery gate to prevent concurrent retry/fallback operations.
- Added a buffering watchdog so recovery cannot remain stuck indefinitely in `Buffering`.
- Preserved the logical playback queue and track/source identity during server outages.
- Reused the existing `PlaybackCandidateSource` fallback policy when sibling candidates are available.
- Added a manual `Retry` action when playback reaches an unavailable/error state.
- Retry re-resolves the current track using the normal resolution flow.
- Added tests covering disappearance, retry exhaustion, fallback, buffering timeout, recovery, and concurrent failures.
- Added a small `RepeatMode` import fix required by the current Flutter SDK for the affected widget tests.

## Recovery behavior

The recovery flow is bounded:

1. Detect a mid-stream failure.
2. Attempt one retry for the current candidate.
3. If the retry is exhausted, try remaining sibling candidates using the existing fallback policy.
4. If no candidate works, show an error/retry state.
5. If the server becomes available again, the user can Retry and the track is resolved again.

Concurrent recovery triggers are coalesced so an engine error and buffering watchdog cannot start duplicate recovery operations.

## Tests

Focused playback tests:

- Stream recovery tests
- Fallback tests
- Playback controller tests
- Playback race tests
- Stream interruption tests
- Player status layout tests

Result:

**56/56 tests passed.**

## Notes

The existing error-state behavior resets playback position when transitioning to `PlaybackStatus.error`. Preserving the exact mid-track position after an error is outside the scope of this issue.