### PR TITLE
feat(linux): crash-safe playback state restoration

### DIFF
--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -246,6 +246,21 @@ widget.
 alone. If someone re-runs `flutter create --platforms=linux .` anyway, the
 checker above is what catches the reverted title and the lost SQLite seam.
 
+## Crash-safe playback restore
+
+On Linux, Linthra persists a small **logical** playback session while a track is
+queued — provider-namespaced track ids (`jellyfin:…`), local paths, shuffle/
+repeat modes, and position. It never writes authenticated stream URLs or
+provider tokens. After an unexpected process exit, the next launch restores that
+queue as **paused** (never autoplay); pressing play re-resolves remote tracks
+through the normal signed-in provider path. Missing local files, signed-out
+providers, and wrong-version/corrupt records drop only the invalid rows (or the
+whole session) and never block startup.
+
+Automated coverage: `test/core/models/persisted_playback_session_test.dart`,
+`test/data/repositories/shared_preferences_playback_session_store_test.dart`,
+`test/core/services/playback_session_persistence_test.dart`.
+
 ## Release tarball
 
 Every official release gets `Linthra-<tag>-linux-x64.tar.gz` attached to its

--- a/lib/core/models/persisted_playback_session.dart
+++ b/lib/core/models/persisted_playback_session.dart
@@ -76,7 +76,8 @@ class PersistedPlaybackSession {
       position: position < Duration.zero ? Duration.zero : position,
       shuffleEnabled: shuffleEnabled,
       repeatMode: repeatMode,
-      originalOrder: originalOrder == null ? null : List<Track>.of(originalOrder),
+      originalOrder:
+          originalOrder == null ? null : List<Track>.of(originalOrder),
     );
   }
 
@@ -147,7 +148,8 @@ class PersistedPlaybackSession {
     }
 
     final Object? rawPosition = json['p'];
-    final int positionMs = rawPosition is int && rawPosition >= 0 ? rawPosition : 0;
+    final int positionMs =
+        rawPosition is int && rawPosition >= 0 ? rawPosition : 0;
 
     final bool shuffleEnabled = json['s'] == true;
     final RepeatMode repeatMode = _repeatModeFromName(json['r']);
@@ -223,9 +225,7 @@ bool isLogicalTrackUri(String uri) {
   final String? bareId = MusicProviders.bareRemoteIdForTrackUri(trimmed);
   if (bareId != null) {
     // Remote: must be exactly `scheme:<non-empty id>` with no path/query noise.
-    return bareId.isNotEmpty &&
-        !bareId.contains('/') &&
-        !bareId.contains('?');
+    return bareId.isNotEmpty && !bareId.contains('/') && !bareId.contains('?');
   }
 
   // Local: anything non-HTTP that isn't a remote scheme is treated as a path /
@@ -246,8 +246,7 @@ Map<String, dynamic> logicalTrackToJson(Track track) {
     if (track.albumArtistName != null) 'albumArtist': track.albumArtistName,
     'durationMs': track.duration.inMilliseconds,
     if (track.trackNumber != null) 'trackNumber': track.trackNumber,
-    if (track.artworkUri != null &&
-        isPersistableArtworkUri(track.artworkUri!))
+    if (track.artworkUri != null && isPersistableArtworkUri(track.artworkUri!))
       'artwork': track.artworkUri.toString(),
   };
 }

--- a/lib/core/models/persisted_playback_session.dart
+++ b/lib/core/models/persisted_playback_session.dart
@@ -1,0 +1,321 @@
+import 'package:flutter/foundation.dart';
+
+import '../sources/music_provider.dart';
+import 'repeat_mode.dart';
+import 'track.dart';
+
+/// Crash-safe snapshot of non-secret playback state that can survive a process
+/// restart.
+///
+/// Carries only **logical** track identity (provider-namespaced uris like
+/// `jellyfin:101`, local paths), queue order/modes, and a seek position — never
+/// an authenticated stream URL, provider token, or raw resolver output. Remote
+/// playback always re-resolves through the normal provider/session path after
+/// restore.
+@immutable
+class PersistedPlaybackSession {
+  const PersistedPlaybackSession({
+    required this.tracks,
+    required this.currentIndex,
+    this.position = Duration.zero,
+    this.shuffleEnabled = false,
+    this.repeatMode = RepeatMode.off,
+    this.originalOrder,
+    this.schemaVersion = currentSchemaVersion,
+  });
+
+  /// Bump when the on-disk shape changes in a way older readers cannot ignore.
+  /// Unknown/future versions are dropped wholesale on load (fail safe).
+  static const int currentSchemaVersion = 1;
+
+  /// Effective play order at the time of the snapshot (already shuffled when
+  /// [shuffleEnabled] is true).
+  final List<Track> tracks;
+
+  /// Index of the current track within [tracks].
+  final int currentIndex;
+
+  /// Seek position within the current track. Clamped on restore when duration
+  /// is known.
+  final Duration position;
+
+  final bool shuffleEnabled;
+  final RepeatMode repeatMode;
+
+  /// Pre-shuffle order when [shuffleEnabled], otherwise null. Same logical
+  /// track identity rules as [tracks].
+  final List<Track>? originalOrder;
+
+  final int schemaVersion;
+
+  bool get isEmpty => tracks.isEmpty;
+
+  Track? get current {
+    if (currentIndex < 0 || currentIndex >= tracks.length) return null;
+    return tracks[currentIndex];
+  }
+
+  /// Builds a session from live playback, or `null` when there is nothing
+  /// useful / safe to persist (no current track, or any identity that is not
+  /// logical).
+  static PersistedPlaybackSession? fromPlayback({
+    required List<Track> previous,
+    required Track current,
+    required List<Track> upNext,
+    required Duration position,
+    required bool shuffleEnabled,
+    required RepeatMode repeatMode,
+    List<Track>? originalOrder,
+  }) {
+    final List<Track> tracks = <Track>[...previous, current, ...upNext];
+    if (!_allLogical(tracks)) return null;
+    if (originalOrder != null && !_allLogical(originalOrder)) return null;
+    return PersistedPlaybackSession(
+      tracks: tracks,
+      currentIndex: previous.length,
+      position: position < Duration.zero ? Duration.zero : position,
+      shuffleEnabled: shuffleEnabled,
+      repeatMode: repeatMode,
+      originalOrder: originalOrder == null ? null : List<Track>.of(originalOrder),
+    );
+  }
+
+  /// Serializes to a JSON-compatible map. Never includes stream URLs or tokens.
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'v': schemaVersion,
+      'i': currentIndex,
+      'p': position.inMilliseconds,
+      's': shuffleEnabled,
+      'r': repeatMode.name,
+      't': <Map<String, dynamic>>[
+        for (final Track track in tracks) logicalTrackToJson(track),
+      ],
+      if (originalOrder != null)
+        'o': <Map<String, dynamic>>[
+          for (final Track track in originalOrder!) logicalTrackToJson(track),
+        ],
+    };
+  }
+
+  /// Rebuilds a session from [toJson] output, or `null` if the record is
+  /// unusable (wrong version, corrupt shape, no restorable tracks).
+  ///
+  /// Invalid individual tracks are dropped; [currentIndex] is remapped onto the
+  /// surviving list. A wholly empty result yields `null` so callers clear the
+  /// store rather than restoring nothing useful.
+  static PersistedPlaybackSession? fromJson(
+    Map<String, dynamic> json, {
+    bool Function(Track track)? isTrackRestorable,
+  }) {
+    final Object? version = json['v'];
+    if (version is! int || version != currentSchemaVersion) return null;
+
+    final Object? rawTracks = json['t'];
+    if (rawTracks is! List) return null;
+
+    final Object? rawIndex = json['i'];
+    final int requestedIndex = rawIndex is int ? rawIndex : 0;
+    String? preferredCurrentUri;
+    if (requestedIndex >= 0 && requestedIndex < rawTracks.length) {
+      final Object? preferred = rawTracks[requestedIndex];
+      if (preferred is Map) {
+        final Object? uri = preferred['uri'];
+        if (uri is String && uri.isNotEmpty) preferredCurrentUri = uri;
+      }
+    }
+
+    final List<Track> parsed = <Track>[];
+    for (final Object? entry in rawTracks) {
+      if (entry is! Map) continue;
+      final Track? track =
+          logicalTrackFromJson(Map<String, dynamic>.from(entry));
+      if (track == null) continue;
+      if (isTrackRestorable != null && !isTrackRestorable(track)) continue;
+      parsed.add(track);
+    }
+    if (parsed.isEmpty) return null;
+
+    // Prefer the originally current identity when it survived filtering;
+    // otherwise land on the first surviving track so restore never points past
+    // the end or at a dropped remote/local row.
+    int currentIndex = 0;
+    if (preferredCurrentUri != null) {
+      final int found =
+          parsed.indexWhere((Track t) => t.uri == preferredCurrentUri);
+      if (found >= 0) currentIndex = found;
+    }
+
+    final Object? rawPosition = json['p'];
+    final int positionMs = rawPosition is int && rawPosition >= 0 ? rawPosition : 0;
+
+    final bool shuffleEnabled = json['s'] == true;
+    final RepeatMode repeatMode = _repeatModeFromName(json['r']);
+
+    List<Track>? originalOrder;
+    final Object? rawOriginal = json['o'];
+    if (shuffleEnabled && rawOriginal is List) {
+      final List<Track> order = <Track>[];
+      for (final Object? entry in rawOriginal) {
+        if (entry is! Map) continue;
+        final Track? track =
+            logicalTrackFromJson(Map<String, dynamic>.from(entry));
+        if (track == null) continue;
+        if (isTrackRestorable != null && !isTrackRestorable(track)) continue;
+        order.add(track);
+      }
+      if (order.isNotEmpty) originalOrder = order;
+    }
+
+    final Track current = parsed[currentIndex];
+    final Duration position = _clampPosition(
+      Duration(milliseconds: positionMs),
+      current.duration,
+    );
+
+    return PersistedPlaybackSession(
+      tracks: parsed,
+      currentIndex: currentIndex,
+      position: position,
+      shuffleEnabled: shuffleEnabled,
+      repeatMode: repeatMode,
+      originalOrder: shuffleEnabled ? originalOrder : null,
+    );
+  }
+
+  static bool _allLogical(List<Track> tracks) {
+    for (final Track track in tracks) {
+      if (!isLogicalTrackUri(track.uri)) return false;
+    }
+    return true;
+  }
+
+  static RepeatMode _repeatModeFromName(Object? name) {
+    if (name is! String) return RepeatMode.off;
+    for (final RepeatMode mode in RepeatMode.values) {
+      if (mode.name == name) return mode;
+    }
+    return RepeatMode.off;
+  }
+
+  static Duration _clampPosition(Duration position, Duration duration) {
+    if (position < Duration.zero) return Duration.zero;
+    if (duration > Duration.zero && position > duration) return duration;
+    return position;
+  }
+}
+
+/// Whether [uri] is a persistable logical track identity.
+///
+/// Accepts provider-namespaced remote ids (`jellyfin:…`, `subsonic:…`,
+/// `plex:…`) and non-HTTP local paths. Rejects authenticated stream URLs,
+/// token-bearing query strings, and blank values so a bad write can never put a
+/// secret on disk.
+bool isLogicalTrackUri(String uri) {
+  final String trimmed = uri.trim();
+  if (trimmed.isEmpty) return false;
+  final String lower = trimmed.toLowerCase();
+  if (lower.startsWith('http://') || lower.startsWith('https://')) {
+    return false;
+  }
+  if (_looksTokenBearing(lower)) return false;
+
+  final String? bareId = MusicProviders.bareRemoteIdForTrackUri(trimmed);
+  if (bareId != null) {
+    // Remote: must be exactly `scheme:<non-empty id>` with no path/query noise.
+    return bareId.isNotEmpty &&
+        !bareId.contains('/') &&
+        !bareId.contains('?');
+  }
+
+  // Local: anything non-HTTP that isn't a remote scheme is treated as a path /
+  // content uri identity. Still reject token-looking query fragments.
+  return true;
+}
+
+/// JSON shape for one logical [Track]. Deliberately omits ReplayGain (optional
+/// loudness metadata) — restore never needs it to re-resolve playback.
+Map<String, dynamic> logicalTrackToJson(Track track) {
+  return <String, dynamic>{
+    'id': track.id,
+    'title': track.title,
+    'uri': track.uri,
+    if (track.artistName != null) 'artist': track.artistName,
+    if (track.albumName != null) 'album': track.albumName,
+    if (track.albumId != null) 'albumId': track.albumId,
+    if (track.albumArtistName != null) 'albumArtist': track.albumArtistName,
+    'durationMs': track.duration.inMilliseconds,
+    if (track.trackNumber != null) 'trackNumber': track.trackNumber,
+    if (track.artworkUri != null &&
+        isPersistableArtworkUri(track.artworkUri!))
+      'artwork': track.artworkUri.toString(),
+  };
+}
+
+/// Rebuilds a [Track] from [logicalTrackToJson] output, or `null` when the
+/// identity is missing/unsafe.
+Track? logicalTrackFromJson(Map<String, dynamic> json) {
+  final Object? id = json['id'];
+  final Object? title = json['title'];
+  final Object? uri = json['uri'];
+  if (id is! String || id.isEmpty) return null;
+  if (title is! String || title.isEmpty) return null;
+  if (uri is! String || !isLogicalTrackUri(uri)) return null;
+
+  final Object? durationMs = json['durationMs'];
+  final Duration duration = durationMs is int && durationMs >= 0
+      ? Duration(milliseconds: durationMs)
+      : Duration.zero;
+
+  final Object? trackNumber = json['trackNumber'];
+  final Object? artwork = json['artwork'];
+  Uri? artworkUri;
+  if (artwork is String && artwork.isNotEmpty) {
+    final Uri? parsed = Uri.tryParse(artwork);
+    if (parsed != null && isPersistableArtworkUri(parsed)) {
+      artworkUri = parsed;
+    }
+  }
+
+  return Track(
+    id: id,
+    title: title,
+    uri: uri,
+    artistName: json['artist'] as String?,
+    albumName: json['album'] as String?,
+    albumId: json['albumId'] as String?,
+    albumArtistName: json['albumArtist'] as String?,
+    duration: duration,
+    trackNumber: trackNumber is int ? trackNumber : null,
+    artworkUri: artworkUri,
+  );
+}
+
+/// Artwork is safe to persist when it is a credential-free reference (Jellyfin
+/// primary-image URL without a token, `subsonic-cover:…`, `plex-thumb:…`, or a
+/// local path). Token-bearing query strings are rejected.
+bool isPersistableArtworkUri(Uri uri) {
+  final String raw = uri.toString().toLowerCase();
+  if (_looksTokenBearing(raw)) return false;
+  return true;
+}
+
+bool _looksTokenBearing(String value) {
+  // Common provider token query keys and auth header-ish fragments that must
+  // never reach the playback-session document.
+  const List<String> markers = <String>[
+    'api_key=',
+    'apikey=',
+    'access_token=',
+    'accesstoken=',
+    'x-plex-token=',
+    'x_plex_token=',
+    'authorization=',
+    'bearer ',
+    'jwt=',
+  ];
+  for (final String marker in markers) {
+    if (value.contains(marker)) return true;
+  }
+  return false;
+}

--- a/lib/core/repositories/playback_session_store.dart
+++ b/lib/core/repositories/playback_session_store.dart
@@ -1,0 +1,23 @@
+import '../models/persisted_playback_session.dart';
+
+/// Durable storage for a crash-safe [PersistedPlaybackSession].
+///
+/// The persistence seam under [PlaybackSessionPersistence]: it knows nothing
+/// about the audio engine — only how to load, save, and clear the session
+/// document. Splitting it out lets the backing store swap freely (in-memory for
+/// tests, key/value in the app), mirroring [PlayHistoryStore].
+///
+/// Privacy: only logical track identity, queue/modes, and position are stored —
+/// never a token or authenticated stream URL. The document stays on the device.
+abstract interface class PlaybackSessionStore {
+  /// The last persisted session, or `null` when none / unusable.
+  Future<PersistedPlaybackSession?> load();
+
+  /// Replaces the persisted session. Callers must only pass logical, sanitized
+  /// sessions.
+  Future<void> save(PersistedPlaybackSession session);
+
+  /// Drops any persisted session (explicit stop/clear, or after a failed
+  /// restore that should not be retried).
+  Future<void> clear();
+}

--- a/lib/core/services/just_audio_playback_controller.dart
+++ b/lib/core/services/just_audio_playback_controller.dart
@@ -1456,6 +1456,31 @@ class JustAudioPlaybackController implements LocalPlaybackController {
   }
 
   @override
+  Future<void> restoreSession({
+    required List<Track> tracks,
+    int startIndex = 0,
+    Duration position = Duration.zero,
+    bool shuffleEnabled = false,
+    RepeatMode repeatMode = RepeatMode.off,
+    List<Track>? originalOrder,
+  }) async {
+    if (tracks.isEmpty) return;
+    // Crash restore must never surprise-start audio, even if a cast handoff
+    // left the engine suspended — clear that flag and load paused.
+    _suspended = false;
+    _shuffleEnabled = shuffleEnabled;
+    _repeatMode = repeatMode;
+    final int index = startIndex.clamp(0, tracks.length - 1);
+    _queue = PlaybackQueue(
+      tracks: List<Track>.of(tracks),
+      currentIndex: index,
+      originalOrder:
+          originalOrder == null ? null : List<Track>.of(originalOrder),
+    );
+    await _playCurrent(startAt: position, autoplay: false);
+  }
+
+  @override
   Future<void> restartQueue() async {
     _queue = _queue.restarted();
     await _playCurrent();

--- a/lib/core/services/local_playback_controller.dart
+++ b/lib/core/services/local_playback_controller.dart
@@ -1,3 +1,5 @@
+import '../models/repeat_mode.dart';
+import '../models/track.dart';
 import 'playback_controller.dart';
 
 /// A [PlaybackController] that owns an on-device audio engine and can be
@@ -21,6 +23,19 @@ abstract interface class LocalPlaybackController implements PlaybackController {
   /// starts playing or stays paused per [play] (paused by default, so ending a
   /// cast session never auto-starts the phone). Clears the suspended flag.
   Future<void> resume({Duration at = Duration.zero, bool play = false});
+
+  /// Restores a previously persisted queue as a **paused** session: sets modes,
+  /// installs [tracks] at [startIndex], seeks to [position], and loads the
+  /// current track through the normal resolver **without autoplay**. Used after
+  /// an unexpected process restart so the user can resume deliberately.
+  Future<void> restoreSession({
+    required List<Track> tracks,
+    int startIndex = 0,
+    Duration position = Duration.zero,
+    bool shuffleEnabled = false,
+    RepeatMode repeatMode = RepeatMode.off,
+    List<Track>? originalOrder,
+  });
 
   /// Wraps the queue back to its first track and (re)loads it. Used to honour
   /// repeat-all when a cast track finishes at the end of the queue.

--- a/lib/core/services/playback_session_persistence.dart
+++ b/lib/core/services/playback_session_persistence.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+import 'dart:io' show File;
+
+import '../models/persisted_playback_session.dart';
+import '../models/playback_state.dart';
+import '../models/track.dart';
+import '../repositories/playback_session_store.dart';
+import '../sources/music_provider.dart';
+import 'local_playback_controller.dart';
+
+/// Persists logical playback state across unexpected process restarts and
+/// restores it as a **paused** queue on the next launch.
+///
+/// Writes only [PersistedPlaybackSession] documents (logical track identity,
+/// modes, position) — never stream URLs or tokens. On restore, remote tracks
+/// are loaded through the engine's normal resolver path and [autoplay] stays
+/// off so a crash/restart never blasts audio. Invalid/stale rows are dropped;
+/// a wholly unusable record is cleared and never blocks startup.
+class PlaybackSessionPersistence {
+  PlaybackSessionPersistence({
+    required PlaybackSessionStore store,
+    required LocalPlaybackController controller,
+    required Stream<PlaybackState> playbackStates,
+    bool Function(MusicProvider provider)? isRemoteProviderAvailable,
+    bool Function(String localUri)? localFileExists,
+    Duration positionSaveInterval = const Duration(seconds: 2),
+  })  : _store = store,
+        _controller = controller,
+        _isRemoteProviderAvailable = isRemoteProviderAvailable,
+        _localFileExists = localFileExists ?? _defaultLocalFileExists,
+        _positionSaveInterval = positionSaveInterval {
+    _subscription = playbackStates.listen(_onPlaybackState);
+  }
+
+  final PlaybackSessionStore _store;
+  final LocalPlaybackController _controller;
+  final bool Function(MusicProvider provider)? _isRemoteProviderAvailable;
+  final bool Function(String localUri) _localFileExists;
+  final Duration _positionSaveInterval;
+
+  StreamSubscription<PlaybackState>? _subscription;
+  Timer? _positionTimer;
+  PlaybackState? _lastPersisted;
+  bool _restoring = false;
+  bool _disposed = false;
+
+  /// Loads any persisted session, sanitizes it, and restores it paused onto
+  /// the local engine. Best-effort: failures are swallowed and the bad record
+  /// is cleared so startup can never be blocked by restore.
+  Future<void> restore() async {
+    if (_disposed) return;
+    _restoring = true;
+    try {
+      final PersistedPlaybackSession? raw = await _store.load();
+      if (raw == null) return;
+
+      final PersistedPlaybackSession? session = PersistedPlaybackSession.fromJson(
+        raw.toJson(),
+        isTrackRestorable: _isTrackRestorable,
+      );
+      if (session == null || session.current == null) {
+        await _store.clear();
+        return;
+      }
+
+      await _controller.restoreSession(
+        tracks: session.tracks,
+        startIndex: session.currentIndex,
+        position: session.position,
+        shuffleEnabled: session.shuffleEnabled,
+        repeatMode: session.repeatMode,
+        originalOrder: session.originalOrder,
+      );
+    } catch (_) {
+      try {
+        await _store.clear();
+      } catch (_) {
+        // Ignore: a clear failure must not block startup either.
+      }
+    } finally {
+      _restoring = false;
+    }
+  }
+
+  void _onPlaybackState(PlaybackState state) {
+    if (_disposed || _restoring) return;
+
+    if (state.currentTrack == null) {
+      _positionTimer?.cancel();
+      _positionTimer = null;
+      _lastPersisted = null;
+      unawaited(_clearQuietly());
+      return;
+    }
+
+    // Persist immediately on structural / mode / status changes; debounce the
+    // high-frequency position ticks while playing.
+    final bool structuralChange = _lastPersisted == null ||
+        _lastPersisted!.currentTrack?.uri != state.currentTrack?.uri ||
+        !_listEqualsByUri(_lastPersisted!.upNext, state.upNext) ||
+        !_listEqualsByUri(_lastPersisted!.previous, state.previous) ||
+        _lastPersisted!.shuffleEnabled != state.shuffleEnabled ||
+        _lastPersisted!.repeatMode != state.repeatMode ||
+        _lastPersisted!.status != state.status;
+
+    if (structuralChange) {
+      _positionTimer?.cancel();
+      _positionTimer = null;
+      unawaited(_persist(state));
+      return;
+    }
+
+    if (state.status == PlaybackStatus.playing) {
+      _positionTimer ??= Timer(_positionSaveInterval, () {
+        _positionTimer = null;
+        unawaited(_persist(state));
+      });
+    } else {
+      _positionTimer?.cancel();
+      _positionTimer = null;
+      unawaited(_persist(state));
+    }
+  }
+
+  Future<void> _persist(PlaybackState state) async {
+    final Track? current = state.currentTrack;
+    if (current == null) return;
+
+    final PersistedPlaybackSession? session =
+        PersistedPlaybackSession.fromPlayback(
+      previous: state.previous,
+      current: current,
+      upNext: state.upNext,
+      position: state.position,
+      shuffleEnabled: state.shuffleEnabled,
+      repeatMode: state.repeatMode,
+      // The live controller does not expose originalOrder on PlaybackState; a
+      // shuffled queue is persisted in its effective order and restored as
+      // already-shuffled (originalOrder null → unshuffle becomes a no-op until
+      // the user toggles shuffle off/on). That keeps the document free of a
+      // second secret-bearing surface while still restoring useful up-next.
+      originalOrder: null,
+    );
+    if (session == null) return;
+
+    try {
+      await _store.save(session);
+      _lastPersisted = state;
+    } catch (_) {
+      // Non-fatal: persistence must never break playback.
+    }
+  }
+
+  Future<void> _clearQuietly() async {
+    try {
+      await _store.clear();
+    } catch (_) {
+      // Non-fatal.
+    }
+  }
+
+  bool _isTrackRestorable(Track track) {
+    if (!isLogicalTrackUri(track.uri)) return false;
+    final MusicProvider provider = MusicProviders.forTrackUri(track.uri);
+    if (identical(provider, MusicProviders.local)) {
+      return _localFileExists(track.uri);
+    }
+    final bool Function(MusicProvider)? available = _isRemoteProviderAvailable;
+    if (available == null) return true;
+    return available(provider);
+  }
+
+  static bool _defaultLocalFileExists(String uri) {
+    // content:// and similar non-file local identities are kept; only plain
+    // filesystem paths are probed so a missing file after a move is dropped.
+    if (uri.contains(':') && !uri.startsWith('/')) return true;
+    try {
+      return File(uri).existsSync();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static bool _listEqualsByUri(List<Track> a, List<Track> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i].uri != b[i].uri) return false;
+    }
+    return true;
+  }
+
+  /// Stops listening. Safe to call more than once.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _positionTimer?.cancel();
+    _positionTimer = null;
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/lib/core/services/playback_session_persistence.dart
+++ b/lib/core/services/playback_session_persistence.dart
@@ -54,7 +54,8 @@ class PlaybackSessionPersistence {
       final PersistedPlaybackSession? raw = await _store.load();
       if (raw == null) return;
 
-      final PersistedPlaybackSession? session = PersistedPlaybackSession.fromJson(
+      final PersistedPlaybackSession? session =
+          PersistedPlaybackSession.fromJson(
         raw.toJson(),
         isTrackRestorable: _isTrackRestorable,
       );

--- a/lib/core/services/unsupported_playback_controller.dart
+++ b/lib/core/services/unsupported_playback_controller.dart
@@ -158,6 +158,21 @@ class UnsupportedPlaybackController implements LocalPlaybackController {
   Future<void> resume({Duration at = Duration.zero, bool play = false}) async {}
 
   @override
+  Future<void> restoreSession({
+    required List<Track> tracks,
+    int startIndex = 0,
+    Duration position = Duration.zero,
+    bool shuffleEnabled = false,
+    RepeatMode repeatMode = RepeatMode.off,
+    List<Track>? originalOrder,
+  }) async {
+    // No engine to load into; refuse with the same clear error as playTracks so
+    // a persisted session on an unsupported host never pretends to restore.
+    final bool inRange = startIndex >= 0 && startIndex < tracks.length;
+    _refuse(inRange ? tracks[startIndex] : null);
+  }
+
+  @override
   Future<void> restartQueue() async {}
 
   @override

--- a/lib/data/repositories/in_memory_playback_session_store.dart
+++ b/lib/data/repositories/in_memory_playback_session_store.dart
@@ -1,0 +1,22 @@
+import '../../core/models/persisted_playback_session.dart';
+import '../../core/repositories/playback_session_store.dart';
+
+/// A non-persistent [PlaybackSessionStore] for development and tests.
+class InMemoryPlaybackSessionStore implements PlaybackSessionStore {
+  InMemoryPlaybackSessionStore([this._session]);
+
+  PersistedPlaybackSession? _session;
+
+  @override
+  Future<PersistedPlaybackSession?> load() async => _session;
+
+  @override
+  Future<void> save(PersistedPlaybackSession session) async {
+    _session = session;
+  }
+
+  @override
+  Future<void> clear() async {
+    _session = null;
+  }
+}

--- a/lib/data/repositories/playback_session_store_provider.dart
+++ b/lib/data/repositories/playback_session_store_provider.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/platform/host_platform.dart';
+import '../../core/repositories/playback_session_store.dart';
+import '../../core/services/playback_session_persistence.dart';
+import '../../core/sources/music_provider.dart';
+import '../../features/player/player_providers.dart';
+import '../../features/settings/jellyfin/jellyfin_settings_controller.dart';
+import '../../features/settings/plex/plex_settings_controller.dart';
+import '../../features/settings/subsonic/subsonic_settings_controller.dart';
+import 'host_platform_provider.dart';
+import 'in_memory_playback_session_store.dart';
+import 'shared_preferences_playback_session_store.dart';
+
+/// Durable store of the crash-safe playback session. Defaults to in-memory so
+/// tests and non-Linux hosts need no plugins; Linux production overrides it
+/// with the `shared_preferences` binding below.
+final playbackSessionStoreProvider = Provider<PlaybackSessionStore>((ref) {
+  return InMemoryPlaybackSessionStore();
+});
+
+/// Production binding: persist the playback session via `shared_preferences`
+/// so an unexpected restart can restore the logical queue. Applied in `main`
+/// on Linux only; other platforms keep the in-memory default (no restore).
+final sharedPreferencesPlaybackSessionStoreOverride =
+    playbackSessionStoreProvider.overrideWithValue(
+  const SharedPreferencesPlaybackSessionStore(),
+);
+
+/// Crash-safe playback session persistence + restore.
+///
+/// Constructed only on Linux: it listens to the local engine's state stream,
+/// writes logical sessions, and restores them paused on startup. Returns
+/// `null` on other platforms so Android behaviour is unchanged. Side-effect
+/// only; `main` instantiates it once and awaits
+/// [PlaybackSessionPersistence.restore].
+final playbackSessionPersistenceProvider =
+    Provider<PlaybackSessionPersistence?>((ref) {
+  if (ref.watch(hostPlatformProvider) != HostPlatform.linux) {
+    return null;
+  }
+
+  final PlaybackSessionPersistence service = PlaybackSessionPersistence(
+    store: ref.watch(playbackSessionStoreProvider),
+    controller: ref.read(localPlaybackControllerProvider),
+    playbackStates: ref.read(localPlaybackControllerProvider).stateStream,
+    isRemoteProviderAvailable: (MusicProvider provider) {
+      if (identical(provider, MusicProviders.jellyfin)) {
+        return ref.read(jellyfinMusicSourceProvider) != null;
+      }
+      if (identical(provider, MusicProviders.subsonic)) {
+        return ref.read(subsonicMusicSourceProvider) != null;
+      }
+      if (identical(provider, MusicProviders.plex)) {
+        return ref.read(plexMusicSourceProvider) != null;
+      }
+      return true;
+    },
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});

--- a/lib/data/repositories/shared_preferences_playback_session_store.dart
+++ b/lib/data/repositories/shared_preferences_playback_session_store.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/persisted_playback_session.dart';
+import '../../core/repositories/playback_session_store.dart';
+
+/// A [PlaybackSessionStore] backed by `shared_preferences`.
+///
+/// A single JSON document is the right weight for one queue snapshot (the same
+/// reasoning playlists and play history follow). A corrupt, wrong-version, or
+/// secret-bearing record reads as "no session" rather than crashing startup.
+///
+/// Security: only logical track identity, modes, and position are written —
+/// never a token or authenticated stream URL. [PersistedPlaybackSession.fromJson]
+/// re-validates on read as a second line of defense.
+class SharedPreferencesPlaybackSessionStore implements PlaybackSessionStore {
+  const SharedPreferencesPlaybackSessionStore();
+
+  static const String key = 'playback_session_v1';
+
+  @override
+  Future<PersistedPlaybackSession?> load() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final String? raw = prefs.getString(key);
+    if (raw == null || raw.isEmpty) return null;
+    Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return null;
+    }
+    if (decoded is! Map) return null;
+    return PersistedPlaybackSession.fromJson(
+      Map<String, dynamic>.from(decoded),
+    );
+  }
+
+  @override
+  Future<void> save(PersistedPlaybackSession session) async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString(key, jsonEncode(session.toJson()));
+  }
+
+  @override
+  Future<void> clear() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(key);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,10 @@ import 'app/linthra_app.dart';
 import 'core/models/plex_session.dart';
 import 'core/models/subsonic_session.dart';
 import 'core/models/theme_mode_preference.dart';
+import 'core/platform/host_platform.dart';
 import 'core/services/artwork_disk_cache.dart';
 import 'core/services/media_session_binding.dart';
+import 'core/services/playback_session_persistence.dart';
 import 'core/sources/plex/plex_artwork.dart';
 import 'core/sources/subsonic/subsonic_artwork.dart';
 import 'data/repositories/app_icon_variant_store_provider.dart';
@@ -22,6 +24,7 @@ import 'data/repositories/library_added_store_provider.dart';
 import 'data/repositories/music_library_repository_provider.dart';
 import 'data/repositories/play_history_repository_provider.dart';
 import 'data/repositories/playback_preferences_provider.dart';
+import 'data/repositories/playback_session_store_provider.dart';
 import 'data/repositories/playback_source_strategy_store_provider.dart';
 import 'data/repositories/playlist_repository_provider.dart';
 import 'data/repositories/plex_session_store_provider.dart';
@@ -90,6 +93,10 @@ Future<void> main() async {
       sharedPreferencesDownloadStoreOverride,
       sharedPreferencesDownloadPreferencesOverride,
       sharedPreferencesPlaybackPreferencesOverride,
+      // Linux only: persist logical queue/position so an unexpected restart can
+      // restore a paused session without ever writing stream URLs or tokens.
+      if (HostPlatform.current == HostPlatform.linux)
+        sharedPreferencesPlaybackSessionStoreOverride,
       fileSystemOfflineFileStoreOverride,
       remoteTrackDownloaderOverride,
       // Let playback fall back to another copy of the same song when the
@@ -314,6 +321,20 @@ Future<void> main() async {
   // so synced playlists appear on the Playlists tab from the first frame.
   // Best-effort and offline-tolerant.
   unawaited(container.read(playlistRepositoryProvider).refreshFromRemote());
+
+  // Linux crash-safe restore: after sessions are warm, rehydrate any persisted
+  // logical queue as a paused/resumable state. Remote tracks re-resolve through
+  // the normal provider path when the user presses play — never autoplay, and
+  // never block launch on a bad record.
+  final PlaybackSessionPersistence? sessionPersistence =
+      container.read(playbackSessionPersistenceProvider);
+  if (sessionPersistence != null) {
+    try {
+      await sessionPersistence.restore();
+    } catch (_) {
+      // Ignore: a failed restore must never stop the app from launching.
+    }
+  }
 
   runApp(
     UncontrolledProviderScope(

--- a/test/app/linux_startup_test.dart
+++ b/test/app/linux_startup_test.dart
@@ -7,6 +7,7 @@ import 'package:linthra/data/repositories/download_repository_provider.dart';
 import 'package:linthra/data/repositories/favorites_repository_provider.dart';
 import 'package:linthra/data/repositories/host_platform_provider.dart';
 import 'package:linthra/data/repositories/music_library_repository_provider.dart';
+import 'package:linthra/data/repositories/playback_session_store_provider.dart';
 import 'package:linthra/data/repositories/playlist_repository_provider.dart';
 import 'package:linthra/data/repositories/remote_cache_index_provider.dart';
 import 'package:linthra/features/library/library_providers.dart';
@@ -58,7 +59,10 @@ void main() {
       container.read(remoteControlServiceProvider);
       container.read(remoteControlActivatorProvider);
       container.read(localPlaybackControllerProvider);
+      // Linux crash-safe session restore (null on non-Linux).
+      container.read(playbackSessionPersistenceProvider);
     }, returnsNormally);
+    expect(container.read(playbackSessionPersistenceProvider), isNotNull);
   });
 
   test('the library and lyrics seams build on Linux too', () {

--- a/test/core/models/persisted_playback_session_test.dart
+++ b/test/core/models/persisted_playback_session_test.dart
@@ -193,8 +193,7 @@ void main() {
 
       final Track? roundTrip = logicalTrackFromJson(<String, dynamic>{
         ...logicalTrackToJson(jellyfin),
-        'artwork':
-            'https://server/Items/101/Images/Primary?api_key=secret',
+        'artwork': 'https://server/Items/101/Images/Primary?api_key=secret',
       });
       expect(roundTrip!.artworkUri, isNull);
     });

--- a/test/core/models/persisted_playback_session_test.dart
+++ b/test/core/models/persisted_playback_session_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/persisted_playback_session.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+
+void main() {
+  const Track jellyfin = Track(
+    id: '101',
+    title: 'Remote',
+    uri: 'jellyfin:101',
+    artistName: 'A',
+    duration: Duration(minutes: 3),
+  );
+  const Track local = Track(
+    id: '/music/a.mp3',
+    title: 'Local',
+    uri: '/music/a.mp3',
+    duration: Duration(minutes: 2),
+  );
+  const Track subsonic = Track(
+    id: '55',
+    title: 'Sub',
+    uri: 'subsonic:55',
+  );
+
+  group('isLogicalTrackUri', () {
+    test('accepts provider-namespaced and local path identities', () {
+      expect(isLogicalTrackUri('jellyfin:101'), isTrue);
+      expect(isLogicalTrackUri('subsonic:abc'), isTrue);
+      expect(isLogicalTrackUri('plex:9'), isTrue);
+      expect(isLogicalTrackUri('/home/me/Music/song.mp3'), isTrue);
+    });
+
+    test('rejects authenticated stream URLs and token-bearing strings', () {
+      expect(
+        isLogicalTrackUri(
+          'https://server/Audio/101/stream?api_key=secret-token',
+        ),
+        isFalse,
+      );
+      expect(
+        isLogicalTrackUri(
+          'http://plex.local/library/parts/1?X-Plex-Token=tok',
+        ),
+        isFalse,
+      );
+      expect(isLogicalTrackUri('jellyfin:101?api_key=x'), isFalse);
+      expect(isLogicalTrackUri(''), isFalse);
+      expect(isLogicalTrackUri('   '), isFalse);
+    });
+  });
+
+  group('PersistedPlaybackSession', () {
+    test('round-trips logical queue, modes, and position', () {
+      const PersistedPlaybackSession session = PersistedPlaybackSession(
+        tracks: <Track>[local, jellyfin, subsonic],
+        currentIndex: 1,
+        position: Duration(seconds: 42),
+        shuffleEnabled: true,
+        repeatMode: RepeatMode.all,
+      );
+
+      final PersistedPlaybackSession? loaded =
+          PersistedPlaybackSession.fromJson(session.toJson());
+
+      expect(loaded, isNotNull);
+      expect(loaded!.tracks.map((Track t) => t.uri), <String>[
+        local.uri,
+        jellyfin.uri,
+        subsonic.uri,
+      ]);
+      expect(loaded.currentIndex, 1);
+      expect(loaded.position, const Duration(seconds: 42));
+      expect(loaded.shuffleEnabled, isTrue);
+      expect(loaded.repeatMode, RepeatMode.all);
+      expect(loaded.toJson().toString(), isNot(contains('http')));
+      expect(loaded.toJson().toString(), isNot(contains('api_key')));
+      expect(loaded.toJson().toString(), isNot(contains('token')));
+    });
+
+    test('fromPlayback refuses a queue that includes a stream URL', () {
+      const Track poisoned = Track(
+        id: 'bad',
+        title: 'Bad',
+        uri: 'https://server/stream?AccessToken=abc',
+      );
+      expect(
+        PersistedPlaybackSession.fromPlayback(
+          previous: const <Track>[],
+          current: poisoned,
+          upNext: const <Track>[],
+          position: Duration.zero,
+          shuffleEnabled: false,
+          repeatMode: RepeatMode.off,
+        ),
+        isNull,
+      );
+    });
+
+    test('fromJson drops a future schema version entirely', () {
+      expect(
+        PersistedPlaybackSession.fromJson(<String, dynamic>{
+          'v': PersistedPlaybackSession.currentSchemaVersion + 1,
+          'i': 0,
+          'p': 0,
+          's': false,
+          'r': 'off',
+          't': <Map<String, dynamic>>[logicalTrackToJson(jellyfin)],
+        }),
+        isNull,
+      );
+    });
+
+    test('fromJson drops invalid tracks and remaps the current item', () {
+      final PersistedPlaybackSession? loaded =
+          PersistedPlaybackSession.fromJson(<String, dynamic>{
+        'v': 1,
+        'i': 1,
+        'p': 1500,
+        's': false,
+        'r': 'one',
+        't': <Map<String, dynamic>>[
+          logicalTrackToJson(local),
+          <String, dynamic>{
+            'id': 'x',
+            'title': 'Stream',
+            'uri': 'https://evil/stream?api_key=secret',
+            'durationMs': 1000,
+          },
+          logicalTrackToJson(jellyfin),
+        ],
+      });
+
+      expect(loaded, isNotNull);
+      // The stream URL row is gone; preferred current (index 1) was that row, so
+      // restore lands on the first surviving track.
+      expect(loaded!.tracks.map((Track t) => t.uri), <String>[
+        local.uri,
+        jellyfin.uri,
+      ]);
+      expect(loaded.current!.uri, local.uri);
+      expect(loaded.repeatMode, RepeatMode.one);
+    });
+
+    test('fromJson keeps the preferred current when it survives filtering', () {
+      final PersistedPlaybackSession? loaded =
+          PersistedPlaybackSession.fromJson(
+        <String, dynamic>{
+          'v': 1,
+          'i': 1,
+          'p': 9000,
+          's': false,
+          'r': 'off',
+          't': <Map<String, dynamic>>[
+            logicalTrackToJson(local),
+            logicalTrackToJson(jellyfin),
+            logicalTrackToJson(subsonic),
+          ],
+        },
+        isTrackRestorable: (Track t) => t.uri != local.uri,
+      );
+
+      expect(loaded, isNotNull);
+      expect(loaded!.tracks.map((Track t) => t.uri), <String>[
+        jellyfin.uri,
+        subsonic.uri,
+      ]);
+      expect(loaded.current!.uri, jellyfin.uri);
+      expect(loaded.position, const Duration(milliseconds: 9000));
+    });
+
+    test('fromJson clamps position to track duration when known', () {
+      final PersistedPlaybackSession? loaded =
+          PersistedPlaybackSession.fromJson(<String, dynamic>{
+        'v': 1,
+        'i': 0,
+        'p': const Duration(minutes: 10).inMilliseconds,
+        's': false,
+        'r': 'off',
+        't': <Map<String, dynamic>>[logicalTrackToJson(local)],
+      });
+      expect(loaded!.position, local.duration);
+    });
+
+    test('artwork with a token query is stripped on write/read', () {
+      final Track withTokenArt = jellyfin.copyWith(
+        artworkUri: Uri.parse(
+          'https://server/Items/101/Images/Primary?api_key=secret',
+        ),
+      );
+      final Map<String, dynamic> json = logicalTrackToJson(withTokenArt);
+      expect(json.containsKey('artwork'), isFalse);
+
+      final Track? roundTrip = logicalTrackFromJson(<String, dynamic>{
+        ...logicalTrackToJson(jellyfin),
+        'artwork':
+            'https://server/Items/101/Images/Primary?api_key=secret',
+      });
+      expect(roundTrip!.artworkUri, isNull);
+    });
+  });
+}

--- a/test/core/services/playback_session_persistence_test.dart
+++ b/test/core/services/playback_session_persistence_test.dart
@@ -60,7 +60,8 @@ void main() {
       expect(saved!.current!.uri, remote.uri);
       expect(saved.position, const Duration(seconds: 33));
 
-      final FakePlaybackController restoredController = FakePlaybackController();
+      final FakePlaybackController restoredController =
+          FakePlaybackController();
       final PlaybackSessionPersistence restorer = PlaybackSessionPersistence(
         store: store,
         controller: restoredController,
@@ -71,7 +72,8 @@ void main() {
 
       expect(restoredController.restoreSessionCount, 1);
       expect(restoredController.lastRestoreAutoplay, isFalse);
-      expect(restoredController.lastRestorePosition, const Duration(seconds: 33));
+      expect(
+          restoredController.lastRestorePosition, const Duration(seconds: 33));
       expect(restoredController.state.status, PlaybackStatus.paused);
       expect(restoredController.state.currentTrack?.uri, remote.uri);
       expect(restoredController.state.isPlaying, isFalse);
@@ -171,7 +173,8 @@ void main() {
           currentIndex: 0,
         ),
       );
-      final _ThrowingRestoreController controller = _ThrowingRestoreController();
+      final _ThrowingRestoreController controller =
+          _ThrowingRestoreController();
       final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
         store: store,
         controller: controller,

--- a/test/core/services/playback_session_persistence_test.dart
+++ b/test/core/services/playback_session_persistence_test.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/persisted_playback_session.dart';
+import 'package:linthra/core/models/playback_state.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/core/services/playback_session_persistence.dart';
+import 'package:linthra/core/sources/music_provider.dart';
+import 'package:linthra/data/repositories/in_memory_playback_session_store.dart';
+
+import '../../features/player/fake_playback_controller.dart';
+
+void main() {
+  const Track remote = Track(
+    id: '101',
+    title: 'Remote',
+    uri: 'jellyfin:101',
+    duration: Duration(minutes: 3),
+  );
+  const Track localMissing = Track(
+    id: '/missing/song.mp3',
+    title: 'Gone',
+    uri: '/missing/song.mp3',
+    duration: Duration(minutes: 2),
+  );
+  const Track localOk = Track(
+    id: '/tmp/linthra-session-test.mp3',
+    title: 'Ok',
+    uri: '/tmp/linthra-session-test.mp3',
+    duration: Duration(minutes: 2),
+  );
+
+  group('PlaybackSessionPersistence', () {
+    test('persists a paused/playing state and restores it without autoplay',
+        () async {
+      final InMemoryPlaybackSessionStore store = InMemoryPlaybackSessionStore();
+      final FakePlaybackController controller = FakePlaybackController();
+      final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
+        store: store,
+        controller: controller,
+        playbackStates: controller.stateStream,
+        localFileExists: (_) => true,
+        positionSaveInterval: Duration.zero,
+      );
+
+      controller.emit(const PlaybackState(
+        status: PlaybackStatus.playing,
+        currentTrack: remote,
+        position: Duration(seconds: 33),
+        duration: Duration(minutes: 3),
+        upNext: <Track>[],
+        previous: <Track>[],
+      ));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final PersistedPlaybackSession? saved = await store.load();
+      expect(saved, isNotNull);
+      expect(saved!.current!.uri, remote.uri);
+      expect(saved.position, const Duration(seconds: 33));
+
+      final FakePlaybackController restoredController = FakePlaybackController();
+      final PlaybackSessionPersistence restorer = PlaybackSessionPersistence(
+        store: store,
+        controller: restoredController,
+        playbackStates: restoredController.stateStream,
+        localFileExists: (_) => true,
+      );
+      await restorer.restore();
+
+      expect(restoredController.restoreSessionCount, 1);
+      expect(restoredController.lastRestoreAutoplay, isFalse);
+      expect(restoredController.lastRestorePosition, const Duration(seconds: 33));
+      expect(restoredController.state.status, PlaybackStatus.paused);
+      expect(restoredController.state.currentTrack?.uri, remote.uri);
+      expect(restoredController.state.isPlaying, isFalse);
+
+      await persistence.dispose();
+      await restorer.dispose();
+      await controller.dispose();
+      await restoredController.dispose();
+    });
+
+    test('drops signed-out remote tracks and missing local files on restore',
+        () async {
+      final InMemoryPlaybackSessionStore store = InMemoryPlaybackSessionStore(
+        const PersistedPlaybackSession(
+          tracks: <Track>[localMissing, remote, localOk],
+          currentIndex: 1,
+          position: Duration(seconds: 5),
+        ),
+      );
+      final FakePlaybackController controller = FakePlaybackController();
+      final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
+        store: store,
+        controller: controller,
+        playbackStates: const Stream<PlaybackState>.empty(),
+        isRemoteProviderAvailable: (MusicProvider p) =>
+            !identical(p, MusicProviders.jellyfin),
+        localFileExists: (String uri) => uri == localOk.uri,
+      );
+
+      await persistence.restore();
+
+      expect(controller.restoreSessionCount, 1);
+      expect(controller.state.currentTrack?.uri, localOk.uri);
+      expect(controller.state.upNext, isEmpty);
+      expect(controller.state.isPlaying, isFalse);
+
+      await persistence.dispose();
+      await controller.dispose();
+    });
+
+    test('a wholly invalid session is cleared and does not restore', () async {
+      final InMemoryPlaybackSessionStore store = InMemoryPlaybackSessionStore(
+        const PersistedPlaybackSession(
+          tracks: <Track>[remote],
+          currentIndex: 0,
+        ),
+      );
+      final FakePlaybackController controller = FakePlaybackController();
+      final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
+        store: store,
+        controller: controller,
+        playbackStates: const Stream<PlaybackState>.empty(),
+        isRemoteProviderAvailable: (_) => false,
+        localFileExists: (_) => false,
+      );
+
+      await persistence.restore();
+
+      expect(controller.restoreSessionCount, 0);
+      expect(await store.load(), isNull);
+
+      await persistence.dispose();
+      await controller.dispose();
+    });
+
+    test('clears persistence when playback becomes idle without a track',
+        () async {
+      final InMemoryPlaybackSessionStore store = InMemoryPlaybackSessionStore();
+      final FakePlaybackController controller = FakePlaybackController();
+      final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
+        store: store,
+        controller: controller,
+        playbackStates: controller.stateStream,
+        localFileExists: (_) => true,
+        positionSaveInterval: Duration.zero,
+      );
+
+      controller.emit(const PlaybackState(
+        status: PlaybackStatus.paused,
+        currentTrack: remote,
+      ));
+      await Future<void>.delayed(Duration.zero);
+      expect(await store.load(), isNotNull);
+
+      controller.emit(PlaybackState.idle);
+      await Future<void>.delayed(Duration.zero);
+      expect(await store.load(), isNull);
+
+      await persistence.dispose();
+      await controller.dispose();
+    });
+
+    test('restore failure clears the store and never throws', () async {
+      final InMemoryPlaybackSessionStore store = InMemoryPlaybackSessionStore(
+        const PersistedPlaybackSession(
+          tracks: <Track>[remote],
+          currentIndex: 0,
+        ),
+      );
+      final _ThrowingRestoreController controller = _ThrowingRestoreController();
+      final PlaybackSessionPersistence persistence = PlaybackSessionPersistence(
+        store: store,
+        controller: controller,
+        playbackStates: const Stream<PlaybackState>.empty(),
+        localFileExists: (_) => true,
+      );
+
+      await expectLater(persistence.restore(), completes);
+      expect(await store.load(), isNull);
+
+      await persistence.dispose();
+      await controller.dispose();
+    });
+  });
+}
+
+/// Local engine that throws from [restoreSession] so startup-safety can be
+/// asserted without a real audio backend.
+class _ThrowingRestoreController extends FakePlaybackController {
+  @override
+  Future<void> restoreSession({
+    required List<Track> tracks,
+    int startIndex = 0,
+    Duration position = Duration.zero,
+    bool shuffleEnabled = false,
+    RepeatMode repeatMode = RepeatMode.off,
+    List<Track>? originalOrder,
+  }) async {
+    throw StateError('simulated restore failure');
+  }
+}

--- a/test/data/repositories/playback_session_store_provider_test.dart
+++ b/test/data/repositories/playback_session_store_provider_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/platform/host_platform.dart';
+import 'package:linthra/data/repositories/host_platform_provider.dart';
+import 'package:linthra/data/repositories/playback_session_store_provider.dart';
+import 'package:linthra/features/player/player_providers.dart';
+
+import '../../support/fake_audio_player.dart';
+
+void main() {
+  test('playback session persistence is Linux-only', () {
+    final ProviderContainer linux = ProviderContainer(
+      overrides: <Override>[
+        hostPlatformProvider.overrideWithValue(HostPlatform.linux),
+        linuxAudioPlayerProvider.overrideWithValue(FakeAudioPlayer()),
+      ],
+    );
+    addTearDown(linux.dispose);
+    expect(linux.read(playbackSessionPersistenceProvider), isNotNull);
+
+    final ProviderContainer android = ProviderContainer(
+      overrides: <Override>[
+        hostPlatformProvider.overrideWithValue(HostPlatform.android),
+      ],
+    );
+    addTearDown(android.dispose);
+    expect(android.read(playbackSessionPersistenceProvider), isNull);
+  });
+}

--- a/test/data/repositories/shared_preferences_playback_session_store_test.dart
+++ b/test/data/repositories/shared_preferences_playback_session_store_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linthra/core/models/persisted_playback_session.dart';
+import 'package:linthra/core/models/repeat_mode.dart';
+import 'package:linthra/core/models/track.dart';
+import 'package:linthra/data/repositories/shared_preferences_playback_session_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  const Track track = Track(
+    id: '101',
+    title: 'Song',
+    uri: 'jellyfin:101',
+    duration: Duration(minutes: 4),
+  );
+
+  group('SharedPreferencesPlaybackSessionStore', () {
+    test('round-trips a logical session', () async {
+      const SharedPreferencesPlaybackSessionStore store =
+          SharedPreferencesPlaybackSessionStore();
+      const PersistedPlaybackSession session = PersistedPlaybackSession(
+        tracks: <Track>[track],
+        currentIndex: 0,
+        position: Duration(seconds: 12),
+        shuffleEnabled: false,
+        repeatMode: RepeatMode.off,
+      );
+
+      await store.save(session);
+      final PersistedPlaybackSession? loaded = await store.load();
+
+      expect(loaded, isNotNull);
+      expect(loaded!.current!.uri, 'jellyfin:101');
+      expect(loaded.position, const Duration(seconds: 12));
+    });
+
+    test('returns null for no stored value', () async {
+      const SharedPreferencesPlaybackSessionStore store =
+          SharedPreferencesPlaybackSessionStore();
+      expect(await store.load(), isNull);
+    });
+
+    test('a corrupt record reads as no session', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        SharedPreferencesPlaybackSessionStore.key: 'not json {',
+      });
+      const SharedPreferencesPlaybackSessionStore store =
+          SharedPreferencesPlaybackSessionStore();
+      expect(await store.load(), isNull);
+    });
+
+    test('a wrong-version record reads as no session', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        SharedPreferencesPlaybackSessionStore.key: jsonEncode(<String, dynamic>{
+          'v': 99,
+          'i': 0,
+          'p': 0,
+          's': false,
+          'r': 'off',
+          't': <Map<String, dynamic>>[logicalTrackToJson(track)],
+        }),
+      });
+      const SharedPreferencesPlaybackSessionStore store =
+          SharedPreferencesPlaybackSessionStore();
+      expect(await store.load(), isNull);
+    });
+
+    test('persisted document never contains stream URLs or tokens', () async {
+      const String token = 'super-secret-token-1234567890';
+      const SharedPreferencesPlaybackSessionStore store =
+          SharedPreferencesPlaybackSessionStore();
+      await store.save(const PersistedPlaybackSession(
+        tracks: <Track>[track],
+        currentIndex: 0,
+      ));
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final String raw =
+          prefs.getString(SharedPreferencesPlaybackSessionStore.key) ?? '';
+      expect(raw, contains('jellyfin:101'));
+      expect(raw, isNot(contains(token)));
+      expect(raw, isNot(contains('http')));
+      expect(raw, isNot(contains('api_key')));
+      expect(raw, isNot(contains('AccessToken')));
+    });
+
+    test('clear removes the document', () async {
+      const SharedPreferencesPlaybackSessionStore store =
+          SharedPreferencesPlaybackSessionStore();
+      await store.save(const PersistedPlaybackSession(
+        tracks: <Track>[track],
+        currentIndex: 0,
+      ));
+      await store.clear();
+      expect(await store.load(), isNull);
+    });
+  });
+}

--- a/test/features/player/fake_playback_controller.dart
+++ b/test/features/player/fake_playback_controller.dart
@@ -193,6 +193,49 @@ class FakePlaybackController implements LocalPlaybackController {
     foregroundedCount++;
   }
 
+  int restoreSessionCount = 0;
+  Duration? lastRestorePosition;
+  bool? lastRestoreAutoplay;
+
+  @override
+  Future<void> restoreSession({
+    required List<Track> tracks,
+    int startIndex = 0,
+    Duration position = Duration.zero,
+    bool shuffleEnabled = false,
+    RepeatMode repeatMode = RepeatMode.off,
+    List<Track>? originalOrder,
+  }) async {
+    if (tracks.isEmpty) return;
+    restoreSessionCount++;
+    lastRestorePosition = position;
+    lastRestoreAutoplay = false;
+    _suspended = false;
+    _shuffleEnabled = shuffleEnabled;
+    _repeatMode = repeatMode;
+    final int index = startIndex.clamp(0, tracks.length - 1);
+    _queue = PlaybackQueue(
+      tracks: List<Track>.of(tracks),
+      currentIndex: index,
+      originalOrder:
+          originalOrder == null ? null : List<Track>.of(originalOrder),
+    );
+    // Mirror production: load the current track paused at [position], never
+    // autoplay after a crash restore.
+    playedTracks.add(_queue.current!);
+    emit(PlaybackState(
+      status: PlaybackStatus.paused,
+      currentTrack: _queue.current,
+      upNext: _queue.upNext,
+      previous: _queue.history,
+      hasPrevious: _queue.hasPrevious,
+      position: position,
+      duration: _queue.current?.duration ?? Duration.zero,
+      shuffleEnabled: _shuffleEnabled,
+      repeatMode: _repeatMode,
+    ));
+  }
+
   /// Test seam mirroring the production controller's completion handling: drives
   /// what plays when the current track finishes, honouring the repeat mode.
   void completeCurrent() {


### PR DESCRIPTION
## Summary
- Closes #465: after an unexpected Linux crash/restart, restore the logical queue, current item, modes, and position as a **paused** session (never autoplay).
- Persist only logical track identity (`jellyfin:` / `subsonic:` / `plex:` / local paths) — never authenticated stream URLs, tokens, or resolver output; remotes re-resolve through the normal provider path on play.
- Invalid/stale rows (missing local files, signed-out providers, corrupt/wrong-version records) are dropped safely and never block startup. Android behaviour is unchanged.


