### PR TITLE
[Flatpak] Bundle the Linux audio runtime correctly (#433)

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,11 +1,34 @@
-# Flatpak (local build — issue #432)
+# Flatpak (local build — issues #432, #433)
 
 This is the packaging **foundation**: enough to build Linthra's native Flutter
 Linux bundle inside `flatpak-builder`, install it, and launch the real
-`io.github.thezupzup.linthra` app to a usable first frame. It is
-deliberately not the Flathub submission, not a desktop-integrated package, and
-not a full audio-quality Flatpak — see "What's deferred" below and the
-comments in `io.github.thezupzup.linthra.yml` itself.
+`io.github.thezupzup.linthra` app to real, audible local and remote playback
+through a fully self-contained audio runtime. It is deliberately not the
+Flathub submission and not a desktop-integrated package — see "What's
+deferred" below and the comments in `io.github.thezupzup.linthra.yml` itself.
+
+## Audio runtime
+
+The Flatpak bundles its own `libmpv`, built from source together with its
+`ffmpeg`/`libplacebo`/`libass` dependencies (see the `modules:` comments in
+`flatpak-flutter.yml`) and installed under `/app/lib`. **Host `mpv-libs` /
+`libmpv` is never used and is not required to install or run the Flatpak** —
+`media_kit`/`just_audio_media_kit` dlopen the bundled copy, which resolves
+before anything under `/usr/lib*` or `/lib*` because the Flatpak sandbox
+exposes no host library path. Playback uses `--socket=pulseaudio` for audio
+output, which reaches both a native PulseAudio session and PipeWire's
+`pipewire-pulse` compatibility server (there is no separate PipeWire
+finish-arg). The bundled ffmpeg is also built with `--enable-network
+--enable-gnutls`, so the same libmpv decodes local files and plays HTTP(S)
+audio streams (Jellyfin, Navidrome/Subsonic, Plex) without any host codec or
+TLS library — see the `ffmpeg` module comments for exactly which formats that
+covers and why no additional codec library was needed.
+
+**Native, non-Flatpak Linthra is unaffected**: `flutter build linux` outside
+this packaging still links nothing at build time and still expects the
+system `mpv-libs`/`libmpv` runtime documented in
+[docs/linux-desktop.md](../docs/linux-desktop.md#required-packages). The two
+are independent audio runtimes by design; only the Flatpak is self-contained.
 
 ## Files here
 
@@ -65,6 +88,36 @@ before the sandbox is entered, exactly like any other Flatpak module.
 To uninstall: `flatpak --user uninstall io.github.thezupzup.linthra` and
 `flatpak --user remote-delete linthra-dev`.
 
+## Testing audio locally
+
+The committed manifest grants `--socket=pulseaudio` but no filesystem or
+network access, matching #438/#439/#440's scope. To manually verify playback
+of your own local files or a real remote stream, use *temporary*,
+non-committed `flatpak override` grants and remove them afterward — never add
+these to `io.github.thezupzup.linthra.yml`:
+
+```bash
+# Local file: point a temporary filesystem grant at a directory with a test
+# track, launch, play it from within the app, then revoke the grant.
+flatpak --user override --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
+flatpak run io.github.thezupzup.linthra
+flatpak --user override --reset io.github.thezupzup.linthra   # or targeted --nofilesystem
+
+# Remote HTTP(S) stream: same idea with network instead.
+flatpak --user override --share=network io.github.thezupzup.linthra
+flatpak run io.github.thezupzup.linthra
+flatpak --user override --reset io.github.thezupzup.linthra
+```
+
+Confirm the grant is actually gone afterward:
+
+```bash
+flatpak override --user --show io.github.thezupzup.linthra
+```
+
+should print nothing beyond what `io.github.thezupzup.linthra.yml` itself
+declares. Automated audio smoke coverage is #446's job, not this file's.
+
 ## Regenerating the pinned sources
 
 Re-run this whenever `.flutter-version` or `pubspec.lock` changes:
@@ -88,21 +141,23 @@ Not in this manifest — each has its own issue:
 * **Desktop file** (#434), **AppStream metainfo** (#435), **scalable icon
   packaging** (#436) — `rename-desktop-file`/`rename-icon`/`--filesystem`
   finish-args and the associated install steps are absent on purpose.
-* **Provider network access** (#440), **filesystem/portal permissions**
-  (#438/#439), **Secret Service** (#441) — no `--share=network`,
-  `--filesystem=host|home`, or `--talk-name=org.freedesktop.secrets`.
+* **Provider network access** (#440) — no permanent `--share=network`.
+  #433 proved the bundled ffmpeg/libmpv can decode HTTP(S) audio using only a
+  *temporary*, non-committed `flatpak override --user --share=network`
+  applied and removed for that validation; permanently granting Linthra
+  network access for real provider use (Jellyfin/Navidrome-Subsonic/Plex) is
+  #440's job, not this manifest's.
+* **Filesystem/portal permissions** (#438/#439), **Secret Service** (#441) —
+  no `--filesystem=host|home` or `--talk-name=org.freedesktop.secrets`.
   Jellyfin/Subsonic/Plex session restore and secure-storage reads already
   degrade to "not signed in" without them (`docs/linux-desktop.md` §"Secure
-  storage").
-* **Full audio runtime** (#433) — the `ffmpeg`/`libplacebo`/`libass`/`mpv`
-  modules here build the *smallest* libmpv that lets Linthra's startup
-  bootstrap (which dlopens libmpv before the first frame — see
-  `lib/core/services/linux_playback_controller.dart`) succeed instead of
-  crashing. `--socket=pulseaudio` is likewise absent: startup only registers
-  the backend and never opens an audio device before first frame (verified —
-  the installed Flatpak reaches the same first frame without it). Codec
-  breadth, hardware acceleration, actual audio output, and tuned mpv options
-  are #433's job, not this one's.
-* **CI** (#444), **automated launch/audio smoke tests** (#445/#446), **Fedora
-  Atomic development documentation** (#448) — out of scope here; this file is
-  the minimal "how do I build this locally" note #432 asked for.
+  storage"). #433's local-audio validation likewise used a temporary,
+  non-committed filesystem override rather than a committed grant.
+* **Video codecs, hardware acceleration/hwaccel, subtitle-adjacent tuning
+  beyond what libmpv/libass require to build** — Linthra is audio-only; the
+  ffmpeg/mpv build stays scoped to the container/codec/protocol support
+  Linthra's supported formats and HTTP(S) streaming actually need.
+* **CI** (#444), **automated launch/audio smoke tests** (#445/#446), **local-
+  library sandbox test** (#447), **Fedora Atomic development documentation**
+  (#448) — out of scope here; this file is the minimal "how do I build and
+  validate this locally" note #432/#433 asked for.

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -93,30 +93,38 @@ To uninstall: `flatpak --user uninstall io.github.thezupzup.linthra` and
 The committed manifest grants `--socket=pulseaudio` but no filesystem or
 network access, matching #438/#439/#440's scope. To manually verify playback
 of your own local files or a real remote stream, use *temporary*,
-non-committed `flatpak override` grants and remove them afterward — never add
-these to `io.github.thezupzup.linthra.yml`:
+non-committed `flatpak override` grants and revoke exactly what you added
+afterward — never add these to `io.github.thezupzup.linthra.yml`, and never
+use `--reset`, which wipes *every* persistent override you have for this app
+(including any unrelated ones you already had) rather than just the one this
+test added:
 
 ```bash
 # Local file: point a temporary filesystem grant at a directory with a test
-# track, launch, play it from within the app, then revoke the grant.
+# track, launch, play it from within the app, then revoke that exact grant.
 flatpak --user override --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
 flatpak run io.github.thezupzup.linthra
-flatpak --user override --reset io.github.thezupzup.linthra   # or targeted --nofilesystem
+flatpak --user override --nofilesystem=/path/to/test-music io.github.thezupzup.linthra
 
 # Remote HTTP(S) stream: same idea with network instead.
 flatpak --user override --share=network io.github.thezupzup.linthra
 flatpak run io.github.thezupzup.linthra
-flatpak --user override --reset io.github.thezupzup.linthra
+flatpak --user override --unshare=network io.github.thezupzup.linthra
 ```
 
-Confirm the grant is actually gone afterward:
+Confirm each grant is actually gone afterward — check the specific
+permission you added rather than assuming empty output, since you may
+already have unrelated overrides set for this app:
 
 ```bash
 flatpak override --user --show io.github.thezupzup.linthra
+# Look for the absence of the filesystem/network line you added above;
+# any other overrides already there are not this test's concern.
 ```
 
-should print nothing beyond what `io.github.thezupzup.linthra.yml` itself
-declares. Automated audio smoke coverage is #446's job, not this file's.
+should no longer list the `filesystem`/`network` line the test added, though
+any other override you already had for this app before testing is expected
+to remain. Automated audio smoke coverage is #446's job, not this file's.
 
 ## Regenerating the pinned sources
 

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -41,17 +41,23 @@ finish-args:
   # renders, just on software rendering; --device=dri is the minimal grant
   # that lets it use the real GPU.
   - --device=dri
+  # Audio output (#433). LinuxPlaybackController's libmpv now actually opens
+  # an audio device (ao=auto, built with -Dpulse=enabled below) instead of
+  # only being dlopened/registered at startup as it was for #432. On the
+  # current org.gnome.Platform//50 / freedesktop-sdk 25.08 runtime this is
+  # still the correct, minimal grant for audio: PipeWire's default desktop
+  # deployment ships pipewire-pulse, a PulseAudio-protocol-compatible server,
+  # so --socket=pulseaudio is what reaches both a native PulseAudio session
+  # and a PipeWire one — there is no separate "--socket=pipewire" finish-arg.
+  - --socket=pulseaudio
   #
-  # Deliberately withheld for issue #432 (see flatpak/README.md "What's
-  # deferred" for the reasoning):
-  #   --socket=pulseaudio        (audio output: #433 — mpv_initialize() never
-  #                                opens an audio device; LinuxPlaybackController
-  #                                only dlopens/registers libmpv at startup and
-  #                                never creates a player before first frame, so
-  #                                nothing at startup touches audio. Verified:
-  #                                the installed Flatpak reaches the same first
-  #                                frame with this permission absent.)
-  #   --share=network            (provider streaming: #440)
+  # Deliberately withheld for issue #432, still withheld here (see
+  # flatpak/README.md "What's deferred" for the reasoning):
+  #   --share=network            (provider streaming: #440. #433 only proves
+  #                                the bundled runtime *can* play HTTP(S)
+  #                                audio, using a temporary, non-committed
+  #                                `flatpak override` for that validation —
+  #                                see flatpak/README.md.)
   #   --filesystem=host/home     (broad filesystem access: #438/#439)
   #   --talk-name=org.freedesktop.secrets  (Secret Service: #441)
   # Their absence is safe: flutter_secure_storage/Jellyfin-Subsonic-Plex
@@ -59,28 +65,55 @@ finish-args:
   # in" and keeps running (docs/linux-desktop.md "Secure storage").
 
 modules:
-  # === Bare libmpv, built from pinned upstream source =======================
+  # === Self-contained libmpv audio runtime, built from pinned upstream source
   #
   # media_kit/just_audio_media_kit dlopen libmpv.so/.so.1/.so.2 synchronously
   # during Linthra's startup bootstrap — before the first frame — and nothing
   # in the call path catches a failed dlopen (see linux_playback_controller.dart
   # and media_kit's native_library.dart). A GNOME/freedesktop runtime does not
-  # ship libmpv, so without it the app cannot reach a usable first frame at
-  # all, which makes a bare libmpv a genuine #432 requirement rather than
-  # #433 scope creep. Fully-featured audio (codec coverage, hardware
-  # acceleration, tuned config) stays #433's job; this module is deliberately
-  # the smallest buildable libmpv, because mpv's own meson.build hard-requires
+  # ship libmpv, so this module exists in the first place because #432 could
+  # not reach a usable first frame without it. #433 turns that bootstrap
+  # libmpv into a real playback engine: mpv's own meson.build hard-requires
   # libavcodec/libavfilter/libavformat/libavutil/libswresample/libswscale
-  # (ffmpeg), libplacebo and libass unconditionally — there is no smaller mpv.
+  # (ffmpeg), libplacebo and libass unconditionally — there is no smaller mpv
+  # — so this stays one module chain, just configured for real audio output
+  # and remote streaming instead of the #432 bootstrap minimum.
   #
   # ffmpeg is built from source, not via org.freedesktop.Platform.ffmpeg-full:
   # mpv links against libavcodec/libavformat/etc. at compile time via
   # pkg-config, and ffmpeg-full/codecs-extra is a *runtime* extension (mounted
   # into /app only after the build), so it cannot satisfy a build-time
   # pkg-config dependency() check. This is also what the official
-  # io.mpv.Mpv Flathub manifest does. LGPL only (no --enable-gpl/--enable-nonfree)
-  # and no video codecs/hwaccel/network-protocol libs: Linthra is audio-only
-  # and #432 grants no network permission, so none of that is reachable yet.
+  # io.mpv.Mpv Flathub manifest does. LGPL only (no --enable-gpl/--enable-nonfree):
+  # Linthra is audio-only, so no video codec/hwaccel libraries are enabled —
+  # only the container/codec support current main actually needs (see
+  # lib/core/sources/local/audio_file_types.dart's `supportedExtensions`:
+  # mp3, flac, m4a, aac, ogg, opus, wav) plus network protocols for remote
+  # HTTP(S) playback (#433's other requirement). Every one of those seven
+  # formats decodes with an ffmpeg *native* decoder (mp3float/aac/flac/
+  # vorbis/opus/pcm_*/alac) — none needs an external codec library
+  # (libmp3lame/libvorbis/libopus are encoder-side only) — so no additional
+  # codec module was added; the #432 chain already carried full decode
+  # coverage for Linthra's supported formats, it just couldn't reach the
+  # network to fetch remote bytes.
+  #
+  # --enable-network (replacing #432's --disable-network) turns on ffmpeg's
+  # http/https/tcp/tls protocol layer, which mpv's stream_lavf.c uses
+  # directly for any http(s):// URL — the same path both local files and
+  # resolved Jellyfin/Navidrome-Subsonic/Plex stream URLs already go through
+  # (see docs/linux-desktop.md "Audio playback"). --enable-gnutls adds the
+  # TLS backend https:// needs: GnuTLS is LGPLv2.1+, so it keeps this LGPL-only
+  # build's licensing unchanged, and org.gnome.Sdk//50 already ships gnutls.pc
+  # (verified: `pkg-config --modversion gnutls` inside the SDK resolves to
+  # 3.8.13), so no new module/source is declared for it — it links against
+  # the runtime's own gnutls the same way mpv already links the runtime's
+  # alsa/pulse below. Flatpak's sandbox also always exposes the host's CA
+  # trust store at /etc/ssl/certs regardless of filesystem permissions, so
+  # certificate verification needs no extra grant either. OpenSSL is present
+  # in the same runtime too (verified) but gnutls was chosen as the
+  # traditionally-LGPL-compatible, commonly-used choice for an LGPL ffmpeg
+  # build and to sidestep OpenSSL's historical GPL-linking caveats entirely,
+  # even though modern OpenSSL (3.x, Apache-2.0) would also be acceptable.
   - name: ffmpeg
     cleanup:
       - /include
@@ -91,7 +124,8 @@ modules:
       - --enable-shared
       - --disable-doc
       - --disable-programs
-      - --disable-network
+      - --enable-network
+      - --enable-gnutls
     sources:
       - type: archive
         url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n9.0.1.tar.gz
@@ -168,8 +202,32 @@ modules:
       - -Dvapoursynth=disabled
       - -Dcplugins=disabled
       - -Drubberband=disabled
+      # Both audio outputs were already declared in #432 in anticipation of
+      # this issue. They now do real work: mpv's ao=auto picks pulse, which
+      # is also the protocol pipewire-pulse (the default PipeWire
+      # compatibility server on modern desktops) speaks — the same target
+      # --socket=pulseaudio opens up above. alsa=enabled stays as the
+      # non-PipeWire/non-Pulse fallback (org.gnome.Sdk//50 ships both
+      # alsa.pc and libpulse.pc — verified). No new mpv build option is
+      # needed for network streaming: mpv has no separate "network" toggle
+      # of its own — it opens http(s):// URLs straight through ffmpeg's
+      # protocol layer, which is where --enable-network/--enable-gnutls
+      # above actually live.
       - -Dalsa=enabled
       - -Dpulse=enabled
+      # mpv's own `pipewire` audio-output option defaults to meson's `auto`
+      # (unlike every other feature here, which #432 already pinned
+      # explicitly), and org.gnome.Sdk//50 happens to carry libpipewire's
+      # dev files — so leaving it on `auto` would silently build a *second*,
+      # undeclared audio backend the committed finish-args don't grant a
+      # socket for (a native PipeWire client needs its own IPC socket;
+      # --socket=pulseaudio only exposes the PulseAudio-protocol/
+      # pipewire-pulse endpoint pulse=enabled above already targets — see
+      # flatpak-flutter.yml's finish-args comment). Disabling it explicitly
+      # keeps this module's actual audio-output surface matching exactly
+      # what's declared and granted, rather than depending on what a future
+      # SDK bump happens to ship.
+      - -Dpipewire=disabled
     sources:
       - type: archive
         url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.41.0.tar.gz

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -18,6 +18,7 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --device=dri
+  - --socket=pulseaudio
 modules:
   - name: ffmpeg
     cleanup:
@@ -29,7 +30,8 @@ modules:
       - --enable-shared
       - --disable-doc
       - --disable-programs
-      - --disable-network
+      - --enable-network
+      - --enable-gnutls
     sources:
       - type: archive
         url: https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n9.0.1.tar.gz
@@ -92,6 +94,7 @@ modules:
       - -Drubberband=disabled
       - -Dalsa=enabled
       - -Dpulse=enabled
+      - -Dpipewire=disabled
     sources:
       - type: archive
         url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.41.0.tar.gz


### PR DESCRIPTION
## What

Turns #432's bootstrap-only libmpv into a real, self-contained
Flatpak audio runtime: local and remote (HTTP/HTTPS) audio now
actually plays, entirely from libraries inside `/app` and the
declared Flatpak runtime — no host libmpv dependency.

## Changes

- `flatpak/flatpak-flutter.yml` (source of truth):
  - ffmpeg: `--disable-network` → `--enable-network --enable-gnutls`
    (HTTP(S)/TLS for remote streaming; GnuTLS already ships in
    `org.gnome.Sdk//50`, no new declared source)
  - mpv: added `-Dpipewire=disabled` — caught during the clean
    build, since the SDK's meson `auto`-feature would otherwise
    silently link a second, undeclared audio backend the manifest
    grants no socket for
  - finish-args: added `--socket=pulseaudio`
- `flatpak/io.github.thezupzup.linthra.yml`, `flatpak/generated/`:
  regenerated via `./scripts/regenerate_flatpak_sources.sh`
  (deterministic, verified 3x)
- `flatpak/README.md`: documents the self-contained audio runtime,
  the PulseAudio permission, and how to validate local/remote audio
  with temporary (non-committed) overrides

No new codec libraries were added — every format Linthra's local
scanner recognizes (mp3/flac/m4a/aac/ogg/opus/wav, per
`AudioFileTypes.supportedExtensions`) decodes via ffmpeg's built-in
native decoders.

## Verification

- Clean `flatpak-builder --force-clean` rebuild: zero errors, zero
  unexpected network access during the sandboxed build
- Local audio: played wav/mp3/flac/ogg fixtures through Linthra's
  real UI, confirmed **audibly**, plus pause/resume/stop confirmed
- Remote audio: played a real HTTPS OGG stream through libmpv's
  client C API (same API media_kit's FFI bindings use), confirmed
  **audibly**, with objective position/pause/resume/stop proof from
  the API itself
- libmpv resolution proven exclusive to `/app` via `LD_DEBUG=libs`
  and `ldd`, shown distinct from the test host's own
  `/usr/lib64/libmpv.so.2` (Fedora)
- `flatpak info --show-permissions`: exactly `shared=ipc`,
  `sockets=fallback-x11;pulseaudio;wayland`, `devices=dri` — no
  network, filesystem, or secrets permission
- Two temporary overrides used for testing, both fully removed and
  verified gone (`flatpak override --user --show` empty)
- `check_secrets.sh`, `check_vendored_packages.sh`, both Linux
  runner checks, `dart format` — all pass
- Native non-Flatpak Linux untouched: diff touches nothing under
  `linux/`, `lib/`, or `pubspec.yaml`

## Found but not fixed (separate issues)

- **#438** (portal folder selection): `file_picker`'s Linux backend
  needs `zenity`/`kdialog`/`qarma`, none of which belong in this
  Flatpak — confirmed root cause, not addressed here.
- A pre-existing, non-fatal `media_kit`/mpv disk-cache warning,
  unrelated to this diff, doesn't block playback.

## Out of scope (unchanged)

#434–#437, #439–#449 — no desktop file, icons, AppStream, permanent
network/filesystem/secrets permissions, or CI changes here.

Closes #433
