### PR TITLE
feat(flatpak): install the io.github.thezupzup.linthra desktop entry

### DIFF
--- a/.github/workflows/linux-desktop-build.yml
+++ b/.github/workflows/linux-desktop-build.yml
@@ -141,6 +141,8 @@ jobs:
       #                                              also supplies runtime libmpv
       #   libasound2-plugins                        — ALSA null PCM for headless
       #                                              native audio lifecycle smoke
+      #   desktop-file-utils                        — desktop-file-validate, for
+      #                                              the installed desktop entry
       - name: Install Linux build dependencies
         run: |
           set -euo pipefail
@@ -156,6 +158,7 @@ jobs:
             libsecret-1-dev \
             libmpv-dev \
             libasound2-plugins \
+            desktop-file-utils \
             xauth \
             xvfb
 
@@ -192,6 +195,21 @@ jobs:
 
       - name: Test the Linux runner tooling
         run: python3 test/tooling/check_linux_runner_test.py
+
+      # Syntax half of the desktop entry check (#434); the identity half — the
+      # filename, Name, Exec, Icon and the Flatpak install step — is in
+      # check_linux_runner.py above. desktop-file-validate exits 0 for
+      # everything it calls a warning, hint, or "error (will be fatal in the
+      # future)", so its exit status alone would let a deprecated key or a
+      # miscategorised entry through; any output at all is the failure signal.
+      - name: Validate the desktop entry
+        run: |
+          set -euo pipefail
+          report="$(desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop)"
+          if [ -n "$report" ]; then
+            printf '%s\n' "$report" >&2
+            exit 1
+          fi
 
       # A normal Flutter widget test cannot load the Linux plugin bundle, so
       # this target runs in the real GTK runner and opens a silent local WAV

--- a/docs/flatpak-development.md
+++ b/docs/flatpak-development.md
@@ -19,9 +19,10 @@ Three docs, three jobs:
 
 > Flatpak packaging is in progress ([issue #376](https://github.com/TheZupZup/Linthra/issues/376)).
 > The committed manifest builds, installs and launches the real app with
-> working audio, but it is not the Flathub submission: there is no desktop
-> file, icon or AppStream metadata yet, and no network, filesystem or
-> Secret Service access. See [What the sandbox allows today](#what-the-sandbox-allows-today).
+> working audio, and installs a desktop entry so Linthra appears in the
+> application menu, but it is not the Flathub submission: there is no icon or
+> AppStream metadata yet, and no network, filesystem or Secret Service access.
+> See [What the sandbox allows today](#what-the-sandbox-allows-today).
 
 All commands are relative to the repository. Run them from the repository root
 unless a block starts with `cd flatpak`.
@@ -303,11 +304,13 @@ So these are **expected**, not bugs, and not worth debugging:
 * Saved sessions come back as "not signed in" — no Secret Service access yet
   ([#441](https://github.com/TheZupZup/Linthra/issues/441)). Linthra treats
   that as signed-out and keeps running; it never falls back to plaintext.
-* There is no desktop entry or icon in the application menu
-  ([#434](https://github.com/TheZupZup/Linthra/issues/434) /
-  [#435](https://github.com/TheZupZup/Linthra/issues/435) /
-  [#436](https://github.com/TheZupZup/Linthra/issues/436)). Launch it with
-  `flatpak run`.
+* Linthra is in the application menu now
+  ([#434](https://github.com/TheZupZup/Linthra/issues/434)) — but with the
+  desktop's fallback icon, because the icon files are still to come
+  ([#436](https://github.com/TheZupZup/Linthra/issues/436)), and with no
+  software-centre listing
+  ([#435](https://github.com/TheZupZup/Linthra/issues/435)). `flatpak run`
+  still works and is what these debugging commands assume.
 
 To exercise those paths anyway, pass the permission to `flatpak run` for a
 single launch — it applies to that invocation only, so there is nothing to

--- a/docs/linux-desktop.md
+++ b/docs/linux-desktop.md
@@ -104,7 +104,10 @@ To run the same checks CI runs:
 ```
 
 That does `pub get --enforce-lockfile`, `dart format --set-exit-if-changed`,
-`flutter analyze`, `flutter test`, the runner configuration check, the same
+`flutter analyze`, `flutter test`, the runner configuration check, the desktop
+entry check (`desktop-file-validate` on
+`linux/packaging/io.github.thezupzup.linthra.desktop`, skipped with a note if
+`desktop-file-utils` is not installed), the same
 native audio lifecycle smoke CI runs (builds and runs
 `tool/linux_audio_backend_smoke.dart`), and `flutter build linux --release`.
 It skips the smoke test and the build if the native packages above are
@@ -355,7 +358,9 @@ That packaging is now underway in #376 and lives outside this page: the
 committed manifest is in [`flatpak/`](../flatpak/README.md) and the contributor
 workflow for building, installing and debugging it on Fedora Atomic is
 [flatpak-development.md](./flatpak-development.md). It builds, installs and
-launches with working audio; desktop file, icons, AppStream metadata and the
+launches with working audio, and installs the desktop entry
+(`linux/packaging/io.github.thezupzup.linthra.desktop`, shared with any future
+native package rather than Flatpak-only); icons, AppStream metadata and the
 network/filesystem/Secret Service permissions are still open sub-issues. None
 of it changes the native build on this page.
 

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,11 +1,13 @@
-# Flatpak (local build — issues #432, #433)
+# Flatpak (local build — issues #432, #433, #434)
 
 This is the packaging **foundation**: enough to build Linthra's native Flutter
-Linux bundle inside `flatpak-builder`, install it, and launch the real
-`io.github.thezupzup.linthra` app to real, audible local and remote playback
-through a fully self-contained audio runtime. It is deliberately not the
-Flathub submission and not a desktop-integrated package — see "What's
-deferred" below and the comments in `io.github.thezupzup.linthra.yml` itself.
+Linux bundle inside `flatpak-builder`, install it, launch the real
+`io.github.thezupzup.linthra` app from the application menu, and get real,
+audible local and remote playback through a fully self-contained audio
+runtime. It is deliberately not the Flathub submission — the icon and
+AppStream metadata that go with the desktop entry are still open, and so are
+the sandbox permissions; see "What's deferred" below and the comments in
+`io.github.thezupzup.linthra.yml` itself.
 
 ## Audio runtime
 
@@ -30,11 +32,49 @@ system `mpv-libs`/`libmpv` runtime documented in
 [docs/linux-desktop.md](../docs/linux-desktop.md#required-packages). The two
 are independent audio runtimes by design; only the Flatpak is self-contained.
 
+## Desktop entry
+
+`../linux/packaging/io.github.thezupzup.linthra.desktop` is what puts Linthra
+in the application menu. The `linthra` module installs it verbatim:
+
+```
+install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop \
+  /app/share/applications/io.github.thezupzup.linthra.desktop
+```
+
+`/app/share/applications` is the only directory flatpak-builder exports from at
+`finish` time, and it only exports files whose name starts with the app id —
+this one *is* the app id, so there is no `rename-desktop-file` in the manifest.
+Export
+rewrites `Exec=linthra` into the host-side `flatpak run …` form, so the entry
+carries the bare command and no absolute path; the same file works unchanged
+for a native package that puts `linthra` on `PATH`.
+
+Two things keep it honest, both offline and both already in CI
+(`.github/workflows/linux-desktop-build.yml`):
+
+```bash
+desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop
+python3 scripts/check_linux_runner.py
+```
+
+The first is syntax — note that `desktop-file-validate` exits 0 even for
+warnings and "will be fatal in the future" errors, so CI and
+`scripts/verify_linux.sh` treat *any* output from it as a failure rather than
+trusting its exit status. The second is identity: `scripts/check_linux_runner.py`
+checks the entry's filename, `Name`, `Exec`, `Icon` and `Categories` against
+the same sources of truth the Linux runner is held to (`AppInfo.name`,
+`pubspec.yaml`'s `name`, Android's `applicationId`), and checks that **both**
+this directory's manifests — the hand-authored template and the generated
+manifest — actually install it, so a regeneration that was never run shows up
+as a failure rather than as a Flatpak with no menu entry.
+
 ## Files here
 
 | File | What it is |
 | --- | --- |
 | `flatpak-flutter.yml` | Hand-authored input. Never built directly. |
+| `../linux/packaging/io.github.thezupzup.linthra.desktop` | Hand-authored, and not Flatpak-only: the installed desktop entry (#434), which this manifest copies into `/app/share/applications/` for flatpak-builder to export. It lives beside the rest of the Linux packaging inputs rather than here so a future native package installs the same file. |
 | `io.github.thezupzup.linthra.yml` | **Generated.** The real manifest `flatpak-builder` consumes. Do not hand-edit — regenerate instead (below). |
 | `generated/sources/pubspec.json` | **Generated.** One pinned, hashed source per package in the committed `pubspec.lock` (plus Flutter's own internal `flutter_tools` package), so `flutter pub get --offline` inside the sandbox never touches pub.dev. Also carries two known per-plugin fixes from flatpak-flutter's own `foreign-deps` database: `sqlite3_flutter_libs` and `media_kit_libs_linux`'s own CMake `FetchContent` downloads (sqlite amalgamation, mimalloc) are pre-placed at the exact cache paths CMake checks before downloading, so they're satisfied without a network hit even though `linux/CMakeLists.txt` already disables/redirects both independently. |
 | `generated/modules/flutter-sdk-3.44.7.json` | **Generated.** Pins the Dart SDK and Linux engine artifacts for the exact `.flutter-version` tag by their real `storage.googleapis.com` URLs and sha256, plus a small patch so Flutter's own internal tool bootstrap runs `pub upgrade --offline`. |
@@ -125,9 +165,13 @@ and the current `pubspec.lock`. Diff the result before committing.
 
 Not in this manifest — each has its own issue:
 
-* **Desktop file** (#434), **AppStream metainfo** (#435), **scalable icon
-  packaging** (#436) — `rename-desktop-file`/`rename-icon`/`--filesystem`
-  finish-args and the associated install steps are absent on purpose.
+* **AppStream metainfo** (#435), **scalable icon packaging** (#436) — no
+  `<app-id>.metainfo.xml` and no icon is installed, so the desktop entry's
+  `Icon=io.github.thezupzup.linthra` currently resolves to nothing and the
+  launcher falls back to a generic icon. The entry deliberately names the icon
+  anyway: #436 installs the files under exactly that name and nothing here has
+  to change when it lands. `rename-desktop-file`/`rename-icon` are not used and
+  are not needed — everything is installed under the app id already.
 * **Provider network access** (#440) — no permanent `--share=network`.
   #433 proved the bundled ffmpeg/libmpv can decode HTTP(S) audio using only a
   temporary, non-committed grant for that validation (see

--- a/flatpak/flatpak-flutter.yml
+++ b/flatpak/flatpak-flutter.yml
@@ -254,6 +254,19 @@ modules:
       - cp -r build/linux/x64/release/bundle/. /app/lib/linthra/
       - install -d /app/bin
       - ln -s ../lib/linthra/linthra /app/bin/linthra
+      # Desktop entry (#434). Installed from the app's own source tree (the
+      # `dir` source below stages the whole checkout into this module's build
+      # directory), so the file that a native package would install is the one
+      # the Flatpak installs — there is no packaging-only copy to drift.
+      #
+      # /app/share/applications is where flatpak-builder looks at `finish`
+      # time: it exports every desktop file it finds there, rewriting `Exec=`
+      # into the `flatpak run io.github.thezupzup.linthra` form the host
+      # launcher needs, and it only exports files whose name starts with the
+      # app id — this one *is* the app id, so no `rename-desktop-file`. `Icon=`
+      # names the icon #436 will install; until then the entry appears with the
+      # desktop's fallback icon rather than a wrong one.
+      - install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop /app/share/applications/io.github.thezupzup.linthra.desktop
     sources:
       # The app's own source. flatpak-flutter's pre-processing step cannot
       # read a `dir` source (it only fetches `git` sources to inspect

--- a/flatpak/io.github.thezupzup.linthra.yml
+++ b/flatpak/io.github.thezupzup.linthra.yml
@@ -113,6 +113,7 @@ modules:
       - cp -r build/linux/x64/release/bundle/. /app/lib/linthra/
       - install -d /app/bin
       - ln -s ../lib/linthra/linthra /app/bin/linthra
+      - install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop /app/share/applications/io.github.thezupzup.linthra.desktop
     sources:
       - type: dir
         path: ..

--- a/linux/packaging/io.github.thezupzup.linthra.desktop
+++ b/linux/packaging/io.github.thezupzup.linthra.desktop
@@ -1,0 +1,39 @@
+# Linthra's installed desktop entry (#434).
+#
+# The filename is the application id — io.github.thezupzup.linthra — because
+# that is what every desktop-integration lookup keys off: flatpak-builder only
+# exports a desktop file whose name starts with the app id, AppStream (#435)
+# will point its `<launchable type="desktop-id">` at this exact filename, and
+# the icon (#436) is installed as `<app-id>.png/.svg`, which is what makes
+# `Icon=` below resolve.
+# The same id is already `APPLICATION_ID` in linux/CMakeLists.txt, Android's
+# `applicationId`, and the Flatpak `app-id`; scripts/check_linux_runner.py
+# holds all of those together.
+#
+# Nothing here may name a build machine: `Exec=` is a bare command, resolved
+# from PATH (`/app/bin/linthra` inside the Flatpak, wherever a native package
+# puts it otherwise), and `Icon=` is an icon-theme name rather than a path.
+# check_linux_runner.py's absolute-path scan covers this file too.
+#
+# The window this launches identifies itself with the same id — the runner
+# calls `g_set_prgname(APPLICATION_ID)` and registers its GtkApplication under
+# it (linux/runner/my_application.cc) — so the running window associates with
+# this entry on both Wayland and X11 without a `StartupWMClass=` override.
+#
+# Validate after editing:  desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop
+[Desktop Entry]
+Type=Application
+Name=Linthra
+GenericName=Music Player
+Comment=Play your own music, from this device or your own server
+Exec=linthra
+Icon=io.github.thezupzup.linthra
+Terminal=false
+# AudioVideo is the required main category; Audio and Player narrow it to an
+# audio player, and Music is the registered additional category launchers use
+# to group music apps. No %U/%F field code and no MimeType: Linthra does not
+# take a file or URI argument today, and claiming one would advertise an
+# "Open with Linthra" handler that drops whatever it is given.
+Categories=AudioVideo;Audio;Player;Music;
+Keywords=music;audio;player;library;playlist;jellyfin;subsonic;navidrome;plex;
+StartupNotify=true

--- a/scripts/check_linux_runner.py
+++ b/scripts/check_linux_runner.py
@@ -21,6 +21,16 @@ that disagrees with Android's would mean two different identities for one
 product; a window title that disagrees with `AppInfo.name` would mean the title
 bar and the About screen disagree.
 
+The same three answers are what the installed desktop entry
+(`linux/packaging/<app-id>.desktop`, #434) has to repeat — its filename, its
+`Icon=`, its `Name=` and its `Exec=` — so it is checked against those sources
+of truth too, rather than against the runner's copy of them. A desktop entry
+that disagrees is not a build failure either: it installs, it just launches
+nothing, shows the wrong name, or (with a filename that is not the app id)
+never gets exported by flatpak-builder at all. The Flatpak manifests are
+checked for the install step that puts it in `/app/share/applications`, since
+an entry nothing installs is the same silence.
+
 It also checks two things that are about *how* the runner builds rather than
 what it is called:
 
@@ -55,6 +65,23 @@ MY_APPLICATION = Path("linux") / "runner" / "my_application.cc"
 PUBSPEC = Path("pubspec.yaml")
 APP_INFO = Path("lib") / "core" / "app_info.dart"
 BUILD_GRADLE = Path("android") / "app" / "build.gradle"
+# The installed desktop entry and the two Flatpak manifests that install it.
+# All three are named after the application id, so their real paths are built
+# from it at check time rather than hardcoded here.
+PACKAGING_DIR = Path("linux") / "packaging"
+FLATPAK_DIR = Path("flatpak")
+FLATPAK_TEMPLATE = FLATPAK_DIR / "flatpak-flutter.yml"
+
+# Where a Flatpak's desktop entry has to land: flatpak-builder exports what it
+# finds in this directory at `finish` time and nothing from anywhere else.
+DESKTOP_ENTRY_INSTALL_DIR = "/app/share/applications"
+
+# freedesktop's main categories for an audio player. `Audio` is only valid
+# alongside `AudioVideo`, and `Player` alone would leave the entry ungrouped in
+# menus that split media by kind. Extra categories (Music, …) are fine.
+REQUIRED_CATEGORIES = ("AudioVideo", "Audio", "Player")
+
+DESKTOP_ENTRY_GROUP = "Desktop Entry"
 
 # The CMake variable linux/CMakeLists.txt uses to accept an already-unpacked
 # SQLite amalgamation instead of downloading one. See docs/linux-desktop.md.
@@ -169,6 +196,112 @@ def app_display_name(root: Path) -> str:
     )
 
 
+def desktop_entry_file(root: Path) -> Path:
+    """Where the installed desktop entry has to live, from the app id.
+
+    The filename is not decoration: Flatpak only exports `<app-id>.desktop`,
+    and AppStream (#435) will key its component id to the same name.
+    """
+    return PACKAGING_DIR / f"{android_application_id(root)}.desktop"
+
+
+def desktop_entry(root: Path) -> dict[str, str]:
+    """The `[Desktop Entry]` group of the installed entry, as key -> value.
+
+    A hand-rolled reader rather than `configparser`, which lowercases option
+    names by default (`Name` and `Exec` would come back as `name`/`exec`) and
+    whose default interpolation treats `%` — the field-code character in a
+    desktop `Exec=` — as syntax. Only the default group is returned; a
+    localized `Name[de]` key is a distinct key here, and a later group
+    (`[Desktop Action …]`) is not read at all.
+    """
+    text = _read(root, desktop_entry_file(root))
+    values: dict[str, str] = {}
+    in_group = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_group = stripped[1:-1] == DESKTOP_ENTRY_GROUP
+            continue
+        if in_group and "=" in stripped:
+            key, _, value = stripped.partition("=")
+            values[key.strip()] = value.strip()
+    if not values:
+        raise CheckError(
+            f"{desktop_entry_file(root)}: no [{DESKTOP_ENTRY_GROUP}] group"
+        )
+    return values
+
+
+def desktop_entry_problems(root: Path) -> list[str]:
+    """Disagreements between the desktop entry and the app's identity."""
+    entry = desktop_entry(root)
+    where = desktop_entry_file(root)
+    problems: list[str] = []
+
+    def require(key: str, expected: str, source: str) -> None:
+        actual = entry.get(key)
+        if actual is None:
+            problems.append(f"{where}: no {key}=, expected {expected!r} ({source})")
+        elif actual != expected:
+            problems.append(
+                f"{where}: {key}={actual!r} but {source} says {expected!r}"
+            )
+
+    require("Type", "Application", "a launchable desktop entry")
+    require("Name", app_display_name(root), "lib/core/app_info.dart AppInfo.name")
+    # Exec is the bare command, not a path: /app/bin/<name> inside the Flatpak,
+    # whatever a native package chose outside it. No `%U`/`%F` field code —
+    # Linthra takes no file or URI argument, so accepting one would advertise a
+    # handler that silently drops what it is opened with.
+    require("Exec", pubspec_name(root), "pubspec.yaml name")
+    # Icon is an icon-theme name, which is the app id: #436 installs the icon
+    # files under exactly that name.
+    require(
+        "Icon",
+        android_application_id(root),
+        "android/app/build.gradle applicationId",
+    )
+
+    categories = [item for item in entry.get("Categories", "").split(";") if item]
+    missing = [name for name in REQUIRED_CATEGORIES if name not in categories]
+    if missing:
+        problems.append(
+            f"{where}: Categories is missing {', '.join(missing)} — an audio "
+            f"player needs {';'.join(REQUIRED_CATEGORIES)}"
+        )
+
+    return problems
+
+
+def desktop_entry_install_problems(root: Path) -> list[str]:
+    """Flatpak manifests that do not install the desktop entry.
+
+    Both are checked: `flatpak-flutter.yml` is hand-authored and
+    `<app-id>.yml` is generated from it by
+    scripts/regenerate_flatpak_sources.sh, so a manifest change that was never
+    regenerated leaves the built Flatpak without the entry while the diff looks
+    complete.
+    """
+    app_id = android_application_id(root)
+    source = desktop_entry_file(root)
+    destination = f"{DESKTOP_ENTRY_INSTALL_DIR}/{app_id}.desktop"
+    install = re.compile(
+        rf"install\s+-Dm644\s+{re.escape(str(source))}\s+{re.escape(destination)}"
+    )
+
+    problems: list[str] = []
+    for manifest in (FLATPAK_TEMPLATE, FLATPAK_DIR / f"{app_id}.yml"):
+        if install.search(_read(root, manifest)) is None:
+            problems.append(
+                f"{manifest} does not install {source} to {destination}, so the "
+                "built Flatpak has no desktop entry to export"
+            )
+    return problems
+
+
 def absolute_paths_under_linux(root: Path) -> list[str]:
     """Absolute host paths hardcoded in the committed Linux build files.
 
@@ -220,6 +353,12 @@ def check(root: Path) -> list[str]:
         app_display_name(root),
         "lib/core/app_info.dart AppInfo.name",
     )
+
+    # The installed desktop entry repeats the identity above; it is checked
+    # against the same sources of truth, not against the runner's copy, so a
+    # runner that drifts is reported once rather than twice.
+    problems.extend(desktop_entry_problems(root))
+    problems.extend(desktop_entry_install_problems(root))
 
     # Window metrics: a minimum larger than the default would open the window
     # already clamped, which reads as the app ignoring its own default.

--- a/scripts/verify_linux.sh
+++ b/scripts/verify_linux.sh
@@ -121,6 +121,17 @@ run_audio_smoke() {
   fi
 }
 
+# desktop-file-validate reports warnings, hints and "error (will be fatal in
+# the future)" on stdout while still exiting 0, so its exit status alone would
+# pass a deprecated key or a miscategorised entry. Any output is a failure —
+# same rule as the CI step in .github/workflows/linux-desktop-build.yml.
+validate_desktop_entry() {
+  local entry="$REPO_ROOT/linux/packaging/io.github.thezupzup.linthra.desktop"
+  local report
+  report="$(desktop-file-validate "$entry")" || return 1
+  [ -z "$report" ] || { printf '%s\n' "$report" >&2; return 1; }
+}
+
 FAILED=()
 
 run_step() {
@@ -150,6 +161,17 @@ main() {
   # and can still build without a network. Cheap, so it runs before the build.
   run_step "Linux runner configuration" python3 scripts/check_linux_runner.py
   run_step "Linux runner tooling tests" python3 test/tooling/check_linux_runner_test.py
+
+  # The desktop entry's syntax (#434). check_linux_runner.py above already
+  # covers its agreement with the app; this is the freedesktop tooling's own
+  # verdict on the file. Optional locally — desktop-file-utils is not one of
+  # the build dependencies — but CI always has it.
+  if command -v desktop-file-validate >/dev/null 2>&1; then
+    run_step "Desktop entry validation" validate_desktop_entry
+  else
+    warn "desktop-file-validate not found (package desktop-file-utils);"
+    warn "skipping the desktop entry syntax check. CI still runs it."
+  fi
 
   # Read line by line: a dependency name can contain spaces ("gtk+-3.0
   # development headers"), so word splitting would mangle the report.

--- a/test/tooling/check_linux_runner_test.py
+++ b/test/tooling/check_linux_runner_test.py
@@ -11,6 +11,11 @@ caught", built on a synthetic checkout rather than the real one: a fixture that
 can be broken is the only way to prove the checker fails when it should, and it
 keeps these tests from depending on Linthra's current version or app id.
 
+The desktop entry (#434) is tested the same way, and for the same reason: a
+`.desktop` file that names the wrong binary, the wrong icon or the wrong app id
+is still a perfectly valid desktop file, so only a comparison against the app's
+own identity catches it.
+
 One test does run against the real repository, because "the checker passes on
 the actual runner" is the thing the CI job cares about.
 
@@ -101,6 +106,34 @@ abstract final class AppInfo {{
 }}
 """
 
+DESKTOP_ENTRY = """\
+# A comment, which the reader has to skip rather than parse.
+[Desktop Entry]
+Type=Application
+Name={display_name}
+GenericName=Music Player
+Comment=An example.
+Exec={binary}
+Icon={app_id}
+Terminal=false
+Categories=AudioVideo;Audio;Player;Music;
+StartupNotify=true
+"""
+
+# Only the parts of a Flatpak manifest this checker reads. Both the
+# hand-authored template and the file generated from it are written from this,
+# because the check exists precisely to catch the two disagreeing.
+FLATPAK_MANIFEST = """\
+app-id: {app_id}
+command: {binary}
+modules:
+  - name: {binary}
+    buildsystem: simple
+    build-commands:
+      - install -d /app/bin
+      - install -Dm644 linux/packaging/{app_id}.desktop /app/share/applications/{app_id}.desktop
+"""
+
 
 def build_checkout(
     directory: Path,
@@ -110,9 +143,14 @@ def build_checkout(
     build_gradle: str | None = None,
     pubspec: str | None = None,
     app_info: str | None = None,
+    desktop_entry: str | None = None,
+    desktop_entry_name: str | None = None,
+    flatpak_manifest: str | None = None,
 ) -> Path:
     """Write a minimal, internally consistent checkout the checker can read."""
     (directory / "linux" / "runner").mkdir(parents=True, exist_ok=True)
+    (directory / "linux" / "packaging").mkdir(parents=True, exist_ok=True)
+    (directory / "flatpak").mkdir(parents=True, exist_ok=True)
     (directory / "android" / "app").mkdir(parents=True, exist_ok=True)
     (directory / "lib" / "core").mkdir(parents=True, exist_ok=True)
 
@@ -144,6 +182,24 @@ def build_checkout(
         else APP_INFO.format(display_name=DISPLAY_NAME),
         encoding="utf-8",
     )
+    packaging = directory / "linux" / "packaging"
+    (packaging / (desktop_entry_name or f"{APP_ID}.desktop")).write_text(
+        desktop_entry
+        if desktop_entry is not None
+        else DESKTOP_ENTRY.format(
+            display_name=DISPLAY_NAME, binary=BINARY, app_id=APP_ID
+        ),
+        encoding="utf-8",
+    )
+    manifest = (
+        flatpak_manifest
+        if flatpak_manifest is not None
+        else FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY)
+    )
+    (directory / "flatpak" / "flatpak-flutter.yml").write_text(
+        FLATPAK_MANIFEST.format(app_id=APP_ID, binary=BINARY), encoding="utf-8"
+    )
+    (directory / "flatpak" / f"{APP_ID}.yml").write_text(manifest, encoding="utf-8")
     return directory
 
 
@@ -213,6 +269,129 @@ class IdentityDriftTest(CheckoutCase):
             my_application=MY_APPLICATION.format(display_name="Other"),
         )
         self.assertEqual(len(checker.check(self.root)), 3)
+
+
+class DesktopEntryTest(CheckoutCase):
+    """The installed entry (#434) repeating the identity it launches.
+
+    Every case here installs and validates fine as a desktop file; what breaks
+    is the agreement with the app, which is exactly what nothing else notices.
+    """
+
+    def entry(self, **overrides: str) -> str:
+        fields = {
+            "display_name": DISPLAY_NAME,
+            "binary": BINARY,
+            "app_id": APP_ID,
+            **overrides,
+        }
+        return DESKTOP_ENTRY.format(**fields)
+
+    def test_the_name_must_match_app_info(self) -> None:
+        build_checkout(self.root, desktop_entry=self.entry(display_name="Other"))
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Name=", problems[0])
+
+    def test_the_exec_must_be_the_binary_name(self) -> None:
+        # The launcher entry pointing at something that is not the installed
+        # binary: menu item present, click does nothing.
+        build_checkout(self.root, desktop_entry=self.entry(binary="otherapp"))
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Exec=", problems[0])
+
+    def test_a_field_code_in_exec_is_rejected(self) -> None:
+        # `%U` advertises a URI handler the app does not implement.
+        build_checkout(self.root, desktop_entry=self.entry(binary=f"{BINARY} %U"))
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Exec=", problems[0])
+
+    def test_the_icon_must_be_the_app_id(self) -> None:
+        # The icon files (#436) are installed under the app id; any other name
+        # resolves to nothing and the entry shows a fallback icon forever.
+        build_checkout(
+            self.root,
+            desktop_entry=self.entry().replace(f"Icon={APP_ID}", "Icon=exampleapp"),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Icon=", problems[0])
+
+    def test_a_missing_key_is_reported(self) -> None:
+        build_checkout(
+            self.root,
+            desktop_entry=self.entry().replace(f"Icon={APP_ID}\n", ""),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no Icon=", problems[0])
+
+    def test_audio_player_categories_are_required(self) -> None:
+        build_checkout(
+            self.root,
+            desktop_entry=self.entry().replace(
+                "Categories=AudioVideo;Audio;Player;Music;", "Categories=Utility;"
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("Categories", problems[0])
+
+    def test_extra_categories_are_allowed(self) -> None:
+        build_checkout(
+            self.root,
+            desktop_entry=self.entry().replace(
+                "Categories=AudioVideo;Audio;Player;Music;",
+                "Categories=AudioVideo;Audio;Player;Music;Recorder;",
+            ),
+        )
+        self.assertEqual(checker.check(self.root), [])
+
+    def test_an_entry_not_named_for_the_app_id_is_not_found(self) -> None:
+        # Flatpak exports `<app-id>.desktop` and nothing else, so a renamed
+        # file is not a cosmetic difference — it is an entry that never ships.
+        build_checkout(self.root, desktop_entry_name="exampleapp.desktop")
+        with self.assertRaises(checker.CheckError):
+            checker.check(self.root)
+
+    def test_a_file_without_the_group_header_is_an_error(self) -> None:
+        build_checkout(self.root, desktop_entry="Name=ExampleApp\n")
+        with self.assertRaises(checker.CheckError):
+            checker.check(self.root)
+
+
+class DesktopEntryInstallTest(CheckoutCase):
+    def test_a_generated_manifest_that_lost_the_install_step_is_caught(self) -> None:
+        # The realistic failure: flatpak-flutter.yml gains the install step and
+        # nobody re-runs scripts/regenerate_flatpak_sources.sh, so the manifest
+        # flatpak-builder actually consumes still ships no desktop entry.
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace(
+                f"      - install -Dm644 linux/packaging/{APP_ID}.desktop "
+                f"/app/share/applications/{APP_ID}.desktop\n",
+                "",
+            ),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn(f"flatpak/{APP_ID}.yml", problems[0])
+        self.assertIn("/app/share/applications", problems[0])
+
+    def test_installing_somewhere_flatpak_does_not_export_is_caught(self) -> None:
+        build_checkout(
+            self.root,
+            flatpak_manifest=FLATPAK_MANIFEST.format(
+                app_id=APP_ID, binary=BINARY
+            ).replace("/app/share/applications/", "/app/share/"),
+        )
+        problems = checker.check(self.root)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("no desktop entry to export", problems[0])
 
 
 class WindowMetricsTest(CheckoutCase):


### PR DESCRIPTION
Closes #434

Adds the Linux desktop entry and the packaging that installs it, so Linthra appears in GNOME/KDE application menus after installing the Flatpak instead of only being launchable with `flatpak run`. Nothing else about the package changes: `finish-args` are untouched, Android is untouched, and no icon or AppStream file is added (#436 / #435).

## The entry

`linux/packaging/io.github.thezupzup.linthra.desktop`:

```ini
[Desktop Entry]
Type=Application
Name=Linthra
GenericName=Music Player
Comment=Play your own music, from this device or your own server
Exec=linthra
Icon=io.github.thezupzup.linthra
Terminal=false
Categories=AudioVideo;Audio;Player;Music;
Keywords=music;audio;player;library;playlist;jellyfin;subsonic;navidrome;plex;
StartupNotify=true
```

* **Filename = application id.** flatpak-builder only exports a desktop file whose name starts with the app id; AppStream (#435) will point its `<launchable type="desktop-id">` at this exact name; the icon (#436) gets installed under the same name.
* **`Exec=linthra`** — the bare command the manifest declares as `command:`, installed at `/app/bin/linthra`. No absolute path, so nothing names a build machine and the same file works for a native package that puts `linthra` on `PATH`. Export rewrites it into the host-side `flatpak run …` form. No `%U`/`%F` field code and no `MimeType`: Linthra takes no file or URI argument today, and claiming one would advertise a handler that drops what it is given.
* **`Icon=io.github.thezupzup.linthra`** — an icon-theme name, matching what #436 will install. Until then the launcher falls back to a generic icon rather than a wrong one.
* **`Categories=AudioVideo;Audio;Player;Music;`** — `AudioVideo` is the required main category, `Audio`/`Player` narrow it to an audio player, `Music` is the registered additional category launchers group music apps by.
* No `StartupWMClass`: the runner already calls `g_set_prgname(APPLICATION_ID)` and registers its `GtkApplication` under the same id, so the window associates with this entry on both Wayland and X11.

It lives under `linux/packaging/` rather than `flatpak/` so a future native package installs the same file — and, usefully, `check_linux_runner.py`'s existing "no absolute host path under `linux/`" scan already covers it.

## Packaging

One install step in the hand-authored `flatpak/flatpak-flutter.yml`, into the only directory flatpak-builder exports from:

```
install -Dm644 linux/packaging/io.github.thezupzup.linthra.desktop \
  /app/share/applications/io.github.thezupzup.linthra.desktop
```

The file comes from the module's own `dir` source (the whole checkout), so there is no packaging-only copy to drift. No `rename-desktop-file` is needed — everything is already named for the app id.

`flatpak/io.github.thezupzup.linthra.yml` was **regenerated** with `scripts/regenerate_flatpak_sources.sh`, not hand-edited. The generated diff is exactly the one added line; `flatpak/generated/` is unchanged. Running the generator twice produced an identical file.

## Validation added

* `scripts/check_linux_runner.py` gains the identity half: the entry's filename, `Name`, `Exec`, `Icon` and `Categories` are checked against the same sources of truth the runner is held to (`AppInfo.name`, `pubspec.yaml`'s `name`, Android's `applicationId`), plus the install step in **both** the hand-authored and the generated manifest — so a manifest change that was never regenerated fails here instead of silently shipping a Flatpak with no menu entry. 11 new cases in `test/tooling/check_linux_runner_test.py`.
* CI (`linux-desktop-build.yml`) and `scripts/verify_linux.sh` run `desktop-file-validate` for the syntax half. It exits 0 for warnings and "will be fatal in the future" errors, so any output at all is treated as the failure signal. `verify_linux.sh` skips it with a note when `desktop-file-utils` is not installed locally.

## Validation run

| Check | Result |
| --- | --- |
| `desktop-file-validate linux/packaging/io.github.thezupzup.linthra.desktop` | clean, no output |
| `python3 scripts/check_linux_runner.py` | `Linux runner configuration OK.` |
| `python3 test/tooling/check_linux_runner_test.py` | 33 tests OK (22 existing + 11 new) |
| all `test/tooling/*.py` | pass |
| `scripts/regenerate_flatpak_sources.sh` | exit 0; one-line manifest diff, reproducible, `generated/` unchanged |
| YAML parse of both manifests + the workflow | OK; `finish-args` unchanged |
| simulated `install -Dm644` into a scratch prefix | lands at `app/share/applications/io.github.thezupzup.linthra.desktop`, `0644`, still validates |
| `scripts/check_pr_security_surface.py` | flags the usual CI/automation paths for maintainer review (workflow + two scripts) |

**Not verified here:** this environment has no `flatpak`/`flatpak-builder`, so the built-and-installed result was not tested. The install path, filename and export behaviour above are from the manifest and flatpak-builder's export rules, not from an observed build. A local `flatpak-builder` run per `docs/flatpak-development.md` is the remaining manual check for "Linthra appears in the launcher and starts from it".

## Left for the follow-ups

* **#435** — no `io.github.thezupzup.linthra.metainfo.xml`; nothing here needs to change when it lands, it will just point its `desktop-id` at this file.
* **#436** — no icon files, so `Icon=` currently resolves to nothing and the launcher shows a fallback icon. The name is already the one #436 will install under.
* Sandbox permissions (#438/#439/#440/#441) are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPEG6muGA5TTtFRja6hy3V)_