### PR TITLE
chore(release): prepare v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Platform: Android](https://img.shields.io/badge/platform-Android-3ddc84.svg)](#install)
 [![Platform: Linux](https://img.shields.io/badge/platform-Linux-FCC624.svg)](#install)
 [![Built with Flutter](https://img.shields.io/badge/built%20with-Flutter-02569B.svg)](https://flutter.dev)
-[![Latest release: v0.2.2](https://img.shields.io/badge/release-v0.2.2-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
+[![Latest release: v0.2.3](https://img.shields.io/badge/release-v0.2.3-7C5CFF.svg)](https://github.com/thezupzup/linthra/releases/latest)
 [![Releases](https://img.shields.io/badge/download-releases-blue.svg)](https://github.com/thezupzup/linthra/releases)
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="75">](https://f-droid.org/packages/io.github.thezupzup.linthra/)
@@ -75,7 +75,7 @@ with no account, the F-Droid build is yours, free, for good.
 New versions land on
 [GitHub Releases](https://github.com/thezupzup/linthra/releases) first, as
 signed Android APKs and, starting with v0.2.2, a native Linux x64 archive. The
-current stable is v0.2.2. Linthra is also on
+current stable is v0.2.3. Linthra is also on
 [F-Droid](https://f-droid.org/packages/io.github.thezupzup.linthra/); F-Droid
 builds may arrive a bit later while their build and review process runs. Not on
 Google Play yet.
@@ -97,7 +97,7 @@ Or download the `.apk` from the
 [latest release](https://github.com/thezupzup/linthra/releases/latest) and open
 it on your phone.
 
-For Linux, download `Linthra-v0.2.2-linux-x64.tar.gz` from the same GitHub
+For Linux, download `Linthra-v0.2.3-linux-x64.tar.gz` from the same GitHub
 Release. This is the native bundle, not a Flatpak yet; required runtime packages
 and native development instructions are in
 [docs/linux-desktop.md](./docs/linux-desktop.md).

--- a/docs/release-notes/v0.2.3.md
+++ b/docs/release-notes/v0.2.3.md
@@ -58,6 +58,8 @@ No manual migration is required. The SQLite schema upgrade that adds the source 
 
 ## Community
 
-A big part of v0.2.3 came from external contributors. Special thanks to **@jpdexter101-lang** for the shared server URL work, IPv6 fixes, accessibility, database indexing, XDG Music support, and Audiobookshelf foundation, and to **@Borhan2004** for the Linux playback recovery, reconnect, suspend/resume, and crash-safe restoration work.
+A big part of v0.2.3 came from community contributions across self-hosted server support, Audiobookshelf, accessibility, database performance, Linux desktop integration, and playback reliability.
+
+Special thanks to **@jpdexter101-lang** and **@Borhan2004** for their contributions to this release. These acknowledgements are release-level thanks, not a one-to-one mapping between each nearby feature bullet and a specific commit author.
 
 Thank you to everyone testing Linthra, reporting edge cases, reviewing changes, and helping the project grow.

--- a/docs/release-notes/v0.2.3.md
+++ b/docs/release-notes/v0.2.3.md
@@ -1,0 +1,63 @@
+# Linthra v0.2.3
+
+Linthra 0.2.3 is a community-driven stability and Linux desktop release, with stronger playback recovery, safer session restoration, better self-hosted server handling, and the first Audiobookshelf integration foundation.
+
+## What's new
+
+- **Linux playback recovers instead of getting stuck.** Mid-stream server and network failures now use bounded recovery, a buffering watchdog, sibling-source fallback when available, and a clear Retry path instead of looping forever.
+- **Temporary network drops have a real reconnect state.** Now Playing can show **Reconnecting…** while Linthra re-resolves a fresh authenticated stream URL and resumes near the preserved position.
+- **Suspend/resume is much safer on Linux.** A track that was actively playing before system sleep can be re-resolved and reloaded after wake on the same player, while a track the user paused stays paused.
+- **Crash-safe Linux playback restoration.** After an unexpected restart, Linthra can restore the logical queue, current item, repeat/shuffle state, and position as a **paused** session. It never persists authenticated stream URLs or provider tokens, and remote tracks re-resolve normally when playback resumes.
+- **Audiobookshelf support has started.** This release adds the connection, authentication, server validation, session model, and library-listing foundation. Audiobook playback, chapters, progress sync, bookmarks, and offline audiobook support remain follow-up milestones.
+- **Self-hosted server URLs are more robust.** Jellyfin, Plex, and Subsonic/Navidrome now share one URL-normalization path, including correct handling for IPv6 literal hosts.
+- **Large source re-syncs are cheaper.** The local database now indexes `tracks.source_id`, avoiding a full catalog scan when one source is refreshed. Existing databases migrate automatically.
+- **Linux library defaults fit the desktop better.** The folder chooser can start from the user's XDG Music directory instead of assuming `~/Music`, including localized or relocated Music folders.
+- **System theme behavior is documented and guarded across desktop/mobile.** Linthra keeps one shared Flutter `ThemeMode.system` path rather than adding GNOME/KDE-specific theme code.
+- **Player accessibility improved.** The custom play/pause control now exposes the proper button role and enabled state to assistive technologies.
+
+## Linux reliability
+
+The recent Linux playback work intentionally reuses Linthra's existing playback controller rather than creating provider-specific retry systems or extra players. Recovery is bounded, concurrent recovery triggers are coalesced, and failure still ends in a normal user-visible error/Retry state.
+
+Real hardware timing can vary after suspend — especially with Bluetooth, PipeWire/PulseAudio, or networking that returns after the Flutter lifecycle signal — so `docs/linux-desktop.md` includes the manual matrix used for milestone testing.
+
+## Audiobookshelf status
+
+Audiobookshelf in v0.2.3 is the **first integration milestone**, not the complete audiobook player. The foundation validates the server before credentials are sent, uses the server's supported login/token flow, and keeps session parsing defensive against corrupt persisted data.
+
+The next milestones can build browsing/domain models, chapters/playback, progress sync, bookmarks, and offline behavior on top of this base without mixing audiobook behavior into the existing music providers.
+
+## Android and F-Droid
+
+Android remains a first-class target. The Linux-specific recovery/restore paths are gated so Android screen-on and normal mobile lifecycle behavior do not begin auto-restarting playback.
+
+The canonical Android version for this release is:
+
+- versionName: `0.2.3`
+- base versionCode: `203999`
+
+F-Droid's split-ABI scheme remains:
+
+- armeabi-v7a: `2039991`
+- arm64-v8a: `2039992`
+- x86_64: `2039993`
+
+GitHub APKs and F-Droid packages remain signed by different keys, so users should keep updating from the same install source they originally chose.
+
+## Linux download
+
+The GitHub Release workflow can attach:
+
+`Linthra-v0.2.3-linux-x64.tar.gz`
+
+This is the native Flutter Linux bundle, not the future Flatpak. Runtime requirements and the current Linux support matrix are documented in `docs/linux-desktop.md`.
+
+## Upgrade notes
+
+No manual migration is required. The SQLite schema upgrade that adds the source index is handled automatically, and crash-safe playback state uses defensive versioned persistence. Existing Android library/settings data remain in place during a normal same-source update.
+
+## Community
+
+A big part of v0.2.3 came from external contributors. Special thanks to **@jpdexter101-lang** for the shared server URL work, IPv6 fixes, accessibility, database indexing, XDG Music support, and Audiobookshelf foundation, and to **@Borhan2004** for the Linux playback recovery, reconnect, suspend/resume, and crash-safe restoration work.
+
+Thank you to everyone testing Linthra, reporting edge cases, reviewing changes, and helping the project grow.

--- a/fastlane/metadata/android/en-US/changelogs/203999.txt
+++ b/fastlane/metadata/android/en-US/changelogs/203999.txt
@@ -1,0 +1,7 @@
+Linthra 0.2.3
+
+- Makes Linux playback recover more reliably from server/network drops and suspend/resume.
+- Restores the Linux queue and position safely after an unexpected restart, without autoplay.
+- Adds the first Audiobookshelf connection, authentication, and library foundation.
+- Improves self-hosted server URLs, including IPv6 literals, and speeds up source re-syncs.
+- Improves Linux defaults, System theme coverage, and player accessibility.

--- a/lib/core/app_info.dart
+++ b/lib/core/app_info.dart
@@ -14,7 +14,7 @@ abstract final class AppInfo {
   /// the in-app version always matches the released APK/AAB without any
   /// build-time injection. `test/core/app_info_version_test.dart` fails CI if
   /// this constant ever drifts from `pubspec.yaml`, so bump both together.
-  static const String _devVersionName = '0.2.2';
+  static const String _devVersionName = '0.2.3';
 
   /// Optional build-time override for the in-app `versionName`, read from
   /// `--dart-define=LINTHRA_VERSION_NAME=...`. Normally **empty** — `pubspec.yaml`

--- a/lib/features/settings/about/whats_new_section.dart
+++ b/lib/features/settings/about/whats_new_section.dart
@@ -20,9 +20,10 @@ class WhatsNewSection extends StatelessWidget {
   /// handful of concise bullets and updated when cutting a new build; exposed so
   /// the widget test can assert each line renders without duplicating the copy.
   static const List<String> releaseNotes = <String>[
-    'Now Playing has a smoother wavy seek bar and a redesigned synced-lyrics experience.',
-    'Remote artwork is cached on disk so covers can survive restarts without being downloaded again.',
-    'Automatic song precaching can now be disabled while normal streaming and manual downloads keep working.',
+    'Linux playback now recovers more reliably from network/server drops and suspend/resume.',
+    'Linux can restore the previous queue and position safely after an unexpected restart, without autoplay.',
+    'Audiobookshelf connection, authentication, and library support has started with the first integration milestone.',
+    'Self-hosted server URLs, IPv6 handling, source re-sync performance, and desktop defaults are improved.',
   ];
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none"
 # Android build (versionName/versionCode) and the in-app version mirrors it via
 # AppInfo._devVersionName, so a plain `flutter build` (CI and F-Droid alike) and
 # the tag all agree.
-version: 0.2.2+202999
+version: 0.2.3+203999
 
 environment:
   sdk: ">=3.6.0 <4.0.0"


### PR DESCRIPTION
## Summary

Prepare Linthra **v0.2.3** from the current `main` after #491.

- bump `pubspec.yaml` to `0.2.3+203999`
- update `AppInfo` to `0.2.3`
- refresh the in-app What's new card
- add the Fastlane changelog for versionCode `203999`
- add full v0.2.3 release notes
- update README release/install references to v0.2.3

## v0.2.3 highlights

- much stronger Linux playback recovery for server/network drops
- explicit **Reconnecting…** state with bounded retry and preserved position
- Linux suspend/resume recovery without auto-starting user-paused tracks
- crash-safe Linux queue/position restoration as a paused session
- first Audiobookshelf integration milestone: connection, authentication, validation, and library foundation
- shared self-hosted server URL normalization and IPv6 literal support
- faster source re-syncs via the `tracks.source_id` database index
- XDG Music directory support for Linux folder defaults
- System-theme coverage/documentation and player accessibility improvements

## Community

This release includes substantial community contributions. Special thanks to **@jpdexter101-lang** and **@Borhan2004** for contributing to v0.2.3.

### Review guidance for acknowledgements

The **Community** section follows the same kind of release-note convention used by large open-source projects: contributor mentions are editorial, release-level acknowledgements. They are **not** intended to be a one-to-one authorship ledger tying every nearby feature phrase to a specific commit author.

Automated review should therefore **not flag a contributor simply because another contributor or the maintainer authored one of the other features summarized in the same release section**. Only flag a credit if the text explicitly makes a concrete false authorship claim (for example, “X implemented feature Y”) that is contradicted by the repository history.

## Versioning

- versionName: `0.2.3`
- base versionCode: `203999`
- armeabi-v7a: `2039991`
- arm64-v8a: `2039992`
- x86_64: `2039993`
- tag after merge: `v0.2.3`

The code follows Linthra's canonical stable-release encoding:
`MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + 999`.

## Safety / scope

This PR is release preparation only. It does **not** create the tag, publish a GitHub Release, modify signing secrets, change Android/F-Droid signing behavior, or add new runtime features beyond refreshing the existing What's new copy.

The release notes explicitly keep Audiobookshelf scoped to its first milestone; audiobook playback/chapters/progress sync remain follow-up work.

## Before publishing

1. Wait for all PR CI checks to pass.
2. Review the release notes and What's new copy.
3. Merge this PR into `main`.
4. Confirm `main` contains `version: 0.2.3+203999` and `AppInfo._devVersionName = '0.2.3'`.
5. Publish/tag `v0.2.3` using the repository's stable release flow.
6. Verify signed Android assets and `Linthra-v0.2.3-linux-x64.tar.gz`.
7. Let F-Droid discover/build the immutable source tag through its normal update path.

No tag or GitHub Release is created by this PR.