### PR TITLE
docs(flatpak): document local Flatpak development on Fedora Atomic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,9 @@ For the other areas:
   what is still unsupported there — is in
   [docs/linux-desktop.md](./docs/linux-desktop.md); `./scripts/verify_linux.sh`
   is the desktop twin of `verify_android.sh`.
+- `flatpak/` packages that Linux build as a Flatpak. Building, installing and
+  debugging it locally — on Fedora Atomic (Kinoite/Silverblue) or anywhere
+  else — is [docs/flatpak-development.md](./docs/flatpak-development.md).
 - `tools/large_library/` contains the Python and SQLite large-library tooling.
 
 ## Before you start

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ The full index of Linthra's docs. New to the project? Start with the
 | Contributing & setup | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Development, build & CI | [development.md](./development.md) |
 | Linux desktop build (experimental) | [linux-desktop.md](./linux-desktop.md) |
+| Flatpak development (Fedora Atomic) | [flatpak-development.md](./flatpak-development.md) |
 | Codebase tour (where everything lives) | [codebase-tour.md](./codebase-tour.md) |
 | Architecture & extension points | [architecture.md](./architecture.md) |
 | Where to help (contributor roadmap) | [contributor-roadmap.md](./contributor-roadmap.md) |

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -1,0 +1,345 @@
+# Flatpak development on Fedora Atomic
+
+How to build, install, run, debug and clean up Linthra's Flatpak on an
+immutable Fedora system (**Kinoite**, **Silverblue**, or any other rpm-ostree
+variant) without layering anything onto the host image. Everything here also
+works on Fedora Workstation and other distributions — see
+[Other distributions](#other-distributions) for the one command that differs.
+
+Three docs, three jobs:
+
+* **This page** — the contributor workflow: host tools, build, install, run,
+  rebuild, clean, debug.
+* [`flatpak/README.md`](../flatpak/README.md) — what the packaging *files* are,
+  why the manifest looks the way it does, and what is deliberately not in it
+  yet.
+* [`linux-desktop.md`](./linux-desktop.md) — the **native** Flutter Linux
+  build, which is a different thing with different dependencies. See
+  [Native Linux vs Flatpak](#native-linux-vs-flatpak) before mixing the two.
+
+> Flatpak packaging is in progress ([issue #376](https://github.com/TheZupZup/Linthra/issues/376)).
+> The committed manifest builds, installs and launches the real app with
+> working audio, but it is not the Flathub submission: there is no desktop
+> file, icon or AppStream metadata yet, and no network, filesystem or
+> Secret Service access. See [What the sandbox allows today](#what-the-sandbox-allows-today).
+
+All commands are relative to the repository. Run them from the repository root
+unless a block starts with `cd flatpak`.
+
+## Native Linux vs Flatpak
+
+The two builds share Dart source and nothing else. Do not install host
+packages for one expecting them to help the other.
+
+| | Native Flutter Linux | Flatpak |
+| --- | --- | --- |
+| Where you work on Atomic | inside a `toolbox` | on the **host** |
+| Toolchain | clang/cmake/ninja + GTK 3, libsecret, xz headers from your distro | `org.gnome.Sdk//50` + the LLVM SDK extension, inside `flatpak-builder` |
+| libmpv | **host** `mpv-libs`/`libmpv` required at runtime | **bundled** in the image; host libmpv is never loaded and is not required |
+| Build | `flutter build linux --release` | `flatpak run org.flatpak.Builder …` (below) |
+| Run | `./build/linux/x64/release/bundle/linthra` | `flatpak run io.github.thezupzup.linthra` |
+| App data | `~/.local/share/` and `~/.config/` | `~/.var/app/io.github.thezupzup.linthra/` |
+| Credentials | host Secret Service (encrypted) | not granted yet — sessions degrade to "not signed in" |
+| Automated checks | `./scripts/verify_linux.sh` | manual today — see [Smoke testing](#smoke-testing) |
+
+A libmpv-related failure in one says nothing about the other: the Flatpak
+carries its own ffmpeg/libplacebo/libass/mpv chain under `/app/lib`, so it runs
+on a host with no mpv installed at all, and the native bundle keeps needing the
+host library documented in
+[linux-desktop.md](./linux-desktop.md#required-packages).
+
+## Host tools
+
+`flatpak` itself is already part of the Fedora Atomic base image. The only
+other thing you need is `flatpak-builder`, and it is available **as a Flatpak**
+— so nothing gets layered onto the host image and no reboot is involved.
+
+> Do **not** `rpm-ostree install flatpak-builder`. Layering costs a reboot,
+> slows every future system update, and buys nothing here: `org.flatpak.Builder`
+> is the same tool, sandboxed, and the Flatpak build never needs the native
+> Linux toolchain from
+> [linux-desktop.md](./linux-desktop.md#required-packages) on the host.
+
+```bash
+# A user-level Flathub remote. Fedora's preinstalled remote is filtered on some
+# images, so add the full one for your user; both can coexist.
+flatpak remote-add --user --if-not-exists \
+  flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+
+# flatpak-builder, plus the runtime/SDK/extension the manifest declares.
+flatpak install --user flathub \
+  org.flatpak.Builder \
+  org.gnome.Platform//50 org.gnome.Sdk//50 \
+  org.freedesktop.Sdk.Extension.llvm20//25.08
+```
+
+Those versions mirror the committed manifest. If a manifest bump ever makes
+them stale, read the current values instead of trusting this page:
+
+```bash
+grep -E '^(app-id|runtime|runtime-version|sdk):|Extension\.' \
+  flatpak/io.github.thezupzup.linthra.yml
+```
+
+`org.gnome.Sdk//50` is built on freedesktop-sdk 25.08, which is where the
+`//25.08` branch of the LLVM extension comes from. `flatpak-builder` can also
+resolve all of that from the manifest itself, which never goes stale:
+
+```bash
+cd flatpak
+flatpak run org.flatpak.Builder --user --install-deps-from=flathub \
+  --install-deps-only flatpak-builder-build io.github.thezupzup.linthra.yml
+```
+
+Also expect to spend **several GB** and a long first build: ffmpeg,
+libplacebo, libass and mpv are compiled from source, and the Flutter SDK plus
+the Linux engine artifacts are downloaded. Both land in the git-ignored
+`flatpak/.flatpak-builder/` cache and are reused afterwards.
+
+Typing `flatpak run org.flatpak.Builder` everywhere gets old; an alias in
+`~/.bashrc` makes every command below read like the upstream documentation:
+
+```bash
+alias flatpak-builder='flatpak run org.flatpak.Builder'
+```
+
+### When toolbox is (and isn't) the answer
+
+| Task | Where |
+| --- | --- |
+| `flutter` / native Linux build / `./scripts/verify_linux.sh` | **toolbox** — that is what [linux-desktop.md](./linux-desktop.md#required-packages) sets up |
+| Any `flatpak` or `flatpak-builder` command on this page | **host** — a toolbox has no access to the host's Flatpak installations |
+| `./scripts/regenerate_flatpak_sources.sh` | either — it needs `git`, `python3` and network, not Flatpak. Run it on the host, or in a toolbox if your image lacks them |
+
+If your terminal is *itself* inside a Flatpak (e.g. the VS Code Flatpak),
+prefix host commands with `flatpak-spawn --host`, e.g.
+`flatpak-spawn --host flatpak run org.flatpak.Builder --user …`. That is the
+escape hatch for that specific situation, not the normal path.
+
+### Other distributions
+
+On Fedora Workstation, Debian/Ubuntu, Arch and friends, install
+`flatpak-builder` from the package manager (Fedora:
+`sudo dnf install flatpak flatpak-builder`) and drop the
+`flatpak run org.flatpak.Builder` prefix — run plain `flatpak-builder …`
+instead. Everything else on this page is identical.
+
+## Build
+
+```bash
+cd flatpak
+flatpak run org.flatpak.Builder --user --force-clean --repo=repo \
+  flatpak-builder-build io.github.thezupzup.linthra.yml
+```
+
+* `io.github.thezupzup.linthra.yml` is **generated** — never hand-edit it. See
+  [Regenerating the pinned sources](#regenerating-the-pinned-sources).
+* `flatpak-builder-build/` and `repo/` are the build tree and the local Flatpak
+  repository. Both are git-ignored.
+* `--force-clean` empties `flatpak-builder-build/` only. It does **not** touch
+  the `flatpak/.flatpak-builder/` download and per-module build cache, so it is
+  not a clean build and is safe to keep in the loop.
+* The app module builds from your working tree (the manifest's
+  `type: dir, path: ..`), so uncommitted changes are picked up.
+* The sandboxed build itself has no network. Every source — pub packages, the
+  Flutter SDK, the ffmpeg/mpv archives — is fetched from the pinned URLs
+  *before* the sandbox is entered, like any other Flatpak module.
+
+## Install locally
+
+User-level, no `sudo`, nothing system-wide:
+
+```bash
+cd flatpak
+flatpak --user remote-add --if-not-exists --no-gpg-verify linthra-dev repo
+flatpak --user install -y linthra-dev io.github.thezupzup.linthra
+```
+
+`--no-gpg-verify` is correct here and only here: this is your own unsigned
+local build repository, not a distribution channel.
+
+## Run
+
+```bash
+flatpak run io.github.thezupzup.linthra
+```
+
+That is the packaged app, in its sandbox, with its bundled audio runtime — the
+same command a user would run. It is **not** the same as launching the native
+bundle (`./build/linux/x64/release/bundle/linthra`), which uses your host's
+libraries and your host's data directories. When you are checking a packaging
+change, only the `flatpak run` form proves anything.
+
+Launch from a terminal while developing: that is where the app's stdout and
+stderr go.
+
+## Rebuild after changing Linthra source
+
+Repeat the build command, then update the installed app:
+
+```bash
+cd flatpak
+flatpak run org.flatpak.Builder --user --force-clean --repo=repo \
+  flatpak-builder-build io.github.thezupzup.linthra.yml
+flatpak --user update io.github.thezupzup.linthra
+```
+
+Unchanged modules come straight from the cache, so ffmpeg, libplacebo, libass
+and mpv are not rebuilt — only the `linthra` module is. A full rebuild is only
+needed when the manifest's own modules change, and even then flatpak-builder
+decides that for you. **Do not delete `flatpak/.flatpak-builder/` to "get a
+clean build"** unless you are specifically debugging the cache: it throws away
+the compiled dependency chain and the next build starts from source again.
+
+If an update ever refuses to apply, reinstall over the top:
+
+```bash
+flatpak --user install --reinstall -y linthra-dev io.github.thezupzup.linthra
+```
+
+## Regenerating the pinned sources
+
+Only needed when `.flutter-version` or `pubspec.lock` changes — not on a normal
+source edit:
+
+```bash
+./scripts/regenerate_flatpak_sources.sh
+```
+
+It regenerates `flatpak/io.github.thezupzup.linthra.yml` and
+`flatpak/generated/` from `flatpak/flatpak-flutter.yml`, using a pinned
+flatpak-flutter checkout in `.tool/`. Needs network (it pins every dependency
+by URL + sha256). Review the diff before committing — see
+[`flatpak/README.md`](../flatpak/README.md#regenerating-the-pinned-sources).
+
+## Clean and uninstall
+
+Ordered least to most destructive. Nothing here needs `sudo`.
+
+| Command | Removes | Cost of running it |
+| --- | --- | --- |
+| `flatpak --user uninstall io.github.thezupzup.linthra` | the installed dev build | Safe. Leaves `~/.var/app/…` data behind |
+| `flatpak --user remote-delete linthra-dev` | the local dev remote | Safe |
+| `rm -rf flatpak/flatpak-builder-build flatpak/repo` | build tree + local repo | Safe; both are recreated by the next build. Delete the remote too, or it dangles |
+| `flatpak --user uninstall --unused` | runtimes nothing installed needs any more | Safe, but re-downloads them next time you build |
+| `rm -rf flatpak/.flatpak-builder` | downloaded sources + every cached module build | **Expensive.** The next build recompiles ffmpeg/libplacebo/libass/mpv and re-downloads the Flutter SDK |
+| `flatpak --user uninstall --delete-data io.github.thezupzup.linthra` | the app **and** `~/.var/app/io.github.thezupzup.linthra/` | **Destructive.** Wipes the Flatpak install's settings, library database and cache. Your native build's data under `~/.local/share`/`~/.config` is untouched |
+| `rm -rf .tool/flatpak-flutter .tool/flatpak-flutter-venv` | the source-regeneration tool checkout | Safe; refetched by `regenerate_flatpak_sources.sh` |
+
+Never use `flatpak override --reset` to tidy up: it wipes *every* persistent
+override you have for the app, including unrelated ones you set yourself.
+Revoke the specific grant you added instead — see
+[`flatpak/README.md`](../flatpak/README.md#testing-audio-locally).
+
+## Debugging
+
+### Output and logs
+
+```bash
+# Run from a terminal: the app's stdout/stderr appear there directly.
+flatpak run io.github.thezupzup.linthra
+
+# Flatpak's own sandbox setup, when the app dies before printing anything.
+flatpak --verbose run io.github.thezupzup.linthra
+
+# Launched from the desktop rather than a terminal? Its output usually lands
+# in the journal.
+journalctl --user -b | grep -i linthra
+```
+
+### Inside the sandbox
+
+```bash
+# One-off command in the app's own runtime.
+flatpak run --command=sh io.github.thezupzup.linthra -c 'ls /app/lib/linthra'
+
+# Confirm the bundled audio runtime is really there (host libmpv is never used).
+flatpak run --command=sh io.github.thezupzup.linthra -c 'ls /app/lib | grep -i mpv'
+
+# A shell with the SDK's tools instead of the bare platform runtime
+# (needs org.gnome.Sdk//50, installed in Host tools above).
+flatpak run --devel --command=bash io.github.thezupzup.linthra
+
+# Attach to an already-running instance.
+flatpak ps
+flatpak enter <instance-id> sh
+```
+
+### Permissions
+
+```bash
+# What the package itself declares.
+flatpak info --show-permissions io.github.thezupzup.linthra
+
+# Full metadata: runtime, commit, SDK, installed size.
+flatpak info io.github.thezupzup.linthra
+flatpak info -m io.github.thezupzup.linthra
+
+# Local overrides only — what *you* have granted on top, not what's packaged.
+flatpak override --user --show io.github.thezupzup.linthra
+```
+
+### What the sandbox allows today
+
+The committed manifest grants exactly:
+
+```
+--socket=wayland  --socket=fallback-x11  --share=ipc
+--device=dri      --socket=pulseaudio
+```
+
+So these are **expected**, not bugs, and not worth debugging:
+
+* Jellyfin, Navidrome/Subsonic and Plex cannot reach a server — there is no
+  `--share=network` yet ([#440](https://github.com/TheZupZup/Linthra/issues/440)).
+* No local music folder is visible — no filesystem or portal access yet
+  ([#438](https://github.com/TheZupZup/Linthra/issues/438) /
+  [#439](https://github.com/TheZupZup/Linthra/issues/439)).
+* Saved sessions come back as "not signed in" — no Secret Service access yet
+  ([#441](https://github.com/TheZupZup/Linthra/issues/441)). Linthra treats
+  that as signed-out and keeps running; it never falls back to plaintext.
+* There is no desktop entry or icon in the application menu
+  ([#434](https://github.com/TheZupZup/Linthra/issues/434) /
+  [#435](https://github.com/TheZupZup/Linthra/issues/435) /
+  [#436](https://github.com/TheZupZup/Linthra/issues/436)). Launch it with
+  `flatpak run`.
+
+To exercise those paths anyway, use **temporary** `flatpak override` grants and
+revoke exactly what you added — the recipe, including how to verify the grant
+is gone, is in
+[`flatpak/README.md`](../flatpak/README.md#testing-audio-locally). Never commit
+them to the manifest.
+
+## Smoke testing
+
+**There is no Flatpak-specific automated smoke test yet, and no Flatpak CI.**
+Nothing in `.github/workflows/` builds or launches the Flatpak; validating a
+packaging change is manual today. The follow-ups:
+
+| Coverage | Issue |
+| --- | --- |
+| `flatpak-builder` CI validation/build | [#444](https://github.com/TheZupZup/Linthra/issues/444) |
+| Flatpak launch smoke | [#445](https://github.com/TheZupZup/Linthra/issues/445) |
+| Flatpak audio playback smoke | [#446](https://github.com/TheZupZup/Linthra/issues/446) |
+| Local-library sandbox test | [#447](https://github.com/TheZupZup/Linthra/issues/447) |
+
+What **does** exist is `./scripts/verify_linux.sh`, and it is a *native* check:
+it builds and runs `tool/linux_audio_backend_smoke.dart` with the host
+toolchain against the host's libmpv, outside any sandbox. It catches app and
+native-runner regressions, and says nothing about whether the package is
+correct. Run it for source changes; it is not a substitute for building the
+Flatpak.
+
+Until #445/#446 land, the manual pass for a packaging change is:
+
+1. Build and install as above (a rebuild is enough; a from-scratch build only
+   when you changed the manifest's modules).
+2. `flatpak run io.github.thezupzup.linthra` → the window opens and renders.
+   A missing bundled library shows up here, as a startup failure before the
+   first frame.
+3. Play audio through a temporary override, per
+   [`flatpak/README.md`](../flatpak/README.md#testing-audio-locally), then
+   revoke the grant and confirm it is gone.
+4. `flatpak info --show-permissions io.github.thezupzup.linthra` → still only
+   the five finish-args listed above, i.e. you did not widen the sandbox by
+   accident.

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -226,10 +226,14 @@ Ordered least to most destructive. Nothing here needs `sudo`.
 | `flatpak --user uninstall --delete-data io.github.thezupzup.linthra` | the app **and** `~/.var/app/io.github.thezupzup.linthra/` | **Destructive.** Wipes the Flatpak install's settings, library database and cache. Your native build's data under `~/.local/share`/`~/.config` is untouched |
 | `rm -rf .tool/flatpak-flutter .tool/flatpak-flutter-venv` | the source-regeneration tool checkout | Safe; refetched by `regenerate_flatpak_sources.sh` |
 
-Never use `flatpak override --reset` to tidy up: it wipes *every* persistent
-override you have for the app, including unrelated ones you set yourself.
-Revoke the specific grant you added instead — see
-[`flatpak/README.md`](../flatpak/README.md#testing-audio-locally).
+The audio/network testing in
+[`flatpak/README.md`](../flatpak/README.md#testing-audio-locally) leaves
+nothing to clean up: those permissions are passed to `flatpak run` and last
+only for that invocation. That is why it does not use `flatpak override` —
+override grants persist, `--nofilesystem=…`/`--unshare=network` add a
+*negative* override rather than deleting the grant, and `--reset` wipes
+*every* persistent override you have for the app, including unrelated ones you
+set yourself.
 
 ## Debugging
 
@@ -275,7 +279,8 @@ flatpak info --show-permissions io.github.thezupzup.linthra
 flatpak info io.github.thezupzup.linthra
 flatpak info -m io.github.thezupzup.linthra
 
-# Local overrides only — what *you* have granted on top, not what's packaged.
+# Persistent local overrides — what *you* have granted on top, not what's
+# packaged. Empty if you have stuck to one-shot `flatpak run` permissions.
 flatpak override --user --show io.github.thezupzup.linthra
 ```
 
@@ -304,11 +309,19 @@ So these are **expected**, not bugs, and not worth debugging:
   [#436](https://github.com/TheZupZup/Linthra/issues/436)). Launch it with
   `flatpak run`.
 
-To exercise those paths anyway, use **temporary** `flatpak override` grants and
-revoke exactly what you added — the recipe, including how to verify the grant
-is gone, is in
+To exercise those paths anyway, pass the permission to `flatpak run` for a
+single launch — it applies to that invocation only, so there is nothing to
+revoke and nothing left behind:
+
+```bash
+flatpak run --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
+flatpak run --share=network io.github.thezupzup.linthra
+```
+
+Use that rather than `flatpak override`, whose grants persist and cannot be
+cleanly undone — see
 [`flatpak/README.md`](../flatpak/README.md#testing-audio-locally). Never commit
-them to the manifest.
+either permission to the manifest.
 
 ## Smoke testing
 
@@ -337,9 +350,11 @@ Until #445/#446 land, the manual pass for a packaging change is:
 2. `flatpak run io.github.thezupzup.linthra` → the window opens and renders.
    A missing bundled library shows up here, as a startup failure before the
    first frame.
-3. Play audio through a temporary override, per
-   [`flatpak/README.md`](../flatpak/README.md#testing-audio-locally), then
-   revoke the grant and confirm it is gone.
+3. Play audio with a one-shot permission —
+   `flatpak run --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra`,
+   or `--share=network` for a stream, per
+   [`flatpak/README.md`](../flatpak/README.md#testing-audio-locally). It lasts
+   for that launch only.
 4. `flatpak info --show-permissions io.github.thezupzup.linthra` → still only
    the five finish-args listed above, i.e. you did not widen the sandbox by
    accident.

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -31,7 +31,12 @@ what works today, and what deliberately does not yet.
 
 ## Required packages
 
-The Flutter Linux toolchain plus the native libraries Linthra's plugins need.
+The Flutter Linux toolchain plus the native libraries Linthra's plugins need,
+for the **native** build described on this page.
+
+> Building the **Flatpak** instead? None of these packages are needed for it —
+> it brings its own toolchain and bundles its own libmpv. See
+> [flatpak-development.md](./flatpak-development.md).
 
 ### Fedora / Fedora Kinoite
 
@@ -186,7 +191,9 @@ that recorded patch.
 
 libmpv provides broad codec/container support and PulseAudio/PipeWire output.
 It is a native runtime dependency, not a binary downloaded when Linthra starts.
-The future Flatpak manifest must build or include libmpv as a declared module.
+The Flatpak manifest therefore builds libmpv as a declared module and bundles
+it, so the packaged app needs no host libmpv at all
+([flatpak-development.md](./flatpak-development.md)).
 `media_kit_libs_linux` normally offers an optional build-time mimalloc download;
 Linthra explicitly disables it in `linux/CMakeLists.txt`, so this backend adds no
 undeclared network access to an isolated `flatpak-builder` build.
@@ -342,9 +349,15 @@ for exactly how the CI job builds and attaches it.
 ## Where this is going
 
 The Linux distribution target is **Flathub**. A locally installable Flatpak on
-Fedora Kinoite is a validation step on the way, not the destination. Flatpak
-packaging — manifest, desktop file, icons, AppStream metadata, sandbox
-permissions — is later work in #376 and is not part of this milestone.
+Fedora Kinoite is a validation step on the way, not the destination.
+
+That packaging is now underway in #376 and lives outside this page: the
+committed manifest is in [`flatpak/`](../flatpak/README.md) and the contributor
+workflow for building, installing and debugging it on Fedora Atomic is
+[flatpak-development.md](./flatpak-development.md). It builds, installs and
+launches with working audio; desktop file, icons, AppStream metadata and the
+network/filesystem/Secret Service permissions are still open sub-issues. None
+of it changes the native build on this page.
 
 Decisions already taken with that destination in mind:
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -42,51 +42,31 @@ are independent audio runtimes by design; only the Flatpak is self-contained.
 
 ## Building, installing, running
 
-### Fedora Atomic (Kinoite / Silverblue) — the normal case
-
-`flatpak` itself is already part of the base image. Install `flatpak-builder`
-as a Flatpak app rather than layering it — no `rpm-ostree install`, no reboot:
+The full contributor workflow — host tools, build, install, run, rebuild,
+clean/uninstall and debugging, written for Fedora Atomic (Kinoite/Silverblue)
+and usable anywhere else — is
+[docs/flatpak-development.md](../docs/flatpak-development.md). The short
+version, run from this directory:
 
 ```bash
-flatpak install --user flathub org.flatpak.Builder \
-  org.gnome.Platform//50 org.gnome.Sdk//50 \
-  org.freedesktop.Sdk.Extension.llvm20//25.08
-
-cd flatpak
 flatpak run org.flatpak.Builder --user --force-clean --repo=repo \
   flatpak-builder-build io.github.thezupzup.linthra.yml
 
-flatpak --user remote-add --if-not-exists --no-gpg-verify \
-  linthra-dev repo
+flatpak --user remote-add --if-not-exists --no-gpg-verify linthra-dev repo
 flatpak --user install -y linthra-dev io.github.thezupzup.linthra
 
 flatpak run io.github.thezupzup.linthra
 ```
 
-(A shell alias, e.g. `alias flatpak-builder='flatpak run org.flatpak.Builder'`
-in `~/.bashrc`, lets you type the commands below as-is instead.)
-
-### Fedora Workstation / other distros with a native `flatpak-builder`
-
-Install both from your package manager (Fedora: `sudo dnf install flatpak
-flatpak-builder`) and drop the `flatpak run org.flatpak.Builder` prefix —
-everywhere above, run plain `flatpak-builder ...` instead.
-
-### Running from inside another sandbox (e.g. this repo opened in the VS Code Flatpak)
-
-If your own terminal is itself inside a Flatpak sandbox, neither `flatpak`
-nor `flatpak-builder` is reachable directly — prefix every command above
-(from either section) with `flatpak-spawn --host`, e.g.
-`flatpak-spawn --host flatpak run org.flatpak.Builder --user ...`. This is
-an extra note for that specific situation, not the normal path.
+On a distribution with a native `flatpak-builder`, drop the
+`flatpak run org.flatpak.Builder` prefix and run plain `flatpak-builder ...`.
+To uninstall: `flatpak --user uninstall io.github.thezupzup.linthra` and
+`flatpak --user remote-delete linthra-dev`.
 
 Nothing above needs network access during the actual sandboxed build —
 `flatpak-builder`'s normal declared-source fetch (`generated/sources/pubspec.json`,
 the Flutter SDK module, the ffmpeg/libplacebo/libass/mpv archives) happens
 before the sandbox is entered, exactly like any other Flatpak module.
-
-To uninstall: `flatpak --user uninstall io.github.thezupzup.linthra` and
-`flatpak --user remote-delete linthra-dev`.
 
 ## Testing audio locally
 
@@ -166,6 +146,7 @@ Not in this manifest — each has its own issue:
   ffmpeg/mpv build stays scoped to the container/codec/protocol support
   Linthra's supported formats and HTTP(S) streaming actually need.
 * **CI** (#444), **automated launch/audio smoke tests** (#445/#446), **local-
-  library sandbox test** (#447), **Fedora Atomic development documentation**
-  (#448) — out of scope here; this file is the minimal "how do I build and
-  validate this locally" note #432/#433 asked for.
+  library sandbox test** (#447) — out of scope here; this file is the minimal
+  "how do I build and validate this locally" note #432/#433 asked for, and
+  [docs/flatpak-development.md](../docs/flatpak-development.md) is the
+  contributor workflow around it.

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -72,39 +72,38 @@ before the sandbox is entered, exactly like any other Flatpak module.
 
 The committed manifest grants `--socket=pulseaudio` but no filesystem or
 network access, matching #438/#439/#440's scope. To manually verify playback
-of your own local files or a real remote stream, use *temporary*,
-non-committed `flatpak override` grants and revoke exactly what you added
-afterward — never add these to `io.github.thezupzup.linthra.yml`, and never
-use `--reset`, which wipes *every* persistent override you have for this app
-(including any unrelated ones you already had) rather than just the one this
-test added:
+of your own local files or a real remote stream, pass the extra permission to
+`flatpak run` itself. Options given there apply to that one invocation only,
+so there is nothing to revoke afterwards and nothing is left behind:
 
 ```bash
-# Local file: point a temporary filesystem grant at a directory with a test
-# track, launch, play it from within the app, then revoke that exact grant.
-flatpak --user override --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
-flatpak run io.github.thezupzup.linthra
-flatpak --user override --nofilesystem=/path/to/test-music io.github.thezupzup.linthra
+# Local file: read-only access to a directory with a test track, for this
+# launch only. Play it from within the app.
+flatpak run --filesystem=/path/to/test-music:ro io.github.thezupzup.linthra
 
 # Remote HTTP(S) stream: same idea with network instead.
-flatpak --user override --share=network io.github.thezupzup.linthra
-flatpak run io.github.thezupzup.linthra
-flatpak --user override --unshare=network io.github.thezupzup.linthra
+flatpak run --share=network io.github.thezupzup.linthra
 ```
 
-Confirm each grant is actually gone afterward — check the specific
-permission you added rather than assuming empty output, since you may
-already have unrelated overrides set for this app:
+Do **not** use `flatpak override` for this. Its grants are persistent, and the
+apparent undo is not one: `--nofilesystem=…`/`--unshare=network` record a
+*negative* override on top of the grant rather than deleting it, so the app
+keeps leftover permission state either way. `--reset` is worse — it wipes
+*every* persistent override you have for this app, including unrelated ones
+you set yourself. A one-shot `flatpak run` permission avoids the whole problem.
+
+Never add these permissions to `io.github.thezupzup.linthra.yml` either: a
+committed grant is #440's (network) and #438/#439's (filesystem) decision, not
+a testing convenience. The package itself is unchanged by the runs above, and
+stays that way:
 
 ```bash
-flatpak override --user --show io.github.thezupzup.linthra
-# Look for the absence of the filesystem/network line you added above;
-# any other overrides already there are not this test's concern.
+flatpak info --show-permissions io.github.thezupzup.linthra
+# Still only the manifest's finish-args — a permission passed to `flatpak run`
+# never appears here.
 ```
 
-should no longer list the `filesystem`/`network` line the test added, though
-any other override you already had for this app before testing is expected
-to remain. Automated audio smoke coverage is #446's job, not this file's.
+Automated audio smoke coverage is #446's job, not this file's.
 
 ## Regenerating the pinned sources
 
@@ -131,16 +130,16 @@ Not in this manifest — each has its own issue:
   finish-args and the associated install steps are absent on purpose.
 * **Provider network access** (#440) — no permanent `--share=network`.
   #433 proved the bundled ffmpeg/libmpv can decode HTTP(S) audio using only a
-  *temporary*, non-committed `flatpak override --user --share=network`
-  applied and removed for that validation; permanently granting Linthra
-  network access for real provider use (Jellyfin/Navidrome-Subsonic/Plex) is
-  #440's job, not this manifest's.
+  temporary, non-committed grant for that validation (see
+  [Testing audio locally](#testing-audio-locally)); permanently granting
+  Linthra network access for real provider use
+  (Jellyfin/Navidrome-Subsonic/Plex) is #440's job, not this manifest's.
 * **Filesystem/portal permissions** (#438/#439), **Secret Service** (#441) —
   no `--filesystem=host|home` or `--talk-name=org.freedesktop.secrets`.
   Jellyfin/Subsonic/Plex session restore and secure-storage reads already
   degrade to "not signed in" without them (`docs/linux-desktop.md` §"Secure
   storage"). #433's local-audio validation likewise used a temporary,
-  non-committed filesystem override rather than a committed grant.
+  non-committed filesystem grant rather than a committed one.
 * **Video codecs, hardware acceleration/hwaccel, subtitle-adjacent tuning
   beyond what libmpv/libass require to build** — Linthra is audio-only; the
   ffmpeg/mpv build stays scoped to the container/codec/protocol support


### PR DESCRIPTION
Closes #448 (documentation only — no production behaviour changes).

## What this adds

`docs/flatpak-development.md`: the copy-pasteable contributor workflow for the **committed** Flatpak manifest, written for Fedora Atomic (Kinoite/Silverblue) and usable anywhere else.

- **Host tools** — `flatpak` is already in the base image; `flatpak-builder` is installed as `org.flatpak.Builder` alongside `org.gnome.Platform//50`, `org.gnome.Sdk//50` and `org.freedesktop.Sdk.Extension.llvm20//25.08`. No `rpm-ostree install`, no reboot, no layering. A `grep` on the manifest and `--install-deps-from=flathub` are given so the version list can't silently rot.
- **Toolbox, only where useful** — native Flutter work goes in a toolbox; every `flatpak`/`flatpak-builder` command is a host command; `regenerate_flatpak_sources.sh` works in either (it needs git/python3/network, not Flatpak). Keeps the `flatpak-spawn --host` note for a sandboxed terminal.
- **Build / install / run / rebuild** — repo-relative, user-level throughout, using the generated manifest and the git-ignored `flatpak/flatpak-builder-build` + `flatpak/repo` paths. Documents that `--force-clean` only empties the build tree and does **not** discard the `.flatpak-builder` module cache, so the normal loop is rebuild + `flatpak --user update`, not a clean build.
- **Clean / uninstall** — a table ordered least-to-most destructive, separating "safe", "expensive" (dropping the cache means recompiling ffmpeg/mpv) and "destructive" (`--delete-data` wipes `~/.var/app/…`).
- **Debugging** — terminal output and journal fallback, `--command=sh` / `--devel` / `flatpak ps` + `flatpak enter`, and the `flatpak info --show-permissions` / `flatpak override --user --show` commands. Lists the five finish-args the package actually grants today, so no-network / no-local-folders / "not signed in" / no desktop entry read as expected state rather than bugs.
- **Smoke testing** — states plainly that there is **no** Flatpak-specific smoke test and no Flatpak CI yet (#444/#445/#446/#447), that `scripts/verify_linux.sh` is a native check against the host toolchain and host libmpv and proves nothing about the package, and gives the manual pass to run until those land.
- **Native Linux vs Flatpak** — a table separating the two toolchains, libmpv sources, run commands, data directories and check scripts, so host runtime dependencies aren't confused with the libraries bundled inside the image.

## Other files

- `flatpak/README.md` — keeps the manifest rationale and the one-shot audio/network testing recipe; its build section now points at the new doc instead of carrying a second divergent command list. #448 dropped from "What's deferred".
- `docs/linux-desktop.md` — the Required packages section is marked native-only, the libmpv note reflects that the manifest now bundles it, and "Where this is going" no longer says Flatpak packaging doesn't exist.
- `docs/README.md`, `CONTRIBUTING.md` — index/pointer rows.

## Verification

- Every internal link and heading anchor in the touched docs resolves (scripted check).
- Every repo path, script and file named in the new doc exists in the tree; the runtime/SDK/extension versions and the five finish-args were read out of `flatpak/io.github.thezupzup.linthra.yml`; the build/repo directory names match `.gitignore`.
- `./scripts/check_secrets.sh` passes; `scripts/check_pr_security_surface.py --base origin/main --head HEAD` reports an ordinary-risk diff.
- No personal absolute paths — the only `~/` references are XDG/Flatpak locations.
- `flatpak-builder` is not available in this environment, so the documented build was not executed here; the commands were checked against the committed manifest, scripts and `.gitignore` rather than run.

## Left for later issues

Deliberately not documented as existing: Flatpak CI (#444), launch smoke (#445), audio smoke (#446), local-library sandbox test (#447), desktop file/AppStream/icons (#434/#435/#436), network (#440), filesystem/portals (#438/#439), Secret Service (#441). They are referenced as open follow-ups where a contributor would otherwise expect them to work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoNS28to5Z4CqTeu2vsEEk)_