### PR TITLE
fix: harden Linux playback across system suspend/resume

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -179,6 +179,7 @@ undeclared network access to an isolated `flatpak-builder` build.
 | Area | State | Why |
 | --- | --- | --- |
 | **Audio playback** | Supported | media_kit/libmpv through `LinuxPlaybackController`; local files and resolved Jellyfin, Navidrome/Subsonic, and Plex HTTP(S) streams share one backend. |
+| **Suspend / resume** | Supported (app side); real device/sink timing varies | Lifecycle `paused`→`resumed` arms a bounded Linux-only reload of an actively playing track after a short backoff ([issue #466](https://github.com/TheZupZup/Linthra/issues/466)). See [Suspend / resume (manual matrix)](#suspend--resume-manual-matrix). |
 | **Light/Dark/System theme** | Supported (app side); the native brightness bridge itself is Flutter's, not independently verified here | Settings → Appearance's System/Light/Dark choice ([issue #459](https://github.com/TheZupZup/Linthra/issues/459)) is the same shared `ThemeModePreference`/`ThemeModeController` Android uses, mapped onto `MaterialApp`'s own `themeMode` — no `gsettings`/D-Bus/GNOME/KDE-specific code in Linthra itself, and no separate Linux theme path (`test/app/theme_mode_test.dart` proves that). *Supplying* System's brightness on Linux is Flutter's GTK embedder (via the XDG desktop portal or a GNOME GSettings fallback); that native bridge is outside Linthra's code and isn't exercised by `flutter test`, which runs on the Dart VM and injects brightness straight into Flutter's test `PlatformDispatcher`. Reproducing the real bridge deterministically in CI would need a running portal daemon or GNOME schemas — exactly the DE-specific setup this app avoids adding — so it stays untested here and is a known gap, not a claimed guarantee. |
 | Media session / MPRIS | Unsupported | `audio_service` is Android/iOS only. `PlatformMediaSessionBinding` returns the inert binding on Linux, so `audio_service` is never initialised there. MPRIS is later desktop work. |
 | Android Auto | Android-only, by design | It is an Android platform integration, not a Linthra feature. |
@@ -245,6 +246,35 @@ widget.
 `unmanaged_files` in `.metadata`, so `flutter migrate` leaves Linthra's edits
 alone. If someone re-runs `flutter create --platforms=linux .` anyway, the
 checker above is what catches the reverted title and the lost SQLite seam.
+
+## Suspend / resume (manual matrix)
+
+System sleep and wake are only partly visible to Flutter: the embedder usually
+delivers `AppLifecycleState.paused` → `resumed`, but audio devices (PulseAudio /
+PipeWire, Bluetooth sinks) and the network often come back later than that
+signal. Linthra therefore:
+
+* arms recovery only on **`paused`** (not brief `inactive` dialogs);
+* on Linux, after resume, waits a short backoff then **re-resolves and reloads
+  the current track on the same engine** when playback was active across
+  suspend — never a second player, so audio cannot duplicate;
+* leaves a **user-paused** track paused;
+* surfaces the existing error + Retry UI when recovery fails;
+* does **not** enable this path on Android (screen-on must never auto-restart).
+
+Automated coverage: `test/core/services/linux_suspend_resume_recovery_test.dart`
+and the ActivePlaybackController lifecycle tests. Re-check on a real machine
+before a Linux milestone release:
+
+| Scenario | While… | Expect after wake |
+| --- | --- | --- |
+| Lid close / Sleep | Playing a **local** file | Same track/queue; audio returns near the prior position; no second stream |
+| Lid close / Sleep | Playing a **remote** (Jellyfin / Navidrome / Plex) stream | Fresh stream URL; same logical track/queue; Reconnecting… then playing, or error + Retry if the server is still down |
+| Lid close / Sleep | **Paused** | Still paused; pressing play resumes the same track |
+| Sleep with **Bluetooth** headphones offline | Playing | Recoverable error or success once the sink returns; never hung forever |
+| Sleep with **network** offline | Playing remote | Bounded recovery; Retry works when connectivity returns |
+| Minimize only (no sleep) | Playing | App stays responsive; no crash; ideally continues without a full reload |
+| Repeat sleep/wake **3×** | Playing | Still one coherent queue/position; no growing listener/service leak; UI stays usable |
 
 ## Release tarball
 

--- a/lib/app/linthra_app.dart
+++ b/lib/app/linthra_app.dart
@@ -95,8 +95,15 @@ class _LinthraAppState extends ConsumerState<LinthraApp>
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden ||
         state == AppLifecycleState.inactive) {
-      final status = ref.read(playbackControllerProvider).state.status;
-      StabilityDiagnostics.backgroundPlaybackState(status.name);
+      final controller = ref.read(playbackControllerProvider);
+      StabilityDiagnostics.backgroundPlaybackState(
+          controller.state.status.name);
+      // Arm suspend recovery only on a true pause (system sleep / window
+      // background). Brief `inactive` (dialogs, focus blips) must not reload.
+      if (state == AppLifecycleState.paused &&
+          controller is ActivePlaybackController) {
+        controller.onAppBackgrounded();
+      }
     }
     if (state == AppLifecycleState.resumed) {
       final controller = ref.read(playbackControllerProvider);

--- a/lib/core/services/active_playback_controller.dart
+++ b/lib/core/services/active_playback_controller.dart
@@ -199,11 +199,19 @@ class ActivePlaybackController implements PlaybackController {
     }
   }
 
+  /// Handles the app/OS entering a paused lifecycle. While casting the local
+  /// engine is already silent, so background arming is skipped. Otherwise the
+  /// local controller remembers whether playback should be recovered on wake.
+  void onAppBackgrounded() {
+    if (_casting) return;
+    _local.onAppBackgrounded();
+  }
+
   /// Handles the app returning to the foreground. While casting, re-syncs from
-  /// the receiver. Otherwise runs the local engine's audio-focus safety restore
-  /// — undoing any lingering duck and resuming only a transient-focus-loss pause
-  /// — so a voice/mic session in another app that ended without a clean focus
-  /// gain can't leave Linthra stuck silent or ducked.
+  /// the receiver. Otherwise runs the local engine's foreground restore —
+  /// undoing any lingering duck and, on Linux, a bounded post-suspend recovery
+  /// when a track was playing across sleep — so wake never duplicates playback
+  /// and never auto-starts a user-paused track.
   void onAppResumed() {
     if (_casting) {
       unawaited(_cast.refresh());

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -69,12 +69,14 @@ class JustAudioPlaybackController implements LocalPlaybackController {
     PlayableUriResolver? streamingFallbackResolver,
     Random? random,
     TrackCompletionCallback? onTrackCompleted,
+    bool recoverPlaybackAfterSuspend = false,
   })  : _player = player ?? _defaultPlayer(),
         _resolver = resolver,
         _candidates = candidates,
         _streamingFallbackResolver = streamingFallbackResolver,
         _random = random ?? Random(),
         _onTrackCompleted = onTrackCompleted,
+        _recoverPlaybackAfterSuspend = recoverPlaybackAfterSuspend,
         // Own audio focus only for the engine we created. An injected player
         // (tests, or a future custom engine) keeps whatever interruption
         // handling its owner configured, so unit tests never touch the
@@ -137,6 +139,11 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   static const Duration _defaultMidStreamBufferingTimeout =
       Duration(seconds: 30);
 
+  /// Delay before a Linux-style post-suspend recovery reload, so audio devices
+  /// and the network have a chance to return after wake. Zero in tests.
+  static const Duration _defaultSuspendResumeBackoff =
+      Duration(milliseconds: 750);
+
   final AudioPlayer _player;
   final PlayableUriResolver _resolver;
 
@@ -157,6 +164,12 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   final PlayableUriResolver? _streamingFallbackResolver;
 
   final Random _random;
+
+  /// When true (Linux desktop), a lifecycle resume after suspend reloads the
+  /// current track at the preserved position if it was playing — audio devices
+  /// and tokenized streams are often dead after wake. Android keeps this false
+  /// so screen-on never auto-restarts playback.
+  final bool _recoverPlaybackAfterSuspend;
 
   /// Invoked once each time a track reaches its natural end, before the repeat
   /// mode decides what plays next. Null when no listener is wired (tests, or the
@@ -273,6 +286,19 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// tests set this to [Duration.zero] so recovery stays deterministic.
   @visibleForTesting
   Duration streamRetryBackoff = _defaultStreamRetryBackoff;
+
+  /// Delay before post-suspend recovery reload. Never changed in production;
+  /// tests set this to [Duration.zero].
+  @visibleForTesting
+  Duration suspendResumeBackoff = _defaultSuspendResumeBackoff;
+
+  /// Whether active playback should be recovered after the next lifecycle
+  /// resume. Set by [onAppBackgrounded]; consumed by [onAppForegrounded].
+  bool _recoverPlaybackOnForeground = false;
+
+  /// Coalesces concurrent lifecycle resumes so repeated suspend/wake cycles
+  /// never stack overlapping reloads or re-subscribe anything.
+  bool _suspendRecoveryInFlight = false;
 
   // Guards against overlapping playback transitions. Every action that changes
   // what's playing — skip to next/previous, jump within the queue or history,
@@ -582,18 +608,70 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   /// If a duck somehow lingered (e.g. an iOS duck whose unduck was never
   /// delivered), restore full volume so Linthra is never left quietly ducked.
   ///
-  /// It deliberately does **not** resume playback. The only valid signal that a
-  /// transient interruption has ended is an `AUDIOFOCUS_GAIN`, which is now
-  /// processed reliably in the background (the media service stays foreground
-  /// across a pause, so the isolate isn't frozen — see the audio-service config
-  /// in `LinthraAudioHandler`). Resuming on a mere foreground event could
-  /// restart audio over an interruption that is *still* holding focus — e.g.
-  /// opening Linthra while a call is ongoing — so resume is left entirely to the
-  /// real focus regain. A no-op while playing or paused-without-a-duck.
+  /// On Android it deliberately does **not** resume playback — screen-on must
+  /// never auto-start audio. On Linux ([_recoverPlaybackAfterSuspend]) a track
+  /// that was *playing* across system suspend is reloaded once at the preserved
+  /// position after a short backoff (audio devices and the network are often
+  /// not ready immediately after wake). A user-paused track stays paused.
+  @override
+  void onAppBackgrounded() {
+    if (_suspended) {
+      _recoverPlaybackOnForeground = false;
+      return;
+    }
+    // Remember intent only: playing/busy → recover; paused/error/idle → leave.
+    _recoverPlaybackOnForeground = _state.isPlaying || _state.isBusy;
+  }
+
   @override
   void onAppForegrounded() {
     if (_suspended) return;
     _restoreDuckedVolume();
+    if (!_recoverPlaybackAfterSuspend) {
+      // Android/iOS: never auto-recover on screen-on; drop any arming.
+      _recoverPlaybackOnForeground = false;
+      return;
+    }
+    unawaited(_recoverAfterSuspendIfNeeded());
+  }
+
+  /// Bounded post-suspend recovery for Linux. One in-flight attempt at a time;
+  /// never adds listeners; preserves queue/track; surfaces error+Retry on fail.
+  Future<void> _recoverAfterSuspendIfNeeded() async {
+    if (!_recoverPlaybackOnForeground) return;
+    if (_suspendRecoveryInFlight) return;
+    final Track? track = _queue.current;
+    if (track == null) {
+      _recoverPlaybackOnForeground = false;
+      return;
+    }
+
+    _suspendRecoveryInFlight = true;
+    // Consume the arming up front so a nested lifecycle event during backoff
+    // cannot schedule a second overlapping recovery for the same wake.
+    final bool shouldPlay = _recoverPlaybackOnForeground;
+    _recoverPlaybackOnForeground = false;
+    try {
+      final Duration backoff = suspendResumeBackoff;
+      if (backoff > Duration.zero) {
+        await Future<void>.delayed(backoff);
+      }
+      if (_suspended) return;
+      if (_queue.current?.uri != track.uri) return;
+      if (!shouldPlay) return;
+
+      StabilityDiagnostics.playbackError('suspend-resume-recovery');
+      _retriesForCurrent = 0;
+      // Re-resolve (fresh tokenized URL after a long sleep) and reload on the
+      // *same* engine — never a second player, so playback cannot duplicate.
+      await _playCurrent(
+        startAt: _state.position,
+        autoplay: true,
+        isRetry: true,
+      );
+    } finally {
+      _suspendRecoveryInFlight = false;
+    }
   }
 
   /// Classifies an audio-focus [event] into the action the engine should take,

--- a/lib/core/services/linux_playback_controller.dart
+++ b/lib/core/services/linux_playback_controller.dart
@@ -39,7 +39,9 @@ class LinuxPlaybackBackendInitializer {
 ///
 /// The transport, queue, resolver fallback and completion behaviour deliberately
 /// stay in [JustAudioPlaybackController]. This class only registers the Linux
-/// federated implementation before that controller creates its [AudioPlayer].
+/// federated implementation before that controller creates its [AudioPlayer],
+/// and enables post-suspend recovery so a system sleep/wake can re-prime the
+/// audio device and re-resolve remote streams without duplicating playback.
 /// Android never constructs this type and therefore keeps just_audio's native
 /// ExoPlayer implementation and its existing audio-service/audio-focus path.
 class LinuxPlaybackController extends JustAudioPlaybackController {
@@ -74,5 +76,5 @@ class LinuxPlaybackController extends JustAudioPlaybackController {
     super.streamingFallbackResolver,
     super.random,
     super.onTrackCompleted,
-  });
+  }) : super(recoverPlaybackAfterSuspend: true);
 }

--- a/lib/core/services/local_playback_controller.dart
+++ b/lib/core/services/local_playback_controller.dart
@@ -32,10 +32,15 @@ abstract interface class LocalPlaybackController implements PlaybackController {
   /// loaded track immediately, so toggling takes effect without a track change.
   void setVolumeNormalizationEnabled(bool enabled);
 
+  /// Notes that the app/OS is entering a paused lifecycle (screen lock, window
+  /// hide, or system suspend). Remembers whether active playback should be
+  /// recovered after wake — without auto-starting a track the user had paused.
+  void onAppBackgrounded();
+
   /// A safety restore when the app returns to the foreground: undoes any
-  /// lingering audio-focus duck and resumes playback only if a transient focus
-  /// loss had paused it, recovering the case where another app's voice/mic
-  /// session ended without delivering a clean focus gain. Never resumes a track
-  /// the user paused, and a no-op while suspended or when nothing is pending.
+  /// lingering audio-focus duck and, on platforms that need it (Linux), runs a
+  /// bounded audio/network recovery for a track that was playing across
+  /// suspend. Never resumes a track the user paused, and a no-op while
+  /// suspended or when nothing is pending.
   void onAppForegrounded();
 }

--- a/lib/core/services/unsupported_playback_controller.dart
+++ b/lib/core/services/unsupported_playback_controller.dart
@@ -164,6 +164,9 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
   void setVolumeNormalizationEnabled(bool enabled) {}
 
   @override
+  void onAppBackgrounded() {}
+
+  @override
   void onAppForegrounded() {}
 
   @override

--- a/test/app/playback_lifecycle_test.dart
+++ b/test/app/playback_lifecycle_test.dart
@@ -101,6 +101,9 @@ void main() {
     await _foreground(tester);
 
     // No re-load (playTracks) and no extra play(): the engine is left running.
+    // (Linux post-suspend recovery is covered in
+    // linux_suspend_resume_recovery_test.dart; this fake stands in for the
+    // ActivePlaybackController production path.)
     expect(controller.playedTracks, isEmpty);
     expect(controller.playCount, 0);
     expect(controller.pauseCount, 0);

--- a/test/core/services/active_playback_controller_test.dart
+++ b/test/core/services/active_playback_controller_test.dart
@@ -417,6 +417,29 @@ void main() {
       expect(cast.refreshCount, 0);
       expect(local.foregroundedCount, 1);
     });
+
+    test('onAppBackgrounded arms the local controller when not casting', () {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      controller.onAppBackgrounded();
+
+      expect(local.backgroundedCount, 1);
+      expect(cast.refreshCount, 0);
+    });
+
+    test('onAppBackgrounded is a no-op while casting', () async {
+      final controller = build();
+      addTearDown(controller.dispose);
+
+      cast.emit(_casting());
+      await _waitFor(controller,
+          (_) => controller.activeOutput == ActivePlaybackOutput.cast);
+
+      controller.onAppBackgrounded();
+
+      expect(local.backgroundedCount, 0);
+    });
   });
 
   group('cast track completion advances per repeat mode', () {

--- a/test/core/services/linux_suspend_resume_recovery_test.dart
+++ b/test/core/services/linux_suspend_resume_recovery_test.dart
@@ -1,0 +1,272 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:linthra/core/models/playback_source.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/just_audio_playback_controller.dart';
+import 'package:linthra/core/services/linux_playback_controller.dart';
+import 'package:linthra/core/services/playable_uri_resolver.dart';
+import 'package:linthra/core/services/playback_candidate_source.dart';
+
+/// Controllable engine for suspend/resume recovery — no platform channel.
+class _Engine extends Fake implements AudioPlayer {
+  final StreamController<PlayerState> _states =
+      StreamController<PlayerState>.broadcast();
+  final StreamController<PlaybackEvent> _events =
+      StreamController<PlaybackEvent>.broadcast();
+
+  final List<String> setUrlCalls = <String>[];
+  final List<Duration?> seekCalls = <Duration?>[];
+  int playCalls = 0;
+  bool failUrls = false;
+
+  @override
+  Stream<PlayerState> get playerStateStream => _states.stream;
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+  @override
+  Stream<Duration?> get durationStream => const Stream<Duration?>.empty();
+  @override
+  Stream<PlaybackEvent> get playbackEventStream => _events.stream;
+
+  @override
+  Future<Duration?> setUrl(
+    String url, {
+    Map<String, String>? headers,
+    Duration? initialPosition,
+    bool preload = true,
+    dynamic tag,
+  }) async {
+    setUrlCalls.add(url);
+    if (failUrls) throw Exception('device not ready after wake');
+    return const Duration(minutes: 3);
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> play() async => playCalls++;
+  @override
+  Future<void> pause() async {}
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> seek(Duration? position, {int? index}) async {
+    seekCalls.add(position);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+    await _events.close();
+  }
+}
+
+class _Resolver implements PlayableUriResolver {
+  _Resolver({this.reachable = true});
+
+  bool reachable;
+  final List<String> calls = <String>[];
+  int _n = 0;
+
+  @override
+  bool handles(Track track) => true;
+
+  @override
+  Future<ResolvedPlayable> resolve(Track track) async {
+    calls.add(track.uri);
+    if (!reachable) {
+      throw const PlaybackResolutionException(
+        "Couldn't reach your music server.",
+        kind: PlaybackResolutionErrorKind.serverUnreachable,
+      );
+    }
+    _n++;
+    return ResolvedPlayable(
+      Uri.parse('https://server.example/stream/${track.uri}?n=$_n'),
+      track.uri.startsWith('/')
+          ? PlaybackSource.localFile
+          : PlaybackSource.streamingDirect,
+    );
+  }
+}
+
+Track _track(String id, String uri) => Track(
+      id: id,
+      title: 'Song',
+      uri: uri,
+      artistName: 'Artist',
+      albumName: 'Album',
+      duration: const Duration(minutes: 3),
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final Track local = _track('l', '/music/a.flac');
+  final Track remote = _track('r', 'jellyfin:r');
+  final Track next = _track('n', 'jellyfin:n');
+
+  LinuxPlaybackController buildLinux({
+    required _Engine player,
+    required _Resolver resolver,
+  }) {
+    final controller = LinuxPlaybackController(
+      player: player,
+      resolver: resolver,
+      candidates: const NoFallbackCandidateSource(),
+    )
+      ..suspendResumeBackoff = Duration.zero
+      ..midStreamBufferingTimeout = const Duration(hours: 1);
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  JustAudioPlaybackController buildAndroid({
+    required _Engine player,
+    required _Resolver resolver,
+  }) {
+    final controller = JustAudioPlaybackController(
+      player: player,
+      resolver: resolver,
+      // Android default: recoverPlaybackAfterSuspend == false
+    )..suspendResumeBackoff = Duration.zero;
+    addTearDown(controller.dispose);
+    return controller;
+  }
+
+  Future<void> startPlaying(
+    JustAudioPlaybackController controller,
+    Track track,
+  ) async {
+    await controller.playTracks(<Track>[track, next]);
+    controller.handleEngineState(PlayerState(true, ProcessingState.ready));
+  }
+
+  group('Linux suspend/resume recovery', () {
+    test('paused across suspend stays paused — no reload, no autoplay',
+        () async {
+      final player = _Engine();
+      final resolver = _Resolver();
+      final controller = buildLinux(player: player, resolver: resolver);
+
+      await startPlaying(controller, local);
+      await controller.pause();
+      controller.handleEngineState(PlayerState(false, ProcessingState.ready));
+      expect(controller.state.status, PlaybackStatus.paused);
+      final int urlsBefore = player.setUrlCalls.length;
+
+      controller.onAppBackgrounded();
+      controller.onAppForegrounded();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(player.setUrlCalls.length, urlsBefore);
+      expect(controller.state.status, PlaybackStatus.paused);
+      expect(controller.state.currentTrack?.uri, local.uri);
+    });
+
+    test('playing across suspend reloads once at the preserved position',
+        () async {
+      final player = _Engine();
+      final resolver = _Resolver();
+      final controller = buildLinux(player: player, resolver: resolver);
+
+      await startPlaying(controller, remote);
+      const Duration preserved = Duration(minutes: 1, seconds: 5);
+      controller.setPositionForTesting(preserved);
+      expect(player.setUrlCalls, hasLength(1));
+      final String firstUrl = player.setUrlCalls.single;
+
+      controller.onAppBackgrounded();
+      controller.onAppForegrounded();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(resolver.calls, <String>[remote.uri, remote.uri]);
+      expect(player.setUrlCalls, hasLength(2));
+      expect(player.setUrlCalls.last, isNot(firstUrl));
+      expect(player.seekCalls, contains(preserved));
+      expect(controller.state.currentTrack?.uri, remote.uri);
+      expect(controller.state.upNext.map((Track t) => t.uri).toList(),
+          <String>[next.uri]);
+      expect(controller.state.status, isNot(PlaybackStatus.error));
+    });
+
+    test('concurrent resumes coalesce into one recovery', () async {
+      final player = _Engine();
+      final resolver = _Resolver();
+      final controller = buildLinux(player: player, resolver: resolver);
+      controller.suspendResumeBackoff = const Duration(milliseconds: 30);
+
+      await startPlaying(controller, remote);
+      expect(resolver.calls, <String>[remote.uri]);
+
+      controller.onAppBackgrounded();
+      controller.onAppForegrounded();
+      controller.onAppForegrounded();
+      controller.onAppForegrounded();
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(resolver.calls, <String>[remote.uri, remote.uri]);
+      expect(player.setUrlCalls, hasLength(2));
+    });
+
+    test('failed recovery surfaces error and preserves the queue', () async {
+      final player = _Engine();
+      final resolver = _Resolver();
+      final controller = buildLinux(player: player, resolver: resolver);
+
+      await startPlaying(controller, remote);
+      controller.onAppBackgrounded();
+
+      resolver.reachable = false;
+      controller.onAppForegrounded();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.state.status, PlaybackStatus.error);
+      expect(controller.state.currentTrack?.uri, remote.uri);
+      expect(controller.state.upNext.map((Track t) => t.uri).toList(),
+          <String>[next.uri]);
+      expect(controller.state.errorMessage, isNot(contains('http')));
+      expect(controller.state.errorMessage, isNotNull);
+    });
+
+    test('repeated suspend/resume cycles never stack overlapping reloads',
+        () async {
+      final player = _Engine();
+      final resolver = _Resolver();
+      final controller = buildLinux(player: player, resolver: resolver);
+
+      await startPlaying(controller, local);
+
+      for (int i = 0; i < 3; i++) {
+        controller.onAppBackgrounded();
+        controller.onAppForegrounded();
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      // Initial load + one recovery per cycle.
+      expect(player.setUrlCalls.length, 4);
+      expect(controller.state.currentTrack?.uri, local.uri);
+    });
+  });
+
+  group('Android suspend path stays inert', () {
+    test('screen-on never reloads a playing track', () async {
+      final player = _Engine();
+      final resolver = _Resolver();
+      final controller = buildAndroid(player: player, resolver: resolver);
+
+      await startPlaying(controller, remote);
+      final int urlsBefore = player.setUrlCalls.length;
+
+      controller.onAppBackgrounded();
+      controller.onAppForegrounded();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(player.setUrlCalls.length, urlsBefore);
+      expect(resolver.calls, <String>[remote.uri]);
+    });
+  });
+}

--- a/test/core/services/linux_suspend_resume_recovery_test.dart
+++ b/test/core/services/linux_suspend_resume_recovery_test.dart
@@ -65,9 +65,7 @@ class _Engine extends Fake implements AudioPlayer {
 }
 
 class _Resolver implements PlayableUriResolver {
-  _Resolver({this.reachable = true});
-
-  bool reachable;
+  bool reachable = true;
   final List<String> calls = <String>[];
   int _n = 0;
 

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -188,6 +188,14 @@ class FakePlaybackController implements LocalPlaybackController {
   /// cast-routing tests can assert it runs only off the cast path.
   int foregroundedCount = 0;
 
+  /// How many times a background/suspend lifecycle arming was invoked.
+  int backgroundedCount = 0;
+
+  @override
+  void onAppBackgrounded() {
+    backgroundedCount++;
+  }
+
   @override
   void onAppForegrounded() {
     foregroundedCount++;


### PR DESCRIPTION
## Summary
- Closes #466: Linux playback recovers predictably after system suspend/resume.
- Arms recovery only on `AppLifecycleState.paused` (not brief `inactive` dialogs); on Linux, a track that was **playing** is re-resolved/reloaded once on the same engine after a short backoff.
- User-paused tracks stay paused; failed recovery keeps the queue and surfaces the existing error + Retry UI; Android screen-on stays inert.
- Documents a manual suspend/resume matrix in `docs/linux-desktop.md`.

## Test plan
- [x] `flutter test` on linux suspend/resume recovery, Linux playback controller, ActivePlaybackController lifecycle, app playback lifecycle, unsupported controller, focus tests
- [x] `dart analyze` clean on changed Dart paths
- [ ] Manual matrix in `docs/linux-desktop.md`: sleep while playing local/remote, while paused, with Bluetooth/network delayed after wake, and 3× repeat cycles
