### PR TITLE
fix: recover remote playback after temporary network loss

### DIFF
--- a/lib/core/models/playback_state.dart
+++ b/lib/core/models/playback_state.dart
@@ -8,13 +8,16 @@ import 'track.dart';
 ///
 /// [loading] is the initial *preparing* state (resolving + opening a source);
 /// [buffering] is a distinct mid-playback re-buffer (the engine wants to play but
-/// is waiting for more data over the network). Keeping them apart lets the UI
-/// show a calm "Buffering…" hint instead of a fresh-load spinner, and keeps the
-/// mini-player from looking frozen during a brief network stall.
+/// is waiting for more data over the network). [reconnecting] is a bounded
+/// mid-stream recovery after a network drop (re-resolving a fresh stream URL),
+/// shown separately from plain buffering and from a permanent [error]. Keeping
+/// them apart lets the UI show "Buffering…" / "Reconnecting…" / Retry instead of
+/// a frozen player or a misleading permanent-failure look.
 enum PlaybackStatus {
   idle,
   loading,
   buffering,
+  reconnecting,
   playing,
   paused,
   completed,
@@ -88,14 +91,22 @@ class PlaybackState {
   bool get hasTrack => currentTrack != null;
   bool get hasNext => upNext.isNotEmpty;
 
-  /// Whether a mid-playback re-buffer is in progress (engine waiting on data).
-  bool get isBuffering => status == PlaybackStatus.buffering;
+  /// Whether a mid-playback re-buffer is in progress (engine waiting on data),
+  /// including a bounded network reconnect attempt.
+  bool get isBuffering =>
+      status == PlaybackStatus.buffering ||
+      status == PlaybackStatus.reconnecting;
 
-  /// Whether the player is preparing or re-buffering — i.e. working, not idle and
-  /// not steadily playing. The mini-player shows a spinner for this so it never
-  /// looks frozen during a network stall.
+  /// Whether a temporary network drop is being recovered (fresh URL resolve).
+  bool get isReconnecting => status == PlaybackStatus.reconnecting;
+
+  /// Whether the player is preparing, re-buffering, or reconnecting — i.e.
+  /// working, not idle and not steadily playing. The mini-player shows a
+  /// spinner for this so it never looks frozen during a network stall.
   bool get isBusy =>
-      status == PlaybackStatus.loading || status == PlaybackStatus.buffering;
+      status == PlaybackStatus.loading ||
+      status == PlaybackStatus.buffering ||
+      status == PlaybackStatus.reconnecting;
 
   PlaybackState copyWith({
     PlaybackStatus? status,

--- a/lib/core/services/cast/chromecast_cast_transport.dart
+++ b/lib/core/services/cast/chromecast_cast_transport.dart
@@ -242,6 +242,7 @@ class _ChromecastSessionHandle implements CastSessionHandle {
     switch (playbackStatus) {
       case PlaybackStatus.playing:
       case PlaybackStatus.buffering:
+      case PlaybackStatus.reconnecting:
       case PlaybackStatus.loading:
         _startPolling();
       case PlaybackStatus.paused:

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -126,6 +126,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// recovers without ever looping forever on a real outage/expiry.
   static const int _maxStreamRetries = 1;
 
+  /// Pause before the bounded mid-stream retry so a brief glitch can clear and
+  /// we never hammer the server on every drop. Zero in tests.
+  static const Duration _defaultStreamRetryBackoff =
+      Duration(milliseconds: 500);
+
   /// How long a mid-stream re-buffer may persist before it is treated as a dead
   /// stream. Prevents an unreachable server from leaving the UI stuck on
   /// "Buffering…" when the engine never surfaces an error. Set shorter in tests.
@@ -263,6 +268,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// runs. Never changed in production; tests set this to keep runs fast.
   @visibleForTesting
   Duration midStreamBufferingTimeout = _defaultMidStreamBufferingTimeout;
+
+  /// Delay before the single mid-stream retry. Never changed in production;
+  /// tests set this to [Duration.zero] so recovery stays deterministic.
+  @visibleForTesting
+  Duration streamRetryBackoff = _defaultStreamRetryBackoff;
 
   // Guards against overlapping playback transitions. Every action that changes
   // what's playing — skip to next/previous, jump within the queue or history,
@@ -668,6 +678,13 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     // map to a still-`playing` session) and a real pause/completion/error is
     // unaffected.
     if (status == PlaybackStatus.idle) return;
+    // While a bounded reconnect owns the UI, ignore engine buffering/loading
+    // noise that would replace "Reconnecting…" with plain "Buffering…".
+    if (_state.status == PlaybackStatus.reconnecting &&
+        (status == PlaybackStatus.buffering ||
+            status == PlaybackStatus.loading)) {
+      return;
+    }
     // Playback is healthy again: give a later, independent drop a fresh retry.
     // Do not reset while a mid-stream recovery is still loading — a stale
     // ready/playing event from setUrl must not refill the retry budget mid-attempt.
@@ -701,7 +718,8 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   void _onEngineError(Object error, StackTrace _) {
     if (_suspended) return;
     if (_state.status != PlaybackStatus.playing &&
-        _state.status != PlaybackStatus.buffering) {
+        _state.status != PlaybackStatus.buffering &&
+        _state.status != PlaybackStatus.reconnecting) {
       return;
     }
     _handleStreamFailure(classifyEngineError(error));
@@ -733,16 +751,26 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     try {
       if (interruption.retryable && _retriesForCurrent < _maxStreamRetries) {
         _retriesForCurrent++;
+        // Surface reconnecting before the backoff so the UI is never left on
+        // "playing" while we wait, and never looks like a permanent error.
+        _emit(_state.copyWith(status: PlaybackStatus.reconnecting));
+        _armBufferingWatchdog();
+        final Duration backoff = streamRetryBackoff;
+        if (backoff > Duration.zero) {
+          await Future<void>.delayed(backoff);
+        }
+        // A skip/stop during the backoff owns playback now — don't reload.
+        if (_queue.current?.uri != track.uri) return;
         await _playCurrent(startAt: _state.position, isRetry: true);
         return;
       }
       await _tryRemainingCandidatesOrError(track, interruption.message);
     } finally {
       _streamRecoveryInFlight = false;
-      // Recovery may finish while the UI is still on buffering (setUrl/play
-      // issued, engine quiet). Re-arm so that hang cannot outlive the bound;
-      // [_streamRecoveryInFlight] is clear, so a later timeout can run. No-ops
-      // when we already left buffering (playing / error / loading).
+      // Recovery may finish while the UI is still on buffering/reconnecting
+      // (setUrl/play issued, engine quiet). Re-arm so that hang cannot outlive
+      // the bound; [_streamRecoveryInFlight] is clear, so a later timeout can
+      // run. No-ops when we already left that busy state.
       _armBufferingWatchdogIfBuffering();
     }
   }
@@ -755,9 +783,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   }
 
   /// Arms the buffering watchdog only when status is already mid-stream
-  /// buffering — never for initial [PlaybackStatus.loading].
+  /// buffering or reconnecting — never for initial [PlaybackStatus.loading].
   void _armBufferingWatchdogIfBuffering() {
-    if (_state.status != PlaybackStatus.buffering) return;
+    if (_state.status != PlaybackStatus.buffering &&
+        _state.status != PlaybackStatus.reconnecting) {
+      return;
+    }
     _armBufferingWatchdog();
   }
 
@@ -769,7 +800,10 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   void _onBufferingTimeout() {
     _bufferingWatchdog = null;
     if (_suspended) return;
-    if (_state.status != PlaybackStatus.buffering) return;
+    if (_state.status != PlaybackStatus.buffering &&
+        _state.status != PlaybackStatus.reconnecting) {
+      return;
+    }
     if (_queue.current == null) return;
     _handleStreamFailure(
       const StreamInterruption(
@@ -854,6 +888,13 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// Drives [_onBufferingTimeout] from a test without waiting on a timer.
   @visibleForTesting
   void onBufferingTimeoutForTesting() => _onBufferingTimeout();
+
+  /// Seeds [PlaybackState.position] so mid-stream recovery tests can assert the
+  /// preserved seek target without driving the engine position stream.
+  @visibleForTesting
+  void setPositionForTesting(Duration position) {
+    _emit(_state.copyWith(position: position));
+  }
 
   /// Maps the engine's (playing, processingState) pair to a [PlaybackStatus].
   ///
@@ -1162,10 +1203,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
 
     if (isRetry) {
       // Recovering from a mid-stream drop: keep the current track and position
-      // visible and show a calm buffering state, rather than blanking to a fresh
-      // load (which would look like the track jumped back to the start).
-      _emit(_state.copyWith(status: PlaybackStatus.buffering));
-      // Bound this recovery buffering: playing→buffering is not observed here.
+      // visible and show reconnecting, rather than blanking to a fresh load
+      // (which would look like the track jumped back to the start) or a
+      // permanent error.
+      _emit(_state.copyWith(status: PlaybackStatus.reconnecting));
+      // Bound this recovery: playing→buffering is not observed here.
       _armBufferingWatchdog();
     } else {
       // Reset position/duration up front so the UI doesn't show the previous

--- a/lib/core/services/linthra_audio_handler.dart
+++ b/lib/core/services/linthra_audio_handler.dart
@@ -470,6 +470,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
     switch (status) {
       case PlaybackStatus.playing:
       case PlaybackStatus.buffering:
+      case PlaybackStatus.reconnecting:
       case PlaybackStatus.loading:
         return true;
       case PlaybackStatus.idle:
@@ -525,6 +526,7 @@ class LinthraAudioHandler extends audio.BaseAudioHandler {
       case PlaybackStatus.loading:
         return audio.AudioProcessingState.loading;
       case PlaybackStatus.buffering:
+      case PlaybackStatus.reconnecting:
         return audio.AudioProcessingState.buffering;
       case PlaybackStatus.playing:
       case PlaybackStatus.paused:

--- a/lib/core/services/playback_reporting_service.dart
+++ b/lib/core/services/playback_reporting_service.dart
@@ -163,8 +163,9 @@ class PlaybackReportingService {
         }
       case PlaybackStatus.loading:
       case PlaybackStatus.buffering:
-        // Indeterminate: keep the last reported phase. A re-buffer stays
-        // "playing"; a fresh load reports nothing until it actually plays.
+      case PlaybackStatus.reconnecting:
+        // Indeterminate: keep the last reported phase. A re-buffer / reconnect
+        // stays "playing"; a fresh load reports nothing until it actually plays.
         break;
     }
   }

--- a/lib/core/services/stream_interruption.dart
+++ b/lib/core/services/stream_interruption.dart
@@ -94,7 +94,10 @@ StreamInterruption classifyEngineError(Object error) {
   ])) {
     return const StreamInterruption(
       StreamInterruptionKind.networkDropped,
-      'The connection dropped while streaming. Reconnecting…',
+      // Terminal-safe wording: the Now Playing UI shows "Reconnecting…" while
+      // [PlaybackStatus.reconnecting] is active; this message is for a
+      // permanent failure after the bounded retry is spent.
+      'The connection dropped while streaming. Check your connection and try again.',
       retryable: true,
     );
   }

--- a/lib/features/player/player_screen.dart
+++ b/lib/features/player/player_screen.dart
@@ -441,6 +441,11 @@ class _SourceOrError extends ConsumerWidget {
         ],
       );
     }
+    // A mid-stream network reconnect: distinct from plain "Buffering…" and from
+    // a permanent error + Retry, so the listener knows recovery is in flight.
+    if (state.status == PlaybackStatus.reconnecting) {
+      return const _ReconnectingIndicator();
+    }
     // A mid-stream re-buffer: a calm "Buffering…" hint rather than the source
     // badge, so it's clear the stream is catching up (not stalled).
     if (state.status == PlaybackStatus.buffering) {
@@ -464,6 +469,29 @@ class _BufferingIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return const _BusyStatusIndicator(label: 'Buffering…');
+  }
+}
+
+/// Shown while a bounded mid-stream network recovery re-resolves a fresh URL.
+/// Deliberately distinct from [_BufferingIndicator] and from the permanent
+/// error + Retry row.
+class _ReconnectingIndicator extends StatelessWidget {
+  const _ReconnectingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return const _BusyStatusIndicator(label: 'Reconnecting…');
+  }
+}
+
+class _BusyStatusIndicator extends StatelessWidget {
+  const _BusyStatusIndicator({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -478,7 +506,7 @@ class _BufferingIndicator extends StatelessWidget {
         ),
         const SizedBox(width: AppSpacing.xs),
         Text(
-          'Buffering…',
+          label,
           style: theme.textTheme.labelLarge?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
             letterSpacing: 0.3,

--- a/test/core/services/just_audio_playback_controller_stream_recovery_test.dart
+++ b/test/core/services/just_audio_playback_controller_stream_recovery_test.dart
@@ -21,6 +21,7 @@ class _ControllablePlayer extends Fake implements AudioPlayer {
       StreamController<PlaybackEvent>.broadcast();
 
   final List<String> setUrlCalls = <String>[];
+  final List<Duration?> seekCalls = <Duration?>[];
   int playCalls = 0;
 
   /// URIs whose [setUrl] should throw.
@@ -73,7 +74,10 @@ class _ControllablePlayer extends Fake implements AudioPlayer {
   @override
   Future<void> stop() async {}
   @override
-  Future<void> seek(Duration? position, {int? index}) async {}
+  Future<void> seek(Duration? position, {int? index}) async {
+    seekCalls.add(position);
+  }
+
   @override
   Future<void> dispose() async {
     await _playerStateController.close();
@@ -138,7 +142,9 @@ void main() {
       player: player,
       resolver: resolver,
       candidates: MapPlaybackCandidateSource(() => candidates),
-    )..midStreamBufferingTimeout = Duration.zero;
+    )
+      ..midStreamBufferingTimeout = Duration.zero
+      ..streamRetryBackoff = Duration.zero;
     addTearDown(controller.dispose);
     return controller;
   }
@@ -222,7 +228,7 @@ void main() {
       await controller.handleStreamFailureForTestingAsync(
         const StreamInterruption(
           StreamInterruptionKind.networkDropped,
-          'The connection dropped while streaming. Reconnecting…',
+          'The connection dropped while streaming. Check your connection and try again.',
           retryable: true,
         ),
       );
@@ -371,13 +377,13 @@ void main() {
       await controller.handleStreamFailureForTestingAsync(
         const StreamInterruption(
           StreamInterruptionKind.networkDropped,
-          'The connection dropped while streaming. Reconnecting…',
+          'The connection dropped while streaming. Check your connection and try again.',
           retryable: true,
         ),
       );
       // Retry loaded (second resolve) but we never emit playing.
       expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
-      expect(controller.state.status, PlaybackStatus.buffering);
+      expect(controller.state.status, PlaybackStatus.reconnecting);
 
       // Same escape the re-armed watchdog uses: budget already spent → error.
       controller.onBufferingTimeoutForTesting();
@@ -490,6 +496,103 @@ void main() {
         resolver.calls.where((String u) => u == 'subsonic:s').length,
         greaterThanOrEqualTo(1),
       );
+    });
+  });
+
+  group('fake-network reconnect during remote playback', () {
+    const StreamInterruption networkDrop = StreamInterruption(
+      StreamInterruptionKind.networkDropped,
+      'The connection dropped while streaming. Check your connection and try again.',
+      retryable: true,
+    );
+
+    for (final String scheme in <String>['jellyfin', 'subsonic', 'plex']) {
+      test('$scheme-shaped short loss recovers with a fresh URL and position',
+          () async {
+        final Track remote = _track('r', '$scheme:r');
+        final player = _ControllablePlayer();
+        final resolver = _FlappingResolver(reachable: <String>{remote.uri});
+        final controller = build(player: player, resolver: resolver);
+
+        await controller.playTracks(<Track>[remote]);
+        controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+        expect(player.setUrlCalls, hasLength(1));
+        final String firstUrl = player.setUrlCalls.single;
+
+        const Duration preserved = Duration(minutes: 1, seconds: 12);
+        controller.setPositionForTesting(preserved);
+
+        final List<PlaybackStatus> statuses = <PlaybackStatus>[];
+        final sub = controller.stateStream.listen((PlaybackState s) {
+          statuses.add(s.status);
+        });
+        addTearDown(sub.cancel);
+
+        await controller.handleStreamFailureForTestingAsync(networkDrop);
+
+        expect(statuses, contains(PlaybackStatus.reconnecting));
+        expect(controller.state.status, isNot(PlaybackStatus.error));
+        expect(controller.state.currentTrack?.uri, remote.uri);
+        expect(resolver.calls, <String>[remote.uri, remote.uri]);
+        expect(player.setUrlCalls, hasLength(2));
+        // Fresh authenticated URL — never replay the first tokenized stream.
+        expect(player.setUrlCalls.last, isNot(firstUrl));
+        expect(player.setUrlCalls.last, contains('?n=2'));
+        expect(player.seekCalls, contains(preserved));
+        // No secret-bearing URL surfaces on the public playback state.
+        expect(controller.state.errorMessage, isNull);
+      });
+    }
+
+    test('permanent network loss surfaces error, not Reconnecting…', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(
+        player: player,
+        resolver: resolver,
+        candidates: const <String, List<Track>>{},
+      );
+
+      await controller.playTracks(<Track>[jelly, next]);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+
+      resolver.reachable.remove('jellyfin:j');
+      await controller.handleStreamFailureForTestingAsync(networkDrop);
+      // Budget spent; a second failure (watchdog or engine) ends permanently.
+      await controller.handleStreamFailureForTestingAsync(networkDrop);
+
+      final PlaybackState s = controller.state;
+      expect(s.status, PlaybackStatus.error);
+      expect(s.status, isNot(PlaybackStatus.reconnecting));
+      expect(s.errorMessage, isNot(contains('Reconnecting')));
+      expect(s.errorMessage, isNot(contains('http')));
+      expect(s.errorMessage, isNot(contains('api_key')));
+      expect(s.currentTrack?.uri, 'jellyfin:j');
+      expect(s.upNext.map((Track t) => t.uri).toList(), <String>['jellyfin:n']);
+      // Bounded: initial play + one retry resolve attempt, no infinite hammer.
+      expect(resolver.calls.length, lessThanOrEqualTo(3));
+    });
+
+    test('retry backoff is observed before the fresh resolve', () async {
+      final player = _ControllablePlayer();
+      final resolver = _FlappingResolver(reachable: <String>{'jellyfin:j'});
+      final controller = build(player: player, resolver: resolver);
+      controller.streamRetryBackoff = const Duration(milliseconds: 40);
+
+      await controller.playTracks(<Track>[jelly]);
+      controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+      expect(resolver.calls, <String>['jellyfin:j']);
+
+      final Future<void> recovery =
+          controller.handleStreamFailureForTestingAsync(networkDrop);
+      // Immediately after kickoff — still in reconnecting, resolve not yet.
+      await Future<void>.delayed(Duration.zero);
+      expect(controller.state.status, PlaybackStatus.reconnecting);
+      expect(resolver.calls, <String>['jellyfin:j']);
+
+      await recovery;
+      expect(resolver.calls, <String>['jellyfin:j', 'jellyfin:j']);
+      expect(controller.state.status, isNot(PlaybackStatus.error));
     });
   });
 }

--- a/test/core/services/stream_interruption_test.dart
+++ b/test/core/services/stream_interruption_test.dart
@@ -88,6 +88,7 @@ void main() {
       expect(result.message, isNot(contains('music.example.com')));
       // It is still classified as a recoverable network drop.
       expect(result.retryable, isTrue);
+      expect(result.message, isNot(contains('Reconnecting')));
     });
   });
 }

--- a/test/features/player/player_status_layout_test.dart
+++ b/test/features/player/player_status_layout_test.dart
@@ -138,4 +138,39 @@ void main() {
 
     expect(controller.playCount, 1);
   });
+
+  testWidgets('reconnecting is distinct from buffering and from error', (
+    tester,
+  ) async {
+    final controller = _streamingController();
+    await _pumpPlayer(tester, controller);
+
+    controller.emit(
+      const PlaybackState(
+        status: PlaybackStatus.reconnecting,
+        currentTrack: _track,
+        duration: Duration(minutes: 4),
+        position: Duration(minutes: 1),
+      ),
+    );
+    await _pumpStreamUpdate(tester);
+
+    expect(find.text('Reconnecting…'), findsOneWidget);
+    expect(find.text('Buffering…'), findsNothing);
+    expect(find.text('Retry'), findsNothing);
+
+    controller.emit(
+      const PlaybackState(
+        status: PlaybackStatus.buffering,
+        currentTrack: _track,
+        duration: Duration(minutes: 4),
+        position: Duration(minutes: 1),
+      ),
+    );
+    await _pumpStreamUpdate(tester);
+
+    expect(find.text('Buffering…'), findsOneWidget);
+    expect(find.text('Reconnecting…'), findsNothing);
+    expect(find.text('Retry'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary
- Closes #467: remote Linux playback recovers predictably after a short network drop without restarting Linthra.
- Adds `PlaybackStatus.reconnecting` so Now Playing shows **Reconnecting…** (distinct from Buffering… and permanent error + Retry).
- Bounds mid-stream recovery with one retry and a short backoff, then re-resolves a fresh authenticated stream URL and resumes at the preserved position.

## Test plan
- [x] `flutter test` on stream recovery, stream interruption, player status layout, just_audio controller, Linux controller, audio handler, playback reporting, playback state, player screen, mini player (175 tests)
- [x] `dart analyze` clean on changed paths
- [ ] Manual: start Jellyfin/Navidrome/Plex-shaped playback on Linux, briefly cut network, confirm Reconnecting… then resume without app restart
- [ ] Manual: keep network down through the bounded retry, confirm error + Retry (not stuck Reconnecting…), queue preserved, Retry works when the network returns


